### PR TITLE
Improve leaderboard.json structure (First Contribution #48)

### DIFF
--- a/leaderboard.json
+++ b/leaderboard.json
@@ -1,4 +1,5 @@
 {
+    "description": "Leaderboard tracking vintage CPU validators by entropy score",
     "validators": [
         {
             "wallet": "example-wallet-123",
@@ -7,7 +8,27 @@
             "entropy_score": 3.47,
             "score_composite": 9.14,
             "rank": 1
+        },
+        {
+            "wallet": "example-wallet-456",
+            "cpu_model": "PowerPC G4",
+            "bios_timestamp": "2001-06-15",
+            "entropy_score": 4.12,
+            "score_composite": 11.35,
+            "rank": 2
+        },
+        {
+            "wallet": "example-wallet-789",
+            "cpu_model": "AMD Athlon XP",
+            "bios_timestamp": "2002-03-22",
+            "entropy_score": 3.89,
+            "score_composite": 10.21,
+            "rank": 3
         }
     ],
-    "last_updated": "2025-04-21T16:37:47.088498Z"
+    "scoring": {
+        "entropy_score": "Measures CPU uniqueness based on vintage silicon variations",
+        "score_composite": "Combined score including age, rarity, and entropy"
+    },
+    "last_updated": "2026-02-08T15:35:00.000000Z"
 }


### PR DESCRIPTION
## Summary

This PR improves the leaderboard.json file structure for better documentation and realism, as the first contribution to RustChain.

## Changes

1. Added description field - Makes the JSON self-documenting
2. Expanded validator examples - Now 3 entries (was 1) showing realistic data
3. Added scoring field explanations - Documents entropy_score and score_composite
4. Updated timestamp - Current date instead of stale 2025 data

## Bounty Claim

This is my first contribution to RustChain. Per issue #48, this qualifies for the **10 RTC bounty** for the first merged PR.

---

**Bounty**: 10 RTC (First Contribution)  
**Issue**: Scottcjn/Rustchain#48