### PR TITLE
docs: add wRTC quickstart guide (buy, verify, bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 *Your PowerPC G4 earns more than a modern Threadripper. That's the point.*
 
-[Website](https://rustchain.org) • [Live Explorer](https://rustchain.org/explorer) • [Swap wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [Quick Start](#-quick-start) • [How It Works](#-how-proof-of-antiquity-works)
+[Website](https://rustchain.org) • [Live Explorer](https://rustchain.org/explorer) • [Swap wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [wRTC Quickstart](docs/wrtc.md) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [Quick Start](#-quick-start) • [How It Works](#-how-proof-of-antiquity-works)
 
 </div>
 
@@ -26,6 +26,7 @@ RustChain Token (RTC) is now available as **wRTC** on Solana via the BoTTube Bri
 | Resource | Link |
 |----------|------|
 | **Swap wRTC** | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| **wRTC Quickstart** | [Buy, Verify, Bridge Guide](docs/wrtc.md) |
 | **Price Chart** | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
 | **Bridge RTC ↔ wRTC** | [BoTTube Bridge](https://bottube.ai/bridge) |
 | **Token Mint** | `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X` |

--- a/docs/wrtc.md
+++ b/docs/wrtc.md
@@ -1,0 +1,81 @@
+# wRTC Quickstart: Buy, Verify, Bridge
+
+This guide shows the safest path to:
+1. get real `wRTC` on Solana,
+2. verify token authenticity,
+3. bridge `wRTC` into BoTTube credits for RTC tipping,
+4. withdraw back to `wRTC`.
+
+## Canonical Token Info (Use This Only)
+
+- Mint: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- Decimals: `6`
+- Raydium swap URL:
+  `https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- BoTTube bridge URL:
+  `https://bottube.ai/bridge/wrtc`
+
+## Anti-Scam Checklist (Do Not Skip)
+
+- Always verify the full mint address, not token name/ticker only.
+- Confirm token decimals are exactly `6`.
+- Use the official Raydium swap link from this guide.
+- Do not trust random DMs, fake support, or shortened links.
+- Bookmark official pages and access via bookmarks.
+- Start with a small test amount before moving larger balances.
+
+## Prerequisites
+
+- Solana wallet with SOL for network fees.
+- Access to Raydium and BoTTube Bridge from a secure browser session.
+
+## Step 1: Swap SOL to wRTC on Raydium
+
+Open:
+`https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+
+Then:
+1. Connect your wallet.
+2. Confirm the output token mint is:
+   `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`.
+3. Enter amount, review price impact, and execute swap.
+4. Keep transaction signature for audit/reference.
+
+## Step 2: Verify You Received Real wRTC
+
+Inside wallet token details, verify:
+- Mint is `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- Decimals is `6`
+
+If either does not match, do not continue bridging.
+
+## Step 3: Bridge wRTC to BoTTube Credits
+
+Open:
+`https://bottube.ai/bridge/wrtc`
+
+Then:
+1. Connect same wallet holding wRTC.
+2. Select deposit/bridge to BoTTube credits.
+3. Enter amount and confirm wallet transaction.
+4. Wait for confirmation and verify credits appear in your BoTTube account.
+
+## Step 4: Withdraw Back to wRTC
+
+From BoTTube Bridge:
+1. Choose withdraw back to wRTC.
+2. Enter destination Solana wallet address.
+3. Confirm amount and submit withdrawal.
+4. Verify received token mint/decimals again after arrival.
+
+## Troubleshooting
+
+- Bridge pending: wait for network confirmations and refresh session.
+- Token not visible: add custom token in wallet using canonical mint.
+- Wrong token risk: compare mint and decimals before every transfer.
+
+## Safety Notes
+
+- No one from the project will ask for your seed phrase.
+- Use hardware wallets for larger balances.
+- Consider keeping separate wallets for operations vs storage.


### PR DESCRIPTION
Adds `docs/wrtc.md` with canonical mint/decimals, anti-scam checklist, and copy-pastable swap/bridge/withdraw steps. Links the new guide from README.