### PR TITLE
docs: complete public API endpoint index with curl examples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,243 +1,279 @@
-# RustChain API Reference
+﻿# RustChain API Reference (Complete Public Endpoint Index)
 
 Base URL: `https://50.28.86.131`
 
-All endpoints use HTTPS. Self-signed certificates require `-k` flag with curl.
+Notes:
+- Use `-k` with curl because the node may use a self-signed TLS certificate.
+- Endpoints marked `admin` require `X-Admin-Key` or `X-API-Key`.
+- Endpoints marked `signed` require cryptographic signatures.
 
----
+## Quick Health Checks
 
-## Health & Status
-
-### `GET /health`
-
-Check node status and version.
-
-**Request:**
 ```bash
-curl -sk https://50.28.86.131/health | jq .
+curl -sk https://50.28.86.131/health
+curl -sk https://50.28.86.131/ready
+curl -sk https://50.28.86.131/ops/readiness
 ```
 
-**Response:**
-```json
-{
-  "backup_age_hours": 6.75,
-  "db_rw": true,
-  "ok": true,
-  "tip_age_slots": 0,
-  "uptime_s": 18728,
-  "version": "2.2.1-rip200"
-}
-```
+## Read Endpoints (Public)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `ok` | boolean | Node healthy |
-| `version` | string | Protocol version |
-| `uptime_s` | integer | Seconds since node start |
-| `db_rw` | boolean | Database writable |
-| `backup_age_hours` | float | Hours since last backup |
-| `tip_age_slots` | integer | Slots behind tip (0 = synced) |
+### Node and Chain State
 
----
-
-## Epoch Information
-
-### `GET /epoch`
-
-Get current epoch details.
-
-**Request:**
 ```bash
-curl -sk https://50.28.86.131/epoch | jq .
+# Node health
+curl -sk https://50.28.86.131/health
+
+# Ready check
+curl -sk https://50.28.86.131/ready
+
+# Readiness detail
+curl -sk https://50.28.86.131/ops/readiness
+
+# Prometheus metrics
+curl -sk https://50.28.86.131/metrics
+
+# mac-specific metrics
+curl -sk https://50.28.86.131/metrics_mac
+
+# Current epoch
+curl -sk https://50.28.86.131/epoch
+
+# Header tip
+curl -sk https://50.28.86.131/headers/tip
+
+# OUI enforce flag
+curl -sk https://50.28.86.131/ops/oui/enforce
+
+# Chain stats
+curl -sk https://50.28.86.131/api/stats
+
+# Known nodes
+curl -sk https://50.28.86.131/api/nodes
+
+# Miner list
+curl -sk https://50.28.86.131/api/miners
+
+# Explorer UI
+curl -sk https://50.28.86.131/explorer
+
+# OpenAPI spec
+curl -sk https://50.28.86.131/openapi.json
 ```
 
-**Response:**
-```json
-{
-  "blocks_per_epoch": 144,
-  "enrolled_miners": 2,
-  "epoch": 62,
-  "epoch_pot": 1.5,
-  "slot": 9010
-}
-```
+### Rewards and Ledger
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `epoch` | integer | Current epoch number |
-| `slot` | integer | Current slot within epoch |
-| `blocks_per_epoch` | integer | Slots per epoch (144 = ~24h) |
-| `epoch_pot` | float | RTC to distribute this epoch |
-| `enrolled_miners` | integer | Miners eligible for rewards |
-
----
-
-## Miners
-
-### `GET /api/miners`
-
-List all active/enrolled miners.
-
-**Request:**
 ```bash
-curl -sk https://50.28.86.131/api/miners | jq .
+# Reward distribution by epoch
+curl -sk https://50.28.86.131/rewards/epoch/62
+
+# Wallet balance by miner_id
+curl -sk "https://50.28.86.131/wallet/balance?miner_id=your_miner_id"
+
+# Wallet ledger (global)
+curl -sk https://50.28.86.131/wallet/ledger
+
+# Wallet ledger (filtered)
+curl -sk "https://50.28.86.131/wallet/ledger?miner_id=your_miner_id"
+
+# All balances
+curl -sk https://50.28.86.131/wallet/balances/all
+
+# Pending transfers (default pending)
+curl -sk https://50.28.86.131/pending/list
+
+# Pending transfers (all statuses)
+curl -sk "https://50.28.86.131/pending/list?status=all&limit=200"
+
+# Integrity check
+curl -sk https://50.28.86.131/pending/integrity
 ```
 
-**Response:**
-```json
-[
-  {
-    "antiquity_multiplier": 2.5,
-    "device_arch": "G4",
-    "device_family": "PowerPC",
-    "entropy_score": 0.0,
-    "hardware_type": "PowerPC G4 (Vintage)",
-    "last_attest": 1770112912,
-    "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC"
-  },
-  {
-    "antiquity_multiplier": 2.0,
-    "device_arch": "G5",
-    "device_family": "PowerPC",
-    "entropy_score": 0.0,
-    "hardware_type": "PowerPC G5 (Vintage)",
-    "last_attest": 1770112865,
-    "miner": "g5-selena-179"
-  }
-]
-```
+### Withdrawal Read APIs
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `miner` | string | Unique miner ID (wallet address) |
-| `device_family` | string | CPU family (PowerPC, x86_64, etc.) |
-| `device_arch` | string | Specific architecture (G4, G5, M2) |
-| `hardware_type` | string | Human-readable hardware description |
-| `antiquity_multiplier` | float | Reward multiplier (1.0-2.5x) |
-| `entropy_score` | float | Hardware entropy quality |
-| `last_attest` | integer | Unix timestamp of last attestation |
-
----
-
-## Wallet
-
-### `GET /wallet/balance`
-
-Check RTC balance for a miner.
-
-**Request:**
 ```bash
-curl -sk "https://50.28.86.131/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
+# Withdrawal status
+curl -sk https://50.28.86.131/withdraw/status/WD_1234567890_abcdef
+
+# Withdrawal history
+curl -sk "https://50.28.86.131/withdraw/history/your_miner_pk?limit=50"
 ```
 
-**Response:**
-```json
-{
-  "amount_i64": 118357193,
-  "amount_rtc": 118.357193,
-  "miner_id": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC"
-}
-```
+### Download APIs
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `miner_id` | string | Wallet/miner identifier |
-| `amount_rtc` | float | Balance in RTC (human readable) |
-| `amount_i64` | integer | Balance in micro-RTC (6 decimals) |
-
-### `POST /wallet/transfer/signed`
-
-Transfer RTC to another wallet. Requires Ed25519 signature.
-
-**Request:**
 ```bash
-curl -sk -X POST https://50.28.86.131/wallet/transfer/signed \
+# Download landing page
+curl -sk https://50.28.86.131/downloads
+
+# Installer
+curl -sk -OJ https://50.28.86.131/download/installer
+
+# Miner package
+curl -sk -OJ https://50.28.86.131/download/miner
+
+# Uninstaller
+curl -sk -OJ https://50.28.86.131/download/uninstaller
+
+# Test miner files
+curl -sk -OJ https://50.28.86.131/download/test
+curl -sk -OJ https://50.28.86.131/download/test-bat
+```
+
+## Write Endpoints (Public, Signed, or Policy-Gated)
+
+### Attestation and Enrollment
+
+```bash
+# Get attestation challenge nonce
+curl -sk -X POST https://50.28.86.131/attest/challenge \
   -H "Content-Type: application/json" \
-  -d '{
-    "from": "sender_miner_id",
-    "to": "recipient_miner_id",
-    "amount_i64": 1000000,
-    "nonce": 12345,
-    "signature": "base64_ed25519_signature"
-  }'
-```
+  -d '{}'
 
-**Response (Success):**
-```json
-{
-  "success": true,
-  "tx_hash": "abc123...",
-  "new_balance": 117357193
-}
-```
-
----
-
-## Attestation
-
-### `POST /attest/submit`
-
-Submit hardware fingerprint for epoch enrollment.
-
-**Request:**
-```bash
+# Submit attestation
 curl -sk -X POST https://50.28.86.131/attest/submit \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "your_miner_id",
-    "fingerprint": {
-      "clock_skew": {...},
-      "cache_timing": {...},
-      "simd_identity": {...},
-      "thermal_entropy": {...},
-      "instruction_jitter": {...},
-      "behavioral_heuristics": {...}
-    },
-    "signature": "base64_ed25519_signature"
+    "nonce": "challenge_nonce",
+    "device": {"family": "PowerPC", "arch": "G4"},
+    "fingerprint": {},
+    "signals": {}
+  }'
+
+# Enroll in epoch
+curl -sk -X POST https://50.28.86.131/epoch/enroll \
+  -H "Content-Type: application/json" \
+  -d '{
+    "miner_pubkey": "your_miner_pubkey",
+    "miner_id": "your_miner_id",
+    "device": {"family": "PowerPC", "arch": "G4"}
+  }'
+
+# Lottery eligibility
+curl -sk "https://50.28.86.131/lottery/eligibility?miner_id=your_miner_id"
+```
+
+### Header and Mining Compatibility
+
+```bash
+# Submit signed block header
+curl -sk -X POST https://50.28.86.131/headers/ingest_signed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "miner_id": "your_miner_id",
+    "header": {"slot": 12345},
+    "message": "hex_message",
+    "signature": "hex_signature"
+  }'
+
+# Legacy mine API (returns 410 Gone by design)
+curl -sk -X POST https://50.28.86.131/api/mine -H "Content-Type: application/json" -d '{}'
+curl -sk -X POST https://50.28.86.131/compat/v1/api/mine -H "Content-Type: application/json" -d '{}'
+```
+
+### Wallet and Withdrawals
+
+```bash
+# Signed wallet transfer (Ed25519)
+curl -sk -X POST https://50.28.86.131/wallet/transfer/signed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_address": "RTC...",
+    "to_address": "RTC...",
+    "amount_rtc": 1.25,
+    "nonce": 1730000000,
+    "signature": "hex_or_base64_sig",
+    "public_key": "hex_pubkey",
+    "memo": "test transfer"
+  }'
+
+# Register withdrawal key
+curl -sk -X POST https://50.28.86.131/withdraw/register \
+  -H "Content-Type: application/json" \
+  -d '{
+    "miner_pk": "your_miner_pk",
+    "pubkey_sr25519": "hex_pubkey"
+  }'
+
+# Request withdrawal
+curl -sk -X POST https://50.28.86.131/withdraw/request \
+  -H "Content-Type: application/json" \
+  -d '{
+    "miner_pk": "your_miner_pk",
+    "amount": 10.0,
+    "destination": "destination_address",
+    "signature": "base64_or_hex_signature",
+    "nonce": "unique_nonce"
   }'
 ```
 
-**Response (Success):**
-```json
-{
-  "success": true,
-  "enrolled": true,
-  "epoch": 62,
-  "multiplier": 2.5,
-  "next_settlement_slot": 9216
-}
+## Operator/Admin Endpoints (Protected)
+
+These are not open user APIs. They are listed for completeness.
+
+```bash
+# Set miner header key (admin)
+curl -sk -X POST https://50.28.86.131/miner/headerkey \
+  -H "X-API-Key: $RC_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"miner_id":"your_miner_id","pubkey_hex":"64_hex_chars"}'
+
+# Toggle OUI deny enforcement (admin)
+curl -sk -X POST https://50.28.86.131/admin/oui_deny/enforce \
+  -H "X-API-Key: $RC_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"enforce": true}'
+
+# OUI deny list (admin)
+curl -sk -H "X-API-Key: $RC_ADMIN_KEY" https://50.28.86.131/admin/oui_deny/list
+curl -sk -X POST -H "X-API-Key: $RC_ADMIN_KEY" -H "Content-Type: application/json" \
+  -d '{"prefix":"AA:BB:CC"}' https://50.28.86.131/admin/oui_deny/add
+curl -sk -X POST -H "X-API-Key: $RC_ADMIN_KEY" -H "Content-Type: application/json" \
+  -d '{"prefix":"AA:BB:CC"}' https://50.28.86.131/admin/oui_deny/remove
+
+# Rewards settle (admin/cron)
+curl -sk -X POST https://50.28.86.131/rewards/settle \
+  -H "Content-Type: application/json" \
+  -d '{"epoch": 62}'
+
+# Internal transfer (admin only)
+curl -sk -X POST https://50.28.86.131/wallet/transfer \
+  -H "X-Admin-Key: $RC_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"from_miner":"A","to_miner":"B","amount_rtc":1.0,"reason":"admin_transfer"}'
+
+# Pending worker/admin controls
+curl -sk -X POST https://50.28.86.131/pending/void \
+  -H "X-Admin-Key: $RC_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"pending_id":123,"reason":"manual void","voided_by":"admin"}'
+curl -sk -X POST https://50.28.86.131/pending/confirm \
+  -H "X-Admin-Key: $RC_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{}'
+
+# Governance endpoints
+curl -sk -X POST https://50.28.86.131/gov/rotate/stage   -H "X-API-Key: $RC_ADMIN_KEY" -H "Content-Type: application/json" -d '{}'
+curl -sk        https://50.28.86.131/gov/rotate/message/62
+curl -sk -X POST https://50.28.86.131/gov/rotate/approve -H "Content-Type: application/json" -d '{}'
+curl -sk -X POST https://50.28.86.131/gov/rotate/commit  -H "X-API-Key: $RC_ADMIN_KEY" -H "Content-Type: application/json" -d '{}'
+
+# Genesis export
+curl -sk https://50.28.86.131/genesis/export
 ```
 
-**Response (Rejected):**
-```json
-{
-  "success": false,
-  "error": "VM_DETECTED",
-  "check_failed": "behavioral_heuristics",
-  "detail": "Hypervisor signature detected in CPUID"
-}
+## Legacy Proxy (server_proxy.py)
+
+If running the optional proxy service on port `8089`:
+
+```bash
+curl -s http://50.28.86.131:8089/status
+curl -s http://50.28.86.131:8089/
+curl -s http://50.28.86.131:8089/api/stats
 ```
 
----
+## Related Docs
 
-## Error Codes
-
-| Code | Meaning |
-|------|---------|
-| `VM_DETECTED` | Attestation failed - virtual machine detected |
-| `INVALID_SIGNATURE` | Ed25519 signature verification failed |
-| `INSUFFICIENT_BALANCE` | Not enough RTC for transfer |
-| `MINER_NOT_FOUND` | Unknown miner ID |
-| `RATE_LIMITED` | Too many requests |
-
----
-
-## Rate Limits
-
-- Public endpoints: 100 requests/minute
-- Attestation: 1 per 10 minutes per miner
-- Transfers: 10 per minute per wallet
-
----
-
-*Documentation generated for RustChain v2.2.1-rip200*
+- `docs/PROTOCOL.md`
+- `docs/GLOSSARY.md`
+- `docs/tokenomics_v1.md`
+- `docs/api/openapi.yaml`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# RustChain Documentation
+﻿# RustChain Documentation
 
 > **RustChain** is a Proof-of-Antiquity blockchain that rewards vintage hardware with higher mining multipliers. The network uses 6 hardware fingerprint checks to prevent VMs and emulators from earning rewards.
 
@@ -7,7 +7,8 @@
 | Document | Description |
 |----------|-------------|
 | [Protocol Specification](./PROTOCOL.md) | Full RIP-200 consensus protocol |
-| [API Reference](./API.md) | All endpoints with curl examples |
+| [API Reference](./API.md) | Complete public endpoint index + curl examples |
+| [OpenAPI Spec](./api/openapi.yaml) | Machine-readable API schema |
 | [Glossary](./GLOSSARY.md) | Terms and definitions |
 | [Tokenomics](./tokenomics_v1.md) | RTC supply and distribution |
 
@@ -33,18 +34,18 @@ curl -sk https://50.28.86.131/epoch | jq .
 ## Architecture Overview
 
 ```
-┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
-│  Vintage Miner  │────▶│ Attestation Node │────▶│  Ergo Anchor    │
-│  (G4/G5/SPARC)  │     │  (50.28.86.131)  │     │ (Immutability)  │
-└─────────────────┘     └──────────────────┘     └─────────────────┘
-        │                        │
-        │ Hardware Fingerprint   │ Epoch Settlement
-        │ (6 checks)             │ Hash
-        ▼                        ▼
-   ┌─────────┐              ┌─────────┐
-   │ RTC     │              │ Ergo    │
-   │ Rewards │              │ Chain   │
-   └─────────┘              └─────────┘
+鈹屸攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?    鈹屸攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?    鈹屸攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?
+鈹? Vintage Miner  鈹傗攢鈹€鈹€鈹€鈻垛攤 Attestation Node 鈹傗攢鈹€鈹€鈹€鈻垛攤  Ergo Anchor    鈹?
+鈹? (G4/G5/SPARC)  鈹?    鈹? (50.28.86.131)  鈹?    鈹?(Immutability)  鈹?
+鈹斺攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?    鈹斺攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?    鈹斺攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?
+        鈹?                       鈹?
+        鈹?Hardware Fingerprint   鈹?Epoch Settlement
+        鈹?(6 checks)             鈹?Hash
+        鈻?                       鈻?
+   鈹屸攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?             鈹屸攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?
+   鈹?RTC     鈹?             鈹?Ergo    鈹?
+   鈹?Rewards 鈹?             鈹?Chain   鈹?
+   鈹斺攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?             鈹斺攢鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹?
 ```
 
 ## Getting Started
@@ -59,3 +60,4 @@ Active bounties: [github.com/Scottcjn/rustchain-bounties](https://github.com/Sco
 
 ---
 *Documentation maintained by the RustChain community.*
+


### PR DESCRIPTION
## Summary\n- expand docs/API.md into a complete public endpoint index\n- add curl examples for read/write endpoints, including signed and admin-protected routes\n- keep links to PROTOCOL.md, GLOSSARY.md, 	okenomics_v1.md, and OpenAPI spec\n- update docs/README.md quick links to include OpenAPI schema and the expanded API reference\n\n## Why\nThis addresses bounty #8 acceptance criteria around API documentation coverage and runnable examples for developers and agents.\n\n## Notes\n- docs-only change\n- no runtime code changes\n- examples use -k because the node may present a self-signed TLS certificate\n