### PR TITLE
docs: add wallet user guide and contributing guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing Guide
+
+Thanks for helping improve RustChain.
+
+## 1) Before you start
+
+1. Read:
+   - `README.md`
+   - `docs/PROTOCOL.md`
+   - `docs/API.md`
+2. Search existing issues and PRs first to avoid duplicate work.
+
+## 2) Recommended contribution flow
+
+1. Fork `Scottcjn/Rustchain`.
+2. Create a branch from `main`.
+3. Keep changes focused (one feature/fix/doc topic per PR).
+4. Test commands/examples locally whenever possible.
+5. Open a PR with a clear summary and test notes.
+
+## 3) Branch naming
+
+Examples:
+
+- `feat/node-health-alerts`
+- `fix/transfer-validation`
+- `docs/wallet-user-guide`
+
+## 4) Commit message format
+
+Use short, scoped messages:
+
+- `feat: add wallet export helper`
+- `fix: handle invalid miner id input`
+- `docs: improve API transfer examples`
+
+## 5) Pull request checklist
+
+- [ ] PR title clearly describes intent.
+- [ ] Description explains what changed and why.
+- [ ] Linked issue/bounty (if relevant).
+- [ ] Documentation updated for behavior changes.
+- [ ] No secrets/private keys in code, logs, or screenshots.
+
+## 6) Documentation contributions
+
+For docs PRs:
+
+1. Use Markdown with runnable examples.
+2. Verify endpoint examples against live/API docs.
+3. Keep security warnings explicit (key handling, phishing, fake token mints).
+
+## 7) Security reporting
+
+Do not open public issues for critical vulnerabilities before maintainers can patch.
+
+- Use responsible disclosure via project maintainers.
+- Include reproduction steps, impact, and proposed mitigation.
+
+## 8) Bounty submissions
+
+When a contribution is tied to a bounty:
+
+1. Comment on the bounty issue using required claim format.
+2. Submit PR(s) and link them back to the bounty thread.
+3. Include wallet/miner id exactly as requested by the bounty rules.
+
+## 9) Code of conduct expectations
+
+- Be precise and respectful in technical discussion.
+- Prefer reproducible evidence over assumptions.
+- Keep PR review discussions focused on correctness and risk.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
 | [API Reference](./API.md) | All endpoints with curl examples |
 | [Glossary](./GLOSSARY.md) | Terms and definitions |
 | [Tokenomics](./tokenomics_v1.md) | RTC supply and distribution |
+| [Wallet User Guide](./WALLET_USER_GUIDE.md) | Wallet basics, balance checks, and safe operations |
+| [Contributing Guide](./CONTRIBUTING.md) | Contribution workflow, PR checklist, and bounty submission notes |
 
 ## Live Network
 

--- a/docs/WALLET_USER_GUIDE.md
+++ b/docs/WALLET_USER_GUIDE.md
@@ -1,0 +1,83 @@
+# Wallet User Guide
+
+This guide explains wallet basics, balance checks, and safe transfer practices for RustChain users.
+
+## 1) Wallet basics
+
+- In RustChain docs, wallet identity is often represented by `miner_id`.
+- Keep your wallet/miner id consistent across setup, mining, and balance checks.
+
+## 2) Check wallet balance
+
+```bash
+curl -sk "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+```
+
+Expected response shape:
+
+```json
+{
+  "amount_i64": 0,
+  "amount_rtc": 0.0,
+  "miner_id": "YOUR_WALLET_NAME"
+}
+```
+
+## 3) Confirm miner is active
+
+```bash
+curl -sk https://50.28.86.131/api/miners | jq .
+```
+
+If your miner does not appear:
+
+1. Wait a few minutes after startup.
+2. Confirm the same wallet/miner id was used when starting miner.
+3. Check network reachability to the node.
+
+## 4) Wallet-safe operations checklist
+
+- Verify URLs before signing transactions.
+- Never share private keys or seed phrases.
+- Keep a small test transfer habit before large moves.
+- Save tx IDs and timestamps for audit/recovery.
+
+## 5) Signed transfer endpoint (advanced)
+
+The API supports signed transfers:
+
+- Endpoint: `POST /wallet/transfer/signed`
+- Reference examples: `docs/API.md`
+
+Only use this when you fully understand signing and key custody.
+
+## 6) Common wallet issues
+
+### Balance always zero
+
+- Miner may not have completed a reward cycle yet.
+- Queried `miner_id` may not match your running miner wallet.
+
+### API SSL warning
+
+Current docs use `curl -k` for self-signed TLS:
+
+```bash
+curl -sk https://50.28.86.131/health
+```
+
+### Wrong chain/token confusion (RTC vs wRTC)
+
+- RTC: RustChain native token
+- wRTC: wrapped Solana representation
+- Official wRTC mint:
+  `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+
+## 7) Quick support data to collect
+
+When reporting wallet issues, include:
+
+1. `miner_id` used
+2. command run and output snippet
+3. timestamp (UTC)
+4. relevant tx hash (if any)


### PR DESCRIPTION
Adds two docs for the documentation sprint:\n\n- docs/WALLET_USER_GUIDE.md\n- docs/CONTRIBUTING.md\n\nAlso updates docs index:\n- docs/README.md\n\nValidation performed:\n- /wallet/balance command verified\n- /api/miners command verified\n\nThis extends doc coverage for onboarding and contribution workflows.