### PR TITLE
fix(security): protect OUI denylist admin endpoints

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2678,6 +2678,8 @@ def api_miners():
 @app.route('/admin/oui_deny/list', methods=['GET'])
 def list_oui_deny():
     """List all denied OUIs"""
+    if not is_admin(request):
+        return jsonify({"ok": False, "error": "forbidden"}), 403
     with sqlite3.connect(DB_PATH) as conn:
         rows = conn.execute("SELECT oui, vendor, added_ts, enforce FROM oui_deny ORDER BY vendor").fetchall()
     return jsonify({
@@ -2689,6 +2691,8 @@ def list_oui_deny():
 @app.route('/admin/oui_deny/add', methods=['POST'])
 def add_oui_deny():
     """Add OUI to denylist"""
+    if not is_admin(request):
+        return jsonify({"ok": False, "error": "forbidden"}), 403
     data = request.get_json()
 
     # Extract client IP (handle nginx proxy)
@@ -2714,6 +2718,8 @@ def add_oui_deny():
 @app.route('/admin/oui_deny/remove', methods=['POST'])
 def remove_oui_deny():
     """Remove OUI from denylist"""
+    if not is_admin(request):
+        return jsonify({"ok": False, "error": "forbidden"}), 403
     data = request.get_json()
 
     # Extract client IP (handle nginx proxy)


### PR DESCRIPTION
Security hardening discovered during red-team bounty #57.

## Issue
`/admin/oui_deny/list`, `/admin/oui_deny/add`, `/admin/oui_deny/remove` were reachable without admin authentication, allowing unauthenticated modification of the OUI denylist.

## Fix
Require admin auth (`X-API-Key` matching `RC_ADMIN_KEY`) for all OUI denylist endpoints.

## Validation
Manual reproduction against live node prior to patch:
- Unauthenticated POST /admin/oui_deny/add succeeded
- Unauthenticated POST /admin/oui_deny/remove succeeded

After patch, these should return 403 when not authenticated.

Related bounty: https://github.com/Scottcjn/rustchain-bounties/issues/57
