### PR TITLE
feat(security): attestation nonce binding + replay prevention

### DIFF
--- a/node/__init__.py
+++ b/node/__init__.py
@@ -1,0 +1,2 @@
+# Package marker for `node.*` imports used by tools/tests.
+

--- a/node/attest_nonce.py
+++ b/node/attest_nonce.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import secrets
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+
+@dataclass(frozen=True)
+class Challenge:
+    nonce: str
+    expires_at: int
+
+
+def ensure_tables(conn: sqlite3.Connection) -> None:
+    c = conn.cursor()
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS used_nonces (
+            miner_id TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            used_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL,
+            PRIMARY KEY (miner_id, nonce)
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_used_nonces_expires ON used_nonces(expires_at)")
+    c.execute(
+        """
+        CREATE TABLE IF NOT EXISTS attest_challenges (
+            nonce TEXT PRIMARY KEY,
+            issued_at INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL
+        )
+        """
+    )
+    c.execute("CREATE INDEX IF NOT EXISTS idx_attest_challenges_expires ON attest_challenges(expires_at)")
+    conn.commit()
+
+
+def cleanup_expired(conn: sqlite3.Connection, now_ts: Optional[int] = None) -> None:
+    now = int(now_ts or time.time())
+    c = conn.cursor()
+    c.execute("DELETE FROM used_nonces WHERE expires_at < ?", (now,))
+    c.execute("DELETE FROM attest_challenges WHERE expires_at < ?", (now,))
+    conn.commit()
+
+
+def issue_challenge(conn: sqlite3.Connection, ttl_seconds: int = 120, now_ts: Optional[int] = None) -> Challenge:
+    now = int(now_ts or time.time())
+    expires_at = now + int(ttl_seconds)
+    nonce = secrets.token_hex(32)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO attest_challenges (nonce, issued_at, expires_at) VALUES (?, ?, ?)",
+        (nonce, now, expires_at),
+    )
+    conn.commit()
+    return Challenge(nonce=nonce, expires_at=expires_at)
+
+
+def consume_challenge(conn: sqlite3.Connection, nonce: str, now_ts: Optional[int] = None) -> bool:
+    if not nonce:
+        return False
+    now = int(now_ts or time.time())
+    c = conn.cursor()
+    row = c.execute("SELECT expires_at FROM attest_challenges WHERE nonce = ?", (nonce,)).fetchone()
+    if not row:
+        return False
+    expires_at = int(row[0])
+    if expires_at < now:
+        c.execute("DELETE FROM attest_challenges WHERE nonce = ?", (nonce,))
+        conn.commit()
+        return False
+    c.execute("DELETE FROM attest_challenges WHERE nonce = ?", (nonce,))
+    conn.commit()
+    return True
+
+
+def validate_nonce_freshness(nonce: str, now_ts: Optional[int] = None, skew_seconds: int = 60) -> Tuple[bool, str]:
+    if not nonce:
+        return False, "missing_nonce"
+    if not str(nonce).isdigit():
+        return False, "nonce_not_timestamp"
+    now = int(now_ts or time.time())
+    try:
+        ts = int(str(nonce))
+    except ValueError:
+        return False, "nonce_not_timestamp"
+    if abs(ts - now) > int(skew_seconds):
+        return False, "nonce_out_of_window"
+    return True, "ok"
+
+
+def mark_nonce_used(
+    conn: sqlite3.Connection,
+    miner_id: str,
+    nonce: str,
+    ttl_seconds: int = 3600,
+    now_ts: Optional[int] = None,
+) -> Tuple[bool, str]:
+    if not miner_id:
+        return False, "missing_miner_id"
+    if not nonce:
+        return False, "missing_nonce"
+    now = int(now_ts or time.time())
+    expires_at = now + int(ttl_seconds)
+    c = conn.cursor()
+    try:
+        c.execute(
+            "INSERT INTO used_nonces (miner_id, nonce, used_at, expires_at) VALUES (?, ?, ?, ?)",
+            (miner_id, str(nonce), now, expires_at),
+        )
+        conn.commit()
+        return True, "ok"
+    except sqlite3.IntegrityError:
+        return False, "replay_detected"

--- a/node/tests/test_attest_nonce.py
+++ b/node/tests/test_attest_nonce.py
@@ -1,0 +1,49 @@
+import sqlite3
+import time
+import unittest
+
+from node.attest_nonce import (
+    consume_challenge,
+    ensure_tables,
+    issue_challenge,
+    mark_nonce_used,
+    validate_nonce_freshness,
+)
+
+
+class AttestNonceTests(unittest.TestCase):
+    def setUp(self):
+        self.conn = sqlite3.connect(":memory:")
+        ensure_tables(self.conn)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test_freshness_ok(self):
+        now = int(time.time())
+        ok, reason = validate_nonce_freshness(str(now), now_ts=now, skew_seconds=60)
+        self.assertTrue(ok)
+        self.assertEqual(reason, "ok")
+
+    def test_freshness_rejects_out_of_window(self):
+        now = int(time.time())
+        ok, reason = validate_nonce_freshness(str(now - 999), now_ts=now, skew_seconds=60)
+        self.assertFalse(ok)
+        self.assertEqual(reason, "nonce_out_of_window")
+
+    def test_mark_nonce_used_replay(self):
+        ok1, _ = mark_nonce_used(self.conn, miner_id="m1", nonce="123", ttl_seconds=60, now_ts=1000)
+        ok2, why2 = mark_nonce_used(self.conn, miner_id="m1", nonce="123", ttl_seconds=60, now_ts=1001)
+        self.assertTrue(ok1)
+        self.assertFalse(ok2)
+        self.assertEqual(why2, "replay_detected")
+
+    def test_challenge_one_time(self):
+        ch = issue_challenge(self.conn, ttl_seconds=120, now_ts=1000)
+        self.assertTrue(consume_challenge(self.conn, ch.nonce, now_ts=1001))
+        self.assertFalse(consume_challenge(self.conn, ch.nonce, now_ts=1002))
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Implements bounty #18: Nonce Binding & Attestation Replay Prevention.

## What’s included
- `used_nonces` table (TTL-based cleanup) to reject replayed attestations.
- Timestamp freshness validation for attestation nonces (default +/- 60s, configurable via env `RC_ATTEST_NONCE_SKEW_SECONDS`).
- Optional challenge-response flow:
  - `GET /attest/challenge` issues a short-lived server challenge nonce.
  - Client includes `challenge` in attestation payload (top-level or report.challenge) which is one-time consumable.
- Backward compatible:
  - Miners without `challenge` still work (server logs warning).
  - Nonce checks apply when `nonce` is provided; missing nonce logs warning.
- Unit tests for replay + freshness + one-time challenge.

## Config
- `RC_ATTEST_NONCE_SKEW_SECONDS` (default 60)
- `RC_ATTEST_NONCE_TTL_SECONDS` (default 3600)
- `RC_ATTEST_CHALLENGE_TTL_SECONDS` (default 120)

## Validation
- `python3 -m py_compile node/attest_nonce.py node/rustchain_v2_integrated_v2.2.1_rip200.py`
- `PYTHONPATH=. python3 -m unittest node/tests/test_attest_nonce.py`

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/18
