### PR TITLE
fix(security): protect /pending/list and /pending/integrity

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3175,6 +3175,10 @@ def wallet_transfer_v2():
 @app.route('/pending/list', methods=['GET'])
 def list_pending():
     """List all pending transfers"""
+    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+    if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        return jsonify({"error": "Unauthorized"}), 401
+
     status_filter = request.args.get('status', 'pending')
     limit = min(int(request.args.get('limit', 100)), 500)
     
@@ -3378,6 +3382,10 @@ def confirm_pending():
 @app.route('/pending/integrity', methods=['GET'])
 def check_integrity():
     """Check balance integrity: sum of ledger should match balances"""
+    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+    if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        return jsonify({"error": "Unauthorized"}), 401
+
     with sqlite3.connect(DB_PATH) as db:
         # Sum all ledger deltas per miner
         ledger_sums = dict(db.execute("""


### PR DESCRIPTION
Fixes security exposure: /pending/list and /pending/integrity were publicly accessible.

## Problem
- Unauthenticated callers can query pending transfer metadata and ledger integrity summaries.

## Fix
- Require admin key (X-Admin-Key or X-API-Key matching RC_ADMIN_KEY) for:
  - GET /pending/list
  - GET /pending/integrity

## Validation
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py`

Bug bounty report: https://github.com/Scottcjn/rustchain-bounties/issues/135
