### PR TITLE
Fix(security): require admin key for /wallet/ledger and /wallet/balances/all

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3500,6 +3500,11 @@ def wallet_transfer_OLD():
 @app.route('/wallet/ledger', methods=['GET'])
 def api_wallet_ledger():
     """Get transaction ledger (optionally filtered by miner)"""
+    # SECURITY: ledger entries include transfer reasons + wallet identifiers; require admin key.
+    admin_key = request.headers.get("X-Admin-Key", "")
+    if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        return jsonify({"ok": False, "reason": "admin_required"}), 401
+
     miner_id = request.args.get("miner_id", "").strip()
 
     with sqlite3.connect(DB_PATH) as db:
@@ -3541,6 +3546,11 @@ def api_wallet_ledger():
 @app.route('/wallet/balances/all', methods=['GET'])
 def api_wallet_balances_all():
     """Get all miner balances"""
+    # SECURITY: exporting all balances is sensitive; require admin key.
+    admin_key = request.headers.get("X-Admin-Key", "")
+    if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        return jsonify({"ok": False, "reason": "admin_required"}), 401
+
     with sqlite3.connect(DB_PATH) as db:
         rows = db.execute(
             "SELECT miner_id, amount_i64 FROM balances ORDER BY amount_i64 DESC"


### PR DESCRIPTION
Fixes rustchain-bounties#136.

Problem
- Live node exposes full balances and ledger data without authentication:
  - GET /wallet/balances/all
  - GET /wallet/ledger

Fix
- Require X-Admin-Key == RC_ADMIN_KEY for both endpoints; otherwise return 401 {ok:false, reason:admin_required}.

Proof (pre-fix)
- curl -sk https://50.28.86.131/wallet/balances/all -> 200
- curl -sk https://50.28.86.131/wallet/ledger -> 200
