### PR TITLE
Fix(security): require admin key for /rewards/settle

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2987,6 +2987,11 @@ def metrics():
 @app.route('/rewards/settle', methods=['POST'])
 def api_rewards_settle():
     """Settle rewards for a specific epoch (admin/cron callable)"""
+    # SECURITY: settling rewards mutates chain state; require admin key.
+    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+    if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        return jsonify({"ok": False, "reason": "admin_required"}), 401
+
     body = request.get_json(force=True, silent=True) or {}
     epoch = int(body.get("epoch", -1))
     if epoch < 0:


### PR DESCRIPTION
Fixes rustchain-bounties#140.

- /rewards/settle mutates state (epoch reward settlement) but was unauthenticated.
- Require X-Admin-Key/X-API-Key == RC_ADMIN_KEY; return 401 otherwise.

Proof (pre-fix)
- POST /rewards/settle with {} returned 400 epoch required (not 401), indicating no auth gate.