### PR TITLE
node: add fingerprint preflight validator

### DIFF
--- a/node/README_FINGERPRINT_PREFLIGHT.md
+++ b/node/README_FINGERPRINT_PREFLIGHT.md
@@ -1,0 +1,58 @@
+# Fingerprint Preflight (Contributor Test Harness)
+
+This is a standalone runner for the RustChain hardware fingerprint checks, intended for:
+- contributors porting the miner to new platforms (ARM64, SPARC, PPC, 68K)
+- operators validating that a machine will likely pass attestation before deploying
+
+## Run
+
+From `node/`:
+
+```bash
+python3 test_fingerprints.py
+```
+
+Write a JSON report (attach to bug reports / PRs):
+
+```bash
+python3 test_fingerprints.py --json-out fingerprint_report.json
+```
+
+Skip ROM check (most modern systems do not need it):
+
+```bash
+python3 test_fingerprints.py --no-rom
+```
+
+## Reference Profile Compare (optional)
+
+List built-in reference profiles:
+
+```bash
+python3 test_fingerprints.py --list-profiles
+```
+
+Compare your results to a profile (basic sanity checks):
+
+```bash
+python3 test_fingerprints.py --compare modern_x86
+```
+
+Profiles live in `node/fingerprint_reference_profiles/` and currently encode lightweight expectations
+(SIMD traits + minimum clock drift CV). They are meant to catch obvious mis-detection, not to be a strict
+"hardware authenticity" oracle.
+
+## What Each Check Is Doing (high level)
+
+- Clock drift: tries to detect synthetic / perfectly stable timing sources.
+- Cache timing: checks that L1/L2/L3 access times are meaningfully different (real cache hierarchy).
+- SIMD identity: confirms the CPU exposes expected SIMD features for the architecture.
+- Thermal drift: expects timing variance between cold and warm runs.
+- Instruction jitter: expects non-zero timing variance across integer/float/branch loops.
+- Anti-emulation: scans for common VM/container indicators (should be empty on bare metal).
+
+## Exit Codes
+
+- `0`: all checks passed
+- `2`: at least one check failed
+

--- a/node/README_FINGERPRINT_PREFLIGHT.md
+++ b/node/README_FINGERPRINT_PREFLIGHT.md
@@ -18,6 +18,12 @@ Write a JSON report (attach to bug reports / PRs):
 python3 test_fingerprints.py --json-out fingerprint_report.json
 ```
 
+If you plan to share the report publicly, you can redact host identifiers:
+
+```bash
+python3 test_fingerprints.py --json-out fingerprint_report.json --redact
+```
+
 Skip ROM check (most modern systems do not need it):
 
 ```bash
@@ -41,6 +47,11 @@ python3 test_fingerprints.py --compare modern_x86
 Profiles live in `node/fingerprint_reference_profiles/` and currently encode lightweight expectations
 (SIMD traits + minimum clock drift CV). They are meant to catch obvious mis-detection, not to be a strict
 "hardware authenticity" oracle.
+
+## Security Notes
+
+- `--json-out` writes to the provided path. Treat CLI args as trusted (do not run untrusted commands as admin/root).
+- The runner imports `fingerprint_checks.py` from the local `node/` directory to avoid module shadowing via `PYTHONPATH`.
 
 ## What Each Check Is Doing (high level)
 

--- a/node/fingerprint_reference_profiles/apple_silicon.json
+++ b/node/fingerprint_reference_profiles/apple_silicon.json
@@ -1,0 +1,13 @@
+{
+  "name": "apple_silicon",
+  "expects": {
+    "results.simd_identity.data.has_neon": true
+  },
+  "ranges": {
+    "results.clock_drift.data.cv": [
+      0.0001,
+      1.0
+    ]
+  }
+}
+

--- a/node/fingerprint_reference_profiles/arm64_linux.json
+++ b/node/fingerprint_reference_profiles/arm64_linux.json
@@ -1,0 +1,13 @@
+{
+  "name": "arm64_linux",
+  "expects": {
+    "results.simd_identity.data.has_neon": true
+  },
+  "ranges": {
+    "results.clock_drift.data.cv": [
+      0.0001,
+      1.0
+    ]
+  }
+}
+

--- a/node/fingerprint_reference_profiles/modern_x86.json
+++ b/node/fingerprint_reference_profiles/modern_x86.json
@@ -1,0 +1,13 @@
+{
+  "name": "modern_x86",
+  "expects": {
+    "results.simd_identity.data.has_sse": true
+  },
+  "ranges": {
+    "results.clock_drift.data.cv": [
+      0.0001,
+      1.0
+    ]
+  }
+}
+

--- a/node/fingerprint_reference_profiles/ppc_g4.json
+++ b/node/fingerprint_reference_profiles/ppc_g4.json
@@ -1,0 +1,13 @@
+{
+  "name": "ppc_g4",
+  "expects": {
+    "results.simd_identity.data.has_altivec": true
+  },
+  "ranges": {
+    "results.clock_drift.data.cv": [
+      0.0001,
+      1.0
+    ]
+  }
+}
+

--- a/node/fingerprint_reference_profiles/ppc_g5.json
+++ b/node/fingerprint_reference_profiles/ppc_g5.json
@@ -1,0 +1,13 @@
+{
+  "name": "ppc_g5",
+  "expects": {
+    "results.simd_identity.data.has_altivec": true
+  },
+  "ranges": {
+    "results.clock_drift.data.cv": [
+      0.0001,
+      1.0
+    ]
+  }
+}
+

--- a/node/test_fingerprints.py
+++ b/node/test_fingerprints.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+Hardware Fingerprint Preflight Runner
+====================================
+
+Usage:
+  python3 test_fingerprints.py
+  python3 test_fingerprints.py --json-out out.json
+  python3 test_fingerprints.py --list-profiles
+  python3 test_fingerprints.py --compare modern_x86
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+HERE = Path(__file__).resolve().parent
+PROFILE_DIR = HERE / "fingerprint_reference_profiles"
+
+
+def _now_iso() -> str:
+    # RFC3339-ish, stable and human-readable.
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, obj: Any) -> None:
+    path.write_text(json.dumps(obj, indent=2, sort_keys=True, default=str) + "\n", encoding="utf-8")
+
+
+def _get_nested(d: Dict[str, Any], dotted: str) -> Tuple[bool, Any]:
+    cur: Any = d
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False, None
+        cur = cur[part]
+    return True, cur
+
+
+@dataclass
+class ProfileCheck:
+    ok: bool
+    key: str
+    expected: Any
+    got: Any
+    reason: str
+
+
+def list_profiles() -> List[str]:
+    if not PROFILE_DIR.exists():
+        return []
+    return sorted([p.stem for p in PROFILE_DIR.glob("*.json") if p.is_file()])
+
+
+def load_profile(profile_name: str) -> Dict[str, Any]:
+    path = PROFILE_DIR / f"{profile_name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"unknown profile '{profile_name}' (expected {path})")
+    return _read_json(path)
+
+
+def compare_to_profile(results: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Compare fingerprint check results against a reference profile.
+
+    Profile format:
+      {
+        "name": "modern_x86",
+        "expects": {
+          "simd_identity.data.has_sse": true,
+          "simd_identity.data.has_avx": true
+        },
+        "ranges": {
+          "clock_drift.data.cv": [0.0001, 1.0]
+        }
+      }
+    """
+    checks: List[ProfileCheck] = []
+    expects = profile.get("expects", {}) or {}
+    ranges = profile.get("ranges", {}) or {}
+
+    for k, expected in expects.items():
+        ok, got = _get_nested(results, k)
+        if not ok:
+            checks.append(ProfileCheck(False, k, expected, None, "missing_key"))
+            continue
+        if got != expected:
+            checks.append(ProfileCheck(False, k, expected, got, "value_mismatch"))
+        else:
+            checks.append(ProfileCheck(True, k, expected, got, "ok"))
+
+    for k, rng in ranges.items():
+        ok, got = _get_nested(results, k)
+        if not ok:
+            checks.append(ProfileCheck(False, k, rng, None, "missing_key"))
+            continue
+        if not isinstance(rng, list) or len(rng) != 2:
+            checks.append(ProfileCheck(False, k, rng, got, "bad_profile_range"))
+            continue
+        lo, hi = rng
+        try:
+            gv = float(got)
+            if gv < float(lo) or gv > float(hi):
+                checks.append(ProfileCheck(False, k, rng, got, "out_of_range"))
+            else:
+                checks.append(ProfileCheck(True, k, rng, got, "ok"))
+        except Exception:
+            checks.append(ProfileCheck(False, k, rng, got, "non_numeric_value"))
+
+    failed = [c for c in checks if not c.ok]
+    return {
+        "profile": profile.get("name", profile.get("id", "unknown")),
+        "ok": len(failed) == 0,
+        "failed": [
+            {"key": c.key, "expected": c.expected, "got": c.got, "reason": c.reason}
+            for c in failed
+        ],
+        "total_checks": len(checks),
+        "failed_checks": len(failed),
+    }
+
+
+def _recommendations(results: Dict[str, Any]) -> List[str]:
+    recs: List[str] = []
+    for key, item in results.items():
+        passed = item.get("passed", False)
+        data = item.get("data", {}) or {}
+        if passed:
+            continue
+
+        reason = data.get("fail_reason") or data.get("reason") or data.get("error") or "unknown"
+        if key == "anti_emulation":
+            recs.append(f"[anti_emulation] VM indicators detected ({reason}). Run on bare metal; disable hypervisor.")
+        elif key == "clock_drift":
+            recs.append(f"[clock_drift] Timing looked synthetic ({reason}). Ensure no CPU pinning/turbo lock; try higher load.")
+        elif key == "cache_timing":
+            recs.append(f"[cache_timing] Cache hierarchy not detected ({reason}). Ensure native execution; avoid emulators/containers.")
+        elif key == "simd_identity":
+            recs.append(f"[simd_identity] SIMD features missing ({reason}). Verify architecture detection and /proc/sysctl access.")
+        elif key == "thermal_drift":
+            recs.append(f"[thermal_drift] No thermal variance ({reason}). Try running longer; ensure CPU can heat up.")
+        elif key == "instruction_jitter":
+            recs.append(f"[instruction_jitter] No jitter variance ({reason}). Ensure native execution; avoid deterministic runtimes.")
+        else:
+            recs.append(f"[{key}] failed ({reason}).")
+
+    return recs
+
+
+def run_checks(include_rom_check: bool) -> Tuple[bool, Dict[str, Any]]:
+    # Import lazily so this runner stays lightweight.
+    import fingerprint_checks  # type: ignore
+
+    return fingerprint_checks.validate_all_checks(include_rom_check=include_rom_check)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Run RustChain hardware fingerprint checks (preflight).")
+    ap.add_argument("--json-out", help="Write full results JSON to this path.")
+    ap.add_argument("--no-rom", action="store_true", help="Skip ROM check even if available.")
+    ap.add_argument("--list-profiles", action="store_true", help="List built-in reference profiles.")
+    ap.add_argument("--compare", help="Compare results to a built-in profile name (e.g. modern_x86).")
+    ap.add_argument("--quiet", action="store_true", help="Reduce console output.")
+    args = ap.parse_args(argv)
+
+    if args.list_profiles:
+        names = list_profiles()
+        if not names:
+            print("No reference profiles found.")
+            return 1
+        for n in names:
+            print(n)
+        return 0
+
+    include_rom = not args.no_rom
+
+    started = time.time()
+    passed, results = run_checks(include_rom_check=include_rom)
+    elapsed_s = round(time.time() - started, 3)
+
+    envelope: Dict[str, Any] = {
+        "meta": {
+            "timestamp_utc": _now_iso(),
+            "hostname": platform.node(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": sys.version.split()[0],
+            "elapsed_s": elapsed_s,
+            "rom_included": include_rom,
+            "cwd": os.getcwd(),
+        },
+        "overall_passed": passed,
+        "results": results,
+    }
+
+    envelope["recommendations"] = _recommendations(results)
+
+    if args.compare:
+        try:
+            prof = load_profile(args.compare)
+            envelope["profile_compare"] = compare_to_profile(envelope, prof)
+        except Exception as e:
+            envelope["profile_compare"] = {"profile": args.compare, "ok": False, "error": str(e)}
+
+    if args.json_out:
+        out_path = Path(args.json_out).expanduser().resolve()
+        _write_json(out_path, envelope)
+
+    if not args.quiet:
+        # Keep output short and actionable: failed checks + next steps.
+        failed = [k for k, v in results.items() if not v.get("passed", False)]
+        if failed:
+            print("\nPreflight summary: FAIL")
+            print("Failed checks:", ", ".join(failed))
+            for r in envelope["recommendations"]:
+                print("-", r)
+        else:
+            print("\nPreflight summary: PASS (all checks passed)")
+
+        if args.json_out:
+            print(f"JSON written: {args.json_out}")
+
+        if args.compare and "profile_compare" in envelope:
+            pc = envelope["profile_compare"]
+            if pc.get("ok"):
+                print(f"Profile compare: OK ({pc.get('profile')})")
+            else:
+                print(f"Profile compare: NOT OK ({pc.get('profile')})")
+
+    return 0 if passed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/node/tests/test_fingerprint_preflight.py
+++ b/node/tests/test_fingerprint_preflight.py
@@ -1,7 +1,14 @@
+import os
+import sys
 import unittest
 
 
-import test_fingerprints
+try:
+    import test_fingerprints
+except ModuleNotFoundError:
+    # Allow running tests from repo root (node/ isn't on sys.path by default).
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    import test_fingerprints
 
 
 class TestFingerprintPreflight(unittest.TestCase):
@@ -41,4 +48,3 @@ class TestFingerprintPreflight(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/node/tests/test_fingerprint_preflight.py
+++ b/node/tests/test_fingerprint_preflight.py
@@ -1,0 +1,44 @@
+import unittest
+
+
+import test_fingerprints
+
+
+class TestFingerprintPreflight(unittest.TestCase):
+    def test_get_nested(self):
+        ok, v = test_fingerprints._get_nested({"a": {"b": 1}}, "a.b")
+        self.assertTrue(ok)
+        self.assertEqual(v, 1)
+
+        ok, v = test_fingerprints._get_nested({"a": {}}, "a.b")
+        self.assertFalse(ok)
+        self.assertIsNone(v)
+
+    def test_compare_profile_ok(self):
+        envelope = {
+            "results": {
+                "simd_identity": {"passed": True, "data": {"has_sse": True}},
+                "clock_drift": {"passed": True, "data": {"cv": 0.01}},
+            }
+        }
+        profile = {
+            "name": "modern_x86",
+            "expects": {"results.simd_identity.data.has_sse": True},
+            "ranges": {"results.clock_drift.data.cv": [0.0001, 1.0]},
+        }
+
+        out = test_fingerprints.compare_to_profile(envelope, profile)
+        self.assertTrue(out["ok"])
+
+    def test_compare_profile_fail(self):
+        envelope = {"results": {"simd_identity": {"passed": True, "data": {"has_sse": False}}}}
+        profile = {"name": "modern_x86", "expects": {"results.simd_identity.data.has_sse": True}}
+
+        out = test_fingerprints.compare_to_profile(envelope, profile)
+        self.assertFalse(out["ok"])
+        self.assertEqual(out["failed_checks"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
Implements bounty rustchain-bounties#44 (Hardware Fingerprint Test Suite - Preflight Validator).

Adds:
- node/test_fingerprints.py: standalone runner w/ PASS/FAIL summary, JSON export, and optional reference profile compare
- node/fingerprint_reference_profiles/: lightweight built-in profiles (G4/G5/x86/ARM)
- node/README_FINGERPRINT_PREFLIGHT.md
- unit tests for the compare logic

Miner ID: liu971227-sys