### PR TITLE
fix(payment-widget): prevent DOM XSS via label/memo; restrict callbacks

### DIFF
--- a/payment-widget/README.md
+++ b/payment-widget/README.md
@@ -30,7 +30,9 @@ A lightweight, embeddable JavaScript widget for accepting **RTC (RustChain Token
 <div id="rtc-pay" 
      data-to="RTCyour_wallet_address_here" 
      data-amount="10" 
-     data-memo="Payment for services">
+     data-memo="Payment for services"
+     data-allow-iframe="false"
+     data-allow-callback-any-origin="false">
 </div>
 ```
 
@@ -128,6 +130,8 @@ console.log(balance.amount_rtc); // e.g., 150.5
 | `data-memo` | No | Payment memo/description |
 | `data-label` | No | Custom button text |
 | `data-callback` | No | Webhook URL for payment notification |
+| `data-allow-iframe` | No | Set to `true` to allow running inside an iframe (default: blocked) |
+| `data-allow-callback-any-origin` | No | Set to `true` to allow cross-origin callback URLs (default: same-origin only) |
 
 ### Success Callback Payload
 
@@ -143,6 +147,11 @@ console.log(balance.amount_rtc); // e.g., 150.5
 ```
 
 ## 🔐 Security
+
+### Embed Hardening
+- The widget renders user-controlled fields via `textContent`/text nodes, not `innerHTML`.
+- By default the widget blocks running inside iframes unless `data-allow-iframe="true"` is set.
+- Callback URL (`data-callback`) is same-origin only by default; set `data-allow-callback-any-origin="true"` to override.
 
 ### Client-Side Signing
 

--- a/payment-widget/poc/xss-label.html
+++ b/payment-widget/poc/xss-label.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PoC: XSS via data-label (Payment Widget)</title>
+  </head>
+  <body>
+    <h1>PoC: XSS via <code>data-label</code></h1>
+    <p>
+      Vulnerable behavior (before patch): the widget rendered <code>data-label</code> via
+      <code>innerHTML</code>, so HTML/JS would execute.
+    </p>
+    <p>
+      Expected behavior (after patch): label is rendered via a text node and should not execute.
+    </p>
+
+    <div
+      id="rtc-pay"
+      data-to="RTC0123456789abcdef0123456789abcdef01234567"
+      data-amount="1"
+      data-label="Pay 1 RTC &lt;img src=x onerror=alert('xss-label')&gt;"
+    ></div>
+
+    <script src="../rustchain-pay.js"></script>
+  </body>
+</html>
+

--- a/payment-widget/poc/xss-memo.html
+++ b/payment-widget/poc/xss-memo.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>PoC: XSS via data-memo (Payment Widget)</title>
+  </head>
+  <body>
+    <h1>PoC: XSS via <code>data-memo</code></h1>
+    <p>
+      Vulnerable behavior (before patch): memo was injected into modal HTML via <code>innerHTML</code>.
+    </p>
+    <p>
+      Expected behavior (after patch): memo is rendered via <code>textContent</code> and should not execute.
+    </p>
+
+    <div
+      id="rtc-pay"
+      data-to="RTC0123456789abcdef0123456789abcdef01234567"
+      data-amount="1"
+      data-memo="Order &lt;img src=x onerror=alert('xss-memo')&gt;"
+    ></div>
+
+    <script src="../rustchain-pay.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
Bounty #67: Payment widget XSS/injection hardening.

Findings (before patch):
- DOM XSS via data-label: createButton() set btn.innerHTML = LOGO_SVG + config.label.
- DOM XSS via data-memo / data-to: modal summary interpolated memo/to directly into overlay.innerHTML.
- Inline onclick in success UI (CSP-unfriendly).
- Callback URL accepted arbitrary origin (SSRF-style footgun for integrators).

Fix:
- Render label/memo/to/tx_hash via text nodes/textContent.
- Validate recipient format (RTC + 40 hex) and normalize amount.
- Default-deny running inside iframes unless data-allow-iframe="true".
- Callback URL is same-origin only by default; optional override via data-allow-callback-any-origin="true".
- Added PoCs in payment-widget/poc/.

PoCs:
- payment-widget/poc/xss-label.html
- payment-widget/poc/xss-memo.html

Wallet: davidtang-codex