### PR TITLE
fix: update CURRENT_YEAR to 2026

### DIFF
--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -20,7 +20,7 @@ from typing import Tuple, Optional, Dict
 from dataclasses import dataclass
 from datetime import datetime
 
-CURRENT_YEAR = 2025
+CURRENT_YEAR = 2026
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Update CURRENT_YEAR constant from 2025 to 2026 in cpu_architecture_detection.py for accurate CPU age calculation.

## Changes

- Changed `CURRENT_YEAR = 2025` to `CURRENT_YEAR = 2026`

## Why

The year constant is used to calculate hardware age for antiquity rewards. Updating to 2026 ensures accurate age computation.