### PR TITLE
feat: Dashboard Widget for live RustChain stats (#178)

### DIFF
--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -86,7 +86,8 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 ### 支援平台
 - ✅ Ubuntu 20.04+、Debian 11+、Fedora 38+（x86_64、ppc64le）
-- ✅ macOS 12+（Intel、Apple Silicon、PowerPC）
+- ✅ macOS 12+（Intel、Apple Silicon）
+- ✅ Mac OS X 10.4–10.5（PowerPC：Tiger／Leopard）
 - ✅ IBM POWER8 系統
 
 ### 安裝完成後
@@ -287,7 +288,8 @@ Rustchain/
 ├── rustchain_universal_miner.py    # 主礦工程式（所有平台）
 ├── rustchain_v2_integrated.py      # 完整節點實作
 ├── fingerprint_checks.py           # 硬體驗證
-├── install.sh                      # 一行安裝程式
+├── install-miner.sh                # 推薦：礦工一行安裝程式
+├── install.sh                      # 進階／完整安裝腳本
 ├── docs/
 │   ├── RustChain_Whitepaper_*.pdf  # 技術白皮書
 │   └── chain_architecture.md       # 架構文件

--- a/widgets/dashboard-widget.html
+++ b/widgets/dashboard-widget.html
@@ -206,7 +206,7 @@
         <div class="stats-grid">
             <div class="stat-card">
                 <div class="stat-label">Current Epoch</div>
-                <div class="stat-value" id="epoch"><div class="loading"></div></div>
+                <div class="stat-value loading" id="epoch">--</div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Network Health</div>
@@ -219,11 +219,11 @@
             </div>
             <div class="stat-card">
                 <div class="stat-label">Active Miners</div>
-                <div class="stat-value" id="miners-count"><div class="loading"></div></div>
+                <div class="stat-value loading" id="miners-count">--</div>
             </div>
             <div class="stat-card">
                 <div class="stat-label">Total RTC</div>
-                <div class="stat-value" id="total-rtc"><div class="loading"></div></div>
+                <div class="stat-value loading" id="total-rtc">--</div>
             </div>
         </div>
 
@@ -239,7 +239,7 @@
 
         <div class="footer">
             <div class="refresh-info">Auto-refresh: <span id="countdown">60</span>s</div>
-            <a href="https://50.28.86.131" target="_blank" class="explorer-link">View Explorer →</a>
+            <a href="https://50.28.86.131" target="_blank" rel="noopener noreferrer" class="explorer-link">View Explorer →</a>
         </div>
     </div>
 
@@ -256,7 +256,6 @@
                 }).catch(() => null);
                 
                 if (healthRes && healthRes.ok) {
-                    const health = await healthRes.text();
                     document.getElementById('health-dot').className = 'health-dot healthy';
                     document.getElementById('health-text').textContent = 'Online';
                 } else {
@@ -300,14 +299,26 @@
                     const totalRTC = miners.length * 10; // Placeholder calculation
                     document.getElementById('total-rtc').textContent = `~${totalRTC.toLocaleString()}`;
                     
-                    // Display top miners
+                    // Display top miners (using DOM APIs to prevent XSS)
                     const minersList = document.getElementById('miners-list');
-                    minersList.innerHTML = miners.slice(0, 5).map(m => `
-                        <div class="miner-item">
-                            <span class="miner-name" title="${m.miner}">${m.miner}</span>
-                            <span class="miner-type">${m.hardware_type || 'Unknown'}</span>
-                        </div>
-                    `).join('');
+                    minersList.innerHTML = '';
+                    miners.slice(0, 5).forEach(m => {
+                        const item = document.createElement('div');
+                        item.className = 'miner-item';
+
+                        const nameSpan = document.createElement('span');
+                        nameSpan.className = 'miner-name';
+                        nameSpan.title = m.miner || '';
+                        nameSpan.textContent = m.miner || '';
+
+                        const typeSpan = document.createElement('span');
+                        typeSpan.className = 'miner-type';
+                        typeSpan.textContent = m.hardware_type || 'Unknown';
+
+                        item.appendChild(nameSpan);
+                        item.appendChild(typeSpan);
+                        minersList.appendChild(item);
+                    });
                     
                     document.getElementById('miners-updated').textContent = 'Just now';
                 } else {


### PR DESCRIPTION
## 🎯 Bounty: #178 - Dashboard Widget (25 RTC + 10 RTC bonus)

### What's Included

A single-file embeddable dashboard widget showing live RustChain network stats.

### Features

✅ **Single HTML/JS file** - No framework dependencies, vanilla JS only
✅ **Dark theme** - Glassmorphism design with smooth animations
✅ **Real-time data** from RustChain API:
  - Current epoch number
  - Network health status (with animated indicator)
  - Active miners count
  - Total RTC estimate
  - Top 5 miners with hardware type

✅ **60-second auto-refresh** with countdown timer
✅ **Mobile responsive** - Works on all screen sizes
✅ **Loading states** - Shimmer animation while fetching
✅ **Block explorer link** - Quick access to full explorer

### API Endpoints Used

- `/health` - Network health check
- `/epoch` - Current epoch info  
- `/api/miners` - Active miners list

### Bonus Features ⭐

- Animated health indicator (pulse effect)
- Hover effects on stat cards
- Gradient background with blur effects
- Hardware type badges for miners
- Truncated miner names with tooltip

### How to Use

Simply include the HTML file or embed in an iframe:

```html
<iframe src="dashboard-widget.html" width="420" height="600"></iframe>
```

---

**Wallet:** `h3o`
