### PR TITLE
fix: create missing ip_rate_limit table in init_db #71

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -576,6 +576,7 @@ def init_db():
     with sqlite3.connect(DB_PATH) as c:
         # Core tables
         c.execute("CREATE TABLE IF NOT EXISTS nonces (nonce TEXT PRIMARY KEY, expires_at INTEGER)")
+        c.execute("CREATE TABLE IF NOT EXISTS ip_rate_limit (client_ip TEXT, miner_id TEXT, ts INTEGER, PRIMARY KEY (client_ip, miner_id))")
         c.execute("CREATE TABLE IF NOT EXISTS tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT)")
 
         # Epoch tables


### PR DESCRIPTION
Fixed a bug where the attestation endpoint would crash due to a missing `ip_rate_limit` table definition. \n\n- Miner ID: createker02140054RTC