### PR TITLE
feat: Grafana monitoring stack with Prometheus dashboards + alerts (bounty #21)

### DIFF
--- a/docs/GRAFANA_MONITORING_SETUP.md
+++ b/docs/GRAFANA_MONITORING_SETUP.md
@@ -1,0 +1,40 @@
+# RustChain Grafana Monitoring (Bounty #21)
+
+This package adds Grafana + Prometheus monitoring for:
+- Active miners & attestations
+- RTC transfers & volume
+- Epoch rewards
+- Node health & API response latency
+- Alerts for node down, unusual volume, miner drop
+
+## Files
+- `monitoring/docker-compose.monitoring.yml`
+- `monitoring/prometheus.yml`
+- `monitoring/alerts/rustchain-alerts.yml`
+- `monitoring/grafana/dashboards/rustchain-overview.json`
+- `monitoring/grafana/provisioning/*`
+
+## Quick start
+
+```bash
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+```
+
+Open:
+- Grafana: http://localhost:3000 (admin / admin)
+- Prometheus: http://localhost:9090
+
+## Important target setting
+Default target is `host.docker.internal:8099` (RustChain node metrics endpoint).
+If your node runs elsewhere, edit `monitoring/prometheus.yml` target.
+
+## Alert rules
+- `RustChainNodeDown`
+- `RustChainHighApiLatencyP95`
+- `MinerCountDrop`
+- `UnusualTransferVolume`
+
+## Ubuntu 22.04
+- Install Docker + Compose plugin
+- Ensure RustChain node is reachable on configured metrics target
+- Run the compose command above

--- a/monitoring/alerts/rustchain-alerts.yml
+++ b/monitoring/alerts/rustchain-alerts.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: rustchain-alerts
+    rules:
+      - alert: RustChainNodeDown
+        expr: up{job="rustchain-node"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain node is down"
+          description: "Prometheus cannot scrape /metrics on RustChain for over 2 minutes."
+
+      - alert: RustChainHighApiLatencyP95
+        expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High API latency (p95 > 1s)"
+          description: "RustChain API p95 latency has been above 1 second for 5 minutes."
+
+      - alert: MinerCountDrop
+        expr: (max_over_time(active_miners[30m]) - active_miners) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Active miner count dropped"
+          description: "Active miners dropped by more than 5 compared with the last 30 minutes."
+
+      - alert: UnusualTransferVolume
+        expr: rate(wallet_transfers_total[5m]) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Unusual transfer volume"
+          description: "Transfer transaction rate is unusually high (>10 tx/s over 5m)."

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,28 @@
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.0
+    container_name: rustchain-prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alerts:/etc/prometheus/alerts:ro
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: rustchain-grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/monitoring/grafana/dashboards/rustchain-overview.json
+++ b/monitoring/grafana/dashboards/rustchain-overview.json
@@ -1,0 +1,68 @@
+{
+  "annotations": {"list": []},
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Node Up",
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "targets": [{"expr": "up{job=\"rustchain-node\"}", "refId": "A"}],
+      "fieldConfig": {"defaults": {"mappings": [], "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}}}
+    },
+    {
+      "type": "stat",
+      "title": "Active Miners",
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 0},
+      "targets": [{"expr": "active_miners", "refId": "A"}]
+    },
+    {
+      "type": "stat",
+      "title": "Attestation Rate (5m)",
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 0},
+      "targets": [{"expr": "rate(attestations_total[5m])", "refId": "A"}]
+    },
+    {
+      "type": "stat",
+      "title": "Transfer Rate (5m)",
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 0},
+      "targets": [{"expr": "rate(wallet_transfers_total[5m])", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "API Latency P95",
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "targets": [{"expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Epoch Rewards",
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "targets": [{"expr": "rate(epoch_rewards_total[5m])", "refId": "A"}]
+    },
+    {
+      "type": "timeseries",
+      "title": "Attestations vs Transfers",
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 12},
+      "targets": [
+        {"expr": "rate(attestations_total[5m])", "legendFormat": "attestations", "refId": "A"},
+        {"expr": "rate(wallet_transfers_total[5m])", "legendFormat": "transfers", "refId": "B"}
+      ]
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["rustchain", "bounty-21"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "RustChain Monitoring Overview",
+  "uid": "rustchain-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: RustChain Dashboards
+    orgId: 1
+    folder: RustChain
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/alerts/rustchain-alerts.yml
+
+scrape_configs:
+  - job_name: rustchain-node
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['host.docker.internal:8099']
+
+  - job_name: rustchain-health
+    metrics_path: /health
+    static_configs:
+      - targets: ['host.docker.internal:8099']


### PR DESCRIPTION
Implements bounty #21 (Grafana Monitoring Dashboard).

## Delivered
- Prometheus config for RustChain node metrics scraping
- Grafana provisioning:
  - Prometheus datasource
  - auto-loaded dashboard folder
- Dashboard JSON (`RustChain Monitoring Overview`) with:
  - node up/down
  - active miners
  - attestation rate
  - transfer rate
  - API latency p95
  - epoch rewards rate
- Alert rules:
  - RustChainNodeDown
  - RustChainHighApiLatencyP95
  - MinerCountDrop
  - UnusualTransferVolume
- `monitoring/docker-compose.monitoring.yml` for one-command bring-up
- Setup guide: `docs/GRAFANA_MONITORING_SETUP.md`

## Run
```bash
docker compose -f monitoring/docker-compose.monitoring.yml up -d
```

Grafana: `http://localhost:3000` (admin/admin)

Miner ID: createker02140054RTC

Closes #21
