### PR TITLE
fix(windows miner): run without tkinter (headless mode)

### DIFF
--- a/miners/README.md
+++ b/miners/README.md
@@ -22,6 +22,9 @@ python3 rustchain_mac_miner_v2.4.py
 
 # Windows
 python rustchain_windows_miner.py
+
+# If your Python does not include Tcl/Tk (common on minimal/embeddable installs):
+python rustchain_windows_miner.py --headless --wallet YOUR_WALLET_ID --node https://50.28.86.131
 ```
 
 ## Windows installer & build helpers

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -20,12 +20,23 @@ echo Python 3.11+ not found. Downloading official installer...
 if not exist "%PYTHON_INSTALLER%" (
     powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%PYTHON_URL%' -OutFile '%PYTHON_INSTALLER%'"
 )
-echo Running Python installer (silent)...
-start /wait "" "%PYTHON_INSTALLER%" /quiet InstallAllUsers=1 PrependPath=1 Include_pip=1
+echo Running Python installer (silent, includes Tcl/Tk for tkinter)...
+start /wait "" "%PYTHON_INSTALLER%" /quiet InstallAllUsers=1 PrependPath=1 Include_pip=1 Include_tcltk=1
 goto :check_python
 
 :python_ready
 echo Python detected.
+echo Checking tkinter availability...
+python -c "import tkinter" >nul 2>&1
+if errorlevel 1 (
+    echo WARNING: tkinter is missing in this Python install.
+    echo Attempting to install/repair official Python with Tcl/Tk enabled...
+    if not exist "%PYTHON_INSTALLER%" (
+        powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%PYTHON_URL%' -OutFile '%PYTHON_INSTALLER%'"
+    )
+    start /wait "" "%PYTHON_INSTALLER%" /quiet InstallAllUsers=1 PrependPath=1 Include_pip=1 Include_tcltk=1
+)
+
 python -m pip install --upgrade pip
 echo Installing miner dependencies...
 python -m pip install -r "%REQUIREMENTS%"
@@ -40,4 +51,6 @@ if exist "%MINER_SCRIPT%" (
 echo.
 echo Miner is ready. Run:
 echo    python "%MINER_SCRIPT%"
+echo If you still get a tkinter error, run headless:
+echo    python "%MINER_SCRIPT%" --headless --wallet YOUR_WALLET_ID --node https://50.28.86.131
 echo You can create a scheduled task or shortcut to keep it running.


### PR DESCRIPTION
Windows users sometimes hit a tkinter/Tcl error on minimal/embeddable Python installs.

This PR:
- Makes tkinter optional and auto-falls back to headless mode when missing
- Adds explicit CLI flags: --headless, --wallet, --node
- Updates miners README with the headless command

How to test:
- python miners/windows/rustchain_windows_miner.py --headless --wallet test_wallet --node https://50.28.86.131
- Or run without args on a Python that lacks tkinter and confirm it falls back to headless


Update:
- Updated `miners/windows/rustchain_miner_setup.bat` to detect missing tkinter and run the official Python installer with `Include_tcltk=1` (and still documents `--headless` as fallback).
