### PR TITLE
hardening(anchor): remove default Ergo API key and wallet password

### DIFF
--- a/node/ergo_raw_tx.py
+++ b/node/ergo_raw_tx.py
@@ -4,7 +4,7 @@ import os, json, sqlite3, time, requests
 from hashlib import blake2b
 
 ERGO_NODE = "http://localhost:9053"
-ERGO_API_KEY = os.environ.get("ERGO_API_KEY", "BE7YM1fYWrMQ9tSmxAc9jzLNw42nEXTX")
+ERGO_API_KEY = os.environ.get("ERGO_API_KEY", "")
 DB_PATH = "/root/rustchain/rustchain_v2.db"
 
 def encode_coll_byte(hex_str):

--- a/node/run_anchor_service.py
+++ b/node/run_anchor_service.py
@@ -4,13 +4,11 @@ import os
 import sys
 import time
 
-# Set env vars
-os.environ["ERGO_NODE_URL"] = "http://localhost:9053"
-os.environ["ERGO_API_KEY"] = "hello"
-
 from rustchain_ergo_anchor import AnchorService, ErgoClient
 
-DB_PATH = "/root/rustchain/rustchain_v2.db"
+DB_PATH = os.environ.get("DB_PATH", "/root/rustchain/rustchain_v2.db")
+ERGO_NODE_URL = os.environ.get("ERGO_NODE_URL", "http://localhost:9053")
+ERGO_API_KEY = os.environ.get("ERGO_API_KEY", "")
 
 print("=" * 60)
 print("RustChain -> Ergo Anchor Service Starting")
@@ -20,10 +18,13 @@ print("=" * 60)
 client = ErgoClient()
 info = client.get_info()
 if info:
-    print(f"Ergo height: {info.get(\"fullHeight\", \"N/A\")}")
+    print(f"Ergo height: {info.get('fullHeight', 'N/A')}")
 else:
     print("WARNING: Cannot connect to Ergo node")
     sys.exit(1)
+
+if not ERGO_API_KEY:
+    print("WARNING: ERGO_API_KEY is not set; wallet operations may fail.")
 
 service = AnchorService(
     db_path=DB_PATH,


### PR DESCRIPTION
## Summary\n- remove hard-coded default ERGO_API_KEY from anchor scripts\n- remove hard-coded default wallet unlock password (ustchain123)\n- require explicit env-provided wallet password for unlock flow\n- fail closed in anchor tx creation when credentials are missing\n- keep runner env-driven instead of setting static key values in code\n\n## Security Impact\nHard-coded anchor credentials in repository scripts can lead to unauthorized wallet/anchor operations in misconfigured deployments (or when script defaults are used directly).\n\nThis patch moves to explicit-secret configuration and safer failure behavior.\n\n## Validation\n- python -m py_compile node/ergo_miner_anchor.py\n- python -m py_compile node/ergo_raw_tx.py\n- python -m py_compile node/run_anchor_service.py\n- python -m py_compile ergo-anchor/ergo_miner_anchor.py\n\n## Related\n- rustchain-bounties#60