### PR TITLE
docs: fix manual install commands and repository structure paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,9 @@ tail -f ~/.rustchain/miner.log             # View logs
 ```bash
 git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
-pip install -r requirements.txt
-python3 rustchain_universal_miner.py --wallet YOUR_WALLET_NAME
+bash install-miner.sh --wallet YOUR_WALLET_NAME
+# Optional: preview actions without changing your system
+bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```
 
 ## 💰 Bounty Board
@@ -329,10 +330,13 @@ Each hardware fingerprint is bound to one wallet. Prevents:
 
 ```
 Rustchain/
-├── rustchain_universal_miner.py    # Main miner (all platforms)
-├── rustchain_v2_integrated.py      # Full node implementation
-├── fingerprint_checks.py           # Hardware verification
-├── install.sh                      # One-line installer
+├── install-miner.sh                # Universal miner installer (Linux/macOS)
+├── node/
+│   ├── rustchain_v2_integrated_v2.2.1_rip200.py  # Full node implementation
+│   └── fingerprint_checks.py       # Hardware verification
+├── miners/
+│   ├── linux/rustchain_linux_miner.py            # Linux miner
+│   └── macos/rustchain_mac_miner_v2.4.py         # macOS miner
 ├── docs/
 │   ├── RustChain_Whitepaper_*.pdf  # Technical whitepaper
 │   └── chain_architecture.md       # Architecture docs


### PR DESCRIPTION
## Summary
- replace the README manual install snippet that referenced non-existent `requirements.txt` and `rustchain_universal_miner.py`
- switch manual install to the actual `install-miner.sh` flow with an optional `--dry-run` example
- update the repository structure section to point at real current paths (`install-miner.sh`, `node/*`, `miners/*`)

## Why
The previous manual install and file-map examples no longer matched files in `main`, which makes first-time setup and navigation harder for contributors.

## Verification
- confirmed all newly referenced files exist in the repo
- checked Markdown diff renders cleanly