### PR TITLE
feat: add /api/badge/<miner_id> endpoint + GitHub Action for mining status badge

### DIFF
--- a/.github/workflows/mining-status.yml
+++ b/.github/workflows/mining-status.yml
@@ -1,0 +1,48 @@
+name: Mining Status Badge
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  update-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify Badge Endpoint
+        run: |
+          RESPONSE=$(curl -s --fail --max-time 10 "https://rustchain.org/api/badge/scott" || echo '{}')
+          SCHEMA=$(echo "$RESPONSE" | jq -r '.schemaVersion // empty' 2>/dev/null)
+          if [ "$SCHEMA" = "1" ]; then
+            echo "Badge endpoint healthy"
+            echo "$RESPONSE" | jq .
+          else
+            echo "Badge endpoint not yet deployed or unreachable"
+            echo "Response: $RESPONSE"
+          fi
+
+      - name: Ensure badge in README
+        run: |
+          if ! grep -q 'img.shields.io/endpoint.*api/badge' README.md 2>/dev/null; then
+            echo "" >> README.md
+            echo "## Mining Status" >> README.md
+            echo "" >> README.md
+            echo '![Mining Status](https://img.shields.io/endpoint?url=https://rustchain.org/api/badge/scott&style=flat-square)' >> README.md
+            echo "" >> README.md
+            echo "Badge added to README"
+          else
+            echo "Badge already present in README"
+          fi
+
+      - name: Commit if changed
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add -A
+          git diff --cached --quiet || git commit -m "docs: ensure mining status badge in README [skip ci]"
+          git push || echo "Nothing to push"


### PR DESCRIPTION
## Summary

Reworked implementation addressing all feedback from PR #339:

### What changed from #339

| Issue | #339 (old) | This PR |
|-------|-----------|---------|
| Badge API | Standalone Flask app on port 8082 | **Inline in main server** (`rustchain_v2_integrated_v2.2.1_rip200.py`) |
| Data source | Hardcoded 'Active' / wrong endpoint | **Queries `miner_attest_recent`** table for real attestation data |
| Workflow → API | Disconnected (workflow used `/relay/discover`) | **Connected**: workflow verifies `/api/badge/` endpoint directly |
| Badge rendering | Fragile hand-built SVG via echo commands | **shields.io/endpoint** — live rendering, no SVG files needed |

### New Endpoint

```
GET /api/badge/<miner_id>
```

Returns shields.io-compatible JSON:

```json
{
  "schemaVersion": 1,
  "label": "⛏ scott",
  "message": "Active (2.5x)",
  "color": "brightgreen"
}
```

**Status logic** (based on `miner_attest_recent.ts_ok`):
- **Active** (green): attested within 20 minutes — shows antiquity multiplier for vintage hardware
- **Idle** (yellow): attested within 1 hour
- **Inactive** (grey): no recent attestation or unknown miner

### GitHub Action

`.github/workflows/mining-status.yml` runs every 15 minutes:
1. Verifies badge endpoint returns valid `schemaVersion: 1` JSON
2. Ensures badge markdown is present in README
3. No SVG generation — shields.io handles rendering live

### Usage

Add to any README:
```markdown
![Mining Status](https://img.shields.io/endpoint?url=https://rustchain.org/api/badge/YOUR_MINER_ID&style=flat-square)
```

### Files Changed

- `node/rustchain_v2_integrated_v2.2.1_rip200.py` — added `/api/badge/<miner_id>` route (+62 lines)
- `.github/workflows/mining-status.yml` — new workflow (+48 lines)

No standalone files. No new dependencies. Purely additive.

### Bounty Reference

Implements: #256 — GitHub Action: RustChain Mining Status Badge (40 RTC)

Wallet: `RTC-agent-antigravity-9944`