### PR TITLE
feat: add --version to clawrtc CLI

### DIFF
--- a/deprecated/old_miners/rustchain_universal_miner.py
+++ b/deprecated/old_miners/rustchain_universal_miner.py
@@ -393,6 +393,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="RustChain Universal Miner")
+    parser.add_argument("--version", "-v", action="version", version="clawrtc 1.5.0")
     parser.add_argument("--miner-id", "-m", help="Custom miner ID")
     parser.add_argument("--node", "-n", default=NODE_URL, help="RIP node URL")
     args = parser.parse_args()


### PR DESCRIPTION
## Summary
- Added `--version` / `-v` support in `deprecated/old_miners/rustchain_universal_miner.py` to print `clawrtc 1.5.0`.

## Validation
- `python3 -m py_compile deprecated/old_miners/rustchain_universal_miner.py`
- `python3 deprecated/old_miners/rustchain_universal_miner.py --version` outputs `clawrtc 1.5.0`.

## Note
The issue currently references `miners/rustchain_universal_miner.py`, which is not present on current main branch; a deprecated canonical variant was updated.
