### PR TITLE
docs: add requirements.txt for development setup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Development dependencies for RustChain
+# For node development:
+flask>=2.0.0
+# For miner and SDK:
+requests>=2.25.0
+# For running tests:
+pytest>=7.0.0


### PR DESCRIPTION
This PR adds a requirements.txt file with basic dependencies (Flask, requests, pytest) to fix the broken `pip install -r requirements.txt` command in CONTRIBUTING.md.

Closes #304.