### PR TITLE
fix: resolve SyntaxError in node/hardware_fingerprint.py __main__ output

### DIFF
--- a/node/hardware_fingerprint.py
+++ b/node/hardware_fingerprint.py
@@ -572,7 +572,7 @@ if __name__ == "__main__":
     fingerprints = HardwareFingerprint.collect_all()
     
     print("\n" + "=" * 60)
-    print(f"RESULTS: {fingerprints[\"checks_passed\"]}/7 checks passed")
+    print(f"RESULTS: {fingerprints['checks_passed']}/7 checks passed")
     print("=" * 60)
     
     for name, data in fingerprints.items():
@@ -580,4 +580,4 @@ if __name__ == "__main__":
             status = "PASS" if data["valid"] else "FAIL"
             print(f"  {name}: {status}")
     
-    print(f"\nAll Valid: {fingerprints[\"all_valid\"]}")
+    print(f"\nAll Valid: {fingerprints['all_valid']}")


### PR DESCRIPTION
## Summary
Fixes a syntax error in `node/hardware_fingerprint.py` caused by escaped double quotes inside f-string expressions in the `__main__` output block.

## Root cause
The file used:
- `fingerprints[\"checks_passed\"]`
- `fingerprints[\"all_valid\"]`
inside f-string expressions.

This causes `python3 -m py_compile node/hardware_fingerprint.py` to fail with:
`SyntaxError: unexpected character after line continuation character`.

## Changes
- Replace escaped-double-quote key access with single-quoted keys in both f-strings:
  - `fingerprints['checks_passed']`
  - `fingerprints['all_valid']`

## Validation
- `python3 -m py_compile node/hardware_fingerprint.py` -> pass (exit 0)
- `python3 node/hardware_fingerprint.py` -> script runs and prints summary output

Closes #362
