### PR TITLE
feat(sync): multi-node sync hardening for issue #36

### DIFF
--- a/rustchain_sync.py
+++ b/rustchain_sync.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Compatibility wrapper for RustChain sync module.
+
+Issue #36 deliverable asks for `rustchain_sync.py`. The implementation lives in
+`node/rustchain_sync.py`; this shim keeps import paths simple for operators.
+"""
+
+from node.rustchain_sync import RustChainSyncManager  # re-export
+
+__all__ = ["RustChainSyncManager"]

--- a/scripts/test_three_node_sync_consistency.py
+++ b/scripts/test_three_node_sync_consistency.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Check sync status consistency across three RustChain nodes.
+
+Validates:
+- `/sync/status` availability
+- merkle root equality
+- per-table row counts and table hashes
+- peer sync history visibility
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict, Any, List
+
+import requests
+
+
+DEFAULT_NODES = [
+    "https://50.28.86.131:8099",
+    "https://50.28.86.153:8099",
+    "https://76.8.228.245:8099",
+]
+
+
+def fetch_status(base: str, admin_key: str, verify_ssl: bool, timeout: float) -> Dict[str, Any]:
+    url = f"{base.rstrip('/')}/sync/status"
+    headers = {"X-Admin-Key": admin_key} if admin_key else {}
+    r = requests.get(url, headers=headers, timeout=timeout, verify=verify_ssl)
+    r.raise_for_status()
+    data = r.json()
+    data["_node"] = base
+    return data
+
+
+def summarize(statuses: List[Dict[str, Any]]) -> Dict[str, Any]:
+    roots = {s.get("_node"): s.get("merkle_root") for s in statuses}
+    root_set = {v for v in roots.values() if v}
+
+    table_counts = {}
+    table_hashes = {}
+    for s in statuses:
+        node = s.get("_node")
+        for t, info in (s.get("tables") or {}).items():
+            table_counts.setdefault(t, {})[node] = info.get("count")
+            table_hashes.setdefault(t, {})[node] = info.get("hash")
+
+    mismatched_counts = {t: vals for t, vals in table_counts.items() if len(set(vals.values())) > 1}
+    mismatched_hashes = {t: vals for t, vals in table_hashes.items() if len(set(vals.values())) > 1}
+
+    return {
+        "nodes": [s.get("_node") for s in statuses],
+        "merkle_roots": roots,
+        "merkle_consistent": len(root_set) <= 1,
+        "mismatched_table_counts": mismatched_counts,
+        "mismatched_table_hashes": mismatched_hashes,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Validate 3-node RustChain sync consistency")
+    ap.add_argument("--nodes", nargs="+", default=DEFAULT_NODES)
+    ap.add_argument("--admin-key", default=os.getenv("RC_ADMIN_KEY", ""))
+    ap.add_argument("--insecure", action="store_true", help="Disable TLS cert verification")
+    ap.add_argument("--timeout", type=float, default=10.0)
+    args = ap.parse_args()
+
+    verify_ssl = not args.insecure
+    statuses = []
+    for n in args.nodes:
+        try:
+            statuses.append(fetch_status(n, args.admin_key, verify_ssl, args.timeout))
+        except Exception as e:
+            statuses.append({"_node": n, "error": str(e)})
+
+    ok = [s for s in statuses if "error" not in s]
+    report = summarize(ok) if ok else {"nodes": args.nodes, "error": "No reachable nodes"}
+    report["errors"] = [{"node": s.get("_node"), "error": s.get("error")} for s in statuses if "error" in s]
+    print(json.dumps(report, indent=2))
+
+    if report.get("errors"):
+        return 2
+    if not report.get("merkle_consistent", False):
+        return 3
+    if report.get("mismatched_table_counts") or report.get("mismatched_table_hashes"):
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary\nImplements the core deliverables for #36 multi-node sync hardening:\n\n- Added/updated sync module behavior in \n  - Supports sync table set covering , , , plus ledger-compatible optional tables (, , )\n  - Conflict resolution improvements:\n    - latest timestamp wins (best-effort timestamp fields)\n    -  updates accepted only from configured primary peer ()\n  - Preserves anti-downgrade rule for balances (reject lower balance values)\n- Hardened sync endpoints in \n  - Added HTTPS enforcement decorator (configurable via , default on)\n  - Added alias routes so both  and  work\n  - Enforced peer-aware apply path for epoch authority logic\n  - Maintained admin key auth + per-peer rate limiting\n- Added top-level  compatibility shim (deliverable path)\n- Added {
  "nodes": [
    "https://50.28.86.131:8099",
    "https://50.28.86.153:8099",
    "https://76.8.228.245:8099"
  ],
  "error": "No reachable nodes",
  "errors": [
    {
      "node": "https://50.28.86.131:8099",
      "error": "HTTPSConnectionPool(host='50.28.86.131', port=8099): Read timed out. (read timeout=10.0)"
    },
    {
      "node": "https://50.28.86.153:8099",
      "error": "HTTPSConnectionPool(host='50.28.86.153', port=8099): Read timed out. (read timeout=10.0)"
    },
    {
      "node": "https://76.8.228.245:8099",
      "error": "HTTPSConnectionPool(host='76.8.228.245', port=8099): Max retries exceeded with url: /sync/status (Caused by ConnectTimeoutError(<urllib3.connection.HTTPSConnection object at 0x78ced0570920>, 'Connection to 76.8.228.245 timed out. (connect timeout=10.0)'))"
    }
  ]
} to validate 3-node consistency via \n\n## Security notes\n- All sync endpoints require admin key and now support HTTPS-only enforcement.\n- Per-peer rate limit remains max 1 sync/minute.\n- Balance-reduction payloads remain rejected.\n\n## Validation\n- \n\nCloses #36