### PR TITLE
security: fail closed on mock-signature mode outside test runtime

### DIFF
--- a/node/tests/test_mock_signature_guard.py
+++ b/node/tests/test_mock_signature_guard.py
@@ -1,0 +1,64 @@
+import importlib.util
+import os
+import sys
+import unittest
+from pathlib import Path
+
+
+def _load_integrated_node():
+    module_name = "integrated_node_guard_tests"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+
+    project_root = Path(__file__).resolve().parents[2]
+    node_dir = project_root / "node"
+    module_path = node_dir / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+    os.environ.setdefault("DB_PATH", ":memory:")
+
+    spec = importlib.util.spec_from_file_location(module_name, str(module_path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+integrated_node = _load_integrated_node()
+
+
+class MockSignatureGuardTests(unittest.TestCase):
+    def setUp(self):
+        self._orig_mock_sig = integrated_node.TESTNET_ALLOW_MOCK_SIG
+        self._orig_runtime_env = os.environ.get("RC_RUNTIME_ENV")
+        self._orig_rustchain_env = os.environ.get("RUSTCHAIN_ENV")
+
+    def tearDown(self):
+        integrated_node.TESTNET_ALLOW_MOCK_SIG = self._orig_mock_sig
+        if self._orig_runtime_env is None:
+            os.environ.pop("RC_RUNTIME_ENV", None)
+        else:
+            os.environ["RC_RUNTIME_ENV"] = self._orig_runtime_env
+        if self._orig_rustchain_env is None:
+            os.environ.pop("RUSTCHAIN_ENV", None)
+        else:
+            os.environ["RUSTCHAIN_ENV"] = self._orig_rustchain_env
+
+    def test_fails_closed_when_mock_signatures_enabled_in_production(self):
+        integrated_node.TESTNET_ALLOW_MOCK_SIG = True
+        os.environ["RC_RUNTIME_ENV"] = "production"
+        os.environ.pop("RUSTCHAIN_ENV", None)
+
+        with self.assertRaisesRegex(RuntimeError, "TESTNET_ALLOW_MOCK_SIG"):
+            integrated_node.enforce_mock_signature_runtime_guard()
+
+    def test_allows_mock_signatures_in_test_runtime(self):
+        integrated_node.TESTNET_ALLOW_MOCK_SIG = True
+        os.environ["RC_RUNTIME_ENV"] = "test"
+        os.environ.pop("RUSTCHAIN_ENV", None)
+
+        integrated_node.enforce_mock_signature_runtime_guard()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,3 +94,28 @@ def test_client_ip_from_request_untrusted_remote_uses_remote_addr(monkeypatch):
     )
 
     assert integrated_node.client_ip_from_request(req) == "198.51.100.12"
+
+
+def test_mock_signature_guard_fails_closed_outside_test_runtime(monkeypatch):
+    monkeypatch.setattr(integrated_node, "TESTNET_ALLOW_MOCK_SIG", True)
+    monkeypatch.setenv("RC_RUNTIME_ENV", "production")
+    monkeypatch.delenv("RUSTCHAIN_ENV", raising=False)
+
+    with pytest.raises(RuntimeError, match="TESTNET_ALLOW_MOCK_SIG"):
+        integrated_node.enforce_mock_signature_runtime_guard()
+
+
+def test_mock_signature_guard_allows_test_runtime(monkeypatch):
+    monkeypatch.setattr(integrated_node, "TESTNET_ALLOW_MOCK_SIG", True)
+    monkeypatch.setenv("RC_RUNTIME_ENV", "test")
+    monkeypatch.delenv("RUSTCHAIN_ENV", raising=False)
+
+    integrated_node.enforce_mock_signature_runtime_guard()
+
+
+def test_mock_signature_guard_allows_when_disabled(monkeypatch):
+    monkeypatch.setattr(integrated_node, "TESTNET_ALLOW_MOCK_SIG", False)
+    monkeypatch.setenv("RC_RUNTIME_ENV", "production")
+    monkeypatch.delenv("RUSTCHAIN_ENV", raising=False)
+
+    integrated_node.enforce_mock_signature_runtime_guard()


### PR DESCRIPTION
## Summary
This PR adds a startup fail-closed guard for mock-signature mode and regression tests.

## Attack Path (why this matters)
`/headers/ingest_signed` currently accepts any 128-hex signature when `TESTNET_ALLOW_MOCK_SIG` is enabled.

1. An operator enables `TESTNET_ALLOW_MOCK_SIG` for testing.
2. The same config is deployed in a non-test runtime by mistake.
3. An attacker submits forged signed-header payloads to `/headers/ingest_signed`.
4. The request takes the mock-accept branch and bypasses real Ed25519 verification.
5. Forged headers are persisted and can influence tip/epoch processing.

This creates a residual risk if test-mode flags leak into production startup.

## What changed
- Added `enforce_mock_signature_runtime_guard()` and `_runtime_env_name()` in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.
- Guard behavior:
  - If `TESTNET_ALLOW_MOCK_SIG` is `False`: normal startup.
  - If `TESTNET_ALLOW_MOCK_SIG` is `True`: startup is allowed only when runtime env is explicitly `test`/`testing`/`ci`.
  - Otherwise startup exits immediately (fail-closed) with a fatal error.
- Wired guard into `__main__` before node initialization.
- Added regression coverage:
  - `tests/test_api.py` (pytest-style guard tests)
  - `node/tests/test_mock_signature_guard.py` (stdlib `unittest` executable in this environment)

## Test Evidence
Executed locally:

```bash
python3 -m unittest -q node.tests.test_mock_signature_guard
```

Output:

```text
----------------------------------------------------------------------
Ran 2 tests in 0.000s

OK
```

(Additional module init warnings are expected in test mode due to optional runtime dependencies not installed in the test environment.)
