### PR TITLE
security: harden public endpoints against sensitive disclosure

### DIFF
--- a/node/tests/test_public_api_disclosure.py
+++ b/node/tests/test_public_api_disclosure.py
@@ -1,0 +1,138 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+
+
+class TestPublicApiDisclosure(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_public_api_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def test_epoch_public_response_is_redacted(self):
+        with patch.object(self.mod, "current_slot", return_value=12345), \
+             patch.object(self.mod, "slot_to_epoch", return_value=85), \
+             patch.object(self.mod.sqlite3, "connect") as mock_connect:
+            mock_conn = mock_connect.return_value.__enter__.return_value
+            mock_conn.execute.return_value.fetchone.return_value = [10]
+
+            resp = self.client.get("/epoch")
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+
+            self.assertEqual(body["epoch"], 85)
+            self.assertEqual(body["visibility"], "public_redacted")
+            self.assertNotIn("slot", body)
+            self.assertNotIn("epoch_pot", body)
+            self.assertNotIn("enrolled_miners", body)
+
+    def test_epoch_admin_receives_full_fields(self):
+        with patch.object(self.mod, "current_slot", return_value=12345), \
+             patch.object(self.mod, "slot_to_epoch", return_value=85), \
+             patch.object(self.mod.sqlite3, "connect") as mock_connect:
+            mock_conn = mock_connect.return_value.__enter__.return_value
+            mock_conn.execute.return_value.fetchone.return_value = [10]
+
+            resp = self.client.get("/epoch", headers={"X-Admin-Key": ADMIN_KEY})
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+
+            self.assertEqual(body["slot"], 12345)
+            self.assertEqual(body["epoch_pot"], self.mod.PER_EPOCH_RTC)
+            self.assertEqual(body["enrolled_miners"], 10)
+
+    def test_miners_public_response_is_redacted(self):
+        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
+            mock_conn = mock_connect.return_value.__enter__.return_value
+            mock_conn.execute.return_value.fetchone.return_value = [7]
+
+            resp = self.client.get("/api/miners")
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+
+            self.assertEqual(body["active_miners"], 7)
+            self.assertEqual(body["window_seconds"], 3600)
+            self.assertEqual(body["visibility"], "public_redacted")
+            self.assertNotIn("miners", body)
+
+    def test_miners_admin_receives_full_records(self):
+        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
+            mock_conn = mock_connect.return_value.__enter__.return_value
+            mock_cursor = mock_conn.cursor.return_value
+
+            row = {
+                "miner": "addr1",
+                "ts_ok": 1700000000,
+                "device_family": "PowerPC",
+                "device_arch": "G4",
+                "entropy_score": 0.95,
+            }
+
+            miners_query = MagicMock()
+            miners_query.fetchall.return_value = [row]
+
+            first_attest_query = MagicMock()
+            first_attest_query.fetchone.return_value = [1699990000]
+
+            mock_cursor.execute.side_effect = [miners_query, first_attest_query]
+
+            resp = self.client.get("/api/miners", headers={"X-Admin-Key": ADMIN_KEY})
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+
+            self.assertEqual(len(body), 1)
+            self.assertEqual(body[0]["miner"], "addr1")
+            self.assertEqual(body[0]["hardware_type"], "PowerPC G4 (Vintage)")
+            self.assertEqual(body[0]["antiquity_multiplier"], 2.5)
+
+    def test_wallet_balance_denies_unauthenticated_access(self):
+        resp = self.client.get("/wallet/balance?miner_id=alice")
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.get_json(), {"ok": False, "reason": "admin_required"})
+
+    def test_wallet_balance_admin_receives_value(self):
+        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
+            mock_conn = mock_connect.return_value.__enter__.return_value
+            mock_conn.execute.return_value.fetchone.return_value = [1234567]
+
+            resp = self.client.get("/wallet/balance?miner_id=alice", headers={"X-Admin-Key": ADMIN_KEY})
+            self.assertEqual(resp.status_code, 200)
+            body = resp.get_json()
+
+            self.assertEqual(body["miner_id"], "alice")
+            self.assertEqual(body["amount_i64"], 1234567)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,7 +28,7 @@ def test_api_health(client):
         assert 'uptime_s' in data
 
 def test_api_epoch(client):
-    """Test the /epoch endpoint."""
+    """Unauthenticated /epoch must return a redacted payload."""
     with patch('integrated_node.current_slot', return_value=12345), \
          patch('integrated_node.slot_to_epoch', return_value=85), \
          patch('sqlite3.connect') as mock_connect:
@@ -42,11 +42,45 @@ def test_api_epoch(client):
         assert response.status_code == 200
         data = response.get_json()
         assert data['epoch'] == 85
+        assert 'blocks_per_epoch' in data
+        assert data['visibility'] == 'public_redacted'
+        assert 'slot' not in data
+        assert 'epoch_pot' not in data
+        assert 'enrolled_miners' not in data
+
+
+def test_api_epoch_admin_sees_full_payload(client):
+    with patch('integrated_node.current_slot', return_value=12345), \
+         patch('integrated_node.slot_to_epoch', return_value=85), \
+         patch('sqlite3.connect') as mock_connect:
+
+        mock_conn = mock_connect.return_value.__enter__.return_value
+        mock_cursor = mock_conn.execute.return_value
+        mock_cursor.fetchone.return_value = [10]
+
+        response = client.get('/epoch', headers={'X-Admin-Key': '0' * 32})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['epoch'] == 85
         assert data['slot'] == 12345
         assert data['enrolled_miners'] == 10
 
 def test_api_miners(client):
-    """Test the /api/miners endpoint."""
+    """Unauthenticated /api/miners must return redacted aggregate data."""
+    with patch('sqlite3.connect') as mock_connect:
+        mock_conn = mock_connect.return_value.__enter__.return_value
+        mock_cursor = mock_conn.execute.return_value
+        mock_cursor.fetchone.return_value = [7]
+
+        response = client.get('/api/miners')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['active_miners'] == 7
+        assert data['visibility'] == 'public_redacted'
+        assert 'miners' not in data
+
+
+def test_api_miners_admin_sees_full_payload(client):
     with patch('sqlite3.connect') as mock_connect:
         mock_conn = mock_connect.return_value.__enter__.return_value
         mock_cursor = mock_conn.cursor.return_value
@@ -61,13 +95,35 @@ def test_api_miners(client):
         }
         mock_cursor.execute.return_value.fetchall.return_value = [mock_row]
 
-        response = client.get('/api/miners')
+        response = client.get('/api/miners', headers={'X-Admin-Key': '0' * 32})
         assert response.status_code == 200
         data = response.get_json()
         assert len(data) == 1
         assert data[0]['miner'] == "addr1"
         assert data[0]['hardware_type'] == "PowerPC G4 (Vintage)"
         assert data[0]['antiquity_multiplier'] == 2.5
+
+
+def test_wallet_balance_rejects_unauthenticated_requests(client):
+    response = client.get('/wallet/balance?miner_id=alice')
+    assert response.status_code == 401
+    data = response.get_json()
+    assert data == {"ok": False, "reason": "admin_required"}
+
+
+def test_wallet_balance_admin_allows_access(client):
+    with patch('sqlite3.connect') as mock_connect:
+        mock_conn = mock_connect.return_value.__enter__.return_value
+        mock_conn.execute.return_value.fetchone.return_value = [1234567]
+
+        response = client.get(
+            '/wallet/balance?miner_id=alice',
+            headers={'X-Admin-Key': '0' * 32}
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['miner_id'] == 'alice'
+        assert data['amount_i64'] == 1234567
 
 
 def test_client_ip_from_request_ignores_leftmost_xff_spoof(monkeypatch):


### PR DESCRIPTION
## Summary
This PR fixes sensitive information disclosure reported in `rustchain-bounties#409` by preventing unauthenticated callers from reading miner identity/hardware details, per-miner balances, and detailed epoch internals.

### What changed
- `GET /api/miners`
  - Unauthenticated callers now receive only a redacted aggregate payload:
    - `active_miners`
    - `window_seconds`
    - `visibility: public_redacted`
  - Full miner records remain available with a valid admin key (`X-Admin-Key` or `X-API-Key`).

- `GET /wallet/balance?miner_id=...`
  - Now requires admin key.
  - Unauthenticated callers get `401 {"ok": false, "reason": "admin_required"}`.

- `GET /epoch`
  - Unauthenticated callers now receive redacted public fields only:
    - `epoch`
    - `blocks_per_epoch`
    - `visibility: public_redacted`
  - Full payload (`slot`, `epoch_pot`, `enrolled_miners`) remains available with a valid admin key.

## Regression tests
Added `node/tests/test_public_api_disclosure.py` to verify:
- unauthenticated callers cannot access sensitive fields on `/api/miners` and `/epoch`
- unauthenticated callers are rejected on `/wallet/balance`
- authenticated callers retain full access

## Before / After curl evidence
All commands were run locally against seeded test data.

### Before (upstream `main`, unauthenticated)
```bash
curl -s "http://127.0.0.1:18099/api/miners"
[ {"miner":"xiaoer-bot", "device_family":"PowerPC", "device_arch":"G4", "last_attest":..., "first_attest":..., "entropy_score":0.95, "antiquity_multiplier":2.5, ...} ]

curl -s "http://127.0.0.1:18099/wallet/balance?miner_id=xiaoer-bot"
{"amount_i64":12345000,"amount_rtc":12.345,"miner_id":"xiaoer-bot"}

curl -s "http://127.0.0.1:18099/epoch"
{"blocks_per_epoch":144,"enrolled_miners":1,"epoch":82,"epoch_pot":1.5,"slot":11906}
```

### After (this PR, unauthenticated)
```bash
curl -s "http://127.0.0.1:18100/api/miners"
{"active_miners":1,"visibility":"public_redacted","window_seconds":3600}

curl -s "http://127.0.0.1:18100/wallet/balance?miner_id=xiaoer-bot"
{"ok":false,"reason":"admin_required"}

curl -s "http://127.0.0.1:18100/epoch"
{"blocks_per_epoch":144,"epoch":82,"visibility":"public_redacted"}
```

### After (this PR, authenticated)
```bash
curl -s -H "X-Admin-Key: 0123456789abcdef0123456789abcdef" "http://127.0.0.1:18100/api/miners"
[ {"miner":"xiaoer-bot", "device_family":"PowerPC", "device_arch":"G4", ...} ]

curl -s -H "X-Admin-Key: 0123456789abcdef0123456789abcdef" "http://127.0.0.1:18100/wallet/balance?miner_id=xiaoer-bot"
{"amount_i64":12345000,"amount_rtc":12.345,"miner_id":"xiaoer-bot"}

curl -s -H "X-Admin-Key: 0123456789abcdef0123456789abcdef" "http://127.0.0.1:18100/epoch"
{"blocks_per_epoch":144,"enrolled_miners":1,"epoch":82,"epoch_pot":1.5,"slot":11906}
```

## Test command output
```bash
$ python3 -m unittest -q node.tests.test_public_api_disclosure
----------------------------------------------------------------------
Ran 6 tests in 0.464s

OK
```
