### PR TITLE
security: validate limit query params to avoid endpoint 500s

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3037,11 +3037,29 @@ def api_miners():
     return jsonify(miners)
 
 
+def _parse_int_query_arg(name: str, default: int, min_value: int | None = None, max_value: int | None = None):
+    raw_value = request.args.get(name)
+    if raw_value is None or str(raw_value).strip() == "":
+        value = default
+    else:
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None, f"{name} must be an integer"
+
+    if min_value is not None and value < min_value:
+        value = min_value
+    if max_value is not None and value > max_value:
+        value = max_value
+    return value, None
+
+
 @app.route("/api/miner/<miner_id>/attestations", methods=["GET"])
 def api_miner_attestations(miner_id: str):
     """Best-effort attestation history for a single miner (museum detail view)."""
-    limit = int(request.args.get("limit", "120") or 120)
-    limit = max(1, min(limit, 500))
+    limit, limit_err = _parse_int_query_arg("limit", 120, min_value=1, max_value=500)
+    if limit_err:
+        return jsonify({"ok": False, "error": limit_err}), 400
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row
@@ -3079,8 +3097,9 @@ def api_miner_attestations(miner_id: str):
 @app.route("/api/balances", methods=["GET"])
 def api_balances():
     """Return wallet balances (best-effort across schema variants)."""
-    limit = int(request.args.get("limit", "2000") or 2000)
-    limit = max(1, min(limit, 5000))
+    limit, limit_err = _parse_int_query_arg("limit", 2000, min_value=1, max_value=5000)
+    if limit_err:
+        return jsonify({"ok": False, "error": limit_err}), 400
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row
@@ -3638,7 +3657,9 @@ def list_pending():
         return jsonify({"error": "Unauthorized"}), 401
 
     status_filter = request.args.get('status', 'pending')
-    limit = min(int(request.args.get('limit', 100)), 500)
+    limit, limit_err = _parse_int_query_arg("limit", 100, min_value=1, max_value=500)
+    if limit_err:
+        return jsonify({"ok": False, "error": limit_err}), 400
     
     with sqlite3.connect(DB_PATH) as db:
         if status_filter == 'all':

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -170,6 +170,24 @@ def client_ip_from_request(req) -> str:
             return hop
     return remote
 
+
+def _parse_int_query_arg(name: str, default: int, min_value: int | None = None, max_value: int | None = None):
+    raw_value = request.args.get(name)
+    if raw_value is None or str(raw_value).strip() == "":
+        value = default
+    else:
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None, f"{name} must be an integer"
+
+    if min_value is not None and value < min_value:
+        value = min_value
+    if max_value is not None and value > max_value:
+        value = max_value
+    return value, None
+
+
 # Register Hall of Rust blueprint (tables initialized after DB_PATH is set)
 try:
     from hall_of_rust import hall_bp
@@ -3097,23 +3115,6 @@ def api_badge(miner_id: str):
         "message": message,
         "color": color,
     })
-
-
-def _parse_int_query_arg(name: str, default: int, min_value: int | None = None, max_value: int | None = None):
-    raw_value = request.args.get(name)
-    if raw_value is None or str(raw_value).strip() == "":
-        value = default
-    else:
-        try:
-            value = int(raw_value)
-        except (TypeError, ValueError):
-            return None, f"{name} must be an integer"
-
-    if min_value is not None and value < min_value:
-        value = min_value
-    if max_value is not None and value > max_value:
-        value = max_value
-    return value, None
 
 
 @app.route("/api/miner/<miner_id>/attestations", methods=["GET"])

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3037,6 +3037,68 @@ def api_miners():
     return jsonify(miners)
 
 
+@app.route("/api/badge/<miner_id>", methods=["GET"])
+def api_badge(miner_id: str):
+    """Shields.io-compatible JSON badge endpoint for a miner's mining status.
+
+    Usage in README:
+        ![Mining Status](https://img.shields.io/endpoint?url=https://rustchain.org/api/badge/YOUR_MINER_ID)
+
+    Returns JSON with schemaVersion, label, message, and color per
+    https://shields.io/endpoint spec.
+    """
+    miner_id = miner_id.strip()
+    if not miner_id:
+        return jsonify({"schemaVersion": 1, "label": "RustChain", "message": "invalid", "color": "red"}), 400
+
+    now = int(time.time())
+    status = "Inactive"
+    hw_type = ""
+    multiplier = 1.0
+
+    try:
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.row_factory = sqlite3.Row
+            c = conn.cursor()
+            row = c.execute(
+                "SELECT ts_ok, device_family, device_arch FROM miner_attest_recent WHERE miner = ?",
+                (miner_id,),
+            ).fetchone()
+
+            if row and row["ts_ok"]:
+                age = now - int(row["ts_ok"])
+                if age < 1200:       # attested within 20 minutes
+                    status = "Active"
+                elif age < 3600:     # attested within 1 hour
+                    status = "Idle"
+                else:
+                    status = "Inactive"
+
+                fam = (row["device_family"] or "unknown")
+                arch = (row["device_arch"] or "unknown")
+                hw_type = f"{fam}/{arch}"
+                multiplier = HARDWARE_WEIGHTS.get(fam, {}).get(
+                    arch, HARDWARE_WEIGHTS.get(fam, {}).get("default", 1.0)
+                )
+    except Exception:
+        pass
+
+    color_map = {"Active": "brightgreen", "Idle": "yellow", "Inactive": "lightgrey"}
+    color = color_map.get(status, "lightgrey")
+    label = f"⛏ {miner_id}"
+
+    message = status
+    if status == "Active" and multiplier > 1.0:
+        message = f"{status} ({multiplier}x)"
+
+    return jsonify({
+        "schemaVersion": 1,
+        "label": label,
+        "message": message,
+        "color": color,
+    })
+
+
 def _parse_int_query_arg(name: str, default: int, min_value: int | None = None, max_value: int | None = None):
     raw_value = request.args.get(name)
     if raw_value is None or str(raw_value).strip() == "":

--- a/node/tests/test_limit_validation.py
+++ b/node/tests/test_limit_validation.py
@@ -1,0 +1,59 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+
+
+class TestLimitValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_limit_validation_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def test_api_miner_attestations_rejects_non_integer_limit(self):
+        resp = self.client.get("/api/miner/alice/attestations?limit=abc")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+    def test_api_balances_rejects_non_integer_limit(self):
+        resp = self.client.get("/api/balances?limit=abc")
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+    def test_pending_list_rejects_non_integer_limit(self):
+        resp = self.client.get("/pending/list?limit=abc", headers={"X-Admin-Key": ADMIN_KEY})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -126,6 +126,24 @@ def test_wallet_balance_admin_allows_access(client):
         assert data['amount_i64'] == 1234567
 
 
+def test_api_miner_attestations_rejects_non_integer_limit(client):
+    response = client.get('/api/miner/alice/attestations?limit=abc')
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "limit must be an integer"}
+
+
+def test_api_balances_rejects_non_integer_limit(client):
+    response = client.get('/api/balances?limit=abc')
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "limit must be an integer"}
+
+
+def test_pending_list_rejects_non_integer_limit(client):
+    response = client.get('/pending/list?limit=abc', headers={'X-Admin-Key': '0' * 32})
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "limit must be an integer"}
+
+
 def test_client_ip_from_request_ignores_leftmost_xff_spoof(monkeypatch):
     """Trusted-proxy mode should ignore client-injected left-most XFF entries."""
     monkeypatch.setattr(integrated_node, "_TRUSTED_PROXY_IPS", {"127.0.0.1"})


### PR DESCRIPTION
## Summary
- add `_parse_int_query_arg` helper for robust integer query parsing
- return `400` with a clear error when `limit` is non-numeric instead of raising `ValueError`
- apply validation to:
  - `/api/miner/<miner_id>/attestations`
  - `/api/balances`
  - `/pending/list`

## Why
A malformed query such as `?limit=abc` previously raised uncaught exceptions and returned `500` on these endpoints.

## Repro
Before this patch:
- `GET /api/miner/alice/attestations?limit=abc` -> `500`
- `GET /api/balances?limit=abc` -> `500`
- `GET /pending/list?limit=abc` (with admin key) -> `500`

After this patch:
- all above return `400` with `{"ok": false, "error": "limit must be an integer"}`

## Tests
- added `node/tests/test_limit_validation.py`
- command: `python3 -m unittest -q node.tests.test_limit_validation`

Refs: Scottcjn/rustchain-bounties#71
