### PR TITLE
feat: POWER8 vec_perm benchmark suite with scalar baseline

### DIFF
--- a/benchmarks/power8_vecperm/README.md
+++ b/benchmarks/power8_vecperm/README.md
@@ -1,0 +1,34 @@
+# POWER8 vec_perm Benchmark Suite
+
+Microbenchmark suite for comparing scalar permutation versus POWER8 Altivec `vec_perm` path.
+
+## Run
+
+```bash
+cd benchmarks/power8_vecperm
+./run_bench.sh
+```
+
+Optional:
+
+```bash
+ITERS=5000000 OUT_DIR=./results-5m ./run_bench.sh
+```
+
+## Output
+
+JSON line files in `results/`:
+- `scalar_or_host.json`
+- `power8_vecperm.json` (on PowerPC64 with Altivec toolchain)
+
+Fields:
+- `iters`
+- `scalar_ns`
+- `vecperm_ns`
+- `speedup`
+- `altivec`
+
+## Notes
+
+- On non-PowerPC hosts, scalar benchmark still runs for CI/dev sanity.
+- On POWER8 hosts, compile with `-maltivec -mvsx` to enable vec_perm path.

--- a/benchmarks/power8_vecperm/run_bench.sh
+++ b/benchmarks/power8_vecperm/run_bench.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CC=${CC:-gcc}
+ITERS=${ITERS:-2000000}
+OUT_DIR=${OUT_DIR:-./results}
+mkdir -p "$OUT_DIR"
+
+CFLAGS_COMMON="-O3 -std=c11 -Wall"
+
+$CC $CFLAGS_COMMON vecperm_bench.c -o vecperm_bench_scalar
+./vecperm_bench_scalar "$ITERS" | tee "$OUT_DIR/scalar_or_host.json"
+
+if $CC -dM -E - < /dev/null | grep -q '__powerpc64__'; then
+  $CC $CFLAGS_COMMON -maltivec -mvsx vecperm_bench.c -o vecperm_bench_power8
+  ./vecperm_bench_power8 "$ITERS" | tee "$OUT_DIR/power8_vecperm.json"
+fi
+
+echo "Wrote results to $OUT_DIR"

--- a/benchmarks/power8_vecperm/vecperm_bench.c
+++ b/benchmarks/power8_vecperm/vecperm_bench.c
@@ -1,0 +1,84 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#ifndef ITERS
+#define ITERS 2000000UL
+#endif
+
+static inline uint64_t nsec_now(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
+}
+
+static void scalar_perm(const uint8_t *a, const uint8_t *b, const uint8_t *mask, uint8_t *out) {
+    for (int i = 0; i < 16; i++) {
+        uint8_t m = mask[i] & 0x1f;
+        out[i] = (m < 16) ? a[m] : b[m - 16];
+    }
+}
+
+#if defined(__ALTIVEC__)
+#include <altivec.h>
+typedef __vector unsigned char v16u8;
+
+static inline void vecperm_once(const uint8_t *a, const uint8_t *b, const uint8_t *mask, uint8_t *out) {
+    v16u8 va = vec_vsx_ld(0, a);
+    v16u8 vb = vec_vsx_ld(0, b);
+    v16u8 vm = vec_vsx_ld(0, mask);
+    v16u8 vo = vec_perm(va, vb, vm);
+    vec_vsx_st(vo, 0, out);
+}
+#endif
+
+int main(int argc, char **argv) {
+    unsigned long iters = ITERS;
+    if (argc > 1) iters = strtoul(argv[1], NULL, 10);
+
+    uint8_t a[16], b[16], mask[16], out[16];
+    for (int i = 0; i < 16; i++) {
+        a[i] = (uint8_t)i;
+        b[i] = (uint8_t)(i + 16);
+        mask[i] = (uint8_t)((i * 7) & 0x1f);
+    }
+
+    uint64_t t0 = nsec_now();
+    for (unsigned long i = 0; i < iters; i++) {
+        scalar_perm(a, b, mask, out);
+        mask[i & 15] ^= (uint8_t)(out[(i + 3) & 15] & 1);
+    }
+    uint64_t t1 = nsec_now();
+
+#if defined(__ALTIVEC__)
+    uint64_t t2 = nsec_now();
+    for (unsigned long i = 0; i < iters; i++) {
+        vecperm_once(a, b, mask, out);
+        mask[i & 15] ^= (uint8_t)(out[(i + 3) & 15] & 1);
+    }
+    uint64_t t3 = nsec_now();
+#else
+    uint64_t t2 = 0, t3 = 0;
+#endif
+
+    double scalar_ns = (double)(t1 - t0) / (double)iters;
+#if defined(__ALTIVEC__)
+    double vec_ns = (double)(t3 - t2) / (double)iters;
+    double speedup = (vec_ns > 0.0) ? (scalar_ns / vec_ns) : 0.0;
+#else
+    double vec_ns = -1.0;
+    double speedup = 0.0;
+#endif
+
+    printf("{\"iters\":%lu,\"scalar_ns\":%.4f,\"vecperm_ns\":%.4f,\"speedup\":%.4f,\"altivec\":%s}\n",
+           iters, scalar_ns, vec_ns, speedup,
+#if defined(__ALTIVEC__)
+           "true"
+#else
+           "false"
+#endif
+    );
+    return 0;
+}


### PR DESCRIPTION
## Summary
Implements a reproducible POWER8 vec_perm benchmark suite with scalar fallback comparison and JSON outputs.

## Added
- `benchmarks/power8_vecperm/vecperm_bench.c`
- `benchmarks/power8_vecperm/run_bench.sh`
- `benchmarks/power8_vecperm/README.md`

## Features
- Scalar permutation baseline (`scalar_perm`)
- POWER8 Altivec `vec_perm` path when available
- Iteration control via CLI/env
- JSON output with ns/op and speedup metrics
- Host-safe fallback behavior on non-PowerPC machines

Fixes #35
