### PR TITLE
feat: self-hostable RustChain block explorer dashboard (issue #425)

### DIFF
--- a/dashboard/block-explorer/README.md
+++ b/dashboard/block-explorer/README.md
@@ -1,0 +1,24 @@
+# RustChain Block Explorer Dashboard
+
+Self-hostable dashboard for RustChain network visibility.
+
+## Features
+- Health summary from `/health`
+- Active miner table from `/api/miners`
+- Epoch metadata from `/epoch`
+- Transaction history table (when `/epoch` includes tx data)
+
+## Run
+```bash
+cd dashboard/block-explorer
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python app.py
+```
+Then open: `http://localhost:8080`
+
+## Config
+- `RUSTCHAIN_API_BASE` (default `https://rustchain.org`)
+- `RUSTCHAIN_API_TIMEOUT` (default `8`)
+- `PORT` (default `8080`)

--- a/dashboard/block-explorer/app.py
+++ b/dashboard/block-explorer/app.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import requests
+from flask import Flask, render_template
+
+BASE_URL = os.getenv("RUSTCHAIN_API_BASE", "https://rustchain.org")
+TIMEOUT = float(os.getenv("RUSTCHAIN_API_TIMEOUT", "8"))
+
+app = Flask(__name__, template_folder="templates", static_folder="static")
+
+
+def _get_json(path: str) -> Any:
+    url = f"{BASE_URL}{path}"
+    r = requests.get(url, timeout=TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _safe_get(path: str, fallback: Any) -> Any:
+    try:
+        return _get_json(path)
+    except Exception:
+        return fallback
+
+
+def _normalize_miners(miners: Any) -> List[Dict[str, Any]]:
+    if not isinstance(miners, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for m in miners[:300]:
+        if not isinstance(m, dict):
+            continue
+        out.append({
+            "miner_id": m.get("miner_id") or m.get("id") or "-",
+            "arch": m.get("arch") or m.get("architecture") or "-",
+            "weight": m.get("weight") or m.get("multiplier") or "-",
+            "last_seen": m.get("last_seen") or m.get("updated_at") or m.get("timestamp") or "-",
+            "balance": m.get("balance") or m.get("amount") or "-",
+        })
+    return out
+
+
+def _normalize_txs(epoch_data: Any) -> List[Dict[str, Any]]:
+    if not isinstance(epoch_data, dict):
+        return []
+    candidates = epoch_data.get("transactions") or epoch_data.get("txs") or epoch_data.get("history") or []
+    if not isinstance(candidates, list):
+        return []
+    txs: List[Dict[str, Any]] = []
+    for t in candidates[:200]:
+        if not isinstance(t, dict):
+            continue
+        txs.append({
+            "tx_hash": t.get("tx_hash") or t.get("hash") or "-",
+            "from": t.get("from") or t.get("from_address") or "-",
+            "to": t.get("to") or t.get("to_address") or "-",
+            "amount": t.get("amount") or t.get("value") or "-",
+            "ts": t.get("timestamp") or t.get("created_at") or "-",
+        })
+    return txs
+
+
+@app.route("/")
+def index():
+    health = _safe_get("/health", {})
+    miners_raw = _safe_get("/api/miners", [])
+    epoch = _safe_get("/epoch", {})
+
+    miners = _normalize_miners(miners_raw)
+    txs = _normalize_txs(epoch)
+
+    summary = {
+        "active_miners": len(miners),
+        "epoch": (epoch.get("epoch") if isinstance(epoch, dict) else "-") or "-",
+        "version": (health.get("version") if isinstance(health, dict) else "-") or "-",
+        "tip_age_slots": (health.get("tip_age_slots") if isinstance(health, dict) else "-") or "-",
+        "uptime_s": (health.get("uptime_s") if isinstance(health, dict) else "-") or "-",
+    }
+
+    now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+    return render_template(
+        "index.html",
+        base_url=BASE_URL,
+        summary=summary,
+        health=health if isinstance(health, dict) else {},
+        epoch=epoch if isinstance(epoch, dict) else {},
+        miners=miners,
+        txs=txs,
+        now_utc=now_utc,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "8080")), debug=False)

--- a/dashboard/block-explorer/requirements.txt
+++ b/dashboard/block-explorer/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=3.0.0
+requests>=2.31.0

--- a/dashboard/block-explorer/templates/index.html
+++ b/dashboard/block-explorer/templates/index.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>RustChain Block Explorer Dashboard</title>
+  <style>
+    body { font-family: Arial, sans-serif; background:#0f1220; color:#e8ecff; margin:0; }
+    .wrap { max-width:1200px; margin:20px auto; padding:0 16px; }
+    .grid { display:grid; grid-template-columns: repeat(auto-fit,minmax(180px,1fr)); gap:10px; }
+    .card { background:#171b2e; padding:12px; border-radius:10px; }
+    h1,h2 { margin:10px 0; }
+    table { width:100%; border-collapse:collapse; font-size:13px; }
+    th,td { border-bottom:1px solid #2a3050; padding:8px; text-align:left; }
+    .muted { color:#9aa6d1; }
+    .pill { background:#223; padding:2px 8px; border-radius:999px; }
+    .section { margin-top:20px; }
+  </style>
+</head>
+<body>
+<div class="wrap">
+  <h1>RustChain Block Explorer Dashboard</h1>
+  <p class="muted">Data source: <span class="pill">{{ base_url }}</span> · Last refresh: {{ now_utc }}</p>
+
+  <div class="grid">
+    <div class="card"><div class="muted">Active Miners</div><div><b>{{ summary.active_miners }}</b></div></div>
+    <div class="card"><div class="muted">Current Epoch</div><div><b>{{ summary.epoch }}</b></div></div>
+    <div class="card"><div class="muted">Node Version</div><div><b>{{ summary.version }}</b></div></div>
+    <div class="card"><div class="muted">Tip Age (slots)</div><div><b>{{ summary.tip_age_slots }}</b></div></div>
+    <div class="card"><div class="muted">Uptime (s)</div><div><b>{{ summary.uptime_s }}</b></div></div>
+  </div>
+
+  <div class="section">
+    <h2>Miners</h2>
+    <table>
+      <thead><tr><th>miner_id</th><th>arch</th><th>weight</th><th>last_seen</th><th>balance</th></tr></thead>
+      <tbody>
+      {% for m in miners %}
+        <tr>
+          <td>{{ m.miner_id }}</td>
+          <td>{{ m.arch }}</td>
+          <td>{{ m.weight }}</td>
+          <td>{{ m.last_seen }}</td>
+          <td>{{ m.balance }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  <div class="section">
+    <h2>Epoch Rewards / Meta</h2>
+    <pre>{{ epoch | tojson(indent=2) }}</pre>
+  </div>
+
+  <div class="section">
+    <h2>Transaction History (if provided by /epoch)</h2>
+    <table>
+      <thead><tr><th>tx_hash</th><th>from</th><th>to</th><th>amount</th><th>timestamp</th></tr></thead>
+      <tbody>
+      {% for t in txs %}
+        <tr>
+          <td>{{ t.tx_hash }}</td>
+          <td>{{ t.from }}</td>
+          <td>{{ t.to }}</td>
+          <td>{{ t.amount }}</td>
+          <td>{{ t.ts }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary\nImplements a self-hostable web dashboard for RustChain network data.\n\n### Included\n-  (Flask dashboard app)\n-  (UI)\n- \n- \n\n### Data sources\n- \n- \n- \n\n### What it shows\n- Active miners\n- Current epoch / node version / uptime / tip age\n- Miner table (arch, weight, balance, last seen)\n- Epoch metadata\n- Transaction history table (when available in )\n\n### Validation\n- \n\nCloses Scottcjn/rustchain-bounties#425