### PR TITLE
fix: prevent sparse-entropy overlap bypass in collision checks

### DIFF
--- a/tests/test_hardware_binding_v2_security.py
+++ b/tests/test_hardware_binding_v2_security.py
@@ -60,3 +60,58 @@ def test_detect_collision_with_rich_entropy_profiles(tmp_path):
     assert not ok2
     assert reason2 == 'entropy_collision'
     assert 'collision_hash' in details2
+
+
+def test_collision_check_requires_min_comparable_overlap(tmp_path):
+    db = tmp_path / 'hb.db'
+    hb.DB_PATH = str(db)
+    hb.init_hardware_bindings_v2()
+
+    # Baseline binding with rich profile
+    fp_base = _mk_fingerprint(clock=0.20, l1=100.0, l2=220.0, thermal=1.8, jitter=0.07)
+    ok, reason, _ = hb.bind_hardware_v2(
+        serial='SER-BASE-2',
+        wallet='RTCwalletBase2',
+        arch='x86_64',
+        cores=8,
+        fingerprint=fp_base,
+    )
+    assert ok and reason == 'new_binding'
+
+    # Sparse-overlap payload: three non-zero fields, but only one overlaps with baseline (clock_cv)
+    # This must NOT be used for collision decisions.
+    crafted = {
+        'clock_cv': 0.20,      # overlaps
+        'cache_l1': 0.0,       # no overlap
+        'cache_l2': 0.0,       # no overlap
+        'thermal_ratio': 0.0,  # no overlap
+        'jitter_cv': 0.30,     # non-zero but not present in stored if attacker manipulates payloads
+    }
+
+    # Force one more non-overlap non-zero to satisfy input quality gate
+    crafted['cache_l1'] = 0.01
+
+    # Make stored comparable overlap effectively < MIN by editing stored profile directly
+    with sqlite3.connect(str(db)) as conn:
+        conn.execute(
+            "UPDATE hardware_bindings_v2 SET entropy_profile = ? WHERE serial_hash = ?",
+            (
+                json.dumps({'clock_cv': 0.21, 'cache_l1': 0, 'cache_l2': 0, 'thermal_ratio': 0, 'jitter_cv': 0}),
+                hb.compute_serial_hash('SER-BASE-2', 'x86_64'),
+            ),
+        )
+        conn.commit()
+
+    collision = hb.check_entropy_collision(crafted)
+    assert collision is None
+
+
+def test_compare_entropy_profiles_marks_sparse_overlap_low_confidence():
+    stored = {'clock_cv': 0.2, 'cache_l1': 0, 'cache_l2': 0, 'thermal_ratio': 0, 'jitter_cv': 0}
+    current = {'clock_cv': 0.21, 'cache_l1': 0.0, 'cache_l2': 0.0, 'thermal_ratio': 0.0, 'jitter_cv': 0.3}
+
+    ok, score, reason = hb.compare_entropy_profiles(stored, current)
+    assert ok
+    assert reason in ('entropy_ok', 'insufficient_comparable_overlap')
+    # comparable overlap is only one field; ensure score does not imply a strong multi-signal match
+    assert score <= 1.0


### PR DESCRIPTION
## Summary

Hardens  and profile comparison to prevent sparse-entropy payloads from weakening collision decisions.

## Changes

- add shared core entropy field list + helper counters
- compare fields only when **both** stored/current values are non-zero (true comparable overlap)
- require minimum comparable overlap () before collision matching
- treat zero-overlap comparison as low-confidence ()
- add regression tests for sparse-overlap bypass pattern and overlap-quality behavior

## Validation

- 
- manual sanity script with temp DB verifies sparse-overlap payload does not trigger weak collision decisions

Fixes Scottcjn/Rustchain#396