### PR TITLE
Fix: Update python.org link and standardize spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ curl -sk https://50.28.86.131/epoch
 
 Before opening a docs PR, please verify:
 
-- [ ] Instructions work exactly as written (commands are copy-pasteable).
+- [ ] Instructions work exactly as written (commands are copy-pastable).
 - [ ] OS/architecture assumptions are explicit (Linux/macOS/Windows).
 - [ ] New terms are defined at first use.
 - [ ] Broken links are removed or corrected.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Open Issues](https://img.shields.io/github/issues/Scottcjn/Rustchain?color=orange)](https://github.com/Scottcjn/Rustchain/issues)
 [![PowerPC](https://img.shields.io/badge/PowerPC-G3%2FG4%2FG5-orange)](https://github.com/Scottcjn/Rustchain)
 [![Blockchain](https://img.shields.io/badge/Consensus-Proof--of--Antiquity-green)](https://github.com/Scottcjn/Rustchain)
-[![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://python.org)
+[![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://www.python.org)
 [![Network](https://img.shields.io/badge/Nodes-3%20Active-brightgreen)](https://rustchain.org/explorer)
 [![Bounties](https://img.shields.io/badge/Bounties-Open%20%F0%9F%92%B0-green)](https://github.com/Scottcjn/rustchain-bounties/issues)
 [![As seen on BoTTube](https://bottube.ai/badge/seen-on-bottube.svg)](https://bottube.ai)


### PR DESCRIPTION
## Summary
Fixed two minor issues found during documentation review:

1. **Python.org link redirect**: Updated badge link from `python.org` to `www.python.org` to avoid 301 redirect
2. **Spelling standardization**: Changed 'copy-pasteable' to 'copy-pastable' (more standard spelling)

## Changes
- `README.md`: Updated Python badge link
- `CONTRIBUTING.md`: Standardized spelling in documentation checklist

## Testing
- Verified `https://python.org` returns 301 redirect
- Verified `https://www.python.org` returns 200 OK

Closes #444 (Find a Typo or Broken Link bounty)