### PR TITLE
fix: standardize Windows miner default node URL to rustchain.org

### DIFF
--- a/miners/windows/install-miner.sh
+++ b/miners/windows/install-miner.sh
@@ -9,7 +9,7 @@ REPO_BASE="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners"
 CHECKSUM_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/checksums.sha256"
 INSTALL_DIR="$HOME/.rustchain"
 VENV_DIR="$INSTALL_DIR/venv"
-NODE_URL="https://50.28.86.131"
+NODE_URL="https://rustchain.org"
 SERVICE_NAME="rustchain-miner"
 VERSION="1.1.0"
 

--- a/miners/windows/installer/README.md
+++ b/miners/windows/installer/README.md
@@ -66,14 +66,14 @@ rustchain-installer/
 
 ### Failure Recovery
 1. **Miner won't start:** Check `%APPDATA%\RustChain\logs\miner.log` for error messages.
-2. **"Node unreachable":** Verify your internet connection and ensure `node_url` in `config.json` is set to `https://50.28.86.131`.
+2. **"Node unreachable":** Verify your internet connection and ensure `node_url` in `config.json` is set to `https://rustchain.org`.
 3. **Hardware Fingerprint Failed:** Ensure you are running on real hardware. Virtual machines and emulators are restricted.
 
 ---
 
 ## Technical Notes
 
-- **Network:** Default node is `https://50.28.86.131`.
+- **Network:** Default node is `https://rustchain.org` (fallback: `http://50.28.86.131:8088` if TLS/proxy is unavailable).
 - **Security:** TLS verification is currently set to `verify=False` to support the node's self-signed certificate.
 - **Builds:** Automated Windows builds are handled via GitHub Actions (see `.github/workflows/windows-build.yml`).
 

--- a/miners/windows/installer/rustchain_setup.iss
+++ b/miners/windows/installer/rustchain_setup.iss
@@ -72,7 +72,7 @@ begin
     Lines.Add('  "wallet_name": "' + WalletPage.Values[0] + '",');
     Lines.Add('  "auto_start": false,');
     Lines.Add('  "minimize_to_tray": true,');
-    Lines.Add('  "node_url": "https://50.28.86.131",');
+    Lines.Add('  "node_url": "https://rustchain.org",');
     Lines.Add('  "log_level": "INFO",');
     Lines.Add('  "version": "1.0.0"');
     Lines.Add('}');

--- a/miners/windows/installer/src/config_manager.py
+++ b/miners/windows/installer/src/config_manager.py
@@ -19,7 +19,7 @@ DEFAULT_CONFIG = {
     "wallet_name": "",
     "auto_start": False,
     "minimize_to_tray": True,
-    "node_url": "https://50.28.86.131",
+    "node_url": "https://rustchain.org",
     "log_level": "INFO",
     "version": "1.0.0"
 }

--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -60,7 +60,7 @@ logging.basicConfig(
 logger = logging.getLogger("RustChain")
 
 # Configuration
-RUSTCHAIN_API = CONFIG.node_url if CONFIG else "https://50.28.86.131"
+RUSTCHAIN_API = CONFIG.node_url if CONFIG else "https://rustchain.org"
 WALLET_DIR = Path.home() / ".rustchain"
 CONFIG_FILE = WALLET_DIR / "config.json"
 WALLET_FILE = WALLET_DIR / "wallet.json"

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -52,5 +52,5 @@ echo.
 echo Miner is ready. Run:
 echo    python "%MINER_SCRIPT%"
 echo If you still get a tkinter error, run headless:
-echo    python "%MINER_SCRIPT%" --headless --wallet YOUR_WALLET_ID --node https://50.28.86.131
+echo    python "%MINER_SCRIPT%" --headless --wallet YOUR_WALLET_ID --node https://rustchain.org
 echo You can create a scheduled task or shortcut to keep it running.

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -49,7 +49,7 @@ except ImportError:
     print("[WARN] fingerprint_checks.py not found - fingerprint attestation disabled")
 
 # Configuration - Use HTTPS (self-signed cert on server)
-RUSTCHAIN_API = "https://50.28.86.131"
+RUSTCHAIN_API = "https://rustchain.org"
 WALLET_DIR = Path.home() / ".rustchain"
 CONFIG_FILE = WALLET_DIR / "config.json"
 WALLET_FILE = WALLET_DIR / "wallet.json"
@@ -654,7 +654,7 @@ def main(argv=None):
     ap = argparse.ArgumentParser(description="RustChain Windows wallet + miner (GUI or headless fallback).")
     ap.add_argument("--version", "-v", action="version", version=f"clawrtc {MINER_VERSION}")
     ap.add_argument("--headless", action="store_true", help="Run without GUI (recommended for embeddable Python).")
-    ap.add_argument("--node", default=RUSTCHAIN_API, help="RustChain node base URL.")
+    ap.add_argument("--node", default=RUSTCHAIN_API, help="RustChain node base URL (default: https://rustchain.org; fallback: http://50.28.86.131:8088).")
     ap.add_argument("--wallet", default="", help="Wallet address / miner ID string.")
     ap.add_argument("--no-update", action="store_true", help="Disable auto-update.")
     args = ap.parse_args(argv)


### PR DESCRIPTION
## Summary\nStandardize Windows miner defaults to a single canonical node URL: .\n\n## Changes\n- Updated Windows miner default node URL\n- Updated installer defaults (, , Inno Setup config, installer config manager, installer source miner)\n- Updated CLI help text to document fallback endpoint \n- Updated installer README network guidance\n\n## Validation\n- Python syntax check () for updated Python files\n\nFixes #400