### PR TITLE
fix(tx): reject non-positive transfer amounts (balance inflation guard)

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -253,7 +253,10 @@ class TransactionPool:
         if tx.nonce != expected_nonce:
             return False, f"Invalid nonce: expected {expected_nonce}, got {tx.nonce}"
 
-        # 4. Check balance
+        # 4. Validate amount and check balance
+        if tx.amount_urtc <= 0:
+            return False, "Invalid amount: must be > 0"
+
         available = self.get_available_balance(tx.from_addr)
         if tx.amount_urtc > available:
             return False, f"Insufficient balance: have {available}, need {tx.amount_urtc}"

--- a/node/tests/test_tx_negative_amount_rejected.py
+++ b/node/tests/test_tx_negative_amount_rejected.py
@@ -1,0 +1,60 @@
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+mock = types.ModuleType("rustchain_crypto")
+class SignedTransaction: pass
+class Ed25519Signer: pass
+def blake2b256_hex(x): return "00" * 32
+def address_from_public_key(b: bytes) -> str: return "addr-from-pub"
+mock.SignedTransaction = SignedTransaction
+mock.Ed25519Signer = Ed25519Signer
+mock.blake2b256_hex = blake2b256_hex
+mock.address_from_public_key = address_from_public_key
+sys.modules["rustchain_crypto"] = mock
+
+import rustchain_tx_handler as txh
+
+class FakeTx:
+    def __init__(self, amount_urtc: int):
+        self.from_addr = "addr-from-pub"
+        self.to_addr = "addr-target"
+        self.amount_urtc = amount_urtc
+        self.nonce = 1
+        self.timestamp = 1234567890
+        self.memo = "poc"
+        self.signature = "sig"
+        self.public_key = "00"
+        self.tx_hash = f"tx-{amount_urtc}"
+    def verify(self): return True
+
+class TestNegativeAmountRejected(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.pool = txh.TransactionPool(self.db_path)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("CREATE TABLE IF NOT EXISTS balances (wallet TEXT PRIMARY KEY, balance_urtc INTEGER NOT NULL, wallet_nonce INTEGER DEFAULT 0)")
+            conn.execute("INSERT OR REPLACE INTO balances (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)", ("addr-from-pub", 1_000_000, 0))
+    def tearDown(self):
+        try: os.unlink(self.db_path)
+        except FileNotFoundError: pass
+    def test_negative_amount_rejected(self):
+        ok, err = self.pool.validate_transaction(FakeTx(-100))
+        self.assertFalse(ok)
+        self.assertIn("Invalid amount", err)
+    def test_zero_amount_rejected(self):
+        ok, err = self.pool.validate_transaction(FakeTx(0))
+        self.assertFalse(ok)
+        self.assertIn("Invalid amount", err)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\nThe transaction validator accepted non-positive  values.\n\nA negative amount can pass balance checks and, during confirmation, invert balance updates (), creating balance inflation / transfer accounting corruption.\n\n## Changes\n- Added strict validation in :\n  - reject  with \n- Added regression tests:\n  - \n  - covers both negative and zero values\n\n## Repro (before fix)\n- submit signed tx with \n- validation passes nonce/signature/balance gate\n- confirmation path applies inverted debit/credit semantics\n\n## Validation\n- \n- \n\nRelated bounty thread: Scottcjn/rustchain-bounties#54