### PR TITLE
feat(pow): focused Ergo proof verification (server-side)

### DIFF
--- a/node/pow_adapters.py
+++ b/node/pow_adapters.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Server-side PoW proof adapters (focused, verifiable)."""
+
+from __future__ import annotations
+
+import json
+from typing import Dict, Tuple, Any
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+
+def _json_get(url: str, timeout: float = 3.0, headers: Dict[str, str] | None = None) -> Dict[str, Any]:
+    req = Request(url, headers=headers or {})
+    with urlopen(req, timeout=timeout) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+
+
+def verify_ergo_node_rpc(evidence: Dict[str, Any]) -> Tuple[bool, Dict[str, Any], str]:
+    """Verify Ergo node mining proof via local node RPC."""
+    endpoint = evidence.get("endpoint") or "http://127.0.0.1:9053/info"
+    expected_is_mining = bool(evidence.get("is_mining", True))
+    try:
+        data = _json_get(endpoint, timeout=float(evidence.get("timeout_sec", 3.0)))
+    except (URLError, HTTPError, TimeoutError, ValueError, json.JSONDecodeError) as e:
+        return False, {}, f"ergo_node_unreachable:{e}"
+
+    is_mining = bool(data.get("isMining", False))
+    height = int(data.get("fullHeight", 0) or 0)
+    peers = int(data.get("peersCount", 0) or 0)
+    best = data.get("bestFullHeaderId") or data.get("bestHeaderId") or ""
+
+    if expected_is_mining and not is_mining:
+        return False, {"isMining": is_mining, "height": height, "peers": peers}, "ergo_not_mining"
+    if height <= 0:
+        return False, {"isMining": is_mining, "height": height, "peers": peers}, "ergo_invalid_height"
+
+    expected_best = (evidence.get("best_block_hash") or "").strip()
+    if expected_best and best and expected_best != best:
+        return False, {"isMining": is_mining, "height": height, "peers": peers, "best": best}, "ergo_best_block_mismatch"
+
+    return True, {"isMining": is_mining, "height": height, "peers": peers, "best": best}, ""
+
+
+def verify_ergo_pool(evidence: Dict[str, Any]) -> Tuple[bool, Dict[str, Any], str]:
+    """Verify pool-side hashrate/account presence for Ergo mining."""
+    pool_url = (evidence.get("pool_api_url") or "").strip()
+    if not pool_url:
+        return False, {}, "missing_pool_api_url"
+
+    try:
+        data = _json_get(pool_url, timeout=float(evidence.get("timeout_sec", 3.0)))
+    except (URLError, HTTPError, TimeoutError, ValueError, json.JSONDecodeError) as e:
+        return False, {}, f"ergo_pool_unreachable:{e}"
+
+    # Tolerant extraction across common pool API styles
+    hashrate = 0.0
+    for k in ("hashrate", "currentHashrate", "reportedHashrate"):
+        v = data.get(k)
+        if v is not None:
+            try:
+                hashrate = float(v)
+                break
+            except Exception:
+                pass
+
+    if hashrate <= 0:
+        nested = data.get("data") if isinstance(data.get("data"), dict) else {}
+        for k in ("hashrate", "currentHashrate", "reportedHashrate"):
+            v = nested.get(k)
+            if v is not None:
+                try:
+                    hashrate = float(v)
+                    break
+                except Exception:
+                    pass
+
+    if hashrate <= 0:
+        return False, {"hashrate": hashrate}, "ergo_pool_no_hashrate"
+
+    miner = (evidence.get("miner") or evidence.get("wallet") or "").strip()
+    if miner:
+        blob = json.dumps(data, ensure_ascii=False)
+        if miner not in blob:
+            return False, {"hashrate": hashrate}, "ergo_pool_miner_not_found"
+
+    return True, {"hashrate": hashrate}, ""

--- a/node/pow_proof.py
+++ b/node/pow_proof.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Focused PoW proof validation entrypoint."""
+
+from __future__ import annotations
+
+from typing import Dict, Any, Tuple
+
+from pow_adapters import verify_ergo_node_rpc, verify_ergo_pool
+
+
+def validate_pow_proof(pow_proof: Dict[str, Any], miner_id: str = "") -> Tuple[bool, Dict[str, Any], str]:
+    if not isinstance(pow_proof, dict):
+        return False, {}, "invalid_pow_proof_payload"
+
+    coin = (pow_proof.get("coin") or "").strip().lower()
+    proof_type = (pow_proof.get("proof_type") or "").strip().lower()
+    evidence = pow_proof.get("evidence") if isinstance(pow_proof.get("evidence"), dict) else pow_proof
+
+    if not coin:
+        return False, {}, "missing_coin"
+    if not proof_type:
+        return False, {}, "missing_proof_type"
+
+    # Initial focused scope per review feedback: Ergo integration first.
+    if coin != "ergo":
+        return False, {}, f"unsupported_coin:{coin}"
+
+    if proof_type == "node_rpc":
+        ok, details, err = verify_ergo_node_rpc(evidence)
+    elif proof_type == "pool":
+        ok, details, err = verify_ergo_pool(evidence)
+    else:
+        return False, {}, f"unsupported_proof_type:{proof_type}"
+
+    if not ok:
+        return False, details, err
+
+    result = {
+        "coin": coin,
+        "proof_type": proof_type,
+        "verified": True,
+        "details": details,
+        "miner_id": miner_id,
+    }
+    return True, result, ""

--- a/node/tests/test_pow_proof_validation.py
+++ b/node/tests/test_pow_proof_validation.py
@@ -1,0 +1,43 @@
+import unittest
+from unittest.mock import patch
+
+import pow_proof
+
+
+class TestPowProofValidation(unittest.TestCase):
+    @patch('pow_proof.verify_ergo_node_rpc')
+    def test_ergo_node_rpc_success(self, mock_verify):
+        mock_verify.return_value = (True, {"height": 123, "isMining": True}, "")
+        ok, res, err = pow_proof.validate_pow_proof({
+            "coin": "ergo",
+            "proof_type": "node_rpc",
+            "evidence": {"endpoint": "http://127.0.0.1:9053/info"}
+        }, miner_id="m1")
+        self.assertTrue(ok)
+        self.assertEqual(err, "")
+        self.assertTrue(res.get("verified"))
+
+    @patch('pow_proof.verify_ergo_pool')
+    def test_ergo_pool_failure(self, mock_verify):
+        mock_verify.return_value = (False, {}, "ergo_pool_no_hashrate")
+        ok, res, err = pow_proof.validate_pow_proof({
+            "coin": "ergo",
+            "proof_type": "pool",
+            "evidence": {"pool_api_url": "https://example.com/api"}
+        }, miner_id="m2")
+        self.assertFalse(ok)
+        self.assertEqual(err, "ergo_pool_no_hashrate")
+
+    def test_reject_unsupported_coin(self):
+        ok, _, err = pow_proof.validate_pow_proof({"coin": "kaspa", "proof_type": "node_rpc"}, miner_id="m3")
+        self.assertFalse(ok)
+        self.assertIn("unsupported_coin", err)
+
+    def test_reject_missing_fields(self):
+        ok, _, err = pow_proof.validate_pow_proof({"coin": "ergo"}, miner_id="m4")
+        self.assertFalse(ok)
+        self.assertEqual(err, "missing_proof_type")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
Focused resubmission for dual-mining PoW validation with no unrelated scaffolds.

## Scope (only requested files/areas)
- `node/pow_proof.py`
- `node/pow_adapters.py`
- `node/tests/test_pow_proof_validation.py`
- `submit_attestation` integration in `node/rustchain_v2_integrated_v2.2.1_rip200.py`

## What changed
- Added server-side PoW validation entrypoint (`validate_pow_proof`) with focused support for **Ergo**.
- Added actual verification adapters:
  - Ergo node RPC verification (`localhost:9053/info` style endpoint)
  - Ergo pool verification (hashrate + miner presence checks)
- Integrated verification into `/attest/submit`:
  - if `pow_proof` is present, server verifies it
  - invalid/forged claims are rejected with `POW_PROOF_INVALID`
  - accepted response includes `pow_verified` + `pow_result`
- Added unit tests for success/failure/unsupported paths.

## Why
This removes trust in client-declared `proof_type` and enforces server-side evidence checks.

## Validation
- `python3 -m py_compile node/pow_adapters.py node/pow_proof.py node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_pow_proof_validation.py`
- `PYTHONPATH=/root/bounty/Rustchain/node python3 -m unittest -v node/tests/test_pow_proof_validation.py`
