### PR TITLE
fix: update HTTP links to HTTPS for security

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -338,7 +338,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 - **Documentation:** https://github.com/Scottcjn/Rustchain
 - **Issues:** https://github.com/Scottcjn/Rustchain/issues
-- **Explorer:** http://50.28.86.131/explorer
+- **Explorer:** https://50.28.86.131/explorer
 - **Bounties:** https://github.com/Scottcjn/rustchain-bounties
 
 ## Security Notes

--- a/docs/US_REGULATORY_POSITION.md
+++ b/docs/US_REGULATORY_POSITION.md
@@ -143,4 +143,4 @@ Representative public statements:
 
 This document represents Elyan Labs' analysis of RTC's regulatory status based on publicly available legal frameworks. It is not legal advice. For a formal legal opinion, consult a qualified securities attorney.
 
-**Contact**: scott@elyanlabs.ai | [rustchain.org](http://rustchain.org) | [@RustchainPOA](https://x.com/RustchainPOA)
+**Contact**: scott@elyanlabs.ai | [rustchain.org](https://rustchain.org) | [@RustchainPOA](https://x.com/RustchainPOA)


### PR DESCRIPTION
## Summary

Updates HTTP links to HTTPS for improved security.

## Changes

- INSTALL.md: Explorer URL (http:// → https://)
- docs/US_REGULATORY_POSITION.md: rustchain.org link (http:// → https://)

## Testing

- Verified both URLs support HTTPS
- Links now use encrypted connections

This is a minor security improvement ensuring users access the explorer and website over secure connections.