### PR TITLE
feat: Prometheus Metrics Exporter + Grafana Dashboard (40 RTC)

### DIFF
--- a/tools/prometheus/Dockerfile
+++ b/tools/prometheus/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY rustchain_exporter.py .
+
+ENV RUSTCHAIN_NODE_URL=http://localhost:8080
+ENV EXPORTER_PORT=9100
+ENV SCRAPE_INTERVAL=60
+
+EXPOSE 9100
+
+CMD ["python3", "rustchain_exporter.py"]

--- a/tools/prometheus/README.md
+++ b/tools/prometheus/README.md
@@ -1,0 +1,79 @@
+# RustChain Prometheus Exporter
+
+Prometheus metrics exporter for RustChain node monitoring.
+
+## Quick Start
+
+```bash
+# Install dependencies
+cd tools/prometheus
+pip install -r requirements.txt
+
+# Run exporter
+export RUSTCHAIN_NODE_URL="http://localhost:8080"
+python3 rustchain_exporter.py
+```
+
+## Configuration
+
+Environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUSTCHAIN_NODE_URL` | `http://localhost:8080` | RustChain node URL |
+| `EXPORTER_PORT` | `9100` | Prometheus exporter port |
+| `SCRAPE_INTERVAL` | `60` | Scrape interval in seconds |
+
+## Metrics
+
+- `rustchain_node_up` - Node health status
+- `rustchain_node_uptime_seconds` - Node uptime
+- `rustchain_active_miners_total` - Active miners count
+- `rustchain_enrolled_miners_total` - Enrolled miners count
+- `rustchain_miner_last_attest_timestamp` - Last attestation per miner
+- `rustchain_current_epoch` - Current epoch
+- `rustchain_current_slot` - Current slot
+- `rustchain_epoch_slot_progress` - Epoch progress (0-1)
+- `rustchain_epoch_seconds_remaining` - Seconds remaining in epoch
+- `rustchain_balance_rtc` - Miner balances
+- `rustchain_total_machines` - Hall of Fame machines
+- `rustchain_total_attestations` - Total attestations
+- `rustchain_oldest_machine_year` - Oldest machine year
+- `rustchain_highest_rust_score` - Highest rust score
+- `rustchain_total_fees_collected_rtc` - Total fees collected
+- `rustchain_fee_events_total` - Total fee events
+
+## Systemd Installation
+
+```bash
+sudo cp rustchain-exporter.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable rustchain-exporter
+sudo systemctl start rustchain-exporter
+```
+
+## Docker Compose (Bonus)
+
+```yaml
+version: '3.8'
+services:
+  rustchain-exporter:
+    build: .
+    ports:
+      - "9100:9100"
+    environment:
+      - RUSTCHAIN_NODE_URL=http://node:8080
+      - EXPORTER_PORT=9100
+
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+```

--- a/tools/prometheus/docker-compose.yml
+++ b/tools/prometheus/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.8'
+
+services:
+  rustchain-exporter:
+    image: python:3.11-slim
+    container_name: rustchain-exporter
+    working_dir: /app
+    volumes:
+      - ./rustchain_exporter.py:/app/rustchain_exporter.py:ro
+      - ./requirements.txt:/app/requirements.txt:ro
+    environment:
+      - RUSTCHAIN_NODE_URL=http://host.docker.internal:8080
+      - EXPORTER_PORT=9100
+      - SCRAPE_INTERVAL=60
+    ports:
+      - "9100:9100"
+    command: >
+      sh -c "pip install --no-cache-dir -r requirements.txt &&
+             python3 rustchain_exporter.py"
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana-provisioning:/etc/grafana/provisioning:ro
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - rustchain-exporter
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/tools/prometheus/grafana-dashboard.json
+++ b/tools/prometheus/grafana-dashboard.json
@@ -1,0 +1,183 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [{"options": {"0": {"text": "DOWN"}, "1": {"text": "UP"}},"type": "value"}],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "red", "value": null}, {"color": "green", "value": 1}]}
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 0},
+      "id": 1,
+      "options": {"colorMode": "background", "graphMode": "none", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_node_up", "refId": "A"}],
+      "title": "Node Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "s"
+        }
+      },
+      "gridPos": {"h": 4, "w": 9, "x": 6, "y": 0},
+      "id": 2,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [{"expr": "rustchain_node_uptime_seconds", "legendFormat": "Uptime", "refId": "A"}],
+      "title": "Node Uptime",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 9, "x": 15, "y": 0},
+      "id": 3,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_current_epoch", "refId": "A"}],
+      "title": "Current Epoch",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 0, "y": 4},
+      "id": 4,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "targets": [{"expr": "rustchain_active_miners_total", "legendFormat": "Active", "refId": "A"}, {"expr": "rustchain_enrolled_miners_total", "legendFormat": "Enrolled", "refId": "B"}],
+      "title": "Miners",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {"axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz": false}, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "never", "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle": {"mode": "off"}},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "green", "value": null}]},
+          "unit": "percentunit"
+        }
+      },
+      "gridPos": {"h": 5, "w": 12, "x": 12, "y": 4},
+      "id": 5,
+      "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false}, "tooltip": {"mode": "single", "sort": "none"}},
+      "targets": [{"expr": "rustchain_epoch_slot_progress", "legendFormat": "Progress", "refId": "A"}],
+      "title": "Epoch Progress",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "blue", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "y": 9},
+      "id": 6,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_total_machines", "refId": "A"}],
+      "title": "Total Machines (HoF)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "purple", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 9},
+      "id": 7,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_total_attestations", "refId": "A"}],
+      "title": "Total Attestations",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "orange", "value": null}]},
+          "unit": "short"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 9},
+      "id": 8,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_highest_rust_score", "refId": "A"}],
+      "title": "Highest Rust Score",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {"mode": "absolute", "steps": [{"color": "yellow", "value": null}]},
+          "unit": "rtc"
+        }
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 9},
+      "id": 9,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto"},
+      "targets": [{"expr": "rustchain_total_fees_collected_rtc", "refId": "A"}],
+      "title": "Total Fees (RTC)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["rustchain", "monitoring"],
+  "templating": {"list": []},
+  "time": {"from": "now-1h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "RustChain Node Dashboard",
+  "uid": "rustchain-node",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tools/prometheus/prometheus.yml
+++ b/tools/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 60s
+
+scrape_configs:
+  - job_name: 'rustchain-exporter'
+    static_configs:
+      - targets: ['rustchain-exporter:9100']

--- a/tools/prometheus/requirements.txt
+++ b/tools/prometheus/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_client>=0.19.0
+requests>=2.31.0

--- a/tools/prometheus/rustchain-exporter.service
+++ b/tools/prometheus/rustchain-exporter.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=RustChain Prometheus Metrics Exporter
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/rustchain-exporter
+Environment=RUSTCHAIN_NODE_URL=http://localhost:8080
+Environment=EXPORTER_PORT=9100
+Environment=SCRAPE_INTERVAL=60
+ExecStart=/usr/bin/python3 /opt/rustchain-exporter/rustchain_exporter.py
+Restart=always
+RestartSec=10
+
+# Security hardening
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/rustchain-exporter
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+RustChain Prometheus Metrics Exporter
+
+Scraps RustChain node API and exposes metrics for Prometheus/Grafana monitoring.
+
+Usage:
+    export RUSTCHAIN_NODE_URL="http://localhost:8080"
+    python3 rustchain_exporter.py
+
+Metrics exposed on http://localhost:9100/metrics
+"""
+
+import os
+import time
+import logging
+from typing import Optional
+
+import requests
+from prometheus_client import start_http_server, Gauge, Counter, Info
+from prometheus_client.core import REGISTRY
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Configuration
+RUSTCHAIN_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "http://localhost:8080")
+SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
+PORT = int(os.getenv("EXPORTER_PORT", "9100"))
+
+# Prometheus metrics
+NODE_UP = Gauge("rustchain_node_up", "Node health status", ["version"])
+NODE_UPTIME = Gauge("rustchain_node_uptime_seconds", "Node uptime in seconds")
+
+ACTIVE_MINERS = Gauge("rustchain_active_miners_total", "Number of active miners")
+ENROLLED_MINERS = Gauge("rustchain_enrolled_miners_total", "Number of enrolled miners")
+MINER_LAST_ATTEST = Gauge("rustchain_miner_last_attest_timestamp", "Miner last attestation timestamp", ["miner", "arch"])
+
+CURRENT_EPOCH = Gauge("rustchain_current_epoch", "Current epoch number")
+CURRENT_SLOT = Gauge("rustchain_current_slot", "Current slot number")
+EPOCH_SLOT_PROGRESS = Gauge("rustchain_epoch_slot_progress", "Epoch progress (0-1)")
+EPOCH_SECONDS_REMAINING = Gauge("rustchain_epoch_seconds_remaining", "Seconds remaining in epoch")
+
+BALANCE_RTC = Gauge("rustchain_balance_rtc", "Miner balance in RTC", ["miner"])
+
+TOTAL_MACHINES = Gauge("rustchain_total_machines", "Total machines in Hall of Fame")
+TOTAL_ATTESTATIONS = Gauge("rustchain_total_attestations", "Total attestations")
+OLDEST_MACHINE_YEAR = Gauge("rustchain_oldest_machine_year", "Oldest machine year")
+HIGHEST_RUST_SCORE = Gauge("rustchain_highest_rust_score", "Highest rust score")
+
+TOTAL_FEES_RTC = Gauge("rustchain_total_fees_collected_rtc", "Total fees collected in RTC")
+FEE_EVENTS_TOTAL = Gauge("rustchain_fee_events_total", "Total fee events")
+
+SCRAPES_TOTAL = Counter("rustchain_exporter_scrapes_total", "Total number of scrapes")
+SCRAPE_ERRORS = Counter("rustchain_exporter_scrapes_errors_total", "Total number of scrape errors")
+
+NODE_INFO = Info("rustchain_node", "Node information")
+
+
+def get_json(endpoint: str, timeout: int = 10) -> Optional[dict]:
+    """Fetch JSON from RustChain node API."""
+    url = f"{RUSTCHAIN_NODE_URL}{endpoint}"
+    try:
+        resp = requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as e:
+        logger.error(f"Failed to fetch {endpoint}: {e}")
+        SCRAPE_ERRORS.inc()
+        return None
+
+
+def scrape_metrics():
+    """Scrape all metrics from RustChain node."""
+    SCRAPES_TOTAL.inc()
+    
+    # Node health
+    health = get_json("/health")
+    if health:
+        version = health.get("version", "unknown")
+        NODE_UP.labels(version=version).set(1)
+        uptime = health.get("uptime", 0)
+        NODE_UPTIME.set(uptime)
+        NODE_INFO.info({
+            "version": version,
+            "status": health.get("status", "unknown")
+        })
+    
+    # Epoch info
+    epoch = get_json("/epoch")
+    if epoch:
+        CURRENT_EPOCH.set(epoch.get("current_epoch", 0))
+        CURRENT_SLOT.set(epoch.get("current_slot", 0))
+        progress = epoch.get("epoch_slot_progress", 0)
+        EPOCH_SLOT_PROGRESS.set(progress)
+        remaining = epoch.get("epoch_seconds_remaining", 0)
+        EPOCH_SECONDS_REMAINING.set(remaining)
+    
+    # Miners
+    miners = get_json("/api/miners")
+    if miners:
+        active = miners.get("active_miners", [])
+        enrolled = miners.get("enrolled_miners", [])
+        ACTIVE_MINERS.set(len(active))
+        ENROLLED_MINERS.set(len(enrolled))
+        
+        for miner in enrolled:
+            miner_id = miner.get("miner_id", miner.get("miner", "unknown"))
+            arch = miner.get("arch", "unknown")
+            last_attest = miner.get("last_attest_timestamp", 0)
+            if last_attest:
+                MINER_LAST_ATTEST.labels(miner=miner_id, arch=arch).set(last_attest)
+    
+    # Hall of Fame
+    hof = get_json("/api/hall_of_fame")
+    if hof:
+        TOTAL_MACHINES.set(hof.get("total_machines", 0))
+        TOTAL_ATTESTATIONS.set(hof.get("total_attestations", 0))
+        OLDEST_MACHINE_YEAR.set(hof.get("oldest_machine_year", 0))
+        HIGHEST_RUST_SCORE.set(hof.get("highest_rust_score", 0))
+    
+    # Fee pool
+    fees = get_json("/api/fee_pool")
+    if fees:
+        TOTAL_FEES_RTC.set(fees.get("total_fees_collected_rtc", 0))
+        FEE_EVENTS_TOTAL.set(fees.get("fee_events_total", 0))
+    
+    # Stats
+    stats = get_json("/api/stats")
+    if stats:
+        for miner, balance in stats.get("top_balances", {}).items():
+            BALANCE_RTC.labels(miner=miner).set(balance)
+
+
+def main():
+    """Main entry point."""
+    logger.info(f"Starting RustChain exporter on port {PORT}")
+    logger.info(f"Node URL: {RUSTCHAIN_NODE_URL}")
+    logger.info(f"Scrape interval: {SCRAPE_INTERVAL}s")
+    
+    start_http_server(PORT)
+    logger.info(f"HTTP server started on port {PORT}")
+    
+    while True:
+        scrape_metrics()
+        time.sleep(SCRAPE_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements Prometheus metrics exporter for RustChain node monitoring (Bounty #504).

### Files Added

| File | Description |
|------|-------------|
| `tools/prometheus/rustchain_exporter.py` | Main exporter script |
| `tools/prometheus/requirements.txt` | Python dependencies |
| `tools/prometheus/rustchain-exporter.service` | Systemd unit |
| `tools/prometheus/grafana-dashboard.json` | Pre-built Grafana dashboard |
| `tools/prometheus/docker-compose.yml` | Full monitoring stack |
| `tools/prometheus/Dockerfile` | Containerized exporter |
| `tools/prometheus/prometheus.yml` | Prometheus config |
| `tools/prometheus/README.md` | Documentation |

### Metrics Exported

- Node health & uptime
- Active/enrolled miners count
- Miner last attestation timestamps
- Current epoch & slot
- Epoch progress
- Hall of Fame stats (machines, attestations, rust score)
- Fee pool data
- Top miner balances

### Usage

```bash
cd tools/prometheus
pip install -r requirements.txt
export RUSTCHAIN_NODE_URL=http://localhost:8080
python3 rustchain_exporter.py
```

Metrics available at `http://localhost:9100/metrics`

### Bonus Completed

- [x] Grafana dashboard JSON
- [x] Docker compose file
- [x] Systemd service file

### Wallet

RTC wallet: larryjiang-openclaw

---

Closes #504