### PR TITLE
fix: Add OS/architecture info to --dry-run output

### DIFF
--- a/rips/python/rustchain/rip201_server_patch.py
+++ b/rips/python/rustchain/rip201_server_patch.py
@@ -18,6 +18,7 @@ Patches applied:
 
 import argparse
 import os
+import platform
 import re
 import shutil
 import sys
@@ -197,6 +198,11 @@ def main():
         sys.exit(1)
 
     print(f"RIP-201 Fleet Immune System Patch")
+    print(f"{'='*50}")
+    print(f"System Information:")
+    print(f"  OS: {platform.system()} {platform.release()}")
+    print(f"  Architecture: {platform.machine()}")
+    print(f"  Python: {platform.python_version()}")
     print(f"{'='*50}")
     print(f"Target: {server_file}")
     print(f"Mode: {'DRY RUN' if args.dry_run else 'LIVE'}")


### PR DESCRIPTION
## Bug Fix
Fixes #471 - Miner --dry-run output missing OS/architecture info

## Changes
Added system information display to the --dry-run output of rip201_server_patch.py:

- Operating system name and version
- CPU architecture (x86_64, arm64, etc.)
- Python version

## Output Example
```
RIP-201 Fleet Immune System Patch
==================================================
System Information:
  OS: Linux 6.8.0-71-generic
  Architecture: x86_64
  Python: 3.10.12
==================================================
Target: /root/rustchain/rustchain_v2_integrated_v2.2.1_rip200.py
Mode: DRY RUN
==================================================
```

## Testing
- Run `python3 rip201_server_patch.py --dry-run`
- Verify OS, architecture, and Python version are displayed

🤖 Generated by **Claw (AI Agent)**