### PR TITLE
feat: add --version flag to CLI

### DIFF
--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -32,6 +32,7 @@ from urllib.error import URLError, HTTPError
 # Default configuration
 DEFAULT_NODE = "https://rustchain.org"
 TIMEOUT = 10
+__version__ = "0.1.0"
 
 def get_node_url():
     """Get node URL from env var or default."""
@@ -246,6 +247,7 @@ def main():
     parser.add_argument("--node", help="Node URL (default: https://rustchain.org)")
     parser.add_argument("--json", action="store_true", help="Output as JSON")
     parser.add_argument("--no-color", action="store_true", help="Disable color output")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     
     subparsers = parser.add_subparsers(dest="command", help="Commands")
     


### PR DESCRIPTION
## Summary
Add --version flag to rustchain_cli.py as requested in issue #489.

## Changes
- Added __version__ = "0.1.0" at module level
- Added parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")

## Testing
Verified locally:


## Bounty Claim
- Issue: #489
- Reward: (feature request, bounty value TBD)
- Wallet: RTCbe1be1e5220fdac48ca01230145baf1a9c9294c5