### PR TITLE
feat(wallet): add rustchain-wallet CLI for headless RTC management (bounty #39)

### DIFF
--- a/docs/WALLET_CLI_COMPATIBILITY_39.md
+++ b/docs/WALLET_CLI_COMPATIBILITY_39.md
@@ -1,0 +1,57 @@
+# Wallet CLI Compatibility Notes (Issue #39)
+
+This note documents format compatibility and cross-platform validation for the RustChain Wallet CLI.
+
+## Keystore compatibility
+
+CLI keystore output fields:
+- `version`
+- `name`
+- `address`
+- `public_key_hex`
+- `mnemonic_words`
+- `crypto`:
+  - `cipher: AES-256-GCM`
+  - `kdf: PBKDF2-HMAC-SHA256`
+  - `kdf_iterations: 100000`
+  - `salt_b64`
+  - `nonce_b64`
+  - `ciphertext_b64`
+
+Backward-compatible decryption aliases supported by the CLI loader:
+- `salt_b64` or `salt`
+- `nonce_b64` or `nonce` or `iv_b64` or `iv`
+- `ciphertext_b64` or `ciphertext` or `encrypted_private_key`
+- `kdf_iterations` or `iterations` or `pbkdf2_iterations`
+
+This allows the CLI to read equivalent legacy JSON key names while preserving modern output format.
+
+## Signature payload compatibility
+
+Signed transfer payload uses:
+- `from_address`
+- `to_address`
+- `amount_rtc`
+- `nonce`
+- `memo`
+- `public_key`
+- `signature`
+
+Signature is Ed25519 over canonical JSON message:
+
+```json
+{"amount":<float>,"from":"<RTC...>","memo":"...","nonce":"<nonce>","to":"<RTC...>"}
+```
+
+This matches `/wallet/transfer/signed` server-side verification pattern.
+
+## Validation summary
+
+Local (macOS):
+- `python3 -m pytest -q tests/test_wallet_cli_39.py` -> passed
+- `python3 tools/rustchain_wallet_cli.py epoch` -> success
+- `python3 tools/rustchain_wallet_cli.py miners` -> success
+- `python3 tools/rustchain_wallet_cli.py balance <wallet>` -> success
+
+Remote (Linux, HK machine):
+- same test command and CLI command smoke checks executed successfully.

--- a/docs/WALLET_CLI_PREVIEW_39.md
+++ b/docs/WALLET_CLI_PREVIEW_39.md
@@ -1,0 +1,42 @@
+# RustChain Wallet CLI (Preview for bounty #39)
+
+This draft adds a headless wallet tool:
+
+- `rustchain-wallet create`
+- `rustchain-wallet import <mnemonic>`
+- `rustchain-wallet export <wallet-name>`
+- `rustchain-wallet balance <wallet-address>`
+- `rustchain-wallet send <to> <amount> --from <wallet-name>`
+- `rustchain-wallet history <wallet-address>`
+- `rustchain-wallet miners`
+- `rustchain-wallet epoch`
+
+## Paths
+
+- CLI implementation: `tools/rustchain_wallet_cli.py`
+- Command wrapper: `scripts/rustchain-wallet`
+- Keystore dir: `~/.rustchain/wallets/`
+
+## Security / format notes
+
+- Private keys are encrypted with **AES-256-GCM**
+- KDF: **PBKDF2-HMAC-SHA256** with **100,000 iterations**
+- Address derivation: `RTC` + `SHA256(pubkey)[:40]`
+- Transfer signing: Ed25519 over canonical payload used by `/wallet/transfer/signed`
+
+## Dependency
+
+Install BIP39 helper once:
+
+```bash
+python3 -m pip install mnemonic
+```
+
+## Quick smoke test
+
+```bash
+scripts/rustchain-wallet create --name demo
+scripts/rustchain-wallet export demo
+scripts/rustchain-wallet epoch
+scripts/rustchain-wallet miners
+```

--- a/scripts/rustchain-wallet
+++ b/scripts/rustchain-wallet
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+python3 "$(cd "$(dirname "$0")/.." && pwd)/tools/rustchain_wallet_cli.py" "$@"

--- a/tests/test_wallet_cli_39.py
+++ b/tests/test_wallet_cli_39.py
@@ -9,6 +9,19 @@ def test_encrypt_decrypt_roundtrip():
     assert out == priv
 
 
+def test_decrypt_compat_alias_fields():
+    priv = "22" * 32
+    enc = cli._encrypt_private_key(priv, "pw456")
+    legacy = {
+        "salt": enc["salt_b64"],
+        "nonce": enc["nonce_b64"],
+        "encrypted_private_key": enc["ciphertext_b64"],
+        "iterations": enc["kdf_iterations"],
+    }
+    out = cli._decrypt_private_key(legacy, "pw456")
+    assert out == priv
+
+
 def test_address_format_from_pubkey():
     pub = "22" * 32
     addr = cli._address_from_pubkey_hex(pub)

--- a/tests/test_wallet_cli_39.py
+++ b/tests/test_wallet_cli_39.py
@@ -1,0 +1,34 @@
+import json
+from tools import rustchain_wallet_cli as cli
+
+
+def test_encrypt_decrypt_roundtrip():
+    priv = "11" * 32
+    enc = cli._encrypt_private_key(priv, "pw123")
+    out = cli._decrypt_private_key(enc, "pw123")
+    assert out == priv
+
+
+def test_address_format_from_pubkey():
+    pub = "22" * 32
+    addr = cli._address_from_pubkey_hex(pub)
+    assert addr.startswith("RTC")
+    assert len(addr) == 43
+
+
+def test_sign_transfer_shape():
+    # deterministic private key bytes for test
+    priv = "01" * 32
+    tx = cli._sign_transfer(priv, "RTC" + "a" * 40, "RTC" + "b" * 40, 1.23, "m", 123)
+    assert tx["from_address"].startswith("RTC")
+    assert tx["to_address"].startswith("RTC")
+    assert tx["amount_rtc"] == 1.23
+    assert isinstance(tx["signature"], str) and len(tx["signature"]) > 20
+    assert isinstance(tx["public_key"], str) and len(tx["public_key"]) == 64
+
+
+def test_balance_normalization():
+    payload = {"balance_rtc": 9.5}
+    if "amount_rtc" not in payload and "balance_rtc" in payload:
+        payload["amount_rtc"] = payload.get("balance_rtc")
+    assert payload["amount_rtc"] == 9.5

--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -86,11 +86,31 @@ def _encrypt_private_key(priv_hex: str, password: str) -> dict:
     }
 
 
+def _pick(enc: dict, *names: str):
+    for n in names:
+        if n in enc and enc[n] not in (None, ""):
+            return enc[n]
+    return None
+
+
 def _decrypt_private_key(enc: dict, password: str) -> str:
-    salt = base64.b64decode(enc["salt_b64"])
-    nonce = base64.b64decode(enc["nonce_b64"])
-    ct = base64.b64decode(enc["ciphertext_b64"])
-    key = _pbkdf2_key(password, salt, int(enc.get("kdf_iterations", 100000)))
+    """Decrypt keystore payload with compatibility aliases.
+
+    Supports current keys (salt_b64/nonce_b64/ciphertext_b64) and common
+    legacy aliases (salt, nonce, ciphertext, encrypted_private_key).
+    """
+    salt_s = _pick(enc, "salt_b64", "salt")
+    nonce_s = _pick(enc, "nonce_b64", "nonce", "iv_b64", "iv")
+    ct_s = _pick(enc, "ciphertext_b64", "ciphertext", "encrypted_private_key")
+    if not (salt_s and nonce_s and ct_s):
+        raise ValueError("Unsupported keystore crypto format")
+
+    salt = base64.b64decode(salt_s)
+    nonce = base64.b64decode(nonce_s)
+    ct = base64.b64decode(ct_s)
+
+    iterations = int(_pick(enc, "kdf_iterations", "iterations", "pbkdf2_iterations") or 100000)
+    key = _pbkdf2_key(password, salt, iterations)
     aes = AESGCM(key)
     pt = aes.decrypt(nonce, ct, None)
     if len(pt) != 32:

--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""RustChain Wallet CLI (draft for bounty #39).
+
+Commands:
+  rustchain-wallet create
+  rustchain-wallet import <mnemonic>
+  rustchain-wallet export <wallet_name>
+  rustchain-wallet balance <wallet_address>
+  rustchain-wallet send <to> <amount> --from <wallet_name>
+  rustchain-wallet history <wallet_address>
+  rustchain-wallet miners
+  rustchain-wallet epoch
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import getpass
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import sys
+import time
+from pathlib import Path
+from typing import Tuple
+
+import requests
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+try:
+    from mnemonic import Mnemonic
+except Exception:  # pragma: no cover
+    Mnemonic = None
+
+NODE_URL = os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")
+VERIFY_SSL = os.environ.get("RUSTCHAIN_VERIFY_SSL", "0") in {"1", "true", "True"}
+KEYSTORE_DIR = Path.home() / ".rustchain" / "wallets"
+KEYSTORE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _derive_ed25519_from_mnemonic(mnemonic_phrase: str, passphrase: str = "") -> Tuple[str, str]:
+    """Return (private_key_hex, public_key_hex) derived from BIP39 seed.
+
+    Uses BIP39 seed + SLIP10-style master key extraction for ed25519.
+    """
+    if Mnemonic is None:
+        raise RuntimeError("Missing dependency: mnemonic. Install via `python3 -m pip install mnemonic`.")
+
+    m = Mnemonic("english")
+    if not m.check(mnemonic_phrase):
+        raise ValueError("Invalid BIP39 mnemonic")
+
+    seed = Mnemonic.to_seed(mnemonic_phrase, passphrase=passphrase)
+    i = hmac.new(b"ed25519 seed", seed, hashlib.sha512).digest()
+    sk = i[:32]
+    priv = Ed25519PrivateKey.from_private_bytes(sk)
+    pub = priv.public_key().public_bytes_raw().hex()
+    return sk.hex(), pub
+
+
+def _address_from_pubkey_hex(pub_hex: str) -> str:
+    return "RTC" + hashlib.sha256(bytes.fromhex(pub_hex)).hexdigest()[:40]
+
+
+def _pbkdf2_key(password: str, salt: bytes, iterations: int = 100_000) -> bytes:
+    return hashlib.pbkdf2_hmac("sha256", password.encode(), salt, iterations, dklen=32)
+
+
+def _encrypt_private_key(priv_hex: str, password: str) -> dict:
+    salt = secrets.token_bytes(16)
+    nonce = secrets.token_bytes(12)
+    key = _pbkdf2_key(password, salt)
+    aes = AESGCM(key)
+    ct = aes.encrypt(nonce, bytes.fromhex(priv_hex), None)
+    return {
+        "cipher": "AES-256-GCM",
+        "kdf": "PBKDF2-HMAC-SHA256",
+        "kdf_iterations": 100000,
+        "salt_b64": base64.b64encode(salt).decode(),
+        "nonce_b64": base64.b64encode(nonce).decode(),
+        "ciphertext_b64": base64.b64encode(ct).decode(),
+    }
+
+
+def _decrypt_private_key(enc: dict, password: str) -> str:
+    salt = base64.b64decode(enc["salt_b64"])
+    nonce = base64.b64decode(enc["nonce_b64"])
+    ct = base64.b64decode(enc["ciphertext_b64"])
+    key = _pbkdf2_key(password, salt, int(enc.get("kdf_iterations", 100000)))
+    aes = AESGCM(key)
+    pt = aes.decrypt(nonce, ct, None)
+    if len(pt) != 32:
+        raise ValueError("Invalid private key length")
+    return pt.hex()
+
+
+def _keystore_path(name: str) -> Path:
+    safe = "".join(c for c in name if c.isalnum() or c in "-_.")
+    if not safe:
+        raise ValueError("Invalid wallet name")
+    return KEYSTORE_DIR / f"{safe}.json"
+
+
+def _load_keystore(name: str) -> dict:
+    p = _keystore_path(name)
+    if not p.exists():
+        raise FileNotFoundError(f"Keystore not found: {p}")
+    return json.loads(p.read_text())
+
+
+def _save_keystore(name: str, data: dict) -> Path:
+    p = _keystore_path(name)
+    p.write_text(json.dumps(data, indent=2))
+    return p
+
+
+
+
+def _read_password(prompt: str, env_key: str) -> str:
+    env_val = os.environ.get(env_key)
+    if env_val:
+        return env_val
+    return getpass.getpass(prompt)
+
+def _sign_transfer(priv_hex: str, from_addr: str, to_addr: str, amount_rtc: float, memo: str, nonce: int) -> dict:
+    tx_data = {
+        "from": from_addr,
+        "to": to_addr,
+        "amount": amount_rtc,
+        "memo": memo,
+        "nonce": str(nonce),
+    }
+    message = json.dumps(tx_data, sort_keys=True, separators=(",", ":")).encode()
+    priv = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(priv_hex))
+    sig_hex = priv.sign(message).hex()
+    pub_hex = priv.public_key().public_bytes_raw().hex()
+    return {
+        "from_address": from_addr,
+        "to_address": to_addr,
+        "amount_rtc": amount_rtc,
+        "nonce": nonce,
+        "memo": memo,
+        "public_key": pub_hex,
+        "signature": sig_hex,
+    }
+
+
+def cmd_create(args):
+    if Mnemonic is None:
+        print("Error: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
+        return 2
+
+    wallet_name = args.name or f"wallet-{int(time.time())}"
+    password = _read_password("Set wallet password: ", "RUSTCHAIN_WALLET_PASSWORD")
+    confirm = _read_password("Confirm password: ", "RUSTCHAIN_WALLET_PASSWORD_CONFIRM")
+    if password != confirm:
+        print("Error: password mismatch", file=sys.stderr)
+        return 2
+
+    m = Mnemonic("english")
+    phrase = m.generate(strength=256)  # 24 words
+    priv_hex, pub_hex = _derive_ed25519_from_mnemonic(phrase)
+    address = _address_from_pubkey_hex(pub_hex)
+
+    ks = {
+        "version": 1,
+        "name": wallet_name,
+        "address": address,
+        "public_key_hex": pub_hex,
+        "mnemonic_words": 24,
+        "crypto": _encrypt_private_key(priv_hex, password),
+        "created_at": int(time.time()),
+    }
+    path = _save_keystore(wallet_name, ks)
+
+    print(f"Wallet created: {wallet_name}")
+    print(f"Address: {address}")
+    print(f"Keystore: {path}")
+    print("Seed phrase (write this down safely):")
+    print(phrase)
+    return 0
+
+
+def cmd_import(args):
+    if Mnemonic is None:
+        print("Error: missing dependency 'mnemonic'. Install: python3 -m pip install mnemonic", file=sys.stderr)
+        return 2
+
+    phrase = args.mnemonic.strip().lower()
+    wallet_name = args.name or f"imported-{int(time.time())}"
+    password = _read_password("Set wallet password: ", "RUSTCHAIN_WALLET_PASSWORD")
+    confirm = _read_password("Confirm password: ", "RUSTCHAIN_WALLET_PASSWORD_CONFIRM")
+    if password != confirm:
+        print("Error: password mismatch", file=sys.stderr)
+        return 2
+
+    priv_hex, pub_hex = _derive_ed25519_from_mnemonic(phrase)
+    address = _address_from_pubkey_hex(pub_hex)
+    ks = {
+        "version": 1,
+        "name": wallet_name,
+        "address": address,
+        "public_key_hex": pub_hex,
+        "mnemonic_words": 24,
+        "crypto": _encrypt_private_key(priv_hex, password),
+        "created_at": int(time.time()),
+    }
+    path = _save_keystore(wallet_name, ks)
+    print(f"Wallet imported: {wallet_name}")
+    print(f"Address: {address}")
+    print(f"Keystore: {path}")
+    return 0
+
+
+def cmd_export(args):
+    ks = _load_keystore(args.wallet)
+    print(json.dumps(ks, indent=2))
+    return 0
+
+
+def cmd_balance(args):
+    url = f"{NODE_URL}/wallet/balance"
+    r = requests.get(url, params={"miner_id": args.wallet_id}, timeout=12, verify=VERIFY_SSL)
+    data = r.json()
+    if isinstance(data, dict):
+        if "amount_rtc" not in data and "balance_rtc" in data:
+            data["amount_rtc"] = data.get("balance_rtc")
+        data["wallet_id"] = args.wallet_id
+    print(json.dumps(data, indent=2))
+    return 0
+
+
+def cmd_send(args):
+    ks = _load_keystore(args.from_wallet)
+    password = _read_password("Wallet password: ", "RUSTCHAIN_WALLET_PASSWORD")
+    priv_hex = _decrypt_private_key(ks["crypto"], password)
+    from_addr = ks["address"]
+    nonce = int(time.time())
+    payload = _sign_transfer(priv_hex, from_addr, args.to, float(args.amount), args.memo or "", nonce)
+
+    url = f"{NODE_URL}/wallet/transfer/signed"
+    r = requests.post(url, json=payload, timeout=20, verify=VERIFY_SSL)
+    print(json.dumps(r.json(), indent=2))
+    return 0 if r.ok else 1
+
+
+def cmd_history(args):
+    url = f"{NODE_URL}/wallet/ledger"
+    r = requests.get(url, params={"miner_id": args.wallet_id}, timeout=12, verify=VERIFY_SSL)
+    data = r.json()
+    if isinstance(data, list):
+        data = {"wallet_id": args.wallet_id, "transactions": data}
+    print(json.dumps(data, indent=2))
+    return 0
+
+
+def cmd_miners(args):
+    r = requests.get(f"{NODE_URL}/api/miners", timeout=12, verify=VERIFY_SSL)
+    print(json.dumps(r.json(), indent=2))
+    return 0
+
+
+def cmd_epoch(args):
+    r = requests.get(f"{NODE_URL}/epoch", timeout=12, verify=VERIFY_SSL)
+    print(json.dumps(r.json(), indent=2))
+    return 0
+
+
+def build_parser():
+    p = argparse.ArgumentParser(prog="rustchain-wallet", description="RustChain Wallet CLI")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    p_create = sub.add_parser("create", help="Generate new wallet (24-word mnemonic + encrypted keystore)")
+    p_create.add_argument("--name", help="Wallet name (default: wallet-<timestamp>)")
+    p_create.set_defaults(func=cmd_create)
+
+    p_import = sub.add_parser("import", help="Import wallet from 24-word mnemonic")
+    p_import.add_argument("mnemonic", help="Quoted 24-word seed phrase")
+    p_import.add_argument("--name", help="Wallet name")
+    p_import.set_defaults(func=cmd_import)
+
+    p_export = sub.add_parser("export", help="Export encrypted keystore JSON")
+    p_export.add_argument("wallet", help="Wallet name")
+    p_export.set_defaults(func=cmd_export)
+
+    p_balance = sub.add_parser("balance", help="Check wallet balance")
+    p_balance.add_argument("wallet_id", help="RTC wallet address")
+    p_balance.set_defaults(func=cmd_balance)
+
+    p_send = sub.add_parser("send", help="Send signed transfer")
+    p_send.add_argument("to", help="Recipient RTC address")
+    p_send.add_argument("amount", type=float, help="Amount in RTC")
+    p_send.add_argument("--from", dest="from_wallet", required=True, help="Local keystore wallet name")
+    p_send.add_argument("--memo", default="", help="Optional memo")
+    p_send.set_defaults(func=cmd_send)
+
+    p_hist = sub.add_parser("history", help="Wallet transaction history")
+    p_hist.add_argument("wallet_id", help="RTC wallet address")
+    p_hist.set_defaults(func=cmd_history)
+
+    p_miners = sub.add_parser("miners", help="List active miners")
+    p_miners.set_defaults(func=cmd_miners)
+
+    p_epoch = sub.add_parser("epoch", help="Show current epoch")
+    p_epoch.set_defaults(func=cmd_epoch)
+
+    return p
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR implements a headless RustChain wallet CLI for bounty #39 with encrypted local keystores and signed transfer support.

Implemented commands:
- rustchain-wallet create
- rustchain-wallet import <mnemonic>
- rustchain-wallet export <wallet-name>
- rustchain-wallet balance <wallet-address>
- rustchain-wallet send <to> <amount> --from <wallet-name>
- rustchain-wallet history <wallet-address>
- rustchain-wallet miners
- rustchain-wallet epoch

Security and compatibility details:
- Encrypted keystore stored in ~/.rustchain/wallets/
- AES-256-GCM keystore encryption
- PBKDF2-HMAC-SHA256 (100000 iterations)
- Ed25519 signed payload for /wallet/transfer/signed
- RTC address derivation: RTC + sha256(pubkey)[:40]
- Password input uses hidden prompt (getpass)

Files added:
- tools/rustchain_wallet_cli.py
- scripts/rustchain-wallet
- tests/test_wallet_cli_39.py
- docs/WALLET_CLI_PREVIEW_39.md

Validation run:
- python3 -m pytest -q tests/test_wallet_cli_39.py (4 passed)
- python3 tools/rustchain_wallet_cli.py epoch
- python3 tools/rustchain_wallet_cli.py miners
- python3 tools/rustchain_wallet_cli.py balance <wallet>

Payout wallet: RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35
