### PR TITLE
test: add Miner API tests (bounty #655)

### DIFF
--- a/tests/test_miner_api_v57.py
+++ b/tests/test_miner_api_v57.py
@@ -1,0 +1,94 @@
+"""
+Miner API Tests v57 (Bounty #655)
+
+Tests for Miner API endpoints on the RustChain node.
+Verifies implemented endpoints return valid responses and
+unimplemented endpoints correctly return 404.
+"""
+import pytest
+import requests
+
+# Base URL for the live RustChain node
+BASE_URL = "https://50.28.86.131"
+
+# Endpoints to test
+ENDPOINTS = {
+    "implemented": [
+        "/api/miners",
+    ],
+    "not_implemented": [
+        "/api/miner",
+        "/miner",
+        "/miners",
+        "/api/hashrate",
+        "/hashrate",
+        "/api/power",
+        "/power",
+    ]
+}
+
+
+class TestMinerAPI:
+    """Test class for Miner API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False  # Skip SSL verification for testing
+
+    def test_api_miners_returns_200(self):
+        """Test that /api/miners returns 200 OK."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+    def test_api_miners_returns_json(self):
+        """Test that /api/miners returns valid JSON."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list), "Response should be a list"
+
+    def test_api_miners_has_miner_data(self):
+        """Test that /api/miners returns miner data with expected fields."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        
+        if len(data) > 0:
+            miner = data[0]
+            # Check for expected fields in miner data
+            assert "miner" in miner, "Miner should have 'miner' field"
+            assert "antiquity_multiplier" in miner, "Miner should have 'antiquity_multiplier' field"
+            assert "hardware_type" in miner, "Miner should have 'hardware_type' field"
+
+    def test_api_miners_antiquity_multiplier_valid(self):
+        """Test that antiquity_multiplier is a valid positive number."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        
+        for miner in data:
+            mult = miner.get("antiquity_multiplier", 0)
+            assert mult > 0, f"antiquity_multiplier should be positive, got {mult}"
+
+
+class TestMinerAPINotImplemented:
+    """Test class for unimplemented Miner API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS["not_implemented"])
+    def test_endpoint_returns_404(self, endpoint):
+        """Test that unimplemented endpoints return 404."""
+        response = self.session.get(f"{BASE_URL}{endpoint}")
+        assert response.status_code == 404, \
+            f"Endpoint {endpoint} should return 404, got {response.status_code}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Adds comprehensive tests for Miner API endpoints.

## Changes
- Created `tests/test_miner_api_v57.py` with 11 tests
- Tests implemented endpoint `/api/miners` returns valid JSON
- Verifies miner data contains expected fields
- Confirms all unimplemented endpoints return 404

## Test Results
```
11 passed in 13.86s
```

## Endpoints Tested
| Endpoint | Status | Result |
|----------|--------|--------|
| /api/miners | OK | ✅ Returns valid miner list |
| /api/miner | 404 | ✅ Not implemented |
| /miner | 404 | ✅ Not implemented |
| /miners | 404 | ✅ Not implemented |
| /api/hashrate | 404 | ✅ Not implemented |
| /hashrate | 404 | ✅ Not implemented |
| /api/power | 404 | ✅ Not implemented |
| /power | 404 | ✅ Not implemented |

Addresses bounty: Scottcjn/rustchain-bounties#655