### PR TITLE
test: add Epoch/Attest API tests (bounty #656)

### DIFF
--- a/tests/test_epoch_attest_api_v58.py
+++ b/tests/test_epoch_attest_api_v58.py
@@ -1,0 +1,92 @@
+"""
+Epoch/Attest API Tests v58 (Bounty #656)
+
+Tests for Epoch and Attestation API endpoints on the RustChain node.
+Verifies implemented endpoints return valid responses and
+unimplemented endpoints correctly return 404.
+"""
+import pytest
+import requests
+
+# Base URL for the live RustChain node
+BASE_URL = "https://50.28.86.131"
+
+# Endpoints to test
+IMPLEMENTED_ENDPOINTS = [
+    "/epoch",
+]
+
+NOT_IMPLEMENTED_ENDPOINTS = [
+    "/api/epoch",
+    "/attest",
+    "/api/attest",
+    "/api/attestation",
+    "/attestation",
+    "/api/epoch/attest",
+    "/api/attest/epoch",
+]
+
+
+class TestEpochAPI:
+    """Test class for Epoch API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False
+
+    def test_epoch_returns_200(self):
+        """Test that /epoch returns 200 OK."""
+        response = self.session.get(f"{BASE_URL}/epoch")
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+    def test_epoch_returns_json(self):
+        """Test that /epoch returns valid JSON."""
+        response = self.session.get(f"{BASE_URL}/epoch")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict), "Response should be a JSON object"
+
+    def test_epoch_has_required_fields(self):
+        """Test that /epoch returns epoch data with expected fields."""
+        response = self.session.get(f"{BASE_URL}/epoch")
+        assert response.status_code == 200
+        data = response.json()
+        
+        # Check for expected fields
+        assert "epoch" in data, "Response should have 'epoch' field"
+        assert "slot" in data, "Response should have 'slot' field"
+
+    def test_epoch_values_are_valid(self):
+        """Test that epoch values are valid."""
+        response = self.session.get(f"{BASE_URL}/epoch")
+        assert response.status_code == 200
+        data = response.json()
+        
+        epoch = data.get("epoch", -1)
+        slot = data.get("slot", -1)
+        
+        assert epoch >= 0, f"Epoch should be non-negative, got {epoch}"
+        assert slot >= 0, f"Slot should be non-negative, got {slot}"
+
+
+class TestEpochAttestAPINotImplemented:
+    """Test class for unimplemented Epoch/Attest API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False
+
+    @pytest.mark.parametrize("endpoint", NOT_IMPLEMENTED_ENDPOINTS)
+    def test_endpoint_returns_404(self, endpoint):
+        """Test that unimplemented endpoints return 404."""
+        response = self.session.get(f"{BASE_URL}{endpoint}")
+        assert response.status_code == 404, \
+            f"Endpoint {endpoint} should return 404, got {response.status_code}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_miner_api_v57.py
+++ b/tests/test_miner_api_v57.py
@@ -1,0 +1,94 @@
+"""
+Miner API Tests v57 (Bounty #655)
+
+Tests for Miner API endpoints on the RustChain node.
+Verifies implemented endpoints return valid responses and
+unimplemented endpoints correctly return 404.
+"""
+import pytest
+import requests
+
+# Base URL for the live RustChain node
+BASE_URL = "https://50.28.86.131"
+
+# Endpoints to test
+ENDPOINTS = {
+    "implemented": [
+        "/api/miners",
+    ],
+    "not_implemented": [
+        "/api/miner",
+        "/miner",
+        "/miners",
+        "/api/hashrate",
+        "/hashrate",
+        "/api/power",
+        "/power",
+    ]
+}
+
+
+class TestMinerAPI:
+    """Test class for Miner API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False  # Skip SSL verification for testing
+
+    def test_api_miners_returns_200(self):
+        """Test that /api/miners returns 200 OK."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+    def test_api_miners_returns_json(self):
+        """Test that /api/miners returns valid JSON."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list), "Response should be a list"
+
+    def test_api_miners_has_miner_data(self):
+        """Test that /api/miners returns miner data with expected fields."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        
+        if len(data) > 0:
+            miner = data[0]
+            # Check for expected fields in miner data
+            assert "miner" in miner, "Miner should have 'miner' field"
+            assert "antiquity_multiplier" in miner, "Miner should have 'antiquity_multiplier' field"
+            assert "hardware_type" in miner, "Miner should have 'hardware_type' field"
+
+    def test_api_miners_antiquity_multiplier_valid(self):
+        """Test that antiquity_multiplier is a valid positive number."""
+        response = self.session.get(f"{BASE_URL}/api/miners")
+        assert response.status_code == 200
+        data = response.json()
+        
+        for miner in data:
+            mult = miner.get("antiquity_multiplier", 0)
+            assert mult > 0, f"antiquity_multiplier should be positive, got {mult}"
+
+
+class TestMinerAPINotImplemented:
+    """Test class for unimplemented Miner API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Setup for each test."""
+        self.session = requests.Session()
+        self.session.verify = False
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS["not_implemented"])
+    def test_endpoint_returns_404(self, endpoint):
+        """Test that unimplemented endpoints return 404."""
+        response = self.session.get(f"{BASE_URL}{endpoint}")
+        assert response.status_code == 404, \
+            f"Endpoint {endpoint} should return 404, got {response.status_code}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Adds comprehensive tests for Epoch and Attestation API endpoints.

## Changes
- Created `tests/test_epoch_attest_api_v58.py` with 11 tests
- Tests implemented endpoint `/epoch` returns valid JSON
- Verifies epoch data contains required fields
- Confirms all unimplemented endpoints return 404

## Test Results
```
11 passed in 13.35s
```

## Endpoints Tested
| Endpoint | Status | Result |
|----------|--------|--------|
| /epoch | OK | ✅ Returns valid epoch data |
| /api/epoch | 404 | ✅ Not implemented |
| /attest | 404 | ✅ Not implemented |
| /api/attest | 404 | ✅ Not implemented |
| /api/attestation | 404 | ✅ Not implemented |

Addresses bounty: Scottcjn/rustchain-bounties#656