### PR TITLE
test: save/restore coinbase_wallet.INSTALL_DIR in TestWalletFilePermissions

### DIFF
--- a/tests/test_wallet_coinbase_show.py
+++ b/tests/test_wallet_coinbase_show.py
@@ -191,6 +191,8 @@ class TestWalletFilePermissions(unittest.TestCase):
         """Set up test fixtures."""
         self.temp_dir = tempfile.mkdtemp()
         import coinbase_wallet
+        self.original_install_dir = coinbase_wallet.INSTALL_DIR
+        self.original_coinbase_file = coinbase_wallet.COINBASE_FILE
         coinbase_wallet.INSTALL_DIR = self.temp_dir
         coinbase_wallet.COINBASE_FILE = os.path.join(self.temp_dir, "coinbase_wallet.json")
 
@@ -198,7 +200,8 @@ class TestWalletFilePermissions(unittest.TestCase):
         """Clean up test fixtures."""
         import coinbase_wallet
         import shutil
-        coinbase_wallet.INSTALL_DIR = "/tmp/.clawrtc"  # Restore default
+        coinbase_wallet.INSTALL_DIR = self.original_install_dir
+        coinbase_wallet.COINBASE_FILE = self.original_coinbase_file
         if os.path.exists(self.temp_dir):
             shutil.rmtree(self.temp_dir)
 


### PR DESCRIPTION
Follow-up fix for PR #721 review note.

## Changes
- Add tests/test_wallet_coinbase_show.py with TestWalletFilePermissions class
- Use setUp/tearDown to save/restore coinbase_wallet.INSTALL_DIR instead of hardcoding /tmp/.clawrtc
- Test-only change, minimal scope

## Testing
- Both tests pass locally