### PR TITLE
fix: persist signed-transfer nonces and reject replay across restarts (#728)

### DIFF
--- a/rustchain-wallet/examples/storage_example.rs
+++ b/rustchain-wallet/examples/storage_example.rs
@@ -14,8 +14,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     
     println!("1. Initializing storage...");
     println!("   Storage path: {}\n", storage_path.display());
-    
-    let storage = WalletStorage::new(&storage_path);
+
+    let storage = WalletStorage::new(&storage_path)?;
 
     // Create and save multiple wallets
     println!("2. Creating and saving wallets...");

--- a/rustchain-wallet/src/bin/rtc_wallet.rs
+++ b/rustchain-wallet/src/bin/rtc_wallet.rs
@@ -194,12 +194,9 @@ async fn main() -> anyhow::Result<()> {
 
     // Get wallet storage
     let storage = if let Some(dir) = cli.wallet_dir {
-        WalletStorage::new(dir)
+        WalletStorage::new(dir)?
     } else {
-        WalletStorage::default().unwrap_or_else(|e| {
-            error!("Failed to initialize wallet storage: {}", e);
-            std::process::exit(1);
-        })
+        WalletStorage::default()?
     };
 
     // Execute command

--- a/rustchain-wallet/src/lib.rs
+++ b/rustchain-wallet/src/lib.rs
@@ -28,12 +28,14 @@ pub mod keys;
 pub mod storage;
 pub mod transaction;
 pub mod client;
+pub mod nonce_store;
 
 pub use error::{Result, WalletError};
 pub use keys::KeyPair;
 pub use storage::WalletStorage;
 pub use transaction::{Transaction, TransactionBuilder};
 pub use client::RustChainClient;
+pub use nonce_store::NonceStore;
 
 /// Main wallet structure
 #[derive(Clone)]

--- a/rustchain-wallet/src/nonce_store.rs
+++ b/rustchain-wallet/src/nonce_store.rs
@@ -1,0 +1,305 @@
+//! Nonce persistence and replay protection
+//!
+//! This module provides persistent storage of used nonces to prevent
+//! replay attacks across application restarts.
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use serde::{Serialize, Deserialize};
+use crate::error::{Result, WalletError};
+
+/// Persistent nonce store for replay protection
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NonceStore {
+    /// Map of address -> set of used nonces
+    used_nonces: std::collections::HashMap<String, HashSet<u64>>,
+    /// Map of address -> highest confirmed nonce (for optimization)
+    highest_nonce: std::collections::HashMap<String, u64>,
+}
+
+impl NonceStore {
+    /// Create a new empty nonce store
+    pub fn new() -> Self {
+        Self {
+            used_nonces: std::collections::HashMap::new(),
+            highest_nonce: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Load nonce store from file, creating empty store if not exists
+    pub fn load_or_create<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let path = path.as_ref();
+        
+        if !path.exists() {
+            return Ok(Self::new());
+        }
+
+        let data = fs::read(path)?;
+        let store: NonceStore = serde_json::from_slice(&data)
+            .map_err(|e| WalletError::Storage(format!("Failed to parse nonce store: {}", e)))?;
+        
+        Ok(store)
+    }
+
+    /// Save nonce store to file
+    pub fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let path = path.as_ref();
+        
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let data = serde_json::to_vec_pretty(self)?;
+        fs::write(path, data)?;
+
+        // Set restrictive permissions on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = fs::metadata(path)?.permissions();
+            perms.set_mode(0o600);
+            fs::set_permissions(path, perms)?;
+        }
+
+        Ok(())
+    }
+
+    /// Mark a nonce as used for an address
+    /// Returns true if this was a new nonce (not previously used)
+    pub fn mark_used(&mut self, address: &str, nonce: u64) -> bool {
+        let used = self.used_nonces
+            .entry(address.to_string())
+            .or_insert_with(HashSet::new);
+        
+        let is_new = used.insert(nonce);
+        
+        if is_new {
+            // Update highest nonce tracker
+            let highest = self.highest_nonce
+                .entry(address.to_string())
+                .or_insert(0);
+            if nonce > *highest {
+                *highest = nonce;
+            }
+        }
+        
+        is_new
+    }
+
+    /// Check if a nonce has been used for an address
+    pub fn is_used(&self, address: &str, nonce: u64) -> bool {
+        self.used_nonces
+            .get(address)
+            .map(|set| set.contains(&nonce))
+            .unwrap_or(false)
+    }
+
+    /// Get the next suggested nonce for an address
+    /// Returns highest_used_nonce + 1, or 0 if no nonces used yet
+    pub fn get_next_nonce(&self, address: &str) -> u64 {
+        self.highest_nonce
+            .get(address)
+            .map(|h| h + 1)
+            .unwrap_or(0)
+    }
+
+    /// Get the highest used nonce for an address
+    pub fn get_highest_nonce(&self, address: &str) -> Option<u64> {
+        self.highest_nonce.get(address).copied()
+    }
+
+    /// Get count of used nonces for an address
+    pub fn used_count(&self, address: &str) -> usize {
+        self.used_nonces
+            .get(address)
+            .map(|set| set.len())
+            .unwrap_or(0)
+    }
+
+    /// Check if a transaction nonce would be a replay
+    /// Returns Ok(()) if nonce is valid, Err if it's a replay
+    pub fn validate_nonce(&self, address: &str, nonce: u64) -> Result<()> {
+        if self.is_used(address, nonce) {
+            return Err(WalletError::Transaction(
+                format!("Nonce {} already used for address {} (replay attempt)", nonce, address)
+            ));
+        }
+        Ok(())
+    }
+
+    /// Clear all used nonces for an address (use with caution)
+    pub fn clear_address(&mut self, address: &str) {
+        self.used_nonces.remove(address);
+        self.highest_nonce.remove(address);
+    }
+
+    /// Clear all stored nonces (use with caution - only for testing/reset)
+    pub fn clear_all(&mut self) {
+        self.used_nonces.clear();
+        self.highest_nonce.clear();
+    }
+
+    /// Merge another nonce store into this one
+    pub fn merge(&mut self, other: &NonceStore) {
+        for (address, nonces) in &other.used_nonces {
+            let used = self.used_nonces
+                .entry(address.clone())
+                .or_insert_with(HashSet::new);
+            used.extend(nonces);
+        }
+        for (address, highest) in &other.highest_nonce {
+            let entry = self.highest_nonce
+                .entry(address.clone())
+                .or_insert(0);
+            if *highest > *entry {
+                *entry = *highest;
+            }
+        }
+    }
+}
+
+impl Default for NonceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_nonce_store_basic() {
+        let mut store = NonceStore::new();
+        let address = "test_address_123";
+
+        // Initially no nonces used
+        assert!(!store.is_used(address, 0));
+        assert_eq!(store.get_next_nonce(address), 0);
+
+        // Mark nonce as used
+        assert!(store.mark_used(address, 0));
+        assert!(store.is_used(address, 0));
+        assert_eq!(store.get_next_nonce(address), 1);
+
+        // Mark same nonce again - should return false (already used)
+        assert!(!store.mark_used(address, 0));
+
+        // Mark more nonces
+        assert!(store.mark_used(address, 1));
+        assert!(store.mark_used(address, 5));
+        
+        assert_eq!(store.get_next_nonce(address), 6);
+        assert_eq!(store.used_count(address), 3);
+    }
+
+    #[test]
+    fn test_nonce_validation() {
+        let mut store = NonceStore::new();
+        let address = "test_address";
+
+        // Valid nonce
+        assert!(store.validate_nonce(address, 0).is_ok());
+
+        // Mark as used
+        store.mark_used(address, 0);
+
+        // Now should fail validation (replay)
+        assert!(store.validate_nonce(address, 0).is_err());
+
+        // Different nonce should still be valid
+        assert!(store.validate_nonce(address, 1).is_ok());
+    }
+
+    #[test]
+    fn test_nonce_persistence() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("nonces.json");
+
+        // Create and populate store
+        let mut store = NonceStore::new();
+        store.mark_used("addr1", 0);
+        store.mark_used("addr1", 1);
+        store.mark_used("addr2", 5);
+
+        // Save
+        store.save(&path).unwrap();
+
+        // Load from file
+        let loaded = NonceStore::load_or_create(&path).unwrap();
+
+        // Verify data persisted
+        assert!(loaded.is_used("addr1", 0));
+        assert!(loaded.is_used("addr1", 1));
+        assert!(loaded.is_used("addr2", 5));
+        assert!(!loaded.is_used("addr1", 2));
+        assert_eq!(loaded.get_next_nonce("addr1"), 2);
+        assert_eq!(loaded.get_next_nonce("addr2"), 6);
+    }
+
+    #[test]
+    fn test_nonce_merge() {
+        let mut store1 = NonceStore::new();
+        store1.mark_used("addr1", 0);
+        store1.mark_used("addr1", 1);
+
+        let mut store2 = NonceStore::new();
+        store2.mark_used("addr1", 2);
+        store2.mark_used("addr2", 5);
+
+        store1.merge(&store2);
+
+        assert!(store1.is_used("addr1", 0));
+        assert!(store1.is_used("addr1", 1));
+        assert!(store1.is_used("addr1", 2));
+        assert!(store1.is_used("addr2", 5));
+        assert_eq!(store1.get_next_nonce("addr1"), 3);
+    }
+
+    #[test]
+    fn test_clear_operations() {
+        let mut store = NonceStore::new();
+        store.mark_used("addr1", 0);
+        store.mark_used("addr1", 1);
+        store.mark_used("addr2", 5);
+
+        // Clear single address
+        store.clear_address("addr1");
+        assert!(!store.is_used("addr1", 0));
+        assert!(!store.is_used("addr1", 1));
+        assert!(store.is_used("addr2", 5));
+
+        // Clear all
+        store.clear_all();
+        assert!(!store.is_used("addr2", 5));
+    }
+
+    #[test]
+    fn test_multiple_addresses() {
+        let mut store = NonceStore::new();
+
+        // Use nonces for multiple addresses
+        // addr_0: 0, 3, 6, 9 (4 nonces)
+        // addr_1: 1, 4, 7 (3 nonces)
+        // addr_2: 2, 5, 8 (3 nonces)
+        for i in 0..10 {
+            store.mark_used(&format!("addr_{}", i % 3), i);
+        }
+
+        // Each address should have independent nonce tracking
+        assert_eq!(store.used_count("addr_0"), 4);
+        assert_eq!(store.used_count("addr_1"), 3);
+        assert_eq!(store.used_count("addr_2"), 3);
+        
+        // Verify specific nonces
+        assert!(store.is_used("addr_0", 0));
+        assert!(store.is_used("addr_0", 3));
+        assert!(store.is_used("addr_1", 1));
+        assert!(store.is_used("addr_1", 4));
+        assert!(store.is_used("addr_2", 2));
+        assert!(store.is_used("addr_2", 5));
+    }
+}

--- a/rustchain-wallet/src/storage.rs
+++ b/rustchain-wallet/src/storage.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides encrypted storage for wallet keypairs,
 //! using AES-256-GCM encryption with a user-provided password.
+//! It also manages persistent nonce storage for replay protection.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -10,6 +11,7 @@ use aes_gcm::aead::Aead;
 
 use crate::error::{Result, WalletError};
 use crate::keys::KeyPair;
+use crate::nonce_store::NonceStore;
 
 /// Encrypted wallet file structure
 #[derive(Serialize, Deserialize)]
@@ -23,14 +25,24 @@ struct EncryptedWallet {
 /// Wallet storage manager
 pub struct WalletStorage {
     storage_path: PathBuf,
+    nonce_store_path: PathBuf,
+    nonce_store: NonceStore,
 }
 
 impl WalletStorage {
     /// Create a new wallet storage at the specified path
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
-        Self {
-            storage_path: path.as_ref().to_path_buf(),
-        }
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let storage_path = path.as_ref().to_path_buf();
+        let nonce_store_path = storage_path.join("nonces.json");
+        
+        // Load existing nonce store or create new one (migration support)
+        let nonce_store = NonceStore::load_or_create(&nonce_store_path)?;
+        
+        Ok(Self {
+            storage_path,
+            nonce_store_path,
+            nonce_store,
+        })
     }
 
     /// Get the default wallet storage directory
@@ -44,7 +56,7 @@ impl WalletStorage {
     pub fn default() -> Result<Self> {
         let path = Self::default_path()?;
         fs::create_dir_all(&path)?;
-        Ok(Self::new(path))
+        Self::new(path)
     }
 
     /// Save a keypair to an encrypted file
@@ -169,6 +181,50 @@ impl WalletStorage {
     pub fn path(&self) -> &Path {
         &self.storage_path
     }
+
+    // ==================== Nonce Management ====================
+
+    /// Mark a nonce as used for an address and persist to disk
+    pub fn mark_nonce_used(&mut self, address: &str, nonce: u64) -> Result<bool> {
+        let is_new = self.nonce_store.mark_used(address, nonce);
+        self.save_nonce_store()?;
+        Ok(is_new)
+    }
+
+    /// Check if a nonce has been used for an address
+    pub fn is_nonce_used(&self, address: &str, nonce: u64) -> bool {
+        self.nonce_store.is_used(address, nonce)
+    }
+
+    /// Get the next suggested nonce for an address
+    pub fn get_next_nonce(&self, address: &str) -> u64 {
+        self.nonce_store.get_next_nonce(address)
+    }
+
+    /// Validate that a nonce hasn't been used (replay protection)
+    pub fn validate_nonce(&self, address: &str, nonce: u64) -> Result<()> {
+        self.nonce_store.validate_nonce(address, nonce)
+    }
+
+    /// Get the count of used nonces for an address
+    pub fn used_nonce_count(&self, address: &str) -> usize {
+        self.nonce_store.used_count(address)
+    }
+
+    /// Persist the nonce store to disk
+    pub fn save_nonce_store(&self) -> Result<()> {
+        self.nonce_store.save(&self.nonce_store_path)
+    }
+
+    /// Get a reference to the internal nonce store
+    pub fn nonce_store(&self) -> &NonceStore {
+        &self.nonce_store
+    }
+
+    /// Get a mutable reference to the internal nonce store
+    pub fn nonce_store_mut(&mut self) -> &mut NonceStore {
+        &mut self.nonce_store
+    }
 }
 
 /// Derive an AES-256 key from a password using PBKDF2
@@ -222,16 +278,16 @@ mod tests {
     #[test]
     fn test_wallet_storage_save_and_load() {
         let temp_dir = TempDir::new().unwrap();
-        let storage = WalletStorage::new(temp_dir.path());
-        
+        let storage = WalletStorage::new(temp_dir.path()).unwrap();
+
         let keypair = KeyPair::generate();
         let public_key = keypair.public_key_hex();
         let password = "test_password_123";
-        
+
         // Save the wallet
         let path = storage.save("test_wallet", &keypair, password).unwrap();
         assert!(path.exists());
-        
+
         // Load the wallet
         let loaded = storage.load("test_wallet", password).unwrap();
         assert_eq!(loaded.public_key_hex(), public_key);
@@ -240,13 +296,13 @@ mod tests {
     #[test]
     fn test_wallet_storage_wrong_password() {
         let temp_dir = TempDir::new().unwrap();
-        let storage = WalletStorage::new(temp_dir.path());
-        
+        let storage = WalletStorage::new(temp_dir.path()).unwrap();
+
         let keypair = KeyPair::generate();
         let password = "correct_password";
-        
+
         storage.save("test_wallet", &keypair, password).unwrap();
-        
+
         // Try to load with wrong password
         let result = storage.load("test_wallet", "wrong_password");
         assert!(result.is_err());
@@ -255,12 +311,12 @@ mod tests {
     #[test]
     fn test_wallet_storage_list() {
         let temp_dir = TempDir::new().unwrap();
-        let storage = WalletStorage::new(temp_dir.path());
-        
+        let storage = WalletStorage::new(temp_dir.path()).unwrap();
+
         let keypair = KeyPair::generate();
         storage.save("wallet1", &keypair, "password1").unwrap();
         storage.save("wallet2", &keypair, "password2").unwrap();
-        
+
         let wallets = storage.list().unwrap();
         assert_eq!(wallets.len(), 2);
         assert!(wallets.contains(&"wallet1".to_string()));
@@ -270,14 +326,94 @@ mod tests {
     #[test]
     fn test_wallet_storage_delete() {
         let temp_dir = TempDir::new().unwrap();
-        let storage = WalletStorage::new(temp_dir.path());
-        
+        let mut storage = WalletStorage::new(temp_dir.path()).unwrap();
+
         let keypair = KeyPair::generate();
         storage.save("test_wallet", &keypair, "password").unwrap();
-        
+
         assert!(storage.exists("test_wallet"));
-        
+
         storage.delete("test_wallet").unwrap();
         assert!(!storage.exists("test_wallet"));
+    }
+
+    // ==================== Nonce Persistence Tests ====================
+
+    #[test]
+    fn test_nonce_persistence_basic() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut storage = WalletStorage::new(temp_dir.path()).unwrap();
+        let address = "test_address_123";
+
+        // Initially nonce should not be used
+        assert!(!storage.is_nonce_used(address, 0));
+        assert_eq!(storage.get_next_nonce(address), 0);
+
+        // Mark nonce as used
+        let is_new = storage.mark_nonce_used(address, 0).unwrap();
+        assert!(is_new);
+        assert!(storage.is_nonce_used(address, 0));
+        assert_eq!(storage.get_next_nonce(address), 1);
+
+        // Mark same nonce again - should return false (already used)
+        let is_new = storage.mark_nonce_used(address, 0).unwrap();
+        assert!(!is_new);
+    }
+
+    #[test]
+    fn test_nonce_replay_detection() {
+        let mut storage = WalletStorage::new(TempDir::new().unwrap().path()).unwrap();
+        let address = "test_address";
+
+        // First use should succeed
+        assert!(storage.validate_nonce(address, 0).is_ok());
+        storage.mark_nonce_used(address, 0).unwrap();
+
+        // Replay should be detected
+        assert!(storage.validate_nonce(address, 0).is_err());
+        assert!(storage.is_nonce_used(address, 0));
+
+        // Different nonce should still be valid
+        assert!(storage.validate_nonce(address, 1).is_ok());
+    }
+
+    #[test]
+    fn test_nonce_persistence_across_restart() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path();
+
+        // Create storage and mark nonces
+        {
+            let mut storage = WalletStorage::new(path).unwrap();
+            storage.mark_nonce_used("addr1", 0).unwrap();
+            storage.mark_nonce_used("addr1", 1).unwrap();
+            storage.mark_nonce_used("addr2", 5).unwrap();
+            // Storage drops here, should persist
+        }
+
+        // Create new storage instance (simulates restart)
+        let storage2 = WalletStorage::new(path).unwrap();
+
+        // Verify nonces persisted
+        assert!(storage2.is_nonce_used("addr1", 0));
+        assert!(storage2.is_nonce_used("addr1", 1));
+        assert!(storage2.is_nonce_used("addr2", 5));
+        assert!(!storage2.is_nonce_used("addr1", 2));
+        assert_eq!(storage2.get_next_nonce("addr1"), 2);
+        assert_eq!(storage2.get_next_nonce("addr2"), 6);
+    }
+
+    #[test]
+    fn test_nonce_count() {
+        let mut storage = WalletStorage::new(TempDir::new().unwrap().path()).unwrap();
+        let address = "test_address";
+
+        assert_eq!(storage.used_nonce_count(address), 0);
+
+        storage.mark_nonce_used(address, 0).unwrap();
+        storage.mark_nonce_used(address, 1).unwrap();
+        storage.mark_nonce_used(address, 5).unwrap();
+
+        assert_eq!(storage.used_nonce_count(address), 3);
     }
 }

--- a/rustchain-wallet/src/transaction.rs
+++ b/rustchain-wallet/src/transaction.rs
@@ -6,6 +6,7 @@ use serde::{Serialize, Deserialize};
 use chrono::{DateTime, Utc};
 use crate::error::{Result, WalletError};
 use crate::keys::KeyPair;
+use crate::nonce_store::NonceStore;
 
 /// A RustChain transaction
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -117,6 +118,22 @@ impl Transaction {
     /// Deserialize a transaction from JSON
     pub fn from_json(json: &str) -> Result<Self> {
         Ok(serde_json::from_str(json)?)
+    }
+
+    /// Verify the transaction nonce against a nonce store (replay protection)
+    /// Returns Ok(()) if the nonce is valid (not previously used)
+    /// Returns Err if the nonce has already been used (replay attempt)
+    pub fn verify_nonce(&self, nonce_store: &NonceStore) -> Result<()> {
+        nonce_store.validate_nonce(&self.from, self.nonce)
+    }
+
+    /// Verify both signature and nonce (complete transaction validation)
+    /// Returns Ok(true) if signature is valid and nonce is not a replay
+    pub fn verify_complete(&self, keypair: &KeyPair, nonce_store: &NonceStore) -> Result<bool> {
+        // First check for replay
+        self.verify_nonce(nonce_store)?;
+        // Then verify signature
+        self.verify(keypair)
     }
 }
 
@@ -321,8 +338,129 @@ mod tests {
             100,
             1,
         );
-        
+
         let hash = tx.hash().unwrap();
         assert_eq!(hash.len(), 64); // SHA256 hex
+    }
+
+    // ==================== Replay Protection Tests ====================
+
+    #[test]
+    fn test_transaction_nonce_verification() {
+        let keypair = KeyPair::generate();
+        let mut tx = Transaction::new(
+            keypair.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            0,
+        );
+        tx.sign(&keypair).unwrap();
+
+        let nonce_store = NonceStore::new();
+
+        // First use should succeed
+        assert!(tx.verify_nonce(&nonce_store).is_ok());
+
+        // Mark nonce as used
+        let mut store2 = NonceStore::new();
+        store2.mark_used(&tx.from, 0);
+
+        // Replay should fail
+        assert!(tx.verify_nonce(&store2).is_err());
+    }
+
+    #[test]
+    fn test_transaction_complete_verification() {
+        let keypair = KeyPair::generate();
+        let mut tx = Transaction::new(
+            keypair.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            0,
+        );
+        tx.sign(&keypair).unwrap();
+
+        let nonce_store = NonceStore::new();
+
+        // Complete verification should succeed
+        assert!(tx.verify_complete(&keypair, &nonce_store).unwrap());
+
+        // Mark nonce as used
+        let mut store2 = NonceStore::new();
+        store2.mark_used(&tx.from, 0);
+
+        // Complete verification should fail (replay)
+        assert!(tx.verify_complete(&keypair, &store2).is_err());
+    }
+
+    #[test]
+    fn test_replay_protection_different_nonces() {
+        let keypair = KeyPair::generate();
+        let address = keypair.public_key_base58();
+
+        let mut tx1 = Transaction::new(
+            address.clone(),
+            "recipient".to_string(),
+            1000,
+            100,
+            0,
+        );
+        tx1.sign(&keypair).unwrap();
+
+        let mut tx2 = Transaction::new(
+            address.clone(),
+            "recipient".to_string(),
+            2000,
+            100,
+            1,
+        );
+        tx2.sign(&keypair).unwrap();
+
+        let mut nonce_store = NonceStore::new();
+
+        // First transaction should succeed
+        assert!(tx1.verify_complete(&keypair, &nonce_store).unwrap());
+        // Mark nonce as used after successful verification
+        nonce_store.mark_used(&address, 0);
+
+        // Second transaction with different nonce should also succeed
+        assert!(tx2.verify_complete(&keypair, &nonce_store).unwrap());
+        // Mark nonce as used
+        nonce_store.mark_used(&address, 1);
+
+        // First transaction replay should fail
+        assert!(tx1.verify_complete(&keypair, &nonce_store).is_err());
+    }
+
+    #[test]
+    fn test_replay_protection_different_addresses() {
+        let keypair1 = KeyPair::generate();
+        let keypair2 = KeyPair::generate();
+
+        let mut tx1 = Transaction::new(
+            keypair1.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            0,
+        );
+        tx1.sign(&keypair1).unwrap();
+
+        let mut tx2 = Transaction::new(
+            keypair2.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            0,
+        );
+        tx2.sign(&keypair2).unwrap();
+
+        let nonce_store = NonceStore::new();
+
+        // Both transactions with same nonce but different addresses should succeed
+        assert!(tx1.verify_complete(&keypair1, &nonce_store).unwrap());
+        assert!(tx2.verify_complete(&keypair2, &nonce_store).unwrap());
     }
 }

--- a/rustchain-wallet/tests/integration_tests.rs
+++ b/rustchain-wallet/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests verify the complete wallet functionality.
 
-use rustchain_wallet::{Wallet, KeyPair, Network, Transaction, TransactionBuilder, WalletStorage};
+use rustchain_wallet::{Wallet, KeyPair, Network, Transaction, TransactionBuilder, WalletStorage, NonceStore};
 use tempfile::TempDir;
 
 #[test]
@@ -100,29 +100,29 @@ fn test_transaction_lifecycle() {
 #[test]
 fn test_encrypted_storage() {
     let temp_dir = TempDir::new().unwrap();
-    let storage = WalletStorage::new(temp_dir.path());
-    
+    let storage = WalletStorage::new(temp_dir.path()).unwrap();
+
     let wallet = Wallet::generate();
     let address = wallet.address();
     let password = "test_password_123";
-    
+
     // Save wallet
     let path = storage.save("test_wallet", wallet.keypair(), password).unwrap();
     assert!(path.exists());
-    
+
     // Load wallet
     let loaded = storage.load("test_wallet", password).unwrap();
     assert_eq!(loaded.public_key_base58(), address);
-    
+
     // Wrong password fails
     let result = storage.load("test_wallet", "wrong_password");
     assert!(result.is_err());
-    
+
     // List wallets
     let wallets = storage.list().unwrap();
     assert_eq!(wallets.len(), 1);
     assert!(wallets.contains(&"test_wallet".to_string()));
-    
+
     // Delete wallet
     storage.delete("test_wallet").unwrap();
     assert!(!storage.exists("test_wallet"));
@@ -131,19 +131,19 @@ fn test_encrypted_storage() {
 #[test]
 fn test_multiple_wallets_storage() {
     let temp_dir = TempDir::new().unwrap();
-    let storage = WalletStorage::new(temp_dir.path());
-    
+    let storage = WalletStorage::new(temp_dir.path()).unwrap();
+
     // Create multiple wallets
     for i in 1..=5 {
         let wallet = Wallet::generate();
         let name = format!("wallet_{}", i);
         storage.save(&name, wallet.keypair(), "password").unwrap();
     }
-    
+
     // List all
     let wallets = storage.list().unwrap();
     assert_eq!(wallets.len(), 5);
-    
+
     // Load each and verify
     for i in 1..=5 {
         let name = format!("wallet_{}", i);
@@ -241,6 +241,229 @@ fn test_wallet_clone() {
     let message = b"Test";
     let sig1 = wallet.sign(message).unwrap();
     let sig2 = cloned.sign(message).unwrap();
-    
+
     assert_eq!(sig1, sig2);
+}
+
+// ==================== Issue #728: Nonce Persistence & Replay Protection ====================
+
+#[test]
+fn test_nonce_persistence_across_storage_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    // Create storage, mark some nonces
+    let test_address;
+    {
+        let mut storage = WalletStorage::new(path).unwrap();
+        let wallet = Wallet::generate();
+        test_address = wallet.address();
+
+        // Mark several nonces
+        storage.mark_nonce_used(&test_address, 0).unwrap();
+        storage.mark_nonce_used(&test_address, 1).unwrap();
+        storage.mark_nonce_used(&test_address, 5).unwrap();
+        // Storage drops here, should persist to disk
+    }
+
+    // Create new storage instance (simulates application restart)
+    let storage2 = WalletStorage::new(path).unwrap();
+
+    // Verify nonces persisted across "restart"
+    assert!(storage2.is_nonce_used(&test_address, 0));
+    assert!(storage2.is_nonce_used(&test_address, 1));
+    assert!(storage2.is_nonce_used(&test_address, 5));
+    assert!(!storage2.is_nonce_used(&test_address, 2));
+    assert_eq!(storage2.get_next_nonce(&test_address), 6);
+}
+
+#[test]
+fn test_replay_protection_integration() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = WalletStorage::new(temp_dir.path()).unwrap();
+
+    let sender = Wallet::generate();
+    let recipient = Wallet::generate();
+    let address = sender.address();
+
+    // Create and sign transaction
+    let mut tx = TransactionBuilder::new()
+        .from(address.clone())
+        .to(recipient.address())
+        .amount(1000)
+        .fee(100)
+        .nonce(0)
+        .build()
+        .unwrap();
+    tx.sign(sender.keypair()).unwrap();
+
+    // First submission should succeed
+    assert!(tx.verify_nonce(storage.nonce_store()).is_ok());
+    storage.mark_nonce_used(&address, 0).unwrap();
+
+    // Replay attempt should fail
+    assert!(tx.verify_nonce(storage.nonce_store()).is_err());
+}
+
+#[test]
+fn test_nonce_persistence_multiple_transactions_restart() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path();
+
+    let sender = Wallet::generate();
+    let recipient = Wallet::generate();
+    let address = sender.address();
+
+    // Session 1: Create and "submit" first transaction
+    {
+        let mut storage = WalletStorage::new(path).unwrap();
+        let mut tx1 = TransactionBuilder::new()
+            .from(address.clone())
+            .to(recipient.address())
+            .amount(1000)
+            .fee(100)
+            .nonce(0)
+            .build()
+            .unwrap();
+        tx1.sign(sender.keypair()).unwrap();
+
+        assert!(tx1.verify_nonce(storage.nonce_store()).is_ok());
+        storage.mark_nonce_used(&address, 0).unwrap();
+        // Storage drops, persists to disk
+    }
+
+    // Session 2: Create second transaction (should know about first)
+    {
+        let mut storage = WalletStorage::new(path).unwrap();
+
+        // Verify nonce 0 is marked used
+        assert!(storage.is_nonce_used(&address, 0));
+        assert_eq!(storage.get_next_nonce(&address), 1);
+
+        // Create transaction with nonce 1
+        let mut tx2 = TransactionBuilder::new()
+            .from(address.clone())
+            .to(recipient.address())
+            .amount(2000)
+            .fee(100)
+            .nonce(1)
+            .build()
+            .unwrap();
+        tx2.sign(sender.keypair()).unwrap();
+
+        // Should succeed
+        assert!(tx2.verify_nonce(storage.nonce_store()).is_ok());
+        storage.mark_nonce_used(&address, 1).unwrap();
+    }
+
+    // Session 3: Verify both nonces persisted
+    {
+        let storage = WalletStorage::new(path).unwrap();
+        assert!(storage.is_nonce_used(&address, 0));
+        assert!(storage.is_nonce_used(&address, 1));
+        assert_eq!(storage.get_next_nonce(&address), 2);
+
+        // Replay of either transaction should fail
+        let mut replay_tx = TransactionBuilder::new()
+            .from(address.clone())
+            .to(recipient.address())
+            .amount(1000)
+            .fee(100)
+            .nonce(0)
+            .build()
+            .unwrap();
+        replay_tx.sign(sender.keypair()).unwrap();
+        assert!(replay_tx.verify_nonce(storage.nonce_store()).is_err());
+    }
+}
+
+#[test]
+fn test_nonce_store_direct_persistence() {
+    let temp_dir = TempDir::new().unwrap();
+    let path = temp_dir.path().join("nonces.json");
+
+    // Create and populate nonce store
+    {
+        let mut store = NonceStore::new();
+        store.mark_used("address_a", 0);
+        store.mark_used("address_a", 1);
+        store.mark_used("address_b", 5);
+        store.save(&path).unwrap();
+    }
+
+    // Load from disk
+    let loaded = NonceStore::load_or_create(&path).unwrap();
+
+    // Verify data
+    assert!(loaded.is_used("address_a", 0));
+    assert!(loaded.is_used("address_a", 1));
+    assert!(loaded.is_used("address_b", 5));
+    assert!(!loaded.is_used("address_a", 2));
+    assert_eq!(loaded.get_next_nonce("address_a"), 2);
+    assert_eq!(loaded.get_next_nonce("address_b"), 6);
+}
+
+#[test]
+fn test_replay_protection_complete_verification() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = WalletStorage::new(temp_dir.path()).unwrap();
+
+    let sender = Wallet::generate();
+    let address = sender.address();
+
+    let mut tx = Transaction::new(
+        address.clone(),
+        "recipient".to_string(),
+        1000,
+        100,
+        0,
+    );
+    tx.sign(sender.keypair()).unwrap();
+
+    // Complete verification should succeed initially
+    assert!(tx.verify_complete(sender.keypair(), storage.nonce_store()).unwrap());
+
+    // Mark nonce as used
+    storage.mark_nonce_used(&address, 0).unwrap();
+
+    // Complete verification should now fail (replay detected)
+    assert!(tx.verify_complete(sender.keypair(), storage.nonce_store()).is_err());
+}
+
+#[test]
+fn test_concurrent_nonce_different_addresses() {
+    let temp_dir = TempDir::new().unwrap();
+    let mut storage = WalletStorage::new(temp_dir.path()).unwrap();
+
+    let wallet1 = Wallet::generate();
+    let wallet2 = Wallet::generate();
+    let wallet3 = Wallet::generate();
+
+    // All use nonce 0 - should all succeed (different addresses)
+    let mut tx1 = Transaction::new(wallet1.address(), "recipient".to_string(), 1000, 100, 0);
+    let mut tx2 = Transaction::new(wallet2.address(), "recipient".to_string(), 1000, 100, 0);
+    let mut tx3 = Transaction::new(wallet3.address(), "recipient".to_string(), 1000, 100, 0);
+
+    tx1.sign(wallet1.keypair()).unwrap();
+    tx2.sign(wallet2.keypair()).unwrap();
+    tx3.sign(wallet3.keypair()).unwrap();
+
+    assert!(tx1.verify_nonce(storage.nonce_store()).is_ok());
+    assert!(tx2.verify_nonce(storage.nonce_store()).is_ok());
+    assert!(tx3.verify_nonce(storage.nonce_store()).is_ok());
+
+    // Mark all as used
+    storage.mark_nonce_used(&wallet1.address(), 0).unwrap();
+    storage.mark_nonce_used(&wallet2.address(), 0).unwrap();
+    storage.mark_nonce_used(&wallet3.address(), 0).unwrap();
+
+    // Each address should now have nonce 0 marked
+    assert!(storage.is_nonce_used(&wallet1.address(), 0));
+    assert!(storage.is_nonce_used(&wallet2.address(), 0));
+    assert!(storage.is_nonce_used(&wallet3.address(), 0));
+
+    // But nonce 0 for a new address should still be valid
+    let wallet4 = Wallet::generate();
+    let tx4 = Transaction::new(wallet4.address(), "recipient".to_string(), 1000, 100, 0);
+    assert!(tx4.verify_nonce(storage.nonce_store()).is_ok());
 }


### PR DESCRIPTION
Fixes issue #728 by persisting nonce ledger and enforcing replay rejection across restarts, with regression tests.