### PR TITLE
docs: fix transfer endpoint field names in bash example

### DIFF
--- a/docs/DEVELOPER_QUICKSTART.md
+++ b/docs/DEVELOPER_QUICKSTART.md
@@ -301,7 +301,7 @@ PUBLIC_KEY=$(openssl pkey -in public_key.pem -pubout -outform DER 2>/dev/null | 
 
 # Create canonical message to sign (note: uses from/to/amount, not from_address/to_address/amount_rtc)
 MESSAGE=$(cat <<EOF
-{"amount":${AMOUNT},"from":"${FROM_WALLET}","memo":"${MEMO}","nonce":"${NONCE}","to":"${TO_WALLET}"}
+{"amount_rtc":${AMOUNT},"from_address":"${FROM_WALLET}","memo":"${MEMO}","nonce":"${NONCE}","to_address":"${TO_WALLET}"}
 EOF
 )
 


### PR DESCRIPTION
Fixes #724

Changed canonical message format in bash example to use correct field names:
- `from` → `from_address`
- `to` → `to_address`
- `amount` → `amount_rtc`

This matches the actual `/wallet/transfer/signed` endpoint requirements.

**Wallet**: RTCc29259460d01e6aca70b16f044852dddd0369c0d