### PR TITLE
fix: close SQLite connections on exception in calculate_table_hash and _get_count

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -99,21 +99,22 @@ class RustChainSyncManager:
         if not schema:
             return ""
 
-        conn = self._get_connection()
-        cursor = conn.cursor()
-
         pk = schema["pk"]
-        cursor.execute(f"SELECT * FROM {table_name} ORDER BY {pk} ASC")
-        rows = cursor.fetchall()
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT * FROM {table_name} ORDER BY {pk} ASC")
+            rows = cursor.fetchall()
 
-        hasher = hashlib.sha256()
-        for row in rows:
-            row_dict = dict(row)
-            row_str = json.dumps(row_dict, sort_keys=True, separators=(",", ":"))
-            hasher.update(row_str.encode())
+            hasher = hashlib.sha256()
+            for row in rows:
+                row_dict = dict(row)
+                row_str = json.dumps(row_dict, sort_keys=True, separators=(",", ":"))
+                hasher.update(row_str.encode())
 
-        conn.close()
-        return hasher.hexdigest()
+            return hasher.hexdigest()
+        finally:
+            conn.close()
 
     def get_merkle_root(self) -> str:
         """Generates a master Merkle root hash for all synced tables."""
@@ -262,8 +263,10 @@ class RustChainSyncManager:
         if table_name not in self.SYNC_TABLES:
             return 0
         conn = self._get_connection()
-        cursor = conn.cursor()
-        cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
-        count = cursor.fetchone()[0]
-        conn.close()
-        return int(count)
+        try:
+            cursor = conn.cursor()
+            cursor.execute(f"SELECT COUNT(*) FROM {table_name}")
+            count = cursor.fetchone()[0]
+            return int(count)
+        finally:
+            conn.close()


### PR DESCRIPTION
Fixes #767

## Problem

`calculate_table_hash()` and `_get_count()` in `node/rustchain_sync.py` opened a SQLite connection but relied on reaching `conn.close()` at the end of the function. Any exception (disk I/O error, locked DB, etc.) would bypass the close call, leaking the connection. Under sustained error conditions this exhausts the SQLite connection limit and the node can no longer open new DB connections.

## Fix

Wrap all cursor operations in `try/finally` blocks so `conn.close()` is guaranteed, matching the pattern already used in `apply_sync_payload` and `_load_table_schema`.