### PR TITLE
docs(i18n): Add Korean translation of Quick Start section

### DIFF
--- a/docs/i18n/ko/QUICKSTART.md
+++ b/docs/i18n/ko/QUICKSTART.md
@@ -1,0 +1,50 @@
+# 🚀 빠른 시작
+
+## 1. 설치
+
+```bash
+pip install clawrtc
+```
+
+## 2. 지갑 생성
+
+```bash
+# 새 RTC 지갑 생성
+clawrtc wallet new
+
+# 또는 기존 지갑 가져오기
+clawrtc wallet import --private-key YOUR_KEY
+```
+
+## 3. 채굴 시작
+
+```bash
+# 단일 코어로 채굴 시작
+clawrtc mine start
+
+# 또는 모든 코어 사용
+clawrtc mine start --threads auto
+```
+
+## 4. 잔액 확인
+
+```bash
+clawrtc balance
+```
+
+## 5. RTC 전송
+
+```bash
+clawrtc transfer --to RTC_DESTINATION_ADDRESS --amount 10.0
+```
+
+---
+
+**지원하는 언어**: Python 3.8+
+**지원하는 플랫폼**: Linux, macOS, Windows, PowerPC G3/G4/G5
+
+---
+
+*Translated by: Async777*
+*Language: Korean (ko)*
+*Wallet: RTCc29259460d01e6aca70b16f044852dddd0369c0d*


### PR DESCRIPTION
## Translation Bounty Claim (#774)

This PR adds a Korean (ko) translation of the Quick Start section.

### Changes
- Created `docs/i18n/ko/QUICKSTART.md`
- Translated all 5 quick start steps to Korean
- Maintained code examples in original format
- Added translator attribution and wallet info

### Translation Quality
- Native-level Korean translation
- Technical terms preserved appropriately
- Clear and concise instructions

### Bounty Details
- Bounty: #774 - Translate a README section (0.5 RTC)
- Language: Korean (ko)
- Section: Quick Start

BCOS-L2

**Wallet:** RTCc29259460d01e6aca70b16f044852dddd0369c0d