### PR TITLE
docs: Add docstring to _get_connection method

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -38,6 +38,13 @@ class RustChainSyncManager:
         self._schema_cache: Dict[str, Dict[str, Any]] = {}
 
     def _get_connection(self):
+        """
+        Create and return a new SQLite database connection.
+        
+        Returns:
+            sqlite3.Connection: Connection with row_factory set to sqlite3.Row
+                               for column-name access to result rows.
+        """
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         return conn


### PR DESCRIPTION
## Description
Fixes #772 by adding a detailed docstring to the `_get_connection()` method in `node/rustchain_sync.py`.

The docstring explains:
- What the method does (creates SQLite connection)
- Return type and configuration (row_factory set to sqlite3.Row)

### Claim Info
- Wallet: `GCC3hN21nJgJ97YTo1ZrWSJMGFF54BFVwjSqQsX9NLcb`
- Label: BCOS-L2