### PR TITLE
docs: Add docstring to _fingerprint_check_data (#772)

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -38,6 +38,13 @@ class RustChainSyncManager:
         self._schema_cache: Dict[str, Dict[str, Any]] = {}
 
     def _get_connection(self):
+        """
+        Create and return a new SQLite database connection.
+        
+        Returns:
+            sqlite3.Connection: Connection with row_factory set to sqlite3.Row
+                               for column-name access to result rows.
+        """
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         return conn

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1120,6 +1120,15 @@ ARM_CPU_BRANDS = {"arm", "aarch64", "cortex", "neoverse", "apple m1", "apple m2"
 
 
 def _fingerprint_checks_map(fingerprint: dict) -> dict:
+    """
+    Extract the checks dictionary from a hardware fingerprint payload.
+    
+    Args:
+        fingerprint: Hardware fingerprint dict containing device and check data.
+    
+    Returns:
+        dict: The 'checks' section of the fingerprint, or empty dict if invalid.
+    """
     if not isinstance(fingerprint, dict):
         return {}
     checks = fingerprint.get("checks", {})

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1136,6 +1136,16 @@ def _fingerprint_checks_map(fingerprint: dict) -> dict:
 
 
 def _fingerprint_check_data(fingerprint: dict, check_name: str) -> dict:
+    """
+    Extract specific check data from a hardware fingerprint by check name.
+    
+    Args:
+        fingerprint: Hardware fingerprint dict containing checks and device info.
+        check_name: Name of the specific check to extract (e.g., 'simd_identity').
+    
+    Returns:
+        dict: The 'data' section of the specified check, or empty dict if not found.
+    """
     item = _fingerprint_checks_map(fingerprint).get(check_name, {})
     if isinstance(item, dict):
         data = item.get("data", {})


### PR DESCRIPTION
## Description

Fixes #772 by adding a detailed docstring to the `_fingerprint_check_data()` function in `node/rustchain_v2_integrated_v2.2.1_rip200.py`.

The docstring explains:
- What the function does (extracts specific check data from hardware fingerprint)
- Parameters (fingerprint dict and check_name string)
- Return value (data dict or empty dict)

### Claim Info
- Wallet: `GCC3hN21nJgJ97YTo1ZrWSJMGFF54BFVwjSqQsX9NLcb`
- Label: BCOS-L2