### PR TITLE
docs: add docstring to RustChainSync._get_connection

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -38,6 +38,12 @@ class RustChainSyncManager:
         self._schema_cache: Dict[str, Dict[str, Any]] = {}
 
     def _get_connection(self):
+        """Open and return a new SQLite connection to the node database.
+
+        Configures ``conn.row_factory = sqlite3.Row`` so that query results
+        can be accessed by column name as well as by index.  Callers are
+        responsible for closing the returned connection when finished.
+        """
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
         return conn


### PR DESCRIPTION
Fixes #772

Adds a clear docstring to the `_get_connection` method in `node/rustchain_sync.py` explaining:
- Opens a new SQLite connection to the node database
- Sets `row_factory = sqlite3.Row` for named column access
- Caller is responsible for closing the connection

---
**BCOS-L2 bounty claim**

Wallet ID: (to be filled - no RTC wallet configured yet, please DM for wallet coordination)