### PR TITLE
fix: correct typo homogenous -> homogeneous in tokenomics.md

### DIFF
--- a/docs/whitepaper/tokenomics.md
+++ b/docs/whitepaper/tokenomics.md
@@ -72,7 +72,7 @@ RustChain’s design explicitly targets common centralization drivers:
 - Gas fees do not provide an advantage to sophisticated MEV operators.
 - VM-scale strategies are economically discouraged by the fingerprint gate and binding logic.
 
-Residual centralization risks still exist (e.g., shared NAT environments, homogenous hardware fleets), and the system is expected to evolve as adversaries adapt.
+Residual centralization risks still exist (e.g., shared NAT environments, homogeneous hardware fleets), and the system is expected to evolve as adversaries adapt.
 
 ## Open Questions / Future Work
 


### PR DESCRIPTION
Fixes #771

## Change

Fixes a spelling error in `docs/whitepaper/tokenomics.md` line 75:

```
- homogenous hardware fleets
+ homogeneous hardware fleets
```

`homogeneous` is the standard scientific/technical spelling. `homogenous` is a common misspelling detected by `codespell`.

---
**BCOS-L2 bounty claim**

Wallet ID: (please DM for wallet coordination — no RTC wallet configured yet)