### PR TITLE
feat: add RustChain node health monitor CLI tool (#1606)

### DIFF
--- a/tools/node-health-cli/README.md
+++ b/tools/node-health-cli/README.md
@@ -1,0 +1,339 @@
+# RustChain Node Health Monitor CLI
+
+A command-line tool to monitor RustChain node health with comprehensive checks for health status, epoch information, and peer/API reachability.
+
+## Features
+
+- **Health Checks**: Verify node health status, uptime, database status, and version
+- **Epoch Information**: Display current epoch, slot, enrolled miners, and reward pot
+- **API Reachability**: Test connectivity to multiple API endpoints with latency measurement
+- **Multiple Output Formats**: Human-readable text or machine-parseable JSON
+- **Proper Exit Codes**: Suitable for scripting and CI/CD integration
+- **Configurable**: Custom node URLs, timeouts, and endpoints
+
+## Installation
+
+No installation required. The tool is a standalone Python script with no external dependencies (uses only Python standard library).
+
+### Requirements
+
+- Python 3.7+
+- Network access to RustChain node
+
+## Quick Start
+
+```bash
+# Check default node (rustchain.org)
+python node_health.py
+
+# Check local node
+python node_health.py -n http://localhost:8099
+
+# Output as JSON
+python node_health.py --json
+
+# Verbose output
+python node_health.py -v
+
+# Quiet mode (exit code only)
+python node_health.py -q && echo "OK" || echo "FAILED"
+```
+
+## Usage
+
+```
+usage: node-health [-h] [-n NODE] [-t TIMEOUT] [-e ENDPOINTS [ENDPOINTS ...]]
+                   [--json] [-v] [-q]
+
+RustChain Node Health Monitor - Check node health, epoch info, and API reachability
+
+options:
+  -h, --help            show this help message and exit
+  -n, --node NODE       Node URL to check (default: https://rustchain.org)
+  -t, --timeout TIMEOUT
+                        Request timeout in seconds (default: 10)
+  -e, --endpoints ENDPOINTS [ENDPOINTS ...]
+                        Custom endpoints to check reachability
+  --json                Output in JSON format
+  -v, --verbose         Verbose output with additional details
+  -q, --quiet           Quiet mode - only output exit code
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All checks passed |
+| 1 | Health check failed (node unhealthy or unreachable) |
+| 2 | Epoch check failed (epoch data unavailable) |
+| 3 | API reachability check failed |
+| 4 | Multiple checks failed |
+
+## Examples
+
+### Basic Health Check
+
+```bash
+$ python node_health.py
+============================================================
+RustChain Node Health Check
+============================================================
+Node URL: https://rustchain.org
+Timestamp: 2024-01-15T10:30:00Z
+
+[✓] Health Status
+    OK: True
+    Version: 2.2.1
+    Uptime: 1d 5h 30m
+    DB Read/Write: OK
+
+[✓] Epoch Information
+    Epoch: 1234
+    Slot: 567
+    Epoch Pot: 1.5 RTC
+    Enrolled Miners: 42
+    Total Supply: 1000000 RTC
+
+[✓] API Reachability
+    ✓ /health: 45ms (HTTP 200)
+    ✓ /epoch: 52ms (HTTP 200)
+    ✓ /api/miners: 78ms (HTTP 200)
+    ✓ /ready: 38ms (HTTP 200)
+
+------------------------------------------------------------
+STATUS: ALL CHECKS PASSED
+EXIT CODE: 0
+============================================================
+```
+
+### JSON Output for Automation
+
+```bash
+$ python node_health.py --json
+{
+  "node_url": "https://rustchain.org",
+  "timestamp": "2024-01-15T10:30:00Z",
+  "health": {
+    "ok": true,
+    "version": "2.2.1",
+    "uptime_s": 106200,
+    "db_rw": true,
+    "backup_age_hours": 1.5,
+    "tip_age_slots": 2,
+    "error": null
+  },
+  "epoch": {
+    "epoch": 1234,
+    "slot": 567,
+    "epoch_pot": 1.5,
+    "enrolled_miners": 42,
+    "blocks_per_epoch": 600,
+    "total_supply_rtc": 1000000.0,
+    "error": null
+  },
+  "reachability": [
+    {
+      "endpoint": "/health",
+      "reachable": true,
+      "latency_ms": 45.2,
+      "status_code": 200,
+      "error": null
+    }
+  ],
+  "overall_ok": true,
+  "exit_code": 0
+}
+```
+
+### Check Specific Endpoints
+
+```bash
+# Check only health and epoch endpoints
+python node_health.py -e /health /epoch
+
+# Check custom API endpoints
+python node_health.py -e /health /epoch /api/stats /ready
+```
+
+### Verbose Output
+
+```bash
+$ python node_health.py -v
+============================================================
+RustChain Node Health Check
+============================================================
+Node URL: https://rustchain.org
+Timestamp: 2024-01-15T10:30:00Z
+
+[✓] Health Status
+    OK: True
+    Version: 2.2.1
+    Uptime: 1d 5h 30m
+    DB Read/Write: OK
+    Backup Age: 1.5 hours
+    Tip Age: 2 slots
+
+[✓] Epoch Information
+    Epoch: 1234
+    Slot: 567
+    Epoch Pot: 1.5 RTC
+    Enrolled Miners: 42
+    Total Supply: 1000000 RTC
+
+[✓] API Reachability
+    ✓ /health: 45ms (HTTP 200)
+    ✓ /epoch: 52ms (HTTP 200)
+    ✓ /api/miners: 78ms (HTTP 200)
+    ✓ /ready: 38ms (HTTP 200)
+
+------------------------------------------------------------
+STATUS: ALL CHECKS PASSED
+EXIT CODE: 0
+============================================================
+```
+
+### Scripting Integration
+
+```bash
+#!/bin/bash
+# Monitor script with alerting
+
+NODE_URL="https://rustchain.org"
+
+python node_health.py -n "$NODE_URL" -q
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    echo "Node health check failed with exit code $EXIT_CODE"
+    # Send alert (email, Slack, PagerDuty, etc.)
+    # send_alert "RustChain node $NODE_URL health check failed"
+    exit 1
+fi
+
+echo "Node health check passed"
+exit 0
+```
+
+### Cron Job Monitoring
+
+```bash
+# Add to crontab for hourly checks
+0 * * * * /usr/bin/python3 /path/to/node_health.py -n https://rustchain.org -q || /path/to/alert_script.sh
+```
+
+### Docker Health Check
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD python /app/node_health.py -n http://localhost:8099 -q || exit 1
+```
+
+## Output Fields
+
+### Health Status
+
+| Field | Description |
+|-------|-------------|
+| `ok` | Overall health status (true/false) |
+| `version` | Node software version |
+| `uptime_s` | Node uptime in seconds |
+| `db_rw` | Database read/write status |
+| `backup_age_hours` | Age of last backup in hours |
+| `tip_age_slots` | Age of chain tip in slots |
+
+### Epoch Information
+
+| Field | Description |
+|-------|-------------|
+| `epoch` | Current epoch number |
+| `slot` | Current slot within epoch |
+| `epoch_pot` | Reward pot size for current epoch (RTC) |
+| `enrolled_miners` | Number of enrolled miners |
+| `blocks_per_epoch` | Total blocks per epoch |
+| `total_supply_rtc` | Total RTC supply |
+
+### Reachability Status
+
+| Field | Description |
+|-------|-------------|
+| `endpoint` | API endpoint path |
+| `reachable` | Whether endpoint is reachable |
+| `latency_ms` | Response latency in milliseconds |
+| `status_code` | HTTP status code |
+| `error` | Error message if unreachable |
+
+## Troubleshooting
+
+### Connection Timeout
+
+```
+Error: Connection timeout
+```
+
+**Solution**: Increase timeout with `-t` flag or check network connectivity.
+
+```bash
+python node_health.py -t 30  # 30 second timeout
+```
+
+### Node Unreachable
+
+```
+Error: Connection refused
+```
+
+**Solution**: Verify node is running and URL is correct.
+
+```bash
+# Test with curl first
+curl -s https://rustchain.org/health
+
+# Then check with node_health
+python node_health.py -n https://rustchain.org
+```
+
+### JSON Parse Error
+
+```
+Error: JSON parse error: ...
+```
+
+**Solution**: Node may be returning HTML error page. Check if node is properly configured.
+
+## API Endpoints
+
+The tool checks these endpoints by default:
+
+| Endpoint | Description |
+|----------|-------------|
+| `/health` | Node health status |
+| `/epoch` | Current epoch information |
+| `/api/miners` | List of enrolled miners |
+
+Custom endpoints can be specified with `-e` flag.
+
+## Related Tools
+
+- **monitoring/rustchain-exporter.py**: Prometheus exporter for continuous monitoring
+- **node/consensus_probe.py**: Cross-node consistency checker
+- **sdk/python/rustchain_sdk.py**: Python SDK for RustChain API
+
+## License
+
+MIT - Same as RustChain
+
+## Contributing
+
+See main [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+
+## Testing
+
+Run the test suite:
+
+```bash
+cd tools/node-health-cli
+python -m pytest tests/test_node_health.py -v
+
+# Or with unittest
+python -m unittest tests/test_node_health.py -v
+```

--- a/tools/node-health-cli/__init__.py
+++ b/tools/node-health-cli/__init__.py
@@ -1,0 +1,9 @@
+"""
+RustChain Node Health Monitor CLI
+
+A command-line tool to monitor RustChain node health with comprehensive checks
+for health status, epoch information, and peer/API reachability.
+"""
+
+__version__ = "1.0.0"
+__author__ = "RustChain Contributors"

--- a/tools/node-health-cli/node_health.py
+++ b/tools/node-health-cli/node_health.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+RustChain Node Health Monitor CLI
+
+A command-line tool to monitor RustChain node health with comprehensive checks
+for health status, epoch information, and peer/API reachability.
+
+Exit codes:
+    0 - All checks passed
+    1 - Health check failed (node unhealthy or unreachable)
+    2 - Epoch check failed (epoch data unavailable or inconsistent)
+    3 - Peer/API reachability check failed
+    4 - Multiple checks failed
+"""
+
+import argparse
+import json
+import sys
+import time
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Optional
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+
+# Exit codes
+EXIT_OK = 0
+EXIT_HEALTH_FAIL = 1
+EXIT_EPOCH_FAIL = 2
+EXIT_REACHABILITY_FAIL = 3
+EXIT_MULTI_FAIL = 4
+
+# Default configuration
+DEFAULT_NODE_URL = "https://rustchain.org"
+DEFAULT_TIMEOUT = 10
+DEFAULT_RETRIES = 3
+DEFAULT_RETRY_DELAY = 1.0
+
+
+@dataclass
+class HealthStatus:
+    """Node health status"""
+    ok: bool
+    version: Optional[str]
+    uptime_s: Optional[int]
+    db_rw: Optional[bool]
+    backup_age_hours: Optional[float]
+    tip_age_slots: Optional[int]
+    error: Optional[str]
+
+
+@dataclass
+class EpochStatus:
+    """Epoch information"""
+    epoch: Optional[int]
+    slot: Optional[int]
+    epoch_pot: Optional[float]
+    enrolled_miners: Optional[int]
+    blocks_per_epoch: Optional[int]
+    total_supply_rtc: Optional[float]
+    error: Optional[str]
+
+
+@dataclass
+class ReachabilityStatus:
+    """API endpoint reachability"""
+    endpoint: str
+    reachable: bool
+    latency_ms: Optional[float]
+    status_code: Optional[int]
+    error: Optional[str]
+
+
+@dataclass
+class CheckResult:
+    """Overall check result"""
+    node_url: str
+    timestamp: str
+    health: HealthStatus
+    epoch: EpochStatus
+    reachability: List[ReachabilityStatus]
+    overall_ok: bool
+    exit_code: int
+
+
+def fetch_json(url: str, timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
+    """Fetch JSON data from URL with retry logic"""
+    last_error = None
+    
+    for attempt in range(DEFAULT_RETRIES):
+        try:
+            req = Request(url, headers={"Accept": "application/json"})
+            with urlopen(req, timeout=timeout) as response:
+                payload = response.read().decode("utf-8")
+            return json.loads(payload)
+        except HTTPError as e:
+            last_error = f"HTTP {e.code}: {e.reason}"
+            time.sleep(DEFAULT_RETRY_DELAY)
+        except URLError as e:
+            last_error = f"Connection error: {e.reason}"
+            time.sleep(DEFAULT_RETRY_DELAY)
+        except json.JSONDecodeError as e:
+            last_error = f"JSON parse error: {e}"
+            break
+        except Exception as e:
+            last_error = f"Unexpected error: {e}"
+            time.sleep(DEFAULT_RETRY_DELAY)
+    
+    raise Exception(last_error or "Unknown error")
+
+
+def check_health(node_url: str, timeout: int) -> HealthStatus:
+    """Check node health status"""
+    try:
+        url = f"{node_url.rstrip('/')}/health"
+        data = fetch_json(url, timeout)
+        
+        return HealthStatus(
+            ok=bool(data.get("ok", False)),
+            version=data.get("version"),
+            uptime_s=data.get("uptime_s"),
+            db_rw=data.get("db_rw"),
+            backup_age_hours=data.get("backup_age_hours"),
+            tip_age_slots=data.get("tip_age_slots"),
+            error=None
+        )
+    except Exception as e:
+        return HealthStatus(
+            ok=False,
+            version=None,
+            uptime_s=None,
+            db_rw=None,
+            backup_age_hours=None,
+            tip_age_slots=None,
+            error=str(e)
+        )
+
+
+def check_epoch(node_url: str, timeout: int) -> EpochStatus:
+    """Check current epoch information"""
+    try:
+        url = f"{node_url.rstrip('/')}/epoch"
+        data = fetch_json(url, timeout)
+        
+        return EpochStatus(
+            epoch=data.get("epoch"),
+            slot=data.get("slot"),
+            epoch_pot=data.get("epoch_pot"),
+            enrolled_miners=data.get("enrolled_miners"),
+            blocks_per_epoch=data.get("blocks_per_epoch"),
+            total_supply_rtc=data.get("total_supply_rtc"),
+            error=None
+        )
+    except Exception as e:
+        return EpochStatus(
+            epoch=None,
+            slot=None,
+            epoch_pot=None,
+            enrolled_miners=None,
+            blocks_per_epoch=None,
+            total_supply_rtc=None,
+            error=str(e)
+        )
+
+
+def check_reachability(node_url: str, endpoints: List[str], timeout: int) -> List[ReachabilityStatus]:
+    """Check API endpoint reachability"""
+    results = []
+    base_url = node_url.rstrip('/')
+    
+    for endpoint in endpoints:
+        url = f"{base_url}{endpoint}"
+        start_time = time.time()
+        
+        try:
+            req = Request(url, headers={"Accept": "application/json"})
+            with urlopen(req, timeout=timeout) as response:
+                latency_ms = (time.time() - start_time) * 1000
+                results.append(ReachabilityStatus(
+                    endpoint=endpoint,
+                    reachable=True,
+                    latency_ms=round(latency_ms, 2),
+                    status_code=response.status,
+                    error=None
+                ))
+        except HTTPError as e:
+            latency_ms = (time.time() - start_time) * 1000
+            results.append(ReachabilityStatus(
+                endpoint=endpoint,
+                reachable=False,
+                latency_ms=round(latency_ms, 2),
+                status_code=e.code,
+                error=f"HTTP {e.code}"
+            ))
+        except URLError as e:
+            latency_ms = (time.time() - start_time) * 1000
+            results.append(ReachabilityStatus(
+                endpoint=endpoint,
+                reachable=False,
+                latency_ms=round(latency_ms, 2),
+                status_code=None,
+                error=str(e.reason)
+            ))
+        except Exception as e:
+            latency_ms = (time.time() - start_time) * 1000
+            results.append(ReachabilityStatus(
+                endpoint=endpoint,
+                reachable=False,
+                latency_ms=round(latency_ms, 2),
+                status_code=None,
+                error=str(e)
+            ))
+    
+    return results
+
+
+def run_checks(node_url: str, timeout: int, custom_endpoints: Optional[List[str]] = None) -> CheckResult:
+    """Run all health checks"""
+    default_endpoints = ["/health", "/epoch", "/api/miners"]
+    endpoints = custom_endpoints if custom_endpoints else default_endpoints
+    
+    health = check_health(node_url, timeout)
+    epoch = check_epoch(node_url, timeout)
+    reachability = check_reachability(node_url, endpoints, timeout)
+    
+    # Determine overall status and exit code
+    health_ok = health.ok and health.error is None
+    epoch_ok = epoch.epoch is not None and epoch.error is None
+    reachability_ok = all(r.reachable for r in reachability)
+    
+    failures = []
+    if not health_ok:
+        failures.append("health")
+    if not epoch_ok:
+        failures.append("epoch")
+    if not reachability_ok:
+        failures.append("reachability")
+    
+    overall_ok = len(failures) == 0
+    
+    # Determine exit code
+    if len(failures) == 0:
+        exit_code = EXIT_OK
+    elif len(failures) >= 2:
+        exit_code = EXIT_MULTI_FAIL
+    elif "health" in failures:
+        exit_code = EXIT_HEALTH_FAIL
+    elif "epoch" in failures:
+        exit_code = EXIT_EPOCH_FAIL
+    elif "reachability" in failures:
+        exit_code = EXIT_REACHABILITY_FAIL
+    else:
+        exit_code = EXIT_MULTI_FAIL
+    
+    return CheckResult(
+        node_url=node_url,
+        timestamp=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        health=health,
+        epoch=epoch,
+        reachability=reachability,
+        overall_ok=overall_ok,
+        exit_code=exit_code
+    )
+
+
+def format_text(result: CheckResult, verbose: bool = False) -> str:
+    """Format result as human-readable text"""
+    lines = []
+    
+    # Header
+    lines.append("=" * 60)
+    lines.append("RustChain Node Health Check")
+    lines.append("=" * 60)
+    lines.append(f"Node URL: {result.node_url}")
+    lines.append(f"Timestamp: {result.timestamp}")
+    lines.append("")
+    
+    # Health status
+    health_icon = "✓" if result.health.ok else "✗"
+    lines.append(f"[{health_icon}] Health Status")
+    if result.health.error:
+        lines.append(f"    Error: {result.health.error}")
+    else:
+        lines.append(f"    OK: {result.health.ok}")
+        lines.append(f"    Version: {result.health.version or 'N/A'}")
+        lines.append(f"    Uptime: {format_uptime(result.health.uptime_s)}")
+        lines.append(f"    DB Read/Write: {'OK' if result.health.db_rw else 'FAIL'}")
+        if verbose and result.health.backup_age_hours is not None:
+            lines.append(f"    Backup Age: {result.health.backup_age_hours:.1f} hours")
+        if verbose and result.health.tip_age_slots is not None:
+            lines.append(f"    Tip Age: {result.health.tip_age_slots} slots")
+    lines.append("")
+    
+    # Epoch status
+    epoch_icon = "✓" if result.epoch.epoch is not None else "✗"
+    lines.append(f"[{epoch_icon}] Epoch Information")
+    if result.epoch.error:
+        lines.append(f"    Error: {result.epoch.error}")
+    else:
+        lines.append(f"    Epoch: {result.epoch.epoch}")
+        lines.append(f"    Slot: {result.epoch.slot}")
+        lines.append(f"    Epoch Pot: {result.epoch.epoch_pot} RTC")
+        lines.append(f"    Enrolled Miners: {result.epoch.enrolled_miners}")
+        lines.append(f"    Total Supply: {result.epoch.total_supply_rtc} RTC")
+    lines.append("")
+    
+    # Reachability status
+    lines.append("[✓] API Reachability" if all(r.reachable for r in result.reachability) else "[✗] API Reachability")
+    for r in result.reachability:
+        status_icon = "✓" if r.reachable else "✗"
+        latency = f"{r.latency_ms:.0f}ms" if r.latency_ms else "N/A"
+        status = f"{status_icon} {r.endpoint}: {latency}"
+        if r.status_code:
+            status += f" (HTTP {r.status_code})"
+        if r.error:
+            status += f" - {r.error}"
+        lines.append(f"    {status}")
+    lines.append("")
+    
+    # Summary
+    lines.append("-" * 60)
+    if result.overall_ok:
+        lines.append("STATUS: ALL CHECKS PASSED")
+    else:
+        lines.append("STATUS: CHECKS FAILED")
+        if not result.health.ok:
+            lines.append("  - Health check failed")
+        if result.epoch.epoch is None:
+            lines.append("  - Epoch check failed")
+        if not all(r.reachable for r in result.reachability):
+            lines.append("  - Reachability check failed")
+    lines.append(f"EXIT CODE: {result.exit_code}")
+    lines.append("=" * 60)
+    
+    return "\n".join(lines)
+
+
+def format_json(result: CheckResult) -> str:
+    """Format result as JSON"""
+    data = {
+        "node_url": result.node_url,
+        "timestamp": result.timestamp,
+        "health": asdict(result.health),
+        "epoch": asdict(result.epoch),
+        "reachability": [asdict(r) for r in result.reachability],
+        "overall_ok": result.overall_ok,
+        "exit_code": result.exit_code
+    }
+    return json.dumps(data, indent=2)
+
+
+def format_uptime(seconds: Optional[int]) -> str:
+    """Format uptime in human-readable format"""
+    if seconds is None:
+        return "N/A"
+    
+    days = seconds // 86400
+    hours = (seconds % 86400) // 3600
+    minutes = (seconds % 3600) // 60
+    
+    parts = []
+    if days > 0:
+        parts.append(f"{days}d")
+    if hours > 0:
+        parts.append(f"{hours}h")
+    if minutes > 0 or not parts:
+        parts.append(f"{minutes}m")
+    
+    return " ".join(parts)
+
+
+def parse_args(args: Optional[List[str]] = None) -> argparse.Namespace:
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(
+        prog="node-health",
+        description="RustChain Node Health Monitor - Check node health, epoch info, and API reachability",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Exit Codes:
+  0  All checks passed
+  1  Health check failed
+  2  Epoch check failed
+  3  API reachability check failed
+  4  Multiple checks failed
+
+Examples:
+  %(prog)s                              # Check default node (rustchain.org)
+  %(prog)s -n http://localhost:8099     # Check local node
+  %(prog)s --json                       # Output as JSON
+  %(prog)s -v                           # Verbose output
+  %(prog)s -e /health /epoch            # Check specific endpoints
+        """
+    )
+    
+    parser.add_argument(
+        "-n", "--node",
+        default=DEFAULT_NODE_URL,
+        help=f"Node URL to check (default: {DEFAULT_NODE_URL})"
+    )
+    
+    parser.add_argument(
+        "-t", "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Request timeout in seconds (default: {DEFAULT_TIMEOUT})"
+    )
+    
+    parser.add_argument(
+        "-e", "--endpoints",
+        nargs="+",
+        help="Custom endpoints to check reachability (default: /health /epoch /api/miners /ready)"
+    )
+    
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output in JSON format"
+    )
+    
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output with additional details"
+    )
+    
+    parser.add_argument(
+        "-q", "--quiet",
+        action="store_true",
+        help="Quiet mode - only output exit code"
+    )
+    
+    return parser.parse_args(args)
+
+
+def main(args: Optional[List[str]] = None) -> int:
+    """Main entry point"""
+    parsed_args = parse_args(args)
+    
+    # Run health checks
+    result = run_checks(
+        node_url=parsed_args.node,
+        timeout=parsed_args.timeout,
+        custom_endpoints=parsed_args.endpoints
+    )
+    
+    # Output results
+    if not parsed_args.quiet:
+        if parsed_args.json:
+            print(format_json(result))
+        else:
+            print(format_text(result, verbose=parsed_args.verbose))
+    
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/node-health-cli/tests/test_node_health.py
+++ b/tools/node-health-cli/tests/test_node_health.py
@@ -1,0 +1,456 @@
+#!/usr/bin/env python3
+"""
+Tests for RustChain Node Health Monitor CLI
+"""
+
+import json
+import unittest
+from io import StringIO
+from unittest.mock import patch, MagicMock
+from urllib.error import URLError, HTTPError
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from node_health import (
+    HealthStatus, EpochStatus, ReachabilityStatus, CheckResult,
+    fetch_json, check_health, check_epoch, check_reachability,
+    run_checks, format_text, format_json, format_uptime,
+    EXIT_OK, EXIT_HEALTH_FAIL, EXIT_EPOCH_FAIL, EXIT_REACHABILITY_FAIL, EXIT_MULTI_FAIL
+)
+
+
+class TestHealthStatus(unittest.TestCase):
+    """Test HealthStatus dataclass"""
+    
+    def test_health_status_ok(self):
+        """Test healthy node status"""
+        status = HealthStatus(
+            ok=True,
+            version="2.2.1",
+            uptime_s=3600,
+            db_rw=True,
+            backup_age_hours=1.5,
+            tip_age_slots=2,
+            error=None
+        )
+        self.assertTrue(status.ok)
+        self.assertEqual(status.version, "2.2.1")
+        self.assertEqual(status.uptime_s, 3600)
+        self.assertIsNone(status.error)
+    
+    def test_health_status_error(self):
+        """Test unhealthy node status"""
+        status = HealthStatus(
+            ok=False,
+            version=None,
+            uptime_s=None,
+            db_rw=None,
+            backup_age_hours=None,
+            tip_age_slots=None,
+            error="Connection timeout"
+        )
+        self.assertFalse(status.ok)
+        self.assertEqual(status.error, "Connection timeout")
+
+
+class TestEpochStatus(unittest.TestCase):
+    """Test EpochStatus dataclass"""
+    
+    def test_epoch_status_ok(self):
+        """Test valid epoch status"""
+        status = EpochStatus(
+            epoch=1234,
+            slot=567,
+            epoch_pot=1.5,
+            enrolled_miners=42,
+            blocks_per_epoch=600,
+            total_supply_rtc=1000000.0,
+            error=None
+        )
+        self.assertEqual(status.epoch, 1234)
+        self.assertEqual(status.slot, 567)
+        self.assertEqual(status.enrolled_miners, 42)
+    
+    def test_epoch_status_error(self):
+        """Test epoch status with error"""
+        status = EpochStatus(
+            epoch=None,
+            slot=None,
+            epoch_pot=None,
+            enrolled_miners=None,
+            blocks_per_epoch=None,
+            total_supply_rtc=None,
+            error="Endpoint unavailable"
+        )
+        self.assertIsNone(status.epoch)
+        self.assertEqual(status.error, "Endpoint unavailable")
+
+
+class TestReachabilityStatus(unittest.TestCase):
+    """Test ReachabilityStatus dataclass"""
+    
+    def test_reachable_endpoint(self):
+        """Test reachable endpoint"""
+        status = ReachabilityStatus(
+            endpoint="/health",
+            reachable=True,
+            latency_ms=45.2,
+            status_code=200,
+            error=None
+        )
+        self.assertTrue(status.reachable)
+        self.assertEqual(status.latency_ms, 45.2)
+        self.assertEqual(status.status_code, 200)
+    
+    def test_unreachable_endpoint(self):
+        """Test unreachable endpoint"""
+        status = ReachabilityStatus(
+            endpoint="/api/miners",
+            reachable=False,
+            latency_ms=5000.0,
+            status_code=None,
+            error="Connection refused"
+        )
+        self.assertFalse(status.reachable)
+        self.assertEqual(status.error, "Connection refused")
+
+
+class TestFormatUptime(unittest.TestCase):
+    """Test uptime formatting"""
+    
+    def test_uptime_seconds(self):
+        """Test uptime in seconds"""
+        self.assertEqual(format_uptime(120), "2m")
+    
+    def test_uptime_minutes(self):
+        """Test uptime in minutes"""
+        self.assertEqual(format_uptime(3660), "1h 1m")
+    
+    def test_uptime_hours(self):
+        """Test uptime in hours"""
+        self.assertEqual(format_uptime(90060), "1d 1h 1m")
+    
+    def test_uptime_none(self):
+        """Test None uptime"""
+        self.assertEqual(format_uptime(None), "N/A")
+    
+    def test_uptime_zero(self):
+        """Test zero uptime"""
+        self.assertEqual(format_uptime(0), "0m")
+
+
+class TestFormatText(unittest.TestCase):
+    """Test text formatting"""
+    
+    def test_format_text_all_ok(self):
+        """Test text formatting when all checks pass"""
+        result = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=True, version="2.2.1", uptime_s=3600,
+                               db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                                  status_code=200, error=None)
+            ],
+            overall_ok=True,
+            exit_code=EXIT_OK
+        )
+        
+        output = format_text(result)
+        self.assertIn("RustChain Node Health Check", output)
+        self.assertIn("STATUS: ALL CHECKS PASSED", output)
+        self.assertIn("EXIT CODE: 0", output)
+    
+    def test_format_text_health_fail(self):
+        """Test text formatting when health check fails"""
+        result = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=False, version=None, uptime_s=None,
+                               db_rw=None, backup_age_hours=None, tip_age_slots=None,
+                               error="Connection refused"),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=False, latency_ms=1000.0,
+                                  status_code=None, error="Connection refused")
+            ],
+            overall_ok=False,
+            exit_code=EXIT_HEALTH_FAIL
+        )
+        
+        output = format_text(result)
+        self.assertIn("STATUS: CHECKS FAILED", output)
+        self.assertIn("Health check failed", output)
+
+
+class TestFormatJson(unittest.TestCase):
+    """Test JSON formatting"""
+    
+    def test_format_json_valid(self):
+        """Test JSON formatting produces valid JSON"""
+        result = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=True, version="2.2.1", uptime_s=3600,
+                               db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                                  status_code=200, error=None)
+            ],
+            overall_ok=True,
+            exit_code=EXIT_OK
+        )
+        
+        output = format_json(result)
+        data = json.loads(output)  # Should not raise
+        
+        self.assertEqual(data["node_url"], "https://rustchain.org")
+        self.assertEqual(data["exit_code"], 0)
+        self.assertTrue(data["overall_ok"])
+        self.assertEqual(data["health"]["version"], "2.2.1")
+
+
+class TestCheckFunctions(unittest.TestCase):
+    """Test check functions with mocked responses"""
+    
+    @patch('node_health.urlopen')
+    def test_check_health_success(self, mock_urlopen):
+        """Test health check with successful response"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "ok": True,
+            "version": "2.2.1",
+            "uptime_s": 3600,
+            "db_rw": True,
+            "backup_age_hours": 1.0,
+            "tip_age_slots": 1
+        }).encode()
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        
+        result = check_health("https://rustchain.org", timeout=10)
+        
+        self.assertTrue(result.ok)
+        self.assertEqual(result.version, "2.2.1")
+        self.assertEqual(result.uptime_s, 3600)
+        self.assertIsNone(result.error)
+    
+    @patch('node_health.urlopen')
+    def test_check_health_failure(self, mock_urlopen):
+        """Test health check with connection error"""
+        mock_urlopen.side_effect = URLError("Connection refused")
+        
+        result = check_health("https://rustchain.org", timeout=10)
+        
+        self.assertFalse(result.ok)
+        self.assertIsNotNone(result.error)
+        self.assertIn("Connection refused", result.error)
+    
+    @patch('node_health.urlopen')
+    def test_check_epoch_success(self, mock_urlopen):
+        """Test epoch check with successful response"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "epoch": 1234,
+            "slot": 567,
+            "epoch_pot": 1.5,
+            "enrolled_miners": 42,
+            "blocks_per_epoch": 600,
+            "total_supply_rtc": 1000000.0
+        }).encode()
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        
+        result = check_epoch("https://rustchain.org", timeout=10)
+        
+        self.assertEqual(result.epoch, 1234)
+        self.assertEqual(result.slot, 567)
+        self.assertEqual(result.enrolled_miners, 42)
+        self.assertIsNone(result.error)
+    
+    @patch('node_health.urlopen')
+    def test_check_reachability(self, mock_urlopen):
+        """Test reachability check"""
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+        
+        results = check_reachability(
+            "https://rustchain.org",
+            ["/health", "/epoch"],
+            timeout=10
+        )
+        
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r.reachable for r in results))
+
+
+class TestRunChecks(unittest.TestCase):
+    """Test integrated check runner"""
+    
+    @patch('node_health.check_health')
+    @patch('node_health.check_epoch')
+    @patch('node_health.check_reachability')
+    def test_run_checks_all_pass(self, mock_reach, mock_epoch, mock_health):
+        """Test when all checks pass"""
+        mock_health.return_value = HealthStatus(
+            ok=True, version="2.2.1", uptime_s=3600,
+            db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None
+        )
+        mock_epoch.return_value = EpochStatus(
+            epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+            blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None
+        )
+        mock_reach.return_value = [
+            ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                              status_code=200, error=None)
+        ]
+        
+        result = run_checks("https://rustchain.org", timeout=10)
+        
+        self.assertTrue(result.overall_ok)
+        self.assertEqual(result.exit_code, EXIT_OK)
+    
+    @patch('node_health.check_health')
+    @patch('node_health.check_epoch')
+    @patch('node_health.check_reachability')
+    def test_run_checks_health_fail(self, mock_reach, mock_epoch, mock_health):
+        """Test when only health check fails (node reports unhealthy but reachable)"""
+        mock_health.return_value = HealthStatus(
+            ok=False, version="2.2.1", uptime_s=3600,
+            db_rw=False, backup_age_hours=1.0, tip_age_slots=1,
+            error=None  # No error, just unhealthy status
+        )
+        mock_epoch.return_value = EpochStatus(
+            epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+            blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None
+        )
+        mock_reach.return_value = [
+            ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                              status_code=503, error=None)  # Reachable but returns 503
+        ]
+        
+        result = run_checks("https://rustchain.org", timeout=10)
+        
+        self.assertFalse(result.overall_ok)
+        self.assertEqual(result.exit_code, EXIT_HEALTH_FAIL)
+    
+    @patch('node_health.check_health')
+    @patch('node_health.check_epoch')
+    @patch('node_health.check_reachability')
+    def test_run_checks_multiple_fail(self, mock_reach, mock_epoch, mock_health):
+        """Test when multiple checks fail"""
+        mock_health.return_value = HealthStatus(
+            ok=False, version=None, uptime_s=None,
+            db_rw=None, backup_age_hours=None, tip_age_slots=None,
+            error="Node unreachable"
+        )
+        mock_epoch.return_value = EpochStatus(
+            epoch=None, slot=None, epoch_pot=None, enrolled_miners=None,
+            blocks_per_epoch=None, total_supply_rtc=None,
+            error="Epoch endpoint unavailable"
+        )
+        mock_reach.return_value = [
+            ReachabilityStatus(endpoint="/health", reachable=False, latency_ms=1000.0,
+                              status_code=None, error="Connection refused")
+        ]
+        
+        result = run_checks("https://rustchain.org", timeout=10)
+        
+        self.assertFalse(result.overall_ok)
+        self.assertEqual(result.exit_code, EXIT_MULTI_FAIL)
+
+
+class TestMainFunction(unittest.TestCase):
+    """Test main CLI entry point"""
+    
+    @patch('node_health.run_checks')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_text_output(self, mock_stdout, mock_run):
+        """Test main function with text output"""
+        mock_run.return_value = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=True, version="2.2.1", uptime_s=3600,
+                               db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                                  status_code=200, error=None)
+            ],
+            overall_ok=True,
+            exit_code=EXIT_OK
+        )
+        
+        from node_health import main
+        exit_code = main(["-n", "https://rustchain.org"])
+        
+        self.assertEqual(exit_code, EXIT_OK)
+        output = mock_stdout.getvalue()
+        self.assertIn("RustChain Node Health Check", output)
+    
+    @patch('node_health.run_checks')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_json_output(self, mock_stdout, mock_run):
+        """Test main function with JSON output"""
+        mock_run.return_value = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=True, version="2.2.1", uptime_s=3600,
+                               db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                                  status_code=200, error=None)
+            ],
+            overall_ok=True,
+            exit_code=EXIT_OK
+        )
+        
+        from node_health import main
+        exit_code = main(["-n", "https://rustchain.org", "--json"])
+        
+        self.assertEqual(exit_code, EXIT_OK)
+        output = mock_stdout.getvalue()
+        data = json.loads(output)  # Should be valid JSON
+        self.assertEqual(data["exit_code"], 0)
+    
+    @patch('node_health.run_checks')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_main_quiet_mode(self, mock_stdout, mock_run):
+        """Test main function in quiet mode"""
+        mock_run.return_value = CheckResult(
+            node_url="https://rustchain.org",
+            timestamp="2024-01-01T00:00:00Z",
+            health=HealthStatus(ok=True, version="2.2.1", uptime_s=3600,
+                               db_rw=True, backup_age_hours=1.0, tip_age_slots=1, error=None),
+            epoch=EpochStatus(epoch=100, slot=50, epoch_pot=1.5, enrolled_miners=10,
+                             blocks_per_epoch=600, total_supply_rtc=1000000.0, error=None),
+            reachability=[
+                ReachabilityStatus(endpoint="/health", reachable=True, latency_ms=50.0,
+                                  status_code=200, error=None)
+            ],
+            overall_ok=True,
+            exit_code=EXIT_OK
+        )
+        
+        from node_health import main
+        exit_code = main(["-n", "https://rustchain.org", "-q"])
+        
+        self.assertEqual(exit_code, EXIT_OK)
+        self.assertEqual(mock_stdout.getvalue(), "")  # No output in quiet mode
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements issue #1606 with a practical node-health CLI (health/epoch/reachability checks), clear exit codes, and JSON/human output.\n\nCloses #1606