### PR TITLE
test: add unit coverage for rustchain-wallet core helpers (#1589)

### DIFF
--- a/rustchain-wallet/src/lib.rs
+++ b/rustchain-wallet/src/lib.rs
@@ -173,10 +173,10 @@ mod tests {
     fn test_wallet_signing() {
         let wallet = Wallet::generate();
         let message = b"Hello, RustChain!";
-        
+
         let signature = wallet.sign(message).unwrap();
         assert_eq!(signature.len(), 64); // Ed25519 signature size
-        
+
         let valid = wallet.verify(message, &signature).unwrap();
         assert!(valid);
     }
@@ -185,8 +185,29 @@ mod tests {
     fn test_wallet_network() {
         let wallet = Wallet::generate();
         assert_eq!(wallet.network(), Network::Mainnet);
-        
+
         let wallet_testnet = Wallet::with_network(KeyPair::generate(), Network::Testnet);
         assert_eq!(wallet_testnet.network(), Network::Testnet);
+    }
+
+    #[test]
+    fn test_network_rpc_urls() {
+        assert_eq!(Network::Mainnet.rpc_url(), "https://rpc.rustchain.org");
+        assert_eq!(Network::Testnet.rpc_url(), "https://testnet-rpc.rustchain.org");
+        assert_eq!(Network::Devnet.rpc_url(), "https://devnet-rpc.rustchain.org");
+    }
+
+    #[test]
+    fn test_network_explorer_urls() {
+        assert_eq!(Network::Mainnet.explorer_url(), "https://explorer.rustchain.org");
+        assert_eq!(Network::Testnet.explorer_url(), "https://testnet-explorer.rustchain.org");
+        assert_eq!(Network::Devnet.explorer_url(), "https://devnet-explorer.rustchain.org");
+    }
+
+    #[test]
+    fn test_network_display() {
+        assert_eq!(format!("{}", Network::Mainnet), "mainnet");
+        assert_eq!(format!("{}", Network::Testnet), "testnet");
+        assert_eq!(format!("{}", Network::Devnet), "devnet");
     }
 }

--- a/rustchain-wallet/src/nonce_store.rs
+++ b/rustchain-wallet/src/nonce_store.rs
@@ -302,4 +302,40 @@ mod tests {
         assert!(store.is_used("addr_2", 2));
         assert!(store.is_used("addr_2", 5));
     }
+
+    #[test]
+    fn test_get_highest_nonce() {
+        let mut store = NonceStore::new();
+        let address = "test_address";
+
+        // Initially no highest nonce
+        assert_eq!(store.get_highest_nonce(address), None);
+
+        // Mark some nonces
+        store.mark_used(address, 0);
+        assert_eq!(store.get_highest_nonce(address), Some(0));
+
+        store.mark_used(address, 5);
+        assert_eq!(store.get_highest_nonce(address), Some(5));
+
+        store.mark_used(address, 3); // Lower than 5, shouldn't change highest
+        assert_eq!(store.get_highest_nonce(address), Some(5));
+
+        store.mark_used(address, 10);
+        assert_eq!(store.get_highest_nonce(address), Some(10));
+    }
+
+    #[test]
+    fn test_get_highest_nonce_multiple_addresses() {
+        let mut store = NonceStore::new();
+
+        store.mark_used("addr_a", 0);
+        store.mark_used("addr_a", 5);
+        store.mark_used("addr_b", 3);
+        store.mark_used("addr_b", 7);
+
+        assert_eq!(store.get_highest_nonce("addr_a"), Some(5));
+        assert_eq!(store.get_highest_nonce("addr_b"), Some(7));
+        assert_eq!(store.get_highest_nonce("addr_c"), None);
+    }
 }

--- a/rustchain-wallet/src/transaction.rs
+++ b/rustchain-wallet/src/transaction.rs
@@ -463,4 +463,46 @@ mod tests {
         assert!(tx1.verify_complete(&keypair1, &nonce_store).unwrap());
         assert!(tx2.verify_complete(&keypair2, &nonce_store).unwrap());
     }
+
+    #[test]
+    fn test_transaction_verify_with_pubkey() {
+        let signer = KeyPair::generate();
+        let verifier = KeyPair::generate();
+
+        let mut tx = Transaction::new(
+            signer.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            1,
+        );
+
+        // Sign with signer
+        tx.sign(&signer).unwrap();
+        assert!(tx.signature.is_some());
+
+        // Verify with signer's public key should succeed
+        let valid = tx.verify_with_pubkey(&signer).unwrap();
+        assert!(valid);
+
+        // Verify with different key should fail
+        let valid = tx.verify_with_pubkey(&verifier).unwrap();
+        assert!(!valid);
+    }
+
+    #[test]
+    fn test_transaction_verify_with_pubkey_unsigned() {
+        let keypair = KeyPair::generate();
+        let tx = Transaction::new(
+            keypair.public_key_base58(),
+            "recipient".to_string(),
+            1000,
+            100,
+            1,
+        );
+
+        // Verify unsigned transaction should fail
+        let result = tx.verify_with_pubkey(&keypair);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Implements issue #1589 by adding targeted unit tests for previously untested public helpers in rustchain-wallet.\n\nCloses #1589