### PR TITLE
test: add RustChain API load test suite (k6/locust) (#1614)

### DIFF
--- a/load-tests/.env.example
+++ b/load-tests/.env.example
@@ -1,0 +1,72 @@
+# RustChain API Load Test Configuration
+# Copy this file to .env and customize for your testing needs
+
+# =============================================================================
+# TARGET CONFIGURATION
+# =============================================================================
+
+# API base URL for load testing
+# Default: https://rustchain.org
+# For local testing: http://localhost:8099
+TARGET_URL=https://rustchain.org
+
+# =============================================================================
+# TEST PARAMETERS
+# =============================================================================
+
+# Miner wallet ID for balance/eligibility tests
+# Use a valid wallet ID or 'scott' for public testing
+MINER_ID=scott
+
+# Number of concurrent users (Locust)
+USERS=10
+
+# User spawn rate per second (Locust)
+SPAWN_RATE=2
+
+# Test duration (e.g., 30s, 5m, 1h)
+DURATION=5m
+
+# =============================================================================
+# K6 SPECIFIC
+# =============================================================================
+
+# Virtual users for k6 constant load
+K6_VUS=10
+
+# Rate limit (requests per second)
+K6_RATE_LIMIT=30
+
+# =============================================================================
+# SCENARIO SELECTION
+# =============================================================================
+
+# Test scenario to run: smoke, load, stress, baseline, soak, spike
+TEST_SCENARIO=load
+
+# =============================================================================
+# OUTPUT CONFIGURATION
+# =============================================================================
+
+# Output directory for test results
+OUTPUT_DIR=./results
+
+# Generate HTML report (true/false)
+GENERATE_HTML=true
+
+# Generate JSON results (true/false)
+GENERATE_JSON=true
+
+# =============================================================================
+# ADVANCED OPTIONS
+# =============================================================================
+
+# Skip TLS verification (needed for self-signed certs)
+# Default: true (RustChain uses self-signed certificates)
+INSECURE_SKIP_TLS_VERIFY=true
+
+# Enable debug logging (true/false)
+DEBUG=false
+
+# Custom user agent string
+USER_AGENT=k6-rustchain-load-test/1.0

--- a/load-tests/.gitignore
+++ b/load-tests/.gitignore
@@ -1,0 +1,22 @@
+# Load test results (generated during test runs)
+results/
+*.html
+*-results.json
+locust-report*.html
+locust-results*.json
+# Generated k6 result files (but keep config files)
+k6-*.json
+!k6-config.json
+!k6-scenarios.json
+
+# Environment files (may contain sensitive data)
+.env
+
+# Python cache
+__pycache__/
+*.pyc
+.pytest_cache/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -1,0 +1,333 @@
+# RustChain API Load Test Suite
+
+> **Issue #1614**: Add load test suite for RustChain API with configurable targets/rates
+
+This directory contains comprehensive load testing tools for the RustChain API, supporting both **k6** (JavaScript) and **Locust** (Python) frameworks.
+
+## Quick Start
+
+### Using k6 (Recommended)
+
+```bash
+# Install k6
+brew install k6  # macOS
+sudo apt-get install k6  # Linux
+
+# Run a quick smoke test
+./run-load-test.sh k6 smoke
+
+# Run standard load test
+./run-load-test.sh k6 load
+
+# Run stress test
+./run-load-test.sh k6 stress
+```
+
+### Using Locust
+
+```bash
+# Install dependencies
+pip install -r locust-requirements.txt
+
+# Run with web UI (open http://localhost:8089)
+./run-load-test.sh locust web
+
+# Run headless
+./run-load-test.sh locust headless
+```
+
+## Configuration
+
+### Environment Variables
+
+Copy `.env.example` to `.env` and customize:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TARGET_URL` | `https://rustchain.org` | API base URL |
+| `MINER_ID` | `scott` | Miner wallet ID for testing |
+| `DURATION` | `5m` | Test duration (e.g., `30s`, `5m`, `1h`) |
+| `USERS` | `10` | Concurrent users (Locust) |
+| `SPAWN_RATE` | `2` | User spawn rate per second (Locust) |
+| `OUTPUT_DIR` | `./results` | Results output directory |
+
+### k6 Configuration
+
+k6 tests can be configured via:
+
+1. **Environment variables** (runtime):
+   ```bash
+   k6 run -e TARGET_URL=http://localhost:8099 -e MINER_ID=test k6-load-test.js
+   ```
+
+2. **Config file** (`k6-config.json`):
+   ```bash
+   k6 run --config k6-config.json k6-load-test.js
+   ```
+
+3. **Scenario presets** (`k6-scenarios.json`):
+   ```bash
+   k6 run --config k6-scenarios.json --scenario api-baseline k6-load-test.js
+   ```
+
+## Test Scenarios
+
+### k6 Scenarios
+
+| Scenario | Description | Duration | VUs | Use Case |
+|----------|-------------|----------|-----|----------|
+| `smoke` | Basic health check | 30s | 1 | Quick validation |
+| `load` | Standard load test | 5m | 0→10→0 | Regular testing |
+| `stress` | Peak load test | 6m | 0→100→0 | Capacity planning |
+| `quick-smoke` | CI/CD smoke test | 30s | 2 | Pipeline integration |
+| `api-baseline` | Performance baseline | 5m | 10 | Benchmarking |
+| `soak-test` | Endurance test | 30m | 25 | Memory leak detection |
+| `spike-test` | Sudden load spike | 5m | 5→75→5 | Resilience testing |
+
+### Locust User Classes
+
+| User Class | Description | Wait Time | Use Case |
+|------------|-------------|-----------|----------|
+| `RustChainAPIUser` | Standard API user | 1-3s | Normal load testing |
+| `HeavyLoadUser` | Aggressive user | 0.1-0.5s | Stress testing |
+| `WriteLoadUser` | Write operations | 2-5s | Mutation testing |
+
+## Endpoints Tested
+
+| Endpoint | Method | Description | Weight |
+|----------|--------|-------------|--------|
+| `/health` | GET | Node health status | High |
+| `/ready` | GET | Kubernetes readiness probe | Medium |
+| `/epoch` | GET | Current epoch/slot info | High |
+| `/api/miners` | GET | List active miners | High |
+| `/api/nodes` | GET | List connected nodes | Medium |
+| `/wallet/balance` | GET | Wallet balance lookup | Medium |
+| `/governance/proposals` | GET | Governance proposals | Low |
+| `/lottery/eligibility` | GET | Miner eligibility check | Low |
+
+## Output & Reporting
+
+### k6 Output
+
+k6 generates:
+- **Console output**: Real-time metrics during test
+- **JSON results**: `load-test-results.json` with summary metrics
+- **Detailed logs**: When using `--out json=<file>`
+
+Example metrics:
+```json
+{
+  "test_info": {
+    "target_url": "https://rustchain.org",
+    "timestamp": "2026-03-11T12:00:00Z"
+  },
+  "metrics": {
+    "total_requests": 1500,
+    "request_rate": 5.0,
+    "error_rate": 0.02,
+    "avg_latency_ms": 245.5,
+    "p95_latency_ms": 890.2,
+    "p99_latency_ms": 1250.8
+  },
+  "checks": {
+    "health_pass_rate": 0.99,
+    "epoch_pass_rate": 0.98,
+    "miners_pass_rate": 0.97,
+    "balance_pass_rate": 0.95
+  }
+}
+```
+
+### Locust Output
+
+Locust generates:
+- **HTML report**: Interactive report with charts
+- **JSON results**: Raw data for further analysis
+- **Web UI**: Real-time monitoring (when running with `--web`)
+
+## Performance Thresholds
+
+Default thresholds (configurable in `k6-config.json`):
+
+| Metric | Threshold | Description |
+|--------|-----------|-------------|
+| `p50 latency` | < 500ms | 50th percentile response time |
+| `p95 latency` | < 2000ms | 95th percentile response time |
+| `p99 latency` | < 5000ms | 99th percentile response time |
+| `error rate` | < 5% | HTTP error rate |
+| `health check` | > 95% | Health endpoint pass rate |
+| `balance check` | > 90% | Balance endpoint pass rate |
+
+## CI/CD Integration
+
+### GitHub Actions Example
+
+```yaml
+name: API Load Test
+
+on: [push, pull_request]
+
+jobs:
+  load-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install k6
+        run: |
+          curl https://github.com/grafana/k6/releases/download/v0.47.0/k6-v0.47.0-linux-amd64.tar.gz | tar xz
+          sudo cp k6-v0.47.0-linux-amd64/k6 /usr/local/bin/
+      
+      - name: Run smoke test
+        run: |
+          cd load-tests
+          k6 run --config k6-scenarios.json --scenario quick-smoke k6-load-test.js
+        env:
+          TARGET_URL: ${{ secrets.RUSTCHAIN_TEST_URL }}
+```
+
+### GitLab CI Example
+
+```yaml
+load_test:
+  stage: test
+  image: grafana/k6:latest
+  script:
+    - cd load-tests
+    - k6 run --config k6-scenarios.json --scenario quick-smoke k6-load-test.js
+  variables:
+    TARGET_URL: https://rustchain.org
+  artifacts:
+    reports:
+      load_test: load-tests/load-test-results.json
+```
+
+## Advanced Usage
+
+### Custom k6 Scenarios
+
+Create custom scenarios in a new config file:
+
+```json
+{
+  "scenarios": {
+    "custom-test": {
+      "executor": "ramping-vus",
+      "startVUs": 5,
+      "stages": [
+        { "duration": "2m", "target": 30 },
+        { "duration": "5m", "target": 30 },
+        { "duration": "1m", "target": 0 }
+      ]
+    }
+  }
+}
+```
+
+Run with:
+```bash
+k6 run --config custom-config.json --scenario custom-test k6-load-test.js
+```
+
+### Distributed Load Testing (Locust)
+
+For high-load tests, run Locust in distributed mode:
+
+```bash
+# Master node
+locust -f locust-load-test.py --master --expect-workers 4
+
+# Worker nodes (on separate machines)
+locust -f locust-load-test.py --worker --master-host=<master-ip>
+```
+
+### Custom Metrics
+
+Add custom metrics in k6:
+
+```javascript
+import { Trend } from 'k6/metrics';
+
+const customMetric = new Trend('custom_metric');
+
+export default function() {
+  const response = http.get('https://rustchain.org/health');
+  customMetric.add(response.timings.duration);
+}
+```
+
+## Troubleshooting
+
+### k6 Issues
+
+**Problem**: `k6: command not found`
+```bash
+# Install k6
+brew install k6  # macOS
+sudo apt-get install k6  # Debian/Ubuntu
+winget install k6  # Windows
+```
+
+**Problem**: TLS certificate errors
+```bash
+# k6 handles self-signed certs with insecureSkipTLSVerify in config
+# Or use environment variable:
+export K6_INSECURE_SKIP_TLS_VERIFY=true
+```
+
+### Locust Issues
+
+**Problem**: `ModuleNotFoundError: No module named 'locust'`
+```bash
+pip install -r locust-requirements.txt
+```
+
+**Problem**: Connection refused
+```bash
+# Verify TARGET_URL is accessible
+curl -sk https://rustchain.org/health
+
+# Check firewall/proxy settings
+```
+
+## Best Practices
+
+1. **Start small**: Begin with smoke tests before running load/stress tests
+2. **Monitor resources**: Watch server CPU, memory, and network during tests
+3. **Use realistic data**: Configure `MINER_ID` with actual wallet addresses
+4. **Run regularly**: Schedule load tests in CI/CD pipelines
+5. **Compare baselines**: Track performance metrics over time
+6. **Test in staging**: Never run stress tests directly on production
+
+## File Structure
+
+```
+load-tests/
+├── README.md                    # This file
+├── .env.example                 # Environment configuration template
+├── k6-load-test.js              # Main k6 test script
+├── k6-config.json               # Default k6 configuration
+├── k6-scenarios.json            # Pre-configured k6 scenarios
+├── locust-load-test.py          # Locust test script
+├── locust-requirements.txt      # Python dependencies
+├── run-load-test.sh             # Unified test runner
+└── results/                     # Test output directory (gitignored)
+    ├── k6-*.json
+    ├── locust-*.html
+    └── locust-*.json
+```
+
+## References
+
+- [k6 Documentation](https://k6.io/docs/)
+- [Locust Documentation](https://docs.locust.io/)
+- [RustChain API Reference](../docs/api-reference.md)
+- [RustChain Postman Collection](../docs/postman/RustChain.postman_collection.json)
+
+## License
+
+Same as RustChain project license.

--- a/load-tests/k6-config.json
+++ b/load-tests/k6-config.json
@@ -1,0 +1,47 @@
+{
+  "description": "RustChain API Load Test Configuration",
+  "scenarios": {
+    "smoke": {
+      "executor": "constant-vus",
+      "vus": 1,
+      "duration": "30s",
+      "tags": { "test_type": "smoke" }
+    },
+    "load": {
+      "executor": "ramping-vus",
+      "startVUs": 0,
+      "stages": [
+        { "duration": "1m", "target": 10 },
+        { "duration": "3m", "target": 10 },
+        { "duration": "1m", "target": 0 }
+      ],
+      "tags": { "test_type": "load" },
+      "startTime": "35s"
+    },
+    "stress": {
+      "executor": "ramping-vus",
+      "startVUs": 0,
+      "stages": [
+        { "duration": "2m", "target": 50 },
+        { "duration": "2m", "target": 50 },
+        { "duration": "1m", "target": 100 },
+        { "duration": "1m", "target": 0 }
+      ],
+      "tags": { "test_type": "stress" },
+      "startTime": "8m5s"
+    }
+  },
+  "thresholds": {
+    "http_req_duration": ["p(50)<500", "p(95)<2000", "p(99)<5000"],
+    "http_req_failed": ["rate<0.05"],
+    "errors": ["rate<0.1"],
+    "health_check_pass": ["rate>0.95"],
+    "epoch_check_pass": ["rate>0.95"],
+    "miners_check_pass": ["rate>0.95"],
+    "balance_check_pass": ["rate>0.90"]
+  },
+  "summaryTimeWindow": "10s",
+  "noConnectionReuse": false,
+  "userAgent": "k6-rustchain-load-test/1.0",
+  "insecureSkipTLSVerify": true
+}

--- a/load-tests/k6-load-test.js
+++ b/load-tests/k6-load-test.js
@@ -1,0 +1,351 @@
+/**
+ * RustChain API Load Test Suite (k6)
+ * 
+ * Usage:
+ *   k6 run --config k6-config.json k6-load-test.js
+ *   k6 run -e TARGET_URL=https://rustchain.org -e RATE_LIMIT=30 k6-load-test.js
+ * 
+ * Environment Variables:
+ *   TARGET_URL    - API base URL (default: https://rustchain.org)
+ *   RATE_LIMIT    - Requests per second (default: 30)
+ *   DURATION      - Test duration (default: 5m)
+ *   VUS           - Virtual users (default: 10)
+ *   MINER_ID      - Miner wallet ID for testing (default: scott)
+ */
+
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+
+// Custom metrics
+const errorRate = new Rate('errors');
+const apiLatency = new Trend('api_latency_ms');
+const healthCheckPass = new Rate('health_check_pass');
+const epochCheckPass = new Rate('epoch_check_pass');
+const minersCheckPass = new Rate('miners_check_pass');
+const balanceCheckPass = new Rate('balance_check_pass');
+
+// Configuration from environment or defaults
+const BASE_URL = __ENV.TARGET_URL || 'https://rustchain.org';
+const TEST_MINER_ID = __ENV.MINER_ID || 'scott';
+
+// Test scenarios configuration
+export const options = {
+  // Default scenario - can be overridden via --config
+  scenarios: {
+    // Smoke test: quick health check
+    smoke: {
+      executor: 'constant-vus',
+      vus: 1,
+      duration: '30s',
+      tags: { test_type: 'smoke' },
+    },
+    // Load test: sustained load
+    load: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '1m', target: 10 },  // Ramp up
+        { duration: '3m', target: 10 },  // Sustained load
+        { duration: '1m', target: 0 },   // Ramp down
+      ],
+      tags: { test_type: 'load' },
+      startTime: '35s',
+    },
+    // Stress test: peak load
+    stress: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { duration: '2m', target: 50 },  // Ramp to stress
+        { duration: '2m', target: 50 },  // Hold stress
+        { duration: '1m', target: 100 }, // Spike
+        { duration: '1m', target: 0 },   // Recovery
+      ],
+      tags: { test_type: 'stress' },
+      startTime: '8m5s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(50)<500', 'p(95)<2000', 'p(99)<5000'],
+    http_req_failed: ['rate<0.05'],
+    errors: ['rate<0.1'],
+    health_check_pass: ['rate>0.95'],
+    epoch_check_pass: ['rate>0.95'],
+    miners_check_pass: ['rate>0.95'],
+    balance_check_pass: ['rate>0.90'],
+  },
+};
+
+/**
+ * Test the /health endpoint
+ */
+function testHealth() {
+  const response = http.get(`${BASE_URL}/health`, {
+    tags: { name: 'health' },
+  });
+  
+  const passed = check(response, {
+    'health status is 200': (r) => r.status === 200,
+    'health response has ok field': (r) => {
+      try {
+        const body = r.json();
+        return body.ok === true;
+      } catch (e) {
+        return false;
+      }
+    },
+    'health response has version': (r) => {
+      try {
+        const body = r.json();
+        return body.version !== undefined;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+  
+  healthCheckPass.add(passed);
+  errorRate.add(!passed);
+  apiLatency.add(response.timings.duration);
+  
+  sleep(0.5);
+}
+
+/**
+ * Test the /epoch endpoint
+ */
+function testEpoch() {
+  const response = http.get(`${BASE_URL}/epoch`, {
+    tags: { name: 'epoch' },
+  });
+  
+  const passed = check(response, {
+    'epoch status is 200': (r) => r.status === 200,
+    'epoch response has epoch field': (r) => {
+      try {
+        const body = r.json();
+        return typeof body.epoch === 'number';
+      } catch (e) {
+        return false;
+      }
+    },
+    'epoch response has slot field': (r) => {
+      try {
+        const body = r.json();
+        return typeof body.slot === 'number';
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+  
+  epochCheckPass.add(passed);
+  errorRate.add(!passed);
+  apiLatency.add(response.timings.duration);
+  
+  sleep(0.3);
+}
+
+/**
+ * Test the /api/miners endpoint
+ */
+function testMiners() {
+  const response = http.get(`${BASE_URL}/api/miners`, {
+    tags: { name: 'miners' },
+  });
+  
+  const passed = check(response, {
+    'miners status is 200': (r) => r.status === 200,
+    'miners response is array': (r) => {
+      try {
+        const body = r.json();
+        return Array.isArray(body);
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+  
+  minersCheckPass.add(passed);
+  errorRate.add(!passed);
+  apiLatency.add(response.timings.duration);
+  
+  sleep(0.5);
+}
+
+/**
+ * Test the /wallet/balance endpoint
+ */
+function testBalance() {
+  const params = {
+    params: { miner_id: TEST_MINER_ID },
+    tags: { name: 'balance' },
+  };
+  
+  const response = http.get(`${BASE_URL}/wallet/balance`, params);
+  
+  const passed = check(response, {
+    'balance status is 200': (r) => r.status === 200,
+    'balance response has ok field': (r) => {
+      try {
+        const body = r.json();
+        return body.ok !== undefined;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+  
+  balanceCheckPass.add(passed);
+  errorRate.add(!passed);
+  apiLatency.add(response.timings.duration);
+  
+  sleep(0.3);
+}
+
+/**
+ * Test the /ready endpoint (Kubernetes readiness probe)
+ */
+function testReady() {
+  const response = http.get(`${BASE_URL}/ready`, {
+    tags: { name: 'ready' },
+  });
+  
+  check(response, {
+    'ready status is 200': (r) => r.status === 200,
+    'ready response indicates ready': (r) => {
+      try {
+        const body = r.json();
+        return body.ready === true;
+      } catch (e) {
+        return false;
+      }
+    },
+  });
+  
+  sleep(0.2);
+}
+
+/**
+ * Test the /governance/proposals endpoint
+ */
+function testGovernance() {
+  const response = http.get(`${BASE_URL}/governance/proposals`, {
+    tags: { name: 'governance_proposals' },
+  });
+  
+  check(response, {
+    'governance proposals status is 200': (r) => r.status === 200,
+  });
+  
+  sleep(0.3);
+}
+
+/**
+ * Test the /api/nodes endpoint
+ */
+function testNodes() {
+  const response = http.get(`${BASE_URL}/api/nodes`, {
+    tags: { name: 'nodes' },
+  });
+  
+  check(response, {
+    'nodes status is 200': (r) => r.status === 200,
+  });
+  
+  sleep(0.3);
+}
+
+/**
+ * Main load test function - executes all endpoint tests
+ */
+export default function () {
+  // Execute all endpoint tests
+  testHealth();
+  testEpoch();
+  testMiners();
+  testBalance();
+  testReady();
+  testGovernance();
+  testNodes();
+}
+
+/**
+ * Handle test start - log configuration
+ */
+export function handleSummary(data) {
+  const summary = {
+    test_info: {
+      target_url: BASE_URL,
+      test_miner_id: TEST_MINER_ID,
+      timestamp: new Date().toISOString(),
+    },
+    metrics: {
+      total_requests: data.metrics.http_reqs ? data.metrics.http_reqs.values.count : 0,
+      request_rate: data.metrics.http_reqs ? data.metrics.http_reqs.values.rate : 0,
+      error_rate: data.metrics.errors ? data.metrics.errors.values.rate : 0,
+      avg_latency_ms: data.metrics.api_latency_ms ? data.metrics.api_latency_ms.values.avg : 0,
+      p95_latency_ms: data.metrics.api_latency_ms ? data.metrics.api_latency_ms.values['p(95)'] : 0,
+      p99_latency_ms: data.metrics.api_latency_ms ? data.metrics.api_latency_ms.values['p(99)'] : 0,
+    },
+    checks: {
+      health_pass_rate: data.metrics.health_check_pass ? data.metrics.health_check_pass.values.rate : 0,
+      epoch_pass_rate: data.metrics.epoch_check_pass ? data.metrics.epoch_check_pass.values.rate : 0,
+      miners_pass_rate: data.metrics.miners_check_pass ? data.metrics.miners_check_pass.values.rate : 0,
+      balance_pass_rate: data.metrics.balance_check_pass ? data.metrics.balance_check_pass.values.rate : 0,
+    },
+  };
+  
+  return {
+    stdout: textSummary(data, { indent: ' ', enableColors: true }),
+    'load-test-results.json': JSON.stringify(summary, null, 2),
+  };
+}
+
+function textSummary(data, options) {
+  const { indent = '', enableColors = false } = options;
+  
+  let output = '\n';
+  output += `${indent}═══════════════════════════════════════════════════════════\n`;
+  output += `${indent}  RustChain API Load Test Results\n`;
+  output += `${indent}═══════════════════════════════════════════════════════════\n\n`;
+  
+  output += `${indent}Target URL: ${BASE_URL}\n`;
+  output += `${indent}Test Miner: ${TEST_MINER_ID}\n\n`;
+  
+  if (data.metrics.http_reqs) {
+    output += `${indent}Requests:\n`;
+    output += `${indent}  Total: ${data.metrics.http_reqs.values.count}\n`;
+    output += `${indent}  Rate:  ${data.metrics.http_reqs.values.rate.toFixed(2)} req/s\n\n`;
+  }
+  
+  if (data.metrics.api_latency_ms) {
+    output += `${indent}Latency:\n`;
+    output += `${indent}  Avg:  ${data.metrics.api_latency_ms.values.avg.toFixed(2)} ms\n`;
+    output += `${indent}  P95:  ${data.metrics.api_latency_ms.values['p(95)'].toFixed(2)} ms\n`;
+    output += `${indent}  P99:  ${data.metrics.api_latency_ms.values['p(99)'].toFixed(2)} ms\n\n`;
+  }
+  
+  if (data.metrics.errors) {
+    output += `${indent}Error Rate: ${(data.metrics.errors.values.rate * 100).toFixed(2)}%\n\n`;
+  }
+  
+  output += `${indent}Check Pass Rates:\n`;
+  if (data.metrics.health_check_pass) {
+    output += `${indent}  Health:  ${(data.metrics.health_check_pass.values.rate * 100).toFixed(1)}%\n`;
+  }
+  if (data.metrics.epoch_check_pass) {
+    output += `${indent}  Epoch:   ${(data.metrics.epoch_check_pass.values.rate * 100).toFixed(1)}%\n`;
+  }
+  if (data.metrics.miners_check_pass) {
+    output += `${indent}  Miners:  ${(data.metrics.miners_check_pass.values.rate * 100).toFixed(1)}%\n`;
+  }
+  if (data.metrics.balance_check_pass) {
+    output += `${indent}  Balance: ${(data.metrics.balance_check_pass.values.rate * 100).toFixed(1)}%\n`;
+  }
+  
+  output += `\n${indent}═══════════════════════════════════════════════════════════\n`;
+  
+  return output;
+}

--- a/load-tests/k6-scenarios.json
+++ b/load-tests/k6-scenarios.json
@@ -1,0 +1,118 @@
+{
+  "description": "Pre-configured k6 scenarios for different testing needs",
+  "scenarios": {
+    "quick-smoke": {
+      "description": "Quick 30-second smoke test for CI/CD",
+      "config": {
+        "executor": "constant-vus",
+        "vus": 2,
+        "duration": "30s",
+        "thresholds": {
+          "http_req_duration": ["p(95)<1000"],
+          "http_req_failed": ["rate<0.01"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario quick-smoke k6-load-test.js"
+    },
+    "api-baseline": {
+      "description": "Baseline performance test - 5 minutes at moderate load",
+      "config": {
+        "executor": "constant-vus",
+        "vus": 10,
+        "duration": "5m",
+        "thresholds": {
+          "http_req_duration": ["p(50)<300", "p(95)<1500", "p(99)<3000"],
+          "http_req_failed": ["rate<0.02"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario api-baseline k6-load-test.js"
+    },
+    "load-ramp": {
+      "description": "Gradual load increase test - 10 minutes",
+      "config": {
+        "executor": "ramping-vus",
+        "startVUs": 0,
+        "stages": [
+          { "duration": "2m", "target": 5 },
+          { "duration": "3m", "target": 20 },
+          { "duration": "3m", "target": 50 },
+          { "duration": "2m", "target": 0 }
+        ],
+        "thresholds": {
+          "http_req_duration": ["p(95)<2000"],
+          "http_req_failed": ["rate<0.05"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario load-ramp k6-load-test.js"
+    },
+    "stress-peak": {
+      "description": "Stress test with peak load - 5 minutes",
+      "config": {
+        "executor": "ramping-vus",
+        "startVUs": 0,
+        "stages": [
+          { "duration": "1m", "target": 50 },
+          { "duration": "2m", "target": 100 },
+          { "duration": "1m", "target": 50 },
+          { "duration": "1m", "target": 0 }
+        ],
+        "thresholds": {
+          "http_req_duration": ["p(95)<5000"],
+          "http_req_failed": ["rate<0.10"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario stress-peak k6-load-test.js"
+    },
+    "soak-test": {
+      "description": "Soak/endurance test - 30 minutes at steady load",
+      "config": {
+        "executor": "constant-vus",
+        "vus": 25,
+        "duration": "30m",
+        "thresholds": {
+          "http_req_duration": ["p(95)<2500"],
+          "http_req_failed": ["rate<0.03"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario soak-test k6-load-test.js"
+    },
+    "spike-test": {
+      "description": "Spike test - sudden load increase",
+      "config": {
+        "executor": "ramping-vus",
+        "startVUs": 5,
+        "stages": [
+          { "duration": "1m", "target": 5 },
+          { "duration": "30s", "target": 75 },
+          { "duration": "1m", "target": 75 },
+          { "duration": "30s", "target": 5 },
+          { "duration": "2m", "target": 5 }
+        ],
+        "thresholds": {
+          "http_req_duration": ["p(95)<4000"],
+          "http_req_failed": ["rate<0.15"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario spike-test k6-load-test.js"
+    },
+    "endpoint-health": {
+      "description": "Health-focused test on critical endpoints only",
+      "config": {
+        "executor": "constant-vus",
+        "vus": 5,
+        "duration": "2m",
+        "tags": { "endpoint_focus": "health" },
+        "thresholds": {
+          "health_check_pass": ["rate>0.99"],
+          "http_req_failed": ["rate<0.01"]
+        }
+      },
+      "command": "k6 run --config k6-scenarios.json --scenario endpoint-health k6-load-test.js"
+    }
+  },
+  "options": {
+    "insecureSkipTLSVerify": true,
+    "noConnectionReuse": false,
+    "userAgent": "k6-rustchain-load-test/1.0"
+  }
+}

--- a/load-tests/locust-load-test.py
+++ b/load-tests/locust-load-test.py
@@ -1,0 +1,298 @@
+"""
+RustChain API Load Test Suite (Locust)
+
+Usage:
+    # Install dependencies
+    pip install -r locust-requirements.txt
+    
+    # Run with web UI
+    locust -f locust-load-test.py --host=https://rustchain.org
+    
+    # Run headless
+    locust -f locust-load-test.py --host=https://rustchain.org --headless \
+        -u 10 -r 2 --run-time 5m --html=locust-report.html
+    
+    # Run with custom configuration
+    locust -f locust-load-test.py --host=$TARGET_URL --headless \
+        -u $USERS -r $SPAWN_RATE --run-time $DURATION
+
+Environment Variables:
+    TARGET_URL    - API base URL (default: https://rustchain.org)
+    MINER_ID      - Miner wallet ID for testing (default: scott)
+"""
+
+import os
+import json
+from locust import HttpUser, task, between, events
+from locust.runners import MasterRunner, WorkerRunner
+
+
+class RustChainAPIUser(HttpUser):
+    """
+    Locust user class for RustChain API load testing.
+    Simulates a client making various API calls.
+    """
+    
+    # Wait time between tasks (1-3 seconds)
+    wait_time = between(1, 3)
+    
+    # Disable SSL verification for self-signed certificates
+    verify = False
+    
+    def on_start(self):
+        """Called when a simulated user starts"""
+        self.miner_id = os.environ.get('MINER_ID', 'scott')
+        self.base_url = self.host or 'https://rustchain.org'
+        
+    @task(5)
+    def test_health(self):
+        """Test the /health endpoint - high frequency"""
+        with self.client.get(
+            "/health",
+            name="GET /health",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and data.get('ok') is True:
+                    response.success()
+                else:
+                    response.failure(f"Health check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+    
+    @task(4)
+    def test_epoch(self):
+        """Test the /epoch endpoint - high frequency"""
+        with self.client.get(
+            "/epoch",
+            name="GET /epoch",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and 'epoch' in data:
+                    response.success()
+                else:
+                    response.failure(f"Epoch check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+    
+    @task(4)
+    def test_miners(self):
+        """Test the /api/miners endpoint - high frequency"""
+        with self.client.get(
+            "/api/miners",
+            name="GET /api/miners",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and isinstance(data, list):
+                    response.success()
+                else:
+                    response.failure(f"Miners check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+    
+    @task(3)
+    def test_balance(self):
+        """Test the /wallet/balance endpoint - medium frequency"""
+        with self.client.get(
+            f"/wallet/balance?miner_id={self.miner_id}",
+            name="GET /wallet/balance",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and 'ok' in data:
+                    response.success()
+                else:
+                    response.failure(f"Balance check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+    
+    @task(3)
+    def test_ready(self):
+        """Test the /ready endpoint - medium frequency"""
+        with self.client.get(
+            "/ready",
+            name="GET /ready",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and data.get('ready') is True:
+                    response.success()
+                else:
+                    response.failure(f"Ready check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+    
+    @task(2)
+    def test_nodes(self):
+        """Test the /api/nodes endpoint - lower frequency"""
+        with self.client.get(
+            "/api/nodes",
+            name="GET /api/nodes",
+            catch_response=True
+        ) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                response.failure(f"Nodes check failed: {response.status_code}")
+    
+    @task(2)
+    def test_governance(self):
+        """Test the /governance/proposals endpoint - lower frequency"""
+        with self.client.get(
+            "/governance/proposals",
+            name="GET /governance/proposals",
+            catch_response=True
+        ) as response:
+            if response.status_code == 200:
+                response.success()
+            else:
+                response.failure(f"Governance check failed: {response.status_code}")
+    
+    @task(1)
+    def test_lottery_eligibility(self):
+        """Test the /lottery/eligibility endpoint - low frequency"""
+        with self.client.get(
+            f"/lottery/eligibility?miner_id={self.miner_id}",
+            name="GET /lottery/eligibility",
+            catch_response=True
+        ) as response:
+            try:
+                data = response.json()
+                if response.status_code == 200 and 'eligible' in data:
+                    response.success()
+                else:
+                    response.failure(f"Eligibility check failed: {data}")
+            except json.JSONDecodeError:
+                response.failure("Invalid JSON response")
+
+
+class HeavyLoadUser(HttpUser):
+    """
+    Heavy load user - more aggressive request patterns.
+    Use this for stress testing.
+    """
+    
+    wait_time = between(0.1, 0.5)
+    verify = False
+    
+    @task
+    def rapid_health_check(self):
+        """Rapid health checks for stress testing"""
+        self.client.get("/health", name="GET /health [stress]")
+    
+    @task
+    def rapid_epoch_check(self):
+        """Rapid epoch checks for stress testing"""
+        self.client.get("/epoch", name="GET /epoch [stress]")
+
+
+class WriteLoadUser(HttpUser):
+    """
+    User class for testing write operations (if available).
+    Note: Most write operations require authentication.
+    """
+    
+    wait_time = between(2, 5)
+    verify = False
+    
+    @task
+    def test_attest_submit(self):
+        """Test attestation submission (will fail without valid signature)"""
+        payload = {
+            "miner_id": os.environ.get('MINER_ID', 'scott'),
+            "timestamp": 1771187406,
+            "device_info": {
+                "arch": "x86_64",
+                "family": "test"
+            },
+            "fingerprint": {
+                "clock_skew": {"drift_ppm": 24.3, "jitter_ns": 1247},
+                "cache_timing": {"l1_latency_ns": 5, "l2_latency_ns": 15}
+            },
+            "signature": "test_signature_placeholder"
+        }
+
+        with self.client.post(
+            "/attest/submit",
+            json=payload,
+            name="POST /attest/submit",
+            catch_response=True
+        ) as response:
+            # This is expected to fail without valid signature
+            # We're testing the endpoint availability and response format
+            if response.status_code in [200, 400, 401]:
+                response.success()
+            else:
+                response.failure(f"Unexpected status: {response.status_code}")
+
+
+# Event handlers for custom reporting
+@events.test_start.add_listener
+def on_test_start(environment, **kwargs):
+    """Called when load test starts"""
+    print(f"\n{'='*60}")
+    print("RustChain API Load Test Starting")
+    print(f"{'='*60}")
+    print(f"Target URL: {environment.host or 'https://rustchain.org'}")
+    print(f"Miner ID: {os.environ.get('MINER_ID', 'scott')}")
+    print(f"{'='*60}\n")
+
+
+@events.test_stop.add_listener
+def on_test_stop(environment, **kwargs):
+    """Called when load test stops"""
+    stats = environment.stats
+    
+    print(f"\n{'='*60}")
+    print("RustChain API Load Test Complete")
+    print(f"{'='*60}")
+    print(f"Total Requests: {stats.total.num_requests}")
+    print(f"Total Failures: {stats.total.num_failures}")
+    print(f"Failure Rate: {(stats.total.num_failures / max(stats.total.num_requests, 1)) * 100:.2f}%")
+    print(f"Average Response Time: {stats.total.avg_response_time:.2f}ms")
+    print(f"Requests/sec: {stats.total.current_rps:.2f}")
+    print(f"{'='*60}\n")
+
+
+# Configuration for running without web UI
+def setup_locust_config():
+    """
+    Setup configuration for headless runs.
+    Can be imported and used in custom scripts.
+    """
+    return {
+        'host': os.environ.get('TARGET_URL', 'https://rustchain.org'),
+        'users': int(os.environ.get('USERS', '10')),
+        'spawn_rate': int(os.environ.get('SPAWN_RATE', '2')),
+        'run_time': os.environ.get('DURATION', '5m'),
+    }
+
+
+# For programmatic usage
+if __name__ == "__main__":
+    import subprocess
+    import sys
+    
+    config = setup_locust_config()
+    
+    cmd = [
+        sys.executable, "-m", "locust",
+        "-f", __file__,
+        "--host", config['host'],
+        "--headless",
+        "-u", str(config['users']),
+        "-r", str(config['spawn_rate']),
+        "--run-time", config['run_time'],
+        "--html", "locust-report.html",
+        "--json", "locust-results.json"
+    ]
+    
+    print(f"Running: {' '.join(cmd)}")
+    subprocess.run(cmd)

--- a/load-tests/locust-requirements.txt
+++ b/load-tests/locust-requirements.txt
@@ -1,0 +1,11 @@
+# RustChain API Load Test Dependencies (Locust)
+# Install with: pip install -r locust-requirements.txt
+
+# Core load testing framework
+locust>=2.20.0
+
+# HTTP client (included with locust, but explicit for clarity)
+requests>=2.31.0
+
+# Optional: For enhanced reporting
+# locust-plugins>=4.0.0

--- a/load-tests/run-load-test.sh
+++ b/load-tests/run-load-test.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+#
+# RustChain API Load Test Runner
+# 
+# Usage:
+#   ./run-load-test.sh [k6|locust] [scenario]
+#
+# Examples:
+#   ./run-load-test.sh k6 smoke
+#   ./run-load-test.sh k6 load
+#   ./run-load-test.sh locust --headless
+#
+
+set -e
+
+# Load environment variables
+if [ -f .env ]; then
+    export $(cat .env | grep -v '^#' | xargs)
+fi
+
+# Defaults
+TARGET_URL="${TARGET_URL:-https://rustchain.org}"
+MINER_ID="${MINER_ID:-scott}"
+DURATION="${DURATION:-5m}"
+USERS="${USERS:-10}"
+SPAWN_RATE="${SPAWN_RATE:-2}"
+OUTPUT_DIR="${OUTPUT_DIR:-./results}"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+print_header() {
+    echo -e "${BLUE}============================================================${NC}"
+    echo -e "${BLUE}  RustChain API Load Test${NC}"
+    echo -e "${BLUE}============================================================${NC}"
+    echo ""
+}
+
+print_config() {
+    echo -e "${YELLOW}Configuration:${NC}"
+    echo "  Target URL:  ${TARGET_URL}"
+    echo "  Miner ID:    ${MINER_ID}"
+    echo "  Duration:    ${DURATION}"
+    echo "  Users:       ${USERS}"
+    echo "  Spawn Rate:  ${SPAWN_RATE}"
+    echo "  Output Dir:  ${OUTPUT_DIR}"
+    echo ""
+}
+
+setup_output_dir() {
+    mkdir -p "${OUTPUT_DIR}"
+    echo -e "${GREEN}Output directory ready: ${OUTPUT_DIR}${NC}"
+}
+
+run_k6() {
+    local scenario="${1:-load}"
+    
+    echo -e "${GREEN}Running k6 load test (scenario: ${scenario})...${NC}"
+    echo ""
+    
+    # Check if k6 is installed
+    if ! command -v k6 &> /dev/null; then
+        echo -e "${RED}Error: k6 is not installed.${NC}"
+        echo "Install k6: https://k6.io/docs/getting-started/installation/"
+        echo ""
+        echo "macOS:     brew install k6"
+        echo "Linux:     sudo apt-get install k6"
+        echo "Windows:   winget install k6"
+        exit 1
+    fi
+    
+    # Create timestamp for results
+    local timestamp=$(date +%Y%m%d_%H%M%S)
+    
+    case "${scenario}" in
+        smoke)
+            k6 run \
+                --out json="${OUTPUT_DIR}/k6-smoke-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        load)
+            k6 run \
+                --config k6-config.json \
+                --out json="${OUTPUT_DIR}/k6-load-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        stress)
+            k6 run \
+                --config k6-config.json \
+                --out json="${OUTPUT_DIR}/k6-stress-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        quick-smoke)
+            k6 run \
+                --config k6-scenarios.json \
+                --scenario quick-smoke \
+                --out json="${OUTPUT_DIR}/k6-quick-smoke-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        api-baseline)
+            k6 run \
+                --config k6-scenarios.json \
+                --scenario api-baseline \
+                --out json="${OUTPUT_DIR}/k6-baseline-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        soak-test)
+            k6 run \
+                --config k6-scenarios.json \
+                --scenario soak-test \
+                --out json="${OUTPUT_DIR}/k6-soak-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        spike-test)
+            k6 run \
+                --config k6-scenarios.json \
+                --scenario spike-test \
+                --out json="${OUTPUT_DIR}/k6-spike-${timestamp}.json" \
+                -e TARGET_URL="${TARGET_URL}" \
+                -e MINER_ID="${MINER_ID}" \
+                k6-load-test.js
+            ;;
+        *)
+            echo -e "${RED}Unknown scenario: ${scenario}${NC}"
+            echo "Available scenarios: smoke, load, stress, quick-smoke, api-baseline, soak-test, spike-test"
+            exit 1
+            ;;
+    esac
+    
+    echo ""
+    echo -e "${GREEN}k6 test complete!${NC}"
+    echo "Results saved to: ${OUTPUT_DIR}/"
+}
+
+run_locust() {
+    local mode="${1:---headless}"
+    
+    echo -e "${GREEN}Running Locust load test (mode: ${mode})...${NC}"
+    echo ""
+    
+    # Check if locust is installed
+    if ! command -v locust &> /dev/null; then
+        echo -e "${RED}Error: Locust is not installed.${NC}"
+        echo "Install with: pip install -r locust-requirements.txt"
+        exit 1
+    fi
+    
+    # Create timestamp for results
+    local timestamp=$(date +%Y%m%d_%H%M%S)
+    
+    if [ "${mode}" = "web" ] || [ "${mode}" = "--web" ]; then
+        # Web UI mode
+        locust \
+            -f locust-load-test.py \
+            --host="${TARGET_URL}" \
+            --web-host=127.0.0.1 \
+            --web-port=8089
+    else
+        # Headless mode
+        locust \
+            -f locust-load-test.py \
+            --host="${TARGET_URL}" \
+            --headless \
+            -u "${USERS}" \
+            -r "${SPAWN_RATE}" \
+            --run-time="${DURATION}" \
+            --html="${OUTPUT_DIR}/locust-report-${timestamp}.html" \
+            --json="${OUTPUT_DIR}/locust-results-${timestamp}.json"
+    fi
+    
+    echo ""
+    echo -e "${GREEN}Locust test complete!${NC}"
+    echo "Results saved to: ${OUTPUT_DIR}/"
+}
+
+show_help() {
+    echo "RustChain API Load Test Runner"
+    echo ""
+    echo "Usage: $0 [tool] [options]"
+    echo ""
+    echo "Tools:"
+    echo "  k6       - Run k6 load tests"
+    echo "  locust   - Run Locust load tests"
+    echo "  help     - Show this help message"
+    echo ""
+    echo "K6 Scenarios:"
+    echo "  smoke      - Quick 30s smoke test"
+    echo "  load       - Standard load test (5m)"
+    echo "  stress     - Stress test with peak load"
+    echo "  quick-smoke - Very quick CI/CD test"
+    echo "  api-baseline - Baseline performance test"
+    echo "  soak-test  - Long-running endurance test"
+    echo "  spike-test - Sudden load spike test"
+    echo ""
+    echo "Locust Modes:"
+    echo "  web        - Run with web UI (default port 8089)"
+    echo "  headless   - Run without UI (default)"
+    echo ""
+    echo "Examples:"
+    echo "  $0 k6 smoke"
+    echo "  $0 k6 load"
+    echo "  $0 k6 stress"
+    echo "  $0 locust web"
+    echo "  $0 locust headless"
+    echo ""
+    echo "Environment Variables:"
+    echo "  TARGET_URL  - API base URL (default: https://rustchain.org)"
+    echo "  MINER_ID    - Miner wallet ID (default: scott)"
+    echo "  DURATION    - Test duration (default: 5m)"
+    echo "  USERS       - Concurrent users for Locust (default: 10)"
+    echo "  SPAWN_RATE  - User spawn rate for Locust (default: 2)"
+    echo "  OUTPUT_DIR  - Results output directory (default: ./results)"
+    echo ""
+}
+
+# Main
+print_header
+
+case "${1:-help}" in
+    k6)
+        setup_output_dir
+        print_config
+        run_k6 "${2:-load}"
+        ;;
+    locust)
+        setup_output_dir
+        print_config
+        run_locust "${2:-headless}"
+        ;;
+    help|--help|-h)
+        show_help
+        ;;
+    *)
+        echo -e "${RED}Unknown command: ${1}${NC}"
+        echo ""
+        show_help
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Implements issue #1614 by adding a configurable load test suite for RustChain API with k6 and Locust runners plus usage docs.\n\nCloses #1614