### PR TITLE
docs: fix typos and grammar in documentation (#1590)

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -143,7 +143,7 @@ cat < /dev/ttyACM0
 
 - Existing miners unaffected
 - Console miners use new code paths but same API
-- Backwards compatible with legacy miners
+- Backward compatible with legacy miners
 
 ## Security Model
 

--- a/docs/chain_architecture.md
+++ b/docs/chain_architecture.md
@@ -2,7 +2,7 @@
 
 ## Core Design
 
-RustChain is a memory-preservation blockchain utilizing entropy benchmarks, hardware age, and artifact rarity to validate and score block creation.
+RustChain is a memory-preservation blockchain that uses entropy benchmarks, hardware age, and artifact rarity to validate and score block creation.
 
 ### Consensus: Proof of Antiquity (PoA)
 

--- a/rips/docs/RIP-302-agent-economy.md
+++ b/rips/docs/RIP-302-agent-economy.md
@@ -406,9 +406,9 @@ for bounty in bounties:
         )
 ```
 
-## Backwards Compatibility
+## Backward Compatibility
 
-RIP-302 is designed to be backwards compatible with:
+RIP-302 is designed to be backward compatible with:
 - Existing RustChain wallet system
 - Core blockchain transactions
 - Previous agent implementations


### PR DESCRIPTION
Implements issue #1590 with targeted typo/grammar fixes in docs while preserving technical meaning.\n\nCloses #1590