### PR TITLE
feat: add Grafana dashboard for RustChain metrics (#1609)

### DIFF
--- a/dashboards/grafana-rustchain/README.md
+++ b/dashboards/grafana-rustchain/README.md
@@ -1,0 +1,308 @@
+# RustChain Grafana Dashboard
+
+A comprehensive Grafana dashboard for monitoring RustChain network metrics, including node health, miner activity, epoch statistics, and hardware distribution.
+
+![Dashboard Preview](./screenshot.png)
+
+## Overview
+
+This dashboard provides real-time visualization of RustChain blockchain metrics using Prometheus as the data source. It includes 19 panels covering:
+
+- **Node Health**: Health status, uptime, database status
+- **Network Statistics**: Active miners, enrolled miners, epoch info
+- **Token Metrics**: Total RTC supply, epoch pot
+- **Hardware Analytics**: Distribution by hardware type and architecture
+- **Performance**: Scrape duration, error rates
+- **Alerts**: Active alert list
+
+## Datasource Assumptions
+
+This dashboard expects a **Prometheus** data source with the following metrics exposed by the RustChain exporter:
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `rustchain_node_health` | Gauge | Node health status (1=healthy, 0=unhealthy) |
+| `rustchain_node_uptime_seconds` | Gauge | Node uptime in seconds |
+| `rustchain_node_db_status` | Gauge | Database status (1=ok, 0=error) |
+| `rustchain_epoch_number` | Gauge | Current epoch number |
+| `rustchain_epoch_slot` | Gauge | Current slot within epoch |
+| `rustchain_epoch_pot` | Gauge | Epoch reward pool in RTC |
+| `rustchain_enrolled_miners` | Gauge | Total enrolled miners |
+| `rustchain_total_supply_rtc` | Gauge | Total RTC token supply |
+| `rustchain_active_miners` | Gauge | Currently active miners |
+| `rustchain_miners_by_hardware{hardware_type}` | Gauge | Miners grouped by hardware type |
+| `rustchain_miners_by_arch{arch}` | Gauge | Miners grouped by CPU architecture |
+| `rustchain_avg_antiquity_multiplier` | Gauge | Average antiquity multiplier |
+| `rustchain_scrape_errors_total` | Counter | Total scrape errors |
+| `rustchain_scrape_duration_seconds` | Gauge | Duration of last scrape |
+
+## Prerequisites
+
+- Grafana 9.x or 10.x
+- Prometheus data source configured
+- RustChain exporter running and being scraped by Prometheus
+
+## Quick Start
+
+### Option 1: Import via Grafana UI
+
+1. Open Grafana in your browser
+2. Navigate to **Dashboards** → **Import**
+3. Click **Upload dashboard JSON file**
+4. Select `rustchain-network-dashboard.json`
+5. Choose your Prometheus data source from the dropdown
+6. Click **Import**
+
+### Option 2: Import via Grafana CLI
+
+```bash
+# Copy dashboard to Grafana provisioning directory
+cp rustchain-network-dashboard.json /etc/grafana/provisioning/dashboards/
+
+# Or use grafana-cli (if available)
+grafana-cli --admin-user admin --admin-password <password> \
+  dashboard import rustchain-network-dashboard.json
+```
+
+### Option 3: Import via API
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-api-key>" \
+  -d @rustchain-network-dashboard.json \
+  http://localhost:3000/api/dashboards/db
+```
+
+## Setup Instructions
+
+### Step 1: Configure Prometheus Data Source
+
+1. In Grafana, go to **Configuration** → **Data Sources**
+2. Click **Add data source**
+3. Select **Prometheus**
+4. Configure:
+   - **Name**: `Prometheus` (or update the dashboard's `__inputs` section)
+   - **URL**: `http://prometheus:9090` (adjust for your setup)
+   - **Access**: Server (default)
+5. Click **Save & Test**
+
+### Step 2: Import the Dashboard
+
+Follow one of the import methods above.
+
+### Step 3: Verify Panels
+
+After import, verify that all panels display data:
+- Check the time range (default: last 24 hours)
+- Ensure Prometheus data source is selected
+- Refresh the dashboard if needed
+
+## Using with Docker Compose
+
+If you're using the monitoring stack from `../../monitoring/`:
+
+```bash
+cd ../../monitoring
+docker-compose up -d
+```
+
+Then import the dashboard into Grafana at `http://localhost:3000`:
+- Username: `admin`
+- Password: `rustchain`
+
+## Dashboard Variables
+
+The dashboard includes template variables for dynamic filtering:
+
+| Variable | Description | Query |
+|----------|-------------|-------|
+| `DS_PROMETHEUS` | Prometheus data source | Datasource selector |
+| `hardware_type` | Filter by hardware type | `label_values(rustchain_miners_by_hardware, hardware_type)` |
+
+## Panel Descriptions
+
+### Row 1: Quick Stats (8 panels)
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Node Health | Stat | Health status with color-coded background |
+| Active Miners | Stat | Current active miner count |
+| Current Epoch | Stat | Blockchain epoch number |
+| Epoch Pot (RTC) | Stat | Current epoch reward pool |
+| Total Supply (RTC) | Stat | Total RTC token supply |
+| Enrolled Miners | Stat | Total enrolled miners |
+| Node Uptime | Stat | Uptime in hours |
+| DB Status | Stat | Database read/write status |
+
+### Row 2-3: Time Series (4 panels)
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Active Miners (24h) | Time series | Miner count trend over 24 hours |
+| RTC Total Supply | Time series | Token supply evolution |
+| Node Uptime | Time series | Uptime progression |
+| Scrape Duration | Time series | Metrics collection performance |
+
+### Row 4: Distribution (3 panels)
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Miners by Hardware Type | Pie chart | Hardware distribution |
+| Miners by Architecture | Pie chart | CPU architecture distribution |
+| Avg Antiquity Multiplier | Gauge | Average multiplier value |
+
+### Row 5: Advanced Metrics (2 panels)
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Epoch Pot Evolution | Time series | Reward pool changes |
+| Scrape Errors Rate | Time series | Error rate per minute |
+
+### Row 6: Detailed Views (2 panels)
+
+| Panel | Type | Description |
+|-------|------|-------------|
+| Miner Hardware Distribution | Table | Detailed hardware breakdown |
+| Active Alerts | Alert list | Currently firing alerts |
+
+## Customization
+
+### Changing Colors
+
+Edit the dashboard JSON or use Grafana's UI to modify panel colors in the **Field** tab.
+
+### Adding New Panels
+
+1. Click **Add panel** → **Add new panel**
+2. Write your PromQL query
+3. Configure visualization type
+4. Save to dashboard
+
+### Modifying Refresh Rate
+
+Click the refresh interval dropdown (top-right) and select your preferred interval:
+- 5s, 10s, 30s, 1m, 5m, 15m, 30m, 1h, 2h, 1d
+
+## Useful PromQL Queries
+
+```promql
+# Active miners with 5-minute moving average
+avg_over_time(rustchain_active_miners[5m])
+
+# Miner growth rate
+deriv(rustchain_active_miners[1h])
+
+# Hardware type percentage
+rustchain_miners_by_hardware / ignoring(hardware_type) group_left() sum(rustchain_miners_by_hardware) * 100
+
+# Node uptime in days
+rustchain_node_uptime_seconds / 86400
+
+# Scrape errors per hour
+increase(rustchain_scrape_errors_total[1h])
+
+# Epoch duration (time between epoch changes)
+time() - (rustchain_epoch_number - ignoring() group_left() (rustchain_epoch_number offset 1h)) * 3600
+```
+
+## Alerts Configuration
+
+The dashboard includes a pre-configured alert for slow scrape times. To add more alerts:
+
+1. Go to **Alerting** → **Alert rules**
+2. Click **New alert rule**
+3. Configure your query and conditions
+4. Set up notification channels
+
+### Example Alert Rules
+
+```yaml
+# Node Down Alert
+- alert: RustChainNodeDown
+  expr: rustchain_node_health == 0
+  for: 2m
+  labels:
+    severity: critical
+  annotations:
+    summary: "RustChain node is down"
+    description: "Node has been unhealthy for more than 2 minutes"
+
+# Miner Drop Alert
+- alert: RustChainMinerDrop
+  expr: deriv(rustchain_active_miners[10m]) < -0.5
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Significant miner drop detected"
+    description: "Active miners decreasing rapidly"
+
+# High Scrape Duration
+- alert: RustChainHighScrapeDuration
+  expr: rustchain_scrape_duration_seconds > 5
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Exporter scrape taking too long"
+    description: "Scrape duration exceeded 5 seconds"
+```
+
+## Troubleshooting
+
+### No Data Showing
+
+1. **Check data source**: Ensure Prometheus is selected and connected
+2. **Verify metrics**: Query `rustchain_active_miners` in Prometheus directly
+3. **Time range**: Expand the time range if no recent data exists
+4. **Exporter status**: Confirm the RustChain exporter is running
+
+### Panels Show Errors
+
+1. **PromQL syntax**: Check query syntax in panel edit mode
+2. **Metric names**: Verify metric names match your exporter
+3. **Label names**: Ensure label names (e.g., `hardware_type`) exist
+
+### Import Fails
+
+1. **Grafana version**: Ensure Grafana 9.x or 10.x
+2. **JSON validity**: Validate JSON syntax
+3. **Permissions**: Check user has dashboard import permissions
+
+## File Structure
+
+```
+grafana-rustchain/
+├── rustchain-network-dashboard.json    # Importable dashboard
+└── README.md                           # This file
+```
+
+## Related Files
+
+- `../../monitoring/rustchain-exporter.py` - Prometheus metrics exporter
+- `../../monitoring/prometheus.yml` - Prometheus configuration
+- `../../monitoring/docker-compose.yml` - Full monitoring stack
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-03-11 | Initial dashboard for issue #1609 |
+
+## License
+
+MIT License - Same as RustChain
+
+## Contributing
+
+Contributions welcome! Please ensure any dashboard changes:
+1. Include updated panel descriptions
+2. Test with live Prometheus data
+3. Document new metrics requirements
+
+---
+
+**Issue**: [#1609](https://github.com/Scottcjn/Rustchain/issues/1609)
+**Author**: xiaoma
+**RTC Wallet**: `xiaoma-miner`

--- a/dashboards/grafana-rustchain/rustchain-network-dashboard.json
+++ b/dashboards/grafana-rustchain/rustchain-network-dashboard.json
@@ -1,0 +1,936 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus data source for RustChain metrics",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {"type": "panel", "id": "stat", "name": "Stat", "version": ""},
+    {"type": "panel", "id": "timeseries", "name": "Time series", "version": ""},
+    {"type": "panel", "id": "gauge", "name": "Gauge", "version": ""},
+    {"type": "panel", "id": "piechart", "name": "Pie chart", "version": ""},
+    {"type": "panel", "id": "table", "name": "Table", "version": ""},
+    {"type": "panel", "id": "alertlist", "name": "Alert list", "version": ""},
+    {"type": "datasource", "id": "prometheus", "name": "Prometheus", "version": ""}
+  ],
+  "__annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {"type": "grafana", "id": "-- Grafana --"},
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      },
+      {
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "enable": true,
+        "expr": "rustchain_epoch_number != rustchain_epoch_number offset 1h",
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "name": "Epoch Changes",
+        "step": "3600",
+        "tagKeys": "epoch",
+        "titleFormat": "Epoch Transition"
+      }
+    ]
+  },
+  "__templating": {
+    "list": [
+      {
+        "current": {"selected": false, "text": "Prometheus", "value": "Prometheus"},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {"selected": true, "text": "All", "value": "$__all"},
+        "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+        "definition": "label_values(rustchain_miners_by_hardware, hardware_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Hardware Type",
+        "multi": true,
+        "name": "hardware_type",
+        "options": [],
+        "query": {"query": "label_values(rustchain_miners_by_hardware, hardware_type)", "refId": "StandardVariableQuery"},
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {"from": "now-24h", "to": "now"},
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "browser",
+  "title": "RustChain Network Monitor",
+  "uid": "rustchain-network-v2",
+  "version": 1,
+  "weekStart": "",
+  "gnetId": null,
+  "tags": ["rustchain", "blockchain", "cryptocurrency", "mining"],
+  "style": "dark",
+  "editable": true,
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [
+    {"icon": "doc", "tags": [], "targetBlank": true, "title": "RustChain Docs", "tooltip": "Open RustChain Documentation", "type": "link", "url": "https://github.com/Scottcjn/Rustchain"},
+    {"icon": "info", "tags": [], "targetBlank": true, "title": "Exporter Metrics", "tooltip": "View Exporter Metrics", "type": "link", "url": "http://localhost:9100/metrics"}
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "gridPos": {"h": 4, "w": 3, "x": 0, "y": 0},
+      "type": "stat",
+      "title": "Node Health",
+      "description": "Current node health status (1=healthy, 0=unhealthy)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_node_health",
+          "legendFormat": "Health"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 1, "text": "Unhealthy"}, "1": {"color": "green", "index": 0, "text": "Healthy"}}, "type": "value"}
+          ],
+          "noValue": "N/A"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0",
+      "transparent": false
+    },
+    {
+      "id": 2,
+      "gridPos": {"h": 4, "w": 3, "x": 3, "y": 0},
+      "type": "stat",
+      "title": "Active Miners",
+      "description": "Current number of active miners on the network",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_active_miners",
+          "legendFormat": "Miners"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 5, "color": "yellow"},
+              {"value": 10, "color": "green"}
+            ]
+          },
+          "decimals": 0,
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 3,
+      "gridPos": {"h": 4, "w": 3, "x": 6, "y": 0},
+      "type": "stat",
+      "title": "Current Epoch",
+      "description": "Current blockchain epoch number",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_epoch_number",
+          "legendFormat": "Epoch {{epoch}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 0,
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 4,
+      "gridPos": {"h": 4, "w": 3, "x": 9, "y": 0},
+      "type": "stat",
+      "title": "Epoch Pot (RTC)",
+      "description": "Current epoch reward pool in RTC",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_epoch_pot",
+          "legendFormat": "Pot"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "decimals": 2,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 5,
+      "gridPos": {"h": 4, "w": 3, "x": 12, "y": 0},
+      "type": "stat",
+      "title": "Total Supply (RTC)",
+      "description": "Total RTC token supply",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_total_supply_rtc",
+          "legendFormat": "Supply"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 2,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 6,
+      "gridPos": {"h": 4, "w": 3, "x": 15, "y": 0},
+      "type": "stat",
+      "title": "Enrolled Miners",
+      "description": "Total number of enrolled miners",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_enrolled_miners",
+          "legendFormat": "Enrolled"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 7,
+      "gridPos": {"h": 4, "w": 3, "x": 18, "y": 0},
+      "type": "stat",
+      "title": "Node Uptime",
+      "description": "Node uptime in hours",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_node_uptime_seconds / 3600",
+          "legendFormat": "Uptime"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"}
+            ]
+          },
+          "decimals": 1,
+          "unit": "h"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 8,
+      "gridPos": {"h": 4, "w": 3, "x": 21, "y": 0},
+      "type": "stat",
+      "title": "DB Status",
+      "description": "Database read/write status (1=ok, 0=error)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_node_db_status",
+          "legendFormat": "DB"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "red"},
+              {"value": 1, "color": "green"}
+            ]
+          },
+          "mappings": [
+            {"options": {"0": {"color": "red", "index": 1, "text": "Error"}, "1": {"color": "green", "index": 0, "text": "OK"}}, "type": "value"}
+          ]
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 9,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 4},
+      "type": "timeseries",
+      "title": "Active Miners (24h)",
+      "description": "Active miner count over the last 24 hours",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_active_miners",
+          "legendFormat": "Active Miners",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Miners",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 10,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 4},
+      "type": "timeseries",
+      "title": "RTC Total Supply",
+      "description": "Total RTC supply over time",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_total_supply_rtc",
+          "legendFormat": "Total Supply",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "RTC",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 11,
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 12},
+      "type": "piechart",
+      "title": "Miners by Hardware Type",
+      "description": "Distribution of miners by hardware type",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_miners_by_hardware",
+          "legendFormat": "{{hardware_type}}",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "right", "showLegend": true, "values": ["value"]},
+        "pieType": "pie",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 12,
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 12},
+      "type": "piechart",
+      "title": "Miners by Architecture",
+      "description": "Distribution of miners by CPU architecture",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_miners_by_arch",
+          "legendFormat": "{{arch}}",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"displayMode": "list", "placement": "right", "showLegend": true, "values": ["value"]},
+        "pieType": "pie",
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 13,
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 12},
+      "type": "gauge",
+      "title": "Avg Antiquity Multiplier",
+      "description": "Average antiquity multiplier across all miners (higher = older hardware bonus)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_avg_antiquity_multiplier",
+          "legendFormat": "Multiplier",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 1.5, "color": "yellow"},
+              {"value": 2.5, "color": "orange"},
+              {"value": 3.5, "color": "red"}
+            ]
+          },
+          "min": 1,
+          "max": 5,
+          "decimals": 2,
+          "unit": "x"
+        },
+        "overrides": []
+      },
+      "options": {
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+        "text": {"valueSize": 40}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 14,
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 20},
+      "type": "timeseries",
+      "title": "Node Uptime",
+      "description": "Node uptime in seconds over time",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_node_uptime_seconds",
+          "legendFormat": "Uptime (seconds)",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 15,
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 20},
+      "type": "timeseries",
+      "title": "Scrape Duration",
+      "description": "Duration of each metrics scrape operation (alert if >5s)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_scrape_duration_seconds",
+          "legendFormat": "Scrape Time",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Seconds",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "line"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 3, "color": "yellow"},
+              {"value": 5, "color": "red"}
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0",
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {"params": [5], "type": "gt"},
+            "operator": {"type": "and"},
+            "query": {"params": ["A", "5m", "now"]},
+            "reducer": {"params": [], "type": "avg"},
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "name": "Slow Scrape Alert",
+        "noDataState": "no_data",
+        "notifications": []
+      }
+    },
+    {
+      "id": 16,
+      "gridPos": {"h": 6, "w": 12, "x": 0, "y": 28},
+      "type": "timeseries",
+      "title": "Epoch Pot Evolution",
+      "description": "Epoch reward pool changes over time",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_epoch_pot",
+          "legendFormat": "Epoch Pot",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "RTC",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 17,
+      "gridPos": {"h": 6, "w": 12, "x": 12, "y": 28},
+      "type": "timeseries",
+      "title": "Scrape Errors Rate",
+      "description": "Rate of scrape errors per minute (should be 0)",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rate(rustchain_scrape_errors_total[5m])",
+          "legendFormat": "Errors/min",
+          "format": "time_series"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "green"},
+              {"value": 0.1, "color": "yellow"},
+              {"value": 0.5, "color": "red"}
+            ]
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Errors/min",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {"legend": false, "tooltip": false, "viz": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "none"},
+            "thresholdsStyle": {"mode": "line"}
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {"calcs": ["min", "max", "avg", "last"], "displayMode": "table", "placement": "bottom", "showLegend": true},
+        "tooltip": {"mode": "single", "sort": "none"}
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 18,
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 34},
+      "type": "table",
+      "title": "Miner Hardware Distribution",
+      "description": "Detailed breakdown of miners by hardware type",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_miners_by_hardware",
+          "legendFormat": "{{hardware_type}}",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"value": null, "color": "blue"}
+            ]
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false,
+            "width": 150
+          },
+          "decimals": 0
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "hardware_type"},
+            "properties": [{"id": "custom.width", "value": 250}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "Value"},
+            "properties": [{"id": "custom.cellOptions", "value": {"type": "color-background"}}]
+          }
+        ]
+      },
+      "options": {
+        "cellHeight": "sm",
+        "footer": {"countRows": false, "fields": "", "reducer": ["sum"], "show": true},
+        "showHeader": true,
+        "sortBy": [{"desc": true, "displayName": "Value"}]
+      },
+      "pluginVersion": "10.0.0"
+    },
+    {
+      "id": 19,
+      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 40},
+      "type": "alertlist",
+      "title": "Active Alerts",
+      "description": "List of currently firing alerts",
+      "datasource": {"type": "prometheus", "uid": "${DS_PROMETHEUS}"},
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "rustchain_node_health == 0",
+          "legendFormat": "Node Down"
+        }
+      ],
+      "options": {
+        "alertInstanceLabelFilter": "",
+        "alertName": "",
+        "dashboardAlerts": false,
+        "groupBy": [],
+        "groupMode": "default",
+        "maxItems": 20,
+        "sortOrder": 1,
+        "stateFilter": {"alerting": true, "error": true, "no_data": true, "pending": true}
+      },
+      "pluginVersion": "10.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
Implements issue #1609 with an importable Grafana dashboard covering core RustChain metrics and setup guidance.\n\nCloses #1609