### PR TITLE
feat: add Telegram bot for RustChain API queries (#1597)

### DIFF
--- a/telegram_bot/.env.example
+++ b/telegram_bot/.env.example
@@ -1,0 +1,22 @@
+# RustChain Telegram Query Bot Configuration
+# Issue #1597
+# Copy this file to .env and customize for your deployment
+
+# === Telegram Bot Configuration ===
+# Required: Get your bot token from @BotFather on Telegram
+TELEGRAM_BOT_TOKEN=YOUR_BOT_TOKEN_HERE
+
+# === RustChain API Configuration ===
+# RustChain node API URL (default: testnet)
+RUSTCHAIN_API_URL=https://50.28.86.131
+
+# Verify SSL certificates (set to 'true' for production with valid certs)
+RUSTCHAIN_VERIFY_SSL=false
+
+# === Rate Limiting ===
+# Maximum requests per minute per user (prevents API abuse)
+RATE_LIMIT_PER_MINUTE=10
+
+# === Logging ===
+# Log level: DEBUG, INFO, WARNING, ERROR, CRITICAL
+LOG_LEVEL=INFO

--- a/telegram_bot/.gitignore
+++ b/telegram_bot/.gitignore
@@ -1,0 +1,71 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/telegram_bot/README.md
+++ b/telegram_bot/README.md
@@ -1,0 +1,273 @@
+# RustChain Telegram Query Bot
+
+> Issue #1597 - A minimal, safe Telegram bot for querying RustChain API
+
+[![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Overview
+
+This Telegram bot provides a simple interface to query the RustChain blockchain network. It supports read-only operations for checking node health, epoch information, wallet balances, and network statistics.
+
+## Features
+
+- ✅ **Safe & Read-Only**: All commands are query-only, no write operations
+- ✅ **Environment Configuration**: Easy setup via environment variables
+- ✅ **Rate Limiting**: Built-in protection against API abuse
+- ✅ **Error Handling**: Graceful error handling with user-friendly messages
+- ✅ **Minimal Dependencies**: Lightweight with only essential packages
+
+## Available Commands
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `/start` | Welcome message and introduction | `/start` |
+| `/help` | Show available commands and usage | `/help` |
+| `/health` | Check node health status | `/health` |
+| `/epoch` | Get current epoch information | `/epoch` |
+| `/balance` | Check wallet balance | `/balance Ivan-houzhiwen` |
+| `/stats` | Get network statistics | `/stats` |
+
+## Quick Start
+
+### 1. Create a Telegram Bot
+
+1. Open Telegram and message [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` to create a new bot
+3. Follow the instructions to name your bot
+4. Copy the API token provided
+
+### 2. Install Dependencies
+
+```bash
+cd telegram_bot
+pip install -r requirements.txt
+```
+
+### 3. Configure Environment
+
+```bash
+# Copy the example environment file
+cp .env.example .env
+
+# Edit .env and add your bot token
+TELEGRAM_BOT_TOKEN=your_bot_token_here
+```
+
+Or set environment variables directly:
+
+```bash
+export TELEGRAM_BOT_TOKEN='your_bot_token_here'
+export RUSTCHAIN_API_URL='https://50.28.86.131'
+```
+
+### 4. Run the Bot
+
+```bash
+python rustchain_query_bot.py
+```
+
+## Configuration
+
+All configuration is done via environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEGRAM_BOT_TOKEN` | (required) | Bot token from @BotFather |
+| `RUSTCHAIN_API_URL` | `https://50.28.86.131` | RustChain API endpoint |
+| `RUSTCHAIN_VERIFY_SSL` | `false` | Verify SSL certificates |
+| `RATE_LIMIT_PER_MINUTE` | `10` | Max requests per user per minute |
+| `LOG_LEVEL` | `INFO` | Logging level |
+
+## Command Examples
+
+### Check Node Health
+
+```
+/health
+```
+
+Response:
+```
+✅ Node Health
+
+Status: Online
+Version: 2.2.1-rip200
+Uptime: 5d 3h 42m
+
+API: https://50.28.86.131
+```
+
+### Get Epoch Information
+
+```
+/epoch
+```
+
+Response:
+```
+📅 Current Epoch
+
+Epoch: 95
+Slot: 12345
+Height: 67890
+
+Network: RustChain Mainnet
+```
+
+### Check Wallet Balance
+
+```
+/balance Ivan-houzhiwen
+```
+
+Response:
+```
+💰 Wallet Balance
+
+Wallet: Ivan-houzhiwen
+Balance: 155.0 RTC
+(Raw: 155000000 units)
+```
+
+### Get Network Statistics
+
+```
+/stats
+```
+
+Response:
+```
+📊 Network Statistics
+
+Active Miners: 42
+Current Epoch: 95
+Block Height: 67890
+
+API: https://50.28.86.131
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+# Install test dependencies
+pip install pytest pytest-asyncio pytest-cov
+
+# Run tests
+pytest tests/ -v
+
+# Run with coverage
+pytest tests/ -v --cov=telegram_bot --cov-report=html
+```
+
+## Development
+
+### Code Style
+
+This project uses `ruff` for linting:
+
+```bash
+pip install ruff
+ruff check telegram_bot/
+```
+
+### Type Checking
+
+Optional type checking with `mypy`:
+
+```bash
+pip install mypy
+mypy telegram_bot/
+```
+
+## Project Structure
+
+```
+telegram_bot/
+├── __init__.py                 # Package initialization
+├── rustchain_query_bot.py      # Main bot implementation
+├── requirements.txt            # Python dependencies
+├── .env.example               # Environment configuration template
+└── README.md                  # This file
+```
+
+## API Reference
+
+### RustChainClient
+
+The bot uses a simple client for the RustChain API:
+
+```python
+from rustchain_query_bot import RustChainClient
+
+client = RustChainClient()
+
+# Health check
+health = client.health()
+
+# Epoch info
+epoch = client.epoch()
+
+# Wallet balance
+balance = client.balance("Ivan-houzhiwen")
+
+# Miners list
+miners = client.miners()
+```
+
+## Security Considerations
+
+1. **Bot Token**: Never commit your `.env` file or expose your bot token
+2. **SSL Verification**: Enable SSL verification in production (`RUSTCHAIN_VERIFY_SSL=true`)
+3. **Rate Limiting**: Adjust rate limits based on your API capacity
+4. **Read-Only**: This bot only performs read operations - no private keys needed
+
+## Troubleshooting
+
+### Bot doesn't respond
+
+1. Check if the bot token is correct
+2. Verify the bot is added to a group (if using in groups)
+3. Check logs for error messages
+
+### API connection errors
+
+1. Verify `RUSTCHAIN_API_URL` is accessible
+2. Check network connectivity
+3. Try enabling/disabling SSL verification
+
+### Rate limit errors
+
+- Wait a minute before sending more commands
+- Increase `RATE_LIMIT_PER_MINUTE` if needed
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run tests and linting
+5. Submit a pull request
+
+## License
+
+MIT License - see LICENSE file for details
+
+## Related Links
+
+- [RustChain Official Website](https://rustchain.io)
+- [RustChain API Documentation](../API_WALKTHROUGH.md)
+- [Telegram Bot API](https://core.telegram.org/bots/api)
+- [python-telegram-bot Documentation](https://docs.python-telegram-bot.org/)
+
+## Support
+
+For issues or questions:
+- Open an issue on GitHub
+- Join the RustChain community Telegram group
+
+---
+
+*Built with ❤️ for the RustChain community*

--- a/telegram_bot/__init__.py
+++ b/telegram_bot/__init__.py
@@ -1,0 +1,6 @@
+"""
+RustChain Telegram Query Bot
+Issue #1597 - Telegram bot for querying RustChain API
+"""
+
+__version__ = "1.0.0"

--- a/telegram_bot/requirements.txt
+++ b/telegram_bot/requirements.txt
@@ -1,0 +1,22 @@
+# RustChain Telegram Query Bot
+# Issue #1597 - Dependencies
+
+# Telegram Bot API
+python-telegram-bot>=20.0
+
+# Environment variable management
+python-dotenv>=1.0.0
+
+# HTTP client
+requests>=2.28.0
+
+# Testing
+pytest>=7.0.0
+pytest-asyncio>=0.21.0
+pytest-cov>=4.0.0
+
+# Type checking (optional)
+mypy>=1.0.0
+
+# Linting (optional)
+ruff>=0.1.0

--- a/telegram_bot/rustchain_query_bot.py
+++ b/telegram_bot/rustchain_query_bot.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+RustChain Telegram Query Bot
+Issue #1597
+
+A minimal, safe Telegram bot for querying RustChain API endpoints.
+Supports health, epoch, and balance queries via environment-configured API.
+
+Commands:
+- /start - Welcome message and help
+- /help - Show available commands
+- /health - Check node health status
+- /epoch - Get current epoch information
+- /balance <wallet> - Check wallet balance
+- /stats - Get network statistics
+"""
+
+import os
+import sys
+import logging
+from typing import Optional, Dict, Any
+
+import requests
+from telegram import Update, BotCommand
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+)
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# RustChain API configuration
+RUSTCHAIN_API_URL = os.getenv("RUSTCHAIN_API_URL", "https://50.28.86.131")
+RUSTCHAIN_VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true"
+
+# Telegram bot configuration
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+
+# Rate limiting (requests per minute per user)
+RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "10"))
+
+# Logging configuration
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+# =============================================================================
+# Logging Setup
+# =============================================================================
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format=LOG_FORMAT,
+    handlers=[logging.StreamHandler(sys.stdout)]
+)
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# Rate Limiting
+# =============================================================================
+
+class RateLimiter:
+    """Simple in-memory rate limiter per user."""
+
+    def __init__(self, max_requests: int = RATE_LIMIT_PER_MINUTE):
+        self.max_requests = max_requests
+        self.user_requests: Dict[int, list] = {}
+
+    def is_allowed(self, user_id: int) -> bool:
+        """Check if user is allowed to make a request."""
+        import time
+        current_time = time.time()
+        minute_ago = current_time - 60
+
+        if user_id not in self.user_requests:
+            self.user_requests[user_id] = []
+
+        # Clean old requests
+        self.user_requests[user_id] = [
+            t for t in self.user_requests[user_id] if t > minute_ago
+        ]
+
+        # Check rate limit
+        if len(self.user_requests[user_id]) >= self.max_requests:
+            return False
+
+        # Record new request
+        self.user_requests[user_id].append(current_time)
+        return True
+
+
+rate_limiter = RateLimiter()
+
+# =============================================================================
+# RustChain API Client
+# =============================================================================
+
+class RustChainClient:
+    """Client for RustChain API endpoints."""
+
+    def __init__(self, base_url: str = RUSTCHAIN_API_URL, verify_ssl: bool = RUSTCHAIN_VERIFY_SSL):
+        self.base_url = base_url.rstrip('/')
+        self.verify_ssl = verify_ssl
+        self.session = requests.Session()
+        self.session.verify = verify_ssl
+
+    def _get(self, endpoint: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+        """Make GET request to API."""
+        url = f"{self.base_url}{endpoint}"
+        try:
+            response = self.session.get(url, params=params, timeout=15)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.Timeout:
+            logger.error(f"Timeout requesting {url}")
+            return {"error": "Request timeout"}
+        except requests.exceptions.ConnectionError as e:
+            logger.error(f"Connection error to {url}: {e}")
+            return {"error": f"Connection failed: {str(e)}"}
+        except requests.exceptions.HTTPError as e:
+            logger.error(f"HTTP error from {url}: {e}")
+            return {"error": f"HTTP error: {e.response.status_code}"}
+        except Exception as e:
+            logger.error(f"Unexpected error requesting {url}: {e}")
+            return {"error": str(e)}
+
+    def health(self) -> Dict[str, Any]:
+        """Get node health status."""
+        return self._get("/health")
+
+    def epoch(self) -> Dict[str, Any]:
+        """Get current epoch information."""
+        return self._get("/epoch")
+
+    def balance(self, miner_id: str) -> Dict[str, Any]:
+        """Get wallet balance for a miner ID."""
+        return self._get("/wallet/balance", params={"miner_id": miner_id})
+
+    def miners(self) -> Dict[str, Any]:
+        """Get active miners list."""
+        return self._get("/api/miners")
+
+
+# Global API client instance
+api_client = RustChainClient()
+
+# =============================================================================
+# Bot Commands
+# =============================================================================
+
+async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /start command - welcome message."""
+    user = update.effective_user
+    logger.info(f"User {user.id} ({user.username}) started the bot")
+
+    welcome_text = f"""
+🛡️ **Welcome to RustChain Query Bot!**
+
+I can help you query the RustChain network.
+
+**Available Commands:**
+/health - Check node health status
+/epoch - Get current epoch info
+/balance <wallet> - Check wallet balance
+/stats - Get network statistics
+/help - Show this help message
+
+**API Endpoint:** `{RUSTCHAIN_API_URL}`
+
+Start mining at: rustchain.io
+"""
+    await update.message.reply_text(welcome_text, parse_mode="Markdown")
+
+
+async def cmd_help(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /help command - show available commands."""
+    help_text = """
+🛡️ **RustChain Query Bot - Help**
+
+**Commands:**
+
+/health
+  Check node health status and version
+
+/epoch
+  Get current epoch, slot, and height info
+
+/balance <wallet>
+  Check RTC balance for a wallet/miner ID
+  Example: /balance Ivan-houzhiwen
+
+/stats
+  Get network statistics (miner count)
+
+/help
+  Show this help message
+
+**Notes:**
+- All queries are read-only and safe
+- Rate limit: {rate_limit} requests/minute
+- API: `{api_url}`
+""".format(
+        rate_limit=RATE_LIMIT_PER_MINUTE,
+        api_url=RUSTCHAIN_API_URL
+    )
+    await update.message.reply_text(help_text, parse_mode="Markdown")
+
+
+async def cmd_health(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /health command - check node health."""
+    user = update.effective_user
+
+    # Rate limiting
+    if not rate_limiter.is_allowed(user.id):
+        await update.message.reply_text(
+            f"⚠️ Rate limit exceeded. Please wait before making more requests."
+        )
+        return
+
+    logger.info(f"User {user.id} requested health check")
+
+    await update.message.reply_text("🔍 Checking node health...")
+
+    result = api_client.health()
+
+    if "error" in result:
+        await update.message.reply_text(f"❌ Error: {result['error']}")
+        return
+
+    # Format health response
+    status = result.get("ok", False)
+    version = result.get("version", "N/A")
+    uptime = result.get("uptime_s", 0)
+
+    # Format uptime
+    if uptime > 0:
+        days = int(uptime // 86400)
+        hours = int((uptime % 86400) // 3600)
+        minutes = int((uptime % 3600) // 60)
+        uptime_str = f"{days}d {hours}h {minutes}m"
+    else:
+        uptime_str = "N/A"
+
+    status_icon = "✅" if status else "❌"
+    health_text = f"""
+{status_icon} **Node Health**
+
+Status: *{'Online' if status else 'Offline'}*
+Version: `{version}`
+Uptime: `{uptime_str}`
+
+API: `{RUSTCHAIN_API_URL}`
+"""
+    await update.message.reply_text(health_text, parse_mode="Markdown")
+
+
+async def cmd_epoch(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /epoch command - get epoch info."""
+    user = update.effective_user
+
+    # Rate limiting
+    if not rate_limiter.is_allowed(user.id):
+        await update.message.reply_text(
+            f"⚠️ Rate limit exceeded. Please wait before making more requests."
+        )
+        return
+
+    logger.info(f"User {user.id} requested epoch info")
+
+    await update.message.reply_text("📅 Fetching epoch information...")
+
+    result = api_client.epoch()
+
+    if "error" in result:
+        await update.message.reply_text(f"❌ Error: {result['error']}")
+        return
+
+    epoch = result.get("epoch", "N/A")
+    slot = result.get("slot", "N/A")
+    height = result.get("height", "N/A")
+
+    epoch_text = f"""
+📅 **Current Epoch**
+
+Epoch: *{epoch}*
+Slot: `{slot}`
+Height: `{height}`
+
+Network: RustChain Mainnet
+"""
+    await update.message.reply_text(epoch_text, parse_mode="Markdown")
+
+
+async def cmd_balance(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /balance command - check wallet balance."""
+    user = update.effective_user
+
+    # Rate limiting
+    if not rate_limiter.is_allowed(user.id):
+        await update.message.reply_text(
+            f"⚠️ Rate limit exceeded. Please wait before making more requests."
+        )
+        return
+
+    # Check for wallet argument
+    if not context.args:
+        await update.message.reply_text(
+            "❌ Usage: /balance <wallet_id>\n\n"
+            "Example: /balance Ivan-houzhiwen"
+        )
+        return
+
+    wallet_id = context.args[0]
+    logger.info(f"User {user.id} requested balance for {wallet_id}")
+
+    await update.message.reply_text(f"💰 Checking balance for `{wallet_id}`...")
+
+    result = api_client.balance(wallet_id)
+
+    if "error" in result:
+        await update.message.reply_text(f"❌ Error: {result['error']}")
+        return
+
+    amount_rtc = result.get("amount_rtc", 0)
+    amount_i64 = result.get("amount_i64", 0)
+    miner_id = result.get("miner_id", wallet_id)
+
+    balance_text = f"""
+💰 **Wallet Balance**
+
+Wallet: `{miner_id}`
+Balance: *{amount_rtc} RTC*
+(Raw: {amount_i64} units)
+"""
+    await update.message.reply_text(balance_text, parse_mode="Markdown")
+
+
+async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /stats command - get network statistics."""
+    user = update.effective_user
+
+    # Rate limiting
+    if not rate_limiter.is_allowed(user.id):
+        await update.message.reply_text(
+            f"⚠️ Rate limit exceeded. Please wait before making more requests."
+        )
+        return
+
+    logger.info(f"User {user.id} requested network stats")
+
+    await update.message.reply_text("📊 Fetching network statistics...")
+
+    # Get miners list
+    miners_result = api_client.miners()
+    miner_count = "N/A"
+
+    if "error" not in miners_result and isinstance(miners_result, list):
+        miner_count = len(miners_result)
+
+    # Get epoch info for additional stats
+    epoch_result = api_client.epoch()
+    current_epoch = epoch_result.get("epoch", "N/A")
+    current_height = epoch_result.get("height", "N/A")
+
+    stats_text = f"""
+📊 **Network Statistics**
+
+Active Miners: *{miner_count}*
+Current Epoch: `{current_epoch}`
+Block Height: `{current_height}`
+
+API: `{RUSTCHAIN_API_URL}`
+"""
+    await update.message.reply_text(stats_text, parse_mode="Markdown")
+
+
+async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle errors caused by updates."""
+    logger.error(f"Update {update} caused error: {context.error}")
+
+    if update and update.effective_message:
+        await update.effective_message.reply_text(
+            "❌ An error occurred while processing your request."
+        )
+
+
+# =============================================================================
+# Bot Initialization
+# =============================================================================
+
+def set_bot_commands(application: Application):
+    """Set up bot command list for Telegram menu."""
+    commands = [
+        BotCommand("start", "Start the bot"),
+        BotCommand("help", "Show available commands"),
+        BotCommand("health", "Check node health"),
+        BotCommand("epoch", "Get current epoch info"),
+        BotCommand("balance", "Check wallet balance"),
+        BotCommand("stats", "Get network statistics"),
+    ]
+    return commands
+
+
+async def post_init(application: Application):
+    """Post-initialization setup."""
+    commands = set_bot_commands(application)
+    await application.bot.set_my_commands(commands)
+    logger.info(f"Bot commands set: {[c.name for c in commands]}")
+
+
+def validate_config() -> bool:
+    """Validate required configuration."""
+    if not TELEGRAM_BOT_TOKEN:
+        logger.error("TELEGRAM_BOT_TOKEN environment variable is not set")
+        print("\n❌ Error: TELEGRAM_BOT_TOKEN environment variable is required")
+        print("\nTo get a bot token:")
+        print("1. Open Telegram and message @BotFather")
+        print("2. Send /newbot to create a new bot")
+        print("3. Follow the instructions to name your bot")
+        print("4. Copy the API token")
+        print("5. Set it: export TELEGRAM_BOT_TOKEN='your-token-here'")
+        print("\nOr create a .env file with:")
+        print("  TELEGRAM_BOT_TOKEN=your-token-here\n")
+        return False
+
+    if TELEGRAM_BOT_TOKEN == "YOUR_BOT_TOKEN_HERE":
+        logger.error("Please replace 'YOUR_BOT_TOKEN_HERE' with your actual bot token")
+        print("\n❌ Error: Please replace 'YOUR_BOT_TOKEN_HERE' with your actual bot token")
+        return False
+
+    logger.info(f"Configuration validated. API URL: {RUSTCHAIN_API_URL}")
+    return True
+
+
+def main():
+    """Main entry point - start the bot."""
+    logger.info("Starting RustChain Query Bot...")
+    logger.info(f"Python version: {sys.version}")
+
+    # Validate configuration
+    if not validate_config():
+        sys.exit(1)
+
+    # Build application
+    application = Application.builder().token(TELEGRAM_BOT_TOKEN).build()
+
+    # Register command handlers
+    application.add_handler(CommandHandler("start", cmd_start))
+    application.add_handler(CommandHandler("help", cmd_help))
+    application.add_handler(CommandHandler("health", cmd_health))
+    application.add_handler(CommandHandler("epoch", cmd_epoch))
+    application.add_handler(CommandHandler("balance", cmd_balance))
+    application.add_handler(CommandHandler("stats", cmd_stats))
+
+    # Register error handler
+    application.add_error_handler(error_handler)
+
+    # Set post-init callback
+    application.post_init = post_init
+
+    # Start the bot
+    print("\n🛡️ RustChain Query Bot starting...")
+    print(f"   API: {RUSTCHAIN_API_URL}")
+    print(f"   Verify SSL: {RUSTCHAIN_VERIFY_SSL}")
+    print(f"   Rate limit: {RATE_LIMIT_PER_MINUTE} req/min")
+    print("\nPress Ctrl+C to stop\n")
+
+    # Run polling
+    application.run_polling(
+        allowed_updates=Update.ALL_TYPES,
+        drop_pending_updates=True
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram_bot/tests/__init__.py
+++ b/telegram_bot/tests/__init__.py
@@ -1,0 +1,4 @@
+"""
+Tests for RustChain Telegram Query Bot
+Issue #1597
+"""

--- a/telegram_bot/tests/conftest.py
+++ b/telegram_bot/tests/conftest.py
@@ -1,0 +1,21 @@
+"""
+pytest configuration for telegram_bot tests
+"""
+
+import pytest
+
+
+def pytest_configure(config):
+    """Configure pytest."""
+    config.addinivalue_line(
+        "markers", "asyncio: mark test as an asyncio test."
+    )
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    """Create an instance of the default event loop for the test session."""
+    import asyncio
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()

--- a/telegram_bot/tests/test_bot_commands.py
+++ b/telegram_bot/tests/test_bot_commands.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for Telegram bot commands
+"""
+
+import pytest
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestBotCommands:
+    """Tests for bot command handlers."""
+
+    @pytest.fixture
+    def mock_update(self):
+        """Create a mock update object."""
+        update = Mock()
+        update.message = AsyncMock()
+        update.message.reply_text = AsyncMock()
+        update.effective_user = Mock()
+        update.effective_user.id = 12345
+        update.effective_user.username = "testuser"
+        return update
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock context object."""
+        context = Mock()
+        context.args = []
+        return context
+
+    @pytest.mark.asyncio
+    async def test_cmd_start(self, mock_update, mock_context):
+        """Test /start command."""
+        from rustchain_query_bot import cmd_start
+
+        await cmd_start(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "Welcome to RustChain Query Bot" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_cmd_help(self, mock_update, mock_context):
+        """Test /help command."""
+        from rustchain_query_bot import cmd_help
+
+        await cmd_help(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "Available Commands" in call_args[0][0] or "Commands:" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_cmd_balance_no_args(self, mock_update, mock_context):
+        """Test /balance command without arguments."""
+        from rustchain_query_bot import cmd_balance
+
+        mock_context.args = []
+        await cmd_balance(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "Usage:" in call_args[0][0] or "usage" in call_args[0][0].lower()
+
+    @pytest.mark.asyncio
+    @patch('rustchain_query_bot.api_client')
+    async def test_cmd_balance_success(self, mock_client, mock_update, mock_context):
+        """Test /balance command with valid wallet."""
+        from rustchain_query_bot import cmd_balance
+
+        mock_context.args = ["test-wallet"]
+        mock_client.balance.return_value = {
+            "amount_rtc": 100.5,
+            "amount_i64": 100500000,
+            "miner_id": "test-wallet"
+        }
+
+        await cmd_balance(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "100.5" in call_args[0][0]
+        assert "test-wallet" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    @patch('rustchain_query_bot.api_client')
+    async def test_cmd_balance_error(self, mock_client, mock_update, mock_context):
+        """Test /balance command with API error."""
+        from rustchain_query_bot import cmd_balance
+
+        mock_context.args = ["test-wallet"]
+        mock_client.balance.return_value = {"error": "Wallet not found"}
+
+        await cmd_balance(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "error" in call_args[0][0].lower() or "Error" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    @patch('rustchain_query_bot.api_client')
+    async def test_cmd_health_success(self, mock_client, mock_update, mock_context):
+        """Test /health command success."""
+        from rustchain_query_bot import cmd_health
+
+        mock_client.health.return_value = {
+            "ok": True,
+            "version": "2.2.1",
+            "uptime_s": 86400
+        }
+
+        await cmd_health(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "Online" in call_args[0][0] or "online" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    @patch('rustchain_query_bot.api_client')
+    async def test_cmd_epoch_success(self, mock_client, mock_update, mock_context):
+        """Test /epoch command success."""
+        from rustchain_query_bot import cmd_epoch
+
+        mock_client.epoch.return_value = {
+            "epoch": 100,
+            "slot": 5000,
+            "height": 10000
+        }
+
+        await cmd_epoch(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "100" in call_args[0][0]
+
+    @pytest.mark.asyncio
+    @patch('rustchain_query_bot.api_client')
+    async def test_cmd_stats_success(self, mock_client, mock_update, mock_context):
+        """Test /stats command success."""
+        from rustchain_query_bot import cmd_stats
+
+        mock_client.miners.return_value = ["miner1", "miner2"]
+        mock_client.epoch.return_value = {"epoch": 100, "height": 5000}
+
+        await cmd_stats(mock_update, mock_context)
+
+        assert mock_update.message.reply_text.called
+        call_args = mock_update.message.reply_text.call_args
+        assert "2" in call_args[0][0]  # miner count
+
+
+class TestConfiguration:
+    """Tests for configuration validation."""
+
+    @patch('rustchain_query_bot.TELEGRAM_BOT_TOKEN', '')
+    def test_validate_config_missing_token(self):
+        """Test validation fails without bot token."""
+        from rustchain_query_bot import validate_config
+
+        result = validate_config()
+        assert result is False
+
+    @patch('rustchain_query_bot.TELEGRAM_BOT_TOKEN', 'YOUR_BOT_TOKEN_HERE')
+    def test_validate_config_default_token(self):
+        """Test validation fails with default token."""
+        from rustchain_query_bot import validate_config
+
+        result = validate_config()
+        assert result is False
+
+    @patch('rustchain_query_bot.TELEGRAM_BOT_TOKEN', 'test-token-123')
+    def test_validate_config_valid_token(self):
+        """Test validation passes with valid token."""
+        from rustchain_query_bot import validate_config
+
+        result = validate_config()
+        assert result is True
+
+
+class TestBotCommandsSetup:
+    """Tests for bot command setup."""
+
+    def test_set_bot_commands(self):
+        """Test bot commands are set correctly."""
+        from rustchain_query_bot import set_bot_commands
+        from telegram import BotCommand
+
+        commands = set_bot_commands(None)
+
+        assert len(commands) == 6
+        # BotCommand uses 'command' attribute for the command name
+        command_names = [c.command for c in commands]
+        assert "start" in command_names
+        assert "help" in command_names
+        assert "health" in command_names
+        assert "epoch" in command_names
+        assert "balance" in command_names
+        assert "stats" in command_names

--- a/telegram_bot/tests/test_rustchain_client.py
+++ b/telegram_bot/tests/test_rustchain_client.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for RustChainClient
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import sys
+import os
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_query_bot import RustChainClient, RateLimiter
+
+
+class TestRustChainClient:
+    """Tests for RustChainClient class."""
+
+    def test_init_default_values(self):
+        """Test client initialization with default values."""
+        client = RustChainClient()
+        assert client.base_url == "https://50.28.86.131"
+        assert client.verify_ssl is False
+
+    def test_init_custom_values(self):
+        """Test client initialization with custom values."""
+        client = RustChainClient(base_url="https://custom.api.com", verify_ssl=True)
+        assert client.base_url == "https://custom.api.com"
+        assert client.verify_ssl is True
+
+    def test_init_strips_trailing_slash(self):
+        """Test that trailing slash is removed from base URL."""
+        client = RustChainClient(base_url="https://api.com/")
+        assert client.base_url == "https://api.com"
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_health_success(self, mock_session_class):
+        """Test health endpoint success."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        
+        mock_response = Mock()
+        mock_response.json.return_value = {"ok": True, "version": "2.2.1"}
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        client = RustChainClient()
+        result = client.health()
+
+        assert result == {"ok": True, "version": "2.2.1"}
+        mock_session.get.assert_called_once_with(
+            "https://50.28.86.131/health",
+            params=None,
+            timeout=15
+        )
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_health_timeout(self, mock_session_class):
+        """Test health endpoint timeout."""
+        import requests
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        mock_session.get.side_effect = requests.exceptions.Timeout()
+
+        client = RustChainClient()
+        result = client.health()
+
+        assert "error" in result
+        assert "timeout" in result["error"].lower()
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_health_connection_error(self, mock_session_class):
+        """Test health endpoint connection error."""
+        import requests
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        mock_session.get.side_effect = requests.exceptions.ConnectionError("Connection refused")
+
+        client = RustChainClient()
+        result = client.health()
+
+        assert "error" in result
+        assert "connection" in result["error"].lower()
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_epoch_success(self, mock_session_class):
+        """Test epoch endpoint success."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        
+        mock_response = Mock()
+        mock_response.json.return_value = {"epoch": 95, "slot": 12345, "height": 67890}
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        client = RustChainClient()
+        result = client.epoch()
+
+        assert result == {"epoch": 95, "slot": 12345, "height": 67890}
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_balance_success(self, mock_session_class):
+        """Test balance endpoint success."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "amount_i64": 155000000,
+            "amount_rtc": 155.0,
+            "miner_id": "Ivan-houzhiwen"
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        client = RustChainClient()
+        result = client.balance("Ivan-houzhiwen")
+
+        assert result["amount_rtc"] == 155.0
+        assert result["miner_id"] == "Ivan-houzhiwen"
+        mock_session.get.assert_called_once()
+
+    @patch('rustchain_query_bot.requests.Session')
+    def test_miners_success(self, mock_session_class):
+        """Test miners endpoint success."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+        
+        mock_response = Mock()
+        mock_response.json.return_value = ["miner1", "miner2", "miner3"]
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        client = RustChainClient()
+        result = client.miners()
+
+        assert result == ["miner1", "miner2", "miner3"]
+
+
+class TestRateLimiter:
+    """Tests for RateLimiter class."""
+
+    def test_init_default_limit(self):
+        """Test rate limiter initialization."""
+        limiter = RateLimiter()
+        assert limiter.max_requests == 10  # Default from config
+
+    def test_init_custom_limit(self):
+        """Test rate limiter with custom limit."""
+        limiter = RateLimiter(max_requests=5)
+        assert limiter.max_requests == 5
+
+    def test_first_request_allowed(self):
+        """Test that first request is always allowed."""
+        limiter = RateLimiter(max_requests=5)
+        assert limiter.is_allowed(user_id=123) is True
+
+    def test_requests_within_limit_allowed(self):
+        """Test that requests within limit are allowed."""
+        limiter = RateLimiter(max_requests=3)
+        
+        assert limiter.is_allowed(123) is True
+        assert limiter.is_allowed(123) is True
+        assert limiter.is_allowed(123) is True
+
+    def test_requests_exceeding_limit_blocked(self):
+        """Test that requests exceeding limit are blocked."""
+        limiter = RateLimiter(max_requests=2)
+        
+        assert limiter.is_allowed(123) is True
+        assert limiter.is_allowed(123) is True
+        assert limiter.is_allowed(123) is False
+
+    def test_different_users_independent(self):
+        """Test that rate limits are per-user."""
+        limiter = RateLimiter(max_requests=1)
+        
+        assert limiter.is_allowed(123) is True
+        assert limiter.is_allowed(123) is False
+        assert limiter.is_allowed(456) is True  # Different user
+
+    @patch('time.time')
+    def test_old_requests_expire(self, mock_time):
+        """Test that old requests are cleaned up."""
+        mock_time.return_value = 1000.0
+        
+        limiter = RateLimiter(max_requests=2)
+        limiter.is_allowed(123)  # Request at t=1000
+        limiter.is_allowed(123)  # Request at t=1000
+        
+        # At this point, user should be rate limited
+        assert limiter.is_allowed(123) is False
+        
+        # Advance time by 61 seconds (past the 60-second window)
+        mock_time.return_value = 1061.0
+        
+        # Now the request should be allowed again
+        assert limiter.is_allowed(123) is True


### PR DESCRIPTION
Implements issue #1597 with a read-only Telegram bot for RustChain query commands, env-based config, and tests/docs.\n\nCloses #1597