### PR TITLE
docs: add RustChain vs Ethereum PoS technical comparison (#1610)

### DIFF
--- a/docs/RUSTCHAIN_VS_ETHEREUM_POS_COMPARISON.md
+++ b/docs/RUSTCHAIN_VS_ETHEREUM_POS_COMPARISON.md
@@ -1,0 +1,682 @@
+# RustChain vs Ethereum Proof-of-Stake: A Comprehensive Comparison
+
+**Last Updated:** March 2026  
+**Document Type:** Technical Comparison Analysis  
+**Audience:** Developers, Researchers, Blockchain Architects, Investors
+
+---
+
+## Executive Summary
+
+This document provides an objective, technical comparison between **RustChain** (a Proof-of-Antiquity blockchain) and **Ethereum** (a Proof-of-Stake blockchain). Both networks represent innovative approaches to consensus, but serve fundamentally different purposes and optimize for different values.
+
+**Key Finding:** RustChain and Ethereum PoS are not direct competitors—they address different market segments. Ethereum targets global decentralized computation and DeFi at scale, while RustChain focuses on hardware preservation, anti-e-waste incentives, and democratized participation through vintage hardware validation.
+
+| Criterion | Ethereum PoS | RustChain PoA |
+|-----------|--------------|---------------|
+| **Primary Goal** | Global settlement layer, smart contracts | Hardware preservation, e-waste reduction |
+| **Consensus Type** | Proof-of-Stake (Gasper) | Proof-of-Antiquity (RIP-200) |
+| **Validator Entry** | 32 ETH (~$100K+ USD) | Vintage hardware + attestation |
+| **Energy Efficiency** | High (no PoW computations) | Very High (passive hardware verification) |
+| **Decentralization** | ~1M validators (theoretical) | ~11,626+ active miners (Feb 2026) |
+| **Block Time** | 12 seconds | Epoch-based (144 slots) |
+| **Finality** | ~15 minutes (2 epochs) | Epoch settlement + Ergo anchor |
+| **Smart Contracts** | Full EVM support | Limited (Ergo-anchored) |
+| **Token Supply** | Inflationary (no hard cap) | Fixed 8M RTC |
+
+---
+
+## 1. Architecture Comparison
+
+### 1.1 Network Topology
+
+#### Ethereum PoS
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ETHEREUM NETWORK                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ┌──────────────┐      ┌──────────────┐                   │
+│   │  Beacon      │◄────►│  Validator   │                   │
+│   │  Chain       │      │  Clients     │                   │
+│   │  (Consensus) │      │  (~1M)       │                   │
+│   └──────┬───────┘      └──────────────┘                   │
+│          │                                                  │
+│          ▼                                                  │
+│   ┌──────────────┐      ┌──────────────┐                   │
+│   │  Execution   │      │  Block       │                   │
+│   │  Layer       │◄─────│  Builders    │                   │
+│   │  (EVM)       │      │  (MEV)       │                   │
+│   └──────────────┘      └──────────────┘                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Characteristics:**
+- **Three-client architecture:** Execution client + Consensus client + Validator client
+- **Permissionless entry:** Any user with 32 ETH can become a validator
+- **Global distribution:** Validators span 100+ countries
+- **MEV ecosystem:** Specialized block builders optimize transaction ordering
+
+#### RustChain PoA
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    RUSTCHAIN NETWORK                        │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   ┌──────────────┐      ┌──────────────┐                   │
+│   │  PRIMARY     │◄────►│  ATTESTATION │                   │
+│   │  NODE        │      │  NODES       │                   │
+│   │  (Explorer)  │      │  (3 active)  │                   │
+│   └──────┬───────┘      └──────────────┘                   │
+│          │                                                  │
+│          ▼                                                  │
+│   ┌──────────────┐      ┌──────────────┐                   │
+│   │  ERGO        │      │  MINER       │                   │
+│   │  ANCHOR      │◄─────│  CLIENTS     │                   │
+│   │  NODE        │      │  (11,626+)   │                   │
+│   └──────────────┘      └──────────────┘                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Characteristics:**
+- **Federated architecture:** Primary node + 3 attestation nodes
+- **Hardware-gated entry:** Requires authentic vintage hardware
+- **6-layer fingerprinting:** Clock skew, cache timing, SIMD identity, thermal entropy, instruction jitter, behavioral heuristics
+- **Ergo anchoring:** Settlement hashes anchored to Ergo blockchain for immutability
+
+### 1.2 Design Philosophy
+
+| Aspect | Ethereum | RustChain |
+|--------|----------|-----------|
+| **Philosophy** | "World Computer" | "Hardware Preservation" |
+| **Optimization** | Throughput, programmability | Authenticity, accessibility |
+| **Innovation** | General-purpose smart contracts | Novel consensus (PoA) |
+| **Target User** | Developers, DeFi users, enterprises | Retro computing enthusiasts, collectors |
+| **Geographic Focus** | Global, borderless | Global, but appeals to niche communities |
+
+---
+
+## 2. Consensus Mechanism Deep Dive
+
+### 2.1 Ethereum: Gasper (PoS)
+
+**Consensus Algorithm:** Gasper = LMD-GHOST + Casper-FFG
+
+#### Time Structure
+| Parameter | Value |
+|-----------|-------|
+| Slot Duration | 12 seconds |
+| Slots per Epoch | 32 |
+| Epoch Duration | 6.4 minutes (384 seconds) |
+| Finality Time | ~2 epochs (~15 minutes) |
+
+#### Validator Lifecycle
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│  Deposit    │ ──▶ │  Activation │ ──▶ │  Attesting  │
+│  (32 ETH)   │     │   Queue     │     │  Proposing  │
+└─────────────┘     └─────────────┘     └─────────────┘
+                                               │
+                                               ▼
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Exit      │ ◀── │  Slashing   │ ◀── │  Misbehavior│
+│  (Voluntary)│     │  (Penalty)  │     │  Detected   │
+└─────────────┘     └─────────────┘     └─────────────┘
+```
+
+#### Fork Choice Rule: LMD-GHOST
+- **Latest Message Drive:** Only considers most recent attestation from each validator
+- **Greedy Heaviest Observed Subtree:** Selects chain with most accumulated weight
+- **Proposer Boost:** Recent block proposers receive weight advantage to prevent reorgs
+
+#### Finality: Casper-FFG
+- **Checkpoint Blocks:** First block of each epoch
+- **Supermajority Link:** 2/3 of total stake must attest
+- **Finalization Condition:** Two justified checkpoints in sequence
+- **Inactivity Leak:** Bleeds stake from minority validators if finality stalls
+
+### 2.2 RustChain: RIP-200 (PoA)
+
+**Consensus Algorithm:** Round-Robin with Hardware Attestation
+
+#### Epoch Structure
+| Parameter | Value |
+|-----------|-------|
+| Epoch Duration | 144 slots |
+| Slot Assignment | Round-robin by validator ID |
+| Settlement | End-of-epoch batch processing |
+| Finality | Ergo anchor + epoch hash |
+
+#### Attestation Flow
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Miner     │ ──▶ │  Hardware   │ ──▶ │  Node       │
+│  Starts     │     │  Fingerprint│     │  Validates  │
+│  Session    │     │  (6 checks) │     │  Profile    │
+└─────────────┘     └─────────────┘     └─────────────┘
+                                               │
+                          ┌────────────────────┤
+                          ▼                    ▼
+                   ┌─────────────┐     ┌─────────────┐
+                   │   Enroll    │     │   Reject    │
+                   │  (Multiplier│     │  (VM/Emu)   │
+                   │   Applied)  │     │             │
+                   └─────────────┘     └─────────────┘
+```
+
+#### Six-Layer Fingerprinting
+
+| # | Check | Purpose | VM Detection Mechanism |
+|---|-------|---------|------------------------|
+| 1 | **Clock Skew** | Crystal oscillator imperfections | VMs use host clock (too perfect) |
+| 2 | **Cache Timing** | L1/L2 latency curves | Emulators flatten cache hierarchy |
+| 3 | **SIMD Identity** | AltiVec/SSE/NEON biases | Different timing in emulation |
+| 4 | **Thermal Entropy** | CPU temp under load | VMs report static temperatures |
+| 5 | **Instruction Jitter** | Opcode execution variance | Real silicon has nanosecond jitter |
+| 6 | **Behavioral Heuristics** | Hypervisor signatures | Detects VMware, QEMU, etc. |
+
+#### Antiquity Multipliers
+
+| Hardware | Era | Base Multiplier | Example Earnings/Epoch |
+|----------|-----|-----------------|------------------------|
+| PowerPC G4 | 1999-2005 | 2.5× | 0.30 RTC |
+| PowerPC G5 | 2003-2006 | 2.0× | 0.24 RTC |
+| PowerPC G3 | 1997-2003 | 1.8× | 0.21 RTC |
+| IBM POWER8 | 2014 | 1.5× | 0.18 RTC |
+| Pentium 4 | 2000-2008 | 1.5× | 0.18 RTC |
+| Pentium III | 1999-2003 | 1.4× | 0.17 RTC |
+| Core 2 Duo | 2006-2011 | 1.3× | 0.16 RTC |
+| Apple M1/M2/M3 | 2020+ | 1.2× | 0.14 RTC |
+| Modern x86_64 | Current | 1.0× | 0.12 RTC |
+| ARM (Raspberry Pi) | Current | 0.0001× | ~0 RTC |
+| VM/Emulator | N/A | 0.0000000025× | ~0 RTC |
+
+### 2.3 Consensus Comparison Table
+
+| Property | Ethereum PoS | RustChain PoA |
+|----------|--------------|---------------|
+| **Consensus Type** | Proof-of-Stake | Proof-of-Antiquity |
+| **Validator Selection** | Pseudo-random (RANDAO) | Round-robin + attestation |
+| **Block Production** | 1 proposer per slot | Epoch-based settlement |
+| **Finality Mechanism** | Casper-FFG (2/3 supermajority) | Ergo anchor + epoch hash |
+| **Fork Resolution** | LMD-GHOST | Heaviest chain + anchor |
+| **Slashing Conditions** | Equivocation, contradictory attestations | N/A (no slashing) |
+| **Inactivity Penalty** | Inactivity leak | No penalty (passive) |
+| **Sybil Resistance** | Economic (32 ETH stake) | Physical (hardware uniqueness) |
+| **Long-Range Attack Defense** | Weak subjectivity | Hardware attestation history |
+| **Energy Consumption** | ~0.01% of PoW Ethereum | Negligible (passive verification) |
+
+---
+
+## 3. Economic Models
+
+### 3.1 Token Supply & Emission
+
+#### Ethereum (ETH)
+| Parameter | Value |
+|-----------|-------|
+| **Total Supply** | ~120M ETH (Feb 2026) |
+| **Supply Cap** | None (inflationary) |
+| **Issuance Rate** | ~0.5-2% APR (varies with stake) |
+| **Burn Mechanism** | EIP-1559 base fee burn |
+| **Net Inflation** | Can be deflationary during high usage |
+
+**Emission Dynamics:**
+- Validators earn staking rewards (issuance) + transaction tips
+- Base fees are burned, reducing net supply growth
+- During high network activity: net deflation possible
+- During low activity: low inflation (~0.5-1% APR)
+
+#### RustChain (RTC)
+| Parameter | Value |
+|-----------|-------|
+| **Total Supply** | 8,000,000 RTC (fixed) |
+| **Supply Cap** | Hard cap (no inflation) |
+| **Premine** | 75,000 RTC (0.94%) |
+| **Mining Allocation** | 7,925,000 RTC (99.06%) |
+| **Current Emission** | ~1.5 RTC/epoch (~547.5 RTC/year) |
+| **Years to Full Emission** | ~14,500 years |
+
+**Distribution:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    RTC Total Supply                         │
+│                      8,000,000 RTC                          │
+├─────────────────────────────────────────────────────────────┤
+│  Premine (Dev/Bounties)  │  Mining Rewards                  │
+│       75,000 RTC         │    7,925,000 RTC                 │
+│         0.94%            │       99.06%                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Validator Economics
+
+#### Ethereum Validator ROI
+
+| Scenario | Annual Return | Notes |
+|----------|---------------|-------|
+| **Base Case** | 3-5% APR | ~900K validators, moderate activity |
+| **High Activity** | 4-6% APR | Increased tips + MEV |
+| **Low Activity** | 2-3% APR | Minimal tips, base issuance only |
+| **Post-Slashing** | -100% | Total loss of stake (worst case) |
+
+**Costs:**
+- 32 ETH opportunity cost (~$100K+ USD)
+- Hardware: $500-2000 (consumer-grade sufficient)
+- Electricity: ~$50-150/year
+- Time: Active management required
+
+**Risks:**
+- Slashing (up to 100% stake loss)
+- Inactivity leaks (gradual stake reduction)
+- ETH price volatility
+- Regulatory uncertainty
+
+#### RustChain Miner ROI
+
+| Hardware | Multiplier | Daily Earnings | Annual Earnings |
+|----------|------------|----------------|-----------------|
+| PowerPC G4 | 2.5× | 0.0082 RTC | ~3.0 RTC |
+| PowerPC G5 | 2.0× | 0.0066 RTC | ~2.4 RTC |
+| Pentium 4 | 1.5× | 0.0049 RTC | ~1.8 RTC |
+| Modern x86 | 1.0× | 0.0033 RTC | ~1.2 RTC |
+
+**Costs:**
+- Hardware: $50-500 (vintage machines, one-time)
+- Electricity: ~$20-80/year (low-power vintage hardware)
+- Time: Passive operation after setup
+
+**Risks:**
+- Hardware failure (vintage equipment)
+- RTC price volatility
+- Network adoption risk
+- Limited utility outside ecosystem
+
+### 3.3 Economic Incentive Alignment
+
+| Goal | Ethereum | RustChain |
+|------|----------|-----------|
+| **Network Security** | Validators economically invested (stake at risk) | Miners incentivized to maintain hardware |
+| **Decentralization** | Low barrier (relative to PoW), but capital-intensive | Ultra-low barrier, hardware-gated |
+| **Long-term Alignment** | Validators benefit from ETH appreciation | Miners benefit from RTC + hardware appreciation |
+| **Anti-Centralization** | No direct mechanism (pools dominate) | Natural limit (finite vintage hardware) |
+| **Speculative Pressure** | High (DeFi, NFTs, trading) | Low (niche collector market) |
+
+---
+
+## 4. Performance & Scalability
+
+### 4.1 Throughput Metrics
+
+| Metric | Ethereum | RustChain |
+|--------|----------|-----------|
+| **Block Time** | 12 seconds | Epoch-based (144 slots) |
+| **TPS (Theoretical)** | 15-100 TPS (L1) | ~1-10 TPS (L1) |
+| **TPS (With L2)** | 1,000-10,000+ TPS | N/A (no L2 ecosystem) |
+| **Finality Time** | ~15 minutes | Epoch settlement + anchor |
+| **State Growth** | ~100GB+ (full node) | Minimal (attestation-focused) |
+
+### 4.2 Scalability Roadmap
+
+#### Ethereum
+- **Layer 2 Rollups:** Optimistic (Arbitrum, Optimism) + ZK (zkSync, StarkNet)
+- **Sharding:** Danksharding (EIP-4844) for data availability
+- **Target:** 100,000+ TPS with L2s + sharding
+
+#### RustChain
+- **Current Focus:** Network stability, attestation quality
+- **Future Plans:** Ergo interoperability, potential sidechains
+- **Philosophy:** Scale deliberately, preserve authenticity
+
+### 4.3 Node Requirements
+
+| Requirement | Ethereum | RustChain |
+|-------------|----------|-----------|
+| **Hardware** | 16GB RAM, 2TB SSD, modern CPU | Any vintage hardware (Pentium III+) |
+| **Storage** | 1TB+ (pruned), 2TB+ (full) | Minimal (<10GB) |
+| **Bandwidth** | 10-50 GB/day | <1 GB/day |
+| **Uptime** | 95%+ recommended | Passive (attestation periodic) |
+| **Technical Skill** | Moderate (3 clients to manage) | Low (client script) |
+
+---
+
+## 5. Security Analysis
+
+### 5.1 Attack Vectors
+
+#### Ethereum Security Model
+
+| Attack Type | Cost/Feasibility | Defense |
+|-------------|------------------|---------|
+| **51% Attack** | >$40B+ (1/3 stake) | Social recovery, stake destruction |
+| **Long-Range Attack** | Theoretically possible | Weak subjectivity, checkpoints |
+| **Short-Range Reorg** | Expensive (~$M) | Proposer boosting |
+| **Censorship (1/3 stake)** | ~$13B+ | Inactivity leak |
+| **Sybil Attack** | Prohibitive (32 ETH each) | Economic barrier |
+| **DDoS** | Moderate cost | Peer diversity, gossip protocols |
+
+**Security Properties:**
+- **Economic Finality:** 2/3 stake must agree
+- **Slashing:** Up to 100% stake loss for malicious behavior
+- **Inactivity Leak:** Gradual stake bleed if finality stalls
+- **Weak Subjectivity:** New nodes must sync from trusted checkpoint
+
+#### RustChain Security Model
+
+| Attack Type | Cost/Feasibility | Defense |
+|-------------|------------------|---------|
+| **51% Attack** | Acquire majority of vintage hardware | Finite supply, attestation verification |
+| **VM/Emulation Attack** | Defeat 6-layer fingerprinting | Clock skew, thermal entropy, jitter |
+| **Sybil Attack** | Acquire many vintage machines | Hardware uniqueness, profile validation |
+| **Attestation Spoofing** | Reverse-engineer fingerprint | Ed25519 signatures, node validation |
+| **Epoch Manipulation** | Compromise attestation nodes | Ergo anchor, multi-node consensus |
+| **DDoS** | Moderate cost | Federated node structure |
+
+**Security Properties:**
+- **Physical Uniqueness:** Real silicon required (no VMs)
+- **6-Layer Verification:** Multi-dimensional fingerprinting
+- **Ergo Anchoring:** Immutable settlement records
+- **Round-Robin Fairness:** Equal opportunity per epoch
+
+### 5.2 Trust Assumptions
+
+| Assumption | Ethereum | RustChain |
+|------------|----------|-----------|
+| **Validator Honesty** | 2/3 must be honest | Attestation nodes must be honest |
+| **Client Correctness** | 3 independent implementations | Single reference implementation |
+| **Network Synchrony** | Partial synchrony assumed | Partial synchrony assumed |
+| **External Anchor** | None (self-sovereign) | Ergo blockchain |
+| **Hardware Authenticity** | N/A | Must trust fingerprinting system |
+
+### 5.3 Security Tradeoffs
+
+**Ethereum Strengths:**
+- Battle-tested (since 2015, PoS since 2022)
+- Massive validator set (~1M)
+- Formal verification, extensive audits
+- Economic finality with clear slashing
+
+**Ethereum Weaknesses:**
+- Capital concentration risk (large staking pools)
+- Complex multi-client setup
+- Regulatory scrutiny (staking = security?)
+
+**RustChain Strengths:**
+- Novel anti-Sybil (physical hardware)
+- Low barrier to entry
+- No slashing (user-friendly)
+- Ergo anchoring for immutability
+
+**RustChain Weaknesses:**
+- Untested consensus (novel PoA)
+- Smaller network (fewer nodes)
+- Single implementation risk
+- Hardware fingerprinting could be bypassed (theoretical)
+
+---
+
+## 6. Practical Use Cases
+
+### 6.1 Ethereum: Best For
+
+| Use Case | Fit | Rationale |
+|----------|-----|-----------|
+| **DeFi Protocols** | ✅ Excellent | Deep liquidity, composability |
+| **NFT Marketplaces** | ✅ Excellent | ERC-721 standard, large audience |
+| **DAOs** | ✅ Excellent | Governance tooling, treasury management |
+| **Stablecoins** | ✅ Excellent | USDC, USDT, DAI all on Ethereum |
+| **Enterprise Settlement** | ✅ Good | Institutional adoption, regulatory clarity |
+| **L2 Deployment** | ✅ Excellent | Rollup ecosystem maturity |
+| **Smart Contract Dev** | ✅ Excellent | Solidity, Vyper, extensive tooling |
+| **Hardware Preservation** | ❌ Poor | No hardware-based incentives |
+| **Low-Cost Microtransactions** | ⚠️ Moderate | L1 fees high; requires L2 |
+
+**Example Applications:**
+- Uniswap (DEX)
+- Aave (lending)
+- OpenSea (NFT marketplace)
+- MakerDAO (stablecoin governance)
+- Lido (liquid staking)
+
+### 6.2 RustChain: Best For
+
+| Use Case | Fit | Rationale |
+|----------|-----|-----------|
+| **Hardware Preservation** | ✅ Excellent | Direct economic incentives |
+| **Retro Computing Community** | ✅ Excellent | Niche alignment, collector appeal |
+| **E-Waste Reduction** | ✅ Excellent | Anti-obsolescence mechanism |
+| **Educational Projects** | ✅ Excellent | Low barrier, teaching tool |
+| **Collectible Token Economy** | ✅ Good | Fixed supply, vintage theme |
+| **Ergo Ecosystem Integration** | ✅ Good | Anchoring, interoperability |
+| **DeFi Protocols** | ❌ Poor | Limited smart contract support |
+| **Enterprise Settlement** | ⚠️ Moderate | Niche appeal, limited adoption |
+| **High-Frequency Trading** | ❌ Poor | Epoch-based, not real-time |
+
+**Example Applications:**
+- Vintage hardware mining network
+- Retro computing achievement tracking
+- E-waste awareness initiatives
+- Educational blockchain demos
+- Collector community tokens
+
+### 6.3 Overlapping Use Cases
+
+| Use Case | Ethereum Fit | RustChain Fit | Winner |
+|----------|--------------|---------------|--------|
+| **Store of Value** | Good (deflationary potential) | Moderate (fixed supply, niche) | Ethereum |
+| **Community Building** | Good (large ecosystem) | Excellent (tight-knit niche) | RustChain |
+| **Speculative Trading** | Excellent (liquidity) | Moderate (limited markets) | Ethereum |
+| **Educational Tool** | Moderate (complexity) | Excellent (simplicity) | RustChain |
+| **Environmental Statement** | Good (PoS efficiency) | Excellent (anti-e-waste) | RustChain |
+
+---
+
+## 7. Developer Experience
+
+### 7.1 Tooling & Ecosystem
+
+#### Ethereum
+| Category | Tools/Frameworks | Maturity |
+|----------|------------------|----------|
+| **Languages** | Solidity, Vyper, Huff | ✅ Mature |
+| **Frameworks** | Hardhat, Foundry, Truffle | ✅ Mature |
+| **Libraries** | web3.js, ethers.js, viem | ✅ Mature |
+| **Testnets** | Sepolia, Holesky | ✅ Active |
+| **Explorers** | Etherscan, Blockscout | ✅ Mature |
+| **Wallets** | MetaMask, WalletConnect, Rainbow | ✅ Mature |
+| **Oracles** | Chainlink, API3 | ✅ Mature |
+| **Indexers** | The Graph, SubQuery | ✅ Mature |
+
+#### RustChain
+| Category | Tools/Frameworks | Maturity |
+|----------|------------------|----------|
+| **Languages** | Python (client scripts) | ⚠️ Early |
+| **Frameworks** | Custom attestation scripts | ⚠️ Early |
+| **Libraries** | Ed25519, requests | ⚠️ Early |
+| **Testnets** | Mainnet-only (test mode) | ⚠️ Early |
+| **Explorers** | Custom (rustchain.org) | ⚠️ Early |
+| **Wallets** | ErgoTool CLI integration | ⚠️ Early |
+| **Oracles** | N/A | ❌ Not available |
+| **Indexers** | Custom API | ⚠️ Early |
+
+### 7.2 Learning Curve
+
+| Skill Level | Ethereum | RustChain |
+|-------------|----------|-----------|
+| **Beginner** | Steep (Solidity, gas, wallets) | Moderate (Python scripts) |
+| **Intermediate** | Moderate (frameworks, L2s) | Easy (API integration) |
+| **Advanced** | Easy (full ecosystem access) | Limited (custom development) |
+
+### 7.3 Documentation Quality
+
+| Aspect | Ethereum | RustChain |
+|--------|----------|-----------|
+| **Official Docs** | ethereum.org (excellent) | docs/ (comprehensive for niche) |
+| **Tutorials** | Thousands available | Dozens (focused) |
+| **Community Support** | Discord, Reddit, StackExchange | Discord, GitHub |
+| **Code Examples** | Extensive | Moderate (use-case specific) |
+
+---
+
+## 8. Environmental Impact
+
+### 8.1 Energy Consumption
+
+| Metric | Ethereum PoS | RustChain PoA | Bitcoin PoW (for reference) |
+|--------|--------------|---------------|-----------------------------|
+| **Annual Energy** | ~0.01 TWh | ~0.001 TWh (estimated) | ~150 TWh |
+| **Per Transaction** | ~0.01 kWh | ~0.001 kWh | ~1,000 kWh |
+| **Carbon Footprint** | Minimal | Minimal | Significant |
+| **E-Waste Impact** | Low (general hardware) | **Negative** (preserves hardware) | High (ASIC turnover) |
+
+### 8.2 Sustainability Philosophy
+
+#### Ethereum
+- **Goal:** Minimize energy while maintaining security
+- **Achievement:** 99.95% energy reduction vs. PoW
+- **Tradeoff:** General-purpose hardware (no preservation incentive)
+
+#### RustChain
+- **Goal:** Actively reduce e-waste through economic incentives
+- **Achievement:** Extends lifespan of vintage hardware
+- **Tradeoff:** Niche appeal, limited scalability
+
+---
+
+## 9. Regulatory Considerations
+
+### 9.1 Security Classification Risk
+
+| Jurisdiction | Ethereum | RustChain |
+|--------------|----------|-----------|
+| **USA (SEC)** | Moderate-High (staking scrutiny) | Moderate (novel mechanism) |
+| **EU (MiCA)** | Moderate (compliance pathway) | Moderate (unclear classification) |
+| **Asia** | Varies by country | Varies by country |
+
+### 9.2 Compliance Factors
+
+| Factor | Ethereum | RustChain |
+|--------|----------|-----------|
+| **Decentralization** | High (1M+ validators) | Moderate (federated nodes) |
+| **Premine/Allocation** | Fair launch (no premine) | 0.94% premine (dev/bounties) |
+| **Staking Rewards** | Yield-like (regulatory risk) | Mining rewards (potentially clearer) |
+| **Utility** | Clear (smart contracts, DeFi) | Niche (hardware preservation) |
+
+---
+
+## 10. Summary & Recommendations
+
+### 10.1 When to Choose Ethereum
+
+**Choose Ethereum if:**
+- ✅ Building DeFi, NFT, or DAO applications
+- ✅ Need smart contract flexibility
+- ✅ Require deep liquidity and composability
+- ✅ Target institutional or mainstream users
+- ✅ Want L2 scalability options
+- ✅ Value battle-tested security
+
+**Avoid Ethereum if:**
+- ❌ Need ultra-low transaction costs (without L2)
+- ❌ Building hardware-specific incentives
+- ❌ Prefer novel consensus mechanisms
+- ❌ Want fixed token supply
+
+### 10.2 When to Choose RustChain
+
+**Choose RustChain if:**
+- ✅ Passionate about hardware preservation
+- ✅ Part of retro computing community
+- ✅ Want to reduce e-waste impact
+- ✅ Prefer fixed token supply
+- ✅ Value ultra-low barrier to entry
+- ✅ Interested in novel consensus research
+
+**Avoid RustChain if:**
+- ❌ Need smart contract functionality
+- ❌ Require high throughput or low latency
+- ❌ Building DeFi or complex dApps
+- ❌ Need institutional-grade security track record
+
+### 10.3 Final Assessment
+
+| Criterion | Winner | Rationale |
+|-----------|--------|-----------|
+| **Smart Contracts** | 🏆 Ethereum | Mature ecosystem, tooling |
+| **Hardware Preservation** | 🏆 RustChain | Core mission, economic incentives |
+| **Security Track Record** | 🏆 Ethereum | 10+ years, battle-tested |
+| **Innovation** | 🏆 RustChain | Novel PoA consensus |
+| **Accessibility** | 🏆 RustChain | No capital requirement |
+| **Scalability** | 🏆 Ethereum | L2 ecosystem, sharding |
+| **Environmental Impact** | 🏆 RustChain | Active e-waste reduction |
+| **Decentralization** | 🏆 Ethereum | Larger validator set |
+| **Token Economics** | ⚖️ Tie | ETH (deflationary potential) vs. RTC (fixed supply) |
+| **Developer Experience** | 🏆 Ethereum | Mature tooling, documentation |
+
+**Bottom Line:** Ethereum and RustChain serve different purposes. Ethereum is the global settlement layer for decentralized applications. RustChain is a specialized network for hardware preservation and e-waste reduction. They are complementary, not competitive.
+
+---
+
+## 11. References
+
+### Ethereum Sources
+1. Ethereum Foundation. "Proof-of-Stake." *ethereum.org*. Updated February 2026. https://ethereum.org/developers/docs/consensus-mechanisms/pos/
+2. Ethereum Consensus Specifications. *GitHub*. https://github.com/ethereum/consensus-specs
+3. Buterin, V. "Casper the Friendly Finality Gadget." *arXiv:1710.09437*. 2017.
+4. Gasper Specification. *Ethereum Foundation*. 2020.
+5. EIP-1559: Fee market change. *Ethereum Improvement Proposals*. 2021.
+6. EIP-4844: Proto-Danksharding. *Ethereum Improvement Proposals*. 2023.
+
+### RustChain Sources
+1. Johnson, S. "RustChain: A Proof-of-Antiquity Blockchain for Hardware Preservation." *Whitepaper v1.0*. February 2026.
+2. RustChain Documentation. "Protocol Specification." *docs/PROTOCOL.md*. 2026.
+3. RustChain Documentation. "Token Economics." *docs/token-economics.md*. 2026.
+4. RustChain Documentation. "Mechanism Spec and Falsification Matrix." *docs/MECHANISM_SPEC_AND_FALSIFICATION_MATRIX.md*. 2026.
+5. RustChain Live Network. *rustchain.org*. Accessed March 2026.
+
+### External Sources
+1. Global E-waste Monitor 2024. *United Nations Institute for Training and Research*. 2024.
+2. "Consensus Mechanisms: Beyond PoW and PoS in 2025." *Our Crypto Talk*. September 2024.
+3. Ethereum Energy Consumption Index. *Digiconomist*. 2025.
+
+---
+
+## Appendix A: Quick Reference Table
+
+| Feature | Ethereum PoS | RustChain PoA |
+|---------|--------------|---------------|
+| **Launch Date** | 2015 (PoS: 2022) | 2025 (beta) |
+| **Consensus** | Gasper (PoS) | RIP-200 (PoA) |
+| **Token** | ETH (inflationary) | RTC (8M fixed) |
+| **Validator Entry** | 32 ETH | Vintage hardware |
+| **Block Time** | 12 seconds | Epoch-based |
+| **Finality** | ~15 minutes | Epoch + anchor |
+| **TPS (L1)** | 15-100 | ~1-10 |
+| **Smart Contracts** | Full EVM | Limited |
+| **Node Count** | ~1M validators | ~11,626 miners |
+| **Energy/Year** | ~0.01 TWh | ~0.001 TWh |
+| **GitHub** | ethereum/consensus-specs | rustchain-bounties/rustchain |
+| **Website** | ethereum.org | rustchain.org |
+
+---
+
+## Appendix B: Glossary
+
+| Term | Definition |
+|------|------------|
+| **PoS (Proof-of-Stake)** | Consensus where validators stake capital to secure network |
+| **PoA (Proof-of-Antiquity)** | Consensus where validators prove hardware age/authenticity |
+| **LMD-GHOST** | Ethereum's fork choice rule (Latest Message Drive Greedy Heaviest Observed Subtree) |
+| **Casper-FFG** | Ethereum's finality gadget (Friendly Finality Gadget) |
+| **RIP-200** | RustChain's consensus protocol (Round-Robin with hardware attestation) |
+| **Epoch** | Time period for consensus (32 slots in Ethereum, 144 slots in RustChain) |
+| **Finality** | Point at which block cannot be reverted without massive stake loss |
+| **Slashing** | Penalty where validator loses stake for malicious behavior |
+| **Antiquity Multiplier** | RustChain reward bonus for older hardware (up to 2.5×) |
+| **Ergo Anchor** | RustChain settlement hashes recorded on Ergo blockchain |
+
+---
+
+*This document is intended for educational and informational purposes. Always conduct your own research before making investment or technical decisions.*


### PR DESCRIPTION
Implements issue #1610 with a comprehensive, structured technical comparison between RustChain and Ethereum PoS, including architecture, consensus, economics, performance, security, and practical use-case analysis.\n\nCloses #1610