### PR TITLE
Add OTC Bridge for peer-to-peer RTC swaps

### DIFF
--- a/web/otc-bridge/index.html
+++ b/web/otc-bridge/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>RustChain OTC Bridge | Swap RTC</title>
+  <title>RustChain OTC Bridge Prototype | Swap RTC</title>
   <meta name="description" content="RustChain OTC Bridge - Swap RTC for ETH or ERG peer-to-peer with no intermediary.">
   <meta name="keywords" content="RustChain, RTC, OTC, swap, bridge, ETH, ERG, peer-to-peer">
   <meta name="author" content="Elyan Labs">
@@ -449,13 +449,9 @@
       document.getElementById('priceErg').textContent = fmt(prices.erg, 6);
       document.getElementById('priceUsd').textContent = '$' + fmt(prices.usd, 6);
 
-      // Simulated 24h changes for display
+      // Remove simulated 24h changes — real data only
       ['changeEth','changeErg','changeUsd'].forEach(id => {
-        const el = document.getElementById(id);
-        const pct = (Math.random() * 10 - 4).toFixed(2);
-        const positive = parseFloat(pct) >= 0;
-        el.textContent = (positive ? '+' : '') + pct + '% (24h)';
-        el.className = 'ticker-change ' + (positive ? 'up' : 'down');
+        document.getElementById(id).textContent = '';
       });
     }
 


### PR DESCRIPTION
## Summary

- Adds `web/otc-bridge/index.html` — a self-contained OTC swap page for trading RTC against ETH and ERG
- Dark theme with purple accent matching RustChain branding
- Features: wallet connect, create/fill orders, live order book, DexScreener price feed, responsive layout

## Details

**Trading pairs:** RTC/ETH, RTC/ERG  
**Price data:** Pulls live prices from DexScreener API with CoinGecko fallback for cross-rates  
**Order flow:** Users connect wallet, create sell/buy orders with custom pricing, other users can fill orders partially or fully  
**Order book:** Filterable by side (all / sell / buy) with real-time updates  

Single HTML file, zero dependencies, drops into the existing `web/` directory structure.

Closes Scottcjn/rustchain-bounties#695