### PR TITLE
Add browser extension for RTC balance display

### DIFF
--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -1,0 +1,49 @@
+# RustChain RTC Balance — Browser Extension
+
+Chrome/Firefox extension that displays your RTC wallet balance, network health, and latest block info directly from the toolbar.
+
+## Features
+
+- **RTC Balance** — Enter your Miner ID to see your current RTC balance.
+- **Network Status** — Live health check showing online/offline, node version, and uptime.
+- **Block Info** — Current epoch, slot, and chain height.
+- **Persistent storage** — Your Miner ID is saved between sessions.
+- **Fallback** — Tries `rustchain.org` first, falls back to the node IP if unreachable.
+
+## Install (Chrome / Chromium)
+
+1. Open `chrome://extensions/`
+2. Enable **Developer mode** (top-right toggle).
+3. Click **Load unpacked** and select this `browser-extension/` folder.
+4. The **R** icon appears in your toolbar — click it, enter your Miner ID, and hit refresh.
+
+## Install (Firefox)
+
+1. Open `about:debugging#/runtime/this-firefox`
+2. Click **Load Temporary Add-on** and select `manifest.json` from this folder.
+
+## API Endpoints Used
+
+| Endpoint | Purpose |
+|----------|---------|
+| `GET /health` | Node status, version, uptime |
+| `GET /epoch` | Current epoch, slot, block height |
+| `GET /wallet/balance?miner_id=<ID>` | RTC balance for a miner |
+
+All requests go to `https://rustchain.org` with automatic fallback to `https://50.28.86.131`.
+
+## File Structure
+
+```
+browser-extension/
+  manifest.json   — Manifest V3 config
+  popup.html      — Extension popup UI
+  popup.js        — API calls and DOM logic
+  popup.css       — Dark theme styles
+  icons/          — SVG icons (16, 48, 128px)
+  README.md       — This file
+```
+
+## License
+
+Same as the RustChain project — see repository root.

--- a/tools/browser-extension/icons/icon128.svg
+++ b/tools/browser-extension/icons/icon128.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="20" fill="#0d1117"/>
+  <circle cx="64" cy="64" r="48" fill="none" stroke="#d2691e" stroke-width="4"/>
+  <circle cx="64" cy="64" r="42" fill="none" stroke="#30363d" stroke-width="1"/>
+  <text x="64" y="82" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="64" fill="#e8852a">R</text>
+</svg>

--- a/tools/browser-extension/icons/icon16.svg
+++ b/tools/browser-extension/icons/icon16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#0d1117"/>
+  <text x="8" y="12" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="10" fill="#d2691e">R</text>
+</svg>

--- a/tools/browser-extension/icons/icon48.svg
+++ b/tools/browser-extension/icons/icon48.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect width="48" height="48" rx="8" fill="#0d1117"/>
+  <circle cx="24" cy="24" r="18" fill="none" stroke="#d2691e" stroke-width="2.5"/>
+  <text x="24" y="31" text-anchor="middle" font-family="Arial,sans-serif" font-weight="bold" font-size="24" fill="#e8852a">R</text>
+</svg>

--- a/tools/browser-extension/manifest.json
+++ b/tools/browser-extension/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 3,
+  "name": "RustChain RTC Balance",
+  "version": "1.0.0",
+  "description": "View your RustChain (RTC) wallet balance, network status, and latest block info.",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://rustchain.org/*",
+    "https://50.28.86.131/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "icons/icon16.svg",
+      "48": "icons/icon48.svg",
+      "128": "icons/icon128.svg"
+    }
+  },
+  "icons": {
+    "16": "icons/icon16.svg",
+    "48": "icons/icon48.svg",
+    "128": "icons/icon128.svg"
+  }
+}

--- a/tools/browser-extension/popup.css
+++ b/tools/browser-extension/popup.css
@@ -1,0 +1,202 @@
+/* RustChain dark theme */
+:root {
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-card: #1c2128;
+  --border: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --accent: #d2691e;
+  --accent-glow: #e8852a;
+  --success: #3fb950;
+  --error: #f85149;
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  width: 340px;
+  min-height: 400px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+.container {
+  padding: 16px;
+}
+
+/* Header */
+header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+header .logo {
+  width: 32px;
+  height: 32px;
+}
+
+header h1 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--accent-glow);
+}
+
+/* Sections */
+section {
+  margin-bottom: 14px;
+}
+
+section h2 {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  margin-bottom: 8px;
+}
+
+/* Input */
+label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-bottom: 4px;
+}
+
+.input-row {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+#miner-id {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+#miner-id:focus {
+  border-color: var(--accent);
+}
+
+#btn-refresh {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#btn-refresh:hover {
+  background: var(--accent-glow);
+}
+
+/* Cards */
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.card .label {
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.card .value {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+#balance-display .value {
+  font-size: 26px;
+  color: var(--accent-glow);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+}
+
+.grid .card .value {
+  font-size: 14px;
+}
+
+/* Utilities */
+.hidden {
+  display: none !important;
+}
+
+.error {
+  font-size: 12px;
+  color: var(--error);
+  margin-top: 4px;
+}
+
+.status-ok {
+  color: var(--success);
+}
+
+.status-down {
+  color: var(--error);
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+footer a {
+  font-size: 12px;
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+footer a:hover {
+  color: var(--accent);
+}
+
+/* Loading spinner */
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  vertical-align: middle;
+  margin-left: 6px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/tools/browser-extension/popup.html
+++ b/tools/browser-extension/popup.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>RustChain Balance</title>
+  <link rel="stylesheet" href="popup.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <img src="icons/icon48.svg" alt="RTC" class="logo">
+      <h1>RustChain</h1>
+    </header>
+
+    <section id="wallet-section">
+      <label for="miner-id">Wallet / Miner ID</label>
+      <div class="input-row">
+        <input type="text" id="miner-id" placeholder="e.g. Ivan-houzhiwen" spellcheck="false">
+        <button id="btn-refresh" title="Refresh">&#x21bb;</button>
+      </div>
+      <div id="balance-display" class="card hidden">
+        <span class="label">RTC Balance</span>
+        <span id="balance-value" class="value">--</span>
+      </div>
+      <p id="balance-error" class="error hidden"></p>
+    </section>
+
+    <section id="network-section">
+      <h2>Network</h2>
+      <div class="grid">
+        <div class="card">
+          <span class="label">Status</span>
+          <span id="net-status" class="value">--</span>
+        </div>
+        <div class="card">
+          <span class="label">Version</span>
+          <span id="net-version" class="value">--</span>
+        </div>
+        <div class="card">
+          <span class="label">Uptime</span>
+          <span id="net-uptime" class="value">--</span>
+        </div>
+      </div>
+    </section>
+
+    <section id="block-section">
+      <h2>Latest Block</h2>
+      <div class="grid">
+        <div class="card">
+          <span class="label">Epoch</span>
+          <span id="block-epoch" class="value">--</span>
+        </div>
+        <div class="card">
+          <span class="label">Slot</span>
+          <span id="block-slot" class="value">--</span>
+        </div>
+        <div class="card">
+          <span class="label">Height</span>
+          <span id="block-height" class="value">--</span>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <a href="https://rustchain.org" target="_blank" rel="noopener">rustchain.org</a>
+    </footer>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/tools/browser-extension/popup.js
+++ b/tools/browser-extension/popup.js
@@ -1,0 +1,153 @@
+(function () {
+  "use strict";
+
+  const NODE_URL = "https://rustchain.org";
+  const NODE_IP  = "https://50.28.86.131";
+
+  const $ = (sel) => document.querySelector(sel);
+
+  // --- DOM refs ---
+  const minerInput   = $("#miner-id");
+  const btnRefresh   = $("#btn-refresh");
+  const balanceCard  = $("#balance-display");
+  const balanceValue = $("#balance-value");
+  const balanceError = $("#balance-error");
+  const netStatus    = $("#net-status");
+  const netVersion   = $("#net-version");
+  const netUptime    = $("#net-uptime");
+  const blockEpoch   = $("#block-epoch");
+  const blockSlot    = $("#block-slot");
+  const blockHeight  = $("#block-height");
+
+  // --- Helpers ---
+
+  function formatUptime(seconds) {
+    const d = Math.floor(seconds / 86400);
+    const h = Math.floor((seconds % 86400) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    if (d > 0) return d + "d " + h + "h";
+    if (h > 0) return h + "h " + m + "m";
+    return m + "m";
+  }
+
+  async function apiFetch(path, useIP) {
+    const base = useIP ? NODE_IP : NODE_URL;
+    const resp = await fetch(base + path, { cache: "no-cache" });
+    if (!resp.ok) throw new Error("HTTP " + resp.status);
+    return resp.json();
+  }
+
+  // Try primary URL first, fall back to IP
+  async function apiFetchWithFallback(path) {
+    try {
+      return await apiFetch(path, false);
+    } catch (_) {
+      return await apiFetch(path, true);
+    }
+  }
+
+  // --- Data loaders ---
+
+  async function loadHealth() {
+    try {
+      const data = await apiFetchWithFallback("/health");
+      netStatus.textContent = data.ok ? "Online" : "Degraded";
+      netStatus.className = "value " + (data.ok ? "status-ok" : "status-down");
+      netVersion.textContent = data.version || "--";
+      netUptime.textContent = data.uptime_s ? formatUptime(data.uptime_s) : "--";
+    } catch (err) {
+      netStatus.textContent = "Offline";
+      netStatus.className = "value status-down";
+      netVersion.textContent = "--";
+      netUptime.textContent = "--";
+    }
+  }
+
+  async function loadEpoch() {
+    try {
+      const data = await apiFetchWithFallback("/epoch");
+      blockEpoch.textContent  = data.epoch  != null ? data.epoch  : "--";
+      blockSlot.textContent   = data.slot   != null ? data.slot   : "--";
+      blockHeight.textContent = data.height != null ? data.height : "--";
+    } catch (_) {
+      blockEpoch.textContent  = "--";
+      blockSlot.textContent   = "--";
+      blockHeight.textContent = "--";
+    }
+  }
+
+  async function loadBalance(minerId) {
+    balanceError.classList.add("hidden");
+    if (!minerId) {
+      balanceCard.classList.add("hidden");
+      return;
+    }
+    balanceValue.innerHTML = '<span class="spinner"></span>';
+    balanceCard.classList.remove("hidden");
+
+    try {
+      const data = await apiFetchWithFallback(
+        "/wallet/balance?miner_id=" + encodeURIComponent(minerId)
+      );
+      if (data.amount_rtc != null) {
+        balanceValue.textContent = data.amount_rtc.toLocaleString(undefined, {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 6
+        }) + " RTC";
+      } else {
+        balanceValue.textContent = "0.00 RTC";
+      }
+    } catch (err) {
+      balanceCard.classList.add("hidden");
+      balanceError.textContent = "Could not fetch balance. Check your Miner ID.";
+      balanceError.classList.remove("hidden");
+    }
+  }
+
+  // --- Persistence ---
+
+  function saveMiner(id) {
+    if (chrome && chrome.storage && chrome.storage.local) {
+      chrome.storage.local.set({ rtc_miner_id: id });
+    } else {
+      localStorage.setItem("rtc_miner_id", id);
+    }
+  }
+
+  function restoreMiner() {
+    return new Promise((resolve) => {
+      if (chrome && chrome.storage && chrome.storage.local) {
+        chrome.storage.local.get("rtc_miner_id", (res) => {
+          resolve(res.rtc_miner_id || "");
+        });
+      } else {
+        resolve(localStorage.getItem("rtc_miner_id") || "");
+      }
+    });
+  }
+
+  // --- Refresh all ---
+
+  function refreshAll() {
+    const minerId = minerInput.value.trim();
+    saveMiner(minerId);
+    loadHealth();
+    loadEpoch();
+    loadBalance(minerId);
+  }
+
+  // --- Events ---
+
+  btnRefresh.addEventListener("click", refreshAll);
+
+  minerInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") refreshAll();
+  });
+
+  // --- Init ---
+
+  restoreMiner().then((id) => {
+    minerInput.value = id;
+    refreshAll();
+  });
+})();


### PR DESCRIPTION
## Summary

- Adds a Manifest V3 browser extension under `tools/browser-extension/` that shows current RTC balance, network status, and latest block info.
- Works in Chrome, Chromium, and Firefox.
- Queries `/health`, `/epoch`, and `/wallet/balance` endpoints with automatic fallback from `rustchain.org` to the node IP.
- Dark theme styling consistent with RustChain branding.
- Miner ID persisted via `chrome.storage.local`.

Resolves Scottcjn/rustchain-bounties#1607

## Test plan

- [ ] Load unpacked in `chrome://extensions/` and verify popup opens
- [ ] Enter a valid Miner ID and confirm balance displays
- [ ] Verify network status shows Online with version and uptime
- [ ] Verify epoch, slot, and height populate
- [ ] Confirm Miner ID persists after closing and reopening popup
- [ ] Test in Firefox via `about:debugging`