### PR TITLE
Add Docker Compose development stack

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -1,0 +1,19 @@
+# RustChain Dev Stack - Environment Variables
+# Copy to .env and customise as needed:  cp .env.dev.example .env
+
+# ── Node ──────────────────────────────────────────────────────────
+NODE_PORT=8099
+
+# ── MongoDB ───────────────────────────────────────────────────────
+MONGO_PORT=27017
+
+# ── Redis ─────────────────────────────────────────────────────────
+REDIS_PORT=6379
+
+# ── Prometheus ────────────────────────────────────────────────────
+PROMETHEUS_PORT=9090
+
+# ── Grafana ───────────────────────────────────────────────────────
+GRAFANA_PORT=3000
+GRAFANA_USER=admin
+GRAFANA_PASSWORD=rustchain

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -1,0 +1,110 @@
+# RustChain Development Environment
+
+A Docker Compose stack that brings up everything you need to develop and test against RustChain locally.
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| **RustChain Node** | `8099` | PoA blockchain node with dashboard and API |
+| **MongoDB** | `27017` | Block and transaction storage |
+| **Redis** | `6379` | Caching layer (LRU, 128 MB limit) |
+| **Prometheus** | `9090` | Metrics collection (15-day retention) |
+| **Grafana** | `3000` | Pre-configured dashboards for network monitoring |
+
+## Quick Start
+
+```bash
+# One-command setup
+chmod +x dev-setup.sh
+./dev-setup.sh
+```
+
+Or manually:
+
+```bash
+cp .env.dev.example .env    # customise ports / passwords if needed
+docker compose -f docker-compose.dev.yml up -d
+```
+
+## Prerequisites
+
+- Docker Engine 24+
+- Docker Compose v2 plugin
+
+## Configuration
+
+All tuneable settings live in `.env` (created from `.env.example` on first run).
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `NODE_PORT` | `8099` | Host port for the RustChain node dashboard |
+| `MONGO_PORT` | `27017` | Host port for MongoDB |
+| `REDIS_PORT` | `6379` | Host port for Redis |
+| `PROMETHEUS_PORT` | `9090` | Host port for Prometheus |
+| `GRAFANA_PORT` | `3000` | Host port for Grafana |
+| `GRAFANA_USER` | `admin` | Grafana admin username |
+| `GRAFANA_PASSWORD` | `rustchain` | Grafana admin password |
+
+## Monitoring
+
+Grafana is pre-provisioned with:
+
+- **Prometheus datasource** pointing at the in-stack Prometheus instance.
+- **RustChain Network Monitor dashboard** showing node health, active miners, epoch info, hardware breakdown, and scrape latency.
+
+Open Grafana at `http://localhost:3000` and log in with the credentials from your `.env` file (defaults: `admin` / `rustchain`).
+
+## Common Commands
+
+```bash
+# View logs (all services)
+docker compose -f docker-compose.dev.yml logs -f
+
+# View logs (single service)
+docker compose -f docker-compose.dev.yml logs -f rustchain-node
+
+# Restart a single service
+docker compose -f docker-compose.dev.yml restart rustchain-node
+
+# Stop everything
+docker compose -f docker-compose.dev.yml down
+
+# Stop everything and delete volumes (full reset)
+docker compose -f docker-compose.dev.yml down -v
+
+# Rebuild after code changes
+docker compose -f docker-compose.dev.yml up -d --build rustchain-node
+```
+
+## Architecture
+
+```
+                  ┌─────────────┐
+                  │  Grafana    │ :3000
+                  └──────┬──────┘
+                         │
+                  ┌──────▼──────┐
+                  │ Prometheus  │ :9090
+                  └──────┬──────┘
+                         │
+                  ┌──────▼──────┐
+                  │  Exporter   │ :9100 (internal)
+                  └──────┬──────┘
+                         │
+              ┌──────────▼──────────┐
+              │   RustChain Node    │ :8099
+              └───┬────────────┬────┘
+                  │            │
+          ┌───────▼──┐   ┌────▼────┐
+          │ MongoDB  │   │  Redis  │
+          │  :27017  │   │  :6379  │
+          └──────────┘   └─────────┘
+```
+
+## Development Tips
+
+- The node source directory (`./node`) is bind-mounted read-only, so edits are reflected on container restart without a full rebuild.
+- MongoDB is initialised with the `rustchain` database automatically; no seed scripts are required.
+- Redis is configured with `allkeys-lru` eviction so it will never run out of memory during development.
+- Prometheus is configured with `--web.enable-lifecycle` so you can hot-reload its config by sending `POST /-/reload`.

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ────────────────────────────────────────────────────────────────
+# RustChain Development Stack - One-command setup
+# ────────────────────────────────────────────────────────────────
+
+COMPOSE_FILE="docker-compose.dev.yml"
+ENV_FILE=".env"
+ENV_EXAMPLE=".env.dev.example"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+info()  { printf "${GREEN}[+]${NC} %s\n" "$*"; }
+warn()  { printf "${YELLOW}[!]${NC} %s\n" "$*"; }
+error() { printf "${RED}[x]${NC} %s\n" "$*"; exit 1; }
+
+# ── Pre-flight checks ────────────────────────────────────────────
+command -v docker  >/dev/null 2>&1 || error "docker is not installed."
+command -v docker  >/dev/null 2>&1 && docker compose version >/dev/null 2>&1 || error "docker compose v2 plugin is required."
+
+info "RustChain Dev Stack Setup"
+echo "─────────────────────────────────────────────"
+
+# ── Env file ──────────────────────────────────────────────────────
+if [ ! -f "$ENV_FILE" ]; then
+    if [ -f "$ENV_EXAMPLE" ]; then
+        cp "$ENV_EXAMPLE" "$ENV_FILE"
+        info "Created $ENV_FILE from $ENV_EXAMPLE"
+    else
+        warn "No $ENV_EXAMPLE found, continuing without .env"
+    fi
+else
+    info "$ENV_FILE already exists, skipping copy"
+fi
+
+# ── Pull / Build ─────────────────────────────────────────────────
+info "Pulling base images..."
+docker compose -f "$COMPOSE_FILE" pull --ignore-buildable 2>/dev/null || true
+
+info "Building project images..."
+docker compose -f "$COMPOSE_FILE" build
+
+# ── Launch ────────────────────────────────────────────────────────
+info "Starting services..."
+docker compose -f "$COMPOSE_FILE" up -d
+
+# ── Wait for health ──────────────────────────────────────────────
+info "Waiting for RustChain node to become healthy..."
+ATTEMPTS=0
+MAX_ATTEMPTS=30
+until docker inspect --format='{{.State.Health.Status}}' rc-dev-node 2>/dev/null | grep -q "healthy"; do
+    ATTEMPTS=$((ATTEMPTS + 1))
+    if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+        warn "Node did not become healthy within ${MAX_ATTEMPTS}0s. Check logs: docker compose -f $COMPOSE_FILE logs rustchain-node"
+        break
+    fi
+    sleep 10
+done
+
+if [ "$ATTEMPTS" -lt "$MAX_ATTEMPTS" ]; then
+    info "Node is healthy!"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────────"
+info "RustChain Dev Stack is running"
+echo ""
+echo "  Node dashboard   http://localhost:${NODE_PORT:-8099}"
+echo "  MongoDB          mongodb://localhost:${MONGO_PORT:-27017}/rustchain"
+echo "  Redis            redis://localhost:${REDIS_PORT:-6379}"
+echo "  Prometheus       http://localhost:${PROMETHEUS_PORT:-9090}"
+echo "  Grafana          http://localhost:${GRAFANA_PORT:-3000}  (admin / rustchain)"
+echo ""
+echo "  Logs:   docker compose -f $COMPOSE_FILE logs -f"
+echo "  Stop:   docker compose -f $COMPOSE_FILE down"
+echo "  Reset:  docker compose -f $COMPOSE_FILE down -v"
+echo "─────────────────────────────────────────────"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,160 @@
+version: "3.8"
+
+# RustChain Development Stack
+# Usage: docker compose -f docker-compose.dev.yml up -d
+# Docs:  See README-DEV.md
+
+x-logging: &default-logging
+  driver: "json-file"
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  # ── RustChain Node ──────────────────────────────────────────────
+  rustchain-node:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: rc-dev-node
+    restart: unless-stopped
+    environment:
+      PYTHONUNBUFFERED: "1"
+      RUSTCHAIN_HOME: /rustchain
+      RUSTCHAIN_DB: /rustchain/data/rustchain_v2.db
+      DOWNLOAD_DIR: /rustchain/downloads
+      MONGO_URI: "mongodb://mongo:27017/rustchain"
+      REDIS_URL: "redis://redis:6379/0"
+      PORT: "8099"
+    volumes:
+      - node-data:/rustchain/data
+      - node-downloads:/rustchain/downloads
+      # Live-reload: mount source for development
+      - ./node:/app/node:ro
+      - ./docker-entrypoint.py:/app/docker-entrypoint.py:ro
+    ports:
+      - "${NODE_PORT:-8099}:8099"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8099/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - rustchain-dev
+    logging: *default-logging
+
+  # ── MongoDB (block storage) ────────────────────────────────────
+  mongo:
+    image: mongo:7
+    container_name: rc-dev-mongo
+    restart: unless-stopped
+    environment:
+      MONGO_INITDB_DATABASE: rustchain
+    volumes:
+      - mongo-data:/data/db
+    ports:
+      - "${MONGO_PORT:-27017}:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+    networks:
+      - rustchain-dev
+    logging: *default-logging
+
+  # ── Redis (caching) ───────────────────────────────────────────
+  redis:
+    image: redis:7-alpine
+    container_name: rc-dev-redis
+    restart: unless-stopped
+    command: redis-server --maxmemory 128mb --maxmemory-policy allkeys-lru
+    volumes:
+      - redis-data:/data
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    networks:
+      - rustchain-dev
+    logging: *default-logging
+
+  # ── Prometheus Exporter ────────────────────────────────────────
+  rustchain-exporter:
+    build:
+      context: ./monitoring
+      dockerfile: Dockerfile.exporter
+    container_name: rc-dev-exporter
+    restart: unless-stopped
+    environment:
+      RUSTCHAIN_NODE: "http://rustchain-node:8099"
+      EXPORTER_PORT: "9100"
+      SCRAPE_INTERVAL: "30"
+      TLS_VERIFY: "false"
+    networks:
+      - rustchain-dev
+    depends_on:
+      rustchain-node:
+        condition: service_healthy
+    logging: *default-logging
+
+  # ── Prometheus ─────────────────────────────────────────────────
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    container_name: rc-dev-prometheus
+    restart: unless-stopped
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "${PROMETHEUS_PORT:-9090}:9090"
+    networks:
+      - rustchain-dev
+    depends_on:
+      - rustchain-exporter
+    logging: *default-logging
+
+  # ── Grafana ────────────────────────────────────────────────────
+  grafana:
+    image: grafana/grafana:10.4.1
+    container_name: rc-dev-grafana
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: "${GRAFANA_USER:-admin}"
+      GF_SECURITY_ADMIN_PASSWORD: "${GRAFANA_PASSWORD:-rustchain}"
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/rustchain.json
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+      - ./monitoring/grafana-dashboard.json:/etc/grafana/provisioning/dashboards/rustchain.json:ro
+      - ./grafana-dashboard-provider.yml:/etc/grafana/provisioning/dashboards/provider.yml:ro
+    ports:
+      - "${GRAFANA_PORT:-3000}:3000"
+    networks:
+      - rustchain-dev
+    depends_on:
+      - prometheus
+    logging: *default-logging
+
+volumes:
+  node-data:
+  node-downloads:
+  mongo-data:
+  redis-data:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  rustchain-dev:
+    driver: bridge

--- a/grafana-dashboard-provider.yml
+++ b/grafana-dashboard-provider.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "RustChain"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false


### PR DESCRIPTION
## Summary

- Adds `docker-compose.dev.yml` with a complete local development stack: RustChain node, MongoDB (block storage), Redis (caching), Prometheus + Grafana (monitoring with pre-provisioned dashboards).
- Adds `dev-setup.sh` for one-command bootstrap — pulls images, builds, starts services, and waits for the node health check.
- Adds `README-DEV.md` documenting all services, ports, environment variables, and common commands.

## What's included

| Service | Default Port | Purpose |
|---------|-------------|---------|
| RustChain Node | 8099 | PoA node with dashboard & API |
| MongoDB 7 | 27017 | Block / transaction storage |
| Redis 7 | 6379 | LRU cache (128 MB) |
| Prometheus | 9090 | Metrics (15-day retention) |
| Grafana | 3000 | Pre-provisioned RustChain dashboard |

All ports are configurable via `.env` (see `.env.dev.example`). Reuses the existing `monitoring/` Prometheus exporter, datasource, and Grafana dashboard — no duplication.

## Test plan

- [ ] `./dev-setup.sh` completes without errors on a clean machine
- [ ] `docker compose -f docker-compose.dev.yml ps` shows all services healthy
- [ ] Node dashboard accessible at `http://localhost:8099`
- [ ] Grafana loads with RustChain Network Monitor dashboard pre-configured
- [ ] `docker compose -f docker-compose.dev.yml down -v` cleans up cleanly