### PR TITLE
Add monitoring and alerting system for RustChain nodes

### DIFF
--- a/tools/alerting/README.md
+++ b/tools/alerting/README.md
@@ -1,0 +1,103 @@
+# RustChain Monitoring & Alerting
+
+Production-ready alerting system for RustChain nodes, built on Prometheus Alertmanager with a standalone fallback notifier.
+
+## Components
+
+| File | Purpose |
+|---|---|
+| `alert-rules.yml` | Prometheus recording/alert rules for all RustChain-specific conditions |
+| `alertmanager.yml` | Alertmanager routing, receivers (email/Slack/webhook), and inhibit rules |
+| `notify.py` | Standalone Python notifier — works as an Alertmanager webhook receiver **or** an independent node poller |
+
+## Alert Coverage
+
+| Alert | Condition | Severity |
+|---|---|---|
+| **Node Down** | `/health` returns unhealthy or exporter unreachable for 2 min | Critical |
+| **Epoch Stalled** | No slot change in 10 minutes | Critical |
+| **Low Miner Count** | Fewer than 3 active miners for 5 min | Warning |
+| **No Miners** | Zero active miners for 2 min | Critical |
+| **High API Latency** | Exporter scrape exceeds 5 seconds for 3 min | Warning |
+| **Very High API Latency** | Exporter scrape exceeds 15 seconds for 2 min | Critical |
+| **Disk Space Low** | Root filesystem below 15% free for 5 min | Warning |
+| **Disk Space Critical** | Root filesystem below 5% free for 2 min | Critical |
+| **Scrape Errors** | Elevated error rate against the node API | Warning |
+
+## Quick Start
+
+### Option A — Full Prometheus Stack
+
+1. Copy the alert rules into your Prometheus config directory:
+
+```bash
+cp alert-rules.yml /etc/prometheus/alert-rules.yml
+```
+
+2. Reference the rules file in `prometheus.yml`:
+
+```yaml
+rule_files:
+  - '/etc/prometheus/alert-rules.yml'
+```
+
+3. Deploy Alertmanager with the provided config:
+
+```bash
+alertmanager --config.file=alertmanager.yml
+```
+
+4. Update the Alertmanager target in `prometheus.yml`:
+
+```yaml
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['localhost:9093']
+```
+
+5. Start the webhook receiver so Alertmanager can forward to email/Slack:
+
+```bash
+python notify.py --mode webhook --port 9095
+```
+
+### Option B — Standalone Poller (no Prometheus required)
+
+```bash
+# Configure at least one notification channel
+export SLACK_WEBHOOK_URL="https://hooks.slack.com/services/T.../B.../xxx"
+# or
+export SMTP_USER="alerts@example.com"
+export SMTP_PASS="app-password"
+export SMTP_TO="ops@example.com"
+
+# Start polling
+python notify.py --mode poll --node https://rustchain.org --interval 60
+```
+
+## Environment Variables
+
+| Variable | Description |
+|---|---|
+| `RUSTCHAIN_NODE` | Node URL (default: `https://rustchain.org`) |
+| `SMTP_HOST` | SMTP server (default: `smtp.gmail.com`) |
+| `SMTP_PORT` | SMTP port (default: `587`) |
+| `SMTP_USER` | SMTP username |
+| `SMTP_PASS` | SMTP password / app password |
+| `SMTP_FROM` | Sender address (defaults to `SMTP_USER`) |
+| `SMTP_TO` | Comma-separated recipient list |
+| `SLACK_WEBHOOK_URL` | Slack incoming webhook URL |
+| `WEBHOOK_URL` | Generic webhook endpoint for alert payloads |
+
+## Integration with Existing Monitoring
+
+This builds on the existing `monitoring/rustchain-exporter.py` which exposes the following Prometheus metrics:
+
+- `rustchain_node_health` — binary health status
+- `rustchain_epoch_slot` / `rustchain_epoch_number` — epoch progress
+- `rustchain_active_miners` — current miner count
+- `rustchain_scrape_duration_seconds` — API response time
+- `rustchain_scrape_errors_total` — error counter
+
+The alert rules in `alert-rules.yml` query these metrics directly. For disk space alerts, the standard `node_exporter` must also be running on the host.

--- a/tools/alerting/alert-rules.yml
+++ b/tools/alerting/alert-rules.yml
@@ -1,0 +1,159 @@
+# Prometheus Alert Rules for RustChain Nodes
+# Requires the rustchain-exporter (monitoring/rustchain-exporter.py) to be
+# scraping the node and exposing metrics on :9100.
+
+groups:
+  - name: rustchain_node_health
+    rules:
+
+      # ---------------------------------------------------------------
+      # 1. Node Down — health-check endpoint unreachable or returning 0
+      # ---------------------------------------------------------------
+      - alert: RustChainNodeDown
+        expr: rustchain_node_health == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain node is down"
+          description: >-
+            The /health endpoint on {{ $labels.instance }} has been
+            reporting unhealthy for more than 2 minutes.
+          runbook: "Check node process, network connectivity, and disk I/O."
+
+      - alert: RustChainNodeUnreachable
+        expr: up{job="rustchain-exporter"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain exporter target is unreachable"
+          description: >-
+            Prometheus cannot reach the rustchain-exporter on
+            {{ $labels.instance }}. The node or exporter may be offline.
+
+      # ---------------------------------------------------------------
+      # 2. Epoch Stalled — no new slot observed in 10 minutes
+      # ---------------------------------------------------------------
+      - alert: RustChainEpochStalled
+        expr: changes(rustchain_epoch_slot[10m]) == 0
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Epoch progress has stalled"
+          description: >-
+            The epoch slot counter on {{ $labels.instance }} has not
+            advanced in the last 10 minutes. Current epoch:
+            {{ $value }} — possible consensus halt or network partition.
+          runbook: "Verify peer connectivity, check for chain forks."
+
+      - alert: RustChainEpochNumberStuck
+        expr: changes(rustchain_epoch_number[30m]) == 0 and rustchain_epoch_slot > 50
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Epoch has not advanced in 30 minutes"
+          description: >-
+            Epoch number on {{ $labels.instance }} is unchanged for
+            30 minutes while the slot counter is high ({{ $value }}).
+            Settlement may be stuck.
+
+      # ---------------------------------------------------------------
+      # 3. Low Miner Count — fewer than 3 active miners
+      # ---------------------------------------------------------------
+      - alert: RustChainLowMinerCount
+        expr: rustchain_active_miners < 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Active miner count is critically low"
+          description: >-
+            Only {{ $value }} active miners reported by
+            {{ $labels.instance }}. Minimum recommended is 3 for
+            healthy consensus and block production.
+
+      - alert: RustChainNoMiners
+        expr: rustchain_active_miners == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No active miners on the network"
+          description: >-
+            Zero miners are reporting to {{ $labels.instance }}.
+            Block production has likely halted.
+
+      # ---------------------------------------------------------------
+      # 4. High API Latency — scrape takes > 5 seconds
+      # ---------------------------------------------------------------
+      - alert: RustChainHighAPILatency
+        expr: rustchain_scrape_duration_seconds > 5
+        for: 3m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RustChain API response time exceeds 5 seconds"
+          description: >-
+            The exporter scrape on {{ $labels.instance }} took
+            {{ $value | printf "%.1f" }}s. This may indicate database
+            contention, heavy load, or network issues.
+
+      - alert: RustChainVeryHighAPILatency
+        expr: rustchain_scrape_duration_seconds > 15
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "RustChain API response time exceeds 15 seconds"
+          description: >-
+            Scrape duration on {{ $labels.instance }} is
+            {{ $value | printf "%.1f" }}s — the node may be
+            unresponsive.
+
+      # ---------------------------------------------------------------
+      # 5. Disk Space Low — standard node_exporter filesystem metric
+      # ---------------------------------------------------------------
+      - alert: RustChainDiskSpaceLow
+        expr: |
+          (node_filesystem_avail_bytes{mountpoint="/"} /
+           node_filesystem_size_bytes{mountpoint="/"}) * 100 < 15
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Disk space below 15% on RustChain host"
+          description: >-
+            {{ $labels.instance }} has only
+            {{ $value | printf "%.1f" }}% free disk space on /.
+            The RustChain database may fail to write new blocks.
+
+      - alert: RustChainDiskSpaceCritical
+        expr: |
+          (node_filesystem_avail_bytes{mountpoint="/"} /
+           node_filesystem_size_bytes{mountpoint="/"}) * 100 < 5
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Disk space below 5% — imminent write failure"
+          description: >-
+            {{ $labels.instance }} is at {{ $value | printf "%.1f" }}%
+            free disk space. Immediate action required.
+
+      # ---------------------------------------------------------------
+      # Scrape error rate climbing
+      # ---------------------------------------------------------------
+      - alert: RustChainScrapeErrors
+        expr: rate(rustchain_scrape_errors_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Elevated scrape error rate against RustChain node"
+          description: >-
+            The exporter on {{ $labels.instance }} is seeing
+            {{ $value | printf "%.2f" }} errors/s while scraping the
+            RustChain API.

--- a/tools/alerting/alertmanager.yml
+++ b/tools/alerting/alertmanager.yml
@@ -1,0 +1,86 @@
+# Prometheus Alertmanager Configuration for RustChain
+# Routes alerts to email, Slack, and webhook receivers.
+
+global:
+  resolve_timeout: 5m
+
+  # SMTP defaults — fill in for email alerts
+  smtp_smarthost: 'smtp.gmail.com:587'
+  smtp_from: 'rustchain-alerts@example.com'
+  smtp_auth_username: 'rustchain-alerts@example.com'
+  smtp_auth_password: ''          # use env var or secret file in production
+  smtp_require_tls: true
+
+  # Slack defaults
+  slack_api_url: ''               # https://hooks.slack.com/services/T.../B.../xxx
+
+route:
+  receiver: default
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  routes:
+    # Critical alerts go to all channels immediately
+    - match:
+        severity: critical
+      receiver: critical-all
+      group_wait: 10s
+      repeat_interval: 1h
+
+    # Warnings go to Slack only
+    - match:
+        severity: warning
+      receiver: slack-warnings
+      repeat_interval: 6h
+
+receivers:
+  - name: default
+    webhook_configs:
+      - url: 'http://localhost:9095/webhook'
+        send_resolved: true
+
+  - name: critical-all
+    email_configs:
+      - to: 'ops@example.com'
+        send_resolved: true
+        headers:
+          Subject: '[CRITICAL] RustChain: {{ .GroupLabels.alertname }}'
+
+    slack_configs:
+      - channel: '#rustchain-alerts'
+        send_resolved: true
+        title: '{{ .Status | toUpper }}: {{ .GroupLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *{{ .Labels.alertname }}* ({{ .Labels.severity }})
+          {{ .Annotations.summary }}
+          {{ .Annotations.description }}
+          {{ end }}
+        color: '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}'
+
+    webhook_configs:
+      - url: 'http://localhost:9095/webhook'
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - channel: '#rustchain-alerts'
+        send_resolved: true
+        title: '{{ .Status | toUpper }}: {{ .GroupLabels.alertname }}'
+        text: >-
+          {{ range .Alerts }}
+          *{{ .Labels.alertname }}* — {{ .Annotations.summary }}
+          {{ end }}
+        color: '{{ if eq .Status "firing" }}warning{{ else }}good{{ end }}'
+
+inhibit_rules:
+  # If the node is completely down, suppress epoch/miner/latency alerts
+  - source_match:
+      alertname: RustChainNodeDown
+    target_match_re:
+      alertname: 'RustChainEpochStalled|RustChainLowMinerCount|RustChainHighAPILatency'
+    equal: ['instance']
+
+templates: []

--- a/tools/alerting/notify.py
+++ b/tools/alerting/notify.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""
+RustChain Alert Notifier
+
+Lightweight alerting script that can:
+  1. Receive Alertmanager webhook POSTs and forward them
+  2. Run standalone as a poller against a RustChain node
+  3. Send notifications via Email (SMTP), Slack, and generic webhooks
+
+Usage:
+  # Webhook receiver mode (listens for Alertmanager POSTs):
+  python notify.py --mode webhook --port 9095
+
+  # Poller mode (checks the node directly and fires alerts):
+  python notify.py --mode poll --node https://rustchain.org --interval 60
+
+Environment variables (all optional — override via flags or config file):
+  SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS, SMTP_TO, SMTP_FROM
+  SLACK_WEBHOOK_URL
+  WEBHOOK_URL
+  RUSTCHAIN_NODE
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import smtplib
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from email.mime.text import MIMEText
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, List, Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger("rustchain-notify")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+class Config:
+    """Centralised config populated from env vars and CLI flags."""
+
+    def __init__(self, args: Optional[argparse.Namespace] = None):
+        self.smtp_host: str = os.getenv("SMTP_HOST", "smtp.gmail.com")
+        self.smtp_port: int = int(os.getenv("SMTP_PORT", "587"))
+        self.smtp_user: str = os.getenv("SMTP_USER", "")
+        self.smtp_pass: str = os.getenv("SMTP_PASS", "")
+        self.smtp_from: str = os.getenv("SMTP_FROM", self.smtp_user)
+        self.smtp_to: str = os.getenv("SMTP_TO", "")
+
+        self.slack_webhook_url: str = os.getenv("SLACK_WEBHOOK_URL", "")
+        self.webhook_url: str = os.getenv("WEBHOOK_URL", "")
+
+        self.node: str = os.getenv("RUSTCHAIN_NODE", "https://rustchain.org")
+        self.interval: int = 60
+        self.port: int = 9095
+
+        if args:
+            self.node = args.node or self.node
+            self.interval = args.interval
+            self.port = args.port
+
+    @property
+    def email_enabled(self) -> bool:
+        return bool(self.smtp_user and self.smtp_to)
+
+    @property
+    def slack_enabled(self) -> bool:
+        return bool(self.slack_webhook_url)
+
+    @property
+    def webhook_enabled(self) -> bool:
+        return bool(self.webhook_url)
+
+
+# ---------------------------------------------------------------------------
+# Notification backends
+# ---------------------------------------------------------------------------
+
+def send_email(cfg: Config, subject: str, body: str) -> bool:
+    """Send an alert email via SMTP/TLS."""
+    if not cfg.email_enabled:
+        log.debug("Email not configured — skipping")
+        return False
+    try:
+        msg = MIMEText(body, "plain", "utf-8")
+        msg["Subject"] = subject
+        msg["From"] = cfg.smtp_from
+        msg["To"] = cfg.smtp_to
+
+        ctx = ssl.create_default_context()
+        with smtplib.SMTP(cfg.smtp_host, cfg.smtp_port) as srv:
+            srv.ehlo()
+            srv.starttls(context=ctx)
+            srv.ehlo()
+            srv.login(cfg.smtp_user, cfg.smtp_pass)
+            srv.sendmail(cfg.smtp_from, cfg.smtp_to.split(","), msg.as_string())
+        log.info("Email sent to %s", cfg.smtp_to)
+        return True
+    except Exception as exc:
+        log.error("Email send failed: %s", exc)
+        return False
+
+
+def send_slack(cfg: Config, text: str) -> bool:
+    """Post a message to Slack via incoming webhook."""
+    if not cfg.slack_enabled:
+        log.debug("Slack not configured — skipping")
+        return False
+    try:
+        payload = json.dumps({"text": text}).encode("utf-8")
+        req = urllib.request.Request(
+            cfg.slack_webhook_url,
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+        log.info("Slack notification sent")
+        return True
+    except Exception as exc:
+        log.error("Slack send failed: %s", exc)
+        return False
+
+
+def send_webhook(cfg: Config, payload: Dict[str, Any]) -> bool:
+    """Forward the full alert payload to a generic webhook endpoint."""
+    if not cfg.webhook_enabled:
+        log.debug("Webhook not configured — skipping")
+        return False
+    try:
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            cfg.webhook_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            resp.read()
+        log.info("Webhook delivered to %s", cfg.webhook_url)
+        return True
+    except Exception as exc:
+        log.error("Webhook send failed: %s", exc)
+        return False
+
+
+def dispatch(cfg: Config, subject: str, body: str, raw: Optional[Dict] = None):
+    """Fan-out alert to every configured channel."""
+    send_email(cfg, subject, body)
+    send_slack(cfg, f"*{subject}*\n{body}")
+    send_webhook(cfg, raw or {"subject": subject, "body": body})
+
+
+# ---------------------------------------------------------------------------
+# Alertmanager webhook receiver
+# ---------------------------------------------------------------------------
+
+class AlertHandler(BaseHTTPRequestHandler):
+    """Receives POST /webhook from Prometheus Alertmanager."""
+
+    cfg: Config  # set on the class before starting the server
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        raw = self.rfile.read(length)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        alerts: List[Dict] = data.get("alerts", [])
+        for alert in alerts:
+            status = alert.get("status", "unknown")
+            name = alert.get("labels", {}).get("alertname", "UnknownAlert")
+            severity = alert.get("labels", {}).get("severity", "info")
+            summary = alert.get("annotations", {}).get("summary", "")
+            description = alert.get("annotations", {}).get("description", "")
+
+            prefix = "RESOLVED" if status == "resolved" else status.upper()
+            subject = f"[{prefix}] RustChain: {name} ({severity})"
+            body = f"{summary}\n\n{description}"
+
+            log.info("Alert received: %s — %s", subject, summary)
+            dispatch(self.cfg, subject, body, raw=data)
+
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, fmt, *args):
+        log.debug(fmt, *args)
+
+
+def run_webhook_server(cfg: Config):
+    """Start the webhook receiver HTTP server."""
+    AlertHandler.cfg = cfg
+    server = HTTPServer(("0.0.0.0", cfg.port), AlertHandler)
+    log.info("Webhook receiver listening on :%d", cfg.port)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("Shutting down webhook server")
+        server.server_close()
+
+
+# ---------------------------------------------------------------------------
+# Standalone poller mode
+# ---------------------------------------------------------------------------
+
+def fetch_json(url: str, timeout: int = 10) -> Optional[Dict]:
+    try:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        req = urllib.request.Request(url, headers={"User-Agent": "rustchain-notify/1.0"})
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            return json.loads(resp.read().decode())
+    except Exception as exc:
+        log.warning("Fetch %s failed: %s", url, exc)
+        return None
+
+
+def poll_loop(cfg: Config):
+    """Continuously poll the RustChain node and fire alerts locally."""
+    log.info("Polling %s every %ds", cfg.node, cfg.interval)
+
+    last_slot: Optional[int] = None
+    last_slot_change: float = time.time()
+    node_was_down: bool = False
+
+    while True:
+        # --- Health check ---
+        health = fetch_json(f"{cfg.node}/health")
+        if health is None or not health.get("ok"):
+            if not node_was_down:
+                dispatch(cfg, "[CRITICAL] RustChain Node Down",
+                         f"Health check failed for {cfg.node}")
+                node_was_down = True
+        else:
+            if node_was_down:
+                dispatch(cfg, "[RESOLVED] RustChain Node Recovered",
+                         f"Health check passing again for {cfg.node}")
+                node_was_down = False
+
+        # --- Epoch stall check ---
+        epoch = fetch_json(f"{cfg.node}/epoch")
+        if epoch:
+            slot = epoch.get("slot", 0)
+            if last_slot is not None and slot != last_slot:
+                last_slot_change = time.time()
+            elif last_slot is not None and (time.time() - last_slot_change) > 600:
+                dispatch(cfg, "[CRITICAL] Epoch Stalled",
+                         f"No slot change in 10 min on {cfg.node}. "
+                         f"Stuck at epoch {epoch.get('epoch')}, slot {slot}.")
+                last_slot_change = time.time()  # debounce re-fire
+            last_slot = slot
+
+        # --- Miner count ---
+        miners = fetch_json(f"{cfg.node}/api/miners")
+        if miners is not None:
+            count = len(miners)
+            if count == 0:
+                dispatch(cfg, "[CRITICAL] No Active Miners",
+                         f"Zero miners reporting on {cfg.node}.")
+            elif count < 3:
+                dispatch(cfg, "[WARNING] Low Miner Count",
+                         f"Only {count} active miners on {cfg.node}.")
+
+        # --- API latency (measure health round-trip) ---
+        t0 = time.time()
+        fetch_json(f"{cfg.node}/health")
+        latency = time.time() - t0
+        if latency > 5.0:
+            dispatch(cfg, "[WARNING] High API Latency",
+                     f"Health endpoint took {latency:.1f}s on {cfg.node}.")
+
+        time.sleep(cfg.interval)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="RustChain Alert Notifier")
+    parser.add_argument("--mode", choices=["webhook", "poll"], default="poll",
+                        help="Run as Alertmanager webhook receiver or standalone poller")
+    parser.add_argument("--node", default=None,
+                        help="RustChain node URL (default: $RUSTCHAIN_NODE or https://rustchain.org)")
+    parser.add_argument("--interval", type=int, default=60,
+                        help="Poll interval in seconds (poller mode only)")
+    parser.add_argument("--port", type=int, default=9095,
+                        help="HTTP port for webhook receiver mode")
+    args = parser.parse_args()
+
+    cfg = Config(args)
+
+    if not (cfg.email_enabled or cfg.slack_enabled or cfg.webhook_enabled):
+        log.warning(
+            "No notification channels configured. Set SMTP_*, SLACK_WEBHOOK_URL, "
+            "or WEBHOOK_URL environment variables."
+        )
+
+    if args.mode == "webhook":
+        run_webhook_server(cfg)
+    else:
+        poll_loop(cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `tools/alerting/` with a production-ready monitoring and alerting system for RustChain nodes
- Prometheus alert rules covering node health, epoch progress, miner count, API latency, disk space, and scrape errors
- Alertmanager config with routing for critical (email + Slack + webhook) and warning (Slack) severity levels, plus inhibit rules to suppress noise when a node is fully down
- Standalone Python notifier (`notify.py`) that works both as an Alertmanager webhook receiver and as an independent node poller for deployments without Prometheus

## Alert Coverage

| Alert | Trigger | Severity |
|---|---|---|
| Node Down | `/health` unhealthy for 2 min | Critical |
| Epoch Stalled | No slot change in 10 min | Critical |
| Low Miner Count | < 3 active miners for 5 min | Warning |
| No Miners | 0 miners for 2 min | Critical |
| High API Latency | Scrape > 5s for 3 min | Warning |
| Disk Space Low | < 15% free for 5 min | Warning |
| Disk Space Critical | < 5% free for 2 min | Critical |

## Test Plan

- [ ] Validate `alert-rules.yml` with `promtool check rules alert-rules.yml`
- [ ] Validate `alertmanager.yml` with `amtool check-config alertmanager.yml`
- [ ] Run `notify.py --mode poll` against a live node and verify log output
- [ ] Run `notify.py --mode webhook` and POST a sample Alertmanager payload
- [ ] Confirm email delivery with test SMTP credentials
- [ ] Confirm Slack message delivery with test webhook URL