### PR TITLE
fix: implement /wallet/history endpoint (fixes #908, #775, #886)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4978,7 +4978,12 @@ def api_wallet_balance():
 
 @app.route('/wallet/history', methods=['GET'])
 def api_wallet_history():
-    """Get public transfer history for a specific wallet."""
+    """Get unified transaction history for a wallet (fixes #775, #886).
+
+    Queries both the ``ledger`` table (immutable transfer log) and the
+    ``epoch_rewards`` table (mining payouts) and returns them in a single
+    time-sorted response with ``limit``/``offset`` pagination.
+    """
     miner_id = request.args.get("miner_id", "").strip()
     address = request.args.get("address", "").strip()
 
@@ -4994,84 +4999,134 @@ def api_wallet_history():
     if not miner_id:
         return jsonify({"ok": False, "error": "miner_id or address required"}), 400
 
-    limit_raw = request.args.get("limit", "50").strip()
     try:
-        limit = int(limit_raw or "50")
-    except ValueError:
+        limit = max(1, min(int(request.args.get("limit", "50")), 200))
+    except (ValueError, TypeError):
         return jsonify({"ok": False, "error": "limit must be an integer"}), 400
 
-    limit = max(1, min(limit, 200))
+    try:
+        offset = max(0, int(request.args.get("offset", "0")))
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "offset must be an integer"}), 400
+
+    transactions = []
 
     with sqlite3.connect(DB_PATH) as db:
-        rows = db.execute(
-            """
-            SELECT id, ts, from_miner, to_miner, amount_i64, reason, status,
-                   created_at, confirms_at, confirmed_at, tx_hash, voided_reason
-            FROM pending_ledger
-            WHERE from_miner = ? OR to_miner = ?
-            ORDER BY COALESCE(created_at, ts) DESC, id DESC
-            LIMIT ?
-            """,
-            (miner_id, miner_id, limit),
-        ).fetchall()
+        # --- Ledger entries (transfers) ---
+        try:
+            ledger_rows = db.execute(
+                """
+                SELECT ts, epoch, miner_id, delta_i64, reason
+                FROM ledger
+                WHERE miner_id = ?
+                ORDER BY ts DESC
+                """,
+                (miner_id,),
+            ).fetchall()
 
-    items = []
-    for row in rows:
-        (
-            pending_id,
-            ts,
-            from_miner,
-            to_miner,
-            amount_i64,
-            reason,
-            raw_status,
-            created_at,
-            confirms_at,
-            confirmed_at,
-            tx_hash,
-            voided_reason,
-        ) = row
+            for ts, epoch, _mid, delta_i64, reason in ledger_rows:
+                reason_str = str(reason or "")
+                if reason_str.startswith("transfer_in:"):
+                    parts = reason_str.split(":")
+                    tx_type = "transfer_in"
+                    from_addr = parts[1] if len(parts) > 1 else None
+                    tx_hash = parts[2] if len(parts) > 2 else None
+                elif reason_str.startswith("transfer_out:"):
+                    parts = reason_str.split(":")
+                    tx_type = "transfer_out"
+                    from_addr = parts[1] if len(parts) > 1 else None
+                    tx_hash = parts[2] if len(parts) > 2 else None
+                else:
+                    tx_type = "ledger"
+                    from_addr = None
+                    tx_hash = None
 
-        direction = "sent" if from_miner == miner_id else "received"
-        counterparty = to_miner if direction == "sent" else from_miner
+                entry = {
+                    "type": tx_type,
+                    "amount": abs(int(delta_i64)) / UNIT,
+                    "epoch": int(epoch) if epoch else None,
+                    "timestamp": int(ts) if ts else 0,
+                    "tx_hash": tx_hash,
+                    "reason": reason_str or None,
+                }
+                if tx_type == "transfer_in":
+                    entry["from"] = from_addr
+                elif tx_type == "transfer_out":
+                    entry["to"] = from_addr
+                transactions.append(entry)
+        except Exception:
+            pass  # ledger table may not exist on all nodes
 
-        public_status = "confirmed"
-        if raw_status == "pending":
-            public_status = "pending"
-        elif raw_status != "confirmed":
-            public_status = "failed"
+        # --- Epoch rewards (mining payouts) ---
+        try:
+            reward_rows = db.execute(
+                """
+                SELECT er.epoch, er.share_i64, es.accepted_blocks
+                FROM epoch_rewards er
+                LEFT JOIN epoch_state es ON er.epoch = es.epoch
+                WHERE er.miner_id = ?
+                ORDER BY er.epoch DESC
+                """,
+                (miner_id,),
+            ).fetchall()
 
-        memo = None
-        if isinstance(reason, str) and reason.startswith("signed_transfer:"):
-            memo = reason.split(":", 1)[1] or None
+            for epoch, share_i64, _blocks in reward_rows:
+                transactions.append({
+                    "type": "reward",
+                    "amount": int(share_i64) / UNIT,
+                    "epoch": int(epoch),
+                    "timestamp": 0,
+                    "tx_hash": None,
+                })
+        except Exception:
+            pass  # epoch_rewards table may not exist on all nodes
 
-        tx_id = tx_hash or f"pending_{pending_id}"
-        created_ts = int(created_at or ts or 0)
+        # --- Pending ledger entries (in-flight transfers) ---
+        try:
+            pending_rows = db.execute(
+                """
+                SELECT ts, from_miner, to_miner, amount_i64, reason,
+                       status, tx_hash, COALESCE(created_at, ts) as created
+                FROM pending_ledger
+                WHERE from_miner = ? OR to_miner = ?
+                ORDER BY COALESCE(created_at, ts) DESC
+                """,
+                (miner_id, miner_id),
+            ).fetchall()
 
-        items.append({
-            "id": int(pending_id),
-            "tx_id": tx_id,
-            "tx_hash": tx_id,
-            "from_addr": from_miner,
-            "to_addr": to_miner,
-            "amount": int(amount_i64) / UNIT,
-            "amount_i64": int(amount_i64),
-            "amount_rtc": int(amount_i64) / UNIT,
-            "timestamp": created_ts,
-            "created_at": created_ts,
-            "confirmed_at": int(confirmed_at) if confirmed_at else None,
-            "confirms_at": int(confirms_at) if confirms_at else None,
-            "status": public_status,
-            "raw_status": raw_status,
-            "status_reason": voided_reason,
-            "confirmations": 1 if raw_status == "confirmed" else 0,
-            "direction": direction,
-            "counterparty": counterparty,
-            "reason": reason,
-            "memo": memo,
-        })
+            for ts, from_m, to_m, amt, reason, status, tx_hash, created in pending_rows:
+                if status == "confirmed":
+                    continue  # already captured in ledger table
+                tx_type = "transfer_out" if from_m == miner_id else "transfer_in"
+                entry = {
+                    "type": tx_type,
+                    "amount": abs(int(amt)) / UNIT,
+                    "epoch": None,
+                    "timestamp": int(created or ts or 0),
+                    "tx_hash": tx_hash,
+                    "status": status,
+                }
+                if tx_type == "transfer_in":
+                    entry["from"] = from_m
+                else:
+                    entry["to"] = to_m
+                transactions.append(entry)
+        except Exception:
+            pass
 
-    return jsonify(items)
+    # Sort all transactions by timestamp descending
+    transactions.sort(key=lambda t: t.get("timestamp", 0), reverse=True)
+    total = len(transactions)
+
+    # Apply pagination
+    page = transactions[offset:offset + limit]
+
+    return jsonify({
+        "ok": True,
+        "miner_id": miner_id,
+        "transactions": page,
+        "total": total,
+    })
 
 # =============================================================================
 # 2-PHASE COMMIT PENDING LEDGER SYSTEM


### PR DESCRIPTION
## Summary

Fixes #908 (also resolves #775 and #886).

The `/wallet/history` endpoint was documented in the API spec but returned incomplete data — it only queried `pending_ledger` and returned a flat array instead of the documented response format.

### Changes

Rewrites `/wallet/history` to:

- **Query all three data sources:**
  - `ledger` table — immutable confirmed transfer log
  - `epoch_rewards` table — mining reward payouts  
  - `pending_ledger` table — in-flight transfers (pending/voided only; confirmed entries are already in `ledger`)

- **Return spec-compliant response format:**
  ```json
  {
    "ok": true,
    "miner_id": "dual-g4-125",
    "transactions": [
      {"type": "reward", "amount": 0.297, "epoch": 424, "timestamp": ...},
      {"type": "transfer_in", "from": "founder_community", "amount": 10.0, ...}
    ],
    "total": 42
  }
  ```

- **Add `offset` pagination** alongside existing `limit` support
- **Handle missing tables gracefully** — nodes that don't have all tables won't crash
- **Sort unified results by timestamp** descending across all sources

### Testing

- Unknown `miner_id` returns `{"ok": true, "miner_id": "...", "transactions": [], "total": 0}`
- Pagination: `?miner_id=X&limit=10&offset=20` works correctly
- Both `miner_id` and `address` query params accepted (backward compatible)

Wallet for payout: wirework