### PR TITLE
feat: API rate limiting middleware

### DIFF
--- a/node/middleware/__init__.py
+++ b/node/middleware/__init__.py
@@ -1,0 +1,9 @@
+"""
+RustChain Node Middleware
+=========================
+Pluggable middleware components for the RustChain Flask node.
+"""
+
+from .rate_limiter import RateLimiter, init_rate_limiter
+
+__all__ = ["RateLimiter", "init_rate_limiter"]

--- a/node/middleware/rate_limiter.py
+++ b/node/middleware/rate_limiter.py
@@ -1,0 +1,375 @@
+"""
+RustChain API Rate Limiter
+==========================
+Token-bucket rate limiting middleware for the RustChain Flask node.
+
+Features:
+- Per-IP token bucket algorithm with configurable burst and refill rates
+- Endpoint-specific limits (e.g. stricter limits on /api/mine, /attest/submit)
+- Redis-backed storage for distributed multi-node deployments
+- Automatic fallback to thread-safe in-memory storage when Redis is unavailable
+- Proper 429 responses with Retry-After header (RFC 6585 / RFC 7231)
+- Admin and health endpoints exempt by default
+
+Usage:
+    from middleware import init_rate_limiter
+    init_rate_limiter(app)
+"""
+
+import time
+import threading
+import logging
+from functools import wraps
+from typing import Dict, Optional, Tuple
+
+from flask import Flask, request, jsonify, g
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Default configuration
+# ---------------------------------------------------------------------------
+
+# Global default: 60 requests per minute, burst of 20
+DEFAULT_RATE = 60          # tokens added per window
+DEFAULT_WINDOW = 60        # window length in seconds
+DEFAULT_BURST = 20         # max tokens (bucket capacity)
+
+# Per-endpoint overrides  (endpoint_prefix -> (rate, window, burst))
+# Lower limits on write-heavy / compute-heavy paths
+DEFAULT_ENDPOINT_LIMITS: Dict[str, Tuple[int, int, int]] = {
+    "/api/mine":            (10,  60, 5),    # mining submissions
+    "/attest/submit":       (15,  60, 5),    # attestation submissions
+    "/attest/challenge":    (20,  60, 10),   # challenge requests
+    "/epoch/enroll":        (10,  60, 5),    # epoch enrollment
+    "/withdraw/request":    (5,   60, 3),    # withdrawal requests
+    "/headers/ingest_signed": (20, 60, 10),  # signed header ingestion
+    "/withdraw/register":   (10,  60, 5),    # withdrawal registration
+}
+
+# Paths that are never rate-limited
+DEFAULT_EXEMPT_PREFIXES = (
+    "/admin/",
+    "/metrics",
+    "/health",
+    "/openapi.json",
+)
+
+
+# ---------------------------------------------------------------------------
+# Token bucket implementation
+# ---------------------------------------------------------------------------
+
+class TokenBucket:
+    """Single token bucket with atomic refill-and-consume."""
+
+    __slots__ = ("capacity", "refill_rate", "tokens", "last_refill")
+
+    def __init__(self, capacity: int, refill_rate: float):
+        self.capacity = capacity
+        self.refill_rate = refill_rate       # tokens per second
+        self.tokens = float(capacity)
+        self.last_refill = time.monotonic()
+
+    def consume(self) -> Tuple[bool, float]:
+        """Try to consume one token.
+
+        Returns:
+            (allowed, retry_after)  -- retry_after is 0.0 when allowed.
+        """
+        now = time.monotonic()
+        elapsed = now - self.last_refill
+        self.tokens = min(self.capacity, self.tokens + elapsed * self.refill_rate)
+        self.last_refill = now
+
+        if self.tokens >= 1.0:
+            self.tokens -= 1.0
+            return True, 0.0
+
+        deficit = 1.0 - self.tokens
+        retry_after = deficit / self.refill_rate
+        return False, retry_after
+
+
+# ---------------------------------------------------------------------------
+# Storage backends
+# ---------------------------------------------------------------------------
+
+class InMemoryStore:
+    """Thread-safe in-memory bucket store with periodic eviction."""
+
+    def __init__(self, max_entries: int = 50_000, evict_after: float = 600.0):
+        self._buckets: Dict[str, TokenBucket] = {}
+        self._lock = threading.Lock()
+        self._max_entries = max_entries
+        self._evict_after = evict_after
+        self._last_eviction = time.monotonic()
+
+    def consume(self, key: str, capacity: int, refill_rate: float) -> Tuple[bool, float]:
+        with self._lock:
+            self._maybe_evict()
+            bucket = self._buckets.get(key)
+            if bucket is None:
+                bucket = TokenBucket(capacity, refill_rate)
+                self._buckets[key] = bucket
+            return bucket.consume()
+
+    def _maybe_evict(self):
+        now = time.monotonic()
+        if now - self._last_eviction < 60.0:
+            return
+        self._last_eviction = now
+        if len(self._buckets) <= self._max_entries:
+            return
+        # Evict buckets that have been idle longer than evict_after
+        cutoff = now - self._evict_after
+        stale = [k for k, b in self._buckets.items() if b.last_refill < cutoff]
+        for k in stale:
+            del self._buckets[k]
+        logger.debug("Rate-limiter evicted %d stale buckets", len(stale))
+
+
+class RedisStore:
+    """Redis-backed token bucket using a Lua script for atomic operations.
+
+    Falls back to InMemoryStore on connection errors so the node never
+    hard-fails on a Redis outage.
+    """
+
+    # Atomic Lua script: refill tokens, try to consume, return result
+    _LUA_SCRIPT = """
+    local key       = KEYS[1]
+    local capacity  = tonumber(ARGV[1])
+    local refill    = tonumber(ARGV[2])
+    local now       = tonumber(ARGV[3])
+    local ttl       = tonumber(ARGV[4])
+
+    local data = redis.call('HMGET', key, 'tokens', 'ts')
+    local tokens = tonumber(data[1])
+    local last   = tonumber(data[2])
+
+    if tokens == nil then
+        tokens = capacity
+        last   = now
+    end
+
+    local elapsed = math.max(0, now - last)
+    tokens = math.min(capacity, tokens + elapsed * refill)
+
+    local allowed = 0
+    local retry   = 0
+
+    if tokens >= 1 then
+        tokens  = tokens - 1
+        allowed = 1
+    else
+        retry = (1 - tokens) / refill
+    end
+
+    redis.call('HMSET', key, 'tokens', tostring(tokens), 'ts', tostring(now))
+    redis.call('EXPIRE', key, ttl)
+
+    return {allowed, tostring(retry)}
+    """
+
+    def __init__(self, redis_url: str = "redis://localhost:6379/0",
+                 key_prefix: str = "rc:rl:", ttl: int = 600):
+        self._prefix = key_prefix
+        self._ttl = ttl
+        self._fallback = InMemoryStore()
+        self._redis = None
+        self._script_sha: Optional[str] = None
+        self._available = False
+
+        try:
+            import redis as _redis
+            self._redis = _redis.Redis.from_url(redis_url, decode_responses=True,
+                                                  socket_connect_timeout=2,
+                                                  socket_timeout=1)
+            self._redis.ping()
+            self._script_sha = self._redis.script_load(self._LUA_SCRIPT)
+            self._available = True
+            logger.info("Rate-limiter connected to Redis at %s", redis_url)
+        except Exception as exc:
+            logger.warning("Rate-limiter Redis unavailable (%s) -- using in-memory fallback", exc)
+            self._available = False
+
+    @property
+    def is_redis_active(self) -> bool:
+        return self._available
+
+    def consume(self, key: str, capacity: int, refill_rate: float) -> Tuple[bool, float]:
+        if not self._available:
+            return self._fallback.consume(key, capacity, refill_rate)
+
+        full_key = f"{self._prefix}{key}"
+        try:
+            result = self._redis.evalsha(
+                self._script_sha, 1, full_key,
+                str(capacity), str(refill_rate),
+                str(time.time()), str(self._ttl),
+            )
+            allowed = int(result[0]) == 1
+            retry_after = float(result[1])
+            return allowed, retry_after
+        except Exception as exc:
+            logger.warning("Redis rate-limit call failed (%s) -- falling back to in-memory", exc)
+            self._available = False
+            return self._fallback.consume(key, capacity, refill_rate)
+
+
+# ---------------------------------------------------------------------------
+# Flask middleware
+# ---------------------------------------------------------------------------
+
+class RateLimiter:
+    """Flask extension that applies per-IP token-bucket rate limiting."""
+
+    def __init__(self, app: Optional[Flask] = None, **kwargs):
+        self.store = None
+        self.default_rate: int = DEFAULT_RATE
+        self.default_window: int = DEFAULT_WINDOW
+        self.default_burst: int = DEFAULT_BURST
+        self.endpoint_limits: Dict[str, Tuple[int, int, int]] = dict(DEFAULT_ENDPOINT_LIMITS)
+        self.exempt_prefixes: tuple = DEFAULT_EXEMPT_PREFIXES
+        self.enabled: bool = True
+
+        if app is not None:
+            self.init_app(app, **kwargs)
+
+    def init_app(self, app: Flask, **kwargs):
+        """Attach the rate limiter to a Flask app.
+
+        Config keys (also settable via kwargs):
+            RATELIMIT_ENABLED          bool   (default True)
+            RATELIMIT_DEFAULT_RATE     int    requests per window
+            RATELIMIT_DEFAULT_WINDOW   int    window in seconds
+            RATELIMIT_DEFAULT_BURST    int    max burst
+            RATELIMIT_REDIS_URL        str    Redis connection URL
+            RATELIMIT_ENDPOINT_LIMITS  dict   endpoint prefix -> (rate, window, burst)
+            RATELIMIT_EXEMPT_PREFIXES  tuple  prefixes to skip
+        """
+        cfg = app.config
+
+        self.enabled = kwargs.get("enabled",
+                                  cfg.get("RATELIMIT_ENABLED", True))
+        if not self.enabled:
+            logger.info("Rate limiter disabled via configuration")
+            return
+
+        self.default_rate = kwargs.get("default_rate",
+                                       cfg.get("RATELIMIT_DEFAULT_RATE", DEFAULT_RATE))
+        self.default_window = kwargs.get("default_window",
+                                         cfg.get("RATELIMIT_DEFAULT_WINDOW", DEFAULT_WINDOW))
+        self.default_burst = kwargs.get("default_burst",
+                                        cfg.get("RATELIMIT_DEFAULT_BURST", DEFAULT_BURST))
+
+        extra_limits = kwargs.get("endpoint_limits",
+                                  cfg.get("RATELIMIT_ENDPOINT_LIMITS"))
+        if extra_limits:
+            self.endpoint_limits.update(extra_limits)
+
+        exempt = kwargs.get("exempt_prefixes",
+                            cfg.get("RATELIMIT_EXEMPT_PREFIXES"))
+        if exempt is not None:
+            self.exempt_prefixes = tuple(exempt)
+
+        # Initialise storage backend
+        redis_url = kwargs.get("redis_url",
+                               cfg.get("RATELIMIT_REDIS_URL"))
+        if redis_url:
+            self.store = RedisStore(redis_url=redis_url)
+        else:
+            # Try default localhost Redis, fall back to in-memory
+            store = RedisStore()
+            if store.is_redis_active:
+                self.store = store
+            else:
+                self.store = InMemoryStore()
+                logger.info("Rate limiter using in-memory storage")
+
+        # Register before_request hook
+        app.before_request(self._check_rate_limit)
+
+        logger.info("Rate limiter initialised  (default %d req / %ds, burst %d)",
+                     self.default_rate, self.default_window, self.default_burst)
+
+    # ---- internal ---------------------------------------------------------
+
+    def _resolve_client_ip(self) -> str:
+        """Extract client IP, respecting X-Forwarded-For behind a reverse proxy."""
+        forwarded = request.headers.get("X-Forwarded-For")
+        if forwarded:
+            # First entry is the original client
+            return forwarded.split(",")[0].strip()
+        return request.remote_addr or "127.0.0.1"
+
+    def _match_endpoint(self, path: str) -> Tuple[int, int, int]:
+        """Return (rate, window, burst) for the given request path."""
+        for prefix, limits in self.endpoint_limits.items():
+            if path.startswith(prefix):
+                return limits
+        return self.default_rate, self.default_window, self.default_burst
+
+    def _check_rate_limit(self):
+        """Flask before_request hook."""
+        if not self.enabled:
+            return None
+
+        path = request.path
+
+        # Skip exempt paths
+        for prefix in self.exempt_prefixes:
+            if path.startswith(prefix):
+                return None
+
+        client_ip = self._resolve_client_ip()
+        rate, window, burst = self._match_endpoint(path)
+        refill_rate = rate / window  # tokens per second
+
+        # Build a bucket key scoped to IP + endpoint group
+        endpoint_group = path
+        for prefix in self.endpoint_limits:
+            if path.startswith(prefix):
+                endpoint_group = prefix
+                break
+        bucket_key = f"{client_ip}:{endpoint_group}"
+
+        allowed, retry_after = self.store.consume(bucket_key, burst, refill_rate)
+
+        if allowed:
+            # Attach rate info to g for optional use by endpoints
+            g.rate_limit_remaining = True
+            return None
+
+        # 429 Too Many Requests
+        retry_after_int = max(1, int(retry_after + 0.5))
+        response = jsonify({
+            "ok": False,
+            "error": "rate_limited",
+            "message": f"Too many requests. Retry after {retry_after_int}s.",
+            "retry_after": retry_after_int,
+        })
+        response.status_code = 429
+        response.headers["Retry-After"] = str(retry_after_int)
+        response.headers["X-RateLimit-Limit"] = str(rate)
+        response.headers["X-RateLimit-Window"] = str(window)
+        return response
+
+
+# ---------------------------------------------------------------------------
+# Convenience initialiser
+# ---------------------------------------------------------------------------
+
+def init_rate_limiter(app: Flask, **kwargs) -> RateLimiter:
+    """One-liner to attach rate limiting to a Flask app.
+
+    Example::
+
+        from middleware import init_rate_limiter
+        init_rate_limiter(app)
+
+    Returns the RateLimiter instance for further customisation.
+    """
+    limiter = RateLimiter(app, **kwargs)
+    return limiter

--- a/node/tests/test_rate_limiter.py
+++ b/node/tests/test_rate_limiter.py
@@ -1,0 +1,195 @@
+"""
+Tests for the RustChain API rate limiter middleware.
+"""
+
+import time
+import pytest
+from flask import Flask
+
+# Adjust path so the middleware package is importable
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from middleware.rate_limiter import (
+    RateLimiter, InMemoryStore, TokenBucket, init_rate_limiter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_app(**limiter_kwargs):
+    """Create a minimal Flask app with rate limiter attached."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.route("/api/mine", methods=["POST"])
+    def mine():
+        return {"ok": True}
+
+    @app.route("/epoch", methods=["GET"])
+    def epoch():
+        return {"epoch": 1}
+
+    @app.route("/admin/status", methods=["GET"])
+    def admin_status():
+        return {"admin": True}
+
+    @app.route("/health", methods=["GET"])
+    def health():
+        return {"healthy": True}
+
+    init_rate_limiter(app, **limiter_kwargs)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# TokenBucket unit tests
+# ---------------------------------------------------------------------------
+
+class TestTokenBucket:
+    def test_allows_up_to_capacity(self):
+        bucket = TokenBucket(capacity=3, refill_rate=1.0)
+        for _ in range(3):
+            allowed, _ = bucket.consume()
+            assert allowed
+
+    def test_rejects_when_empty(self):
+        bucket = TokenBucket(capacity=1, refill_rate=0.1)
+        bucket.consume()  # drain
+        allowed, retry = bucket.consume()
+        assert not allowed
+        assert retry > 0
+
+    def test_refills_over_time(self):
+        bucket = TokenBucket(capacity=2, refill_rate=100.0)  # fast refill
+        bucket.consume()
+        bucket.consume()
+        # Wait a tiny bit for refill
+        time.sleep(0.02)
+        allowed, _ = bucket.consume()
+        assert allowed
+
+
+# ---------------------------------------------------------------------------
+# InMemoryStore tests
+# ---------------------------------------------------------------------------
+
+class TestInMemoryStore:
+    def test_basic_consume(self):
+        store = InMemoryStore()
+        allowed, _ = store.consume("ip:1", capacity=5, refill_rate=1.0)
+        assert allowed
+
+    def test_rate_limit_hit(self):
+        store = InMemoryStore()
+        for _ in range(3):
+            store.consume("ip:2", capacity=3, refill_rate=0.01)
+        allowed, retry = store.consume("ip:2", capacity=3, refill_rate=0.01)
+        assert not allowed
+        assert retry > 0
+
+    def test_independent_keys(self):
+        store = InMemoryStore()
+        for _ in range(3):
+            store.consume("ip:A", capacity=3, refill_rate=0.01)
+        # ip:A is exhausted, but ip:B should still work
+        allowed, _ = store.consume("ip:B", capacity=3, refill_rate=0.01)
+        assert allowed
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (Flask test client)
+# ---------------------------------------------------------------------------
+
+class TestRateLimiterMiddleware:
+    def test_allows_normal_requests(self):
+        app = _make_app(default_rate=100, default_window=60, default_burst=50)
+        client = app.test_client()
+        resp = client.get("/epoch")
+        assert resp.status_code == 200
+
+    def test_returns_429_on_excess(self):
+        app = _make_app(
+            default_rate=2, default_window=60, default_burst=2,
+            endpoint_limits={"/epoch": (2, 60, 2)},
+        )
+        client = app.test_client()
+        # Exhaust the bucket
+        for _ in range(2):
+            client.get("/epoch")
+        resp = client.get("/epoch")
+        assert resp.status_code == 429
+        data = resp.get_json()
+        assert data["error"] == "rate_limited"
+        assert "Retry-After" in resp.headers
+
+    def test_retry_after_header_is_positive_int(self):
+        app = _make_app(
+            default_rate=1, default_window=60, default_burst=1,
+            endpoint_limits={},
+        )
+        client = app.test_client()
+        client.get("/epoch")
+        resp = client.get("/epoch")
+        assert resp.status_code == 429
+        assert int(resp.headers["Retry-After"]) >= 1
+
+    def test_exempt_admin_path(self):
+        app = _make_app(default_rate=1, default_window=60, default_burst=1)
+        client = app.test_client()
+        # Admin paths should never be limited
+        for _ in range(5):
+            resp = client.get("/admin/status")
+            assert resp.status_code == 200
+
+    def test_exempt_health_path(self):
+        app = _make_app(default_rate=1, default_window=60, default_burst=1)
+        client = app.test_client()
+        for _ in range(5):
+            resp = client.get("/health")
+            assert resp.status_code == 200
+
+    def test_endpoint_specific_limits(self):
+        app = _make_app(
+            default_rate=100, default_window=60, default_burst=100,
+            endpoint_limits={"/api/mine": (1, 60, 1)},
+        )
+        client = app.test_client()
+        client.post("/api/mine")
+        resp = client.post("/api/mine")
+        assert resp.status_code == 429
+
+    def test_different_endpoints_independent(self):
+        app = _make_app(
+            default_rate=100, default_window=60, default_burst=100,
+            endpoint_limits={"/api/mine": (1, 60, 1)},
+        )
+        client = app.test_client()
+        # Exhaust /api/mine
+        client.post("/api/mine")
+        resp = client.post("/api/mine")
+        assert resp.status_code == 429
+        # /epoch should still work (uses global limit)
+        resp = client.get("/epoch")
+        assert resp.status_code == 200
+
+    def test_disabled_limiter(self):
+        app = _make_app(enabled=False, default_rate=1, default_window=60, default_burst=1)
+        client = app.test_client()
+        for _ in range(10):
+            resp = client.get("/epoch")
+            assert resp.status_code == 200
+
+    def test_x_ratelimit_headers_on_429(self):
+        app = _make_app(
+            default_rate=1, default_window=60, default_burst=1,
+            endpoint_limits={},
+        )
+        client = app.test_client()
+        client.get("/epoch")
+        resp = client.get("/epoch")
+        assert resp.status_code == 429
+        assert "X-RateLimit-Limit" in resp.headers
+        assert "X-RateLimit-Window" in resp.headers

--- a/node/wsgi.py
+++ b/node/wsgi.py
@@ -31,6 +31,16 @@ DB_PATH = rustchain_main.DB_PATH
 # Initialize database
 init_db()
 
+# Initialize rate limiting middleware
+try:
+    from middleware import init_rate_limiter
+    init_rate_limiter(app)
+    print("[WSGI] Rate limiter initialized successfully")
+except ImportError as e:
+    print(f"[WSGI] Rate limiter not available: {e}")
+except Exception as e:
+    print(f"[WSGI] Rate limiter init failed: {e}")
+
 # Initialize P2P if available
 p2p_node = None
 try:


### PR DESCRIPTION
## Summary

- Adds a token-bucket rate limiter as Flask `before_request` middleware (`node/middleware/rate_limiter.py`)
- Per-IP tracking with configurable per-endpoint limits (stricter on write-heavy paths like `/api/mine`, `/attest/submit`, `/withdraw/request`)
- Redis-backed storage via atomic Lua script for distributed deployments; automatic fallback to thread-safe in-memory store when Redis is unavailable
- Returns **429 Too Many Requests** with `Retry-After` and `X-RateLimit-*` headers per RFC 6585 / RFC 7231
- Admin, health, and metrics endpoints are exempt by default
- Fully configurable via Flask app config or kwargs
- Integrated into `node/wsgi.py` entry point

## Files Changed

| File | Description |
|------|-------------|
| `node/middleware/__init__.py` | Package init, exports `RateLimiter` and `init_rate_limiter` |
| `node/middleware/rate_limiter.py` | Core implementation: token bucket, in-memory store, Redis store, Flask middleware |
| `node/tests/test_rate_limiter.py` | 15 tests covering bucket logic, store isolation, Flask integration, exempt paths |
| `node/wsgi.py` | Hook rate limiter into WSGI startup |

## Test Plan

- [x] 15 unit/integration tests passing (`pytest node/tests/test_rate_limiter.py`)
- [ ] Verify with Redis running locally (`RATELIMIT_REDIS_URL=redis://localhost:6379/0`)
- [ ] Load test with multiple concurrent clients to confirm per-IP isolation
- [ ] Confirm admin/health endpoints remain accessible under heavy load