### PR TITLE
Add database migration tool

### DIFF
--- a/tools/db-migrate/README.md
+++ b/tools/db-migrate/README.md
@@ -1,0 +1,91 @@
+# RustChain Database Migration Tool
+
+Versioned, reversible schema migration runner for the RustChain SQLite database.
+
+## Quick Start
+
+```bash
+# Show current migration status
+python tools/db-migrate/migrate.py status
+
+# Apply all pending migrations
+python tools/db-migrate/migrate.py up
+
+# Roll back the last applied migration
+python tools/db-migrate/migrate.py down
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `up` | Apply all pending migrations in version order |
+| `down` | Roll back the single most-recent migration |
+| `status` | List every migration and whether it has been applied |
+| `create NAME` | Scaffold a new empty migration file |
+
+### Options
+
+```
+--db PATH    Path to the SQLite database
+             Default: $RUSTCHAIN_DB_PATH or ./rustchain_v2.db
+
+--dir PATH   Path to the migrations/ directory
+             Default: tools/db-migrate/migrations/
+```
+
+## Writing Migrations
+
+Each migration is a single `.sql` file inside `migrations/` with the naming
+convention:
+
+```
+V{version}__{description}.sql
+```
+
+The file must contain two clearly marked sections:
+
+```sql
+-- UP
+CREATE TABLE foo (id INTEGER PRIMARY KEY);
+
+-- DOWN
+DROP TABLE IF EXISTS foo;
+```
+
+- **UP** — forward (apply) SQL.
+- **DOWN** — rollback SQL that cleanly reverses the UP block.
+
+### Creating a new migration
+
+```bash
+python tools/db-migrate/migrate.py create "add staking rewards table"
+# Creates migrations/V0021__add_staking_rewards_table.sql
+```
+
+Edit the generated file and fill in the UP / DOWN blocks.
+
+## How It Works
+
+The runner stores applied-migration state in a `_migrations` table inside the
+target database.  Each row records the version string, a human-readable name,
+the unix timestamp when it was applied, and a checksum of the UP SQL so that
+`migrate status` can flag files that were modified after being applied.
+
+Migrations are executed inside a transaction so a failure leaves the database
+unchanged.
+
+## Included Migrations
+
+| Version | Description |
+|---------|-------------|
+| V0018 | Baseline schema — records the full v2.2.1 table set |
+| V0019 | Add miner uptime tracking table |
+| V0020 | Add peer reputation table |
+
+## Integration with the Node
+
+The node's `init_db()` uses `CREATE TABLE IF NOT EXISTS` statements, so
+running migrations alongside the node is safe — both paths are idempotent.
+The migration tool simply provides a structured, auditable way to evolve
+the schema over time and roll back if needed.

--- a/tools/db-migrate/migrate.py
+++ b/tools/db-migrate/migrate.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""
+RustChain Database Migration Runner
+====================================
+
+Versioned schema migration tool for the RustChain SQLite database.
+
+Usage:
+    python migrate.py up [--db PATH] [--dir PATH]     Apply all pending migrations
+    python migrate.py down [--db PATH] [--dir PATH]   Roll back the most recent migration
+    python migrate.py status [--db PATH] [--dir PATH] Show applied/pending migrations
+    python migrate.py create NAME                      Scaffold a new migration file
+
+The runner stores applied migration state in a `_migrations` table inside the
+target database.  Each migration file lives under migrations/ and contains
+paired `-- UP` and `-- DOWN` SQL blocks.
+"""
+
+import argparse
+import glob
+import os
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+MIGRATIONS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "migrations")
+DEFAULT_DB = os.environ.get("RUSTCHAIN_DB_PATH", "./rustchain_v2.db")
+
+TRACKING_TABLE_DDL = """
+CREATE TABLE IF NOT EXISTS _migrations (
+    version     TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    applied_at  INTEGER NOT NULL,
+    checksum    TEXT NOT NULL
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ensure_tracking_table(conn: sqlite3.Connection) -> None:
+    conn.execute(TRACKING_TABLE_DDL)
+    conn.commit()
+
+
+def _applied_versions(conn: sqlite3.Connection) -> dict:
+    """Return {version: (name, applied_at, checksum)} for every applied migration."""
+    _ensure_tracking_table(conn)
+    rows = conn.execute(
+        "SELECT version, name, applied_at, checksum FROM _migrations ORDER BY version"
+    ).fetchall()
+    return {r[0]: {"name": r[1], "applied_at": r[2], "checksum": r[3]} for r in rows}
+
+
+def _checksum(text: str) -> str:
+    import hashlib
+    return hashlib.sha256(text.encode()).hexdigest()[:16]
+
+
+def _parse_migration(filepath: str) -> Tuple[str, str]:
+    """Parse a migration file and return (up_sql, down_sql)."""
+    content = Path(filepath).read_text(encoding="utf-8")
+
+    up_match = re.search(r"--\s*UP\b(.*?)(?=--\s*DOWN\b|$)", content, re.DOTALL | re.IGNORECASE)
+    down_match = re.search(r"--\s*DOWN\b(.*?)$", content, re.DOTALL | re.IGNORECASE)
+
+    up_sql = up_match.group(1).strip() if up_match else ""
+    down_sql = down_match.group(1).strip() if down_match else ""
+
+    return up_sql, down_sql
+
+
+def _discover_migrations(migrations_dir: str) -> List[dict]:
+    """Return sorted list of migration descriptors found on disk."""
+    pattern = os.path.join(migrations_dir, "V*__*.sql")
+    files = sorted(glob.glob(pattern))
+
+    migrations = []
+    for fp in files:
+        basename = os.path.basename(fp)
+        # Expected format: V{version}__{description}.sql
+        m = re.match(r"V(\d+)__(.+)\.sql$", basename)
+        if not m:
+            continue
+        version = m.group(1)
+        name = m.group(2).replace("_", " ")
+        up_sql, down_sql = _parse_migration(fp)
+        migrations.append({
+            "version": version,
+            "name": name,
+            "file": fp,
+            "up_sql": up_sql,
+            "down_sql": down_sql,
+            "checksum": _checksum(up_sql),
+        })
+    return migrations
+
+
+def _run_sql_block(conn: sqlite3.Connection, sql: str) -> None:
+    """Execute a block of SQL statements separated by semicolons."""
+    statements = [s.strip() for s in sql.split(";") if s.strip()]
+    for stmt in statements:
+        conn.execute(stmt)
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_up(db_path: str, migrations_dir: str) -> int:
+    """Apply all pending migrations in order."""
+    conn = sqlite3.connect(db_path)
+    _ensure_tracking_table(conn)
+    applied = _applied_versions(conn)
+    available = _discover_migrations(migrations_dir)
+
+    pending = [m for m in available if m["version"] not in applied]
+    if not pending:
+        print("Nothing to migrate — database is up to date.")
+        conn.close()
+        return 0
+
+    errors = 0
+    for mig in pending:
+        print(f"  Applying V{mig['version']}  {mig['name']} ... ", end="", flush=True)
+        if not mig["up_sql"]:
+            print("SKIP (empty UP block)")
+            continue
+        try:
+            _run_sql_block(conn, mig["up_sql"])
+            conn.execute(
+                "INSERT INTO _migrations (version, name, applied_at, checksum) VALUES (?, ?, ?, ?)",
+                (mig["version"], mig["name"], int(time.time()), mig["checksum"]),
+            )
+            conn.commit()
+            print("OK")
+        except Exception as exc:
+            conn.rollback()
+            print(f"FAILED\n    Error: {exc}")
+            errors += 1
+            break  # stop on first failure
+
+    conn.close()
+    return 1 if errors else 0
+
+
+def cmd_down(db_path: str, migrations_dir: str) -> int:
+    """Roll back the most recently applied migration."""
+    conn = sqlite3.connect(db_path)
+    applied = _applied_versions(conn)
+    if not applied:
+        print("Nothing to roll back — no migrations have been applied.")
+        conn.close()
+        return 0
+
+    available = {m["version"]: m for m in _discover_migrations(migrations_dir)}
+    latest_version = max(applied.keys())
+    mig = available.get(latest_version)
+
+    if not mig:
+        print(f"Migration file for V{latest_version} not found on disk. Cannot roll back.")
+        conn.close()
+        return 1
+
+    print(f"  Rolling back V{mig['version']}  {mig['name']} ... ", end="", flush=True)
+    if not mig["down_sql"]:
+        print("SKIP (empty DOWN block)")
+        conn.close()
+        return 0
+
+    try:
+        _run_sql_block(conn, mig["down_sql"])
+        conn.execute("DELETE FROM _migrations WHERE version = ?", (mig["version"],))
+        conn.commit()
+        print("OK")
+    except Exception as exc:
+        conn.rollback()
+        print(f"FAILED\n    Error: {exc}")
+        conn.close()
+        return 1
+
+    conn.close()
+    return 0
+
+
+def cmd_status(db_path: str, migrations_dir: str) -> int:
+    """Print a table of applied and pending migrations."""
+    conn = sqlite3.connect(db_path)
+    _ensure_tracking_table(conn)
+    applied = _applied_versions(conn)
+    available = _discover_migrations(migrations_dir)
+    conn.close()
+
+    if not available:
+        print("No migration files found.")
+        return 0
+
+    print(f"Database: {db_path}")
+    print(f"Migrations directory: {migrations_dir}")
+    print()
+    print(f"{'Version':<10} {'Name':<45} {'State':<10} {'Applied At'}")
+    print("-" * 90)
+
+    for mig in available:
+        v = mig["version"]
+        if v in applied:
+            ts = applied[v]["applied_at"]
+            dt = datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+            state = "applied"
+            # Check for checksum drift
+            if applied[v]["checksum"] != mig["checksum"]:
+                state = "MODIFIED"
+        else:
+            dt = ""
+            state = "pending"
+        print(f"V{v:<9} {mig['name']:<45} {state:<10} {dt}")
+
+    applied_count = sum(1 for m in available if m["version"] in applied)
+    pending_count = len(available) - applied_count
+    print()
+    print(f"Total: {len(available)}  Applied: {applied_count}  Pending: {pending_count}")
+    return 0
+
+
+def cmd_create(name: str, migrations_dir: str) -> int:
+    """Create a new empty migration file with the next version number."""
+    available = _discover_migrations(migrations_dir)
+    if available:
+        next_version = max(int(m["version"]) for m in available) + 1
+    else:
+        next_version = 18  # Continue from the node's current schema_version (17)
+
+    slug = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+    filename = f"V{next_version:04d}__{slug}.sql"
+    filepath = os.path.join(migrations_dir, filename)
+
+    content = f"""\
+-- Migration: {name}
+-- Version: {next_version}
+-- Created: {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}
+
+-- UP
+-- Write your forward migration SQL here.
+
+
+-- DOWN
+-- Write your rollback SQL here.
+
+"""
+    Path(filepath).write_text(content, encoding="utf-8")
+    print(f"Created {filepath}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="migrate",
+        description="RustChain database migration runner",
+    )
+    parser.add_argument(
+        "--db",
+        default=DEFAULT_DB,
+        help="Path to the SQLite database (default: $RUSTCHAIN_DB_PATH or ./rustchain_v2.db)",
+    )
+    parser.add_argument(
+        "--dir",
+        default=MIGRATIONS_DIR,
+        help="Path to migrations directory (default: ./migrations/)",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("up", help="Apply all pending migrations")
+    sub.add_parser("down", help="Roll back the most recent migration")
+    sub.add_parser("status", help="Show migration status")
+
+    create_parser = sub.add_parser("create", help="Create a new migration file")
+    create_parser.add_argument("name", help="Short description for the migration")
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        return 1
+
+    if args.command == "up":
+        return cmd_up(args.db, args.dir)
+    elif args.command == "down":
+        return cmd_down(args.db, args.dir)
+    elif args.command == "status":
+        return cmd_status(args.db, args.dir)
+    elif args.command == "create":
+        return cmd_create(args.name, args.dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/db-migrate/migrations/V0018__baseline_schema.sql
+++ b/tools/db-migrate/migrations/V0018__baseline_schema.sql
@@ -1,0 +1,202 @@
+-- Migration: Baseline schema snapshot
+-- Version: 18
+-- Captures the full v2.2.1 schema so future migrations have a known starting point.
+-- If the database already contains these tables (normal case) the IF NOT EXISTS
+-- clauses make this a no-op, but the migration is recorded so `migrate status`
+-- knows where we stand.
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS nonces (
+    nonce TEXT PRIMARY KEY,
+    expires_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS tickets (
+    ticket_id TEXT PRIMARY KEY,
+    expires_at INTEGER,
+    commitment TEXT
+);
+
+CREATE TABLE IF NOT EXISTS epoch_state (
+    epoch INTEGER PRIMARY KEY,
+    accepted_blocks INTEGER DEFAULT 0,
+    finalized INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS epoch_enroll (
+    epoch INTEGER,
+    miner_pk TEXT,
+    weight REAL,
+    PRIMARY KEY (epoch, miner_pk)
+);
+
+CREATE TABLE IF NOT EXISTS balances (
+    miner_pk TEXT PRIMARY KEY,
+    balance_rtc REAL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS pending_ledger (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts INTEGER NOT NULL,
+    epoch INTEGER NOT NULL,
+    from_miner TEXT NOT NULL,
+    to_miner TEXT NOT NULL,
+    amount_i64 INTEGER NOT NULL,
+    reason TEXT,
+    status TEXT DEFAULT 'pending',
+    created_at INTEGER NOT NULL,
+    confirms_at INTEGER NOT NULL,
+    tx_hash TEXT,
+    voided_by TEXT,
+    voided_reason TEXT,
+    confirmed_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_ledger_status ON pending_ledger(status);
+CREATE INDEX IF NOT EXISTS idx_pending_ledger_confirms_at ON pending_ledger(confirms_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pending_ledger_tx_hash ON pending_ledger(tx_hash);
+
+CREATE TABLE IF NOT EXISTS transfer_nonces (
+    from_address TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    used_at INTEGER NOT NULL,
+    PRIMARY KEY (from_address, nonce)
+);
+
+CREATE TABLE IF NOT EXISTS withdrawals (
+    withdrawal_id TEXT PRIMARY KEY,
+    miner_pk TEXT NOT NULL,
+    amount REAL NOT NULL,
+    fee REAL NOT NULL,
+    destination TEXT NOT NULL,
+    signature TEXT NOT NULL,
+    status TEXT DEFAULT 'pending',
+    created_at INTEGER NOT NULL,
+    processed_at INTEGER,
+    tx_hash TEXT,
+    error_msg TEXT
+);
+
+CREATE TABLE IF NOT EXISTS withdrawal_limits (
+    miner_pk TEXT NOT NULL,
+    date TEXT NOT NULL,
+    total_withdrawn REAL DEFAULT 0,
+    PRIMARY KEY (miner_pk, date)
+);
+
+CREATE TABLE IF NOT EXISTS fee_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    source TEXT NOT NULL,
+    source_id TEXT,
+    miner_pk TEXT,
+    fee_rtc REAL NOT NULL,
+    fee_urtc INTEGER NOT NULL,
+    destination TEXT NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS miner_keys (
+    miner_pk TEXT PRIMARY KEY,
+    pubkey_sr25519 TEXT NOT NULL,
+    registered_at INTEGER NOT NULL,
+    last_withdrawal INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS withdrawal_nonces (
+    miner_pk TEXT NOT NULL,
+    nonce TEXT NOT NULL,
+    used_at INTEGER NOT NULL,
+    PRIMARY KEY (miner_pk, nonce)
+);
+
+CREATE TABLE IF NOT EXISTS gov_rotation_proposals (
+    epoch_effective INTEGER PRIMARY KEY,
+    threshold INTEGER NOT NULL,
+    members_json TEXT NOT NULL,
+    created_ts BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gov_rotation_approvals (
+    epoch_effective INTEGER NOT NULL,
+    signer_id INTEGER NOT NULL,
+    sig_hex TEXT NOT NULL,
+    approved_ts BIGINT NOT NULL,
+    UNIQUE(epoch_effective, signer_id)
+);
+
+CREATE TABLE IF NOT EXISTS gov_signers (
+    signer_id INTEGER PRIMARY KEY,
+    pubkey_hex TEXT NOT NULL,
+    active INTEGER DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS gov_threshold (
+    id INTEGER PRIMARY KEY,
+    threshold INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gov_rotation (
+    epoch_effective INTEGER PRIMARY KEY,
+    committed INTEGER DEFAULT 0,
+    threshold INTEGER NOT NULL,
+    created_ts BIGINT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS gov_rotation_members (
+    epoch_effective INTEGER NOT NULL,
+    signer_id INTEGER NOT NULL,
+    pubkey_hex TEXT NOT NULL,
+    PRIMARY KEY (epoch_effective, signer_id)
+);
+
+CREATE TABLE IF NOT EXISTS checkpoints_meta (
+    k TEXT PRIMARY KEY,
+    v TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS wallet_review_holds (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    wallet TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'needs_review',
+    reason TEXT NOT NULL,
+    coach_note TEXT DEFAULT '',
+    reviewer_note TEXT DEFAULT '',
+    created_at INTEGER NOT NULL,
+    reviewed_at INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_review_wallet ON wallet_review_holds(wallet, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_wallet_review_status ON wallet_review_holds(status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS headers (
+    slot INTEGER PRIMARY KEY,
+    header_json TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    applied_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS beacon_envelopes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    agent_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    nonce TEXT UNIQUE NOT NULL,
+    sig TEXT NOT NULL,
+    pubkey TEXT NOT NULL,
+    payload_hash TEXT NOT NULL,
+    anchored INTEGER DEFAULT 0,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_beacon_anchored ON beacon_envelopes(anchored);
+CREATE INDEX IF NOT EXISTS idx_beacon_agent ON beacon_envelopes(agent_id, created_at);
+
+
+-- DOWN
+
+-- Rolling back the baseline is intentionally a no-op.
+-- Dropping every table would destroy the database; if you really need a
+-- clean slate, delete the .db file and re-run init_db().

--- a/tools/db-migrate/migrations/V0019__add_miner_uptime_tracking.sql
+++ b/tools/db-migrate/migrations/V0019__add_miner_uptime_tracking.sql
@@ -1,0 +1,26 @@
+-- Migration: Add miner uptime tracking
+-- Version: 19
+-- Adds a table to track per-epoch miner uptime for reward weighting.
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS miner_uptime (
+    miner_pk TEXT NOT NULL,
+    epoch INTEGER NOT NULL,
+    heartbeat_count INTEGER DEFAULT 0,
+    first_seen INTEGER NOT NULL,
+    last_seen INTEGER NOT NULL,
+    PRIMARY KEY (miner_pk, epoch)
+);
+
+CREATE INDEX IF NOT EXISTS idx_miner_uptime_epoch ON miner_uptime(epoch);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at)
+    VALUES (19, CAST(strftime('%s', 'now') AS INTEGER));
+
+
+-- DOWN
+
+DROP TABLE IF EXISTS miner_uptime;
+
+DELETE FROM schema_version WHERE version = 19;

--- a/tools/db-migrate/migrations/V0020__add_peer_reputation.sql
+++ b/tools/db-migrate/migrations/V0020__add_peer_reputation.sql
@@ -1,0 +1,26 @@
+-- Migration: Add peer reputation table
+-- Version: 20
+-- Tracks P2P peer behaviour scores for gossip protocol quality-of-service.
+
+-- UP
+
+CREATE TABLE IF NOT EXISTS peer_reputation (
+    peer_id TEXT PRIMARY KEY,
+    score REAL DEFAULT 100.0,
+    good_blocks INTEGER DEFAULT 0,
+    bad_blocks INTEGER DEFAULT 0,
+    last_contact INTEGER,
+    banned_until INTEGER DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_peer_reputation_score ON peer_reputation(score);
+
+INSERT OR IGNORE INTO schema_version (version, applied_at)
+    VALUES (20, CAST(strftime('%s', 'now') AS INTEGER));
+
+
+-- DOWN
+
+DROP TABLE IF EXISTS peer_reputation;
+
+DELETE FROM schema_version WHERE version = 20;


### PR DESCRIPTION
## Summary

- Adds `tools/db-migrate/` — a versioned database migration runner for the RustChain SQLite database
- Supports `up`, `down`, `status`, and `create` CLI commands for managing schema changes
- Includes a baseline migration (V0018) capturing the full v2.2.1 schema, plus two sample incremental migrations: miner uptime tracking (V0019) and peer reputation (V0020)
- Tracks applied migrations in a `_migrations` table with SHA-256 checksums to detect post-apply file edits

## Motivation

The node currently uses `CREATE TABLE IF NOT EXISTS` in `init_db()`, which works but makes it difficult to:
- Track which schema changes have been applied to a given database
- Roll back a change that introduced a problem
- Coordinate schema changes across contributors

This tool provides a structured, auditable migration workflow without changing the existing node startup path.

## Test plan

- [x] `migrate status` lists all migrations and their state
- [x] `migrate up` applies pending migrations in version order
- [x] `migrate down` rolls back the most recent migration
- [x] `migrate create` scaffolds a new migration file with the correct next version
- [x] Re-running `migrate up` on an already-migrated database is a no-op
- [x] Checksum drift is flagged in status output