### PR TITLE
feat: improve Telegram bot with async HTTP, correct API fields & all bonuses (#249)

### DIFF
--- a/tools/telegram_bot/README.md
+++ b/tools/telegram_bot/README.md
@@ -1,83 +1,65 @@
-# RustChain Telegram Bot
+# RustChain Telegram Community Bot
 
-Telegram bot for RustChain community.
+Telegram bot for RustChain community — Bounty #249 (50 RTC + bonuses).
 
 ## Commands
 
-- `/price` - Get real-time wRTC price from Raydium via DexScreener API
-- `/miners` - Get active miner count from RustChain network
-- `/epoch` - Get current epoch information
-- `/balance <wallet>` - Check wallet balance
-- `/health` - Check node health status
-- `/help` - Show all available commands
+| Command | Description |
+|---------|-------------|
+| `/price` | wRTC price from Raydium via DexScreener |
+| `/miners` | Active miner list and count |
+| `/epoch` | Current epoch, slot, pot, enrolled miners |
+| `/balance <wallet>` | Check RTC balance for a wallet |
+| `/health` | Node health, version, uptime, DB status |
+| `/subscribe` | Enable mining & price alerts in this chat |
+| `/unsubscribe` | Disable alerts |
+
+## Bonus Features
+
+- **Mining alerts** — notifies subscribed chats when a new miner joins or an epoch settles
+- **Price alerts** — notifies when wRTC price moves >5% (configurable)
+- **Inline queries** — type `@YourBot price`, `miners`, or `epoch` in any chat
 
 ## Setup
 
-### 1. Install dependencies
 ```bash
 pip install -r requirements.txt
 ```
 
-### 2. Create a Telegram Bot
-1. Talk to @BotFather on Telegram
-2. Create a new bot with `/newbot`
-3. Copy the bot token provided
+1. Create a bot via [@BotFather](https://t.me/BotFather) and copy the token.
+2. Enable inline mode via BotFather (`/setinline`) for inline queries.
+3. Configure environment:
 
-### 3. Configure environment variables
-Create a `.env` file:
 ```bash
-TELEGRAM_BOT_TOKEN=your_bot_token_here
-RUSTCHAIN_API=https://rustchain.org  # Optional, default is used
+cp .env.example .env
+# Edit .env with your bot token
 ```
 
-### 4. Run the bot
-```bash
-# Option 1: Using .env file
-python telegram_bot.py
+4. Run:
 
-# Option 2: Set environment variables directly
-export TELEGRAM_BOT_TOKEN=your_bot_token_here
+```bash
 python telegram_bot.py
 ```
 
-## Docker Deployment
+## Environment Variables
 
-Create a Dockerfile:
-```dockerfile
-FROM python:3.10-slim
-WORKDIR /app
-COPY . .
-RUN pip install -r requirements.txt
-CMD ["python", "telegram_bot.py"]
-```
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TELEGRAM_BOT_TOKEN` | _(required)_ | Bot token from BotFather |
+| `RUSTCHAIN_API` | `https://rustchain.org` | RustChain node URL |
+| `PRICE_ALERT_INTERVAL` | `120` | Seconds between price checks |
+| `MINER_ALERT_INTERVAL` | `60` | Seconds between miner checks |
+| `PRICE_CHANGE_THRESHOLD` | `5.0` | % change to trigger price alert |
 
-Build and run:
+## Docker
+
 ```bash
-docker build -t rustchain-telegram-bot .
-docker run --env-file .env rustchain-telegram-bot
+docker build -t rustchain-tg-bot .
+docker run --env-file .env rustchain-tg-bot
 ```
 
-## Features
+## Key Improvements
 
-- ✅ Real-time wRTC price fetching from DexScreener API
-- ✅ Active miner count from RustChain network
-- ✅ Wallet balance checking
-- ✅ Node health monitoring
-- ✅ Environment variable configuration
-- ✅ Comprehensive error handling
-
-## Technical Details
-
-- Uses `python-telegram-bot` library (v20.0+)
-- Fetches wRTC price from DexScreener API
-- Connects to RustChain API at `https://rustchain.org`
-- Supports both Raydium and other DEXs for price data
-
-## Bounty
-
-50 RTC - Issue #249
-Fixed version addressing code quality issues:
-1. Removed duplicate files
-2. Implemented real /price command (no placeholder)
-3. Added environment variable support
-4. Improved error handling and logging
+- **Async HTTP** — uses `aiohttp` instead of blocking `requests` in async handlers
+- **Correct API fields** — uses `amount_rtc`, `ok`, `slot`, `enrolled_miners` per API docs
+- **All bonus features** — mining alerts, price alerts, inline queries

--- a/tools/telegram_bot/requirements.txt
+++ b/tools/telegram_bot/requirements.txt
@@ -1,4 +1,3 @@
 python-telegram-bot>=20.0
-requests
-urllib3
+aiohttp>=3.9
 python-dotenv

--- a/tools/telegram_bot/telegram_bot.py
+++ b/tools/telegram_bot/telegram_bot.py
@@ -1,239 +1,410 @@
 """
 RustChain Telegram Community Bot
-Bounty: 50 RTC
-Issue: #249
+Bounty #249 — 50 RTC + Bonuses
 
-Fixed version addressing code quality issues:
-1. Removed duplicate files (bot.py deleted)
-2. Implemented real /price command using DexScreener API
-3. Added environment variable support for configuration
-4. Improved error handling and logging
+Core commands:
+  /price   — wRTC price from Raydium (DexScreener)
+  /miners  — Active miner list & count
+  /epoch   — Current epoch info
+  /balance — Check RTC balance
+  /health  — Node health status
+
+Bonus features:
+  - Mining alerts   (new miner joins / epoch settles)
+  - Price alerts    (wRTC moves >5%)
+  - Inline queries  (type @bot price/miners/epoch)
+
+Improvements over prior version:
+  - Async HTTP (aiohttp) instead of blocking requests in async handlers
+  - Correct API field names per REFERENCE.md (amount_rtc, ok, slot, etc.)
+  - All three bonus features implemented
 """
 
 import os
 import asyncio
 import logging
-import requests
-from dotenv import load_dotenv
-from telegram import Update
-from telegram.ext import Application, CommandHandler, MessageHandler, filters, ContextTypes
 
-# Load environment variables from .env file
+import aiohttp
+from dotenv import load_dotenv
+from telegram import Update, InlineQueryResultArticle, InputTextMessageContent
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    InlineQueryHandler,
+    ContextTypes,
+)
+
 load_dotenv()
 
-# Configure logging
-logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-logger = logging.getLogger(__name__)
+logging.basicConfig(
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s", level=logging.INFO
+)
+logger = logging.getLogger("rustchain_bot")
 
-# Configuration - use environment variables or defaults
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API", "https://rustchain.org")
-BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "YOUR_BOT_TOKEN_HERE")
-
-# DexScreener API for wRTC price
 WRTC_MINT = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
-DEXSCREENER_API = f"https://api.dexscreener.com/latest/dex/tokens/{WRTC_MINT}"
+DEXSCREENER_URL = f"https://api.dexscreener.com/latest/dex/tokens/{WRTC_MINT}"
+
+# Alert config
+PRICE_ALERT_INTERVAL = int(os.getenv("PRICE_ALERT_INTERVAL", "120"))   # seconds
+MINER_ALERT_INTERVAL = int(os.getenv("MINER_ALERT_INTERVAL", "60"))    # seconds
+PRICE_CHANGE_THRESHOLD = float(os.getenv("PRICE_CHANGE_THRESHOLD", "5.0"))  # percent
 
 
-def get_wrtc_price_data():
-    """Fetch wRTC price data from DexScreener API."""
+# ---------------------------------------------------------------------------
+# Async HTTP helpers (non-blocking, self-signed cert safe)
+# ---------------------------------------------------------------------------
+async def _get_json(url: str, params: dict | None = None, *, verify_ssl: bool = True):
+    connector = aiohttp.TCPConnector(ssl=verify_ssl)
+    async with aiohttp.ClientSession(connector=connector) as session:
+        async with session.get(
+            url, params=params, timeout=aiohttp.ClientTimeout(total=10)
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def fetch_rustchain(path: str, params: dict | None = None):
+    """Fetch from RustChain node (self-signed cert → ssl=False)."""
+    return await _get_json(f"{RUSTCHAIN_API}{path}", params, verify_ssl=False)
+
+
+async def fetch_price_data() -> dict | None:
+    """Fetch wRTC price from DexScreener, preferring the Raydium pair."""
     try:
-        response = requests.get(DEXSCREENER_API, timeout=10)
-        response.raise_for_status()
-        data = response.json()
-        
-        pairs = data.get('pairs', [])
+        data = await _get_json(DEXSCREENER_URL)
+        pairs = data.get("pairs", [])
         if not pairs:
             return None
-            
-        # Filter for Raydium pair (preferred) or use first available
-        raydium_pair = next((p for p in pairs if p.get('dexId') == 'raydium'), pairs[0])
-        
+        pair = next((p for p in pairs if p.get("dexId") == "raydium"), pairs[0])
         return {
-            'price_usd': float(raydium_pair.get('priceUsd', 0)),
-            'price_native': raydium_pair.get('priceNative', 'N/A'),
-            'h24_change': raydium_pair.get('priceChange', {}).get('h24', 0),
-            'liquidity_usd': raydium_pair.get('liquidity', {}).get('usd', 0),
-            'volume_h24': raydium_pair.get('volume', {}).get('h24', 0),
-            'url': raydium_pair.get('url', 'https://dexscreener.com')
+            "price_usd": float(pair.get("priceUsd", 0)),
+            "price_sol": pair.get("priceNative", "N/A"),
+            "h24_change": pair.get("priceChange", {}).get("h24", 0),
+            "liquidity": pair.get("liquidity", {}).get("usd", 0),
+            "volume_24h": pair.get("volume", {}).get("h24", 0),
+            "url": pair.get("url", "https://dexscreener.com"),
         }
     except Exception as e:
-        logger.error(f"Error fetching price data: {e}")
+        logger.error("fetch_price_data: %s", e)
         return None
 
 
-async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Send a message when the command /start is issued."""
-    welcome_text = """
-🛡️ *Welcome to RustChain Bot!*
-
-Available commands:
-/price - Current wRTC price from Raydium
-/miners - Active miner count
-/epoch - Current epoch info
-/balance <wallet> - Check wallet balance
-/health - Node health status
-/help - Show this help message
-
-Earn RTC by mining! Visit: rustchain.io
-    """
-    await update.message.reply_text(welcome_text, parse_mode='Markdown')
-
-
-async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Send a message when the command /help is issued."""
-    help_text = """
-🛡️ *RustChain Bot Commands*
-
-/price - Get wRTC price from Raydium (real-time)
-/miners - Get active miner count from RustChain network
-/epoch - Get current epoch information
-/balance <wallet> - Check wallet balance
-/health - Check node health status
-/help - Show this message
-
-Need help? Join our community!
-    """
-    await update.message.reply_text(help_text, parse_mode='Markdown')
+# ---------------------------------------------------------------------------
+# Command handlers
+# ---------------------------------------------------------------------------
+async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    text = (
+        "*RustChain Community Bot*\n\n"
+        "/price — wRTC price (Raydium)\n"
+        "/miners — Active miners\n"
+        "/epoch — Current epoch\n"
+        "/balance <wallet> — Wallet balance\n"
+        "/health — Node health\n"
+        "/subscribe — Enable alerts in this chat\n"
+        "/unsubscribe — Disable alerts"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
 
 
-async def price_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Get wRTC price from Raydium via DexScreener API."""
-    try:
-        price_data = get_wrtc_price_data()
-        if not price_data:
-            await update.message.reply_text("❌ Could not fetch wRTC price at this time. Please try again later.")
-            return
-            
-        message = (
-            f"💎 *wRTC Price Update*\n\n"
-            f"💵 *USD:* `${price_data['price_usd']:.4f}`\n"
-            f"☀️ *SOL:* `{price_data['price_native']} SOL`\n"
-            f"📈 *24h Change:* `{price_data['h24_change']}%`\n"
-            f"💧 *Liquidity:* `${price_data['liquidity_usd']:,.0f}`\n"
-            f"📊 *24h Volume:* `${price_data['volume_h24']:,.0f}`\n\n"
-            f"🔗 [View on DexScreener]({price_data['url']})"
-        )
-        await update.message.reply_text(message, parse_mode='Markdown', disable_web_page_preview=True)
-    except Exception as e:
-        logger.error(f"Error in price command: {e}")
-        await update.message.reply_text(f"❌ Error fetching price: {str(e)}")
-
-
-async def miners_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Get active miner count."""
-    try:
-        response = requests.get(f"{RUSTCHAIN_API}/api/miners", verify=False, timeout=10)
-        miners = response.json()
-        count = len(miners) if isinstance(miners, list) else "N/A"
-        
-        text = f"""
-⛏️ *RustChain Miners*
-
-Active Miners: *{count}*
-
-Join the network and start mining!
-"""
-        await update.message.reply_text(text, parse_mode='Markdown')
-    except Exception as e:
-        await update.message.reply_text(f"❌ Error fetching miners: {str(e)}")
-
-
-async def epoch_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Get current epoch information."""
-    try:
-        response = requests.get(f"{RUSTCHAIN_API}/epoch", verify=False, timeout=10)
-        epoch = response.json()
-        
-        text = f"""
-📅 *Current Epoch*
-
-Epoch: *{epoch.get('epoch', 'N/A')}*
-Status: *{epoch.get('status', 'N/A')}*
-
-Learn more: docs.rustchain.io
-"""
-        await update.message.reply_text(text, parse_mode='Markdown')
-    except Exception as e:
-        await update.message.reply_text(f"❌ Error fetching epoch: {str(e)}")
-
-
-async def balance_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Check wallet balance."""
-    try:
-        if not context.args:
-            await update.message.reply_text("Usage: /balance <wallet_address>")
-            return
-            
-        wallet = context.args[0]
-        response = requests.get(
-            f"{RUSTCHAIN_API}/wallet/balance",
-            params={"miner_id": wallet},
-            verify=False,
-            timeout=10
-        )
-        data = response.json()
-        
-        text = f"""
-💰 *Wallet Balance*
-
-Wallet: `{wallet}`
-Balance: *{data.get('balance', 'N/A')}* wRTC
-"""
-        await update.message.reply_text(text, parse_mode='Markdown')
-    except Exception as e:
-        await update.message.reply_text(f"❌ Error fetching balance: {str(e)}")
-
-
-async def health_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Check node health status."""
-    try:
-        response = requests.get(f"{RUSTCHAIN_API}/health", verify=False, timeout=10)
-        health = response.json()
-        
-        text = f"""
-❤️ *Node Health*
-
-Status: *{health.get('status', 'N/A')}*
-Version: *{health.get('version', 'N/A')}*
-
-Network: rustchain.io
-"""
-        await update.message.reply_text(text, parse_mode='Markdown')
-    except Exception as e:
-        await update.message.reply_text(f"❌ Error fetching health: {str(e)}")
-
-
-async def error_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Log Errors caused by Updates."""
-    logger.error(f"Update {update} caused error {context.error}")
-
-
-def main():
-    """Start the bot."""
-    if BOT_TOKEN == "YOUR_BOT_TOKEN_HERE":
-        logger.error("Please set TELEGRAM_BOT_TOKEN environment variable")
-        print("ERROR: Please set TELEGRAM_BOT_TOKEN environment variable")
-        print("Example: export TELEGRAM_BOT_TOKEN='your_bot_token_here'")
+async def cmd_price(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    data = await fetch_price_data()
+    if not data:
+        await update.message.reply_text("Could not fetch wRTC price. Try again later.")
         return
-        
-    application = Application.builder().token(BOT_TOKEN).build()
+    text = (
+        f"*wRTC Price*\n\n"
+        f"USD: `${data['price_usd']:.6f}`\n"
+        f"SOL: `{data['price_sol']}`\n"
+        f"24h: `{data['h24_change']}%`\n"
+        f"Liquidity: `${data['liquidity']:,.0f}`\n"
+        f"Volume 24h: `${data['volume_24h']:,.0f}`\n\n"
+        f"[DexScreener]({data['url']})"
+    )
+    await update.message.reply_text(
+        text, parse_mode="Markdown", disable_web_page_preview=True
+    )
 
-    # Register command handlers
-    application.add_handler(CommandHandler("start", start_command))
-    application.add_handler(CommandHandler("help", help_command))
-    application.add_handler(CommandHandler("price", price_command))
-    application.add_handler(CommandHandler("miners", miners_command))
-    application.add_handler(CommandHandler("epoch", epoch_command))
-    application.add_handler(CommandHandler("balance", balance_command))
-    application.add_handler(CommandHandler("health", health_command))
 
-    # Register error handler
-    application.add_error_handler(error_handler)
+async def cmd_miners(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    try:
+        miners = await fetch_rustchain("/api/miners")
+        if not isinstance(miners, list):
+            await update.message.reply_text("Unexpected response from /api/miners.")
+            return
+        lines = [f"*Active Miners: {len(miners)}*\n"]
+        for m in miners[:15]:
+            name = m.get("miner", "?")
+            hw = m.get("hardware_type", m.get("device_arch", ""))
+            mult = m.get("antiquity_multiplier", "")
+            lines.append(f"  `{name}` — {hw} (x{mult})")
+        if len(miners) > 15:
+            lines.append(f"\n_…and {len(miners) - 15} more_")
+        await update.message.reply_text("\n".join(lines), parse_mode="Markdown")
+    except Exception as e:
+        logger.error("cmd_miners: %s", e)
+        await update.message.reply_text(f"Error: {e}")
 
-    # Start the bot
-    print("🤖 RustChain Telegram Bot starting...")
-    print(f"Using RustChain API: {RUSTCHAIN_API}")
-    application.run_polling(ping_interval=30)
+
+async def cmd_epoch(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    try:
+        ep = await fetch_rustchain("/epoch")
+        text = (
+            f"*Epoch Info*\n\n"
+            f"Epoch: `{ep.get('epoch', 'N/A')}`\n"
+            f"Slot: `{ep.get('slot', 'N/A')}`\n"
+            f"Blocks/Epoch: `{ep.get('blocks_per_epoch', 'N/A')}`\n"
+            f"Epoch Pot: `{ep.get('epoch_pot', 'N/A')} RTC`\n"
+            f"Enrolled Miners: `{ep.get('enrolled_miners', 'N/A')}`"
+        )
+        await update.message.reply_text(text, parse_mode="Markdown")
+    except Exception as e:
+        logger.error("cmd_epoch: %s", e)
+        await update.message.reply_text(f"Error: {e}")
+
+
+async def cmd_balance(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    if not ctx.args:
+        await update.message.reply_text(
+            "Usage: `/balance <wallet_name>`", parse_mode="Markdown"
+        )
+        return
+    wallet = ctx.args[0]
+    try:
+        data = await fetch_rustchain("/wallet/balance", {"miner_id": wallet})
+        if not data.get("ok"):
+            await update.message.reply_text(
+                f"Wallet `{wallet}` not found.", parse_mode="Markdown"
+            )
+            return
+        text = (
+            f"*Wallet Balance*\n\n"
+            f"Wallet: `{data.get('miner_id', wallet)}`\n"
+            f"Balance: `{data.get('amount_rtc', 0)} RTC`"
+        )
+        await update.message.reply_text(text, parse_mode="Markdown")
+    except Exception as e:
+        logger.error("cmd_balance: %s", e)
+        await update.message.reply_text(f"Error: {e}")
+
+
+async def cmd_health(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    try:
+        h = await fetch_rustchain("/health")
+        status = "Healthy" if h.get("ok") else "Degraded"
+        uptime_h = round(h.get("uptime_s", 0) / 3600, 1)
+        text = (
+            f"*Node Health*\n\n"
+            f"Status: `{status}`\n"
+            f"Version: `{h.get('version', 'N/A')}`\n"
+            f"Uptime: `{uptime_h}h`\n"
+            f"DB R/W: `{h.get('db_rw', 'N/A')}`\n"
+            f"Tip Age: `{h.get('tip_age_slots', 'N/A')} slots`"
+        )
+        await update.message.reply_text(text, parse_mode="Markdown")
+    except Exception as e:
+        logger.error("cmd_health: %s", e)
+        await update.message.reply_text(f"Error: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Subscribe / Unsubscribe for alerts
+# ---------------------------------------------------------------------------
+_subscribed_chats: set[int] = set()
+
+
+async def cmd_subscribe(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    _subscribed_chats.add(update.effective_chat.id)
+    await update.message.reply_text(
+        "Alerts enabled. Use /unsubscribe to turn off."
+    )
+
+
+async def cmd_unsubscribe(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    _subscribed_chats.discard(update.effective_chat.id)
+    await update.message.reply_text("Alerts disabled.")
+
+
+# ---------------------------------------------------------------------------
+# Bonus 1: Mining alerts — new miner joins / epoch settles
+# ---------------------------------------------------------------------------
+_last_known_miners: set[str] = set()
+_last_known_epoch: int | None = None
+
+
+async def mining_alert_loop(app: Application):
+    global _last_known_miners, _last_known_epoch
+    await asyncio.sleep(5)
+    while True:
+        try:
+            miners = await fetch_rustchain("/api/miners")
+            if isinstance(miners, list):
+                current = {m.get("miner", "") for m in miners}
+                if _last_known_miners:
+                    for name in current - _last_known_miners:
+                        msg = f"*New Miner Joined!*\n`{name}` is now mining on RustChain."
+                        for cid in list(_subscribed_chats):
+                            try:
+                                await app.bot.send_message(
+                                    cid, msg, parse_mode="Markdown"
+                                )
+                            except Exception:
+                                _subscribed_chats.discard(cid)
+                _last_known_miners = current
+
+            ep = await fetch_rustchain("/epoch")
+            epoch_num = ep.get("epoch")
+            if _last_known_epoch is not None and epoch_num != _last_known_epoch:
+                msg = (
+                    f"*Epoch Settled!*\n"
+                    f"New epoch: `{epoch_num}` | Pot: `{ep.get('epoch_pot', '?')} RTC`"
+                )
+                for cid in list(_subscribed_chats):
+                    try:
+                        await app.bot.send_message(cid, msg, parse_mode="Markdown")
+                    except Exception:
+                        _subscribed_chats.discard(cid)
+            _last_known_epoch = epoch_num
+        except Exception as e:
+            logger.warning("mining_alert_loop: %s", e)
+        await asyncio.sleep(MINER_ALERT_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# Bonus 2: Price alerts — wRTC moves >5%
+# ---------------------------------------------------------------------------
+_last_alert_price: float | None = None
+
+
+async def price_alert_loop(app: Application):
+    global _last_alert_price
+    await asyncio.sleep(10)
+    while True:
+        try:
+            data = await fetch_price_data()
+            if data and data["price_usd"] > 0:
+                price = data["price_usd"]
+                if _last_alert_price is not None and _last_alert_price > 0:
+                    pct = abs(price - _last_alert_price) / _last_alert_price * 100
+                    if pct >= PRICE_CHANGE_THRESHOLD:
+                        direction = "up" if price > _last_alert_price else "down"
+                        msg = (
+                            f"*wRTC Price Alert!*\n"
+                            f"Price moved {direction} {pct:.1f}%\n"
+                            f"Now: `${price:.6f}` (was `${_last_alert_price:.6f}`)"
+                        )
+                        for cid in list(_subscribed_chats):
+                            try:
+                                await app.bot.send_message(
+                                    cid, msg, parse_mode="Markdown"
+                                )
+                            except Exception:
+                                _subscribed_chats.discard(cid)
+                        _last_alert_price = price
+                else:
+                    _last_alert_price = price
+        except Exception as e:
+            logger.warning("price_alert_loop: %s", e)
+        await asyncio.sleep(PRICE_ALERT_INTERVAL)
+
+
+# ---------------------------------------------------------------------------
+# Bonus 3: Inline query support
+# ---------------------------------------------------------------------------
+async def inline_query(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    query = (update.inline_query.query or "").strip().lower()
+    results = []
+
+    if not query or "price" in query:
+        data = await fetch_price_data()
+        if data:
+            results.append(
+                InlineQueryResultArticle(
+                    id="price",
+                    title=f"wRTC ${data['price_usd']:.6f}",
+                    description=f"24h change: {data['h24_change']}%",
+                    input_message_content=InputTextMessageContent(
+                        f"wRTC: ${data['price_usd']:.6f} | 24h: {data['h24_change']}%"
+                    ),
+                )
+            )
+
+    if not query or "miners" in query:
+        try:
+            miners = await fetch_rustchain("/api/miners")
+            count = len(miners) if isinstance(miners, list) else "?"
+            results.append(
+                InlineQueryResultArticle(
+                    id="miners",
+                    title=f"Active Miners: {count}",
+                    description="Current miner count on RustChain",
+                    input_message_content=InputTextMessageContent(
+                        f"RustChain has {count} active miners."
+                    ),
+                )
+            )
+        except Exception:
+            pass
+
+    if not query or "epoch" in query:
+        try:
+            ep = await fetch_rustchain("/epoch")
+            results.append(
+                InlineQueryResultArticle(
+                    id="epoch",
+                    title=f"Epoch {ep.get('epoch', '?')}",
+                    description=f"Slot {ep.get('slot', '?')} | Pot {ep.get('epoch_pot', '?')} RTC",
+                    input_message_content=InputTextMessageContent(
+                        f"Epoch {ep.get('epoch', '?')} — Slot {ep.get('slot', '?')}, "
+                        f"Pot {ep.get('epoch_pot', '?')} RTC, "
+                        f"{ep.get('enrolled_miners', '?')} enrolled miners"
+                    ),
+                )
+            )
+        except Exception:
+            pass
+
+    await update.inline_query.answer(results, cache_time=30)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    if not BOT_TOKEN:
+        print("ERROR: Set TELEGRAM_BOT_TOKEN environment variable.")
+        print("  export TELEGRAM_BOT_TOKEN='your_token'")
+        return
+
+    app = Application.builder().token(BOT_TOKEN).build()
+
+    for name, handler in [
+        ("start", cmd_start),
+        ("help", cmd_start),
+        ("price", cmd_price),
+        ("miners", cmd_miners),
+        ("epoch", cmd_epoch),
+        ("balance", cmd_balance),
+        ("health", cmd_health),
+        ("subscribe", cmd_subscribe),
+        ("unsubscribe", cmd_unsubscribe),
+    ]:
+        app.add_handler(CommandHandler(name, handler))
+
+    app.add_handler(InlineQueryHandler(inline_query))
+
+    async def post_init(application: Application):
+        asyncio.create_task(mining_alert_loop(application))
+        asyncio.create_task(price_alert_loop(application))
+
+    app.post_init = post_init
+
+    print(f"RustChain Telegram Bot starting — API: {RUSTCHAIN_API}")
+    app.run_polling(allowed_updates=Update.ALL_TYPES)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Async HTTP**: Replaced blocking `requests` calls with `aiohttp` — the previous version used synchronous HTTP inside async handlers, blocking the event loop
- **Correct API fields**: Fixed field name mismatches per `docs/api/REFERENCE.md` — `amount_rtc` instead of `balance`, `ok` instead of `status`, `slot`/`enrolled_miners` instead of `status` in epoch
- **All 3 bonus features implemented**:
  - Mining alerts (new miner joins, epoch settles) — `/subscribe` to enable
  - Price alerts (wRTC moves >5%) — configurable threshold
  - Inline query support (`@bot price`, `miners`, `epoch`)

## Changes
- `tools/telegram_bot/telegram_bot.py` — full rewrite with aiohttp, correct field parsing, bonus features
- `tools/telegram_bot/requirements.txt` — replaced `requests`/`urllib3` with `aiohttp`
- `tools/telegram_bot/README.md` — updated docs with all commands, env vars, bonus feature docs

## Test Plan
- [ ] Set `TELEGRAM_BOT_TOKEN` and run `python telegram_bot.py`
- [ ] Verify `/price`, `/miners`, `/epoch`, `/balance scott`, `/health` return correct data
- [ ] Verify `/subscribe` enables alerts, `/unsubscribe` disables
- [ ] Test inline query by typing `@BotName price` in any chat

Bounty: #249 (50 RTC + bonus)
Wallet: genesis

🤖 Generated with [Claude Code](https://claude.com/claude-code)