### PR TITLE
Add Terraform modules for infrastructure deployment

### DIFF
--- a/deploy/terraform/README.md
+++ b/deploy/terraform/README.md
@@ -1,0 +1,109 @@
+# RustChain Terraform Deployment
+
+Terraform modules for provisioning RustChain Proof-of-Antiquity blockchain infrastructure on DigitalOcean or AWS.
+
+## Architecture
+
+```
+deploy/terraform/
+  main.tf              Root module — wires providers, modules, and cloud-init
+  variables.tf         All configurable inputs
+  outputs.tf           Node IPs, dashboard URLs, monitoring endpoints
+  cloud-init.sh        Bootstrap script (templated by Terraform)
+  modules/
+    node/              VPS provisioning (DO droplet / AWS EC2)
+    monitoring/        Prometheus + Grafana stack generation
+```
+
+## Prerequisites
+
+- Terraform >= 1.5
+- A DigitalOcean API token **or** AWS credentials configured
+- An SSH public key
+
+## Quick Start
+
+### DigitalOcean
+
+```bash
+cd deploy/terraform
+
+terraform init
+
+terraform apply \
+  -var 'cloud_provider=digitalocean' \
+  -var 'do_token=dop_v1_xxx' \
+  -var 'ssh_public_key=ssh-ed25519 AAAA...'
+```
+
+### AWS
+
+```bash
+cd deploy/terraform
+
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+
+terraform init
+
+terraform apply \
+  -var 'cloud_provider=aws' \
+  -var 'ssh_public_key=ssh-ed25519 AAAA...'
+```
+
+## Variables
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `cloud_provider` | `digitalocean` | `digitalocean` or `aws` |
+| `do_token` | — | DigitalOcean API token |
+| `do_region` | `nyc3` | DO region |
+| `do_droplet_size` | `s-2vcpu-4gb` | DO droplet size |
+| `aws_region` | `us-east-1` | AWS region |
+| `aws_instance_type` | `t3.medium` | EC2 instance type |
+| `aws_key_pair_name` | — | Existing AWS key pair (optional) |
+| `ssh_public_key` | — | SSH public key for access |
+| `node_count` | `1` | Number of nodes (1-10) |
+| `enable_monitoring` | `true` | Deploy Prometheus + Grafana |
+| `domain_name` | — | Domain for TLS (optional) |
+| `grafana_admin_password` | `rustchain` | Grafana admin password |
+| `environment` | `prod` | Environment tag |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `node_ips` | Public IPs of all deployed nodes |
+| `dashboard_urls` | RustChain dashboard URLs |
+| `grafana_url` | Grafana dashboard URL |
+| `prometheus_url` | Prometheus URL |
+| `api_endpoints` | RustChain API endpoints |
+| `ssh_commands` | Ready-to-use SSH commands |
+
+## What Gets Deployed
+
+Each node receives via cloud-init:
+
+1. **RustChain node** — cloned from GitHub, built and run with Docker Compose
+2. **Nginx reverse proxy** — fronts the node on ports 80/443
+3. **Firewall** — UFW with only required ports open
+4. **Fail2Ban** — SSH brute-force protection
+5. **Systemd watchdog** — auto-restarts containers every 5 minutes if down
+6. **Prometheus + Grafana** (optional) — scrapes node metrics on the primary node
+7. **TLS** (optional) — auto-provisions Let's Encrypt certificate if `domain_name` is set
+
+## Multi-Node
+
+```bash
+terraform apply \
+  -var 'node_count=3' \
+  -var 'cloud_provider=digitalocean' \
+  -var 'do_token=dop_v1_xxx' \
+  -var 'ssh_public_key=ssh-ed25519 AAAA...'
+```
+
+## Tear Down
+
+```bash
+terraform destroy
+```

--- a/deploy/terraform/cloud-init.sh
+++ b/deploy/terraform/cloud-init.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# ──────────────────────────────────────────────────────────────
+# RustChain Node — Cloud-Init Bootstrap Script
+# ──────────────────────────────────────────────────────────────
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+LOG_FILE="/var/log/rustchain-bootstrap.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+echo "[$(date -u)] RustChain bootstrap starting..."
+
+# ── System Updates ──────────────────────────────────────────
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y \
+  docker.io \
+  docker-compose \
+  git \
+  curl \
+  ufw \
+  fail2ban \
+  sqlite3 \
+  python3 \
+  python3-pip \
+  certbot
+
+# ── Docker ──────────────────────────────────────────────────
+systemctl enable docker
+systemctl start docker
+
+# ── Firewall ────────────────────────────────────────────────
+ufw default deny incoming
+ufw default allow outgoing
+ufw allow 22/tcp     # SSH
+ufw allow 80/tcp     # HTTP
+ufw allow 443/tcp    # HTTPS
+ufw allow 8099/tcp   # RustChain dashboard
+ufw allow 8088/tcp   # RustChain API
+${MONITORING_FIREWALL_RULES}
+ufw --force enable
+
+# ── Fail2Ban ────────────────────────────────────────────────
+systemctl enable fail2ban
+systemctl start fail2ban
+
+# ── Clone RustChain ─────────────────────────────────────────
+RUSTCHAIN_DIR="/opt/rustchain"
+mkdir -p "$RUSTCHAIN_DIR"
+git clone --depth 1 https://github.com/Scottcjn/Rustchain.git "$RUSTCHAIN_DIR"
+cd "$RUSTCHAIN_DIR"
+
+# ── Build & Start Node ─────────────────────────────────────
+docker-compose up -d --build
+
+echo "[$(date -u)] RustChain node is running."
+
+# ── Monitoring Stack ────────────────────────────────────────
+${MONITORING_BLOCK}
+
+# ── TLS (optional) ──────────────────────────────────────────
+${TLS_BLOCK}
+
+# ── Systemd Watchdog ────────────────────────────────────────
+cat > /etc/systemd/system/rustchain-watchdog.service <<'UNIT'
+[Unit]
+Description=RustChain container watchdog
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -c 'cd /opt/rustchain && docker-compose up -d'
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+cat > /etc/systemd/system/rustchain-watchdog.timer <<'TIMER'
+[Unit]
+Description=Check RustChain containers every 5 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+TIMER
+
+systemctl daemon-reload
+systemctl enable rustchain-watchdog.timer
+systemctl start rustchain-watchdog.timer
+
+echo "[$(date -u)] RustChain bootstrap complete."

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,83 @@
+# ──────────────────────────────────────────────────────────────
+# RustChain Infrastructure — Root Module
+# Deploys RustChain nodes with optional monitoring on
+# DigitalOcean or AWS.
+# ──────────────────────────────────────────────────────────────
+
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# ── Providers ───────────────────────────────────────────────
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+# ── Monitoring (generates cloud-init fragments) ────────────
+
+module "monitoring" {
+  count  = var.enable_monitoring ? 1 : 0
+  source = "./modules/monitoring"
+
+  node_ips               = [for i in range(var.node_count) : "localhost"]
+  grafana_admin_password = var.grafana_admin_password
+}
+
+# ── Cloud-Init Rendering ───────────────────────────────────
+
+locals {
+  monitoring_block = var.enable_monitoring ? module.monitoring[0].cloud_init_monitoring_block : "echo 'Monitoring disabled.'"
+  monitoring_fw    = var.enable_monitoring ? module.monitoring[0].cloud_init_firewall_rules : ""
+
+  tls_block = var.domain_name != "" ? <<-BASH
+echo "[$(date -u)] Obtaining TLS certificate for ${var.domain_name}..."
+certbot certonly --standalone --non-interactive --agree-tos \
+  --register-unsafely-without-email \
+  -d ${var.domain_name}
+BASH
+  : "echo 'No domain configured; skipping TLS.'"
+
+  cloud_init_rendered = templatefile("${path.module}/cloud-init.sh", {
+    MONITORING_BLOCK          = local.monitoring_block
+    MONITORING_FIREWALL_RULES = local.monitoring_fw
+    TLS_BLOCK                 = local.tls_block
+  })
+}
+
+# ── Node Instances ──────────────────────────────────────────
+
+module "node" {
+  count  = var.node_count
+  source = "./modules/node"
+
+  cloud_provider    = var.cloud_provider
+  node_index        = count.index
+  ssh_public_key    = var.ssh_public_key
+  cloud_init_script = local.cloud_init_rendered
+  environment       = var.environment
+
+  # DigitalOcean
+  do_region       = var.do_region
+  do_droplet_size = var.do_droplet_size
+
+  # AWS
+  aws_region        = var.aws_region
+  aws_instance_type = var.aws_instance_type
+  aws_key_pair_name = var.aws_key_pair_name
+}

--- a/deploy/terraform/modules/monitoring/main.tf
+++ b/deploy/terraform/modules/monitoring/main.tf
@@ -1,0 +1,109 @@
+# ──────────────────────────────────────────────────────────────
+# RustChain Monitoring Module
+# Generates Prometheus + Grafana configuration rendered into
+# the cloud-init script of the primary node.
+# ──────────────────────────────────────────────────────────────
+
+locals {
+  # Build Prometheus scrape targets from all node IPs
+  scrape_targets = join(", ", [for ip in var.node_ips : "'${ip}:9100'"])
+
+  prometheus_config = <<-YAML
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: 'rustchain-exporter'
+    static_configs:
+      - targets: [${local.scrape_targets}]
+
+  - job_name: 'rustchain-nodes'
+    static_configs:
+      - targets: [${join(", ", [for ip in var.node_ips : "'${ip}:8099'"])}]
+    metrics_path: /health
+YAML
+
+  monitoring_compose = <<-YAML
+version: '3.8'
+
+services:
+  rustchain-exporter:
+    build:
+      context: ./monitoring
+      dockerfile: Dockerfile.exporter
+    container_name: rustchain-exporter
+    restart: unless-stopped
+    environment:
+      - RUSTCHAIN_NODE=http://localhost:8099
+      - EXPORTER_PORT=9100
+      - SCRAPE_INTERVAL=30
+    ports:
+      - "9100:9100"
+    network_mode: host
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: rustchain-prometheus
+    restart: unless-stopped
+    volumes:
+      - /opt/rustchain/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    ports:
+      - "9090:9090"
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: rustchain-grafana
+    restart: unless-stopped
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - /opt/rustchain/monitoring/grafana-dashboard.json:/etc/grafana/provisioning/dashboards/rustchain.json:ro
+      - /opt/rustchain/monitoring/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yml:ro
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${var.grafana_admin_password}
+
+volumes:
+  prometheus-data:
+  grafana-data:
+YAML
+
+  # Firewall rules to open monitoring ports
+  firewall_rules = <<-BASH
+ufw allow 9090/tcp   # Prometheus
+ufw allow 9100/tcp   # Node exporter
+ufw allow 3000/tcp   # Grafana
+BASH
+
+  # Shell block for cloud-init to start monitoring stack
+  cloud_init_block = <<-BASH
+echo "[$(date -u)] Starting monitoring stack..."
+cd /opt/rustchain
+
+# Write generated Prometheus config
+cat > monitoring/prometheus.yml <<'PROMCFG'
+${local.prometheus_config}
+PROMCFG
+
+# Start monitoring containers
+cd monitoring
+docker-compose up -d --build
+echo "[$(date -u)] Monitoring stack running."
+BASH
+}
+
+output "cloud_init_monitoring_block" {
+  description = "Shell commands to insert into cloud-init for monitoring setup"
+  value       = local.cloud_init_block
+}
+
+output "cloud_init_firewall_rules" {
+  description = "UFW rules for monitoring ports"
+  value       = local.firewall_rules
+}

--- a/deploy/terraform/modules/monitoring/variables.tf
+++ b/deploy/terraform/modules/monitoring/variables.tf
@@ -1,0 +1,9 @@
+variable "node_ips" {
+  description = "List of RustChain node IPs to scrape"
+  type        = list(string)
+}
+
+variable "grafana_admin_password" {
+  type      = string
+  sensitive = true
+}

--- a/deploy/terraform/modules/node/main.tf
+++ b/deploy/terraform/modules/node/main.tf
@@ -1,0 +1,159 @@
+# ──────────────────────────────────────────────────────────────
+# RustChain Node Module
+# Provisions a single VPS on DigitalOcean or AWS
+# ──────────────────────────────────────────────────────────────
+
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  node_name = "rustchain-node-${var.node_index}"
+}
+
+# ── DigitalOcean ────────────────────────────────────────────
+
+resource "digitalocean_ssh_key" "rustchain" {
+  count      = var.cloud_provider == "digitalocean" ? 1 : 0
+  name       = "${local.node_name}-key"
+  public_key = var.ssh_public_key
+}
+
+resource "digitalocean_droplet" "node" {
+  count     = var.cloud_provider == "digitalocean" ? 1 : 0
+  name      = local.node_name
+  region    = var.do_region
+  size      = var.do_droplet_size
+  image     = "ubuntu-22-04-x64"
+  ssh_keys  = [digitalocean_ssh_key.rustchain[0].fingerprint]
+  user_data = var.cloud_init_script
+
+  tags = ["rustchain", var.environment]
+}
+
+# ── AWS ─────────────────────────────────────────────────────
+
+data "aws_ami" "ubuntu" {
+  count       = var.cloud_provider == "aws" ? 1 : 0
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_security_group" "rustchain" {
+  count       = var.cloud_provider == "aws" ? 1 : 0
+  name        = "${local.node_name}-sg"
+  description = "RustChain node security group"
+
+  ingress {
+    description = "SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "RustChain Dashboard"
+    from_port   = 8099
+    to_port     = 8099
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "RustChain API"
+    from_port   = 8088
+    to_port     = 8088
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Grafana"
+    from_port   = 3000
+    to_port     = 3000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Prometheus"
+    from_port   = 9090
+    to_port     = 9090
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = local.node_name
+    Environment = var.environment
+  }
+}
+
+resource "aws_key_pair" "rustchain" {
+  count      = var.cloud_provider == "aws" && var.aws_key_pair_name == "" ? 1 : 0
+  key_name   = "${local.node_name}-key"
+  public_key = var.ssh_public_key
+}
+
+resource "aws_instance" "node" {
+  count                  = var.cloud_provider == "aws" ? 1 : 0
+  ami                    = data.aws_ami.ubuntu[0].id
+  instance_type          = var.aws_instance_type
+  key_name               = var.aws_key_pair_name != "" ? var.aws_key_pair_name : aws_key_pair.rustchain[0].key_name
+  vpc_security_group_ids = [aws_security_group.rustchain[0].id]
+  user_data              = var.cloud_init_script
+
+  root_block_device {
+    volume_size = 50
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name        = local.node_name
+    Environment = var.environment
+    Project     = "rustchain"
+  }
+}

--- a/deploy/terraform/modules/node/outputs.tf
+++ b/deploy/terraform/modules/node/outputs.tf
@@ -1,0 +1,21 @@
+output "node_ip" {
+  description = "Public IP of the RustChain node"
+  value = var.cloud_provider == "digitalocean" ? (
+    length(digitalocean_droplet.node) > 0 ? digitalocean_droplet.node[0].ipv4_address : ""
+  ) : (
+    length(aws_instance.node) > 0 ? aws_instance.node[0].public_ip : ""
+  )
+}
+
+output "node_id" {
+  description = "Provider-specific node ID"
+  value = var.cloud_provider == "digitalocean" ? (
+    length(digitalocean_droplet.node) > 0 ? tostring(digitalocean_droplet.node[0].id) : ""
+  ) : (
+    length(aws_instance.node) > 0 ? aws_instance.node[0].id : ""
+  )
+}
+
+output "node_name" {
+  value = local.node_name
+}

--- a/deploy/terraform/modules/node/variables.tf
+++ b/deploy/terraform/modules/node/variables.tf
@@ -1,0 +1,47 @@
+variable "cloud_provider" {
+  type = string
+}
+
+variable "do_region" {
+  type    = string
+  default = "nyc3"
+}
+
+variable "do_droplet_size" {
+  type    = string
+  default = "s-2vcpu-4gb"
+}
+
+variable "aws_region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "aws_instance_type" {
+  type    = string
+  default = "t3.medium"
+}
+
+variable "aws_key_pair_name" {
+  type    = string
+  default = ""
+}
+
+variable "ssh_public_key" {
+  type = string
+}
+
+variable "node_index" {
+  description = "Index of this node (for naming)"
+  type        = number
+}
+
+variable "cloud_init_script" {
+  description = "Rendered cloud-init bootstrap script"
+  type        = string
+}
+
+variable "environment" {
+  type    = string
+  default = "prod"
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -1,0 +1,46 @@
+# ──────────────────────────────────────────────────────────────
+# RustChain Infrastructure — Outputs
+# ──────────────────────────────────────────────────────────────
+
+output "node_ips" {
+  description = "Public IP addresses of RustChain nodes"
+  value       = module.node[*].node_ip
+}
+
+output "dashboard_urls" {
+  description = "RustChain dashboard URLs"
+  value = [
+    for ip in module.node[*].node_ip :
+    var.domain_name != "" ? "https://${var.domain_name}" : "http://${ip}"
+  ]
+}
+
+output "ssh_commands" {
+  description = "SSH commands to connect to each node"
+  value = [
+    for ip in module.node[*].node_ip :
+    "ssh root@${ip}"
+  ]
+}
+
+output "grafana_url" {
+  description = "Grafana dashboard URL (if monitoring enabled)"
+  value = var.enable_monitoring && length(module.node) > 0 ? (
+    var.domain_name != "" ? "https://${var.domain_name}:3000" : "http://${module.node[0].node_ip}:3000"
+  ) : "monitoring disabled"
+}
+
+output "prometheus_url" {
+  description = "Prometheus URL (if monitoring enabled)"
+  value = var.enable_monitoring && length(module.node) > 0 ? (
+    "http://${module.node[0].node_ip}:9090"
+  ) : "monitoring disabled"
+}
+
+output "api_endpoints" {
+  description = "RustChain API endpoints"
+  value = [
+    for ip in module.node[*].node_ip :
+    "http://${ip}:8099"
+  ]
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,100 @@
+# ──────────────────────────────────────────────────────────────
+# RustChain Infrastructure — Input Variables
+# ──────────────────────────────────────────────────────────────
+
+# ── Provider Selection ──────────────────────────────────────
+
+variable "cloud_provider" {
+  description = "Cloud provider to deploy on: digitalocean or aws"
+  type        = string
+  default     = "digitalocean"
+
+  validation {
+    condition     = contains(["digitalocean", "aws"], var.cloud_provider)
+    error_message = "cloud_provider must be 'digitalocean' or 'aws'."
+  }
+}
+
+# ── DigitalOcean ────────────────────────────────────────────
+
+variable "do_token" {
+  description = "DigitalOcean API token"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "do_region" {
+  description = "DigitalOcean region slug"
+  type        = string
+  default     = "nyc3"
+}
+
+variable "do_droplet_size" {
+  description = "DigitalOcean droplet size slug"
+  type        = string
+  default     = "s-2vcpu-4gb"
+}
+
+# ── AWS ─────────────────────────────────────────────────────
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_instance_type" {
+  description = "AWS EC2 instance type"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "aws_key_pair_name" {
+  description = "Existing AWS key pair name for SSH access"
+  type        = string
+  default     = ""
+}
+
+# ── Common ──────────────────────────────────────────────────
+
+variable "ssh_public_key" {
+  description = "SSH public key for node access"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of RustChain nodes to deploy"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.node_count >= 1 && var.node_count <= 10
+    error_message = "node_count must be between 1 and 10."
+  }
+}
+
+variable "enable_monitoring" {
+  description = "Deploy Prometheus + Grafana monitoring stack"
+  type        = bool
+  default     = true
+}
+
+variable "domain_name" {
+  description = "Domain name pointed at the node (optional, for TLS)"
+  type        = string
+  default     = ""
+}
+
+variable "grafana_admin_password" {
+  description = "Grafana admin password"
+  type        = string
+  default     = "rustchain"
+  sensitive   = true
+}
+
+variable "environment" {
+  description = "Deployment environment tag (dev, staging, prod)"
+  type        = string
+  default     = "prod"
+}


### PR DESCRIPTION
## Summary

- Adds `deploy/terraform/` with full infrastructure-as-code for deploying RustChain nodes on DigitalOcean or AWS
- **Node module** provisions VPS instances with security groups, SSH keys, and cloud-init bootstrapping that clones the repo, builds Docker containers, and starts the node
- **Monitoring module** generates Prometheus + Grafana configuration baked into the cloud-init script
- **Cloud-init script** handles end-to-end setup: Docker, UFW firewall, Fail2Ban, systemd watchdog, optional TLS via certbot
- Supports 1-10 node deployments with a single `node_count` variable

## What's Included

```
deploy/terraform/
  main.tf              — Root module (providers, cloud-init rendering, module wiring)
  variables.tf         — All configurable inputs with validation
  outputs.tf           — Node IPs, dashboard URLs, Grafana/Prometheus endpoints
  cloud-init.sh        — Templated bootstrap script
  README.md            — Usage docs with DO and AWS examples
  modules/
    node/              — VPS provisioning (DO droplet or AWS EC2)
    monitoring/        — Prometheus + Grafana stack
```

## Test Plan

- [ ] `terraform init` succeeds
- [ ] `terraform validate` passes
- [ ] `terraform plan` with DigitalOcean variables produces expected resources
- [ ] `terraform plan` with AWS variables produces expected resources
- [ ] Deploy single node on DO and verify dashboard at port 8099
- [ ] Deploy with `enable_monitoring=true` and verify Grafana at port 3000