### PR TITLE
Add Ansible playbooks for automated node deployment

### DIFF
--- a/deploy/ansible/README.md
+++ b/deploy/ansible/README.md
@@ -1,0 +1,110 @@
+# RustChain Ansible Deployment
+
+Automated deployment playbooks for RustChain nodes and monitoring infrastructure.
+
+## Structure
+
+```
+deploy/ansible/
+  inventory.yml              # Target hosts
+  playbook.yml               # Main entry point
+  roles/
+    rustchain-node/           # Node deployment
+      tasks/main.yml          # Install deps, create user, deploy code, configure services
+      handlers/main.yml       # Service restart/reload handlers
+      defaults/main.yml       # Default variables
+      templates/
+        rustchain-node.service.j2    # systemd unit for gunicorn
+        nginx-rustchain.conf.j2     # Reverse proxy with optional SSL
+    rustchain-monitor/        # Prometheus + Grafana stack
+      tasks/main.yml          # Install Prometheus, exporter, Grafana
+      handlers/main.yml       # Service restart handlers
+      defaults/main.yml       # Default variables
+      templates/
+        prometheus.yml.j2              # Scrape config
+        prometheus.service.j2          # systemd unit
+        rustchain-exporter.service.j2  # Exporter systemd unit
+        grafana-datasource.yml.j2      # Auto-provision datasource
+```
+
+## Requirements
+
+- Ansible 2.14+
+- Target hosts running Ubuntu 22.04+ / Debian 12+
+- SSH access with sudo privileges
+
+## Quick Start
+
+1. Copy and edit the inventory:
+
+```bash
+cp inventory.yml inventory.local.yml
+# Edit hosts, IPs, and domain settings
+```
+
+2. Run the full playbook:
+
+```bash
+ansible-playbook -i inventory.local.yml playbook.yml
+```
+
+3. Deploy only nodes or only monitoring:
+
+```bash
+ansible-playbook -i inventory.local.yml playbook.yml --tags node
+ansible-playbook -i inventory.local.yml playbook.yml --tags monitor
+```
+
+## Configuration
+
+### Node Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `rustchain_bind_port` | `8099` | Gunicorn listen port |
+| `rustchain_workers` | `4` | Gunicorn worker count |
+| `rustchain_enable_ssl` | `false` | Enable HTTPS via nginx |
+| `rustchain_domain` | `localhost` | Server name for nginx |
+| `rustchain_version` | `main` | Git branch/tag to deploy |
+
+### Monitoring Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `grafana_admin_password` | `changeme` | Grafana admin password |
+| `prometheus_retention_days` | `30` | Metrics retention period |
+| `rustchain_node_url` | `https://rustchain.org` | Node URL for the exporter |
+
+### SSL Setup
+
+Set `rustchain_enable_ssl: true` and provide certificate paths:
+
+```yaml
+rustchain_enable_ssl: true
+rustchain_ssl_cert: /etc/letsencrypt/live/rustchain.example.com/fullchain.pem
+rustchain_ssl_key: /etc/letsencrypt/live/rustchain.example.com/privkey.pem
+```
+
+## Services Deployed
+
+**Node host:**
+- `rustchain-node.service` — Gunicorn running the Flask app
+- `nginx` — Reverse proxy with security headers
+
+**Monitor host:**
+- `prometheus.service` — Metrics collection
+- `rustchain-exporter.service` — Scrapes RustChain API for Prometheus
+- `grafana-server` — Dashboard UI (port 3000)
+
+## Post-Deploy Verification
+
+```bash
+# Check node health
+curl http://node-01/health
+
+# Prometheus targets
+curl http://monitor-01:9090/api/v1/targets
+
+# Grafana
+open http://monitor-01:3000  # admin / <grafana_admin_password>
+```

--- a/deploy/ansible/inventory.yml
+++ b/deploy/ansible/inventory.yml
@@ -1,0 +1,26 @@
+---
+all:
+  vars:
+    ansible_user: deploy
+    ansible_python_interpreter: /usr/bin/python3
+
+  children:
+    rustchain_nodes:
+      hosts:
+        node-01:
+          ansible_host: 203.0.113.10
+          rustchain_node_name: rustchain-primary
+        node-02:
+          ansible_host: 203.0.113.11
+          rustchain_node_name: rustchain-secondary
+      vars:
+        rustchain_enable_ssl: false
+        rustchain_domain: rustchain.example.com
+
+    monitoring:
+      hosts:
+        monitor-01:
+          ansible_host: 203.0.113.20
+      vars:
+        grafana_admin_password: "{{ vault_grafana_admin_password | default('changeme') }}"
+        prometheus_retention_days: 30

--- a/deploy/ansible/playbook.yml
+++ b/deploy/ansible/playbook.yml
@@ -1,0 +1,14 @@
+---
+- name: Deploy RustChain nodes
+  hosts: rustchain_nodes
+  become: true
+  roles:
+    - role: rustchain-node
+      tags: [node]
+
+- name: Deploy monitoring stack
+  hosts: monitoring
+  become: true
+  roles:
+    - role: rustchain-monitor
+      tags: [monitor]

--- a/deploy/ansible/roles/rustchain-monitor/defaults/main.yml
+++ b/deploy/ansible/roles/rustchain-monitor/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Prometheus
+prometheus_version: "2.51.1"
+prometheus_retention_days: 30
+prometheus_port: 9090
+prometheus_data_dir: /var/lib/prometheus
+prometheus_config_dir: /etc/prometheus
+
+# Grafana
+grafana_version: "10.4.1"
+grafana_port: 3000
+grafana_admin_password: changeme
+
+# RustChain exporter
+rustchain_exporter_port: 9100
+rustchain_exporter_dir: /opt/rustchain-exporter
+rustchain_node_url: "https://rustchain.org"
+
+# Scrape targets — built from the rustchain_nodes group
+rustchain_scrape_targets: "{{ groups['rustchain_nodes'] | default([]) }}"

--- a/deploy/ansible/roles/rustchain-monitor/handlers/main.yml
+++ b/deploy/ansible/roles/rustchain-monitor/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart prometheus
+  ansible.builtin.systemd:
+    name: prometheus
+    state: restarted
+
+- name: restart rustchain-exporter
+  ansible.builtin.systemd:
+    name: rustchain-exporter
+    state: restarted
+
+- name: restart grafana
+  ansible.builtin.systemd:
+    name: grafana-server
+    state: restarted

--- a/deploy/ansible/roles/rustchain-monitor/tasks/main.yml
+++ b/deploy/ansible/roles/rustchain-monitor/tasks/main.yml
@@ -1,0 +1,184 @@
+---
+# --- Prometheus -----------------------------------------------------------
+
+- name: Create prometheus system user
+  ansible.builtin.user:
+    name: prometheus
+    system: true
+    shell: /usr/sbin/nologin
+    create_home: false
+
+- name: Create prometheus directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: "0755"
+  loop:
+    - "{{ prometheus_config_dir }}"
+    - "{{ prometheus_data_dir }}"
+
+- name: Download Prometheus
+  ansible.builtin.unarchive:
+    src: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
+    dest: /tmp
+    remote_src: true
+    creates: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64"
+
+- name: Install Prometheus binaries
+  ansible.builtin.copy:
+    src: "/tmp/prometheus-{{ prometheus_version }}.linux-amd64/{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - prometheus
+    - promtool
+
+- name: Deploy Prometheus configuration
+  ansible.builtin.template:
+    src: prometheus.yml.j2
+    dest: "{{ prometheus_config_dir }}/prometheus.yml"
+    owner: prometheus
+    group: prometheus
+    mode: "0644"
+  notify: restart prometheus
+
+- name: Deploy Prometheus systemd unit
+  ansible.builtin.template:
+    src: prometheus.service.j2
+    dest: /etc/systemd/system/prometheus.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart prometheus
+
+- name: Enable and start Prometheus
+  ansible.builtin.systemd:
+    name: prometheus
+    enabled: true
+    state: started
+    daemon_reload: true
+
+# --- RustChain Exporter ---------------------------------------------------
+
+- name: Install exporter dependencies
+  ansible.builtin.apt:
+    name:
+      - python3
+      - python3-pip
+      - python3-venv
+      - git
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create exporter directory
+  ansible.builtin.file:
+    path: "{{ rustchain_exporter_dir }}"
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: "0755"
+
+- name: Copy exporter script from source
+  ansible.builtin.copy:
+    src: "{{ rustchain_home | default('/opt/rustchain') }}/src/monitoring/rustchain-exporter.py"
+    dest: "{{ rustchain_exporter_dir }}/rustchain-exporter.py"
+    remote_src: true
+    owner: prometheus
+    group: prometheus
+    mode: "0755"
+  ignore_errors: true
+
+- name: Create exporter venv and install deps
+  ansible.builtin.pip:
+    name:
+      - requests
+      - prometheus_client
+    virtualenv: "{{ rustchain_exporter_dir }}/venv"
+    virtualenv_command: python3 -m venv
+  become_user: prometheus
+
+- name: Deploy exporter systemd unit
+  ansible.builtin.template:
+    src: rustchain-exporter.service.j2
+    dest: /etc/systemd/system/rustchain-exporter.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart rustchain-exporter
+
+- name: Enable and start exporter
+  ansible.builtin.systemd:
+    name: rustchain-exporter
+    enabled: true
+    state: started
+    daemon_reload: true
+
+# --- Grafana --------------------------------------------------------------
+
+- name: Add Grafana APT key
+  ansible.builtin.apt_key:
+    url: https://apt.grafana.com/gpg.key
+    state: present
+
+- name: Add Grafana APT repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://apt.grafana.com stable main"
+    state: present
+    filename: grafana
+
+- name: Install Grafana
+  ansible.builtin.apt:
+    name: grafana
+    state: present
+    update_cache: true
+
+- name: Set Grafana admin password
+  ansible.builtin.lineinfile:
+    path: /etc/grafana/grafana.ini
+    regexp: "^;?admin_password ="
+    line: "admin_password = {{ grafana_admin_password }}"
+    section: security
+
+- name: Deploy Grafana datasource
+  ansible.builtin.template:
+    src: grafana-datasource.yml.j2
+    dest: /etc/grafana/provisioning/datasources/prometheus.yml
+    owner: grafana
+    group: grafana
+    mode: "0640"
+  notify: restart grafana
+
+- name: Create Grafana dashboard provisioning dir
+  ansible.builtin.file:
+    path: /var/lib/grafana/dashboards
+    state: directory
+    owner: grafana
+    group: grafana
+    mode: "0755"
+
+- name: Copy RustChain Grafana dashboard
+  ansible.builtin.copy:
+    src: "{{ rustchain_home | default('/opt/rustchain') }}/src/monitoring/grafana-dashboard.json"
+    dest: /var/lib/grafana/dashboards/rustchain.json
+    remote_src: true
+    owner: grafana
+    group: grafana
+    mode: "0644"
+  ignore_errors: true
+  notify: restart grafana
+
+- name: Enable and start Grafana
+  ansible.builtin.systemd:
+    name: grafana-server
+    enabled: true
+    state: started

--- a/deploy/ansible/roles/rustchain-monitor/templates/grafana-datasource.yml.j2
+++ b/deploy/ansible/roles/rustchain-monitor/templates/grafana-datasource.yml.j2
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://localhost:{{ prometheus_port }}
+    isDefault: true
+    editable: false

--- a/deploy/ansible/roles/rustchain-monitor/templates/prometheus.service.j2
+++ b/deploy/ansible/roles/rustchain-monitor/templates/prometheus.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prometheus Monitoring
+Documentation=https://prometheus.io/docs
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=prometheus
+Group=prometheus
+ExecStart=/usr/local/bin/prometheus \
+    --config.file={{ prometheus_config_dir }}/prometheus.yml \
+    --storage.tsdb.path={{ prometheus_data_dir }} \
+    --storage.tsdb.retention.time={{ prometheus_retention_days }}d \
+    --web.listen-address=0.0.0.0:{{ prometheus_port }}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/rustchain-monitor/templates/prometheus.yml.j2
+++ b/deploy/ansible/roles/rustchain-monitor/templates/prometheus.yml.j2
@@ -1,0 +1,21 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:{{ prometheus_port }}']
+
+  - job_name: 'rustchain-exporter'
+    static_configs:
+      - targets: ['localhost:{{ rustchain_exporter_port }}']
+
+{% if rustchain_scrape_targets | length > 0 %}
+  - job_name: 'rustchain-nodes'
+    static_configs:
+      - targets:
+{% for host in rustchain_scrape_targets %}
+          - '{{ hostvars[host].ansible_host | default(host) }}:{{ rustchain_exporter_port }}'
+{% endfor %}
+{% endif %}

--- a/deploy/ansible/roles/rustchain-monitor/templates/rustchain-exporter.service.j2
+++ b/deploy/ansible/roles/rustchain-monitor/templates/rustchain-exporter.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=RustChain Prometheus Exporter
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=prometheus
+Group=prometheus
+WorkingDirectory={{ rustchain_exporter_dir }}
+ExecStart={{ rustchain_exporter_dir }}/venv/bin/python {{ rustchain_exporter_dir }}/rustchain-exporter.py
+Restart=on-failure
+RestartSec=10
+Environment="RUSTCHAIN_NODE={{ rustchain_node_url }}"
+Environment="EXPORTER_PORT={{ rustchain_exporter_port }}"
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ansible/roles/rustchain-node/defaults/main.yml
+++ b/deploy/ansible/roles/rustchain-node/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# System user that runs the node
+rustchain_user: rustchain
+rustchain_group: rustchain
+
+# Directories
+rustchain_home: /opt/rustchain
+rustchain_data_dir: "{{ rustchain_home }}/data"
+rustchain_log_dir: /var/log/rustchain
+rustchain_venv: "{{ rustchain_home }}/venv"
+
+# Git source
+rustchain_repo: https://github.com/Scottcjn/Rustchain.git
+rustchain_version: main
+
+# Application
+rustchain_bind_host: 127.0.0.1
+rustchain_bind_port: 8099
+rustchain_workers: 4
+rustchain_db_path: "{{ rustchain_data_dir }}/rustchain_v2.db"
+
+# Nginx
+rustchain_enable_nginx: true
+rustchain_domain: localhost
+rustchain_enable_ssl: false
+rustchain_ssl_cert: /etc/ssl/certs/rustchain.pem
+rustchain_ssl_key: /etc/ssl/private/rustchain.key
+
+# Node identity
+rustchain_node_name: "rustchain-{{ inventory_hostname }}"
+
+# Python
+rustchain_python_version: python3.11

--- a/deploy/ansible/roles/rustchain-node/handlers/main.yml
+++ b/deploy/ansible/roles/rustchain-node/handlers/main.yml
@@ -1,0 +1,14 @@
+---
+- name: reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: restart rustchain
+  ansible.builtin.systemd:
+    name: rustchain-node
+    state: restarted
+
+- name: reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded

--- a/deploy/ansible/roles/rustchain-node/tasks/main.yml
+++ b/deploy/ansible/roles/rustchain-node/tasks/main.yml
@@ -1,0 +1,128 @@
+---
+- name: Install system dependencies
+  ansible.builtin.apt:
+    name:
+      - "{{ rustchain_python_version }}"
+      - "{{ rustchain_python_version }}-venv"
+      - "{{ rustchain_python_version }}-dev"
+      - python3-pip
+      - git
+      - curl
+      - sqlite3
+      - gcc
+      - nginx
+      - acl
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Create rustchain group
+  ansible.builtin.group:
+    name: "{{ rustchain_group }}"
+    system: true
+    state: present
+
+- name: Create rustchain user
+  ansible.builtin.user:
+    name: "{{ rustchain_user }}"
+    group: "{{ rustchain_group }}"
+    home: "{{ rustchain_home }}"
+    shell: /usr/sbin/nologin
+    system: true
+    create_home: false
+    state: present
+
+- name: Create directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ rustchain_user }}"
+    group: "{{ rustchain_group }}"
+    mode: "0755"
+  loop:
+    - "{{ rustchain_home }}"
+    - "{{ rustchain_data_dir }}"
+    - "{{ rustchain_log_dir }}"
+
+- name: Clone RustChain repository
+  ansible.builtin.git:
+    repo: "{{ rustchain_repo }}"
+    dest: "{{ rustchain_home }}/src"
+    version: "{{ rustchain_version }}"
+    depth: 1
+    force: true
+  become_user: "{{ rustchain_user }}"
+  notify: restart rustchain
+
+- name: Create Python virtual environment
+  ansible.builtin.command:
+    cmd: "{{ rustchain_python_version }} -m venv {{ rustchain_venv }}"
+    creates: "{{ rustchain_venv }}/bin/activate"
+  become_user: "{{ rustchain_user }}"
+
+- name: Install Python dependencies
+  ansible.builtin.pip:
+    requirements: "{{ rustchain_home }}/src/requirements-node.txt"
+    virtualenv: "{{ rustchain_venv }}"
+  become_user: "{{ rustchain_user }}"
+  notify: restart rustchain
+
+- name: Deploy systemd service
+  ansible.builtin.template:
+    src: rustchain-node.service.j2
+    dest: /etc/systemd/system/rustchain-node.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - reload systemd
+    - restart rustchain
+
+- name: Deploy nginx site configuration
+  ansible.builtin.template:
+    src: nginx-rustchain.conf.j2
+    dest: /etc/nginx/sites-available/rustchain
+    owner: root
+    group: root
+    mode: "0644"
+  when: rustchain_enable_nginx
+  notify: reload nginx
+
+- name: Enable nginx site
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/rustchain
+    dest: /etc/nginx/sites-enabled/rustchain
+    state: link
+  when: rustchain_enable_nginx
+  notify: reload nginx
+
+- name: Remove default nginx site
+  ansible.builtin.file:
+    path: /etc/nginx/sites-enabled/default
+    state: absent
+  when: rustchain_enable_nginx
+  notify: reload nginx
+
+- name: Enable and start rustchain-node service
+  ansible.builtin.systemd:
+    name: rustchain-node
+    enabled: true
+    state: started
+    daemon_reload: true
+
+- name: Enable and start nginx
+  ansible.builtin.systemd:
+    name: nginx
+    enabled: true
+    state: started
+  when: rustchain_enable_nginx
+
+- name: Wait for node health endpoint
+  ansible.builtin.uri:
+    url: "http://{{ rustchain_bind_host }}:{{ rustchain_bind_port }}/health"
+    method: GET
+    status_code: 200
+  register: health_check
+  retries: 10
+  delay: 5
+  until: health_check.status == 200

--- a/deploy/ansible/roles/rustchain-node/templates/nginx-rustchain.conf.j2
+++ b/deploy/ansible/roles/rustchain-node/templates/nginx-rustchain.conf.j2
@@ -1,0 +1,65 @@
+upstream rustchain_backend {
+    server {{ rustchain_bind_host }}:{{ rustchain_bind_port }};
+}
+
+{% if rustchain_enable_ssl %}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ rustchain_domain }};
+    return 301 https://$server_name$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name {{ rustchain_domain }};
+
+    ssl_certificate     {{ rustchain_ssl_cert }};
+    ssl_certificate_key {{ rustchain_ssl_key }};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+{% else %}
+server {
+    listen 80;
+    listen [::]:80;
+    server_name {{ rustchain_domain }};
+{% endif %}
+
+    add_header X-Frame-Options        "SAMEORIGIN"  always;
+    add_header X-Content-Type-Options "nosniff"      always;
+    add_header X-XSS-Protection       "1; mode=block" always;
+    server_tokens off;
+
+    location / {
+        proxy_pass http://rustchain_backend;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout    60s;
+        proxy_read_timeout    60s;
+    }
+
+    location /health {
+        proxy_pass http://rustchain_backend/health;
+        access_log off;
+    }
+
+    location /static/ {
+        proxy_pass http://rustchain_backend/static/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+}

--- a/deploy/ansible/roles/rustchain-node/templates/rustchain-node.service.j2
+++ b/deploy/ansible/roles/rustchain-node/templates/rustchain-node.service.j2
@@ -1,0 +1,36 @@
+[Unit]
+Description=RustChain Node ({{ rustchain_node_name }})
+Documentation=https://github.com/Scottcjn/Rustchain
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User={{ rustchain_user }}
+Group={{ rustchain_group }}
+WorkingDirectory={{ rustchain_home }}/src/node
+ExecStart={{ rustchain_venv }}/bin/gunicorn \
+    --workers {{ rustchain_workers }} \
+    --bind {{ rustchain_bind_host }}:{{ rustchain_bind_port }} \
+    --timeout 120 \
+    --access-logfile {{ rustchain_log_dir }}/access.log \
+    --error-logfile {{ rustchain_log_dir }}/error.log \
+    wsgi:app
+Restart=on-failure
+RestartSec=15
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+Environment="PYTHONUNBUFFERED=1"
+Environment="RUSTCHAIN_HOME={{ rustchain_home }}"
+Environment="RUSTCHAIN_DB={{ rustchain_db_path }}"
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths={{ rustchain_data_dir }} {{ rustchain_log_dir }}
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Adds `deploy/ansible/` with two roles for fully automated RustChain infrastructure provisioning
- **rustchain-node** role: installs system deps, creates a locked-down `rustchain` user, clones the repo into a Python venv, deploys gunicorn behind nginx with optional SSL, and wires up systemd with security hardening (NoNewPrivileges, ProtectSystem=strict, PrivateTmp)
- **rustchain-monitor** role: installs Prometheus from binary, deploys the existing `rustchain-exporter.py` as a systemd service, installs Grafana from official APT repo with auto-provisioned datasource and dashboard
- Includes example inventory, configurable defaults for all tunables (ports, workers, retention, SSL paths), and a README with quick-start instructions

## Files added

```
deploy/ansible/
  inventory.yml
  playbook.yml
  README.md
  roles/
    rustchain-node/
      defaults/main.yml
      tasks/main.yml
      handlers/main.yml
      templates/
        rustchain-node.service.j2
        nginx-rustchain.conf.j2
    rustchain-monitor/
      defaults/main.yml
      tasks/main.yml
      handlers/main.yml
      templates/
        prometheus.yml.j2
        prometheus.service.j2
        rustchain-exporter.service.j2
        grafana-datasource.yml.j2
```

## Test plan

- [ ] `ansible-playbook --syntax-check playbook.yml` passes
- [ ] Deploy to a fresh Ubuntu 22.04 VM and verify `rustchain-node.service` starts
- [ ] Confirm `/health` returns 200 through nginx
- [ ] Deploy monitor role and verify Prometheus scrapes the exporter
- [ ] Confirm Grafana dashboard loads at port 3000