### PR TITLE
Add Go SDK client for RustChain API

### DIFF
--- a/tools/go-sdk/README.md
+++ b/tools/go-sdk/README.md
@@ -1,0 +1,90 @@
+# RustChain Go SDK
+
+Go client library for the RustChain v2.2.1 API.
+
+## Install
+
+```bash
+go get github.com/CelebrityPunks/Rustchain/tools/go-sdk
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    rustchain "github.com/CelebrityPunks/Rustchain/tools/go-sdk"
+)
+
+func main() {
+    client := rustchain.NewClient(
+        "https://50.28.86.131",
+        rustchain.WithInsecureTLS(), // self-signed cert
+    )
+
+    // Health check
+    health, err := client.Health()
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Node %s up for %.0fs\n", health.Version, health.UptimeSeconds)
+
+    // Check balance
+    bal, err := client.WalletBalance("Ivan-houzhiwen")
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Balance: %.2f RTC\n", bal.AmountRTC)
+
+    // Current epoch
+    epoch, err := client.Epoch()
+    if err != nil {
+        log.Fatal(err)
+    }
+    fmt.Printf("Epoch %d, slot %d, %d miners enrolled\n",
+        epoch.Epoch, epoch.Slot, epoch.EnrolledMiners)
+}
+```
+
+## Coverage
+
+| Category               | Methods                                                             |
+|------------------------|---------------------------------------------------------------------|
+| Health & Status        | `Health`, `Ready`, `Stats`                                          |
+| Epochs & Enrollment    | `Epoch`, `Enroll`, `LotteryEligibility`, `EpochRewards`             |
+| Wallet & Balance       | `Balance`, `WalletBalance`, `WalletHistory`, `SignedTransfer`, `ResolveWallet` |
+| Block Headers          | `ChainTip`                                                          |
+| Attestation            | `AttestChallenge`, `AttestSubmit`                                   |
+| Miners & Network       | `Miners`, `Nodes`, `MinerBadge`, `MinerDashboard`, `BountyMultiplier`, `FeePool` |
+| Beacon Protocol        | `BeaconSubmit`, `BeaconDigest`, `BeaconEnvelopes`                   |
+| Governance             | `GovernanceProposals`, `GovernanceProposal`, `GovernancePropose`, `GovernanceVote` |
+| Withdrawals            | `WithdrawRequest`, `WithdrawStatus`                                 |
+| P2P                    | `P2PStats`                                                          |
+
+## Configuration
+
+```go
+// With admin key for privileged endpoints
+client := rustchain.NewClient(baseURL, rustchain.WithAdminKey("your-key"))
+
+// With custom HTTP client
+client := rustchain.NewClient(baseURL, rustchain.WithHTTPClient(myClient))
+
+// Skip TLS verification (self-signed certs)
+client := rustchain.NewClient(baseURL, rustchain.WithInsecureTLS())
+```
+
+## Testing
+
+```bash
+cd tools/go-sdk
+go test -v ./...
+```
+
+## License
+
+Same as the parent RustChain project.

--- a/tools/go-sdk/client.go
+++ b/tools/go-sdk/client.go
@@ -1,0 +1,387 @@
+// Package rustchain provides a Go client for the RustChain API.
+//
+// The client covers all public and authenticated endpoints exposed by
+// RustChain v2.2.1 nodes, including health checks, epoch/enrollment,
+// wallet operations, attestation, beacon protocol, governance, and
+// withdrawal management.
+package rustchain
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Client is a RustChain API client.
+type Client struct {
+	BaseURL    string
+	AdminKey   string
+	HTTPClient *http.Client
+}
+
+// Option configures a Client.
+type Option func(*Client)
+
+// WithAdminKey sets the admin/API key used for privileged endpoints.
+func WithAdminKey(key string) Option {
+	return func(c *Client) { c.AdminKey = key }
+}
+
+// WithHTTPClient overrides the default HTTP client.
+func WithHTTPClient(hc *http.Client) Option {
+	return func(c *Client) { c.HTTPClient = hc }
+}
+
+// WithInsecureTLS disables TLS certificate verification (useful for
+// self-signed certificates on RustChain nodes).
+func WithInsecureTLS() Option {
+	return func(c *Client) {
+		c.HTTPClient.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+}
+
+// NewClient creates a new RustChain API client.
+func NewClient(baseURL string, opts ...Option) *Client {
+	c := &Client{
+		BaseURL: baseURL,
+		HTTPClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// ---- internal helpers ----
+
+func (c *Client) doGet(path string, query url.Values, out interface{}) error {
+	u := c.BaseURL + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	return c.do(req, out)
+}
+
+func (c *Client) doGetAdmin(path string, query url.Values, out interface{}) error {
+	u := c.BaseURL + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-API-Key", c.AdminKey)
+	return c.do(req, out)
+}
+
+func (c *Client) doGetAdminKey(path string, query url.Values, out interface{}) error {
+	u := c.BaseURL + path
+	if len(query) > 0 {
+		u += "?" + query.Encode()
+	}
+	req, err := http.NewRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Admin-Key", c.AdminKey)
+	return c.do(req, out)
+}
+
+func (c *Client) doPost(path string, body interface{}, out interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.BaseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return c.do(req, out)
+}
+
+func (c *Client) doPostAdmin(path string, body interface{}, out interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.BaseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", c.AdminKey)
+	return c.do(req, out)
+}
+
+func (c *Client) doPostAdminKey(path string, body interface{}, out interface{}) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.BaseURL+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Admin-Key", c.AdminKey)
+	return c.do(req, out)
+}
+
+func (c *Client) do(req *http.Request, out interface{}) error {
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading response: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		var apiErr ErrorResponse
+		if json.Unmarshal(body, &apiErr) == nil && apiErr.Error != "" {
+			return fmt.Errorf("api error %d: %s – %s", resp.StatusCode, apiErr.Error, apiErr.Message)
+		}
+		return fmt.Errorf("api error %d: %s", resp.StatusCode, string(body))
+	}
+
+	if out != nil {
+		return json.Unmarshal(body, out)
+	}
+	return nil
+}
+
+// ---- Health & Status ----
+
+// Health returns the node health status.
+func (c *Client) Health() (*HealthResponse, error) {
+	var out HealthResponse
+	return &out, c.doGet("/health", nil, &out)
+}
+
+// Ready returns the node readiness status.
+func (c *Client) Ready() (*ReadinessResponse, error) {
+	var out ReadinessResponse
+	return &out, c.doGet("/ready", nil, &out)
+}
+
+// Stats returns system-wide statistics.
+func (c *Client) Stats() (*StatsResponse, error) {
+	var out StatsResponse
+	return &out, c.doGet("/api/stats", nil, &out)
+}
+
+// ---- Epochs & Enrollment ----
+
+// Epoch returns the current epoch information.
+func (c *Client) Epoch() (*EpochResponse, error) {
+	var out EpochResponse
+	return &out, c.doGet("/epoch", nil, &out)
+}
+
+// Enroll enrolls a miner in the current epoch.
+func (c *Client) Enroll(req *EnrollRequest) (*EnrollResponse, error) {
+	var out EnrollResponse
+	return &out, c.doPost("/epoch/enroll", req, &out)
+}
+
+// LotteryEligibility checks round-robin eligibility for a miner.
+func (c *Client) LotteryEligibility(minerID string) (*EligibilityResponse, error) {
+	var out EligibilityResponse
+	q := url.Values{"miner_id": {minerID}}
+	return &out, c.doGet("/lottery/eligibility", q, &out)
+}
+
+// EpochRewards returns the reward distribution for a specific epoch.
+func (c *Client) EpochRewards(epoch int) (*EpochRewardsResponse, error) {
+	var out EpochRewardsResponse
+	return &out, c.doGet(fmt.Sprintf("/rewards/epoch/%d", epoch), nil, &out)
+}
+
+// ---- Wallet & Balance ----
+
+// Balance returns the balance for a miner public key.
+func (c *Client) Balance(minerPK string) (*BalanceResponse, error) {
+	var out BalanceResponse
+	return &out, c.doGet("/balance/"+url.PathEscape(minerPK), nil, &out)
+}
+
+// WalletBalance returns the balance for a miner by ID.
+func (c *Client) WalletBalance(minerID string) (*WalletBalanceResponse, error) {
+	var out WalletBalanceResponse
+	q := url.Values{"miner_id": {minerID}}
+	return &out, c.doGet("/wallet/balance", q, &out)
+}
+
+// WalletHistory returns the public transfer history for a wallet.
+func (c *Client) WalletHistory(minerID string, limit int) ([]TransferHistoryEntry, error) {
+	var out []TransferHistoryEntry
+	q := url.Values{
+		"miner_id": {minerID},
+		"limit":    {strconv.Itoa(limit)},
+	}
+	return out, c.doGet("/wallet/history", q, &out)
+}
+
+// SignedTransfer submits a signed RTC transfer.
+func (c *Client) SignedTransfer(req *SignedTransferRequest) (*SignedTransferResponse, error) {
+	var out SignedTransferResponse
+	return &out, c.doPost("/wallet/transfer/signed", req, &out)
+}
+
+// ResolveWallet resolves a beacon address to its RTC wallet.
+func (c *Client) ResolveWallet(address string) (*ResolveWalletResponse, error) {
+	var out ResolveWalletResponse
+	q := url.Values{"address": {address}}
+	return &out, c.doGet("/wallet/resolve", q, &out)
+}
+
+// ---- Block Headers ----
+
+// ChainTip returns the current chain tip.
+func (c *Client) ChainTip() (*ChainTipResponse, error) {
+	var out ChainTipResponse
+	return &out, c.doGet("/headers/tip", nil, &out)
+}
+
+// ---- Attestation ----
+
+// AttestChallenge requests a hardware attestation challenge nonce.
+func (c *Client) AttestChallenge() (*AttestChallengeResponse, error) {
+	var out AttestChallengeResponse
+	return &out, c.doPost("/attest/challenge", nil, &out)
+}
+
+// AttestSubmit submits a hardware attestation.
+func (c *Client) AttestSubmit(req *AttestSubmitRequest) (*AttestSubmitResponse, error) {
+	var out AttestSubmitResponse
+	return &out, c.doPost("/attest/submit", req, &out)
+}
+
+// ---- Miners & Network ----
+
+// Miners returns the list of active miners.
+func (c *Client) Miners() ([]Miner, error) {
+	var out []Miner
+	return out, c.doGet("/api/miners", nil, &out)
+}
+
+// Nodes returns the list of registered network nodes.
+func (c *Client) Nodes() (*NodesResponse, error) {
+	var out NodesResponse
+	return &out, c.doGet("/api/nodes", nil, &out)
+}
+
+// MinerBadge returns a Shields.io badge for a miner.
+func (c *Client) MinerBadge(minerID string) (*BadgeResponse, error) {
+	var out BadgeResponse
+	return &out, c.doGet("/api/badge/"+url.PathEscape(minerID), nil, &out)
+}
+
+// MinerDashboard returns aggregated dashboard data for a miner.
+func (c *Client) MinerDashboard(minerID string) (*MinerDashboardResponse, error) {
+	var out MinerDashboardResponse
+	return &out, c.doGet("/api/miner_dashboard/"+url.PathEscape(minerID), nil, &out)
+}
+
+// BountyMultiplier returns the current bounty decay multiplier.
+func (c *Client) BountyMultiplier() (*BountyMultiplierResponse, error) {
+	var out BountyMultiplierResponse
+	return &out, c.doGet("/api/bounty-multiplier", nil, &out)
+}
+
+// FeePool returns the fee pool statistics (RIP-301).
+func (c *Client) FeePool() (*FeePoolResponse, error) {
+	var out FeePoolResponse
+	return &out, c.doGet("/api/fee_pool", nil, &out)
+}
+
+// ---- Beacon Protocol ----
+
+// BeaconSubmit submits a beacon envelope for anchoring.
+func (c *Client) BeaconSubmit(req *BeaconSubmitRequest) (*BeaconSubmitResponse, error) {
+	var out BeaconSubmitResponse
+	return &out, c.doPost("/beacon/submit", req, &out)
+}
+
+// BeaconDigest returns the current beacon digest.
+func (c *Client) BeaconDigest() (*BeaconDigestResponse, error) {
+	var out BeaconDigestResponse
+	return &out, c.doGet("/beacon/digest", nil, &out)
+}
+
+// BeaconEnvelopes lists recent beacon envelopes with pagination.
+func (c *Client) BeaconEnvelopes(limit, offset int) (*BeaconEnvelopesResponse, error) {
+	var out BeaconEnvelopesResponse
+	q := url.Values{
+		"limit":  {strconv.Itoa(limit)},
+		"offset": {strconv.Itoa(offset)},
+	}
+	return &out, c.doGet("/beacon/envelopes", q, &out)
+}
+
+// ---- Governance ----
+
+// GovernanceProposals lists all governance proposals.
+func (c *Client) GovernanceProposals() (*ProposalsResponse, error) {
+	var out ProposalsResponse
+	return &out, c.doGet("/governance/proposals", nil, &out)
+}
+
+// GovernanceProposal returns the detail of a governance proposal.
+func (c *Client) GovernanceProposal(id int) (*ProposalDetailResponse, error) {
+	var out ProposalDetailResponse
+	return &out, c.doGet(fmt.Sprintf("/governance/proposal/%d", id), nil, &out)
+}
+
+// GovernancePropose creates a new governance proposal.
+func (c *Client) GovernancePropose(req *ProposeRequest) (*ProposalDetailResponse, error) {
+	var out ProposalDetailResponse
+	return &out, c.doPost("/governance/propose", req, &out)
+}
+
+// GovernanceVote casts a vote on an active proposal.
+func (c *Client) GovernanceVote(req *VoteRequest) (*VoteResponse, error) {
+	var out VoteResponse
+	return &out, c.doPost("/governance/vote", req, &out)
+}
+
+// ---- Withdrawals ----
+
+// WithdrawRequest submits a withdrawal request.
+func (c *Client) WithdrawRequest(req *WithdrawalRequest) (*WithdrawalResponse, error) {
+	var out WithdrawalResponse
+	return &out, c.doPost("/withdraw/request", req, &out)
+}
+
+// WithdrawStatus returns the status of a withdrawal.
+func (c *Client) WithdrawStatus(withdrawalID string) (*WithdrawalStatus, error) {
+	var out WithdrawalStatus
+	return &out, c.doGet("/withdraw/status/"+url.PathEscape(withdrawalID), nil, &out)
+}
+
+// ---- P2P ----
+
+// P2PStats returns P2P network statistics.
+func (c *Client) P2PStats() (*P2PStatsResponse, error) {
+	var out P2PStatsResponse
+	return &out, c.doGet("/p2p/stats", nil, &out)
+}

--- a/tools/go-sdk/client_test.go
+++ b/tools/go-sdk/client_test.go
@@ -1,0 +1,499 @@
+package rustchain
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// helper: create a test server that returns the given JSON body for a path.
+func newTestServer(t *testing.T, handlers map[string]interface{}) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	for path, resp := range handlers {
+		body, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write(body)
+		})
+	}
+	return httptest.NewServer(mux)
+}
+
+func TestHealth(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/health": HealthResponse{
+			OK:            true,
+			Version:       "2.2.1-security-hardened",
+			UptimeSeconds: 86400,
+			DBRW:          true,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.Health()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.Version != "2.2.1-security-hardened" {
+		t.Errorf("unexpected version %q", resp.Version)
+	}
+	if resp.UptimeSeconds != 86400 {
+		t.Errorf("unexpected uptime %f", resp.UptimeSeconds)
+	}
+}
+
+func TestReady(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/ready": ReadinessResponse{Ready: true, Version: "2.2.1"},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.Ready()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Ready {
+		t.Error("expected ready=true")
+	}
+}
+
+func TestStats(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/api/stats": StatsResponse{
+			Version:     "2.2.1",
+			ChainID:     "rustchain-mainnet-candidate",
+			Epoch:       42,
+			TotalMiners: 150,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.Stats()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Epoch != 42 {
+		t.Errorf("expected epoch 42, got %d", resp.Epoch)
+	}
+	if resp.TotalMiners != 150 {
+		t.Errorf("expected 150 miners, got %d", resp.TotalMiners)
+	}
+}
+
+func TestEpoch(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/epoch": EpochResponse{
+			Epoch:          42,
+			Slot:           25200,
+			EpochPot:       1.5,
+			EnrolledMiners: 12,
+			BlocksPerEpoch: 600,
+			TotalSupplyRTC: 21000000,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.Epoch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Epoch != 42 {
+		t.Errorf("expected epoch 42, got %d", resp.Epoch)
+	}
+	if resp.EnrolledMiners != 12 {
+		t.Errorf("expected 12 enrolled miners, got %d", resp.EnrolledMiners)
+	}
+}
+
+func TestWalletBalance(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wallet/balance", func(w http.ResponseWriter, r *http.Request) {
+		minerID := r.URL.Query().Get("miner_id")
+		resp := WalletBalanceResponse{
+			MinerID:   minerID,
+			AmountI64: 42500000,
+			AmountRTC: 42.5,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.WalletBalance("g4-powerbook-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.MinerID != "g4-powerbook-01" {
+		t.Errorf("unexpected miner_id %q", resp.MinerID)
+	}
+	if resp.AmountRTC != 42.5 {
+		t.Errorf("expected 42.5 RTC, got %f", resp.AmountRTC)
+	}
+}
+
+func TestBalance(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/balance/RTCabc123", func(w http.ResponseWriter, r *http.Request) {
+		resp := BalanceResponse{
+			MinerPK:    "RTCabc123",
+			BalanceRTC: 10.0,
+			AmountI64:  10000000,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.Balance("RTCabc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.BalanceRTC != 10.0 {
+		t.Errorf("expected 10.0 RTC, got %f", resp.BalanceRTC)
+	}
+}
+
+func TestSignedTransfer(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wallet/transfer/signed", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", 405)
+			return
+		}
+		var req SignedTransferRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		resp := SignedTransferResponse{
+			OK:          true,
+			Verified:    true,
+			Phase:       "pending",
+			PendingID:   42,
+			TxHash:      "abc123def456",
+			FromAddress: req.FromAddress,
+			ToAddress:   req.ToAddress,
+			AmountRTC:   req.AmountRTC,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.SignedTransfer(&SignedTransferRequest{
+		FromAddress: "RTCsender",
+		ToAddress:   "RTCreceiver",
+		AmountRTC:   10.0,
+		Nonce:       "12345",
+		Signature:   "aabbccdd",
+		PublicKey:   "eeff0011",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.OK {
+		t.Error("expected ok=true")
+	}
+	if resp.PendingID != 42 {
+		t.Errorf("expected pending_id 42, got %d", resp.PendingID)
+	}
+}
+
+func TestChainTip(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/headers/tip": ChainTipResponse{
+			Slot:            25200,
+			Miner:           "g4-powerbook-01",
+			TipAge:          120,
+			SignaturePrefix: "a1b2c3d4",
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.ChainTip()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Slot != 25200 {
+		t.Errorf("expected slot 25200, got %d", resp.Slot)
+	}
+	if resp.Miner != "g4-powerbook-01" {
+		t.Errorf("unexpected miner %q", resp.Miner)
+	}
+}
+
+func TestMiners(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/miners", func(w http.ResponseWriter, r *http.Request) {
+		miners := []Miner{
+			{
+				MinerID:             "g4-powerbook-01",
+				DeviceFamily:        "powerpc",
+				DeviceArch:          "g4",
+				EntropyScore:        0.85,
+				AntiquityMultiplier: 2.0,
+			},
+		}
+		json.NewEncoder(w).Encode(miners)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	miners, err := c.Miners()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(miners) != 1 {
+		t.Fatalf("expected 1 miner, got %d", len(miners))
+	}
+	if miners[0].MinerID != "g4-powerbook-01" {
+		t.Errorf("unexpected miner id %q", miners[0].MinerID)
+	}
+}
+
+func TestBeaconSubmit(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/beacon/submit", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(201)
+		json.NewEncoder(w).Encode(BeaconSubmitResponse{OK: true, EnvelopeID: 42})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.BeaconSubmit(&BeaconSubmitRequest{
+		AgentID: "bcn_agent123",
+		Kind:    "heartbeat",
+		Nonce:   "nonce123",
+		Sig:     "aabbccdd",
+		Pubkey:  "eeff0011",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.EnvelopeID != 42 {
+		t.Errorf("expected envelope_id 42, got %d", resp.EnvelopeID)
+	}
+}
+
+func TestBeaconDigest(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/beacon/digest": BeaconDigestResponse{
+			OK:     true,
+			Digest: "sha256abc",
+			Count:  1000,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.BeaconDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1000 {
+		t.Errorf("expected count 1000, got %d", resp.Count)
+	}
+}
+
+func TestGovernanceProposals(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/governance/proposals": ProposalsResponse{
+			OK:    true,
+			Count: 1,
+			Proposals: []GovernanceProposal{
+				{ID: 1, Title: "Test Proposal", Status: "active"},
+			},
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.GovernanceProposals()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Count != 1 {
+		t.Errorf("expected 1 proposal, got %d", resp.Count)
+	}
+}
+
+func TestMinerDashboard(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/miner_dashboard/g4-powerbook-01", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(MinerDashboardResponse{
+			OK:         true,
+			MinerID:    "g4-powerbook-01",
+			BalanceRTC: 42.5,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.MinerDashboard("g4-powerbook-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.BalanceRTC != 42.5 {
+		t.Errorf("expected 42.5 RTC, got %f", resp.BalanceRTC)
+	}
+}
+
+func TestErrorResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		json.NewEncoder(w).Encode(ErrorResponse{
+			OK:      false,
+			Error:   "internal_error",
+			Message: "something went wrong",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	_, err := c.Health()
+	if err == nil {
+		t.Fatal("expected error for 500 status")
+	}
+}
+
+func TestWithAdminKey(t *testing.T) {
+	c := NewClient("http://localhost", WithAdminKey("secret"))
+	if c.AdminKey != "secret" {
+		t.Errorf("expected admin key 'secret', got %q", c.AdminKey)
+	}
+}
+
+func TestWithHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 5}
+	c := NewClient("http://localhost", WithHTTPClient(custom))
+	if c.HTTPClient != custom {
+		t.Error("expected custom HTTP client")
+	}
+}
+
+func TestLotteryEligibility(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/lottery/eligibility", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(EligibilityResponse{
+			Eligible: true,
+			MinerID:  r.URL.Query().Get("miner_id"),
+			Slot:     25200,
+			Reason:   "round_robin_selected",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.LotteryEligibility("g4-powerbook-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.Eligible {
+		t.Error("expected eligible=true")
+	}
+}
+
+func TestFeePool(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/api/fee_pool": FeePoolResponse{
+			RIP:                   301,
+			TotalFeesCollectedRTC: 1.5,
+			TotalFeeEvents:        150,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.FeePool()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.RIP != 301 {
+		t.Errorf("expected RIP 301, got %d", resp.RIP)
+	}
+}
+
+func TestWithdrawStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/withdraw/status/WD_123", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(WithdrawalStatus{
+			WithdrawalID: "WD_123",
+			Status:       "pending",
+			Amount:       10.0,
+			Fee:          0.01,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.WithdrawStatus("WD_123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Status != "pending" {
+		t.Errorf("expected pending, got %q", resp.Status)
+	}
+}
+
+func TestResolveWallet(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wallet/resolve", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ResolveWalletResponse{
+			OK:       true,
+			BeaconID: r.URL.Query().Get("address"),
+			RTCAddr:  "RTCabc",
+			Status:   "active",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.ResolveWallet("bcn_agent123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.BeaconID != "bcn_agent123" {
+		t.Errorf("unexpected beacon id %q", resp.BeaconID)
+	}
+}
+
+func TestBountyMultiplier(t *testing.T) {
+	srv := newTestServer(t, map[string]interface{}{
+		"/api/bounty-multiplier": BountyMultiplierResponse{
+			OK:                true,
+			DecayModel:        "half-life",
+			CurrentMultiplier: 0.87,
+		},
+	})
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	resp, err := c.BountyMultiplier()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.CurrentMultiplier != 0.87 {
+		t.Errorf("expected 0.87, got %f", resp.CurrentMultiplier)
+	}
+}

--- a/tools/go-sdk/go.mod
+++ b/tools/go-sdk/go.mod
@@ -1,0 +1,3 @@
+module github.com/CelebrityPunks/Rustchain/tools/go-sdk
+
+go 1.21

--- a/tools/go-sdk/types.go
+++ b/tools/go-sdk/types.go
@@ -1,0 +1,465 @@
+package rustchain
+
+// HealthResponse is returned by GET /health.
+type HealthResponse struct {
+	OK            bool    `json:"ok"`
+	Version       string  `json:"version"`
+	UptimeSeconds float64 `json:"uptime_s"`
+	DBRW          bool    `json:"db_rw"`
+	BackupAgeHrs  float64 `json:"backup_age_hours,omitempty"`
+	TipAgeSlots   int     `json:"tip_age_slots,omitempty"`
+}
+
+// ReadinessResponse is returned by GET /ready.
+type ReadinessResponse struct {
+	Ready   bool   `json:"ready"`
+	Version string `json:"version"`
+}
+
+// StatsResponse is returned by GET /api/stats.
+type StatsResponse struct {
+	Version            string   `json:"version"`
+	ChainID            string   `json:"chain_id"`
+	Epoch              int      `json:"epoch"`
+	BlockTime          int      `json:"block_time"`
+	TotalMiners        int      `json:"total_miners"`
+	TotalBalance       float64  `json:"total_balance"`
+	PendingWithdrawals int      `json:"pending_withdrawals"`
+	Features           []string `json:"features"`
+	Security           []string `json:"security"`
+}
+
+// EpochResponse is returned by GET /epoch.
+type EpochResponse struct {
+	Epoch          int     `json:"epoch"`
+	Slot           int     `json:"slot"`
+	EpochPot       float64 `json:"epoch_pot"`
+	EnrolledMiners int     `json:"enrolled_miners"`
+	BlocksPerEpoch int     `json:"blocks_per_epoch"`
+	TotalSupplyRTC float64 `json:"total_supply_rtc"`
+}
+
+// EnrollRequest is sent to POST /epoch/enroll.
+type EnrollRequest struct {
+	MinerPubkey string       `json:"miner_pubkey"`
+	MinerID     string       `json:"miner_id"`
+	Device      EnrollDevice `json:"device"`
+}
+
+// EnrollDevice describes the miner hardware for enrollment.
+type EnrollDevice struct {
+	Family string `json:"family"`
+	Arch   string `json:"arch"`
+}
+
+// EnrollResponse is returned by POST /epoch/enroll.
+type EnrollResponse struct {
+	OK                bool    `json:"ok"`
+	Epoch             int     `json:"epoch"`
+	Weight            float64 `json:"weight"`
+	HWWeight          float64 `json:"hw_weight"`
+	FingerprintFailed bool    `json:"fingerprint_failed"`
+	MinerPK           string  `json:"miner_pk"`
+	MinerID           string  `json:"miner_id"`
+}
+
+// EligibilityResponse is returned by GET /lottery/eligibility.
+type EligibilityResponse struct {
+	Eligible bool   `json:"eligible"`
+	MinerID  string `json:"miner_id"`
+	Slot     int    `json:"slot"`
+	Reason   string `json:"reason"`
+}
+
+// EpochReward represents a single miner reward entry.
+type EpochReward struct {
+	MinerID  string  `json:"miner_id"`
+	ShareI64 int64   `json:"share_i64"`
+	ShareRTC float64 `json:"share_rtc"`
+}
+
+// EpochRewardsResponse is returned by GET /rewards/epoch/:epoch.
+type EpochRewardsResponse struct {
+	Epoch   int           `json:"epoch"`
+	Rewards []EpochReward `json:"rewards"`
+}
+
+// BalanceResponse is returned by GET /balance/:minerPk.
+type BalanceResponse struct {
+	MinerPK    string  `json:"miner_pk"`
+	BalanceRTC float64 `json:"balance_rtc"`
+	AmountI64  int64   `json:"amount_i64"`
+}
+
+// WalletBalanceResponse is returned by GET /wallet/balance.
+type WalletBalanceResponse struct {
+	MinerID   string  `json:"miner_id"`
+	AmountI64 int64   `json:"amount_i64"`
+	AmountRTC float64 `json:"amount_rtc"`
+}
+
+// TransferHistoryEntry represents a single transfer record.
+type TransferHistoryEntry struct {
+	ID            int     `json:"id"`
+	TxID          string  `json:"tx_id"`
+	TxHash        string  `json:"tx_hash"`
+	FromAddr      string  `json:"from_addr"`
+	ToAddr        string  `json:"to_addr"`
+	Amount        float64 `json:"amount"`
+	AmountI64     int64   `json:"amount_i64"`
+	AmountRTC     float64 `json:"amount_rtc"`
+	Timestamp     int64   `json:"timestamp"`
+	CreatedAt     int64   `json:"created_at"`
+	ConfirmedAt   int64   `json:"confirmed_at"`
+	ConfirmsAt    int64   `json:"confirms_at"`
+	Status        string  `json:"status"`
+	Direction     string  `json:"direction"`
+	Counterparty  string  `json:"counterparty"`
+	Reason        string  `json:"reason"`
+	Memo          string  `json:"memo"`
+	Confirmations int     `json:"confirmations"`
+}
+
+// SignedTransferRequest is sent to POST /wallet/transfer/signed.
+type SignedTransferRequest struct {
+	FromAddress string  `json:"from_address"`
+	ToAddress   string  `json:"to_address"`
+	AmountRTC   float64 `json:"amount_rtc"`
+	Nonce       string  `json:"nonce"`
+	Signature   string  `json:"signature"`
+	PublicKey   string  `json:"public_key"`
+	Memo        string  `json:"memo,omitempty"`
+	ChainID     string  `json:"chain_id,omitempty"`
+}
+
+// SignedTransferResponse is returned by POST /wallet/transfer/signed.
+type SignedTransferResponse struct {
+	OK              bool    `json:"ok"`
+	Verified        bool    `json:"verified"`
+	SignatureType   string  `json:"signature_type"`
+	ReplayProtected bool    `json:"replay_protected"`
+	Phase           string  `json:"phase"`
+	PendingID       int     `json:"pending_id"`
+	TxHash          string  `json:"tx_hash"`
+	FromAddress     string  `json:"from_address"`
+	ToAddress       string  `json:"to_address"`
+	AmountRTC       float64 `json:"amount_rtc"`
+	ChainID         string  `json:"chain_id"`
+	ConfirmsAt      int64   `json:"confirms_at"`
+	ConfirmsInHours float64 `json:"confirms_in_hours"`
+	Message         string  `json:"message"`
+}
+
+// ResolveWalletResponse is returned by GET /wallet/resolve.
+type ResolveWalletResponse struct {
+	OK        bool   `json:"ok"`
+	BeaconID  string `json:"beacon_id"`
+	PubkeyHex string `json:"pubkey_hex"`
+	RTCAddr   string `json:"rtc_address"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+}
+
+// ChainTipResponse is returned by GET /headers/tip.
+type ChainTipResponse struct {
+	Slot            int    `json:"slot"`
+	Miner           string `json:"miner"`
+	TipAge          int    `json:"tip_age"`
+	SignaturePrefix string `json:"signature_prefix"`
+}
+
+// AttestChallengeResponse is returned by POST /attest/challenge.
+type AttestChallengeResponse struct {
+	Nonce      string `json:"nonce"`
+	ExpiresAt  int64  `json:"expires_at"`
+	ServerTime int64  `json:"server_time"`
+}
+
+// AttestSubmitRequest is sent to POST /attest/submit.
+type AttestSubmitRequest struct {
+	Miner       string              `json:"miner"`
+	Nonce       string              `json:"nonce"`
+	Report      AttestReport        `json:"report"`
+	Device      AttestDevice        `json:"device"`
+	Signals     AttestSignals       `json:"signals"`
+	Fingerprint AttestFingerprint   `json:"fingerprint"`
+}
+
+// AttestReport is the hardware attestation report.
+type AttestReport struct {
+	Nonce          string   `json:"nonce"`
+	DeviceModel    string   `json:"device_model"`
+	DeviceArch     string   `json:"device_arch"`
+	DeviceFamily   string   `json:"device_family"`
+	Cores          int      `json:"cores"`
+	CPUSerial      string   `json:"cpu_serial"`
+	EntropySources []string `json:"entropy_sources"`
+	EntropyScore   float64  `json:"entropy_score"`
+}
+
+// AttestDevice describes the attesting hardware.
+type AttestDevice struct {
+	DeviceModel  string `json:"device_model"`
+	DeviceArch   string `json:"device_arch"`
+	DeviceFamily string `json:"device_family"`
+	Cores        int    `json:"cores"`
+}
+
+// AttestSignals carries MAC addresses for OUI validation.
+type AttestSignals struct {
+	MACs []string `json:"macs"`
+}
+
+// AttestFingerprint carries CPU fingerprint data.
+type AttestFingerprint struct {
+	CPUFlags string `json:"cpu_flags"`
+	BootID   string `json:"boot_id"`
+}
+
+// AttestSubmitResponse is returned by POST /attest/submit.
+type AttestSubmitResponse struct {
+	OK                bool    `json:"ok"`
+	Miner             string  `json:"miner"`
+	Accepted          bool    `json:"accepted"`
+	EntropyScore      float64 `json:"entropy_score"`
+	FingerprintPassed bool    `json:"fingerprint_passed"`
+	TemporalReview    bool    `json:"temporal_review_flag"`
+	MACsRecorded      int     `json:"macs_recorded"`
+	WarthogBonus      int     `json:"warthog_bonus"`
+}
+
+// Miner represents an active miner from GET /api/miners.
+type Miner struct {
+	MinerID             string  `json:"miner"`
+	LastAttest          int64   `json:"last_attest"`
+	FirstAttest         int64   `json:"first_attest"`
+	DeviceFamily        string  `json:"device_family"`
+	DeviceArch          string  `json:"device_arch"`
+	HardwareType        string  `json:"hardware_type"`
+	EntropyScore        float64 `json:"entropy_score"`
+	AntiquityMultiplier float64 `json:"antiquity_multiplier"`
+}
+
+// MinerDashboardResponse is returned by GET /api/miner_dashboard/:minerID.
+type MinerDashboardResponse struct {
+	OK                 bool            `json:"ok"`
+	MinerID            string          `json:"miner_id"`
+	BalanceRTC         float64         `json:"balance_rtc"`
+	TotalEarnedRTC     float64         `json:"total_earned_rtc"`
+	RewardEvents       int             `json:"reward_events"`
+	EpochParticipation int             `json:"epoch_participation"`
+	RewardHistory      []RewardEntry   `json:"reward_history"`
+	AttestTimeline24h  []AttestBucket  `json:"attest_timeline_24h"`
+	GeneratedAt        int64           `json:"generated_at"`
+}
+
+// RewardEntry is a single epoch reward history item.
+type RewardEntry struct {
+	Epoch       int     `json:"epoch"`
+	AmountRTC   float64 `json:"amount_rtc"`
+	TxHash      string  `json:"tx_hash"`
+	ConfirmedAt int64   `json:"confirmed_at"`
+}
+
+// AttestBucket is an hourly attestation count.
+type AttestBucket struct {
+	HourBucket int `json:"hour_bucket"`
+	Count      int `json:"count"`
+}
+
+// BountyMultiplierResponse is returned by GET /api/bounty-multiplier.
+type BountyMultiplierResponse struct {
+	OK                   bool    `json:"ok"`
+	DecayModel           string  `json:"decay_model"`
+	HalfLifeRTC          float64 `json:"half_life_rtc"`
+	InitialFundRTC       float64 `json:"initial_fund_rtc"`
+	TotalPaidRTC         float64 `json:"total_paid_rtc"`
+	RemainingRTC         float64 `json:"remaining_rtc"`
+	CurrentMultiplier    float64 `json:"current_multiplier"`
+	CurrentMultiplierPct string  `json:"current_multiplier_pct"`
+}
+
+// FeePoolResponse is returned by GET /api/fee_pool.
+type FeePoolResponse struct {
+	RIP                    int     `json:"rip"`
+	Description            string  `json:"description"`
+	TotalFeesCollectedRTC  float64 `json:"total_fees_collected_rtc"`
+	TotalFeeEvents         int     `json:"total_fee_events"`
+	Destination            string  `json:"destination"`
+	DestinationBalanceRTC  float64 `json:"destination_balance_rtc"`
+	WithdrawalFeeRTC       float64 `json:"withdrawal_fee_rtc"`
+}
+
+// WithdrawalRequest is sent to POST /withdraw/request.
+type WithdrawalRequest struct {
+	MinerPK     string  `json:"miner_pk"`
+	Amount      float64 `json:"amount"`
+	Destination string  `json:"destination"`
+	Signature   string  `json:"signature"`
+	Nonce       string  `json:"nonce"`
+}
+
+// WithdrawalResponse is returned by POST /withdraw/request.
+type WithdrawalResponse struct {
+	WithdrawalID string  `json:"withdrawal_id"`
+	Status       string  `json:"status"`
+	Amount       float64 `json:"amount"`
+	Fee          float64 `json:"fee"`
+	NetAmount    float64 `json:"net_amount"`
+}
+
+// WithdrawalStatus is returned by GET /withdraw/status/:id.
+type WithdrawalStatus struct {
+	WithdrawalID string  `json:"withdrawal_id"`
+	MinerPK      string  `json:"miner_pk"`
+	Amount       float64 `json:"amount"`
+	Fee          float64 `json:"fee"`
+	Destination  string  `json:"destination"`
+	Status       string  `json:"status"`
+	CreatedAt    int64   `json:"created_at"`
+	ProcessedAt  *int64  `json:"processed_at"`
+	TxHash       *string `json:"tx_hash"`
+	ErrorMsg     *string `json:"error_msg"`
+}
+
+// Node represents a registered network node.
+type Node struct {
+	NodeID       string `json:"node_id"`
+	Wallet       string `json:"wallet"`
+	URL          string `json:"url"`
+	Name         string `json:"name"`
+	RegisteredAt int64  `json:"registered_at"`
+	IsActive     bool   `json:"is_active"`
+	Online       bool   `json:"online"`
+}
+
+// NodesResponse is returned by GET /api/nodes.
+type NodesResponse struct {
+	Nodes []Node `json:"nodes"`
+	Count int    `json:"count"`
+}
+
+// BadgeResponse is returned by GET /api/badge/:minerID.
+type BadgeResponse struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	Label         string `json:"label"`
+	Message       string `json:"message"`
+	Color         string `json:"color"`
+}
+
+// BeaconSubmitRequest is sent to POST /beacon/submit.
+type BeaconSubmitRequest struct {
+	AgentID string `json:"agent_id"`
+	Kind    string `json:"kind"`
+	Nonce   string `json:"nonce"`
+	Sig     string `json:"sig"`
+	Pubkey  string `json:"pubkey"`
+}
+
+// BeaconSubmitResponse is returned by POST /beacon/submit.
+type BeaconSubmitResponse struct {
+	OK         bool `json:"ok"`
+	EnvelopeID int  `json:"envelope_id"`
+}
+
+// BeaconDigestResponse is returned by GET /beacon/digest.
+type BeaconDigestResponse struct {
+	OK       bool   `json:"ok"`
+	Digest   string `json:"digest"`
+	Count    int    `json:"count"`
+	LatestTS int64  `json:"latest_ts"`
+}
+
+// BeaconEnvelopesResponse is returned by GET /beacon/envelopes.
+type BeaconEnvelopesResponse struct {
+	OK        bool          `json:"ok"`
+	Count     int           `json:"count"`
+	Envelopes []interface{} `json:"envelopes"`
+}
+
+// GovernanceProposal represents a governance proposal.
+type GovernanceProposal struct {
+	ID              int     `json:"id"`
+	ProposerWallet  string  `json:"proposer_wallet"`
+	Title           string  `json:"title"`
+	Description     string  `json:"description"`
+	CreatedAt       int64   `json:"created_at"`
+	ActivatedAt     int64   `json:"activated_at"`
+	EndsAt          int64   `json:"ends_at"`
+	Status          string  `json:"status"`
+	YesWeight       float64 `json:"yes_weight"`
+	NoWeight        float64 `json:"no_weight"`
+	TotalWeight     float64 `json:"total_weight,omitempty"`
+	Result          string  `json:"result,omitempty"`
+}
+
+// ProposalsResponse is returned by GET /governance/proposals.
+type ProposalsResponse struct {
+	OK        bool                 `json:"ok"`
+	Count     int                  `json:"count"`
+	Proposals []GovernanceProposal `json:"proposals"`
+}
+
+// ProposalDetailResponse is returned by GET /governance/proposal/:id.
+type ProposalDetailResponse struct {
+	OK       bool               `json:"ok"`
+	Proposal GovernanceProposal `json:"proposal"`
+	Votes    []ProposalVote     `json:"votes"`
+}
+
+// ProposalVote is a single vote on a proposal.
+type ProposalVote struct {
+	VoterWallet    string  `json:"voter_wallet"`
+	Vote           string  `json:"vote"`
+	Weight         float64 `json:"weight"`
+	Multiplier     float64 `json:"multiplier"`
+	BaseBalanceRTC float64 `json:"base_balance_rtc"`
+	CreatedAt      int64   `json:"created_at"`
+}
+
+// ProposeRequest is sent to POST /governance/propose.
+type ProposeRequest struct {
+	Wallet      string `json:"wallet"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+}
+
+// VoteRequest is sent to POST /governance/vote.
+type VoteRequest struct {
+	ProposalID int    `json:"proposal_id"`
+	Wallet     string `json:"wallet"`
+	Vote       string `json:"vote"`
+	Nonce      string `json:"nonce"`
+	Signature  string `json:"signature"`
+	PublicKey  string `json:"public_key"`
+}
+
+// VoteResponse is returned by POST /governance/vote.
+type VoteResponse struct {
+	OK                   bool    `json:"ok"`
+	ProposalID           int     `json:"proposal_id"`
+	VoterWallet          string  `json:"voter_wallet"`
+	Vote                 string  `json:"vote"`
+	BaseBalanceRTC       float64 `json:"base_balance_rtc"`
+	AntiquityMultiplier  float64 `json:"antiquity_multiplier"`
+	VoteWeight           float64 `json:"vote_weight"`
+	Status               string  `json:"status"`
+	YesWeight            float64 `json:"yes_weight"`
+	NoWeight             float64 `json:"no_weight"`
+	Result               string  `json:"result"`
+}
+
+// P2PStatsResponse is returned by GET /p2p/stats.
+type P2PStatsResponse struct {
+	OK        bool          `json:"ok"`
+	Peers     []interface{} `json:"peers,omitempty"`
+	SyncState interface{}   `json:"sync_state,omitempty"`
+}
+
+// ErrorResponse represents an API error.
+type ErrorResponse struct {
+	OK      bool   `json:"ok"`
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+	Code    string `json:"code,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Adds a full-featured Go SDK client under `tools/go-sdk/` for the RustChain v2.2.1 API
- Covers all public endpoints: health, epochs, wallet/balance, attestation, beacon protocol, governance, withdrawals, P2P
- Includes typed request/response structs, functional options (`WithAdminKey`, `WithInsecureTLS`, `WithHTTPClient`), and `httptest`-based unit tests

## Files

- `tools/go-sdk/go.mod` — module definition
- `tools/go-sdk/types.go` — Go structs for all API request/response types
- `tools/go-sdk/client.go` — `RustChainClient` with methods for every endpoint
- `tools/go-sdk/client_test.go` — unit tests using `net/http/httptest`
- `tools/go-sdk/README.md` — usage docs, quick start, and method coverage table

## Test plan

- [ ] `cd tools/go-sdk && go test -v ./...`
- [ ] Verify all 20 tests pass against httptest mock servers
- [ ] Smoke-test `Health()` and `WalletBalance()` against live node