### PR TITLE
Add Kubernetes deployment manifests

### DIFF
--- a/deploy/kubernetes/README.md
+++ b/deploy/kubernetes/README.md
@@ -1,0 +1,172 @@
+# RustChain Kubernetes Deployment
+
+Production-ready Kubernetes manifests for deploying a RustChain node with monitoring.
+
+## Architecture
+
+```
+                    ┌─────────────┐
+                    │   Ingress   │
+                    │ (nginx+TLS) │
+                    └──────┬──────┘
+                           │
+              ┌────────────┼────────────┐
+              │            │            │
+        ┌─────▼─────┐ ┌───▼───┐ ┌─────▼─────┐
+        │  Dashboard │ │  API  │ │  Grafana  │
+        │   :8099    │ │ :8088 │ │   :3000   │
+        └─────┬──────┘ └───┬───┘ └─────┬─────┘
+              │            │            │
+        ┌─────▼────────────▼──┐  ┌─────▼──────┐
+        │   RustChain Node    │  │ Prometheus  │
+        │  (PVC: data + dl)   │  │ (PVC: 10G) │
+        └─────────────────────┘  └─────────────┘
+```
+
+## Prerequisites
+
+- Kubernetes 1.24+
+- kubectl configured for your cluster
+- nginx ingress controller installed
+- (Optional) cert-manager for automated TLS
+
+## Quick Start
+
+### Using kustomize
+
+```bash
+# Preview what will be applied
+kubectl kustomize deploy/kubernetes/
+
+# Deploy everything
+kubectl apply -k deploy/kubernetes/
+```
+
+### Manual step-by-step
+
+```bash
+# 1. Create the namespace
+kubectl apply -f deploy/kubernetes/namespace.yaml
+
+# 2. Update secrets with real values
+#    Edit secret.yaml and replace all CHANGE_ME placeholders
+vim deploy/kubernetes/secret.yaml
+
+# 3. Apply configuration
+kubectl apply -f deploy/kubernetes/configmap.yaml
+kubectl apply -f deploy/kubernetes/secret.yaml
+
+# 4. Deploy the node
+kubectl apply -f deploy/kubernetes/node-deployment.yaml
+kubectl apply -f deploy/kubernetes/node-service.yaml
+
+# 5. Deploy monitoring
+kubectl apply -f deploy/kubernetes/monitoring-deployment.yaml
+
+# 6. Configure ingress (update hostname first)
+kubectl apply -f deploy/kubernetes/ingress.yaml
+```
+
+## Configuration
+
+### Secrets
+
+Before deploying, update `secret.yaml` with real values:
+
+| Key | Description |
+|-----|-------------|
+| `ADMIN_API_KEY` | API key for admin endpoints |
+| `ADMIN_WALLET_ADDRESS` | Admin wallet address |
+| `ADMIN_PRIVATE_KEY` | Admin wallet private key |
+| `GF_SECURITY_ADMIN_PASSWORD` | Grafana admin password |
+
+### Ingress
+
+Edit `ingress.yaml` and replace `rustchain.example.com` with your domain.
+
+For automated TLS with cert-manager, uncomment the `cert-manager.io/cluster-issuer` annotation.
+
+For manual TLS, create the secret:
+
+```bash
+kubectl create secret tls rustchain-tls \
+  --cert=path/to/tls.crt \
+  --key=path/to/tls.key \
+  -n rustchain
+```
+
+### Node Configuration
+
+Environment variables are managed through `configmap.yaml`. Key settings:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NODE_HOST` | `0.0.0.0` | Bind address |
+| `NODE_PORT` | `8099` | Dashboard port |
+| `API_PORT` | `8088` | API port |
+| `LOG_LEVEL` | `INFO` | Log verbosity |
+
+## Access
+
+### Dashboard (via NodePort)
+
+```bash
+# Get the node IP
+kubectl get nodes -o wide
+
+# Access dashboard at http://<node-ip>:30099
+# Access API at http://<node-ip>:30088
+```
+
+### Grafana
+
+```bash
+# Port-forward for local access
+kubectl port-forward svc/rustchain-grafana 3000:3000 -n rustchain
+
+# Open http://localhost:3000 (admin / <your-password>)
+```
+
+### Prometheus
+
+```bash
+kubectl port-forward svc/rustchain-prometheus 9090:9090 -n rustchain
+```
+
+## Operations
+
+### Check status
+
+```bash
+kubectl get all -n rustchain
+kubectl get pvc -n rustchain
+```
+
+### View logs
+
+```bash
+kubectl logs -f deployment/rustchain-node -n rustchain
+kubectl logs -f deployment/rustchain-monitoring -c prometheus -n rustchain
+kubectl logs -f deployment/rustchain-monitoring -c grafana -n rustchain
+```
+
+### Scale (if running stateless replicas behind a shared DB)
+
+```bash
+kubectl scale deployment rustchain-node --replicas=3 -n rustchain
+```
+
+### Cleanup
+
+```bash
+kubectl delete -k deploy/kubernetes/
+```
+
+## Storage
+
+| PVC | Size | Purpose |
+|-----|------|---------|
+| `rustchain-data-pvc` | 10Gi | SQLite database |
+| `rustchain-downloads-pvc` | 5Gi | Downloaded files |
+| `prometheus-data-pvc` | 10Gi | Metrics (30d retention) |
+| `grafana-data-pvc` | 2Gi | Dashboards and config |

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rustchain-config
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+data:
+  RUSTCHAIN_HOME: "/rustchain"
+  RUSTCHAIN_DB: "/rustchain/data/rustchain_v2.db"
+  DOWNLOAD_DIR: "/rustchain/downloads"
+  PYTHONUNBUFFERED: "1"
+  # Node networking
+  NODE_HOST: "0.0.0.0"
+  NODE_PORT: "8099"
+  API_PORT: "8088"
+  # Logging
+  LOG_LEVEL: "INFO"
+  # Prometheus exporter
+  RUSTCHAIN_NODE: "http://rustchain-node:8099"
+  EXPORTER_PORT: "9100"
+  SCRAPE_INTERVAL: "30"
+  TLS_VERIFY: "false"
+  # Prometheus config
+  prometheus.yml: |
+    global:
+      scrape_interval: 30s
+      evaluation_interval: 30s
+    scrape_configs:
+      - job_name: 'rustchain-exporter'
+        static_configs:
+          - targets: ['localhost:9100']
+      - job_name: 'rustchain-node'
+        metrics_path: /metrics
+        static_configs:
+          - targets: ['rustchain-node:8099']
+    alerting:
+      alertmanagers:
+        - static_configs:
+            - targets: []
+  # Grafana datasource provisioning
+  grafana-datasource.yml: |
+    apiVersion: 1
+    datasources:
+      - name: Prometheus
+        type: prometheus
+        access: proxy
+        url: http://localhost:9090
+        isDefault: true
+        editable: false

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -1,0 +1,59 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: rustchain-ingress
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "60"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+    # WebSocket support
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    # Security headers
+    nginx.ingress.kubernetes.io/server-snippets: |
+      add_header X-Frame-Options "SAMEORIGIN" always;
+      add_header X-Content-Type-Options "nosniff" always;
+      add_header X-XSS-Protection "1; mode=block" always;
+      add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    # TLS via cert-manager (uncomment when cert-manager is installed)
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - rustchain.example.com
+      secretName: rustchain-tls
+  rules:
+    - host: rustchain.example.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: rustchain-node
+                port:
+                  name: dashboard
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: rustchain-node
+                port:
+                  name: api
+          - path: /grafana
+            pathType: Prefix
+            backend:
+              service:
+                name: rustchain-grafana
+                port:
+                  name: grafana

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: rustchain
+
+commonLabels:
+  app.kubernetes.io/managed-by: kustomize
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - secret.yaml
+  - node-deployment.yaml
+  - node-service.yaml
+  - monitoring-deployment.yaml
+  - ingress.yaml
+
+images:
+  - name: rustchain/node
+    newTag: latest

--- a/deploy/kubernetes/monitoring-deployment.yaml
+++ b/deploy/kubernetes/monitoring-deployment.yaml
@@ -1,0 +1,193 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustchain-monitoring
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rustchain
+      app.kubernetes.io/component: monitoring
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rustchain
+        app.kubernetes.io/component: monitoring
+    spec:
+      securityContext:
+        fsGroup: 472
+      containers:
+        # Prometheus
+        - name: prometheus
+          image: prom/prometheus:v2.51.0
+          args:
+            - "--config.file=/etc/prometheus/prometheus.yml"
+            - "--storage.tsdb.path=/prometheus"
+            - "--storage.tsdb.retention.time=30d"
+            - "--web.listen-address=:9090"
+          ports:
+            - name: prometheus
+              containerPort: 9090
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: prometheus
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: prometheus
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+            - name: prometheus-data
+              mountPath: /prometheus
+
+        # Grafana
+        - name: grafana
+          image: grafana/grafana:10.4.1
+          ports:
+            - name: grafana
+              containerPort: 3000
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: grafana-secrets
+          env:
+            - name: GF_INSTALL_PLUGINS
+              value: ""
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: grafana
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: grafana
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: grafana-data
+              mountPath: /var/lib/grafana
+            - name: grafana-datasource
+              mountPath: /etc/grafana/provisioning/datasources/prometheus.yml
+              subPath: grafana-datasource.yml
+
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: rustchain-config
+            items:
+              - key: prometheus.yml
+                path: prometheus.yml
+        - name: grafana-datasource
+          configMap:
+            name: rustchain-config
+            items:
+              - key: grafana-datasource.yml
+                path: grafana-datasource.yml
+        - name: prometheus-data
+          persistentVolumeClaim:
+            claimName: prometheus-data-pvc
+        - name: grafana-data
+          persistentVolumeClaim:
+            claimName: grafana-data-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data-pvc
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-data-pvc
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustchain-prometheus
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+  ports:
+    - name: prometheus
+      port: 9090
+      targetPort: prometheus
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustchain-grafana
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+  ports:
+    - name: grafana
+      port: 3000
+      targetPort: grafana
+      protocol: TCP

--- a/deploy/kubernetes/namespace.yaml
+++ b/deploy/kubernetes/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/part-of: rustchain

--- a/deploy/kubernetes/node-deployment.yaml
+++ b/deploy/kubernetes/node-deployment.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rustchain-node
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: rustchain
+      app.kubernetes.io/component: node
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: rustchain
+        app.kubernetes.io/component: node
+    spec:
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: rustchain-node
+          image: rustchain/node:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: dashboard
+              containerPort: 8099
+              protocol: TCP
+            - name: api
+              containerPort: 8088
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: rustchain-config
+            - secretRef:
+                name: rustchain-secrets
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: dashboard
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: dashboard
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 3
+          startupProbe:
+            httpGet:
+              path: /health
+              port: dashboard
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+          volumeMounts:
+            - name: rustchain-data
+              mountPath: /rustchain/data
+            - name: rustchain-downloads
+              mountPath: /rustchain/downloads
+      volumes:
+        - name: rustchain-data
+          persistentVolumeClaim:
+            claimName: rustchain-data-pvc
+        - name: rustchain-downloads
+          persistentVolumeClaim:
+            claimName: rustchain-downloads-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustchain-data-pvc
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: rustchain-downloads-pvc
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/kubernetes/node-service.yaml
+++ b/deploy/kubernetes/node-service.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustchain-node
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+  ports:
+    - name: dashboard
+      port: 8099
+      targetPort: dashboard
+      protocol: TCP
+    - name: api
+      port: 8088
+      targetPort: api
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rustchain-node-external
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+spec:
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+  ports:
+    - name: dashboard
+      port: 8099
+      targetPort: dashboard
+      nodePort: 30099
+      protocol: TCP
+    - name: api
+      port: 8088
+      targetPort: api
+      nodePort: 30088
+      protocol: TCP

--- a/deploy/kubernetes/secret.yaml
+++ b/deploy/kubernetes/secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rustchain-secrets
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: node
+type: Opaque
+stringData:
+  # Replace these placeholder values before deploying
+  ADMIN_API_KEY: "CHANGE_ME_admin_api_key"
+  ADMIN_WALLET_ADDRESS: "CHANGE_ME_wallet_address"
+  ADMIN_PRIVATE_KEY: "CHANGE_ME_private_key"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-secrets
+  namespace: rustchain
+  labels:
+    app.kubernetes.io/name: rustchain
+    app.kubernetes.io/component: monitoring
+type: Opaque
+stringData:
+  GF_SECURITY_ADMIN_USER: "admin"
+  GF_SECURITY_ADMIN_PASSWORD: "CHANGE_ME_grafana_password"


### PR DESCRIPTION
## Summary

- Add production-ready Kubernetes manifests under `deploy/kubernetes/` for deploying RustChain nodes to any K8s cluster
- Includes node deployment with health probes (liveness, readiness, startup), persistent volume claims, and resource limits
- Bundles Prometheus + Grafana monitoring stack as a sidecar deployment with pre-configured datasource provisioning
- Provides nginx ingress with TLS termination, WebSocket support, and security headers
- Ships with kustomize overlay for one-command deploys (`kubectl apply -k deploy/kubernetes/`)

## Manifests

| File | Purpose |
|------|---------|
| `namespace.yaml` | Dedicated `rustchain` namespace |
| `configmap.yaml` | Node config, Prometheus scrape config, Grafana datasource |
| `secret.yaml` | Template for admin keys and Grafana credentials |
| `node-deployment.yaml` | RustChain node + PVCs for data and downloads |
| `node-service.yaml` | ClusterIP (internal) + NodePort (external access) |
| `monitoring-deployment.yaml` | Prometheus + Grafana with persistent storage |
| `ingress.yaml` | Nginx ingress with TLS and security headers |
| `kustomization.yaml` | Kustomize entrypoint |

## Test plan

- [ ] `kubectl kustomize deploy/kubernetes/` renders all resources without errors
- [ ] `kubectl apply -k deploy/kubernetes/` deploys successfully to a test cluster
- [ ] Node health checks pass after startup period
- [ ] Prometheus scrapes metrics from the RustChain node
- [ ] Grafana datasource auto-provisions and connects to Prometheus
- [ ] Ingress routes traffic to dashboard, API, and Grafana paths
- [ ] NodePort services are accessible on ports 30099/30088