### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/deploy/helm/rustchain/Chart.yaml
+++ b/deploy/helm/rustchain/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: rustchain
+description: Helm chart for deploying RustChain Proof-of-Antiquity blockchain node on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+keywords:
+  - blockchain
+  - rustchain
+  - proof-of-antiquity
+  - node
+maintainers:
+  - name: RustChain Community
+    url: https://github.com/CelebrityPunks/Rustchain
+home: https://github.com/CelebrityPunks/Rustchain
+sources:
+  - https://github.com/CelebrityPunks/Rustchain

--- a/deploy/helm/rustchain/README.md
+++ b/deploy/helm/rustchain/README.md
@@ -1,0 +1,98 @@
+# RustChain Helm Chart
+
+Helm chart for deploying a RustChain Proof-of-Antiquity blockchain node on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.x
+- A container image of RustChain pushed to a registry (see [Building the Image](#building-the-image))
+
+## Building the Image
+
+From the repository root:
+
+```bash
+docker build -t ghcr.io/celebritypunks/rustchain:latest .
+docker push ghcr.io/celebritypunks/rustchain:latest
+```
+
+## Installing the Chart
+
+```bash
+helm install rustchain ./deploy/helm/rustchain
+```
+
+With custom values:
+
+```bash
+helm install rustchain ./deploy/helm/rustchain -f my-values.yaml
+```
+
+## Uninstalling
+
+```bash
+helm uninstall rustchain
+```
+
+> PersistentVolumeClaims are not deleted automatically. To remove all data:
+> `kubectl delete pvc -l app.kubernetes.io/name=rustchain`
+
+## Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of pod replicas | `1` |
+| `image.repository` | Container image repository | `ghcr.io/celebritypunks/rustchain` |
+| `image.tag` | Container image tag | `latest` |
+| `rustchain.logLevel` | Application log level | `INFO` |
+| `rustchain.dashboardPort` | Dashboard HTTP port | `8099` |
+| `rustchain.apiPort` | API endpoint port | `8088` |
+| `persistence.data.enabled` | Enable persistent storage for chain data | `true` |
+| `persistence.data.size` | Size of the data volume | `10Gi` |
+| `persistence.downloads.enabled` | Enable persistent storage for downloads | `true` |
+| `persistence.downloads.size` | Size of the downloads volume | `5Gi` |
+| `ingress.enabled` | Enable Ingress resource | `false` |
+| `ingress.className` | Ingress class name | `nginx` |
+| `resources.limits.cpu` | CPU limit | `1` |
+| `resources.limits.memory` | Memory limit | `1Gi` |
+| `resources.requests.cpu` | CPU request | `250m` |
+| `resources.requests.memory` | Memory request | `256Mi` |
+| `secrets.githubToken` | GitHub API token (stored as Secret) | `""` |
+| `secrets.tipBotWallet` | Tip bot wallet address (stored as Secret) | `""` |
+
+## Enabling Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: rustchain.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: 8099
+  tls:
+    - secretName: rustchain-tls
+      hosts:
+        - rustchain.example.com
+```
+
+## Persistence
+
+The chart creates two PVCs by default:
+
+- **data** (`10Gi`) -- SQLite database and chain state at `/rustchain/data`
+- **downloads** (`5Gi`) -- Downloaded artifacts at `/rustchain/downloads`
+
+The Deployment uses `strategy: Recreate` to avoid volume mount conflicts with SQLite.
+
+## Security
+
+- Runs as non-root user (UID 1000)
+- Drops all Linux capabilities
+- Secrets are base64-encoded in a Kubernetes Secret resource
+- Pass sensitive values via `--set secrets.githubToken=<token>` rather than committing them to `values.yaml`

--- a/deploy/helm/rustchain/templates/NOTES.txt
+++ b/deploy/helm/rustchain/templates/NOTES.txt
@@ -1,0 +1,27 @@
+RustChain has been deployed successfully!
+
+1. Get the dashboard URL:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "rustchain.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  Watch status with:
+    kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "rustchain.fullname" . }}
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "rustchain.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.dashboardPort }}
+{{- else }}
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "rustchain.fullname" . }} 8099:{{ .Values.service.dashboardPort }}
+  Then open http://localhost:8099 in your browser.
+{{- end }}
+
+2. Check pod status:
+  kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "rustchain.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+3. View logs:
+  kubectl logs --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "rustchain.name" . }}" -f

--- a/deploy/helm/rustchain/templates/_helpers.tpl
+++ b/deploy/helm/rustchain/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "rustchain.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "rustchain.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "rustchain.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "rustchain.labels" -}}
+helm.sh/chart: {{ include "rustchain.chart" . }}
+{{ include "rustchain.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "rustchain.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "rustchain.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "rustchain.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "rustchain.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/rustchain/templates/configmap.yaml
+++ b/deploy/helm/rustchain/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "rustchain.fullname" . }}
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+data:
+  RUSTCHAIN_HOME: {{ .Values.rustchain.home | quote }}
+  RUSTCHAIN_DB: {{ .Values.rustchain.db | quote }}
+  DOWNLOAD_DIR: {{ .Values.rustchain.downloadDir | quote }}
+  LOG_LEVEL: {{ .Values.rustchain.logLevel | quote }}
+  {{- range $key, $value := .Values.config }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/deploy/helm/rustchain/templates/deployment.yaml
+++ b/deploy/helm/rustchain/templates/deployment.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "rustchain.fullname" . }}
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "rustchain.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "rustchain.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "rustchain.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: dashboard
+              containerPort: {{ .Values.rustchain.dashboardPort }}
+              protocol: TCP
+            - name: api
+              containerPort: {{ .Values.rustchain.apiPort }}
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "rustchain.fullname" . }}
+            - secretRef:
+                name: {{ include "rustchain.fullname" . }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.persistence.data.enabled }}
+            - name: data
+              mountPath: /rustchain/data
+            {{- end }}
+            {{- if .Values.persistence.downloads.enabled }}
+            - name: downloads
+              mountPath: /rustchain/downloads
+            {{- end }}
+      volumes:
+        {{- if .Values.persistence.data.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "rustchain.fullname" . }}-data
+        {{- end }}
+        {{- if .Values.persistence.downloads.enabled }}
+        - name: downloads
+          persistentVolumeClaim:
+            claimName: {{ include "rustchain.fullname" . }}-downloads
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/rustchain/templates/ingress.yaml
+++ b/deploy/helm/rustchain/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "rustchain.fullname" . }}
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "rustchain.fullname" $ }}
+                port:
+                  number: {{ .servicePort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/rustchain/templates/pvc.yaml
+++ b/deploy/helm/rustchain/templates/pvc.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.persistence.data.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rustchain.fullname" . }}-data
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.data.size }}
+{{- end }}
+---
+{{- if .Values.persistence.downloads.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "rustchain.fullname" . }}-downloads
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.downloads.accessMode }}
+  {{- if .Values.persistence.downloads.storageClass }}
+  storageClassName: {{ .Values.persistence.downloads.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.downloads.size }}
+{{- end }}

--- a/deploy/helm/rustchain/templates/service.yaml
+++ b/deploy/helm/rustchain/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "rustchain.fullname" . }}
+  labels:
+    {{- include "rustchain.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.dashboardPort }}
+      targetPort: dashboard
+      protocol: TCP
+      name: dashboard
+    - port: {{ .Values.service.apiPort }}
+      targetPort: api
+      protocol: TCP
+      name: api
+  selector:
+    {{- include "rustchain.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/rustchain/values.yaml
+++ b/deploy/helm/rustchain/values.yaml
@@ -1,0 +1,117 @@
+# Default values for RustChain Helm chart
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/celebritypunks/rustchain
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL
+
+# RustChain node configuration
+rustchain:
+  home: /rustchain
+  db: /rustchain/data/rustchain_v2.db
+  downloadDir: /rustchain/downloads
+  logLevel: INFO
+  dashboardPort: 8099
+  apiPort: 8088
+
+# Environment variables injected via ConfigMap
+config:
+  PYTHONUNBUFFERED: "1"
+
+# Sensitive values injected via Secret
+secrets:
+  # GitHub token for API access (leave empty to disable)
+  githubToken: ""
+  # Tip bot wallet address
+  tipBotWallet: ""
+
+service:
+  type: ClusterIP
+  dashboardPort: 8099
+  apiPort: 8088
+
+ingress:
+  enabled: false
+  className: nginx
+  annotations: {}
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: rustchain.local
+      paths:
+        - path: /
+          pathType: Prefix
+          servicePort: 8099
+  tls: []
+  #  - secretName: rustchain-tls
+  #    hosts:
+  #      - rustchain.local
+
+persistence:
+  data:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 10Gi
+  downloads:
+    enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 5Gi
+
+resources:
+  limits:
+    cpu: "1"
+    memory: 1Gi
+  requests:
+    cpu: 250m
+    memory: 256Mi
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: dashboard
+  initialDelaySeconds: 40
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: dashboard
+  initialDelaySeconds: 20
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
## Summary

- Adds a production-ready Helm chart under `deploy/helm/rustchain/` for deploying RustChain nodes on Kubernetes
- Includes templates for Deployment, Service, ConfigMap, Secret, Ingress, and PersistentVolumeClaims
- Derived from the existing Dockerfile and docker-compose.yml -- mirrors ports (8099 dashboard, 8088 API), health checks, volume mounts, and non-root security context
- Fully configurable via `values.yaml` with sensible defaults (resource limits, persistence sizing, probe tuning)

## What's included

| File | Purpose |
|------|---------|
| `Chart.yaml` | Chart metadata (v0.1.0) |
| `values.yaml` | All configurable defaults |
| `templates/deployment.yaml` | Pod spec with probes, env, volumes |
| `templates/service.yaml` | ClusterIP service for dashboard + API |
| `templates/configmap.yaml` | Non-sensitive environment variables |
| `templates/secret.yaml` | GitHub token, wallet address |
| `templates/ingress.yaml` | Optional ingress with TLS support |
| `templates/pvc.yaml` | Persistent volumes for data + downloads |
| `templates/_helpers.tpl` | Naming and labeling helpers |
| `templates/NOTES.txt` | Post-install instructions |
| `README.md` | Usage and configuration reference |

## Test plan

- [ ] `helm template rustchain ./deploy/helm/rustchain/` renders valid manifests
- [ ] `helm lint ./deploy/helm/rustchain/` passes without errors
- [ ] Deploy to a test cluster with `helm install rustchain ./deploy/helm/rustchain/`
- [ ] Verify health endpoint responds at `/health` on port 8099
- [ ] Confirm PVCs are created and bound
- [ ] Test ingress by enabling it with a custom host