### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -1,0 +1,322 @@
+# API Reference
+
+RustChain exposes a REST API over HTTPS. The node uses a self-signed certificate, so pass `-sk` flags to `curl` or set `verify=False` in Python requests.
+
+**Base URL**: `https://rustchain.org`
+
+## Authentication
+
+Most endpoints are public. Admin endpoints require the `X-Admin-Key` header:
+
+```bash
+curl -sk -H "X-Admin-Key: YOUR_ADMIN_KEY" https://rustchain.org/admin/...
+```
+
+---
+
+## Health & Status
+
+### GET /health
+
+Check node health.
+
+```bash
+curl -sk https://rustchain.org/health
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "version": "2.2.1-rip200",
+  "uptime_s": 4313,
+  "db_rw": true,
+  "backup_age_hours": 17.15,
+  "tip_age_slots": 0
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `ok` | boolean | Node is healthy |
+| `version` | string | Node software version |
+| `uptime_s` | integer | Seconds since node start |
+| `db_rw` | boolean | Database is read/write |
+| `backup_age_hours` | float | Hours since last backup |
+| `tip_age_slots` | integer | Slots behind tip (0 = synced) |
+
+### GET /ready
+
+Kubernetes-style readiness probe.
+
+```bash
+curl -sk https://rustchain.org/ready
+```
+
+```json
+{
+  "ready": true
+}
+```
+
+---
+
+## Epoch Information
+
+### GET /epoch
+
+Get current epoch and slot information.
+
+```bash
+curl -sk https://rustchain.org/epoch
+```
+
+**Response:**
+
+```json
+{
+  "epoch": 75,
+  "slot": 10800,
+  "blocks_per_epoch": 144,
+  "epoch_pot": 1.5,
+  "enrolled_miners": 10
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `epoch` | integer | Current epoch number |
+| `slot` | integer | Current slot within epoch |
+| `blocks_per_epoch` | integer | Slots per epoch (144) |
+| `epoch_pot` | float | RTC reward pool for this epoch |
+| `enrolled_miners` | integer | Active miners this epoch |
+
+---
+
+## Miners
+
+### GET /api/miners
+
+List all active miners.
+
+```bash
+curl -sk https://rustchain.org/api/miners
+```
+
+**Response:**
+
+```json
+[
+  {
+    "miner_id": "abc123RTC",
+    "hardware": "PowerPC G4",
+    "multiplier": 2.5,
+    "enrolled_epoch": 75
+  }
+]
+```
+
+---
+
+## Wallets
+
+### GET /wallet/balance
+
+Check wallet balance.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `miner_id` | string | Wallet ID (query parameter) |
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+```
+
+**Response:**
+
+```json
+{
+  "amount_i64": 155000000,
+  "amount_rtc": 155.0,
+  "miner_id": "YOUR_WALLET"
+}
+```
+
+!!! note
+    RustChain uses its own wallet ID system (e.g., `Ivan-houzhiwen`), not Ethereum or Solana addresses. 1 RTC = 1,000,000 smallest units.
+
+### POST /wallet/transfer/signed
+
+Submit a signed transfer.
+
+```bash
+curl -sk -X POST https://rustchain.org/wallet/transfer/signed \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from": "sender_wallet_id",
+    "to": "recipient_wallet_id",
+    "amount": 1000000,
+    "fee": 1000,
+    "signature": "hex_encoded_ed25519_signature",
+    "timestamp": 1234567890
+  }'
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `from` | string | Sender's RustChain wallet ID |
+| `to` | string | Recipient's RustChain wallet ID |
+| `amount` | integer | Amount in smallest units (1 RTC = 1,000,000) |
+| `fee` | float | Transaction fee |
+| `signature` | hex string | Ed25519 signature of the transfer payload |
+| `timestamp` | integer | Unix timestamp (replay protection) |
+
+---
+
+## Attestation
+
+### POST /attest/submit
+
+Submit a hardware attestation. Called automatically by the miner client.
+
+```bash
+curl -sk -X POST https://rustchain.org/attest/submit \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "miner_id": "abc123RTC",
+    "timestamp": 1770112912,
+    "fingerprint": { ... },
+    "signature": "hex_signature"
+  }'
+```
+
+**Success response:**
+
+```json
+{
+  "enrolled": true,
+  "multiplier": 2.5
+}
+```
+
+**Failure response:**
+
+```json
+{
+  "error": "VM_DETECTED"
+}
+```
+
+---
+
+## Governance
+
+### POST /governance/propose
+
+Create a governance proposal. The submitting wallet must hold more than 10 RTC.
+
+```bash
+curl -sk -X POST https://rustchain.org/governance/propose \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "wallet": "RTC...",
+    "title": "Enable parameter X",
+    "description": "Rationale and implementation details"
+  }'
+```
+
+### GET /governance/proposals
+
+List all governance proposals.
+
+```bash
+curl -sk https://rustchain.org/governance/proposals
+```
+
+### GET /governance/proposal/{id}
+
+Get details of a specific proposal.
+
+```bash
+curl -sk https://rustchain.org/governance/proposal/1
+```
+
+### POST /governance/vote
+
+Submit a signed vote. The voter must be an active miner.
+
+```bash
+curl -sk -X POST https://rustchain.org/governance/vote \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "proposal_id": 1,
+    "wallet": "RTC...",
+    "vote": "yes",
+    "nonce": "1700000000",
+    "public_key": "<ed25519_pubkey_hex>",
+    "signature": "<ed25519_signature_hex>"
+  }'
+```
+
+**Voting rules:**
+
+- Proposal lifecycle: `Draft -> Active (7 days) -> Passed/Failed`
+- Vote weight: 1 RTC = 1 base vote, multiplied by the miner's antiquity multiplier
+- Pass condition: `yes_weight > no_weight` at close
+
+---
+
+## x402 Premium Endpoints
+
+Machine-to-machine payment endpoints using the HTTP 402 protocol (currently free while proving the flow):
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/premium/videos` | Bulk video export (BoTTube) |
+| `GET /api/premium/analytics/<agent>` | Deep agent analytics (BoTTube) |
+| `GET /api/premium/reputation` | Full reputation export (Beacon Atlas) |
+| `GET /wallet/swap-info` | USDC/wRTC swap guidance |
+
+---
+
+## Python Example
+
+```python
+import requests
+
+# Check balance
+response = requests.get(
+    "https://rustchain.org/wallet/balance",
+    params={"miner_id": "my-wallet"},
+    verify=False
+)
+print(f"Balance: {response.json()['amount_rtc']} RTC")
+
+# Transfer (requires Ed25519 signature)
+transfer = {
+    "from": "sender_wallet",
+    "to": "recipient_wallet",
+    "amount": 1000000,  # 1 RTC
+    "fee": 1000,
+    "signature": "...",
+    "timestamp": 1234567890
+}
+response = requests.post(
+    "https://rustchain.org/wallet/transfer/signed",
+    json=transfer,
+    verify=False
+)
+print(response.json())
+```
+
+---
+
+## Reference
+
+| Resource | URL |
+|---|---|
+| Live node | `https://rustchain.org` |
+| Block explorer | `https://rustchain.org/explorer` |
+| Health check | `https://rustchain.org/health` |
+| Postman collection | [`RustChain_API.postman_collection.json`](https://github.com/Scottcjn/Rustchain/blob/main/RustChain_API.postman_collection.json) |

--- a/docs-site/docs/architecture.md
+++ b/docs-site/docs/architecture.md
@@ -1,0 +1,131 @@
+# Architecture
+
+RustChain is a memory-preservation blockchain that uses entropy benchmarks, hardware age, and artifact rarity to validate and score block creation.
+
+## Consensus: Proof of Antiquity (RIP-200)
+
+The consensus mechanism is defined in **RIP-200** (RustChain Iterative Protocol). Instead of hash-rate competition, RustChain uses round-robin consensus where each verified hardware device gets exactly one vote per epoch.
+
+### Core Principles
+
+- **1 CPU = 1 Vote** -- Each unique hardware device gets one vote per epoch, regardless of processing speed.
+- **Antiquity Weighting** -- Rewards are multiplied by how old the hardware is.
+- **Anti-Emulation** -- Six fingerprint checks ensure miners run on real silicon, not VMs.
+
+### Attestation Flow
+
+```
+1. Miner starts a mining session
+2. Client script runs 6 hardware fingerprint checks
+3. POST /attest/submit sends fingerprint + signature to attestation node
+4. Node validates fingerprint against known hardware profiles
+5. Valid hardware -> enrolled in current epoch
+6. At epoch boundary (slot 144) -> settlement
+7. Reward pool distributed (equal split x antiquity multiplier)
+8. Settlement hash anchored to Ergo blockchain
+```
+
+### Epoch Lifecycle
+
+Each epoch lasts 10 minutes (600 seconds) and contains 144 slots. At the end of each epoch:
+
+1. All enrolled miners receive their share of the 1.5 RTC reward pool.
+2. Shares are scaled by each miner's antiquity multiplier.
+3. A commitment hash of the epoch state is written to the Ergo blockchain (R4 register) for immutability.
+
+## Hardware Fingerprinting
+
+Six hardware checks form the fingerprint:
+
+| # | Check | Measurement | Anti-Emulation |
+|---|---|---|---|
+| 1 | Clock Skew | Crystal oscillator drift in ppm, jitter in ns | VMs inherit host clock (too stable) |
+| 2 | Cache Timing | L1/L2/L3 latency in ns | Emulators flatten the cache hierarchy |
+| 3 | SIMD Identity | AltiVec/SSE/NEON execution bias | Timing differs under emulation |
+| 4 | Thermal Entropy | CPU temperature curves under load | VMs report static temperatures |
+| 5 | Instruction Jitter | Opcode execution variance in ns | Real silicon has unique nanosecond jitter |
+| 6 | Behavioral Heuristics | Hypervisor detection signatures | Catches VMware, QEMU, SheepShaver |
+
+### Fingerprint Payload
+
+```json
+{
+  "miner_id": "abc123RTC",
+  "timestamp": 1770112912,
+  "fingerprint": {
+    "clock_skew": { "drift_ppm": 12.5, "jitter_ns": 847 },
+    "cache_timing": { "l1_latency_ns": 4, "l2_latency_ns": 12, "l3_latency_ns": 42 },
+    "simd_identity": { "vector_unit": "AltiVec", "bias_score": 0.87 },
+    "thermal_entropy": { "temp_c": 62.3, "variance": 1.2 },
+    "instruction_jitter": { "mean_ns": 4.2, "stddev_ns": 0.8 },
+    "behavioral": { "vm_detected": false, "confidence": 0.99 }
+  },
+  "signature": "ed25519_hex_signature"
+}
+```
+
+## Block Structure
+
+Each block contains:
+
+- **Validator ID** -- Wallet address (Ergo backend)
+- **BIOS Timestamp** -- Hardware age proof + entropy duration
+- **NFT Unlocks** -- Badges earned (e.g., "Paw Paw" retro bonus)
+- **Lore Metadata** -- Optional attached artifact data
+- **Score Metadata** -- For leaderboard and faucet access
+
+## Token Emission
+
+- **Block reward**: 5 RTC per block to the validator
+- **Epoch reward pool**: 1.5 RTC distributed among enrolled miners
+- **Halving**: Every 2 years or at epoch milestones
+- **NFT modifiers**: Certain badges alter payout (retro bonuses)
+
+## Network Topology
+
+### Live Nodes
+
+| Node | Address | Role |
+|---|---|---|
+| Node 1 | 50.28.86.131 | Primary + Explorer |
+| Node 2 | 50.28.86.153 | Ergo Anchor |
+| Node 3 | 76.8.228.245 | Community Node |
+
+### Ergo Anchoring
+
+RustChain periodically writes a commitment hash to the Ergo blockchain:
+
+```
+RustChain Epoch -> Commitment Hash -> Ergo Transaction (R4 register)
+```
+
+This provides cryptographic proof that RustChain state existed at a specific point in time, giving the chain external immutability guarantees without running its own full PoW.
+
+## External Integrations
+
+- **ErgoTool CLI** -- Wallet creation and transaction signing
+- **Ergo NFT Standards** -- Soulbound badge issuance for achievements
+- **Solana Bridge** -- wRTC token on Solana via BoTTube Bridge
+- **Base Bridge** -- wRTC on Base (Coinbase L2) at `0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6`
+- **x402 Protocol** -- HTTP 402 machine-to-machine payments for premium API access
+- **Coinbase Agent Wallets** -- Agents can own Base wallets for autonomous payments
+
+## RIP System
+
+RustChain uses a proposal system called **RIPs** (RustChain Iterative Protocols) for protocol changes:
+
+| RIP | Title | Status |
+|---|---|---|
+| RIP-0001 | Proof of Antiquity | Active |
+| RIP-0007 | Entropy Fingerprinting | Active |
+| RIP-200 | 1 CPU = 1 Vote (Round Robin) | Active |
+| RIP-201 | Fleet Immune System | Active |
+| RIP-304 | Retro Console Mining | Draft |
+| RIP-305 | Cross-Chain Airdrop | Draft |
+
+## Design Goals
+
+- Keep validator requirements low (Pentium III or older can participate)
+- Preserve retro OS compatibility
+- Limit chain bloat via badge logs and off-chain metadata anchors
+- Reward hardware preservation over raw compute power

--- a/docs-site/docs/faq.md
+++ b/docs-site/docs/faq.md
@@ -1,0 +1,127 @@
+# FAQ
+
+## General
+
+### What is RustChain?
+
+RustChain is a Proof-of-Antiquity blockchain that rewards vintage hardware. Unlike traditional PoW chains that reward the fastest, newest machines, RustChain gives higher rewards to older hardware. A PowerPC G4 from 2001 earns more than a modern Threadripper.
+
+### Why is it called "RustChain"?
+
+The name comes from a 486 laptop with oxidized (rusty) serial ports that still boots to DOS and mines RTC. "Rust" refers to iron oxide on decades-old silicon -- not the Rust programming language, although there are Rust components in the codebase.
+
+### What is Proof-of-Antiquity?
+
+Proof-of-Antiquity is a consensus mechanism where miners prove they are running on authentic vintage hardware through six fingerprinting checks (clock skew, cache timing, SIMD identity, thermal entropy, instruction jitter, and behavioral heuristics). Rewards scale with how old the hardware is.
+
+### How is this different from Proof-of-Work?
+
+In PoW, the fastest hardware wins. In Proof-of-Antiquity, the oldest hardware wins. There is no hash grinding -- each verified CPU gets exactly one vote per epoch (1 CPU = 1 Vote), and rewards are multiplied by an antiquity score.
+
+---
+
+## Mining
+
+### How do I start mining?
+
+Install the miner with a single command:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+```
+
+See the [Getting Started](getting-started.md) guide for full details.
+
+### What hardware can I use?
+
+Any computer can mine RTC, but older hardware earns more. Supported platforms include:
+
+- Linux (x86_64, ppc64le, ppc)
+- macOS (Intel, Apple Silicon, PowerPC G3/G4/G5)
+- IBM POWER8 systems
+- Vintage x86 (Pentium 4, Core 2 Duo, etc.)
+
+### Can I mine in a VM?
+
+No. The hardware fingerprinting system detects virtual machines and emulators (VMware, QEMU, SheepShaver, etc.). You must mine on real physical hardware.
+
+### How much can I earn?
+
+Earnings depend on your hardware's antiquity multiplier and the number of active miners. With a PowerPC G4 (2.5x multiplier) and 5 miners in an epoch, you would earn roughly 0.30 RTC per epoch (10 minutes).
+
+### What is an epoch?
+
+An epoch is a 10-minute period (144 slots). At the end of each epoch, the 1.5 RTC reward pool is distributed among all enrolled miners, weighted by their antiquity multipliers.
+
+### Do multipliers last forever?
+
+No. Multipliers decay at 15% per year to prevent any single hardware class from holding a permanent advantage.
+
+---
+
+## RTC Token
+
+### What is RTC worth?
+
+The reference rate is 1 RTC = $0.10 USD. RTC is tradable as wRTC on Solana via [Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) and on Base via [Aerodrome](https://aerodrome.finance/swap?from=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6).
+
+### How do I check my balance?
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+### What is wRTC?
+
+wRTC is the wrapped version of RTC on Solana. You can bridge RTC to wRTC (and back) using the [BoTTube Bridge](https://bottube.ai/bridge). The Solana token mint is `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`.
+
+### Is wRTC also on Base?
+
+Yes. wRTC is available on Base (Coinbase L2) at contract address `0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6`. You can swap USDC to wRTC on [Aerodrome](https://aerodrome.finance).
+
+---
+
+## Contributing
+
+### How do I earn RTC by contributing?
+
+Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues), pick an issue, fork the repo, submit a PR, and get paid in RTC on merge. See [CONTRIBUTING.md](https://github.com/Scottcjn/Rustchain/blob/main/CONTRIBUTING.md) for details.
+
+### What are the bounty tiers?
+
+| Tier | Reward | Examples |
+|---|---|---|
+| Micro | 1--10 RTC | Typo fixes, small docs |
+| Standard | 20--50 RTC | Features, refactors, endpoints |
+| Major | 75--100 RTC | Security fixes, consensus work |
+| Critical | 100--150 RTC | Vulnerability patches, protocol upgrades |
+
+---
+
+## Governance
+
+### How does governance work?
+
+Any wallet holding more than 10 RTC can create a proposal. Active miners vote with Ed25519-signed messages. Vote weight is 1 RTC = 1 base vote, multiplied by the voter's antiquity multiplier. Proposals are active for 7 days and pass when `yes_weight > no_weight`.
+
+### Where can I see proposals?
+
+```bash
+curl -sk https://rustchain.org/governance/proposals
+```
+
+---
+
+## Technical
+
+### What does the Ergo anchor do?
+
+At the end of each epoch, RustChain writes a commitment hash to the Ergo blockchain (R4 register). This provides external, immutable proof that the RustChain state existed at that point in time.
+
+### Does RustChain use the Rust programming language?
+
+The core node and miners are written in Python. There are Rust components in the ecosystem (see [clawrtc-rs](https://github.com/Scottcjn/clawrtc-rs)), but the name refers to physical rust on vintage hardware, not the language.
+
+### Where can I find the whitepaper?
+
+The whitepaper is available at [RustChain_Whitepaper_Flameholder_v0.97-1.pdf](https://github.com/Scottcjn/Rustchain/blob/main/RustChain_Whitepaper_Flameholder_v0.97-1.pdf).

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -1,0 +1,161 @@
+# Getting Started
+
+This guide walks you through installing the RustChain miner, creating a wallet, and verifying your first attestation.
+
+## Requirements
+
+- Python 3.6+ (Python 2.5+ for vintage PowerPC systems)
+- `curl` or `wget`
+- 50 MB disk space
+- Internet connection
+
+### Platform-Specific
+
+- **Linux**: systemd (for auto-start), `python3-venv` or `virtualenv`
+- **macOS**: Command Line Tools (installed automatically if needed)
+
+## One-Line Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+```
+
+The installer will:
+
+1. Auto-detect your platform (Linux/macOS, x86_64/ARM/PowerPC)
+2. Create an isolated Python virtualenv at `~/.rustchain/venv`
+3. Download the correct miner for your hardware
+4. Set up auto-start on boot (systemd or launchd)
+5. Prompt for your wallet name (or auto-generate one)
+
+### Install with a Specific Wallet
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet my-wallet-name
+```
+
+### Preview Without Installing
+
+```bash
+bash install-miner.sh --dry-run --wallet my-wallet-name
+```
+
+### Uninstall
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --uninstall
+```
+
+## Manual Install
+
+```bash
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+bash install-miner.sh --wallet YOUR_WALLET_NAME
+```
+
+## Supported Platforms
+
+### Linux
+
+| Distribution | Versions |
+|---|---|
+| Ubuntu | 20.04, 22.04, 24.04 |
+| Debian | 11, 12 |
+| Fedora | 38, 39, 40 |
+| RHEL | 8, 9 |
+
+Architectures: x86_64, ppc64le, ppc (PowerPC 32-bit)
+
+### macOS
+
+macOS 12 (Monterey) and later. Architectures: arm64 (Apple Silicon), x86_64 (Intel), powerpc (G3/G4/G5).
+
+### Special Hardware
+
+IBM POWER8 systems, PowerPC G4/G5 Macs, vintage x86 CPUs (Pentium 4, Core 2 Duo, etc.)
+
+## Verify Your Setup
+
+After installation, confirm the miner is running and connected:
+
+```bash
+# Check node health
+curl -sk https://rustchain.org/health
+
+# Check your wallet balance
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+
+# List active miners
+curl -sk https://rustchain.org/api/miners
+
+# Get current epoch
+curl -sk https://rustchain.org/epoch
+```
+
+## Managing the Miner Service
+
+=== "Linux (systemd)"
+
+    ```bash
+    systemctl --user status rustchain-miner    # Check status
+    systemctl --user stop rustchain-miner      # Stop mining
+    systemctl --user start rustchain-miner     # Start mining
+    journalctl --user -u rustchain-miner -f    # View logs
+    ```
+
+=== "macOS (launchd)"
+
+    ```bash
+    launchctl list | grep rustchain            # Check status
+    launchctl stop com.rustchain.miner         # Stop mining
+    launchctl start com.rustchain.miner        # Start mining
+    tail -f ~/.rustchain/miner.log             # View logs
+    ```
+
+## Windows (via pip)
+
+```powershell
+pip install clawrtc
+clawrtc mine --dry-run
+```
+
+## Directory Structure
+
+After installation, the miner lives at `~/.rustchain/`:
+
+```
+~/.rustchain/
+├── venv/                    # Isolated Python virtualenv
+│   └── bin/python           # Virtualenv Python interpreter
+├── miner.py                 # Miner script for your platform
+├── miner.log                # Runtime logs
+└── config.json              # Wallet and node configuration
+```
+
+## Troubleshooting
+
+**Installer fails with permission errors**
+:   Re-run using an account with write access to `~/.local`. Avoid running inside a system Python's global site-packages.
+
+**Python version errors (`SyntaxError` / `ModuleNotFoundError`)**
+:   Install Python 3.10+ and ensure `python3` points to that interpreter.
+
+**`clawrtc wallet show` says "could not reach network"**
+:   Verify the live node directly: `curl -sk https://rustchain.org/health`
+
+**HTTPS certificate errors in `curl`**
+:   The node may use a self-signed certificate. Use `curl -sk` (silent + insecure) for API calls.
+
+**Miner exits immediately**
+:   Verify your wallet exists and the service is running (`systemctl --user status rustchain-miner` or `launchctl list | grep rustchain`).
+
+If an issue persists, open an issue on GitHub with logs, OS details, and the output of `install-miner.sh --dry-run`.
+
+## Next Steps
+
+- Read the [Mining Guide](mining.md) to understand reward mechanics and hardware multipliers
+- Explore the [API Reference](api-reference.md) for programmatic access
+- Check [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues) to earn RTC by contributing

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,0 +1,49 @@
+# RustChain
+
+**The first blockchain that rewards vintage hardware for being old, not fast.**
+
+RustChain is a Proof-of-Antiquity blockchain where authentic vintage hardware earns more than modern machines. A PowerPC G4 from 2001 outearns a current-gen Threadripper. The name comes from a 486 laptop with oxidized serial ports that still boots to DOS and mines RTC -- "Rust" means iron oxide on decades-old silicon, not the programming language.
+
+---
+
+## Core Idea
+
+Traditional proof-of-work blockchains reward the fastest, newest hardware. RustChain flips that model:
+
+| Traditional PoW | Proof-of-Antiquity |
+|---|---|
+| Rewards fastest hardware | Rewards oldest hardware |
+| Newer = Better | Older = Better |
+| Wasteful energy consumption | Preserves computing history |
+| Race to the bottom | Rewards digital preservation |
+
+Every miner must prove their hardware is real through six fingerprinting checks that detect VMs and emulators. Real vintage silicon has unique aging patterns -- clock drift, cache timing curves, thermal entropy -- that cannot be faked.
+
+## Key Features
+
+- **1 CPU = 1 Vote** -- Round-robin consensus (RIP-200). No advantage from faster CPUs or more threads.
+- **Antiquity Multipliers** -- Older hardware earns higher rewards. A PowerPC G4 gets a 2.5x multiplier; modern x86_64 gets 1.0x.
+- **Anti-Emulation** -- Six hardware fingerprint checks prevent VM spoofing.
+- **Ergo Anchoring** -- Epoch settlement hashes are anchored to the Ergo blockchain for immutability.
+- **wRTC on Solana** -- RTC tokens are bridged to Solana as wRTC via the BoTTube Bridge.
+- **Bounty Program** -- Earn RTC tokens for contributing code, docs, security fixes, and more.
+
+## Quick Links
+
+- [Getting Started](getting-started.md) -- Install the miner and start earning RTC
+- [Mining Guide](mining.md) -- Hardware multipliers, epochs, and reward mechanics
+- [API Reference](api-reference.md) -- REST endpoints for wallets, miners, governance
+- [Architecture](architecture.md) -- Consensus protocol, block structure, network topology
+- [FAQ](faq.md) -- Common questions answered
+
+## Live Network
+
+| Resource | URL |
+|---|---|
+| Website | [rustchain.org](https://rustchain.org) |
+| Block Explorer | [rustchain.org/explorer](https://rustchain.org/explorer) |
+| Health Check | `curl -sk https://rustchain.org/health` |
+| Swap wRTC | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| Price Chart | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
+| GitHub | [Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain) |
+| Bounties | [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties/issues) |

--- a/docs-site/docs/mining.md
+++ b/docs-site/docs/mining.md
@@ -1,0 +1,133 @@
+# Mining
+
+RustChain mining is fundamentally different from traditional proof-of-work. Instead of competing on hash rate, miners prove they are running on authentic hardware and earn rewards weighted by how old that hardware is.
+
+## How It Works
+
+1. **Attestation** -- Your miner runs six hardware fingerprint checks every epoch.
+2. **Enrollment** -- The attestation node validates your fingerprint and enrolls you for the current epoch.
+3. **Reward Distribution** -- At epoch end, the reward pool is split equally among enrolled miners, then multiplied by each miner's antiquity score.
+
+There is no hash grinding. A Pentium 4 and a Threadripper each get one vote per epoch -- but the Pentium 4 earns more because of its antiquity multiplier.
+
+## Epochs
+
+| Parameter | Value |
+|---|---|
+| Epoch duration | 10 minutes (600 seconds) |
+| Slots per epoch | 144 |
+| Base reward pool | 1.5 RTC per epoch |
+| Distribution | Equal split among enrolled miners, scaled by antiquity multiplier |
+
+## Antiquity Multipliers
+
+Your hardware's manufacturing era determines your multiplier:
+
+| Hardware | Era | Multiplier | Example Earnings/Epoch |
+|---|---|---|---|
+| PowerPC G4 | 1999--2005 | 2.5x | 0.30 RTC |
+| PowerPC G5 | 2003--2006 | 2.0x | 0.24 RTC |
+| PowerPC G3 | 1997--2003 | 1.8x | 0.21 RTC |
+| IBM POWER8 | 2014 | 1.5x | 0.18 RTC |
+| Pentium 4 | 2000--2008 | 1.5x | 0.18 RTC |
+| Core 2 Duo | 2006--2011 | 1.3x | 0.16 RTC |
+| Apple Silicon | 2020+ | 1.2x | 0.14 RTC |
+| Modern x86_64 | Current | 1.0x | 0.12 RTC |
+
+!!! note "Multiplier Decay"
+    Multipliers decay at 15% per year to prevent any single hardware class from holding a permanent advantage.
+
+## Hardware Fingerprinting
+
+Every miner must pass six checks to prove their hardware is real and not emulated:
+
+| Check | What It Measures | Why VMs Fail |
+|---|---|---|
+| Clock Skew | Crystal oscillator drift (ppm) | VMs use the host clock -- too perfect |
+| Cache Timing | L1/L2/L3 latency curves (ns) | Emulators flatten cache hierarchy |
+| SIMD Identity | AltiVec/SSE/NEON execution bias | Emulated SIMD has different timing |
+| Thermal Entropy | CPU temperature under load | VMs report static temperatures |
+| Instruction Jitter | Opcode execution variance (ns) | Real silicon has nanosecond jitter |
+| Behavioral Heuristics | Hypervisor signatures | Detects VMware, QEMU, SheepShaver, etc. |
+
+The fingerprint is packaged into a `proof_of_antiquity.json` payload, signed, and submitted to the attestation node via `POST /attest/submit`.
+
+## Attestation Flow
+
+```
+Miner starts session
+    |
+    v
+Run 6 hardware fingerprint checks locally
+    |
+    v
+POST /attest/submit  (fingerprint + signature)
+    |
+    v
+Attestation node validates against known hardware profiles
+    |
+    +--- Valid hardware --> Enrolled in current epoch
+    |
+    +--- VM/Emulator detected --> Rejected (error: VM_DETECTED)
+    |
+    v
+End of epoch (every 144 slots)
+    |
+    v
+Calculate reward distribution (equal split x antiquity multiplier)
+    |
+    v
+Anchor settlement hash to Ergo blockchain
+    |
+    v
+Credit RTC to enrolled wallets
+```
+
+## Reward Example
+
+With 5 miners enrolled in an epoch:
+
+```
+G4 Mac      (2.5x):  0.30 RTC
+G5 Mac      (2.0x):  0.24 RTC
+Modern PC   (1.0x):  0.12 RTC
+Modern PC   (1.0x):  0.12 RTC
+Modern PC   (1.0x):  0.12 RTC
+                      ---------
+Total distributed:    0.90 RTC
+Returned to pool:     0.60 RTC
+```
+
+## Token Economics
+
+- **Token**: RTC (RustChain Token)
+- **Emission**: 5 RTC per block to the validator
+- **Halving**: Every 2 years or at epoch milestones
+- **Exchange rate**: 1 RTC = $0.10 USD (reference rate)
+- **Solana bridge**: RTC bridges to wRTC on Solana via BoTTube Bridge
+
+## Monitoring Your Miner
+
+```bash
+# Check your balance
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+
+# List all active miners
+curl -sk https://rustchain.org/api/miners
+
+# Current epoch info
+curl -sk https://rustchain.org/epoch
+```
+
+## Earning RTC Through Contributions
+
+Beyond mining, you can earn RTC by contributing to the project:
+
+| Tier | Reward | Examples |
+|---|---|---|
+| Micro | 1--10 RTC | Typo fixes, small docs, simple tests |
+| Standard | 20--50 RTC | Features, refactors, new endpoints |
+| Major | 75--100 RTC | Security fixes, consensus improvements |
+| Critical | 100--150 RTC | Vulnerability patches, protocol upgrades |
+
+Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues) or pick a [good first issue](https://github.com/Scottcjn/Rustchain/labels/good%20first%20issue).

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,0 +1,64 @@
+site_name: RustChain Documentation
+site_url: https://docs.rustchain.org
+site_description: Official documentation for RustChain, the Proof-of-Antiquity blockchain that rewards vintage hardware.
+repo_url: https://github.com/Scottcjn/Rustchain
+repo_name: Scottcjn/Rustchain
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.tabs.link
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Mining: mining.md
+  - API Reference: api-reference.md
+  - Architecture: architecture.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - tables
+  - attr_list
+  - def_list
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Scottcjn/Rustchain
+  generator: false


### PR DESCRIPTION
## Summary

- Adds `docs-site/` with a full MkDocs documentation site using the Material theme
- Six documentation pages covering project overview, installation & setup, mining mechanics, REST API reference, architecture & consensus protocol, and FAQ
- Ready to deploy with `mkdocs serve` or `mkdocs gh-deploy`

## Pages

| Page | Content |
|---|---|
| `index.md` | Project overview, key features, quick links |
| `getting-started.md` | One-line install, manual install, platform support, troubleshooting |
| `mining.md` | Proof-of-Antiquity mechanics, antiquity multipliers, epoch rewards, hardware fingerprinting |
| `api-reference.md` | Full REST API docs: health, epoch, miners, wallets, attestation, governance, x402 |
| `architecture.md` | RIP-200 consensus, fingerprint payload structure, block structure, network topology, Ergo anchoring |
| `faq.md` | Common questions on mining, RTC/wRTC tokens, contributing, governance |

## Test plan

- [ ] Run `pip install mkdocs mkdocs-material` then `cd docs-site && mkdocs serve` to verify local build
- [ ] Confirm all six pages render correctly with navigation tabs
- [ ] Verify code blocks, tables, and admonitions display properly