### PR TITLE
Add MkDocs documentation site with Material theme

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -1,0 +1,60 @@
+# RustChain Documentation Site
+
+MkDocs-powered documentation site for [RustChain](https://github.com/Scottcjn/Rustchain), the Proof-of-Antiquity blockchain.
+
+## Setup
+
+```bash
+pip install mkdocs mkdocs-material mkdocs-minify-plugin
+```
+
+## Development
+
+Serve locally with live reload:
+
+```bash
+cd docs-site
+mkdocs serve
+```
+
+Open [http://127.0.0.1:8000](http://127.0.0.1:8000) in your browser.
+
+## Build
+
+Generate static files:
+
+```bash
+cd docs-site
+mkdocs build
+```
+
+Output is written to `docs-site/site/`.
+
+## Deploy to GitHub Pages
+
+```bash
+cd docs-site
+mkdocs gh-deploy
+```
+
+## Structure
+
+```
+docs-site/
+├── mkdocs.yml              # MkDocs configuration (Material theme)
+├── docs/
+│   ├── index.md            # Landing page
+│   ├── getting-started.md  # Quickstart and installation guide
+│   ├── mining.md           # Mining guide and reward multipliers
+│   ├── architecture.md     # System architecture and protocol design
+│   ├── api-reference.md    # REST API documentation
+│   ├── contributing.md     # Contribution guide and bounty tiers
+│   └── faq.md              # Frequently asked questions
+└── README.md               # This file
+```
+
+## Links
+
+- **RustChain**: [rustchain.org](https://rustchain.org)
+- **GitHub**: [Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain)
+- **Discord**: [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q)

--- a/docs-site/docs/api-reference.md
+++ b/docs-site/docs/api-reference.md
@@ -1,0 +1,322 @@
+# API Reference
+
+RustChain exposes a REST API for querying network state, managing wallets, submitting attestations, and participating in governance.
+
+**Base URL**: `https://rustchain.org`
+
+!!! note "SSL Certificates"
+    The node may use a self-signed SSL certificate. Use `curl -sk` or `verify=False` in Python requests.
+
+---
+
+## Health and Status
+
+### Health Check
+
+Check if the node is online and responsive.
+
+```
+GET /health
+```
+
+```bash
+curl -sk https://rustchain.org/health
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "version": "2.2.1-rip200",
+  "uptime_s": 200000
+}
+```
+
+### Current Epoch
+
+Get the current epoch, slot, and block height.
+
+```
+GET /epoch
+```
+
+```bash
+curl -sk https://rustchain.org/epoch
+```
+
+**Response:**
+
+```json
+{
+  "epoch": 95,
+  "slot": 12345,
+  "height": 67890
+}
+```
+
+---
+
+## Miners
+
+### List Active Miners
+
+Returns all currently active miners on the network.
+
+```
+GET /api/miners
+```
+
+```bash
+curl -sk https://rustchain.org/api/miners
+```
+
+---
+
+## Wallet
+
+### Check Balance
+
+Query the balance for a specific wallet.
+
+```
+GET /wallet/balance?miner_id={wallet_id}
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `miner_id` | string | The RustChain wallet identifier |
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+**Response:**
+
+```json
+{
+  "amount_i64": 155000000,
+  "amount_rtc": 155.0,
+  "miner_id": "Ivan-houzhiwen"
+}
+```
+
+### Signed Transfer
+
+Submit a signed RTC transfer between wallets.
+
+```
+POST /wallet/transfer/signed
+```
+
+**Request Body:**
+
+```json
+{
+  "from": "sender_wallet_id",
+  "to": "recipient_wallet_id",
+  "amount": 10,
+  "fee": 0.001,
+  "signature": "hex_encoded_signature",
+  "timestamp": 1234567890
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `from` | string | Sender's RustChain wallet ID |
+| `to` | string | Recipient's RustChain wallet ID |
+| `amount` | integer | Amount in RTC (smallest unit: 1 RTC = 1,000,000 units) |
+| `fee` | float | Transaction fee |
+| `signature` | hex string | Ed25519 signature of the transfer payload |
+| `timestamp` | integer | Unix timestamp for replay protection |
+
+!!! important "Wallet IDs"
+    RustChain uses its own wallet system (e.g., `Ivan-houzhiwen`), not Ethereum or Solana addresses.
+
+---
+
+## Governance
+
+### Create Proposal
+
+Submit a governance proposal. The wallet must hold more than 10 RTC.
+
+```
+POST /governance/propose
+```
+
+```bash
+curl -sk -X POST https://rustchain.org/governance/propose \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "wallet": "RTC...",
+    "title": "Enable parameter X",
+    "description": "Rationale and implementation details"
+  }'
+```
+
+### List Proposals
+
+```
+GET /governance/proposals
+```
+
+```bash
+curl -sk https://rustchain.org/governance/proposals
+```
+
+### Get Proposal Detail
+
+```
+GET /governance/proposal/{id}
+```
+
+```bash
+curl -sk https://rustchain.org/governance/proposal/1
+```
+
+### Submit Vote
+
+Votes require an Ed25519 signature. The voter must be an active miner (attested).
+
+```
+POST /governance/vote
+```
+
+```bash
+curl -sk -X POST https://rustchain.org/governance/vote \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "proposal_id": 1,
+    "wallet": "RTC...",
+    "vote": "yes",
+    "nonce": "1700000000",
+    "public_key": "<ed25519_pubkey_hex>",
+    "signature": "<ed25519_signature_hex>"
+  }'
+```
+
+**Governance Rules:**
+
+- Proposal lifecycle: `Draft -> Active (7 days) -> Passed/Failed`
+- Proposal creation requires wallet balance > 10 RTC
+- Voting eligibility: voter must be an active miner
+- Vote weight: `1 RTC = 1 base vote`, multiplied by the miner's antiquity multiplier
+- Pass condition: `yes_weight > no_weight` at close
+
+### Governance Web UI
+
+A lightweight web interface is available at:
+
+```
+GET /governance/ui
+```
+
+---
+
+## Block Explorer
+
+The block explorer is available as a web interface:
+
+```
+GET /explorer
+```
+
+Open [https://rustchain.org/explorer](https://rustchain.org/explorer) in a browser.
+
+---
+
+## x402 Premium Endpoints
+
+Machine-to-machine payment endpoints via the x402 protocol (currently free while proving the flow):
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/premium/videos` | Bulk video export (BoTTube) |
+| `GET /api/premium/analytics/<agent>` | Deep agent analytics (BoTTube) |
+| `GET /api/premium/reputation` | Full reputation export (Beacon Atlas) |
+| `GET /wallet/swap-info` | USDC/wRTC swap guidance |
+
+---
+
+## Agent Wallets (Coinbase Base)
+
+Create and manage Coinbase Base wallets for agent-to-agent payments:
+
+```bash
+# Install with Coinbase support
+pip install clawrtc[coinbase]
+
+# Create a Coinbase wallet
+clawrtc wallet coinbase create
+
+# Check swap info
+clawrtc wallet coinbase swap-info
+
+# Link existing Base address
+clawrtc wallet coinbase link 0xYourBaseAddress
+```
+
+| Resource | Details |
+|----------|---------|
+| wRTC on Base | `0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6` |
+| Swap USDC to wRTC | [Aerodrome DEX](https://aerodrome.finance/swap?from=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6) |
+| Base Bridge | [bottube.ai/bridge/base](https://bottube.ai/bridge/base) |
+
+---
+
+## Python Example
+
+```python
+import requests
+
+# Check balance
+response = requests.get(
+    "https://rustchain.org/wallet/balance",
+    params={"miner_id": "Ivan-houzhiwen"},
+    verify=False
+)
+print(f"Balance: {response.json()['amount_rtc']} RTC")
+
+# Signed transfer
+transfer_data = {
+    "from": "sender_wallet",
+    "to": "recipient_wallet",
+    "amount": 1000000,  # 1 RTC
+    "fee": 1000,
+    "signature": "...",
+    "timestamp": 1234567890
+}
+response = requests.post(
+    "https://rustchain.org/wallet/transfer/signed",
+    json=transfer_data,
+    verify=False
+)
+print(response.json())
+```
+
+---
+
+## Postman Collection
+
+A full Postman collection is available in the repository:
+[RustChain_API.postman_collection.json](https://github.com/Scottcjn/Rustchain/blob/main/RustChain_API.postman_collection.json)
+
+---
+
+## Live Infrastructure
+
+| Endpoint | URL |
+|----------|-----|
+| Node Health | `https://rustchain.org/health` |
+| Active Miners | `https://rustchain.org/api/miners` |
+| Current Epoch | `https://rustchain.org/epoch` |
+| Block Explorer | `https://rustchain.org/explorer` |
+| wRTC Bridge | `https://bottube.ai/bridge` |
+
+| Node | IP | Role |
+|------|----|------|
+| Node 1 | 50.28.86.131 | Primary + Explorer |
+| Node 2 | 50.28.86.153 | Ergo Anchor |
+| Node 3 | 76.8.228.245 | Community Node |

--- a/docs-site/docs/architecture.md
+++ b/docs-site/docs/architecture.md
@@ -1,0 +1,235 @@
+# System Architecture
+
+RustChain is a memory-preservation blockchain built on Proof-of-Antiquity consensus. This document covers the protocol design, network topology, consensus flow, and security model.
+
+---
+
+## High-Level Overview
+
+RustChain validates and rewards miners based on three pillars:
+
+1. **Hardware authenticity** -- cryptographic fingerprinting proves real silicon
+2. **Hardware age** -- antiquity multipliers reward vintage equipment
+3. **Fair consensus** -- 1 CPU = 1 vote, regardless of speed or cores
+
+---
+
+## RIP-200 Consensus Flow
+
+```mermaid
+graph TB
+    A[Miner Starts] --> B[Run Hardware Fingerprint]
+    B --> C[Submit Attestation]
+    C --> D{Valid Hardware?}
+    D -->|Yes| E[Enroll in Epoch]
+    D -->|No| F[Reject / Penalty]
+    E --> G[Accumulate Rewards]
+    G --> H{Epoch End?}
+    H -->|No| G
+    H -->|Yes| I[Settlement]
+    I --> J[Distribute RTC]
+    J --> K[Anchor to Ergo]
+    K --> A
+```
+
+### Epoch System
+
+- **Duration**: ~24 hours (144 slots of 10 minutes each)
+- **Reward Pool**: 1.5 RTC per epoch
+- **Distribution**: Proportional to antiquity multipliers
+- **Settlement**: Anchored to the Ergo blockchain for immutability
+
+---
+
+## Hardware Fingerprinting (RIP-PoA)
+
+Six cryptographic checks verify that miners run on real physical hardware:
+
+```
++-------------------------------------------------------------+
+|                   6 Hardware Checks                         |
++-------------------------------------------------------------+
+| 1. Clock-Skew & Oscillator Drift   <- Silicon aging pattern |
+| 2. Cache Timing Fingerprint        <- L1/L2/L3 latency     |
+| 3. SIMD Unit Identity              <- AltiVec/SSE/NEON bias |
+| 4. Thermal Drift Entropy           <- Heat curves unique    |
+| 5. Instruction Path Jitter         <- Microarch jitter map  |
+| 6. Anti-Emulation Checks           <- Detect VMs/emulators  |
++-------------------------------------------------------------+
+```
+
+Results are packaged in `proof_of_antiquity.json`, signed with Ed25519, and submitted to the chain.
+
+### Anti-Emulation Detection
+
+VMs and emulators fail fingerprint checks due to:
+
+- **Clock Virtualization Artifacts** -- host clock passthrough is too perfect
+- **Simplified Cache Models** -- emulators flatten cache hierarchy
+- **Missing Thermal Sensors** -- VMs report static or host temperatures
+- **Deterministic Execution** -- real silicon has nanosecond-scale jitter
+
+Detected emulators receive a **1 billionth** reward penalty (0.0000000025x multiplier).
+
+---
+
+## Network Topology
+
+```mermaid
+graph LR
+    subgraph Miners
+        M1[PowerPC G4]
+        M2[PowerPC G5]
+        M3[x86_64]
+        M4[Apple Silicon]
+    end
+
+    subgraph RustChain Network
+        N1[Primary Node<br>50.28.86.131]
+        N2[Ergo Anchor<br>50.28.86.153]
+        N3[Community Node<br>76.8.228.245]
+    end
+
+    subgraph External
+        ERGO[Ergo Blockchain]
+        SOL[Solana<br>wRTC Bridge]
+    end
+
+    M1 --> N1
+    M2 --> N1
+    M3 --> N1
+    M4 --> N1
+    N1 --> N2
+    N2 --> ERGO
+    N1 --> SOL
+```
+
+### Live Nodes
+
+| Node | IP | Role | Status |
+|------|----|------|--------|
+| Node 1 | 50.28.86.131 | Primary + Explorer | Active |
+| Node 2 | 50.28.86.153 | Ergo Anchor | Active |
+| Node 3 | 76.8.228.245 | Community | Active |
+
+---
+
+## Block Structure
+
+Each block contains:
+
+- **Validator ID** -- wallet from Ergo backend
+- **BIOS Timestamp** -- hardware age + entropy duration
+- **NFT Unlocks** -- badge metadata
+- **Lore Metadata** -- optional attached data
+- **Score Metadata** -- for leaderboard and faucet access
+
+---
+
+## Ergo Blockchain Anchoring
+
+RustChain periodically anchors state to the Ergo blockchain for cryptographic immutability:
+
+```
+RustChain Epoch -> Commitment Hash -> Ergo Transaction (R4 register)
+```
+
+This provides external proof that RustChain state existed at a specific point in time, independent of RustChain's own validators.
+
+---
+
+## Token Emission
+
+| Parameter | Value |
+|-----------|-------|
+| Total Supply | 8,000,000 RTC |
+| Block Reward | 1.5 RTC per epoch |
+| Premine | 75,000 RTC (dev/bounty fund) |
+| Halving | Every 2 years or epoch milestone |
+| Annual Inflation | ~0.68% (decreasing) |
+
+---
+
+## wRTC Bridge (Solana)
+
+RTC is bridged to Solana as **wRTC** via the BoTTube Bridge:
+
+- **Token Mint**: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- **DEX**: Raydium
+- **Bridge Operator**: BoTTube
+
+### wRTC on Coinbase Base
+
+wRTC is also available on Coinbase Base for agent-to-agent payments:
+
+- **Contract**: `0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6`
+- **DEX**: Aerodrome Finance
+- **Protocol**: x402 (HTTP 402 Payment Required)
+
+---
+
+## Security Model
+
+### Sybil Resistance
+
+- **Hardware Binding**: Each physical CPU maps to exactly one wallet
+- **Fingerprint Uniqueness**: Silicon aging patterns cannot be cloned
+- **Economic Disincentive**: Vintage hardware is expensive and scarce
+
+### Cryptographic Security
+
+- **Signatures**: Ed25519 for all transactions and attestations
+- **Wallet Format**: Simple UTF-8 identifiers (e.g., `scott`, `pffs1802`)
+- **Replay Protection**: Unix timestamps on all signed payloads
+
+### Governance Security
+
+- Proposals require > 10 RTC balance to create
+- Votes require active miner status and Ed25519 signature
+- Vote weight: `1 RTC = 1 base vote` x antiquity multiplier
+- 7-day voting period with pass condition: `yes_weight > no_weight`
+
+---
+
+## Repository Structure
+
+```
+Rustchain/
++-- install-miner.sh                    # Universal miner installer
++-- node/
+|   +-- rustchain_v2_integrated_*.py    # Full node implementation
+|   +-- fingerprint_checks.py           # Hardware verification
++-- miners/
+|   +-- linux/rustchain_linux_miner.py  # Linux miner
+|   +-- macos/rustchain_mac_miner_*.py  # macOS miner
++-- docs/
+|   +-- RustChain_Whitepaper_*.pdf      # Technical whitepaper
+|   +-- chain_architecture.md           # Architecture details
++-- tools/
+|   +-- validator_core.py               # Block validation
++-- bridge/                             # Solana bridge components
++-- contracts/                          # Smart contracts
++-- sdk/                                # SDK libraries
++-- nfts/                               # Badge definitions
++-- explorer/                           # Block explorer frontend
+```
+
+---
+
+## Design Goals
+
+- Keep validator requirements low (Pentium III or older can participate)
+- Preserve retro OS compatibility (Mac OS X Tiger, DOS)
+- Limit bloat via badge logs and off-chain metadata anchors
+- Democratic consensus where money cannot buy votes
+
+---
+
+## Related Protocols
+
+| RIP | Name | Description |
+|-----|------|-------------|
+| RIP-200 | 1 CPU = 1 Vote | Round-robin consensus protocol |
+| RIP-PoA | Proof-of-Antiquity | Hardware fingerprinting specification |
+| RIP-302 | Agent Economy | AI agent wallet and reputation system |
+| RIP-305 | Cross-Chain Airdrop | Multi-chain token distribution |

--- a/docs-site/docs/contributing.md
+++ b/docs-site/docs/contributing.md
@@ -1,0 +1,159 @@
+# Contributing
+
+RustChain pays bounties in RTC tokens for quality contributions. Every merged PR earns real cryptocurrency.
+
+---
+
+## Quick Start
+
+1. **Browse open bounties** -- Check [Issues](https://github.com/Scottcjn/Rustchain/issues?q=is%3Aissue+is%3Aopen+label%3Abounty) labeled `bounty`
+2. **Comment on the issue** you want to work on (prevents duplicate work)
+3. **Fork the repo** and create a feature branch
+4. **Submit a PR** referencing the issue number
+5. **Get paid** in RTC on merge
+
+---
+
+## Bounty Tiers
+
+| Tier | RTC Range | Examples |
+|------|-----------|---------|
+| Micro | 1-10 RTC | Star + share, small docs fixes |
+| Standard | 20-50 RTC | Docker setup, monitoring tools, calculators |
+| Major | 75-100 RTC | SDK, CLI tools, CI pipeline, Windows installer |
+| Critical | 100-150 RTC | Security audits, protocol work, bridges |
+
+**Reference rate: 1 RTC = $0.10 USD**
+
+---
+
+## Development Setup
+
+```bash
+# Clone
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain
+
+# Python environment
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+
+# Test against live node
+curl -sk https://rustchain.org/health
+curl -sk https://rustchain.org/api/miners
+curl -sk https://rustchain.org/epoch
+```
+
+---
+
+## What Gets Merged
+
+- Code that works against the live node (`https://rustchain.org`)
+- Tests that actually test something meaningful
+- Documentation that a human can follow end-to-end
+- Security fixes with proof of concept
+- Tools that make the ecosystem more useful
+
+## What Gets Rejected
+
+- AI-generated bulk PRs with no testing evidence
+- PRs that include all code from prior PRs (contributions are tracked)
+- "Fixes" that break existing functionality
+- Submissions that do not match the bounty requirements
+- Placeholder data, fake screenshots, or fabricated metrics
+
+---
+
+## Code Style
+
+- Python 3.8+ compatible
+- Type hints appreciated but not yet enforced
+- Keep PRs focused -- one issue per PR
+- Test against the live node, not just local mocks
+
+---
+
+## Documentation Quality Checklist
+
+Before opening a docs PR, verify:
+
+- [ ] Instructions work exactly as written (commands are copy-pastable)
+- [ ] OS/architecture assumptions are explicit (Linux/macOS/Windows)
+- [ ] New terms are defined at first use
+- [ ] Broken links are removed or corrected
+- [ ] At least one example command/output is updated if behavior changed
+- [ ] File and section names follow existing naming conventions
+
+---
+
+## BCOS (Beacon Certified Open Source)
+
+RustChain uses BCOS checks to keep contributions auditable and license-clean.
+
+**Tier label required (non-doc PRs)**: Add `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`).
+
+**Doc-only exception**: PRs that only touch `docs/**`, `*.md`, or common image/PDF files do not require a tier label.
+
+**SPDX required (new code files only)**: Newly added code files must include an SPDX header:
+
+```python
+# SPDX-License-Identifier: MIT
+```
+
+**When to pick a tier:**
+
+- `BCOS-L1`: Normal features, refactors, non-sensitive changes
+- `BCOS-L2`: Security-sensitive changes, transfer/wallet logic, consensus/rewards, auth/crypto
+
+CI uploads `bcos-artifacts` (SBOM, license report, hashes, and attestation JSON).
+
+---
+
+## RTC Payout Process
+
+1. PR gets reviewed and merged
+2. Maintainer comments asking for your wallet address
+3. RTC is transferred from the community fund
+4. Bridge RTC to wRTC (Solana) via [bottube.ai/bridge](https://bottube.ai/bridge)
+5. Trade on [Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X)
+
+---
+
+## Common Troubleshooting for Docs
+
+If you changed setup or CLI documentation, add at least one section covering common failures:
+
+- `Command not found`: verify PATH and virtualenv activation
+- `Permission denied` on scripts: ensure execute bit and shell compatibility
+- `Connection error to live node`: include curl timeout/retry guidance and fallback endpoint checks
+
+---
+
+## Start Mining While You Contribute
+
+Install the miner and earn RTC in the background:
+
+```bash
+pip install clawrtc
+clawrtc --wallet YOUR_NAME
+```
+
+Vintage hardware (PowerPC G4/G5, POWER8) earns **2-2.5x** more than modern PCs.
+
+---
+
+## Live Infrastructure
+
+| Endpoint | URL |
+|----------|-----|
+| Node Health | `https://rustchain.org/health` |
+| Active Miners | `https://rustchain.org/api/miners` |
+| Current Epoch | `https://rustchain.org/epoch` |
+| Block Explorer | `https://rustchain.org/explorer` |
+| wRTC Bridge | `https://bottube.ai/bridge` |
+
+---
+
+## Questions?
+
+Open an [issue](https://github.com/Scottcjn/Rustchain/issues) or join the [Discord](https://discord.gg/VqVVS2CW9Q).

--- a/docs-site/docs/faq.md
+++ b/docs-site/docs/faq.md
@@ -1,0 +1,222 @@
+# FAQ
+
+Frequently asked questions about RustChain, mining, RTC tokens, and the ecosystem.
+
+---
+
+## General
+
+### What is RustChain?
+
+RustChain is a **Proof-of-Antiquity** blockchain that rewards vintage hardware for being old, not fast. Unlike traditional PoW blockchains that favor the newest, most powerful hardware, RustChain gives higher mining rewards to older machines like PowerPC Macs, Pentium 4 towers, and IBM POWER8 servers.
+
+### Why is it called "RustChain"?
+
+The name comes from a literal 486 laptop with oxidized (rusty) serial ports that still boots to DOS and mines RTC. "Rust" here means iron oxide on 30-year-old silicon -- not the Rust programming language (though RustChain does have [Rust components](https://github.com/Scottcjn/clawrtc-rs) as well).
+
+### What is Proof-of-Antiquity?
+
+Proof-of-Antiquity is a consensus mechanism where hardware age determines mining rewards. Six cryptographic fingerprint checks verify that miners run on real physical hardware (not VMs or emulators), and older hardware receives higher reward multipliers.
+
+### How is this different from Proof-of-Work?
+
+| Traditional PoW | Proof-of-Antiquity |
+|----------------|-------------------|
+| Rewards fastest hardware | Rewards oldest hardware |
+| Newer = Better | Older = Better |
+| Wasteful energy consumption | Preserves computing history |
+| Race to the bottom | Rewards digital preservation |
+
+---
+
+## Mining
+
+### How do I start mining?
+
+```bash
+# One-line install (Linux/macOS)
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+
+# Or via pip (all platforms)
+pip install clawrtc
+clawrtc --wallet YOUR_NAME
+```
+
+### What hardware can I mine with?
+
+Any computer can mine RTC. Supported platforms include:
+
+- PowerPC Macs (G3/G4/G5) -- highest multipliers
+- IBM POWER8 servers
+- x86_64 Linux/Windows machines
+- Apple Silicon Macs (M1-M4)
+- ARM64 (Raspberry Pi 4/5)
+- DOS machines (experimental, badge rewards only)
+
+### How much can I earn?
+
+Earnings depend on your hardware's antiquity multiplier and the number of active miners:
+
+| Hardware | Multiplier | Example Earnings |
+|----------|------------|------------------|
+| PowerPC G4 | 2.5x | 0.30 RTC/epoch |
+| PowerPC G5 | 2.0x | 0.24 RTC/epoch |
+| IBM POWER8 | 1.5x | 0.18 RTC/epoch |
+| Modern x86_64 | 1.0x | 0.12 RTC/epoch |
+
+### What is an epoch?
+
+An epoch is 10 minutes (600 seconds). The base reward pool is 1.5 RTC per epoch, split among all active miners proportionally to their antiquity multipliers.
+
+### Can I mine with a virtual machine?
+
+No. VMs and emulators are detected by the hardware fingerprinting system and receive 1 billionth of normal rewards (effectively zero). Real physical hardware is required.
+
+### Do multipliers stay the same forever?
+
+No. Vintage hardware bonuses decay at 15% per year to reward early adopters. Modern hardware can earn a loyalty bonus of up to 50% for sustained uptime.
+
+---
+
+## RTC Token
+
+### What is RTC?
+
+RTC (RustChain Token) is the native cryptocurrency of the RustChain network. It is earned through mining and ecosystem contributions.
+
+**Reference rate: 1 RTC = $0.10 USD**
+
+### What is wRTC?
+
+wRTC is a wrapped version of RTC on the Solana blockchain. You can bridge RTC to wRTC and trade it on decentralized exchanges.
+
+- **Token Mint (Solana)**: `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X`
+- **wRTC on Base**: `0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6`
+
+### Where can I trade RTC?
+
+| Action | Link |
+|--------|------|
+| Swap wRTC (Solana) | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| Swap wRTC (Base) | [Aerodrome DEX](https://aerodrome.finance/swap?from=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6) |
+| Price Chart | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
+| Bridge RTC to wRTC | [BoTTube Bridge](https://bottube.ai/bridge) |
+
+### How do I check my balance?
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+### What is the total supply?
+
+8,000,000 RTC total supply. 75,000 RTC premine allocated to development and bounties. Annual inflation is approximately 0.68% and decreasing.
+
+---
+
+## Bounties and Contributing
+
+### How do I earn RTC by contributing?
+
+1. Browse [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
+2. Comment on the issue you want to work on
+3. Fork, fix, submit a PR referencing the issue
+4. Get paid in RTC on merge
+
+### What are the bounty tiers?
+
+| Tier | Reward | Examples |
+|------|--------|----------|
+| Micro | 1-10 RTC | Typo fix, small docs, simple test |
+| Standard | 20-50 RTC | Feature, refactor, new endpoint |
+| Major | 75-100 RTC | Security fix, consensus improvement |
+| Critical | 100-150 RTC | Vulnerability patch, protocol upgrade |
+
+### What PRs get rejected?
+
+- AI-generated bulk PRs with no testing evidence
+- PRs that duplicate prior work without attribution
+- Submissions that break existing functionality
+- Placeholder data or fabricated metrics
+
+---
+
+## Technical
+
+### What consensus mechanism does RustChain use?
+
+RIP-200 (1 CPU = 1 Vote): round-robin consensus where each unique physical CPU gets exactly one vote per epoch, regardless of speed or core count.
+
+### How does Ergo anchoring work?
+
+RustChain periodically writes commitment hashes to the Ergo blockchain as R4 register data. This provides cryptographic proof that RustChain state existed at a specific time, independent of RustChain's own validators.
+
+### What signatures does RustChain use?
+
+Ed25519 for all transactions, attestations, and governance votes.
+
+### What is the x402 protocol?
+
+x402 (HTTP 402 Payment Required) enables machine-to-machine payments between AI agents using RustChain wallets. Agents can create Coinbase Base wallets and pay for premium API endpoints.
+
+### Where are the network nodes?
+
+| Node | IP | Role |
+|------|----|------|
+| Node 1 | 50.28.86.131 | Primary + Explorer |
+| Node 2 | 50.28.86.153 | Ergo Anchor |
+| Node 3 | 76.8.228.245 | Community |
+
+---
+
+## Troubleshooting
+
+### The installer fails with permission errors
+
+Re-run using an account with write access to `~/.local` and avoid running inside a system Python's global site-packages.
+
+### Python version errors
+
+Install Python 3.10+ and ensure `python3` points to that interpreter:
+
+```bash
+python3 --version
+```
+
+### Wallet shows "could not reach network"
+
+Verify the live node directly:
+
+```bash
+curl -sk https://rustchain.org/health
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+### HTTPS certificate errors
+
+The node may use a self-signed certificate. Use `-sk` flags with curl.
+
+### Miner exits immediately
+
+Verify wallet exists and service is running:
+
+```bash
+# Linux
+systemctl --user status rustchain-miner
+# macOS
+launchctl list | grep rustchain
+```
+
+---
+
+## Community
+
+### Where can I get help?
+
+- [GitHub Issues](https://github.com/Scottcjn/Rustchain/issues)
+- [GitHub Discussions](https://github.com/Scottcjn/Rustchain/discussions)
+- [Discord](https://discord.gg/VqVVS2CW9Q)
+
+### Who builds RustChain?
+
+[Elyan Labs](https://elyanlabs.ai) -- built with $0 VC funding and a room full of pawn shop hardware.

--- a/docs-site/docs/getting-started.md
+++ b/docs-site/docs/getting-started.md
@@ -1,0 +1,215 @@
+# Getting Started
+
+This guide walks you through installing the RustChain miner, creating a wallet, and earning your first RTC.
+
+---
+
+## Prerequisites
+
+- **Python 3.8+** (3.10+ recommended)
+- **curl** (for installation and API access)
+- A machine running Linux, macOS, or Windows
+- Network access to `https://rustchain.org`
+
+---
+
+## One-Line Install (Recommended)
+
+The fastest way to get mining:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+```
+
+The installer automatically:
+
+- Detects your platform (Linux/macOS, x86_64/ARM/PowerPC)
+- Creates an isolated Python virtualenv (no system pollution)
+- Downloads the correct miner for your hardware
+- Sets up auto-start on boot (systemd/launchd)
+- Provides easy uninstall
+
+### Install with a Specific Wallet
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet my-miner-wallet
+```
+
+### Dry Run (Preview Only)
+
+```bash
+bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
+```
+
+### Uninstall
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --uninstall
+```
+
+---
+
+## Manual Install
+
+```bash
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+bash install-miner.sh --wallet YOUR_WALLET_NAME
+```
+
+---
+
+## Windows Install
+
+```powershell
+pip install clawrtc
+clawrtc --wallet YOUR_NAME
+```
+
+Verify hardware detection works:
+
+```powershell
+clawrtc mine --dry-run
+```
+
+---
+
+## Supported Platforms
+
+| Platform | Architecture | Status | Notes |
+|----------|--------------|--------|-------|
+| Mac OS X Tiger | PowerPC G4/G5 | Full Support | Python 2.5 compatible miner |
+| Mac OS X Leopard | PowerPC G4/G5 | Full Support | Recommended for vintage Macs |
+| Ubuntu Linux | ppc64le/POWER8 | Full Support | Best performance |
+| Ubuntu Linux | x86_64 | Full Support | Standard miner |
+| macOS Sonoma+ | Apple Silicon | Full Support | M1/M2/M3/M4 chips |
+| Windows 10/11 | x86_64 | Full Support | Python 3.8+ required |
+| DOS | 8086/286/386 | Experimental | Badge rewards only |
+
+---
+
+## After Installation
+
+### Check Node Health
+
+```bash
+curl -sk https://rustchain.org/health
+```
+
+### Check Your Wallet Balance
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+### List Active Miners
+
+```bash
+curl -sk https://rustchain.org/api/miners
+```
+
+### Get Current Epoch
+
+```bash
+curl -sk https://rustchain.org/epoch
+```
+
+---
+
+## Managing the Miner Service
+
+=== "Linux (systemd)"
+
+    ```bash
+    systemctl --user status rustchain-miner    # Check status
+    systemctl --user stop rustchain-miner      # Stop mining
+    systemctl --user start rustchain-miner     # Start mining
+    journalctl --user -u rustchain-miner -f    # View logs
+    ```
+
+=== "macOS (launchd)"
+
+    ```bash
+    launchctl list | grep rustchain            # Check status
+    launchctl stop com.rustchain.miner         # Stop mining
+    launchctl start com.rustchain.miner        # Start mining
+    tail -f ~/.rustchain/miner.log             # View logs
+    ```
+
+---
+
+## ARM64 Validation (Raspberry Pi 4/5)
+
+```bash
+pip install clawrtc
+clawrtc mine --dry-run
+```
+
+All 6 hardware fingerprint checks should execute on native ARM64 without architecture fallback errors.
+
+---
+
+## Docker Install
+
+Pull and run the miner container:
+
+```bash
+docker-compose -f docker-compose.miner.yml up -d
+```
+
+Or build from the provided Dockerfile:
+
+```bash
+docker build -f Dockerfile.miner -t rustchain-miner .
+docker run -d --name miner rustchain-miner
+```
+
+See [DOCKER_DEPLOYMENT.md](https://github.com/Scottcjn/Rustchain/blob/main/DOCKER_DEPLOYMENT.md) for full Docker configuration options.
+
+---
+
+## Troubleshooting
+
+!!! warning "Installer fails with permission errors"
+    Re-run using an account with write access to `~/.local` and avoid running inside a system Python's global site-packages.
+
+!!! warning "Python version errors (SyntaxError / ModuleNotFoundError)"
+    Install with Python 3.10+ and set `python3` to that interpreter:
+    ```bash
+    python3 --version
+    curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+    ```
+
+!!! warning "Wallet shows 'could not reach network'"
+    Verify the live node directly:
+    ```bash
+    curl -sk https://rustchain.org/health
+    curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+    ```
+
+!!! warning "HTTPS certificate errors"
+    The node may use a self-signed certificate. Use the `-sk` flags with curl:
+    ```bash
+    curl -I https://rustchain.org
+    ```
+
+!!! warning "Miner exits immediately"
+    Verify wallet exists and service is running:
+    ```bash
+    # Linux
+    systemctl --user status rustchain-miner
+    # macOS
+    launchctl list | grep rustchain
+    ```
+
+If an issue persists, include logs and OS details in a [new issue](https://github.com/Scottcjn/Rustchain/issues) with exact error output and your `install-miner.sh --dry-run` result.
+
+---
+
+## Next Steps
+
+- Read the [Mining Guide](mining.md) for hardware multipliers and reward mechanics
+- Explore the [API Reference](api-reference.md) to integrate with RustChain
+- Check [open bounties](https://github.com/Scottcjn/rustchain-bounties/issues) and start earning RTC for contributions

--- a/docs-site/docs/index.md
+++ b/docs-site/docs/index.md
@@ -1,0 +1,109 @@
+# RustChain: Proof-of-Antiquity Blockchain
+
+**The first blockchain that rewards vintage hardware for being old, not fast.**
+
+Named after a 486 with rusty serial ports that still boots -- RustChain flips mining on its head. Your PowerPC G4 earns more than a modern Threadripper.
+
+---
+
+## What is RustChain?
+
+RustChain is a **Proof-of-Antiquity (PoA)** blockchain where hardware age determines mining rewards. Instead of racing to buy the newest GPUs, miners dust off vintage machines -- PowerPC Macs, Pentium 4 towers, IBM POWER8 servers -- and put them to work earning RTC tokens.
+
+| Traditional PoW | Proof-of-Antiquity |
+|----------------|-------------------|
+| Rewards fastest hardware | Rewards oldest hardware |
+| Newer = Better | Older = Better |
+| Wasteful energy consumption | Preserves computing history |
+| Race to the bottom | Rewards digital preservation |
+
+**Core principle**: Authentic vintage hardware that has survived decades deserves recognition. RustChain proves that corroding vintage hardware still has computational value and dignity.
+
+---
+
+## Key Features
+
+- **Hardware Fingerprinting** -- Six cryptographic checks verify authentic vintage silicon. No VM spoofing.
+- **1 CPU = 1 Vote** -- Fair round-robin consensus via RIP-200. Hash power is irrelevant.
+- **Antiquity Multipliers** -- A PowerPC G4 earns 2.5x rewards; a G5 earns 2.0x. Modern hardware earns baseline 1.0x.
+- **Ergo Anchoring** -- Epoch settlements are cryptographically anchored to the Ergo blockchain for immutability.
+- **wRTC on Solana** -- Bridge RTC to Solana as wRTC and trade on Raydium DEX.
+- **Agent Wallets + x402** -- Machine-to-machine payments via Coinbase Base wallets and the x402 protocol.
+- **Bounty System** -- Earn RTC for code contributions, bug fixes, docs, and security audits.
+
+---
+
+## Quick Links
+
+| Resource | URL |
+|----------|-----|
+| Website | [rustchain.org](https://rustchain.org) |
+| Block Explorer | [rustchain.org/explorer](https://rustchain.org/explorer) |
+| Swap wRTC (Raydium) | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| Price Chart | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
+| Bridge RTC to wRTC | [BoTTube Bridge](https://bottube.ai/bridge) |
+| Whitepaper | [Flameholder v0.97](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) |
+| Discord | [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q) |
+| GitHub | [Scottcjn/Rustchain](https://github.com/Scottcjn/Rustchain) |
+| Open Bounties | [rustchain-bounties](https://github.com/Scottcjn/rustchain-bounties/issues) |
+
+---
+
+## wRTC on Solana
+
+RustChain Token (RTC) is available as **wRTC** on Solana via the BoTTube Bridge:
+
+| Resource | Link |
+|----------|------|
+| Swap wRTC | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| Price Chart | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
+| Bridge RTC to wRTC | [BoTTube Bridge](https://bottube.ai/bridge) |
+| Token Mint | `12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X` |
+
+---
+
+## Contribute and Earn RTC
+
+Every contribution earns RTC tokens. Bug fixes, features, docs, security audits -- all paid.
+
+| Tier | Reward | Examples |
+|------|--------|----------|
+| Micro | 1-10 RTC | Typo fix, small docs, simple test |
+| Standard | 20-50 RTC | Feature, refactor, new endpoint |
+| Major | 75-100 RTC | Security fix, consensus improvement |
+| Critical | 100-150 RTC | Vulnerability patch, protocol upgrade |
+
+**1 RTC = $0.10 USD** -- Get started with `pip install clawrtc`
+
+---
+
+## Supported Platforms
+
+| Platform | Architecture | Status |
+|----------|--------------|--------|
+| Mac OS X Tiger/Leopard | PowerPC G4/G5 | Full Support |
+| Ubuntu Linux | ppc64le / POWER8 | Full Support |
+| Ubuntu Linux | x86_64 | Full Support |
+| macOS Sonoma+ | Apple Silicon (M1-M4) | Full Support |
+| Windows 10/11 | x86_64 | Full Support |
+| DOS | 8086/286/386 | Experimental |
+
+---
+
+## Academic Publications
+
+| Paper | DOI |
+|-------|-----|
+| RustChain: One CPU, One Vote | [10.5281/zenodo.18623592](https://doi.org/10.5281/zenodo.18623592) |
+| Non-Bijunctive Permutation Collapse | [10.5281/zenodo.18623920](https://doi.org/10.5281/zenodo.18623920) |
+| PSE Hardware Entropy | [10.5281/zenodo.18623922](https://doi.org/10.5281/zenodo.18623922) |
+| Neuromorphic Prompt Translation | [10.5281/zenodo.18623594](https://doi.org/10.5281/zenodo.18623594) |
+| RAM Coffers | [10.5281/zenodo.18321905](https://doi.org/10.5281/zenodo.18321905) |
+
+---
+
+## License
+
+RustChain is released under the [Apache License 2.0](https://github.com/Scottcjn/Rustchain/blob/main/LICENSE).
+
+Built by [Elyan Labs](https://elyanlabs.ai) -- with $0 VC and a room full of pawn shop hardware.

--- a/docs-site/docs/mining.md
+++ b/docs-site/docs/mining.md
@@ -1,0 +1,218 @@
+# Mining Guide
+
+RustChain uses **Proof-of-Antiquity** consensus -- your hardware's age determines your mining rewards. Older hardware earns more.
+
+---
+
+## How Mining Works
+
+### 1 CPU = 1 Vote (RIP-200)
+
+Unlike Proof-of-Work where hash power equals votes, RustChain uses round-robin consensus:
+
+- Each unique hardware device gets exactly 1 vote per epoch
+- Rewards are split equally among all voters, then multiplied by antiquity
+- No advantage from running multiple threads or faster CPUs
+
+### Epoch-Based Rewards
+
+```
+Epoch Duration:     10 minutes (600 seconds)
+Base Reward Pool:   1.5 RTC per epoch
+Distribution:       Equal split x antiquity multiplier
+```
+
+---
+
+## Antiquity Multipliers
+
+Your hardware's age determines your reward multiplier:
+
+| Hardware | Era | Multiplier | Example Earnings |
+|----------|-----|------------|------------------|
+| PowerPC G4 | 1999-2005 | **2.5x** | 0.30 RTC/epoch |
+| PowerPC G5 | 2003-2006 | **2.0x** | 0.24 RTC/epoch |
+| PowerPC G3 | 1997-2003 | **1.8x** | 0.21 RTC/epoch |
+| IBM POWER8 | 2014 | **1.5x** | 0.18 RTC/epoch |
+| Pentium 4 | 2000-2008 | **1.5x** | 0.18 RTC/epoch |
+| Core 2 Duo | 2006-2011 | **1.3x** | 0.16 RTC/epoch |
+| Apple Silicon | 2020+ | **1.2x** | 0.14 RTC/epoch |
+| Modern x86_64 | Current | **1.0x** | 0.12 RTC/epoch |
+
+Multipliers decay over time (15%/year) to prevent permanent advantage.
+
+### Reward Distribution Example
+
+With 5 miners in an epoch:
+
+```
+G4 Mac (2.5x):     0.30 RTC  ====================
+G5 Mac (2.0x):     0.24 RTC  ================
+Modern PC (1.0x):  0.12 RTC  ========
+Modern PC (1.0x):  0.12 RTC  ========
+Modern PC (1.0x):  0.12 RTC  ========
+                   ---------
+Total:             0.90 RTC (+ 0.60 RTC returned to pool)
+```
+
+---
+
+## Hardware Fingerprinting
+
+Every miner must prove their hardware is real, not emulated. RustChain runs 6 cryptographic checks:
+
+| Check | What It Detects |
+|-------|-----------------|
+| Clock-Skew and Oscillator Drift | Silicon aging patterns unique to each chip |
+| Cache Timing Fingerprint | L1/L2/L3 latency profile |
+| SIMD Unit Identity | AltiVec/SSE/NEON bias characteristics |
+| Thermal Drift Entropy | Heat curves unique to physical hardware |
+| Instruction Path Jitter | Microarchitecture jitter map |
+| Anti-Emulation Checks | VM/emulator detection |
+
+A SheepShaver VM pretending to be a G4 Mac will fail these checks. Real vintage silicon has unique aging patterns that cannot be faked.
+
+### Anti-VM Penalty
+
+VMs and emulators are detected and receive **1 billionth** of normal rewards:
+
+```
+Real G4 Mac:      2.5x multiplier    = 0.30 RTC/epoch
+Emulated G4:      0.0000000025x      = 0.0000000003 RTC/epoch
+```
+
+### Hardware Binding
+
+Each hardware fingerprint is bound to one wallet. This prevents:
+
+- Multiple wallets on the same hardware
+- Hardware spoofing
+- Sybil attacks
+
+---
+
+## Time Decay Formula
+
+Vintage hardware bonuses decay to reward early adopters:
+
+**Vintage Hardware (>5 years old):**
+
+```python
+decay_factor = 1.0 - (0.15 * (age - 5) / 5.0)
+final_multiplier = 1.0 + (vintage_bonus * decay_factor)
+```
+
+**Example**: PowerPC G4 (base 2.5x, age 24 years)
+
+- Vintage bonus: 1.5x (2.5 - 1.0)
+- Age beyond 5 years: 19 years
+- Decay: 1.0 - (0.15 x 19/5) = 0.43
+- Final multiplier: 1.0 + (1.5 x 0.43) = **1.645x**
+
+### Loyalty Bonus (Modern Hardware)
+
+Modern hardware (5 years old or less) earns a loyalty bonus for sustained uptime:
+
+```python
+loyalty_bonus = min(0.5, uptime_years * 0.15)  # Capped at +50%
+final_multiplier = base + loyalty_bonus         # Max 1.5x total
+```
+
+**Example**: AMD Ryzen 9 7950X (base 1.0x)
+
+- 0 years uptime: 1.0x
+- 1 year uptime: 1.15x
+- 3 years uptime: 1.45x
+- 5+ years uptime: 1.5x (capped)
+
+---
+
+## CPU Multiplier Reference
+
+### Intel Generations
+
+| Architecture | Years | Base Multiplier |
+|-------------|-------|-----------------|
+| Pentium 4 (NetBurst) | 2000-2006 | 1.5x |
+| Core 2 | 2006-2008 | 1.3x |
+| Nehalem/Westmere | 2008-2011 | 1.2x |
+| Sandy Bridge / Ivy Bridge | 2011-2013 | 1.1x |
+| Haswell | 2013-2015 | 1.1x |
+| Broadwell / Skylake | 2014-2017 | 1.05x |
+| Kaby Lake+ | 2016+ | 1.0x |
+
+### AMD Generations
+
+| Architecture | Years | Base Multiplier |
+|-------------|-------|-----------------|
+| Athlon 64 / Opteron | 2003-2007 | 1.3x |
+| Phenom / Phenom II | 2007-2012 | 1.2x |
+| Bulldozer / Piledriver | 2011-2017 | 1.1x |
+| Zen / Zen+ | 2017-2019 | 1.0x |
+| Zen 2+ | 2019+ | 1.0x (loyalty eligible) |
+
+### Apple Silicon
+
+| Chip | Base Multiplier |
+|------|-----------------|
+| M1 | 1.2x |
+| M2 | 1.15x |
+| M3 | 1.1x |
+| M4 | 1.05x |
+
+### PowerPC
+
+| Chip | Base Multiplier |
+|------|-----------------|
+| G3 | 1.8x |
+| G4 | 2.5x |
+| G5 | 2.0x |
+
+### Server Bonus
+
+Enterprise-class hardware (Xeon, POWER8, Opteron) receives an additional **+10%** multiplier bonus.
+
+---
+
+## Start Mining
+
+### Quick Start
+
+```bash
+pip install clawrtc
+clawrtc --wallet YOUR_NAME
+```
+
+### Check Your Earnings
+
+```bash
+curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+```
+
+### NFT Badge System
+
+Mining milestones unlock commemorative badges:
+
+| Badge | Requirement | Rarity |
+|-------|-------------|--------|
+| Bondi G3 Flamekeeper | Mine on PowerPC G3 | Rare |
+| QuickBasic Listener | Mine from DOS machine | Legendary |
+| DOS WiFi Alchemist | Network DOS machine | Mythic |
+| Pantheon Pioneer | First 100 miners | Limited |
+
+---
+
+## Token Economics
+
+| Metric | Value |
+|--------|-------|
+| Total Supply | 8,000,000 RTC |
+| Premine | 75,000 RTC (dev/bounties) |
+| Epoch Reward | 1.5 RTC |
+| Epoch Duration | ~24 hours |
+| Annual Inflation | ~0.68% (decreasing) |
+| Reference Rate | 1 RTC = $0.10 USD |
+
+### Bridge to Solana
+
+Convert RTC to wRTC (Solana SPL token) via the [BoTTube Bridge](https://bottube.ai/bridge) and trade on [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X).

--- a/docs-site/mkdocs.yml
+++ b/docs-site/mkdocs.yml
@@ -1,0 +1,90 @@
+site_name: RustChain Documentation
+site_url: https://docs.rustchain.org
+site_description: Official documentation for RustChain — the Proof-of-Antiquity blockchain that rewards vintage hardware.
+site_author: Elyan Labs
+
+repo_name: Scottcjn/Rustchain
+repo_url: https://github.com/Scottcjn/Rustchain
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep orange
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/link-variant
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Mining Guide: mining.md
+  - Architecture: architecture.md
+  - API Reference: api-reference.md
+  - Contributing: contributing.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.mark
+  - pymdownx.critic
+  - pymdownx.keys
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Scottcjn/Rustchain
+    - icon: fontawesome/brands/discord
+      link: https://discord.gg/VqVVS2CW9Q
+  generator: false
+
+extra_css: []
+
+copyright: Copyright &copy; 2025-2026 Elyan Labs &mdash; RustChain is licensed under Apache 2.0


### PR DESCRIPTION
## Summary

- Adds a `docs-site/` directory with a complete MkDocs documentation site using the Material theme
- Includes seven documentation pages: landing page, quickstart guide, mining guide, system architecture, API reference, contribution guide, and FAQ
- All content is sourced from existing project documentation (README, CONTRIBUTING, API_WALKTHROUGH, protocol-overview, chain_architecture, CPU_ANTIQUITY_SYSTEM, etc.)
- Configured with dark/light mode toggle, code copy buttons, Mermaid diagram support, search, and RustChain branding (deep orange/amber palette)

## Pages

| Page | Description |
|------|-------------|
| `index.md` | Landing page with project overview, features, quick links, and platform support |
| `getting-started.md` | Installation guide covering one-line install, manual install, Windows, Docker, and troubleshooting |
| `mining.md` | Mining mechanics, antiquity multipliers, hardware fingerprinting, time decay formulas, CPU reference tables |
| `architecture.md` | RIP-200 consensus flow, network topology, block structure, Ergo anchoring, security model |
| `api-reference.md` | REST API endpoints for health, wallet, miners, governance, x402, and agent wallets |
| `contributing.md` | Bounty tiers, dev setup, code style, BCOS requirements, payout process |
| `faq.md` | Frequently asked questions covering general, mining, tokens, technical, and troubleshooting topics |

## Usage

```bash
pip install mkdocs mkdocs-material mkdocs-minify-plugin
cd docs-site
mkdocs serve        # local dev server
mkdocs build        # static build
mkdocs gh-deploy    # deploy to GitHub Pages
```

## Test plan

- [ ] Run `mkdocs serve` and verify all pages render correctly
- [ ] Verify Mermaid diagrams render on the Architecture page
- [ ] Confirm dark/light mode toggle works
- [ ] Test code copy buttons on code blocks
- [ ] Verify all external links resolve
- [ ] Build with `mkdocs build` and confirm no warnings