### PR TITLE
feat: email notification service for RustChain events

### DIFF
--- a/tools/email-alerts/README.md
+++ b/tools/email-alerts/README.md
@@ -1,0 +1,160 @@
+# RustChain Email Alerts
+
+Email notification service for RustChain blockchain events. Subscribe to on-chain events and receive HTML email alerts via SMTP with support for instant delivery or digest summaries.
+
+## Features
+
+- **Event subscriptions** — new epoch, miner changes, balance changes
+- **HTML email templates** — styled, responsive email notifications
+- **SMTP support** — Gmail, Outlook, Yahoo presets or custom SMTP servers
+- **Digest mode** — instant, hourly, or daily event summaries
+- **Unsubscribe management** — HMAC-signed tokens for secure unsubscribe links
+- **SQLite storage** — lightweight subscriber and digest queue persistence
+- **CLI interface** — manage subscriptions and run the service from the command line
+
+## Quick Start
+
+### 1. Configure SMTP
+
+Set environment variables for your mail server:
+
+```bash
+# Gmail example (use App Password, not account password)
+export RUSTCHAIN_SMTP_PRESET=gmail
+export RUSTCHAIN_SMTP_USER=you@gmail.com
+export RUSTCHAIN_SMTP_PASS=your-app-password
+
+# Or use custom SMTP
+export RUSTCHAIN_SMTP_HOST=mail.example.com
+export RUSTCHAIN_SMTP_PORT=587
+export RUSTCHAIN_SMTP_TLS=true
+export RUSTCHAIN_SMTP_USER=alerts@example.com
+export RUSTCHAIN_SMTP_PASS=secret
+export RUSTCHAIN_SMTP_FROM=alerts@example.com
+
+# Unsubscribe token secret (change in production)
+export RUSTCHAIN_UNSUB_SECRET=my-secret-key
+```
+
+### 2. Add Subscribers
+
+```bash
+# Subscribe to all events (instant delivery)
+python alerts.py subscribe alice@example.com
+
+# Subscribe to specific events with daily digest
+python alerts.py subscribe bob@example.com \
+  --events new_epoch balance_change \
+  --digest daily \
+  --wallet RTC1abc...
+
+# List subscribers
+python alerts.py list
+```
+
+### 3. Run the Service
+
+```bash
+# Start polling (default: every 30 seconds)
+python alerts.py run
+
+# Custom node URL and interval
+python alerts.py run --node-url http://localhost:8099 --interval 60
+
+# Custom database path
+python alerts.py run --db /path/to/alerts.db
+```
+
+## Programmatic Usage
+
+```python
+from alerts import RustChainEmailAlerts, SMTPConfig
+
+smtp = SMTPConfig(
+    host="smtp.gmail.com",
+    port=587,
+    tls=True,
+    username="you@gmail.com",
+    password="app-password",
+    from_addr="you@gmail.com",
+)
+
+svc = RustChainEmailAlerts(
+    node_url="https://50.28.86.131",
+    smtp=smtp,
+    poll_interval=30,
+)
+
+# Add subscribers
+svc.subscribe("alice@example.com", ["new_epoch", "miner_change"])
+svc.subscribe("bob@example.com", ["balance_change"], digest="hourly", wallet="RTC1...")
+
+# Start background polling
+svc.start()
+
+# ... later ...
+svc.stop()
+```
+
+## Event Types
+
+| Event | Description | Payload |
+|-------|-------------|---------|
+| `new_epoch` | A new epoch begins | `previous_epoch`, `new_epoch`, `epoch_data` |
+| `miner_change` | Miners join or leave | `joined`, `left`, `total_miners` |
+| `balance_change` | Wallet balance changes | `wallet`, `old_balance`, `new_balance`, `change` |
+
+## Digest Modes
+
+| Mode | Description |
+|------|-------------|
+| `instant` | Send immediately when an event is detected |
+| `hourly` | Batch events and send a summary every hour |
+| `daily` | Batch events and send a summary every 24 hours |
+
+## Templates
+
+HTML email templates are in the `templates/` directory:
+
+| File | Purpose |
+|------|---------|
+| `welcome.html` | Sent on new subscription |
+| `new_epoch.html` | New epoch notification |
+| `miner_change.html` | Miner join/leave notification |
+| `balance_change.html` | Wallet balance change notification |
+| `digest.html` | Hourly/daily event summary |
+| `generic_event.html` | Fallback for unknown event types |
+| `base.html` | Base template with shared styles |
+
+Templates use `{{ variable }}` placeholders that are replaced at render time.
+
+## CLI Reference
+
+```
+usage: alerts.py [-h] {run,subscribe,unsubscribe,list} ...
+
+RustChain Email Alert Service
+
+commands:
+  run            Start the alert polling service
+  subscribe      Add a subscriber
+  unsubscribe    Remove a subscriber
+  list           List all subscribers
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RUSTCHAIN_SMTP_PRESET` | — | SMTP preset: `gmail`, `outlook`, `yahoo` |
+| `RUSTCHAIN_SMTP_HOST` | `smtp.gmail.com` | SMTP server hostname |
+| `RUSTCHAIN_SMTP_PORT` | `587` | SMTP server port |
+| `RUSTCHAIN_SMTP_TLS` | `true` | Enable STARTTLS |
+| `RUSTCHAIN_SMTP_USER` | — | SMTP username |
+| `RUSTCHAIN_SMTP_PASS` | — | SMTP password |
+| `RUSTCHAIN_SMTP_FROM` | `SMTP_USER` | Sender email address |
+| `RUSTCHAIN_UNSUB_SECRET` | `change-me-in-production` | HMAC secret for unsubscribe tokens |
+
+## License
+
+Apache-2.0 — same as the RustChain project.

--- a/tools/email-alerts/__init__.py
+++ b/tools/email-alerts/__init__.py
@@ -1,0 +1,21 @@
+"""RustChain Email Alert Service."""
+
+from .alerts import (
+    RustChainEmailAlerts,
+    SMTPConfig,
+    EventType,
+    DigestMode,
+    Subscriber,
+    Event,
+    SubscriberStore,
+)
+
+__all__ = [
+    "RustChainEmailAlerts",
+    "SMTPConfig",
+    "EventType",
+    "DigestMode",
+    "Subscriber",
+    "Event",
+    "SubscriberStore",
+]

--- a/tools/email-alerts/alerts.py
+++ b/tools/email-alerts/alerts.py
@@ -1,0 +1,726 @@
+#!/usr/bin/env python3
+"""
+RustChain Email Notification Service
+
+Subscribe to blockchain events (new epoch, miner changes, balance changes)
+and receive HTML email alerts via SMTP. Supports digest mode (hourly/daily)
+and per-subscriber unsubscribe management.
+"""
+
+import json
+import hashlib
+import hmac
+import logging
+import os
+import smtplib
+import sqlite3
+import threading
+import time
+import urllib.request
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timedelta, timezone
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger("rustchain.email-alerts")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_NODE_URL = "https://50.28.86.131"
+DEFAULT_DB_PATH = Path.home() / ".rustchain" / "email_alerts.db"
+DEFAULT_POLL_INTERVAL = 30  # seconds
+UNSUBSCRIBE_SECRET = os.getenv("RUSTCHAIN_UNSUB_SECRET", "change-me-in-production")
+
+
+# ---------------------------------------------------------------------------
+# Enums & data classes
+# ---------------------------------------------------------------------------
+
+class EventType(str, Enum):
+    NEW_EPOCH = "new_epoch"
+    MINER_CHANGE = "miner_change"
+    BALANCE_CHANGE = "balance_change"
+
+
+class DigestMode(str, Enum):
+    INSTANT = "instant"
+    HOURLY = "hourly"
+    DAILY = "daily"
+
+
+@dataclass
+class Subscriber:
+    email: str
+    events: list[str]
+    digest: str = DigestMode.INSTANT
+    wallet: str = ""
+    active: bool = True
+    created_at: str = ""
+    token: str = ""
+
+
+@dataclass
+class Event:
+    event_type: str
+    payload: dict
+    timestamp: str = ""
+
+    def __post_init__(self):
+        if not self.timestamp:
+            self.timestamp = datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# SMTP presets
+# ---------------------------------------------------------------------------
+
+SMTP_PRESETS = {
+    "gmail": {"host": "smtp.gmail.com", "port": 587, "tls": True},
+    "outlook": {"host": "smtp.office365.com", "port": 587, "tls": True},
+    "yahoo": {"host": "smtp.mail.yahoo.com", "port": 587, "tls": True},
+}
+
+
+@dataclass
+class SMTPConfig:
+    host: str = "smtp.gmail.com"
+    port: int = 587
+    tls: bool = True
+    username: str = ""
+    password: str = ""
+    from_addr: str = ""
+
+    @classmethod
+    def from_env(cls) -> "SMTPConfig":
+        preset_name = os.getenv("RUSTCHAIN_SMTP_PRESET", "").lower()
+        preset = SMTP_PRESETS.get(preset_name, {})
+        return cls(
+            host=os.getenv("RUSTCHAIN_SMTP_HOST", preset.get("host", "smtp.gmail.com")),
+            port=int(os.getenv("RUSTCHAIN_SMTP_PORT", preset.get("port", 587))),
+            tls=os.getenv("RUSTCHAIN_SMTP_TLS", str(preset.get("tls", True))).lower()
+            in ("true", "1", "yes"),
+            username=os.getenv("RUSTCHAIN_SMTP_USER", ""),
+            password=os.getenv("RUSTCHAIN_SMTP_PASS", ""),
+            from_addr=os.getenv(
+                "RUSTCHAIN_SMTP_FROM",
+                os.getenv("RUSTCHAIN_SMTP_USER", "alerts@rustchain.org"),
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Template loader
+# ---------------------------------------------------------------------------
+
+TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+
+def _load_template(name: str) -> str:
+    path = TEMPLATE_DIR / name
+    if path.exists():
+        return path.read_text(encoding="utf-8")
+    raise FileNotFoundError(f"Template not found: {path}")
+
+
+def _render(template: str, ctx: dict) -> str:
+    """Minimal {{ key }} replacement."""
+    out = template
+    for key, val in ctx.items():
+        out = out.replace("{{" + f" {key} " + "}}", str(val))
+        out = out.replace("{{" + key + "}}", str(val))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Database layer
+# ---------------------------------------------------------------------------
+
+class SubscriberStore:
+    def __init__(self, db_path: Path = DEFAULT_DB_PATH):
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+        self._lock = threading.Lock()
+        self._init_tables()
+
+    def _init_tables(self):
+        with self._lock, self._conn:
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS subscribers (
+                    email       TEXT PRIMARY KEY,
+                    events      TEXT NOT NULL,
+                    digest      TEXT NOT NULL DEFAULT 'instant',
+                    wallet      TEXT NOT NULL DEFAULT '',
+                    active      INTEGER NOT NULL DEFAULT 1,
+                    created_at  TEXT NOT NULL,
+                    token       TEXT NOT NULL
+                )
+            """)
+            self._conn.execute("""
+                CREATE TABLE IF NOT EXISTS pending_digests (
+                    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                    email       TEXT NOT NULL,
+                    event_type  TEXT NOT NULL,
+                    payload     TEXT NOT NULL,
+                    created_at  TEXT NOT NULL,
+                    FOREIGN KEY (email) REFERENCES subscribers(email)
+                )
+            """)
+
+    @staticmethod
+    def _make_token(email: str) -> str:
+        return hmac.new(
+            UNSUBSCRIBE_SECRET.encode(), email.encode(), hashlib.sha256
+        ).hexdigest()[:16]
+
+    def subscribe(self, sub: Subscriber) -> Subscriber:
+        sub.created_at = sub.created_at or datetime.now(timezone.utc).isoformat()
+        sub.token = self._make_token(sub.email)
+        with self._lock, self._conn:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO subscribers
+                   (email, events, digest, wallet, active, created_at, token)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    sub.email,
+                    json.dumps(sub.events),
+                    sub.digest,
+                    sub.wallet,
+                    int(sub.active),
+                    sub.created_at,
+                    sub.token,
+                ),
+            )
+        log.info("Subscribed %s to %s (digest=%s)", sub.email, sub.events, sub.digest)
+        return sub
+
+    def unsubscribe(self, email: str, token: str) -> bool:
+        expected = self._make_token(email)
+        if not hmac.compare_digest(token, expected):
+            log.warning("Invalid unsubscribe token for %s", email)
+            return False
+        with self._lock, self._conn:
+            self._conn.execute(
+                "UPDATE subscribers SET active = 0 WHERE email = ?", (email,)
+            )
+        log.info("Unsubscribed %s", email)
+        return True
+
+    def resubscribe(self, email: str) -> bool:
+        with self._lock, self._conn:
+            cur = self._conn.execute(
+                "UPDATE subscribers SET active = 1 WHERE email = ?", (email,)
+            )
+        return cur.rowcount > 0
+
+    def get_subscribers(self, event_type: str) -> list[Subscriber]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT email, events, digest, wallet, active, created_at, token "
+                "FROM subscribers WHERE active = 1"
+            ).fetchall()
+        out = []
+        for row in rows:
+            events = json.loads(row[1])
+            if event_type in events:
+                out.append(
+                    Subscriber(
+                        email=row[0],
+                        events=events,
+                        digest=row[2],
+                        wallet=row[3],
+                        active=bool(row[4]),
+                        created_at=row[5],
+                        token=row[6],
+                    )
+                )
+        return out
+
+    def list_all(self) -> list[Subscriber]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT email, events, digest, wallet, active, created_at, token "
+                "FROM subscribers"
+            ).fetchall()
+        return [
+            Subscriber(
+                email=r[0],
+                events=json.loads(r[1]),
+                digest=r[2],
+                wallet=r[3],
+                active=bool(r[4]),
+                created_at=r[5],
+                token=r[6],
+            )
+            for r in rows
+        ]
+
+    # -- digest queue -------------------------------------------------------
+
+    def queue_digest(self, email: str, event: Event):
+        with self._lock, self._conn:
+            self._conn.execute(
+                "INSERT INTO pending_digests (email, event_type, payload, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (email, event.event_type, json.dumps(event.payload), event.timestamp),
+            )
+
+    def flush_digest(self, email: str) -> list[Event]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT event_type, payload, created_at FROM pending_digests "
+                "WHERE email = ? ORDER BY created_at",
+                (email,),
+            ).fetchall()
+            self._conn.execute(
+                "DELETE FROM pending_digests WHERE email = ?", (email,)
+            )
+            self._conn.commit()
+        return [Event(r[0], json.loads(r[1]), r[2]) for r in rows]
+
+    def close(self):
+        self._conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Email sender
+# ---------------------------------------------------------------------------
+
+class EmailSender:
+    def __init__(self, smtp: SMTPConfig):
+        self.smtp = smtp
+
+    def send(self, to: str, subject: str, html_body: str):
+        msg = MIMEMultipart("alternative")
+        msg["From"] = self.smtp.from_addr
+        msg["To"] = to
+        msg["Subject"] = subject
+
+        # plain text fallback
+        plain = html_body.replace("<br>", "\n").replace("</p>", "\n")
+        import re
+        plain = re.sub(r"<[^>]+>", "", plain)
+
+        msg.attach(MIMEText(plain, "plain"))
+        msg.attach(MIMEText(html_body, "html"))
+
+        try:
+            if self.smtp.tls:
+                server = smtplib.SMTP(self.smtp.host, self.smtp.port, timeout=15)
+                server.ehlo()
+                server.starttls()
+            else:
+                server = smtplib.SMTP(self.smtp.host, self.smtp.port, timeout=15)
+
+            if self.smtp.username:
+                server.login(self.smtp.username, self.smtp.password)
+
+            server.sendmail(self.smtp.from_addr, [to], msg.as_string())
+            server.quit()
+            log.info("Email sent to %s: %s", to, subject)
+        except Exception:
+            log.exception("Failed to send email to %s", to)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Node poller
+# ---------------------------------------------------------------------------
+
+class NodePoller:
+    """Polls the RustChain node for state changes."""
+
+    def __init__(self, node_url: str = DEFAULT_NODE_URL):
+        self.node_url = node_url.rstrip("/")
+        self._last_epoch: Optional[int] = None
+        self._last_miners: Optional[set] = None
+        self._last_balances: dict[str, float] = {}
+
+    def _get(self, path: str, timeout: int = 10) -> Optional[dict]:
+        try:
+            req = urllib.request.Request(
+                f"{self.node_url}{path}",
+                headers={"Accept": "application/json"},
+            )
+            with urllib.request.urlopen(req, timeout=timeout) as r:
+                return json.loads(r.read())
+        except Exception as exc:
+            log.debug("Polling %s failed: %s", path, exc)
+            return None
+
+    def check_epoch(self) -> Optional[Event]:
+        data = self._get("/epoch")
+        if data is None:
+            return None
+        epoch_num = data.get("epoch") or data.get("current_epoch")
+        if epoch_num is None:
+            return None
+        if self._last_epoch is not None and epoch_num != self._last_epoch:
+            event = Event(
+                EventType.NEW_EPOCH,
+                {
+                    "previous_epoch": self._last_epoch,
+                    "new_epoch": epoch_num,
+                    "epoch_data": data,
+                },
+            )
+            self._last_epoch = epoch_num
+            return event
+        self._last_epoch = epoch_num
+        return None
+
+    def check_miners(self) -> Optional[Event]:
+        data = self._get("/miners") or self._get("/health")
+        if data is None:
+            return None
+        miners = set()
+        if isinstance(data, list):
+            miners = {m.get("id", str(m)) for m in data}
+        elif isinstance(data, dict) and "miners" in data:
+            miners = set(data["miners"]) if isinstance(data["miners"], list) else set()
+        elif isinstance(data, dict) and "active_miners" in data:
+            miners = set(str(data["active_miners"]))
+
+        if not miners:
+            return None
+
+        if self._last_miners is not None and miners != self._last_miners:
+            joined = miners - self._last_miners
+            left = self._last_miners - miners
+            event = Event(
+                EventType.MINER_CHANGE,
+                {
+                    "joined": list(joined),
+                    "left": list(left),
+                    "total_miners": len(miners),
+                },
+            )
+            self._last_miners = miners
+            return event
+        self._last_miners = miners
+        return None
+
+    def check_balance(self, wallet: str) -> Optional[Event]:
+        data = self._get(f"/balance/{wallet}")
+        if data is None:
+            return None
+        balance = data.get("balance") or data.get("amount")
+        if balance is None:
+            return None
+        balance = float(balance)
+        old = self._last_balances.get(wallet)
+        if old is not None and balance != old:
+            event = Event(
+                EventType.BALANCE_CHANGE,
+                {
+                    "wallet": wallet,
+                    "old_balance": old,
+                    "new_balance": balance,
+                    "change": round(balance - old, 8),
+                },
+            )
+            self._last_balances[wallet] = balance
+            return event
+        self._last_balances[wallet] = balance
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Alert service (main orchestrator)
+# ---------------------------------------------------------------------------
+
+class RustChainEmailAlerts:
+    """
+    Main service: polls the node, detects events, sends emails.
+
+    Usage:
+        svc = RustChainEmailAlerts()
+        svc.subscribe("alice@example.com", ["new_epoch", "balance_change"],
+                       digest="daily", wallet="RTC...")
+        svc.start()     # starts background polling
+        svc.stop()
+    """
+
+    def __init__(
+        self,
+        node_url: str = DEFAULT_NODE_URL,
+        smtp: Optional[SMTPConfig] = None,
+        db_path: Path = DEFAULT_DB_PATH,
+        poll_interval: int = DEFAULT_POLL_INTERVAL,
+        base_url: str = "https://alerts.rustchain.org",
+    ):
+        self.store = SubscriberStore(db_path)
+        self.sender = EmailSender(smtp or SMTPConfig.from_env())
+        self.poller = NodePoller(node_url)
+        self.poll_interval = poll_interval
+        self.base_url = base_url.rstrip("/")
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._digest_thread: Optional[threading.Thread] = None
+
+    # -- public API ---------------------------------------------------------
+
+    def subscribe(
+        self,
+        email: str,
+        events: list[str],
+        digest: str = DigestMode.INSTANT,
+        wallet: str = "",
+    ) -> Subscriber:
+        sub = Subscriber(email=email, events=events, digest=digest, wallet=wallet)
+        self.store.subscribe(sub)
+        # send welcome email
+        try:
+            html = _load_template("welcome.html")
+            html = _render(html, {
+                "email": email,
+                "events": ", ".join(events),
+                "digest": digest,
+                "unsubscribe_url": self._unsub_url(email, sub.token),
+            })
+            self.sender.send(email, "Welcome to RustChain Alerts", html)
+        except Exception:
+            log.debug("Could not send welcome email (template or SMTP issue)")
+        return sub
+
+    def unsubscribe(self, email: str, token: str) -> bool:
+        return self.store.unsubscribe(email, token)
+
+    def list_subscribers(self) -> list[Subscriber]:
+        return self.store.list_all()
+
+    def start(self):
+        if self._thread and self._thread.is_alive():
+            log.warning("Alert service already running")
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._thread.start()
+        self._digest_thread = threading.Thread(target=self._digest_loop, daemon=True)
+        self._digest_thread.start()
+        log.info("RustChain email alert service started (interval=%ds)", self.poll_interval)
+
+    def stop(self):
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=10)
+        if self._digest_thread:
+            self._digest_thread.join(timeout=10)
+        self.store.close()
+        log.info("RustChain email alert service stopped")
+
+    # -- internals ----------------------------------------------------------
+
+    def _unsub_url(self, email: str, token: str) -> str:
+        return f"{self.base_url}/unsubscribe?email={email}&token={token}"
+
+    def _poll_loop(self):
+        while not self._stop.is_set():
+            try:
+                self._poll_once()
+            except Exception:
+                log.exception("Poll cycle error")
+            self._stop.wait(self.poll_interval)
+
+    def _poll_once(self):
+        # check epoch
+        event = self.poller.check_epoch()
+        if event:
+            self._dispatch(event)
+
+        # check miners
+        event = self.poller.check_miners()
+        if event:
+            self._dispatch(event)
+
+        # check balances for each subscribed wallet
+        wallets = set()
+        for sub in self.store.get_subscribers(EventType.BALANCE_CHANGE):
+            if sub.wallet:
+                wallets.add((sub.wallet, sub.email))
+        for wallet, _ in wallets:
+            event = self.poller.check_balance(wallet)
+            if event:
+                self._dispatch(event)
+
+    def _dispatch(self, event: Event):
+        subscribers = self.store.get_subscribers(event.event_type)
+        if not subscribers:
+            return
+
+        # for balance_change, filter to matching wallet
+        if event.event_type == EventType.BALANCE_CHANGE:
+            wallet = event.payload.get("wallet", "")
+            subscribers = [s for s in subscribers if s.wallet == wallet]
+
+        for sub in subscribers:
+            if sub.digest == DigestMode.INSTANT:
+                self._send_event(sub, event)
+            else:
+                self.store.queue_digest(sub.email, event)
+
+    def _send_event(self, sub: Subscriber, event: Event):
+        try:
+            template_name = f"{event.event_type}.html"
+            html = _load_template(template_name)
+        except FileNotFoundError:
+            html = _load_template("generic_event.html")
+
+        ctx = {
+            "email": sub.email,
+            "event_type": event.event_type.replace("_", " ").title(),
+            "timestamp": event.timestamp,
+            "unsubscribe_url": self._unsub_url(sub.email, sub.token),
+            **event.payload,
+        }
+        # flatten nested dicts
+        for k, v in list(ctx.items()):
+            if isinstance(v, (dict, list)):
+                ctx[k] = json.dumps(v, indent=2)
+
+        html = _render(html, ctx)
+        subject = f"RustChain Alert: {ctx['event_type']}"
+        try:
+            self.sender.send(sub.email, subject, html)
+        except Exception:
+            log.exception("Failed to deliver alert to %s", sub.email)
+
+    def _digest_loop(self):
+        """Flush digest queues on schedule."""
+        last_hourly = datetime.now(timezone.utc)
+        last_daily = datetime.now(timezone.utc)
+
+        while not self._stop.is_set():
+            now = datetime.now(timezone.utc)
+
+            # hourly flush
+            if (now - last_hourly) >= timedelta(hours=1):
+                self._flush_digests(DigestMode.HOURLY)
+                last_hourly = now
+
+            # daily flush
+            if (now - last_daily) >= timedelta(days=1):
+                self._flush_digests(DigestMode.DAILY)
+                last_daily = now
+
+            self._stop.wait(60)
+
+    def _flush_digests(self, mode: str):
+        subs = [s for s in self.store.list_all() if s.active and s.digest == mode]
+        for sub in subs:
+            events = self.store.flush_digest(sub.email)
+            if not events:
+                continue
+            self._send_digest(sub, events)
+
+    def _send_digest(self, sub: Subscriber, events: list[Event]):
+        try:
+            html = _load_template("digest.html")
+        except FileNotFoundError:
+            html = _load_template("generic_event.html")
+
+        rows = ""
+        for ev in events:
+            rows += (
+                f"<tr><td>{ev.timestamp}</td>"
+                f"<td>{ev.event_type.replace('_', ' ').title()}</td>"
+                f"<td><pre>{json.dumps(ev.payload, indent=2)}</pre></td></tr>\n"
+            )
+
+        ctx = {
+            "email": sub.email,
+            "event_count": str(len(events)),
+            "digest_mode": sub.digest.title(),
+            "event_rows": rows,
+            "unsubscribe_url": self._unsub_url(sub.email, sub.token),
+        }
+        html = _render(html, ctx)
+        subject = f"RustChain {sub.digest.title()} Digest — {len(events)} events"
+        try:
+            self.sender.send(sub.email, subject, html)
+        except Exception:
+            log.exception("Failed to send digest to %s", sub.email)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="RustChain Email Alert Service")
+    sub = parser.add_subparsers(dest="command")
+
+    # --- run ---------------------------------------------------------------
+    run_p = sub.add_parser("run", help="Start the alert polling service")
+    run_p.add_argument("--node-url", default=DEFAULT_NODE_URL)
+    run_p.add_argument("--interval", type=int, default=DEFAULT_POLL_INTERVAL)
+    run_p.add_argument("--db", default=str(DEFAULT_DB_PATH))
+
+    # --- subscribe ---------------------------------------------------------
+    sub_p = sub.add_parser("subscribe", help="Add a subscriber")
+    sub_p.add_argument("email")
+    sub_p.add_argument(
+        "--events",
+        nargs="+",
+        default=["new_epoch", "miner_change", "balance_change"],
+    )
+    sub_p.add_argument("--digest", choices=["instant", "hourly", "daily"], default="instant")
+    sub_p.add_argument("--wallet", default="")
+    sub_p.add_argument("--db", default=str(DEFAULT_DB_PATH))
+
+    # --- unsubscribe -------------------------------------------------------
+    unsub_p = sub.add_parser("unsubscribe", help="Remove a subscriber")
+    unsub_p.add_argument("email")
+    unsub_p.add_argument("token")
+    unsub_p.add_argument("--db", default=str(DEFAULT_DB_PATH))
+
+    # --- list --------------------------------------------------------------
+    list_p = sub.add_parser("list", help="List all subscribers")
+    list_p.add_argument("--db", default=str(DEFAULT_DB_PATH))
+
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if args.command == "run":
+        svc = RustChainEmailAlerts(
+            node_url=args.node_url,
+            db_path=Path(args.db),
+            poll_interval=args.interval,
+        )
+        svc.start()
+        try:
+            while True:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            svc.stop()
+
+    elif args.command == "subscribe":
+        svc = RustChainEmailAlerts(db_path=Path(args.db))
+        sub = svc.subscribe(args.email, args.events, args.digest, args.wallet)
+        print(f"Subscribed {sub.email} (token={sub.token})")
+
+    elif args.command == "unsubscribe":
+        store = SubscriberStore(Path(args.db))
+        ok = store.unsubscribe(args.email, args.token)
+        print("Unsubscribed" if ok else "Invalid token")
+        store.close()
+
+    elif args.command == "list":
+        store = SubscriberStore(Path(args.db))
+        for s in store.list_all():
+            status = "active" if s.active else "inactive"
+            print(f"  {s.email}  events={s.events}  digest={s.digest}  [{status}]")
+        store.close()
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/email-alerts/templates/balance_change.html
+++ b/tools/email-alerts/templates/balance_change.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Balance Change Alert</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #27ae60; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .balance { text-align: center; margin: 24px 0; }
+  .balance .amount { font-size: 36px; font-weight: 700; color: #1a1a2e; }
+  .balance .change-pos { color: #27ae60; font-size: 18px; }
+  .balance .change-neg { color: #e74c3c; font-size: 18px; }
+  .balance .label { font-size: 14px; color: #999; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #27ae60; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .wallet-addr { font-family: 'Courier New', monospace; font-size: 13px; background: #eee; padding: 4px 8px; border-radius: 4px; word-break: break-all; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <span class="badge">Balance Change</span>
+      <h2>Wallet Balance Updated</h2>
+
+      <p>Wallet: <span class="wallet-addr">{{ wallet }}</span></p>
+
+      <div class="balance">
+        <div class="amount">{{ new_balance }} RTC</div>
+        <div class="label">Current Balance</div>
+      </div>
+
+      <div class="info-box">
+        <p><strong>Previous balance:</strong> {{ old_balance }} RTC</p>
+        <p><strong>Change:</strong> {{ change }} RTC</p>
+        <p><strong>Detected at:</strong> {{ timestamp }}</p>
+      </div>
+    </div>
+    <div class="footer">
+      <p>You received this because you subscribed to balance alerts for this wallet.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/base.html
+++ b/tools/email-alerts/templates/base.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{{ title }}</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; letter-spacing: 0.5px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #e94560; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #e94560; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .info-box pre { margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 13px; color: #555; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+  .btn { display: inline-block; background: #e94560; color: #fff; padding: 10px 24px; border-radius: 6px; text-decoration: none; font-weight: 600; margin: 8px 0; }
+  table.data { width: 100%; border-collapse: collapse; margin: 16px 0; }
+  table.data th, table.data td { border: 1px solid #e0e0e0; padding: 10px 12px; text-align: left; font-size: 13px; }
+  table.data th { background: #1a1a2e; color: #fff; }
+  table.data tr:nth-child(even) { background: #f8f9fa; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      {{ content }}
+    </div>
+    <div class="footer">
+      <p>You received this because you subscribed to RustChain alerts.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/digest.html
+++ b/tools/email-alerts/templates/digest.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RustChain {{ digest_mode }} Digest</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #8e44ad; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .stat { text-align: center; margin: 24px 0; }
+  .stat .num { font-size: 48px; font-weight: 700; color: #e94560; }
+  .stat .label { font-size: 14px; color: #999; }
+  table.data { width: 100%; border-collapse: collapse; margin: 16px 0; }
+  table.data th, table.data td { border: 1px solid #e0e0e0; padding: 10px 12px; text-align: left; font-size: 13px; }
+  table.data th { background: #1a1a2e; color: #fff; }
+  table.data tr:nth-child(even) { background: #f8f9fa; }
+  table.data pre { margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 12px; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <span class="badge">{{ digest_mode }} Digest</span>
+      <h2>Event Summary</h2>
+
+      <div class="stat">
+        <div class="num">{{ event_count }}</div>
+        <div class="label">Events in this digest</div>
+      </div>
+
+      <table class="data">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Event</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ event_rows }}
+        </tbody>
+      </table>
+    </div>
+    <div class="footer">
+      <p>You received this {{ digest_mode }} digest because you subscribed to RustChain alerts.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/generic_event.html
+++ b/tools/email-alerts/templates/generic_event.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RustChain Alert: {{ event_type }}</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #e94560; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #e94560; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .info-box pre { margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 13px; color: #555; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <span class="badge">{{ event_type }}</span>
+      <h2>{{ event_type }}</h2>
+      <p>A blockchain event was detected at <strong>{{ timestamp }}</strong>.</p>
+      <div class="info-box">
+        <pre>{{ event_data }}</pre>
+      </div>
+    </div>
+    <div class="footer">
+      <p>You received this because you subscribed to RustChain alerts.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/miner_change.html
+++ b/tools/email-alerts/templates/miner_change.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Miner Change Alert</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #f5a623; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .stat { text-align: center; margin: 24px 0; }
+  .stat .num { font-size: 48px; font-weight: 700; color: #1a1a2e; }
+  .stat .label { font-size: 14px; color: #999; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #f5a623; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .info-box pre { margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 13px; color: #555; }
+  .joined { color: #27ae60; font-weight: 600; }
+  .left { color: #e74c3c; font-weight: 600; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <span class="badge">Miner Change</span>
+      <h2>Network Miner Update</h2>
+
+      <div class="stat">
+        <div class="num">{{ total_miners }}</div>
+        <div class="label">Active Miners</div>
+      </div>
+
+      <div class="info-box">
+        <p class="joined">Joined:</p>
+        <pre>{{ joined }}</pre>
+      </div>
+
+      <div class="info-box">
+        <p class="left">Left:</p>
+        <pre>{{ left }}</pre>
+      </div>
+
+      <p style="font-size: 13px; color: #999;">Detected at {{ timestamp }}</p>
+    </div>
+    <div class="footer">
+      <p>You received this because you subscribed to miner change alerts.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/new_epoch.html
+++ b/tools/email-alerts/templates/new_epoch.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>New Epoch Alert</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #e94560; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+  .epoch-num { font-size: 48px; font-weight: 700; color: #e94560; text-align: center; margin: 16px 0; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #e94560; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .info-box pre { margin: 0; white-space: pre-wrap; word-break: break-all; font-size: 13px; color: #555; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <span class="badge">New Epoch</span>
+      <h2>Epoch Transition</h2>
+
+      <div class="epoch-num">{{ new_epoch }}</div>
+
+      <div class="info-box">
+        <p><strong>Previous epoch:</strong> {{ previous_epoch }}</p>
+        <p><strong>New epoch:</strong> {{ new_epoch }}</p>
+        <p><strong>Detected at:</strong> {{ timestamp }}</p>
+      </div>
+
+      <p><strong>Epoch details:</strong></p>
+      <div class="info-box">
+        <pre>{{ epoch_data }}</pre>
+      </div>
+    </div>
+    <div class="footer">
+      <p>You received this because you subscribed to epoch alerts.</p>
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tools/email-alerts/templates/welcome.html
+++ b/tools/email-alerts/templates/welcome.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Welcome to RustChain Alerts</title>
+<style>
+  body { margin: 0; padding: 0; background: #f4f4f7; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; }
+  .wrapper { width: 100%; background: #f4f4f7; padding: 24px 0; }
+  .container { max-width: 600px; margin: 0 auto; background: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+  .header { background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%); padding: 32px 24px; text-align: center; }
+  .header h1 { color: #e94560; margin: 0; font-size: 24px; }
+  .header p { color: #a0a0b0; margin: 8px 0 0; font-size: 13px; }
+  .body { padding: 32px 24px; color: #333; line-height: 1.6; }
+  .body h2 { color: #1a1a2e; margin-top: 0; }
+  .badge { display: inline-block; background: #e94560; color: #fff; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; margin: 2px; }
+  .info-box { background: #f8f9fa; border-left: 4px solid #e94560; padding: 16px; margin: 16px 0; border-radius: 0 4px 4px 0; }
+  .footer { background: #f8f9fa; padding: 20px 24px; text-align: center; font-size: 12px; color: #999; border-top: 1px solid #eee; }
+  .footer a { color: #e94560; text-decoration: none; }
+</style>
+</head>
+<body>
+<div class="wrapper">
+  <div class="container">
+    <div class="header">
+      <h1>RustChain</h1>
+      <p>Proof-of-Antiquity Blockchain Alerts</p>
+    </div>
+    <div class="body">
+      <h2>Welcome!</h2>
+      <p>You have been subscribed to RustChain blockchain alerts at <strong>{{ email }}</strong>.</p>
+
+      <div class="info-box">
+        <p><strong>Subscribed events:</strong> {{ events }}</p>
+        <p><strong>Delivery mode:</strong> {{ digest }}</p>
+      </div>
+
+      <p>You will receive notifications when the following events occur on the RustChain network:</p>
+      <ul>
+        <li><strong>New Epoch</strong> &mdash; A new epoch begins on the chain</li>
+        <li><strong>Miner Changes</strong> &mdash; Miners join or leave the network</li>
+        <li><strong>Balance Changes</strong> &mdash; Your tracked wallet balance changes</li>
+      </ul>
+
+      <p>If you did not request this subscription, you can unsubscribe at any time using the link below.</p>
+    </div>
+    <div class="footer">
+      <p><a href="{{ unsubscribe_url }}">Unsubscribe</a> &middot; <a href="https://rustchain.org">rustchain.org</a></p>
+    </div>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Adds `tools/email-alerts/` with a complete email notification service for RustChain blockchain events
- Supports subscribing to **new epoch**, **miner changes**, and **balance changes** with per-subscriber event filtering
- Includes responsive HTML email templates for each event type plus digest summaries
- SMTP delivery with built-in presets for Gmail, Outlook, and Yahoo, plus custom server support
- Digest mode: choose between instant delivery, hourly, or daily batched summaries
- Secure unsubscribe management using HMAC-signed tokens
- SQLite-backed subscriber storage with CLI and programmatic API

## Test plan

- [ ] Verify `python alerts.py subscribe user@example.com` creates a subscriber in the SQLite database
- [ ] Verify `python alerts.py list` shows all subscribers with correct status
- [ ] Verify `python alerts.py run` starts polling the node without errors
- [ ] Test SMTP delivery with a Gmail App Password against a test mailbox
- [ ] Confirm HTML templates render correctly in Gmail, Outlook, and Apple Mail
- [ ] Verify digest mode queues events and flushes on schedule
- [ ] Test unsubscribe flow with valid and invalid tokens