### PR TITLE
docs: add RIP proposal template

### DIFF
--- a/rips/templates/RIP-TEMPLATE.md
+++ b/rips/templates/RIP-TEMPLATE.md
@@ -1,0 +1,42 @@
+# RIP-XXXX: [Title]
+
+| Field | Value |
+|-------|-------|
+| **RIP** | XXXX |
+| **Title** | [Title] |
+| **Author** | [Name] |
+| **Status** | Draft |
+| **Type** | Standards Track / Process / Informational |
+| **Created** | YYYY-MM-DD |
+
+## Abstract
+
+One paragraph summary.
+
+## Motivation
+
+Why is this change needed?
+
+## Specification
+
+Technical details of the proposed change.
+
+## Rationale
+
+Why this approach was chosen over alternatives.
+
+## Backwards Compatibility
+
+Impact on existing functionality.
+
+## Security Considerations
+
+Security implications.
+
+## Reference Implementation
+
+Link to implementation PR.
+
+## Copyright
+
+This RIP is licensed under MIT.


### PR DESCRIPTION
Standardized template for RustChain Improvement Proposals with all required sections.