### PR TITLE
feat: GitHub Tip Bot — /tip @user <amount> RTC (#694)

### DIFF
--- a/.github/workflows/tip-bot.yml
+++ b/.github/workflows/tip-bot.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install PyGithub requests cryptography
+          pip install requests PyYAML
       
       - name: Process tip command
         env:

--- a/integrations/rustchain-bounties/README.md
+++ b/integrations/rustchain-bounties/README.md
@@ -1,175 +1,254 @@
-# RustChain GitHub Tip Bot
+# rustchain-tip-bot
 
-A practical GitHub integration for managing RTC bounty payouts via `/tip` commands in issue comments.
-
-## Features
-
-- **Simple Tip Commands**: Send RTC tips with `/tip @username <amount> RTC`
-- **Bounty Tracking**: Track bounty claims and payouts
-- **Automated Responses**: Bot responds to tip commands with confirmation
-- **State Persistence**: All tips are recorded in a JSON state file
-- **Dry Run Mode**: Test without actual processing
-- **Webhook Integration**: GitHub Actions workflow for automatic processing
-
-## Quick Start
-
-### 1. Install Dependencies
-
-```bash
-cd integrations/rustchain-bounties
-pip install -r requirements.txt
-```
-
-### 2. Configure Environment
-
-Set the following environment variables:
-
-```bash
-export GITHUB_TOKEN="your_github_token"
-export TIP_BOT_WALLET="RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35"
-export TIP_BOT_ADMINS="admin1,admin2"  # Optional
-```
-
-### 3. Test the Bot
-
-```bash
-# Test command parsing
-python tip_bot.py --test-parse "/tip @contributor 50 RTC"
-
-# Check status
-python tip_bot.py --status
-
-# Run in dry-run mode
-python tip_bot.py --dry-run --status
-```
-
-## Usage
-
-### Tip Commands
-
-Post a comment on any issue with:
-
-```
-/tip @username 50 RTC
-```
-
-Or with claim syntax:
-
-```
-/tip claim @username 100 RTC
-```
-
-### Other Commands
-
-```
-/tip status    - Show bot statistics
-/tip help      - Show help message
-```
-
-### Examples
-
-```
-# Tip a contributor
-/tip @scottcjn 75 RTC
-
-# Check status
-/tip status
-
-# Get help
-/tip help
-```
-
-## GitHub Actions Integration
-
-The tip bot automatically processes comments via the GitHub Actions workflow:
-
-1. User posts `/tip` comment on an issue
-2. Workflow triggers on `issue_comment` event
-3. Bot processes the command and posts a response
-
-### Workflow Configuration
-
-The workflow is defined in `.github/workflows/tip-bot.yml`.
-
-### Required Secrets
-
-Add these secrets to your repository:
-
-| Secret | Description | Example |
-|--------|-------------|---------|
-| `TIP_BOT_WALLET` | Payout wallet address | `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35` |
-| `TIP_BOT_ADMINS` | Comma-separated admin list | `admin1,admin2` |
-| `TIP_BOT_DRY_RUN` | Enable dry-run mode | `true` or `false` |
-
-## Bounty Tracker
-
-The bounty tracker manages bounty issues and claims:
-
-```bash
-# Scan for bounty issues
-python bounty_tracker.py --token $GITHUB_TOKEN --scan
-
-# Show summary
-python bounty_tracker.py --token $GITHUB_TOKEN --summary
-
-# Show pending claims
-python bounty_tracker.py --token $GITHUB_TOKEN --pending
-```
-
-## State Files
-
-The bot maintains two state files:
-
-- `bounty_state.json`: Tip transaction records
-- `bounty_tracker_state.json`: Bounty issue tracking
-
-## Testing
-
-Run the test suite:
-
-```bash
-cd integrations/rustchain-bounties
-pytest test_tip_bot.py -v
-```
-
-## Payout Wallet
-
-**Default Payout Wallet**: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
-
-This is the split createkr-wallet address for RustChain bounty distributions.
-
-## Security
-
-- Webhook signatures are verified using HMAC-SHA256
-- Only issue authors and collaborators can issue tips
-- Tip amounts are capped at 1000 RTC per transaction
-- Admin override available via `TIP_BOT_ADMINS`
-
-## Troubleshooting
-
-### Bot not responding to commands
-
-1. Check that the workflow is enabled in repository settings
-2. Verify `GITHUB_TOKEN` has write permissions for issues
-3. Check workflow runs in Actions tab
-
-### Tips not being recorded
-
-1. Ensure state file directory is writable
-2. Check for JSON parsing errors in state file
-3. Run in dry-run mode to test without persistence
-
-## License
-
-MIT License - See main RustChain repository for details.
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Add tests for new functionality
-4. Submit a pull request
+GitHub bot for issuing RTC tips via `/tip` commands in issue and PR comments.
 
 ---
 
-**Related**: [RustChain Bounties](../../bounties/dev_bounties.json) | [Bounty Claim Template](../../.github/ISSUE_TEMPLATE/bounty-claim.yml)
+## How It Works
+
+A maintainer posts a comment containing:
+
+```
+/tip @username <amount> RTC
+```
+
+The bot (triggered by GitHub Actions) validates the command, records it to a
+persistent state file, posts a confirmation comment, and commits the updated
+state back to the repo. In v1 (log-only mode) the maintainer manually processes
+the actual RTC transfer using the logged data.
+
+---
+
+## Command Format
+
+```
+/tip @username <amount> RTC
+```
+
+| Field | Rules |
+|-------|-------|
+| `@username` | Valid GitHub username (1–39 chars, letters/numbers/hyphens) |
+| `<amount>` | Positive number, min 1 RTC, max 10000 RTC |
+| `RTC` | Must be the literal token symbol (case-insensitive) |
+
+The command can appear anywhere in a comment body (inline or on its own line).
+
+**Valid examples:**
+```
+/tip @contributor 50 RTC
+Great fix! /tip @alice 25 RTC for the patch.
+/tip @bob 12.5 RTC
+```
+
+**Rejected examples:**
+```
+/tip alice 50 RTC         # missing @ sign
+/tip @alice RTC           # missing amount
+/tip @alice 50 ETH        # wrong token
+/tip @alice 0 RTC         # zero amount
+/tip @alice 99999 RTC     # exceeds maximum
+```
+
+---
+
+## Setup
+
+### 1. Add this repo as a submodule (or copy files into your repo)
+
+```bash
+# Option A: standalone repo
+git clone https://github.com/mtarcure/rustchain-tip-bot
+cp -r rustchain-tip-bot/.github/workflows/tip-bot.yml your-repo/.github/workflows/
+cp rustchain-tip-bot/{tip_bot.py,auth.py,state.py,config.yml,requirements.txt} your-repo/
+
+# Option B: reference directly via workflow
+# Point the workflow's checkout step to this repo
+```
+
+### 2. Initialize the state file
+
+```bash
+echo '{"processed_comment_ids":[],"tip_log":[],"version":1}' > tip_state.json
+git add tip_state.json
+git commit -m "chore: initialize tip bot state"
+```
+
+### 3. Configure maintainers
+
+Edit `config.yml` and add the GitHub usernames that are allowed to issue tips:
+
+```yaml
+tip_bot:
+  maintainers:
+    - Scottcjn
+    - your-username
+```
+
+### 4. Set GitHub repository secrets
+
+Go to **Settings → Secrets and variables → Actions** and add:
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `TIP_BOT_WEBHOOK_SECRET` | Optional | HMAC secret for webhook signature verification (external webhook deployments only — **not needed for GitHub Actions**). Generate with: `openssl rand -hex 32` |
+| `RUSTCHAIN_NODE_URL` | Optional | Override the default RustChain node URL |
+| `WALLET_ADDRESS` | v2 only | Your RustChain wallet address (for auto-payout) |
+| `WALLET_PRIVATE_KEY` | v2 only | Wallet private key — **never commit this** |
+
+The `GITHUB_TOKEN` secret is provided automatically by GitHub Actions.
+
+### 5. Grant the Action write access
+
+In **Settings → Actions → General → Workflow permissions**, select
+**Read and write permissions** (needed so the bot can post comments and commit
+the state file).
+
+---
+
+## Payout Workflow (v1 — Log Only)
+
+In v1, the bot **does not send RTC automatically**. It logs each tip to
+`tip_state.json` with status `pending_payout`. The maintainer processes payouts
+manually:
+
+1. After the bot posts a confirmation, check `tip_state.json` for pending tips:
+
+```bash
+python3 - <<'EOF'
+import json
+with open("tip_state.json") as f:
+    state = json.load(f)
+pending = [t for t in state["tip_log"] if t["status"] == "pending_payout"]
+for t in pending:
+    print(f"  {t['timestamp'][:10]}  {t['sender']} → @{t['recipient']}  {t['amount']} {t['token']}")
+    print(f"    Context: {t['context_url']}")
+EOF
+```
+
+2. Send the RTC to the recipient's wallet via the RustChain interface.
+
+3. Mark as paid (update `tip_state.json` manually or run the helper):
+
+```bash
+python3 - <<'EOF'
+import json
+TIP_ID = "org/repo/COMMENT_ID"
+TX_REF = "your-tx-hash-or-ref"
+
+with open("tip_state.json") as f:
+    state = json.load(f)
+for tip in state["tip_log"]:
+    if tip["id"] == TIP_ID:
+        tip["status"] = "paid"
+        tip["tx_ref"] = TX_REF
+with open("tip_state.json", "w") as f:
+    json.dump(state, f, indent=2)
+print("Marked as paid.")
+EOF
+git add tip_state.json && git commit -m "chore: mark tip paid [skip ci]"
+```
+
+---
+
+## Wallet / Payout Configuration
+
+The bot is designed to work with the RustChain ecosystem:
+
+- **Node API:** `https://bulbous-bouffant.metalseed.net` (default, override via `RUSTCHAIN_NODE_URL`)
+- **Balance check:** `GET /wallet/balance?miner_id=<wallet_id>`
+- **Miners list:** `GET /api/miners`
+
+> **SSL note:** The default node uses a self-signed certificate. The bot uses
+> `verify=False` for node queries (consistent with existing RustChain tooling).
+> Do **not** disable SSL verification for the GitHub API calls.
+
+For auto-payout (v2), you will need:
+- `WALLET_ADDRESS` — the maintainer/project wallet address that funds tips
+- `WALLET_PRIVATE_KEY` — kept in GitHub Secrets, never in code or state files
+
+---
+
+## Security
+
+### Webhook Signature Verification
+
+When `TIP_BOT_WEBHOOK_SECRET` is set **and** an `HTTP_X_HUB_SIGNATURE_256` header
+is present, the bot verifies the HMAC-SHA256 signature before processing. This
+prevents forged webhooks from triggering tip commands.
+
+**Important:** This is only relevant for **external webhook deployments** (e.g.,
+running the bot as a standalone server). When using **GitHub Actions**, the payload
+comes from GitHub's own infrastructure via `GITHUB_EVENT_PATH` — there is no HTTP
+signature header. **Do not set `TIP_BOT_WEBHOOK_SECRET` for GitHub Actions** as
+it is unnecessary and has no effect.
+
+For external webhook deployments, configure the same secret in both:
+- Environment variable: `WEBHOOK_SECRET`
+- GitHub webhook settings → Secret
+
+### Maintainer Allowlist
+
+Only users listed in `config.yml` under `maintainers` can issue `/tip` commands.
+All other users receive an unauthorized error comment. The check is
+case-insensitive.
+
+### Idempotency
+
+Each comment is identified by its GitHub comment ID. The bot records processed
+comment IDs in `tip_state.json`. If the same comment ID is seen again (e.g., a
+workflow retry), the tip is not recorded twice and a duplicate notice is posted.
+
+### Rate Limiting
+
+Each maintainer is limited to 20 tip commands per hour (configurable in
+`config.yml`). This prevents accidental spam.
+
+---
+
+## Configuration Reference (`config.yml`)
+
+```yaml
+tip_bot:
+  maintainers:            # GitHub usernames allowed to issue /tip
+    - Scottcjn
+
+  token_symbol: RTC       # Token symbol (case-insensitive in commands)
+  min_amount: 1           # Minimum tip amount
+  max_amount: 10000       # Maximum tip amount
+
+  rate_limit:
+    max_per_hour: 20      # Max tips per maintainer per hour
+
+  rustchain_node_url: "https://bulbous-bouffant.metalseed.net"
+  payout_mode: log_only   # "log_only" (v1) or "auto" (v2, future)
+  state_file: "tip_state.json"
+```
+
+---
+
+## Running Tests
+
+```bash
+pip install -r requirements.txt
+pytest test_tip_bot.py -v
+```
+
+60 tests covering: command parsing, validation, authorization, idempotency,
+state persistence, end-to-end event processing, webhook verification,
+rate limiting, and comment formatting.
+
+---
+
+## File Structure
+
+```
+.github/workflows/tip-bot.yml   GitHub Action (triggers on issue_comment)
+tip_bot.py                      Main bot — parsing, validation, event loop
+auth.py                         Webhook verification + maintainer allowlist
+state.py                        JSON state persistence + idempotency
+config.yml                      Bot configuration
+tip_state.json                  Live tip log (committed by the bot)
+test_tip_bot.py                 Full test suite (60 tests)
+requirements.txt                Python dependencies
+README.md                       This file
+```

--- a/integrations/rustchain-bounties/auth.py
+++ b/integrations/rustchain-bounties/auth.py
@@ -1,0 +1,82 @@
+"""
+auth.py — Webhook signature verification and maintainer authorization.
+"""
+
+import hashlib
+import hmac
+import os
+import time
+from typing import Optional
+
+
+def verify_webhook_signature(payload_bytes: bytes, signature_header: Optional[str]) -> bool:
+    """
+    Verify GitHub webhook HMAC-SHA256 signature.
+
+    GitHub sends: X-Hub-Signature-256: sha256=<hex>
+    We recompute using WEBHOOK_SECRET and compare via constant-time equality.
+
+    Returns True if valid, False if missing/invalid.
+    """
+    secret = os.environ.get("WEBHOOK_SECRET", "")
+    if not secret:
+        # No secret configured — skip verification (development/local mode)
+        return True
+
+    if not signature_header:
+        return False
+
+    if not signature_header.startswith("sha256="):
+        return False
+
+    expected = hmac.new(
+        secret.encode("utf-8"),
+        msg=payload_bytes,
+        digestmod=hashlib.sha256,
+    ).hexdigest()
+
+    received = signature_header[len("sha256="):]
+    return hmac.compare_digest(expected, received)
+
+
+def is_authorized_sender(username: str, maintainers: list[str]) -> bool:
+    """
+    Check if the comment author is in the maintainer allowlist.
+    Comparison is case-insensitive.
+    """
+    return username.lower() in {m.lower() for m in maintainers}
+
+
+class RateLimiter:
+    """
+    In-memory rate limiter: tracks tip command timestamps per sender.
+    Resets when the process restarts (GitHub Actions are ephemeral).
+    For persistent rate limiting, use the state file.
+    """
+
+    def __init__(self, max_per_hour: int = 20) -> None:
+        self.max_per_hour = max_per_hour
+        self._timestamps: dict[str, list[float]] = {}
+
+    def check(self, username: str) -> bool:
+        """Return True if allowed, False if rate limit exceeded."""
+        now = time.time()
+        cutoff = now - 3600  # one hour window
+
+        timestamps = self._timestamps.get(username, [])
+        # Keep only events within the window
+        timestamps = [t for t in timestamps if t > cutoff]
+        self._timestamps[username] = timestamps
+
+        if len(timestamps) >= self.max_per_hour:
+            return False
+
+        timestamps.append(now)
+        self._timestamps[username] = timestamps
+        return True
+
+    def count(self, username: str) -> int:
+        """Return current tip count for the user in the past hour."""
+        now = time.time()
+        cutoff = now - 3600
+        return sum(1 for t in self._timestamps.get(username, []) if t > cutoff)

--- a/integrations/rustchain-bounties/config.yml
+++ b/integrations/rustchain-bounties/config.yml
@@ -1,0 +1,24 @@
+tip_bot:
+  # GitHub usernames allowed to issue /tip commands
+  maintainers:
+    - Scottcjn
+
+  # Token symbol accepted in tip commands (case-insensitive)
+  token_symbol: RTC
+
+  # Minimum and maximum tip amounts
+  min_amount: 1
+  max_amount: 10000
+
+  # Rate limiting: max tips per maintainer per hour
+  rate_limit:
+    max_per_hour: 20
+
+  # RustChain node for balance checks (set RUSTCHAIN_NODE_URL secret to override)
+  rustchain_node_url: "https://bulbous-bouffant.metalseed.net"
+
+  # Payout mode: "log_only" (v1 — maintainer manually sends RTC) or "auto" (future)
+  payout_mode: log_only
+
+  # State file path (relative to repo root) — committed to repo for persistence across runs
+  state_file: "tip_state.json"

--- a/integrations/rustchain-bounties/requirements.txt
+++ b/integrations/rustchain-bounties/requirements.txt
@@ -1,14 +1,4 @@
-# RustChain GitHub Tip Bot Dependencies
-
-# GitHub API
-PyGithub>=2.1.0
-
-# HTTP requests
-requests>=2.25.0
-
-# Cryptography for webhook signatures
-cryptography>=41.0
-
-# Testing
-pytest>=7.0.0
-pytest-mock>=3.0.0
+requests>=2.31.0
+PyYAML>=6.0.1
+pytest>=7.4.0
+pytest-mock>=3.12.0

--- a/integrations/rustchain-bounties/state.py
+++ b/integrations/rustchain-bounties/state.py
@@ -1,0 +1,115 @@
+"""
+state.py — Persistent tip state for idempotency and payout logging.
+
+The state is a JSON file committed back to the repository after each run.
+This prevents duplicate processing across independent GitHub Actions runs.
+
+State schema:
+{
+  "processed_comment_ids": ["<repo>/<comment_id>", ...],
+  "tip_log": [
+    {
+      "id": "<repo>/<comment_id>",
+      "timestamp": "2026-03-15T10:00:00Z",
+      "issue_or_pr": 42,
+      "sender": "Scottcjn",
+      "recipient": "contributor",
+      "amount": 50,
+      "token": "RTC",
+      "status": "pending_payout",
+      "context_url": "https://github.com/org/repo/issues/42#issuecomment-12345"
+    }
+  ],
+  "version": 1
+}
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+
+class TipState:
+    VERSION = 1
+
+    def __init__(self, state_file: str) -> None:
+        self.state_file = state_file
+        self._data: dict[str, Any] = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if os.path.exists(self.state_file):
+            try:
+                with open(self.state_file) as f:
+                    data = json.load(f)
+                # Migrate if needed
+                if data.get("version") != self.VERSION:
+                    data = self._migrate(data)
+                return data
+            except (json.JSONDecodeError, KeyError):
+                pass
+        return {"processed_comment_ids": [], "tip_log": [], "version": self.VERSION}
+
+    def _migrate(self, data: dict) -> dict:
+        """Handle future schema migrations."""
+        data.setdefault("processed_comment_ids", [])
+        data.setdefault("tip_log", [])
+        data["version"] = self.VERSION
+        return data
+
+    def save(self) -> None:
+        with open(self.state_file, "w") as f:
+            json.dump(self._data, f, indent=2)
+
+    def is_processed(self, idempotency_key: str) -> bool:
+        """
+        Check if this comment_id was already processed.
+        idempotency_key format: "<owner>/<repo>/<comment_id>"
+        """
+        return idempotency_key in self._data["processed_comment_ids"]
+
+    def record_tip(
+        self,
+        idempotency_key: str,
+        issue_or_pr: int,
+        sender: str,
+        recipient: str,
+        amount: float,
+        token: str,
+        context_url: str,
+        status: str = "pending_payout",
+    ) -> None:
+        """
+        Record a processed tip. Marks the comment_id as seen and appends to the log.
+        """
+        self._data["processed_comment_ids"].append(idempotency_key)
+        self._data["tip_log"].append(
+            {
+                "id": idempotency_key,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "issue_or_pr": issue_or_pr,
+                "sender": sender,
+                "recipient": recipient,
+                "amount": amount,
+                "token": token,
+                "status": status,
+                "context_url": context_url,
+            }
+        )
+
+    def get_pending_payouts(self) -> list[dict]:
+        """Return all tips with status 'pending_payout'."""
+        return [t for t in self._data["tip_log"] if t["status"] == "pending_payout"]
+
+    def mark_paid(self, idempotency_key: str, tx_ref: str = "") -> None:
+        """Update a tip entry to 'paid' status."""
+        for tip in self._data["tip_log"]:
+            if tip["id"] == idempotency_key:
+                tip["status"] = "paid"
+                if tx_ref:
+                    tip["tx_ref"] = tx_ref
+                break
+
+    @property
+    def tip_log(self) -> list[dict]:
+        return self._data["tip_log"]

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -1,366 +1,526 @@
-#!/usr/bin/env python3
 """
-Tests for RustChain GitHub Tip Bot
+test_tip_bot.py — Tests for the RustChain GitHub tip bot.
+
+Coverage:
+- Command parsing (valid, malformed, edge cases)
+- Validation (amount bounds, self-tip, rate limiting)
+- Authorization (maintainer allowlist)
+- Idempotency / duplicate detection
+- State persistence
+- End-to-end event processing (mocked GitHub API)
+- Webhook signature verification
 """
 
+import hashlib
+import hmac
 import json
 import os
-import sys
 import tempfile
-from datetime import datetime, timezone
-from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-# Add parent directory to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
-from tip_bot import TipBot, TipRecord, BountyState
-from bounty_tracker import BountyTracker, Bounty
-
-
-class TestTipBotParse:
-    """Test tip command parsing"""
-    
-    def test_parse_simple_tip(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip @user 50 RTC")
-        assert result == ("user", 50.0)
-    
-    def test_parse_tip_without_at(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip user 25 RTC")
-        assert result == ("user", 25.0)
-    
-    def test_parse_tip_lowercase(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip @user 10 rtc")
-        assert result == ("user", 10.0)
-    
-    def test_parse_tip_decimal(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip @user 15.5 RTC")
-        assert result == ("user", 15.5)
-    
-    def test_parse_tip_with_claim(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip claim @user 100 RTC")
-        assert result == ("user", 100.0)
-    
-    def test_parse_invalid_command(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("Hello world")
-        assert result is None
-    
-    def test_parse_tip_in_multiline(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        comment = """Thanks for the contribution!
-/tip @contributor 75 RTC
-Great work!"""
-        
-        result = bot.parse_tip_command(comment)
-        assert result == ("contributor", 75.0)
-    
-    def test_parse_zero_amount(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        result = bot.parse_tip_command("/tip @user 0 RTC")
-        assert result == ("user", 0.0)
+from auth import RateLimiter, is_authorized_sender, verify_webhook_signature
+from state import TipState
+from tip_bot import (
+    ParseResult,
+    TipCommand,
+    build_duplicate_comment,
+    build_failure_comment,
+    build_success_comment,
+    build_unauthorized_comment,
+    parse_tip_command,
+    process_event,
+    validate_tip,
+)
 
 
-class TestTipBotValidation:
-    """Test tip validation logic"""
-    
-    @pytest.fixture
-    def bot(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            state_file = f.name
-        
-        bot = TipBot(
-            github_token="dummy",
-            payout_wallet="RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35",
-            state_file=state_file,
-            dry_run=True,
-        )
-        yield bot
-        
-        # Cleanup
-        if os.path.exists(state_file):
-            os.unlink(state_file)
-    
-    def test_validate_positive_amount(self, bot):
-        # Should pass validation
-        result = bot.parse_tip_command("/tip @user 50 RTC")
-        assert result is not None
-        assert result[1] > 0
-    
-    def test_reject_negative_amount(self, bot):
-        # Negative amounts won't match regex, but test boundary
-        result = bot.parse_tip_command("/tip @user -10 RTC")
-        assert result is None
-    
-    def test_reject_excessive_amount(self, bot):
-        """Amounts over 1000 should be rejected in processing"""
-        result = bot.parse_tip_command("/tip @user 1500 RTC")
-        assert result == ("user", 1500.0)
-        # The actual rejection happens in process_tip, not parsing
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def state_file(tmp_path):
+    return str(tmp_path / "tip_state.json")
 
 
-class TestTipBotState:
-    """Test state persistence"""
-    
-    def test_save_and_load_state(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            state_file = f.name
-        
-        try:
-            bot = TipBot(
-                github_token="dummy",
-                payout_wallet="RTC123",
-                state_file=state_file,
-            )
-            
-            # Add a tip record
-            tip = TipRecord(
-                issue_number=1153,
-                from_user="admin",
-                to_user="contributor",
-                amount_rtc=50.0,
-                timestamp=datetime.now(timezone.utc).isoformat(),
-                tx_hash="0xabc123",
-                status="completed",
-            )
-            bot.state.tips.append(tip)
-            bot.state.total_distributed = 50.0
-            bot._save_state()
-            
-            # Load in new bot instance
-            bot2 = TipBot(
-                github_token="dummy",
-                payout_wallet="RTC123",
-                state_file=state_file,
-            )
-            
-            assert len(bot2.state.tips) == 1
-            assert bot2.state.total_distributed == 50.0
-            assert bot2.state.tips[0].to_user == "contributor"
-            
-        finally:
-            if os.path.exists(state_file):
-                os.unlink(state_file)
-    
-    def test_empty_state(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            state_file = f.name
-        
-        try:
-            bot = TipBot(
-                github_token="dummy",
-                payout_wallet="RTC123",
-                state_file=state_file,
-            )
-            
-            assert len(bot.state.tips) == 0
-            assert bot.state.total_distributed == 0.0
-            
-        finally:
-            if os.path.exists(state_file):
-                os.unlink(state_file)
+@pytest.fixture()
+def state(state_file):
+    return TipState(state_file)
 
 
-class TestTipBotMessages:
-    """Test bot message generation"""
-    
-    def test_help_message(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        help_text = bot.get_help()
-        
-        assert "/tip" in help_text
-        assert "RTC" in help_text
-        assert "status" in help_text
-    
-    def test_status_message(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        status = bot.get_status("test/repo")
-        
-        assert "Tip Bot Status" in status
-        assert "RTC" in status
-    
-    def test_status_with_tips(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        # Add some tips
-        for i in range(3):
-            tip = TipRecord(
-                issue_number=100 + i,
-                from_user="admin",
-                to_user=f"user{i}",
-                amount_rtc=10.0 * (i + 1),
-                timestamp=datetime.now(timezone.utc).isoformat(),
-            )
-            bot.state.tips.append(tip)
-            bot.state.total_distributed += tip.amount_rtc
-        
-        status = bot.get_status("test/repo")
-        assert "**Total Tips:** 3" in status
-        assert "60.00" in status  # 10 + 20 + 30
+@pytest.fixture()
+def config():
+    return {
+        "maintainers": ["Scottcjn", "alice"],
+        "token_symbol": "RTC",
+        "min_amount": 1,
+        "max_amount": 10000,
+        "rate_limit": {"max_per_hour": 20},
+        "rustchain_node_url": "https://example.com",
+        "payout_mode": "log_only",
+        "state_file": "tip_state.json",
+    }
 
 
-class TestBountyTracker:
-    """Test bounty tracker functionality"""
-    
-    @pytest.fixture
-    def tracker(self):
-        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
-            state_file = f.name
-        
-        tr = BountyTracker(
-            github_token="dummy",
-            repo="test/repo",
-            state_file=state_file,
-        )
-        yield tr
-        
-        if os.path.exists(state_file):
-            os.unlink(state_file)
-    
-    def test_bounty_creation(self, tracker):
-        bounty = Bounty(
-            issue_number=1153,
-            title="Test Bounty",
-            description="Test description",
-            reward_rtc=50.0,
-        )
-        
-        tracker.bounties[1153] = bounty
-        tracker._save_state()
-        
-        # Reload
-        tracker2 = BountyTracker(
-            github_token="dummy",
-            repo="test/repo",
-            state_file=tracker.state_file,
-        )
-        
-        assert 1153 in tracker2.bounties
-        assert tracker2.bounties[1153].title == "Test Bounty"
-    
-    def test_claim_bounty(self, tracker):
-        bounty = Bounty(
-            issue_number=1153,
-            title="Test Bounty",
-            description="Test",
-            reward_rtc=50.0,
-            status="open",
-        )
-        tracker.bounties[1153] = bounty
-        
-        result = tracker.claim_bounty(1153, "contributor", "https://github.com/pr/1")
-        
-        assert result is not None
-        assert result.status == "claimed"
-        assert result.claimant == "contributor"
-    
-    def test_mark_paid(self, tracker):
-        bounty = Bounty(
-            issue_number=1153,
-            title="Test Bounty",
-            description="Test",
-            reward_rtc=50.0,
-            status="completed",
-            claimant="contributor",
-        )
-        tracker.bounties[1153] = bounty
-        
-        result = tracker.mark_paid(1153)
-        
-        assert result is not None
-        assert result.status == "paid"
-        assert result.paid_at is not None
-    
-    def test_get_summary(self, tracker):
-        # Add bounties in different states
-        for i, status in enumerate(["open", "claimed", "completed", "paid"]):
-            bounty = Bounty(
-                issue_number=100 + i,
-                title=f"Bounty {i}",
-                description="Test",
-                reward_rtc=25.0,
-                status=status,
-            )
-            tracker.bounties[100 + i] = bounty
-        
-        summary = tracker.get_summary()
-        
-        assert "**Total Bounties:** 4" in summary
-        assert "**Open:** 1" in summary
-        assert "**Claimed:** 1" in summary
-        assert "**Completed:** 1" in summary
-        assert "**Paid:** 1" in summary
+@pytest.fixture()
+def rate_limiter():
+    return RateLimiter(max_per_hour=20)
 
 
-class TestWebhookSignature:
-    """Test webhook signature verification"""
-    
+def make_event(
+    comment_body: str,
+    sender: str = "Scottcjn",
+    comment_id: int = 12345,
+    issue_number: int = 42,
+    comment_url: str = "https://github.com/org/repo/issues/42#issuecomment-12345",
+) -> dict[str, Any]:
+    return {
+        "comment": {
+            "id": comment_id,
+            "body": comment_body,
+            "user": {"login": sender},
+            "html_url": comment_url,
+        },
+        "issue": {"number": issue_number},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parsing tests
+# ---------------------------------------------------------------------------
+
+class TestParseTipCommand:
+
+    def test_valid_basic(self):
+        result = parse_tip_command("/tip @alice 50 RTC", "RTC")
+        assert result.error is None
+        assert result.command is not None
+        assert result.command.recipient == "alice"
+        assert result.command.amount == 50.0
+        assert result.command.token == "RTC"
+
+    def test_valid_decimal_amount(self):
+        result = parse_tip_command("/tip @bob 12.5 RTC", "RTC")
+        assert result.error is None
+        assert result.command.amount == 12.5
+
+    def test_valid_inline_in_comment(self):
+        body = "Great work! /tip @contributor 100 RTC for fixing that bug."
+        result = parse_tip_command(body, "RTC")
+        assert result.error is None
+        assert result.command.recipient == "contributor"
+
+    def test_valid_case_insensitive_token(self):
+        result = parse_tip_command("/tip @alice 10 rtc", "RTC")
+        assert result.error is None
+        assert result.command.token == "RTC"
+
+    def test_valid_multiline_body(self):
+        body = "Some text\n/tip @alice 25 RTC\nMore text"
+        result = parse_tip_command(body, "RTC")
+        assert result.error is None
+        assert result.command.recipient == "alice"
+
+    def test_valid_hyphenated_username(self):
+        result = parse_tip_command("/tip @alice-dev 10 RTC", "RTC")
+        assert result.error is None
+        assert result.command.recipient == "alice-dev"
+
+    def test_no_tip_command_returns_none_none(self):
+        result = parse_tip_command("This comment has nothing special.", "RTC")
+        assert result.command is None
+        assert result.error is None
+
+    def test_missing_at_sign_is_malformed(self):
+        result = parse_tip_command("/tip alice 50 RTC", "RTC")
+        assert result.command is None
+        assert result.error is not None
+        assert "Malformed" in result.error
+
+    def test_missing_amount_is_malformed(self):
+        result = parse_tip_command("/tip @alice RTC", "RTC")
+        assert result.command is None
+        assert result.error is not None
+
+    def test_missing_token_is_malformed(self):
+        result = parse_tip_command("/tip @alice 50", "RTC")
+        assert result.command is None
+        assert result.error is not None
+
+    def test_wrong_token_symbol(self):
+        result = parse_tip_command("/tip @alice 50 ETH", "RTC")
+        assert result.command is None
+        assert result.error is not None
+        assert "ETH" in result.error
+
+    def test_zero_amount_triggers_error(self):
+        result = parse_tip_command("/tip @alice 0 RTC", "RTC")
+        assert result.command is None
+        assert result.error is not None
+        assert "greater than 0" in result.error
+
+    def test_negative_amount_not_parsed(self):
+        # Regex only matches digits, so -10 won't match
+        result = parse_tip_command("/tip @alice -10 RTC", "RTC")
+        assert result.command is None
+        assert result.error is not None
+
+    def test_empty_body(self):
+        result = parse_tip_command("", "RTC")
+        assert result.command is None
+        assert result.error is None
+
+    def test_just_slash_tip(self):
+        result = parse_tip_command("/tip", "RTC")
+        assert result.command is None
+        assert result.error is not None  # Near-miss → malformed error
+
+    def test_username_too_long_rejected(self):
+        # GitHub max is 39 chars
+        long_name = "a" * 40
+        result = parse_tip_command(f"/tip @{long_name} 10 RTC", "RTC")
+        assert result.command is None
+        assert result.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Validation tests
+# ---------------------------------------------------------------------------
+
+class TestValidateTip:
+
+    def test_valid_tip_passes(self, config, rate_limiter):
+        cmd = TipCommand(recipient="bob", amount=50, token="RTC", raw="/tip @bob 50 RTC")
+        error = validate_tip(cmd, "Scottcjn", config, rate_limiter)
+        assert error is None
+
+    def test_self_tip_rejected(self, config, rate_limiter):
+        cmd = TipCommand(recipient="Scottcjn", amount=10, token="RTC", raw="")
+        error = validate_tip(cmd, "Scottcjn", config, rate_limiter)
+        assert error is not None
+        assert "yourself" in error
+
+    def test_self_tip_case_insensitive(self, config, rate_limiter):
+        cmd = TipCommand(recipient="scottcjn", amount=10, token="RTC", raw="")
+        error = validate_tip(cmd, "Scottcjn", config, rate_limiter)
+        assert error is not None
+
+    def test_amount_below_minimum(self, config, rate_limiter):
+        cmd = TipCommand(recipient="bob", amount=0.5, token="RTC", raw="")
+        error = validate_tip(cmd, "Scottcjn", config, rate_limiter)
+        assert error is not None
+        assert "Minimum" in error
+
+    def test_amount_above_maximum(self, config, rate_limiter):
+        cmd = TipCommand(recipient="bob", amount=99999, token="RTC", raw="")
+        error = validate_tip(cmd, "Scottcjn", config, rate_limiter)
+        assert error is not None
+        assert "Maximum" in error
+
+    def test_rate_limit_exceeded(self, config):
+        limiter = RateLimiter(max_per_hour=2)
+        cmd = TipCommand(recipient="bob", amount=10, token="RTC", raw="")
+
+        assert validate_tip(cmd, "Scottcjn", config, limiter) is None
+        assert validate_tip(cmd, "Scottcjn", config, limiter) is None
+        error = validate_tip(cmd, "Scottcjn", config, limiter)
+        assert error is not None
+        assert "Rate limit" in error
+
+
+# ---------------------------------------------------------------------------
+# Authorization tests
+# ---------------------------------------------------------------------------
+
+class TestAuthorization:
+
+    def test_maintainer_authorized(self):
+        assert is_authorized_sender("Scottcjn", ["Scottcjn", "alice"]) is True
+
+    def test_case_insensitive_match(self):
+        assert is_authorized_sender("scottcjn", ["Scottcjn"]) is True
+        assert is_authorized_sender("SCOTTCJN", ["Scottcjn"]) is True
+
+    def test_unknown_user_unauthorized(self):
+        assert is_authorized_sender("hacker", ["Scottcjn", "alice"]) is False
+
+    def test_empty_allowlist(self):
+        assert is_authorized_sender("Scottcjn", []) is False
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature tests
+# ---------------------------------------------------------------------------
+
+class TestWebhookVerification:
+
+    def _sign(self, payload: bytes, secret: str) -> str:
+        sig = hmac.new(secret.encode(), msg=payload, digestmod=hashlib.sha256).hexdigest()
+        return f"sha256={sig}"
+
     def test_valid_signature(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
         payload = b'{"action": "created"}'
-        secret = "test-secret"
-        
-        import hmac
-        import hashlib
-        
-        expected_sig = "sha256=" + hmac.new(
-            secret.encode(),
-            payload,
-            hashlib.sha256
-        ).hexdigest()
-        
-        assert bot.verify_webhook_signature(payload, expected_sig, secret) is True
-    
-    def test_invalid_signature(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
+        secret = "mysecret"
+        sig = self._sign(payload, secret)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            assert verify_webhook_signature(payload, sig) is True
+
+    def test_invalid_signature_rejected(self):
         payload = b'{"action": "created"}'
-        
-        assert bot.verify_webhook_signature(payload, "sha256=invalid", "secret") is False
-    
-    def test_missing_signature(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        assert bot.verify_webhook_signature(b"{}", "", "secret") is False
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": "mysecret"}):
+            assert verify_webhook_signature(payload, "sha256=deadbeef") is False
+
+    def test_missing_signature_rejected(self):
+        payload = b'{"action": "created"}'
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": "mysecret"}):
+            assert verify_webhook_signature(payload, None) is False
+
+    def test_no_secret_configured_allows_all(self):
+        payload = b'{"action": "created"}'
+        with patch.dict(os.environ, {}, clear=True):
+            # When WEBHOOK_SECRET is not set, verification is skipped
+            assert verify_webhook_signature(payload, None) is True
+
+    def test_tampered_payload_rejected(self):
+        original = b'{"action": "created"}'
+        tampered = b'{"action": "injected"}'
+        secret = "mysecret"
+        sig = self._sign(original, secret)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            assert verify_webhook_signature(tampered, sig) is False
 
 
-class TestTXHashGeneration:
-    """Test transaction hash generation"""
-    
-    def test_deterministic_hash(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        hash1 = bot.generate_tx_hash(1153, "user", 50.0)
-        hash2 = bot.generate_tx_hash(1153, "user", 50.0)
-        
-        assert hash1 == hash2
-        assert hash1.startswith("0x")
-        assert len(hash1) == 42  # 0x + 40 hex chars
-    
-    def test_unique_hashes(self):
-        bot = TipBot(github_token="dummy", payout_wallet="RTC123")
-        
-        hash1 = bot.generate_tx_hash(1153, "user1", 50.0)
-        hash2 = bot.generate_tx_hash(1153, "user2", 50.0)
-        
-        assert hash1 != hash2
+# ---------------------------------------------------------------------------
+# State / idempotency tests
+# ---------------------------------------------------------------------------
+
+class TestTipState:
+
+    def test_fresh_state_empty(self, state):
+        assert state.tip_log == []
+        assert state.get_pending_payouts() == []
+
+    def test_record_and_retrieve(self, state):
+        state.record_tip(
+            "org/repo/111", 42, "Scottcjn", "alice", 50, "RTC",
+            "https://github.com/org/repo/issues/42#issuecomment-111",
+        )
+        state.save()
+        assert len(state.tip_log) == 1
+        assert state.tip_log[0]["sender"] == "Scottcjn"
+        assert state.tip_log[0]["recipient"] == "alice"
+        assert state.tip_log[0]["amount"] == 50
+
+    def test_is_processed_false_initially(self, state):
+        assert state.is_processed("org/repo/111") is False
+
+    def test_is_processed_true_after_record(self, state):
+        state.record_tip("org/repo/111", 42, "Scottcjn", "alice", 50, "RTC", "url")
+        assert state.is_processed("org/repo/111") is True
+
+    def test_duplicate_key_not_double_recorded(self, state):
+        key = "org/repo/111"
+        state.record_tip(key, 42, "Scottcjn", "alice", 50, "RTC", "url")
+        # Simulating what process_event does — it checks is_processed first
+        # so the record_tip call for the same key would not happen.
+        assert len(state.tip_log) == 1
+
+    def test_state_persists_across_instances(self, state_file):
+        s1 = TipState(state_file)
+        s1.record_tip("org/repo/222", 10, "Scottcjn", "bob", 10, "RTC", "url")
+        s1.save()
+
+        s2 = TipState(state_file)
+        assert s2.is_processed("org/repo/222") is True
+        assert len(s2.tip_log) == 1
+
+    def test_mark_paid(self, state):
+        key = "org/repo/333"
+        state.record_tip(key, 5, "Scottcjn", "carol", 25, "RTC", "url")
+        state.mark_paid(key, tx_ref="txabc123")
+        assert state.tip_log[0]["status"] == "paid"
+        assert state.tip_log[0]["tx_ref"] == "txabc123"
+
+    def test_pending_payouts_filter(self, state):
+        state.record_tip("org/repo/1", 1, "Scottcjn", "a", 10, "RTC", "url")
+        state.record_tip("org/repo/2", 2, "Scottcjn", "b", 20, "RTC", "url")
+        state.mark_paid("org/repo/1")
+        pending = state.get_pending_payouts()
+        assert len(pending) == 1
+        assert pending[0]["recipient"] == "b"
+
+    def test_invalid_state_file_resets(self, tmp_path):
+        path = str(tmp_path / "bad.json")
+        with open(path, "w") as f:
+            f.write("not valid json {{{")
+        s = TipState(path)
+        assert s.tip_log == []
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+# ---------------------------------------------------------------------------
+# End-to-end process_event tests (GitHub API mocked)
+# ---------------------------------------------------------------------------
+
+class TestProcessEvent:
+
+    @pytest.fixture(autouse=True)
+    def mock_github(self):
+        """Mock all outbound GitHub API calls."""
+        with patch("tip_bot.github_post_comment", return_value=True) as mock_comment, \
+             patch("tip_bot.github_commit_state", return_value=True) as mock_commit:
+            self.mock_comment = mock_comment
+            self.mock_commit = mock_commit
+            yield
+
+    def test_valid_tip_succeeds(self, config, state):
+        event = make_event("/tip @alice 50 RTC")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "success"
+        assert state.is_processed("org/repo/12345")
+        assert self.mock_comment.call_count == 1
+        body = self.mock_comment.call_args[0][2]
+        assert "alice" in body
+        assert "50" in body
+
+    def test_no_tip_command_skipped(self, config, state):
+        event = make_event("Just a normal comment, nothing to see here.")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "no_command"
+        assert self.mock_comment.call_count == 0
+
+    def test_unauthorized_sender_rejected(self, config, state):
+        event = make_event("/tip @alice 50 RTC", sender="random_user")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "unauthorized"
+        body = self.mock_comment.call_args[0][2]
+        assert "Unauthorized" in body
+
+    def test_malformed_command_gets_error(self, config, state):
+        event = make_event("/tip alice 50 RTC")  # missing @
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "parse_error"
+        body = self.mock_comment.call_args[0][2]
+        assert "failed" in body.lower() or "Tip failed" in body
+
+    def test_duplicate_comment_id_prevented(self, config, state):
+        event = make_event("/tip @alice 50 RTC", comment_id=99)
+        # Process once
+        result1 = process_event(event, config, state, "token", "org/repo")
+        assert result1 == "success"
+        # Process same event again
+        result2 = process_event(event, config, state, "token", "org/repo")
+        assert result2 == "duplicate"
+        # Should have 2 comment calls (success + duplicate notice)
+        assert self.mock_comment.call_count == 2
+        duplicate_body = self.mock_comment.call_args[0][2]
+        assert "Duplicate" in duplicate_body
+
+    def test_replay_prevention_different_amounts(self, config, state):
+        """Idempotency is keyed on comment_id, not content — same id means dup."""
+        event1 = make_event("/tip @alice 50 RTC", comment_id=555)
+        event2 = make_event("/tip @alice 100 RTC", comment_id=555)  # same id, different amount
+        process_event(event1, config, state, "token", "org/repo")
+        result = process_event(event2, config, state, "token", "org/repo")
+        assert result == "duplicate"
+
+    def test_self_tip_rejected(self, config, state):
+        event = make_event("/tip @Scottcjn 10 RTC", sender="Scottcjn")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "validation_error"
+        body = self.mock_comment.call_args[0][2]
+        assert "yourself" in body
+
+    def test_amount_too_large_rejected(self, config, state):
+        event = make_event("/tip @alice 999999 RTC")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "validation_error"
+        body = self.mock_comment.call_args[0][2]
+        assert "Maximum" in body
+
+    def test_amount_below_minimum_rejected(self, config, state):
+        event = make_event("/tip @alice 0.1 RTC")
+        result = process_event(event, config, state, "token", "org/repo")
+        assert result == "validation_error"
+
+    def test_multiple_tips_different_comments_all_succeed(self, config, state):
+        for i, recipient in enumerate(["alice", "bob", "carol"], start=100):
+            event = make_event(f"/tip @{recipient} 10 RTC", comment_id=i)
+            result = process_event(event, config, state, "token", "org/repo")
+            assert result == "success"
+        assert len(state.tip_log) == 3
+
+    def test_state_committed_after_success(self, config, state):
+        event = make_event("/tip @alice 10 RTC")
+        process_event(event, config, state, "token", "org/repo")
+        assert self.mock_commit.call_count == 1
+
+    def test_no_state_commit_on_failure(self, config, state):
+        event = make_event("/tip @alice 10 RTC", sender="attacker")
+        process_event(event, config, state, "token", "org/repo")
+        assert self.mock_commit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Comment format tests
+# ---------------------------------------------------------------------------
+
+class TestCommentBuilders:
+
+    def test_success_comment_contains_fields(self):
+        cmd = TipCommand(recipient="alice", amount=50, token="RTC", raw="")
+        body = build_success_comment("Scottcjn", cmd, "https://example.com")
+        assert "alice" in body
+        assert "Scottcjn" in body
+        assert "50" in body
+        assert "RTC" in body
+        assert "pending" in body.lower()
+
+    def test_failure_comment_contains_error(self):
+        body = build_failure_comment("Scottcjn", "Minimum tip is 1 RTC.")
+        assert "Scottcjn" in body
+        assert "Minimum" in body
+        assert "failed" in body.lower() or "Failed" in body
+
+    def test_duplicate_comment(self):
+        cmd = TipCommand(recipient="alice", amount=50, token="RTC", raw="")
+        body = build_duplicate_comment("Scottcjn", cmd)
+        assert "Duplicate" in body
+        assert "alice" in body
+
+    def test_unauthorized_comment(self):
+        body = build_unauthorized_comment("hacker")
+        assert "hacker" in body
+        assert "Unauthorized" in body
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter tests
+# ---------------------------------------------------------------------------
+
+class TestRateLimiter:
+
+    def test_within_limit_allowed(self):
+        limiter = RateLimiter(max_per_hour=5)
+        for _ in range(5):
+            assert limiter.check("user") is True
+
+    def test_exceeding_limit_blocked(self):
+        limiter = RateLimiter(max_per_hour=3)
+        limiter.check("user")
+        limiter.check("user")
+        limiter.check("user")
+        assert limiter.check("user") is False
+
+    def test_different_users_independent(self):
+        limiter = RateLimiter(max_per_hour=1)
+        assert limiter.check("alice") is True
+        assert limiter.check("bob") is True
+        assert limiter.check("alice") is False
+
+    def test_count_reflects_usage(self):
+        limiter = RateLimiter(max_per_hour=10)
+        limiter.check("user")
+        limiter.check("user")
+        assert limiter.count("user") == 2

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -1,441 +1,414 @@
 #!/usr/bin/env python3
 """
-RustChain GitHub Tip Bot
+tip_bot.py — GitHub tip bot for RustChain /tip commands.
 
-Handles /tip commands in GitHub issues for bounty payouts.
-Supports command patterns:
-  /tip @username <amount> RTC
-  /tip claim @username <amount> RTC
-  /tip status
-  /tip help
+Triggered by GitHub Actions on issue_comment events.
+Parses /tip @username <amount> RTC commands, validates them,
+prevents duplicate processing, and posts confirmation/failure comments.
+
+Usage (GitHub Action):
+    python tip_bot.py
+
+Required environment variables:
+    GITHUB_TOKEN       — Auto-provided by GitHub Actions
+    GITHUB_EVENT_PATH  — Auto-provided by GitHub Actions
+    GITHUB_REPOSITORY  — Auto-provided by GitHub Actions
+    WEBHOOK_SECRET     — GitHub webhook HMAC secret (optional but recommended)
+    RUSTCHAIN_NODE_URL — Override for the RustChain node URL (optional)
+
+Optional secrets (documented in README):
+    WALLET_ADDRESS     — Maintainer's RustChain wallet for outgoing tips
+    WALLET_PRIVATE_KEY — Only needed for auto-payout mode (v2)
 """
 
-import hashlib
-import hmac
 import json
 import os
 import re
-from dataclasses import dataclass, field
-from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+import sys
+from dataclasses import dataclass
+from typing import Optional
 
 import requests
+import yaml
+
+from auth import RateLimiter, is_authorized_sender, verify_webhook_signature
+from state import TipState
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def load_config() -> dict:
+    config_path = os.path.join(os.path.dirname(__file__), "config.yml")
+    with open(config_path) as f:
+        return yaml.safe_load(f)["tip_bot"]
+
+
+# ---------------------------------------------------------------------------
+# Command Parser
+# ---------------------------------------------------------------------------
+
+# Accepted format: /tip @username <amount> RTC
+# Flexible on whitespace and case of token symbol.
+_TIP_PATTERN = re.compile(
+    r"(?:^|\s)/tip\s+"          # /tip command (start-of-line or after whitespace)
+    r"@([A-Za-z0-9_-]{1,39})\s+"  # @username (GitHub max 39 chars)
+    r"(\d+(?:\.\d+)?)\s+"       # amount (integer or decimal)
+    r"([A-Za-z]{1,10})"         # token symbol
+    r"(?:\s|$)",                 # followed by whitespace or end
+    re.IGNORECASE | re.MULTILINE,
+)
 
 
 @dataclass
-class TipRecord:
-    """Record of a tip transaction"""
-    issue_number: int
-    from_user: str
-    to_user: str
-    amount_rtc: float
-    timestamp: str
-    tx_hash: str = ""
-    status: str = "pending"  # pending, completed, failed
-    memo: str = ""
+class TipCommand:
+    recipient: str
+    amount: float
+    token: str
+    raw: str
 
 
 @dataclass
-class BountyState:
-    """State of the bounty system"""
-    total_distributed: float = 0.0
-    tips: List[TipRecord] = field(default_factory=list)
-    pending_claims: Dict[int, Dict] = field(default_factory=dict)
-    
-    def to_dict(self) -> Dict:
-        return {
-            "total_distributed": self.total_distributed,
-            "tips": [
-                {
-                    "issue_number": t.issue_number,
-                    "from_user": t.from_user,
-                    "to_user": t.to_user,
-                    "amount_rtc": t.amount_rtc,
-                    "timestamp": t.timestamp,
-                    "tx_hash": t.tx_hash,
-                    "status": t.status,
-                    "memo": t.memo,
-                }
-                for t in self.tips
-            ],
-            "pending_claims": self.pending_claims,
-        }
-    
-    @classmethod
-    def from_dict(cls, data: Dict) -> "BountyState":
-        state = cls()
-        state.total_distributed = data.get("total_distributed", 0.0)
-        state.tips = [
-            TipRecord(
-                issue_number=t["issue_number"],
-                from_user=t["from_user"],
-                to_user=t["to_user"],
-                amount_rtc=t["amount_rtc"],
-                timestamp=t["timestamp"],
-                tx_hash=t.get("tx_hash", ""),
-                status=t.get("status", "pending"),
-                memo=t.get("memo", ""),
-            )
-            for t in data.get("tips", [])
-        ]
-        state.pending_claims = data.get("pending_claims", {})
-        return state
+class ParseResult:
+    command: Optional[TipCommand]
+    error: Optional[str]
 
 
-class TipBot:
-    """GitHub Tip Bot for RustChain bounties"""
-    
-    TIP_PATTERN = re.compile(
-        r"/tip\s+(?:claim\s+)?(@?\w+)\s+(\d+(?:\.\d+)?)\s*(RTC|rtc)?",
-        re.IGNORECASE
+def parse_tip_command(comment_body: str, expected_token: str) -> ParseResult:
+    """
+    Parse a /tip command from a comment body.
+
+    Returns ParseResult with either a valid TipCommand or an error string.
+    Returns command=None, error=None if no /tip command is present at all
+    (so callers can distinguish "no command" from "malformed command").
+    """
+    # Check if any /tip attempt exists (catch near-misses too)
+    has_tip_attempt = bool(re.search(r"(?:^|\s)/tip\b", comment_body, re.IGNORECASE | re.MULTILINE))
+    if not has_tip_attempt:
+        return ParseResult(command=None, error=None)
+
+    match = _TIP_PATTERN.search(comment_body)
+    if not match:
+        return ParseResult(
+            command=None,
+            error=(
+                "Malformed `/tip` command. Expected format:\n"
+                "```\n/tip @username <amount> RTC\n```\n"
+                "- `@username` must be a valid GitHub username\n"
+                "- `<amount>` must be a positive number\n"
+                "- Token symbol must be `RTC`"
+            ),
+        )
+
+    recipient, amount_str, token = match.group(1), match.group(2), match.group(3)
+
+    # Validate token symbol
+    if token.upper() != expected_token.upper():
+        return ParseResult(
+            command=None,
+            error=f"Unknown token `{token}`. Only `{expected_token}` tips are supported.",
+        )
+
+    # Validate amount
+    try:
+        amount = float(amount_str)
+    except ValueError:
+        return ParseResult(
+            command=None,
+            error=f"Invalid amount `{amount_str}`. Must be a positive number.",
+        )
+
+    if amount <= 0:
+        return ParseResult(
+            command=None,
+            error=f"Amount must be greater than 0. Got `{amount}`.",
+        )
+
+    # Reject obviously invalid amounts (too many decimal places for RTC)
+    if amount != round(amount, 8):
+        return ParseResult(
+            command=None,
+            error=f"Amount `{amount}` has too many decimal places. Max 8.",
+        )
+
+    return ParseResult(
+        command=TipCommand(
+            recipient=recipient,
+            amount=amount,
+            token=token.upper(),
+            raw=match.group(0).strip(),
+        ),
+        error=None,
     )
-    
-    def __init__(
-        self,
-        github_token: str,
-        payout_wallet: str,
-        state_file: Optional[str] = None,
-        dry_run: bool = False,
-    ):
-        self.github_token = github_token
-        self.payout_wallet = payout_wallet
-        self.dry_run = dry_run
-        self.state_file = state_file or "bounty_state.json"
-        self.state = self._load_state()
-        self.session = requests.Session()
-        self.session.headers.update({
-            "Authorization": f"token {github_token}",
-            "Accept": "application/vnd.github.v3+json",
-            "User-Agent": "rustchain-tip-bot/1.0",
-        })
-    
-    def _load_state(self) -> BountyState:
-        """Load state from file"""
-        path = Path(self.state_file)
-        if path.exists():
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-                return BountyState.from_dict(data)
-            except (json.JSONDecodeError, KeyError):
-                pass
-        return BountyState()
-    
-    def _save_state(self):
-        """Save state to file"""
-        path = Path(self.state_file)
-        path.write_text(
-            json.dumps(self.state.to_dict(), indent=2),
-            encoding="utf-8"
-        )
-    
-    def verify_webhook_signature(
-        self, payload: bytes, signature: str, secret: str
-    ) -> bool:
-        """Verify GitHub webhook signature"""
-        if not signature or not secret:
-            return False
-        
-        expected = "sha256=" + hmac.new(
-            secret.encode(),
-            payload,
-            hashlib.sha256
-        ).hexdigest()
-        
-        return hmac.compare_digest(signature, expected)
-    
-    def parse_tip_command(self, comment_body: str) -> Optional[Tuple[str, float]]:
-        """Parse /tip command from comment body"""
-        if not comment_body:
-            return None
-        
-        for line in comment_body.split("\n"):
-            line = line.strip()
-            if line.startswith("/tip"):
-                match = self.TIP_PATTERN.match(line)
-                if match:
-                    recipient = match.group(1).lstrip("@")
-                    amount = float(match.group(2))
-                    return (recipient, amount)
-        
-        return None
-    
-    def get_issue(self, repo: str, issue_number: int) -> Optional[Dict]:
-        """Get issue details"""
-        url = f"https://api.github.com/repos/{repo}/issues/{issue_number}"
-        try:
-            resp = self.session.get(url, timeout=10)
-            resp.raise_for_status()
-            return resp.json()
-        except Exception as e:
-            print(f"[Error] Failed to get issue: {e}")
-            return None
-    
-    def get_user(self, username: str) -> Optional[Dict]:
-        """Get GitHub user details"""
-        url = f"https://api.github.com/users/{username.lstrip('@')}"
-        try:
-            resp = self.session.get(url, timeout=10)
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            return resp.json()
-        except Exception as e:
-            print(f"[Error] Failed to get user: {e}")
-            return None
-    
-    def post_comment(self, repo: str, issue_number: int, body: str) -> bool:
-        """Post comment to issue"""
-        url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
-        try:
-            resp = self.session.post(url, json={"body": body}, timeout=10)
-            resp.raise_for_status()
-            return True
-        except Exception as e:
-            print(f"[Error] Failed to post comment: {e}")
-            return False
-    
-    def generate_tx_hash(self, issue_number: int, recipient: str, amount: float) -> str:
-        """Generate a deterministic tx hash for tracking"""
-        data = f"{issue_number}:{recipient}:{amount}:{self.payout_wallet}"
-        return "0x" + hashlib.sha256(data.encode()).hexdigest()[:40]
-    
-    def process_tip(
-        self,
-        repo: str,
-        issue_number: int,
-        commenter: str,
-        comment_body: str,
-        comment_id: int,
-    ) -> Optional[str]:
-        """
-        Process a tip command from a comment.
-        Returns response message or None if no action needed.
-        """
-        tip_data = self.parse_tip_command(comment_body)
-        if not tip_data:
-            return None
-        
-        recipient, amount = tip_data
-        
-        # Validate amount
-        if amount <= 0:
-            return "❌ Invalid tip amount. Must be positive."
-        
-        if amount > 1000:
-            return "❌ Tip amount exceeds maximum (1000 RTC). Contact admin for larger tips."
-        
-        # Validate recipient
-        user_data = self.get_user(recipient)
-        if not user_data:
-            return f"❌ User @{recipient} not found on GitHub."
-        
-        recipient_username = user_data.get("login", recipient)
-        
-        # Check permissions (commenter must be repo collaborator or issue author)
-        issue = self.get_issue(repo, issue_number)
-        if not issue:
-            return "❌ Issue not found."
-        
-        issue_author = issue.get("user", {}).get("login", "")
-        is_authorized = (
-            commenter == issue_author or
-            self._is_collaborator(repo, commenter)
-        )
-        
-        if not is_authorized and not self._is_admin(commenter):
-            return "❌ Only issue author or collaborators can issue tips."
-        
-        # Generate tx hash
-        tx_hash = self.generate_tx_hash(issue_number, recipient_username, amount)
-        
-        # Record tip
-        tip = TipRecord(
-            issue_number=issue_number,
-            from_user=commenter,
-            to_user=recipient_username,
-            amount_rtc=amount,
-            timestamp=datetime.now(timezone.utc).isoformat(),
-            tx_hash=tx_hash,
-            status="completed" if not self.dry_run else "pending",
-            memo=f"Tip for issue #{issue_number}",
-        )
-        
-        self.state.tips.append(tip)
-        self.state.total_distributed += amount
-        self._save_state()
-        
-        # Format response
-        if self.dry_run:
-            response = (
-                f"✅ **Tip Recorded (Dry Run)**\n\n"
-                f"- **From:** @{commenter}\n"
-                f"- **To:** @{recipient_username}\n"
-                f"- **Amount:** {amount:.2f} RTC\n"
-                f"- **Issue:** #{issue_number}\n"
-                f"- **TX Hash:** `{tx_hash}`\n"
-                f"- **Status:** Pending (dry run mode)\n"
-                f"- **Payout Wallet:** `{self.payout_wallet}`\n\n"
-                f"_Tip will be processed when dry run is disabled._"
-            )
-        else:
-            response = (
-                f"✅ **Tip Sent!**\n\n"
-                f"- **From:** @{commenter}\n"
-                f"- **To:** @{recipient_username}\n"
-                f"- **Amount:** {amount:.2f} RTC\n"
-                f"- **Issue:** #{issue_number}\n"
-                f"- **TX Hash:** `{tx_hash}`\n"
-                f"- **Payout Wallet:** `{self.payout_wallet}`\n\n"
-                f"_Bounty payout will be processed in the next distribution cycle._"
-            )
-        
-        return response
-    
-    def _is_collaborator(self, repo: str, username: str) -> bool:
-        """Check if user is a collaborator"""
-        url = f"https://api.github.com/repos/{repo}/collaborators/{username}"
-        try:
-            resp = self.session.get(url, timeout=10)
-            return resp.status_code == 204
-        except Exception:
-            return False
-    
-    def _is_admin(self, username: str) -> bool:
-        """Check if user is admin (configured via env)"""
-        admins = os.getenv("TIP_BOT_ADMINS", "").split(",")
-        return username in admins
-    
-    def get_status(self, repo: str) -> str:
-        """Get tip bot status"""
-        total_tips = len(self.state.tips)
-        total_distributed = self.state.total_distributed
-        
-        recent_tips = self.state.tips[-5:] if self.state.tips else []
-        recent_lines = []
-        for tip in recent_tips:
-            recent_lines.append(
-                f"- @{tip.to_user}: {tip.amount_rtc:.2f} RTC (#{tip.issue_number})"
-            )
-        
-        recent_text = "\n".join(recent_lines) if recent_lines else "No tips yet."
-        
-        return (
-            f"📊 **RustChain Tip Bot Status**\n\n"
-            f"- **Total Tips:** {total_tips}\n"
-            f"- **Total Distributed:** {total_distributed:.2f} RTC\n"
-            f"- **Payout Wallet:** `{self.payout_wallet}`\n"
-            f"- **Mode:** {'Dry Run' if self.dry_run else 'Live'}\n\n"
-            f"**Recent Tips:**\n{recent_text}"
-        )
-    
-    def get_help(self) -> str:
-        """Get help message"""
-        return (
-            "🤖 **RustChain Tip Bot Commands**\n\n"
-            "```\n"
-            "/tip @username <amount> RTC    - Send a tip to a user\n"
-            "/tip claim @user <amt> RTC     - Claim a bounty tip\n"
-            "/tip status                    - Show bot status\n"
-            "/tip help                      - Show this help\n"
-            "```\n\n"
-            "**Examples:**\n"
-            "- `/tip @contributor 50 RTC` - Tip 50 RTC\n"
-            "- `/tip status` - Check distribution stats\n\n"
-            f"**Payout Wallet:** `{self.payout_wallet}`\n\n"
-            "_Tips are recorded on-chain and distributed in the next cycle._"
-        )
-    
-    def handle_webhook(self, event: str, payload: Dict) -> Optional[Dict]:
-        """
-        Handle GitHub webhook event.
-        Returns action to take (comment to post) or None.
-        """
-        if event != "issue_comment":
-            return None
-        
-        action = payload.get("action", "")
-        if action != "created":
-            return None
-        
-        issue = payload.get("issue", {})
-        issue_number = issue.get("number")
-        if not issue_number:
-            return None
-        
-        comment = payload.get("comment", {})
-        comment_body = comment.get("body", "")
-        commenter = comment.get("user", {}).get("login", "")
-        comment_id = comment.get("id", 0)
-        
-        # Skip bot comments
-        if commenter.endswith("[bot]"):
-            return None
-        
-        repo = payload.get("repository", {}).get("full_name", "")
-        if not repo:
-            return None
-        
-        # Check for /tip command
-        response = self.process_tip(repo, issue_number, commenter, comment_body, comment_id)
-        
-        if response:
-            return {
-                "repo": repo,
-                "issue_number": issue_number,
-                "body": response,
-            }
-        
-        return None
 
 
-def main():
-    """CLI entry point"""
-    import argparse
-    
-    parser = argparse.ArgumentParser(description="RustChain GitHub Tip Bot")
-    parser.add_argument("--token", help="GitHub token")
-    parser.add_argument("--wallet", default="RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35",
-                       help="Payout wallet address")
-    parser.add_argument("--state-file", default="bounty_state.json",
-                       help="State file path")
-    parser.add_argument("--dry-run", action="store_true",
-                       help="Run in dry-run mode")
-    parser.add_argument("--test-parse", type=str,
-                       help="Test parsing a tip command")
-    parser.add_argument("--status", action="store_true",
-                       help="Show bot status")
-    
-    args = parser.parse_args()
-    
-    token = args.token or os.getenv("GITHUB_TOKEN")
-    if not token and not args.test_parse:
-        print("Error: GITHUB_TOKEN required")
-        return 1
-    
-    bot = TipBot(
-        github_token=token or "dummy",
-        payout_wallet=args.wallet,
-        state_file=args.state_file,
-        dry_run=args.dry_run,
+def validate_tip(
+    cmd: TipCommand,
+    sender: str,
+    config: dict,
+    rate_limiter: RateLimiter,
+) -> Optional[str]:
+    """
+    Validate a parsed tip command beyond basic parsing.
+
+    Returns an error string if invalid, None if valid.
+    """
+    # Self-tipping is not allowed
+    if cmd.recipient.lower() == sender.lower():
+        return "You cannot tip yourself."
+
+    # Amount bounds
+    if cmd.amount < config["min_amount"]:
+        return f"Minimum tip is {config['min_amount']} {config['token_symbol']}."
+    if cmd.amount > config["max_amount"]:
+        return f"Maximum tip is {config['max_amount']} {config['token_symbol']}."
+
+    # Rate limit
+    if not rate_limiter.check(sender):
+        limit = config["rate_limit"]["max_per_hour"]
+        return f"Rate limit exceeded. Max {limit} tips per hour."
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+def github_post_comment(repo: str, issue_number: int, body: str, token: str) -> bool:
+    """Post a comment on an issue or PR. Returns True on success."""
+    url = f"https://api.github.com/repos/{repo}/issues/{issue_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    resp = requests.post(url, headers=headers, json={"body": body}, timeout=15)
+    return resp.status_code == 201
+
+
+def github_commit_state(repo: str, state_file: str, token: str) -> bool:
+    """
+    Commit the updated state file back to the repository.
+    Uses the GitHub Contents API to create/update the file.
+    Returns True on success.
+    """
+    import base64
+
+    url = f"https://api.github.com/repos/{repo}/contents/{state_file}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # Read current state
+    with open(state_file, "rb") as f:
+        content = base64.b64encode(f.read()).decode()
+
+    # Get current SHA (needed for updates)
+    resp = requests.get(url, headers=headers, timeout=15)
+    sha = resp.json().get("sha") if resp.status_code == 200 else None
+
+    payload: dict = {
+        "message": "chore: update tip state [skip ci]",
+        "content": content,
+    }
+    if sha:
+        payload["sha"] = sha
+
+    resp = requests.put(url, headers=headers, json=payload, timeout=15)
+    return resp.status_code in (200, 201)
+
+
+# ---------------------------------------------------------------------------
+# Comment builders
+# ---------------------------------------------------------------------------
+
+def build_success_comment(sender: str, cmd: TipCommand, context_url: str) -> str:
+    return (
+        f"**Tip recorded** ✅\n\n"
+        f"| Field | Value |\n"
+        f"|-------|-------|\n"
+        f"| From | @{sender} |\n"
+        f"| To | @{cmd.recipient} |\n"
+        f"| Amount | {cmd.amount} {cmd.token} |\n\n"
+        f"This tip has been logged and is **pending manual payout** by the maintainer. "
+        f"@{cmd.recipient} will receive `{cmd.amount} {cmd.token}` once processed.\n\n"
+        f"---\n"
+        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot) — "
+        f"maintainer approval required for payout*"
     )
-    
-    if args.test_parse:
-        result = bot.parse_tip_command(args.test_parse)
-        if result:
-            print(f"Parsed: @{result[0]} {result[1]:.2f} RTC")
-        else:
-            print("No tip command found")
-        return 0
-    
-    if args.status:
-        print(bot.get_status("Scottcjn/Rustchain"))
-        return 0
-    
-    print("Tip bot initialized. Use --test-parse or --status for testing.")
-    print(f"Payout wallet: {args.wallet}")
-    return 0
+
+
+def build_failure_comment(sender: str, error: str) -> str:
+    return (
+        f"**Tip failed** ❌\n\n"
+        f"@{sender}: {error}\n\n"
+        f"---\n"
+        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+    )
+
+
+def build_duplicate_comment(sender: str, cmd: TipCommand) -> str:
+    return (
+        f"**Duplicate tip ignored** ⚠️\n\n"
+        f"@{sender}: This tip (`{cmd.amount} {cmd.token}` → @{cmd.recipient}) "
+        f"was already recorded from this comment. No action taken.\n\n"
+        f"---\n"
+        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+    )
+
+
+def build_unauthorized_comment(sender: str) -> str:
+    return (
+        f"**Unauthorized** ❌\n\n"
+        f"@{sender}: Only designated maintainers can issue `/tip` commands.\n\n"
+        f"---\n"
+        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def process_event(
+    event: dict,
+    config: dict,
+    state: TipState,
+    token: str,
+    repo: str,
+    rate_limiter: Optional[RateLimiter] = None,
+) -> str:
+    """
+    Core processing logic. Separated from I/O for testability.
+
+    Returns one of: "no_command", "unauthorized", "duplicate",
+                    "parse_error", "validation_error", "success"
+    """
+    if rate_limiter is None:
+        rate_limiter = RateLimiter(max_per_hour=config["rate_limit"]["max_per_hour"])
+
+    comment = event.get("comment", {})
+    issue = event.get("issue", event.get("pull_request", {}))
+
+    comment_body: str = comment.get("body", "")
+    sender: str = comment.get("user", {}).get("login", "")
+    comment_id: int = comment.get("id", 0)
+    issue_number: int = issue.get("number", 0)
+    comment_url: str = comment.get("html_url", "")
+
+    # Parse command first (before auth — to give useful errors even to unauthorized)
+    parse_result = parse_tip_command(comment_body, config["token_symbol"])
+
+    if parse_result.command is None and parse_result.error is None:
+        # No /tip in comment at all
+        return "no_command"
+
+    # Authorization check
+    if not is_authorized_sender(sender, config["maintainers"]):
+        if parse_result.command is not None or parse_result.error is not None:
+            # They tried to use /tip but aren't authorized
+            github_post_comment(repo, issue_number, build_unauthorized_comment(sender), token)
+        return "unauthorized"
+
+    # Malformed command
+    if parse_result.error:
+        github_post_comment(repo, issue_number, build_failure_comment(sender, parse_result.error), token)
+        return "parse_error"
+
+    cmd = parse_result.command
+    assert cmd is not None
+
+    # Idempotency check
+    idempotency_key = f"{repo}/{comment_id}"
+    if state.is_processed(idempotency_key):
+        github_post_comment(repo, issue_number, build_duplicate_comment(sender, cmd), token)
+        return "duplicate"
+
+    # Validation (amount bounds, self-tip, rate limit)
+    validation_error = validate_tip(cmd, sender, config, rate_limiter)
+    if validation_error:
+        github_post_comment(repo, issue_number, build_failure_comment(sender, validation_error), token)
+        return "validation_error"
+
+    # Post confirmation first — only record tip if comment succeeds
+    posted = github_post_comment(
+        repo,
+        issue_number,
+        build_success_comment(sender, cmd, comment_url),
+        token,
+    )
+    if not posted:
+        print(f"ERROR: Failed to post confirmation comment for comment {comment_id}")
+        return "comment_error"
+
+    # Record the tip (only after successful comment)
+    state.record_tip(
+        idempotency_key=idempotency_key,
+        issue_or_pr=issue_number,
+        sender=sender,
+        recipient=cmd.recipient,
+        amount=cmd.amount,
+        token=cmd.token,
+        context_url=comment_url,
+        status="pending_payout",
+    )
+    state.save()
+
+    # Persist state back to repo
+    github_commit_state(repo, config["state_file"], token)
+
+    print(f"Tip recorded: {sender} -> {cmd.recipient} {cmd.amount} {cmd.token} (comment {comment_id})")
+    return "success"
+
+
+def main() -> None:
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path or not os.path.exists(event_path):
+        print("No event payload found. Running in test mode — exiting.")
+        sys.exit(0)
+
+    with open(event_path) as f:
+        event = json.load(f)
+
+    # Verify webhook signature if secret is configured AND a signature header
+    # is present. In GitHub Actions, the payload comes from GitHub's own
+    # infrastructure (GITHUB_EVENT_PATH) — no HTTP signature header exists.
+    # WEBHOOK_SECRET is only useful for external webhook deployments.
+    webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
+    sig = os.environ.get("HTTP_X_HUB_SIGNATURE_256", "")
+    if webhook_secret and sig:
+        raw_payload = open(event_path, "rb").read()
+        if not verify_webhook_signature(raw_payload, sig):
+            print("Webhook signature verification failed. Aborting.")
+            sys.exit(1)
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("GITHUB_REPOSITORY", "")
+
+    if not token or not repo:
+        print("GITHUB_TOKEN and GITHUB_REPOSITORY must be set.")
+        sys.exit(1)
+
+    config = load_config()
+
+    # Override node URL from environment if set
+    node_url_env = os.environ.get("RUSTCHAIN_NODE_URL")
+    if node_url_env:
+        config["rustchain_node_url"] = node_url_env
+
+    state = TipState(config["state_file"])
+    rate_limiter = RateLimiter(max_per_hour=config["rate_limit"]["max_per_hour"])
+
+    result = process_event(event, config, state, token, repo, rate_limiter=rate_limiter)
+    print(f"Result: {result}")
+
+    # Exit 0 for all handled business logic outcomes (unauthorized, no command,
+    # parse error, duplicate). Reserve non-zero for infrastructure failures only.
 
 
 if __name__ == "__main__":
-    exit(main())
+    main()

--- a/integrations/rustchain-bounties/tip_bot_action.py
+++ b/integrations/rustchain-bounties/tip_bot_action.py
@@ -1,74 +1,17 @@
 #!/usr/bin/env python3
 """
-GitHub Action script to process tip commands.
-Called by the tip-bot.yml workflow.
+tip_bot_action.py — Entry point for the GitHub Action workflow.
+
+Imports and runs the main tip bot from tip_bot.py.
 """
 
-import json
-import os
 import sys
-from pathlib import Path
+import os
 
-# Add current directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent))
+# Ensure the integration directory is on the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from tip_bot import TipBot
-
-
-def main():
-    """Process tip command from GitHub event"""
-    
-    # Get event payload
-    event_path = os.getenv("GITHUB_EVENT_PATH")
-    if not event_path:
-        print("Error: GITHUB_EVENT_PATH not set")
-        return 1
-    
-    with open(event_path, "r") as f:
-        payload = json.load(f)
-    
-    # Get event name
-    event_name = os.getenv("GITHUB_EVENT_NAME", "issue_comment")
-    
-    # Get GitHub token
-    github_token = os.getenv("GITHUB_TOKEN")
-    if not github_token:
-        print("Error: GITHUB_TOKEN not set")
-        return 1
-    
-    # Get payout wallet (default to split createkr-wallet)
-    payout_wallet = os.getenv(
-        "TIP_BOT_WALLET",
-        "RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35"
-    )
-    
-    # Initialize bot
-    bot = TipBot(
-        github_token=github_token,
-        payout_wallet=payout_wallet,
-        dry_run=os.getenv("TIP_BOT_DRY_RUN", "false").lower() == "true",
-    )
-    
-    # Process webhook
-    action = bot.handle_webhook(event_name, payload)
-    
-    if action:
-        # Post response comment
-        from github import Github
-        
-        gh = Github(github_token)
-        repo = gh.get_repo(action["repo"])
-        issue = repo.get_issue(action["issue_number"])
-        
-        try:
-            issue.create_comment(action["body"])
-            print(f"Posted tip response to #{action['issue_number']}")
-        except Exception as e:
-            print(f"Error posting comment: {e}")
-            return 1
-    
-    return 0
-
+from tip_bot import main
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/integrations/rustchain-bounties/tip_state.json
+++ b/integrations/rustchain-bounties/tip_state.json
@@ -1,0 +1,5 @@
+{
+  "processed_comment_ids": [],
+  "tip_log": [],
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Implements the GitHub tip bot for RustChain (#694). Processes `/tip @username <amount> RTC` commands in issue and PR comments via GitHub Actions.

### What's included

- **Command parsing** — regex-based parser that distinguishes "no /tip present" from "malformed /tip", with specific error feedback for near-misses (missing @, wrong token, zero amount, etc.)
- **Authorization** — maintainer allowlist (config-based, case-insensitive) + optional HMAC-SHA256 webhook signature verification for external deployments
- **Idempotency** — each comment keyed by `{owner}/{repo}/{comment_id}`, state committed back to repo with `[skip ci]` to prevent workflow loops
- **Rate limiting** — configurable per-hour limit per sender
- **Validation** — self-tip prevention, amount bounds, token symbol check, decimal precision guard
- **Confirmation comments** — success/failure/duplicate/unauthorized responses posted as issue comments
- **60 tests** — covers parsing (16), validation (6), authorization (4), webhook sig (5), state persistence (9), end-to-end event processing (12), comment builders (4), rate limiter (4)

### Architecture

| File | Purpose |
|------|---------|
| `tip_bot.py` | Main bot — command parsing, validation, event processing |
| `auth.py` | HMAC-SHA256 webhook verification + maintainer allowlist + rate limiter |
| `state.py` | JSON state persistence with idempotency keys |
| `config.yml` | Bot configuration (maintainers, limits, node URL) |
| `tip_bot_action.py` | GitHub Action entry point (thin wrapper) |
| `test_tip_bot.py` | Full test suite — 60 tests |

### Payout model

v1 is log-only: tips are recorded with `status: pending_payout` in `tip_state.json`. Maintainer manually sends RTC and marks entries paid. README includes exact commands for both steps.

## Test plan

- [x] All 60 tests passing locally (`pytest test_tip_bot.py -v`)
- [ ] Verify GitHub Action triggers on `/tip` comments in issues/PRs
- [ ] Confirm webhook secret works for external deployments
- [ ] Test idempotency by re-running a workflow manually

Closes #694

Wallet for payout: wirework