### PR TITLE
fix: restore beacon join endpoint and rustchain.org beacon routing (#2127)

### DIFF
--- a/docs/ISSUE_2127_DEPLOYMENT.md
+++ b/docs/ISSUE_2127_DEPLOYMENT.md
@@ -1,0 +1,347 @@
+# Issue #2127 - Beacon Join Routing Deployment Notes
+
+**Date**: 2026-03-16
+**Status**: Implementation Complete
+**Commit**: Local only (no push/PR/comment)
+
+---
+
+## Overview
+
+This implementation adds beacon join routing functionality to the RustChain Beacon Atlas system. Agents can register themselves via POST `/beacon/join` and clients can discover registered agents via GET `/beacon/atlas`.
+
+---
+
+## Endpoints
+
+### POST /beacon/join
+
+Register or update a relay agent in the beacon atlas.
+
+**Request Body** (JSON):
+```json
+{
+  "agent_id": "bcn_my_agent",
+  "pubkey_hex": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+  "name": "My Agent Name",
+  "coinbase_address": "0x1234567890123456789012345678901234567890"
+}
+```
+
+**Required Fields**:
+- `agent_id`: Unique agent identifier
+- `pubkey_hex`: Hex-encoded public key (with or without 0x prefix)
+
+**Optional Fields**:
+- `name`: Human-readable agent name
+- `coinbase_address`: Base network address for payments (must be 0x-prefixed, 40 hex chars)
+
+**Response** (200 OK):
+```json
+{
+  "ok": true,
+  "agent_id": "bcn_my_agent",
+  "pubkey_hex": "0x1234567890abcdef...",
+  "name": "My Agent Name",
+  "status": "active",
+  "timestamp": 1710604800
+}
+```
+
+**Error Responses**:
+- `400 Bad Request`: Invalid input (missing fields, invalid pubkey_hex format)
+
+**Upsert Behavior**: Duplicate `agent_id` updates the existing record (no error).
+
+---
+
+### GET /beacon/atlas
+
+Get list of all registered relay agents.
+
+**Query Parameters**:
+- `status` (optional): Filter by status (e.g., `?status=active`)
+
+**Response** (200 OK):
+```json
+{
+  "agents": [
+    {
+      "agent_id": "bcn_my_agent",
+      "pubkey_hex": "0x1234567890abcdef...",
+      "name": "My Agent Name",
+      "status": "active",
+      "coinbase_address": "0x1234567890123456789012345678901234567890",
+      "created_at": 1710604800,
+      "updated_at": 1710604900
+    }
+  ],
+  "total": 1,
+  "timestamp": 1710605000
+}
+```
+
+---
+
+## Database Schema
+
+### relay_agents Table
+
+```sql
+CREATE TABLE relay_agents (
+    agent_id TEXT PRIMARY KEY,
+    pubkey_hex TEXT NOT NULL,
+    name TEXT,
+    status TEXT DEFAULT 'active',
+    coinbase_address TEXT DEFAULT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER
+);
+
+CREATE INDEX idx_relay_agents_status ON relay_agents(status);
+```
+
+---
+
+## Input Validation
+
+### pubkey_hex Validation
+- Must be valid hexadecimal string
+- Optional `0x` or `0X` prefix (stripped before validation)
+- Empty string after prefix removal returns 400
+
+### coinbase_address Validation (if provided)
+- Must start with `0x` or `0X`
+- Must be exactly 40 hex characters after prefix (20 bytes)
+- Must be valid hexadecimal
+
+---
+
+## Deployment Configuration
+
+### Flask Application
+
+The beacon endpoints are implemented in `node/beacon_api.py` as a Flask blueprint.
+
+**To register the blueprint in your main app**:
+```python
+from beacon_api import beacon_api, init_beacon_tables
+
+# Initialize database tables
+init_beacon_tables('rustchain_v2.db')
+
+# Register blueprint with /beacon prefix
+app.register_blueprint(beacon_api, url_prefix='/beacon')
+```
+
+### Nginx Configuration
+
+Add the following upstream and location blocks to your nginx config:
+
+```nginx
+# Beacon Atlas service upstream
+upstream beacon_atlas_backend {
+    server beacon-atlas:8100;
+}
+
+server {
+    # ... existing config ...
+
+    # Beacon Atlas endpoints
+    location /beacon/join {
+        proxy_pass http://beacon_atlas_backend/beacon/join;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Content-Type application/json;
+
+        # CORS preflight handling
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type';
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+    }
+
+    location /beacon/atlas {
+        proxy_pass http://beacon_atlas_backend/beacon/atlas;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # CORS preflight handling
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type';
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+    }
+}
+```
+
+### Docker Compose (Optional)
+
+For containerized deployment, add the beacon service:
+
+```yaml
+services:
+  beacon-atlas:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: python node/beacon_api.py
+    ports:
+      - "8100:8100"
+    volumes:
+      - beacon_data:/data
+    environment:
+      - DB_PATH=/data/beacon_atlas.db
+    restart: unless-stopped
+
+volumes:
+  beacon_data:
+```
+
+---
+
+## Running Locally
+
+### Development Mode
+
+```bash
+# 1. Install dependencies
+pip install flask
+
+# 2. Initialize and run the beacon API
+cd node/
+python3 -c "from beacon_api import init_beacon_tables; init_beacon_tables()"
+python3 beacon_api.py
+```
+
+The server will start on `http://localhost:8100` (or configured port).
+
+### Test the Endpoints
+
+```bash
+# Register an agent
+curl -X POST http://localhost:8100/beacon/join \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "bcn_test",
+    "pubkey_hex": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    "name": "Test Agent"
+  }'
+
+# Get all agents
+curl http://localhost:8100/beacon/atlas
+
+# Test upsert (same agent_id, different data)
+curl -X POST http://localhost:8100/beacon/join \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "bcn_test",
+    "pubkey_hex": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    "name": "Updated Test Agent"
+  }'
+
+# Test invalid pubkey (should return 400)
+curl -X POST http://localhost:8100/beacon/join \
+  -H "Content-Type: application/json" \
+  -d '{
+    "agent_id": "bcn_invalid",
+    "pubkey_hex": "not-valid-hex"
+  }'
+```
+
+---
+
+## Running Tests
+
+```bash
+cd tests/
+python3 test_beacon_join_routing.py -v
+```
+
+**Expected Output**:
+```
+test_atlas_agent_fields ... ok
+test_atlas_empty_list ... ok
+test_atlas_options_returns_cors_headers ... ok
+test_atlas_returns_registered_agents ... ok
+test_atlas_status_filter ... ok
+test_full_join_then_atlas_workflow ... ok
+test_join_invalid_coinbase_address_returns_400 ... ok
+test_join_invalid_json_returns_400 ... ok
+test_join_invalid_pubkey_hex_returns_400 ... ok
+test_join_missing_agent_id_returns_400 ... ok
+test_join_missing_pubkey_hex_returns_400 ... ok
+test_join_options_returns_cors_headers ... ok
+test_join_pubkey_without_0x_prefix ... ok
+test_join_register_new_agent ... ok
+test_join_upsert_duplicate_agent ... ok
+test_join_with_coinbase_address ... ok
+test_pubkey_hex_format_validation ... ok
+
+Ran 17 tests in ~0.05s
+OK
+```
+
+---
+
+## Acceptance Criteria
+
+| Criterion | Status |
+|-----------|--------|
+| POST /beacon/join registers agent | ✅ Implemented |
+| POST /beacon/join upserts on duplicate agent_id | ✅ Implemented |
+| POST /beacon/join returns 400 for invalid pubkey_hex | ✅ Implemented |
+| GET /beacon/atlas returns list of agents | ✅ Implemented |
+| SQLite upsert on relay_agents table | ✅ Implemented |
+| Input validation for all fields | ✅ Implemented |
+| CORS headers for cross-origin requests | ✅ Implemented |
+| Tests for join/atlas behavior | ✅ 17 tests passing |
+| Nginx route config snippet | ✅ Added to nginx.conf |
+| Deployment notes | ✅ This document |
+
+---
+
+## Files Modified/Created
+
+### Modified
+- `node/beacon_api.py` - Added relay_agents table, /beacon/join, /beacon/atlas endpoints
+- `nginx.conf` - Added beacon proxy routes
+
+### Created
+- `tests/test_beacon_join_routing.py` - Test suite (17 tests)
+- `docs/ISSUE_2127_DEPLOYMENT.md` - This deployment guide
+
+---
+
+## Security Considerations
+
+1. **Input Validation**: All inputs are validated before database insertion
+2. **SQL Injection**: Parameterized queries used throughout
+3. **CORS**: Configured for cross-origin access (adjust for production)
+4. **Rate Limiting**: Consider adding rate limiting in production
+5. **Authentication**: Currently open; add auth for production if needed
+
+---
+
+## Future Enhancements
+
+- Add authentication/authorization for join endpoint
+- Implement rate limiting
+- Add agent heartbeat/health check mechanism
+- Add agent removal endpoint (POST /beacon/leave)
+- Add pagination for /beacon/atlas with many agents
+- Add agent search/filter capabilities

--- a/nginx.conf
+++ b/nginx.conf
@@ -5,6 +5,11 @@ upstream rustchain_backend {
     server rustchain-node:8099;
 }
 
+# Beacon Atlas service (Issue #2127)
+upstream beacon_atlas_backend {
+    server beacon-atlas:8100;
+}
+
 server {
     listen 80;
     listen [::]:80;
@@ -21,16 +26,57 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        
+
         # WebSocket support (if needed in future)
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
-        
+
         # Timeouts
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
         proxy_read_timeout 60s;
+    }
+
+    # Beacon Atlas endpoints (Issue #2127)
+    # Routes beacon join/atlas requests to the beacon service
+    location /beacon/join {
+        proxy_pass http://beacon_atlas_backend/beacon/join;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Content-Type application/json;
+
+        # CORS preflight handling
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'POST, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type';
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
+    }
+
+    location /beacon/atlas {
+        proxy_pass http://beacon_atlas_backend/beacon/atlas;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # CORS preflight handling
+        if ($request_method = 'OPTIONS') {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Headers' 'Content-Type';
+            add_header 'Access-Control-Max-Age' 1728000;
+            add_header 'Content-Type' 'text/plain charset=UTF-8';
+            add_header 'Content-Length' 0;
+            return 204;
+        }
     }
 
     # Health check endpoint

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -108,14 +108,28 @@ def init_beacon_tables(db_path=DB_PATH):
                 created_at INTEGER NOT NULL
             )
         """)
-        
+
+        # Relay agents table (for beacon join routing)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS relay_agents (
+                agent_id TEXT PRIMARY KEY,
+                pubkey_hex TEXT NOT NULL,
+                name TEXT,
+                status TEXT DEFAULT 'active',
+                coinbase_address TEXT DEFAULT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER
+            )
+        """)
+
         # Create indexes
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_from ON beacon_contracts(from_agent)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_to ON beacon_contracts(to_agent)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_state ON beacon_contracts(state)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_bounties_state ON beacon_bounties(state)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_chat_agent ON beacon_chat(agent_id)")
-        
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_relay_agents_status ON relay_agents(status)")
+
         conn.commit()
 
 
@@ -126,15 +140,220 @@ def init_beacon_tables(db_path=DB_PATH):
 @beacon_api.route('/api/agents', methods=['GET'])
 def get_agents():
     """Get all registered agents."""
-    # In production, fetch from database
-    # For now, return empty - frontend has hardcoded agents
-    return jsonify([])
+    try:
+        db = get_db()
+        rows = db.execute(
+            "SELECT agent_id, pubkey_hex, name, status, created_at, updated_at FROM relay_agents ORDER BY created_at DESC"
+        ).fetchall()
+
+        agents = []
+        for row in rows:
+            agents.append({
+                'agent_id': row['agent_id'],
+                'pubkey_hex': row['pubkey_hex'],
+                'name': row['name'],
+                'status': row['status'],
+                'created_at': row['created_at'],
+                'updated_at': row['updated_at'],
+            })
+
+        return jsonify(agents)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
 
 
 @beacon_api.route('/api/agent/<agent_id>', methods=['GET'])
 def get_agent(agent_id):
     """Get single agent details."""
-    return jsonify({'error': 'Agent not found'}), 404
+    try:
+        db = get_db()
+        row = db.execute(
+            "SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at FROM relay_agents WHERE agent_id = ?",
+            (agent_id,)
+        ).fetchone()
+
+        if not row:
+            return jsonify({'error': 'Agent not found'}), 404
+
+        return jsonify({
+            'agent_id': row['agent_id'],
+            'pubkey_hex': row['pubkey_hex'],
+            'name': row['name'],
+            'status': row['status'],
+            'coinbase_address': row['coinbase_address'],
+            'created_at': row['created_at'],
+            'updated_at': row['updated_at'],
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+# ============================================================
+# BEACON JOIN ROUTING ENDPOINTS (Issue #2127)
+# ============================================================
+
+@beacon_api.route('/beacon/join', methods=['POST', 'OPTIONS'])
+def beacon_join():
+    """
+    Register or update a relay agent in the beacon atlas.
+    
+    Accepts JSON with:
+        - agent_id: Unique agent identifier (required)
+        - pubkey_hex: Hex-encoded public key (required, must be valid hex)
+        - name: Optional human-readable name
+        - coinbase_address: Optional Base network address for payments
+    
+    Returns:
+        - 200: Agent registered/updated successfully
+        - 400: Invalid input (missing fields, invalid pubkey_hex format)
+    
+    Upsert behavior: Duplicate agent_id updates existing record.
+    """
+    if request.method == 'OPTIONS':
+        resp = jsonify({'ok': True})
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        resp.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+        resp.headers['Access-Control-Allow-Methods'] = 'POST, OPTIONS'
+        return resp
+
+    try:
+        data = request.get_json(silent=True)
+        if not data:
+            return jsonify({'error': 'Invalid or missing JSON body'}), 400
+
+        # Validate required fields
+        agent_id = data.get('agent_id')
+        pubkey_hex = data.get('pubkey_hex')
+
+        if not agent_id:
+            return jsonify({'error': 'Missing required field: agent_id'}), 400
+        if not pubkey_hex:
+            return jsonify({'error': 'Missing required field: pubkey_hex'}), 400
+
+        # Validate pubkey_hex format (must be valid hex string, optionally with 0x prefix)
+        pubkey_clean = pubkey_hex.strip()
+        if pubkey_clean.startswith('0x') or pubkey_clean.startswith('0X'):
+            pubkey_clean = pubkey_clean[2:]
+        
+        if not pubkey_clean:
+            return jsonify({'error': 'Invalid pubkey_hex: empty after prefix removal'}), 400
+        
+        try:
+            # Validate it's proper hex
+            bytes.fromhex(pubkey_clean)
+        except ValueError:
+            return jsonify({'error': 'Invalid pubkey_hex: must be valid hexadecimal string'}), 400
+
+        # Optional fields
+        name = data.get('name')
+        coinbase_address = data.get('coinbase_address')
+        
+        # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
+        if coinbase_address:
+            cb_clean = coinbase_address.strip()
+            if not (cb_clean.startswith('0x') or cb_clean.startswith('0X')):
+                return jsonify({'error': 'Invalid coinbase_address: must start with 0x'}), 400
+            cb_hex = cb_clean[2:]
+            if len(cb_hex) != 40:
+                return jsonify({'error': 'Invalid coinbase_address: must be 20 bytes (40 hex chars)'}), 400
+            try:
+                bytes.fromhex(cb_hex)
+            except ValueError:
+                return jsonify({'error': 'Invalid coinbase_address: must be valid hexadecimal'}), 400
+
+        now = int(time.time())
+
+        # Upsert into relay_agents table
+        db = get_db()
+        db.execute("""
+            INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at)
+            VALUES (?, ?, ?, 'active', ?, ?, ?)
+            ON CONFLICT(agent_id) DO UPDATE SET
+                pubkey_hex = excluded.pubkey_hex,
+                name = excluded.name,
+                coinbase_address = excluded.coinbase_address,
+                status = 'active',
+                updated_at = excluded.updated_at
+        """, (agent_id, pubkey_hex, name, coinbase_address, now, now))
+        db.commit()
+
+        return jsonify({
+            'ok': True,
+            'agent_id': agent_id,
+            'pubkey_hex': pubkey_hex,
+            'name': name,
+            'status': 'active',
+            'timestamp': now,
+        })
+
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+@beacon_api.route('/beacon/atlas', methods=['GET', 'OPTIONS'])
+def beacon_atlas():
+    """
+    Get list of all registered relay agents in the beacon atlas.
+    
+    Returns array of agent objects with:
+        - agent_id: Unique identifier
+        - pubkey_hex: Public key (hex)
+        - name: Human-readable name (if set)
+        - status: Agent status (active, inactive, etc.)
+        - created_at: Registration timestamp
+        - updated_at: Last update timestamp
+    
+    Query params:
+        - status: Optional filter by status (e.g., ?status=active)
+    """
+    if request.method == 'OPTIONS':
+        resp = jsonify({'ok': True})
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        resp.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+        resp.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+        return resp
+
+    try:
+        db = get_db()
+        
+        # Optional status filter
+        status_filter = request.args.get('status')
+        
+        if status_filter:
+            rows = db.execute(
+                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at 
+                   FROM relay_agents 
+                   WHERE status = ? 
+                   ORDER BY created_at DESC""",
+                (status_filter,)
+            ).fetchall()
+        else:
+            rows = db.execute(
+                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at 
+                   FROM relay_agents 
+                   ORDER BY created_at DESC"""
+            ).fetchall()
+
+        agents = []
+        for row in rows:
+            agents.append({
+                'agent_id': row['agent_id'],
+                'pubkey_hex': row['pubkey_hex'],
+                'name': row['name'],
+                'status': row['status'],
+                'coinbase_address': row['coinbase_address'],
+                'created_at': row['created_at'],
+                'updated_at': row['updated_at'],
+            })
+
+        return jsonify({
+            'agents': agents,
+            'total': len(agents),
+            'timestamp': int(time.time()),
+        })
+
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
 
 
 # ============================================================

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""
+Test suite for Issue #2127 - Beacon Join Routing
+Tests POST /beacon/join and GET /beacon/atlas endpoints.
+"""
+import unittest
+import json
+import time
+import sys
+import os
+import tempfile
+import sqlite3
+
+# Add parent directory to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestBeaconJoinRouting(unittest.TestCase):
+    """Behavioral tests for beacon join routing endpoints."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up test fixtures once for all tests."""
+        # Create temporary database for testing
+        cls.test_db_fd, cls.test_db_path = tempfile.mkstemp(suffix='.db')
+
+        # Import and initialize Flask app
+        from flask import Flask, g
+        import sqlite3
+
+        cls.app = Flask(__name__)
+        cls.app.config['TESTING'] = True
+        cls.app.config['DB_PATH'] = cls.test_db_path
+
+        # Import beacon_api module
+        from node.beacon_api import init_beacon_tables
+
+        # Register blueprint
+        from node import beacon_api as beacon_module
+        cls.app.register_blueprint(beacon_module.beacon_api)
+
+        # Add database setup/teardown handlers
+        @cls.app.before_request
+        def before_request():
+            g.db = sqlite3.connect(cls.test_db_path)
+            g.db.row_factory = sqlite3.Row
+
+        @cls.app.teardown_request
+        def teardown_request(exception):
+            db = getattr(g, 'db', None)
+            if db is not None:
+                db.close()
+
+        # Initialize database tables
+        init_beacon_tables(cls.test_db_path)
+
+        cls.client = cls.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean up after all tests."""
+        os.close(cls.test_db_fd)
+        os.unlink(cls.test_db_path)
+
+    def setUp(self):
+        """Reset database state before each test."""
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("DELETE FROM relay_agents")
+            conn.commit()
+
+    # ============================================================
+    # POST /beacon/join Tests
+    # ============================================================
+
+    def test_join_register_new_agent(self):
+        """POST /beacon/join registers a new agent successfully."""
+        payload = {
+            'agent_id': 'bcn_test_agent_001',
+            'pubkey_hex': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            'name': 'Test Agent',
+        }
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['agent_id'], 'bcn_test_agent_001')
+        self.assertEqual(data['status'], 'active')
+        self.assertIn('timestamp', data)
+
+    def test_join_upsert_duplicate_agent(self):
+        """POST /beacon/join upserts (updates) duplicate agent_id without error."""
+        payload1 = {
+            'agent_id': 'bcn_upsert_test',
+            'pubkey_hex': '0xaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccdddd',
+            'name': 'Original Name',
+        }
+
+        # First registration
+        response1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json'
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Update with new data
+        payload2 = {
+            'agent_id': 'bcn_upsert_test',
+            'pubkey_hex': '0x1111222233334444555566667777888899990000aaaabbbbccccdddd11112222',
+            'name': 'Updated Name',
+        }
+
+        response2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json'
+        )
+        self.assertEqual(response2.status_code, 200)
+
+        # Verify update occurred (not a duplicate error)
+        data2 = json.loads(response2.data)
+        self.assertTrue(data2['ok'])
+        self.assertEqual(data2['name'], 'Updated Name')
+
+        # Verify only one record exists
+        with sqlite3.connect(self.test_db_path) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM relay_agents WHERE agent_id = ?",
+                ('bcn_upsert_test',)
+            ).fetchone()[0]
+            self.assertEqual(count, 1)
+
+    def test_join_invalid_pubkey_hex_returns_400(self):
+        """POST /beacon/join returns 400 for invalid pubkey_hex."""
+        invalid_cases = [
+            {'agent_id': 'bcn_test', 'pubkey_hex': 'not-hex-at-all!'},
+            {'agent_id': 'bcn_test', 'pubkey_hex': '0xGGGG'},  # Invalid hex chars
+            {'agent_id': 'bcn_test', 'pubkey_hex': ''},  # Empty
+            {'agent_id': 'bcn_test', 'pubkey_hex': '0x'},  # Just prefix
+        ]
+
+        for payload in invalid_cases:
+            response = self.client.post(
+                '/beacon/join',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
+            self.assertEqual(
+                response.status_code, 400,
+                f"Expected 400 for invalid pubkey: {payload['pubkey_hex']}"
+            )
+            data = json.loads(response.data)
+            self.assertIn('error', data)
+
+    def test_join_missing_agent_id_returns_400(self):
+        """POST /beacon/join returns 400 when agent_id is missing."""
+        payload = {
+            'pubkey_hex': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+        }
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('error', data)
+        self.assertIn('agent_id', data['error'])
+
+    def test_join_missing_pubkey_hex_returns_400(self):
+        """POST /beacon/join returns 400 when pubkey_hex is missing."""
+        payload = {
+            'agent_id': 'bcn_test',
+        }
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('error', data)
+        self.assertIn('pubkey_hex', data['error'])
+
+    def test_join_invalid_json_returns_400(self):
+        """POST /beacon/join returns 400 for invalid JSON body."""
+        response = self.client.post(
+            '/beacon/join',
+            data='not valid json',
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('error', data)
+
+    def test_join_with_coinbase_address(self):
+        """POST /beacon/join accepts valid coinbase_address."""
+        payload = {
+            'agent_id': 'bcn_wallet_test',
+            'pubkey_hex': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            'coinbase_address': '0x1234567890123456789012345678901234567890',
+        }
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify coinbase_address was stored
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT coinbase_address FROM relay_agents WHERE agent_id = ?",
+                ('bcn_wallet_test',)
+            ).fetchone()
+            self.assertEqual(row[0], '0x1234567890123456789012345678901234567890')
+
+    def test_join_invalid_coinbase_address_returns_400(self):
+        """POST /beacon/join returns 400 for invalid coinbase_address."""
+        invalid_cases = [
+            {'agent_id': 'bcn_test', 'pubkey_hex': '0x1234', 'coinbase_address': 'not-0x-prefixed'},
+            {'agent_id': 'bcn_test', 'pubkey_hex': '0x1234', 'coinbase_address': '0xGGGG'},
+            {'agent_id': 'bcn_test', 'pubkey_hex': '0x1234', 'coinbase_address': '0x123'},  # Too short
+        ]
+
+        for payload in invalid_cases:
+            response = self.client.post(
+                '/beacon/join',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
+            self.assertEqual(
+                response.status_code, 400,
+                f"Expected 400 for invalid coinbase: {payload['coinbase_address']}"
+            )
+
+    def test_join_pubkey_without_0x_prefix(self):
+        """POST /beacon/join accepts pubkey_hex without 0x prefix."""
+        payload = {
+            'agent_id': 'bcn_no_prefix',
+            'pubkey_hex': 'aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd11223344',
+        }
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_join_options_returns_cors_headers(self):
+        """OPTIONS /beacon/join returns CORS headers."""
+        response = self.client.options('/beacon/join')
+
+        self.assertEqual(response.status_code, 200)
+        headers = response.headers
+        self.assertEqual(headers.get('Access-Control-Allow-Origin'), '*')
+        self.assertIn('Content-Type', headers.get('Access-Control-Allow-Headers', ''))
+        self.assertIn('POST', headers.get('Access-Control-Allow-Methods', ''))
+
+    # ============================================================
+    # GET /beacon/atlas Tests
+    # ============================================================
+
+    def test_atlas_empty_list(self):
+        """GET /beacon/atlas returns empty list when no agents registered."""
+        response = self.client.get('/beacon/atlas')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agents'], [])
+        self.assertEqual(data['total'], 0)
+        self.assertIn('timestamp', data)
+
+    def test_atlas_returns_registered_agents(self):
+        """GET /beacon/atlas returns list of registered agents."""
+        # Register two agents
+        agents_data = [
+            {'agent_id': 'bcn_alice', 'pubkey_hex': '0xaaaa' + '00' * 30, 'name': 'Alice'},
+            {'agent_id': 'bcn_bob', 'pubkey_hex': '0xbbbb' + '00' * 30, 'name': 'Bob'},
+        ]
+
+        for agent in agents_data:
+            self.client.post(
+                '/beacon/join',
+                data=json.dumps(agent),
+                content_type='application/json'
+            )
+
+        response = self.client.get('/beacon/atlas')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.data)
+        self.assertEqual(data['total'], 2)
+        self.assertEqual(len(data['agents']), 2)
+
+        agent_ids = {a['agent_id'] for a in data['agents']}
+        self.assertIn('bcn_alice', agent_ids)
+        self.assertIn('bcn_bob', agent_ids)
+
+    def test_atlas_agent_fields(self):
+        """GET /beacon/atlas returns correct agent fields."""
+        payload = {
+            'agent_id': 'bcn_fields_test',
+            'pubkey_hex': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            'name': 'Fields Test Agent',
+            'coinbase_address': '0x1234567890123456789012345678901234567890',
+        }
+
+        self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        response = self.client.get('/beacon/atlas')
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.data)
+        agent = data['agents'][0]
+
+        self.assertEqual(agent['agent_id'], 'bcn_fields_test')
+        self.assertEqual(agent['pubkey_hex'], payload['pubkey_hex'])
+        self.assertEqual(agent['name'], 'Fields Test Agent')
+        self.assertEqual(agent['status'], 'active')
+        self.assertEqual(agent['coinbase_address'], payload['coinbase_address'])
+        self.assertIn('created_at', agent)
+        self.assertIn('updated_at', agent)
+
+    def test_atlas_status_filter(self):
+        """GET /beacon/atlas supports status query param filter."""
+        # Register agents with different statuses
+        with sqlite3.connect(self.test_db_path) as conn:
+            now = int(time.time())
+            conn.execute("""
+                INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, ('bcn_active', '0xaaaa' + '00' * 30, 'Active Agent', 'active', now, now))
+            conn.execute("""
+                INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, ('bcn_inactive', '0xbbbb' + '00' * 30, 'Inactive Agent', 'inactive', now, now))
+            conn.commit()
+
+        # Filter by active
+        response_active = self.client.get('/beacon/atlas?status=active')
+        self.assertEqual(response_active.status_code, 200)
+        data_active = json.loads(response_active.data)
+        self.assertEqual(data_active['total'], 1)
+        self.assertEqual(data_active['agents'][0]['agent_id'], 'bcn_active')
+
+        # Filter by inactive
+        response_inactive = self.client.get('/beacon/atlas?status=inactive')
+        self.assertEqual(response_inactive.status_code, 200)
+        data_inactive = json.loads(response_inactive.data)
+        self.assertEqual(data_inactive['total'], 1)
+        self.assertEqual(data_inactive['agents'][0]['agent_id'], 'bcn_inactive')
+
+        # No filter - should return both
+        response_all = self.client.get('/beacon/atlas')
+        self.assertEqual(response_all.status_code, 200)
+        data_all = json.loads(response_all.data)
+        self.assertEqual(data_all['total'], 2)
+
+    def test_atlas_options_returns_cors_headers(self):
+        """OPTIONS /beacon/atlas returns CORS headers."""
+        response = self.client.options('/beacon/atlas')
+
+        self.assertEqual(response.status_code, 200)
+        headers = response.headers
+        self.assertEqual(headers.get('Access-Control-Allow-Origin'), '*')
+        self.assertIn('Content-Type', headers.get('Access-Control-Allow-Headers', ''))
+        self.assertIn('GET', headers.get('Access-Control-Allow-Methods', ''))
+
+    # ============================================================
+    # Integration Tests
+    # ============================================================
+
+    def test_full_join_then_atlas_workflow(self):
+        """Full workflow: join agent, verify in atlas, update, verify update."""
+        # Step 1: Register agent
+        payload1 = {
+            'agent_id': 'bcn_workflow',
+            'pubkey_hex': '0x1111' + '00' * 30,
+            'name': 'Workflow Agent v1',
+        }
+
+        response1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json'
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        # Step 2: Verify in atlas
+        response2 = self.client.get('/beacon/atlas')
+        self.assertEqual(response2.status_code, 200)
+        data2 = json.loads(response2.data)
+        self.assertEqual(data2['total'], 1)
+        self.assertEqual(data2['agents'][0]['name'], 'Workflow Agent v1')
+
+        # Step 3: Update agent
+        payload3 = {
+            'agent_id': 'bcn_workflow',
+            'pubkey_hex': '0x2222' + '00' * 30,
+            'name': 'Workflow Agent v2',
+        }
+
+        response3 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload3),
+            content_type='application/json'
+        )
+        self.assertEqual(response3.status_code, 200)
+
+        # Step 4: Verify update in atlas
+        response4 = self.client.get('/beacon/atlas')
+        self.assertEqual(response4.status_code, 200)
+        data4 = json.loads(response4.data)
+        self.assertEqual(data4['total'], 1)
+        self.assertEqual(data4['agents'][0]['name'], 'Workflow Agent v2')
+        self.assertEqual(data4['agents'][0]['pubkey_hex'], payload3['pubkey_hex'])
+
+
+class TestBeaconJoinValidation(unittest.TestCase):
+    """Input validation tests for beacon join endpoint."""
+
+    def test_pubkey_hex_format_validation(self):
+        """Test pubkey_hex format validation rules."""
+        valid_pubkeys = [
+            '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            '0xABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890',
+            '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            '00',  # Minimal valid
+        ]
+
+        invalid_pubkeys = [
+            'not-hex',
+            '0xGGGG',  # Invalid hex chars
+            '0x',  # Just prefix
+            None,  # Null
+        ]
+
+        # Valid should pass hex validation
+        for pubkey in valid_pubkeys:
+            pubkey_clean = pubkey.strip() if pubkey else ''
+            if pubkey_clean.startswith('0x') or pubkey_clean.startswith('0X'):
+                pubkey_clean = pubkey_clean[2:]
+            try:
+                bytes.fromhex(pubkey_clean)
+                # If we get here, validation passed (as expected)
+            except ValueError:
+                self.fail(f"Valid pubkey failed validation: {pubkey}")
+
+        # Invalid should fail hex validation (empty string is caught by missing field check)
+        for pubkey in invalid_pubkeys:
+            if pubkey is None:
+                continue  # Skip None, handled by missing field check
+            pubkey_clean = pubkey.strip() if pubkey else ''
+            if pubkey_clean.startswith('0x') or pubkey_clean.startswith('0X'):
+                pubkey_clean = pubkey_clean[2:]
+            if not pubkey_clean:
+                continue  # Empty after prefix removal, handled separately
+            try:
+                bytes.fromhex(pubkey_clean)
+                self.fail(f"Invalid pubkey passed validation: {pubkey}")
+            except ValueError:
+                pass  # Expected
+
+
+def run_tests():
+    """Run all test suites."""
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+
+    # Add test classes
+    suite.addTests(loader.loadTestsFromTestCase(TestBeaconJoinRouting))
+    suite.addTests(loader.loadTestsFromTestCase(TestBeaconJoinValidation))
+
+    # Run tests
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run_tests())


### PR DESCRIPTION
Implements issue #2127 acceptance criteria:\n\n- Adds/fixes POST /beacon/join registration with validation\n- Duplicate agent_id uses upsert behavior (no duplicate error)\n- Invalid pubkey_hex returns 400\n- Adds routing/proxy support for rustchain.org beacon paths\n- Includes deployment notes and focused tests\n\nValidation:\n- pytest tests/test_beacon_join_routing.py (17 passed)\n\nCloses #2127