### PR TITLE
docs: add contribution link to bounty board

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,7 @@ Named after a 486 laptop with oxidized serial ports that still boots to DOS and 
 [Boudreaux Principles](docs/Boudreaux_COMPUTING_PRINCIPLES.md) · [Green Tracker](https://rustchain.org/preserved.html) · [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
 
 </div>
+
+
+## Contributing
+Please read the [Bounty Board](https://github.com/Scottcjn/rustchain-bounties) for active tasks and rewards.


### PR DESCRIPTION
Simple documentation enhancement to guide contributors towards the active bounty board. Payout: 0x9e0EBB56aFf15D2053e93E009bd8D842D0841056