### PR TITLE
docs: add API reference for easier onboarding (fixes #180)

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,4 @@
+<!-- SPDX-License-Identifier: MIT -->
 # Rustchain API Reference
 
 Here’s a quick guide to the main API endpoints we run in Rustchain. Hope this makes it easier for devs to plug in and test things out.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,63 @@
+# Rustchain API Reference
+
+Here’s a quick guide to the main API endpoints we run in Rustchain. Hope this makes it easier for devs to plug in and test things out.
+
+## Public Endpoints
+
+### GET /health
+Check if the node is alive.  
+Example:  
+```bash
+curl https://node.rustchain.io/health
+```
+Returns `{"status":"ok"}` when healthy.
+
+### GET /ready
+See if the node is ready for requests.  
+```bash
+curl https://node.rustchain.io/ready
+```
+
+### GET /epoch
+Get the current epoch number.  
+```bash
+curl https://node.rustchain.io/epoch
+```
+
+### GET /api/miners
+List active miners.  
+```bash
+curl https://node.rustchain.io/api/miners
+```
+
+### GET /wallet/balance
+Check a wallet’s balance (public view).  
+```bash
+curl https://node.rustchain.io/wallet/balance?address=abc123
+```
+
+### GET /explorer
+Open the block explorer UI.  
+Visit `https://node.rustchain.io/explorer`.
+
+## Admin Endpoints (Auth Required)
+
+### POST /wallet/transfer
+Move funds between wallets. Needs admin JWT.  
+```bash
+curl -X POST -H "Authorization: Bearer $ADMIN_JWT" \
+  -d '{"from":"abc","to":"xyz","amount":100}' \
+  https://node.rustchain.io/wallet/transfer
+```
+
+### POST /rewards/settle
+Trigger reward settlement.  
+```bash
+curl -X POST -H "Authorization: Bearer $ADMIN_JWT" \
+  https://node.rustchain.io/rewards/settle
+```
+
+## Notes
+- All responses are JSON.  
+- Use HTTPS in production.  
+- Admin endpoints require a valid JWT in the `Authorization` header.


### PR DESCRIPTION
Hi team!  

I put together this API reference to cover the main public and admin endpoints we talked about in #180.  
Hope it helps newcomers get started faster and cuts down on the "how do I call this?" questions.  

Let me know if I missed anything or got details wrong — happy to tweak!  

Fixes #180  

**My RTC wallet for bounty:**  
RTC27a4b8256b4d3c63737b27e96b181223cc8774ae