### PR TITLE
fix: correct silicon typo in Why RustChain section

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Linux (x86_64, ppc64le) · macOS (Intel, Apple Silicon, PowerPC) · IBM POWER8 �
 
 ## Why "RustChain"?
 
-Named after a 486 laptop with oxidized serial ports that still boots to DOS and mines RTC. "Rust" means iron oxide on 30-year-old silicon. The thesis is that corroding vintage hardware still has computational value and dignity.
+Named after a 486 laptop with oxidized serial ports that still boots to DOS and mines RTC. "Rust" means iron oxide on vintage iron-containing components. The thesis is that corroding vintage hardware still has computational value and dignity.
 
 ---
 


### PR DESCRIPTION
Summary: Fixed a technical inaccuracy in the Why RustChain section. Rust is specifically iron oxide, not silicon dioxide. Changed 'iron oxide on 30-year-old silicon' to 'iron oxide on vintage iron-containing components' to maintain poetic meaning while being scientifically accurate. Bounty: rustchain-bounties issue 2178. Wallet: RTCbc57f8031699a0bab6e9a8a2769822f19f115dc5