### PR TITLE
Verify Beacon envelope signatures before anchoring

### DIFF
--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -6,12 +6,75 @@ Beacon envelopes (hello, heartbeat, want, bounty, mayday, accord, pushback)
 are stored in rustchain_v2.db and periodically committed to Ergo via the
 existing ergo_miner_anchor.py system.
 """
-import sqlite3, time, json
+import hashlib
+import json
+import sqlite3
+import time
 from hashlib import blake2b
+
+try:
+    from nacl.signing import VerifyKey
+    from nacl.exceptions import BadSignatureError
+    NACL_AVAILABLE = True
+except ImportError:
+    VerifyKey = None
+    BadSignatureError = Exception
+    NACL_AVAILABLE = False
 
 DB_PATH = "/root/rustchain/rustchain_v2.db"
 
 VALID_KINDS = {"hello", "heartbeat", "want", "bounty", "mayday", "accord", "pushback"}
+
+
+def _agent_id_from_pubkey(pubkey_bytes: bytes) -> str:
+    """Derive the canonical Beacon agent id from an Ed25519 public key."""
+    return f"bcn_{hashlib.sha256(pubkey_bytes).hexdigest()[:12]}"
+
+
+def _canonical_signing_payload(envelope: dict) -> bytes:
+    """Return the canonical Beacon signing payload (everything except the signature)."""
+    signing_payload = {
+        key: value
+        for key, value in envelope.items()
+        if key not in ("sig", "_beacon_version")
+    }
+    return json.dumps(signing_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def verify_envelope_signature(envelope: dict) -> tuple[bool, str]:
+    """
+    Verify an HTTP-submitted Beacon envelope.
+
+    Beacon v2 envelopes are signed with Ed25519 over the canonical JSON body
+    excluding the `sig` field. The claimed `agent_id` must also match the
+    submitted public key to prevent identity spoofing.
+    """
+    sig_hex = envelope.get("sig", "")
+    pubkey_hex = envelope.get("pubkey", "")
+    agent_id = envelope.get("agent_id", "")
+
+    if not all([sig_hex, pubkey_hex, agent_id]):
+        return False, "missing_signature_fields"
+
+    try:
+        pubkey_bytes = bytes.fromhex(pubkey_hex)
+        signature_bytes = bytes.fromhex(sig_hex)
+    except ValueError:
+        return False, "invalid_signature_or_pubkey_encoding"
+
+    expected_agent_id = _agent_id_from_pubkey(pubkey_bytes)
+    if agent_id != expected_agent_id:
+        return False, "agent_id_pubkey_mismatch"
+
+    if not NACL_AVAILABLE:
+        return False, "signature_verification_unavailable"
+
+    try:
+        verify_key = VerifyKey(pubkey_bytes)
+        verify_key.verify(_canonical_signing_payload(envelope), signature_bytes)
+        return True, ""
+    except (BadSignatureError, Exception):
+        return False, "invalid_signature"
 
 
 def init_beacon_table(db_path=DB_PATH):
@@ -63,6 +126,10 @@ def store_envelope(envelope: dict, db_path=DB_PATH) -> dict:
 
     if kind not in VALID_KINDS:
         return {"ok": False, "error": f"invalid_kind:{kind}"}
+
+    sig_ok, sig_err = verify_envelope_signature(envelope)
+    if not sig_ok:
+        return {"ok": False, "error": sig_err}
 
     payload_hash = hash_envelope(envelope)
     now = int(time.time())

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -1,0 +1,93 @@
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Optional
+
+from nacl.signing import SigningKey
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "beacon_anchor.py"
+SPEC = importlib.util.spec_from_file_location("beacon_anchor", MODULE_PATH)
+beacon_anchor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(beacon_anchor)
+
+
+def _make_temp_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    return path
+
+
+def _build_signed_envelope(agent_id: Optional[str] = None):
+    signing_key = SigningKey.generate()
+    pubkey_bytes = bytes(signing_key.verify_key)
+    derived_agent_id = beacon_anchor._agent_id_from_pubkey(pubkey_bytes)
+    envelope = {
+        "agent_id": agent_id or derived_agent_id,
+        "kind": "heartbeat",
+        "nonce": "beacon-nonce-123456",
+        "pubkey": pubkey_bytes.hex(),
+        "payload": {"status": "alive", "ts": 1234567890},
+    }
+    message = beacon_anchor._canonical_signing_payload(envelope)
+    envelope["sig"] = signing_key.sign(message).signature.hex()
+    return envelope, derived_agent_id
+
+
+class BeaconAnchorSignatureTests(unittest.TestCase):
+    def test_store_envelope_rejects_invalid_signature(self):
+        db_path = _make_temp_db()
+        try:
+            beacon_anchor.init_beacon_table(db_path)
+            envelope, _ = _build_signed_envelope()
+            envelope["sig"] = "00" * 64
+
+            result = beacon_anchor.store_envelope(envelope, db_path)
+
+            self.assertEqual(result, {"ok": False, "error": "invalid_signature"})
+            with sqlite3.connect(db_path) as conn:
+                count = conn.execute("SELECT COUNT(*) FROM beacon_envelopes").fetchone()[0]
+            self.assertEqual(count, 0)
+        finally:
+            os.unlink(db_path)
+
+    def test_store_envelope_rejects_agent_id_pubkey_mismatch(self):
+        db_path = _make_temp_db()
+        try:
+            beacon_anchor.init_beacon_table(db_path)
+            envelope, _ = _build_signed_envelope(agent_id="bcn_deadbeefcafe")
+
+            result = beacon_anchor.store_envelope(envelope, db_path)
+
+            self.assertEqual(result, {"ok": False, "error": "agent_id_pubkey_mismatch"})
+        finally:
+            os.unlink(db_path)
+
+    def test_store_envelope_accepts_valid_signature_and_affects_digest(self):
+        db_path = _make_temp_db()
+        try:
+            beacon_anchor.init_beacon_table(db_path)
+            envelope, agent_id = _build_signed_envelope()
+
+            result = beacon_anchor.store_envelope(envelope, db_path)
+            digest = beacon_anchor.compute_beacon_digest(db_path)
+
+            self.assertTrue(result["ok"])
+            self.assertEqual(digest["count"], 1)
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute(
+                    "SELECT agent_id, kind, nonce, payload_hash FROM beacon_envelopes"
+                ).fetchone()
+            self.assertEqual(row[0], agent_id)
+            self.assertEqual(row[1], "heartbeat")
+            self.assertEqual(row[2], "beacon-nonce-123456")
+            self.assertEqual(row[3], beacon_anchor.hash_envelope(envelope))
+        finally:
+            os.unlink(db_path)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- verify Ed25519 signatures on Beacon envelopes before storing them
- reject `agent_id` / `pubkey` mismatches so callers cannot spoof another Beacon identity
- add regression coverage for invalid signatures, mismatched identities, and valid signed envelopes

## Why
`POST /beacon/submit` currently accepts arbitrary `agent_id`, `pubkey`, and `sig` values and forwards them into `store_envelope(...)`, which persisted them without any cryptographic verification. That lets an attacker forge Beacon envelopes for any claimed agent and pollute the digest that is later anchored.

## Testing
- `/tmp/rustchain-test-venv/bin/python -m unittest /Users/core/Projects/Rustchain/node/tests/test_beacon_anchor_signature.py`
