### PR TITLE
Canonicalize stored Beacon hash by ignoring unsigned metadata

### DIFF
--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -24,6 +24,10 @@ except ImportError:
 DB_PATH = "/root/rustchain/rustchain_v2.db"
 
 VALID_KINDS = {"hello", "heartbeat", "want", "bounty", "mayday", "accord", "pushback"}
+REQUIRED_ENVELOPE_FIELDS = ("agent_id", "kind", "nonce", "sig", "pubkey")
+UNSIGNED_TRANSPORT_FIELDS = ("sig", "_beacon_version")
+LEGACY_PAYLOAD_HASH_VERSION = 1
+CURRENT_PAYLOAD_HASH_VERSION = 2
 
 
 def _agent_id_from_pubkey(pubkey_bytes: bytes) -> str:
@@ -31,23 +35,47 @@ def _agent_id_from_pubkey(pubkey_bytes: bytes) -> str:
     return f"bcn_{hashlib.sha256(pubkey_bytes).hexdigest()[:12]}"
 
 
-def _canonical_signing_payload(envelope: dict) -> bytes:
-    """Return the canonical Beacon signing payload (everything except the signature)."""
-    signing_payload = {
-        key: value
-        for key, value in envelope.items()
-        if key not in ("sig", "_beacon_version")
-    }
-    return json.dumps(signing_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-
-
-def _canonical_stored_envelope(envelope: dict) -> dict:
-    """Drop transport-only Beacon metadata before hashing for anchoring."""
+def _canonical_signed_fields(envelope: dict) -> dict:
+    """Return the exact Beacon v2 body covered by signature verification and payload hashing."""
     return {
-        key: value
-        for key, value in envelope.items()
-        if key != "_beacon_version"
+        field: value
+        for field, value in envelope.items()
+        if field not in UNSIGNED_TRANSPORT_FIELDS
     }
+
+
+def _canonical_signing_payload(envelope: dict) -> bytes:
+    """Return the canonical Beacon signing payload for the explicit signed field set."""
+    return json.dumps(
+        _canonical_signed_fields(envelope),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _ensure_payload_hash_version_column(conn: sqlite3.Connection):
+    """
+    Preserve existing hashes as legacy version 1 and mark new hashes as version 2.
+
+    The table only stores the derived payload hash, not the original envelope body,
+    so pre-upgrade rows cannot be recomputed safely in place. We therefore tag them
+    as legacy and let new writes opt into the explicit signed-field hash contract.
+    """
+    columns = {
+        row[1]
+        for row in conn.execute("PRAGMA table_info(beacon_envelopes)").fetchall()
+    }
+    if "payload_hash_version" not in columns:
+        conn.execute(
+            "ALTER TABLE beacon_envelopes "
+            "ADD COLUMN payload_hash_version INTEGER NOT NULL DEFAULT 1"
+        )
+    conn.execute(
+        "UPDATE beacon_envelopes "
+        "SET payload_hash_version = ? "
+        "WHERE payload_hash_version IS NULL",
+        (LEGACY_PAYLOAD_HASH_VERSION,),
+    )
 
 
 def verify_envelope_signature(envelope: dict) -> tuple[bool, str]:
@@ -98,6 +126,7 @@ def init_beacon_table(db_path=DB_PATH):
                 sig TEXT NOT NULL,
                 pubkey TEXT NOT NULL,
                 payload_hash TEXT NOT NULL,
+                payload_hash_version INTEGER NOT NULL DEFAULT 1,
                 anchored INTEGER DEFAULT 0,
                 created_at INTEGER NOT NULL
             )
@@ -110,13 +139,13 @@ def init_beacon_table(db_path=DB_PATH):
             CREATE INDEX IF NOT EXISTS idx_beacon_agent
             ON beacon_envelopes(agent_id, created_at)
         """)
+        _ensure_payload_hash_version_column(conn)
         conn.commit()
 
 
 def hash_envelope(envelope: dict) -> str:
-    """Compute blake2b hash of the canonical stored envelope JSON."""
-    data = json.dumps(_canonical_stored_envelope(envelope), sort_keys=True, separators=(',', ':')).encode()
-    return blake2b(data, digest_size=32).hexdigest()
+    """Compute the version-2 blake2b hash over the explicit signed field set."""
+    return blake2b(_canonical_signing_payload(envelope), digest_size=32).hexdigest()
 
 
 def store_envelope(envelope: dict, db_path=DB_PATH) -> dict:
@@ -130,7 +159,7 @@ def store_envelope(envelope: dict, db_path=DB_PATH) -> dict:
     sig = envelope.get("sig", "")
     pubkey = envelope.get("pubkey", "")
 
-    if not all([agent_id, kind, nonce, sig, pubkey]):
+    if not all(envelope.get(field, "") for field in REQUIRED_ENVELOPE_FIELDS):
         return {"ok": False, "error": "missing_fields"}
 
     if kind not in VALID_KINDS:
@@ -146,12 +175,26 @@ def store_envelope(envelope: dict, db_path=DB_PATH) -> dict:
     try:
         with sqlite3.connect(db_path) as conn:
             conn.execute("INSERT INTO beacon_envelopes "
-                         "(agent_id, kind, nonce, sig, pubkey, payload_hash, anchored, created_at) "
-                         "VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
-                         (agent_id, kind, nonce, sig, pubkey, payload_hash, now))
+                         "(agent_id, kind, nonce, sig, pubkey, payload_hash, payload_hash_version, anchored, created_at) "
+                         "VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)",
+                         (
+                             agent_id,
+                             kind,
+                             nonce,
+                             sig,
+                             pubkey,
+                             payload_hash,
+                             CURRENT_PAYLOAD_HASH_VERSION,
+                             now,
+                         ))
             conn.commit()
             row_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
-        return {"ok": True, "id": row_id, "payload_hash": payload_hash}
+        return {
+            "ok": True,
+            "id": row_id,
+            "payload_hash": payload_hash,
+            "payload_hash_version": CURRENT_PAYLOAD_HASH_VERSION,
+        }
     except sqlite3.IntegrityError:
         return {"ok": False, "error": "duplicate_nonce"}
 
@@ -161,19 +204,31 @@ def compute_beacon_digest(db_path=DB_PATH) -> dict:
     Compute a blake2b digest of all un-anchored beacon envelopes.
     Returns {"digest": hex, "count": N, "ids": [...], "latest_ts": T}
     or {"digest": None, "count": 0} if no pending envelopes.
+
+    During the transition from legacy payload hashes to explicit signed-field
+    hashes, the digest includes a version prefix per entry and reports whether
+    multiple hash versions are still pending.
     """
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
-            "SELECT id, payload_hash, created_at FROM beacon_envelopes "
+            "SELECT id, payload_hash, payload_hash_version, created_at FROM beacon_envelopes "
             "WHERE anchored = 0 ORDER BY id ASC"
         ).fetchall()
 
     if not rows:
-        return {"digest": None, "count": 0, "ids": [], "latest_ts": 0}
+        return {
+            "digest": None,
+            "count": 0,
+            "ids": [],
+            "latest_ts": 0,
+            "payload_hash_versions": [],
+            "mixed_payload_hash_versions": False,
+        }
 
     ids = [r[0] for r in rows]
-    hashes = [r[1] for r in rows]
-    latest_ts = max(r[2] for r in rows)
+    hashes = [f"v{r[2]}:{r[1]}" for r in rows]
+    versions = sorted({r[2] for r in rows})
+    latest_ts = max(r[3] for r in rows)
 
     # Concatenate all payload hashes and compute digest
     combined = "|".join(hashes).encode()
@@ -183,7 +238,9 @@ def compute_beacon_digest(db_path=DB_PATH) -> dict:
         "digest": digest,
         "count": len(rows),
         "ids": ids,
-        "latest_ts": latest_ts
+        "latest_ts": latest_ts,
+        "payload_hash_versions": versions,
+        "mixed_payload_hash_versions": len(versions) > 1,
     }
 
 
@@ -205,7 +262,7 @@ def get_recent_envelopes(limit=50, offset=0, db_path=DB_PATH) -> list:
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
-            "SELECT id, agent_id, kind, nonce, payload_hash, anchored, created_at "
+            "SELECT id, agent_id, kind, nonce, payload_hash, payload_hash_version, anchored, created_at "
             "FROM beacon_envelopes ORDER BY created_at DESC LIMIT ? OFFSET ?",
             (limit, offset)
         ).fetchall()

--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -206,8 +206,8 @@ def compute_beacon_digest(db_path=DB_PATH) -> dict:
     or {"digest": None, "count": 0} if no pending envelopes.
 
     During the transition from legacy payload hashes to explicit signed-field
-    hashes, the digest includes a version prefix per entry and reports whether
-    multiple hash versions are still pending.
+    hashes, the digest preserves the original payload-hash concatenation and
+    reports whether multiple hash versions are still pending.
     """
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
@@ -226,7 +226,9 @@ def compute_beacon_digest(db_path=DB_PATH) -> dict:
         }
 
     ids = [r[0] for r in rows]
-    hashes = [f"v{r[2]}:{r[1]}" for r in rows]
+    # Preserve the historic digest input for pending rows so a rollout does not
+    # retroactively change the digest of an unchanged legacy-only backlog.
+    hashes = [r[1] for r in rows]
     versions = sorted({r[2] for r in rows})
     latest_ts = max(r[3] for r in rows)
 

--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -41,6 +41,15 @@ def _canonical_signing_payload(envelope: dict) -> bytes:
     return json.dumps(signing_payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
+def _canonical_stored_envelope(envelope: dict) -> dict:
+    """Drop transport-only Beacon metadata before hashing for anchoring."""
+    return {
+        key: value
+        for key, value in envelope.items()
+        if key != "_beacon_version"
+    }
+
+
 def verify_envelope_signature(envelope: dict) -> tuple[bool, str]:
     """
     Verify an HTTP-submitted Beacon envelope.
@@ -105,8 +114,8 @@ def init_beacon_table(db_path=DB_PATH):
 
 
 def hash_envelope(envelope: dict) -> str:
-    """Compute blake2b hash of the full envelope JSON (canonical, sorted keys)."""
-    data = json.dumps(envelope, sort_keys=True, separators=(',', ':')).encode()
+    """Compute blake2b hash of the canonical stored envelope JSON."""
+    data = json.dumps(_canonical_stored_envelope(envelope), sort_keys=True, separators=(',', ':')).encode()
     return blake2b(data, digest_size=32).hexdigest()
 
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1214,11 +1214,6 @@ def init_db():
                   (int(time.time()),))
         c.execute("INSERT OR IGNORE INTO gov_threshold(id, threshold) VALUES(1, 3)")
         c.execute("INSERT OR IGNORE INTO checkpoints_meta(k, v) VALUES('chain_id', 'rustchain-mainnet-candidate')")
-        # Beacon protocol table
-        c.execute("CREATE TABLE IF NOT EXISTS beacon_envelopes (id INTEGER PRIMARY KEY AUTOINCREMENT, agent_id TEXT NOT NULL, kind TEXT NOT NULL, nonce TEXT UNIQUE NOT NULL, sig TEXT NOT NULL, pubkey TEXT NOT NULL, payload_hash TEXT NOT NULL, anchored INTEGER DEFAULT 0, created_at INTEGER NOT NULL)")
-        c.execute("CREATE INDEX IF NOT EXISTS idx_beacon_anchored ON beacon_envelopes(anchored)")
-        c.execute("CREATE INDEX IF NOT EXISTS idx_beacon_agent ON beacon_envelopes(agent_id, created_at)")
-
         # BCOS v2: Blockchain Certified Open Source attestations
         try:
             from bcos_routes import init_bcos_table
@@ -1236,6 +1231,10 @@ def init_db():
             init_lock_ledger_schema(c)
 
         c.commit()
+
+    # Keep Beacon schema migration logic centralized in beacon_anchor.py so
+    # legacy payload hashes are versioned consistently across startup paths.
+    init_beacon_table(DB_PATH)
 
 # Hardware multipliers
 HARDWARE_WEIGHTS = {
@@ -6603,7 +6602,14 @@ def beacon_submit():
 @app.route("/beacon/digest", methods=["GET"])
 def beacon_digest():
     d = compute_beacon_digest(DB_PATH)
-    return jsonify({"ok": True, "digest": d["digest"], "count": d["count"], "latest_ts": d["latest_ts"]})
+    return jsonify({
+        "ok": True,
+        "digest": d["digest"],
+        "count": d["count"],
+        "latest_ts": d["latest_ts"],
+        "payload_hash_versions": d.get("payload_hash_versions", []),
+        "mixed_payload_hash_versions": d.get("mixed_payload_hash_versions", False),
+    })
 
 @app.route("/beacon/envelopes", methods=["GET"])
 def beacon_envelopes_list():

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from hashlib import blake2b
 from pathlib import Path
 from copy import deepcopy
 from typing import Optional
@@ -175,6 +176,55 @@ class BeaconAnchorSignatureTests(unittest.TestCase):
                     ("legacy-nonce",),
                 ).fetchone()[0]
             self.assertEqual(version, beacon_anchor.LEGACY_PAYLOAD_HASH_VERSION)
+        finally:
+            os.unlink(db_path)
+
+    def test_compute_beacon_digest_preserves_legacy_digest_for_legacy_only_rows(self):
+        db_path = _make_temp_db()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE beacon_envelopes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        agent_id TEXT NOT NULL,
+                        kind TEXT NOT NULL,
+                        nonce TEXT UNIQUE NOT NULL,
+                        sig TEXT NOT NULL,
+                        pubkey TEXT NOT NULL,
+                        payload_hash TEXT NOT NULL,
+                        anchored INTEGER DEFAULT 0,
+                        created_at INTEGER NOT NULL
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    INSERT INTO beacon_envelopes
+                    (agent_id, kind, nonce, sig, pubkey, payload_hash, anchored, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+                    """,
+                    (
+                        "bcn_legacy123456",
+                        "heartbeat",
+                        "legacy-nonce",
+                        "ab" * 64,
+                        "cd" * 32,
+                        "legacy-hash",
+                        1234567890,
+                    ),
+                )
+                conn.commit()
+
+            beacon_anchor.init_beacon_table(db_path)
+            digest = beacon_anchor.compute_beacon_digest(db_path)
+
+            self.assertEqual(
+                digest["digest"],
+                blake2b(b"legacy-hash", digest_size=32).hexdigest(),
+            )
+            self.assertEqual(digest["payload_hash_versions"], [1])
+            self.assertFalse(digest["mixed_payload_hash_versions"])
         finally:
             os.unlink(db_path)
 

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
-import json
 import os
 import sqlite3
 import tempfile
 import unittest
-from hashlib import blake2b
 from pathlib import Path
+from copy import deepcopy
 from typing import Optional
 
 from nacl.signing import SigningKey
@@ -24,17 +23,31 @@ def _make_temp_db():
     return path
 
 
-def _build_signed_envelope(agent_id: Optional[str] = None):
-    signing_key = SigningKey.generate()
+def _build_signed_envelope(
+    agent_id: Optional[str] = None,
+    signing_key: Optional[SigningKey] = None,
+    health: Optional[dict] = None,
+    extra_fields: Optional[dict] = None,
+):
+    signing_key = signing_key or SigningKey.generate()
     pubkey_bytes = bytes(signing_key.verify_key)
     derived_agent_id = beacon_anchor._agent_id_from_pubkey(pubkey_bytes)
     envelope = {
         "agent_id": agent_id or derived_agent_id,
         "kind": "heartbeat",
+        "v": 2,
         "nonce": "beacon-nonce-123456",
         "pubkey": pubkey_bytes.hex(),
-        "payload": {"status": "alive", "ts": 1234567890},
+        "name": "agent-alpha",
+        "status": "alive",
+        "beat_count": 1,
+        "uptime_s": 60,
+        "ts": 1234567890,
     }
+    if health:
+        envelope["health"] = health
+    if extra_fields:
+        envelope.update(extra_fields)
     message = beacon_anchor._canonical_signing_payload(envelope)
     envelope["sig"] = signing_key.sign(message).signature.hex()
     return envelope, derived_agent_id
@@ -88,33 +101,130 @@ class BeaconAnchorSignatureTests(unittest.TestCase):
             self.assertEqual(row[1], "heartbeat")
             self.assertEqual(row[2], "beacon-nonce-123456")
             self.assertEqual(row[3], beacon_anchor.hash_envelope(envelope))
+            self.assertEqual(result["payload_hash_version"], beacon_anchor.CURRENT_PAYLOAD_HASH_VERSION)
         finally:
             os.unlink(db_path)
 
-    def test_store_envelope_ignores_unsigned_beacon_version_metadata_in_hash(self):
+    def test_hash_ignores_extra_unsigned_metadata(self):
+        envelope, _ = _build_signed_envelope()
+        envelope_with_metadata = deepcopy(envelope)
+        envelope_with_metadata["_beacon_version"] = 999
+
+        self.assertEqual(
+            beacon_anchor.hash_envelope(envelope),
+            beacon_anchor.hash_envelope(envelope_with_metadata),
+        )
+        sig_ok, sig_err = beacon_anchor.verify_envelope_signature(envelope_with_metadata)
+        self.assertTrue(sig_ok, sig_err)
+
+    def test_hash_changes_when_signed_field_changes(self):
+        signing_key = SigningKey.generate()
+        envelope, _ = _build_signed_envelope(signing_key=signing_key)
+        changed_envelope, _ = _build_signed_envelope(
+            signing_key=signing_key,
+            extra_fields={"status": "degraded"},
+        )
+
+        self.assertNotEqual(
+            beacon_anchor.hash_envelope(envelope),
+            beacon_anchor.hash_envelope(changed_envelope),
+        )
+
+    def test_init_beacon_table_preserves_legacy_payload_hashes_as_version_one(self):
         db_path = _make_temp_db()
         try:
-            beacon_anchor.init_beacon_table(db_path)
-            envelope, _ = _build_signed_envelope()
-            envelope["_beacon_version"] = 999
-
-            result = beacon_anchor.store_envelope(envelope, db_path)
-
-            self.assertTrue(result["ok"])
-            raw_hash = blake2b(
-                json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8"),
-                digest_size=32,
-            ).hexdigest()
-            canonical_hash = beacon_anchor.hash_envelope(
-                {key: value for key, value in envelope.items() if key != "_beacon_version"}
-            )
-            self.assertEqual(result["payload_hash"], canonical_hash)
-            self.assertNotEqual(result["payload_hash"], raw_hash)
             with sqlite3.connect(db_path) as conn:
-                stored_hash = conn.execute(
-                    "SELECT payload_hash FROM beacon_envelopes"
+                conn.execute(
+                    """
+                    CREATE TABLE beacon_envelopes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        agent_id TEXT NOT NULL,
+                        kind TEXT NOT NULL,
+                        nonce TEXT UNIQUE NOT NULL,
+                        sig TEXT NOT NULL,
+                        pubkey TEXT NOT NULL,
+                        payload_hash TEXT NOT NULL,
+                        anchored INTEGER DEFAULT 0,
+                        created_at INTEGER NOT NULL
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    INSERT INTO beacon_envelopes
+                    (agent_id, kind, nonce, sig, pubkey, payload_hash, anchored, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+                    """,
+                    (
+                        "bcn_legacy123456",
+                        "heartbeat",
+                        "legacy-nonce",
+                        "ab" * 64,
+                        "cd" * 32,
+                        "legacy-hash",
+                        1234567890,
+                    ),
+                )
+                conn.commit()
+
+            beacon_anchor.init_beacon_table(db_path)
+
+            with sqlite3.connect(db_path) as conn:
+                version = conn.execute(
+                    "SELECT payload_hash_version FROM beacon_envelopes WHERE nonce = ?",
+                    ("legacy-nonce",),
                 ).fetchone()[0]
-            self.assertEqual(stored_hash, canonical_hash)
+            self.assertEqual(version, beacon_anchor.LEGACY_PAYLOAD_HASH_VERSION)
+        finally:
+            os.unlink(db_path)
+
+    def test_compute_beacon_digest_reports_mixed_hash_versions(self):
+        db_path = _make_temp_db()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE beacon_envelopes (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        agent_id TEXT NOT NULL,
+                        kind TEXT NOT NULL,
+                        nonce TEXT UNIQUE NOT NULL,
+                        sig TEXT NOT NULL,
+                        pubkey TEXT NOT NULL,
+                        payload_hash TEXT NOT NULL,
+                        anchored INTEGER DEFAULT 0,
+                        created_at INTEGER NOT NULL
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    INSERT INTO beacon_envelopes
+                    (agent_id, kind, nonce, sig, pubkey, payload_hash, anchored, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, 0, ?)
+                    """,
+                    (
+                        "bcn_legacy123456",
+                        "heartbeat",
+                        "legacy-nonce",
+                        "ab" * 64,
+                        "cd" * 32,
+                        "legacy-hash",
+                        1234567890,
+                    ),
+                )
+                conn.commit()
+
+            beacon_anchor.init_beacon_table(db_path)
+            envelope, _ = _build_signed_envelope(extra_fields={"nonce": "fresh-nonce"})
+            result = beacon_anchor.store_envelope(envelope, db_path)
+            self.assertTrue(result["ok"])
+
+            digest = beacon_anchor.compute_beacon_digest(db_path)
+
+            self.assertEqual(digest["payload_hash_versions"], [1, 2])
+            self.assertTrue(digest["mixed_payload_hash_versions"])
+            self.assertEqual(digest["count"], 2)
         finally:
             os.unlink(db_path)
 

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import importlib.util
 import os
 import sqlite3

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -1,9 +1,11 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
+import json
 import os
 import sqlite3
 import tempfile
 import unittest
+from hashlib import blake2b
 from pathlib import Path
 from typing import Optional
 
@@ -86,6 +88,33 @@ class BeaconAnchorSignatureTests(unittest.TestCase):
             self.assertEqual(row[1], "heartbeat")
             self.assertEqual(row[2], "beacon-nonce-123456")
             self.assertEqual(row[3], beacon_anchor.hash_envelope(envelope))
+        finally:
+            os.unlink(db_path)
+
+    def test_store_envelope_ignores_unsigned_beacon_version_metadata_in_hash(self):
+        db_path = _make_temp_db()
+        try:
+            beacon_anchor.init_beacon_table(db_path)
+            envelope, _ = _build_signed_envelope()
+            envelope["_beacon_version"] = 999
+
+            result = beacon_anchor.store_envelope(envelope, db_path)
+
+            self.assertTrue(result["ok"])
+            raw_hash = blake2b(
+                json.dumps(envelope, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+                digest_size=32,
+            ).hexdigest()
+            canonical_hash = beacon_anchor.hash_envelope(
+                {key: value for key, value in envelope.items() if key != "_beacon_version"}
+            )
+            self.assertEqual(result["payload_hash"], canonical_hash)
+            self.assertNotEqual(result["payload_hash"], raw_hash)
+            with sqlite3.connect(db_path) as conn:
+                stored_hash = conn.execute(
+                    "SELECT payload_hash FROM beacon_envelopes"
+                ).fetchone()[0]
+            self.assertEqual(stored_hash, canonical_hash)
         finally:
             os.unlink(db_path)
 

--- a/requirements-node.txt
+++ b/requirements-node.txt
@@ -2,6 +2,7 @@
 Flask==3.1.3
 requests==2.32.5
 psutil==7.2.2
+PyNaCl>=1.5.0
 
 # Optional: Enhanced features
 gunicorn==25.1.0  # Production WSGI server

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ flask>=2.0.0
 requests>=2.25.0
 # For wallet CLI (Ed25519 + AES-GCM):
 cryptography>=41.0
+# For node / Beacon Ed25519 verification:
+PyNaCl>=1.5.0
 # For wallet CLI (BIP39 seed phrases):
 mnemonic>=0.20
 # For running tests:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,6 @@
 # Test dependencies for RustChain
 pytest>=7.0.0
+# Needed by Beacon signature verification tests and server-side Ed25519 checks
+PyNaCl>=1.5.0
 # Needed by test_wallet_cli_39 (imports from tools/rustchain_wallet_cli.py)
 cryptography>=41.0


### PR DESCRIPTION
## Summary
- ignore transport-only `_beacon_version` metadata when computing the stored Beacon payload hash
- add a regression test proving unsigned `_beacon_version` does not change the anchored hash
- carry forward the small follow-up hygiene changes already on this branch (`PyNaCl` requirements + SPDX header on the new test file)

## Why
`verify_envelope_signature(...)` intentionally ignores `_beacon_version`, matching the Beacon codec, but `hash_envelope(...)` still hashed the full submitted JSON. Because `/beacon/submit` accepts raw JSON bodies, a caller could add `_beacon_version` after signing and still change the anchored digest.

This follow-up keeps signature verification and anchoring hash canonicalization aligned.

## Testing
- `/tmp/rustchain-test-venv/bin/python -m unittest /Users/core/Projects/Rustchain/node/tests/test_beacon_anchor_signature.py`
