### PR TITLE
Consume attestation challenges and block replayed submits

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -325,6 +325,118 @@ def _normalize_attestation_report(report):
             normalized[field] = text
     return normalized
 
+
+ATTEST_NONCE_SKEW_SECONDS = int(os.getenv("ATTEST_NONCE_SKEW_SECONDS", "60"))
+_ATTEST_CHALLENGE_NONCE_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+def attest_ensure_tables(conn):
+    """Create the attestation nonce tables expected by replay protection."""
+    conn.execute("CREATE TABLE IF NOT EXISTS nonces (nonce TEXT PRIMARY KEY, expires_at INTEGER)")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS used_nonces (
+            nonce TEXT PRIMARY KEY,
+            miner_id TEXT NOT NULL,
+            first_seen INTEGER NOT NULL,
+            expires_at INTEGER NOT NULL
+        )
+        """
+    )
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_used_nonces_expires_at ON used_nonces(expires_at)")
+
+
+def attest_cleanup_expired(conn, now_ts: Optional[int] = None):
+    """Remove expired challenge and used-nonce rows."""
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    attest_ensure_tables(conn)
+    conn.execute("DELETE FROM nonces WHERE expires_at < ?", (now_ts,))
+    conn.execute("DELETE FROM used_nonces WHERE expires_at < ?", (now_ts,))
+    conn.commit()
+
+
+def extract_attestation_timestamp(data: dict, report: dict, nonce: Optional[str]) -> Optional[int]:
+    """Extract an optional attestation timestamp from request payload fields."""
+    for source in (report or {}, data or {}):
+        for field_name in ("nonce_ts", "nonce_timestamp", "timestamp", "server_time"):
+            raw_value = source.get(field_name)
+            if isinstance(raw_value, bool):
+                continue
+            if isinstance(raw_value, (int, float)):
+                if math.isfinite(raw_value):
+                    return int(raw_value)
+                continue
+            if isinstance(raw_value, str) and raw_value.strip().isdigit():
+                return int(raw_value.strip())
+    return None
+
+
+def _attest_nonce_requires_challenge(nonce: str, nonce_ts: Optional[int]) -> bool:
+    """Current challenge endpoint emits 64-hex nonces with no embedded timestamp."""
+    return nonce_ts is None and bool(_ATTEST_CHALLENGE_NONCE_RE.fullmatch(nonce))
+
+
+def attest_validate_challenge(conn, nonce: str, now_ts: Optional[int] = None):
+    """Validate and consume a one-time challenge nonce."""
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    attest_cleanup_expired(conn, now_ts=now_ts)
+    row = conn.execute(
+        "SELECT expires_at FROM nonces WHERE nonce = ? AND expires_at >= ?",
+        (nonce, now_ts),
+    ).fetchone()
+    if not row:
+        return False, "challenge_invalid", None
+
+    expires_at = int(row[0])
+    deleted = conn.execute(
+        "DELETE FROM nonces WHERE nonce = ? AND expires_at = ?",
+        (nonce, expires_at),
+    ).rowcount
+    conn.commit()
+    if deleted != 1:
+        return False, "challenge_invalid", None
+    return True, None, expires_at
+
+
+def attest_validate_and_store_nonce(
+    conn,
+    miner: str,
+    nonce: str,
+    now_ts: Optional[int] = None,
+    nonce_ts: Optional[int] = None,
+    skew_seconds: int = ATTEST_NONCE_SKEW_SECONDS,
+):
+    """Reject replayed or stale attestation nonces and persist accepted ones."""
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    nonce = _attest_text(nonce)
+    miner = _attest_valid_miner(miner) or _attest_text(miner) or ""
+    if nonce is None:
+        return False, "missing_nonce", None
+
+    attest_cleanup_expired(conn, now_ts=now_ts)
+    replay_row = conn.execute(
+        "SELECT 1 FROM used_nonces WHERE nonce = ?",
+        (nonce,),
+    ).fetchone()
+    if replay_row:
+        return False, "nonce_replay", None
+
+    challenge_expires_at = None
+    if _attest_nonce_requires_challenge(nonce, nonce_ts):
+        ok, err, challenge_expires_at = attest_validate_challenge(conn, nonce, now_ts=now_ts)
+        if not ok:
+            return False, err, None
+    elif nonce_ts is not None and abs(int(nonce_ts) - now_ts) > max(int(skew_seconds), 0):
+        return False, "nonce_stale", None
+
+    expires_at = challenge_expires_at or (now_ts + max(int(skew_seconds), 1))
+    conn.execute(
+        "INSERT INTO used_nonces (nonce, miner_id, first_seen, expires_at) VALUES (?, ?, ?, ?)",
+        (nonce, miner, now_ts, expires_at),
+    )
+    conn.commit()
+    return True, None, expires_at
+
 # Register Hall of Rust blueprint (tables initialized after DB_PATH is set)
 try:
     from hall_of_rust import hall_bp
@@ -910,7 +1022,7 @@ def init_db():
     """Initialize all database tables"""
     with sqlite3.connect(DB_PATH) as c:
         # Core tables
-        c.execute("CREATE TABLE IF NOT EXISTS nonces (nonce TEXT PRIMARY KEY, expires_at INTEGER)")
+        attest_ensure_tables(c)
         c.execute("CREATE TABLE IF NOT EXISTS tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT)")
 
         # Epoch tables
@@ -2460,6 +2572,52 @@ def _submit_attestation_impl():
             "message": "Too many unique miners from this IP address",
             "code": "IP_RATE_LIMIT"
         }), 429
+
+    if nonce is None:
+        return jsonify({
+            "ok": False,
+            "error": "missing_nonce",
+            "message": "Attestation nonce is required",
+            "code": "MISSING_NONCE"
+        }), 400
+
+    nonce_ts = extract_attestation_timestamp(data, report, nonce)
+    with sqlite3.connect(DB_PATH) as nonce_conn:
+        nonce_ok, nonce_err, _ = attest_validate_and_store_nonce(
+            nonce_conn,
+            miner=miner,
+            nonce=nonce,
+            now_ts=int(time.time()),
+            nonce_ts=nonce_ts,
+        )
+    if not nonce_ok:
+        nonce_messages = {
+            "challenge_invalid": (
+                "challenge_invalid",
+                "Attestation challenge is missing, expired, or already used",
+                "CHALLENGE_INVALID",
+            ),
+            "nonce_replay": (
+                "nonce_replay",
+                "Attestation nonce has already been used",
+                "NONCE_REPLAY",
+            ),
+            "nonce_stale": (
+                "nonce_stale",
+                "Attestation nonce timestamp is outside the allowed skew window",
+                "NONCE_STALE",
+            ),
+        }
+        error_name, message, code = nonce_messages.get(
+            nonce_err,
+            ("invalid_nonce", "Attestation nonce is invalid", "INVALID_NONCE"),
+        )
+        return jsonify({
+            "ok": False,
+            "error": error_name,
+            "message": message,
+            "code": code
+        }), 409
     signals = _normalize_attestation_signals(data.get('signals'))
     fingerprint = _attest_mapping(data.get('fingerprint'))  # NEW: Extract fingerprint
 

--- a/node/tests/test_attest_submit_challenge_binding.py
+++ b/node/tests/test_attest_submit_challenge_binding.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+EXTRA_SCHEMA = [
+    "CREATE TABLE IF NOT EXISTS blocked_wallets (wallet TEXT PRIMARY KEY, reason TEXT)",
+    "CREATE TABLE IF NOT EXISTS ip_rate_limit (client_ip TEXT NOT NULL, miner_id TEXT NOT NULL, ts INTEGER NOT NULL, PRIMARY KEY (client_ip, miner_id))",
+    "CREATE TABLE IF NOT EXISTS miner_attest_recent (miner TEXT PRIMARY KEY, ts_ok INTEGER NOT NULL, device_family TEXT, device_arch TEXT, entropy_score REAL DEFAULT 0, fingerprint_passed INTEGER DEFAULT 0, source_ip TEXT, warthog_bonus REAL DEFAULT 1.0)",
+    "CREATE TABLE IF NOT EXISTS hardware_bindings (hardware_id TEXT PRIMARY KEY, bound_miner TEXT NOT NULL, device_arch TEXT, device_model TEXT, bound_at INTEGER NOT NULL, attestation_count INTEGER DEFAULT 0)",
+    "CREATE TABLE IF NOT EXISTS miner_header_keys (miner_id TEXT PRIMARY KEY, pubkey_hex TEXT NOT NULL)",
+    "CREATE TABLE IF NOT EXISTS miner_macs (miner TEXT NOT NULL, mac_hash TEXT NOT NULL, first_ts INTEGER NOT NULL, last_ts INTEGER NOT NULL, count INTEGER NOT NULL DEFAULT 1, PRIMARY KEY (miner, mac_hash))",
+]
+
+
+class TestAttestSubmitChallengeBinding(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def _db_path(self, name: str) -> str:
+        return str(Path(self._tmp.name) / name)
+
+    def _load_module(self, module_name: str, db_name: str):
+        db_path = self._db_path(db_name)
+        os.environ["RUSTCHAIN_DB_PATH"] = db_path
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.init_db()
+        with sqlite3.connect(db_path) as conn:
+            for stmt in EXTRA_SCHEMA:
+                conn.execute(stmt)
+            conn.commit()
+        return mod, db_path
+
+    def _response_payload(self, resp):
+        if isinstance(resp, tuple):
+            body, status = resp
+            return status, body.get_json()
+        return resp.status_code, resp.get_json()
+
+    def _submit(self, mod, payload):
+        with mod.app.test_request_context("/attest/submit", method="POST", json=payload):
+            return self._response_payload(mod._submit_attestation_impl())
+
+    def test_same_challenge_nonce_rejected_on_different_node(self):
+        mod1, db1_path = self._load_module("rustchain_attest_node1", "node1.db")
+        mod2, db2_path = self._load_module("rustchain_attest_node2", "node2.db")
+
+        with mod1.app.test_request_context("/attest/challenge", method="POST", json={}):
+            challenge_resp = mod1.get_challenge()
+        challenge = challenge_resp.get_json()
+
+        payload = {
+            "miner": "RTC_REPLAY_POC_MINER",
+            "report": {"nonce": challenge["nonce"], "commitment": "deadbeef"},
+            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
+            "signals": {"hostname": "poc-host", "macs": []},
+            "fingerprint": {},
+        }
+
+        status1, body1 = self._submit(mod1, payload)
+        status2, body2 = self._submit(mod2, payload)
+
+        self.assertEqual(status1, 200)
+        self.assertTrue(body1["ok"])
+        self.assertEqual(status2, 409)
+        self.assertEqual(body2["code"], "CHALLENGE_INVALID")
+
+        with sqlite3.connect(db1_path) as conn1, sqlite3.connect(db2_path) as conn2:
+            self.assertEqual(conn1.execute("SELECT COUNT(*) FROM used_nonces").fetchone()[0], 1)
+            self.assertEqual(conn2.execute("SELECT COUNT(*) FROM nonces").fetchone()[0], 0)
+            self.assertEqual(conn2.execute("SELECT COUNT(*) FROM used_nonces").fetchone()[0], 0)
+
+    def test_same_challenge_nonce_rejected_on_same_node_replay(self):
+        mod, db_path = self._load_module("rustchain_attest_node_single", "single.db")
+
+        with mod.app.test_request_context("/attest/challenge", method="POST", json={}):
+            challenge_resp = mod.get_challenge()
+        challenge = challenge_resp.get_json()
+
+        payload = {
+            "miner": "RTC_REPLAY_POC_MINER",
+            "report": {"nonce": challenge["nonce"], "commitment": "deadbeef"},
+            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
+            "signals": {"hostname": "poc-host", "macs": []},
+            "fingerprint": {},
+        }
+
+        status1, body1 = self._submit(mod, payload)
+        status2, body2 = self._submit(mod, payload)
+
+        self.assertEqual(status1, 200)
+        self.assertTrue(body1["ok"])
+        self.assertEqual(status2, 409)
+        self.assertEqual(body2["code"], "NONCE_REPLAY")
+
+        with sqlite3.connect(db_path) as conn:
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM used_nonces").fetchone()[0], 1)
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM nonces").fetchone()[0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce one-time attestation challenge consumption in `/attest/submit`
- reject challenge-style nonces that were never issued by the local node
- add regression coverage for cross-node and same-node replay attempts

## Root Cause
`/attest/challenge` stored nonces locally, but `/attest/submit` only read `report.nonce` and never validated or consumed it before recording local attestation and enrollment state.

That allowed the same challenge-bearing payload to be:
- accepted by the node that issued the nonce
- replayed to a different node that never issued the nonce
- replayed again on the original node

## Fix
- add attestation nonce helpers to create and clean replay-protection tables
- consume valid local challenge nonces exactly once
- record accepted nonces in `used_nonces`
- require 64-hex challenge-style nonces to exist locally instead of silently treating them as legacy arbitrary nonces
- return explicit attestation nonce errors from `/attest/submit`

## Tests
- `/tmp/rustchain-poc-313/bin/python -m unittest node/tests/test_attest_nonce_replay.py node/tests/test_attest_submit_challenge_binding.py`

## Notes
- dry-run / local reproduction only; no production-node disruption
- motivated by `Scottcjn/rustchain-bounties#2296`
