### PR TITLE
docs: fix typo in API_WALKTHROUGH.md - wallet ID spelling

### DIFF
--- a/API_WALKTHROUGH.md
+++ b/API_WALKTHROUGH.md
@@ -89,7 +89,7 @@ POST /wallet/transfer/signed
 
 ### Important Notes
 
-1. **Wallet IDs are NOT external addresses** - RustChain uses its own wallet system (e.g., `Ivan-houzhiiwen`), not Ethereum or Solana addresses.
+1. **Wallet IDs are NOT external addresses** - RustChain uses its own wallet system (e.g., `Ivan-houzhiwen`), not Ethereum or Solana addresses.
 
 2. **Self-signed certificates** - Use `curl -k` or `verify=False` in Python.
 


### PR DESCRIPTION
## Summary
Fixes a typo in the API_WALKTHROUGH.md documentation where the example wallet ID was inconsistently spelled.

## Change
- Line 92: `Ivan-houzhiiwen` → `Ivan-houzhiwen` (removed extra 'i')

## Verification
The corrected spelling now matches:
- Line 42: The curl example command
- Line 50: The JSON response example  
- Line 109: The Python code example

## Bounty
Claiming bounty #2178 (2 RTC)

**Wallet:** chaotikss@gmail.com (PayPal)