### PR TITLE
[BUG FIX] Consensus: hardcoded year, missing block validation, memory leak (3 bugs, Medium-High severity)

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -49,7 +49,8 @@ FOUNDER_WALLETS = [
 # Consensus Parameters
 # =============================================================================
 
-CURRENT_YEAR: int = 2025
+import datetime as _dt
+CURRENT_YEAR: int = _dt.datetime.now(_dt.timezone.utc).year
 
 # Antiquity Score parameters
 AS_MAX: float = 100.0  # Maximum for reward capping

--- a/rips/rustchain-core/consensus/poa.py
+++ b/rips/rustchain-core/consensus/poa.py
@@ -407,11 +407,30 @@ class ProofOfAntiquity:
         if block.total_reward > max_reward * 1.01:  # 1% tolerance for rounding
             return False
 
+        # Verify merkle root matches miners data
+        expected_merkle = Block(
+            height=block.height,
+            timestamp=block.timestamp,
+            previous_hash=block.previous_hash,
+            miners=block.miners,
+            total_reward=block.total_reward,
+        ).merkle_root
+        if block.merkle_root != expected_merkle:
+            return False
+
+        # Verify block hash matches header data
+        expected_hash = hashlib.sha256(
+            f"{block.height}:{block.timestamp}:{block.previous_hash}:{block.merkle_root}".encode()
+        ).hexdigest()
+        if block.hash != expected_hash:
+            return False
+
         return True
 
     def _reset_block(self):
         """Reset state for next block"""
         self.pending_proofs.clear()
+        self.known_hardware.clear()
         self.block_start_time = int(time.time())
 
     def get_status(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Bug Report & Fix — Ref #305

### Bug 1: CURRENT_YEAR hardcoded to 2025 (Medium)
**File:** `rips/rustchain-core/config/chain_params.py`
**Impact:** All Antiquity Score calculations are wrong in 2026+. A 1992 CPU gets AS based on 33-year age instead of correct 34. Every miner's score is off by ~3%, affecting reward distribution.
**Fix:** Replace hardcoded `2025` with `datetime.now(timezone.utc).year`.

### Bug 2: validate_block() skips merkle_root and hash verification (High)
**File:** `rips/rustchain-core/consensus/poa.py`
**Impact:** Blocks with tampered miner data (fake rewards, fake wallets) pass validation because merkle_root and block hash are never checked. An attacker could submit a block claiming higher rewards for their wallet.
**Fix:** Added merkle root recalculation check and block hash integrity verification.

### Bug 3: known_hardware memory leak (Medium)
**File:** `rips/rustchain-core/consensus/poa.py`
**Impact:** `known_hardware` dict is never cleared between blocks. After N blocks, it holds every hardware hash ever seen. Worse: hardware that mined in block N is permanently blocked from mining in block N+1 (duplicate hardware check always triggers for returning miners).
**Fix:** Clear `known_hardware` in `_reset_block()`.

### Steps to Reproduce
1. **Bug 1:** `print(CURRENT_YEAR)` → outputs 2025 in 2026
2. **Bug 2:** Create a Block, modify `miners[0].reward`, call `validate_block()` → returns True
3. **Bug 3:** Run `submit_proof()` for miner A in block 1, call `produce_block()`, then `submit_proof()` for miner A in block 2 → rejected as duplicate

RTC Wallet: `0x0` (will update)

— grim-cod-29