### PR TITLE
fix: critical SQL syntax error in BFT _apply_settlement blocks all reward payouts

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -606,13 +606,13 @@ class BFTConsensus:
         with sqlite3.connect(self.db_path) as conn:
             for miner_id, reward in distribution.items():
                 # Update balance
+                # Store as integer micro-RTC (1 RTC = 1,000,000 uRTC) to avoid
+                # floating-point drift accumulating across many ledger entries.
                 conn.execute("""
                     INSERT INTO balances (miner_id, amount_i64)
                     VALUES (?, ?)
                     ON CONFLICT(miner_id) DO UPDATE SET
                     amount_i64 = amount_i64 + excluded.amount_i64
-                # Store as integer micro-RTC (1 RTC = 1,000,000 uRTC) to avoid
-                # floating-point drift accumulating across many ledger entries.
                 """, (miner_id, int(reward * 1_000_000)))
 
                 # Log in ledger


### PR DESCRIPTION
## Bug

In `node/rustchain_bft_consensus.py`, the `_apply_settlement()` method has Python-style `#` comments **inside a SQL string literal** (lines 614-615):

```python
conn.execute("""
    INSERT INTO balances (miner_id, amount_i64)
    VALUES (?, ?)
    ON CONFLICT(miner_id) DO UPDATE SET
    amount_i64 = amount_i64 + excluded.amount_i64
# Store as integer micro-RTC ...
# floating-point drift ...
""", (miner_id, int(reward * 1_000_000)))
```

SQLite does **not** support `#` as a comment delimiter (only `--` and `/* */`). This causes:
```
sqlite3.OperationalError: unrecognized token: "#"
```

## Impact
**CRITICAL** — Every time BFT consensus reaches quorum and calls `_apply_settlement()`, the method crashes. **No miner rewards are ever distributed** through the BFT engine.

## Verification
```python
import sqlite3
conn = sqlite3.connect(':memory:')
conn.execute('CREATE TABLE t (a INT)')
conn.execute('INSERT INTO t VALUES (1) # comment')
# → OperationalError: unrecognized token: "#"
```

## Fix
Move the comments outside the SQL string literal. The explanation is preserved as Python comments above the `conn.execute()` call.

Bounty: #305 (Bug Report, 5-15 RTC)