### PR TITLE
fix: TLS verify=False MITM vulnerability in P2P gossip + OTC bridge (Bounty #305)

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -21,6 +21,7 @@ import threading
 import time
 from dataclasses import dataclass, asdict, field
 from enum import Enum
+import os
 from typing import Dict, List, Optional, Set, Tuple, Any
 from collections import defaultdict
 import logging
@@ -349,7 +350,7 @@ class GossipLayer:
                 f"{peer_url}/p2p/gossip",
                 json=msg.to_dict(),
                 timeout=10,
-                verify=False
+                verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false"
             )
             if resp.status_code != 200:
                 logger.warning(f"Peer {peer_url} returned {resp.status_code}")
@@ -549,7 +550,7 @@ class GossipLayer:
                 f"{peer_url}/p2p/gossip",
                 json=msg.to_dict(),
                 timeout=30,
-                verify=False
+                verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false"
             )
             if resp.status_code == 200:
                 data = resp.json()

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -214,7 +214,7 @@ def rtc_get_balance(wallet_id):
         r = requests.get(
             f"{RUSTCHAIN_NODE}/wallet/balance",
             params={"miner_id": wallet_id},
-            verify=False, timeout=10
+            verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=10
         )
         if r.ok:
             data = r.json()
@@ -238,7 +238,7 @@ def rtc_create_escrow_job(poster_wallet, amount_rtc, title, description):
                 "ttl_seconds": ORDER_TTL_DEFAULT,
                 "tags": ["otc_bridge", "escrow"]
             },
-            verify=False, timeout=15
+            verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
         )
         if r.ok:
             data = r.json()
@@ -257,7 +257,7 @@ def rtc_release_escrow(job_id, poster_wallet):
         r = requests.post(
             f"{RUSTCHAIN_NODE}/agent/jobs/{job_id}/accept",
             json={"poster_wallet": poster_wallet},
-            verify=False, timeout=15
+            verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
         )
         return r.ok
     except Exception as e:
@@ -271,7 +271,7 @@ def rtc_cancel_escrow(job_id, poster_wallet):
         r = requests.post(
             f"{RUSTCHAIN_NODE}/agent/jobs/{job_id}/cancel",
             json={"poster_wallet": poster_wallet},
-            verify=False, timeout=15
+            verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
         )
         return r.ok
     except Exception as e:
@@ -638,7 +638,7 @@ def confirm_order(order_id):
             claim_r = requests.post(
                 f"{RUSTCHAIN_NODE}/agent/jobs/{order['escrow_job_id']}/claim",
                 json={"worker_wallet": "otc_bridge_worker"},
-                verify=False, timeout=15
+                verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
             )
 
             if claim_r.ok or "not open" in claim_r.text.lower():
@@ -649,7 +649,7 @@ def confirm_order(order_id):
                         "worker_wallet": "otc_bridge_worker",
                         "result_summary": f"OTC trade confirmed. Order: {order_id}. Quote TX: {quote_tx}"
                     },
-                    verify=False, timeout=15
+                    verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
                 )
 
                 # Accept (releases funds to otc_bridge_worker, then we transfer to actual recipient)
@@ -657,7 +657,7 @@ def confirm_order(order_id):
                     accept_r = requests.post(
                         f"{RUSTCHAIN_NODE}/agent/jobs/{order['escrow_job_id']}/accept",
                         json={"poster_wallet": escrow_poster, "rating": 5},
-                        verify=False, timeout=15
+                        verify=os.getenv("RUSTCHAIN_TLS_VERIFY", "true").lower() != "false", timeout=15
                     )
                     if not accept_r.ok:
                         log.error(f"Escrow accept failed: {accept_r.text}")

--- a/tls_config.py
+++ b/tls_config.py
@@ -1,0 +1,19 @@
+"""
+RustChain TLS Configuration
+Centralizes TLS verification settings to avoid hardcoded verify=False.
+"""
+import os
+
+# Default: verify TLS certificates (secure)
+# Set RUSTCHAIN_TLS_VERIFY=false for local dev with self-signed certs
+TLS_VERIFY = os.getenv('RUSTCHAIN_TLS_VERIFY', 'true').lower() != 'false'
+
+# Optional: custom CA bundle path
+CA_BUNDLE = os.getenv('RUSTCHAIN_CA_BUNDLE', None)
+
+
+def get_verify():
+    """Return the verify parameter for requests calls."""
+    if CA_BUNDLE:
+        return CA_BUNDLE
+    return TLS_VERIFY


### PR DESCRIPTION
Fixes #1826. Replaces hardcoded verify=False with configurable RUSTCHAIN_TLS_VERIFY env var in P2P gossip (2 instances) and OTC bridge (7 instances). Adds tls_config.py. Default: secure (verify=True). No breaking changes.