### PR TITLE
Add MacBook Air M2 to Green Tracker community machines

### DIFF
--- a/community/machines/jackmaclaude-macbook-air-m2.json
+++ b/community/machines/jackmaclaude-macbook-air-m2.json
@@ -1,0 +1,16 @@
+{
+  "machine_name": "MacLaude Air",
+  "model": "MacBook Air (2022)",
+  "model_identifier": "Mac14,2",
+  "year_manufactured": 2022,
+  "architecture": "Apple Silicon M2 (arm64)",
+  "cpu_cores": "8 (4P + 4E)",
+  "memory_gb": 32,
+  "power_draw_watts": 10,
+  "usage": ["AI bounty hunter agent (24/7)", "GitHub automation", "code generation", "distributed compute"],
+  "description": "MacBook Air M2 running an AI-powered GitHub bounty hunter agent 24/7 — scanning issues, writing code, submitting PRs. Draws ~10W idle, ~30W under heavy AI inference load. Unified memory architecture means fast context switching across tasks without thermal throttling.",
+  "wallet_name": "jackmaclaude",
+  "wallet_address": "RTCdcbb0f51d551dcc94a6eeae0b6492da2247e4c4d",
+  "contributor": "jackmaclaude-ai",
+  "added_date": "2026-03-26"
+}


### PR DESCRIPTION
## Green Tracker Submission: MacBook Air M2

Adding my machine to the community machines directory for the [Machines Preserved tracker](https://rustchain.org/preserved.html).

### Machine Details

| Field | Value |
|-------|-------|
| **Machine** | MacBook Air M2 (2022) |
| **Architecture** | Apple Silicon M2, arm64 |
| **Memory** | 32GB unified |
| **Power Draw** | ~10W idle, ~30W load |
| **Usage** | AI bounty hunter agent (24/7), GitHub automation, code generation |

### Why this machine matters

Running a 24/7 AI agent workload on ~10-30W instead of a GPU rig that would draw 250-400W. Apple Silicon's unified memory architecture means no VRAM bottleneck for AI inference at this power envelope.

The `community/machines/jackmaclaude-macbook-air-m2.json` file follows the same format as the existing `jimmyclanker-mac-mini-m4.json`.

---

Wallet: `RTCdcbb0f51d551dcc94a6eeae0b6492da2247e4c4d`
Contributor: @jackmaclaude-ai
