### PR TITLE
security: fix TLS verify=False MITM vulnerability (#1826)

### DIFF
--- a/discord_bot/bot.py
+++ b/discord_bot/bot.py
@@ -39,9 +39,12 @@ class RustChainAPI:
     def __init__(self, base_url: str, timeout: float):
         self.base_url = base_url.rstrip("/")
         self.timeout = timeout
+        import os
+        _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        _verify = _cert if os.path.exists(_cert) else True
         self._client = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout),
-            verify=False,  # Self-signed cert on node
+            verify=_verify,
             headers={"User-Agent": "rustchain-discord-bot/1.0"},
         )
 

--- a/discord_rich_presence.py
+++ b/discord_rich_presence.py
@@ -25,8 +25,12 @@ import requests
 from datetime import datetime, timedelta
 from pypresence import Presence
 
-# RustChain API endpoint (self-signed cert requires verification=False)
+# RustChain API endpoint
 RUSTCHAIN_API: str = "https://rustchain.org"
+
+# TLS verification: pinned cert or system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 
 # Local state file for tracking earnings
 STATE_FILE: str = os.path.expanduser("~/.rustchain_discord_state.json")
@@ -58,7 +62,7 @@ def get_miner_info(miner_id: str) -> Optional[Dict[str, Any]]:
         response = requests.get(
             f"{RUSTCHAIN_API}/wallet/balance",
             params={"miner_id": miner_id},
-            verify=False,  # Self-signed cert
+            verify=TLS_VERIFY,  # Self-signed cert
             timeout=10
         )
         response.raise_for_status()
@@ -73,7 +77,7 @@ def get_miners_list() -> List[Dict[str, Any]]:
     try:
         response = requests.get(
             f"{RUSTCHAIN_API}/api/miners",
-            verify=False,
+            verify=TLS_VERIFY,
             timeout=10
         )
         response.raise_for_status()
@@ -88,7 +92,7 @@ def get_epoch_info() -> Optional[Dict[str, Any]]:
     try:
         response = requests.get(
             f"{RUSTCHAIN_API}/epoch",
-            verify=False,
+            verify=TLS_VERIFY,
             timeout=10
         )
         response.raise_for_status()
@@ -103,7 +107,7 @@ def get_node_health() -> Optional[Dict[str, Any]]:
     try:
         response = requests.get(
             f"{RUSTCHAIN_API}/health",
-            verify=False,
+            verify=TLS_VERIFY,
             timeout=10
         )
         response.raise_for_status()

--- a/docs/postman/validate_postman_collection.py
+++ b/docs/postman/validate_postman_collection.py
@@ -243,7 +243,10 @@ def run_live_tests(collection: Dict[str, Any], base_url: str = None) -> None:
         url = f"{base_url}{path}"
         try:
             if method == 'GET':
-                response = requests.get(url, timeout=10, verify=False)
+                import os as _os
+                _cert = _os.path.expanduser("~/.rustchain/node_cert.pem")
+                _verify = _cert if _os.path.exists(_cert) else True
+                response = requests.get(url, timeout=10, verify=_verify)
             
             if response.status_code == 200:
                 print_success(f"{method} {path} - {response.status_code}")

--- a/explorer/ws_explorer_server.py
+++ b/explorer/ws_explorer_server.py
@@ -41,7 +41,9 @@ state = {
 def fetch_api(path):
     """Fetch data from RustChain API."""
     try:
-        resp = requests.get(f"{API_BASE}{path}", timeout=API_TIMEOUT, verify=False)
+        _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        _verify = _cert if os.path.exists(_cert) else True
+        resp = requests.get(f"{API_BASE}{path}", timeout=API_TIMEOUT, verify=_verify)
         if resp.status_code == 200:
             return resp.json()
     except Exception:

--- a/health-dashboard/server.py
+++ b/health-dashboard/server.py
@@ -220,10 +220,12 @@ def check_node_health(node_config: dict) -> NodeStatus:
     timestamp = datetime.now()
     
     try:
-        # Determine verification behavior for HTTPS
-        verify = True
-        if 'http://' in node_config['endpoint']:
-            verify = False
+        # Use pinned cert for HTTPS, no verification needed for plain HTTP
+        _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        if 'https://' in node_config['endpoint']:
+            verify = _cert if os.path.exists(_cert) else True
+        else:
+            verify = False  # Plain HTTP has no TLS to verify
         
         response = requests.get(
             node_config['endpoint'],

--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -4,7 +4,7 @@ RustChain Local x86 Miner - Modern Ryzen
 With RIP-PoA Hardware Fingerprint Attestation + Serial Binding v2.0
 """
 import warnings
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
+# warnings.filterwarnings('ignore', message='Unverified HTTPS request')  # No longer needed — TLS verification enabled
 
 import os, sys, json, time, hashlib, uuid, requests, socket, subprocess, platform, statistics, re
 from datetime import datetime
@@ -26,6 +26,10 @@ except ImportError:
 
 NODE_URL = "https://rustchain.org"  # Use HTTPS via nginx
 BLOCK_TIME = 600  # 10 minutes
+
+# TLS verification: use pinned cert if available, else system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 
 def get_linux_serial():
     """Get hardware serial number for Linux systems"""
@@ -260,8 +264,8 @@ class LocalMiner:
         self._get_hw_info()
 
         try:
-            # Get challenge (verify=False for self-signed certs)
-            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=False)
+            # Get challenge (verify=TLS_VERIFY for self-signed certs)
+            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=TLS_VERIFY)
             if resp.status_code != 200:
                 print(f"❌ Challenge failed: {resp.status_code}")
                 return False
@@ -317,7 +321,7 @@ class LocalMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/attest/submit",
-                               json=attestation, timeout=30, verify=False)
+                               json=attestation, timeout=30, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -379,7 +383,7 @@ class LocalMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/epoch/enroll",
-                                json=payload, timeout=30, verify=False)
+                                json=payload, timeout=30, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -426,7 +430,7 @@ class LocalMiner:
     def check_balance(self):
         """Check balance"""
         try:
-            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10, verify=False)
+            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10, verify=TLS_VERIFY)
             if resp.status_code == 200:
                 result = resp.json()
                 balance = result.get('balance_rtc', 0)
@@ -462,7 +466,7 @@ class LocalMiner:
 
         # Optional health probe (read-only)
         try:
-            r = requests.get(f"{self.node_url}/health", timeout=8, verify=False)
+            r = requests.get(f"{self.node_url}/health", timeout=8, verify=TLS_VERIFY)
             print(f"[DRY-RUN] Health probe: HTTP {r.status_code}")
             if r.ok:
                 data = r.json()

--- a/miners/macos/intel/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/intel/rustchain_mac_miner_v2.4.py
@@ -5,7 +5,6 @@ Supports: Apple Silicon (M1/M2/M3), Intel Mac, PowerPC (G4/G5)
 With RIP-PoA Hardware Fingerprint Attestation + Serial Binding v2.0
 """
 import warnings
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
 
 import os
 import sys
@@ -29,6 +28,10 @@ except ImportError:
 
 NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
 BLOCK_TIME = 600  # 10 minutes
+
+# TLS verification: pinned cert or system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 LOTTERY_CHECK_INTERVAL = 10  # Check every 10 seconds
 
 def get_mac_serial():
@@ -301,7 +304,7 @@ class MacMiner:
 
         try:
             # Step 1: Get challenge
-            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=15, verify=False)
+            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=15, verify=TLS_VERIFY)
             if resp.status_code != 200:
                 print(f"  ERROR: Challenge failed ({resp.status_code})")
                 return False
@@ -356,7 +359,7 @@ class MacMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/attest/submit",
-                               json=attestation, timeout=30, verify=False)
+                               json=attestation, timeout=30, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -388,7 +391,7 @@ class MacMiner:
                 f"{self.node_url}/lottery/eligibility",
                 params={"miner_id": self.miner_id},
                 timeout=10,
-                verify=False
+                verify=TLS_VERIFY
             )
             if resp.status_code == 200:
                 return resp.json()
@@ -419,7 +422,7 @@ class MacMiner:
                 f"{self.node_url}/headers/ingest_signed",
                 json=header_payload,
                 timeout=15,
-                verify=False
+                verify=TLS_VERIFY
             )
 
             self.shares_submitted += 1

--- a/miners/macos/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/rustchain_mac_miner_v2.4.py
@@ -5,7 +5,6 @@ Supports: Apple Silicon (M1/M2/M3), Intel Mac, PowerPC (G4/G5)
 With RIP-PoA Hardware Fingerprint Attestation + Serial Binding v2.0
 """
 import warnings
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
 
 import os
 import sys
@@ -37,6 +36,10 @@ except ImportError:
 
 NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
 BLOCK_TIME = 600  # 10 minutes
+
+# TLS verification: pinned cert or system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 LOTTERY_CHECK_INTERVAL = 10  # Check every 10 seconds
 
 def get_mac_serial():
@@ -334,7 +337,7 @@ class MacMiner:
 
         try:
             # Step 1: Get challenge
-            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=15, verify=False)
+            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=15, verify=TLS_VERIFY)
             if resp.status_code != 200:
                 print(error(f"  ERROR: Challenge failed ({resp.status_code})"))
                 return False
@@ -389,7 +392,7 @@ class MacMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/attest/submit",
-                               json=attestation, timeout=30, verify=False)
+                               json=attestation, timeout=30, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -421,7 +424,7 @@ class MacMiner:
                 f"{self.node_url}/lottery/eligibility",
                 params={"miner_id": self.miner_id},
                 timeout=10,
-                verify=False
+                verify=TLS_VERIFY
             )
             if resp.status_code == 200:
                 return resp.json()
@@ -452,7 +455,7 @@ class MacMiner:
                 f"{self.node_url}/headers/ingest_signed",
                 json=header_payload,
                 timeout=15,
-                verify=False
+                verify=TLS_VERIFY
             )
 
             self.shares_submitted += 1

--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -13,7 +13,6 @@ New in v2.5:
   - Sleep-resistant: re-attest on wake automatically
 """
 import warnings
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
 
 import os
 import sys
@@ -62,6 +61,10 @@ NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://50.28.86.131")
 PROXY_URL = os.environ.get("RUSTCHAIN_PROXY", "http://192.168.0.160:8089")
 BLOCK_TIME = 600  # 10 minutes
 LOTTERY_CHECK_INTERVAL = 10
+
+# TLS verification: pinned cert or system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 ATTESTATION_TTL = 580  # Re-attest 20s before expiry
 
 
@@ -85,7 +88,7 @@ class NodeTransport:
         try:
             r = requests.get(
                 self.node_url + "/health",
-                timeout=10, verify=False
+                timeout=10, verify=TLS_VERIFY
             )
             if r.status_code == 200:
                 print(success("[TRANSPORT] Direct HTTPS to node: OK"))
@@ -111,7 +114,7 @@ class NodeTransport:
                 print(warning("[TRANSPORT] Proxy {} also failed: {}".format(self.proxy_url, e)))
 
         # Last resort: try direct without verify (may work on some old systems)
-        print(warning("[TRANSPORT] Falling back to direct HTTPS (verify=False)"))
+        print(warning("[TRANSPORT] Falling back to direct HTTPS with TLS verification"))
         self.use_proxy = False
 
     @property

--- a/miners/power8/rustchain_power8_miner.py
+++ b/miners/power8/rustchain_power8_miner.py
@@ -6,8 +6,9 @@ With RIP-PoA Hardware Fingerprint Attestation
 import os, sys, json, time, hashlib, uuid, requests, socket, subprocess, platform, statistics, re, warnings
 from datetime import datetime
 
-# Suppress SSL warnings for self-signed cert
-warnings.filterwarnings('ignore', message='Unverified HTTPS request')
+# TLS verification: use pinned cert if available, else system CA bundle
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 
 # Import fingerprint checks
 try:
@@ -197,7 +198,7 @@ class LocalMiner:
         self._get_hw_info()
 
         try:
-            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=False)
+            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=TLS_VERIFY)
             if resp.status_code != 200:
                 print(f"[FAIL] Challenge failed: {resp.status_code}")
                 return False
@@ -252,7 +253,7 @@ class LocalMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/attest/submit",
-                               json=attestation, timeout=30, verify=False)
+                               json=attestation, timeout=30, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -302,7 +303,7 @@ class LocalMiner:
                 "miner_id": f"power8-s824-{self.hw_info['hostname']}",
                 "miner_pubkey": self.wallet,  # Testnet: wallet as pubkey
                 "signature": "0" * 128   # Testnet: mock signature
-            }, timeout=10, verify=False)
+            }, timeout=10, verify=TLS_VERIFY)
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -348,7 +349,7 @@ class LocalMiner:
     def check_balance(self):
         """Check balance"""
         try:
-            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10, verify=False)
+            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10, verify=TLS_VERIFY)
             if resp.status_code == 200:
                 result = resp.json()
                 balance = result.get('balance_rtc', 0)

--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -19,7 +19,7 @@ import re
 import tkinter as tk
 from tkinter import ttk, messagebox, scrolledtext
 import requests
-import urllib3; urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# urllib3.disable_warnings no longer needed — TLS verification enabled
 from datetime import datetime
 from pathlib import Path
 
@@ -35,6 +35,10 @@ except ImportError:
 RUSTCHAIN_API = "https://rustchain.org"
 WALLET_DIR = Path.home() / ".rustchain"
 CONFIG_FILE = WALLET_DIR / "config.json"
+
+# TLS verification: pinned cert or system CA bundle
+_CERT_PATH = str(WALLET_DIR / "node_cert.pem")
+TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 WALLET_FILE = WALLET_DIR / "wallet.json"
 
 class RustChainWallet:
@@ -459,7 +463,7 @@ class RustChainMiner:
     def attest(self):
         """Perform hardware attestation for PoA."""
         try:
-            challenge = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=False).json()
+            challenge = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=TLS_VERIFY).json()
             nonce = challenge.get("nonce")
         except Exception:
             return False
@@ -496,7 +500,7 @@ class RustChainMiner:
 
         try:
             resp = requests.post(f"{self.node_url}/attest/submit", json=attestation,
-                                 timeout=30, verify=False)
+                                 timeout=30, verify=TLS_VERIFY)
             if resp.status_code == 200 and resp.json().get("ok"):
                 self.attestation_valid_until = time.time() + 580
                 return True
@@ -518,7 +522,7 @@ class RustChainMiner:
         }
 
         try:
-            resp = requests.post(f"{self.node_url}/epoch/enroll", json=payload, timeout=15, verify=False)
+            resp = requests.post(f"{self.node_url}/epoch/enroll", json=payload, timeout=15, verify=TLS_VERIFY)
             if resp.status_code == 200 and resp.json().get("ok"):
                 self.enrolled = True
                 self.last_enroll = time.time()
@@ -530,7 +534,7 @@ class RustChainMiner:
     def check_eligibility(self):
         """Check if eligible to mine"""
         try:
-            response = requests.get(f"{RUSTCHAIN_API}/lottery/eligibility?miner_id={self.miner_id}", verify=False)
+            response = requests.get(f"{RUSTCHAIN_API}/lottery/eligibility?miner_id={self.miner_id}", verify=TLS_VERIFY)
             if response.ok:
                 data = response.json()
                 return data.get("eligible", False)
@@ -555,7 +559,7 @@ class RustChainMiner:
     def submit_header(self, header):
         """Submit mining header"""
         try:
-            response = requests.post(f"{RUSTCHAIN_API}/headers/ingest_signed", json=header, timeout=5, verify=False)
+            response = requests.post(f"{RUSTCHAIN_API}/headers/ingest_signed", json=header, timeout=5, verify=TLS_VERIFY)
             return response.status_code == 200
         except:
             return False

--- a/node/tls_config.py
+++ b/node/tls_config.py
@@ -1,0 +1,55 @@
+"""
+Shared TLS configuration for RustChain modules.
+
+Provides consistent TLS certificate verification across all production
+code. Uses a pinned certificate at ~/.rustchain/node_cert.pem when
+available, otherwise falls back to the system CA bundle.
+
+This eliminates verify=False usage which is vulnerable to MITM attacks.
+"""
+
+import os
+from typing import Union
+
+# Path to pinned node certificate (self-signed cert for rustchain.org)
+_CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
+
+
+def get_tls_verify() -> Union[str, bool]:
+    """Return the appropriate TLS verify parameter for requests/httpx.
+
+    Returns:
+        str: Path to pinned cert file if it exists.
+        bool: True to use system CA bundle as fallback.
+    """
+    if os.path.exists(_CERT_PATH):
+        return _CERT_PATH
+    return True
+
+
+def get_tls_session(node_url: str = None):
+    """Get a requests.Session with proper TLS verification.
+
+    Uses pinned cert if available, otherwise system CA bundle.
+
+    Args:
+        node_url: Optional node URL (unused, reserved for future
+                  per-node cert pinning).
+
+    Returns:
+        requests.Session configured with TLS verification.
+    """
+    import requests
+
+    session = requests.Session()
+    session.verify = get_tls_verify()
+    return session
+
+
+def get_async_tls_verify():
+    """Return TLS verify parameter suitable for httpx.AsyncClient.
+
+    Returns the same value as get_tls_verify() — httpx accepts
+    the same str/bool types as requests.
+    """
+    return get_tls_verify()

--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -46,6 +46,10 @@ class RustChainClient:
         self._base_url = base_url.rstrip("/")
         self._timeout = timeout
         self._client: Optional[httpx.AsyncClient] = None
+        # Use pinned cert if available, else system CA bundle
+        import os
+        cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        self._tls_verify = cert if os.path.exists(cert) else True
 
     async def _get_client(self) -> httpx.AsyncClient:
         """Lazily create the HTTP client."""
@@ -53,7 +57,7 @@ class RustChainClient:
             self._client = httpx.AsyncClient(
                 base_url=self._base_url,
                 timeout=self._timeout,
-                verify=False,  # Self-signed certs
+                verify=self._tls_verify,
             )
         return self._client
 

--- a/static/bridge/update_stats.py
+++ b/static/bridge/update_stats.py
@@ -31,7 +31,7 @@ def get_bridge_stats():
     # 1. Poll Bridge Nodes
     for node in BRIDGE_NODES:
         try:
-            resp = requests.get(node["url"], timeout=10, verify=False)
+            resp = requests.get(node["url"], timeout=10, verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True)
             if resp.status_code == 200:
                 data = resp.json()
                 node_stats = {
@@ -52,7 +52,7 @@ def get_bridge_stats():
     for node in BRIDGE_NODES:
         try:
             ledger_url = node["url"].replace("/stats", "/ledger?limit=10")
-            resp = requests.get(ledger_url, timeout=10, verify=False)
+            resp = requests.get(ledger_url, timeout=10, verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True)
             if resp.status_code == 200:
                 results["recent_transactions"] = resp.json().get("locks", [])
                 break

--- a/static/status/monitor.py
+++ b/static/status/monitor.py
@@ -19,8 +19,10 @@ def check_nodes():
     for node in NODES:
         start_time = time.time()
         try:
-            # Use verify=False because some nodes might have self-signed certs
-            resp = requests.get(node["url"], timeout=10, verify=False)
+            # Use pinned cert if available, else system CA bundle
+            _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+            _verify = _cert if os.path.exists(_cert) else True
+            resp = requests.get(node["url"], timeout=10, verify=_verify)
             latency = (time.time() - start_time) * 1000
             
             if resp.status_code == 200:

--- a/status/status_server.py
+++ b/status/status_server.py
@@ -69,7 +69,9 @@ def check_node(node):
     """Poll a single node and return status dict."""
     start = time.time()
     try:
-        resp = requests.get(node["endpoint"], timeout=10, verify=False)
+        _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        _verify = _cert if os.path.exists(_cert) else True
+        resp = requests.get(node["endpoint"], timeout=10, verify=_verify)
         elapsed_ms = round((time.time() - start) * 1000)
         if resp.status_code == 200:
             try:

--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -59,7 +59,7 @@ class BountyVerifier:
         try:
             resp = requests.get(
                 f"{CONFIG['miner_node_url']}/wallet/balance?miner_id={wallet_name}",
-                verify=False,
+                verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True,
                 timeout=10
             )
             if resp.status_code == 200:

--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -121,7 +121,10 @@ def check_wallet_exists(wallet_address: str) -> bool:
     """Verify that a wallet address exists on the RustChain node."""
     try:
         url = f"{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}"
-        resp = requests.get(url, verify=False, timeout=10)
+        import os
+        _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+        _verify = _cert if os.path.exists(_cert) else True
+        resp = requests.get(url, verify=_verify, timeout=10)
         if resp.status_code == 200:
             return True
     except Exception as exc:

--- a/tools/discord-bot/bot.py
+++ b/tools/discord-bot/bot.py
@@ -52,9 +52,15 @@ class RustChainAPI:
 
     def __init__(self, base_url: str, timeout: float = 10):
         self.base_url = base_url
+        try:
+            from node.tls_config import get_async_tls_verify
+            _verify = get_async_tls_verify()
+        except ImportError:
+            _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+            _verify = _cert if os.path.exists(_cert) else True
         self._http = httpx.AsyncClient(
             timeout=httpx.Timeout(timeout),
-            verify=False,  # node uses self-signed cert
+            verify=_verify,
             headers={"User-Agent": "rustchain-discord-bot/2.0"},
         )
 

--- a/tools/discord_leaderboard_bot.py
+++ b/tools/discord_leaderboard_bot.py
@@ -9,9 +9,16 @@ from datetime import datetime, timezone
 
 import requests
 
+try:
+    from node.tls_config import get_tls_verify
+    _TLS_VERIFY = get_tls_verify()
+except ImportError:
+    _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+    _TLS_VERIFY = _cert if os.path.exists(_cert) else True
+
 
 def get_json(session: requests.Session, url: str, timeout: float):
-    resp = session.get(url, timeout=timeout, verify=False)
+    resp = session.get(url, timeout=timeout, verify=_TLS_VERIFY)
     resp.raise_for_status()
     return resp.json()
 

--- a/tools/monitoring/prometheus_exporter.py
+++ b/tools/monitoring/prometheus_exporter.py
@@ -119,8 +119,13 @@ class RustChainPrometheusExporter:
         self.session.headers.update({
             'User-Agent': 'RustChain-Prometheus-Exporter/1.0',
         })
-        # Self-signed cert on 50.28.86.131
-        self.session.verify = False
+        # Use pinned cert if available, else system CA bundle
+        try:
+            from node.tls_config import get_tls_verify
+            self.session.verify = get_tls_verify()
+        except ImportError:
+            cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+            self.session.verify = cert if os.path.exists(cert) else True
         self.running = False
 
         logger.info("Initialized exporter for node: %s", self.node_url)

--- a/tools/telegram-bot/bot.py
+++ b/tools/telegram-bot/bot.py
@@ -62,7 +62,13 @@ def _rate_ok(user_id: int) -> bool:
 # ---------------------------------------------------------------------------
 
 _session = requests.Session()
-_session.verify = False
+try:
+    from node.tls_config import get_tls_verify
+    _session.verify = get_tls_verify()
+except ImportError:
+    import os as _os
+    _cert = _os.path.expanduser("~/.rustchain/node_cert.pem")
+    _session.verify = _cert if _os.path.exists(_cert) else True
 
 
 def _api_get(path: str, params: Optional[dict[str, Any]] = None) -> dict[str, Any]:

--- a/tools/telegram-bot/rustchain_bot.py
+++ b/tools/telegram-bot/rustchain_bot.py
@@ -61,7 +61,15 @@ def _rate_ok(user_id: int) -> bool:
 # API helpers
 # ---------------------------------------------------------------------------
 
-_http = httpx.AsyncClient(verify=False, timeout=15.0)
+try:
+    from node.tls_config import get_async_tls_verify
+    _tls_verify = get_async_tls_verify()
+except ImportError:
+    import os
+    _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
+    _tls_verify = _cert if os.path.exists(_cert) else True
+
+_http = httpx.AsyncClient(verify=_tls_verify, timeout=15.0)
 
 
 async def _api_get(path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/witness/witness_format.py
+++ b/witness/witness_format.py
@@ -323,7 +323,8 @@ def verify_witness(witness: EpochWitness, node_url: str = "") -> Tuple[bool, str
     if node_url:
         try:
             import requests
-            resp = requests.get(f"{node_url}/epoch", timeout=10, verify=False)
+            from node.tls_config import get_tls_verify
+            resp = requests.get(f"{node_url}/epoch", timeout=10, verify=get_tls_verify())
             if resp.status_code == 200:
                 chain_data = resp.json()
                 chain_epoch = chain_data.get("epoch", chain_data.get("current_epoch", 0))


### PR DESCRIPTION
## Summary
- Adds shared TLS config utility (`node/tls_config.py`) for consistent cert handling
- Replaces `verify=False` with proper TLS cert pinning across 23 production files:
  - **Miners**: Linux, macOS (v2.4 + v2.5 + Intel), Windows, POWER8
  - **SDK**: Python async client (httpx)
  - **Bots**: Discord bot, Discord leaderboard, Telegram bot (x2)
  - **Monitoring**: Prometheus exporter, status server, health dashboard
  - **Tools**: Bounty verifier, bounty-bot-pro, Discord rich presence
  - **Infrastructure**: Explorer WebSocket server, bridge stats, witness format, postman validator
- Uses pinned cert at `~/.rustchain/node_cert.pem` when available, system CA bundle fallback
- Plain HTTP connections (e.g., Node 3/4 on port 8099) correctly skip TLS verification
- Removes suppressed `InsecureRequestWarning` filters (no longer needed)
- Normalizes CRLF line endings on miner files per `.gitattributes` policy

Fixes #1826 (reported by @AliaksandrNazaruk)

## Test plan
- [ ] Verify P2P gossip still connects between nodes after deploying pinned cert
- [ ] Verify miner attestation works with `~/.rustchain/node_cert.pem` present
- [ ] Verify miner attestation works WITHOUT pinned cert (falls back to system CA)
- [ ] Verify Ergo anchor still works with self-signed cert
- [ ] Verify SDK client connects properly
- [ ] Verify Discord/Telegram bots can query the API

🤖 Generated with [Claude Code](https://claude.com/claude-code)