### PR TITLE
docs: fix broken GitHub issues link in console mining setup

### DIFF
--- a/docs/CONSOLE_MINING_SETUP.md
+++ b/docs/CONSOLE_MINING_SETUP.md
@@ -377,7 +377,7 @@ Develop attestation ROMs for additional consoles:
 
 ## Support
 
-- **GitHub Issues**: https://github.com/rustchain/rustchain/issues
+- **GitHub Issues**: https://github.com/Scottcjn/Rustchain/issues
 - **Discord**: https://discord.gg/rustchain
 - **Documentation**: https://docs.rustchain.net
 


### PR DESCRIPTION
This fixes a broken support link in `docs/CONSOLE_MINING_SETUP.md`.

## What changed
- update the GitHub Issues URL from `https://github.com/rustchain/rustchain/issues` to `https://github.com/Scottcjn/Rustchain/issues`

## Verification
- `https://github.com/rustchain/rustchain/issues` returns `404`
- `https://github.com/Scottcjn/Rustchain/issues` returns `200`
- `git diff --check -- docs/CONSOLE_MINING_SETUP.md`