### PR TITLE
fix: add pagination to /api/miners endpoint (limit+offset)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4821,19 +4821,36 @@ def api_nodes():
 
 @app.route("/api/miners", methods=["GET"])
 def api_miners():
-    """Return list of attested miners with their PoA details"""
+    """Return list of attested miners with their PoA details.
+
+    Query params:
+        limit  (int, max 500, default 500)  — max miners to return
+        offset (int, default 0)             — skip this many rows
+    """
     import time as _time
     now = int(_time.time())
+
+    # Parse and clamp pagination parameters
+    try:
+        limit = min(int(request.args.get("limit", 500)), 500)
+    except (TypeError, ValueError):
+        limit = 500
+    try:
+        offset = max(int(request.args.get("offset", 0)), 0)
+    except (TypeError, ValueError):
+        offset = 0
+
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row
         c = conn.cursor()
-        # Get all miners attested in the last hour
+        # Get miners attested in the last hour, with pagination
         rows = c.execute("""
             SELECT miner, ts_ok, device_family, device_arch, entropy_score
-            FROM miner_attest_recent 
+            FROM miner_attest_recent
             WHERE ts_ok > ?
             ORDER BY ts_ok DESC
-        """, (now - 3600,)).fetchall()
+            LIMIT ? OFFSET ?
+        """, (now - 3600, limit, offset)).fetchall()
         
         miners = []
         for r in rows:
@@ -4880,8 +4897,8 @@ def api_miners():
                 "entropy_score": r["entropy_score"] or 0.0,
                 "antiquity_multiplier": mult
             })
-    
-    return jsonify(miners)
+
+    return jsonify({"miners": miners, "count": len(miners), "limit": limit, "offset": offset})
 
 
 @app.route("/api/badge/<miner_id>", methods=["GET"])


### PR DESCRIPTION
Closes #2002

## Changes
- Added optional  (max 500, default 500) and  (default 0) query parameters to 
- SQL query now uses  to prevent unbounded memory/CPU consumption
- Response wrapped in object: 

## Usage
```bash
# Default (up to 500 miners)
curl /api/miners

# First 50 miners
curl /api/miners?limit=50

# Pagination
curl /api/miners?limit=50&offset=50
```

## Security Impact
Mitigates the memory/CPU DoS vector described in #2002 by capping result set size.

**Bounty:** Requesting 5 RTC as confirmed by @Scottcjn in the issue.