### PR TITLE
security: enforce TLS certificate validation by default

### DIFF
--- a/rustchain-miner/.env.example
+++ b/rustchain-miner/.env.example
@@ -24,3 +24,9 @@ RUSTCHAIN_NODE_URL=https://50.28.86.131
 
 # Enable verbose logging (true/false)
 # RUSTCHAIN_VERBOSE=false
+
+# ⚠️  DISABLE TLS CERTIFICATE VALIDATION (DEVELOPMENT ONLY)
+# Setting this to 1 or true disables TLS certificate validation.
+# This is INSECURE and exposes the miner to man-in-the-middle attacks.
+# NEVER use in production or with real mining operations.
+# RUSTCHAIN_DEV_INSECURE_TLS=false

--- a/rustchain-miner/README.md
+++ b/rustchain-miner/README.md
@@ -54,6 +54,7 @@ cargo install --path .
 | `RUSTCHAIN_ATTESTATION_TTL` | Attestation TTL in seconds | `580` |
 | `RUSTCHAIN_DRY_RUN` | Enable dry-run mode | `false` |
 | `RUSTCHAIN_VERBOSE` | Enable verbose logging | `false` |
+| `RUSTCHAIN_DEV_INSECURE_TLS` | Disable TLS cert validation (dev only) | `false` |
 
 ### .env File
 
@@ -205,12 +206,22 @@ cargo build --release
 
 ### TLS/SSL Errors
 
-If you encounter TLS errors on legacy systems:
+TLS certificate validation is **enabled by default**. If you encounter TLS errors
+on legacy systems or local test servers with self-signed certificates, you have
+two options:
 
-```bash
-# Use HTTP proxy instead
-./target/release/rustchain-miner --proxy http://192.168.0.160:8089
-```
+1. **Use an HTTP proxy** (recommended for legacy systems):
+   ```bash
+   ./target/release/rustchain-miner --proxy http://192.168.0.160:8089
+   ```
+
+2. **Disable TLS validation** (development only — **INSECURE**):
+   ```bash
+   export RUSTCHAIN_DEV_INSECURE_TLS=1
+   ./target/release/rustchain-miner
+   ```
+   **WARNING**: This disables TLS certificate validation and exposes the miner to
+   **man-in-the-middle attacks**. Never use this in production.
 
 ### Attestation Failed
 

--- a/rustchain-miner/src/transport.rs
+++ b/rustchain-miner/src/transport.rs
@@ -14,13 +14,32 @@ pub struct NodeTransport {
 }
 
 impl NodeTransport {
-    /// Create a new transport with the given configuration
+    /// Create a new transport with the given configuration.
+    ///
+    /// By default, TLS certificate validation is **enabled**.
+    /// To disable validation (e.g. for local development against a test server
+    /// with self-signed certificates), set the environment variable
+    /// `RUSTCHAIN_DEV_INSECURE_TLS=1`. This is **strongly discouraged** in
+    /// production — it exposes the miner to man-in-the-middle attacks.
     pub fn new(node_url: String, proxy_url: Option<String>, timeout: Duration) -> crate::Result<Self> {
+        let insecure = std::env::var("RUSTCHAIN_DEV_INSECURE_TLS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let builder = Client::builder().timeout(timeout);
+        let builder = if insecure {
+            eprintln!(
+                "WARNING: TLS certificate validation is DISABLED. \
+                 This is INSECURE and exposes the miner to man-in-the-middle attacks. \
+                 Do NOT use in production. Set via RUSTCHAIN_DEV_INSECURE_TLS=1."
+            );
+            builder.danger_accept_invalid_certs(true)
+        } else {
+            builder
+        };
+
         let transport = Self {
-            client: Client::builder()
-                .timeout(timeout)
-                .danger_accept_invalid_certs(true)
-                .build()?,
+            client: builder.build()?,
             node_url: node_url.trim_end_matches('/').to_string(),
             proxy_url: proxy_url.map(|u| u.trim_end_matches('/').to_string()),
             use_proxy: false,

--- a/rustchain-wallet/README.md
+++ b/rustchain-wallet/README.md
@@ -156,6 +156,19 @@ rustchain-wallet/
 - File permissions set to 600 on Unix
 - Zeroize-capable key handling
 - Ed25519 signatures on canonical JSON for tamper-proof transactions
+- **TLS certificate validation is enabled by default** for all API connections
+
+### Development TLS Bypass
+
+For local development against test servers with self-signed certificates, you may
+disable TLS validation by setting:
+
+```bash
+export RUSTCHAIN_DEV_INSECURE_TLS=1
+```
+
+**WARNING**: This disables TLS certificate validation and exposes the wallet to
+**man-in-the-middle attacks**. Never use this in production or with real funds.
 
 ## Dependencies
 

--- a/rustchain-wallet/src/client.rs
+++ b/rustchain-wallet/src/client.rs
@@ -66,12 +66,30 @@ pub struct NetworkInfo {
 }
 
 impl RustChainClient {
-    /// Create a new client with the specified API URL
+    /// Create a new client with the specified API URL.
+    ///
+    /// By default, TLS certificate validation is **enabled**.
+    /// To disable validation (e.g. for local development against a test server
+    /// with self-signed certificates), set the environment variable
+    /// `RUSTCHAIN_DEV_INSECURE_TLS=1`. This is **strongly discouraged** in
+    /// production — it exposes the wallet to man-in-the-middle attacks.
     pub fn new(api_url: String) -> Self {
-        let http_client = Client::builder()
-            .danger_accept_invalid_certs(true)
-            .build()
-            .unwrap_or_else(|_| Client::new());
+        let insecure = std::env::var("RUSTCHAIN_DEV_INSECURE_TLS")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+
+        let builder = Client::builder();
+        let builder = if insecure {
+            eprintln!(
+                "WARNING: TLS certificate validation is DISABLED. \
+                 This is INSECURE and exposes the wallet to man-in-the-middle attacks. \
+                 Do NOT use in production. Set via RUSTCHAIN_DEV_INSECURE_TLS=1."
+            );
+            builder.danger_accept_invalid_certs(true)
+        } else {
+            builder
+        };
+        let http_client = builder.build().unwrap_or_else(|_| Client::new());
 
         Self {
             api_url,


### PR DESCRIPTION
## Summary

This change restores secure TLS behavior in the RustChain wallet and miner clients by keeping certificate validation enabled by default.

### What changed
- Removed insecure default TLS behavior from `rustchain-wallet/src/client.rs`
- Removed insecure default TLS behavior from `rustchain-miner/src/transport.rs`
- Added a development-only opt-in environment variable for intentionally insecure TLS usage, with explicit warning language
- Updated wallet and miner documentation to distinguish secure default behavior from the unsafe development bypass
- Added the development-only environment variable to `rustchain-miner/.env.example`

### Why
Disabling certificate validation allows HTTPS endpoints with invalid or attacker-controlled certificates to be accepted, which enables machine-in-the-middle interception and response tampering.

### Validation
- Verified final change scope is limited to the intended wallet/miner TLS files
- Verified secure-by-default behavior and explicit documentation for the development-only insecure mode

Closes #2048

## Payout Wallet

RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35