### PR TITLE
security: prevent path traversal in download page

### DIFF
--- a/node/rustchain_download_page.py
+++ b/node/rustchain_download_page.py
@@ -181,8 +181,20 @@ class DownloadHandler(SimpleHTTPRequestHandler):
         else:
             # Serve files from downloads directory
             file_path = self.path.lstrip('/')
-            full_path = os.path.join(DOWNLOAD_DIR, file_path)
-            
+
+            # SECURITY: Reject path traversal attempts
+            if '..' in file_path or file_path.startswith(('/', '\\')):
+                self.send_error(403, "Forbidden")
+                return
+
+            full_path = os.path.realpath(os.path.join(DOWNLOAD_DIR, file_path))
+            real_download = os.path.realpath(DOWNLOAD_DIR)
+
+            # SECURITY: Ensure resolved path is within DOWNLOAD_DIR
+            if not full_path.startswith(real_download + os.sep) and full_path != real_download:
+                self.send_error(403, "Forbidden")
+                return
+
             if os.path.isfile(full_path):
                 self.send_response(200)
                 if file_path.endswith('.py'):


### PR DESCRIPTION
## Summary

This change hardens the standalone download page handler against path traversal and arbitrary file read attacks.

### What changed
- Rejected traversal-style request paths before file access
- Canonicalized the resolved path with `os.path.realpath()`
- Enforced that the final resolved path must remain inside `DOWNLOAD_DIR` before serving content

### Why
The previous implementation joined attacker-controlled request paths directly with `DOWNLOAD_DIR` and then opened the resulting path without containment checks. Requests such as `GET /../../etc/passwd` could escape the intended directory and read arbitrary local files.

### Scope
- `node/rustchain_download_page.py` only

Closes #2050

## Payout Wallet

RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35