### PR TITLE
[UTXO-BUG] reject empty-input non-minting transactions

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -293,6 +293,50 @@ class TestUtxoDB(unittest.TestCase):
         recovered = proposition_to_address(prop)
         self.assertEqual(recovered, addr)
 
+    # -- bounty #2819: empty-input minting vulnerability ---------------------
+
+    def test_empty_inputs_rejected_for_transfer(self):
+        """A normal transfer with empty inputs must be rejected.
+        This prevents minting funds from nothing (bounty #2819)."""
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [],
+            'outputs': [{'address': 'attacker', 'value_nrtc': 1_000_000 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }, block_height=10)
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('attacker'), 0)
+
+    def test_empty_inputs_rejected_for_unknown_tx_type(self):
+        """Any non-minting tx_type with empty inputs must be rejected."""
+        ok = self.db.apply_transaction({
+            'tx_type': 'some_random_type',
+            'inputs': [],
+            'outputs': [{'address': 'attacker', 'value_nrtc': 500 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }, block_height=10)
+        self.assertFalse(ok)
+
+    def test_mining_reward_empty_inputs_allowed(self):
+        """Legitimate mining_reward transactions MUST still work with empty inputs."""
+        ok = self._apply_coinbase('alice', 100 * UNIT)
+        self.assertTrue(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+
+    def test_mempool_empty_inputs_rejected_for_transfer(self):
+        """Mempool must also reject non-minting txs with empty inputs."""
+        tx = {
+            'tx_id': 'ffff' * 16,
+            'tx_type': 'transfer',
+            'inputs': [],
+            'outputs': [{'address': 'attacker', 'value_nrtc': 999 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+
 
 class TestCoinSelect(unittest.TestCase):
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -332,7 +332,14 @@ class UtxoDB:
                     return False
                 input_total += row['value_nrtc']
 
-            # -- conservation check (skip for coinbase) ----------------------
+            # -- conservation check ------------------------------------------
+            # Only authorized minting transaction types may have empty inputs.
+            # All other transactions must consume at least one input box.
+            MINTING_TX_TYPES = {'mining_reward'}
+            if not inputs and tx_type not in MINTING_TX_TYPES:
+                conn.execute("ROLLBACK")
+                return False
+
             output_total = sum(o['value_nrtc'] for o in outputs)
             if inputs and (output_total + fee) > input_total:
                 conn.execute("ROLLBACK")
@@ -534,7 +541,13 @@ class UtxoDB:
 
             tx_id = tx.get('tx_id', '')
             inputs = tx.get('inputs', [])
+            tx_type = tx.get('tx_type', 'transfer')
             now = int(time.time())
+
+            # Only authorized minting transaction types may have empty inputs.
+            MINTING_TX_TYPES = {'mining_reward'}
+            if not inputs and tx_type not in MINTING_TX_TYPES:
+                return False
 
             conn.execute("BEGIN IMMEDIATE")
 


### PR DESCRIPTION
## Summary

This PR fixes a critical UTXO validation bug where non-minting transactions with empty inputs could bypass conservation checks and create funds from nothing.

### Root cause
In `node/utxo_db.py`, the conservation check in `apply_transaction()` was gated by `if inputs`, so transactions with `inputs=[]` skipped the value-conservation path entirely. The same gap existed in `mempool_add()`.

### What changed
- Added a strict allowlist so only authorized minting transaction types may use empty inputs
- Rejected empty-input `transfer` and unknown transaction types in `apply_transaction()`
- Rejected the same class of transactions in `mempool_add()`
- Added focused regression tests covering:
  - empty-input `transfer` rejection
  - empty-input unknown-type rejection
  - valid `mining_reward` preservation
  - mempool rejection for empty-input `transfer`

### Validation
Updated tests in `node/test_utxo_db.py` to cover the exploit and the allowed minting path.

### Scope
- `node/utxo_db.py`
- `node/test_utxo_db.py`

## Payout Wallet

RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35