### PR TITLE
security: verify BFT PRE-PREPARE messages before accept

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -392,6 +392,17 @@ class BFTConsensus:
                 logging.warning(f"PRE-PREPARE not from leader: {msg.node_id}")
                 return None
 
+            # Verify HMAC signature (matches pattern in handle_prepare/handle_commit)
+            sign_data = f"{MessageType.PRE_PREPARE.value}:{msg.view}:{epoch}:{msg.digest}:{msg.timestamp}"
+            if not self._verify_signature(msg.node_id, sign_data, msg.signature):
+                logging.warning(f"Invalid PRE-PREPARE signature from {msg.node_id}")
+                return None
+
+            # Check timestamp freshness
+            if abs(time.time() - msg.timestamp) > CONSENSUS_MESSAGE_TTL:
+                logging.warning(f"Stale PRE-PREPARE from {msg.node_id} (age={int(time.time()) - msg.timestamp}s)")
+                return None
+
             # Validate proposal (hardware attestation checks)
             if not self._validate_proposal(msg.proposal):
                 logging.warning(f"Invalid proposal for epoch {epoch}")


### PR DESCRIPTION
## Summary

This change closes an authentication gap in the BFT consensus receive path by verifying `PRE-PREPARE` message signatures and rejecting stale messages before proposal handling continues.

### What changed
- Added HMAC signature verification in `_handle_pre_prepare()`
- Added timestamp freshness enforcement using the existing `CONSENSUS_MESSAGE_TTL` window
- Kept PRE-PREPARE validation behavior consistent with the existing PREPARE and COMMIT handlers

### Why
`PREPARE` and `COMMIT` were already authenticated on receipt, but `PRE-PREPARE` was not. That left the proposal-carrying message type outside the normal verification path and allowed forged or stale PRE-PREPARE messages to reach downstream consensus logic.

### Scope
- `node/rustchain_bft_consensus.py` only

Closes #2061

## Payout Wallet

RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35