### PR TITLE
[UTXO-BUG] reject negative fees in transfer validation

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -138,6 +138,24 @@ class TestUtxoDB(unittest.TestCase):
 
         self.assertFalse(ok)
 
+    def test_negative_fee_rejected(self):
+        """Negative fee should fail — allows minting via weakened conservation."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        alice_boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 1100 * UNIT}],
+            'fee_nrtc': -1000 * UNIT,  # negative fee bypasses conservation
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        # Balances unchanged
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     # -- double-spend --------------------------------------------------------
 
     def test_double_spend_rejected(self):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -334,6 +334,9 @@ class UtxoDB:
 
             # -- conservation check (skip for coinbase) ----------------------
             output_total = sum(o['value_nrtc'] for o in outputs)
+            if fee < 0:
+                conn.execute("ROLLBACK")
+                return False
             if inputs and (output_total + fee) > input_total:
                 conn.execute("ROLLBACK")
                 return False


### PR DESCRIPTION
## Summary

This PR fixes a UTXO accounting bug where a negative `fee_nrtc` value could weaken the conservation check in `apply_transaction()` and allow a normal transfer to create more value in outputs than existed in inputs.

### Root cause
`apply_transaction()` enforced value conservation using `output_total + fee <= input_total`, but it did not validate that `fee_nrtc` was non-negative. A caller could set a negative fee to offset excess outputs and bypass the conservation check.

### What changed
- Rejected transactions with negative `fee_nrtc` in `apply_transaction()`
- Added a focused regression test proving a negative-fee transfer is rejected and balances remain unchanged

### Why this matters
This affects normal transfer transactions with real inputs, not just minting-style paths. Without the non-negative fee guard, a transfer can inflate total supply by encoding the excess value as a negative fee.

### Scope
- `node/utxo_db.py`
- `node/test_utxo_db.py`

## Payout Wallet

RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35