### PR TITLE
[UTXO-BUG] CRIT-1: Conservation law bypass via negative/zero-value outputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -550,6 +550,68 @@ class TestUtxoDB(unittest.TestCase):
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
 
+    # -- bounty #2819: negative / zero value outputs -------------------------
+
+    def test_negative_value_output_rejected(self):
+        """Negative value_nrtc on an output bypasses conservation law.
+
+        Attack: 100 RTC input → [+200 RTC, -100 RTC] outputs.
+        output_total = 200 + (-100) = 100 <= input_total = 100, PASSES.
+        Attacker mints 100 RTC from nothing.
+        """
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': 'attacker', 'value_nrtc': 200 * UNIT},
+                {'address': 'burn',     'value_nrtc': -100 * UNIT},
+            ],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        # Balance must be unchanged
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('attacker'), 0)
+
+    def test_zero_value_output_rejected(self):
+        """Zero-value outputs are meaningless dust that bloats the UTXO set."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': 'bob',  'value_nrtc': 100 * UNIT},
+                {'address': 'dust', 'value_nrtc': 0},
+            ],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+
+    def test_float_value_nrtc_rejected(self):
+        """value_nrtc must be an integer; floats cause silent truncation."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': 'bob', 'value_nrtc': 99.5 * UNIT},
+            ],
+            'fee_nrtc': 0,
+        }, block_height=10)
+        self.assertFalse(ok)
+
 
 class TestCoinSelect(unittest.TestCase):
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -388,6 +388,15 @@ class UtxoDB:
                 return False
 
             output_total = sum(o['value_nrtc'] for o in outputs)
+
+            # Every output must carry a strictly positive value.
+            # Without this, a negative-value output lowers output_total,
+            # letting an attacker create more value than the inputs hold.
+            for o in outputs:
+                if not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
+                    conn.execute("ROLLBACK")
+                    return False
+
             if fee < 0:
                 conn.execute("ROLLBACK")
                 return False


### PR DESCRIPTION
## Vulnerability Class
**Critical — Fund creation from nothing (200 RTC bounty)**

## The Bug
`apply_transaction()` in `utxo_db.py` validates that `output_total + fee <= input_total`, but **never validates that individual output values are positive**.

A negative-value output reduces `output_total`, allowing an attacker to create a second output with value exceeding `input_total` while the conservation check passes.

### Attack Vector
```python
# Alice has 100 RTC in a single UTXO
tx = {
    'tx_type': 'transfer',
    'inputs': [{'box_id': alice_box_id, 'spending_proof': 'sig'}],
    'outputs': [
        {'address': 'attacker', 'value_nrtc': 200 * UNIT},   # 200 RTC
        {'address': 'burn',     'value_nrtc': -100 * UNIT},   # -100 RTC
    ],
    'fee_nrtc': 0,
}
```
# output_total = 200 + (-100) = 100 <= input_total = 100 → PASSES
# Attacker now has 200 RTC from a 100 RTC input
Fix
Added validation in apply_transaction() that every output must have value_nrtc as a strictly positive integer. This also blocks zero-value UTXO set bloat and float-type values that cause silent SQLite truncation.

Tests Added
test_negative_value_output_rejected — demonstrates the attack above
test_zero_value_output_rejected — blocks zero-value dust outputs
test_float_value_nrtc_rejected — blocks non-integer values
All 37 tests pass.

Files Changed
node/utxo_db.py — 6 lines added (validation block)
node/test_utxo_db.py — 63 lines added (3 test cases)
Ref: Bounty #2819 

MY WALLET IS  aroky-x86-miner 