### PR TITLE
[UTXO-BUG] HIGH-1: TOCTOU race in spend_box() — silent double-spend

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -181,6 +181,26 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('bob'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('eve'), 0)
 
+    def test_spend_box_double_spend_raises(self):
+        """spend_box() must raise ValueError on double-spend, not silently
+        return the box dict (bounty #2819 HIGH-1 TOCTOU fix)."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+        box_id = boxes[0]['box_id']
+
+        # First spend succeeds
+        result = self.db.spend_box(box_id, 'tx_first')
+        self.assertIsNotNone(result)
+
+        # Second spend must raise, not return silently
+        with self.assertRaises(ValueError):
+            self.db.spend_box(box_id, 'tx_second')
+
+    def test_spend_box_nonexistent_returns_none(self):
+        """spend_box() on a nonexistent box_id returns None."""
+        result = self.db.spend_box('deadbeef' * 8, 'tx_whatever')
+        self.assertIsNone(result)
+
     def test_nonexistent_input_rejected(self):
         ok = self.db.apply_transaction({
             'tx_type': 'transfer',

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -207,33 +207,62 @@ class UtxoDB:
         """
         Mark a box as spent.  Returns the box dict or None if not found.
         Raises ValueError on double-spend attempt.
+
+        When called without an external ``conn``, acquires BEGIN IMMEDIATE
+        to prevent TOCTOU races between the SELECT and UPDATE.
         """
         own = conn is None
         if own:
             conn = self._conn()
         try:
+            if own:
+                conn.execute("BEGIN IMMEDIATE")
+
             row = conn.execute(
                 "SELECT * FROM utxo_boxes WHERE box_id = ?", (box_id,)
             ).fetchone()
             if not row:
+                if own:
+                    conn.execute("ROLLBACK")
                 return None
             if row['spent_at'] is not None:
+                if own:
+                    conn.execute("ROLLBACK")
                 raise ValueError(
                     f"Double-spend attempt: box {box_id[:16]} already spent "
                     f"by tx {row['spent_by_tx'][:16]}"
                 )
-            conn.execute(
+            updated = conn.execute(
                 """UPDATE utxo_boxes
                    SET spent_at = ?, spent_by_tx = ?
                    WHERE box_id = ? AND spent_at IS NULL""",
                 (int(time.time()), spent_by_tx, box_id),
-            )
+            ).rowcount
+            if updated != 1:
+                # Another connection spent this box between our SELECT
+                # and UPDATE — treat as double-spend.
+                if own:
+                    conn.execute("ROLLBACK")
+                raise ValueError(
+                    f"Double-spend race: box {box_id[:16]} was spent "
+                    f"concurrently"
+                )
             if own:
                 conn.commit()
             return dict(row)
+        except ValueError:
+            raise
+        except Exception:
+            if own:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+            raise
         finally:
             if own:
                 conn.close()
+
 
     def get_box(self, box_id: str) -> Optional[dict]:
         """Get a box by ID (spent or unspent)."""


### PR DESCRIPTION
## Vulnerability Class
**High — Race condition / TOCTOU (100 RTC bounty)**

## The Bug
`spend_box()` performs a SELECT then UPDATE without an exclusive lock when called standalone. Two concurrent callers can both read `spent_at IS NULL`, then both UPDATE — the second gets `rowcount=0` but the method never checks rowcount, so it returns the box dict as if the spend succeeded.

### Race Sequence
1. Thread A: SELECT → sees unspent → proceeds
2. Thread B: SELECT → sees unspent → proceeds
3. Thread A: UPDATE (rowcount=1) → commits ✓
4. Thread B: UPDATE (rowcount=0, already spent) → commits ← **silent failure**

Thread B believes it successfully spent the box but the UPDATE was a no-op.

## Fix
1. Acquire `BEGIN IMMEDIATE` when `own=True` to serialize the SELECT+UPDATE
2. Check `UPDATE rowcount == 1`; raise `ValueError` if 0 (concurrent spend)
3. Proper `ROLLBACK` on all early-exit paths

## Tests Added
- `test_spend_box_double_spend_raises` — verifies ValueError on double-spend via spend_box()
- `test_spend_box_nonexistent_returns_none` — verifies None return for missing box

All 36 tests pass.

## Files Changed
- `node/utxo_db.py` — spend_box() rewritten with BEGIN IMMEDIATE + rowcount check
- `node/test_utxo_db.py` — 2 test cases added

Ref: Bounty #2819

MY WALLET IS  aroky-x86-miner