### PR TITLE
fix: use UTXO state root in block producer

### DIFF
--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -30,6 +30,11 @@ from rustchain_crypto import (
 )
 from rustchain_tx_handler import TransactionPool
 
+try:
+    from utxo_db import UtxoDB as _UtxoDB
+except Exception:  # pragma: no cover - soft dependency for legacy/account-mode use
+    _UtxoDB = None
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s [BLOCK] %(levelname)s: %(message)s'
@@ -190,12 +195,14 @@ class BlockProducer:
         db_path: str,
         tx_pool: TransactionPool,
         signer: Optional[Ed25519Signer] = None,
-        wallet_address: Optional[str] = None
+        wallet_address: Optional[str] = None,
+        utxo_db: Optional["_UtxoDB"] = None
     ):
         self.db_path = db_path
         self.tx_pool = tx_pool
         self.signer = signer
         self.wallet_address = wallet_address
+        self._utxo_db = utxo_db
         self._lock = threading.Lock()
 
     def get_current_slot(self) -> int:
@@ -283,8 +290,15 @@ class BlockProducer:
         """
         Compute current state root.
 
-        State root is hash of all balances sorted by address.
+        Prefer the UTXO Merkle root when a UTXO database is attached; otherwise
+        fall back to the legacy account-model balances table.
         """
+        if self._utxo_db is not None:
+            try:
+                return self._utxo_db.compute_state_root()
+            except Exception as exc:
+                logger.warning("UTXO state root computation failed; falling back to balances table: %s", exc)
+
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()

--- a/node/test_block_producer_state_root.py
+++ b/node/test_block_producer_state_root.py
@@ -1,0 +1,149 @@
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+import unittest
+
+crypto = types.ModuleType('rustchain_crypto')
+class CanonicalBlockHeader: pass
+class MerkleTree: root_hex = '0' * 64
+class SignedTransaction: pass
+class Ed25519Signer: pass
+
+def canonical_json(obj):
+    return json.dumps(obj, separators=(',', ':'), sort_keys=True).encode()
+
+def blake2b256_hex(data):
+    return hashlib.blake2b(data, digest_size=32).hexdigest()
+
+crypto.CanonicalBlockHeader = CanonicalBlockHeader
+crypto.MerkleTree = MerkleTree
+crypto.SignedTransaction = SignedTransaction
+crypto.Ed25519Signer = Ed25519Signer
+crypto.canonical_json = canonical_json
+crypto.blake2b256_hex = blake2b256_hex
+sys.modules['rustchain_crypto'] = crypto
+
+tx_handler = types.ModuleType('rustchain_tx_handler')
+class TransactionPool: pass
+tx_handler.TransactionPool = TransactionPool
+sys.modules['rustchain_tx_handler'] = tx_handler
+
+from rustchain_block_producer import BlockProducer
+from utxo_db import UtxoDB, UNIT
+
+
+class DummyPool:
+    pass
+
+
+class FailingUtxoDB:
+    def compute_state_root(self):
+        raise RuntimeError('boom')
+
+
+class TestBlockProducerStateRoot(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        with sqlite3.connect(self.tmp.name) as conn:
+            conn.execute(
+                'CREATE TABLE balances (wallet TEXT PRIMARY KEY, balance_urtc INTEGER NOT NULL, wallet_nonce INTEGER DEFAULT 0)'
+            )
+            conn.executemany(
+                'INSERT INTO balances (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)',
+                [
+                    ('alice', 200 * UNIT, 1),
+                    ('bob', 50 * UNIT, 2),
+                ],
+            )
+            conn.commit()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def _legacy_root(self):
+        state = [
+            {'wallet': 'alice', 'balance': 200 * UNIT, 'nonce': 1},
+            {'wallet': 'bob', 'balance': 50 * UNIT, 'nonce': 2},
+        ]
+        return blake2b256_hex(canonical_json(state))
+
+    def _make_utxo_db(self):
+        utxo = UtxoDB(self.tmp.name)
+        utxo.init_tables()
+        utxo.apply_transaction(
+            {
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': 'alice', 'value_nrtc': 150 * UNIT}],
+                'fee_nrtc': 0,
+            },
+            block_height=1,
+        )
+        utxo.apply_transaction(
+            {
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': 'bob', 'value_nrtc': 25 * UNIT}],
+                'fee_nrtc': 0,
+            },
+            block_height=2,
+        )
+        return utxo
+
+    def test_utxo_state_root_used_when_utxo_db_available(self):
+        utxo = self._make_utxo_db()
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=utxo)
+        self.assertEqual(producer.get_state_root(), utxo.compute_state_root())
+
+    def test_fallback_to_account_model_when_no_utxo_db(self):
+        producer = BlockProducer(self.tmp.name, DummyPool())
+        self.assertEqual(producer.get_state_root(), self._legacy_root())
+
+    def test_utxo_and_account_roots_differ(self):
+        utxo = self._make_utxo_db()
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=utxo)
+        self.assertNotEqual(producer.get_state_root(), self._legacy_root())
+
+    def test_empty_utxo_state_root(self):
+        utxo = UtxoDB(self.tmp.name)
+        utxo.init_tables()
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=utxo)
+        self.assertEqual(producer.get_state_root(), utxo.compute_state_root())
+        self.assertEqual(len(producer.get_state_root()), 64)
+
+    def test_utxo_state_root_changes_after_spend(self):
+        utxo = self._make_utxo_db()
+        before = utxo.compute_state_root()
+        box = utxo.get_unspent_for_address('alice')[0]
+        utxo.apply_transaction(
+            {
+                'tx_type': 'transfer',
+                'inputs': [{'box_id': box['box_id'], 'spending_proof': 'sig'}],
+                'outputs': [
+                    {'address': 'bob', 'value_nrtc': 100 * UNIT},
+                    {'address': 'alice', 'value_nrtc': 50 * UNIT},
+                ],
+                'fee_nrtc': 0,
+            },
+            block_height=3,
+        )
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=utxo)
+        self.assertNotEqual(producer.get_state_root(), before)
+
+    def test_utxo_state_root_deterministic(self):
+        utxo = self._make_utxo_db()
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=utxo)
+        self.assertEqual(producer.get_state_root(), producer.get_state_root())
+
+    def test_utxo_failure_falls_back_to_legacy_root(self):
+        producer = BlockProducer(self.tmp.name, DummyPool(), utxo_db=FailingUtxoDB())
+        self.assertEqual(producer.get_state_root(), self._legacy_root())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
`BlockProducer.get_state_root()` currently commits the legacy account-model `balances` root even when the node is operating against the UTXO database. This patch lets `BlockProducer` prefer `utxo_db.compute_state_root()` whenever a UTXO handle is available, while preserving the legacy balances-table path as a fallback.

## What changed
- add an optional `utxo_db` handle to `BlockProducer`
- prefer the UTXO Merkle root in `get_state_root()` when `utxo_db` is attached
- fall back to the legacy balances-table root when no UTXO DB is present or UTXO root computation fails
- add focused state-root regression coverage

## Validation
- `PYTHONPATH=node python3 -m py_compile node/rustchain_block_producer.py node/test_block_producer_state_root.py node/utxo_db.py`
- `PYTHONPATH=node python3 node/test_block_producer_state_root.py`

## Reviewer note
The semantic change is intentionally small (constructor wiring + `get_state_root()` preference/fallback logic + focused tests). If GitHub shows the Python file as a large diff, that is due to repository line-ending normalization noise around this file history rather than broad logic churn.
