### PR TITLE
fix: reject value-violating UTXO transactions at mempool admission

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -274,17 +274,17 @@ class TestUtxoDB(unittest.TestCase):
         self._apply_coinbase('alice', 200 * UNIT, block_height=2)
         boxes = self.db.get_unspent_for_address('alice')
 
-        # Add two txs with different fees
+        # Add two txs with different fees (outputs + fee <= inputs)
         self.db.mempool_add({
             'tx_id': 'low_' * 16,
             'inputs': [{'box_id': boxes[0]['box_id']}],
-            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
             'fee_nrtc': 1000,
         })
         self.db.mempool_add({
             'tx_id': 'high' * 16,
             'inputs': [{'box_id': boxes[1]['box_id']}],
-            'outputs': [{'address': 'bob', 'value_nrtc': 200 * UNIT}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 200 * UNIT - 5000}],
             'fee_nrtc': 5000,
         })
 
@@ -351,6 +351,99 @@ class TestUtxoDB(unittest.TestCase):
             'inputs': [],
             'outputs': [{'address': 'attacker', 'value_nrtc': 999 * UNIT}],
             'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+
+    # -- mempool conservation-of-value (DoS prevention) ----------------------
+
+    def test_mempool_rejects_outputs_exceed_inputs(self):
+        """Mempool must reject tx where outputs > inputs (conservation violation).
+        Prevents UTXO locking DoS — invalid tx would lock boxes until expiry."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'cons' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 1_000_000 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        # Box should NOT be locked — still available for legitimate tx
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_rejects_negative_fee(self):
+        """Mempool must reject negative fee (minting via weakened conservation)."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'nfee' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': -50 * UNIT,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        # Box should NOT be locked
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_accepts_valid_tx(self):
+        """Mempool should accept a well-formed tx with valid conservation."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'good' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [
+                {'address': 'bob', 'value_nrtc': 90 * UNIT},
+                {'address': 'alice', 'value_nrtc': 9 * UNIT},
+            ],
+            'fee_nrtc': 1 * UNIT,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertTrue(ok)
+        # Box should be locked
+        self.assertTrue(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_accepts_exact_input_output(self):
+        """Mempool should accept tx where outputs == inputs (no fee, no change)."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'xact' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertTrue(ok)
+
+    def test_mempool_rejects_fee_exceeding_surplus(self):
+        """Mempool must reject tx where outputs + fee > inputs."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'hife' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+            'fee_nrtc': 2 * UNIT,  # 99 + 2 = 101 > 100
         }
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -574,6 +574,29 @@ class UtxoDB:
                     conn.execute("ROLLBACK")
                     return False
 
+            # -- conservation-of-value check ---------------------------------
+            # Prevent mempool admission of transactions that would fail
+            # apply_transaction(), locking UTXOs until expiry (DoS vector).
+            fee = tx.get('fee_nrtc', 0)
+            if fee < 0:
+                conn.execute("ROLLBACK")
+                return False
+
+            input_total = 0
+            for inp in inputs:
+                row = conn.execute(
+                    "SELECT value_nrtc FROM utxo_boxes WHERE box_id = ?",
+                    (inp['box_id'],),
+                ).fetchone()
+                if row:
+                    input_total += row['value_nrtc']
+
+            outputs = tx.get('outputs', [])
+            output_total = sum(o.get('value_nrtc', 0) for o in outputs)
+            if input_total > 0 and (output_total + fee) > input_total:
+                conn.execute("ROLLBACK")
+                return False
+
             # Insert into mempool
             conn.execute(
                 """INSERT OR IGNORE INTO utxo_mempool


### PR DESCRIPTION
# Fix: Add conservation-of-value check to mempool admission

## Problem

`mempool_add()` in `node/utxo_db.py` admitted transactions without validating conservation-of-value or rejecting negative fees. Invalid transactions would lock input UTXOs in `utxo_mempool_inputs` until expiry (1 hour) or manual removal, enabling a denial-of-service attack against legitimate UTXO spenders.

## Fix

Added two checks to `mempool_add()` (inside the `BEGIN IMMEDIATE` transaction):

1. **Negative fee rejection** — `if fee < 0: ROLLBACK; return False`
2. **Conservation-of-value** — query each input box's `value_nrtc`, sum them, and reject if `output_total + fee > input_total`

This mirrors the checks already present in `apply_transaction()`, moving them earlier in the pipeline to prevent UTXO locking by invalid transactions.

## Changes

- `node/utxo_db.py`: +16 lines in `mempool_add()` — conservation check + negative fee check
- `node/test_utxo_db.py`: +5 new tests + 1 pre-existing test fix
  - `test_mempool_rejects_outputs_exceed_inputs` — verifies conservation violation rejected, box not locked
  - `test_mempool_rejects_negative_fee` — verifies negative fee rejected, box not locked
  - `test_mempool_accepts_valid_tx` — regression: valid tx still accepted and locked
  - `test_mempool_accepts_exact_input_output` — edge case: outputs == inputs, fee == 0
  - `test_mempool_rejects_fee_exceeding_surplus` — outputs + fee > inputs rejected
  - Fixed `test_mempool_block_candidates` — pre-existing test had outputs == inputs with non-zero fee (now correctly fails conservation)

## Tests

```
39 passed in 0.24s
```

All existing tests pass. Five new tests cover the conservation and negative fee checks.
