### PR TITLE
[BFT-BUG] CRIT-BFT-2: PREPARE/COMMIT accept mismatched digests — equivocation attack

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -464,6 +464,18 @@ class BFTConsensus:
                 logging.warning(f"Invalid PREPARE signature from {msg.node_id}")
                 return
 
+            # SECURITY: Verify digest matches the PRE-PREPARE proposal.
+            # Without this, a Byzantine node can send PREPARE for a
+            # different digest, enabling equivocation.
+            if epoch in self.pre_prepare_log:
+                expected_digest = self.pre_prepare_log[epoch].digest
+                if msg.digest != expected_digest:
+                    logging.warning(
+                        f"[PREPARE] Digest mismatch from {msg.node_id}: "
+                        f"got {msg.digest[:16]}... expected {expected_digest[:16]}..."
+                    )
+                    return
+
             # Store prepare
             if epoch not in self.prepare_log:
                 self.prepare_log[epoch] = {}
@@ -547,6 +559,18 @@ class BFTConsensus:
             if not self._verify_signature(msg.node_id, sign_data, msg.signature):
                 logging.warning(f"Invalid COMMIT signature from {msg.node_id}")
                 return
+
+            # SECURITY: Verify digest matches the PRE-PREPARE proposal.
+            # Without this, a Byzantine node can commit a different
+            # proposal than what was proposed and prepared.
+            if epoch in self.pre_prepare_log:
+                expected_digest = self.pre_prepare_log[epoch].digest
+                if msg.digest != expected_digest:
+                    logging.warning(
+                        f"[COMMIT] Digest mismatch from {msg.node_id}: "
+                        f"got {msg.digest[:16]}... expected {expected_digest[:16]}..."
+                    )
+                    return
 
             # Store commit
             if epoch not in self.commit_log:

--- a/node/test_bft_digest_validation.py
+++ b/node/test_bft_digest_validation.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Tests for BFT digest validation in PREPARE/COMMIT handlers (CRIT-BFT-2).
+
+Demonstrates that PREPARE and COMMIT messages with a digest that doesn't
+match the PRE-PREPARE proposal are rejected, preventing equivocation.
+"""
+
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from dataclasses import asdict
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rustchain_bft_consensus import (
+    BFTConsensus, ConsensusMessage, MessageType, ConsensusPhase
+)
+
+SECRET_KEY = "test_bft_digest_validation_2025"
+
+
+class TestBFTDigestValidation(unittest.TestCase):
+    """CRIT-BFT-2: PREPARE/COMMIT must validate digest matches pre-prepare."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.bft = BFTConsensus("node-A", self.tmp.name, SECRET_KEY)
+        self.bft.register_peer("node-B", "http://localhost:9001")
+        self.bft.register_peer("node-C", "http://localhost:9002")
+        self.bft.register_peer("node-D", "http://localhost:9003")
+
+        # Inject a PRE-PREPARE so the digest is known
+        self.test_epoch = 100
+        self.real_digest = hashlib.sha256(b"real_proposal").hexdigest()
+        self.fake_digest = hashlib.sha256(b"fake_proposal").hexdigest()
+
+        ts = int(time.time())
+        sign_data = f"{MessageType.PRE_PREPARE.value}:{self.bft.current_view}:{self.test_epoch}:{self.real_digest}:{ts}"
+        sig = self.bft._sign_message(sign_data)
+
+        pre_prepare = ConsensusMessage(
+            msg_type=MessageType.PRE_PREPARE.value,
+            view=self.bft.current_view,
+            epoch=self.test_epoch,
+            digest=self.real_digest,
+            node_id="node-B",  # pretend node-B is leader
+            signature=sig,
+            timestamp=ts,
+            proposal={"epoch": self.test_epoch, "data": "real"}
+        )
+        self.bft.pre_prepare_log[self.test_epoch] = pre_prepare
+
+    def tearDown(self):
+        self.bft._cancel_view_change_timer()
+        try:
+            os.unlink(self.tmp.name)
+        except PermissionError:
+            pass
+
+    def _make_prepare(self, node_id: str, digest: str) -> ConsensusMessage:
+        ts = int(time.time())
+        sign_data = f"{MessageType.PREPARE.value}:{self.bft.current_view}:{self.test_epoch}:{digest}:{ts}"
+        sig = self.bft._sign_message(sign_data)
+        return ConsensusMessage(
+            msg_type=MessageType.PREPARE.value,
+            view=self.bft.current_view,
+            epoch=self.test_epoch,
+            digest=digest,
+            node_id=node_id,
+            signature=sig,
+            timestamp=ts,
+        )
+
+    def _make_commit(self, node_id: str, digest: str) -> ConsensusMessage:
+        ts = int(time.time())
+        sign_data = f"{MessageType.COMMIT.value}:{self.bft.current_view}:{self.test_epoch}:{digest}:{ts}"
+        sig = self.bft._sign_message(sign_data)
+        return ConsensusMessage(
+            msg_type=MessageType.COMMIT.value,
+            view=self.bft.current_view,
+            epoch=self.test_epoch,
+            digest=digest,
+            node_id=node_id,
+            signature=sig,
+            timestamp=ts,
+        )
+
+    # -- PREPARE tests -------------------------------------------------------
+
+    def test_prepare_matching_digest_accepted(self):
+        """PREPARE with correct digest must be accepted."""
+        msg = self._make_prepare("node-C", self.real_digest)
+        self.bft.handle_prepare(msg)
+        self.assertIn("node-C", self.bft.prepare_log.get(self.test_epoch, {}))
+
+    def test_prepare_wrong_digest_rejected(self):
+        """PREPARE with wrong digest must be rejected (equivocation attack)."""
+        msg = self._make_prepare("node-C", self.fake_digest)
+        self.bft.handle_prepare(msg)
+        self.assertNotIn("node-C", self.bft.prepare_log.get(self.test_epoch, {}))
+
+    # -- COMMIT tests --------------------------------------------------------
+
+    def test_commit_matching_digest_accepted(self):
+        """COMMIT with correct digest must be accepted."""
+        msg = self._make_commit("node-C", self.real_digest)
+        self.bft.handle_commit(msg)
+        self.assertIn("node-C", self.bft.commit_log.get(self.test_epoch, {}))
+
+    def test_commit_wrong_digest_rejected(self):
+        """COMMIT with wrong digest must be rejected (equivocation attack)."""
+        msg = self._make_commit("node-C", self.fake_digest)
+        self.bft.handle_commit(msg)
+        self.assertNotIn("node-C", self.bft.commit_log.get(self.test_epoch, {}))
+
+    def test_equivocation_cannot_reach_quorum(self):
+        """Byzantine nodes sending different digests cannot reach quorum.
+
+        Before the fix, 2 honest nodes (real digest) + 1 Byzantine node
+        (fake digest) would all count toward prepare quorum for the epoch,
+        even though they disagree on the proposal content.
+        """
+        # 2 honest prepares with real digest
+        self.bft.handle_prepare(self._make_prepare("node-B", self.real_digest))
+        self.bft.handle_prepare(self._make_prepare("node-C", self.real_digest))
+
+        # 1 Byzantine prepare with fake digest — should be REJECTED
+        self.bft.handle_prepare(self._make_prepare("node-D", self.fake_digest))
+
+        # Only 2 prepares should be in the log (not 3)
+        self.assertEqual(
+            len(self.bft.prepare_log.get(self.test_epoch, {})), 2,
+            "Byzantine node's mismatched digest should not count toward quorum"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Vulnerability Class
**Critical — BFT equivocation via digest mismatch (200 RTC bounty)**

## The Bug
`handle_prepare()` and `handle_commit()` verify HMAC signatures but **never check that `msg.digest` matches the PRE-PREPARE proposal's digest**. Each handler stores whatever digest the remote peer sends and counts it toward quorum.

### Attack Vector
A Byzantine node sends PREPARE/COMMIT with a **different digest** than the leader's proposal:

```python
# Honest leader proposes digest "abc123..." for epoch 500
# Byzantine node-D sends PREPARE with digest "xyz789..."
# Both count toward quorum → conflicting proposals can be "agreed upon"
```
This breaks the core PBFT safety invariant: all honest nodes in the quorum must agree on the same proposal content.

Fix
After signature verification in both handlers, compare msg.digest against pre_prepare_log[epoch].digest. Reject with a warning if they differ.

```python
if epoch in self.pre_prepare_log:
    expected_digest = self.pre_prepare_log[epoch].digest
    if msg.digest != expected_digest:
        logging.warning(f"Digest mismatch from {msg.node_id}")
        return
```
All 5 tests pass.

Files Changed
node/rustchain_bft_consensus.py — digest validation in handle_prepare() + handle_commit()
node/test_bft_digest_validation.py — NEW test file (5 tests)
Ref: Bounty #2819
Wallet:   aroky-x86-miner 