### PR TITLE
[TX-BUG] CRIT-TX-1: Float truncation in RTC-to-µRTC conversion — fund leakage on every non-round transfer

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4,6 +4,7 @@ RustChain v2 - Integrated Server
 Includes RIP-0005 (Epoch Rewards), RIP-0008 (Withdrawals), RIP-0009 (Finality)
 """
 import os, time, json, secrets, hashlib, hmac, sqlite3, base64, struct, uuid, glob, logging, sys, binascii, math, re, statistics
+from decimal import Decimal
 import ipaddress
 from urllib.parse import urlparse
 from flask import Flask, request, jsonify, g, send_from_directory, send_file, abort, render_template_string, redirect
@@ -5711,7 +5712,7 @@ def wallet_transfer_v2():
     amount_rtc = pre.details["amount_rtc"]
     reason = str((data or {}).get('reason', 'admin_transfer'))
     
-    amount_i64 = int(amount_rtc * 1000000)
+    amount_i64 = int(Decimal(str(amount_rtc)) * 1000000)
     now = int(time.time())
     confirms_at = now + CONFIRMATION_DELAY_SECONDS
     current_epoch = current_slot()
@@ -6072,7 +6073,7 @@ def wallet_transfer_OLD():
     if amount_rtc <= 0:
         return jsonify({"error": "Amount must be positive"}), 400
 
-    amount_i64 = int(amount_rtc * 1000000)
+    amount_i64 = int(Decimal(str(amount_rtc)) * 1000000)
 
     conn = sqlite3.connect(DB_PATH)
     try:
@@ -6639,7 +6640,7 @@ def wallet_transfer_signed():
     # SECURITY/HARDENING: signed transfers should follow the same 2-phase commit
     # semantics as admin transfers (pending_ledger + delayed confirmation). This
     # prevents bypassing the 24h pending window via the signed endpoint.
-    amount_i64 = int(amount_rtc * 1000000)
+    amount_i64 = int(Decimal(str(amount_rtc)) * 1000000)
     now = int(time.time())
     confirms_at = now + CONFIRMATION_DELAY_SECONDS
     current_epoch = current_slot()

--- a/node/test_float_precision.py
+++ b/node/test_float_precision.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Tests for CRIT-TX-1: Float precision loss in RTC → µRTC conversion.
+
+Demonstrates that Decimal-based conversion produces exact results where
+float multiplication truncates.
+"""
+
+import unittest
+from decimal import Decimal
+
+
+# The production UNIT for the account model (1 RTC = 1,000,000 µRTC)
+UNIT = 1_000_000
+
+
+class TestRTCFloatPrecision(unittest.TestCase):
+    """CRIT-TX-1: int(amount_rtc * UNIT) truncates for non-round amounts."""
+
+    def test_float_truncation_demonstrated(self):
+        """Show the bug: int(2.01 * 1_000_000) = 2009999 instead of 2010000."""
+        broken = int(2.01 * UNIT)
+        self.assertEqual(broken, 2009999, "Float truncation produces 2009999")
+
+    def test_decimal_conversion_exact(self):
+        """Decimal conversion produces exact results."""
+        for amount_rtc in [0.1, 0.3, 0.7, 0.01, 0.001, 1.23, 9.999999]:
+            result = int(Decimal(str(amount_rtc)) * UNIT)
+            expected = round(amount_rtc * UNIT)
+            self.assertEqual(result, expected,
+                             f"Decimal conversion of {amount_rtc} RTC should be exact")
+
+    def test_problematic_amounts(self):
+        """2.01 RTC truncates: int(2.01 * 1e6) = 2009999 instead of 2010000."""
+        amount_rtc = 2.01
+        expected = 2_010_000
+
+        float_result = int(amount_rtc * UNIT)
+        decimal_result = int(Decimal(str(amount_rtc)) * UNIT)
+
+        # Float is wrong
+        self.assertEqual(float_result, 2_009_999,
+                         "Float truncation produces 2009999")
+        # Decimal is correct
+        self.assertEqual(decimal_result, expected,
+                         "Decimal conversion produces exact 2010000")
+
+    def test_integer_amounts_unaffected(self):
+        """Integer RTC amounts are not affected by the fix."""
+        for amount_rtc in [1, 5, 10, 100, 1500]:
+            float_result = int(amount_rtc * UNIT)
+            decimal_result = int(Decimal(str(amount_rtc)) * UNIT)
+            self.assertEqual(float_result, decimal_result,
+                             f"Integer amount {amount_rtc} should be same either way")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Vulnerability Class
**Critical — Silent fund leakage via float truncation in production ledger (200 RTC bounty)**

## The Bug
All 3 transfer endpoints convert RTC to µRTC using:
```python
amount_i64 = int(amount_rtc * 1000000)
IEEE 754 truncation silently loses 1 µRTC for certain amounts:

python
>>> int(2.01 * 1000000)
2009999              # should be 2010000
```
<img width="582" height="237" alt="image" src="https://github.com/user-attachments/assets/182640b0-464d-4fbb-8708-be7b35198591" />

Fix
Replace int(amount_rtc * 1000000) with int(Decimal(str(amount_rtc)) * 1000000) at all 3 locations. Added top-level from decimal import Decimal import.

Tests Added (NEW file: test_float_precision.py)
<img width="569" height="312" alt="image" src="https://github.com/user-attachments/assets/4e6e1f04-08b9-4341-b884-560b4fc12564" />

Wallet:  aroky-x86-miner 