### PR TITLE
[SYNC-BUG] HIGH-SYNC-2: Peer sync accepts arbitrary balance increases…

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -201,7 +201,12 @@ class RustChainSyncManager:
                         if local_row and local_row["last_attest"] is not None and local_row["last_attest"] >= sanitized["last_attest"]:
                             continue
 
-                # For balances, reject if remote would reduce known local balance
+                # SECURITY: Balances must NEVER be updated via peer sync.
+                # Balance state is authoritative: it can only change through
+                # local transaction processing (mining rewards, signed
+                # transfers, epoch settlements).  Accepting balance data from
+                # peers — even "increases only" — lets a single compromised
+                # node inflate any wallet to an arbitrary value.
                 if table_name == "balances":
                     candidate_balance_col = None
                     for c in ("amount_i64", "balance_i64", "balance_urtc", "amount_rtc"):
@@ -216,12 +221,15 @@ class RustChainSyncManager:
                         )
                         local_row = cursor.fetchone()
                         if local_row and local_row[0] is not None:
-                            try:
-                                if int(local_row[0]) > int(sanitized[candidate_balance_col]):
-                                    self.logger.warning(f"Rejected sync: Balance reduction for {sanitized[pk]}")
-                                    continue
-                            except Exception:
-                                pass
+                            remote_val = int(sanitized[candidate_balance_col])
+                            local_val = int(local_row[0])
+                            if remote_val != local_val:
+                                self.logger.warning(
+                                    f"Rejected sync: Balance modification for "
+                                    f"{sanitized[pk]} (local={local_val}, "
+                                    f"remote={remote_val})"
+                                )
+                                continue
 
                 # Safe upsert (avoid INSERT OR REPLACE data loss semantics)
                 columns = list(sanitized.keys())

--- a/node/test_sync_balance_inflation.py
+++ b/node/test_sync_balance_inflation.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Tests for HIGH-SYNC-2: Peer sync must not allow balance inflation.
+
+Demonstrates that apply_sync_payload() rejects balance changes (both
+increases and decreases) from remote peers for wallets that already
+have a local balance, preventing arbitrary fund inflation.
+"""
+
+import os
+import sys
+import sqlite3
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rustchain_sync import RustChainSyncManager
+
+
+class TestSyncBalanceInflation(unittest.TestCase):
+    """HIGH-SYNC-2: Peer sync must reject balance modifications."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+
+        # Create the balances table matching the production schema
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE balances (
+                    miner_id TEXT PRIMARY KEY,
+                    amount_i64 INTEGER NOT NULL DEFAULT 0
+                )
+            """)
+            # Seed a local balance
+            conn.execute(
+                "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+                ("miner-alice", 5_000_000),  # 5 RTC
+            )
+            conn.commit()
+
+        self.sync = RustChainSyncManager(self.db_path, "test_admin_key")
+        # Clear schema cache so it picks up our freshly created table
+        self.sync._schema_cache.clear()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except PermissionError:
+            pass
+
+    def _get_balance(self, miner_id: str) -> int:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+                (miner_id,),
+            ).fetchone()
+            return row[0] if row else 0
+
+    # -- Tests ---------------------------------------------------------------
+
+    def test_balance_increase_rejected(self):
+        """Peers must NOT be able to inflate a wallet's balance.
+
+        Before the fix, only decreases were rejected — increases sailed
+        through, allowing any peer to set any wallet to any value.
+        """
+        original = self._get_balance("miner-alice")
+        self.assertEqual(original, 5_000_000)
+
+        # Malicious peer syncs a higher balance
+        self.sync.apply_sync_payload("balances", [
+            {"miner_id": "miner-alice", "amount_i64": 999_000_000},  # 999 RTC
+        ])
+
+        after = self._get_balance("miner-alice")
+        self.assertEqual(after, 5_000_000,
+                         "Balance must not increase via peer sync")
+
+    def test_balance_decrease_still_rejected(self):
+        """Existing protection against decreases must still work."""
+        self.sync.apply_sync_payload("balances", [
+            {"miner_id": "miner-alice", "amount_i64": 1_000_000},  # 1 RTC
+        ])
+
+        after = self._get_balance("miner-alice")
+        self.assertEqual(after, 5_000_000,
+                         "Balance must not decrease via peer sync")
+
+    def test_new_wallet_from_sync_allowed(self):
+        """New wallets (no local row yet) CAN be created via sync.
+
+        This allows initial balance propagation for newly registered miners.
+        """
+        self.sync.apply_sync_payload("balances", [
+            {"miner_id": "miner-bob", "amount_i64": 2_000_000},  # 2 RTC
+        ])
+
+        bob_balance = self._get_balance("miner-bob")
+        self.assertEqual(bob_balance, 2_000_000,
+                         "New wallet should be created via sync")
+
+    def test_unchanged_balance_passes(self):
+        """Sync with identical balance value should succeed (no-op upsert)."""
+        self.sync.apply_sync_payload("balances", [
+            {"miner_id": "miner-alice", "amount_i64": 5_000_000},
+        ])
+
+        after = self._get_balance("miner-alice")
+        self.assertEqual(after, 5_000_000,
+                         "Identical balance should not be rejected")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🛡️ Vulnerability Class
**High — Arbitrary wallet inflation via peer sync (100 RTC bounty)**

---

## 🧠 The Bug

The `sync_payload()` in `rustchain_sync.py` has a balance conflict resolution check that only rejects sync data that would **decrease** a local balance.

This allows malicious peers to **increase balances silently**, resulting in unauthorized inflation.

### ❌ Before (vulnerable)
```python
# Before (line 220): only decreases blocked
if int(local_row[0]) > int(sanitized[candidate_balance_col]):
    self.logger.warning("Rejected sync: Balance reduction")
    continue

# increases fall through → wallet inflation

⚔️ Attack Vector

A compromised peer can send a manipulated sync payload:

# Compromised peer sends sync payload:
sync_payload = [{"miner_id": "victim_wallet", "amount_s64": 999000000}]

# Result: victim's balance silently increased from 5 RTC to 999 RTC
```
💥 Impact
Any peer node can inflate any wallet to arbitrary values
Breaks financial integrity of the system
No authentication or authority required
✅ Fix

Reject ALL balance modifications (both increases AND decreases) for wallets that already exist locally.

Allow sync only for:

New wallets (initial propagation)
Non-financial metadata
✔️ After (fixed)
```python
# After: any difference is rejected
if remote_val != local_val:
    self.logger.warning(f"Rejected sync: Balance modification for {pk}")
    continue
```


Files Changed
node/rustchain_sync.py — reject all balance modifications from peers
node/test_sync_balance_inflation.py — NEW test file (4 tests)
Wallet:  aroky-x86-miner
