### PR TITLE
[CLAIMS-BUG] CRIT-CLAIMS-1 + MED-CLAIMS-2: Signature bypass when PyNaCl missing + wrong UNIT divisor

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -36,7 +36,7 @@ try:
     HAVE_NACL = True
 except ImportError:
     HAVE_NACL = False
-    print("[WARN] PyNaCl not available - signature verification disabled")
+    print("[WARN] PyNaCl not available — claim signature verification will REJECT all claims")
 
 try:
     from claims_eligibility import (
@@ -146,9 +146,9 @@ def validate_claim_signature(
         (valid: bool, error_message: str or None)
     """
     if not HAVE_NACL:
-        # In production, this should return False
-        # For testing, we allow mock signatures
-        return True, None
+        # SECURITY: Fail closed — reject claims when the crypto library
+        # is unavailable rather than silently accepting any signature.
+        return False, "Ed25519 library (PyNaCl) is not installed — cannot verify signatures"
     
     try:
         # Decode hex strings
@@ -402,7 +402,7 @@ def get_claim_status(
                 "verified_at": row["verified_at"],
                 "settled_at": row["settled_at"],
                 "reward_urtc": row["reward_urtc"],
-                "reward_rtc": row["reward_urtc"] / 100_000_000,
+                "reward_rtc": row["reward_urtc"] / 1_000_000,
                 "wallet_address": row["wallet_address"],
                 "transaction_hash": row["transaction_hash"],
                 "settlement_batch": row["settlement_batch"],
@@ -522,7 +522,7 @@ def submit_claim(
         result["submitted_at"] = claim_record["submitted_at"]
         result["estimated_settlement"] = claim_record["estimated_settlement"]
         result["reward_urtc"] = eligibility["reward_urtc"]
-        result["reward_rtc"] = eligibility["reward_urtc"] / 100_000_000
+        result["reward_rtc"] = eligibility["reward_urtc"] / 1_000_000
         
         return result
     except DuplicateClaimError as e:
@@ -596,7 +596,7 @@ def get_claim_history(
                 "miner_id": miner_id,
                 "total_claims": total_count,
                 "total_claimed_urtc": total_claimed,
-                "total_claimed_rtc": total_claimed / 100_000_000,
+                "total_claimed_rtc": total_claimed / 1_000_000,
                 "claims": claims
             }
     except sqlite3.Error as e:

--- a/node/test_claims_security.py
+++ b/node/test_claims_security.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Tests for CRIT-CLAIMS-1 (signature bypass) and MED-CLAIMS-2 (UNIT mismatch).
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestClaimsSignatureBypass(unittest.TestCase):
+    """CRIT-CLAIMS-1: validate_claim_signature must fail when PyNaCl missing."""
+
+    def test_no_nacl_rejects_signature(self):
+        """When HAVE_NACL=False, signatures must be REJECTED, not accepted."""
+        import claims_submission as cs
+        original = cs.HAVE_NACL
+        try:
+            cs.HAVE_NACL = False
+            valid, error = cs.validate_claim_signature(
+                payload='{"miner_id":"attacker","epoch":1}',
+                signature="0" * 128,
+                public_key="1" * 64,
+            )
+            self.assertFalse(valid, "Must reject when PyNaCl is unavailable")
+            self.assertIn("not installed", error)
+        finally:
+            cs.HAVE_NACL = original
+
+    def test_nacl_available_verifies_properly(self):
+        """When HAVE_NACL=True, bad signatures must be rejected."""
+        import claims_submission as cs
+        if not cs.HAVE_NACL:
+            self.skipTest("PyNaCl not installed, skipping real verify test")
+
+        valid, error = cs.validate_claim_signature(
+            payload='{"test":"data"}',
+            signature="0" * 128,  # fake signature
+            public_key="1" * 64,  # fake key
+        )
+        self.assertFalse(valid, "Fake signature must be rejected")
+
+
+class TestClaimsUnitConsistency(unittest.TestCase):
+    """MED-CLAIMS-2: reward_rtc must use 1e6 (matching main server), not 1e8."""
+
+    def test_reward_rtc_uses_1e6(self):
+        """1,000,000 µRTC should display as 1.0 RTC, not 0.01 RTC."""
+        reward_urtc = 1_000_000
+        # The correct conversion (1e6 UNIT)
+        reward_rtc = reward_urtc / 1_000_000
+        self.assertEqual(reward_rtc, 1.0)
+
+    def test_old_unit_was_wrong(self):
+        """Verify the old 1e8 UNIT would produce wrong result."""
+        reward_urtc = 1_000_000
+        wrong_rtc = reward_urtc / 100_000_000  # old bug
+        self.assertAlmostEqual(wrong_rtc, 0.01)  # 100x too small
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Vulnerability Class
**Critical — Signature bypass + Medium — UNIT mismatch (250 RTC bounty)**
## Bug 1: CRIT-CLAIMS-1 — Signature verification silently disabled
`validate_claim_signature()` line 148-151:
```python
if not HAVE_NACL:
    return True, None  # ACCEPTS ANY SIGNATURE
The comment says "this should return False" but returns True. When PyNaCl isn't installed, any fake signature is accepted — anyone can claim any miner's epoch reward.

Fix: return False, "Ed25519 library not installed"