### PR TITLE
[BRIDGE-BUG] CRIT-BRIDGE-1: Float truncation in bridge transfer amount conversion

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -19,6 +19,7 @@ import time
 import hashlib
 import os
 from typing import Optional, Tuple, Dict, Any
+from decimal import Decimal
 from dataclasses import dataclass
 from enum import Enum
 
@@ -277,7 +278,7 @@ def create_bridge_transfer(
     now = int(time.time())
     current_epoch = slot_to_epoch(current_slot())
     
-    amount_i64 = int(request.amount_rtc * BRIDGE_UNIT)
+    amount_i64 = int(Decimal(str(request.amount_rtc)) * BRIDGE_UNIT)
     tx_hash = generate_bridge_tx_hash(
         request.direction,
         request.source_chain,

--- a/node/test_bridge_precision.py
+++ b/node/test_bridge_precision.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Tests for CRIT-BRIDGE-1: Float truncation in bridge amount conversion.
+"""
+
+import unittest
+from decimal import Decimal
+
+BRIDGE_UNIT = 1_000_000
+
+
+class TestBridgeFloatPrecision(unittest.TestCase):
+    """CRIT-BRIDGE-1: Bridge amounts must use Decimal, not float."""
+
+    def test_float_truncation_exists(self):
+        """int(2.01 * 1e6) = 2009999, not 2010000."""
+        broken = int(2.01 * BRIDGE_UNIT)
+        self.assertEqual(broken, 2009999)
+
+    def test_decimal_is_exact(self):
+        """Decimal(str(2.01)) * 1e6 = 2010000 exactly."""
+        fixed = int(Decimal("2.01") * BRIDGE_UNIT)
+        self.assertEqual(fixed, 2010000)
+
+    def test_bridge_amounts_exact(self):
+        """Common bridge amounts must be exact."""
+        for amount_rtc in [1.0, 5.5, 10.0, 100.0, 0.5, 2.01]:
+            result = int(Decimal(str(amount_rtc)) * BRIDGE_UNIT)
+            expected = round(amount_rtc * BRIDGE_UNIT)
+            self.assertEqual(result, expected,
+                             f"Bridge amount {amount_rtc} RTC must convert exactly")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Vulnerability Class
**Critical — Float truncation in cross-chain bridge (200 RTC bounty)**
## The Bug
`create_bridge_transfer()` line 280:
```python
amount_i64 = int(request.amount_rtc * BRIDGE_UNIT)
```
Same IEEE 754 truncation as CRIT-TX-1: int(2.01 * 1000000) = 2009999.

Both bridge_transfers and lock_ledger store the wrong amount.

Fix: int(Decimal(str(request.amount_rtc)) * BRIDGE_UNIT)

All 3 tests pass.

Files Changed
node/bridge_api.py — Decimal conversion + import
node/test_bridge_precision.py — NEW (3 tests)
Wallet: aroky-x86-miner 