### PR TITLE
docs: add CONTRIBUTING.md link to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,4 +240,4 @@ Named after a 486 laptop with oxidized serial ports that still boots to DOS and 
 
 
 ## Contributing
-Please read the [Bounty Board](https://github.com/Scottcjn/rustchain-bounties) for active tasks and rewards.
+Please read the [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and the [Bounty Board](https://github.com/Scottcjn/rustchain-bounties) for active tasks and rewards.


### PR DESCRIPTION
Closes #2783

## Summary
This PR adds a link to CONTRIBUTING.md in the Contributing section of README.md, improving documentation navigation for new contributors.

## Changes
- Add link to CONTRIBUTING.md in the Contributing section
- Keep existing Bounty Board link
- Improve documentation navigation for new contributors

## Testing
- Verified that CONTRIBUTING.md exists in the repository
- Verified that the link format is correct
- Followed the link to ensure it works

## Bounty Claim
This is my first PR for the [ONBOARD: 2 RTC] Star + Fix a Doc Issue bounty.

I have starred the Rustchain repository as required.