### PR TITLE
fix: credit withdrawal fees to founder community

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4031,9 +4031,13 @@ def request_withdrawal():
 
         # RIP-301: Route fee to mining pool (founder_community) instead of burning
         fee_urtc = int(WITHDRAWAL_FEE * UNIT)
+        fee_rtc = WITHDRAWAL_FEE
+        # Ensure founder_community row exists before crediting
+        c.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
+                  ("founder_community",))
         c.execute(
-            "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
-            (fee_urtc, "founder_community")
+            "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+            (fee_rtc, "founder_community")
         )
         c.execute(
             """INSERT INTO fee_events (source, source_id, miner_pk, fee_rtc, fee_urtc, destination, created_at)
@@ -4103,9 +4107,9 @@ def api_fee_pool():
 
         # Community fund balance (where fees go)
         fund_row = c.execute(
-            "SELECT COALESCE(amount_i64, 0) FROM balances WHERE miner_id = 'founder_community'"
+            "SELECT COALESCE(balance_rtc, 0) FROM balances WHERE miner_pk = 'founder_community'"
         ).fetchone()
-        fund_balance = fund_row[0] / 1_000_000.0 if fund_row else 0.0
+        fund_balance = fund_row[0] if fund_row else 0.0
 
     return jsonify({
         "rip": 301,
@@ -4748,11 +4752,10 @@ def bounty_multiplier():
 
         # Current balance
         bal_row = c.execute(
-            "SELECT COALESCE(amount_i64, 0) FROM balances WHERE miner_id = ?",
+            "SELECT COALESCE(balance_rtc, 0) FROM balances WHERE miner_pk = ?",
             ("founder_community",)
         ).fetchone()
-        remaining_urtc = bal_row[0] if bal_row else 0
-        remaining_rtc = remaining_urtc / 1000000.0
+        remaining_rtc = bal_row[0] if bal_row else 0.0
 
     # Half-life decay: multiplier = 0.5^(total_paid / half_life)
     multiplier = 0.5 ** (total_paid_rtc / BOUNTY_HALF_LIFE)

--- a/tests/test_requirements_extra.py
+++ b/tests/test_requirements_extra.py
@@ -61,3 +61,71 @@ def test_fee_calculation_logic():
     # Test case: insufficient balance for fee
     balance = 1.005
     assert balance < total_needed
+
+
+def test_withdrawal_fee_routed_to_founder_community(tmp_path):
+    """Verify withdrawal fee is credited to founder_community using correct columns.
+
+    Regression test for the bug where fee routing used non-existent columns
+    (amount_i64 / miner_id) instead of the actual schema columns
+    (balance_rtc / miner_pk), causing fees to be silently burned.
+    """
+    db_path = str(tmp_path / "test_fee_routing.db")
+    UNIT = 1_000_000
+    WITHDRAWAL_FEE = 0.01
+
+    with sqlite3.connect(db_path) as conn:
+        c = conn.cursor()
+        # Create balances table with the actual schema (miner_pk, balance_rtc)
+        c.execute("CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+        c.execute("""CREATE TABLE IF NOT EXISTS fee_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            source TEXT NOT NULL, source_id TEXT, miner_pk TEXT,
+            fee_rtc REAL NOT NULL, fee_urtc INTEGER NOT NULL,
+            destination TEXT NOT NULL, created_at INTEGER NOT NULL
+        )""")
+
+        # Seed miner with enough balance
+        c.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
+                  ("RTC_test_miner", 10.0))
+
+        # Simulate the FIXED withdrawal fee routing logic
+        amount = 1.0
+        total_needed = amount + WITHDRAWAL_FEE
+        c.execute("UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?",
+                  (total_needed, "RTC_test_miner"))
+
+        fee_urtc = int(WITHDRAWAL_FEE * UNIT)
+        fee_rtc = WITHDRAWAL_FEE
+        # Ensure founder_community row exists
+        c.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
+                  ("founder_community",))
+        c.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+                  (fee_rtc, "founder_community"))
+        c.execute(
+            "INSERT INTO fee_events (source, source_id, miner_pk, fee_rtc, fee_urtc, destination, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("withdrawal", "WD_test", "RTC_test_miner", fee_rtc, fee_urtc, "founder_community", int(time.time()))
+        )
+
+        # Verify miner balance was deducted correctly
+        miner_bal = c.execute(
+            "SELECT balance_rtc FROM balances WHERE miner_pk = ?", ("RTC_test_miner",)
+        ).fetchone()[0]
+        assert miner_bal == pytest.approx(10.0 - total_needed), \
+            f"Miner balance should be {10.0 - total_needed}, got {miner_bal}"
+
+        # Verify founder_community received the fee (not burned)
+        fc_bal = c.execute(
+            "SELECT balance_rtc FROM balances WHERE miner_pk = ?", ("founder_community",)
+        ).fetchone()[0]
+        assert fc_bal == pytest.approx(WITHDRAWAL_FEE), \
+            f"founder_community should have {WITHDRAWAL_FEE} RTC, got {fc_bal}"
+
+        # Verify fee_events recorded correctly
+        fee_row = c.execute(
+            "SELECT fee_rtc, destination FROM fee_events WHERE source = 'withdrawal'"
+        ).fetchone()
+        assert fee_row is not None, "fee_events should have a withdrawal entry"
+        assert fee_row[0] == WITHDRAWAL_FEE
+        assert fee_row[1] == "founder_community"


### PR DESCRIPTION
# Fix: Route withdrawal fees to correct columns (balance_rtc / miner_pk)

## Problem
RIP-301 withdrawal fee routing used non-existent columns `amount_i64` and `miner_id` on the `balances` table. The actual schema has `miner_pk` and `balance_rtc`. The `UPDATE` silently affected 0 rows, burning fees instead of crediting `founder_community`.

## Changes

### `node/rustchain_v2_integrated_v2.2.1_rip200.py`
Three locations fixed:

1. **`request_withdrawal()` (line ~4033):** Fee credit `UPDATE` now uses `balance_rtc` / `miner_pk`. Added `INSERT OR IGNORE` to ensure the `founder_community` row exists before crediting.

2. **`/api/fee_pool` (line ~4109):** Community fund balance read now uses `balance_rtc` / `miner_pk`. Removed incorrect `/ 1_000_000` division (the old code treated `amount_i64` as micro-units; `balance_rtc` is already in RTC).

3. **`/api/bounty-multiplier` (line ~4754):** Community fund balance read now uses `balance_rtc` / `miner_pk`. Removed incorrect micro-unit conversion.

### `tests/test_requirements_extra.py`
Added `test_withdrawal_fee_routed_to_founder_community` — a focused regression test that:
- Creates a `balances` table with the actual schema (`miner_pk`, `balance_rtc`)
- Simulates the full withdrawal fee routing flow
- Asserts the fee is credited to `founder_community` (not burned)
- Verifies the `fee_events` audit record is consistent

## Verification
```
pytest tests/test_requirements_extra.py -v
# 4 passed, 0 failed
```

## Scope
Minimal, targeted fix. No refactoring. Only the 3 broken SQL statements and 1 new test.
