### PR TITLE
fix: persist cross-chain airdrop dedup state across restarts

### DIFF
--- a/cross-chain-airdrop/Cargo.lock
+++ b/cross-chain-airdrop/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +292,7 @@ dependencies = [
  "hex",
  "mockito",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -352,6 +365,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "find-msvc-tools"
@@ -505,6 +530,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -517,6 +551,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -862,6 +905,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,6 +1063,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "potential_utf"
@@ -1188,6 +1248,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1709,6 +1783,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/cross-chain-airdrop/Cargo.toml
+++ b/cross-chain-airdrop/Cargo.toml
@@ -55,9 +55,16 @@ bs58 = "0.5"
 # Async trait
 async-trait = "0.1"
 
+# Optional: persistent claim store (SQLite-backed)
+rusqlite = { version = "0.31", features = ["bundled"], optional = true }
+
 [dev-dependencies]
 tokio-test = "0.4"
 mockito = "1.2"
+
+[features]
+default = []
+sqlite-store = ["dep:rusqlite"]
 
 [profile.release]
 opt-level = 3

--- a/cross-chain-airdrop/src/bin/airdrop_cli.rs
+++ b/cross-chain-airdrop/src/bin/airdrop_cli.rs
@@ -13,6 +13,10 @@ use std::sync::Arc;
 use tracing::{info, Level};
 use tracing_subscriber::FmtSubscriber;
 
+/// Default path for the persistent claim store.
+#[cfg(feature = "sqlite-store")]
+const DEFAULT_STORE_PATH: &str = "airdrop_claims.sqlite";
+
 #[derive(Parser)]
 #[command(name = "airdrop-cli")]
 #[command(author = "RustChain Contributors")]
@@ -114,6 +118,19 @@ async fn main() -> Result<()> {
     let solana_adapter = Arc::new(SolanaAdapter::with_defaults(config.solana_rpc_url.clone()));
     let base_adapter = Arc::new(BaseAdapter::with_defaults(config.base_rpc_url.clone()));
 
+    // Use SQLite-backed store for durable duplicate-claim prevention
+    #[cfg(feature = "sqlite-store")]
+    let pipeline = {
+        let store = cross_chain_airdrop::SqliteClaimStore::open(DEFAULT_STORE_PATH)
+            .expect("Failed to open claim store");
+        VerificationPipeline::with_store(
+            github_verifier,
+            vec![solana_adapter.clone(), base_adapter.clone()],
+            store,
+        )
+    };
+
+    #[cfg(not(feature = "sqlite-store"))]
     let pipeline = VerificationPipeline::new(
         github_verifier,
         vec![solana_adapter.clone(), base_adapter.clone()],

--- a/cross-chain-airdrop/src/claim_store.rs
+++ b/cross-chain-airdrop/src/claim_store.rs
@@ -1,0 +1,580 @@
+//! Persistent claim store for duplicate-claim prevention
+//!
+//! The default [`InMemoryClaimStore`] loses state on restart, which means
+//! duplicate claims become possible if the process is restarted between
+//! claims (e.g. each invocation of the `airdrop-cli` CLI).
+//!
+//! For production use, prefer [`SqliteClaimStore`], which persists claimed
+//! GitHub IDs and wallet addresses to a local SQLite file so duplicates are
+//! rejected even after restart.
+
+use crate::error::{AirdropError, Result};
+use crate::models::{ClaimRecord, ClaimStatus};
+use chrono::Utc;
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+// ---------------------------------------------------------------------------
+// Trait
+// ---------------------------------------------------------------------------
+
+/// Abstract store for claim deduplication state.
+///
+/// Implementations must be `Send + Sync` so they can be shared across
+/// async tasks.
+pub trait ClaimStore: Send + Sync {
+    /// Return true if the GitHub account has already claimed.
+    fn is_github_claimed(&self, github_id: u64) -> Result<bool>;
+
+    /// Return true if the wallet has already claimed on the given chain.
+    fn is_wallet_claimed(&self, chain: &str, address: &str) -> Result<bool>;
+
+    /// Atomically record a new claim.  Returns an error if either key
+    /// already exists (implementations should enforce uniqueness).
+    fn record_claim(
+        &self,
+        github_id: u64,
+        chain: &str,
+        address: &str,
+        record: ClaimRecord,
+    ) -> Result<()>;
+
+    /// Look up a stored claim by ID.
+    fn get_claim(&self, claim_id: &str) -> Result<Option<ClaimRecord>>;
+
+    /// Update the status of an existing claim.
+    fn update_claim(
+        &self,
+        claim_id: &str,
+        status: ClaimStatus,
+        lock_id: Option<String>,
+        rejection_reason: Option<String>,
+    ) -> Result<()>;
+
+    /// Return all stored claims.
+    fn get_claims(&self) -> Result<Vec<ClaimRecord>>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory implementation (current behaviour — NOT durable)
+// ---------------------------------------------------------------------------
+
+/// Volatile, in-memory claim store.
+///
+/// This is the **existing behaviour** of `VerificationPipeline`.  It is
+/// provided for backward compatibility and testing, but **should not be
+/// used in production** because all deduplication state is lost on
+/// process restart, allowing duplicate claims.
+#[derive(Default)]
+pub struct InMemoryClaimStore {
+    claims: Mutex<Vec<ClaimRecord>>,
+    claimed_github_ids: Mutex<HashSet<u64>>,
+    claimed_wallets: Mutex<HashSet<String>>,
+}
+
+impl InMemoryClaimStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ClaimStore for InMemoryClaimStore {
+    fn is_github_claimed(&self, github_id: u64) -> Result<bool> {
+        let set = self
+            .claimed_github_ids
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        Ok(set.contains(&github_id))
+    }
+
+    fn is_wallet_claimed(&self, chain: &str, address: &str) -> Result<bool> {
+        let set = self
+            .claimed_wallets
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        Ok(set.contains(&format!("{}:{}", chain, address)))
+    }
+
+    fn record_claim(
+        &self,
+        github_id: u64,
+        chain: &str,
+        address: &str,
+        record: ClaimRecord,
+    ) -> Result<()> {
+        // Check uniqueness before inserting (mimics DB constraint)
+        if self.is_github_claimed(github_id)? {
+            return Err(AirdropError::Claim(format!(
+                "GitHub account {} has already claimed airdrop",
+                record.github_login
+            )));
+        }
+        if self.is_wallet_claimed(chain, address)? {
+            return Err(AirdropError::Claim(format!(
+                "Wallet {} on {} has already claimed airdrop",
+                address, chain
+            )));
+        }
+
+        let mut claims = self
+            .claims
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        claims.push(record);
+
+        let mut gh = self
+            .claimed_github_ids
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        gh.insert(github_id);
+
+        let mut wl = self
+            .claimed_wallets
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        wl.insert(format!("{}:{}", chain, address));
+
+        Ok(())
+    }
+
+    fn get_claim(&self, claim_id: &str) -> Result<Option<ClaimRecord>> {
+        let claims = self
+            .claims
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        Ok(claims.iter().find(|c| c.claim_id == claim_id).cloned())
+    }
+
+    fn update_claim(
+        &self,
+        claim_id: &str,
+        status: ClaimStatus,
+        lock_id: Option<String>,
+        rejection_reason: Option<String>,
+    ) -> Result<()> {
+        let mut claims = self
+            .claims
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        if let Some(claim) = claims.iter_mut().find(|c| c.claim_id == claim_id) {
+            claim.status = status;
+            claim.updated_at = Utc::now();
+            if let Some(lid) = lock_id {
+                claim.lock_id = Some(lid);
+            }
+            claim.rejection_reason = rejection_reason;
+            Ok(())
+        } else {
+            Err(AirdropError::Claim(format!("Claim not found: {}", claim_id)))
+        }
+    }
+
+    fn get_claims(&self) -> Result<Vec<ClaimRecord>> {
+        let claims = self
+            .claims
+            .lock()
+            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        Ok(claims.clone())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite implementation (durable)
+// ---------------------------------------------------------------------------
+
+/// SQLite-backed claim store.
+///
+/// Persists deduplication state to a local file so duplicate claims are
+/// rejected even after process restart.
+#[cfg(feature = "sqlite-store")]
+pub struct SqliteClaimStore {
+    conn: std::sync::Arc<Mutex<rusqlite::Connection>>,
+}
+
+#[cfg(feature = "sqlite-store")]
+impl SqliteClaimStore {
+    /// Open (or create) a SQLite database at the given path.
+    pub fn open(path: &str) -> Result<Self> {
+        let conn = rusqlite::Connection::open(path).map_err(|e| {
+            AirdropError::Claim(format!("Failed to open claim store DB: {}", e))
+        })?;
+
+        conn.execute_batch(
+            "
+            CREATE TABLE IF NOT EXISTS claims (
+                claim_id    TEXT PRIMARY KEY,
+                github_id   INTEGER NOT NULL,
+                chain       TEXT NOT NULL,
+                address     TEXT NOT NULL,
+                record_json TEXT NOT NULL,
+                UNIQUE(github_id),
+                UNIQUE(chain, address)
+            );
+            ",
+        )
+        .map_err(|e| AirdropError::Claim(format!("Failed to init claim store schema: {}", e)))?;
+
+        Ok(Self {
+            conn: std::sync::Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    /// Create an ephemeral in-memory database (useful for testing).
+    pub fn memory() -> Result<Self> {
+        Self::open(":memory:")
+    }
+}
+
+#[cfg(feature = "sqlite-store")]
+impl ClaimStore for SqliteClaimStore {
+    fn is_github_claimed(&self, github_id: u64) -> Result<bool> {
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+        let mut stmt = conn
+            .prepare("SELECT COUNT(*) FROM claims WHERE github_id = ?")
+            .map_err(|e| AirdropError::Claim(format!("SQL prepare error: {}", e)))?;
+        let count: i64 = stmt
+            .query_row([github_id], |row| row.get(0))
+            .map_err(|e| AirdropError::Claim(format!("SQL query error: {}", e)))?;
+        Ok(count > 0)
+    }
+
+    fn is_wallet_claimed(&self, chain: &str, address: &str) -> Result<bool> {
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+        let mut stmt = conn
+            .prepare("SELECT COUNT(*) FROM claims WHERE chain = ? AND address = ?")
+            .map_err(|e| AirdropError::Claim(format!("SQL prepare error: {}", e)))?;
+        let count: i64 = stmt
+            .query_row([chain, address], |row| row.get(0))
+            .map_err(|e| AirdropError::Claim(format!("SQL query error: {}", e)))?;
+        Ok(count > 0)
+    }
+
+    fn record_claim(
+        &self,
+        github_id: u64,
+        chain: &str,
+        address: &str,
+        record: ClaimRecord,
+    ) -> Result<()> {
+        let json = serde_json::to_string(&record).map_err(|e| {
+            AirdropError::Claim(format!("Failed to serialize claim: {}", e))
+        })?;
+
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+
+        conn.execute(
+            "INSERT INTO claims (claim_id, github_id, chain, address, record_json)
+             VALUES (?, ?, ?, ?, ?)",
+            [&record.claim_id, &github_id.to_string(), chain, address, &json],
+        )
+        .map_err(|e: rusqlite::Error| {
+            let msg = e.to_string();
+            if msg.contains("UNIQUE") || msg.contains("unique") {
+                if msg.contains("github_id") {
+                    AirdropError::Claim(format!(
+                        "GitHub account {} has already claimed airdrop",
+                        record.github_login
+                    ))
+                } else {
+                    AirdropError::Claim(format!(
+                        "Wallet {} on {} has already claimed airdrop",
+                        address, chain
+                    ))
+                }
+            } else {
+                AirdropError::Claim(format!("Failed to record claim: {}", e))
+            }
+        })?;
+
+        Ok(())
+    }
+
+    fn get_claim(&self, claim_id: &str) -> Result<Option<ClaimRecord>> {
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+        let mut stmt = conn
+            .prepare("SELECT record_json FROM claims WHERE claim_id = ?")
+            .map_err(|e| AirdropError::Claim(format!("SQL prepare error: {}", e)))?;
+        let result: std::result::Result<String, rusqlite::Error> =
+            stmt.query_row([claim_id], |row| row.get(0));
+
+        match result {
+            Ok(json) => {
+                let record: ClaimRecord = serde_json::from_str(&json).map_err(|e| {
+                    AirdropError::Claim(format!("Failed to deserialize claim: {}", e))
+                })?;
+                Ok(Some(record))
+            }
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(AirdropError::Claim(format!("SQL query error: {}", e))),
+        }
+    }
+
+    fn update_claim(
+        &self,
+        claim_id: &str,
+        status: ClaimStatus,
+        lock_id: Option<String>,
+        rejection_reason: Option<String>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+
+        let mut stmt = conn
+            .prepare("SELECT record_json FROM claims WHERE claim_id = ?")
+            .map_err(|e| AirdropError::Claim(format!("SQL prepare error: {}", e)))?;
+        let result: std::result::Result<String, rusqlite::Error> =
+            stmt.query_row([claim_id], |row| row.get(0));
+
+        let json = result.map_err(|e| match e {
+            rusqlite::Error::QueryReturnedNoRows => {
+                AirdropError::Claim(format!("Claim not found: {}", claim_id))
+            }
+            other => AirdropError::Claim(format!("SQL query error: {}", other)),
+        })?;
+
+        let mut record: ClaimRecord = serde_json::from_str(&json).map_err(|e| {
+            AirdropError::Claim(format!("Failed to deserialize claim: {}", e))
+        })?;
+
+        record.status = status;
+        record.updated_at = Utc::now();
+        if let Some(lid) = lock_id {
+            record.lock_id = Some(lid);
+        }
+        record.rejection_reason = rejection_reason;
+
+        let json = serde_json::to_string(&record).map_err(|e| {
+            AirdropError::Claim(format!("Failed to serialize claim: {}", e))
+        })?;
+        conn.execute(
+            "UPDATE claims SET record_json = ? WHERE claim_id = ?",
+            [&json, claim_id],
+        )
+        .map_err(|e| AirdropError::Claim(format!("Failed to update claim: {}", e)))?;
+
+        Ok(())
+    }
+
+    fn get_claims(&self) -> Result<Vec<ClaimRecord>> {
+        let conn = self.conn.lock().map_err(|e| {
+            AirdropError::Claim(format!("Lock poisoning: {}", e))
+        })?;
+        let mut stmt = conn
+            .prepare("SELECT record_json FROM claims")
+            .map_err(|e| AirdropError::Claim(format!("SQL prepare error: {}", e)))?;
+        let mut rows = stmt
+            .query([])
+            .map_err(|e| AirdropError::Claim(format!("SQL query error: {}", e)))?;
+
+        let mut claims = Vec::new();
+        while let Some(row) = rows.next().map_err(|e| {
+            AirdropError::Claim(format!("SQL row iteration error: {}", e))
+        })? {
+            let json: String = row.get(0).map_err(|e| {
+                AirdropError::Claim(format!("SQL row error: {}", e))
+            })?;
+            let record: ClaimRecord = serde_json::from_str(&json).map_err(|e| {
+                AirdropError::Claim(format!("Failed to deserialize claim: {}", e))
+            })?;
+            claims.push(record);
+        }
+        Ok(claims)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{ClaimStatus, TargetChain};
+
+    fn test_record() -> ClaimRecord {
+        let now = Utc::now();
+        ClaimRecord {
+            claim_id: "test-claim-001".to_string(),
+            github_login: "testuser".to_string(),
+            github_id: 12345,
+            rtc_wallet: "RTCwallet1".to_string(),
+            target_chain: TargetChain::Solana,
+            target_address: "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU".to_string(),
+            status: ClaimStatus::Pending,
+            base_allocation: 100,
+            multiplier: 1.0,
+            final_allocation: 100,
+            lock_id: None,
+            bridge_tx_hash: None,
+            rejection_reason: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    // --- InMemoryClaimStore tests ---
+
+    #[test]
+    fn test_inmemory_record_and_dedup() {
+        let store = InMemoryClaimStore::new();
+        let rec = test_record();
+
+        // First claim should succeed
+        store
+            .record_claim(rec.github_id, "solana", &rec.target_address, rec.clone())
+            .unwrap();
+
+        // Duplicate GitHub should fail
+        assert!(store
+            .record_claim(rec.github_id, "solana", "different_address", rec.clone())
+            .is_err());
+
+        // Duplicate wallet should fail
+        assert!(store
+            .record_claim(99999, "solana", &rec.target_address, rec.clone())
+            .is_err());
+
+        // Different GitHub + different wallet should succeed
+        let mut rec2 = rec.clone();
+        rec2.claim_id = "test-claim-002".to_string();
+        rec2.github_id = 99999;
+        rec2.github_login = "otheruser".to_string();
+        rec2.target_address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string();
+        let addr2 = rec2.target_address.clone();
+        store
+            .record_claim(rec2.github_id, "solana", &addr2, rec2)
+            .unwrap();
+    }
+
+    #[test]
+    fn test_inmemory_get_and_update_claim() {
+        let store = InMemoryClaimStore::new();
+        let rec = test_record();
+        let addr = rec.target_address.clone();
+        store
+            .record_claim(rec.github_id, "solana", &addr, rec.clone())
+            .unwrap();
+
+        // Retrieve
+        let found = store.get_claim(&rec.claim_id).unwrap().unwrap();
+        assert_eq!(found.status, ClaimStatus::Pending);
+
+        // Update
+        store
+            .update_claim(&rec.claim_id, ClaimStatus::Complete, Some("lock-1".to_string()), None)
+            .unwrap();
+
+        let updated = store.get_claim(&rec.claim_id).unwrap().unwrap();
+        assert_eq!(updated.status, ClaimStatus::Complete);
+        assert_eq!(updated.lock_id, Some("lock-1".to_string()));
+    }
+
+    #[test]
+    fn test_inmemory_get_claims() {
+        let store = InMemoryClaimStore::new();
+        assert_eq!(store.get_claims().unwrap().len(), 0);
+
+        let rec = test_record();
+        let addr = rec.target_address.clone();
+        store
+            .record_claim(rec.github_id, "solana", &addr, rec)
+            .unwrap();
+
+        assert_eq!(store.get_claims().unwrap().len(), 1);
+    }
+
+    // --- SqliteClaimStore tests (feature-gated) ---
+
+    #[cfg(feature = "sqlite-store")]
+    #[test]
+    fn test_sqlite_record_and_dedup() {
+        let store = SqliteClaimStore::memory().unwrap();
+        let rec = test_record();
+        let addr = rec.target_address.clone();
+        store
+            .record_claim(rec.github_id, "solana", &addr, rec.clone())
+            .unwrap();
+
+        // Duplicate GitHub
+        assert!(store
+            .record_claim(rec.github_id, "solana", "different_address", rec.clone())
+            .is_err());
+
+        // Duplicate wallet
+        assert!(store
+            .record_claim(99999, "solana", &rec.target_address, rec.clone())
+            .is_err());
+
+        // Different keys → OK
+        let mut rec2 = rec.clone();
+        rec2.claim_id = "test-claim-002".to_string();
+        rec2.github_id = 99999;
+        rec2.github_login = "otheruser".to_string();
+        rec2.target_address = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM".to_string();
+        let addr2 = rec2.target_address.clone();
+        store
+            .record_claim(rec2.github_id, "solana", &addr2, rec2)
+            .unwrap();
+    }
+
+    #[cfg(feature = "sqlite-store")]
+    #[test]
+    fn test_sqlite_survives_reopen() {
+        let path = std::env::temp_dir().join("airdrop_claim_store_test.sqlite");
+        let _ = std::fs::remove_file(&path);
+
+        {
+            let store = SqliteClaimStore::open(path.to_str().unwrap()).unwrap();
+            let rec = test_record();
+            let addr = rec.target_address.clone();
+            store
+                .record_claim(rec.github_id, "solana", &addr, rec)
+                .unwrap();
+        }
+
+        {
+            let store = SqliteClaimStore::open(path.to_str().unwrap()).unwrap();
+            assert!(store.is_github_claimed(12345).unwrap());
+            assert!(store.is_wallet_claimed("solana", "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU").unwrap());
+
+            let rec2 = test_record();
+            let addr2 = rec2.target_address.clone();
+            assert!(store
+                .record_claim(rec2.github_id, "solana", &addr2, rec2)
+                .is_err());
+        }
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[cfg(feature = "sqlite-store")]
+    #[test]
+    fn test_sqlite_get_and_update_claim() {
+        let store = SqliteClaimStore::memory().unwrap();
+        let rec = test_record();
+        let addr = rec.target_address.clone();
+        store
+            .record_claim(rec.github_id, "solana", &addr, rec.clone())
+            .unwrap();
+
+        let found = store.get_claim(&rec.claim_id).unwrap().unwrap();
+        assert_eq!(found.status, ClaimStatus::Pending);
+
+        store
+            .update_claim(&rec.claim_id, ClaimStatus::Complete, Some("lock-1".to_string()), None)
+            .unwrap();
+
+        let updated = store.get_claim(&rec.claim_id).unwrap().unwrap();
+        assert_eq!(updated.status, ClaimStatus::Complete);
+        assert_eq!(updated.lock_id, Some("lock-1".to_string()));
+    }
+}

--- a/cross-chain-airdrop/src/lib.rs
+++ b/cross-chain-airdrop/src/lib.rs
@@ -55,6 +55,7 @@
 
 pub mod bridge_client;
 pub mod chain_adapter;
+pub mod claim_store;
 pub mod config;
 pub mod error;
 pub mod github_verifier;
@@ -62,6 +63,9 @@ pub mod models;
 pub mod pipeline;
 
 // Re-export commonly used types
+pub use claim_store::{ClaimStore, InMemoryClaimStore};
+#[cfg(feature = "sqlite-store")]
+pub use claim_store::SqliteClaimStore;
 pub use config::AirdropConfig as Config;
 pub use error::{AirdropError, Result};
 pub use github_verifier::GitHubVerifier;

--- a/cross-chain-airdrop/src/pipeline.rs
+++ b/cross-chain-airdrop/src/pipeline.rs
@@ -1,39 +1,58 @@
 //! Verification pipeline for cross-chain airdrop claims
 
 use crate::chain_adapter::ChainAdapter;
+use crate::claim_store::{ClaimStore, InMemoryClaimStore};
 use crate::error::{AirdropError, Result};
 use crate::github_verifier::GitHubVerifier;
 use crate::models::{
     ClaimRecord, ClaimRequest, ClaimResponse, ClaimStatus, EligibilityResult, TargetChain,
 };
 use chrono::Utc;
-use std::collections::HashSet;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use uuid::Uuid;
 
-/// Verification pipeline for processing airdrop claims
-pub struct VerificationPipeline {
+/// Verification pipeline for processing airdrop claims.
+///
+/// The `S` type parameter controls where deduplication state is stored.
+/// By default an [`InMemoryClaimStore`] is used (volatile — state is lost
+/// on restart).  For production deployments pass a durable store such as
+/// [`SqliteClaimStore`](crate::SqliteClaimStore) so that duplicate claims
+/// are rejected even after the process restarts.
+pub struct VerificationPipeline<S = InMemoryClaimStore> {
     github_verifier: GitHubVerifier,
     chain_adapters: Vec<Arc<dyn ChainAdapter>>,
-    /// In-memory claim store (would be database in production)
-    claims: Arc<Mutex<Vec<ClaimRecord>>>,
-    /// Track claimed GitHub accounts to prevent duplicates
-    claimed_github_ids: Arc<Mutex<HashSet<u64>>>,
-    /// Track claimed wallet addresses to prevent duplicates
-    claimed_wallets: Arc<Mutex<HashSet<String>>>,
+    store: S,
 }
 
-impl VerificationPipeline {
+impl VerificationPipeline<InMemoryClaimStore> {
+    /// Create a pipeline with the default in-memory claim store.
+    ///
+    /// **Warning:** the in-memory store loses all deduplication state on
+    /// process restart, allowing the same GitHub account or wallet to
+    /// claim again.  Use [`VerificationPipeline::with_store`] with a
+    /// persistent [`ClaimStore`] for production use.
     pub fn new(
         github_verifier: GitHubVerifier,
         chain_adapters: Vec<Arc<dyn ChainAdapter>>,
     ) -> Self {
+        Self::with_store(github_verifier, chain_adapters, InMemoryClaimStore::new())
+    }
+}
+
+impl<S: ClaimStore> VerificationPipeline<S> {
+    /// Create a pipeline with a custom claim store.
+    ///
+    /// Use this to plug in a persistent store (e.g. SQLite) so that
+    /// duplicate-claim prevention survives process restarts.
+    pub fn with_store(
+        github_verifier: GitHubVerifier,
+        chain_adapters: Vec<Arc<dyn ChainAdapter>>,
+        store: S,
+    ) -> Self {
         Self {
             github_verifier,
             chain_adapters,
-            claims: Arc::new(Mutex::new(Vec::new())),
-            claimed_github_ids: Arc::new(Mutex::new(HashSet::new())),
-            claimed_wallets: Arc::new(Mutex::new(HashSet::new())),
+            store,
         }
     }
 
@@ -49,17 +68,15 @@ impl VerificationPipeline {
             .await
             .map_err(|e| AirdropError::Claim(format!("GitHub verification failed: {}", e)))?;
 
-        // Step 2: Check for duplicate GitHub account
+        // Step 2: Check for duplicate GitHub account (via store)
+        if self
+            .store
+            .is_github_claimed(github_verification.profile.id)?
         {
-            let mut claimed = self.claimed_github_ids.lock().map_err(|e| {
-                AirdropError::Claim(format!("Lock poisoning: {}", e))
-            })?;
-            if claimed.contains(&github_verification.profile.id) {
-                return Err(AirdropError::Claim(format!(
-                    "GitHub account {} has already claimed airdrop",
-                    github_verification.profile.login
-                )));
-            }
+            return Err(AirdropError::Claim(format!(
+                "GitHub account {} has already claimed airdrop",
+                github_verification.profile.login
+            )));
         }
 
         // Step 3: Find appropriate chain adapter
@@ -77,18 +94,16 @@ impl VerificationPipeline {
             .await
             .map_err(|e| AirdropError::Claim(format!("Wallet verification failed: {}", e)))?;
 
-        // Step 5: Check for duplicate wallet
+        // Step 5: Check for duplicate wallet (via store)
+        let chain_str = request.target_chain.to_string();
+        if self
+            .store
+            .is_wallet_claimed(&chain_str, &request.target_address)?
         {
-            let claimed = self.claimed_wallets.lock().map_err(|e| {
-                AirdropError::Claim(format!("Lock poisoning: {}", e))
-            })?;
-            let wallet_key = format!("{}:{}", request.target_chain, request.target_address);
-            if claimed.contains(&wallet_key) {
-                return Err(AirdropError::Claim(format!(
-                    "Wallet {} on {} has already claimed airdrop",
-                    request.target_address, request.target_chain
-                )));
-            }
+            return Err(AirdropError::Claim(format!(
+                "Wallet {} on {} has already claimed airdrop",
+                request.target_address, request.target_chain
+            )));
         }
 
         // Step 6: Calculate eligibility
@@ -104,7 +119,7 @@ impl VerificationPipeline {
             )));
         }
 
-        // Step 7: Record the claim as pending
+        // Step 7: Record the claim as pending (atomically checks + inserts)
         let claim_record = ClaimRecord {
             claim_id: claim_id.clone(),
             github_login: github_verification.profile.login.clone(),
@@ -123,33 +138,15 @@ impl VerificationPipeline {
             updated_at: now,
         };
 
-        // Store claim and mark as claimed
-        {
-            let mut claims = self.claims.lock().map_err(|e| {
-                AirdropError::Claim(format!("Lock poisoning: {}", e))
-            })?;
-            claims.push(claim_record.clone());
-        }
-
-        {
-            let mut claimed_github = self.claimed_github_ids.lock().map_err(|e| {
-                AirdropError::Claim(format!("Lock poisoning: {}", e))
-            })?;
-            claimed_github.insert(github_verification.profile.id);
-        }
-
-        {
-            let mut claimed_wallets = self.claimed_wallets.lock().map_err(|e| {
-                AirdropError::Claim(format!("Lock poisoning: {}", e))
-            })?;
-            claimed_wallets.insert(format!(
-                "{}:{}",
-                request.target_chain, request.target_address
-            ));
-        }
+        self.store.record_claim(
+            github_verification.profile.id,
+            &chain_str,
+            &request.target_address,
+            claim_record.clone(),
+        )?;
 
         let target_chain_str = request.target_chain.to_string();
-        
+
         Ok(ClaimResponse {
             claim_id,
             status: ClaimStatus::Pending,
@@ -202,20 +199,12 @@ impl VerificationPipeline {
 
     /// Get all claims
     pub fn get_claims(&self) -> Result<Vec<ClaimRecord>> {
-        let claims = self
-            .claims
-            .lock()
-            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
-        Ok(claims.clone())
+        self.store.get_claims()
     }
 
     /// Get claim by ID
     pub fn get_claim(&self, claim_id: &str) -> Result<Option<ClaimRecord>> {
-        let claims = self
-            .claims
-            .lock()
-            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
-        Ok(claims.iter().find(|c| c.claim_id == claim_id).cloned())
+        self.store.get_claim(claim_id)
     }
 
     /// Update claim status
@@ -226,30 +215,13 @@ impl VerificationPipeline {
         lock_id: Option<String>,
         rejection_reason: Option<String>,
     ) -> Result<()> {
-        let mut claims = self
-            .claims
-            .lock()
-            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
-
-        if let Some(claim) = claims.iter_mut().find(|c| c.claim_id == claim_id) {
-            claim.status = status;
-            claim.updated_at = Utc::now();
-            if let Some(lid) = lock_id {
-                claim.lock_id = Some(lid);
-            }
-            claim.rejection_reason = rejection_reason;
-            Ok(())
-        } else {
-            Err(AirdropError::Claim(format!("Claim not found: {}", claim_id)))
-        }
+        self.store
+            .update_claim(claim_id, status, lock_id, rejection_reason)
     }
 
     /// Get statistics
     pub fn get_stats(&self) -> Result<AirdropStats> {
-        let claims = self
-            .claims
-            .lock()
-            .map_err(|e| AirdropError::Claim(format!("Lock poisoning: {}", e)))?;
+        let claims = self.store.get_claims()?;
 
         let total_claims = claims.len() as u64;
         let total_distributed: u64 = claims
@@ -274,7 +246,7 @@ impl VerificationPipeline {
                 solana: solana_claims,
                 base: base_claims,
             },
-            claims_by_tier: ClaimsByTier::default(), // Would need tier tracking
+            claims_by_tier: ClaimsByTier::default(),
         })
     }
 }


### PR DESCRIPTION
# Fix: persist airdrop dedup state so duplicate claims survive restart

## Problem

Duplicate-claim prevention in `cross-chain-airdrop` was purely in-memory (`HashSet` inside `VerificationPipeline`). After any process restart — including every CLI invocation — all dedup state was lost, allowing the same GitHub account or wallet to claim again.

## Solution

Introduced a `ClaimStore` trait with two implementations:

| Implementation | Persistence | Use case |
|---|---|---|
| `InMemoryClaimStore` | None (volatile) | Backward compat, testing |
| `SqliteClaimStore` | SQLite file | Production, CLI |

The pipeline is now generic over `S: ClaimStore`. `VerificationPipeline::new()` still defaults to `InMemoryClaimStore` (no breaking change). A new `with_store()` constructor accepts any implementation.

The CLI uses `SqliteClaimStore` by default when built with `--features sqlite-store`, writing to `airdrop_claims.sqlite` in the working directory.

## Key changes

- **`src/claim_store.rs`** (new) — `ClaimStore` trait, `InMemoryClaimStore`, `SqliteClaimStore` (feature-gated)
- **`src/pipeline.rs`** — generic over `S: ClaimStore`; `new()` delegates to `with_store(..., InMemoryClaimStore::new())`
- **`src/bin/airdrop_cli.rs`** — conditional compilation: `SqliteClaimStore` when feature enabled, `InMemoryClaimStore` otherwise
- **`Cargo.toml`** — optional `rusqlite` dep + `sqlite-store` feature

## Tests

- 3 new `InMemoryClaimStore` tests
- 3 new `SqliteClaimStore` tests (including `test_sqlite_survives_reopen` which proves state persists across DB close/reopen)
- All 43 tests pass with `--features sqlite-store`
- All 40 tests pass without the feature

## Compatibility

- No breaking changes — `VerificationPipeline::new()` signature unchanged
- `sqlite-store` feature is opt-in; zero new dependencies for existing users
- All existing tests pass without modification
