### PR TITLE
fix: use epoch snapshots for delayed RIP-200 settlement

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -139,32 +139,66 @@ def detect_duplicate_identities(
 ) -> List[MachineIdentity]:
     """
     Detect machines with multiple miner IDs in the same epoch.
-    
+
     Returns a list of MachineIdentity objects for machines that have
     multiple miner IDs associated with them.
+
+    FIX (settlement-integrity): Prefer epoch_enroll as the canonical miner list
+    (per-epoch snapshot, matches finalize_epoch).  Fall back to miner_attest_recent
+    time-window query only when epoch_enroll has no rows.
     """
     cursor = conn.cursor()
-    
-    # Get all attestations in the epoch window
-    cursor.execute("""
-        SELECT 
-            miner,
-            device_arch,
-            fingerprint_passed,
-            entropy_score,
-            (
-                SELECT profile_json 
-                FROM miner_fingerprint_history mfh 
-                WHERE mfh.miner = miner_attest_recent.miner 
-                ORDER BY mfh.ts DESC 
-                LIMIT 1
-            ) as latest_profile
-        FROM miner_attest_recent
-        WHERE ts_ok >= ? AND ts_ok <= ?
-        ORDER BY device_arch, entropy_score DESC
-    """, (epoch_start_ts, epoch_end_ts))
-    
-    rows = cursor.fetchall()
+
+    # Primary source: epoch_enroll (per-epoch snapshot).
+    cursor.execute(
+        "SELECT miner_pk FROM epoch_enroll WHERE epoch = ?",
+        (epoch,)
+    )
+    enrolled = cursor.fetchall()
+
+    if enrolled:
+        rows = []
+        for (miner_pk,) in enrolled:
+            profile_row = cursor.execute(
+                "SELECT profile_json FROM miner_fingerprint_history mfh "
+                "WHERE mfh.miner = ? ORDER BY mfh.ts DESC LIMIT 1",
+                (miner_pk,)
+            ).fetchone()
+            profile_json = profile_row[0] if profile_row else None
+            arch_row = cursor.execute(
+                "SELECT device_arch, fingerprint_passed, entropy_score "
+                "FROM miner_attest_recent WHERE miner = ? LIMIT 1",
+                (miner_pk,)
+            ).fetchone()
+            if arch_row:
+                device_arch = arch_row[0] or "unknown"
+                fingerprint_passed = arch_row[1]
+                entropy_score = arch_row[2]
+            else:
+                device_arch = "unknown"
+                fingerprint_passed = 1
+                entropy_score = 0.0
+            rows.append((miner_pk, device_arch, fingerprint_passed, entropy_score, profile_json))
+    else:
+        # Fallback: legacy path for epochs without enrollment records.
+        cursor.execute("""
+            SELECT
+                miner,
+                device_arch,
+                fingerprint_passed,
+                entropy_score,
+                (
+                    SELECT profile_json
+                    FROM miner_fingerprint_history mfh
+                    WHERE mfh.miner = miner_attest_recent.miner
+                    ORDER BY mfh.ts DESC
+                    LIMIT 1
+                ) as latest_profile
+            FROM miner_attest_recent
+            WHERE ts_ok >= ? AND ts_ok <= ?
+            ORDER BY device_arch, entropy_score DESC
+        """, (epoch_start_ts, epoch_end_ts))
+        rows = cursor.fetchall()
     
     # Group miners by machine identity
     identity_map: Dict[str, List[Tuple[str, Dict]]] = {}  # identity_hash -> [(miner_id, attestation_data)]
@@ -295,26 +329,51 @@ def get_epoch_miner_groups(
     epoch_end_slot = epoch_start_slot + 143
     epoch_start_ts = GENESIS_TIMESTAMP + (epoch_start_slot * BLOCK_TIME)
     epoch_end_ts = GENESIS_TIMESTAMP + (epoch_end_slot * BLOCK_TIME)
-    
+
     cursor = conn.cursor()
-    
-    # Get all attestations in epoch
-    cursor.execute("""
-        SELECT 
-            miner,
-            COALESCE(device_arch, 'unknown') as device_arch,
-            (
-                SELECT profile_json 
-                FROM miner_fingerprint_history mfh 
-                WHERE mfh.miner = miner_attest_recent.miner 
-                ORDER BY mfh.ts DESC 
-                LIMIT 1
-            ) as latest_profile
-        FROM miner_attest_recent
-        WHERE ts_ok >= ? AND ts_ok <= ?
-    """, (epoch_start_ts, epoch_end_ts))
-    
-    rows = cursor.fetchall()
+
+    # FIX (settlement-integrity): Prefer epoch_enroll as the canonical miner list
+    # (per-epoch snapshot, matches finalize_epoch).  Fall back to miner_attest_recent
+    # time-window query only when epoch_enroll has no rows.
+    cursor.execute(
+        "SELECT miner_pk FROM epoch_enroll WHERE epoch = ?",
+        (epoch,)
+    )
+    enrolled = cursor.fetchall()
+
+    if enrolled:
+        # Build miner list from epoch_enroll; look up arch + fingerprint history.
+        rows = []
+        for (miner_pk,) in enrolled:
+            profile_row = cursor.execute(
+                "SELECT profile_json FROM miner_fingerprint_history mfh "
+                "WHERE mfh.miner = ? ORDER BY mfh.ts DESC LIMIT 1",
+                (miner_pk,)
+            ).fetchone()
+            profile_json = profile_row[0] if profile_row else None
+            arch_row = cursor.execute(
+                "SELECT device_arch FROM miner_attest_recent WHERE miner = ? LIMIT 1",
+                (miner_pk,)
+            ).fetchone()
+            device_arch = (arch_row[0] or "unknown") if arch_row else "unknown"
+            rows.append((miner_pk, device_arch, profile_json))
+    else:
+        # Fallback: legacy path for epochs without enrollment records.
+        cursor.execute("""
+            SELECT
+                miner,
+                COALESCE(device_arch, 'unknown') as device_arch,
+                (
+                    SELECT profile_json
+                    FROM miner_fingerprint_history mfh
+                    WHERE mfh.miner = miner_attest_recent.miner
+                    ORDER BY mfh.ts DESC
+                    LIMIT 1
+                ) as latest_profile
+            FROM miner_attest_recent
+            WHERE ts_ok >= ? AND ts_ok <= ?
+        """, (epoch_start_ts, epoch_end_ts))
+        rows = cursor.fetchall()
     
     # Group by machine identity
     groups: Dict[str, List[str]] = {}

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -475,6 +475,12 @@ def calculate_epoch_rewards_time_aged(
     Each attested CPU gets rewards weighted by their time-aged antiquity multiplier.
     More miners = smaller individual rewards (anti-pool design).
 
+    FIX (settlement-integrity): Use epoch_enroll as the canonical miner list when
+    available, then look up device_arch from miner_attest_recent for the multiplier.
+    This ensures delayed settlement produces the same result as finalize_epoch()
+    which reads epoch_enroll directly.  Falls back to the old miner_attest_recent
+    time-window query only when epoch_enroll has no rows for the epoch.
+
     Args:
         db_path: Database path
         epoch: Epoch number to calculate rewards for
@@ -486,7 +492,6 @@ def calculate_epoch_rewards_time_aged(
     """
     chain_age_years = get_chain_age_years(current_slot)
 
-    # Get all miners who were attested during this epoch
     epoch_start_slot = epoch * 144
     epoch_end_slot = epoch_start_slot + 143
     epoch_start_ts = GENESIS_TIMESTAMP + (epoch_start_slot * BLOCK_TIME)
@@ -495,14 +500,40 @@ def calculate_epoch_rewards_time_aged(
     with sqlite3.connect(db_path) as conn:
         cursor = conn.cursor()
 
-        # Get unique attested miners during epoch (any attestation in epoch window)
-        cursor.execute("""
-            SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp
-            FROM miner_attest_recent
-            WHERE ts_ok >= ? AND ts_ok <= ?
-        """, (epoch_start_ts - ATTESTATION_TTL, epoch_end_ts))
+        # Primary source: epoch_enroll (per-epoch snapshot, matches finalize_epoch).
+        cursor.execute(
+            "SELECT miner_pk FROM epoch_enroll WHERE epoch = ?",
+            (epoch,)
+        )
+        enrolled = cursor.fetchall()
 
-        epoch_miners = cursor.fetchall()
+        if enrolled:
+            # Use enrolled miners; look up device_arch from latest attestation.
+            epoch_miners = []
+            for (miner_pk,) in enrolled:
+                arch_row = cursor.execute(
+                    "SELECT device_arch, COALESCE(fingerprint_passed, 1) "
+                    "FROM miner_attest_recent WHERE miner = ? LIMIT 1",
+                    (miner_pk,)
+                ).fetchone()
+                if arch_row:
+                    device_arch = arch_row[0] or "unknown"
+                    fp = arch_row[1]
+                else:
+                    # No attestation record — treat as unknown arch, fingerprint ok.
+                    device_arch = "unknown"
+                    fp = 1
+                epoch_miners.append((miner_pk, device_arch, fp))
+        else:
+            # Fallback: legacy path for epochs without enrollment records.
+            # This is vulnerable to the stale-attestation issue when settlement
+            # is delayed, but preserves backward compatibility.
+            cursor.execute("""
+                SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp
+                FROM miner_attest_recent
+                WHERE ts_ok >= ? AND ts_ok <= ?
+            """, (epoch_start_ts - ATTESTATION_TTL, epoch_end_ts))
+            epoch_miners = cursor.fetchall()
 
     if not epoch_miners:
         return {}

--- a/node/tests/test_settlement_integrity.py
+++ b/node/tests/test_settlement_integrity.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Tests for settlement-integrity fix: delayed settlement must produce the same
+reward distribution as immediate settlement by using epoch_enroll as the
+canonical miner list instead of the stale miner_attest_recent time-window query.
+"""
+
+import os
+import sys
+import sqlite3
+import tempfile
+import unittest
+
+# Ensure the node/ directory is on the import path.
+sys.path.insert(0, os.path.dirname(__file__))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from rip_200_round_robin_1cpu1vote import (
+    calculate_epoch_rewards_time_aged,
+    GENESIS_TIMESTAMP,
+    BLOCK_TIME,
+    ATTESTATION_TTL,
+)
+
+SLOTS_PER_EPOCH = 144
+UNIT = 1_000_000
+PER_EPOCH_URTC = int(1.5 * UNIT)
+
+
+def _setup_db(db_path: str) -> sqlite3.Connection:
+    """Create minimal schema needed for reward calculation."""
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS epoch_enroll (
+            epoch INTEGER, miner_pk TEXT, weight REAL,
+            PRIMARY KEY (epoch, miner_pk)
+        );
+        CREATE TABLE IF NOT EXISTS miner_attest_recent (
+            miner TEXT PRIMARY KEY,
+            device_arch TEXT,
+            fingerprint_passed INTEGER DEFAULT 1,
+            entropy_score REAL DEFAULT 0,
+            ts_ok INTEGER
+        );
+        CREATE TABLE IF NOT EXISTS miner_fingerprint_history (
+            miner TEXT, ts INTEGER, profile_json TEXT
+        );
+        CREATE TABLE IF NOT EXISTS epoch_state (
+            epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER
+        );
+    """)
+    return conn
+
+
+def _enroll_miner(conn, epoch: int, miner_pk: str, weight: float):
+    conn.execute(
+        "INSERT OR IGNORE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+        (epoch, miner_pk, weight),
+    )
+    conn.commit()
+
+
+def _attest_miner(conn, miner_pk: str, device_arch: str, ts_ok: int, fingerprint_passed: int = 1):
+    conn.execute(
+        "INSERT OR REPLACE INTO miner_attest_recent "
+        "(miner, device_arch, fingerprint_passed, entropy_score, ts_ok) "
+        "VALUES (?, ?, ?, 0.5, ?)",
+        (miner_pk, device_arch, fingerprint_passed, ts_ok),
+    )
+    conn.commit()
+
+
+class TestDelayedSettlementIntegrity(unittest.TestCase):
+    """Delayed settlement must use the same miner list as immediate settlement."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.conn = _setup_db(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def _epoch_ts(self, epoch: int):
+        start_ts = GENESIS_TIMESTAMP + (epoch * SLOTS_PER_EPOCH * BLOCK_TIME)
+        end_ts = GENESIS_TIMESTAMP + ((epoch + 1) * SLOTS_PER_EPOCH - 1) * BLOCK_TIME
+        return start_ts, end_ts
+
+    def test_delayed_settlement_uses_epoch_enroll(self):
+        """
+        Miner A enrolls in epoch 10, then re-attests in epoch 11.
+        Delayed settlement of epoch 10 must still include Miner A
+        because epoch_enroll has the per-epoch snapshot.
+        """
+        EPOCH = 10
+        start_ts, end_ts = self._epoch_ts(EPOCH)
+
+        # Miner A (G4) enrolls epoch 10
+        _enroll_miner(self.conn, EPOCH, "miner_A", weight=2.5)
+        _attest_miner(self.conn, "miner_A", "g4", ts_ok=start_ts + 100)
+
+        # Miner B (modern) enrolls epoch 10
+        _enroll_miner(self.conn, EPOCH, "miner_B", weight=1.0)
+        _attest_miner(self.conn, "miner_B", "x86_64", ts_ok=start_ts + 200)
+
+        # Immediate settlement of epoch 10
+        current_slot = EPOCH * SLOTS_PER_EPOCH + 72  # mid-epoch
+        rewards_immediate = calculate_epoch_rewards_time_aged(
+            self.db_path, EPOCH, PER_EPOCH_URTC, current_slot
+        )
+
+        self.assertIn("miner_A", rewards_immediate)
+        self.assertIn("miner_B", rewards_immediate)
+
+        # Now Miner A re-attests in epoch 11 (ts_ok moves forward)
+        epoch11_start = GENESIS_TIMESTAMP + (11 * SLOTS_PER_EPOCH * BLOCK_TIME)
+        _attest_miner(self.conn, "miner_A", "g4", ts_ok=epoch11_start + 100)
+
+        # Delayed settlement of epoch 10 (simulating node restart + catch-up)
+        # The old code would miss miner_A because ts_ok is now in epoch 11.
+        # The fix uses epoch_enroll, so miner_A should still be included.
+        current_slot_late = 11 * SLOTS_PER_EPOCH + 72  # epoch 11
+        rewards_delayed = calculate_epoch_rewards_time_aged(
+            self.db_path, EPOCH, PER_EPOCH_URTC, current_slot_late
+        )
+
+        # Both miners must still be present
+        self.assertIn("miner_A", rewards_delayed,
+                      "miner_A must be in delayed settlement (epoch_enroll source)")
+        self.assertIn("miner_B", rewards_delayed)
+
+        # Total rewards must still sum to PER_EPOCH_URTC
+        self.assertEqual(sum(rewards_delayed.values()), PER_EPOCH_URTC)
+
+    def test_fallback_to_attest_recent_when_no_enroll(self):
+        """
+        When epoch_enroll has no rows, fall back to miner_attest_recent
+        time-window query (legacy compatibility).
+        """
+        EPOCH = 5
+        start_ts, end_ts = self._epoch_ts(EPOCH)
+
+        # Attest miners but DON'T enroll (simulates legacy epochs)
+        _attest_miner(self.conn, "miner_X", "g5", ts_ok=start_ts + 100)
+        _attest_miner(self.conn, "miner_Y", "modern", ts_ok=start_ts + 200)
+
+        current_slot = EPOCH * SLOTS_PER_EPOCH + 72
+        rewards = calculate_epoch_rewards_time_aged(
+            self.db_path, EPOCH, PER_EPOCH_URTC, current_slot
+        )
+
+        # Both miners should be found via fallback path
+        self.assertIn("miner_X", rewards)
+        self.assertIn("miner_Y", rewards)
+
+    def test_enrolled_miner_without_attestation_gets_unknown_arch(self):
+        """
+        A miner enrolled in epoch_enroll but with no attestation record
+        should still receive rewards with 'unknown' arch (multiplier 1.0).
+        """
+        EPOCH = 3
+        start_ts, _ = self._epoch_ts(EPOCH)
+
+        _enroll_miner(self.conn, EPOCH, "orphan_miner", weight=2.0)
+        # No attestation for this miner
+
+        current_slot = EPOCH * SLOTS_PER_EPOCH + 72
+        rewards = calculate_epoch_rewards_time_aged(
+            self.db_path, EPOCH, PER_EPOCH_URTC, current_slot
+        )
+
+        self.assertIn("orphan_miner", rewards)
+        self.assertGreater(rewards["orphan_miner"], 0)
+
+    def test_fingerprint_failed_miner_excluded_from_enroll_path(self):
+        """
+        A miner enrolled in epoch_enroll but with fingerprint_passed=0
+        in miner_attest_recent should receive zero weight.
+        """
+        EPOCH = 7
+        start_ts, _ = self._epoch_ts(EPOCH)
+
+        _enroll_miner(self.conn, EPOCH, "vm_miner", weight=0.0)
+        _attest_miner(self.conn, "vm_miner", "aarch64", ts_ok=start_ts + 100,
+                      fingerprint_passed=0)
+        _enroll_miner(self.conn, EPOCH, "good_miner", weight=2.5)
+        _attest_miner(self.conn, "good_miner", "g4", ts_ok=start_ts + 200,
+                      fingerprint_passed=1)
+
+        current_slot = EPOCH * SLOTS_PER_EPOCH + 72
+        rewards = calculate_epoch_rewards_time_aged(
+            self.db_path, EPOCH, PER_EPOCH_URTC, current_slot
+        )
+
+        # vm_miner should get zero (fingerprint failed)
+        self.assertEqual(rewards.get("vm_miner", 0), 0)
+        # good_miner should get all rewards
+        self.assertEqual(rewards["good_miner"], PER_EPOCH_URTC)
+
+
+class TestAntiDoubleMiningSettlementIntegrity(unittest.TestCase):
+    """Anti-double-mining path must also use epoch_enroll as canonical source."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.conn = _setup_db(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def test_get_epoch_miner_groups_uses_enroll(self):
+        """get_epoch_miner_groups should prefer epoch_enroll over attest_recent."""
+        from anti_double_mining import get_epoch_miner_groups
+
+        EPOCH = 12
+        start_ts, _ = self._epoch_ts(EPOCH)
+
+        _enroll_miner(self.conn, EPOCH, "miner_P", weight=2.5)
+        _attest_miner(self.conn, "miner_P", "g4", ts_ok=start_ts + 100)
+
+        _enroll_miner(self.conn, EPOCH, "miner_Q", weight=1.0)
+        _attest_miner(self.conn, "miner_Q", "x86_64", ts_ok=start_ts + 200)
+
+        groups = get_epoch_miner_groups(self.conn, EPOCH)
+
+        # Both miners should be in the groups
+        all_miners = set()
+        for miners in groups.values():
+            all_miners.update(miners)
+
+        self.assertIn("miner_P", all_miners)
+        self.assertIn("miner_Q", all_miners)
+
+    def test_detect_duplicates_uses_enroll(self):
+        """detect_duplicate_identities should prefer epoch_enroll."""
+        from anti_double_mining import detect_duplicate_identities
+
+        EPOCH = 15
+        start_ts, end_ts = self._epoch_ts(EPOCH)
+
+        _enroll_miner(self.conn, EPOCH, "miner_R", weight=2.5)
+        _attest_miner(self.conn, "miner_R", "g4", ts_ok=start_ts + 100)
+
+        duplicates = detect_duplicate_identities(self.conn, EPOCH, start_ts, end_ts)
+
+        # Should find the enrolled miner (no duplicates in this case)
+        # The key assertion is that the function doesn't crash and returns
+        # based on epoch_enroll data
+        self.assertIsInstance(duplicates, list)
+
+    def _epoch_ts(self, epoch: int):
+        start_ts = GENESIS_TIMESTAMP + (epoch * SLOTS_PER_EPOCH * BLOCK_TIME)
+        end_ts = GENESIS_TIMESTAMP + ((epoch + 1) * SLOTS_PER_EPOCH - 1) * BLOCK_TIME
+        return start_ts, end_ts
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Fix: settlement-integrity — use epoch_enroll as canonical miner list

## Problem

The RIP-200 settlement path (`POST /rewards/settle`) reads eligible miners from `miner_attest_recent` filtered by epoch time window. Because `miner_attest_recent` is a single-row-per-miner table, any miner who re-attested after the epoch ended has their `ts_ok` moved forward and is **silently dropped** from delayed settlement.

The inline `finalize_epoch()` path reads from `epoch_enroll` (per-epoch snapshot) and does not have this bug. The two paths produce different reward distributions for the same epoch.

## Fix

Three functions now prefer `epoch_enroll` as the canonical miner list, falling back to the `miner_attest_recent` time-window query only when `epoch_enroll` has no rows:

1. `calculate_epoch_rewards_time_aged` — RIP-200 standard reward calculation
2. `get_epoch_miner_groups` — anti-double-mining miner grouping
3. `detect_duplicate_identities` — anti-double-mining duplicate detection

Each queries `epoch_enroll WHERE epoch = ?` first. If rows exist, uses them as the miner list and looks up `device_arch`/`fingerprint_passed` from `miner_attest_recent` for multiplier calculation.

## Changes

- `node/rip_200_round_robin_1cpu1vote.py` — `calculate_epoch_rewards_time_aged`: prefer `epoch_enroll`, fallback to attest_recent time-window
- `node/anti_double_mining.py` — `get_epoch_miner_groups`: same pattern
- `node/anti_double_mining.py` — `detect_duplicate_identities`: same pattern
- `node/tests/test_settlement_integrity.py` — 6 new tests covering delayed settlement, fallback behavior, orphan miners, and fingerprint exclusion

## Tests

```
tests/test_settlement_integrity.py: 6 passed
tests/test_rewards_settle_race.py: 4 passed (no regression)
```

## Risk

Low. The change is additive — it adds a primary source (`epoch_enroll`) with a fallback to the existing behavior. Epochs without enrollment records (legacy) continue to work via the fallback path. No schema changes required.
