### PR TITLE
fix: update auto-pay VPS port 8099 → 8088

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -32,7 +32,7 @@ import requests
 # ---------------------------------------------------------------------------
 
 GITHUB_API = "https://api.github.com"
-VPS_PORT = 8099
+VPS_PORT = 8088
 FROM_WALLET = "founder_community"
 
 # Payment directive pattern — matches both bold and plain variants:


### PR DESCRIPTION
## Summary
- Wallet/transfer API moved from port 8099 to 8088
- Auto-pay was failing with `ConnectionError` on every PR merge since the port change
- One-line fix: `VPS_PORT = 8088`

## Test plan
- [ ] Verify `curl http://50.28.86.131:8088/wallet/balance?miner_id=test` returns a response
- [ ] Re-run auto-pay on a merged PR to confirm transfer succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)