### PR TITLE
DOC: Document spending_proof validation boundary in UTXO layer

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -13,6 +13,15 @@ Security properties:
 - Double-spend prevention via spent_at tracking
 - Deterministic Merkle state root for cross-node consensus
 - Mempool-level double-spend detection via utxo_mempool_inputs
+
+Architectural boundary -- spending_proof validation:
+  The ``spending_proof`` field on transaction inputs is stored but **not
+  verified** by this module.  Signature verification (Ed25519 over the
+  canonical input box ID + output commitments) is performed at the
+  endpoint layer (``utxo_endpoints.py``) before any call to
+  ``UtxoDB.apply_transaction()``.  This separation is intentional:
+  the UTXO layer is a pure state-transition engine; authentication
+  belongs to the caller.  See issue #2085 for the rationale.
 """
 
 import hashlib
@@ -141,6 +150,15 @@ class UtxoDB:
 
     All public methods accept an optional ``conn`` parameter.  When provided
     the caller owns the transaction; otherwise a fresh connection is created.
+
+    **Spending-proof boundary:** This module handles UTXO state transitions
+    only.  Signature verification is the caller's responsibility.
+    ``apply_transaction()`` accepts ``spending_proof`` on inputs for
+    storage/recording but never validates it cryptographically.  The endpoint
+    layer (see ``utxo_endpoints.py``) performs Ed25519 verification *before*
+    calling into this module.  Future maintainers: do not add proof
+    verification here -- it would violate the layer separation and create
+    redundant checks.  See issue #2085.
     """
 
     def __init__(self, db_path: str):
@@ -344,6 +362,10 @@ class UtxoDB:
             conn = self._conn()
 
         ts = tx.get('timestamp', int(time.time()))
+        # NOTE(issue #2085): spending_proof is present on each input dict but
+        # is intentionally ignored by this layer.  It is stored for
+        # on-chain auditability, but cryptographic verification is the sole
+        # responsibility of the caller (utxo_endpoints.py).
         inputs = tx.get('inputs', [])
         outputs = tx.get('outputs', [])
         fee = tx.get('fee_nrtc', 0)


### PR DESCRIPTION
## Summary

Addresses #2085 — adds explicit documentation for the architectural decision that the UTXO layer does not validate  fields.

## Problem

The  field in transaction inputs is accepted by the UTXO layer without any validation or parsing. This is intentional — signature verification (Ed25519 over the canonical input box ID + output commitments) happens at the endpoint layer () before  is called. However, this boundary was only implied in the codebase, not explicitly documented, creating risk that future developers might:

1. Assume the UTXO layer validates proofs and introduce redundant validation
2. Rely on the UTXO layer for security properties it doesn't provide
3. Misunderstand where in the stack verification actually happens

## Changes

Three documentation additions to `node/utxo_db.py`:

1. **Module-level docstring** — New "Architectural boundary" section explaining that `spending_proof` is stored but not verified by this module; signature verification is the endpoint layer's responsibility. Cross-references `utxo_endpoints.py` and issue #2085.

2. **UtxoDB class docstring** — New "Spending-proof boundary" section warning future maintainers not to add proof verification to this layer, as it would violate layer separation and create redundant checks. Cross-references `utxo_endpoints.py` and issue #2085.

3. **Inline comment in `apply_transaction()`** — At the `inputs = tx.get('inputs', [])` extraction point, a `NOTE(issue #2085)` comment explaining that `spending_proof` is intentionally ignored by this layer and stored only for on-chain auditability.

## Testing

- No code changes — documentation only
- Existing `test_spending_proof_accepted_without_verification` test still documents the behavior
- All existing tests continue to pass

## References

- Issue #2085
- Related test: test_spending_proof_accepted_without_verification (added in PR #2073)
- Signature verification flow: utxo_endpoints.py line 282 (`_verify_sig_fn`) → line 314 (spending_proof attached from verified signature)