### PR TITLE
docs: Fix broken whitepaper link and incorrect epoch duration

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -444,7 +444,7 @@ MIT License
 
 ### 白皮书与技术文档
 
-- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper.pdf)
+- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
 - [链架构文档](https://github.com/Scottcjn/Rustchain/blob/main/docs/chain_architecture.md)
 - [开发者牵引报告](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md)
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -410,7 +410,7 @@ and a belief that old machines still have dignity.*
 | `Connection refused` when checking balance | The node may be restarting. Wait 30 seconds and retry. |
 | `Python not found` | Install Python 3.8+ from [python.org](https://python.org) (macOS/Windows) or `apt install python3` (Linux) |
 | `ModuleNotFoundError: requests` | Activate the venv first: `source ~/.rustchain/venv/bin/activate` |
-| Miner shows 0 RTC after mining | Mining rewards are paid per epoch (~60 minutes). Check back after an epoch completes. |
+| Miner shows 0 RTC after mining | Mining rewards are paid per epoch (~10 minutes). Check back after an epoch completes. |
 | `SSL certificate verify failed` | Your system clock may be wrong. Sync your clock: `sudo ntpdate pool.ntp.org` (Linux) |
 | `wallet name already taken` | Wallet names are globally unique. Try a different name with a unique prefix. |
 


### PR DESCRIPTION
Two documentation fixes for ONBOARD bounty #2783:

1. **FAQ.md (line 447)**: Broken whitepaper link — pointed to non-existent `RustChain_Whitepaper.pdf`. Fixed to `RustChain_Whitepaper_Flameholder_v0.97-1.pdf` (the actual file, consistent with README link).

2. **QUICKSTART.md (line 413)**: Factual error — troubleshooting section stated epoch duration is "~60 minutes" but every other reference in the codebase (QUICKSTART lines 173, 208, 378; README) says 10 minutes. Fixed to "~10 minutes".

Both are genuine doc issues that would mislead or confuse new users.