### PR TITLE
docs: fix inconsistent link formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ VMs are detected and receive **1 billionth** of normal rewards. Real hardware on
 |--|------|
 | **Swap** | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
 | **Chart** | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
-| **Bridge** | [bottube.ai/bridge](https://bottube.ai/bridge) |
+| **Bridge** | [Bridge](https://bottube.ai/bridge) |
 | **Guide** | [wRTC Quickstart](docs/wrtc.md) |
 
 ---


### PR DESCRIPTION
## Summary

Fixed inconsistent link formatting in the README.md file.

## Changes

- Changed link text from `bottube.ai/bridge` to `Bridge` for consistency with other links in the same table

## Why This Matters

The link table had inconsistent formatting:
- **Swap** | [Raydium DEX](...)
- **Chart** | [DexScreener](...)  
- **Bridge** | [bottube.ai/bridge](...) ← Inconsistent
- **Guide** | [wRTC Quickstart](...)

Now all links follow the same pattern: **Label** | [Display Text](URL)

## Checklist

- [x] Documentation fix (no code changes)
- [x] No breaking changes
- [x] Improves readability

---

This is my first contribution to RustChain. Hope this small fix helps! 🌾