### PR TITLE
docs: fix broken Green Tracker link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 A PowerBook G4 from 2003 earns **2.5x** more than a modern Threadripper.
 A Power Mac G5 earns **2.0x**. A 486 with rusty serial ports earns the most respect of all.
 
-[Explorer](https://rustchain.org/explorer/) · [Machines Preserved](https://rustchain.org/preserved.html) · [Install Miner](#quickstart) · [Beginner Guide](docs/QUICKSTART.md) · [Manifesto](https://rustchain.org/manifesto.html) · [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[Explorer](https://rustchain.org/explorer/) · [Machines Preserved](https://rustchain.org/transparency.html) · [Install Miner](#quickstart) · [Beginner Guide](docs/QUICKSTART.md) · [Manifesto](https://rustchain.org/manifesto.html) · [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
 
 </div>
 
@@ -112,7 +112,7 @@ Proof-of-Antiquity rewards hardware for *surviving*, not for being fast. Older m
 
 Our fleet of 16+ preserved machines draws roughly the same power as ONE modern GPU mining rig — while preventing 1,300 kg of manufacturing CO2 and 250 kg of e-waste.
 
-**[See the Green Tracker →](https://rustchain.org/preserved.html)**
+**[See the Green Tracker →](https://rustchain.org/transparency.html)**
 
 ---
 
@@ -393,7 +393,7 @@ Named after a 486 laptop with oxidized serial ports that still boots to DOS and 
 
 *"Mais, it still works, so why you gonna throw it away?"*
 
-[Boudreaux Principles](https://rustchain.org/principles.html) · [Green Tracker](https://rustchain.org/preserved.html) · [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
+[Boudreaux Principles](https://rustchain.org/principles.html) · [Green Tracker](https://rustchain.org/transparency.html) · [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
 
 </div>
 


### PR DESCRIPTION
This PR fixes a broken link to the Green Tracker in the README. The previous link led to a 404. It now points to the official sustainability dashboard at https://rustchain.org/transparency.html. This is an onboarding task for the bounty #2782.