### PR TITLE
fix: harden mempool_add() against DoS via malformed transactions (#2179)

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -652,6 +652,11 @@ class UtxoDB:
                 return False
 
             tx_id = tx.get('tx_id', '')
+            # FIX(#2179): Reject empty/whitespace-only tx_id to prevent
+            # INSERT OR IGNORE collisions that create orphan input claims.
+            if not tx_id or not tx_id.strip():
+                return False
+
             inputs = tx.get('inputs', [])
             tx_type = tx.get('tx_type', 'transfer')
             now = int(time.time())
@@ -707,14 +712,29 @@ class UtxoDB:
                     input_total += row['value_nrtc']
 
             outputs = tx.get('outputs', [])
-            output_total = sum(o.get('value_nrtc', 0) for o in outputs)
+
+            # FIX(#2179): Mirror apply_transaction() output validation.
+            # Reject outputs with missing, non-int, zero, or negative value_nrtc.
+            # Without this, unmineable transactions enter the mempool and lock
+            # UTXOs until expiry (DoS vector).
+            for o in outputs:
+                val = o.get('value_nrtc')
+                if not isinstance(val, int) or val <= 0:
+                    conn.execute("ROLLBACK")
+                    return False
+
+            output_total = sum(o['value_nrtc'] for o in outputs)
             if input_total > 0 and (output_total + fee) > input_total:
                 conn.execute("ROLLBACK")
                 return False
 
             # Insert into mempool
-            conn.execute(
-                """INSERT OR IGNORE INTO utxo_mempool
+            # FIX(#2179): Use INSERT OR ABORT instead of INSERT OR IGNORE.
+            # With IGNORE, a duplicate tx_id silently skips the insert but
+            # execution continues to claim inputs — creating orphan entries
+            # that lock UTXOs with no corresponding mempool transaction.
+            cursor = conn.execute(
+                """INSERT OR ABORT INTO utxo_mempool
                    (tx_id, tx_data_json, fee_nrtc, submitted_at, expires_at)
                    VALUES (?,?,?,?,?)""",
                 (


### PR DESCRIPTION
## Summary

Fixes three mempool validation bypasses reported by @geldbert in #2179 and proven by red team PoC in PR #2182.

**Bug 1 (MEDIUM):** `mempool_add()` accepted outputs with `value_nrtc: 0` or missing key (defaulted to 0 via `.get()`). These pass the conservation check but always fail `apply_transaction()`, locking UTXOs for up to 1 hour.

**Bug 2 (HIGH):** Empty `tx_id ""` accepted. Multiple transactions with `tx_id: ""` collide on `INSERT OR IGNORE` — second insert silently fails but inputs still get claimed as orphan entries.

**Bug 3 (MEDIUM):** `INSERT OR IGNORE` on duplicate tx_id skips the row but continues to claim inputs in `utxo_mempool_inputs`.

## Changes (23 lines, 1 file)

- **tx_id validation**: Reject empty/whitespace-only tx_id before `BEGIN IMMEDIATE`
- **Output validation**: Mirror `apply_transaction()` — each output must have `value_nrtc` as a positive integer
- **INSERT OR ABORT**: Replace `INSERT OR IGNORE` so duplicate tx_id raises IntegrityError, caught by existing exception handler

## Test plan

- [x] All 4 red team PoC tests pass (previously FAIL, now PASS)
- [x] All 72 UTXO tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)