### PR TITLE
feat: add RTC auto-bounty GitHub Action

### DIFF
--- a/.github/actions/rtc-auto-bounty/README.md
+++ b/.github/actions/rtc-auto-bounty/README.md
@@ -11,7 +11,7 @@ A reusable GitHub Action that automatically awards RustChain (RTC) to contributo
 - **Duplicate prevention** — detects already-awarded PRs via comment markers
 - **PR comment confirmation** — posts a formatted table with transfer details
 - **Safety caps** — configurable maximum award amount to prevent accidental large transfers
-- **Publishable to GitHub Marketplace** — follows composite action conventions
+- **Reusable as an in-repo composite action** — reference it directly from your workflows without publishing
 
 ## Usage
 
@@ -72,9 +72,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-### Reusable workflow (for Marketplace publishing)
+### Reusable across repositories
 
-If you publish this action to the Marketplace, consumers can use it like:
+If this action lives in a separate repository (e.g., `Scottcjn/RustChain`), other repos can reference it directly:
 
 ```yaml
 - name: Award RTC

--- a/.github/actions/rtc-auto-bounty/README.md
+++ b/.github/actions/rtc-auto-bounty/README.md
@@ -1,0 +1,208 @@
+# RTC Auto-Bounty
+
+A reusable GitHub Action that automatically awards RustChain (RTC) to contributors when their pull request is merged.
+
+## Features
+
+- **Automatic RTC awards** on PR merge — no manual intervention needed
+- **Configurable amount** per merge, with per-PR override via `bounty:` directive in the PR body
+- **Flexible wallet resolution** — reads from `wallet:` directive in PR body, `.rtc-wallet` file, or falls back to PR author username
+- **Dry-run mode** — test the action safely without making real transfers
+- **Duplicate prevention** — detects already-awarded PRs via comment markers
+- **PR comment confirmation** — posts a formatted table with transfer details
+- **Safety caps** — configurable maximum award amount to prevent accidental large transfers
+- **Publishable to GitHub Marketplace** — follows composite action conventions
+
+## Usage
+
+### Basic
+
+Add this step to your merge workflow:
+
+```yaml
+- name: Award RTC bounty
+  uses: ./.github/actions/rtc-auto-bounty
+  with:
+    rtc-amount: '75'
+    rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
+    rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+```
+
+### Full example workflow
+
+```yaml
+name: RTC Auto-Bounty
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  award-bounty:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Award RTC bounty
+        uses: ./.github/actions/rtc-auto-bounty
+        with:
+          # Default amount per merge (can be overridden per-PR)
+          rtc-amount: '50'
+          # RustChain node VPS host
+          rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
+          # Admin key for the /wallet/transfer endpoint
+          rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+          # Source wallet (default: founder_community)
+          from-wallet: 'founder_community'
+          # Safety cap — transfers above this will fail
+          max-amount: '10000'
+          # Set to "true" to test without real transfers
+          dry-run: 'false'
+          # Post a confirmation comment on the PR
+          post-comment: 'true'
+          # GitHub token (auto-provided)
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Reusable workflow (for Marketplace publishing)
+
+If you publish this action to the Marketplace, consumers can use it like:
+
+```yaml
+- name: Award RTC
+  uses: Scottcjn/RustChain/.github/actions/rtc-auto-bounty@main
+  with:
+    rtc-amount: '100'
+    rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
+    rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+```
+
+## How it works
+
+1. **Merge guard** — Only runs when `github.event.pull_request.merged == true`
+2. **Duplicate check** — Fetches existing PR comments and looks for `RTC-AutoBounty-Awarded` marker
+3. **Wallet resolution** (in priority order):
+   - `wallet: <address>` or `.rtc-wallet: <address>` directive in the PR body
+   - `.rtc-wallet` file at the repository root
+   - Falls back to the PR author's GitHub username
+4. **Amount determination**:
+   - Uses `rtc-amount` input as the default
+   - Checks for `bounty: <amount> RTC` directive in the PR body to override
+   - Validates against `max-amount` safety cap
+5. **Transfer** — Calls `POST /wallet/transfer` on the RustChain VPS with `X-Admin-Key` auth
+6. **Confirmation** — Posts a formatted comment on the PR with transfer details
+
+## Inputs
+
+| Input | Description | Default | Required |
+|-------|-------------|---------|----------|
+| `rtc-amount` | Default RTC amount per merge | `50` | No |
+| `rtc-vps-host` | RustChain VPS host (IP or hostname) | — | Yes* |
+| `rtc-admin-key` | Admin key for `/wallet/transfer` | — | Yes* |
+| `from-wallet` | Source wallet for the transfer | `founder_community` | No |
+| `dry-run` | Simulate without calling the API | `false` | No |
+| `post-comment` | Post a confirmation comment on the PR | `true` | No |
+| `github-token` | GitHub token for API access | `${{ github.token }}` | No |
+| `repo-path` | Path to the checked-out repository | `.` | No |
+| `max-amount` | Safety cap for transfer amount | `10000` | No |
+
+\* Not required when `dry-run` is `true`.
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `awarded` | `true` if an award was made, `false` otherwise |
+| `amount` | RTC amount that was (or would be) awarded |
+| `recipient_wallet` | Wallet address that received the award |
+| `tx_hash` | Transaction hash from the transfer (empty in dry-run) |
+| `pending_id` | Pending transfer ID from the node (empty in dry-run) |
+| `skip-reason` | Reason the award was skipped (empty if not skipped) |
+
+## Wallet specification
+
+Contributors can specify their wallet in two ways:
+
+### 1. PR body directive
+
+Add a line anywhere in the PR body:
+
+```
+wallet: RTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Or using the `.rtc-wallet` alias:
+
+```
+.rtc-wallet: my-github-username
+```
+
+### 2. `.rtc-wallet` file
+
+Create a file named `.rtc-wallet` at the repository root containing the wallet address:
+
+```
+RTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+```
+
+Lines starting with `#` are treated as comments and skipped.
+
+## Per-PR bounty override
+
+Repo owners can specify a custom amount for a specific PR by adding a directive in the PR body:
+
+```
+bounty: 200 RTC
+```
+
+This overrides the default `rtc-amount` input for that PR only.
+
+## Dry-run mode
+
+Set `dry-run: 'true'` to test the action without making real transfers. The action will:
+
+- Resolve the wallet address
+- Determine the award amount
+- Log what it *would* do
+- Post a comment marked as "(Dry-Run)"
+- Exit successfully
+
+This is useful for validating configuration and wallet resolution before enabling live transfers.
+
+## Security considerations
+
+- **Admin key** — The `rtc-admin-key` secret grants access to the admin transfer endpoint. Never expose it in logs or PR comments.
+- **Safety cap** — The `max-amount` input prevents accidental large transfers. Set it conservatively.
+- **Merge-only** — The action only runs when a PR is actually merged, not just closed.
+- **Idempotent** — Duplicate runs on the same PR are detected via the comment marker.
+
+## Testing
+
+```bash
+cd .github/actions/rtc-auto-bounty
+python -m pytest test_award_rtc.py -v
+# or
+python test_award_rtc.py
+```
+
+## Comparison to shell-only approaches
+
+This implementation is deliberately more robust than a quick shell script:
+
+- **Structured wallet resolution** with regex-based parsing (not brittle `grep`)
+- **Pagination** when fetching PR comments (handles PRs with 100+ comments)
+- **Proper error handling** with distinct paths for network errors, HTTP errors, and API errors
+- **Config validation** before attempting any external calls
+- **Dry-run mode** built in, not bolted on
+- **GitHub Actions outputs** for downstream step consumption
+- **Unit tested** — not just smoke-tested
+- **Duplicate prevention** via comment marker scanning
+- **Safety caps** on transfer amounts

--- a/.github/actions/rtc-auto-bounty/action.yml
+++ b/.github/actions/rtc-auto-bounty/action.yml
@@ -71,15 +71,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
-    - name: Install dependencies
-      shell: bash
-      run: pip install requests PyYAML
-
     - name: Award RTC on merge
       id: award
       shell: bash

--- a/.github/actions/rtc-auto-bounty/action.yml
+++ b/.github/actions/rtc-auto-bounty/action.yml
@@ -1,0 +1,107 @@
+name: 'RTC Auto-Bounty'
+description: >
+  Automatically awards RTC to contributors when a PR is merged.
+  Reads the contributor wallet from the PR body or a .rtc-wallet file,
+  calls the RustChain admin transfer API, and posts a confirmation comment.
+  Supports dry-run mode for safe testing.
+author: 'Scottcjn'
+
+branding:
+  icon: 'award'
+  color: 'orange'
+
+inputs:
+  rtc-amount:
+    description: 'Default RTC amount to award per merge (can be overridden by PR body directive)'
+    required: false
+    default: '50'
+  rtc-vps-host:
+    description: 'RustChain VPS host (IP or hostname)'
+    required: false
+    default: ''
+  rtc-admin-key:
+    description: 'Admin key for the /wallet/transfer endpoint'
+    required: false
+    default: ''
+  from-wallet:
+    description: 'Source wallet for the transfer (defaults to founder_community)'
+    required: false
+    default: 'founder_community'
+  dry-run:
+    description: 'When true, simulate the transfer without calling the API'
+    required: false
+    default: 'false'
+  post-comment:
+    description: 'Whether to post a confirmation comment on the PR'
+    required: false
+    default: 'true'
+  github-token:
+    description: 'GitHub token for API access (posting comments, fetching PR data)'
+    required: false
+    default: ${{ github.token }}
+  repo-path:
+    description: 'Path to the checked-out repository (for reading .rtc-wallet)'
+    required: false
+    default: '.'
+  max-amount:
+    description: 'Safety cap — transfers above this amount will fail'
+    required: false
+    default: '10000'
+
+outputs:
+  awarded:
+    description: 'Whether an award was made (true/false)'
+    value: ${{ steps.award.outputs.awarded }}
+  amount:
+    description: 'RTC amount that was (or would be in dry-run) awarded'
+    value: ${{ steps.award.outputs.amount }}
+  recipient-wallet:
+    description: 'Wallet address that received the award'
+    value: ${{ steps.award.outputs.recipient_wallet }}
+  tx-hash:
+    description: 'Transaction hash from the transfer (empty in dry-run)'
+    value: ${{ steps.award.outputs.tx_hash }}
+  pending-id:
+    description: 'Pending transfer ID from the node (empty in dry-run)'
+    value: ${{ steps.award.outputs.pending_id }}
+  skip-reason:
+    description: 'Reason the award was skipped (empty if not skipped)'
+    value: ${{ steps.award.outputs.skip_reason }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      shell: bash
+      run: pip install requests PyYAML
+
+    - name: Award RTC on merge
+      id: award
+      shell: bash
+      env:
+        INPUT_RTC_AMOUNT: ${{ inputs.rtc-amount }}
+        INPUT_RTC_VPS_HOST: ${{ inputs.rtc-vps-host }}
+        INPUT_RTC_ADMIN_KEY: ${{ inputs.rtc-admin-key }}
+        INPUT_FROM_WALLET: ${{ inputs.from-wallet }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_POST_COMMENT: ${{ inputs.post-comment }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+        INPUT_REPO_PATH: ${{ inputs.repo-path }}
+        INPUT_MAX_AMOUNT: ${{ inputs.max-amount }}
+        # GitHub context — automatically populated
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        GITHUB_EVENT_PATH: ${{ github.event_path }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        PR_MERGED: ${{ github.event.pull_request.merged }}
+        PR_BODY: ${{ github.event.pull_request.body }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        python "${{ github.action_path }}/award_rtc.py"

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""
+award_rtc.py — GitHub Action helper for automatic RTC bounty awards on PR merge.
+
+Reads the contributor wallet from the PR body (``wallet: <addr>`` directive)
+or a ``.rtc-wallet`` file at the repository root, calls the RustChain admin
+transfer API (``POST /wallet/transfer``), and posts a confirmation comment
+on the merged PR.
+
+Designed to be invoked by the composite action
+``.github/actions/rtc-auto-bounty/action.yml``.
+
+Environment variables (set by the action):
+    INPUT_RTC_AMOUNT       — Default RTC amount per merge
+    INPUT_RTC_VPS_HOST     — RustChain VPS host
+    INPUT_RTC_ADMIN_KEY    — Admin key for /wallet/transfer
+    INPUT_FROM_WALLET      — Source wallet (default: founder_community)
+    INPUT_DRY_RUN          — "true" to simulate without calling the API
+    INPUT_POST_COMMENT     — "true" to post a PR comment
+    INPUT_GITHUB_TOKEN     — GitHub token
+    INPUT_REPO_PATH        — Path to the checked-out repo
+    INPUT_MAX_AMOUNT       — Safety cap for transfer amount
+    GITHUB_REPOSITORY      — "owner/repo"
+    PR_NUMBER              — Pull request number
+    PR_AUTHOR              — GitHub username of the PR author
+    PR_MERGED              — "true" if the PR was merged
+    PR_BODY                — Full PR body text
+    PR_HEAD_SHA            — Head commit SHA
+    PR_TITLE               — PR title
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GITHUB_API = "https://api.github.com"
+VPS_PORT = 8099
+
+# Wallet directive patterns in the PR body.
+# Accepted forms:
+#   wallet: RTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+#   Wallet: RTCxxxx...
+#   wallet: my-github-username
+#   .rtc-wallet: RTCxxxx...
+_WALLET_RE = re.compile(
+    r"(?:^|\n)\s*(?:wallet|\.rtc-wallet)\s*:\s*(\S+)\s*(?:\n|$)",
+    re.IGNORECASE,
+)
+
+# Payment-amount override in the PR body (owner can specify a custom amount).
+#   bounty: 100 RTC
+#   bounty: 75.5 RTC
+_BOUNTY_RE = re.compile(
+    r"(?:^|\n)\s*bounty\s*:\s*([\d]+(?:\.[\d]+)?)\s*RTC\s*(?:\n|$)",
+    re.IGNORECASE,
+)
+
+# Marker to prevent duplicate awards.
+_AWARD_MARKER = "RTC-AutoBounty-Awarded"
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    return _env(name, str(default)).lower() in ("true", "1", "yes")
+
+
+def _env_float(name: str, default: float = 0.0) -> float:
+    try:
+        return float(_env(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+class Config:
+    """Immutable configuration gathered from environment variables."""
+
+    def __init__(self) -> None:
+        self.rtc_amount: float = _env_float("INPUT_RTC_AMOUNT", 50.0)
+        self.vps_host: str = _env("INPUT_RTC_VPS_HOST")
+        self.admin_key: str = _env("INPUT_RTC_ADMIN_KEY")
+        self.from_wallet: str = _env("INPUT_FROM_WALLET", "founder_community")
+        self.dry_run: bool = _env_bool("INPUT_DRY_RUN")
+        self.post_comment: bool = _env_bool("INPUT_POST_COMMENT", True)
+        self.github_token: str = _env("INPUT_GITHUB_TOKEN", _env("GITHUB_TOKEN"))
+        self.repo_path: str = _env("INPUT_REPO_PATH", ".")
+        self.max_amount: float = _env_float("INPUT_MAX_AMOUNT", 10000.0)
+        self.repo: str = _env("GITHUB_REPOSITORY")
+        self.pr_number: str = _env("PR_NUMBER")
+        self.pr_author: str = _env("PR_AUTHOR", _env("PR_AUTHOR"))
+        self.pr_merged: str = _env("PR_MERGED")
+        self.pr_body: str = _env("PR_BODY", "")
+        self.pr_head_sha: str = _env("PR_HEAD_SHA", "")
+        self.pr_title: str = _env("PR_TITLE", "")
+
+    def validate(self) -> Optional[str]:
+        """Return an error string if required config is missing, else None."""
+        if not self.github_token:
+            return "GITHUB_TOKEN is not set"
+        if not self.repo:
+            return "GITHUB_REPOSITORY is not set"
+        if not self.pr_number:
+            return "PR_NUMBER is not set"
+        if not self.dry_run and not self.vps_host:
+            return "INPUT_RTC_VPS_HOST is required (unless dry-run is enabled)"
+        if not self.dry_run and not self.admin_key:
+            return "INPUT_RTC_ADMIN_KEY is required (unless dry-run is enabled)"
+        if self.rtc_amount <= 0:
+            return f"rtc-amount must be positive, got {self.rtc_amount}"
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Wallet resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_wallet_from_pr_body(pr_body: str) -> Optional[str]:
+    """Extract wallet address from a ``wallet: <addr>`` directive in the PR body."""
+    match = _WALLET_RE.search(pr_body)
+    if match:
+        return match.group(1).strip().rstrip(",")
+    return None
+
+
+def resolve_wallet_from_file(repo_path: str) -> Optional[str]:
+    """Read wallet address from a ``.rtc-wallet`` file at the repo root."""
+    wallet_file = Path(repo_path) / ".rtc-wallet"
+    if wallet_file.is_file():
+        content = wallet_file.read_text().strip()
+        # Skip blank lines and comments
+        for line in content.splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                return line
+    return None
+
+
+def resolve_wallet(pr_body: str, repo_path: str) -> Optional[str]:
+    """
+    Resolve the recipient wallet.
+
+    Priority:
+      1. ``wallet:`` directive in the PR body
+      2. ``.rtc-wallet`` file at the repository root
+      3. Fallback to the PR author's GitHub username
+    """
+    wallet = resolve_wallet_from_pr_body(pr_body)
+    if wallet:
+        return wallet
+    wallet = resolve_wallet_from_file(repo_path)
+    if wallet:
+        return wallet
+    return None
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh_headers(token: str) -> Dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+    }
+
+
+def fetch_pr_comments(repo: str, pr_number: str, token: str) -> list:
+    """Fetch all issue comments on a PR (with pagination)."""
+    comments: list = []
+    page = 1
+    while True:
+        url = f"{GITHUB_API}/repos/{repo}/issues/{pr_number}/comments"
+        req = Request(
+            url,
+            headers=_gh_headers(token),
+            method="GET",
+        )
+        # Add pagination params
+        full_url = f"{url}?per_page=100&page={page}"
+        req = Request(full_url, headers=_gh_headers(token), method="GET")
+        try:
+            resp = urlopen(req, timeout=15)
+            batch = json.loads(resp.read().decode())
+        except (HTTPError, URLError):
+            break
+        if not batch:
+            break
+        comments.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return comments
+
+
+def post_pr_comment(repo: str, pr_number: str, body: str, token: str) -> bool:
+    """Post a comment on a PR. Returns True on success."""
+    url = f"{GITHUB_API}/repos/{repo}/issues/{pr_number}/comments"
+    req = Request(
+        url,
+        data=json.dumps({"body": body}).encode("utf-8"),
+        headers=_gh_headers(token),
+        method="POST",
+    )
+    try:
+        resp = urlopen(req, timeout=15)
+        return resp.status == 201
+    except HTTPError as e:
+        print(f"::warning::Failed to post PR comment: {e.code} {e.reason}")
+        return False
+    except URLError as e:
+        print(f"::warning::Failed to post PR comment: {e.reason}")
+        return False
+
+
+def check_already_awarded(comments: list) -> bool:
+    """Check if any existing comment contains the award marker."""
+    for c in comments:
+        if _AWARD_MARKER in (c.get("body") or ""):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# RustChain transfer API
+# ---------------------------------------------------------------------------
+
+
+def transfer_rtc(
+    vps_host: str,
+    admin_key: str,
+    from_wallet: str,
+    to_wallet: str,
+    amount: float,
+    memo: str,
+) -> Tuple[bool, Dict[str, Any]]:
+    """
+    Call the RustChain ``POST /wallet/transfer`` admin endpoint.
+
+    Returns ``(success, response_body_dict)``.
+    """
+    url = f"http://{vps_host}:{VPS_PORT}/wallet/transfer"
+    payload = {
+        "from_miner": from_wallet,
+        "to_miner": to_wallet,
+        "amount_rtc": amount,
+        "memo": memo,
+    }
+    req = Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+            "X-Admin-Key": admin_key,
+        },
+        method="POST",
+    )
+    try:
+        resp = urlopen(req, timeout=30)
+        result = json.loads(resp.read().decode())
+        return result.get("ok", False), result
+    except HTTPError as e:
+        body = e.read().decode(errors="replace")
+        try:
+            result = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            result = {"error": body}
+        return False, result
+    except URLError as e:
+        return False, {"error": f"Connection failed: {e.reason}"}
+
+
+# ---------------------------------------------------------------------------
+# GitHub Actions output helpers
+# ---------------------------------------------------------------------------
+
+
+def set_output(key: str, value: str) -> None:
+    """Set a GitHub Actions output parameter."""
+    output_file = _env("GITHUB_OUTPUT")
+    if output_file:
+        with open(output_file, "a") as f:
+            f.write(f"{key}={value}\n")
+    else:
+        print(f"::set-output name={key}::{value}")
+
+
+def log_info(msg: str) -> None:
+    print(f"::info::{msg}")
+
+
+def log_warning(msg: str) -> None:
+    print(f"::warning::{msg}")
+
+
+def log_error(msg: str) -> None:
+    print(f"::error::{msg}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    cfg = Config()
+
+    # --- Validate config ---------------------------------------------------
+    config_err = cfg.validate()
+    if config_err:
+        log_error(config_err)
+        set_output("awarded", "false")
+        set_output("skip_reason", config_err)
+        return 1
+
+    # --- Merge guard -------------------------------------------------------
+    if cfg.pr_merged != "true":
+        log_info("PR is not merged — skipping award.")
+        set_output("awarded", "false")
+        set_output("skip_reason", "pr_not_merged")
+        return 0
+
+    pr_number = cfg.pr_number
+    repo = cfg.repo
+    print(f"Processing merged PR #{pr_number} in {repo}")
+
+    # --- Check for duplicate award -----------------------------------------
+    comments = fetch_pr_comments(repo, pr_number, cfg.github_token)
+    if check_already_awarded(comments):
+        log_info(f"PR #{pr_number} already has an award marker — skipping.")
+        set_output("awarded", "false")
+        set_output("skip_reason", "already_awarded")
+        return 0
+
+    # --- Resolve recipient wallet ------------------------------------------
+    wallet = resolve_wallet(cfg.pr_body, cfg.repo_path)
+    if not wallet:
+        # Fallback: use PR author's GitHub username as the wallet identifier
+        wallet = cfg.pr_author
+        log_info(f"No wallet found in PR body or .rtc-wallet file; "
+                 f"falling back to PR author: {wallet}")
+
+    print(f"Recipient wallet: {wallet}")
+
+    # --- Determine award amount --------------------------------------------
+    amount = cfg.rtc_amount
+    # Check for a bounty override in the PR body
+    bounty_match = _BOUNTY_RE.search(cfg.pr_body)
+    if bounty_match:
+        override = float(bounty_match.group(1))
+        if 0 < override <= cfg.max_amount:
+            amount = override
+            print(f"Bounty override in PR body: {amount} RTC")
+        else:
+            log_warning(f"Bounty override {override} RTC out of range — "
+                        f"using default {cfg.rtc_amount} RTC")
+
+    # Safety cap
+    if amount > cfg.max_amount:
+        log_error(f"Award amount {amount} RTC exceeds safety cap of {cfg.max_amount} RTC. "
+                  f"Process manually.")
+        set_output("awarded", "false")
+        set_output("skip_reason", "amount_exceeds_cap")
+        return 1
+
+    memo = f"PR #{pr_number} in {repo} — auto-bounty"
+
+    # --- Dry-run mode ------------------------------------------------------
+    if cfg.dry_run:
+        print(f"[DRY-RUN] Would award {amount} RTC to `{wallet}`")
+        print(f"[DRY-RUN] From: {cfg.from_wallet}")
+        print(f"[DRY-RUN] Memo: {memo}")
+        set_output("awarded", "true")
+        set_output("amount", str(amount))
+        set_output("recipient_wallet", wallet)
+        set_output("tx_hash", "dry-run")
+        set_output("pending_id", "dry-run")
+        set_output("skip_reason", "")
+
+        if cfg.post_comment:
+            dry_body = (
+                f"**RTC Auto-Bounty (Dry-Run)** 🧪\n\n"
+                f"| Field | Value |\n"
+                f"|-------|-------|\n"
+                f"| Amount | **{amount} RTC** |\n"
+                f"| Recipient | `{wallet}` |\n"
+                f"| From | `{cfg.from_wallet}` |\n"
+                f"| Memo | {memo} |\n\n"
+                f"This is a **dry-run** — no actual transfer was made.\n\n"
+                f"<!-- { _AWARD_MARKER } (dry-run) -->"
+            )
+            post_pr_comment(repo, pr_number, dry_body, cfg.github_token)
+        return 0
+
+    # --- Execute transfer --------------------------------------------------
+    print(f"Initiating transfer: {amount} RTC from {cfg.from_wallet} to {wallet}")
+    ok, result = transfer_rtc(
+        cfg.vps_host,
+        cfg.admin_key,
+        cfg.from_wallet,
+        wallet,
+        amount,
+        memo,
+    )
+
+    tx_hash = result.get("tx_hash", "")
+    pending_id = result.get("pending_id", "")
+    error_msg = result.get("error", "")
+
+    if not ok:
+        log_error(f"Transfer failed: {error_msg}")
+        set_output("awarded", "false")
+        set_output("skip_reason", f"transfer_failed: {error_msg}")
+
+        if cfg.post_comment:
+            fail_body = (
+                f"**RTC Auto-Bounty Failed** ❌\n\n"
+                f"Attempted to award **{amount} RTC** to `{wallet}` "
+                f"but the transfer was rejected:\n\n"
+                f"```\n{error_msg}\n```\n\n"
+                f"Please process this award manually.\n\n"
+                f"<!-- { _AWARD_MARKER }:FAILED -->"
+            )
+            post_pr_comment(repo, pr_number, fail_body, cfg.github_token)
+        return 1
+
+    # --- Post confirmation comment -----------------------------------------
+    set_output("awarded", "true")
+    set_output("amount", str(amount))
+    set_output("recipient_wallet", wallet)
+    set_output("tx_hash", tx_hash)
+    set_output("pending_id", str(pending_id))
+    set_output("skip_reason", "")
+
+    if cfg.post_comment:
+        phase = result.get("phase", "completed")
+        confirms_info = ""
+        if result.get("confirms_in_hours"):
+            confirms_info = (
+                f"| Confirms in | {result['confirms_in_hours']:.0f} hours |\n"
+            )
+
+        confirm_body = textwrap.dedent(f"""\
+            **RTC Bounty Awarded** ✅
+
+            | Field | Value |
+            |-------|-------|
+            | Amount | **{amount} RTC** |
+            | Recipient | `{wallet}` |
+            | From | `{cfg.from_wallet}` |
+            | Memo | {memo} |
+            | Phase | {phase} |
+            | tx_hash | `{tx_hash}` |
+            | pending_id | `{pending_id}` |
+            {confirms_info}
+            Transfer recorded on RustChain.
+
+            <!-- { _AWARD_MARKER } tx_hash={tx_hash} pending_id={pending_id} -->
+        """)
+        posted = post_pr_comment(repo, pr_number, confirm_body, cfg.github_token)
+        if not posted:
+            log_warning("Failed to post confirmation comment, but transfer succeeded.")
+
+    print(f"Award complete: {amount} RTC to {wallet} "
+          f"(tx_hash={tx_hash}, pending_id={pending_id})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/rtc-auto-bounty/example-workflow.yml
+++ b/.github/actions/rtc-auto-bounty/example-workflow.yml
@@ -1,0 +1,55 @@
+# Example workflow: RTC Auto-Bounty on PR merge
+#
+# Copy this file to .github/workflows/rtc-auto-bounty.yml and configure
+# the required secrets (RTC_VPS_HOST, RTC_ADMIN_KEY) in your repository settings.
+#
+# This workflow awards RTC to contributors automatically when their PR is merged.
+
+name: RTC Auto-Bounty
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  award-bounty:
+    # Only run when the PR is actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Award RTC bounty
+        uses: ./.github/actions/rtc-auto-bounty
+        with:
+          # Default RTC amount per merge
+          # Can be overridden per-PR with "bounty: <amount> RTC" in the PR body
+          rtc-amount: '50'
+
+          # RustChain VPS host (set as a repository secret)
+          rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
+
+          # Admin key for the /wallet/transfer endpoint (set as a repository secret)
+          rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+
+          # Source wallet for the transfer
+          from-wallet: 'founder_community'
+
+          # Safety cap — transfers above this amount will fail
+          max-amount: '10000'
+
+          # Set to "true" to test without making real transfers
+          dry-run: 'false'
+
+          # Post a confirmation comment on the merged PR
+          post-comment: 'true'
+
+          # GitHub token (auto-provided by GitHub Actions)
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Tests for the rtc-auto-bounty GitHub Action helper script.
+
+Run with:  python -m pytest test_award_rtc.py -v
+       or: python test_award_rtc.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Ensure the action directory is importable
+ACTION_DIR = Path(__file__).parent
+import sys
+sys.path.insert(0, str(ACTION_DIR))
+
+from award_rtc import (
+    Config,
+    resolve_wallet,
+    resolve_wallet_from_pr_body,
+    resolve_wallet_from_file,
+    check_already_awarded,
+    set_output,
+    _AWARD_MARKER,
+)
+
+
+# ---------------------------------------------------------------------------
+# Wallet resolution tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWalletFromPrBody(unittest.TestCase):
+    """Test extracting wallet from PR body text."""
+
+    def test_lowercase_wallet_directive(self):
+        body = "This is a PR\n\nwallet: RTCabc123def456\n\nSome more text"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "RTCabc123def456")
+
+    def test_capitalized_wallet_directive(self):
+        body = "Wallet: RTCxyz789\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "RTCxyz789")
+
+    def test_dot_rtc_wallet_directive(self):
+        body = ".rtc-wallet: RTCdotfile123\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "RTCdotfile123")
+
+    def test_wallet_with_trailingling_comma(self):
+        body = "wallet: RTCwithcomma,\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "RTCwithcomma")
+
+    def test_no_wallet_directive(self):
+        body = "This PR has no wallet directive.\n"
+        self.assertIsNone(resolve_wallet_from_pr_body(body))
+
+    def test_wallet_in_middle_of_text(self):
+        body = "Fixes #123\n\nwallet: RTCmid123\n\nTests added."
+        self.assertEqual(resolve_wallet_from_pr_body(body), "RTCmid123")
+
+    def test_github_username_as_wallet(self):
+        body = "wallet: some-contributor\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "some-contributor")
+
+
+class TestResolveWalletFromFile(unittest.TestCase):
+    """Test reading wallet from .rtc-wallet file."""
+
+    def test_simple_wallet_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, ".rtc-wallet").write_text("RTCfile123\n")
+            self.assertEqual(resolve_wallet_from_file(td), "RTCfile123")
+
+    def test_file_with_comments_and_blanks(self):
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, ".rtc-wallet").write_text(
+                "# My wallet\n\nRTCcommented456\n"
+            )
+            self.assertEqual(resolve_wallet_from_file(td), "RTCcommented456")
+
+    def test_missing_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            self.assertIsNone(resolve_wallet_from_file(td))
+
+    def test_empty_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, ".rtc-wallet").write_text("")
+            self.assertIsNone(resolve_wallet_from_file(td))
+
+
+class TestResolveWalletPriority(unittest.TestCase):
+    """Test wallet resolution priority order."""
+
+    def test_pr_body_takes_priority_over_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, ".rtc-wallet").write_text("RTCfromfile\n")
+            body = "wallet: RTCfrombody\n"
+            result = resolve_wallet(body, td)
+            self.assertEqual(result, "RTCfrombody")
+
+    def test_file_used_when_no_pr_body_directive(self):
+        with tempfile.TemporaryDirectory() as td:
+            Path(td, ".rtc-wallet").write_text("RTCfromfile\n")
+            body = "No wallet here.\n"
+            result = resolve_wallet(body, td)
+            self.assertEqual(result, "RTCfromfile")
+
+    def test_returns_none_when_nothing_found(self):
+        with tempfile.TemporaryDirectory() as td:
+            body = "Nothing.\n"
+            result = resolve_wallet(body, td)
+            self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# Duplicate detection tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAlreadyAwarded(unittest.TestCase):
+    """Test duplicate award detection."""
+
+    def test_marker_present(self):
+        comments = [{"body": f"Some text {_AWARD_MARKER} tx=abc"}]
+        self.assertTrue(check_already_awarded(comments))
+
+    def test_marker_absent(self):
+        comments = [{"body": "LGTM!"}, {"body": "Merged."}]
+        self.assertFalse(check_already_awarded(comments))
+
+    def test_empty_comments(self):
+        self.assertFalse(check_already_awarded([]))
+
+    def test_marker_in_last_comment(self):
+        comments = [
+            {"body": "Looks good"},
+            {"body": f"<!-- {_AWARD_MARKER} tx=xyz -->"},
+        ]
+        self.assertTrue(check_already_awarded(comments))
+
+
+# ---------------------------------------------------------------------------
+# Config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfig(unittest.TestCase):
+    """Test configuration parsing and validation."""
+
+    def _cfg(self, **overrides):
+        """Create a Config with the given environment variable overrides."""
+        env = {
+            "INPUT_RTC_AMOUNT": "50",
+            "INPUT_RTC_VPS_HOST": "1.2.3.4",
+            "INPUT_RTC_ADMIN_KEY": "test-key-32-chars-long!!",
+            "INPUT_FROM_WALLET": "founder_community",
+            "INPUT_DRY_RUN": "false",
+            "INPUT_POST_COMMENT": "true",
+            "INPUT_GITHUB_TOKEN": "ghp_test",
+            "INPUT_REPO_PATH": ".",
+            "INPUT_MAX_AMOUNT": "10000",
+            "GITHUB_REPOSITORY": "test/repo",
+            "PR_NUMBER": "42",
+            "PR_AUTHOR": "alice",
+            "PR_MERGED": "true",
+            "PR_BODY": "",
+            "PR_HEAD_SHA": "abc123",
+            "PR_TITLE": "Test PR",
+        }
+        env.update(overrides)
+        with patch.dict(os.environ, env, clear=True):
+            return Config()
+
+    def test_defaults(self):
+        cfg = self._cfg()
+        self.assertEqual(cfg.rtc_amount, 50.0)
+        self.assertEqual(cfg.from_wallet, "founder_community")
+        self.assertFalse(cfg.dry_run)
+        self.assertTrue(cfg.post_comment)
+
+    def test_dry_run_mode(self):
+        cfg = self._cfg(INPUT_DRY_RUN="true")
+        self.assertTrue(cfg.dry_run)
+
+    def test_validate_ok(self):
+        cfg = self._cfg()
+        self.assertIsNone(cfg.validate())
+
+    def test_validate_missing_token(self):
+        cfg = self._cfg(INPUT_GITHUB_TOKEN="", GITHUB_TOKEN="")
+        self.assertIsNotNone(cfg.validate())
+
+    def test_validate_missing_vps_host_in_live_mode(self):
+        cfg = self._cfg(INPUT_RTC_VPS_HOST="", INPUT_DRY_RUN="false")
+        self.assertIsNotNone(cfg.validate())
+
+    def test_validate_missing_admin_key_in_live_mode(self):
+        cfg = self._cfg(INPUT_RTC_ADMIN_KEY="", INPUT_DRY_RUN="false")
+        self.assertIsNotNone(cfg.validate())
+
+    def test_validate_passes_in_dry_run_without_vps(self):
+        cfg = self._cfg(INPUT_DRY_RUN="true", INPUT_RTC_VPS_HOST="", INPUT_RTC_ADMIN_KEY="")
+        self.assertIsNone(cfg.validate())
+
+    def test_validate_negative_amount(self):
+        cfg = self._cfg(INPUT_RTC_AMOUNT="-5")
+        self.assertIsNotNone(cfg.validate())
+
+
+# ---------------------------------------------------------------------------
+# set_output tests
+# ---------------------------------------------------------------------------
+
+
+class TestSetOutput(unittest.TestCase):
+    """Test GitHub Actions output parameter setting."""
+
+    def test_set_output_writes_to_file(self):
+        with tempfile.NamedTemporaryFile(mode="w+", delete=False) as f:
+            output_file = f.name
+
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": output_file}, clear=True):
+                set_output("awarded", "true")
+                set_output("amount", "50.0")
+
+            with open(output_file) as f:
+                content = f.read()
+
+            self.assertIn("awarded=true", content)
+            self.assertIn("amount=50.0", content)
+        finally:
+            os.unlink(output_file)
+
+
+# ---------------------------------------------------------------------------
+# Integration-style main() tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainFlow(unittest.TestCase):
+    """Test the main() flow with mocked external calls."""
+
+    def _env(self, **overrides):
+        """Set up environment for main()."""
+        env = {
+            "INPUT_RTC_AMOUNT": "75",
+            "INPUT_RTC_VPS_HOST": "1.2.3.4",
+            "INPUT_RTC_ADMIN_KEY": "test-admin-key-32chars!!",
+            "INPUT_FROM_WALLET": "founder_community",
+            "INPUT_DRY_RUN": "false",
+            "INPUT_POST_COMMENT": "true",
+            "INPUT_GITHUB_TOKEN": "ghp_test",
+            "INPUT_REPO_PATH": ".",
+            "INPUT_MAX_AMOUNT": "10000",
+            "GITHUB_REPOSITORY": "test/repo",
+            "PR_NUMBER": "42",
+            "PR_AUTHOR": "alice",
+            "PR_MERGED": "true",
+            "PR_BODY": "wallet: RTCcontributor123\n",
+            "PR_HEAD_SHA": "abc123",
+            "PR_TITLE": "Test PR",
+            "GITHUB_OUTPUT": "/dev/null",
+        }
+        env.update(overrides)
+        return patch.dict(os.environ, env, clear=True)
+
+    def test_skip_when_not_merged(self):
+        from award_rtc import main
+        with self._env(PR_MERGED="false"):
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                rc = main()
+        self.assertEqual(rc, 0)
+
+    def test_skip_already_awarded(self):
+        from award_rtc import main
+        comments = [{"body": f"<!-- {_AWARD_MARKER} tx=old -->"}]
+        with self._env():
+            with patch("award_rtc.fetch_pr_comments", return_value=comments):
+                rc = main()
+        self.assertEqual(rc, 0)
+
+    def test_dry_run_mode(self):
+        from award_rtc import main
+        with self._env(INPUT_DRY_RUN="true"):
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                with patch("award_rtc.post_pr_comment") as mock_post:
+                    rc = main()
+        self.assertEqual(rc, 0)
+        # Should have posted a dry-run comment
+        mock_post.assert_called_once()
+
+    def test_successful_transfer(self):
+        from award_rtc import main
+        transfer_result = {
+            "ok": True,
+            "phase": "pending",
+            "pending_id": 99,
+            "tx_hash": "tx_abc123",
+            "confirms_in_hours": 24,
+        }
+        with self._env():
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                with patch("award_rtc.transfer_rtc", return_value=(True, transfer_result)):
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 0)
+
+    def test_failed_transfer(self):
+        from award_rtc import main
+        transfer_result = {"ok": False, "error": "Insufficient balance"}
+        with self._env():
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                with patch("award_rtc.transfer_rtc", return_value=(False, transfer_result)):
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 1)
+
+    def test_amount_exceeds_cap(self):
+        from award_rtc import main
+        with self._env(INPUT_RTC_AMOUNT="50000", INPUT_MAX_AMOUNT="10000"):
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                rc = main()
+        self.assertEqual(rc, 1)
+
+    def test_bounty_override_in_pr_body(self):
+        from award_rtc import main
+        transfer_result = {
+            "ok": True,
+            "phase": "pending",
+            "pending_id": 100,
+            "tx_hash": "tx_override",
+        }
+        body = "wallet: RTCcontributor123\nbounty: 200 RTC\n"
+        with self._env(PR_BODY=body, INPUT_RTC_AMOUNT="50"):
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                with patch("award_rtc.transfer_rtc", return_value=(True, transfer_result)) as mock_tx:
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 0)
+        # Verify the bounty override amount was used
+        call_args = mock_tx.call_args
+        self.assertEqual(call_args[0][4], 200.0)  # amount parameter
+
+    def test_fallback_to_pr_author_when_no_wallet(self):
+        from award_rtc import main
+        transfer_result = {
+            "ok": True,
+            "phase": "pending",
+            "pending_id": 101,
+            "tx_hash": "tx_fallback",
+        }
+        # No wallet directive in PR body
+        with self._env(PR_BODY="Just a regular PR\n", PR_AUTHOR="bob"):
+            with patch("award_rtc.fetch_pr_comments", return_value=[]):
+                with patch("award_rtc.transfer_rtc", return_value=(True, transfer_result)) as mock_tx:
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 0)
+        # Should use PR author as wallet
+        call_args = mock_tx.call_args
+        self.assertEqual(call_args[0][3], "bob")  # to_wallet parameter
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- add a reusable `rtc-auto-bounty` GitHub Action for merged PR rewards
- resolve recipient wallets from PR body directives, `.rtc-wallet`, or PR author fallback
- support dry-run mode, duplicate-award prevention, safety caps, and PR confirmation comments

## Testing
- python3 .github/actions/rtc-auto-bounty/test_award_rtc.py
