### PR TITLE
feat: add AgentFolio Beacon integration MVP

### DIFF
--- a/bounties/issue-2890/README.md
+++ b/bounties/issue-2890/README.md
@@ -1,0 +1,293 @@
+# AgentFolio ↔ Beacon Integration
+
+> **Issue**: #2890 — AgentFolio ↔ Beacon Integration Spec + Reference Implementation
+> **Scope**: 100 RTC (MVP)
+> **Status**: MVP Complete — reference implementation with tests and demo
+
+## One-Liner
+
+Unified agent profiles (`AgentFolio`) that aggregate identity and reputation from both **Beacon Atlas** and **Agent Economy (RIP-302)**, plus cryptographically verifiable **bounty submission attestations** as Beacon v2 envelopes.
+
+## Quick Start
+
+```bash
+cd bounties/issue-2890
+
+# Run the demo
+python examples/demo_folio.py
+
+# Run tests
+pytest tests/ -v
+```
+
+## What's Included
+
+| Module | Purpose | Lines |
+|--------|---------|-------|
+| `src/agentfolio_beacon/folio.py` | `AgentFolio` dataclass + `assemble_folio()` | ~200 |
+| `src/agentfolio_beacon/bridge.py` | `BeaconBridge` adapter for Beacon Atlas APIs | ~200 |
+| `src/agentfolio_beacon/attestation.py` | `EnvelopeAttestation` — sign/verify bounty submissions | ~250 |
+| `tests/test_folio.py` | Folio assembly, diff, table conversion | ~300 |
+| `tests/test_bridge.py` | Bridge routing, error handling, mock integration | ~250 |
+| `tests/test_attestation.py` | Attestation creation, verification, tamper detection | ~250 |
+| `docs/SPEC.md` | Full specification | — |
+| `examples/demo_folio.py` | End-to-end demo with mocked data | ~150 |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                  AgentFolio Assembly                  │
+│                                                       │
+│  AgentEconomyClient ──┐                               │
+│                        ├──► BeaconBridge ──► Folio    │
+│  Beacon Atlas API   ──┘                               │
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│              Bounty Submission Attestation             │
+│                                                       │
+│  Submission ──► EnvelopeAttestation ──► Beacon v2     │
+│                   (Ed25519 signed)                     │
+│                                                       │
+│  Anyone with pubkey ──► verify_attestation() ──► ✅   │
+└──────────────────────────────────────────────────────┘
+```
+
+## Usage
+
+### 1. Assemble an AgentFolio
+
+```python
+from rustchain.agent_economy import AgentEconomyClient
+from agentfolio_beacon import BeaconBridge, assemble_folio
+
+# Connect to your node
+client = AgentEconomyClient(base_url="http://localhost:5000")
+bridge = BeaconBridge(client)
+
+# Assemble unified profile
+folio = assemble_folio("my-agent", client, bridge)
+
+print(f"Beacon pubkey: {folio.beacon_pubkey_hex}")
+print(f"Economy score: {folio.economy_score}")
+print(f"Beacon score:  {folio.beacon_score}")
+print(f"Envelopes:     {folio.total_envelopes_sent}")
+print(f"Active contracts: {folio.active_contracts}")
+```
+
+### 2. Create a Bounty Submission Attestation
+
+```python
+from nacl.signing import SigningKey
+from agentfolio_beacon import attest_bounty_submission, verify_attestation
+
+# Load your signing key (from secure storage, never hardcode)
+signing_key = SigningKey(bytes.fromhex("your_private_key_hex"))
+
+# Attest your submission
+attestation = attest_bounty_submission(
+    bounty_id="bounty_123",
+    submission_id="sub_456",
+    submitter_agent_id="my-agent",
+    pr_url="https://github.com/Scottcjn/Rustchain/pull/123",
+    summary="Implemented feature X with tests",
+    signing_key_hex=signing_key.encode().hex(),
+)
+
+# The attestation is a self-contained, verifiable Beacon envelope
+envelope_json = attestation.to_json()
+
+# Anyone can verify it:
+valid, reason = verify_attestation(attestation)
+if valid:
+    print("✅ Attestation is valid")
+else:
+    print(f"❌ Invalid: {reason}")
+```
+
+### 3. Verify an Attestation from JSON
+
+```python
+from agentfolio_beacon import verify_attestation_from_json
+
+# Received from a submitter
+received_json = '{"agent_id":"my-agent","kind":"bounty",...}'
+
+valid, reason = verify_attestation_from_json(received_json)
+```
+
+### 4. Query Beacon Data Directly
+
+```python
+from agentfolio_beacon import BeaconBridge
+
+bridge = BeaconBridge(economy_client)
+
+# Relay agents
+agents = bridge.list_relay_agents(status="active")
+
+# Beacon reputation
+rep = bridge.get_beacon_reputation("some-agent")
+
+# Contracts
+contracts = bridge.get_contracts(agent_id="my-agent", state="active")
+
+# Open bounties
+bounties = bridge.get_open_bounties()
+```
+
+## Dependencies
+
+**Runtime**: Python 3.9+, stdlib only.
+
+**Optional** (for attestation creation):
+```bash
+pip install pynacl
+```
+
+**Optional** (for attestation verification, alternative to pynacl):
+```bash
+pip install cryptography
+```
+
+The `BeaconBridge` and `AgentFolio` modules work without any crypto libraries — they only read data.
+
+## Testing
+
+```bash
+cd bounties/issue-2890
+
+# All tests
+pytest tests/ -v
+
+# With coverage
+pytest tests/ -v --cov=agentfolio_beacon --cov-report=term-missing
+
+# Specific module
+pytest tests/test_attestation.py -v
+```
+
+### Test Coverage
+
+| Module | Tests | What's Covered |
+|--------|-------|----------------|
+| `attestation.py` | 15+ | Nonce generation, canonical fields, serialization, sign/verify, tamper detection, wrong key detection |
+| `bridge.py` | 15+ | Relay agent lookup, reputation, contracts, bounties, envelopes, health, error handling |
+| `folio.py` | 12+ | Dataclass serialization, assembly from both sources, failure isolation, diff detection |
+
+## File Layout
+
+```
+bounties/issue-2890/
+├── README.md                    # This file
+├── docs/
+│   └── SPEC.md                  # Full specification
+├── src/
+│   ├── agentfolio_beacon/
+│   │   ├── __init__.py          # Public exports
+│   │   ├── folio.py             # AgentFolio + assemble_folio()
+│   │   ├── bridge.py            # BeaconBridge adapter
+│   │   └── attestation.py       # EnvelopeAttestation + sign/verify
+│   └── requirements.txt
+├── tests/
+│   ├── test_folio.py
+│   ├── test_bridge.py
+│   └── test_attestation.py
+└── examples/
+    └── demo_folio.py            # End-to-end demo
+```
+
+## Design Decisions
+
+### Why a separate package (not in sdk/)?
+
+This is a **cross-cutting integration** between two existing systems (Beacon Atlas + Agent Economy). It doesn't belong in either — it's a thin adapter layer with its own data model (`AgentFolio`) and attestation mechanism.
+
+### Why graceful degradation?
+
+Not all nodes have PyNaCl or cryptography installed. The folio assembly and bridge modules work with **zero crypto dependencies**. Attestation creation requires PyNaCl, but verification works with either PyNaCl or cryptography.
+
+### Why Beacon v2 envelope format for attestations?
+
+Reusing the existing Beacon envelope format means:
+- Attestations can be stored in `beacon_envelopes` table
+- They participate in the Ergo anchoring digest
+- Verification uses the same canonical JSON rules already implemented
+- No new schema or protocol needed
+
+### Why read-only bridge?
+
+The MVP scope is **aggregation and verification**, not mutation. The bridge reads from Beacon Atlas APIs to build folios. State changes (creating contracts, claiming bounties) are handled by the existing Agent Economy SDK.
+
+## Security Notes
+
+- **No private key storage**: The attestation module signs with caller-provided keys; it never generates or stores long-term keys.
+- **Tamper-evident**: Any modification to an attestation's fields after signing invalidates the Ed25519 signature.
+- **Replay-resistant**: Nonces are derived from `blake2b(submission_id || timestamp)`.
+- **Read-only by default**: `BeaconBridge` never mutates state.
+
+## Caveats and Assumptions
+
+### Beacon API route names are hardcoded
+
+`BeaconBridge` assumes the following routes exist on the Beacon Atlas Flask API
+(`node/beacon_api.py`):
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/agent/<id>` | Single relay agent lookup |
+| `GET /beacon/atlas` | List all relay agents |
+| `GET /api/reputation/<id>` | Agent reputation |
+| `GET /api/reputation` | List all reputations |
+| `GET /api/contracts` | All contracts |
+| `GET /api/bounties` | Open bounties |
+| `GET /api/beacon/envelopes` | Envelope summaries (may not exist on all nodes) |
+| `GET /api/health` | Health check |
+
+If a node renames or removes these endpoints, the corresponding bridge method
+will return `None` or `[]` rather than raising — this is intentional graceful
+degradation, but callers should be aware that an empty result may mean "endpoint
+unavailable" rather than "no data."
+
+### Bridge depends on `AgentEconomyClient._request` internals
+
+`BeaconBridge._request` delegates to `economy_client._request(method, endpoint, ...)`
+and optionally passes `base_url` as a kwarg. This assumes the SDK's `_request`
+method accepts a `base_url` override. If the SDK changes this internal API, the
+bridge will need updating. The bridge is tested against the current SDK behavior
+via mocks; integration tests against a live node would catch drift.
+
+### `count_agent_envelopes` fetches up to 10,000 envelopes
+
+`count_agent_envelopes` calls `get_recent_envelopes(limit=10000)` and counts the
+results. This is a stopgap because there is no `COUNT` endpoint. For agents with
+more than 10,000 envelopes, the count will be capped. A proper solution would add
+a `GET /api/beacon/envelopes/count/<agent_id>` endpoint to the Beacon API.
+
+### `VALID_KINDS` constant is informational
+
+`attestation.py` defines `VALID_KINDS = {"hello", "heartbeat", "want", "bounty", ...}`
+matching the Beacon v2 spec, but the verifier only accepts `kind == "bounty"`.
+The constant is present as a reference for future work that may support other
+envelope kinds.
+
+### Attestation signing requires PyNaCl; verification works with PyNaCl _or_ `cryptography`
+
+- **Creating** attestations requires `pynacl` (Ed25519 signing).
+- **Verifying** attestations works with either `pynacl` or `cryptography`.
+- If neither is installed, `verify_attestation` returns `(False, "signature_verification_unavailable")`.
+- The folio assembly and bridge modules have **zero** crypto dependencies.
+
+### No private key management
+
+This module signs with caller-provided keys and never generates, stores, or
+rotates keys. Key management is the caller's responsibility.
+
+## See Also
+
+- [RIP-302 Agent Economy Spec](../../rips/docs/RIP-302-agent-economy.md)
+- [Beacon Atlas API](../../node/beacon_api.py)
+- [Beacon Anchor (Ergo)](../../node/beacon_anchor.py)
+- [Beacon Identity (TOFU)](../../node/beacon_identity.py)
+- [Agent Economy SDK](../../sdk/docs/AGENT_ECONOMY_SDK.md)

--- a/bounties/issue-2890/docs/SPEC.md
+++ b/bounties/issue-2890/docs/SPEC.md
@@ -1,0 +1,236 @@
+# AgentFolio ↔ Beacon Integration Spec
+
+> **Issue**: #2890 — AgentFolio ↔ Beacon Integration Spec + Reference Implementation
+> **Status**: MVP Complete
+> **Scope**: 100 RTC (MVP)
+> **Created**: 2026-04-10
+
+## 1. Problem Statement
+
+RustChain has two parallel agent identity/reputation systems that don't talk to each other:
+
+| System | Identity | Reputation | Storage |
+|--------|----------|------------|---------|
+| **Beacon Atlas** | `agent_id` + Ed25519 pubkey (TOFU) | Beacon reputation table, contracts, attestations | `rustchain_v2.db` (SQLite) |
+| **Agent Economy (RIP-302)** | `agent_id` + wallet address | `ReputationScore` (0-100), tiers, attestations | Node API + SDK client |
+
+An agent operating across both systems has **no unified view** of its own standing, and third parties cannot easily verify an agent's complete track record.
+
+## 2. Goals (MVP)
+
+1. **AgentFolio** — A single data structure that aggregates an agent's identity, reputation, and activity from both Beacon and Agent Economy sources.
+2. **BeaconBridge** — A thin adapter that lets the Agent Economy SDK query Beacon Atlas data (relay agents, envelopes, contracts) using the same client pattern.
+3. **EnvelopeAttestation** — A mechanism to sign a bounty submission as a Beacon envelope, producing a cryptographically verifiable proof-of-work artifact.
+4. **Spec + Reference Implementation** — This document plus working Python code with tests.
+
+### Non-Goals (explicitly out of scope)
+
+- New consensus or network protocols
+- New payment rails or escrow systems
+- Modifying existing Beacon or Economy database schemas
+- Real-time sync or event streaming
+- UI/dashboard components
+
+## 3. Design
+
+### 3.1 AgentFolio Data Model
+
+```python
+@dataclass
+class AgentFolio:
+    # Core identity
+    agent_id: str                          # e.g. "my-ai-agent"
+    beacon_pubkey_hex: Optional[str]       # From relay_agents / known_keys
+    wallet_address: Optional[str]          # From Agent Economy
+    base_address: Optional[str]            # Optional Coinbase Base address
+
+    # Reputation (Beacon side)
+    beacon_score: Optional[int]            # From beacon_reputation.score
+    beacon_bounties_completed: int         # From beacon_reputation
+    beacon_contracts_completed: int        # From beacon_reputation
+    beacon_contracts_breached: int         # From beacon_reputation
+
+    # Reputation (Economy side)
+    economy_score: Optional[float]         # From RIP-302 ReputationScore (0-100)
+    economy_bounties_completed: int        # From SDK bounty client
+
+    # Activity summary
+    total_envelopes_sent: int              # Count from beacon_envelopes
+    active_contracts: int                  # Contracts in 'active' state
+    open_claims: int                       # Bounties claimed but not completed
+
+    # Metadata
+    first_seen_beacon: Optional[float]     # Unix timestamp
+    first_seen_economy: Optional[float]    # Unix timestamp
+    assembled_at: float                    # When this folio was built
+```
+
+### 3.2 BeaconBridge
+
+`BeaconBridge` wraps an `AgentEconomyClient` and adds methods that query the Beacon Atlas Flask API endpoints already exposed by `node/beacon_api.py`:
+
+| Method | Beacon Endpoint | Returns |
+|--------|----------------|---------|
+| `get_relay_agent(agent_id)` | `GET /api/agent/<id>` | Relay agent dict or None |
+| `list_relay_agents(status?)` | `GET /beacon/atlas` | List of relay agents |
+| `get_beacon_reputation(agent_id)` | `GET /api/reputation/<id>` | Reputation dict or None |
+| `get_beacon_contracts(agent_id?)` | `GET /api/contracts` | List of contracts |
+| `get_recent_envelopes(agent_id?, limit)` | (direct DB query) | List of envelope summaries |
+
+The bridge uses the same `_request` pattern as the SDK, routing Beacon calls to the beacon API base URL.
+
+### 3.3 EnvelopeAttestation
+
+A bounty submission can be attested by encoding it as a **Beacon v2 envelope**:
+
+```
+kind: "bounty"
+agent_id: <submitter agent_id>
+nonce: <unique nonce, e.g. blake2b(submission_id + timestamp)>
+pubkey: <agent's Ed25519 public key>
+sig: Ed25519 signature of canonical JSON body
+```
+
+The envelope body contains:
+```json
+{
+  "agent_id": "submitter-agent",
+  "kind": "bounty",
+  "nonce": "abc123...",
+  "bounty_id": "bounty_456",
+  "submission_id": "sub_789",
+  "pr_url": "https://github.com/.../pull/1",
+  "summary": "Implemented feature X with tests",
+  "timestamp": 1712700000
+}
+```
+
+This produces a **self-contained, cryptographically verifiable** attestation that:
+- Proves the submitter's identity (Ed25519 pubkey)
+- Binds the submission to a specific bounty
+- Can be independently verified by anyone with the pubkey
+- Can be stored in `beacon_envelopes` for Ergo anchoring
+
+### 3.4 Assembly Flow
+
+```
+AgentEconomyClient ──┐
+                      ├──► BeaconBridge ──► AgentFolio.assemble()
+Beacon Atlas API   ──┘
+```
+
+1. Create `AgentEconomyClient` with agent identity
+2. Create `BeaconBridge` pointing to same node
+3. Call `AgentFolio.assemble(agent_id, economy_client, beacon_bridge)`
+4. Returns populated `AgentFolio` with best-effort fields from both sources
+
+## 4. API Surface
+
+### 4.1 Public Exports
+
+```python
+from agentfolio_beacon import (
+    AgentFolio,
+    BeaconBridge,
+    EnvelopeAttestation,
+    assemble_folio,
+    attest_bounty_submission,
+    verify_attestation,
+)
+```
+
+### 4.2 Core Functions
+
+```python
+# Assemble a unified agent folio
+folio = assemble_folio(
+    agent_id="my-agent",
+    economy_client=economy_client,  # AgentEconomyClient
+    beacon_bridge=beacon_bridge,     # BeaconBridge
+)
+
+# Attest a bounty submission as a Beacon envelope
+attestation = attest_bounty_submission(
+    bounty_id="bounty_123",
+    submission_id="sub_456",
+    submitter_agent_id="my-agent",
+    pr_url="https://github.com/.../pull/1",
+    summary="Implemented feature X",
+    identity=agent_identity,  # from beacon_skill or local keypair
+)
+
+# Verify an attestation envelope
+valid, info = verify_attestation(attestation_envelope)
+```
+
+## 5. Dependencies
+
+| Dependency | Source | Required? |
+|------------|--------|-----------|
+| Python 3.9+ | stdlib | Yes |
+| `requests` | Agent Economy SDK | Yes (already used) |
+| `nacl` (PyNaCl) | beacon_anchor.py | Optional (for signing attestations) |
+| `cryptography` | beacon_identity.py | Optional (for verifying attestations) |
+
+The reference implementation **gracefully degrades** when optional crypto libraries are unavailable — attestation creation requires a signing library (PyNaCl), but folio assembly and the bridge work with zero crypto dependencies. Verification works with either PyNaCl or `cryptography`.
+
+## 6. Testing Strategy
+
+1. **Unit tests** — `AgentFolio` dataclass, `BeaconBridge` routing, `EnvelopeAttestation` canonicalization
+2. **Mock integration tests** — Mock HTTP responses from both Beacon API and Economy API
+3. **Smoke test** — End-to-end folio assembly with mocked data, attestation sign + verify cycle
+
+## 7. File Layout
+
+```
+bounties/issue-2890/
+├── README.md                    # Usage guide
+├── docs/
+│   └── SPEC.md                  # This file
+├── src/
+│   ├── agentfolio_beacon/
+│   │   ├── __init__.py          # Public exports
+│   │   ├── folio.py             # AgentFolio dataclass + assemble()
+│   │   ├── bridge.py            # BeaconBridge adapter
+│   │   └── attestation.py       # EnvelopeAttestation + sign/verify
+│   └── requirements.txt
+├── tests/
+│   ├── test_folio.py
+│   ├── test_bridge.py
+│   └── test_attestation.py
+└── examples/
+    └── demo_folio.py            # End-to-end demo with mocks
+```
+
+## 8. Security Considerations
+
+- **No private key storage**: The attestation module signs with keys provided by the caller; it never generates or stores long-term keys.
+- **Read-only by default**: `BeaconBridge` only reads from Beacon API; it never mutates state.
+- **Signature verification**: `verify_attestation` verifies Ed25519 signatures independently — no trust in the attestation creator beyond the pubkey.
+- **Nonce uniqueness**: Nonces are derived from `blake2b(submission_id || timestamp)` to prevent replay.
+
+## 8.1. Implementation Caveats
+
+### Beacon API route names are hardcoded
+
+The bridge assumes specific Flask routes exist on the Beacon Atlas API (see README.md § Caveats). Missing or renamed endpoints return `None`/`[]` rather than raising.
+
+### Bridge depends on `AgentEconomyClient._request` internals
+
+`BeaconBridge` delegates to `economy_client._request(method, endpoint, base_url=...)`. The `base_url` kwarg override is an internal SDK detail not guaranteed by any public API contract.
+
+### Envelope counting is O(N)
+
+`count_agent_envelopes` fetches up to 10,000 envelope records to count them. A dedicated count endpoint would be more efficient.
+
+### `VALID_KINDS` is informational
+
+The `VALID_KINDS` set in `attestation.py` mirrors the Beacon v2 spec but is not enforced. The verifier only accepts `kind == "bounty"`.
+
+## 9. Future Work (post-MVP)
+
+- Persistent AgentFolio cache with change detection
+- Cross-system reputation score normalization
+- Automated bounty claim → Beacon envelope pipeline
+- Ergo anchor integration for attested submissions
+- Multi-agent folio comparison / leaderboard

--- a/bounties/issue-2890/examples/demo_folio.py
+++ b/bounties/issue-2890/examples/demo_folio.py
@@ -1,0 +1,192 @@
+"""
+Demo: AgentFolio ↔ Beacon Integration
+
+End-to-end demonstration using mocked data to show:
+1. Assembling an AgentFolio from Beacon + Economy sources
+2. Creating and verifying a bounty submission attestation
+
+Run with: python examples/demo_folio.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from unittest.mock import MagicMock
+
+from agentfolio_beacon.folio import AgentFolio, assemble_folio
+from agentfolio_beacon.bridge import BeaconBridge
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    verify_attestation,
+    NACL_AVAILABLE,
+)
+
+
+def demo_folio_assembly():
+    """Demonstrate assembling an AgentFolio from mocked data."""
+    print("=" * 60)
+    print("Demo: AgentFolio Assembly")
+    print("=" * 60)
+
+    # --- Mock Agent Economy Client ---
+    economy_client = MagicMock()
+
+    mock_wallet = MagicMock()
+    mock_wallet.wallet_address = "agent_7f3a2b1c"
+    mock_wallet.base_address = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD38"
+    economy_client.agents.get_wallet.return_value = mock_wallet
+
+    mock_rep = MagicMock()
+    mock_rep.score = 87.5
+    economy_client.reputation.get_score.return_value = mock_rep
+
+    economy_client.bounties.get_my_claims.return_value = [
+        {"bounty_id": "bounty_101"},
+    ]
+
+    # --- Mock Beacon Bridge ---
+    beacon_bridge = MagicMock()
+    beacon_bridge.lookup_agent_everything.return_value = {
+        "relay_agent": {
+            "agent_id": "content-curator-bot",
+            "pubkey_hex": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "name": "Content Curator Bot",
+            "status": "active",
+            "coinbase_address": "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD38",
+            "created_at": 1712500000,
+        },
+        "reputation": {
+            "agent_id": "content-curator-bot",
+            "score": 78,
+            "bounties_completed": 12,
+            "contracts_completed": 5,
+            "contracts_breached": 0,
+        },
+        "active_contracts": 2,
+        "total_contracts": 7,
+        "envelopes_recent": 45,
+    }
+
+    # --- Assemble ---
+    folio = assemble_folio("content-curator-bot", economy_client, beacon_bridge)
+
+    print(f"\n  Agent ID:        {folio.agent_id}")
+    print(f"  Beacon Pubkey:   {folio.beacon_pubkey_hex[:20]}...")
+    print(f"  Wallet Address:  {folio.wallet_address}")
+    print(f"  Base Address:    {folio.base_address}")
+    print()
+    print(f"  Beacon Score:    {folio.beacon_score}")
+    print(f"  Economy Score:   {folio.economy_score}")
+    print(f"  Combined Score:  {folio.combined_reputation_score}")
+    print()
+    print(f"  Beacons Sent:    {folio.total_envelopes_sent}")
+    print(f"  Active Contracts: {folio.active_contracts}")
+    print(f"  Open Claims:     {folio.open_claims}")
+    print(f"  Beacon Bounties: {folio.beacon_bounties_completed}")
+    print()
+    print(f"  Summary: {folio.summary()}")
+    print()
+
+    return folio
+
+
+def demo_attestation():
+    """Demonstrate creating and verifying a bounty submission attestation."""
+    print("=" * 60)
+    print("Demo: Bounty Submission Attestation")
+    print("=" * 60)
+
+    if not NACL_AVAILABLE:
+        print("\n  ⚠ PyNaCl not installed — skipping attestation creation.")
+        print("  Install with: pip install pynacl")
+        print("\n  Verification-only mode still works without PyNaCl.")
+        return
+
+    from nacl.signing import SigningKey
+    from agentfolio_beacon.attestation import attest_bounty_submission
+
+    # Generate a demo keypair
+    signing_key = SigningKey.generate()
+    signing_key_hex = signing_key.encode().hex()
+
+    print(f"\n  Signing Key:     {signing_key_hex[:32]}...")
+    print(f"  Verify Key:      {signing_key.verify_key.encode().hex()[:32]}...")
+
+    # Create attestation
+    attestation = attest_bounty_submission(
+        bounty_id="bounty_2890",
+        submission_id="sub_demo_001",
+        submitter_agent_id="content-curator-bot",
+        pr_url="https://github.com/Scottcjn/Rustchain/pull/2890",
+        summary="Implemented AgentFolio ↔ Beacon Integration with tests",
+        signing_key_hex=signing_key_hex,
+    )
+
+    print(f"\n  Attestation created:")
+    print(f"    Bounty:        {attestation.bounty_id}")
+    print(f"    Submission:    {attestation.submission_id}")
+    print(f"    Agent:         {attestation.agent_id}")
+    print(f"    PR:            {attestation.pr_url}")
+    print(f"    Nonce:         {attestation.nonce}")
+    print(f"    Signature:     {attestation.sig_hex[:32]}...")
+
+    # Verify
+    valid, reason = verify_attestation(attestation)
+    print(f"\n  Verification:    {'✅ VALID' if valid else '❌ INVALID'}")
+    if reason:
+        print(f"    Reason: {reason}")
+
+    # Show envelope JSON
+    print(f"\n  Envelope JSON (first 200 chars):")
+    json_str = attestation.to_json()
+    print(f"    {json_str[:200]}...")
+
+    # Demonstrate tamper detection
+    print(f"\n  Tamper detection demo:")
+    tampered = EnvelopeAttestation.from_json(json_str)
+    tampered.summary = "TAMPERED: different summary"
+    valid_tampered, reason_tampered = verify_attestation(tampered)
+    print(f"    After tamper:  {'✅ VALID' if valid_tampered else '❌ INVALID'}")
+    if reason_tampered:
+        print(f"    Reason: {reason_tampered}")
+
+
+def demo_folio_diff():
+    """Demonstrate folio difference detection."""
+    print("\n" + "=" * 60)
+    print("Demo: Folio Change Detection")
+    print("=" * 60)
+
+    from agentfolio_beacon.folio import folio_diff
+
+    old_folio = AgentFolio(
+        agent_id="content-curator-bot",
+        beacon_score=75,
+        total_envelopes_sent=40,
+        active_contracts=1,
+    )
+
+    new_folio = AgentFolio(
+        agent_id="content-curator-bot",
+        beacon_score=80,
+        total_envelopes_sent=45,
+        active_contracts=2,
+    )
+
+    changes = folio_diff(old_folio, new_folio)
+
+    print(f"\n  Changes detected:")
+    for field, (old_val, new_val) in changes.items():
+        print(f"    {field}: {old_val} → {new_val}")
+
+
+if __name__ == "__main__":
+    demo_folio_assembly()
+    demo_attestation()
+    demo_folio_diff()
+    print("\n" + "=" * 60)
+    print("Demo complete.")
+    print("=" * 60)

--- a/bounties/issue-2890/src/agentfolio_beacon/__init__.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/__init__.py
@@ -1,0 +1,32 @@
+"""
+AgentFolio ↔ Beacon Integration
+
+Unified agent profiles, Beacon bridge adapter, and envelope attestation
+for bounty submissions.
+
+See docs/SPEC.md for the full specification.
+"""
+
+from agentfolio_beacon.folio import AgentFolio, assemble_folio, folio_diff, folios_to_table
+from agentfolio_beacon.bridge import BeaconBridge
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    attest_bounty_submission,
+    verify_attestation,
+    verify_attestation_from_envelope,
+    verify_attestation_from_json,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    "AgentFolio",
+    "assemble_folio",
+    "folio_diff",
+    "folios_to_table",
+    "BeaconBridge",
+    "EnvelopeAttestation",
+    "attest_bounty_submission",
+    "verify_attestation",
+    "verify_attestation_from_envelope",
+    "verify_attestation_from_json",
+]

--- a/bounties/issue-2890/src/agentfolio_beacon/attestation.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/attestation.py
@@ -1,0 +1,292 @@
+"""
+EnvelopeAttestation — Sign bounty submissions as Beacon v2 envelopes.
+
+Produces cryptographically verifiable attestations that bind a bounty
+submission to the submitter's Ed25519 identity.
+
+Gracefully degrades when PyNaCl is unavailable (attestation creation
+requires signing, but verification works with just `cryptography`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+# --- Optional crypto imports ---
+try:
+    from nacl.signing import SigningKey, VerifyKey
+    from nacl.exceptions import BadSignatureError
+    NACL_AVAILABLE = True
+except ImportError:
+    SigningKey = None  # type: ignore[misc,assignment]
+    VerifyKey = None   # type: ignore[misc,assignment]
+    BadSignatureError = Exception  # type: ignore[misc,assignment]
+    NACL_AVAILABLE = False
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    _CRYPTO_AVAILABLE = True
+except ImportError:
+    Ed25519PublicKey = None  # type: ignore[misc,assignment]
+    _CRYPTO_AVAILABLE = False
+
+
+# Beacon v2 constants (matching beacon_anchor.py)
+# Note: This set is informational and mirrors the Beacon v2 spec.
+# The verifier currently only accepts kind == "bounty".
+VALID_KINDS = {"hello", "heartbeat", "want", "bounty", "mayday", "accord", "pushback"}
+UNSIGNED_TRANSPORT_FIELDS = ("sig", "_beacon_version")
+
+
+def _generate_nonce(submission_id: str, timestamp: Optional[int] = None) -> str:
+    """Generate a deterministic-but-unique nonce from submission_id + timestamp."""
+    ts = timestamp or int(time.time())
+    payload = f"{submission_id}:{ts}".encode()
+    return hashlib.blake2b(payload, digest_size=16).hexdigest()
+
+
+def _canonical_signed_fields(envelope: dict) -> dict:
+    """Return the exact Beacon v2 body covered by signature verification."""
+    return {
+        field: value
+        for field, value in envelope.items()
+        if field not in UNSIGNED_TRANSPORT_FIELDS
+    }
+
+
+def _canonical_signing_payload(envelope: dict) -> bytes:
+    """Return the canonical Beacon signing payload."""
+    return json.dumps(
+        _canonical_signed_fields(envelope),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass
+class EnvelopeAttestation:
+    """
+    A Beacon v2 envelope attesting to a bounty submission.
+
+    Attributes:
+        agent_id: Submitter's agent ID
+        kind: Always "bounty" for submission attestations
+        nonce: Unique nonce (blake2b of submission_id + timestamp)
+        bounty_id: The bounty being submitted to
+        submission_id: Unique submission identifier
+        pr_url: Pull request URL
+        summary: Brief description of the work
+        timestamp: Unix timestamp of attestation
+        pubkey_hex: Hex-encoded Ed25519 public key
+        sig_hex: Hex-encoded Ed25519 signature
+    """
+    agent_id: str
+    kind: str = "bounty"
+    nonce: str = ""
+    bounty_id: str = ""
+    submission_id: str = ""
+    pr_url: str = ""
+    summary: str = ""
+    timestamp: int = 0
+    pubkey_hex: str = ""
+    sig_hex: str = ""
+
+    def to_envelope(self) -> Dict[str, Any]:
+        """Return the full Beacon envelope dict (suitable for storage/verification)."""
+        return {
+            "agent_id": self.agent_id,
+            "kind": self.kind,
+            "nonce": self.nonce,
+            "bounty_id": self.bounty_id,
+            "submission_id": self.submission_id,
+            "pr_url": self.pr_url,
+            "summary": self.summary,
+            "timestamp": self.timestamp,
+            "pubkey": self.pubkey_hex,
+            "sig": self.sig_hex,
+        }
+
+    def to_json(self) -> str:
+        """Serialize to canonical JSON string."""
+        return json.dumps(self.to_envelope(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_envelope(cls, envelope: Dict[str, Any]) -> "EnvelopeAttestation":
+        """Deserialize from a Beacon envelope dict."""
+        return cls(
+            agent_id=envelope.get("agent_id", ""),
+            kind=envelope.get("kind", "bounty"),
+            nonce=envelope.get("nonce", ""),
+            bounty_id=envelope.get("bounty_id", ""),
+            submission_id=envelope.get("submission_id", ""),
+            pr_url=envelope.get("pr_url", ""),
+            summary=envelope.get("summary", ""),
+            timestamp=envelope.get("timestamp", 0),
+            pubkey_hex=envelope.get("pubkey", ""),
+            sig_hex=envelope.get("sig", ""),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "EnvelopeAttestation":
+        """Deserialize from canonical JSON string."""
+        return cls.from_envelope(json.loads(json_str))
+
+
+def attest_bounty_submission(
+    bounty_id: str,
+    submission_id: str,
+    submitter_agent_id: str,
+    pr_url: str,
+    summary: str,
+    signing_key_hex: str,
+    timestamp: Optional[int] = None,
+) -> EnvelopeAttestation:
+    """
+    Create a Beacon v2 envelope attestation for a bounty submission.
+
+    Args:
+        bounty_id: The bounty being submitted to
+        submission_id: Unique submission identifier
+        submitter_agent_id: Agent ID of the submitter
+        pr_url: Pull request URL
+        summary: Brief description of the work
+        signing_key_hex: Hex-encoded Ed25519 private key for signing
+        timestamp: Optional unix timestamp (defaults to now)
+
+    Returns:
+        EnvelopeAttestation with signature
+
+    Raises:
+        RuntimeError: If PyNaCl is not installed
+        ValueError: If signing key is invalid
+    """
+    if not NACL_AVAILABLE:
+        raise RuntimeError(
+            "PyNaCl is required to create attestations. "
+            "Install with: pip install pynacl"
+        )
+
+    ts = timestamp or int(time.time())
+    nonce = _generate_nonce(submission_id, ts)
+
+    # Derive pubkey from signing key
+    try:
+        signing_key = SigningKey(bytes.fromhex(signing_key_hex))
+        verify_key = signing_key.verify_key
+        pubkey_hex = verify_key.encode().hex()
+    except Exception as e:
+        raise ValueError(f"Invalid signing key: {e}") from e
+
+    # Build envelope body (fields covered by signature)
+    envelope_body = {
+        "agent_id": submitter_agent_id,
+        "kind": "bounty",
+        "nonce": nonce,
+        "bounty_id": bounty_id,
+        "submission_id": submission_id,
+        "pr_url": pr_url,
+        "summary": summary,
+        "timestamp": ts,
+        "pubkey": pubkey_hex,
+    }
+
+    # Sign the canonical payload
+    payload = _canonical_signing_payload(envelope_body)
+    signature = signing_key.sign(payload).signature  # type: ignore[attr-defined]
+    sig_hex = signature.hex()
+
+    return EnvelopeAttestation(
+        agent_id=submitter_agent_id,
+        kind="bounty",
+        nonce=nonce,
+        bounty_id=bounty_id,
+        submission_id=submission_id,
+        pr_url=pr_url,
+        summary=summary,
+        timestamp=ts,
+        pubkey_hex=pubkey_hex,
+        sig_hex=sig_hex,
+    )
+
+
+def verify_attestation(
+    attestation: EnvelopeAttestation,
+) -> Tuple[bool, str]:
+    """
+    Verify an EnvelopeAttestation's Ed25519 signature.
+
+    Args:
+        attestation: The attestation to verify
+
+    Returns:
+        (valid: bool, reason: str) — reason is empty if valid
+    """
+    if not attestation.sig_hex:
+        return False, "missing_signature"
+    if not attestation.pubkey_hex:
+        return False, "missing_pubkey"
+    if not attestation.agent_id:
+        return False, "missing_agent_id"
+    if attestation.kind != "bounty":
+        return False, f"invalid_kind:{attestation.kind}"
+
+    # Validate pubkey is well-formed hex
+    try:
+        pubkey_bytes = bytes.fromhex(attestation.pubkey_hex)
+    except ValueError:
+        return False, "invalid_pubkey_encoding"
+
+    # Reconstruct envelope and verify signature
+    envelope = attestation.to_envelope()
+
+    # Try PyNaCl first
+    if NACL_AVAILABLE:
+        try:
+            verify_key = VerifyKey(bytes.fromhex(attestation.pubkey_hex))
+            payload = _canonical_signing_payload(envelope)
+            verify_key.verify(payload, bytes.fromhex(attestation.sig_hex))
+            return True, ""
+        except (BadSignatureError, Exception):
+            return False, "invalid_signature"
+    elif _CRYPTO_AVAILABLE:
+        try:
+            vk = Ed25519PublicKey.from_public_bytes(pubkey_bytes)
+            payload = _canonical_signing_payload(envelope)
+            vk.verify(bytes.fromhex(attestation.sig_hex), payload)
+            return True, ""
+        except Exception:
+            return False, "invalid_signature"
+    else:
+        return False, "signature_verification_unavailable"
+
+
+def verify_attestation_from_envelope(
+    envelope: Dict[str, Any],
+) -> Tuple[bool, str]:
+    """
+    Verify a raw Beacon envelope dict as an attestation.
+
+    Convenience wrapper that deserializes and verifies in one call.
+    """
+    try:
+        attestation = EnvelopeAttestation.from_envelope(envelope)
+        return verify_attestation(attestation)
+    except Exception as e:
+        return False, f"parse_error:{e}"
+
+
+def verify_attestation_from_json(json_str: str) -> Tuple[bool, str]:
+    """
+    Verify a JSON-encoded attestation.
+
+    Convenience wrapper that deserializes and verifies in one call.
+    """
+    try:
+        attestation = EnvelopeAttestation.from_json(json_str)
+        return verify_attestation(attestation)
+    except Exception as e:
+        return False, f"parse_error:{e}"

--- a/bounties/issue-2890/src/agentfolio_beacon/bridge.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/bridge.py
@@ -1,0 +1,279 @@
+"""
+BeaconBridge — Adapter connecting Agent Economy SDK to Beacon Atlas APIs.
+
+Provides methods on top of AgentEconomyClient that query Beacon Atlas
+Flask endpoints (relay agents, reputation, contracts, envelopes).
+
+All methods are read-only — no state mutation.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+
+class BeaconBridge:
+    """
+    Bridge adapter that queries Beacon Atlas data via the Agent Economy client.
+
+    The Beacon Atlas Flask API (node/beacon_api.py) exposes these endpoints:
+      - GET /api/agent/<id>         — single relay agent
+      - GET /beacon/atlas           — all relay agents
+      - GET /api/reputation/<id>    — agent reputation
+      - GET /api/contracts          — all contracts
+      - GET /api/bounties           — open bounties
+
+    This adapter wraps an AgentEconomyClient and routes Beacon-specific
+    queries through it, returning plain dicts/lists (no SDK dataclasses).
+
+    Example:
+        >>> from rustchain.agent_economy import AgentEconomyClient
+        >>> from agentfolio_beacon import BeaconBridge
+        >>>
+        >>> client = AgentEconomyClient(base_url="http://localhost:5000")
+        >>> bridge = BeaconBridge(client)
+        >>>
+        >>> agents = bridge.list_relay_agents()
+        >>> rep = bridge.get_beacon_reputation("my-agent")
+    """
+
+    def __init__(self, economy_client, beacon_base_url: Optional[str] = None):
+        """
+        Initialize the bridge.
+
+        Args:
+            economy_client: An AgentEconomyClient instance
+            beacon_base_url: Override URL for Beacon API. If None, uses
+                             the economy client's base_url (assumes co-located).
+        """
+        self._client = economy_client
+        self._beacon_url = beacon_base_url
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> Any:
+        """Route request through the economy client, optionally overriding base URL."""
+        if self._beacon_url:
+            kwargs["base_url"] = self._beacon_url
+        return self._client._request(method, endpoint, **kwargs)
+
+    # --- Relay Agent Discovery ---
+
+    def get_relay_agent(self, agent_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get a single relay agent by ID.
+
+        Maps to: GET /api/agent/<agent_id>
+
+        Returns:
+            Agent dict with agent_id, pubkey_hex, name, status, etc.
+            or None if not found.
+        """
+        try:
+            result = self._request("GET", f"/api/agent/{agent_id}")
+            if isinstance(result, dict) and "error" in result:
+                return None
+            return result
+        except Exception:
+            return None
+
+    def list_relay_agents(
+        self,
+        status: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        List all registered relay agents.
+
+        Maps to: GET /beacon/atlas
+
+        Args:
+            status: Optional status filter (e.g. "active")
+
+        Returns:
+            List of agent dicts.
+        """
+        try:
+            params = {}
+            if status:
+                params["status"] = status
+            result = self._request("GET", "/beacon/atlas", params=params)
+            if isinstance(result, dict) and "agents" in result:
+                return result["agents"]
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Beacon Reputation ---
+
+    def get_beacon_reputation(self, agent_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get an agent's Beacon reputation score.
+
+        Maps to: GET /api/reputation/<agent_id>
+
+        Returns:
+            Dict with score, bounties_completed, contracts_completed, etc.
+            or None if not found.
+        """
+        try:
+            result = self._request("GET", f"/api/reputation/{agent_id}")
+            if isinstance(result, dict) and "error" in result:
+                return None
+            return result
+        except Exception:
+            return None
+
+    def list_all_reputation(self) -> List[Dict[str, Any]]:
+        """
+        List all agent reputations (sorted by score descending).
+
+        Maps to: GET /api/reputation
+
+        Returns:
+            List of reputation dicts.
+        """
+        try:
+            result = self._request("GET", "/api/reputation")
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Contracts ---
+
+    def get_contracts(
+        self,
+        agent_id: Optional[str] = None,
+        state: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get contracts, optionally filtered by agent or state.
+
+        Maps to: GET /api/contracts
+
+        Args:
+            agent_id: Filter to contracts involving this agent
+            state: Filter by contract state (offered, active, completed, etc.)
+
+        Returns:
+            List of contract dicts.
+        """
+        try:
+            result = self._request("GET", "/api/contracts")
+            contracts = result if isinstance(result, list) else []
+
+            if agent_id:
+                contracts = [
+                    c for c in contracts
+                    if c.get("from_agent") == agent_id or c.get("to_agent") == agent_id
+                ]
+            if state:
+                contracts = [c for c in contracts if c.get("state") == state]
+
+            return contracts
+        except Exception:
+            return []
+
+    def count_active_contracts(self, agent_id: str) -> int:
+        """Count contracts in 'active' state for a given agent."""
+        contracts = self.get_contracts(agent_id=agent_id, state="active")
+        return len(contracts)
+
+    # --- Bounties (Beacon side) ---
+
+    def get_open_bounties(self) -> List[Dict[str, Any]]:
+        """
+        Get open bounties from Beacon Atlas.
+
+        Maps to: GET /api/bounties
+
+        Returns:
+            List of bounty dicts.
+        """
+        try:
+            result = self._request("GET", "/api/bounties")
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Envelope summaries (direct DB query via API) ---
+
+    def get_recent_envelopes(
+        self,
+        agent_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get recent beacon envelope summaries.
+
+        Note: This endpoint may not exist on all nodes. Returns empty list
+        on failure rather than raising.
+
+        Maps to: GET /api/beacon/envelopes (if available)
+
+        Args:
+            agent_id: Filter envelopes by agent
+            limit: Maximum number of results
+
+        Returns:
+            List of envelope summary dicts.
+        """
+        try:
+            params = {"limit": limit}
+            if agent_id:
+                params["agent_id"] = agent_id
+            result = self._request("GET", "/api/beacon/envelopes", params=params)
+            if isinstance(result, list):
+                return result
+            if isinstance(result, dict) and "envelopes" in result:
+                return result["envelopes"]
+            return []
+        except Exception:
+            return []
+
+    def count_agent_envelopes(self, agent_id: str) -> int:
+        """Count total envelopes sent by an agent (best effort)."""
+        envelopes = self.get_recent_envelopes(agent_id=agent_id, limit=10000)
+        return len(envelopes)
+
+    # --- Health ---
+
+    def beacon_health(self) -> Optional[Dict[str, Any]]:
+        """
+        Check Beacon Atlas API health.
+
+        Maps to: GET /api/health
+
+        Returns:
+            Health dict or None on failure.
+        """
+        try:
+            result = self._request("GET", "/api/health")
+            return result if isinstance(result, dict) else None
+        except Exception:
+            return None
+
+    # --- Unified agent lookup ---
+
+    def lookup_agent_everything(self, agent_id: str) -> Dict[str, Any]:
+        """
+        Convenience method: fetch all Beacon data for a single agent.
+
+        Returns a dict with:
+            - relay_agent: relay agent record or None
+            - reputation: beacon reputation or None
+            - active_contracts: count of active contracts
+            - total_contracts: total contract count involving agent
+            - envelopes_recent: recent envelope count
+        """
+        return {
+            "relay_agent": self.get_relay_agent(agent_id),
+            "reputation": self.get_beacon_reputation(agent_id),
+            "active_contracts": self.count_active_contracts(agent_id),
+            "total_contracts": len(self.get_contracts(agent_id=agent_id)),
+            "envelopes_recent": self.count_agent_envelopes(agent_id),
+        }

--- a/bounties/issue-2890/src/agentfolio_beacon/folio.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/folio.py
@@ -1,0 +1,261 @@
+"""
+AgentFolio — Unified agent profile aggregating Beacon + Agent Economy data.
+
+An AgentFolio is a best-effort snapshot of an agent's identity, reputation,
+and activity across both the Beacon Atlas and Agent Economy (RIP-302) systems.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentfolio_beacon.bridge import BeaconBridge
+
+
+@dataclass
+class AgentFolio:
+    """
+    Unified agent profile from Beacon Atlas + Agent Economy sources.
+
+    All fields are best-effort — missing data is represented as None or 0.
+    This is a read-only snapshot, not a live connection.
+
+    Attributes:
+        agent_id: Unique agent identifier
+        beacon_pubkey_hex: Ed25519 pubkey from Beacon relay registration
+        wallet_address: Agent Economy wallet address
+        base_address: Optional Coinbase Base address
+
+        # Reputation (Beacon side)
+        beacon_score: Beacon reputation score (integer, from beacon_reputation)
+        beacon_bounties_completed: Bounties completed per Beacon
+        economy_score: RIP-302 reputation score (float, 0-100)
+        economy_bounties_completed: Bounties completed per Economy SDK
+        contracts_completed: Contracts completed (Beacon)
+        contracts_breached: Contracts breached (Beacon)
+
+        # Activity summary
+        total_envelopes_sent: Count of beacon_envelopes for this agent
+        active_contracts: Contracts currently in 'active' state
+        open_claims: Bounties claimed but not yet completed
+
+        # Metadata
+        first_seen_beacon: Unix timestamp of first Beacon registration
+        first_seen_economy: Unix timestamp of first Economy wallet creation
+        assembled_at: Unix timestamp when this folio was assembled
+    """
+    # Core identity
+    agent_id: str = ""
+    beacon_pubkey_hex: Optional[str] = None
+    wallet_address: Optional[str] = None
+    base_address: Optional[str] = None
+
+    # Reputation (Beacon)
+    beacon_score: Optional[int] = None
+    beacon_bounties_completed: int = 0
+    beacon_contracts_completed: int = 0
+    beacon_contracts_breached: int = 0
+
+    # Reputation (Economy)
+    economy_score: Optional[float] = None
+    economy_bounties_completed: int = 0
+
+    # Activity summary
+    total_envelopes_sent: int = 0
+    active_contracts: int = 0
+    open_claims: int = 0
+
+    # Metadata
+    first_seen_beacon: Optional[float] = None
+    first_seen_economy: Optional[float] = None
+    assembled_at: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "agent_id": self.agent_id,
+            "beacon_pubkey_hex": self.beacon_pubkey_hex,
+            "wallet_address": self.wallet_address,
+            "base_address": self.base_address,
+            "beacon_score": self.beacon_score,
+            "beacon_bounties_completed": self.beacon_bounties_completed,
+            "beacon_contracts_completed": self.beacon_contracts_completed,
+            "beacon_contracts_breached": self.beacon_contracts_breached,
+            "economy_score": self.economy_score,
+            "economy_bounties_completed": self.economy_bounties_completed,
+            "total_envelopes_sent": self.total_envelopes_sent,
+            "active_contracts": self.active_contracts,
+            "open_claims": self.open_claims,
+            "first_seen_beacon": self.first_seen_beacon,
+            "first_seen_economy": self.first_seen_economy,
+            "assembled_at": self.assembled_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentFolio":
+        """Deserialize from dictionary."""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def summary(self) -> str:
+        """Return a human-readable one-line summary."""
+        parts = [f"AgentFolio({self.agent_id}"]
+        if self.beacon_score is not None:
+            parts.append(f"beacon={self.beacon_score}")
+        if self.economy_score is not None:
+            parts.append(f"economy={self.economy_score:.0f}")
+        if self.total_envelopes_sent:
+            parts.append(f"envelopes={self.total_envelopes_sent}")
+        if self.active_contracts:
+            parts.append(f"contracts={self.active_contracts}")
+        parts.append(")")
+        return " ".join(parts)
+
+    @property
+    def has_beacon_identity(self) -> bool:
+        """Whether the agent has a registered Beacon identity."""
+        return self.beacon_pubkey_hex is not None
+
+    @property
+    def has_economy_wallet(self) -> bool:
+        """Whether the agent has an Economy wallet."""
+        return self.wallet_address is not None
+
+    @property
+    def combined_reputation_score(self) -> Optional[float]:
+        """
+        Return a combined reputation score, preferring Economy score
+        (more granular) and falling back to Beacon score.
+        """
+        if self.economy_score is not None:
+            return self.economy_score
+        if self.beacon_score is not None:
+            return float(self.beacon_score)
+        return None
+
+
+def assemble_folio(
+    agent_id: str,
+    economy_client,
+    beacon_bridge: "BeaconBridge",
+) -> AgentFolio:
+    """
+    Assemble a unified AgentFolio for the given agent.
+
+    This is the primary entry point. It queries both the Agent Economy SDK
+    and the Beacon Bridge, aggregating all available data. Failures in
+    either source are silently caught — the folio will have None/0 for
+    missing fields.
+
+    Args:
+        agent_id: The agent to assemble a folio for
+        economy_client: An AgentEconomyClient instance
+        beacon_bridge: A BeaconBridge wrapping the same (or different) client
+
+    Returns:
+        AgentFolio with best-effort populated fields
+
+    Example:
+        >>> from rustchain.agent_economy import AgentEconomyClient
+        >>> from agentfolio_beacon import BeaconBridge, assemble_folio
+        >>>
+        >>> client = AgentEconomyClient(base_url="http://localhost:5000")
+        >>> bridge = BeaconBridge(client)
+        >>> folio = assemble_folio("my-agent", client, bridge)
+        >>> print(folio.summary())
+    """
+    folio = AgentFolio(agent_id=agent_id, assembled_at=time.time())
+
+    # --- Beacon Atlas data ---
+    try:
+        beacon_data = beacon_bridge.lookup_agent_everything(agent_id)
+
+        # Relay agent info
+        relay = beacon_data.get("relay_agent")
+        if relay:
+            folio.beacon_pubkey_hex = relay.get("pubkey_hex")
+            folio.base_address = relay.get("coinbase_address")
+            folio.first_seen_beacon = relay.get("created_at")
+
+        # Beacon reputation
+        rep = beacon_data.get("reputation")
+        if rep:
+            folio.beacon_score = rep.get("score")
+            folio.beacon_bounties_completed = rep.get("bounties_completed", 0)
+            folio.beacon_contracts_completed = rep.get("contracts_completed", 0)
+            folio.beacon_contracts_breached = rep.get("contracts_breached", 0)
+
+        # Activity counts
+        folio.total_envelopes_sent = beacon_data.get("envelopes_recent", 0)
+        folio.active_contracts = beacon_data.get("active_contracts", 0)
+
+    except Exception:
+        pass  # Beacon data unavailable — leave fields as defaults
+
+    # --- Agent Economy data ---
+    try:
+        # Wallet info
+        wallet = economy_client.agents.get_wallet(agent_id)
+        if wallet:
+            folio.wallet_address = wallet.wallet_address
+            if wallet.base_address:
+                folio.base_address = wallet.base_address
+
+        # Reputation
+        try:
+            rep_score = economy_client.reputation.get_score(agent_id)
+            if rep_score:
+                folio.economy_score = rep_score.score
+        except Exception:
+            pass
+
+        # Bounty claims (open = claimed but not completed)
+        try:
+            claims = economy_client.bounties.get_my_claims(agent_id=agent_id)
+            folio.open_claims = len(claims)
+        except Exception:
+            pass
+
+    except Exception:
+        pass  # Economy data unavailable — leave fields as defaults
+
+    return folio
+
+
+def folio_diff(old: AgentFolio, new: AgentFolio) -> Dict[str, Any]:
+    """
+    Compute the difference between two folios of the same agent.
+
+    Returns a dict of changed fields with (old_value, new_value) tuples.
+    """
+    changes = {}
+    old_dict = old.to_dict()
+    new_dict = new.to_dict()
+
+    for key in old_dict:
+        if key == "assembled_at":
+            continue  # Always different
+        old_val = old_dict[key]
+        new_val = new_dict[key]
+        if old_val != new_val:
+            changes[key] = (old_val, new_val)
+
+    return changes
+
+
+def folios_to_table(folios: list) -> List[Dict[str, Any]]:
+    """
+    Convert a list of AgentFolios to a table-friendly format.
+
+    Returns list of dicts suitable for CSV/JSON export.
+    """
+    rows = []
+    for f in folios:
+        row = f.to_dict()
+        row["combined_score"] = f.combined_reputation_score
+        row["has_beacon_identity"] = f.has_beacon_identity
+        row["has_economy_wallet"] = f.has_economy_wallet
+        rows.append(row)
+    return rows

--- a/bounties/issue-2890/src/requirements.txt
+++ b/bounties/issue-2890/src/requirements.txt
@@ -1,0 +1,12 @@
+# AgentFolio ↔ Beacon Integration
+# No additional runtime deps beyond what the repo already uses.
+# All imports are stdlib or optional crypto libraries.
+
+# Optional: for creating attestations (signing)
+# pynacl>=1.5.0
+
+# Optional: for verifying attestations (alternative to pynacl)
+# cryptography>=41.0.0
+
+# The bridge and folio modules use only stdlib + the existing
+# rustchain.agent_economy SDK (which depends on requests).

--- a/bounties/issue-2890/tests/test_attestation.py
+++ b/bounties/issue-2890/tests/test_attestation.py
@@ -1,0 +1,404 @@
+"""
+Tests for EnvelopeAttestation module.
+
+Run with: pytest tests/test_attestation.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    attest_bounty_submission,
+    verify_attestation,
+    verify_attestation_from_envelope,
+    verify_attestation_from_json,
+    _generate_nonce,
+    _canonical_signed_fields,
+    _canonical_signing_payload,
+    NACL_AVAILABLE,
+)
+
+
+# A known Ed25519 keypair for testing (generated once, never used in production)
+_TEST_SIGNING_KEY_HEX = "a" * 64  # 32 bytes = 64 hex chars (valid but not real)
+
+
+class TestNonceGeneration:
+    """Test nonce generation."""
+
+    def test_nonce_is_deterministic_for_same_input(self):
+        """Same submission_id + timestamp produces same nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_123", 1712700000)
+        assert n1 == n2
+
+    def test_nonce_differs_for_different_submission(self):
+        """Different submission_id produces different nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_456", 1712700000)
+        assert n1 != n2
+
+    def test_nonce_differs_for_different_timestamp(self):
+        """Different timestamp produces different nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_123", 1712700001)
+        assert n1 != n2
+
+    def test_nonce_length(self):
+        """Nonce is 32 hex chars (16 bytes blake2b)."""
+        nonce = _generate_nonce("sub_123", 1712700000)
+        assert len(nonce) == 32
+
+
+class TestCanonicalFields:
+    """Test canonical field extraction."""
+
+    def test_excludes_sig_field(self):
+        """sig field is excluded from signed fields."""
+        envelope = {"agent_id": "test", "sig": "abc123", "kind": "bounty"}
+        fields = _canonical_signed_fields(envelope)
+        assert "sig" not in fields
+        assert "agent_id" in fields
+        assert "kind" in fields
+
+    def test_excludes_beacon_version(self):
+        """_beacon_version field is excluded."""
+        envelope = {"agent_id": "test", "_beacon_version": "2", "kind": "bounty"}
+        fields = _canonical_signed_fields(envelope)
+        assert "_beacon_version" not in fields
+
+    def test_payload_is_canonical_json(self):
+        """Signing payload is canonical JSON (sorted keys, no spaces)."""
+        envelope = {"b": 2, "a": 1, "sig": "x"}
+        payload = _canonical_signing_payload(envelope)
+        expected = b'{"a":1,"b":2}'
+        assert payload == expected
+
+
+class TestEnvelopeAttestationDataclass:
+    """Test EnvelopeAttestation serialization."""
+
+    def test_default_values(self):
+        """Test default field values."""
+        att = EnvelopeAttestation(agent_id="test-agent")
+        assert att.agent_id == "test-agent"
+        assert att.kind == "bounty"
+        assert att.nonce == ""
+        assert att.timestamp == 0
+
+    def test_to_envelope(self):
+        """Test envelope serialization."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc123",
+            bounty_id="bounty_1",
+            submission_id="sub_1",
+            pr_url="https://github.com/test/pull/1",
+            summary="Fixed bug",
+            timestamp=1712700000,
+            pubkey_hex="deadbeef",
+            sig_hex="cafebabe",
+        )
+        env = att.to_envelope()
+        assert env["agent_id"] == "test-agent"
+        assert env["kind"] == "bounty"
+        assert env["nonce"] == "abc123"
+        assert env["bounty_id"] == "bounty_1"
+        assert env["sig"] == "cafebabe"
+
+    def test_roundtrip_envelope(self):
+        """Test envelope → from_envelope → to_envelope roundtrip."""
+        original = {
+            "agent_id": "test-agent",
+            "kind": "bounty",
+            "nonce": "abc123",
+            "bounty_id": "bounty_1",
+            "submission_id": "sub_1",
+            "pr_url": "https://github.com/test/pull/1",
+            "summary": "Fixed bug",
+            "timestamp": 1712700000,
+            "pubkey": "deadbeef",
+            "sig": "cafebabe",
+        }
+        att = EnvelopeAttestation.from_envelope(original)
+        result = att.to_envelope()
+        assert result == original
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc",
+            bounty_id="b1",
+            submission_id="s1",
+            pr_url="https://example.com/pr",
+            summary="Work done",
+            timestamp=1000,
+            pubkey_hex="aa",
+            sig_hex="bb",
+        )
+        json_str = att.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["agent_id"] == "test-agent"
+        assert parsed["kind"] == "bounty"
+
+    def test_roundtrip_json(self):
+        """Test JSON roundtrip."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc",
+            bounty_id="b1",
+            submission_id="s1",
+            pr_url="https://example.com/pr",
+            summary="Work done",
+            timestamp=1000,
+            pubkey_hex="aa",
+            sig_hex="bb",
+        )
+        restored = EnvelopeAttestation.from_json(att.to_json())
+        assert restored.agent_id == att.agent_id
+        assert restored.nonce == att.nonce
+        assert restored.sig_hex == att.sig_hex
+
+
+class TestAttestBountySubmission:
+    """Test attestation creation."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_creates_valid_attestation(self):
+        """Test that a valid attestation is created."""
+        # Generate a real keypair for this test
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Implemented feature",
+            signing_key_hex=sk_hex,
+            timestamp=1712700000,
+        )
+
+        assert att.agent_id == "test-agent"
+        assert att.kind == "bounty"
+        assert att.bounty_id == "bounty_123"
+        assert att.submission_id == "sub_456"
+        assert att.pr_url == "https://github.com/test/pull/1"
+        assert att.summary == "Implemented feature"
+        assert att.timestamp == 1712700000
+        assert att.pubkey_hex  # Non-empty
+        assert att.sig_hex  # Non-empty
+        assert len(att.sig_hex) == 128  # 64 bytes = 128 hex chars
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_nonce_is_unique_per_submission(self):
+        """Test that different submissions get different nonces."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att1 = attest_bounty_submission(
+            bounty_id="b1", submission_id="sub_1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work 1", signing_key_hex=sk_hex,
+        )
+        att2 = attest_bounty_submission(
+            bounty_id="b1", submission_id="sub_2",
+            submitter_agent_id="agent", pr_url="https://x.com/2",
+            summary="Work 2", signing_key_hex=sk_hex,
+        )
+        assert att1.nonce != att2.nonce
+
+    def test_raises_without_pynacl(self):
+        """Test that creation fails without PyNaCl."""
+        with patch("agentfolio_beacon.attestation.NACL_AVAILABLE", False):
+            with pytest.raises(RuntimeError, match="PyNaCl is required"):
+                attest_bounty_submission(
+                    bounty_id="b1", submission_id="s1",
+                    submitter_agent_id="agent", pr_url="https://x.com/1",
+                    summary="Work", signing_key_hex="aa" * 32,
+                )
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_raises_on_invalid_key(self):
+        """Test that invalid signing key raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid signing key"):
+            attest_bounty_submission(
+                bounty_id="b1", submission_id="s1",
+                submitter_agent_id="agent", pr_url="https://x.com/1",
+                summary="Work", signing_key_hex="not_hex!!",
+            )
+
+
+class TestVerifyAttestation:
+    """Test attestation verification."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_valid_attestation_verifies(self):
+        """Test that a properly signed attestation verifies."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Implemented feature",
+            signing_key_hex=sk_hex,
+        )
+
+        valid, reason = verify_attestation(att)
+        assert valid is True
+        assert reason == ""
+
+    def test_missing_signature(self):
+        """Test that missing signature fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            pubkey_hex="aa" * 32,
+            sig_hex="",  # Empty signature
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_signature" in reason
+
+    def test_missing_pubkey(self):
+        """Test that missing pubkey fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            sig_hex="bb" * 64,
+            pubkey_hex="",  # Empty pubkey
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_pubkey" in reason
+
+    def test_missing_agent_id(self):
+        """Test that missing agent_id fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="",  # Empty
+            pubkey_hex="aa" * 32,
+            sig_hex="bb" * 64,
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_agent_id" in reason
+
+    def test_invalid_kind(self):
+        """Test that non-bounty kind fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            kind="heartbeat",  # Wrong kind
+            pubkey_hex="aa" * 32,
+            sig_hex="bb" * 64,
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_kind" in reason
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_tampered_envelope_fails(self):
+        """Test that modifying the envelope after signing fails verification."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Original summary",
+            signing_key_hex=sk_hex,
+        )
+
+        # Tamper with the summary
+        att.summary = "Tampered summary"
+
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_signature" in reason
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_wrong_key_fails(self):
+        """Test that signature from different key fails verification."""
+        from nacl.signing import SigningKey
+        sk1 = SigningKey.generate()
+        sk2 = SigningKey.generate()
+
+        # Sign with key 1
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk1.encode().hex(),
+        )
+
+        # But claim it's from key 2
+        att.pubkey_hex = sk2.verify_key.encode().hex()
+
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_signature" in reason
+
+
+class TestVerifyFromEnvelope:
+    """Test verification from raw envelope dict."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_verify_from_envelope(self):
+        """Test verification directly from envelope dict."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk_hex,
+        )
+
+        envelope = att.to_envelope()
+        valid, reason = verify_attestation_from_envelope(envelope)
+        assert valid is True
+
+    def test_verify_from_envelope_invalid_json(self):
+        """Test that invalid envelope dict is handled."""
+        valid, reason = verify_attestation_from_envelope({"not": "a real envelope"})
+        assert valid is False
+
+
+class TestVerifyFromJson:
+    """Test verification from JSON string."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_verify_from_json(self):
+        """Test verification from JSON string."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk_hex,
+        )
+
+        valid, reason = verify_attestation_from_json(att.to_json())
+        assert valid is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/bounties/issue-2890/tests/test_bridge.py
+++ b/bounties/issue-2890/tests/test_bridge.py
@@ -1,0 +1,397 @@
+"""
+Tests for BeaconBridge adapter.
+
+Run with: pytest tests/test_bridge.py -v
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.bridge import BeaconBridge
+
+
+def make_mock_client():
+    """Create a mock AgentEconomyClient."""
+    client = MagicMock()
+    client._request = MagicMock(return_value={})
+    return client
+
+
+class TestBeaconBridgeInit:
+    """Test BeaconBridge initialization."""
+
+    def test_init_with_default_url(self):
+        """Test bridge uses client's base_url by default."""
+        client = make_mock_client()
+        client.config.base_url = "http://localhost:5000"
+        bridge = BeaconBridge(client)
+        assert bridge._beacon_url is None  # Uses client's URL
+
+    def test_init_with_override_url(self):
+        """Test bridge can override beacon URL."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client, beacon_base_url="http://beacon.example.com")
+        assert bridge._beacon_url == "http://beacon.example.com"
+
+
+class TestBeaconBridgeRelayAgents:
+    """Test relay agent discovery methods."""
+
+    def test_get_relay_agent_success(self):
+        """Test successful relay agent lookup."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agent_id": "test-agent",
+            "pubkey_hex": "deadbeef",
+            "name": "Test Agent",
+            "status": "active",
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("test-agent")
+
+        assert result is not None
+        assert result["agent_id"] == "test-agent"
+        assert result["pubkey_hex"] == "deadbeef"
+        client._request.assert_called_once_with("GET", "/api/agent/test-agent")
+
+    def test_get_relay_agent_not_found(self):
+        """Test relay agent not found returns None."""
+        client = make_mock_client()
+        client._request.return_value = {"error": "Agent not found"}
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("nonexistent")
+
+        assert result is None
+
+    def test_get_relay_agent_exception(self):
+        """Test relay agent exception returns None."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Connection refused")
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("test-agent")
+
+        assert result is None
+
+    def test_list_relay_agents(self):
+        """Test listing relay agents."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agents": [
+                {"agent_id": "agent-a", "status": "active"},
+                {"agent_id": "agent-b", "status": "active"},
+            ],
+            "total": 2,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents()
+
+        assert len(result) == 2
+        assert result[0]["agent_id"] == "agent-a"
+        client._request.assert_called_once_with("GET", "/beacon/atlas", params={})
+
+    def test_list_relay_agents_with_status_filter(self):
+        """Test listing relay agents with status filter."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agents": [{"agent_id": "agent-a", "status": "active"}],
+            "total": 1,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents(status="active")
+
+        client._request.assert_called_once_with(
+            "GET", "/beacon/atlas", params={"status": "active"}
+        )
+
+    def test_list_relay_agents_returns_list_directly(self):
+        """Test handling API that returns list directly."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"agent_id": "agent-a"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents()
+
+        assert len(result) == 1
+
+
+class TestBeaconBridgeReputation:
+    """Test reputation query methods."""
+
+    def test_get_beacon_reputation_success(self):
+        """Test successful reputation lookup."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agent_id": "test-agent",
+            "score": 75,
+            "bounties_completed": 5,
+            "contracts_completed": 3,
+            "contracts_breached": 0,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_beacon_reputation("test-agent")
+
+        assert result is not None
+        assert result["score"] == 75
+        assert result["bounties_completed"] == 5
+        client._request.assert_called_once_with(
+            "GET", "/api/reputation/test-agent"
+        )
+
+    def test_get_beacon_reputation_not_found(self):
+        """Test reputation not found returns None."""
+        client = make_mock_client()
+        client._request.return_value = {"error": "Agent not found"}
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_beacon_reputation("nonexistent")
+
+        assert result is None
+
+    def test_list_all_reputation(self):
+        """Test listing all reputations."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"agent_id": "agent-a", "score": 90},
+            {"agent_id": "agent-b", "score": 75},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_all_reputation()
+
+        assert len(result) == 2
+        assert result[0]["score"] == 90
+
+
+class TestBeaconBridgeContracts:
+    """Test contract query methods."""
+
+    def test_get_contracts(self):
+        """Test getting all contracts."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "to_agent": "b", "state": "active"},
+            {"id": "c2", "from_agent": "a", "to_agent": "c", "state": "completed"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts()
+
+        assert len(result) == 2
+
+    def test_get_contracts_filtered_by_agent(self):
+        """Test filtering contracts by agent."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "to_agent": "b", "state": "active"},
+            {"id": "c2", "from_agent": "x", "to_agent": "y", "state": "active"},
+            {"id": "c3", "from_agent": "b", "to_agent": "a", "state": "completed"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts(agent_id="a")
+
+        assert len(result) == 2  # c1 and c3 involve agent "a"
+
+    def test_get_contracts_filtered_by_state(self):
+        """Test filtering contracts by state."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "state": "active"},
+            {"id": "c2", "state": "completed"},
+            {"id": "c3", "state": "active"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts(state="active")
+
+        assert len(result) == 2
+
+    def test_count_active_contracts(self):
+        """Test counting active contracts."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "state": "active"},
+            {"id": "c2", "from_agent": "a", "state": "completed"},
+            {"id": "c3", "from_agent": "a", "state": "active"},
+        ]
+        bridge = BeaconBridge(client)
+
+        count = bridge.count_active_contracts("a")
+
+        assert count == 2
+
+
+class TestBeaconBridgeBounties:
+    """Test bounty query methods."""
+
+    def test_get_open_bounties(self):
+        """Test getting open bounties."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "b1", "title": "Fix bug", "reward_rtc": 50.0},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_open_bounties()
+
+        assert len(result) == 1
+        assert result[0]["title"] == "Fix bug"
+        client._request.assert_called_once_with("GET", "/api/bounties")
+
+
+class TestBeaconBridgeEnvelopes:
+    """Test envelope query methods."""
+
+    def test_get_recent_envelopes(self):
+        """Test getting recent envelopes."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": 1, "agent_id": "a", "kind": "heartbeat"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_recent_envelopes(agent_id="a", limit=10)
+
+        assert len(result) == 1
+        client._request.assert_called_once_with(
+            "GET", "/api/beacon/envelopes", params={"limit": 10, "agent_id": "a"}
+        )
+
+    def test_get_recent_envelopes_on_failure(self):
+        """Test envelope query returns empty list on failure."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Endpoint not found")
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_recent_envelopes()
+
+        assert result == []
+
+    def test_count_agent_envelopes(self):
+        """Test counting agent envelopes."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": i, "agent_id": "a"} for i in range(5)
+        ]
+        bridge = BeaconBridge(client)
+
+        count = bridge.count_agent_envelopes("a")
+
+        assert count == 5
+
+
+class TestBeaconBridgeHealth:
+    """Test health check."""
+
+    def test_beacon_health_success(self):
+        """Test successful health check."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "status": "ok",
+            "timestamp": 1712700000,
+            "service": "beacon-atlas-api",
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.beacon_health()
+
+        assert result is not None
+        assert result["status"] == "ok"
+
+    def test_beacon_health_failure(self):
+        """Test health check returns None on failure."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Connection refused")
+        bridge = BeaconBridge(client)
+
+        result = bridge.beacon_health()
+
+        assert result is None
+
+
+class TestBeaconBridgeLookupAgentEverything:
+    """Test the unified agent lookup convenience method."""
+
+    def test_lookup_agent_everything(self):
+        """Test unified agent lookup aggregates all data."""
+        client = make_mock_client()
+
+        def mock_request(method, endpoint, **kwargs):
+            if endpoint == "/api/agent/test-agent":
+                return {
+                    "agent_id": "test-agent",
+                    "pubkey_hex": "deadbeef",
+                    "created_at": 1712600000,
+                }
+            elif endpoint == "/api/reputation/test-agent":
+                return {
+                    "agent_id": "test-agent",
+                    "score": 80,
+                    "bounties_completed": 5,
+                    "contracts_completed": 3,
+                    "contracts_breached": 0,
+                }
+            elif endpoint == "/api/contracts":
+                return [
+                    {"id": "c1", "from_agent": "test-agent", "state": "active"},
+                    {"id": "c2", "from_agent": "test-agent", "state": "completed"},
+                ]
+            elif endpoint == "/api/beacon/envelopes":
+                return [{"id": 1, "agent_id": "test-agent"}]
+            return {}
+
+        client._request = MagicMock(side_effect=mock_request)
+        bridge = BeaconBridge(client)
+
+        result = bridge.lookup_agent_everything("test-agent")
+
+        assert result["relay_agent"] is not None
+        assert result["relay_agent"]["pubkey_hex"] == "deadbeef"
+        assert result["reputation"] is not None
+        assert result["reputation"]["score"] == 80
+        assert result["active_contracts"] == 1  # Only "active" state
+        assert result["total_contracts"] == 2
+        assert result["envelopes_recent"] == 1
+
+
+class TestBeaconBridgeBaseUrlOverride:
+    """Test that beacon_base_url override works correctly."""
+
+    def test_request_uses_override_url(self):
+        """Test that requests go to override URL when set."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client, beacon_base_url="http://beacon.local:9000")
+
+        bridge.get_relay_agent("test-agent")
+
+        # Check that base_url was passed to _request
+        call_kwargs = client._request.call_args[1]
+        assert call_kwargs["base_url"] == "http://beacon.local:9000"
+
+    def test_request_no_override_when_not_set(self):
+        """Test that requests don't include base_url when not overridden."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client)
+
+        bridge.get_relay_agent("test-agent")
+
+        call_kwargs = client._request.call_args[1]
+        assert "base_url" not in call_kwargs
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/bounties/issue-2890/tests/test_folio.py
+++ b/bounties/issue-2890/tests/test_folio.py
@@ -1,0 +1,391 @@
+"""
+Tests for AgentFolio dataclass and assemble_folio function.
+
+Run with: pytest tests/test_folio.py -v
+"""
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.folio import (
+    AgentFolio,
+    assemble_folio,
+    folio_diff,
+    folios_to_table,
+)
+
+
+class TestAgentFolioDataclass:
+    """Test AgentFolio dataclass."""
+
+    def test_default_values(self):
+        """Test default field values."""
+        folio = AgentFolio(agent_id="test-agent")
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex is None
+        assert folio.wallet_address is None
+        assert folio.beacon_score is None
+        assert folio.economy_score is None
+        assert folio.total_envelopes_sent == 0
+        assert folio.assembled_at == 0.0
+
+    def test_to_dict(self):
+        """Test dictionary serialization."""
+        folio = AgentFolio(
+            agent_id="test-agent",
+            beacon_pubkey_hex="deadbeef",
+            wallet_address="wallet_123",
+            beacon_score=75,
+            economy_score=82.5,
+            total_envelopes_sent=10,
+            active_contracts=2,
+            assembled_at=1712700000.0,
+        )
+        d = folio.to_dict()
+        assert d["agent_id"] == "test-agent"
+        assert d["beacon_pubkey_hex"] == "deadbeef"
+        assert d["wallet_address"] == "wallet_123"
+        assert d["beacon_score"] == 75
+        assert d["economy_score"] == 82.5
+        assert d["total_envelopes_sent"] == 10
+
+    def test_from_dict(self):
+        """Test dictionary deserialization."""
+        data = {
+            "agent_id": "test-agent",
+            "beacon_pubkey_hex": "deadbeef",
+            "wallet_address": "wallet_123",
+            "beacon_score": 75,
+            "economy_score": 82.5,
+            "total_envelopes_sent": 10,
+            "active_contracts": 2,
+            "assembled_at": 1712700000.0,
+            "extra_field": "should_be_ignored",  # Unknown fields ignored
+        }
+        folio = AgentFolio.from_dict(data)
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert not hasattr(folio, "extra_field")
+
+    def test_summary_with_data(self):
+        """Test human-readable summary with data."""
+        folio = AgentFolio(
+            agent_id="test-agent",
+            beacon_score=75,
+            economy_score=82.5,
+            total_envelopes_sent=10,
+            active_contracts=2,
+        )
+        summary = folio.summary()
+        assert "test-agent" in summary
+        assert "beacon=75" in summary
+        assert "economy=82" in summary
+        assert "envelopes=10" in summary
+        assert "contracts=2" in summary
+
+    def test_summary_minimal(self):
+        """Test summary with minimal data."""
+        folio = AgentFolio(agent_id="minimal-agent")
+        summary = folio.summary()
+        assert "minimal-agent" in summary
+        assert "beacon=" not in summary
+        assert "economy=" not in summary
+
+    def test_has_beacon_identity(self):
+        """Test beacon identity property."""
+        folio_with = AgentFolio(agent_id="a", beacon_pubkey_hex="deadbeef")
+        folio_without = AgentFolio(agent_id="b")
+        assert folio_with.has_beacon_identity is True
+        assert folio_without.has_beacon_identity is False
+
+    def test_has_economy_wallet(self):
+        """Test economy wallet property."""
+        folio_with = AgentFolio(agent_id="a", wallet_address="wallet_123")
+        folio_without = AgentFolio(agent_id="b")
+        assert folio_with.has_economy_wallet is True
+        assert folio_without.has_economy_wallet is False
+
+    def test_combined_reputation_score_prefers_economy(self):
+        """Test combined score prefers economy score."""
+        folio = AgentFolio(
+            agent_id="a",
+            beacon_score=75,
+            economy_score=82.5,
+        )
+        assert folio.combined_reputation_score == 82.5
+
+    def test_combined_reputation_score_falls_back_to_beacon(self):
+        """Test combined score falls back to beacon score."""
+        folio = AgentFolio(
+            agent_id="a",
+            beacon_score=75,
+            economy_score=None,
+        )
+        assert folio.combined_reputation_score == 75.0
+
+    def test_combined_reputation_score_none(self):
+        """Test combined score is None when both unavailable."""
+        folio = AgentFolio(agent_id="a")
+        assert folio.combined_reputation_score is None
+
+
+class TestAssembleFolio:
+    """Test folio assembly function."""
+
+    def _make_mock_client_and_bridge(self):
+        """Create mock economy client and beacon bridge."""
+        # Mock economy client
+        economy_client = MagicMock()
+
+        # Mock wallet
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = "0xBase123"
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        # Mock reputation
+        mock_rep_score = MagicMock()
+        mock_rep_score.score = 85.0
+        economy_client.reputation.get_score.return_value = mock_rep_score
+
+        # Mock bounty claims
+        economy_client.bounties.get_my_claims.return_value = [
+            {"bounty_id": "b1"},
+            {"bounty_id": "b2"},
+        ]
+
+        # Mock beacon bridge
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": {
+                "agent_id": "test-agent",
+                "pubkey_hex": "deadbeef",
+                "coinbase_address": "0xRelay456",
+                "created_at": 1712600000,
+            },
+            "reputation": {
+                "agent_id": "test-agent",
+                "score": 75,
+                "bounties_completed": 5,
+                "contracts_completed": 3,
+                "contracts_breached": 1,
+            },
+            "active_contracts": 2,
+            "total_contracts": 5,
+            "envelopes_recent": 10,
+        }
+
+        return economy_client, beacon_bridge
+
+    def test_assemble_folio_populates_all_fields(self):
+        """Test that folio assembly populates fields from both sources."""
+        economy_client, beacon_bridge = self._make_mock_client_and_bridge()
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Identity
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert folio.wallet_address == "wallet_abc"
+        # Economy wallet's base_address overwrites beacon's coinbase_address
+        # (economy data is assembled after beacon data)
+        assert folio.base_address == "0xBase123"
+
+        # Beacon reputation
+        assert folio.beacon_score == 75
+        assert folio.beacon_bounties_completed == 5
+        assert folio.beacon_contracts_completed == 3
+        assert folio.beacon_contracts_breached == 1
+
+        # Economy reputation
+        assert folio.economy_score == 85.0
+
+        # Activity
+        assert folio.total_envelopes_sent == 10
+        assert folio.active_contracts == 2
+        assert folio.open_claims == 2
+
+        # Metadata
+        assert folio.first_seen_beacon == 1712600000
+        assert folio.assembled_at > 0
+
+    def test_assemble_folio_handles_beacon_failure(self):
+        """Test folio assembly continues when Beacon data unavailable."""
+        economy_client = MagicMock()
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = None
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        mock_rep_score = MagicMock()
+        mock_rep_score.score = 80.0
+        economy_client.reputation.get_score.return_value = mock_rep_score
+        economy_client.bounties.get_my_claims.return_value = []
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.side_effect = Exception("Beacon down")
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Economy data should still be populated
+        assert folio.wallet_address == "wallet_abc"
+        assert folio.economy_score == 80.0
+        # Beacon data should be defaults
+        assert folio.beacon_score is None
+        assert folio.beacon_pubkey_hex is None
+
+    def test_assemble_folio_handles_economy_failure(self):
+        """Test folio assembly continues when Economy data unavailable."""
+        economy_client = MagicMock()
+        economy_client.agents.get_wallet.side_effect = Exception("Economy down")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": {
+                "agent_id": "test-agent",
+                "pubkey_hex": "deadbeef",
+                "created_at": 1712600000,
+            },
+            "reputation": {
+                "score": 75,
+                "bounties_completed": 5,
+                "contracts_completed": 3,
+                "contracts_breached": 0,
+            },
+            "active_contracts": 2,
+            "total_contracts": 5,
+            "envelopes_recent": 10,
+        }
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Beacon data should still be populated
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert folio.beacon_score == 75
+        # Economy data should be defaults
+        assert folio.wallet_address is None
+        assert folio.economy_score is None
+
+    def test_assemble_folio_handles_all_failure(self):
+        """Test folio assembly returns empty folio when both sources fail."""
+        economy_client = MagicMock()
+        economy_client.agents.get_wallet.side_effect = Exception("Down")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.side_effect = Exception("Down")
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex is None
+        assert folio.wallet_address is None
+        assert folio.assembled_at > 0
+
+    def test_assemble_folio_handles_missing_optional_fields(self):
+        """Test folio assembly handles missing optional fields gracefully."""
+        economy_client = MagicMock()
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = None  # No base address
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        # Reputation lookup fails
+        economy_client.reputation.get_score.side_effect = Exception("No rep")
+        economy_client.bounties.get_my_claims.side_effect = Exception("No claims")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": None,  # No relay agent
+            "reputation": None,   # No beacon reputation
+            "active_contracts": 0,
+            "total_contracts": 0,
+            "envelopes_recent": 0,
+        }
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        assert folio.wallet_address == "wallet_abc"
+        assert folio.base_address is None
+        assert folio.beacon_pubkey_hex is None
+        assert folio.beacon_score is None
+        assert folio.economy_score is None
+
+
+class TestFolioDiff:
+    """Test folio difference computation."""
+
+    def test_detects_changes(self):
+        """Test that changed fields are detected."""
+        old = AgentFolio(
+            agent_id="test",
+            beacon_score=70,
+            total_envelopes_sent=5,
+            assembled_at=1000.0,
+        )
+        new = AgentFolio(
+            agent_id="test",
+            beacon_score=80,
+            total_envelopes_sent=10,
+            assembled_at=2000.0,
+        )
+
+        changes = folio_diff(old, new)
+
+        assert "beacon_score" in changes
+        assert changes["beacon_score"] == (70, 80)
+        assert "total_envelopes_sent" in changes
+        assert changes["total_envelopes_sent"] == (5, 10)
+        # assembled_at should be excluded
+        assert "assembled_at" not in changes
+
+    def test_no_changes(self):
+        """Test that identical folios show no changes."""
+        old = AgentFolio(agent_id="test", beacon_score=70)
+        new = AgentFolio(agent_id="test", beacon_score=70)
+
+        changes = folio_diff(old, new)
+
+        assert changes == {}
+
+
+class TestFoliosToTable:
+    """Test folio table conversion."""
+
+    def test_converts_to_table(self):
+        """Test folios are converted to table format."""
+        folios = [
+            AgentFolio(
+                agent_id="agent-a",
+                beacon_score=75,
+                beacon_pubkey_hex="deadbeef",
+                wallet_address="wallet_1",
+            ),
+            AgentFolio(
+                agent_id="agent-b",
+                economy_score=85.0,
+            ),
+        ]
+
+        table = folios_to_table(folios)
+
+        assert len(table) == 2
+        assert table[0]["agent_id"] == "agent-a"
+        assert table[0]["combined_score"] == 75.0
+        assert table[0]["has_beacon_identity"] is True
+        assert table[0]["has_economy_wallet"] is True
+
+        assert table[1]["agent_id"] == "agent-b"
+        assert table[1]["combined_score"] == 85.0
+        assert table[1]["has_beacon_identity"] is False
+        assert table[1]["has_economy_wallet"] is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- add an AgentFolio ↔ Beacon reference implementation under `bounties/issue-2890/`
- assemble a unified agent folio from Beacon Atlas and Agent Economy data via a read-only bridge
- add Beacon v2 envelope-based attestation helpers, spec docs, demo script, and focused tests

## Testing
- cd bounties/issue-2890 && python3 -m pytest tests/ -v
- cd bounties/issue-2890 && python3 examples/demo_folio.py
