### PR TITLE
feat: add RustChain MCP reference server

### DIFF
--- a/bounties/issue-2890/README.md
+++ b/bounties/issue-2890/README.md
@@ -1,0 +1,293 @@
+# AgentFolio ↔ Beacon Integration
+
+> **Issue**: #2890 — AgentFolio ↔ Beacon Integration Spec + Reference Implementation
+> **Scope**: 100 RTC (MVP)
+> **Status**: MVP Complete — reference implementation with tests and demo
+
+## One-Liner
+
+Unified agent profiles (`AgentFolio`) that aggregate identity and reputation from both **Beacon Atlas** and **Agent Economy (RIP-302)**, plus cryptographically verifiable **bounty submission attestations** as Beacon v2 envelopes.
+
+## Quick Start
+
+```bash
+cd bounties/issue-2890
+
+# Run the demo
+python examples/demo_folio.py
+
+# Run tests
+pytest tests/ -v
+```
+
+## What's Included
+
+| Module | Purpose | Lines |
+|--------|---------|-------|
+| `src/agentfolio_beacon/folio.py` | `AgentFolio` dataclass + `assemble_folio()` | ~200 |
+| `src/agentfolio_beacon/bridge.py` | `BeaconBridge` adapter for Beacon Atlas APIs | ~200 |
+| `src/agentfolio_beacon/attestation.py` | `EnvelopeAttestation` — sign/verify bounty submissions | ~250 |
+| `tests/test_folio.py` | Folio assembly, diff, table conversion | ~300 |
+| `tests/test_bridge.py` | Bridge routing, error handling, mock integration | ~250 |
+| `tests/test_attestation.py` | Attestation creation, verification, tamper detection | ~250 |
+| `docs/SPEC.md` | Full specification | — |
+| `examples/demo_folio.py` | End-to-end demo with mocked data | ~150 |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                  AgentFolio Assembly                  │
+│                                                       │
+│  AgentEconomyClient ──┐                               │
+│                        ├──► BeaconBridge ──► Folio    │
+│  Beacon Atlas API   ──┘                               │
+└──────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────┐
+│              Bounty Submission Attestation             │
+│                                                       │
+│  Submission ──► EnvelopeAttestation ──► Beacon v2     │
+│                   (Ed25519 signed)                     │
+│                                                       │
+│  Anyone with pubkey ──► verify_attestation() ──► ✅   │
+└──────────────────────────────────────────────────────┘
+```
+
+## Usage
+
+### 1. Assemble an AgentFolio
+
+```python
+from rustchain.agent_economy import AgentEconomyClient
+from agentfolio_beacon import BeaconBridge, assemble_folio
+
+# Connect to your node
+client = AgentEconomyClient(base_url="http://localhost:5000")
+bridge = BeaconBridge(client)
+
+# Assemble unified profile
+folio = assemble_folio("my-agent", client, bridge)
+
+print(f"Beacon pubkey: {folio.beacon_pubkey_hex}")
+print(f"Economy score: {folio.economy_score}")
+print(f"Beacon score:  {folio.beacon_score}")
+print(f"Envelopes:     {folio.total_envelopes_sent}")
+print(f"Active contracts: {folio.active_contracts}")
+```
+
+### 2. Create a Bounty Submission Attestation
+
+```python
+from nacl.signing import SigningKey
+from agentfolio_beacon import attest_bounty_submission, verify_attestation
+
+# Load your signing key (from secure storage, never hardcode)
+signing_key = SigningKey(bytes.fromhex("your_private_key_hex"))
+
+# Attest your submission
+attestation = attest_bounty_submission(
+    bounty_id="bounty_123",
+    submission_id="sub_456",
+    submitter_agent_id="my-agent",
+    pr_url="https://github.com/Scottcjn/Rustchain/pull/123",
+    summary="Implemented feature X with tests",
+    signing_key_hex=signing_key.encode().hex(),
+)
+
+# The attestation is a self-contained, verifiable Beacon envelope
+envelope_json = attestation.to_json()
+
+# Anyone can verify it:
+valid, reason = verify_attestation(attestation)
+if valid:
+    print("✅ Attestation is valid")
+else:
+    print(f"❌ Invalid: {reason}")
+```
+
+### 3. Verify an Attestation from JSON
+
+```python
+from agentfolio_beacon import verify_attestation_from_json
+
+# Received from a submitter
+received_json = '{"agent_id":"my-agent","kind":"bounty",...}'
+
+valid, reason = verify_attestation_from_json(received_json)
+```
+
+### 4. Query Beacon Data Directly
+
+```python
+from agentfolio_beacon import BeaconBridge
+
+bridge = BeaconBridge(economy_client)
+
+# Relay agents
+agents = bridge.list_relay_agents(status="active")
+
+# Beacon reputation
+rep = bridge.get_beacon_reputation("some-agent")
+
+# Contracts
+contracts = bridge.get_contracts(agent_id="my-agent", state="active")
+
+# Open bounties
+bounties = bridge.get_open_bounties()
+```
+
+## Dependencies
+
+**Runtime**: Python 3.9+, stdlib only.
+
+**Optional** (for attestation creation):
+```bash
+pip install pynacl
+```
+
+**Optional** (for attestation verification, alternative to pynacl):
+```bash
+pip install cryptography
+```
+
+The `BeaconBridge` and `AgentFolio` modules work without any crypto libraries — they only read data.
+
+## Testing
+
+```bash
+cd bounties/issue-2890
+
+# All tests
+pytest tests/ -v
+
+# With coverage
+pytest tests/ -v --cov=agentfolio_beacon --cov-report=term-missing
+
+# Specific module
+pytest tests/test_attestation.py -v
+```
+
+### Test Coverage
+
+| Module | Tests | What's Covered |
+|--------|-------|----------------|
+| `attestation.py` | 15+ | Nonce generation, canonical fields, serialization, sign/verify, tamper detection, wrong key detection |
+| `bridge.py` | 15+ | Relay agent lookup, reputation, contracts, bounties, envelopes, health, error handling |
+| `folio.py` | 12+ | Dataclass serialization, assembly from both sources, failure isolation, diff detection |
+
+## File Layout
+
+```
+bounties/issue-2890/
+├── README.md                    # This file
+├── docs/
+│   └── SPEC.md                  # Full specification
+├── src/
+│   ├── agentfolio_beacon/
+│   │   ├── __init__.py          # Public exports
+│   │   ├── folio.py             # AgentFolio + assemble_folio()
+│   │   ├── bridge.py            # BeaconBridge adapter
+│   │   └── attestation.py       # EnvelopeAttestation + sign/verify
+│   └── requirements.txt
+├── tests/
+│   ├── test_folio.py
+│   ├── test_bridge.py
+│   └── test_attestation.py
+└── examples/
+    └── demo_folio.py            # End-to-end demo
+```
+
+## Design Decisions
+
+### Why a separate package (not in sdk/)?
+
+This is a **cross-cutting integration** between two existing systems (Beacon Atlas + Agent Economy). It doesn't belong in either — it's a thin adapter layer with its own data model (`AgentFolio`) and attestation mechanism.
+
+### Why graceful degradation?
+
+Not all nodes have PyNaCl or cryptography installed. The folio assembly and bridge modules work with **zero crypto dependencies**. Attestation creation requires PyNaCl, but verification works with either PyNaCl or cryptography.
+
+### Why Beacon v2 envelope format for attestations?
+
+Reusing the existing Beacon envelope format means:
+- Attestations can be stored in `beacon_envelopes` table
+- They participate in the Ergo anchoring digest
+- Verification uses the same canonical JSON rules already implemented
+- No new schema or protocol needed
+
+### Why read-only bridge?
+
+The MVP scope is **aggregation and verification**, not mutation. The bridge reads from Beacon Atlas APIs to build folios. State changes (creating contracts, claiming bounties) are handled by the existing Agent Economy SDK.
+
+## Security Notes
+
+- **No private key storage**: The attestation module signs with caller-provided keys; it never generates or stores long-term keys.
+- **Tamper-evident**: Any modification to an attestation's fields after signing invalidates the Ed25519 signature.
+- **Replay-resistant**: Nonces are derived from `blake2b(submission_id || timestamp)`.
+- **Read-only by default**: `BeaconBridge` never mutates state.
+
+## Caveats and Assumptions
+
+### Beacon API route names are hardcoded
+
+`BeaconBridge` assumes the following routes exist on the Beacon Atlas Flask API
+(`node/beacon_api.py`):
+
+| Route | Purpose |
+|-------|---------|
+| `GET /api/agent/<id>` | Single relay agent lookup |
+| `GET /beacon/atlas` | List all relay agents |
+| `GET /api/reputation/<id>` | Agent reputation |
+| `GET /api/reputation` | List all reputations |
+| `GET /api/contracts` | All contracts |
+| `GET /api/bounties` | Open bounties |
+| `GET /api/beacon/envelopes` | Envelope summaries (may not exist on all nodes) |
+| `GET /api/health` | Health check |
+
+If a node renames or removes these endpoints, the corresponding bridge method
+will return `None` or `[]` rather than raising — this is intentional graceful
+degradation, but callers should be aware that an empty result may mean "endpoint
+unavailable" rather than "no data."
+
+### Bridge depends on `AgentEconomyClient._request` internals
+
+`BeaconBridge._request` delegates to `economy_client._request(method, endpoint, ...)`
+and optionally passes `base_url` as a kwarg. This assumes the SDK's `_request`
+method accepts a `base_url` override. If the SDK changes this internal API, the
+bridge will need updating. The bridge is tested against the current SDK behavior
+via mocks; integration tests against a live node would catch drift.
+
+### `count_agent_envelopes` fetches up to 10,000 envelopes
+
+`count_agent_envelopes` calls `get_recent_envelopes(limit=10000)` and counts the
+results. This is a stopgap because there is no `COUNT` endpoint. For agents with
+more than 10,000 envelopes, the count will be capped. A proper solution would add
+a `GET /api/beacon/envelopes/count/<agent_id>` endpoint to the Beacon API.
+
+### `VALID_KINDS` constant is informational
+
+`attestation.py` defines `VALID_KINDS = {"hello", "heartbeat", "want", "bounty", ...}`
+matching the Beacon v2 spec, but the verifier only accepts `kind == "bounty"`.
+The constant is present as a reference for future work that may support other
+envelope kinds.
+
+### Attestation signing requires PyNaCl; verification works with PyNaCl _or_ `cryptography`
+
+- **Creating** attestations requires `pynacl` (Ed25519 signing).
+- **Verifying** attestations works with either `pynacl` or `cryptography`.
+- If neither is installed, `verify_attestation` returns `(False, "signature_verification_unavailable")`.
+- The folio assembly and bridge modules have **zero** crypto dependencies.
+
+### No private key management
+
+This module signs with caller-provided keys and never generates, stores, or
+rotates keys. Key management is the caller's responsibility.
+
+## See Also
+
+- [RIP-302 Agent Economy Spec](../../rips/docs/RIP-302-agent-economy.md)
+- [Beacon Atlas API](../../node/beacon_api.py)
+- [Beacon Anchor (Ergo)](../../node/beacon_anchor.py)
+- [Beacon Identity (TOFU)](../../node/beacon_identity.py)
+- [Agent Economy SDK](../../sdk/docs/AGENT_ECONOMY_SDK.md)

--- a/bounties/issue-2890/docs/SPEC.md
+++ b/bounties/issue-2890/docs/SPEC.md
@@ -1,0 +1,236 @@
+# AgentFolio ↔ Beacon Integration Spec
+
+> **Issue**: #2890 — AgentFolio ↔ Beacon Integration Spec + Reference Implementation
+> **Status**: MVP Complete
+> **Scope**: 100 RTC (MVP)
+> **Created**: 2026-04-10
+
+## 1. Problem Statement
+
+RustChain has two parallel agent identity/reputation systems that don't talk to each other:
+
+| System | Identity | Reputation | Storage |
+|--------|----------|------------|---------|
+| **Beacon Atlas** | `agent_id` + Ed25519 pubkey (TOFU) | Beacon reputation table, contracts, attestations | `rustchain_v2.db` (SQLite) |
+| **Agent Economy (RIP-302)** | `agent_id` + wallet address | `ReputationScore` (0-100), tiers, attestations | Node API + SDK client |
+
+An agent operating across both systems has **no unified view** of its own standing, and third parties cannot easily verify an agent's complete track record.
+
+## 2. Goals (MVP)
+
+1. **AgentFolio** — A single data structure that aggregates an agent's identity, reputation, and activity from both Beacon and Agent Economy sources.
+2. **BeaconBridge** — A thin adapter that lets the Agent Economy SDK query Beacon Atlas data (relay agents, envelopes, contracts) using the same client pattern.
+3. **EnvelopeAttestation** — A mechanism to sign a bounty submission as a Beacon envelope, producing a cryptographically verifiable proof-of-work artifact.
+4. **Spec + Reference Implementation** — This document plus working Python code with tests.
+
+### Non-Goals (explicitly out of scope)
+
+- New consensus or network protocols
+- New payment rails or escrow systems
+- Modifying existing Beacon or Economy database schemas
+- Real-time sync or event streaming
+- UI/dashboard components
+
+## 3. Design
+
+### 3.1 AgentFolio Data Model
+
+```python
+@dataclass
+class AgentFolio:
+    # Core identity
+    agent_id: str                          # e.g. "my-ai-agent"
+    beacon_pubkey_hex: Optional[str]       # From relay_agents / known_keys
+    wallet_address: Optional[str]          # From Agent Economy
+    base_address: Optional[str]            # Optional Coinbase Base address
+
+    # Reputation (Beacon side)
+    beacon_score: Optional[int]            # From beacon_reputation.score
+    beacon_bounties_completed: int         # From beacon_reputation
+    beacon_contracts_completed: int        # From beacon_reputation
+    beacon_contracts_breached: int         # From beacon_reputation
+
+    # Reputation (Economy side)
+    economy_score: Optional[float]         # From RIP-302 ReputationScore (0-100)
+    economy_bounties_completed: int        # From SDK bounty client
+
+    # Activity summary
+    total_envelopes_sent: int              # Count from beacon_envelopes
+    active_contracts: int                  # Contracts in 'active' state
+    open_claims: int                       # Bounties claimed but not completed
+
+    # Metadata
+    first_seen_beacon: Optional[float]     # Unix timestamp
+    first_seen_economy: Optional[float]    # Unix timestamp
+    assembled_at: float                    # When this folio was built
+```
+
+### 3.2 BeaconBridge
+
+`BeaconBridge` wraps an `AgentEconomyClient` and adds methods that query the Beacon Atlas Flask API endpoints already exposed by `node/beacon_api.py`:
+
+| Method | Beacon Endpoint | Returns |
+|--------|----------------|---------|
+| `get_relay_agent(agent_id)` | `GET /api/agent/<id>` | Relay agent dict or None |
+| `list_relay_agents(status?)` | `GET /beacon/atlas` | List of relay agents |
+| `get_beacon_reputation(agent_id)` | `GET /api/reputation/<id>` | Reputation dict or None |
+| `get_beacon_contracts(agent_id?)` | `GET /api/contracts` | List of contracts |
+| `get_recent_envelopes(agent_id?, limit)` | (direct DB query) | List of envelope summaries |
+
+The bridge uses the same `_request` pattern as the SDK, routing Beacon calls to the beacon API base URL.
+
+### 3.3 EnvelopeAttestation
+
+A bounty submission can be attested by encoding it as a **Beacon v2 envelope**:
+
+```
+kind: "bounty"
+agent_id: <submitter agent_id>
+nonce: <unique nonce, e.g. blake2b(submission_id + timestamp)>
+pubkey: <agent's Ed25519 public key>
+sig: Ed25519 signature of canonical JSON body
+```
+
+The envelope body contains:
+```json
+{
+  "agent_id": "submitter-agent",
+  "kind": "bounty",
+  "nonce": "abc123...",
+  "bounty_id": "bounty_456",
+  "submission_id": "sub_789",
+  "pr_url": "https://github.com/.../pull/1",
+  "summary": "Implemented feature X with tests",
+  "timestamp": 1712700000
+}
+```
+
+This produces a **self-contained, cryptographically verifiable** attestation that:
+- Proves the submitter's identity (Ed25519 pubkey)
+- Binds the submission to a specific bounty
+- Can be independently verified by anyone with the pubkey
+- Can be stored in `beacon_envelopes` for Ergo anchoring
+
+### 3.4 Assembly Flow
+
+```
+AgentEconomyClient ──┐
+                      ├──► BeaconBridge ──► AgentFolio.assemble()
+Beacon Atlas API   ──┘
+```
+
+1. Create `AgentEconomyClient` with agent identity
+2. Create `BeaconBridge` pointing to same node
+3. Call `AgentFolio.assemble(agent_id, economy_client, beacon_bridge)`
+4. Returns populated `AgentFolio` with best-effort fields from both sources
+
+## 4. API Surface
+
+### 4.1 Public Exports
+
+```python
+from agentfolio_beacon import (
+    AgentFolio,
+    BeaconBridge,
+    EnvelopeAttestation,
+    assemble_folio,
+    attest_bounty_submission,
+    verify_attestation,
+)
+```
+
+### 4.2 Core Functions
+
+```python
+# Assemble a unified agent folio
+folio = assemble_folio(
+    agent_id="my-agent",
+    economy_client=economy_client,  # AgentEconomyClient
+    beacon_bridge=beacon_bridge,     # BeaconBridge
+)
+
+# Attest a bounty submission as a Beacon envelope
+attestation = attest_bounty_submission(
+    bounty_id="bounty_123",
+    submission_id="sub_456",
+    submitter_agent_id="my-agent",
+    pr_url="https://github.com/.../pull/1",
+    summary="Implemented feature X",
+    identity=agent_identity,  # from beacon_skill or local keypair
+)
+
+# Verify an attestation envelope
+valid, info = verify_attestation(attestation_envelope)
+```
+
+## 5. Dependencies
+
+| Dependency | Source | Required? |
+|------------|--------|-----------|
+| Python 3.9+ | stdlib | Yes |
+| `requests` | Agent Economy SDK | Yes (already used) |
+| `nacl` (PyNaCl) | beacon_anchor.py | Optional (for signing attestations) |
+| `cryptography` | beacon_identity.py | Optional (for verifying attestations) |
+
+The reference implementation **gracefully degrades** when optional crypto libraries are unavailable — attestation creation requires a signing library (PyNaCl), but folio assembly and the bridge work with zero crypto dependencies. Verification works with either PyNaCl or `cryptography`.
+
+## 6. Testing Strategy
+
+1. **Unit tests** — `AgentFolio` dataclass, `BeaconBridge` routing, `EnvelopeAttestation` canonicalization
+2. **Mock integration tests** — Mock HTTP responses from both Beacon API and Economy API
+3. **Smoke test** — End-to-end folio assembly with mocked data, attestation sign + verify cycle
+
+## 7. File Layout
+
+```
+bounties/issue-2890/
+├── README.md                    # Usage guide
+├── docs/
+│   └── SPEC.md                  # This file
+├── src/
+│   ├── agentfolio_beacon/
+│   │   ├── __init__.py          # Public exports
+│   │   ├── folio.py             # AgentFolio dataclass + assemble()
+│   │   ├── bridge.py            # BeaconBridge adapter
+│   │   └── attestation.py       # EnvelopeAttestation + sign/verify
+│   └── requirements.txt
+├── tests/
+│   ├── test_folio.py
+│   ├── test_bridge.py
+│   └── test_attestation.py
+└── examples/
+    └── demo_folio.py            # End-to-end demo with mocks
+```
+
+## 8. Security Considerations
+
+- **No private key storage**: The attestation module signs with keys provided by the caller; it never generates or stores long-term keys.
+- **Read-only by default**: `BeaconBridge` only reads from Beacon API; it never mutates state.
+- **Signature verification**: `verify_attestation` verifies Ed25519 signatures independently — no trust in the attestation creator beyond the pubkey.
+- **Nonce uniqueness**: Nonces are derived from `blake2b(submission_id || timestamp)` to prevent replay.
+
+## 8.1. Implementation Caveats
+
+### Beacon API route names are hardcoded
+
+The bridge assumes specific Flask routes exist on the Beacon Atlas API (see README.md § Caveats). Missing or renamed endpoints return `None`/`[]` rather than raising.
+
+### Bridge depends on `AgentEconomyClient._request` internals
+
+`BeaconBridge` delegates to `economy_client._request(method, endpoint, base_url=...)`. The `base_url` kwarg override is an internal SDK detail not guaranteed by any public API contract.
+
+### Envelope counting is O(N)
+
+`count_agent_envelopes` fetches up to 10,000 envelope records to count them. A dedicated count endpoint would be more efficient.
+
+### `VALID_KINDS` is informational
+
+The `VALID_KINDS` set in `attestation.py` mirrors the Beacon v2 spec but is not enforced. The verifier only accepts `kind == "bounty"`.
+
+## 9. Future Work (post-MVP)
+
+- Persistent AgentFolio cache with change detection
+- Cross-system reputation score normalization
+- Automated bounty claim → Beacon envelope pipeline
+- Ergo anchor integration for attested submissions
+- Multi-agent folio comparison / leaderboard

--- a/bounties/issue-2890/examples/demo_folio.py
+++ b/bounties/issue-2890/examples/demo_folio.py
@@ -1,0 +1,192 @@
+"""
+Demo: AgentFolio ↔ Beacon Integration
+
+End-to-end demonstration using mocked data to show:
+1. Assembling an AgentFolio from Beacon + Economy sources
+2. Creating and verifying a bounty submission attestation
+
+Run with: python examples/demo_folio.py
+"""
+
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from unittest.mock import MagicMock
+
+from agentfolio_beacon.folio import AgentFolio, assemble_folio
+from agentfolio_beacon.bridge import BeaconBridge
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    verify_attestation,
+    NACL_AVAILABLE,
+)
+
+
+def demo_folio_assembly():
+    """Demonstrate assembling an AgentFolio from mocked data."""
+    print("=" * 60)
+    print("Demo: AgentFolio Assembly")
+    print("=" * 60)
+
+    # --- Mock Agent Economy Client ---
+    economy_client = MagicMock()
+
+    mock_wallet = MagicMock()
+    mock_wallet.wallet_address = "agent_7f3a2b1c"
+    mock_wallet.base_address = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD38"
+    economy_client.agents.get_wallet.return_value = mock_wallet
+
+    mock_rep = MagicMock()
+    mock_rep.score = 87.5
+    economy_client.reputation.get_score.return_value = mock_rep
+
+    economy_client.bounties.get_my_claims.return_value = [
+        {"bounty_id": "bounty_101"},
+    ]
+
+    # --- Mock Beacon Bridge ---
+    beacon_bridge = MagicMock()
+    beacon_bridge.lookup_agent_everything.return_value = {
+        "relay_agent": {
+            "agent_id": "content-curator-bot",
+            "pubkey_hex": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "name": "Content Curator Bot",
+            "status": "active",
+            "coinbase_address": "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD38",
+            "created_at": 1712500000,
+        },
+        "reputation": {
+            "agent_id": "content-curator-bot",
+            "score": 78,
+            "bounties_completed": 12,
+            "contracts_completed": 5,
+            "contracts_breached": 0,
+        },
+        "active_contracts": 2,
+        "total_contracts": 7,
+        "envelopes_recent": 45,
+    }
+
+    # --- Assemble ---
+    folio = assemble_folio("content-curator-bot", economy_client, beacon_bridge)
+
+    print(f"\n  Agent ID:        {folio.agent_id}")
+    print(f"  Beacon Pubkey:   {folio.beacon_pubkey_hex[:20]}...")
+    print(f"  Wallet Address:  {folio.wallet_address}")
+    print(f"  Base Address:    {folio.base_address}")
+    print()
+    print(f"  Beacon Score:    {folio.beacon_score}")
+    print(f"  Economy Score:   {folio.economy_score}")
+    print(f"  Combined Score:  {folio.combined_reputation_score}")
+    print()
+    print(f"  Beacons Sent:    {folio.total_envelopes_sent}")
+    print(f"  Active Contracts: {folio.active_contracts}")
+    print(f"  Open Claims:     {folio.open_claims}")
+    print(f"  Beacon Bounties: {folio.beacon_bounties_completed}")
+    print()
+    print(f"  Summary: {folio.summary()}")
+    print()
+
+    return folio
+
+
+def demo_attestation():
+    """Demonstrate creating and verifying a bounty submission attestation."""
+    print("=" * 60)
+    print("Demo: Bounty Submission Attestation")
+    print("=" * 60)
+
+    if not NACL_AVAILABLE:
+        print("\n  ⚠ PyNaCl not installed — skipping attestation creation.")
+        print("  Install with: pip install pynacl")
+        print("\n  Verification-only mode still works without PyNaCl.")
+        return
+
+    from nacl.signing import SigningKey
+    from agentfolio_beacon.attestation import attest_bounty_submission
+
+    # Generate a demo keypair
+    signing_key = SigningKey.generate()
+    signing_key_hex = signing_key.encode().hex()
+
+    print(f"\n  Signing Key:     {signing_key_hex[:32]}...")
+    print(f"  Verify Key:      {signing_key.verify_key.encode().hex()[:32]}...")
+
+    # Create attestation
+    attestation = attest_bounty_submission(
+        bounty_id="bounty_2890",
+        submission_id="sub_demo_001",
+        submitter_agent_id="content-curator-bot",
+        pr_url="https://github.com/Scottcjn/Rustchain/pull/2890",
+        summary="Implemented AgentFolio ↔ Beacon Integration with tests",
+        signing_key_hex=signing_key_hex,
+    )
+
+    print(f"\n  Attestation created:")
+    print(f"    Bounty:        {attestation.bounty_id}")
+    print(f"    Submission:    {attestation.submission_id}")
+    print(f"    Agent:         {attestation.agent_id}")
+    print(f"    PR:            {attestation.pr_url}")
+    print(f"    Nonce:         {attestation.nonce}")
+    print(f"    Signature:     {attestation.sig_hex[:32]}...")
+
+    # Verify
+    valid, reason = verify_attestation(attestation)
+    print(f"\n  Verification:    {'✅ VALID' if valid else '❌ INVALID'}")
+    if reason:
+        print(f"    Reason: {reason}")
+
+    # Show envelope JSON
+    print(f"\n  Envelope JSON (first 200 chars):")
+    json_str = attestation.to_json()
+    print(f"    {json_str[:200]}...")
+
+    # Demonstrate tamper detection
+    print(f"\n  Tamper detection demo:")
+    tampered = EnvelopeAttestation.from_json(json_str)
+    tampered.summary = "TAMPERED: different summary"
+    valid_tampered, reason_tampered = verify_attestation(tampered)
+    print(f"    After tamper:  {'✅ VALID' if valid_tampered else '❌ INVALID'}")
+    if reason_tampered:
+        print(f"    Reason: {reason_tampered}")
+
+
+def demo_folio_diff():
+    """Demonstrate folio difference detection."""
+    print("\n" + "=" * 60)
+    print("Demo: Folio Change Detection")
+    print("=" * 60)
+
+    from agentfolio_beacon.folio import folio_diff
+
+    old_folio = AgentFolio(
+        agent_id="content-curator-bot",
+        beacon_score=75,
+        total_envelopes_sent=40,
+        active_contracts=1,
+    )
+
+    new_folio = AgentFolio(
+        agent_id="content-curator-bot",
+        beacon_score=80,
+        total_envelopes_sent=45,
+        active_contracts=2,
+    )
+
+    changes = folio_diff(old_folio, new_folio)
+
+    print(f"\n  Changes detected:")
+    for field, (old_val, new_val) in changes.items():
+        print(f"    {field}: {old_val} → {new_val}")
+
+
+if __name__ == "__main__":
+    demo_folio_assembly()
+    demo_attestation()
+    demo_folio_diff()
+    print("\n" + "=" * 60)
+    print("Demo complete.")
+    print("=" * 60)

--- a/bounties/issue-2890/src/agentfolio_beacon/__init__.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/__init__.py
@@ -1,0 +1,32 @@
+"""
+AgentFolio ↔ Beacon Integration
+
+Unified agent profiles, Beacon bridge adapter, and envelope attestation
+for bounty submissions.
+
+See docs/SPEC.md for the full specification.
+"""
+
+from agentfolio_beacon.folio import AgentFolio, assemble_folio, folio_diff, folios_to_table
+from agentfolio_beacon.bridge import BeaconBridge
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    attest_bounty_submission,
+    verify_attestation,
+    verify_attestation_from_envelope,
+    verify_attestation_from_json,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    "AgentFolio",
+    "assemble_folio",
+    "folio_diff",
+    "folios_to_table",
+    "BeaconBridge",
+    "EnvelopeAttestation",
+    "attest_bounty_submission",
+    "verify_attestation",
+    "verify_attestation_from_envelope",
+    "verify_attestation_from_json",
+]

--- a/bounties/issue-2890/src/agentfolio_beacon/attestation.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/attestation.py
@@ -1,0 +1,292 @@
+"""
+EnvelopeAttestation — Sign bounty submissions as Beacon v2 envelopes.
+
+Produces cryptographically verifiable attestations that bind a bounty
+submission to the submitter's Ed25519 identity.
+
+Gracefully degrades when PyNaCl is unavailable (attestation creation
+requires signing, but verification works with just `cryptography`).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Tuple
+
+# --- Optional crypto imports ---
+try:
+    from nacl.signing import SigningKey, VerifyKey
+    from nacl.exceptions import BadSignatureError
+    NACL_AVAILABLE = True
+except ImportError:
+    SigningKey = None  # type: ignore[misc,assignment]
+    VerifyKey = None   # type: ignore[misc,assignment]
+    BadSignatureError = Exception  # type: ignore[misc,assignment]
+    NACL_AVAILABLE = False
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    _CRYPTO_AVAILABLE = True
+except ImportError:
+    Ed25519PublicKey = None  # type: ignore[misc,assignment]
+    _CRYPTO_AVAILABLE = False
+
+
+# Beacon v2 constants (matching beacon_anchor.py)
+# Note: This set is informational and mirrors the Beacon v2 spec.
+# The verifier currently only accepts kind == "bounty".
+VALID_KINDS = {"hello", "heartbeat", "want", "bounty", "mayday", "accord", "pushback"}
+UNSIGNED_TRANSPORT_FIELDS = ("sig", "_beacon_version")
+
+
+def _generate_nonce(submission_id: str, timestamp: Optional[int] = None) -> str:
+    """Generate a deterministic-but-unique nonce from submission_id + timestamp."""
+    ts = timestamp or int(time.time())
+    payload = f"{submission_id}:{ts}".encode()
+    return hashlib.blake2b(payload, digest_size=16).hexdigest()
+
+
+def _canonical_signed_fields(envelope: dict) -> dict:
+    """Return the exact Beacon v2 body covered by signature verification."""
+    return {
+        field: value
+        for field, value in envelope.items()
+        if field not in UNSIGNED_TRANSPORT_FIELDS
+    }
+
+
+def _canonical_signing_payload(envelope: dict) -> bytes:
+    """Return the canonical Beacon signing payload."""
+    return json.dumps(
+        _canonical_signed_fields(envelope),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass
+class EnvelopeAttestation:
+    """
+    A Beacon v2 envelope attesting to a bounty submission.
+
+    Attributes:
+        agent_id: Submitter's agent ID
+        kind: Always "bounty" for submission attestations
+        nonce: Unique nonce (blake2b of submission_id + timestamp)
+        bounty_id: The bounty being submitted to
+        submission_id: Unique submission identifier
+        pr_url: Pull request URL
+        summary: Brief description of the work
+        timestamp: Unix timestamp of attestation
+        pubkey_hex: Hex-encoded Ed25519 public key
+        sig_hex: Hex-encoded Ed25519 signature
+    """
+    agent_id: str
+    kind: str = "bounty"
+    nonce: str = ""
+    bounty_id: str = ""
+    submission_id: str = ""
+    pr_url: str = ""
+    summary: str = ""
+    timestamp: int = 0
+    pubkey_hex: str = ""
+    sig_hex: str = ""
+
+    def to_envelope(self) -> Dict[str, Any]:
+        """Return the full Beacon envelope dict (suitable for storage/verification)."""
+        return {
+            "agent_id": self.agent_id,
+            "kind": self.kind,
+            "nonce": self.nonce,
+            "bounty_id": self.bounty_id,
+            "submission_id": self.submission_id,
+            "pr_url": self.pr_url,
+            "summary": self.summary,
+            "timestamp": self.timestamp,
+            "pubkey": self.pubkey_hex,
+            "sig": self.sig_hex,
+        }
+
+    def to_json(self) -> str:
+        """Serialize to canonical JSON string."""
+        return json.dumps(self.to_envelope(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_envelope(cls, envelope: Dict[str, Any]) -> "EnvelopeAttestation":
+        """Deserialize from a Beacon envelope dict."""
+        return cls(
+            agent_id=envelope.get("agent_id", ""),
+            kind=envelope.get("kind", "bounty"),
+            nonce=envelope.get("nonce", ""),
+            bounty_id=envelope.get("bounty_id", ""),
+            submission_id=envelope.get("submission_id", ""),
+            pr_url=envelope.get("pr_url", ""),
+            summary=envelope.get("summary", ""),
+            timestamp=envelope.get("timestamp", 0),
+            pubkey_hex=envelope.get("pubkey", ""),
+            sig_hex=envelope.get("sig", ""),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "EnvelopeAttestation":
+        """Deserialize from canonical JSON string."""
+        return cls.from_envelope(json.loads(json_str))
+
+
+def attest_bounty_submission(
+    bounty_id: str,
+    submission_id: str,
+    submitter_agent_id: str,
+    pr_url: str,
+    summary: str,
+    signing_key_hex: str,
+    timestamp: Optional[int] = None,
+) -> EnvelopeAttestation:
+    """
+    Create a Beacon v2 envelope attestation for a bounty submission.
+
+    Args:
+        bounty_id: The bounty being submitted to
+        submission_id: Unique submission identifier
+        submitter_agent_id: Agent ID of the submitter
+        pr_url: Pull request URL
+        summary: Brief description of the work
+        signing_key_hex: Hex-encoded Ed25519 private key for signing
+        timestamp: Optional unix timestamp (defaults to now)
+
+    Returns:
+        EnvelopeAttestation with signature
+
+    Raises:
+        RuntimeError: If PyNaCl is not installed
+        ValueError: If signing key is invalid
+    """
+    if not NACL_AVAILABLE:
+        raise RuntimeError(
+            "PyNaCl is required to create attestations. "
+            "Install with: pip install pynacl"
+        )
+
+    ts = timestamp or int(time.time())
+    nonce = _generate_nonce(submission_id, ts)
+
+    # Derive pubkey from signing key
+    try:
+        signing_key = SigningKey(bytes.fromhex(signing_key_hex))
+        verify_key = signing_key.verify_key
+        pubkey_hex = verify_key.encode().hex()
+    except Exception as e:
+        raise ValueError(f"Invalid signing key: {e}") from e
+
+    # Build envelope body (fields covered by signature)
+    envelope_body = {
+        "agent_id": submitter_agent_id,
+        "kind": "bounty",
+        "nonce": nonce,
+        "bounty_id": bounty_id,
+        "submission_id": submission_id,
+        "pr_url": pr_url,
+        "summary": summary,
+        "timestamp": ts,
+        "pubkey": pubkey_hex,
+    }
+
+    # Sign the canonical payload
+    payload = _canonical_signing_payload(envelope_body)
+    signature = signing_key.sign(payload).signature  # type: ignore[attr-defined]
+    sig_hex = signature.hex()
+
+    return EnvelopeAttestation(
+        agent_id=submitter_agent_id,
+        kind="bounty",
+        nonce=nonce,
+        bounty_id=bounty_id,
+        submission_id=submission_id,
+        pr_url=pr_url,
+        summary=summary,
+        timestamp=ts,
+        pubkey_hex=pubkey_hex,
+        sig_hex=sig_hex,
+    )
+
+
+def verify_attestation(
+    attestation: EnvelopeAttestation,
+) -> Tuple[bool, str]:
+    """
+    Verify an EnvelopeAttestation's Ed25519 signature.
+
+    Args:
+        attestation: The attestation to verify
+
+    Returns:
+        (valid: bool, reason: str) — reason is empty if valid
+    """
+    if not attestation.sig_hex:
+        return False, "missing_signature"
+    if not attestation.pubkey_hex:
+        return False, "missing_pubkey"
+    if not attestation.agent_id:
+        return False, "missing_agent_id"
+    if attestation.kind != "bounty":
+        return False, f"invalid_kind:{attestation.kind}"
+
+    # Validate pubkey is well-formed hex
+    try:
+        pubkey_bytes = bytes.fromhex(attestation.pubkey_hex)
+    except ValueError:
+        return False, "invalid_pubkey_encoding"
+
+    # Reconstruct envelope and verify signature
+    envelope = attestation.to_envelope()
+
+    # Try PyNaCl first
+    if NACL_AVAILABLE:
+        try:
+            verify_key = VerifyKey(bytes.fromhex(attestation.pubkey_hex))
+            payload = _canonical_signing_payload(envelope)
+            verify_key.verify(payload, bytes.fromhex(attestation.sig_hex))
+            return True, ""
+        except (BadSignatureError, Exception):
+            return False, "invalid_signature"
+    elif _CRYPTO_AVAILABLE:
+        try:
+            vk = Ed25519PublicKey.from_public_bytes(pubkey_bytes)
+            payload = _canonical_signing_payload(envelope)
+            vk.verify(bytes.fromhex(attestation.sig_hex), payload)
+            return True, ""
+        except Exception:
+            return False, "invalid_signature"
+    else:
+        return False, "signature_verification_unavailable"
+
+
+def verify_attestation_from_envelope(
+    envelope: Dict[str, Any],
+) -> Tuple[bool, str]:
+    """
+    Verify a raw Beacon envelope dict as an attestation.
+
+    Convenience wrapper that deserializes and verifies in one call.
+    """
+    try:
+        attestation = EnvelopeAttestation.from_envelope(envelope)
+        return verify_attestation(attestation)
+    except Exception as e:
+        return False, f"parse_error:{e}"
+
+
+def verify_attestation_from_json(json_str: str) -> Tuple[bool, str]:
+    """
+    Verify a JSON-encoded attestation.
+
+    Convenience wrapper that deserializes and verifies in one call.
+    """
+    try:
+        attestation = EnvelopeAttestation.from_json(json_str)
+        return verify_attestation(attestation)
+    except Exception as e:
+        return False, f"parse_error:{e}"

--- a/bounties/issue-2890/src/agentfolio_beacon/bridge.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/bridge.py
@@ -1,0 +1,279 @@
+"""
+BeaconBridge — Adapter connecting Agent Economy SDK to Beacon Atlas APIs.
+
+Provides methods on top of AgentEconomyClient that query Beacon Atlas
+Flask endpoints (relay agents, reputation, contracts, envelopes).
+
+All methods are read-only — no state mutation.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional
+
+
+class BeaconBridge:
+    """
+    Bridge adapter that queries Beacon Atlas data via the Agent Economy client.
+
+    The Beacon Atlas Flask API (node/beacon_api.py) exposes these endpoints:
+      - GET /api/agent/<id>         — single relay agent
+      - GET /beacon/atlas           — all relay agents
+      - GET /api/reputation/<id>    — agent reputation
+      - GET /api/contracts          — all contracts
+      - GET /api/bounties           — open bounties
+
+    This adapter wraps an AgentEconomyClient and routes Beacon-specific
+    queries through it, returning plain dicts/lists (no SDK dataclasses).
+
+    Example:
+        >>> from rustchain.agent_economy import AgentEconomyClient
+        >>> from agentfolio_beacon import BeaconBridge
+        >>>
+        >>> client = AgentEconomyClient(base_url="http://localhost:5000")
+        >>> bridge = BeaconBridge(client)
+        >>>
+        >>> agents = bridge.list_relay_agents()
+        >>> rep = bridge.get_beacon_reputation("my-agent")
+    """
+
+    def __init__(self, economy_client, beacon_base_url: Optional[str] = None):
+        """
+        Initialize the bridge.
+
+        Args:
+            economy_client: An AgentEconomyClient instance
+            beacon_base_url: Override URL for Beacon API. If None, uses
+                             the economy client's base_url (assumes co-located).
+        """
+        self._client = economy_client
+        self._beacon_url = beacon_base_url
+
+    def _request(self, method: str, endpoint: str, **kwargs) -> Any:
+        """Route request through the economy client, optionally overriding base URL."""
+        if self._beacon_url:
+            kwargs["base_url"] = self._beacon_url
+        return self._client._request(method, endpoint, **kwargs)
+
+    # --- Relay Agent Discovery ---
+
+    def get_relay_agent(self, agent_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get a single relay agent by ID.
+
+        Maps to: GET /api/agent/<agent_id>
+
+        Returns:
+            Agent dict with agent_id, pubkey_hex, name, status, etc.
+            or None if not found.
+        """
+        try:
+            result = self._request("GET", f"/api/agent/{agent_id}")
+            if isinstance(result, dict) and "error" in result:
+                return None
+            return result
+        except Exception:
+            return None
+
+    def list_relay_agents(
+        self,
+        status: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        List all registered relay agents.
+
+        Maps to: GET /beacon/atlas
+
+        Args:
+            status: Optional status filter (e.g. "active")
+
+        Returns:
+            List of agent dicts.
+        """
+        try:
+            params = {}
+            if status:
+                params["status"] = status
+            result = self._request("GET", "/beacon/atlas", params=params)
+            if isinstance(result, dict) and "agents" in result:
+                return result["agents"]
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Beacon Reputation ---
+
+    def get_beacon_reputation(self, agent_id: str) -> Optional[Dict[str, Any]]:
+        """
+        Get an agent's Beacon reputation score.
+
+        Maps to: GET /api/reputation/<agent_id>
+
+        Returns:
+            Dict with score, bounties_completed, contracts_completed, etc.
+            or None if not found.
+        """
+        try:
+            result = self._request("GET", f"/api/reputation/{agent_id}")
+            if isinstance(result, dict) and "error" in result:
+                return None
+            return result
+        except Exception:
+            return None
+
+    def list_all_reputation(self) -> List[Dict[str, Any]]:
+        """
+        List all agent reputations (sorted by score descending).
+
+        Maps to: GET /api/reputation
+
+        Returns:
+            List of reputation dicts.
+        """
+        try:
+            result = self._request("GET", "/api/reputation")
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Contracts ---
+
+    def get_contracts(
+        self,
+        agent_id: Optional[str] = None,
+        state: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get contracts, optionally filtered by agent or state.
+
+        Maps to: GET /api/contracts
+
+        Args:
+            agent_id: Filter to contracts involving this agent
+            state: Filter by contract state (offered, active, completed, etc.)
+
+        Returns:
+            List of contract dicts.
+        """
+        try:
+            result = self._request("GET", "/api/contracts")
+            contracts = result if isinstance(result, list) else []
+
+            if agent_id:
+                contracts = [
+                    c for c in contracts
+                    if c.get("from_agent") == agent_id or c.get("to_agent") == agent_id
+                ]
+            if state:
+                contracts = [c for c in contracts if c.get("state") == state]
+
+            return contracts
+        except Exception:
+            return []
+
+    def count_active_contracts(self, agent_id: str) -> int:
+        """Count contracts in 'active' state for a given agent."""
+        contracts = self.get_contracts(agent_id=agent_id, state="active")
+        return len(contracts)
+
+    # --- Bounties (Beacon side) ---
+
+    def get_open_bounties(self) -> List[Dict[str, Any]]:
+        """
+        Get open bounties from Beacon Atlas.
+
+        Maps to: GET /api/bounties
+
+        Returns:
+            List of bounty dicts.
+        """
+        try:
+            result = self._request("GET", "/api/bounties")
+            if isinstance(result, list):
+                return result
+            return []
+        except Exception:
+            return []
+
+    # --- Envelope summaries (direct DB query via API) ---
+
+    def get_recent_envelopes(
+        self,
+        agent_id: Optional[str] = None,
+        limit: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """
+        Get recent beacon envelope summaries.
+
+        Note: This endpoint may not exist on all nodes. Returns empty list
+        on failure rather than raising.
+
+        Maps to: GET /api/beacon/envelopes (if available)
+
+        Args:
+            agent_id: Filter envelopes by agent
+            limit: Maximum number of results
+
+        Returns:
+            List of envelope summary dicts.
+        """
+        try:
+            params = {"limit": limit}
+            if agent_id:
+                params["agent_id"] = agent_id
+            result = self._request("GET", "/api/beacon/envelopes", params=params)
+            if isinstance(result, list):
+                return result
+            if isinstance(result, dict) and "envelopes" in result:
+                return result["envelopes"]
+            return []
+        except Exception:
+            return []
+
+    def count_agent_envelopes(self, agent_id: str) -> int:
+        """Count total envelopes sent by an agent (best effort)."""
+        envelopes = self.get_recent_envelopes(agent_id=agent_id, limit=10000)
+        return len(envelopes)
+
+    # --- Health ---
+
+    def beacon_health(self) -> Optional[Dict[str, Any]]:
+        """
+        Check Beacon Atlas API health.
+
+        Maps to: GET /api/health
+
+        Returns:
+            Health dict or None on failure.
+        """
+        try:
+            result = self._request("GET", "/api/health")
+            return result if isinstance(result, dict) else None
+        except Exception:
+            return None
+
+    # --- Unified agent lookup ---
+
+    def lookup_agent_everything(self, agent_id: str) -> Dict[str, Any]:
+        """
+        Convenience method: fetch all Beacon data for a single agent.
+
+        Returns a dict with:
+            - relay_agent: relay agent record or None
+            - reputation: beacon reputation or None
+            - active_contracts: count of active contracts
+            - total_contracts: total contract count involving agent
+            - envelopes_recent: recent envelope count
+        """
+        return {
+            "relay_agent": self.get_relay_agent(agent_id),
+            "reputation": self.get_beacon_reputation(agent_id),
+            "active_contracts": self.count_active_contracts(agent_id),
+            "total_contracts": len(self.get_contracts(agent_id=agent_id)),
+            "envelopes_recent": self.count_agent_envelopes(agent_id),
+        }

--- a/bounties/issue-2890/src/agentfolio_beacon/folio.py
+++ b/bounties/issue-2890/src/agentfolio_beacon/folio.py
@@ -1,0 +1,261 @@
+"""
+AgentFolio — Unified agent profile aggregating Beacon + Agent Economy data.
+
+An AgentFolio is a best-effort snapshot of an agent's identity, reputation,
+and activity across both the Beacon Atlas and Agent Economy (RIP-302) systems.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agentfolio_beacon.bridge import BeaconBridge
+
+
+@dataclass
+class AgentFolio:
+    """
+    Unified agent profile from Beacon Atlas + Agent Economy sources.
+
+    All fields are best-effort — missing data is represented as None or 0.
+    This is a read-only snapshot, not a live connection.
+
+    Attributes:
+        agent_id: Unique agent identifier
+        beacon_pubkey_hex: Ed25519 pubkey from Beacon relay registration
+        wallet_address: Agent Economy wallet address
+        base_address: Optional Coinbase Base address
+
+        # Reputation (Beacon side)
+        beacon_score: Beacon reputation score (integer, from beacon_reputation)
+        beacon_bounties_completed: Bounties completed per Beacon
+        economy_score: RIP-302 reputation score (float, 0-100)
+        economy_bounties_completed: Bounties completed per Economy SDK
+        contracts_completed: Contracts completed (Beacon)
+        contracts_breached: Contracts breached (Beacon)
+
+        # Activity summary
+        total_envelopes_sent: Count of beacon_envelopes for this agent
+        active_contracts: Contracts currently in 'active' state
+        open_claims: Bounties claimed but not yet completed
+
+        # Metadata
+        first_seen_beacon: Unix timestamp of first Beacon registration
+        first_seen_economy: Unix timestamp of first Economy wallet creation
+        assembled_at: Unix timestamp when this folio was assembled
+    """
+    # Core identity
+    agent_id: str = ""
+    beacon_pubkey_hex: Optional[str] = None
+    wallet_address: Optional[str] = None
+    base_address: Optional[str] = None
+
+    # Reputation (Beacon)
+    beacon_score: Optional[int] = None
+    beacon_bounties_completed: int = 0
+    beacon_contracts_completed: int = 0
+    beacon_contracts_breached: int = 0
+
+    # Reputation (Economy)
+    economy_score: Optional[float] = None
+    economy_bounties_completed: int = 0
+
+    # Activity summary
+    total_envelopes_sent: int = 0
+    active_contracts: int = 0
+    open_claims: int = 0
+
+    # Metadata
+    first_seen_beacon: Optional[float] = None
+    first_seen_economy: Optional[float] = None
+    assembled_at: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to dictionary."""
+        return {
+            "agent_id": self.agent_id,
+            "beacon_pubkey_hex": self.beacon_pubkey_hex,
+            "wallet_address": self.wallet_address,
+            "base_address": self.base_address,
+            "beacon_score": self.beacon_score,
+            "beacon_bounties_completed": self.beacon_bounties_completed,
+            "beacon_contracts_completed": self.beacon_contracts_completed,
+            "beacon_contracts_breached": self.beacon_contracts_breached,
+            "economy_score": self.economy_score,
+            "economy_bounties_completed": self.economy_bounties_completed,
+            "total_envelopes_sent": self.total_envelopes_sent,
+            "active_contracts": self.active_contracts,
+            "open_claims": self.open_claims,
+            "first_seen_beacon": self.first_seen_beacon,
+            "first_seen_economy": self.first_seen_economy,
+            "assembled_at": self.assembled_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AgentFolio":
+        """Deserialize from dictionary."""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+    def summary(self) -> str:
+        """Return a human-readable one-line summary."""
+        parts = [f"AgentFolio({self.agent_id}"]
+        if self.beacon_score is not None:
+            parts.append(f"beacon={self.beacon_score}")
+        if self.economy_score is not None:
+            parts.append(f"economy={self.economy_score:.0f}")
+        if self.total_envelopes_sent:
+            parts.append(f"envelopes={self.total_envelopes_sent}")
+        if self.active_contracts:
+            parts.append(f"contracts={self.active_contracts}")
+        parts.append(")")
+        return " ".join(parts)
+
+    @property
+    def has_beacon_identity(self) -> bool:
+        """Whether the agent has a registered Beacon identity."""
+        return self.beacon_pubkey_hex is not None
+
+    @property
+    def has_economy_wallet(self) -> bool:
+        """Whether the agent has an Economy wallet."""
+        return self.wallet_address is not None
+
+    @property
+    def combined_reputation_score(self) -> Optional[float]:
+        """
+        Return a combined reputation score, preferring Economy score
+        (more granular) and falling back to Beacon score.
+        """
+        if self.economy_score is not None:
+            return self.economy_score
+        if self.beacon_score is not None:
+            return float(self.beacon_score)
+        return None
+
+
+def assemble_folio(
+    agent_id: str,
+    economy_client,
+    beacon_bridge: "BeaconBridge",
+) -> AgentFolio:
+    """
+    Assemble a unified AgentFolio for the given agent.
+
+    This is the primary entry point. It queries both the Agent Economy SDK
+    and the Beacon Bridge, aggregating all available data. Failures in
+    either source are silently caught — the folio will have None/0 for
+    missing fields.
+
+    Args:
+        agent_id: The agent to assemble a folio for
+        economy_client: An AgentEconomyClient instance
+        beacon_bridge: A BeaconBridge wrapping the same (or different) client
+
+    Returns:
+        AgentFolio with best-effort populated fields
+
+    Example:
+        >>> from rustchain.agent_economy import AgentEconomyClient
+        >>> from agentfolio_beacon import BeaconBridge, assemble_folio
+        >>>
+        >>> client = AgentEconomyClient(base_url="http://localhost:5000")
+        >>> bridge = BeaconBridge(client)
+        >>> folio = assemble_folio("my-agent", client, bridge)
+        >>> print(folio.summary())
+    """
+    folio = AgentFolio(agent_id=agent_id, assembled_at=time.time())
+
+    # --- Beacon Atlas data ---
+    try:
+        beacon_data = beacon_bridge.lookup_agent_everything(agent_id)
+
+        # Relay agent info
+        relay = beacon_data.get("relay_agent")
+        if relay:
+            folio.beacon_pubkey_hex = relay.get("pubkey_hex")
+            folio.base_address = relay.get("coinbase_address")
+            folio.first_seen_beacon = relay.get("created_at")
+
+        # Beacon reputation
+        rep = beacon_data.get("reputation")
+        if rep:
+            folio.beacon_score = rep.get("score")
+            folio.beacon_bounties_completed = rep.get("bounties_completed", 0)
+            folio.beacon_contracts_completed = rep.get("contracts_completed", 0)
+            folio.beacon_contracts_breached = rep.get("contracts_breached", 0)
+
+        # Activity counts
+        folio.total_envelopes_sent = beacon_data.get("envelopes_recent", 0)
+        folio.active_contracts = beacon_data.get("active_contracts", 0)
+
+    except Exception:
+        pass  # Beacon data unavailable — leave fields as defaults
+
+    # --- Agent Economy data ---
+    try:
+        # Wallet info
+        wallet = economy_client.agents.get_wallet(agent_id)
+        if wallet:
+            folio.wallet_address = wallet.wallet_address
+            if wallet.base_address:
+                folio.base_address = wallet.base_address
+
+        # Reputation
+        try:
+            rep_score = economy_client.reputation.get_score(agent_id)
+            if rep_score:
+                folio.economy_score = rep_score.score
+        except Exception:
+            pass
+
+        # Bounty claims (open = claimed but not completed)
+        try:
+            claims = economy_client.bounties.get_my_claims(agent_id=agent_id)
+            folio.open_claims = len(claims)
+        except Exception:
+            pass
+
+    except Exception:
+        pass  # Economy data unavailable — leave fields as defaults
+
+    return folio
+
+
+def folio_diff(old: AgentFolio, new: AgentFolio) -> Dict[str, Any]:
+    """
+    Compute the difference between two folios of the same agent.
+
+    Returns a dict of changed fields with (old_value, new_value) tuples.
+    """
+    changes = {}
+    old_dict = old.to_dict()
+    new_dict = new.to_dict()
+
+    for key in old_dict:
+        if key == "assembled_at":
+            continue  # Always different
+        old_val = old_dict[key]
+        new_val = new_dict[key]
+        if old_val != new_val:
+            changes[key] = (old_val, new_val)
+
+    return changes
+
+
+def folios_to_table(folios: list) -> List[Dict[str, Any]]:
+    """
+    Convert a list of AgentFolios to a table-friendly format.
+
+    Returns list of dicts suitable for CSV/JSON export.
+    """
+    rows = []
+    for f in folios:
+        row = f.to_dict()
+        row["combined_score"] = f.combined_reputation_score
+        row["has_beacon_identity"] = f.has_beacon_identity
+        row["has_economy_wallet"] = f.has_economy_wallet
+        rows.append(row)
+    return rows

--- a/bounties/issue-2890/src/requirements.txt
+++ b/bounties/issue-2890/src/requirements.txt
@@ -1,0 +1,12 @@
+# AgentFolio ↔ Beacon Integration
+# No additional runtime deps beyond what the repo already uses.
+# All imports are stdlib or optional crypto libraries.
+
+# Optional: for creating attestations (signing)
+# pynacl>=1.5.0
+
+# Optional: for verifying attestations (alternative to pynacl)
+# cryptography>=41.0.0
+
+# The bridge and folio modules use only stdlib + the existing
+# rustchain.agent_economy SDK (which depends on requests).

--- a/bounties/issue-2890/tests/test_attestation.py
+++ b/bounties/issue-2890/tests/test_attestation.py
@@ -1,0 +1,404 @@
+"""
+Tests for EnvelopeAttestation module.
+
+Run with: pytest tests/test_attestation.py -v
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.attestation import (
+    EnvelopeAttestation,
+    attest_bounty_submission,
+    verify_attestation,
+    verify_attestation_from_envelope,
+    verify_attestation_from_json,
+    _generate_nonce,
+    _canonical_signed_fields,
+    _canonical_signing_payload,
+    NACL_AVAILABLE,
+)
+
+
+# A known Ed25519 keypair for testing (generated once, never used in production)
+_TEST_SIGNING_KEY_HEX = "a" * 64  # 32 bytes = 64 hex chars (valid but not real)
+
+
+class TestNonceGeneration:
+    """Test nonce generation."""
+
+    def test_nonce_is_deterministic_for_same_input(self):
+        """Same submission_id + timestamp produces same nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_123", 1712700000)
+        assert n1 == n2
+
+    def test_nonce_differs_for_different_submission(self):
+        """Different submission_id produces different nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_456", 1712700000)
+        assert n1 != n2
+
+    def test_nonce_differs_for_different_timestamp(self):
+        """Different timestamp produces different nonce."""
+        n1 = _generate_nonce("sub_123", 1712700000)
+        n2 = _generate_nonce("sub_123", 1712700001)
+        assert n1 != n2
+
+    def test_nonce_length(self):
+        """Nonce is 32 hex chars (16 bytes blake2b)."""
+        nonce = _generate_nonce("sub_123", 1712700000)
+        assert len(nonce) == 32
+
+
+class TestCanonicalFields:
+    """Test canonical field extraction."""
+
+    def test_excludes_sig_field(self):
+        """sig field is excluded from signed fields."""
+        envelope = {"agent_id": "test", "sig": "abc123", "kind": "bounty"}
+        fields = _canonical_signed_fields(envelope)
+        assert "sig" not in fields
+        assert "agent_id" in fields
+        assert "kind" in fields
+
+    def test_excludes_beacon_version(self):
+        """_beacon_version field is excluded."""
+        envelope = {"agent_id": "test", "_beacon_version": "2", "kind": "bounty"}
+        fields = _canonical_signed_fields(envelope)
+        assert "_beacon_version" not in fields
+
+    def test_payload_is_canonical_json(self):
+        """Signing payload is canonical JSON (sorted keys, no spaces)."""
+        envelope = {"b": 2, "a": 1, "sig": "x"}
+        payload = _canonical_signing_payload(envelope)
+        expected = b'{"a":1,"b":2}'
+        assert payload == expected
+
+
+class TestEnvelopeAttestationDataclass:
+    """Test EnvelopeAttestation serialization."""
+
+    def test_default_values(self):
+        """Test default field values."""
+        att = EnvelopeAttestation(agent_id="test-agent")
+        assert att.agent_id == "test-agent"
+        assert att.kind == "bounty"
+        assert att.nonce == ""
+        assert att.timestamp == 0
+
+    def test_to_envelope(self):
+        """Test envelope serialization."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc123",
+            bounty_id="bounty_1",
+            submission_id="sub_1",
+            pr_url="https://github.com/test/pull/1",
+            summary="Fixed bug",
+            timestamp=1712700000,
+            pubkey_hex="deadbeef",
+            sig_hex="cafebabe",
+        )
+        env = att.to_envelope()
+        assert env["agent_id"] == "test-agent"
+        assert env["kind"] == "bounty"
+        assert env["nonce"] == "abc123"
+        assert env["bounty_id"] == "bounty_1"
+        assert env["sig"] == "cafebabe"
+
+    def test_roundtrip_envelope(self):
+        """Test envelope → from_envelope → to_envelope roundtrip."""
+        original = {
+            "agent_id": "test-agent",
+            "kind": "bounty",
+            "nonce": "abc123",
+            "bounty_id": "bounty_1",
+            "submission_id": "sub_1",
+            "pr_url": "https://github.com/test/pull/1",
+            "summary": "Fixed bug",
+            "timestamp": 1712700000,
+            "pubkey": "deadbeef",
+            "sig": "cafebabe",
+        }
+        att = EnvelopeAttestation.from_envelope(original)
+        result = att.to_envelope()
+        assert result == original
+
+    def test_to_json(self):
+        """Test JSON serialization."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc",
+            bounty_id="b1",
+            submission_id="s1",
+            pr_url="https://example.com/pr",
+            summary="Work done",
+            timestamp=1000,
+            pubkey_hex="aa",
+            sig_hex="bb",
+        )
+        json_str = att.to_json()
+        parsed = json.loads(json_str)
+        assert parsed["agent_id"] == "test-agent"
+        assert parsed["kind"] == "bounty"
+
+    def test_roundtrip_json(self):
+        """Test JSON roundtrip."""
+        att = EnvelopeAttestation(
+            agent_id="test-agent",
+            nonce="abc",
+            bounty_id="b1",
+            submission_id="s1",
+            pr_url="https://example.com/pr",
+            summary="Work done",
+            timestamp=1000,
+            pubkey_hex="aa",
+            sig_hex="bb",
+        )
+        restored = EnvelopeAttestation.from_json(att.to_json())
+        assert restored.agent_id == att.agent_id
+        assert restored.nonce == att.nonce
+        assert restored.sig_hex == att.sig_hex
+
+
+class TestAttestBountySubmission:
+    """Test attestation creation."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_creates_valid_attestation(self):
+        """Test that a valid attestation is created."""
+        # Generate a real keypair for this test
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Implemented feature",
+            signing_key_hex=sk_hex,
+            timestamp=1712700000,
+        )
+
+        assert att.agent_id == "test-agent"
+        assert att.kind == "bounty"
+        assert att.bounty_id == "bounty_123"
+        assert att.submission_id == "sub_456"
+        assert att.pr_url == "https://github.com/test/pull/1"
+        assert att.summary == "Implemented feature"
+        assert att.timestamp == 1712700000
+        assert att.pubkey_hex  # Non-empty
+        assert att.sig_hex  # Non-empty
+        assert len(att.sig_hex) == 128  # 64 bytes = 128 hex chars
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_nonce_is_unique_per_submission(self):
+        """Test that different submissions get different nonces."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att1 = attest_bounty_submission(
+            bounty_id="b1", submission_id="sub_1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work 1", signing_key_hex=sk_hex,
+        )
+        att2 = attest_bounty_submission(
+            bounty_id="b1", submission_id="sub_2",
+            submitter_agent_id="agent", pr_url="https://x.com/2",
+            summary="Work 2", signing_key_hex=sk_hex,
+        )
+        assert att1.nonce != att2.nonce
+
+    def test_raises_without_pynacl(self):
+        """Test that creation fails without PyNaCl."""
+        with patch("agentfolio_beacon.attestation.NACL_AVAILABLE", False):
+            with pytest.raises(RuntimeError, match="PyNaCl is required"):
+                attest_bounty_submission(
+                    bounty_id="b1", submission_id="s1",
+                    submitter_agent_id="agent", pr_url="https://x.com/1",
+                    summary="Work", signing_key_hex="aa" * 32,
+                )
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_raises_on_invalid_key(self):
+        """Test that invalid signing key raises ValueError."""
+        with pytest.raises(ValueError, match="Invalid signing key"):
+            attest_bounty_submission(
+                bounty_id="b1", submission_id="s1",
+                submitter_agent_id="agent", pr_url="https://x.com/1",
+                summary="Work", signing_key_hex="not_hex!!",
+            )
+
+
+class TestVerifyAttestation:
+    """Test attestation verification."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_valid_attestation_verifies(self):
+        """Test that a properly signed attestation verifies."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Implemented feature",
+            signing_key_hex=sk_hex,
+        )
+
+        valid, reason = verify_attestation(att)
+        assert valid is True
+        assert reason == ""
+
+    def test_missing_signature(self):
+        """Test that missing signature fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            pubkey_hex="aa" * 32,
+            sig_hex="",  # Empty signature
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_signature" in reason
+
+    def test_missing_pubkey(self):
+        """Test that missing pubkey fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            sig_hex="bb" * 64,
+            pubkey_hex="",  # Empty pubkey
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_pubkey" in reason
+
+    def test_missing_agent_id(self):
+        """Test that missing agent_id fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="",  # Empty
+            pubkey_hex="aa" * 32,
+            sig_hex="bb" * 64,
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "missing_agent_id" in reason
+
+    def test_invalid_kind(self):
+        """Test that non-bounty kind fails verification."""
+        att = EnvelopeAttestation(
+            agent_id="test",
+            kind="heartbeat",  # Wrong kind
+            pubkey_hex="aa" * 32,
+            sig_hex="bb" * 64,
+        )
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_kind" in reason
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_tampered_envelope_fails(self):
+        """Test that modifying the envelope after signing fails verification."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="bounty_123",
+            submission_id="sub_456",
+            submitter_agent_id="test-agent",
+            pr_url="https://github.com/test/pull/1",
+            summary="Original summary",
+            signing_key_hex=sk_hex,
+        )
+
+        # Tamper with the summary
+        att.summary = "Tampered summary"
+
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_signature" in reason
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_wrong_key_fails(self):
+        """Test that signature from different key fails verification."""
+        from nacl.signing import SigningKey
+        sk1 = SigningKey.generate()
+        sk2 = SigningKey.generate()
+
+        # Sign with key 1
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk1.encode().hex(),
+        )
+
+        # But claim it's from key 2
+        att.pubkey_hex = sk2.verify_key.encode().hex()
+
+        valid, reason = verify_attestation(att)
+        assert valid is False
+        assert "invalid_signature" in reason
+
+
+class TestVerifyFromEnvelope:
+    """Test verification from raw envelope dict."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_verify_from_envelope(self):
+        """Test verification directly from envelope dict."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk_hex,
+        )
+
+        envelope = att.to_envelope()
+        valid, reason = verify_attestation_from_envelope(envelope)
+        assert valid is True
+
+    def test_verify_from_envelope_invalid_json(self):
+        """Test that invalid envelope dict is handled."""
+        valid, reason = verify_attestation_from_envelope({"not": "a real envelope"})
+        assert valid is False
+
+
+class TestVerifyFromJson:
+    """Test verification from JSON string."""
+
+    @pytest.mark.skipif(not NACL_AVAILABLE, reason="PyNaCl not installed")
+    def test_verify_from_json(self):
+        """Test verification from JSON string."""
+        from nacl.signing import SigningKey
+        sk = SigningKey.generate()
+        sk_hex = sk.encode().hex()
+
+        att = attest_bounty_submission(
+            bounty_id="b1", submission_id="s1",
+            submitter_agent_id="agent", pr_url="https://x.com/1",
+            summary="Work", signing_key_hex=sk_hex,
+        )
+
+        valid, reason = verify_attestation_from_json(att.to_json())
+        assert valid is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/bounties/issue-2890/tests/test_bridge.py
+++ b/bounties/issue-2890/tests/test_bridge.py
@@ -1,0 +1,397 @@
+"""
+Tests for BeaconBridge adapter.
+
+Run with: pytest tests/test_bridge.py -v
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.bridge import BeaconBridge
+
+
+def make_mock_client():
+    """Create a mock AgentEconomyClient."""
+    client = MagicMock()
+    client._request = MagicMock(return_value={})
+    return client
+
+
+class TestBeaconBridgeInit:
+    """Test BeaconBridge initialization."""
+
+    def test_init_with_default_url(self):
+        """Test bridge uses client's base_url by default."""
+        client = make_mock_client()
+        client.config.base_url = "http://localhost:5000"
+        bridge = BeaconBridge(client)
+        assert bridge._beacon_url is None  # Uses client's URL
+
+    def test_init_with_override_url(self):
+        """Test bridge can override beacon URL."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client, beacon_base_url="http://beacon.example.com")
+        assert bridge._beacon_url == "http://beacon.example.com"
+
+
+class TestBeaconBridgeRelayAgents:
+    """Test relay agent discovery methods."""
+
+    def test_get_relay_agent_success(self):
+        """Test successful relay agent lookup."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agent_id": "test-agent",
+            "pubkey_hex": "deadbeef",
+            "name": "Test Agent",
+            "status": "active",
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("test-agent")
+
+        assert result is not None
+        assert result["agent_id"] == "test-agent"
+        assert result["pubkey_hex"] == "deadbeef"
+        client._request.assert_called_once_with("GET", "/api/agent/test-agent")
+
+    def test_get_relay_agent_not_found(self):
+        """Test relay agent not found returns None."""
+        client = make_mock_client()
+        client._request.return_value = {"error": "Agent not found"}
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("nonexistent")
+
+        assert result is None
+
+    def test_get_relay_agent_exception(self):
+        """Test relay agent exception returns None."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Connection refused")
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_relay_agent("test-agent")
+
+        assert result is None
+
+    def test_list_relay_agents(self):
+        """Test listing relay agents."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agents": [
+                {"agent_id": "agent-a", "status": "active"},
+                {"agent_id": "agent-b", "status": "active"},
+            ],
+            "total": 2,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents()
+
+        assert len(result) == 2
+        assert result[0]["agent_id"] == "agent-a"
+        client._request.assert_called_once_with("GET", "/beacon/atlas", params={})
+
+    def test_list_relay_agents_with_status_filter(self):
+        """Test listing relay agents with status filter."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agents": [{"agent_id": "agent-a", "status": "active"}],
+            "total": 1,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents(status="active")
+
+        client._request.assert_called_once_with(
+            "GET", "/beacon/atlas", params={"status": "active"}
+        )
+
+    def test_list_relay_agents_returns_list_directly(self):
+        """Test handling API that returns list directly."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"agent_id": "agent-a"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_relay_agents()
+
+        assert len(result) == 1
+
+
+class TestBeaconBridgeReputation:
+    """Test reputation query methods."""
+
+    def test_get_beacon_reputation_success(self):
+        """Test successful reputation lookup."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "agent_id": "test-agent",
+            "score": 75,
+            "bounties_completed": 5,
+            "contracts_completed": 3,
+            "contracts_breached": 0,
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_beacon_reputation("test-agent")
+
+        assert result is not None
+        assert result["score"] == 75
+        assert result["bounties_completed"] == 5
+        client._request.assert_called_once_with(
+            "GET", "/api/reputation/test-agent"
+        )
+
+    def test_get_beacon_reputation_not_found(self):
+        """Test reputation not found returns None."""
+        client = make_mock_client()
+        client._request.return_value = {"error": "Agent not found"}
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_beacon_reputation("nonexistent")
+
+        assert result is None
+
+    def test_list_all_reputation(self):
+        """Test listing all reputations."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"agent_id": "agent-a", "score": 90},
+            {"agent_id": "agent-b", "score": 75},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.list_all_reputation()
+
+        assert len(result) == 2
+        assert result[0]["score"] == 90
+
+
+class TestBeaconBridgeContracts:
+    """Test contract query methods."""
+
+    def test_get_contracts(self):
+        """Test getting all contracts."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "to_agent": "b", "state": "active"},
+            {"id": "c2", "from_agent": "a", "to_agent": "c", "state": "completed"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts()
+
+        assert len(result) == 2
+
+    def test_get_contracts_filtered_by_agent(self):
+        """Test filtering contracts by agent."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "to_agent": "b", "state": "active"},
+            {"id": "c2", "from_agent": "x", "to_agent": "y", "state": "active"},
+            {"id": "c3", "from_agent": "b", "to_agent": "a", "state": "completed"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts(agent_id="a")
+
+        assert len(result) == 2  # c1 and c3 involve agent "a"
+
+    def test_get_contracts_filtered_by_state(self):
+        """Test filtering contracts by state."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "state": "active"},
+            {"id": "c2", "state": "completed"},
+            {"id": "c3", "state": "active"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_contracts(state="active")
+
+        assert len(result) == 2
+
+    def test_count_active_contracts(self):
+        """Test counting active contracts."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "c1", "from_agent": "a", "state": "active"},
+            {"id": "c2", "from_agent": "a", "state": "completed"},
+            {"id": "c3", "from_agent": "a", "state": "active"},
+        ]
+        bridge = BeaconBridge(client)
+
+        count = bridge.count_active_contracts("a")
+
+        assert count == 2
+
+
+class TestBeaconBridgeBounties:
+    """Test bounty query methods."""
+
+    def test_get_open_bounties(self):
+        """Test getting open bounties."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": "b1", "title": "Fix bug", "reward_rtc": 50.0},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_open_bounties()
+
+        assert len(result) == 1
+        assert result[0]["title"] == "Fix bug"
+        client._request.assert_called_once_with("GET", "/api/bounties")
+
+
+class TestBeaconBridgeEnvelopes:
+    """Test envelope query methods."""
+
+    def test_get_recent_envelopes(self):
+        """Test getting recent envelopes."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": 1, "agent_id": "a", "kind": "heartbeat"},
+        ]
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_recent_envelopes(agent_id="a", limit=10)
+
+        assert len(result) == 1
+        client._request.assert_called_once_with(
+            "GET", "/api/beacon/envelopes", params={"limit": 10, "agent_id": "a"}
+        )
+
+    def test_get_recent_envelopes_on_failure(self):
+        """Test envelope query returns empty list on failure."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Endpoint not found")
+        bridge = BeaconBridge(client)
+
+        result = bridge.get_recent_envelopes()
+
+        assert result == []
+
+    def test_count_agent_envelopes(self):
+        """Test counting agent envelopes."""
+        client = make_mock_client()
+        client._request.return_value = [
+            {"id": i, "agent_id": "a"} for i in range(5)
+        ]
+        bridge = BeaconBridge(client)
+
+        count = bridge.count_agent_envelopes("a")
+
+        assert count == 5
+
+
+class TestBeaconBridgeHealth:
+    """Test health check."""
+
+    def test_beacon_health_success(self):
+        """Test successful health check."""
+        client = make_mock_client()
+        client._request.return_value = {
+            "status": "ok",
+            "timestamp": 1712700000,
+            "service": "beacon-atlas-api",
+        }
+        bridge = BeaconBridge(client)
+
+        result = bridge.beacon_health()
+
+        assert result is not None
+        assert result["status"] == "ok"
+
+    def test_beacon_health_failure(self):
+        """Test health check returns None on failure."""
+        client = make_mock_client()
+        client._request.side_effect = Exception("Connection refused")
+        bridge = BeaconBridge(client)
+
+        result = bridge.beacon_health()
+
+        assert result is None
+
+
+class TestBeaconBridgeLookupAgentEverything:
+    """Test the unified agent lookup convenience method."""
+
+    def test_lookup_agent_everything(self):
+        """Test unified agent lookup aggregates all data."""
+        client = make_mock_client()
+
+        def mock_request(method, endpoint, **kwargs):
+            if endpoint == "/api/agent/test-agent":
+                return {
+                    "agent_id": "test-agent",
+                    "pubkey_hex": "deadbeef",
+                    "created_at": 1712600000,
+                }
+            elif endpoint == "/api/reputation/test-agent":
+                return {
+                    "agent_id": "test-agent",
+                    "score": 80,
+                    "bounties_completed": 5,
+                    "contracts_completed": 3,
+                    "contracts_breached": 0,
+                }
+            elif endpoint == "/api/contracts":
+                return [
+                    {"id": "c1", "from_agent": "test-agent", "state": "active"},
+                    {"id": "c2", "from_agent": "test-agent", "state": "completed"},
+                ]
+            elif endpoint == "/api/beacon/envelopes":
+                return [{"id": 1, "agent_id": "test-agent"}]
+            return {}
+
+        client._request = MagicMock(side_effect=mock_request)
+        bridge = BeaconBridge(client)
+
+        result = bridge.lookup_agent_everything("test-agent")
+
+        assert result["relay_agent"] is not None
+        assert result["relay_agent"]["pubkey_hex"] == "deadbeef"
+        assert result["reputation"] is not None
+        assert result["reputation"]["score"] == 80
+        assert result["active_contracts"] == 1  # Only "active" state
+        assert result["total_contracts"] == 2
+        assert result["envelopes_recent"] == 1
+
+
+class TestBeaconBridgeBaseUrlOverride:
+    """Test that beacon_base_url override works correctly."""
+
+    def test_request_uses_override_url(self):
+        """Test that requests go to override URL when set."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client, beacon_base_url="http://beacon.local:9000")
+
+        bridge.get_relay_agent("test-agent")
+
+        # Check that base_url was passed to _request
+        call_kwargs = client._request.call_args[1]
+        assert call_kwargs["base_url"] == "http://beacon.local:9000"
+
+    def test_request_no_override_when_not_set(self):
+        """Test that requests don't include base_url when not overridden."""
+        client = make_mock_client()
+        bridge = BeaconBridge(client)
+
+        bridge.get_relay_agent("test-agent")
+
+        call_kwargs = client._request.call_args[1]
+        assert "base_url" not in call_kwargs
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/bounties/issue-2890/tests/test_folio.py
+++ b/bounties/issue-2890/tests/test_folio.py
@@ -1,0 +1,391 @@
+"""
+Tests for AgentFolio dataclass and assemble_folio function.
+
+Run with: pytest tests/test_folio.py -v
+"""
+
+import sys
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from agentfolio_beacon.folio import (
+    AgentFolio,
+    assemble_folio,
+    folio_diff,
+    folios_to_table,
+)
+
+
+class TestAgentFolioDataclass:
+    """Test AgentFolio dataclass."""
+
+    def test_default_values(self):
+        """Test default field values."""
+        folio = AgentFolio(agent_id="test-agent")
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex is None
+        assert folio.wallet_address is None
+        assert folio.beacon_score is None
+        assert folio.economy_score is None
+        assert folio.total_envelopes_sent == 0
+        assert folio.assembled_at == 0.0
+
+    def test_to_dict(self):
+        """Test dictionary serialization."""
+        folio = AgentFolio(
+            agent_id="test-agent",
+            beacon_pubkey_hex="deadbeef",
+            wallet_address="wallet_123",
+            beacon_score=75,
+            economy_score=82.5,
+            total_envelopes_sent=10,
+            active_contracts=2,
+            assembled_at=1712700000.0,
+        )
+        d = folio.to_dict()
+        assert d["agent_id"] == "test-agent"
+        assert d["beacon_pubkey_hex"] == "deadbeef"
+        assert d["wallet_address"] == "wallet_123"
+        assert d["beacon_score"] == 75
+        assert d["economy_score"] == 82.5
+        assert d["total_envelopes_sent"] == 10
+
+    def test_from_dict(self):
+        """Test dictionary deserialization."""
+        data = {
+            "agent_id": "test-agent",
+            "beacon_pubkey_hex": "deadbeef",
+            "wallet_address": "wallet_123",
+            "beacon_score": 75,
+            "economy_score": 82.5,
+            "total_envelopes_sent": 10,
+            "active_contracts": 2,
+            "assembled_at": 1712700000.0,
+            "extra_field": "should_be_ignored",  # Unknown fields ignored
+        }
+        folio = AgentFolio.from_dict(data)
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert not hasattr(folio, "extra_field")
+
+    def test_summary_with_data(self):
+        """Test human-readable summary with data."""
+        folio = AgentFolio(
+            agent_id="test-agent",
+            beacon_score=75,
+            economy_score=82.5,
+            total_envelopes_sent=10,
+            active_contracts=2,
+        )
+        summary = folio.summary()
+        assert "test-agent" in summary
+        assert "beacon=75" in summary
+        assert "economy=82" in summary
+        assert "envelopes=10" in summary
+        assert "contracts=2" in summary
+
+    def test_summary_minimal(self):
+        """Test summary with minimal data."""
+        folio = AgentFolio(agent_id="minimal-agent")
+        summary = folio.summary()
+        assert "minimal-agent" in summary
+        assert "beacon=" not in summary
+        assert "economy=" not in summary
+
+    def test_has_beacon_identity(self):
+        """Test beacon identity property."""
+        folio_with = AgentFolio(agent_id="a", beacon_pubkey_hex="deadbeef")
+        folio_without = AgentFolio(agent_id="b")
+        assert folio_with.has_beacon_identity is True
+        assert folio_without.has_beacon_identity is False
+
+    def test_has_economy_wallet(self):
+        """Test economy wallet property."""
+        folio_with = AgentFolio(agent_id="a", wallet_address="wallet_123")
+        folio_without = AgentFolio(agent_id="b")
+        assert folio_with.has_economy_wallet is True
+        assert folio_without.has_economy_wallet is False
+
+    def test_combined_reputation_score_prefers_economy(self):
+        """Test combined score prefers economy score."""
+        folio = AgentFolio(
+            agent_id="a",
+            beacon_score=75,
+            economy_score=82.5,
+        )
+        assert folio.combined_reputation_score == 82.5
+
+    def test_combined_reputation_score_falls_back_to_beacon(self):
+        """Test combined score falls back to beacon score."""
+        folio = AgentFolio(
+            agent_id="a",
+            beacon_score=75,
+            economy_score=None,
+        )
+        assert folio.combined_reputation_score == 75.0
+
+    def test_combined_reputation_score_none(self):
+        """Test combined score is None when both unavailable."""
+        folio = AgentFolio(agent_id="a")
+        assert folio.combined_reputation_score is None
+
+
+class TestAssembleFolio:
+    """Test folio assembly function."""
+
+    def _make_mock_client_and_bridge(self):
+        """Create mock economy client and beacon bridge."""
+        # Mock economy client
+        economy_client = MagicMock()
+
+        # Mock wallet
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = "0xBase123"
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        # Mock reputation
+        mock_rep_score = MagicMock()
+        mock_rep_score.score = 85.0
+        economy_client.reputation.get_score.return_value = mock_rep_score
+
+        # Mock bounty claims
+        economy_client.bounties.get_my_claims.return_value = [
+            {"bounty_id": "b1"},
+            {"bounty_id": "b2"},
+        ]
+
+        # Mock beacon bridge
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": {
+                "agent_id": "test-agent",
+                "pubkey_hex": "deadbeef",
+                "coinbase_address": "0xRelay456",
+                "created_at": 1712600000,
+            },
+            "reputation": {
+                "agent_id": "test-agent",
+                "score": 75,
+                "bounties_completed": 5,
+                "contracts_completed": 3,
+                "contracts_breached": 1,
+            },
+            "active_contracts": 2,
+            "total_contracts": 5,
+            "envelopes_recent": 10,
+        }
+
+        return economy_client, beacon_bridge
+
+    def test_assemble_folio_populates_all_fields(self):
+        """Test that folio assembly populates fields from both sources."""
+        economy_client, beacon_bridge = self._make_mock_client_and_bridge()
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Identity
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert folio.wallet_address == "wallet_abc"
+        # Economy wallet's base_address overwrites beacon's coinbase_address
+        # (economy data is assembled after beacon data)
+        assert folio.base_address == "0xBase123"
+
+        # Beacon reputation
+        assert folio.beacon_score == 75
+        assert folio.beacon_bounties_completed == 5
+        assert folio.beacon_contracts_completed == 3
+        assert folio.beacon_contracts_breached == 1
+
+        # Economy reputation
+        assert folio.economy_score == 85.0
+
+        # Activity
+        assert folio.total_envelopes_sent == 10
+        assert folio.active_contracts == 2
+        assert folio.open_claims == 2
+
+        # Metadata
+        assert folio.first_seen_beacon == 1712600000
+        assert folio.assembled_at > 0
+
+    def test_assemble_folio_handles_beacon_failure(self):
+        """Test folio assembly continues when Beacon data unavailable."""
+        economy_client = MagicMock()
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = None
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        mock_rep_score = MagicMock()
+        mock_rep_score.score = 80.0
+        economy_client.reputation.get_score.return_value = mock_rep_score
+        economy_client.bounties.get_my_claims.return_value = []
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.side_effect = Exception("Beacon down")
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Economy data should still be populated
+        assert folio.wallet_address == "wallet_abc"
+        assert folio.economy_score == 80.0
+        # Beacon data should be defaults
+        assert folio.beacon_score is None
+        assert folio.beacon_pubkey_hex is None
+
+    def test_assemble_folio_handles_economy_failure(self):
+        """Test folio assembly continues when Economy data unavailable."""
+        economy_client = MagicMock()
+        economy_client.agents.get_wallet.side_effect = Exception("Economy down")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": {
+                "agent_id": "test-agent",
+                "pubkey_hex": "deadbeef",
+                "created_at": 1712600000,
+            },
+            "reputation": {
+                "score": 75,
+                "bounties_completed": 5,
+                "contracts_completed": 3,
+                "contracts_breached": 0,
+            },
+            "active_contracts": 2,
+            "total_contracts": 5,
+            "envelopes_recent": 10,
+        }
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        # Beacon data should still be populated
+        assert folio.beacon_pubkey_hex == "deadbeef"
+        assert folio.beacon_score == 75
+        # Economy data should be defaults
+        assert folio.wallet_address is None
+        assert folio.economy_score is None
+
+    def test_assemble_folio_handles_all_failure(self):
+        """Test folio assembly returns empty folio when both sources fail."""
+        economy_client = MagicMock()
+        economy_client.agents.get_wallet.side_effect = Exception("Down")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.side_effect = Exception("Down")
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        assert folio.agent_id == "test-agent"
+        assert folio.beacon_pubkey_hex is None
+        assert folio.wallet_address is None
+        assert folio.assembled_at > 0
+
+    def test_assemble_folio_handles_missing_optional_fields(self):
+        """Test folio assembly handles missing optional fields gracefully."""
+        economy_client = MagicMock()
+        mock_wallet = MagicMock()
+        mock_wallet.wallet_address = "wallet_abc"
+        mock_wallet.base_address = None  # No base address
+        economy_client.agents.get_wallet.return_value = mock_wallet
+
+        # Reputation lookup fails
+        economy_client.reputation.get_score.side_effect = Exception("No rep")
+        economy_client.bounties.get_my_claims.side_effect = Exception("No claims")
+
+        beacon_bridge = MagicMock()
+        beacon_bridge.lookup_agent_everything.return_value = {
+            "relay_agent": None,  # No relay agent
+            "reputation": None,   # No beacon reputation
+            "active_contracts": 0,
+            "total_contracts": 0,
+            "envelopes_recent": 0,
+        }
+
+        folio = assemble_folio("test-agent", economy_client, beacon_bridge)
+
+        assert folio.wallet_address == "wallet_abc"
+        assert folio.base_address is None
+        assert folio.beacon_pubkey_hex is None
+        assert folio.beacon_score is None
+        assert folio.economy_score is None
+
+
+class TestFolioDiff:
+    """Test folio difference computation."""
+
+    def test_detects_changes(self):
+        """Test that changed fields are detected."""
+        old = AgentFolio(
+            agent_id="test",
+            beacon_score=70,
+            total_envelopes_sent=5,
+            assembled_at=1000.0,
+        )
+        new = AgentFolio(
+            agent_id="test",
+            beacon_score=80,
+            total_envelopes_sent=10,
+            assembled_at=2000.0,
+        )
+
+        changes = folio_diff(old, new)
+
+        assert "beacon_score" in changes
+        assert changes["beacon_score"] == (70, 80)
+        assert "total_envelopes_sent" in changes
+        assert changes["total_envelopes_sent"] == (5, 10)
+        # assembled_at should be excluded
+        assert "assembled_at" not in changes
+
+    def test_no_changes(self):
+        """Test that identical folios show no changes."""
+        old = AgentFolio(agent_id="test", beacon_score=70)
+        new = AgentFolio(agent_id="test", beacon_score=70)
+
+        changes = folio_diff(old, new)
+
+        assert changes == {}
+
+
+class TestFoliosToTable:
+    """Test folio table conversion."""
+
+    def test_converts_to_table(self):
+        """Test folios are converted to table format."""
+        folios = [
+            AgentFolio(
+                agent_id="agent-a",
+                beacon_score=75,
+                beacon_pubkey_hex="deadbeef",
+                wallet_address="wallet_1",
+            ),
+            AgentFolio(
+                agent_id="agent-b",
+                economy_score=85.0,
+            ),
+        ]
+
+        table = folios_to_table(folios)
+
+        assert len(table) == 2
+        assert table[0]["agent_id"] == "agent-a"
+        assert table[0]["combined_score"] == 75.0
+        assert table[0]["has_beacon_identity"] is True
+        assert table[0]["has_economy_wallet"] is True
+
+        assert table[1]["agent_id"] == "agent-b"
+        assert table[1]["combined_score"] == 85.0
+        assert table[1]["has_beacon_identity"] is False
+        assert table[1]["has_economy_wallet"] is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/rustchain-bounties-mcp/.gitignore
+++ b/rustchain-bounties-mcp/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.egg-info/
+.pytest_cache/

--- a/rustchain-bounties-mcp/README.md
+++ b/rustchain-bounties-mcp/README.md
@@ -1,0 +1,331 @@
+# RustChain Bounties MCP Server
+
+[![MCP](https://img.shields.io/badge/MCP-Server-blue)](https://modelcontextprotocol.io)
+[![Python 3.10+](https://img.shields.io/badge/Python-3.10+-yellow.svg)](https://www.python.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../LICENSE)
+
+**One-line install + Claude Code config** for an MCP server that gives AI assistants 7 tools to interact with the RustChain blockchain.
+
+## Quick Install
+
+```bash
+pip install "mcp>=1.0.0" aiohttp>=3.9.0
+```
+
+Then clone or copy this directory — no build step needed.
+
+## Claude Code Configuration
+
+Add to your Claude Code MCP config (or Cursor / VS Code Copilot MCP config):
+
+```json
+{
+  "mcpServers": {
+    "rustchain-bounties": {
+      "command": "python",
+      "args": ["-m", "rustchain_bounties_mcp.mcp_server"],
+      "env": {
+        "RUSTCHAIN_NODE_URL": "https://50.28.86.131"
+      }
+    }
+  }
+}
+```
+
+**Cursor** (`.cursor/mcp.json`):
+
+```json
+{
+  "rustchain-bounties": {
+    "command": "python",
+    "args": ["-m", "rustchain_bounties_mcp.mcp_server"],
+    "env": {
+      "RUSTCHAIN_NODE_URL": "https://50.28.86.131"
+    }
+  }
+}
+```
+
+**VS Code Copilot** — add the same JSON to your MCP server configuration file.
+
+## Tools
+
+| Tool | Description | Required Args | Endpoint |
+|------|-------------|---------------|----------|
+| `rustchain_health` | Node health probe (ok, version, uptime, db status) | none | `GET /health` |
+| `rustchain_balance` | Get RTC wallet balance | `miner_id` | `GET /wallet/balance` |
+| `rustchain_miners` | List active miners with filters | none | `GET /api/miners` |
+| `rustchain_epoch` | Current epoch info | none | `GET /epoch` |
+| `rustchain_verify_wallet` | Verify wallet presence for a miner (auto-provisioned) | `miner_id` | `GET /wallet/balance` |
+| `rustchain_submit_attestation` | Submit hardware attestation | `miner_id`, `device` | `POST /attest/submit` |
+| `rustchain_bounties` | List open bounties (via GitHub API) | none | GitHub Issues API |
+
+### Tool Details
+
+#### rustchain_health
+
+Check if the RustChain node is healthy, DB is read/write, and chain tip is recent.
+
+**Input:** `{}`
+
+**Output:**
+```json
+{
+  "ok": true,
+  "healthy": true,
+  "version": "2.2.1",
+  "uptime_s": 86400,
+  "db_rw": true,
+  "backup_age_hours": 12.5,
+  "tip_age_slots": 3
+}
+```
+
+#### rustchain_balance
+
+Get the RTC balance for a miner by ID.
+
+**Input:** `{"miner_id": "scott"}`
+
+**Output:**
+```json
+{
+  "miner_id": "scott",
+  "amount_rtc": 155.0,
+  "amount_i64": 155000000
+}
+```
+
+#### rustchain_miners
+
+List active miners. Supports optional `hardware_type` filter and `limit`.
+
+**Input:** `{"hardware_type": "PowerPC", "limit": 20}`
+
+**Output:**
+```json
+{
+  "total_count": 42,
+  "limit": 20,
+  "offset": 0,
+  "miners": [
+    {
+      "miner": "alice",
+      "hardware_type": "PowerPC G4 (Vintage)",
+      "device_family": "PowerPC",
+      "device_arch": "g4",
+      "antiquity_multiplier": 2.0,
+      "entropy_score": 0.95,
+      "last_attest": 1700000000,
+      "epochs_mined": 10
+    }
+  ]
+}
+```
+
+#### rustchain_epoch
+
+Get current epoch information.
+
+**Input:** `{}`
+
+**Output:**
+```json
+{
+  "epoch": 95,
+  "slot": 12345,
+  "epoch_pot": 1000.0,
+  "enrolled_miners": 42,
+  "blocks_per_epoch": 100,
+  "total_supply_rtc": 21000000.0
+}
+```
+
+#### rustchain_verify_wallet
+
+Verify whether a wallet exists for a given miner_id. The RustChain node does not
+expose a dedicated wallet-creation endpoint — wallets are auto-provisioned on first
+activity (mining payout, transfer). This tool queries the balance endpoint to
+confirm wallet presence and returns the current balance.
+
+**Input:** `{"miner_id": "new_miner"}`
+
+**Output:**
+```json
+{
+  "wallet_address": "new_miner",
+  "exists": true,
+  "balance_rtc": 0.0,
+  "message": "Wallet found for new_miner with balance 0.0 RTC"
+}
+```
+
+#### rustchain_submit_attestation
+
+Submit a hardware attestation for miner enrollment.
+
+**Input:**
+```json
+{
+  "miner_id": "new_miner",
+  "device": {
+    "device_model": "PowerBook G4",
+    "device_arch": "g4",
+    "cores": 1
+  },
+  "signature": "ed25519_sig_hex (optional)",
+  "public_key": "ed25519_pubkey_hex (optional)"
+}
+```
+
+**Output:**
+```json
+{
+  "ok": true,
+  "message": "enrolled",
+  "miner_id": "new_miner",
+  "enrolled_epoch": 96
+}
+```
+
+#### rustchain_bounties
+
+List RustChain bounties. Defaults to open bounties.
+
+**Data source:** The node does not expose a native `/api/bounties` endpoint.
+Bounties are fetched from the GitHub Issues API at
+`Scottcjn/rustchain-bounties`. Reward amounts are parsed from issue labels
+and titles.
+
+**Input:** `{"status": "open", "limit": 20}`
+
+**Output:**
+```json
+{
+  "count": 1,
+  "source": "github:Scottcjn/rustchain-bounties",
+  "bounties": [
+    {
+      "issue_number": 2859,
+      "title": "MCP Server",
+      "reward_rtc": 500.0,
+      "status": "open",
+      "difficulty": "medium",
+      "tags": ["python", "mcp"]
+    }
+  ]
+}
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `RUSTCHAIN_NODE_URL` | `https://50.28.86.131` | RustChain node base URL |
+| `RUSTCHAIN_TIMEOUT` | `30` | HTTP request timeout (seconds) |
+| `RUSTCHAIN_RETRY` | `2` | Number of retries on failure |
+
+## Running
+
+### As a module
+
+```bash
+python -m rustchain_bounties_mcp.mcp_server
+```
+
+### As a console script (after `pip install -e .`)
+
+```bash
+rustchain-bounties-mcp
+```
+
+### With custom node URL
+
+```bash
+RUSTCHAIN_NODE_URL=https://my-node.example.com python -m rustchain_bounties_mcp.mcp_server
+```
+
+## Architecture
+
+```
+┌──────────────────┐       MCP stdio        ┌──────────────────────────┐
+│  AI Assistant    │ ◄────────────────────► │  rustchain-bounties-mcp  │
+│  (Claude/Cursor) │                        │                          │
+│                  │                        │  Tools:                    │
+│  - health        │                        │  - rustchain_health        │
+│  - balance       │                        │  - rustchain_balance       │
+│  - miners        │                        │  - rustchain_miners        │
+│  - epoch         │                        │  - rustchain_epoch         │
+│  - verify_wallet │                        │  - rustchain_verify_wallet │
+│  - attestation   │                        │  - rustchain_submit_attest │
+│  - bounties      │                        │  - rustchain_bounties      │
+└──────────────────┘                        └───────────┬──────────────┘
+                                              ┌─────────┴──────────────┐
+                                              │                        │
+                                         HTTPS│                   HTTPS│
+                                         (node)│              (GitHub)  │
+                                              ▼                        ▼
+                                  ┌──────────────────┐   ┌──────────────────────────┐
+                                  │ RustChain Node   │   │ GitHub Issues API        │
+                                  │ (Flask)          │   │ Scottcjn/rustchain-      │
+                                  │ GET  /health     │   │ bounties                 │
+                                  │ GET  /epoch      │   │                          │
+                                  │ GET  /wallet/    │   │ (bounties only)          │
+                                  │   balance        │   └──────────────────────────┘
+                                  │ GET  /api/miners │
+                                  │ POST /attest/    │
+                                  │   submit         │
+                                  └──────────────────┘
+```
+
+## Testing
+
+```bash
+cd rustchain-bounties-mcp
+pip install -e ".[dev]"
+pytest tests/ -v
+```
+
+## Packaging (PyPI / npm)
+
+### PyPI (local)
+
+```bash
+pip install build
+python -m build
+# Produces dist/rustchain_bounties_mcp-0.1.0-py3-none-any.whl
+pip install dist/rustchain_bounties_mcp-0.1.0-py3-none-any.whl
+```
+
+To publish to PyPI: `twine upload dist/*` (requires PyPI credentials).
+
+### npm (wrapper)
+
+For npm distribution, create a thin wrapper `package.json`:
+
+```json
+{
+  "name": "rustchain-bounties-mcp",
+  "version": "0.1.0",
+  "bin": {
+    "rustchain-bounties-mcp": "run.py"
+  },
+  "scripts": {
+    "postinstall": "pip install -t node_modules/.bin/rustchain-bounties-mcp_venv ."
+  }
+}
+```
+
+Or use [`pipx`](https://github.com/pypa/pipx) for user-level installs.
+
+## Security Notes
+
+- **Self-signed TLS:** The node uses self-signed certificates. The client sets `ssl=False`. In production, pin the node certificate.
+- **Read-only tools:** `health`, `balance`, `miners`, `epoch`, `verify_wallet`, `bounties` are read-only.
+- **State-changing tools:** `submit_attestation` modifies node state. Use with appropriate access controls.
+- **No secrets in MCP output:** The server never logs or returns private keys or signing material.
+- **GitHub API rate limits:** Unauthenticated GitHub API calls are limited to 60/hour. For heavy usage, set a `GITHUB_TOKEN` environment variable (the client can be extended to support auth headers).
+
+## License
+
+MIT

--- a/rustchain-bounties-mcp/README.md
+++ b/rustchain-bounties-mcp/README.md
@@ -56,8 +56,9 @@ Add to your Claude Code MCP config (or Cursor / VS Code Copilot MCP config):
 | `rustchain_balance` | Get RTC wallet balance | `miner_id` | `GET /wallet/balance` |
 | `rustchain_miners` | List active miners with filters | none | `GET /api/miners` |
 | `rustchain_epoch` | Current epoch info | none | `GET /epoch` |
-| `rustchain_verify_wallet` | Verify wallet presence for a miner (auto-provisioned) | `miner_id` | `GET /wallet/balance` |
-| `rustchain_submit_attestation` | Submit hardware attestation | `miner_id`, `device` | `POST /attest/submit` |
+| `rustchain_verify_wallet` | Heuristic wallet check (non-zero balance only) | `miner_id` | `GET /wallet/balance` |
+| `rustchain_attest_challenge` | Fetch attestation nonce for enrollment | none | `POST /attest/challenge` |
+| `rustchain_submit_attestation` | Submit hardware attestation (nonce required) | `miner_id`, `device`, `nonce` | `POST /attest/submit` |
 | `rustchain_bounties` | List open bounties (via GitHub API) | none | GitHub Issues API |
 
 ### Tool Details
@@ -143,20 +144,49 @@ Get current epoch information.
 
 #### rustchain_verify_wallet
 
-Verify whether a wallet exists for a given miner_id. The RustChain node does not
-expose a dedicated wallet-creation endpoint — wallets are auto-provisioned on first
-activity (mining payout, transfer). This tool queries the balance endpoint to
-confirm wallet presence and returns the current balance.
+Heuristically verify whether a wallet exists for a given miner_id. The live
+`/wallet/balance` endpoint returns HTTP 200 with a zero balance for **any**
+miner_id (including nonsense strings), so a 200 response does **not** prove
+wallet existence. This tool uses a conservative heuristic: `exists=True` only
+when the queried miner_id shows a **non-zero** balance, indicating observed
+on-chain activity.
 
-**Input:** `{"miner_id": "new_miner"}`
+**Input:** `{"miner_id": "scott"}`
+
+**Output (non-zero balance):**
+```json
+{
+  "wallet_address": "scott",
+  "exists": true,
+  "balance_rtc": 155.0,
+  "message": "Observed wallet activity for scott with balance 155.0 RTC"
+}
+```
+
+**Output (zero / unknown):**
+```json
+{
+  "wallet_address": "unknown_id",
+  "exists": false,
+  "balance_rtc": 0.0,
+  "message": "Balance endpoint returned a zero-balance row; this does not prove wallet existence on the live API"
+}
+```
+
+#### rustchain_attest_challenge
+
+Fetch a fresh attestation nonce from the node. This nonce **must** be included
+in the subsequent `rustchain_submit_attestation` call — the live endpoint
+rejects submissions without a valid nonce (`MISSING_NONCE`).
+
+**Input:** `{}`
 
 **Output:**
 ```json
 {
-  "wallet_address": "new_miner",
-  "exists": true,
-  "balance_rtc": 0.0,
-  "message": "Wallet found for new_miner with balance 0.0 RTC"
+  "nonce": "da0cd8aafb29b4ccab3ce182d2679015da621919a2b7fd2d804bda890ac53e",
+  "expires_at": 1775911361,
+  "server_time": 1775911061
 }
 ```
 
@@ -192,10 +222,12 @@ Submit a hardware attestation for miner enrollment.
 
 List RustChain bounties. Defaults to open bounties.
 
-**Data source:** The node does not expose a native `/api/bounties` endpoint.
-Bounties are fetched from the GitHub Issues API at
-`Scottcjn/rustchain-bounties`. Reward amounts are parsed from issue labels
-and titles.
+**Data source (intentional):** The live RustChain node does **not** expose a
+native `/api/bounties` endpoint (it returns HTTP 404). Bounties are fetched
+from the GitHub Issues API at `Scottcjn/rustchain-bounties`. Reward amounts are
+parsed from issue labels (e.g. `"bounty: 500 RTC"`) and titles (e.g.
+`"Bounty: MCP Server (500 RTC)"`). This is the authoritative source for bounty
+data and is by design — the bounty workflow is managed through GitHub Issues.
 
 **Input:** `{"status": "open", "limit": 20}`
 
@@ -320,11 +352,19 @@ Or use [`pipx`](https://github.com/pypa/pipx) for user-level installs.
 
 ## Security Notes
 
-- **Self-signed TLS:** The node uses self-signed certificates. The client sets `ssl=False`. In production, pin the node certificate.
-- **Read-only tools:** `health`, `balance`, `miners`, `epoch`, `verify_wallet`, `bounties` are read-only.
+- **Self-signed TLS certificate:** The live RustChain node at `50.28.86.131`
+  uses a self-signed TLS certificate. The client disables certificate
+  verification (`ssl=False`) to connect. In production you should either:
+  - Pin the node's certificate fingerprint, or
+  - Deploy the node behind a properly signed certificate (e.g. Let's Encrypt), or
+  - Use a trusted internal CA.
+  To pin the cert, set `RUSTCHAIN_NODE_URL` to an `https://` URL and modify
+  `client.py` to pass an `ssl.SSLContext` with `load_verify_locations()`.
+- **Read-only tools:** `health`, `balance`, `miners`, `epoch`, `verify_wallet`, `bounties`, `attest_challenge` are read-only.
 - **State-changing tools:** `submit_attestation` modifies node state. Use with appropriate access controls.
 - **No secrets in MCP output:** The server never logs or returns private keys or signing material.
 - **GitHub API rate limits:** Unauthenticated GitHub API calls are limited to 60/hour. For heavy usage, set a `GITHUB_TOKEN` environment variable (the client can be extended to support auth headers).
+- **Attestation nonce expiry:** Nonces returned by `rustchain_attest_challenge` have a short TTL (typically ~5 minutes). Call `rustchain_attest_challenge` immediately before `rustchain_submit_attestation`.
 
 ## License
 

--- a/rustchain-bounties-mcp/pyproject.toml
+++ b/rustchain-bounties-mcp/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rustchain-bounties-mcp"
+version = "0.1.0"
+description = "MCP server for RustChain bounties — health, balance, miners, epoch, wallet creation, attestation, and bounties"
+readme = "README.md"
+license = {text = "MIT"}
+requires-python = ">=3.9"
+keywords = ["rustchain", "mcp", "blockchain", "bounties", "ai"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "aiohttp>=3.9.0",
+]
+
+[project.optional-dependencies]
+mcp = ["mcp>=1.0.0"]
+dev = [
+    "mcp>=1.0.0",
+    "pytest>=7.0.0",
+    "pytest-asyncio>=0.21.0",
+    "ruff>=0.1.0",
+]
+
+[project.scripts]
+rustchain-bounties-mcp = "rustchain_bounties_mcp.mcp_server:main"
+
+[project.urls]
+Homepage = "https://github.com/Scottcjn/RustChain"
+Repository = "https://github.com/Scottcjn/RustChain.git"
+Issues = "https://github.com/Scottcjn/RustChain/issues/2859"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["rustchain_bounties_mcp*"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+select = ["E", "W", "F", "I", "B"]
+ignore = ["E501", "B008"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/rustchain-bounties-mcp/pyproject.toml
+++ b/rustchain-bounties-mcp/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "MCP server for RustChain bounties — health, balance, miners, epoch, wallet creation, attestation, and bounties"
 readme = "README.md"
 license = {text = "MIT"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["rustchain", "mcp", "blockchain", "bounties", "ai"]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -34,7 +34,7 @@ dev = [
 ]
 
 [project.scripts]
-rustchain-bounties-mcp = "rustchain_bounties_mcp.mcp_server:main"
+rustchain-bounties-mcp = "rustchain_bounties_mcp.mcp_server:entry"
 
 [project.urls]
 Homepage = "https://github.com/Scottcjn/RustChain"

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/__init__.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""RustChain Bounties MCP Server."""
+
+__version__ = "0.1.0"

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -1,0 +1,330 @@
+"""
+RustChain Bounties MCP — API Client
+
+Async HTTP client that talks to the RustChain node Flask API.
+All endpoints match the actual routes in rustchain_v2_integrated_v2.2.1_rip200.py.
+
+Bounties are sourced from the GitHub Issues API (the node does not expose
+a native /api/bounties endpoint).  See _fetch_bounties_from_github().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Any, Optional
+
+import aiohttp
+
+from .schemas import (
+    APIError,
+    AttestChallenge,
+    AttestSubmitResult,
+    BountyInfo,
+    EpochInfo,
+    HealthStatus,
+    MinerInfo,
+    WalletBalance,
+    WalletVerifyResult,
+)
+
+logger = logging.getLogger(__name__)
+
+# Defaults — node URL is configurable, defaulting to the live node
+DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://50.28.86.131")
+REQUEST_TIMEOUT = int(os.getenv("RUSTCHAIN_TIMEOUT", "30"))
+RETRY_COUNT = int(os.getenv("RUSTCHAIN_RETRY", "2"))
+
+# GitHub bounties repo — used as the authoritative source for open bounties
+# because the node does not expose a native /api/bounties endpoint.
+GITHUB_BOUNTIES_OWNER = "Scottcjn"
+GITHUB_BOUNTIES_REPO = "rustchain-bounties"
+GITHUB_API_BASE = "https://api.github.com"
+
+
+class RustChainClient:
+    """Async client for the RustChain node API."""
+
+    def __init__(
+        self,
+        node_url: Optional[str] = None,
+        timeout: int = REQUEST_TIMEOUT,
+        retry_count: int = RETRY_COUNT,
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
+        self.node_url = (node_url or DEFAULT_NODE_URL).rstrip("/")
+        self.timeout = timeout
+        self.retry_count = retry_count
+        self._session = session
+        self._owns_session = session is None
+
+    async def __aenter__(self) -> "RustChainClient":
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()
+
+    async def _ensure_session(self) -> None:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=self.timeout),
+                headers={"User-Agent": "RustChain-Bounties-MCP/0.1", "Accept": "application/json"},
+            )
+            self._owns_session = True
+
+    async def close(self) -> None:
+        if self._owns_session and self._session:
+            await self._session.close()
+            self._session = None
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[dict[str, Any]] = None,
+        json_data: Optional[dict[str, Any]] = None,
+    ) -> dict[str, Any]:
+        """HTTP request with retry and self-signed-cert handling."""
+        await self._ensure_session()
+        url = f"{self.node_url}{path}"
+        last_err: Optional[Exception] = None
+
+        for attempt in range(self.retry_count + 1):
+            try:
+                async with self._session.request(
+                    method, url, params=params, json=json_data, ssl=False,
+                ) as resp:
+                    body = await resp.json()
+                    if resp.status >= 400:
+                        raise APIError.from_response(resp.status, body)
+                    return body
+            except aiohttp.ClientError as exc:
+                last_err = exc
+                logger.warning("Request failed (attempt %d): %s", attempt + 1, exc)
+                if attempt < self.retry_count:
+                    await asyncio.sleep(0.5 * (attempt + 1))
+            except APIError:
+                raise
+
+        raise APIError(
+            code="CONNECTION_FAILED",
+            message=f"Failed after {self.retry_count + 1} attempts: {last_err}",
+            status_code=503,
+        )
+
+    # ---- Tool implementations ----
+
+    async def health(self) -> HealthStatus:
+        """GET /health — node health probe."""
+        data = await self._request("GET", "/health")
+        return HealthStatus.from_dict(data)
+
+    async def epoch(self) -> EpochInfo:
+        """GET /epoch — current epoch info."""
+        data = await self._request("GET", "/epoch")
+        return EpochInfo.from_dict(data)
+
+    async def balance(self, miner_id: str) -> WalletBalance:
+        """GET /wallet/balance?miner_id=…"""
+        if not miner_id or not miner_id.strip():
+            raise APIError(code="VALIDATION_ERROR", message="miner_id is required", status_code=400)
+        data = await self._request("GET", "/wallet/balance", params={"miner_id": miner_id.strip()})
+        if data.get("ok") is False and "error" in data:
+            raise APIError.from_response(400, data)
+        return WalletBalance.from_dict(data)
+
+    async def miners(
+        self,
+        limit: int = 50,
+        hardware_type: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """GET /api/miners — returns paginated list with metadata."""
+        params: dict[str, Any] = {"limit": min(max(limit, 1), 1000)}
+        data = await self._request("GET", "/api/miners", params=params)
+        miners_raw = data.get("miners", [])
+        miners = [MinerInfo.from_dict(m) for m in miners_raw]
+
+        if hardware_type:
+            ht = hardware_type.lower()
+            miners = [m for m in miners if ht in m.hardware_type.lower() or ht in m.device_family.lower()]
+
+        return {
+            "miners": miners,
+            "total_count": data.get("total_count", len(miners)),
+            "limit": data.get("limit", limit),
+            "offset": data.get("offset", 0),
+        }
+
+    async def verify_wallet(self, miner_id: str) -> WalletVerifyResult:
+        """Verify wallet presence for a miner_id.
+
+        The node does not expose a dedicated wallet-creation endpoint.
+        Wallets are implicitly provisioned on first activity (mining payout,
+        transfer).  This method queries the balance endpoint to confirm
+        whether the miner_id has a wallet row, and returns its status.
+
+        Returns a WalletVerifyResult indicating whether the wallet exists
+        and its current balance.  This is a *verification* tool, not a
+        *creation* tool — the name reflects the actual capability.
+        """
+        try:
+            bal = await self.balance(miner_id)
+            return WalletVerifyResult(
+                wallet_address=bal.miner_id,
+                exists=True,
+                balance_rtc=bal.amount_rtc,
+                message=f"Wallet found for {miner_id} with balance {bal.amount_rtc} RTC",
+            )
+        except APIError as exc:
+            if exc.status_code == 400:
+                return WalletVerifyResult(
+                    wallet_address=miner_id,
+                    exists=False,
+                    balance_rtc=0.0,
+                    message=f"Could not verify wallet: {exc.message}",
+                )
+            raise
+
+    async def submit_attestation(
+        self,
+        miner_id: str,
+        device: dict[str, Any],
+        signature: Optional[str] = None,
+        public_key: Optional[str] = None,
+    ) -> AttestSubmitResult:
+        """POST /attest/submit — submit hardware fingerprint for enrollment.
+
+        Flow: the caller should first GET a challenge via /attest/challenge,
+        sign it, then call this method.  For MCP convenience we accept the
+        device dict and optional signature/pubkey and forward to the node.
+        """
+        payload: dict[str, Any] = {
+            "miner_id": miner_id,
+            "device": device,
+        }
+        if signature:
+            payload["signature"] = signature
+        if public_key:
+            payload["public_key"] = public_key
+
+        data = await self._request("POST", "/attest/submit", json_data=payload)
+        return AttestSubmitResult.from_dict(data)
+
+    async def get_attest_challenge(self) -> AttestChallenge:
+        """POST /attest/challenge — get nonce for attestation signing."""
+        data = await self._request("POST", "/attest/challenge")
+        return AttestChallenge.from_dict(data)
+
+    async def bounties(
+        self,
+        status: str = "open",
+        limit: int = 50,
+    ) -> list[BountyInfo]:
+        """List bounties from the GitHub Issues API.
+
+        The node does not expose a native /api/bounties endpoint (it returns
+        404).  The authoritative source for bounty data is the GitHub repo
+        at Scottcjn/rustchain-bounties.  We fetch open issues from that repo
+        and parse reward amounts from labels / title patterns.
+
+        If the GitHub API also fails, returns an empty list with a log warning.
+        """
+        return await self._fetch_bounties_from_github(status=status, limit=limit)
+
+    async def _fetch_bounties_from_github(
+        self,
+        status: str = "open",
+        limit: int = 50,
+    ) -> list[BountyInfo]:
+        """Fetch bounties from GitHub Issues API.
+
+        Parses issue titles and labels to extract bounty info.
+        Expected label format: "bounty: <amount> RTC" or similar.
+        """
+        await self._ensure_session()
+        state = status if status in ("open", "closed", "all") else "open"
+        url = f"{GITHUB_API_BASE}/repos/{GITHUB_BOUNTIES_OWNER}/{GITHUB_BOUNTIES_REPO}/issues"
+        params = {"state": state, "per_page": min(limit, 100)}
+        headers = {"Accept": "application/vnd.github.v3+json", "User-Agent": "RustChain-Bounties-MCP/0.1"}
+
+        try:
+            async with self._session.get(url, params=params, headers=headers, ssl=False) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.warning("GitHub API returned %d: %s", resp.status, body[:200])
+                    return []
+
+                issues = await resp.json()
+                bounties: list[BountyInfo] = []
+                for issue in issues[:limit]:
+                    # Skip PRs (issues with pull_request key)
+                    if "pull_request" in issue:
+                        continue
+
+                    bounty = self._parse_github_issue(issue)
+                    if bounty is not None:
+                        bounties.append(bounty)
+
+                return bounties
+        except aiohttp.ClientError as exc:
+            logger.warning("Failed to fetch bounties from GitHub: %s", exc)
+            return []
+
+    @staticmethod
+    def _parse_github_issue(issue: dict[str, Any]) -> Optional[BountyInfo]:
+        """Parse a GitHub issue into a BountyInfo, or None if not a bounty."""
+        title = issue.get("title", "")
+        number = issue.get("number", 0)
+        html_url = issue.get("html_url", "")
+        state = issue.get("state", "open")
+        labels = issue.get("labels", [])
+        body = issue.get("body", "") or ""
+
+        # Extract reward from labels (e.g. "bounty: 500 RTC", "500 RTC", "tier: major")
+        reward_rtc = 0.0
+        difficulty: Optional[str] = None
+        tags: list[str] = []
+
+        for label in labels:
+            label_name = label.get("name", "").lower()
+            # Look for bounty amount in labels
+            for token in label_name.split():
+                try:
+                    val = float(token)
+                    if 0 < val <= 10000:  # reasonable bounty range
+                        reward_rtc = val
+                except ValueError:
+                    pass
+            # Difficulty from labels
+            if any(t in label_name for t in ("easy", "micro", "small")):
+                difficulty = "easy"
+            elif any(t in label_name for t in ("medium", "standard")):
+                difficulty = "medium"
+            elif any(t in label_name for t in ("hard", "major", "critical")):
+                difficulty = "hard"
+            tags.append(label.get("name", ""))
+
+        # Try to extract reward from title (e.g. "Bounty: MCP Server (500 RTC)")
+        title_match = re.search(r"(\d+)\s*RTC", title, re.IGNORECASE)
+        if title_match and reward_rtc == 0:
+            reward_rtc = float(title_match.group(1))
+
+        # If no reward found in labels or title, skip non-bounty issues
+        if reward_rtc == 0 and not any("bounty" in (lbl.get("name", "") or "").lower() for lbl in labels):
+            # Still include it but with 0 reward — better than nothing for discovery
+            pass
+
+        return BountyInfo(
+            issue_number=number,
+            title=title,
+            reward_rtc=reward_rtc,
+            status=state,
+            url=html_url,
+            description=body[:500] if body else None,  # truncate for MCP output
+            difficulty=difficulty,
+            tags=tags,
+        )

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -142,7 +142,7 @@ class RustChainClient:
         limit: int = 50,
         hardware_type: Optional[str] = None,
     ) -> dict[str, Any]:
-        """GET /api/miners — returns paginated list with metadata."""
+        """GET /api/miners — the live API returns `miners` list + `pagination` dict."""
         params: dict[str, Any] = {"limit": min(max(limit, 1), 1000)}
         data = await self._request("GET", "/api/miners", params=params)
         miners_raw = data.get("miners", [])
@@ -152,32 +152,39 @@ class RustChainClient:
             ht = hardware_type.lower()
             miners = [m for m in miners if ht in m.hardware_type.lower() or ht in m.device_family.lower()]
 
+        limited = miners[: params["limit"]]
+
+        # Live API returns pagination as a nested dict: {"miners": [...], "pagination": {"total": N, ...}}
+        pagination = data.get("pagination", {})
+        total_count = pagination.get("total", len(miners))
+
         return {
-            "miners": miners,
-            "total_count": data.get("total_count", len(miners)),
-            "limit": data.get("limit", limit),
-            "offset": data.get("offset", 0),
+            "miners": limited,
+            "total_count": total_count,
+            "limit": params["limit"],
+            "offset": pagination.get("offset", 0),
         }
 
     async def verify_wallet(self, miner_id: str) -> WalletVerifyResult:
-        """Verify wallet presence for a miner_id.
+        """Heuristically verify wallet activity for a miner_id.
 
-        The node does not expose a dedicated wallet-creation endpoint.
-        Wallets are implicitly provisioned on first activity (mining payout,
-        transfer).  This method queries the balance endpoint to confirm
-        whether the miner_id has a wallet row, and returns its status.
-
-        Returns a WalletVerifyResult indicating whether the wallet exists
-        and its current balance.  This is a *verification* tool, not a
-        *creation* tool — the name reflects the actual capability.
+        The live `/wallet/balance` endpoint returns HTTP 200 with a zero
+        balance even for nonsense ids, so it cannot prove wallet existence.
+        For MCP purposes we expose a conservative heuristic instead:
+        `exists=True` only when the queried id shows observed non-zero balance.
         """
         try:
             bal = await self.balance(miner_id)
+            has_observed_activity = bal.amount_i64 > 0 or bal.amount_rtc > 0
             return WalletVerifyResult(
                 wallet_address=bal.miner_id,
-                exists=True,
+                exists=has_observed_activity,
                 balance_rtc=bal.amount_rtc,
-                message=f"Wallet found for {miner_id} with balance {bal.amount_rtc} RTC",
+                message=(
+                    f"Observed wallet activity for {miner_id} with balance {bal.amount_rtc} RTC"
+                    if has_observed_activity
+                    else "Balance endpoint returned a zero-balance row; this does not prove wallet existence on the live API"
+                ),
             )
         except APIError as exc:
             if exc.status_code == 400:
@@ -193,6 +200,7 @@ class RustChainClient:
         self,
         miner_id: str,
         device: dict[str, Any],
+        nonce: str,
         signature: Optional[str] = None,
         public_key: Optional[str] = None,
     ) -> AttestSubmitResult:
@@ -205,6 +213,7 @@ class RustChainClient:
         payload: dict[str, Any] = {
             "miner_id": miner_id,
             "device": device,
+            "nonce": nonce,
         }
         if signature:
             payload["signature"] = signature

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/mcp_server.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/mcp_server.py
@@ -6,13 +6,14 @@ Model Context Protocol (MCP) server for RustChain blockchain.
 Exposes 7 tools over stdio, compatible with Claude Code / Cursor / VS Code Copilot MCP clients.
 
 Tools:
-    rustchain_health            — Node health probe
-    rustchain_balance           — Wallet balance by miner_id
-    rustchain_miners            — List active miners
-    rustchain_epoch             — Current epoch info
-    rustchain_verify_wallet     — Verify wallet presence for a miner
+    rustchain_health             — Node health probe
+    rustchain_balance            — Wallet balance by miner_id
+    rustchain_miners             — List active miners
+    rustchain_epoch              — Current epoch info
+    rustchain_verify_wallet      — Heuristic wallet verification for a miner
+    rustchain_attest_challenge   — Fetch attestation nonce/challenge
     rustchain_submit_attestation — Submit hardware attestation
-    rustchain_bounties          — List open bounties (via GitHub API)
+    rustchain_bounties           — List open bounties (via GitHub API)
 
 Usage:
     python -m rustchain_bounties_mcp.mcp_server
@@ -79,6 +80,7 @@ except ImportError:
 from .client import RustChainClient
 from .schemas import (
     APIError,
+    ATTEST_CHALLENGE_SCHEMA,
     BALANCE_SCHEMA,
     BOUNTIES_SCHEMA,
     EPOCH_SCHEMA,
@@ -156,12 +158,17 @@ class RustchainBountiesMCP:
                 ),
                 Tool(
                     name="rustchain_verify_wallet",
-                    description="Verify wallet presence for a miner_id on RustChain (queries balance endpoint; wallets are auto-provisioned on first activity)",
+                    description="Heuristically verify whether a miner_id shows observed wallet activity on RustChain (the balance endpoint returns 200 even for unknown ids)",
                     inputSchema=VERIFY_WALLET_SCHEMA,
                 ),
                 Tool(
+                    name="rustchain_attest_challenge",
+                    description="Fetch an attestation nonce/challenge from the RustChain node before calling rustchain_submit_attestation",
+                    inputSchema=ATTEST_CHALLENGE_SCHEMA,
+                ),
+                Tool(
                     name="rustchain_submit_attestation",
-                    description="Submit a hardware attestation for a miner (device fingerprint required)",
+                    description="Submit a hardware attestation for a miner (nonce from rustchain_attest_challenge required by the live endpoint)",
                     inputSchema=SUBMIT_ATTESTATION_SCHEMA,
                 ),
                 Tool(
@@ -223,7 +230,6 @@ class RustchainBountiesMCP:
                 "antiquity_multiplier": m.antiquity_multiplier,
                 "entropy_score": m.entropy_score,
                 "last_attest": m.last_attest,
-                "epochs_mined": m.epochs_mined,
             })
         return {
             "total_count": result["total_count"],
@@ -253,14 +259,29 @@ class RustchainBountiesMCP:
             "message": r.message,
         }
 
+    async def _tool_rustchain_attest_challenge(self, _args: dict[str, Any]) -> dict[str, Any]:
+        challenge = await self._require_client().get_attest_challenge()
+        return {
+            "nonce": challenge.nonce,
+            "expires_at": challenge.expires_at,
+            "server_time": challenge.server_time,
+        }
+
     async def _tool_rustchain_submit_attestation(self, args: dict[str, Any]) -> dict[str, Any]:
         miner_id = args.get("miner_id", "")
         device = args.get("device")
+        nonce = args.get("nonce")
         if not device or not isinstance(device, dict):
             return {"error": "VALIDATION_ERROR", "message": "device is required and must be a dict"}
+        if not nonce:
+            return {
+                "error": "VALIDATION_ERROR",
+                "message": "nonce is required; call rustchain_attest_challenge first",
+            }
         r = await self._require_client().submit_attestation(
             miner_id=miner_id,
             device=device,
+            nonce=nonce,
             signature=args.get("signature"),
             public_key=args.get("public_key"),
         )
@@ -321,7 +342,7 @@ async def main() -> None:
             await server.app.run(
                 read_stream,
                 write_stream,
-                server.create_initialization_options(),
+                server.app.create_initialization_options(),
             )
     finally:
         await server.stop()
@@ -333,4 +354,4 @@ def entry() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    entry()

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/mcp_server.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/mcp_server.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+RustChain Bounties MCP Server
+
+Model Context Protocol (MCP) server for RustChain blockchain.
+Exposes 7 tools over stdio, compatible with Claude Code / Cursor / VS Code Copilot MCP clients.
+
+Tools:
+    rustchain_health            — Node health probe
+    rustchain_balance           — Wallet balance by miner_id
+    rustchain_miners            — List active miners
+    rustchain_epoch             — Current epoch info
+    rustchain_verify_wallet     — Verify wallet presence for a miner
+    rustchain_submit_attestation — Submit hardware attestation
+    rustchain_bounties          — List open bounties (via GitHub API)
+
+Usage:
+    python -m rustchain_bounties_mcp.mcp_server
+
+Environment:
+    RUSTCHAIN_NODE_URL  — Node base URL (default: https://50.28.86.131)
+    RUSTCHAIN_TIMEOUT   — Request timeout seconds (default: 30)
+    RUSTCHAIN_RETRY     — Retry count (default: 2)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# MCP SDK — graceful fallback when not installed (for unit testing)
+# ---------------------------------------------------------------------------
+try:
+    from mcp.server import Server
+    from mcp.server.stdio import stdio_server
+    from mcp.types import TextContent, Tool
+
+    MCP_AVAILABLE = True
+except ImportError:
+    MCP_AVAILABLE = False
+
+    class _MockServer:  # type: ignore[no-redef]
+        def __init__(self, name: str) -> None: ...
+        def list_tools(self):  # type: ignore
+            return lambda f: f
+        def call_tool(self):  # type: ignore
+            return lambda f: f
+        async def run(self, *a: Any, **kw: Any) -> None: ...
+        def create_initialization_options(self) -> Any:
+            return {}
+
+    Server = _MockServer  # type: ignore
+
+    class _MockStdio:  # type: ignore
+        async def __aenter__(self):
+            return (None, None)
+        async def __aexit__(self, *a: Any) -> None:
+            pass
+
+    stdio_server = _MockStdio  # type: ignore
+
+    class TextContent:  # type: ignore[no-redef]
+        def __init__(self, *, type: str, text: str) -> None:
+            self.type = type
+            self.text = text
+
+    class Tool:  # type: ignore[no-redef]
+        def __init__(self, *, name: str, description: str, inputSchema: dict[str, Any]) -> None:
+            self.name = name
+            self.description = description
+            self.inputSchema = inputSchema
+
+
+from .client import RustChainClient
+from .schemas import (
+    APIError,
+    BALANCE_SCHEMA,
+    BOUNTIES_SCHEMA,
+    EPOCH_SCHEMA,
+    HEALTH_SCHEMA,
+    MINERS_SCHEMA,
+    SUBMIT_ATTESTATION_SCHEMA,
+    VERIFY_WALLET_SCHEMA,
+)
+
+# ---------------------------------------------------------------------------
+# Logging — stderr so it doesn't interfere with stdio MCP protocol
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    stream=sys.stderr,
+)
+logger = logging.getLogger("rustchain-bounties-mcp")
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://50.28.86.131")
+
+
+# ---------------------------------------------------------------------------
+# Server
+# ---------------------------------------------------------------------------
+class RustchainBountiesMCP:
+    """MCP server exposing 7 RustChain tools over stdio."""
+
+    def __init__(self, node_url: Optional[str] = None) -> None:
+        self.node_url = node_url or DEFAULT_NODE_URL
+        self.app = Server("rustchain-bounties-mcp")
+        self.client: Optional[RustChainClient] = None
+        self._register_handlers()
+
+    # -- lifecycle ----------------------------------------------------------
+
+    async def start(self) -> None:
+        self.client = RustChainClient(node_url=self.node_url)
+        await self.client._ensure_session()
+        logger.info("Started (node=%s)", self.node_url)
+
+    async def stop(self) -> None:
+        if self.client:
+            await self.client.close()
+        logger.info("Stopped")
+
+    # -- handler registration -----------------------------------------------
+
+    def _register_handlers(self) -> None:
+        @self.app.list_tools()
+        async def _list_tools() -> list[Tool]:
+            return [
+                Tool(
+                    name="rustchain_health",
+                    description="Check RustChain node health status (ok, version, uptime, db_rw, tip_age)",
+                    inputSchema=HEALTH_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_balance",
+                    description="Get RTC wallet balance for a miner by miner_id",
+                    inputSchema=BALANCE_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_miners",
+                    description="List active miners with optional hardware_type filter and pagination",
+                    inputSchema=MINERS_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_epoch",
+                    description="Get current epoch information (epoch number, slot, enrolled miners, epoch_pot)",
+                    inputSchema=EPOCH_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_verify_wallet",
+                    description="Verify wallet presence for a miner_id on RustChain (queries balance endpoint; wallets are auto-provisioned on first activity)",
+                    inputSchema=VERIFY_WALLET_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_submit_attestation",
+                    description="Submit a hardware attestation for a miner (device fingerprint required)",
+                    inputSchema=SUBMIT_ATTESTATION_SCHEMA,
+                ),
+                Tool(
+                    name="rustchain_bounties",
+                    description="List RustChain bounties (default: open bounties)",
+                    inputSchema=BOUNTIES_SCHEMA,
+                ),
+            ]
+
+        @self.app.call_tool()
+        async def _call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+            handler = getattr(self, f"_tool_{name}", None)
+            if handler is None:
+                return [self._err(f"Unknown tool: {name}")]
+            try:
+                result = await handler(arguments)
+                return [TextContent(type="text", text=json.dumps(result, indent=2, default=str))]
+            except APIError as exc:
+                logger.error("APIError %s: %s", name, exc.message)
+                return [TextContent(type="text", text=json.dumps(exc.to_dict(), indent=2))]
+            except Exception as exc:
+                logger.exception("Tool error %s", name)
+                return [self._err(f"{name} failed: {exc}")]
+
+    # -- tool implementations -----------------------------------------------
+
+    async def _tool_rustchain_health(self, _args: dict[str, Any]) -> dict[str, Any]:
+        h = await self._require_client().health()
+        return {
+            "ok": h.ok,
+            "healthy": h.is_healthy,
+            "version": h.version,
+            "uptime_s": h.uptime_s,
+            "db_rw": h.db_rw,
+            "backup_age_hours": h.backup_age_hours,
+            "tip_age_slots": h.tip_age_slots,
+        }
+
+    async def _tool_rustchain_balance(self, args: dict[str, Any]) -> dict[str, Any]:
+        miner_id = args.get("miner_id", "")
+        b = await self._require_client().balance(miner_id)
+        return {
+            "miner_id": b.miner_id,
+            "amount_rtc": b.amount_rtc,
+            "amount_i64": b.amount_i64,
+        }
+
+    async def _tool_rustchain_miners(self, args: dict[str, Any]) -> dict[str, Any]:
+        limit = args.get("limit", 50)
+        hw = args.get("hardware_type")
+        result = await self._require_client().miners(limit=limit, hardware_type=hw)
+        miners_out = []
+        for m in result["miners"]:
+            miners_out.append({
+                "miner": m.miner,
+                "hardware_type": m.hardware_type,
+                "device_family": m.device_family,
+                "device_arch": m.device_arch,
+                "antiquity_multiplier": m.antiquity_multiplier,
+                "entropy_score": m.entropy_score,
+                "last_attest": m.last_attest,
+                "epochs_mined": m.epochs_mined,
+            })
+        return {
+            "total_count": result["total_count"],
+            "limit": result["limit"],
+            "offset": result["offset"],
+            "miners": miners_out,
+        }
+
+    async def _tool_rustchain_epoch(self, _args: dict[str, Any]) -> dict[str, Any]:
+        e = await self._require_client().epoch()
+        return {
+            "epoch": e.epoch,
+            "slot": e.slot,
+            "epoch_pot": e.epoch_pot,
+            "enrolled_miners": e.enrolled_miners,
+            "blocks_per_epoch": e.blocks_per_epoch,
+            "total_supply_rtc": e.total_supply_rtc,
+        }
+
+    async def _tool_rustchain_verify_wallet(self, args: dict[str, Any]) -> dict[str, Any]:
+        miner_id = args.get("miner_id", "")
+        r = await self._require_client().verify_wallet(miner_id)
+        return {
+            "wallet_address": r.wallet_address,
+            "exists": r.exists,
+            "balance_rtc": r.balance_rtc,
+            "message": r.message,
+        }
+
+    async def _tool_rustchain_submit_attestation(self, args: dict[str, Any]) -> dict[str, Any]:
+        miner_id = args.get("miner_id", "")
+        device = args.get("device")
+        if not device or not isinstance(device, dict):
+            return {"error": "VALIDATION_ERROR", "message": "device is required and must be a dict"}
+        r = await self._require_client().submit_attestation(
+            miner_id=miner_id,
+            device=device,
+            signature=args.get("signature"),
+            public_key=args.get("public_key"),
+        )
+        out: dict[str, Any] = {"ok": r.ok, "message": r.message}
+        if r.miner_id:
+            out["miner_id"] = r.miner_id
+        if r.enrolled_epoch is not None:
+            out["enrolled_epoch"] = r.enrolled_epoch
+        return out
+
+    async def _tool_rustchain_bounties(self, args: dict[str, Any]) -> dict[str, Any]:
+        status = args.get("status", "open")
+        limit = args.get("limit", 50)
+        bounties = await self._require_client().bounties(status=status, limit=limit)
+        return {
+            "count": len(bounties),
+            "source": "github:Scottcjn/rustchain-bounties",
+            "bounties": [
+                {
+                    "issue_number": b.issue_number,
+                    "title": b.title,
+                    "reward_rtc": b.reward_rtc,
+                    "status": b.status,
+                    "url": b.url,
+                    "difficulty": b.difficulty,
+                    "tags": b.tags,
+                }
+                for b in bounties
+            ],
+        }
+
+    # -- helpers ------------------------------------------------------------
+
+    def _require_client(self) -> RustChainClient:
+        if self.client is None:
+            raise RuntimeError("Client not initialized — call start() first")
+        return self.client
+
+    @staticmethod
+    def _err(msg: str) -> TextContent:
+        return TextContent(type="text", text=json.dumps({"error": msg}, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+async def main() -> None:
+    if not MCP_AVAILABLE:
+        logger.error("MCP SDK not installed.  Install with: pip install mcp>=1.0.0")
+        sys.exit(1)
+
+    node_url = os.getenv("RUSTCHAIN_NODE_URL", DEFAULT_NODE_URL)
+    server = RustchainBountiesMCP(node_url=node_url)
+
+    try:
+        await server.start()
+        async with stdio_server() as (read_stream, write_stream):
+            await server.app.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(),
+            )
+    finally:
+        await server.stop()
+
+
+def entry() -> None:
+    """Console-script entry (pyproject [project.scripts])."""
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main()

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
@@ -102,7 +102,6 @@ class MinerInfo:
     antiquity_multiplier: float
     hardware_type: str
     first_attest: Optional[int] = None
-    epochs_mined: int = 0
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MinerInfo":
@@ -115,7 +114,6 @@ class MinerInfo:
             antiquity_multiplier=float(data.get("antiquity_multiplier", 1.0)),
             hardware_type=data.get("hardware_type", "Unknown/Other"),
             first_attest=data.get("first_attest"),
-            epochs_mined=int(data.get("epochs_mined", 0)),
         )
 
 
@@ -293,6 +291,12 @@ VERIFY_WALLET_SCHEMA: dict[str, Any] = {
     "additionalProperties": False,
 }
 
+ATTEST_CHALLENGE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
 SUBMIT_ATTESTATION_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
@@ -301,10 +305,11 @@ SUBMIT_ATTESTATION_SCHEMA: dict[str, Any] = {
             "type": "object",
             "description": "Device fingerprint dict (device_model, device_arch, cores, etc.)",
         },
+        "nonce": {"type": "string", "description": "Challenge nonce from rustchain_attest_challenge"},
         "signature": {"type": "string", "description": "Ed25519 signature hex (optional)"},
         "public_key": {"type": "string", "description": "Signing public key hex (optional)"},
     },
-    "required": ["miner_id", "device"],
+    "required": ["miner_id", "device", "nonce"],
     "additionalProperties": False,
 }
 

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
@@ -1,0 +1,318 @@
+"""
+RustChain Bounties MCP — Type Schemas
+
+Typed dataclasses for all API responses from the RustChain node.
+Maps directly to JSON returned by the Flask endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+# ---------------------------------------------------------------------------
+# Health  (GET /health)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class HealthStatus:
+    """Response from GET /health."""
+    ok: bool
+    version: str
+    uptime_s: int
+    db_rw: bool
+    backup_age_hours: Optional[float] = None
+    tip_age_slots: Optional[int] = None
+
+    @property
+    def is_healthy(self) -> bool:
+        return self.ok and self.db_rw
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "HealthStatus":
+        return cls(
+            ok=bool(data.get("ok", False)),
+            version=data.get("version", "unknown"),
+            uptime_s=int(data.get("uptime_s", 0)),
+            db_rw=bool(data.get("db_rw", False)),
+            backup_age_hours=data.get("backup_age_hours"),
+            tip_age_slots=data.get("tip_age_slots"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Epoch  (GET /epoch)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class EpochInfo:
+    """Response from GET /epoch."""
+    epoch: int
+    slot: int
+    epoch_pot: float
+    enrolled_miners: int
+    blocks_per_epoch: int
+    total_supply_rtc: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EpochInfo":
+        return cls(
+            epoch=int(data.get("epoch", 0)),
+            slot=int(data.get("slot", 0)),
+            epoch_pot=float(data.get("epoch_pot", 0)),
+            enrolled_miners=int(data.get("enrolled_miners", 0)),
+            blocks_per_epoch=int(data.get("blocks_per_epoch", 0)),
+            total_supply_rtc=float(data.get("total_supply_rtc", 0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Balance  (GET /wallet/balance?miner_id=…)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WalletBalance:
+    """Response from GET /wallet/balance."""
+    miner_id: str
+    amount_i64: int
+    amount_rtc: float
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WalletBalance":
+        return cls(
+            miner_id=data.get("miner_id", ""),
+            amount_i64=int(data.get("amount_i64", 0)),
+            amount_rtc=float(data.get("amount_rtc", 0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Miner  (GET /api/miners)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MinerInfo:
+    """Single miner entry from GET /api/miners."""
+    miner: str
+    last_attest: int
+    device_family: str
+    device_arch: str
+    entropy_score: float
+    antiquity_multiplier: float
+    hardware_type: str
+    first_attest: Optional[int] = None
+    epochs_mined: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MinerInfo":
+        return cls(
+            miner=data.get("miner", ""),
+            last_attest=int(data.get("last_attest", 0)),
+            device_family=data.get("device_family", "unknown"),
+            device_arch=data.get("device_arch", "unknown"),
+            entropy_score=float(data.get("entropy_score", 0)),
+            antiquity_multiplier=float(data.get("antiquity_multiplier", 1.0)),
+            hardware_type=data.get("hardware_type", "Unknown/Other"),
+            first_attest=data.get("first_attest"),
+            epochs_mined=int(data.get("epochs_mined", 0)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wallet Verification  (GET /wallet/balance?miner_id=… — wallet presence check)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WalletVerifyResult:
+    """Result of wallet verification via balance query.
+
+    Note: The node does not expose a dedicated wallet-creation endpoint.
+    Wallets are provisioned implicitly on first activity.  This result
+    reflects whether a wallet row exists for the given miner_id.
+    """
+    wallet_address: str
+    exists: bool
+    balance_rtc: float
+    message: str
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "WalletVerifyResult":
+        return cls(
+            wallet_address=data.get("wallet_address", data.get("address", data.get("miner_id", ""))),
+            exists=bool(data.get("exists", data.get("created", data.get("ok", False)))),
+            balance_rtc=float(data.get("balance_rtc", data.get("amount_rtc", 0))),
+            message=data.get("message", data.get("error", "")),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attestation  (POST /attest/challenge  +  POST /attest/submit)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AttestChallenge:
+    """Response from POST /attest/challenge."""
+    nonce: str
+    expires_at: int
+    server_time: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AttestChallenge":
+        return cls(
+            nonce=data.get("nonce", ""),
+            expires_at=int(data.get("expires_at", 0)),
+            server_time=int(data.get("server_time", 0)),
+        )
+
+
+@dataclass
+class AttestSubmitResult:
+    """Response from POST /attest/submit."""
+    ok: bool
+    message: str
+    miner_id: Optional[str] = None
+    enrolled_epoch: Optional[int] = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AttestSubmitResult":
+        return cls(
+            ok=bool(data.get("ok", data.get("success", False))),
+            message=data.get("message", data.get("error", "")),
+            miner_id=data.get("miner_id"),
+            enrolled_epoch=data.get("enrolled_epoch"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bounties  (GET /api/bounties  — from beacon / bounty registry)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class BountyInfo:
+    """Single bounty entry."""
+    issue_number: int
+    title: str
+    reward_rtc: float
+    status: str
+    url: Optional[str] = None
+    description: Optional[str] = None
+    difficulty: Optional[str] = None
+    tags: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BountyInfo":
+        return cls(
+            issue_number=int(data.get("issue_number", data.get("issue", 0))),
+            title=data.get("title", ""),
+            reward_rtc=float(data.get("reward_rtc", data.get("reward", 0))),
+            status=data.get("status", "open"),
+            url=data.get("url"),
+            description=data.get("description"),
+            difficulty=data.get("difficulty"),
+            tags=data.get("tags", []),
+        )
+
+
+# ---------------------------------------------------------------------------
+# API Error
+# ---------------------------------------------------------------------------
+
+@dataclass
+class APIError(Exception):
+    """Standardized API error."""
+    code: str
+    message: str
+    status_code: int = 500
+    details: Optional[dict[str, Any]] = None
+
+    @classmethod
+    def from_response(cls, status: int, body: Any) -> "APIError":
+        if isinstance(body, dict):
+            return cls(
+                code=body.get("error", body.get("code", "UNKNOWN_ERROR")),
+                message=body.get("message", body.get("error_description", str(body))),
+                status_code=status,
+                details=body.get("details"),
+            )
+        return cls(
+            code="HTTP_ERROR",
+            message=str(body),
+            status_code=status,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "error": self.code,
+            "message": self.message,
+            "status_code": self.status_code,
+            "details": self.details,
+        }
+
+
+# ---------------------------------------------------------------------------
+# MCP Tool Input Schemas (JSON Schema dicts)
+# ---------------------------------------------------------------------------
+
+HEALTH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+EPOCH_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+BALANCE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "miner_id": {"type": "string", "description": "Miner ID or wallet address"},
+    },
+    "required": ["miner_id"],
+    "additionalProperties": False,
+}
+
+MINERS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "limit": {"type": "integer", "description": "Max miners to return (default 50)", "default": 50},
+        "hardware_type": {"type": "string", "description": "Filter by hardware family (e.g. 'PowerPC')"},
+    },
+    "additionalProperties": False,
+}
+
+VERIFY_WALLET_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "miner_id": {"type": "string", "description": "Miner ID to verify wallet for"},
+    },
+    "required": ["miner_id"],
+    "additionalProperties": False,
+}
+
+SUBMIT_ATTESTATION_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "miner_id": {"type": "string", "description": "Miner identifier"},
+        "device": {
+            "type": "object",
+            "description": "Device fingerprint dict (device_model, device_arch, cores, etc.)",
+        },
+        "signature": {"type": "string", "description": "Ed25519 signature hex (optional)"},
+        "public_key": {"type": "string", "description": "Signing public key hex (optional)"},
+    },
+    "required": ["miner_id", "device"],
+    "additionalProperties": False,
+}
+
+BOUNTIES_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string", "description": "Filter by status: open, claimed, completed (default: open)"},
+        "limit": {"type": "integer", "description": "Max results (default 50)", "default": 50},
+    },
+    "additionalProperties": False,
+}

--- a/rustchain-bounties-mcp/tests/__init__.py
+++ b/rustchain-bounties-mcp/tests/__init__.py
@@ -1,0 +1,1 @@
+"""RustChain Bounties MCP — Tests."""

--- a/rustchain-bounties-mcp/tests/test_mcp_server.py
+++ b/rustchain-bounties-mcp/tests/test_mcp_server.py
@@ -35,12 +35,12 @@ class _FakeClient:
             MinerInfo(
                 miner="alice", last_attest=1700000000, device_family="PowerPC",
                 device_arch="g4", entropy_score=0.95, antiquity_multiplier=2.0,
-                hardware_type="PowerPC G4 (Vintage)", epochs_mined=10,
+                hardware_type="PowerPC G4 (Vintage)",
             ),
             MinerInfo(
                 miner="bob", last_attest=1700000001, device_family="x86-64",
                 device_arch="modern", entropy_score=0.5, antiquity_multiplier=1.0,
-                hardware_type="x86-64 (Modern)", epochs_mined=5,
+                hardware_type="x86-64 (Modern)",
             ),
         ]
         self._wallet_result = WalletVerifyResult(
@@ -72,12 +72,12 @@ class _FakeClient:
         if hardware_type:
             ht = hardware_type.lower()
             miners = [m for m in miners if ht in m.hardware_type.lower() or ht in m.device_family.lower()]
-        return {"miners": miners, "total_count": len(self._miners), "limit": limit, "offset": 0}
+        return {"miners": miners, "total_count": len(self._miners), "limit": limit, "offset": 0, "pagination": {"total": len(self._miners), "offset": 0}}
 
     async def verify_wallet(self, miner_id: str):
         return self._wallet_result
 
-    async def submit_attestation(self, miner_id, device, signature=None, public_key=None):
+    async def submit_attestation(self, miner_id, device, nonce=None, signature=None, public_key=None):
         return self._attest_result
 
     async def get_attest_challenge(self):
@@ -145,6 +145,7 @@ class TestMCPTools:
         r = await server._tool_rustchain_submit_attestation({
             "miner_id": "new_miner",
             "device": {"device_model": "PowerBook", "device_arch": "g4", "cores": 1},
+            "nonce": "abc123",
         })
         assert r["ok"] is True
         assert r["miner_id"] == "new_miner"

--- a/rustchain-bounties-mcp/tests/test_mcp_server.py
+++ b/rustchain-bounties-mcp/tests/test_mcp_server.py
@@ -1,0 +1,182 @@
+"""Tests for the MCP server tool handlers (unit, no network)."""
+
+import json
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_bounties_mcp.mcp_server import RustchainBountiesMCP
+from rustchain_bounties_mcp.schemas import (
+    APIError,
+    AttestChallenge,
+    AttestSubmitResult,
+    BountyInfo,
+    EpochInfo,
+    HealthStatus,
+    MinerInfo,
+    WalletBalance,
+    WalletVerifyResult,
+)
+
+
+class _FakeClient:
+    """In-memory fake of RustChainClient for unit testing."""
+
+    def __init__(self):
+        self._health = HealthStatus(ok=True, version="2.2.1", uptime_s=99999, db_rw=True)
+        self._epoch = EpochInfo(
+            epoch=95, slot=12345, epoch_pot=1000.0,
+            enrolled_miners=42, blocks_per_epoch=100, total_supply_rtc=21000000.0,
+        )
+        self._balance = WalletBalance(miner_id="scott", amount_i64=155000000, amount_rtc=155.0)
+        self._miners = [
+            MinerInfo(
+                miner="alice", last_attest=1700000000, device_family="PowerPC",
+                device_arch="g4", entropy_score=0.95, antiquity_multiplier=2.0,
+                hardware_type="PowerPC G4 (Vintage)", epochs_mined=10,
+            ),
+            MinerInfo(
+                miner="bob", last_attest=1700000001, device_family="x86-64",
+                device_arch="modern", entropy_score=0.5, antiquity_multiplier=1.0,
+                hardware_type="x86-64 (Modern)", epochs_mined=5,
+            ),
+        ]
+        self._wallet_result = WalletVerifyResult(
+            wallet_address="scott", exists=True, balance_rtc=155.0, message="Wallet found",
+        )
+        self._attest_result = AttestSubmitResult(
+            ok=True, message="enrolled", miner_id="new_miner", enrolled_epoch=96,
+        )
+        self._bounties = [
+            BountyInfo(
+                issue_number=2859, title="MCP Server", reward_rtc=500.0,
+                status="open", difficulty="medium", tags=["python", "mcp"],
+            ),
+        ]
+
+    async def health(self):
+        return self._health
+
+    async def epoch(self):
+        return self._epoch
+
+    async def balance(self, miner_id: str):
+        if not miner_id:
+            raise APIError(code="VALIDATION_ERROR", message="miner_id is required", status_code=400)
+        return self._balance
+
+    async def miners(self, limit=50, hardware_type=None):
+        miners = self._miners
+        if hardware_type:
+            ht = hardware_type.lower()
+            miners = [m for m in miners if ht in m.hardware_type.lower() or ht in m.device_family.lower()]
+        return {"miners": miners, "total_count": len(self._miners), "limit": limit, "offset": 0}
+
+    async def verify_wallet(self, miner_id: str):
+        return self._wallet_result
+
+    async def submit_attestation(self, miner_id, device, signature=None, public_key=None):
+        return self._attest_result
+
+    async def get_attest_challenge(self):
+        return AttestChallenge(nonce="abc123", expires_at=999, server_time=800)
+
+    async def bounties(self, status="open", limit=50):
+        return self._bounties
+
+
+class TestMCPTools:
+    """Test each MCP tool handler with a fake client."""
+
+    @pytest.fixture
+    def server(self):
+        s = RustchainBountiesMCP(node_url="https://test.local")
+        s.client = _FakeClient()
+        return s
+
+    @pytest.mark.asyncio
+    async def test_health(self, server):
+        r = await server._tool_rustchain_health({})
+        assert r["ok"] is True
+        assert r["version"] == "2.2.1"
+        assert r["healthy"] is True
+
+    @pytest.mark.asyncio
+    async def test_balance(self, server):
+        r = await server._tool_rustchain_balance({"miner_id": "scott"})
+        assert r["miner_id"] == "scott"
+        assert r["amount_rtc"] == 155.0
+
+    @pytest.mark.asyncio
+    async def test_balance_missing_id(self, server):
+        # Empty miner_id → client raises APIError → tool handler returns error dict
+        with pytest.raises(APIError):
+            await server._tool_rustchain_balance({})
+
+    @pytest.mark.asyncio
+    async def test_miners_all(self, server):
+        r = await server._tool_rustchain_miners({"limit": 10})
+        assert r["total_count"] == 2
+        assert len(r["miners"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_miners_filter_powerpc(self, server):
+        r = await server._tool_rustchain_miners({"hardware_type": "PowerPC"})
+        assert len(r["miners"]) == 1
+        assert "PowerPC" in r["miners"][0]["hardware_type"]
+
+    @pytest.mark.asyncio
+    async def test_epoch(self, server):
+        r = await server._tool_rustchain_epoch({})
+        assert r["epoch"] == 95
+        assert r["enrolled_miners"] == 42
+
+    @pytest.mark.asyncio
+    async def test_verify_wallet(self, server):
+        r = await server._tool_rustchain_verify_wallet({"miner_id": "scott"})
+        assert r["exists"] is True
+        assert r["balance_rtc"] == 155.0
+        assert "scott" in r["wallet_address"]
+
+    @pytest.mark.asyncio
+    async def test_submit_attestation(self, server):
+        r = await server._tool_rustchain_submit_attestation({
+            "miner_id": "new_miner",
+            "device": {"device_model": "PowerBook", "device_arch": "g4", "cores": 1},
+        })
+        assert r["ok"] is True
+        assert r["miner_id"] == "new_miner"
+
+    @pytest.mark.asyncio
+    async def test_submit_attestation_no_device(self, server):
+        r = await server._tool_rustchain_submit_attestation({"miner_id": "x"})
+        assert "error" in r
+
+    @pytest.mark.asyncio
+    async def test_bounties(self, server):
+        r = await server._tool_rustchain_bounties({})
+        assert r["count"] == 1
+        assert r["bounties"][0]["issue_number"] == 2859
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool(self, server):
+        # Verify all 7 expected tools are registered by inspecting the server.
+        # The mock Server doesn't execute handlers, so we verify the tool list
+        # is correctly defined by checking the _register_handlers method sets up
+        # the expected tool methods on the server instance.
+        expected_tools = [
+            "rustchain_health", "rustchain_balance", "rustchain_miners",
+            "rustchain_epoch", "rustchain_verify_wallet",
+            "rustchain_submit_attestation", "rustchain_bounties",
+        ]
+        for name in expected_tools:
+            assert hasattr(server, f"_tool_{name}"), f"Missing tool method: _tool_{name}"
+
+    @pytest.mark.asyncio
+    async def test_require_client_none(self):
+        s = RustchainBountiesMCP()
+        s.client = None
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await s._require_client()

--- a/rustchain-bounties-mcp/tests/test_schemas.py
+++ b/rustchain-bounties-mcp/tests/test_schemas.py
@@ -81,7 +81,7 @@ class TestMinerInfo:
             "miner": "alice", "last_attest": 1700000000,
             "device_family": "PowerPC", "device_arch": "g4",
             "entropy_score": 0.95, "antiquity_multiplier": 2.0,
-            "hardware_type": "PowerPC G4 (Vintage)", "epochs_mined": 10,
+            "hardware_type": "PowerPC G4 (Vintage)",
         })
         assert m.miner == "alice"
         assert m.antiquity_multiplier == 2.0

--- a/rustchain-bounties-mcp/tests/test_schemas.py
+++ b/rustchain-bounties-mcp/tests/test_schemas.py
@@ -1,0 +1,268 @@
+"""Tests for schema dataclasses and MCP input schemas."""
+
+import pytest
+import sys
+import os
+from typing import Optional
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_bounties_mcp.schemas import (
+    APIError,
+    AttestChallenge,
+    AttestSubmitResult,
+    BountyInfo,
+    EpochInfo,
+    HealthStatus,
+    MinerInfo,
+    WalletBalance,
+    WalletVerifyResult,
+    BALANCE_SCHEMA,
+    BOUNTIES_SCHEMA,
+    EPOCH_SCHEMA,
+    HEALTH_SCHEMA,
+    MINERS_SCHEMA,
+    SUBMIT_ATTESTATION_SCHEMA,
+    VERIFY_WALLET_SCHEMA,
+)
+
+
+# -- HealthStatus -----------------------------------------------------------
+
+class TestHealthStatus:
+    def test_from_dict_full(self):
+        h = HealthStatus.from_dict({
+            "ok": True, "version": "2.2.1", "uptime_s": 86400,
+            "db_rw": True, "backup_age_hours": 12.5, "tip_age_slots": 3,
+        })
+        assert h.ok is True
+        assert h.is_healthy is True
+        assert h.version == "2.2.1"
+        assert h.uptime_s == 86400
+
+    def test_from_dict_minimal(self):
+        h = HealthStatus.from_dict({"ok": False, "version": "x", "uptime_s": 0, "db_rw": False})
+        assert h.is_healthy is False
+
+    def test_from_dict_defaults(self):
+        h = HealthStatus.from_dict({"ok": True, "version": "v", "uptime_s": 10, "db_rw": True})
+        assert h.backup_age_hours is None
+        assert h.tip_age_slots is None
+
+
+# -- EpochInfo --------------------------------------------------------------
+
+class TestEpochInfo:
+    def test_from_dict(self):
+        e = EpochInfo.from_dict({
+            "epoch": 95, "slot": 12345, "epoch_pot": 1000.0,
+            "enrolled_miners": 42, "blocks_per_epoch": 100, "total_supply_rtc": 21000000.0,
+        })
+        assert e.epoch == 95
+        assert e.slot == 12345
+        assert e.epoch_pot == 1000.0
+
+
+# -- WalletBalance ----------------------------------------------------------
+
+class TestWalletBalance:
+    def test_from_dict(self):
+        b = WalletBalance.from_dict({"miner_id": "scott", "amount_i64": 155000000, "amount_rtc": 155.0})
+        assert b.miner_id == "scott"
+        assert b.amount_rtc == 155.0
+        assert b.amount_i64 == 155000000
+
+
+# -- MinerInfo --------------------------------------------------------------
+
+class TestMinerInfo:
+    def test_from_dict(self):
+        m = MinerInfo.from_dict({
+            "miner": "alice", "last_attest": 1700000000,
+            "device_family": "PowerPC", "device_arch": "g4",
+            "entropy_score": 0.95, "antiquity_multiplier": 2.0,
+            "hardware_type": "PowerPC G4 (Vintage)", "epochs_mined": 10,
+        })
+        assert m.miner == "alice"
+        assert m.antiquity_multiplier == 2.0
+        assert "PowerPC" in m.hardware_type
+
+
+# -- WalletVerifyResult -----------------------------------------------------
+
+class TestWalletVerifyResult:
+    def test_from_dict(self):
+        r = WalletVerifyResult.from_dict({
+            "wallet_address": "0xabc", "exists": True, "balance_rtc": 100.0, "message": "ok",
+        })
+        assert r.wallet_address == "0xabc"
+        assert r.exists is True
+        assert r.balance_rtc == 100.0
+
+    def test_from_dict_legacy_keys(self):
+        """Backwards compat: 'created' maps to 'exists'."""
+        r = WalletVerifyResult.from_dict({
+            "wallet_address": "0xdef", "created": True, "amount_rtc": 50.0, "message": "legacy",
+        })
+        assert r.exists is True
+        assert r.balance_rtc == 50.0
+
+
+# -- AttestChallenge --------------------------------------------------------
+
+class TestAttestChallenge:
+    def test_from_dict(self):
+        c = AttestChallenge.from_dict({
+            "nonce": "deadbeef", "expires_at": 1700000300, "server_time": 1700000000,
+        })
+        assert c.nonce == "deadbeef"
+        assert c.expires_at == 1700000300
+
+
+# -- AttestSubmitResult -----------------------------------------------------
+
+class TestAttestSubmitResult:
+    def test_from_dict_success(self):
+        r = AttestSubmitResult.from_dict({
+            "ok": True, "message": "enrolled", "miner_id": "bob", "enrolled_epoch": 95,
+        })
+        assert r.ok is True
+        assert r.enrolled_epoch == 95
+
+    def test_from_dict_failure(self):
+        r = AttestSubmitResult.from_dict({"ok": False, "message": "invalid nonce"})
+        assert r.ok is False
+        assert r.miner_id is None
+
+
+# -- BountyInfo -------------------------------------------------------------
+
+class TestBountyInfo:
+    def test_from_dict(self):
+        b = BountyInfo.from_dict({
+            "issue_number": 2859, "title": "MCP Server", "reward_rtc": 500.0,
+            "status": "open", "difficulty": "medium",
+            "tags": ["python", "mcp", "ai"],
+        })
+        assert b.issue_number == 2859
+        assert b.reward_rtc == 500.0
+        assert "mcp" in b.tags
+
+
+# -- APIError ---------------------------------------------------------------
+
+class TestAPIError:
+    def test_from_response_dict(self):
+        e = APIError.from_response(400, {"error": "BAD_INPUT", "message": "missing field"})
+        assert e.code == "BAD_INPUT"
+        assert e.status_code == 400
+
+    def test_to_dict(self):
+        e = APIError(code="X", message="y", status_code=500)
+        d = e.to_dict()
+        assert d["error"] == "X"
+        assert d["message"] == "y"
+
+    def test_from_response_plain(self):
+        e = APIError.from_response(503, "service unavailable")
+        assert e.code == "HTTP_ERROR"
+
+
+# -- MCP Input Schemas ------------------------------------------------------
+
+class TestInputSchemas:
+    def test_health_schema_empty(self):
+        assert HEALTH_SCHEMA["type"] == "object"
+        assert HEALTH_SCHEMA.get("required") is None
+
+    def test_epoch_schema_no_required(self):
+        assert EPOCH_SCHEMA["type"] == "object"
+
+    def test_balance_requires_miner_id(self):
+        assert "miner_id" in BALANCE_SCHEMA["required"]
+
+    def test_miners_schema_optional_params(self):
+        assert "limit" in MINERS_SCHEMA["properties"]
+        assert "hardware_type" in MINERS_SCHEMA["properties"]
+
+    def test_verify_wallet_requires_miner_id(self):
+        assert "miner_id" in VERIFY_WALLET_SCHEMA["required"]
+
+    def test_attestation_requires_miner_id_and_device(self):
+        req = SUBMIT_ATTESTATION_SCHEMA["required"]
+        assert "miner_id" in req
+        assert "device" in req
+
+    def test_bounties_schema_optional(self):
+        assert BOUNTIES_SCHEMA.get("required") is None
+
+
+# -- GitHub Bounty Parsing (client-side) ------------------------------------
+
+class TestGitHubBountyParsing:
+    """Test the _parse_github_issue static method on RustChainClient."""
+
+    def _parse(self, issue: dict) -> Optional[BountyInfo]:
+        # Import here to avoid circular deps; the method lives on the client.
+        from rustchain_bounties_mcp.client import RustChainClient
+        return RustChainClient._parse_github_issue(issue)
+
+    def test_parse_issue_with_rtc_in_title(self):
+        issue = {
+            "number": 42,
+            "title": "Bounty: MCP Server (500 RTC)",
+            "html_url": "https://github.com/Scottcjn/rustchain-bounties/issues/42",
+            "state": "open",
+            "labels": [{"name": "bounty"}, {"name": "medium"}],
+            "body": "Build an MCP server for RustChain.",
+        }
+        b = self._parse(issue)
+        assert b is not None
+        assert b.issue_number == 42
+        assert b.reward_rtc == 500.0
+        assert b.difficulty == "medium"
+        assert "bounty" in b.tags
+
+    def test_parse_issue_with_rtc_in_label(self):
+        issue = {
+            "number": 10,
+            "title": "Add documentation",
+            "html_url": "https://github.com/Scottcjn/rustchain-bounties/issues/10",
+            "state": "open",
+            "labels": [{"name": "bounty: 50 RTC"}, {"name": "easy"}],
+            "body": None,
+        }
+        b = self._parse(issue)
+        assert b is not None
+        assert b.reward_rtc == 50.0
+        assert b.difficulty == "easy"
+
+    def test_parse_pr_is_skipped(self):
+        issue = {
+            "number": 99,
+            "title": "Fix typo",
+            "html_url": "https://github.com/Scottcjn/rustchain-bounties/pull/99",
+            "state": "open",
+            "labels": [],
+            "body": "",
+            "pull_request": {"merged_at": None},
+        }
+        # The client filters these out before calling _parse_github_issue,
+        # but the parser itself doesn't skip — the caller does.
+        b = self._parse(issue)
+        assert b is not None  # parser doesn't check pull_request
+        assert b.issue_number == 99
+
+    def test_parse_no_reward(self):
+        issue = {
+            "number": 1,
+            "title": "General discussion",
+            "html_url": "https://github.com/Scottcjn/rustchain-bounties/issues/1",
+            "state": "open",
+            "labels": [{"name": "discussion"}],
+            "body": "Just a discussion thread.",
+        }
+        b = self._parse(issue)
+        assert b is not None
+        assert b.reward_rtc == 0.0
+        assert b.difficulty is None


### PR DESCRIPTION
## Summary
- add a reviewable RustChain MCP reference server under `rustchain-bounties-mcp/`
- expose seven MCP tools for health, balances, miners, epoch info, wallet verification, attestation submission, and bounty discovery
- back bounty discovery with GitHub Issues data, tighten wallet semantics, and include tests plus install/docs

## Testing
- cd rustchain-bounties-mcp && pytest tests/ -v
