### PR TITLE
security: remove auto-approval of unverified claims after timeout

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -379,11 +379,23 @@ def process_claims_batch(
     # Get pending claims
     pending_claims = get_pending_claims(db_path, max_claims)
     
-    # Also get old verifying claims (auto-approve after timeout)
+    # Log stale verifying claims for manual review — NEVER auto-approve.
+    # Auto-approving claims that failed verification is a fund-theft vector:
+    # an attacker submits a fraudulent claim and waits for the timeout.
     old_verifying = get_verifying_claims(db_path, max_wait_seconds // 2)
-    
-    # Combine and deduplicate
-    all_claims = pending_claims + old_verifying
+    if old_verifying:
+        print(f"[SETTLEMENT] WARNING: {len(old_verifying)} claims stuck in 'verifying' "
+              f"for >{max_wait_seconds // 2}s — flagging for manual review")
+        for claim in old_verifying:
+            update_claim_status(
+                db_path=db_path,
+                claim_id=claim["claim_id"],
+                status="review_required",
+                details={"reason": "verification_timeout", "auto_approved": False}
+            )
+
+    # Only process properly approved claims
+    all_claims = pending_claims
     seen = set()
     unique_claims = []
     for claim in all_claims:
@@ -455,15 +467,8 @@ def process_claims_batch(
         batch_id
     )
     
-    # Auto-approve old verifying claims
-    for claim in old_verifying:
-        if claim["claim_id"] not in [c["claim_id"] for c in claims_to_process]:
-            update_claim_status(
-                db_path=db_path,
-                claim_id=claim["claim_id"],
-                status="approved",
-                details={"auto_approved": True, "reason": "verification_timeout"}
-            )
+    # NOTE: Stale verifying claims are flagged for manual review above.
+    # They are NOT auto-approved — that was a fund-theft vector.
     
     result["processed"] = True
     result["claims_count"] = len(claims_to_process)


### PR DESCRIPTION
## Security Fix: Claims Stuck in 'Verifying' Are Auto-Approved After Timeout

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/claims_settlement.py`
**Lines:** 382-386, 458-466

### Description
Claims stuck in `verifying` status were automatically approved after `max_wait_seconds // 2`
(~7.5 minutes) and mixed into settlement batches alongside properly approved claims.

### Exploit Mechanism
1. Attacker submits a fraudulent claim
2. The claim enters `verifying` status but verification fails or stalls
3. After ~7.5 minutes, the system auto-approves the claim with `{"auto_approved": True}`
4. The fraudulent claim is included in the next settlement batch and paid out

### Fix Applied
- **Verifying claims are now flagged as `review_required`** for manual inspection
- **Verifying claims are excluded** from the settlement batch (`all_claims = pending_claims` only)
- Auto-approval loop at lines 458-466 replaced with a comment explaining why it was removed
- Warning log emitted when stale verifying claims are detected

### Testing
- Syntax verification passes
- Settlement batches now contain only properly approved claims