### PR TITLE
security: change payout MOCK_MODE default from True to env-var opt-in

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -3,7 +3,7 @@
 RustChain Payout Worker
 Processes pending withdrawals from queue → sent → completed
 """
-import time, sqlite3, hashlib, json, logging
+import os, time, sqlite3, hashlib, json, logging
 from datetime import datetime
 from typing import Optional, Dict, List
 
@@ -19,7 +19,7 @@ DB_PATH = "./rustchain_v2.db"
 BATCH_SIZE = 10
 POLL_INTERVAL = 30  # seconds
 MAX_RETRIES = 3
-MOCK_MODE = True  # Set False for real blockchain integration
+MOCK_MODE = os.environ.get("RUSTCHAIN_MOCK_MODE", "0") == "1"  # Default: production (False)
 
 class PayoutWorker:
     def __init__(self):


### PR DESCRIPTION
## Security Fix: MOCK_MODE Hardcoded to True in Payout Worker

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/payout_worker.py`
**Line:** 22

### Description
`MOCK_MODE = True` was hardcoded, causing the payout worker to generate fake transaction
hashes in production. Withdrawals appeared completed with fabricated on-chain hashes while
no real funds were transferred.

### Exploit Mechanism
1. All withdrawals are processed in mock mode by default
2. Fake `0x...` transaction hashes are generated
3. The withdrawal is marked "completed" but no real blockchain transaction occurs
4. Users believe their withdrawal succeeded when no funds moved

### Fix Applied
- `MOCK_MODE` now reads from `RUSTCHAIN_MOCK_MODE` env var, defaulting to `False`
- Added `import os` for env var access
- Must explicitly set `RUSTCHAIN_MOCK_MODE=1` for testing environments

### Testing
- `python -c "import py_compile; py_compile.compile('node/payout_worker.py', doraise=True)"` passes