### PR TITLE
security: fix division by zero and zero-weight reward capture in epoc…

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -579,12 +579,26 @@ def calculate_epoch_rewards_time_aged(
         weighted_miners.append((miner_id, weight))
         total_weight += weight
 
+    # Guard: if total weight is zero (all miners failed fingerprint or have
+    # zero multiplier), no rewards can be distributed.  Returning an empty
+    # dict prevents ZeroDivisionError and stops a zero-weight miner from
+    # capturing the entire pool via the "last miner gets remainder" logic.
+    if total_weight <= 0:
+        logger.warning(
+            "Epoch %d: total_weight=0 — all %d miners have zero weight, "
+            "no rewards distributed", epoch, len(weighted_miners)
+        )
+        return {}
+
+    # Filter out zero-weight miners — they should receive nothing
+    eligible_miners = [(m, w) for m, w in weighted_miners if w > 0]
+
     # Distribute rewards proportionally by weight
     rewards = {}
     remaining = total_reward_urtc
 
-    for i, (miner_id, weight) in enumerate(weighted_miners):
-        if i == len(weighted_miners) - 1:
+    for i, (miner_id, weight) in enumerate(eligible_miners):
+        if i == len(eligible_miners) - 1:
             # Last miner gets remainder (prevents rounding issues)
             share = remaining
         else:


### PR DESCRIPTION
## Security Fix: ZeroDivisionError and Full Pool Capture by Zero-Weight Miner

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/rip_200_round_robin_1cpu1vote.py`
**Lines:** 548-596

### Description
Two compounding bugs in `calculate_epoch_rewards_time_aged()`:

1. **ZeroDivisionError**: When all miners have zero weight (e.g., all failed fingerprint),
   `total_weight=0` causes division by zero at line 591
2. **Full pool capture**: The "last miner gets remainder" logic at line 587-589 gives a
   zero-weight miner the entire reward pool when all weights are zero

### Exploit Mechanism
1. Register multiple miners that all fail fingerprint verification (weight=0)
2. The last zero-weight miner in the list captures the entire epoch reward pool
3. Alternatively, if total_weight reaches exactly 0, the node crashes with ZeroDivisionError

### Fix Applied
- **Guard**: if `total_weight <= 0`, return empty dict and log warning — no rewards distributed
- **Filter**: only eligible miners (weight > 0) participate in distribution
- Zero-weight miners can never capture the remainder

### Testing
- Syntax verification passes
- No rewards distributed when all miners have zero weight (safe, logged)