### PR TITLE
security: restore committed_epochs from DB on BFT node restart

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -215,6 +215,37 @@ class BFTConsensus:
 
         logging.info(f"BFT consensus initialized for node {self.node_id}")
 
+        # Restore committed epochs from DB so restarts don't double-credit.
+        # Without this, committed_epochs starts empty and _finalize_epoch /
+        # _apply_settlement will re-apply settlements for already-committed
+        # epochs after a node restart.
+        self._restore_committed_state()
+
+    def _restore_committed_state(self):
+        """Restore committed epochs and view number from DB on startup.
+
+        Without this, a node restart forgets all committed epochs and the
+        consensus engine will re-apply settlements, double-crediting miners.
+        """
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                rows = conn.execute(
+                    "SELECT epoch, view FROM bft_committed_epochs"
+                ).fetchall()
+                for epoch, view in rows:
+                    self.committed_epochs.add(epoch)
+                    if view > self.current_view:
+                        self.current_view = view
+
+            if self.committed_epochs:
+                logging.info(
+                    f"Restored {len(self.committed_epochs)} committed epochs "
+                    f"(max epoch={max(self.committed_epochs)}, view={self.current_view})"
+                )
+        except sqlite3.OperationalError as e:
+            # Table may not exist on first run (will be created by _init_db)
+            logging.debug(f"Could not restore committed state: {e}")
+
     def register_peer(self, node_id: str, url: str):
         """Register a peer node"""
         with self.lock:


### PR DESCRIPTION
## Security Fix: Node Restart Forgets All Committed Epochs

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/rustchain_bft_consensus.py`
**Lines:** 142-216

### Description
`committed_epochs` was initialized as an empty `set()` and never restored from the
`bft_committed_epochs` table on restart. A restarted node forgets all previously
committed epochs.

### Exploit Mechanism
1. Node commits epochs 1-100, crediting miners with rewards
2. Node restarts (crash, maintenance, etc.)
3. `committed_epochs` starts empty — the node doesn't know epochs 1-100 were committed
4. `_finalize_epoch` re-applies `_apply_settlement` for those epochs
5. Miners receive rewards again (double-crediting)

### Fix Applied
- Added `_restore_committed_state()` method that loads all committed epochs from
  `bft_committed_epochs` table into `self.committed_epochs` on startup
- Also restores `current_view` to the max committed view
- Called from `__init__` after `_init_db()`
- Gracefully handles first run (table may not exist yet)

### Testing
- `python -c "import py_compile; py_compile.compile('node/rustchain_bft_consensus.py', doraise=True)"` passes