### PR TITLE
security: add idempotency guard to _apply_settlement preventing rewar…

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -651,27 +651,48 @@ class BFTConsensus:
             self._apply_settlement(pre_prepare.proposal)
 
     def _apply_settlement(self, proposal: Dict):
-        """Apply the consensus settlement to database"""
+        """Apply the consensus settlement to database (idempotent).
+
+        Uses epoch-scoped ledger entries to ensure each epoch's rewards are
+        credited exactly once, even if _apply_settlement is called multiple
+        times for the same epoch (e.g. after a restart before
+        committed_epochs is fully restored).
+        """
         epoch = proposal.get('epoch')
         distribution = proposal.get('distribution', {})
 
         with sqlite3.connect(self.db_path) as conn:
+            # ── Idempotency guard ────────────────────────────────────
+            # If any ledger entry already exists for this epoch, the
+            # settlement was already applied.  Bail out.
+            existing = conn.execute(
+                "SELECT 1 FROM ledger WHERE memo = ? LIMIT 1",
+                (f"epoch_{epoch}_bft",)
+            ).fetchone()
+            if existing:
+                logging.warning(
+                    f"Settlement for epoch {epoch} already applied — skipping "
+                    f"to prevent reward doubling"
+                )
+                return
+
             for miner_id, reward in distribution.items():
-                # Update balance
                 # Store as integer micro-RTC (1 RTC = 1,000,000 uRTC) to avoid
                 # floating-point drift accumulating across many ledger entries.
+                reward_urtc = int(reward * 1_000_000)
+
                 conn.execute("""
                     INSERT INTO balances (miner_id, amount_i64)
                     VALUES (?, ?)
                     ON CONFLICT(miner_id) DO UPDATE SET
                     amount_i64 = amount_i64 + excluded.amount_i64
-                """, (miner_id, int(reward * 1_000_000)))
+                """, (miner_id, reward_urtc))
 
                 # Log in ledger
                 conn.execute("""
                     INSERT INTO ledger (miner_id, delta_i64, tx_type, memo, ts)
                     VALUES (?, ?, 'reward', ?, ?)
-                """, (miner_id, int(reward * 1_000_000), f"epoch_{epoch}_bft", int(time.time())))
+                """, (miner_id, reward_urtc, f"epoch_{epoch}_bft", int(time.time())))
 
             conn.commit()
 


### PR DESCRIPTION
## Security Fix: Settlement Replay Doubles Miner Rewards

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/rustchain_bft_consensus.py`
**Lines:** 653-678

### Description
`_apply_settlement` uses `ON CONFLICT DO UPDATE SET amount_i64 = amount_i64 + excluded.amount_i64`,
which additively increases balances. If the same epoch settlement is replayed (after restart,
consensus retry, or network partition), miners receive the reward multiple times.

### Exploit Mechanism
1. Epoch N is settled, crediting miners with rewards
2. Node restarts (committed_epochs forgotten — see related Bug #6)
3. Consensus re-reaches agreement on epoch N
4. `_apply_settlement` fires again, adding rewards on top of existing balances
5. Each replay doubles the reward for that epoch

### Fix Applied
- **Idempotency guard**: checks if a ledger entry for `epoch_{N}_bft` already exists
- If found, logs warning and returns without applying — prevents double-crediting
- Extracted `reward_urtc` computation to avoid repeated `int(reward * 1_000_000)` calls
- Works independently of Bug #6 fix (defense in depth)

### Testing
- Syntax verification passes
- Second call to `_apply_settlement` for same epoch is safely skipped