### PR TITLE
security: fix empty RC_ADMIN_KEY bypass in lock_ledger admin endpoints

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -19,6 +19,7 @@ Functions:
 - forfeit_lock() - Forfeit a lock (penalty/slashing)
 """
 
+import hmac
 import sqlite3
 import time
 import os
@@ -696,7 +697,10 @@ def register_lock_ledger_routes(app):
     def release_lock_endpoint():
         """Admin: Release a lock."""
         admin_key = request.headers.get("X-Admin-Key", "")
-        if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        expected_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not expected_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — admin endpoints disabled"}), 503
+        if not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         
         data = request.get_json(silent=True)
@@ -727,7 +731,10 @@ def register_lock_ledger_routes(app):
     def forfeit_lock_endpoint():
         """Admin: Forfeit a lock (penalty)."""
         admin_key = request.headers.get("X-Admin-Key", "")
-        if admin_key != os.environ.get("RC_ADMIN_KEY", ""):
+        expected_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not expected_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — admin endpoints disabled"}), 503
+        if not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         
         data = request.get_json(silent=True)


### PR DESCRIPTION
## Security Fix: Unset RC_ADMIN_KEY Grants Admin Access to Anyone

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/lock_ledger.py`
**Lines:** 698-699, 729-730

### Description
When `RC_ADMIN_KEY` env var is unset, `os.environ.get("RC_ADMIN_KEY", "")` returns `""`.
The `X-Admin-Key` header also defaults to `""`. They match — granting admin access to anyone.

Affects both `/api/lock/release` and `/api/lock/forfeit` endpoints.

### Exploit Mechanism
1. Send POST to `/api/lock/release` with no `X-Admin-Key` header
2. Both sides of the comparison are empty string `"" == ""` → passes
3. Attacker can release any locked assets
4. Same for `/api/lock/forfeit` — attacker can slash any miner's locked funds

### Fix Applied
- **Reject when env var is unset**: return 503 "RC_ADMIN_KEY not configured"
- **Constant-time comparison**: use `hmac.compare_digest()` to prevent timing attacks
- Added `import hmac` to module imports
- Applied to both release and forfeit endpoints

### Testing
- Syntax verification passes
- Requests with unset `RC_ADMIN_KEY` now return 503 (service unavailable)