### PR TITLE
security: require authentication on /rewards/settle endpoint

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -270,6 +270,15 @@ def register_rewards_rip200(app, DB_PATH):
 
     @app.route('/rewards/settle', methods=['POST'])
     def settle_rewards():
+        # ── Authentication: settlement is a privileged operation ──────
+        import hmac
+        settle_key = os.environ.get("RC_SETTLE_KEY", "")
+        if not settle_key:
+            return jsonify({"error": "RC_SETTLE_KEY not configured — settle endpoint disabled"}), 503
+        provided_key = request.headers.get("X-Admin-Key", "")
+        if not hmac.compare_digest(provided_key, settle_key):
+            return jsonify({"error": "Unauthorized — valid X-Admin-Key header required"}), 401
+
         data = request.json or {}
         epoch = data.get('epoch')
 


### PR DESCRIPTION
## Security Fix: Unauthenticated Epoch Settlement Trigger

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/rewards_implementation_rip200.py`
**Lines:** 271-283

### Description
The `/rewards/settle` POST endpoint triggers epoch settlement (crediting RTC to miner
balances) with zero authentication. Any unauthenticated caller can trigger arbitrary
epoch settlements.

### Exploit Mechanism
1. Send POST to `/rewards/settle` with `{"epoch": N}` for any epoch
2. Epoch N's rewards are calculated and credited to miner balances
3. No authentication check — anyone on the network can trigger this
4. Could be abused to settle epochs out of order or trigger re-settlement

### Fix Applied
- Requires `RC_SETTLE_KEY` env var to be configured
- `X-Admin-Key` header must match `RC_SETTLE_KEY` (constant-time via `hmac.compare_digest`)
- Returns 503 if key not configured, 401 if key mismatches
- Uses local `import hmac` to avoid module-level dependency

### Testing
- Syntax verification passes
- Unauthenticated POST to `/rewards/settle` now returns 401/503