### PR TITLE
security: prevent public key takeover via /beacon/join upsert

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -263,18 +263,40 @@ def beacon_join():
 
         now = int(time.time())
 
-        # Upsert into relay_agents table
+        # Check if agent already exists
         db = get_db()
-        db.execute("""
-            INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at)
-            VALUES (?, ?, ?, 'active', ?, ?, ?)
-            ON CONFLICT(agent_id) DO UPDATE SET
-                pubkey_hex = excluded.pubkey_hex,
-                name = excluded.name,
-                coinbase_address = excluded.coinbase_address,
-                status = 'active',
-                updated_at = excluded.updated_at
-        """, (agent_id, pubkey_hex, name, coinbase_address, now, now))
+        existing = db.execute(
+            "SELECT pubkey_hex FROM relay_agents WHERE agent_id = ?",
+            (agent_id,)
+        ).fetchone()
+
+        if existing:
+            # Agent exists — NEVER allow pubkey_hex overwrite.
+            # Allowing unauthenticated pubkey changes is a full identity
+            # takeover: attacker sends join with victim's agent_id and
+            # their own public key, hijacking the agent.
+            if pubkey_hex != existing['pubkey_hex']:
+                return jsonify({
+                    'error': 'Cannot change pubkey_hex for existing agent — '
+                             'public key is immutable after registration'
+                }), 403
+
+            # Update mutable fields only
+            db.execute("""
+                UPDATE relay_agents
+                SET name = COALESCE(?, name),
+                    coinbase_address = COALESCE(?, coinbase_address),
+                    status = 'active',
+                    updated_at = ?
+                WHERE agent_id = ?
+            """, (name, coinbase_address, now, agent_id))
+        else:
+            # New agent — insert with pubkey_hex
+            db.execute("""
+                INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at)
+                VALUES (?, ?, ?, 'active', ?, ?, ?)
+            """, (agent_id, pubkey_hex, name, coinbase_address, now, now))
+
         db.commit()
 
         return jsonify({


### PR DESCRIPTION
## Security Fix: Unauthenticated Public Key Overwrite in Beacon Join

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `node/beacon_api.py`
**Line:** 270

### Description
The `/beacon/join` endpoint used `ON CONFLICT(agent_id) DO UPDATE SET pubkey_hex = excluded.pubkey_hex`,
allowing any caller to overwrite an existing agent's public key.

### Exploit Mechanism
1. Identify a target agent's `agent_id` (publicly visible via `/beacon/atlas`)
2. Send POST to `/beacon/join` with the victim's `agent_id` and attacker's own `pubkey_hex`
3. The upsert overwrites the victim's public key with the attacker's
4. Attacker now controls the agent's identity — can sign messages, claim rewards, etc.

### Fix Applied
- **`pubkey_hex` is now immutable** after initial registration
- Existing agents can only update mutable fields (name, coinbase_address, status)
- Attempts to change `pubkey_hex` return **403 Forbidden**
- New agents can still register with their public key normally

### Testing
- Syntax verification passes
- Existing agent with different pubkey_hex gets 403
- New agent registration works normally