### PR TITLE
security: enable SSL verification by default in wallet

### DIFF
--- a/wallet/rustchain_wallet_secure.py
+++ b/wallet/rustchain_wallet_secure.py
@@ -31,12 +31,17 @@ from typing import Optional, Tuple, Dict, Any
 # Import our crypto module
 from rustchain_crypto import RustChainWallet, verify_transaction
 
-# Disable SSL warnings for self-signed certs
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+# SSL verification — default to True for production security.
+# Only disable for local development with self-signed certs by setting
+# RUSTCHAIN_VERIFY_SSL=0 in the environment.
+_ssl_env = os.environ.get("RUSTCHAIN_VERIFY_SSL", "1")
+VERIFY_SSL = _ssl_env != "0"
+if not VERIFY_SSL:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    print("[WALLET] WARNING: SSL verification disabled via RUSTCHAIN_VERIFY_SSL=0")
 
 # Configuration
 NODE_URL = "https://rustchain.org"
-VERIFY_SSL = False
 KEYSTORE_DIR = Path.home() / ".rustchain" / "wallets"
 
 # Retry configuration


### PR DESCRIPTION
## Security Fix: SSL Verification Hardcoded to False in Wallet

**Severity:** 🔴 Critical (200+ RTC Bounty)
**File:** `wallet/rustchain_wallet_secure.py`
**Lines:** 35, 39

### Description
`VERIFY_SSL = False` was hardcoded and `urllib3.disable_warnings(InsecureRequestWarning)` was
called unconditionally. All HTTPS connections (balance queries, signed transaction submission)
were vulnerable to man-in-the-middle attacks.

### Exploit Mechanism
1. Attacker performs MITM on the network between wallet and node
2. All balance queries are intercepted — show fake balances
3. Signed transactions are intercepted — redirect funds to attacker's address
4. SSL warnings are suppressed so the user sees no indication of the attack
5. The wallet handles private keys and signed transactions — this is critical

### Fix Applied
- `VERIFY_SSL` now defaults to `True` (production-safe)
- Read from `RUSTCHAIN_VERIFY_SSL` env var for testing overrides
- Warning suppression only activates when SSL is **explicitly** disabled (`RUSTCHAIN_VERIFY_SSL=0`)
- Console warning printed when SSL verification is disabled

### Testing
- Syntax verification passes
- Default behavior now validates SSL certificates