### PR TITLE
feat: add Telegram bot for issue #2869

### DIFF
--- a/tools/telegram-bot-2869/.env.example
+++ b/tools/telegram-bot-2869/.env.example
@@ -1,0 +1,14 @@
+# Telegram Bot Token from @BotFather
+TELEGRAM_BOT_TOKEN=your-bot-token-here
+
+# RustChain node URL (supports self-signed certs)
+RUSTCHAIN_NODE_URL=https://rustchain.org
+
+# Rate limiting: minimum seconds between requests per user (default: 5)
+RATE_LIMIT_SECONDS=5
+
+# HTTP request timeout in seconds (default: 15)
+REQUEST_TIMEOUT=15
+
+# Fallback RTC price in USD (used when DexScreener is unavailable)
+RTC_PRICE_USD=0.10

--- a/tools/telegram-bot-2869/README.md
+++ b/tools/telegram-bot-2869/README.md
@@ -1,0 +1,192 @@
+# RustChain Telegram Bot — Issue #2869
+
+A complete Telegram bot for querying RustChain wallet and miner status.
+
+## Features
+
+- **`/balance <wallet>`** — Check RTC wallet balance
+- **`/miners`** — List active miners with hardware details
+- **`/epoch`** — Current epoch info (slot, pot, enrolled miners, supply)
+- **`/price`** — RTC/wRTC price in USD (from node + DexScreener)
+- **`/help`** — Show available commands
+- **Rate limiting** — 1 request per 5 seconds per user (configurable)
+- **Error handling** — Graceful messages when node is offline or unreachable
+- **Self-signed cert support** — Works with RustChain node TLS out of the box
+
+## Quick Start
+
+```bash
+# 1. Clone / navigate to the directory
+cd tools/telegram-bot-2869
+
+# 2. Create virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# 3. Install dependencies
+pip install -r requirements.txt
+
+# 4. Configure
+cp .env.example .env
+# Edit .env and set your TELEGRAM_BOT_TOKEN
+
+# 5. Run
+python bot.py
+```
+
+## Getting a Telegram Bot Token
+
+1. Open Telegram and message **@BotFather**
+2. Send `/newbot` and follow the instructions
+3. Copy the API token
+4. Set it in your `.env` file: `TELEGRAM_BOT_TOKEN=your-token-here`
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | *(required)* | Bot token from @BotFather |
+| `RUSTCHAIN_NODE_URL` | `https://rustchain.org` | RustChain node URL |
+| `RATE_LIMIT_SECONDS` | `5` | Min seconds between requests per user |
+| `REQUEST_TIMEOUT` | `15` | HTTP request timeout in seconds |
+| `RTC_PRICE_USD` | `0.10` | Fallback price when DexScreener is down |
+
+## Deployment
+
+### Option 1: Railway
+
+1. Push this directory to a GitHub repo
+2. Create a new project on [Railway](https://railway.app)
+3. Connect your repo
+4. Set environment variables in Railway dashboard:
+   - `TELEGRAM_BOT_TOKEN` — your bot token
+   - `RUSTCHAIN_NODE_URL` — `https://rustchain.org`
+5. Railway auto-deploys using the `requirements.txt`
+6. Set the start command: `python bot.py`
+
+**railway.json** (optional, for clarity):
+```json
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS"
+  },
+  "deploy": {
+    "startCommand": "python bot.py",
+    "healthcheckPath": "/",
+    "restartPolicyType": "ON_FAILURE"
+  }
+}
+```
+
+### Option 2: Fly.io
+
+1. Install [flyctl](https://fly.io/docs/hands-on/install-flyctl/)
+2. Run `fly launch` in this directory
+3. Set secrets:
+   ```bash
+   fly secrets set TELEGRAM_BOT_TOKEN="your-token"
+   fly secrets set RUSTCHAIN_NODE_URL="https://rustchain.org"
+   ```
+4. Deploy:
+   ```bash
+   fly deploy
+   ```
+
+**Dockerfile** for Fly.io:
+```dockerfile
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "bot.py"]
+```
+
+**fly.toml**:
+```toml
+app = "rustchain-telegram-bot"
+primary_region = "sjc"
+
+[build]
+
+[env]
+  RUSTCHAIN_NODE_URL = "https://rustchain.org"
+
+[processes]
+  app = "python bot.py"
+```
+
+### Option 3: systemd (VPS / Dedicated Server)
+
+1. Copy files to `/opt/rustchain-telegram-bot/`:
+   ```bash
+   sudo mkdir -p /opt/rustchain-telegram-bot
+   sudo cp -r * /opt/rustchain-telegram-bot/
+   ```
+
+2. Create virtual environment:
+   ```bash
+   cd /opt/rustchain-telegram-bot
+   sudo python3 -m venv venv
+   sudo venv/bin/pip install -r requirements.txt
+   ```
+
+3. Create `.env` file:
+   ```bash
+   sudo cp .env.example .env
+   sudo nano .env  # set your token and config
+   ```
+
+4. Create a dedicated user:
+   ```bash
+   sudo useradd --system --no-create-home rustchain
+   sudo chown -R rustchain:rustchain /opt/rustchain-telegram-bot
+   ```
+
+5. Install systemd service:
+   ```bash
+   sudo cp rustchain-bot.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable rustchain-bot
+   sudo systemctl start rustchain-bot
+   ```
+
+6. Check status:
+   ```bash
+   sudo systemctl status rustchain-bot
+   sudo journalctl -u rustchain-bot -f
+   ```
+
+## Architecture
+
+```
+User → Telegram → Bot → httpx → RustChain Node
+                          ↓
+                    DexScreener (price)
+```
+
+- **Async I/O**: Uses `python-telegram-bot` v20+ (async) + `httpx` for non-blocking HTTP
+- **Rate limiter**: In-memory per-user token bucket (1 req / 5s)
+- **Error handling**: Catches connection errors, timeouts, HTTP errors — all return user-friendly messages
+- **TLS**: Self-signed certificates disabled by default (RustChain nodes use self-signed certs)
+
+## Testing
+
+Run the smoke tests:
+
+```bash
+pip install -r requirements.txt
+python test_bot.py
+```
+
+Tests cover:
+- Rate limiter logic
+- API response parsing
+- Error handling for offline nodes
+- Markdown escaping
+- Command handler registration
+
+## License
+
+Apache-2.0 (same as RustChain)

--- a/tools/telegram-bot-2869/bot.py
+++ b/tools/telegram-bot-2869/bot.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""
+RustChain Telegram Bot — Issue #2869
+https://github.com/Scottcjn/rustchain-bounties/issues/2869
+
+Commands:
+  /balance <wallet>  — Check RTC wallet balance
+  /miners            — List active miners
+  /epoch             — Current epoch information
+  /price             — RTC/wRTC price
+  /help              — Show available commands
+
+Features:
+  - Rate limiting: 1 request per 5 seconds per user
+  - Error handling for offline/unreachable node
+  - Self-signed certificate support for RustChain nodes
+  - Deployable on Railway, Fly.io, or systemd
+
+Usage:
+  export TELEGRAM_BOT_TOKEN="your-token"
+  python bot.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from telegram import BotCommand, Update
+from telegram.ext import Application, CommandHandler, ContextTypes
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+RUSTCHAIN_NODE_URL = os.getenv("RUSTCHAIN_NODE_URL", "https://rustchain.org")
+BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+RATE_LIMIT_SECONDS = int(os.getenv("RATE_LIMIT_SECONDS", "5"))
+REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
+
+# Reference price fallback (USD)
+RTC_PRICE_USD_FALLBACK = float(os.getenv("RTC_PRICE_USD", "0.10"))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("rustchain_bot_2869")
+
+# ---------------------------------------------------------------------------
+# Rate Limiter — 1 request per 5 seconds per user
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RateLimiter:
+    """Enforce 1 request per RATE_LIMIT_SECONDS per user."""
+
+    window: int = RATE_LIMIT_SECONDS
+    _last_hit: dict[int, float] = field(default_factory=dict)
+
+    def is_allowed(self, user_id: int) -> bool:
+        now = time.monotonic()
+        last = self._last_hit.get(user_id)
+        if last is not None and (now - last) < self.window:
+            return False
+        self._last_hit[user_id] = now
+        return True
+
+    def retry_after(self, user_id: int) -> float:
+        last = self._last_hit.get(user_id)
+        if last is None:
+            return float(self.window)
+        elapsed = time.monotonic() - last
+        return max(0.0, self.window - elapsed)
+
+
+rate_limiter = RateLimiter()
+
+# ---------------------------------------------------------------------------
+# RustChain API Client
+# ---------------------------------------------------------------------------
+
+
+class RustChainAPI:
+    """Async HTTP client for RustChain node endpoints."""
+
+    def __init__(self, base_url: str, timeout: int = REQUEST_TIMEOUT) -> None:
+        self.base_url = base_url.rstrip("/")
+        # RustChain nodes use self-signed certs — disable verification
+        self.client = httpx.AsyncClient(
+            verify=False,
+            timeout=httpx.Timeout(timeout),
+            headers={"User-Agent": "RustChainTelegramBot/1.0"},
+        )
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+    async def _get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        try:
+            resp = await self.client.get(url, params=params)
+            resp.raise_for_status()
+            return resp.json()
+        except httpx.ConnectError:
+            return {"_error": "Node is unreachable. The RustChain node may be offline."}
+        except httpx.TimeoutException:
+            return {"_error": "Request timed out. The node may be slow or unreachable."}
+        except httpx.HTTPStatusError as exc:
+            return {"_error": f"HTTP {exc.response.status_code} from node."}
+        except Exception as exc:
+            log.error("API error %s: %s", path, exc)
+            return {"_error": f"Unexpected error: {exc}"}
+
+    async def health(self) -> dict[str, Any]:
+        return await self._get("/health")
+
+    async def epoch(self) -> dict[str, Any]:
+        return await self._get("/epoch")
+
+    async def balance(self, miner_id: str) -> dict[str, Any]:
+        return await self._get("/wallet/balance", params={"miner_id": miner_id})
+
+    async def miners(self) -> dict[str, Any]:
+        return await self._get("/api/miners")
+
+    async def swap_info(self) -> dict[str, Any]:
+        return await self._get("/wallet/swap-info")
+
+
+# Global API client — created in main()
+api: RustChainAPI | None = None
+
+
+def _fmt_uptime(seconds: float) -> str:
+    d = int(seconds // 86400)
+    h = int((seconds % 86400) // 3600)
+    m = int((seconds % 3600) // 60)
+    return f"{d}d {h}h {m}m"
+
+
+def _error_text(data: dict[str, Any]) -> str:
+    """Extract error text from an API response, or None if ok."""
+    err = data.get("_error")
+    if err:
+        return err
+    if data.get("error"):
+        return str(data["error"])
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Command: /start
+# ---------------------------------------------------------------------------
+
+async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    text = (
+        "🛡️ *RustChain Wallet & Miner Bot*\n\n"
+        "Query the RustChain network directly from Telegram.\n\n"
+        "*Commands:*\n"
+        "/balance <wallet> — Check RTC balance\n"
+        "/miners — Active miners list\n"
+        "/epoch — Current epoch info\n"
+        "/price — RTC/wRTC price\n"
+        "/help — Show this message\n\n"
+        "Start mining at rustchain\\.org"
+    )
+    await update.message.reply_text(text, parse_mode="MarkdownV2")
+
+
+# ---------------------------------------------------------------------------
+# Command: /help
+# ---------------------------------------------------------------------------
+
+async def cmd_help(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    text = (
+        "🛡️ *RustChain Bot — Help*\n\n"
+        "*Available Commands:*\n\n"
+        "/balance <wallet\\_id>\n"
+        "  Check the RTC balance of a wallet/miner\\.\n"
+        "  Example: `/balance Ivan\\-houzhiwen`\n\n"
+        "/miners\n"
+        "  List currently active miners on the network\\.\n\n"
+        "/epoch\n"
+        "  Show current epoch, slot, pot, and enrolled miners\\.\n\n"
+        "/price\n"
+        "  Show the current RTC/wRTC price in USD\\.\n\n"
+        "/help\n"
+        "  Show this help message\\.\n\n"
+        "_Rate limit: 1 request per 5 seconds per user\\._"
+    )
+    await update.message.reply_text(text, parse_mode="MarkdownV2")
+
+
+# ---------------------------------------------------------------------------
+# Command: /balance <wallet>
+# ---------------------------------------------------------------------------
+
+async def cmd_balance(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    if not rate_limiter.is_allowed(user_id):
+        retry = rate_limiter.retry_after(user_id)
+        await update.message.reply_text(
+            f"⏳ Rate limited\\. Please wait {retry:.0f}s before the next request\\.",
+            parse_mode="MarkdownV2",
+        )
+        return
+
+    if not ctx.args:
+        await update.message.reply_text(
+            "Usage: `/balance <wallet_id>`\nExample: `/balance Ivan-houzhiwen`",
+            parse_mode="Markdown",
+        )
+        return
+
+    wallet = ctx.args[0]
+    data = await api.balance(wallet)
+
+    err = _error_text(data)
+    if err:
+        await update.message.reply_text(f"❌ Error: {err}")
+        return
+
+    amount_rtc = data.get("amount_rtc", 0.0)
+    miner_id = data.get("miner_id", wallet)
+
+    text = (
+        f"💰 *Wallet Balance*\n\n"
+        f"Wallet: `{miner_id}`\n"
+        f"Balance: *{amount_rtc} RTC*"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+# ---------------------------------------------------------------------------
+# Command: /miners
+# ---------------------------------------------------------------------------
+
+async def cmd_miners(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    if not rate_limiter.is_allowed(user_id):
+        retry = rate_limiter.retry_after(user_id)
+        await update.message.reply_text(
+            f"⏳ Rate limited\\. Please wait {retry:.0f}s before the next request\\.",
+            parse_mode="MarkdownV2",
+        )
+        return
+
+    data = await api.miners()
+
+    err = _error_text(data)
+    if err:
+        await update.message.reply_text(f"❌ Error: {err}")
+        return
+
+    miners = data.get("miners", [])
+    if not isinstance(miners, list):
+        await update.message.reply_text("Unexpected response from /api/miners.")
+        return
+
+    if not miners:
+        await update.message.reply_text("No active miners found on the network.")
+        return
+
+    lines = [f"⛏️ *Active Miners: {len(miners)}*\n"]
+    for m in miners[:15]:
+        name = m.get("miner", "?")
+        hw = m.get("hardware_type", m.get("device_arch", ""))
+        mult = m.get("antiquity_multiplier", "")
+        # Escape underscores and special chars for MarkdownV2
+        safe_name = _md_escape(name)
+        safe_hw = _md_escape(str(hw))
+        lines.append(f"  `{safe_name}` — {safe_hw} \\(x{mult}\\)")
+
+    if len(miners) > 15:
+        lines.append(f"\n_\\.\\.\\.and {len(miners) - 15} more_")
+
+    await update.message.reply_text("\n".join(lines), parse_mode="MarkdownV2")
+
+
+# ---------------------------------------------------------------------------
+# Command: /epoch
+# ---------------------------------------------------------------------------
+
+async def cmd_epoch(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    if not rate_limiter.is_allowed(user_id):
+        retry = rate_limiter.retry_after(user_id)
+        await update.message.reply_text(
+            f"⏳ Rate limited\\. Please wait {retry:.0f}s before the next request\\.",
+            parse_mode="MarkdownV2",
+        )
+        return
+
+    data = await api.epoch()
+
+    err = _error_text(data)
+    if err:
+        await update.message.reply_text(f"❌ Error: {err}")
+        return
+
+    epoch = data.get("epoch", "N/A")
+    slot = data.get("slot", "N/A")
+    blocks = data.get("blocks_per_epoch", "N/A")
+    pot = data.get("epoch_pot", "N/A")
+    enrolled = data.get("enrolled_miners", "N/A")
+    supply = data.get("total_supply_rtc", "N/A")
+
+    if isinstance(supply, (int, float)):
+        supply = f"{supply:,}"
+
+    text = (
+        f"📅 *Epoch Info*\n\n"
+        f"Epoch: `{epoch}`\n"
+        f"Slot: `{slot}`\n"
+        f"Blocks/Epoch: `{blocks}`\n"
+        f"Epoch Pot: `{pot} RTC`\n"
+        f"Enrolled Miners: `{enrolled}`\n"
+        f"Total Supply: `{supply} RTC`"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+# ---------------------------------------------------------------------------
+# Command: /price
+# ---------------------------------------------------------------------------
+
+async def cmd_price(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = update.effective_user.id
+    if not rate_limiter.is_allowed(user_id):
+        retry = rate_limiter.retry_after(user_id)
+        await update.message.reply_text(
+            f"⏳ Rate limited\\. Please wait {retry:.0f}s before the next request\\.",
+            parse_mode="MarkdownV2",
+        )
+        return
+
+    # Try to get price from the node's swap-info endpoint first
+    price = RTC_PRICE_USD_FALLBACK
+    source = "reference"
+
+    try:
+        info = await api.swap_info()
+        ref = info.get("reference_price_usd")
+        if ref and isinstance(ref, (int, float)) and ref > 0:
+            price = ref
+            source = "node"
+    except Exception:
+        pass
+
+    # Also try DexScreener for the Solana wRTC pair
+    try:
+        async with httpx.AsyncClient(timeout=5) as dx:
+            resp = await dx.get(
+                "https://api.dexscreener.com/latest/dex/search?q=wRTC%20RustChain"
+            )
+            if resp.status_code == 200:
+                pairs = resp.json().get("pairs", [])
+                for pair in pairs:
+                    base = pair.get("baseToken", {})
+                    if "wrtc" in base.get("symbol", "").lower() or "wrtc" in base.get("name", "").lower():
+                        price = float(pair.get("priceUsd", price))
+                        source = "DexScreener"
+                        break
+    except Exception:
+        pass  # keep fallback price
+
+    # Get supply from epoch for market cap
+    epoch_data = await api.epoch()
+    supply = epoch_data.get("total_supply_rtc", 0) if "_error" not in epoch_data else 0
+    mcap = price * supply if isinstance(supply, (int, float)) and supply else 0
+
+    text = (
+        f"💲 *RTC Price*\n\n"
+        f"Price: *${price:.4f}*\n"
+        f"Source: `{source}`\n"
+        f"Total Supply: `{supply:,} RTC`\n"
+        f"Market Cap: `${mcap:,.2f}`"
+    )
+    await update.message.reply_text(text, parse_mode="Markdown")
+
+
+# ---------------------------------------------------------------------------
+# Error handler
+# ---------------------------------------------------------------------------
+
+async def on_error(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    log.error("Update %s caused error: %s", update, ctx.error)
+    if update and update.effective_message:
+        await update.effective_message.reply_text(
+            "❌ An error occurred processing your request\\. Please try again later\\.",
+            parse_mode="MarkdownV2",
+        )
+
+
+# ---------------------------------------------------------------------------
+# MarkdownV2 helper — escape special chars
+# ---------------------------------------------------------------------------
+
+def _md_escape(text: str) -> str:
+    """Escape characters that are special in Telegram MarkdownV2."""
+    special = r"\_*[]()~`>#+-=|{}.!"
+    result = []
+    for ch in text:
+        if ch in special:
+            result.append(f"\\{ch}")
+        else:
+            result.append(ch)
+    return "".join(result)
+
+
+# ---------------------------------------------------------------------------
+# Bot initialization
+# ---------------------------------------------------------------------------
+
+async def post_init(application: Application) -> None:
+    commands = [
+        BotCommand("start", "Welcome message"),
+        BotCommand("balance", "Check wallet balance"),
+        BotCommand("miners", "List active miners"),
+        BotCommand("epoch", "Current epoch info"),
+        BotCommand("price", "RTC/wRTC price"),
+        BotCommand("help", "Show all commands"),
+    ]
+    await application.bot.set_my_commands(commands)
+    log.info("Bot commands registered")
+
+
+def validate_config() -> bool:
+    if not BOT_TOKEN:
+        print(
+            "Error: TELEGRAM_BOT_TOKEN environment variable is not set.\n\n"
+            "1. Message @BotFather on Telegram\n"
+            "2. Send /newbot to create a bot\n"
+            "3. Copy the API token\n"
+            "4. export TELEGRAM_BOT_TOKEN='your-token'\n"
+            "   or add to .env file"
+        )
+        return False
+    return True
+
+
+def main() -> None:
+    global api
+
+    if not validate_config():
+        sys.exit(1)
+
+    api = RustChainAPI(RUSTCHAIN_NODE_URL)
+
+    app = Application.builder().token(BOT_TOKEN).build()
+
+    # Register command handlers
+    for name, handler in [
+        ("start", cmd_start),
+        ("help", cmd_help),
+        ("balance", cmd_balance),
+        ("miners", cmd_miners),
+        ("epoch", cmd_epoch),
+        ("price", cmd_price),
+    ]:
+        app.add_handler(CommandHandler(name, handler))
+
+    app.add_error_handler(on_error)
+    app.post_init = post_init
+
+    log.info("Starting RustChain Bot | Node: %s | Rate limit: 1 req/%ds per user",
+             RUSTCHAIN_NODE_URL, RATE_LIMIT_SECONDS)
+
+    # Cleanup on shutdown
+    async def shutdown_cb(application: Application) -> None:
+        if api:
+            await api.close()
+
+    app.post_shutdown = shutdown_cb
+
+    app.run_polling(allowed_updates=Update.ALL_TYPES, drop_pending_updates=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/telegram-bot-2869/requirements.txt
+++ b/tools/telegram-bot-2869/requirements.txt
@@ -1,0 +1,3 @@
+python-telegram-bot>=20.0
+httpx>=0.24.0
+python-dotenv>=1.0.0

--- a/tools/telegram-bot-2869/rustchain-bot.service
+++ b/tools/telegram-bot-2869/rustchain-bot.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=RustChain Telegram Bot (Issue #2869)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=rustchain
+Group=rustchain
+WorkingDirectory=/opt/rustchain-telegram-bot
+ExecStart=/opt/rustchain-telegram-bot/venv/bin/python bot.py
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+# Environment file
+EnvironmentFile=/opt/rustchain-telegram-bot/.env
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/opt/rustchain-telegram-bot/logs
+
+[Install]
+WantedBy=multi-user.target

--- a/tools/telegram-bot-2869/test_bot.py
+++ b/tools/telegram-bot-2869/test_bot.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""
+Smoke tests for RustChain Telegram Bot (Issue #2869).
+
+Tests cover:
+- Rate limiter logic
+- API response parsing
+- Error handling for offline nodes
+- MarkdownV2 escaping
+- Configuration validation
+
+Run: python test_bot.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Test Rate Limiter
+# ---------------------------------------------------------------------------
+
+class TestRateLimiter(unittest.TestCase):
+    """Test rate limiter with fresh instances to avoid shared state."""
+
+    def test_first_request_allowed(self):
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        self.assertTrue(limiter.is_allowed(123))
+
+    def test_second_request_within_window_blocked(self):
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        self.assertTrue(limiter.is_allowed(123))
+        self.assertFalse(limiter.is_allowed(123))
+
+    def test_different_users_independent(self):
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        self.assertTrue(limiter.is_allowed(123))
+        self.assertTrue(limiter.is_allowed(456))  # different user
+
+    def test_retry_after_calculation(self):
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        limiter.is_allowed(123)
+        retry = limiter.retry_after(123)
+        self.assertGreater(retry, 0)
+        self.assertLessEqual(retry, 5)
+
+    def test_retry_after_for_unused_user(self):
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        retry = limiter.retry_after(999)
+        self.assertEqual(retry, 5.0)
+
+    def test_window_expiry(self):
+        """After window passes, user can request again."""
+        from bot import RateLimiter
+        limiter = RateLimiter(window=5)
+        limiter.is_allowed(123)
+        # Manually advance the last_hit time
+        limiter._last_hit[123] = time.monotonic() - 6
+        self.assertTrue(limiter.is_allowed(123))
+
+
+# ---------------------------------------------------------------------------
+# Test API Error Handling
+# ---------------------------------------------------------------------------
+
+class TestAPIErrorHandling(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI, _error_text
+        self.api = RustChainAPI("https://rustchain.org")
+        self._error_text = _error_text
+
+    def test_error_text_extracts_internal_error(self):
+        data = {"_error": "Node is unreachable."}
+        self.assertEqual(self._error_text(data), "Node is unreachable.")
+
+    def test_error_text_extracts_standard_error(self):
+        data = {"error": "Something went wrong"}
+        self.assertEqual(self._error_text(data), "Something went wrong")
+
+    def test_error_text_returns_empty_for_ok_response(self):
+        data = {"ok": True, "amount_rtc": 42.0}
+        self.assertEqual(self._error_text(data), "")
+
+    def test_connect_error_message(self):
+        """Verify that connect errors produce user-friendly messages."""
+        data = {"_error": "Node is unreachable. The RustChain node may be offline."}
+        err = self._error_text(data)
+        self.assertIn("unreachable", err.lower())
+        self.assertIn("offline", err.lower())
+
+
+# ---------------------------------------------------------------------------
+# Test API Response Parsing (mocked)
+# ---------------------------------------------------------------------------
+
+class TestAPIResponseParsing(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        self.api = RustChainAPI("https://rustchain.org")
+
+    async def test_balance_parsing(self):
+        mock_response = {"amount_i64": 42500000, "amount_rtc": 42.5, "miner_id": "test-wallet"}
+        with patch.object(self.api, '_get', new_callable=AsyncMock, return_value=mock_response):
+            result = await self.api.balance("test-wallet")
+            self.assertEqual(result["amount_rtc"], 42.5)
+            self.assertEqual(result["miner_id"], "test-wallet")
+
+    async def test_epoch_parsing(self):
+        mock_response = {
+            "blocks_per_epoch": 144,
+            "enrolled_miners": 17,
+            "epoch": 129,
+            "epoch_pot": 1.5,
+            "slot": 18686,
+            "total_supply_rtc": 8388608,
+        }
+        with patch.object(self.api, '_get', new_callable=AsyncMock, return_value=mock_response):
+            result = await self.api.epoch()
+            self.assertEqual(result["epoch"], 129)
+            self.assertEqual(result["enrolled_miners"], 17)
+            self.assertEqual(result["total_supply_rtc"], 8388608)
+
+    async def test_miners_parsing(self):
+        mock_response = {
+            "miners": [
+                {
+                    "miner": "test-miner",
+                    "hardware_type": "Apple Silicon (Modern)",
+                    "device_arch": "M4",
+                    "antiquity_multiplier": 1.05,
+                }
+            ]
+        }
+        with patch.object(self.api, '_get', new_callable=AsyncMock, return_value=mock_response):
+            result = await self.api.miners()
+            self.assertIsInstance(result["miners"], list)
+            self.assertEqual(len(result["miners"]), 1)
+
+    async def test_health_parsing(self):
+        mock_response = {
+            "ok": True,
+            "version": "2.2.1-rip200",
+            "uptime_s": 336071,
+            "db_rw": True,
+            "tip_age_slots": 0,
+        }
+        with patch.object(self.api, '_get', new_callable=AsyncMock, return_value=mock_response):
+            result = await self.api.health()
+            self.assertTrue(result["ok"])
+            self.assertEqual(result["version"], "2.2.1-rip200")
+
+
+# ---------------------------------------------------------------------------
+# Test MarkdownV2 Escaping
+# ---------------------------------------------------------------------------
+
+class TestMarkdownEscape(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, ".")
+        from bot import _md_escape
+        self.escape = _md_escape
+
+    def test_underscore_escaped(self):
+        self.assertEqual(self.escape("hello_world"), "hello\\_world")
+
+    def test_dot_escaped(self):
+        self.assertEqual(self.escape("rustchain.org"), "rustchain\\.org")
+
+    def test_parentheses_escaped(self):
+        self.assertEqual(self.escape("x(1.05)"), "x\\(1\\.05\\)")
+
+    def test_no_special_chars_unchanged(self):
+        self.assertEqual(self.escape("hello"), "hello")
+
+    def test_complex_string(self):
+        result = self.escape("Apple Silicon (Modern) x1.05")
+        self.assertIn("\\(", result)
+        self.assertIn("\\)", result)
+        self.assertIn("\\.", result)
+
+
+# ---------------------------------------------------------------------------
+# Test Configuration Validation
+# ---------------------------------------------------------------------------
+
+class TestConfigValidation(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, ".")
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": ""}, clear=True)
+    def test_missing_token_returns_false(self):
+        # Re-import to pick up patched env
+        import importlib
+        import bot
+        importlib.reload(bot)
+        self.assertFalse(bot.validate_config())
+
+    @patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "test-token-123"}, clear=True)
+    def test_valid_token_returns_true(self):
+        import importlib
+        import bot
+        importlib.reload(bot)
+        self.assertTrue(bot.validate_config())
+
+
+# ---------------------------------------------------------------------------
+# Test Uptime Formatting
+# ---------------------------------------------------------------------------
+
+class TestUptimeFormatting(unittest.TestCase):
+    def setUp(self):
+        sys.path.insert(0, ".")
+        from bot import _fmt_uptime
+        self.fmt = _fmt_uptime
+
+    def test_zero_uptime(self):
+        self.assertEqual(self.fmt(0), "0d 0h 0m")
+
+    def test_one_day(self):
+        self.assertEqual(self.fmt(86400), "1d 0h 0m")
+
+    def test_hours_and_minutes(self):
+        self.assertEqual(self.fmt(3661), "0d 1h 1m")
+
+    def test_complex(self):
+        self.assertEqual(self.fmt(336071), "3d 21h 21m")
+
+
+# ---------------------------------------------------------------------------
+# Test Real API Connectivity (integration smoke test)
+# ---------------------------------------------------------------------------
+
+class TestRealAPIConnectivity(unittest.IsolatedAsyncioTestCase):
+    """These tests hit the real RustChain node — skip if offline."""
+
+    async def test_health_endpoint(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        api = RustChainAPI("https://rustchain.org")
+        try:
+            result = await api.health()
+            self.assertNotIn("_error", result)
+            self.assertIn("ok", result)
+        finally:
+            await api.close()
+
+    async def test_epoch_endpoint(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        api = RustChainAPI("https://rustchain.org")
+        try:
+            result = await api.epoch()
+            self.assertNotIn("_error", result)
+            self.assertIn("epoch", result)
+        finally:
+            await api.close()
+
+    async def test_balance_endpoint(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        api = RustChainAPI("https://rustchain.org")
+        try:
+            result = await api.balance("test")
+            self.assertNotIn("_error", result)
+            self.assertIn("amount_rtc", result)
+        finally:
+            await api.close()
+
+    async def test_miners_endpoint(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        api = RustChainAPI("https://rustchain.org")
+        try:
+            result = await api.miners()
+            self.assertNotIn("_error", result)
+            self.assertIn("miners", result)
+            self.assertIsInstance(result["miners"], list)
+        finally:
+            await api.close()
+
+
+# ---------------------------------------------------------------------------
+# Test Offline Node Error Handling
+# ---------------------------------------------------------------------------
+
+class TestOfflineNodeHandling(unittest.IsolatedAsyncioTestCase):
+    async def test_unreachable_node_returns_friendly_error(self):
+        sys.path.insert(0, ".")
+        from bot import RustChainAPI
+        api = RustChainAPI("https://192.0.2.1", timeout=3)  # TEST-NET-1, always unreachable
+        try:
+            result = await api.health()
+            self.assertIn("_error", result)
+            self.assertIn("unreachable", result["_error"].lower())
+        finally:
+            await api.close()
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Adds a complete RustChain Telegram bot implementation for issue #2869.

## What’s included
- `/balance <wallet>` to query RTC wallet balances
- `/miners` to list active miners with hardware details
- `/epoch` to show current epoch, slot, pot, miner count, and supply
- `/price` to show RTC/wRTC price information
- `/help` command and onboarding copy
- per-user rate limiting
- friendly handling for offline/unreachable nodes
- deployment docs for Railway, Fly.io, and systemd
- smoke tests plus live endpoint verification coverage

## Validation
- `python3 test_bot.py`
- 30 tests passed locally
- verified live calls against `/health`, `/epoch`, `/wallet/balance`, and `/api/miners`

## Bounty wallet
RTC payout wallet: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
Linked wallet: `createkr-wallet`

Closes #2869
