### PR TITLE
feat: add RIP-309 fingerprint rotation for issue #3008

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -24,10 +24,10 @@ logger = logging.getLogger(__name__)
 ROTATING_FINGERPRINT_CHECKS = (
     "clock_drift",
     "cache_timing",
-    "simd_identity",
+    "simd_bias",
     "thermal_drift",
     "instruction_jitter",
-    "device_age_oracle",
+    "anti_emulation",
 )
 ACTIVE_FINGERPRINT_CHECK_COUNT = 4
 

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -13,12 +13,38 @@ Key Changes:
 4. Time-aging: Vintage hardware advantage decays over blockchain lifetime
 """
 
+import hashlib
 import logging
 import sqlite3
 import time
 from typing import List, Tuple, Dict
 
 logger = logging.getLogger(__name__)
+
+ROTATING_FINGERPRINT_CHECKS = (
+    "clock_drift",
+    "cache_timing",
+    "simd_identity",
+    "thermal_drift",
+    "instruction_jitter",
+    "device_age_oracle",
+)
+ACTIVE_FINGERPRINT_CHECK_COUNT = 4
+
+
+def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
+    previous_epoch_block_hash = (previous_epoch_block_hash or ("0" * 64)).strip().lower()
+    seed = f"rip-309:{previous_epoch_block_hash}".encode()
+    return hashlib.sha256(seed).hexdigest()
+
+
+def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = ACTIVE_FINGERPRINT_CHECK_COUNT) -> Tuple[str, ...]:
+    nonce = derive_measurement_nonce(previous_epoch_block_hash)
+    ranked = sorted(
+        ROTATING_FINGERPRINT_CHECKS,
+        key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
+    )
+    return tuple(ranked[:active_count])
 
 # Genesis timestamp (adjust to actual genesis block timestamp)
 GENESIS_TIMESTAMP = 1764706927  # First actual block (Dec 2, 2025)
@@ -504,16 +530,20 @@ def calculate_epoch_rewards_time_aged(
         cursor = conn.cursor()
 
         # Primary source: epoch_enroll (per-epoch snapshot, matches finalize_epoch).
-        cursor.execute(
-            "SELECT miner_pk FROM epoch_enroll WHERE epoch = ?",
-            (epoch,)
-        )
-        enrolled = cursor.fetchall()
+        try:
+            cursor.execute(
+                "SELECT miner_pk, weight FROM epoch_enroll WHERE epoch = ?",
+                (epoch,)
+            )
+            enrolled = cursor.fetchall()
+        except sqlite3.Error:
+            enrolled = []
 
         if enrolled:
-            # Use enrolled miners; look up device_arch from latest attestation.
+            # Use enrolled miners; epoch_enroll.weight is the canonical per-epoch
+            # reward weight snapshot and may already include RIP-309 rotation.
             epoch_miners = []
-            for (miner_pk,) in enrolled:
+            for miner_pk, enrolled_weight in enrolled:
                 arch_row = cursor.execute(
                     "SELECT device_arch, COALESCE(fingerprint_passed, 1) "
                     "FROM miner_attest_recent WHERE miner = ? LIMIT 1",
@@ -526,7 +556,7 @@ def calculate_epoch_rewards_time_aged(
                     # No attestation record — treat as unknown arch, fingerprint ok.
                     device_arch = "unknown"
                     fp = 1
-                epoch_miners.append((miner_pk, device_arch, fp))
+                epoch_miners.append((miner_pk, device_arch, fp, enrolled_weight))
         else:
             # SECURITY FIX #2159: Fallback for epochs without enrollment
             # records.  This path is vulnerable to the stale-attestation
@@ -555,11 +585,14 @@ def calculate_epoch_rewards_time_aged(
     for row in epoch_miners:
         miner_id, device_arch = row[0], row[1]
         fingerprint_ok = row[2] if len(row) > 2 else 1
+        enrolled_weight = row[3] if len(row) > 3 else None
         
         # STRICT: VMs/emulators with failed fingerprint get ZERO weight
         if fingerprint_ok == 0:
             weight = 0.0  # No rewards for failed fingerprint
             print(f"[REWARD] {miner_id[:20]}... fingerprint=FAIL -> weight=0")
+        elif enrolled_weight is not None:
+            weight = max(float(enrolled_weight or 0.0), 0.0)
         else:
             weight = get_time_aged_multiplier(device_arch, chain_age_years)
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1028,6 +1028,7 @@ def init_db():
         c.execute("CREATE TABLE IF NOT EXISTS epoch_enroll (epoch INTEGER, miner_pk TEXT, weight REAL, PRIMARY KEY (epoch, miner_pk))")
         c.execute("CREATE TABLE IF NOT EXISTS balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
         ensure_fingerprint_history_table(c)
+        ensure_epoch_fingerprint_rotation_table(c)
 
         # Pending transfers (2-phase commit)
         # NOTE: Production DBs may already have a different balances schema; this table is additive.
@@ -1357,6 +1358,129 @@ def _fingerprint_check_data(fingerprint: dict, check_name: str) -> dict:
         data = item.get("data", {})
         return data if isinstance(data, dict) else {}
     return {}
+
+
+RIP309_ROTATING_FINGERPRINT_CHECKS = (
+    "clock_drift",
+    "cache_timing",
+    "simd_identity",
+    "thermal_drift",
+    "instruction_jitter",
+    "device_age_oracle",
+)
+RIP309_ACTIVE_FINGERPRINT_CHECKS = 4
+RIP309_NONCE_FALLBACK = "0" * 64
+
+
+def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
+    previous_epoch_block_hash = (previous_epoch_block_hash or RIP309_NONCE_FALLBACK).strip().lower()
+    seed = f"rip-309:{previous_epoch_block_hash}".encode()
+    return hashlib.sha256(seed).hexdigest()
+
+
+def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = RIP309_ACTIVE_FINGERPRINT_CHECKS) -> tuple:
+    nonce = derive_measurement_nonce(previous_epoch_block_hash)
+    ranked = sorted(
+        RIP309_ROTATING_FINGERPRINT_CHECKS,
+        key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
+    )
+    return tuple(ranked[:active_count])
+
+
+def _fingerprint_check_passed(check_entry) -> bool:
+    if isinstance(check_entry, bool):
+        return check_entry
+    if isinstance(check_entry, dict):
+        return bool(check_entry.get("passed", True))
+    return False
+
+
+def get_previous_epoch_block_hash(conn, epoch: int) -> str:
+    if epoch <= 0:
+        return RIP309_NONCE_FALLBACK
+
+    prev_epoch_end_height = (epoch * EPOCH_SLOTS) - 1
+    try:
+        row = conn.execute(
+            "SELECT block_hash FROM blocks WHERE height <= ? ORDER BY height DESC LIMIT 1",
+            (prev_epoch_end_height,),
+        ).fetchone()
+    except sqlite3.Error:
+        row = None
+    if row and row[0]:
+        return str(row[0])
+    return RIP309_NONCE_FALLBACK
+
+
+def ensure_epoch_fingerprint_rotation_table(conn):
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS epoch_fingerprint_rotation (
+            epoch INTEGER PRIMARY KEY,
+            previous_epoch_block_hash TEXT NOT NULL,
+            measurement_nonce TEXT NOT NULL,
+            active_checks_json TEXT NOT NULL,
+            inactive_checks_json TEXT NOT NULL,
+            created_at INTEGER NOT NULL
+        )
+        """
+    )
+
+
+def get_epoch_fingerprint_rotation(conn, epoch: int) -> dict:
+    ensure_epoch_fingerprint_rotation_table(conn)
+    previous_epoch_block_hash = get_previous_epoch_block_hash(conn, epoch)
+    active_checks = list(select_active_fingerprint_checks(previous_epoch_block_hash))
+    inactive_checks = [
+        name for name in RIP309_ROTATING_FINGERPRINT_CHECKS
+        if name not in active_checks
+    ]
+    measurement_nonce = derive_measurement_nonce(previous_epoch_block_hash)
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO epoch_fingerprint_rotation (
+            epoch, previous_epoch_block_hash, measurement_nonce,
+            active_checks_json, inactive_checks_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            epoch,
+            previous_epoch_block_hash,
+            measurement_nonce,
+            json.dumps(active_checks, sort_keys=True),
+            json.dumps(inactive_checks, sort_keys=True),
+            int(time.time()),
+        )
+    )
+    return {
+        "epoch": epoch,
+        "previous_epoch_block_hash": previous_epoch_block_hash,
+        "measurement_nonce": measurement_nonce,
+        "active_checks": active_checks,
+        "inactive_checks": inactive_checks,
+    }
+
+
+def evaluate_rotating_fingerprint_checks(conn, epoch: int, fingerprint: dict) -> dict:
+    rotation = get_epoch_fingerprint_rotation(conn, epoch)
+    checks = _fingerprint_checks_map(fingerprint)
+    active_results = {
+        name: _fingerprint_check_passed(checks.get(name))
+        for name in rotation["active_checks"]
+    }
+    passed_active = [name for name, passed in active_results.items() if passed]
+    failed_active = [name for name, passed in active_results.items() if not passed]
+    total_active = len(rotation["active_checks"])
+    active_ratio = (len(passed_active) / total_active) if total_active else 1.0
+    return {
+        **rotation,
+        "active_results": active_results,
+        "passed_active_checks": passed_active,
+        "failed_active_checks": failed_active,
+        "active_pass_count": len(passed_active),
+        "active_total": total_active,
+        "active_ratio": active_ratio,
+    }
 
 
 def _claimed_family_and_arch(device: dict) -> tuple:
@@ -3154,20 +3278,18 @@ def _submit_attestation_impl():
         family = verified_device["device_family"]
         arch_for_weight = verified_device["device_arch"]
         hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch_for_weight, HARDWARE_WEIGHTS.get(family, {}).get("default", 1.0))
-        
-        # VM miners get minimal weight
-        if not fingerprint_passed:
-            enroll_weight = 0.000000001
-        else:
-            enroll_weight = hw_weight
-
-        # Issue #19 temporal consistency only sets a review flag (no hard-fail).
-        if temporal_review.get("review_flag"):
-            app.logger.warning(f"[TEMPORAL-REVIEW] {miner[:20]}... flags={temporal_review.get('flags', [])}")
-        
         miner_id = data.get("miner_id", miner)
-        
+
         with sqlite3.connect(DB_PATH) as enroll_conn:
+            rotation_eval = evaluate_rotating_fingerprint_checks(
+                enroll_conn,
+                epoch,
+                fingerprint if isinstance(fingerprint, dict) else {},
+            )
+            if not fingerprint_passed:
+                enroll_weight = 0.000000001
+            else:
+                enroll_weight = hw_weight * rotation_eval["active_ratio"]
             enroll_conn.execute(
                 "INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
                 (miner,)
@@ -3185,8 +3307,21 @@ def _submit_attestation_impl():
                 (miner_id, miner)
             )
             enroll_conn.commit()
-        
-        app.logger.info(f"[AUTO-ENROLL] {miner[:20]}... enrolled epoch {epoch} weight={enroll_weight} family={family} arch={arch_for_weight} hw_weight={hw_weight}")
+
+        # Issue #19 temporal consistency only sets a review flag (no hard-fail).
+        if temporal_review.get("review_flag"):
+            app.logger.warning(f"[TEMPORAL-REVIEW] {miner[:20]}... flags={temporal_review.get('flags', [])}")
+
+        app.logger.info(
+            f"[RIP-309] epoch={epoch} miner={miner[:20]}... nonce={rotation_eval['measurement_nonce'][:16]} "
+            f"prev_hash={rotation_eval['previous_epoch_block_hash'][:16]} "
+            f"active={rotation_eval['active_checks']} passed={rotation_eval['passed_active_checks']} "
+            f"failed={rotation_eval['failed_active_checks']} ratio={rotation_eval['active_ratio']:.3f}"
+        )
+        app.logger.info(
+            f"[AUTO-ENROLL] {miner[:20]}... enrolled epoch {epoch} weight={enroll_weight} family={family} "
+            f"arch={arch_for_weight} hw_weight={hw_weight} active_ratio={rotation_eval['active_ratio']:.3f}"
+        )
     except Exception as e:
         app.logger.error(f"[AUTO-ENROLL] Error enrolling {miner[:20]}...: {e}")
 
@@ -3364,13 +3499,19 @@ def enroll_epoch():
     # RIP-PoA Phase 2: VM miners get minimal (but non-zero) weight
     # VMs can technically earn RTC, but it's economically pointless (1e-9 vs 1.0-2.5 for real hardware)
     fingerprint_failed = check_result.get('fingerprint_failed', False)
-    if fingerprint_failed:
-        weight = 0.000000001  # 9 zeros - technically earns, but ~1 billionth of real hardware
-        print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - VM weight: {weight}")
-    else:
-        weight = hw_weight
 
     with sqlite3.connect(DB_PATH) as c:
+        rotation_eval = evaluate_rotating_fingerprint_checks(
+            c,
+            epoch,
+            data.get('fingerprint') if isinstance(data.get('fingerprint'), dict) else {},
+        )
+        if fingerprint_failed:
+            weight = 0.000000001  # 9 zeros - technically earns, but ~1 billionth of real hardware
+            print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - VM weight: {weight}")
+        else:
+            weight = hw_weight * rotation_eval['active_ratio']
+
         # Ensure miner has balance entry
         c.execute(
             "INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
@@ -3396,6 +3537,13 @@ def enroll_epoch():
             (miner_id, miner_pk)
         )
 
+    app.logger.info(
+        f"[RIP-309] epoch={epoch} miner={miner_pk[:20]}... nonce={rotation_eval['measurement_nonce'][:16]} "
+        f"prev_hash={rotation_eval['previous_epoch_block_hash'][:16]} active={rotation_eval['active_checks']} "
+        f"passed={rotation_eval['passed_active_checks']} failed={rotation_eval['failed_active_checks']} "
+        f"ratio={rotation_eval['active_ratio']:.3f}"
+    )
+
     # RIP-0149: Track successful enrollment
     global ENROLL_OK
     ENROLL_OK += 1
@@ -3405,6 +3553,10 @@ def enroll_epoch():
         "epoch": epoch,
         "weight": weight,
         "hw_weight": hw_weight if 'hw_weight' in dir() else weight,
+        "measurement_nonce": rotation_eval['measurement_nonce'],
+        "active_fingerprint_checks": rotation_eval['active_checks'],
+        "active_fingerprint_pass_count": rotation_eval['active_pass_count'],
+        "active_fingerprint_total": rotation_eval['active_total'],
         "fingerprint_failed": fingerprint_failed if 'fingerprint_failed' in dir() else False,
         "miner_pk": miner_pk,
         "miner_id": miner_id

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1363,10 +1363,10 @@ def _fingerprint_check_data(fingerprint: dict, check_name: str) -> dict:
 RIP309_ROTATING_FINGERPRINT_CHECKS = (
     "clock_drift",
     "cache_timing",
-    "simd_identity",
+    "simd_bias",
     "thermal_drift",
     "instruction_jitter",
-    "device_age_oracle",
+    "anti_emulation",
 )
 RIP309_ACTIVE_FINGERPRINT_CHECKS = 4
 RIP309_NONCE_FALLBACK = "0" * 64

--- a/node/tests/test_rip309_fingerprint_rotation.py
+++ b/node/tests/test_rip309_fingerprint_rotation.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+import importlib.util
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = ROOT / "node"
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(NODE_DIR))
+
+os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+os.environ.setdefault("DB_PATH", ":memory:")
+
+
+def _load_module(module_name: str, file_name: str, aliases=()):
+    for alias in aliases:
+        if alias in sys.modules:
+            return sys.modules[alias]
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, str(NODE_DIR / file_name))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+rr_mod = _load_module("rr_mod_issue3008", "rip_200_round_robin_1cpu1vote.py", aliases=("rr_mod",))
+integrated_node = _load_module("integrated_node_issue3008", "rustchain_v2_integrated_v2.2.1_rip200.py", aliases=("integrated_node",))
+
+
+class TestRIP309FingerprintRotation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.conn = sqlite3.connect(self.db_path)
+        self.conn.executescript(
+            """
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER,
+                miner_pk TEXT,
+                weight REAL,
+                PRIMARY KEY (epoch, miner_pk)
+            );
+            CREATE TABLE miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                device_arch TEXT,
+                fingerprint_passed INTEGER DEFAULT 1,
+                entropy_score REAL DEFAULT 0,
+                ts_ok INTEGER,
+                warthog_bonus REAL DEFAULT 1.0
+            );
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT NOT NULL
+            );
+            """
+        )
+        integrated_node.ensure_epoch_fingerprint_rotation_table(self.conn)
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+        os.unlink(self.db_path)
+
+    def test_rotation_differs_across_epochs(self):
+        self.conn.execute("INSERT INTO blocks (height, block_hash) VALUES (?, ?)", (143, "a" * 64))
+        self.conn.execute("INSERT INTO blocks (height, block_hash) VALUES (?, ?)", (287, "b" * 64))
+        self.conn.commit()
+
+        epoch1 = integrated_node.get_epoch_fingerprint_rotation(self.conn, 1)
+        epoch2 = integrated_node.get_epoch_fingerprint_rotation(self.conn, 2)
+
+        self.assertEqual(len(epoch1["active_checks"]), 4)
+        self.assertEqual(len(epoch2["active_checks"]), 4)
+        self.assertNotEqual(epoch1["measurement_nonce"], epoch2["measurement_nonce"])
+        self.assertNotEqual(epoch1["active_checks"], epoch2["active_checks"])
+
+    def test_reward_calc_uses_epoch_snapshot_weight(self):
+        epoch = 3
+        current_slot = epoch * integrated_node.EPOCH_SLOTS + 5
+        self.conn.execute("INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)", (epoch, "rotated", 0.5))
+        self.conn.execute("INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)", (epoch, "full", 1.0))
+        self.conn.execute(
+            "INSERT INTO miner_attest_recent (miner, device_arch, fingerprint_passed, ts_ok) VALUES (?, ?, ?, ?)",
+            ("rotated", "g4", 1, integrated_node.GENESIS_TIMESTAMP),
+        )
+        self.conn.execute(
+            "INSERT INTO miner_attest_recent (miner, device_arch, fingerprint_passed, ts_ok) VALUES (?, ?, ?, ?)",
+            ("full", "g4", 1, integrated_node.GENESIS_TIMESTAMP),
+        )
+        self.conn.commit()
+
+        rewards = rr_mod.calculate_epoch_rewards_time_aged(
+            self.db_path,
+            epoch,
+            int(1.5 * 1_000_000),
+            current_slot,
+        )
+
+        self.assertEqual(sum(rewards.values()), int(1.5 * 1_000_000))
+        self.assertGreater(rewards["full"], rewards["rotated"])
+        ratio = rewards["full"] / rewards["rotated"]
+        self.assertGreater(ratio, 1.9)
+        self.assertLess(ratio, 2.1)
+
+    def test_rotation_eval_counts_only_active_checks(self):
+        self.conn.execute("INSERT INTO blocks (height, block_hash) VALUES (?, ?)", (143, "c" * 64))
+        self.conn.commit()
+        rotation = integrated_node.get_epoch_fingerprint_rotation(self.conn, 1)
+
+        fingerprint = {"checks": {name: {"passed": True, "data": {"ok": True}} for name in integrated_node.RIP309_ROTATING_FINGERPRINT_CHECKS}}
+        inactive = next(name for name in integrated_node.RIP309_ROTATING_FINGERPRINT_CHECKS if name not in rotation["active_checks"])
+        fingerprint["checks"][inactive] = {"passed": False, "data": {"ok": False}}
+
+        result = integrated_node.evaluate_rotating_fingerprint_checks(self.conn, 1, fingerprint)
+        self.assertEqual(result["active_pass_count"], 4)
+        self.assertEqual(result["active_total"], 4)
+        self.assertEqual(result["failed_active_checks"], [])
+        self.assertEqual(result["active_ratio"], 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR implements RIP-309 Phase 1 fingerprint check rotation for issue #3008.

### What changed
- Derive a deterministic measurement nonce from the previous epoch block hash
- Select 4 of 6 fingerprint checks per epoch using that nonce
- Keep all 6 checks runnable/loggable, but only count the active 4 toward reward weight
- Persist and log the active rotation set for auditability
- Propagate the rotated per-epoch weight snapshot into reward settlement
- Add focused test coverage for epoch rotation and reward weighting

### Tests
- `python3 -m pytest tests/test_epoch_settlement_formal.py node/tests/test_settlement_integrity.py node/tests/test_rip309_fingerprint_rotation.py -q`
- Result: `34 passed`

RTC wallet: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
