### PR TITLE
fix: add replay protection for utxo signed transfers

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -361,6 +361,8 @@ class UtxoDB:
         if own:
             conn = self._conn()
 
+        manage_tx = own or not conn.in_transaction
+
         ts = tx.get('timestamp', int(time.time()))
         # NOTE(issue #2085): spending_proof is present on each input dict but
         # is intentionally ignored by this layer.  It is stored for
@@ -381,7 +383,13 @@ class UtxoDB:
             return False
 
         try:
-            conn.execute("BEGIN IMMEDIATE")
+            if manage_tx:
+                conn.execute("BEGIN IMMEDIATE")
+
+            def abort() -> bool:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
 
             # -- reject duplicate input box_ids --------------------------------
             # Keyed on box_id alone (the PK of the UTXO being consumed).
@@ -392,8 +400,7 @@ class UtxoDB:
             # today, but only accidentally.  Defense in depth.
             input_box_ids = [i['box_id'] for i in inputs]
             if len(input_box_ids) != len(set(input_box_ids)):
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
 
             # -- validate inputs exist and are unspent -----------------------
             input_total = 0
@@ -404,11 +411,9 @@ class UtxoDB:
                     (inp['box_id'],),
                 ).fetchone()
                 if not row:
-                    conn.execute("ROLLBACK")
-                    return False
+                    return abort()
                 if row['spent_at'] is not None:
-                    conn.execute("ROLLBACK")
-                    return False
+                    return abort()
                 input_total += row['value_nrtc']
 
             # -- conservation check ------------------------------------------
@@ -416,16 +421,14 @@ class UtxoDB:
             # All other transactions must consume at least one input box.
             MINTING_TX_TYPES = {'mining_reward'}
             if not inputs and tx_type not in MINTING_TX_TYPES:
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
 
             # CRITICAL FIX: Reject empty outputs to prevent fund destruction
             # Without this check, outputs=[] bypasses conservation law:
             # output_total=0, fee=0 → (0+0) > input_total → False (bypassed)
             # Result: inputs spent, no outputs created → funds destroyed
             if not outputs and tx_type not in MINTING_TX_TYPES:
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
 
             output_total = sum(o['value_nrtc'] for o in outputs)
 
@@ -434,22 +437,18 @@ class UtxoDB:
             # letting an attacker create more value than the inputs hold.
             for o in outputs:
                 if not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
-                    conn.execute("ROLLBACK")
-                    return False
+                    return abort()
 
             # Cap minting (coinbase) output to prevent unbounded fund creation.
             # Without this, any caller that passes tx_type='mining_reward'
             # can mint arbitrary amounts.
             if tx_type in MINTING_TX_TYPES and output_total > MAX_COINBASE_OUTPUT_NRTC:
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
 
             if fee < 0:
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
             if inputs and (output_total + fee) > input_total:
-                conn.execute("ROLLBACK")
-                return False
+                return abort()
 
             # -- compute output box IDs and build tx_id ----------------------
             # We need a preliminary tx_id for box_id computation.
@@ -496,8 +495,7 @@ class UtxoDB:
                     (now, tx_id_hex, inp['box_id']),
                 ).rowcount
                 if updated != 1:
-                    conn.execute("ROLLBACK")
-                    return False
+                    return abort()
 
             # -- create outputs ----------------------------------------------
             for rec in output_records:
@@ -538,12 +536,14 @@ class UtxoDB:
                 ),
             )
 
-            conn.execute("COMMIT")
+            if manage_tx:
+                conn.execute("COMMIT")
             return True
 
         except Exception:
             try:
-                conn.execute("ROLLBACK")
+                if manage_tx:
+                    conn.execute("ROLLBACK")
             except Exception:
                 pass
             raise
@@ -684,7 +684,8 @@ class UtxoDB:
                     (inp['box_id'],),
                 ).fetchone()
                 if existing:
-                    conn.execute("ROLLBACK")
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
                     return False
 
                 # Check box exists and is unspent
@@ -694,7 +695,8 @@ class UtxoDB:
                     (inp['box_id'],),
                 ).fetchone()
                 if not box:
-                    conn.execute("ROLLBACK")
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
                     return False
 
             # -- conservation-of-value check ---------------------------------
@@ -702,13 +704,15 @@ class UtxoDB:
             # apply_transaction(), locking UTXOs until expiry (DoS vector).
             fee = tx.get('fee_nrtc', 0)
             if fee < 0:
-                conn.execute("ROLLBACK")
+                if manage_tx:
+                        conn.execute("ROLLBACK")
                 return False
 
             # MEDIUM FIX: Reject empty outputs to prevent DoS
             outputs = tx.get('outputs', [])
             if not outputs and tx_type not in MINTING_TX_TYPES:
-                conn.execute("ROLLBACK")
+                if manage_tx:
+                        conn.execute("ROLLBACK")
                 return False
 
             input_total = 0
@@ -729,12 +733,14 @@ class UtxoDB:
             for o in outputs:
                 val = o.get('value_nrtc')
                 if not isinstance(val, int) or val <= 0:
-                    conn.execute("ROLLBACK")
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
                     return False
 
             output_total = sum(o['value_nrtc'] for o in outputs)
             if input_total > 0 and (output_total + fee) > input_total:
-                conn.execute("ROLLBACK")
+                if manage_tx:
+                        conn.execute("ROLLBACK")
                 return False
 
             # Insert into mempool
@@ -766,7 +772,8 @@ class UtxoDB:
             return True
         except Exception:
             try:
-                conn.execute("ROLLBACK")
+                if manage_tx:
+                        conn.execute("ROLLBACK")
             except Exception:
                 pass
             return False

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -18,6 +18,7 @@ Endpoints:
 
 import hashlib
 import json
+import logging
 import sqlite3
 import time
 
@@ -41,6 +42,35 @@ _current_slot_fn = None    # current_slot() -> int
 _dual_write: bool = False
 
 
+def _ensure_transfer_nonce_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS transfer_nonces (
+            from_address TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            used_at INTEGER NOT NULL,
+            PRIMARY KEY (from_address, nonce)
+        )
+        """
+    )
+
+
+
+def _reserve_transfer_nonce(conn: sqlite3.Connection, from_address: str, nonce) -> bool:
+    """Atomically reserve a signed-transfer nonce for replay protection.
+
+    Returns True if the nonce was newly reserved, False if it was already used.
+    The caller is responsible for committing or rolling back the surrounding
+    transaction so failed transfers do not burn the nonce.
+    """
+    _ensure_transfer_nonce_table(conn)
+    conn.execute(
+        "INSERT OR IGNORE INTO transfer_nonces (from_address, nonce, used_at) VALUES (?, ?, ?)",
+        (from_address, str(nonce), int(time.time())),
+    )
+    return conn.execute("SELECT changes()").fetchone()[0] == 1
+
+
 def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
                             verify_sig_fn, addr_from_pk_fn,
                             current_slot_fn, dual_write: bool = False):
@@ -57,6 +87,13 @@ def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
     _addr_from_pk_fn = addr_from_pk_fn
     _current_slot_fn = current_slot_fn
     _dual_write = dual_write
+
+    conn = sqlite3.connect(db_path)
+    try:
+        _ensure_transfer_nonce_table(conn)
+        conn.commit()
+    finally:
+        conn.close()
 
     app.register_blueprint(utxo_bp)
     print(f"[UTXO] Endpoints registered at /utxo/* (dual_write={'ON' if dual_write else 'OFF'})")
@@ -339,9 +376,33 @@ def utxo_transfer():
         'timestamp': int(time.time()),
     }
 
-    ok = _utxo_db.apply_transaction(tx, block_height)
-    if not ok:
-        return jsonify({'error': 'UTXO transaction failed (race condition or validation)'}), 500
+    conn = sqlite3.connect(_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+
+        if not _reserve_transfer_nonce(conn, from_address, nonce):
+            conn.rollback()
+            return jsonify({
+                'error': 'Nonce already used (replay attack detected)',
+                'code': 'REPLAY_DETECTED',
+                'nonce': str(nonce),
+            }), 400
+
+        ok = _utxo_db.apply_transaction(tx, block_height, conn=conn)
+        if not ok:
+            conn.rollback()
+            return jsonify({'error': 'UTXO transaction failed (race condition or validation)'}), 500
+
+        conn.commit()
+    except Exception:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        raise
+    finally:
+        conn.close()
 
     # --- dual-write to account model ----------------------------------------
 

--- a/tests/test_utxo_transfer_replay.py
+++ b/tests/test_utxo_transfer_replay.py
@@ -1,0 +1,134 @@
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from flask import Flask
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "node"))
+
+from utxo_db import UtxoDB, UNIT
+from utxo_endpoints import register_utxo_blueprint
+
+
+def mock_verify_sig(pubkey_hex, message, sig_hex):
+    return True
+
+
+def mock_addr_from_pk(pubkey_hex):
+    return f"RTC_test_{pubkey_hex[:8]}"
+
+
+def mock_current_slot():
+    return 100
+
+
+def build_client():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)"
+    )
+    conn.commit()
+    conn.close()
+
+    utxo_db = UtxoDB(db_path)
+    utxo_db.init_tables()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_utxo_blueprint(
+        app,
+        utxo_db,
+        db_path,
+        verify_sig_fn=mock_verify_sig,
+        addr_from_pk_fn=mock_addr_from_pk,
+        current_slot_fn=mock_current_slot,
+        dual_write=False,
+    )
+
+    return app.test_client(), utxo_db, db_path
+
+
+def seed_coinbase(utxo_db, address, value_nrtc, height=1):
+    ok = utxo_db.apply_transaction(
+        {
+            "tx_type": "mining_reward",
+            "inputs": [],
+            "outputs": [{"address": address, "value_nrtc": value_nrtc}],
+            "timestamp": int(time.time()),
+            "_allow_minting": True,
+        },
+        block_height=height,
+    )
+    assert ok is True
+
+
+def payload(nonce=1733420000000, amount_rtc=10.0):
+    return {
+        "from_address": "RTC_test_aabbccdd",
+        "to_address": "bob",
+        "amount_rtc": amount_rtc,
+        "public_key": "aabbccdd" * 8,
+        "signature": "sig" * 22,
+        "nonce": nonce,
+        "memo": "replay-test",
+    }
+
+
+def test_utxo_transfer_rejects_duplicate_nonce():
+    client, utxo_db, db_path = build_client()
+    try:
+        seed_coinbase(utxo_db, "RTC_test_aabbccdd", 100 * UNIT)
+
+        first = client.post("/utxo/transfer", json=payload())
+        assert first.status_code == 200
+        assert first.get_json()["ok"] is True
+
+        second = client.post("/utxo/transfer", json=payload())
+        assert second.status_code == 400
+        body = second.get_json()
+        assert body["code"] == "REPLAY_DETECTED"
+        assert "Nonce already used" in body["error"]
+
+        assert utxo_db.get_balance("bob") == 10 * UNIT
+
+        with sqlite3.connect(db_path) as conn:
+            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
+
+        assert nonce_count == 1
+    finally:
+        os.unlink(db_path)
+
+
+def test_utxo_transfer_failed_attempt_does_not_burn_nonce():
+    client, utxo_db, db_path = build_client()
+    try:
+        seed_coinbase(utxo_db, "RTC_test_aabbccdd", 5 * UNIT)
+        req = payload(nonce=1733420009999, amount_rtc=10.0)
+
+        rejected = client.post("/utxo/transfer", json=req)
+        assert rejected.status_code == 400
+        assert rejected.get_json()["error"] == "Insufficient UTXO balance"
+
+        with sqlite3.connect(db_path) as conn:
+            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
+        assert nonce_count == 0
+
+        seed_coinbase(utxo_db, "RTC_test_aabbccdd", 20 * UNIT, height=2)
+        accepted = client.post("/utxo/transfer", json=req)
+        assert accepted.status_code == 200
+        assert accepted.get_json()["ok"] is True
+
+        with sqlite3.connect(db_path) as conn:
+            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
+        assert nonce_count == 1
+        assert utxo_db.get_balance("bob") == 10 * UNIT
+    finally:
+        os.unlink(db_path)


### PR DESCRIPTION
## Summary

This PR fixes a replay issue in `POST /utxo/transfer` where the endpoint verified a signed `nonce` but did not persist or enforce one-time nonce use before applying the UTXO spend.

### Impact
A previously valid signed `/utxo/transfer` payload could be replayed multiple times. Because the endpoint performs server-side coin selection after signature verification, repeated submissions could consume fresh UTXOs from the same sender until funds were exhausted.

### Fix
- add durable `(from_address, nonce)` replay protection for `/utxo/transfer`
- reserve nonce usage with `INSERT OR IGNORE`
- make nonce reservation and UTXO spend share the same SQLite transaction
- roll back nonce reservation when transfer application fails, so failed attempts do not burn the nonce
- return `REPLAY_DETECTED` on duplicate nonce reuse

### Tests
- `python3 -m pytest tests/test_utxo_transfer_replay.py -q`
- Result: `2 passed`

RTC wallet: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
