### PR TITLE
feat: add RIP-309 phase 2 observation window jitter

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -48,7 +48,7 @@ except ImportError:
         print("[WARN] utxo_db.py not found but UTXO_DUAL_WRITE=1 — disabling")
         UTXO_DUAL_WRITE = False
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Mapping, Optional, Tuple
 from hashlib import blake2b
 
 # RIP-201: Fleet Detection Immune System
@@ -938,6 +938,111 @@ GENESIS_TIMESTAMP = 1764706927  # First actual block (Dec 2, 2025)
 EPOCH_SLOTS = 144  # 24 hours at 10-min blocks
 PER_EPOCH_RTC = 1.5  # Total RTC distributed per epoch across all miners
 PER_BLOCK_RTC = PER_EPOCH_RTC / EPOCH_SLOTS  # ~0.0104 RTC per block
+
+# RIP-309 Phase 2: deterministic continuity audit observation window.
+# Keep these helpers in this file instead of a separate module because the
+# repo's test/runtime loaders mix direct file loading, root-level imports, and
+# node/ path injection. Inlining avoids brittle clean-clone import failures.
+CONTINUITY_GENESIS_FALLBACK_DOMAIN = "rip309_continuity_genesis"
+CONTINUITY_WINDOW_MIN_HOURS = 6
+CONTINUITY_WINDOW_MAX_HOURS = 168
+CONTINUITY_WINDOW_RANGE_HOURS = (
+    CONTINUITY_WINDOW_MAX_HOURS - CONTINUITY_WINDOW_MIN_HOURS + 1
+)
+
+
+def derive_epoch_nonce(previous_epoch_digest: str) -> bytes:
+    """Derive deterministic epoch nonce bytes from prior-epoch entropy."""
+    digest = str(previous_epoch_digest or "").strip().lower()
+    if not digest:
+        digest = hashlib.sha256(
+            CONTINUITY_GENESIS_FALLBACK_DOMAIN.encode("utf-8")
+        ).hexdigest()
+    return hashlib.sha256(f"rip309:epoch_nonce:{digest}".encode("utf-8")).digest()
+
+
+def get_observation_window_hours(epoch_nonce: bytes) -> int:
+    """Map nonce bytes into the RIP-309 Phase 2 observation window range."""
+    if not isinstance(epoch_nonce, (bytes, bytearray)) or len(epoch_nonce) == 0:
+        raise ValueError("epoch_nonce must be non-empty bytes")
+    value = int.from_bytes(epoch_nonce[:8], "big", signed=False)
+    return CONTINUITY_WINDOW_MIN_HOURS + (value % CONTINUITY_WINDOW_RANGE_HOURS)
+
+
+def _stable_terminal_header_payload(row: Mapping[str, Any]) -> bytes:
+    payload = {
+        "slot": int(row.get("slot") or 0),
+        "miner_id": str(row.get("miner_id") or ""),
+        "message_hex": str(row.get("message_hex") or ""),
+        "signature_hex": str(row.get("signature_hex") or ""),
+        "pubkey_hex": str(row.get("pubkey_hex") or ""),
+        "header_json": str(row.get("header_json") or ""),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def continuity_terminal_header_digest(row: Optional[Mapping[str, Any]]) -> str:
+    if not row:
+        return hashlib.sha256(
+            CONTINUITY_GENESIS_FALLBACK_DOMAIN.encode("utf-8")
+        ).hexdigest()
+    return hashlib.sha256(_stable_terminal_header_payload(row)).hexdigest()
+
+
+def _fetch_previous_epoch_terminal_header(conn: sqlite3.Connection, epoch: int) -> Optional[Dict[str, Any]]:
+    prev_epoch = int(epoch) - 1
+    if prev_epoch < 0:
+        return None
+
+    start_slot = prev_epoch * EPOCH_SLOTS
+    end_slot = start_slot + EPOCH_SLOTS - 1
+    original_row_factory = conn.row_factory
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            """
+            SELECT slot, miner_id, message_hex, signature_hex, pubkey_hex, header_json
+            FROM headers
+            WHERE slot >= ? AND slot <= ?
+            ORDER BY slot DESC
+            LIMIT 1
+            """,
+            (start_slot, end_slot),
+        ).fetchone()
+    except sqlite3.Error:
+        row = None
+    finally:
+        conn.row_factory = original_row_factory
+
+    if not row:
+        return None
+    if isinstance(row, Mapping):
+        return dict(row)
+    if hasattr(row, "keys"):
+        return {key: row[key] for key in row.keys()}
+    return None
+
+
+def get_continuity_audit_window(conn: sqlite3.Connection, epoch: int, epoch_start_ts: int) -> Dict[str, Any]:
+    terminal_header = _fetch_previous_epoch_terminal_header(conn, epoch)
+    previous_epoch_digest = continuity_terminal_header_digest(terminal_header)
+    epoch_nonce = derive_epoch_nonce(previous_epoch_digest)
+    window_hours = get_observation_window_hours(epoch_nonce)
+    window_seconds = int(window_hours * 3600)
+
+    return {
+        "epoch": int(epoch),
+        "nonce": epoch_nonce.hex(),
+        "window_hours": int(window_hours),
+        "window_seconds": window_seconds,
+        "window_starts_at": int(epoch_start_ts),
+        "window_ends_at": int(epoch_start_ts + window_seconds),
+        "window_anchor": "epoch_start",
+        "previous_epoch_terminal_slot": terminal_header.get("slot") if terminal_header else None,
+        "previous_epoch_terminal_digest": previous_epoch_digest,
+        "digest_source": "terminal_header" if terminal_header else "genesis_fallback",
+        "scheduler_ready": True,
+    }
 TOTAL_SUPPLY_RTC = 8_388_608  # Exactly 2**23 — pure binary, immutable
 TOTAL_SUPPLY_URTC = int(TOTAL_SUPPLY_RTC * 1_000_000)  # 8,388,608,000,000 uRTC
 ENFORCE = False  # Start with enforcement off
@@ -3232,12 +3337,14 @@ def get_epoch():
     slot = current_slot()
     epoch = slot_to_epoch(slot)
     epoch_gauge.set(epoch)
+    epoch_start_ts = GENESIS_TIMESTAMP + (epoch * EPOCH_SLOTS * BLOCK_TIME)
 
     with sqlite3.connect(DB_PATH) as c:
         enrolled = c.execute(
             "SELECT COUNT(*) FROM epoch_enroll WHERE epoch = ?",
             (epoch,)
         ).fetchone()[0]
+        continuity_audit = get_continuity_audit_window(c, epoch, epoch_start_ts)
 
     return jsonify({
         "epoch": epoch,
@@ -3245,7 +3352,8 @@ def get_epoch():
         "epoch_pot": PER_EPOCH_RTC,
         "enrolled_miners": enrolled,
         "blocks_per_epoch": EPOCH_SLOTS,
-        "total_supply_rtc": TOTAL_SUPPLY_RTC
+        "total_supply_rtc": TOTAL_SUPPLY_RTC,
+        "continuity_audit": continuity_audit,
     })
 
 @app.route('/epoch/enroll', methods=['POST'])

--- a/node/tests/test_continuity_audit_phase2.py
+++ b/node/tests/test_continuity_audit_phase2.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+HEADER_SCHEMA = """
+CREATE TABLE IF NOT EXISTS headers(
+    slot INTEGER PRIMARY KEY,
+    miner_id TEXT,
+    message_hex TEXT,
+    signature_hex TEXT,
+    pubkey_hex TEXT,
+    header_json TEXT
+)
+"""
+
+EPOCH_ENROLL_SCHEMA = """
+CREATE TABLE IF NOT EXISTS epoch_enroll(
+    epoch INTEGER,
+    miner_pk TEXT,
+    weight REAL,
+    PRIMARY KEY (epoch, miner_pk)
+)
+"""
+
+
+class TestContinuityAuditPhase2(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._db_path = str(Path(cls._tmp.name) / "rip309_phase2.db")
+        os.environ["RC_ADMIN_KEY"] = "0" * 32
+        os.environ["RUSTCHAIN_DB_PATH"] = cls._db_path
+
+        if "integrated_node" in sys.modules:
+            cls.mod = sys.modules["integrated_node"]
+            cls.mod.DB_PATH = cls._db_path
+        else:
+            spec = importlib.util.spec_from_file_location("rustchain_rip309_phase2", MODULE_PATH)
+            cls.mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(cls.mod)
+            cls.mod.DB_PATH = cls._db_path
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        with sqlite3.connect(self._db_path) as conn:
+            conn.execute("DROP TABLE IF EXISTS headers")
+            conn.execute("DROP TABLE IF EXISTS epoch_enroll")
+            conn.execute(HEADER_SCHEMA)
+            conn.execute(EPOCH_ENROLL_SCHEMA)
+            conn.commit()
+
+    def test_nonce_and_window_are_deterministic_and_in_range(self):
+        mod = self.mod
+        prev_digest = mod.hashlib.sha256(b"epoch-42-terminal-header").hexdigest()
+
+        nonce_a = mod.derive_epoch_nonce(prev_digest)
+        nonce_b = mod.derive_epoch_nonce(prev_digest)
+        self.assertEqual(nonce_a, nonce_b)
+
+        hours = mod.get_observation_window_hours(nonce_a)
+        self.assertGreaterEqual(hours, 6)
+        self.assertLessEqual(hours, 168)
+
+    def test_window_uses_previous_epoch_terminal_header(self):
+        mod = self.mod
+        db_path = self._db_path
+        prev_epoch = 4
+        terminal_slot = (prev_epoch + 1) * mod.EPOCH_SLOTS - 1
+        current_epoch = prev_epoch + 1
+        epoch_start_ts = mod.GENESIS_TIMESTAMP + (current_epoch * mod.EPOCH_SLOTS * mod.BLOCK_TIME)
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO headers(slot, miner_id, message_hex, signature_hex, pubkey_hex, header_json) VALUES (?, ?, ?, ?, ?, ?)",
+                (terminal_slot, "miner-a", "aa11", "bb22", "cc33", '{"slot": 719}')
+            )
+            conn.execute(
+                "INSERT INTO headers(slot, miner_id, message_hex, signature_hex, pubkey_hex, header_json) VALUES (?, ?, ?, ?, ?, ?)",
+                (terminal_slot - 1, "miner-b", "older", "sig", "pk", '{"slot": 718}')
+            )
+            conn.commit()
+            audit = mod.get_continuity_audit_window(conn, current_epoch, epoch_start_ts)
+
+        self.assertEqual(audit["previous_epoch_terminal_slot"], terminal_slot)
+        self.assertEqual(audit["digest_source"], "terminal_header")
+        self.assertEqual(audit["window_starts_at"], epoch_start_ts)
+        self.assertEqual(audit["window_ends_at"], epoch_start_ts + audit["window_seconds"])
+        self.assertGreaterEqual(audit["window_hours"], 6)
+        self.assertLessEqual(audit["window_hours"], 168)
+
+    def test_epoch_endpoint_exposes_live_continuity_audit_payload(self):
+        mod = self.mod
+        db_path = self._db_path
+        slot = 5 * mod.EPOCH_SLOTS
+        epoch = 5
+        previous_terminal_slot = slot - 1
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                "INSERT INTO headers(slot, miner_id, message_hex, signature_hex, pubkey_hex, header_json) VALUES (?, ?, ?, ?, ?, ?)",
+                (previous_terminal_slot, "miner-live", "abc", "def", "ghi", '{"slot": 719}')
+            )
+            conn.execute(
+                "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                (epoch, "RTC_TEST_MINER", 1.0)
+            )
+            conn.commit()
+
+        original_current_slot = mod.current_slot
+        try:
+            mod.current_slot = lambda: slot
+            with mod.app.test_request_context("/epoch", method="GET"):
+                payload = mod.get_epoch().get_json()
+        finally:
+            mod.current_slot = original_current_slot
+
+        audit = payload["continuity_audit"]
+        self.assertEqual(payload["epoch"], epoch)
+        self.assertEqual(payload["enrolled_miners"], 1)
+        self.assertEqual(audit["previous_epoch_terminal_slot"], previous_terminal_slot)
+        self.assertEqual(audit["window_anchor"], "epoch_start")
+        self.assertEqual(audit["digest_source"], "terminal_header")
+        self.assertGreaterEqual(audit["window_hours"], 6)
+        self.assertLessEqual(audit["window_hours"], 168)
+        self.assertEqual(audit["window_seconds"], audit["window_hours"] * 3600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a pragmatic first-pass implementation of RIP-309 Phase 2: observation window jitter.

### What changed
- derive a deterministic continuity audit window from previous-epoch chain state
- keep the window within the RIP-309 spec range of 6 to 168 hours
- expose live `continuity_audit` metadata from `/epoch`
- add targeted Phase 2 tests while preserving existing `/epoch` API behavior

### Important implementation note
The current repo does **not** have a dedicated live continuity audit scheduler wired into the node path. Because of that, this PR implements the Phase 2 scheduling substrate and live integration point rather than a full background scheduler daemon.

To keep this stable in the repo's clean-clone test environment, the continuity-audit derivation logic is inlined into the production node file rather than split into a new helper module.

The derivation is still:
- deterministic,
- unpredictable before the previous epoch closes,
- verifiable after the epoch starts.

### Tests
- `python3 -m pytest -q node/tests/test_continuity_audit_phase2.py tests/test_api.py`
- Result: `10 passed`

RTC wallet: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
