### PR TITLE
feat: add RIP-309 phase 4 challenge rotation substrate

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -21,6 +21,23 @@ except ImportError:
     def jsonify(obj):
         return obj
 
+try:
+    from rip_309_measurement_rotation import get_epoch_challenge_plan
+    HAVE_RIP309_CHALLENGE_ROTATION = True
+except ImportError:
+    try:
+        from node.rip_309_measurement_rotation import get_epoch_challenge_plan
+        HAVE_RIP309_CHALLENGE_ROTATION = True
+    except ImportError:
+        HAVE_RIP309_CHALLENGE_ROTATION = False
+
+        def get_epoch_challenge_plan(prev_block_hash, epoch):
+            return {
+                "epoch": epoch,
+                "error": "rip309_challenge_rotation_not_available",
+                "prev_block_hash": prev_block_hash,
+            }
+
 # Import RIP-200 functions
 try:
     # Normal case: this module is imported/run from the RustChain repo where
@@ -380,6 +397,39 @@ def register_rewards_rip200(app, DB_PATH):
             "rotation_size": len(attested_miners),
             "attested_miners": miners_info,
             "chain_age_years": round(chain_age, 2)
+        })
+
+    @app.route('/rip309/challenge_plan', methods=['GET'])
+    def rip309_challenge_plan():
+        """Expose deterministic RIP-309 Phase 4 challenge rotation for inspection."""
+        if not HAVE_RIP309_CHALLENGE_ROTATION:
+            return jsonify({"ok": False, "error": "rip309_challenge_rotation_not_available"}), 503
+
+        epoch_param = request.args.get('epoch')
+        prev_block_hash = (request.args.get('prev_block_hash') or '').strip()
+
+        if not epoch_param:
+            return jsonify({"ok": False, "error": "epoch required"}), 400
+        if not prev_block_hash:
+            return jsonify({"ok": False, "error": "prev_block_hash required"}), 400
+
+        try:
+            epoch = int(epoch_param)
+        except (TypeError, ValueError):
+            return jsonify({"ok": False, "error": "epoch must be an integer"}), 400
+
+        try:
+            plan = get_epoch_challenge_plan(prev_block_hash, epoch)
+        except ValueError as e:
+            return jsonify({"ok": False, "error": f"invalid prev_block_hash: {e}"}), 400
+        except Exception as e:
+            return jsonify({"ok": False, "error": f"challenge plan generation failed: {e}"}), 500
+
+        return jsonify({
+            "ok": True,
+            "epoch": epoch,
+            "prev_block_hash": prev_block_hash,
+            "challenge_plan": plan,
         })
 
     print("[RIP-200] Round-robin consensus endpoints registered")

--- a/node/rip_309_measurement_rotation.py
+++ b/node/rip_309_measurement_rotation.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+RIP-309: Rotating Measurement Freshness
+========================================
+
+Anti-Goodhart mechanism for hardware fingerprint and behavioral trust scoring.
+Each epoch, a deterministic nonce derived from the previous block hash selects
+which measurements are active. All measurements run; only the active subset
+counts toward rewards.
+
+Phase 4 extension in this file:
+- deterministic challenge rotation across layers from the RIP-309 nonce
+- challenge plan generation for:
+  * timing challenge (substrate)
+  * continuity challenge (memory / continuity)
+  * coordination challenge (distinctness / coordination)
+
+This module intentionally provides challenge planning + observability, not a
+pretend challenge-response executor.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import random
+import sqlite3
+import time
+from dataclasses import asdict, dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# All 6 fingerprint check names (must match fingerprint_checks.py)
+ALL_FP_CHECKS = [
+    "clock_drift",
+    "cache_timing",
+    "simd_identity",
+    "thermal_drift",
+    "instruction_jitter",
+    "anti_emulation",
+]
+
+# How many checks are active per epoch
+ACTIVE_FP_COUNT = 4
+
+# Weighted decay factor for EMA (exponential moving average)
+# 0.95 means each epoch is worth 95% of the previous one
+# ~14 epochs (2.3 hours) half-life; ~46 epochs (7.7 hours) to 10% weight
+EMA_DECAY = 0.95
+
+# Spike detection: if a miner's epoch score deviates from their rolling
+# average by more than this many standard deviations, flag it
+SPIKE_THRESHOLD_SIGMA = 2.5
+
+# Minimum epochs before spike detection activates (need enough history)
+SPIKE_MIN_HISTORY = 10
+
+# Observation window modes (bimodal, not uniform)
+# Fast mode catches sudden changes; slow mode catches gradual drift
+WINDOW_FAST_RANGE = (6, 24)    # hours
+WINDOW_SLOW_RANGE = (72, 168)  # hours
+WINDOW_FAST_PROBABILITY = 0.6  # 60% chance of fast window
+
+CHALLENGE_TYPES = [
+    "timing_challenge",
+    "continuity_challenge",
+    "coordination_challenge",
+]
+
+CHALLENGE_LAYER_MAP = {
+    "timing_challenge": "substrate",
+    "continuity_challenge": "memory_continuity",
+    "coordination_challenge": "distinctness_coordination",
+}
+
+TIMING_PROBES = [
+    "clock_drift",
+    "cache_timing",
+    "instruction_jitter",
+    "thermal_drift",
+]
+
+CONTINUITY_MODALITIES = [
+    "memory_anchor_recall",
+    "state_sequence_replay",
+    "uptime_window_consistency",
+    "attestation_chain_gap_check",
+]
+
+COORDINATION_MODALITIES = [
+    "distinct_response_window",
+    "peer_order_divergence",
+    "multi_agent_nonce_partition",
+    "cohort_separation_check",
+]
+
+
+@dataclass(frozen=True)
+class ChallengeSpec:
+    challenge_type: str
+    layer: str
+    seed: str
+    interval_slots: int
+    offset_slots: int
+    timeout_seconds: int
+    parameters: Dict[str, object]
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def derive_epoch_nonce(prev_block_hash: str) -> bytes:
+    """
+    Derive a measurement nonce for this epoch from the previous block hash.
+
+    The nonce is unpredictable before the block is produced but verifiable after.
+    """
+    if not prev_block_hash:
+        logger.warning("RIP-309: No prev_block_hash, using genesis fallback nonce")
+        return hashlib.sha256(b"rip309_genesis_fallback").digest()
+
+    return hashlib.sha256(
+        bytes.fromhex(prev_block_hash) + b"rip309_measurement_nonce"
+    ).digest()
+
+
+def _derive_stream(nonce: bytes, label: str) -> bytes:
+    return hashlib.sha256(nonce + label.encode("utf-8")).digest()
+
+
+def _rng_from_stream(nonce: bytes, label: str) -> random.Random:
+    seed = int.from_bytes(_derive_stream(nonce, label)[:8], "big")
+    return random.Random(seed)
+
+
+def get_active_fp_checks(nonce: bytes) -> List[str]:
+    """Select which 4-of-6 fingerprint checks are active this epoch."""
+    rng = _rng_from_stream(nonce, "active_fingerprint_checks")
+    active = rng.sample(ALL_FP_CHECKS, ACTIVE_FP_COUNT)
+    return sorted(active)
+
+
+def get_observation_window_hours(nonce: bytes) -> int:
+    """Determine the observation window for this epoch (bimodal distribution)."""
+    rng = _rng_from_stream(nonce, "observation_window_hours")
+    if rng.random() < WINDOW_FAST_PROBABILITY:
+        return rng.randint(*WINDOW_FAST_RANGE)
+    return rng.randint(*WINDOW_SLOW_RANGE)
+
+
+def evaluate_fingerprint_rotation(
+    fingerprint_data: dict,
+    active_checks: List[str],
+) -> Tuple[bool, int, int]:
+    """Evaluate a miner's fingerprint against the active check subset."""
+    checks = fingerprint_data.get("checks", {})
+    active_passed = 0
+    active_total = len(active_checks)
+
+    for check_name in active_checks:
+        check_result = checks.get(check_name, {})
+        if check_result.get("passed", False):
+            active_passed += 1
+
+    passed = active_passed == active_total
+    return passed, active_passed, active_total
+
+
+def compute_ema_score(
+    epoch_scores: List[Tuple[int, float]],
+    current_epoch: int,
+    decay: float = EMA_DECAY,
+) -> float:
+    """Compute exponential moving average trust score across epochs."""
+    if not epoch_scores:
+        return 0.0
+
+    weighted_sum = 0.0
+    weight_sum = 0.0
+
+    for epoch_num, score in epoch_scores:
+        age = current_epoch - epoch_num
+        if age < 0:
+            continue
+        w = decay ** age
+        weighted_sum += score * w
+        weight_sum += w
+
+    if weight_sum == 0:
+        return 0.0
+
+    return weighted_sum / weight_sum
+
+
+def detect_score_spike(
+    epoch_scores: List[Tuple[int, float]],
+    current_epoch: int,
+    current_score: float,
+    threshold_sigma: float = SPIKE_THRESHOLD_SIGMA,
+    min_history: int = SPIKE_MIN_HISTORY,
+) -> Tuple[bool, Optional[float]]:
+    """Detect sudden behavioral shift after an honest streak."""
+    recent = [(e, s) for e, s in epoch_scores if current_epoch - e <= 50]
+
+    if len(recent) < min_history:
+        return False, None
+
+    scores = [s for _, s in recent]
+    mean = sum(scores) / len(scores)
+    variance = sum((s - mean) ** 2 for s in scores) / len(scores)
+
+    if variance == 0:
+        if current_score != mean:
+            return True, float("inf")
+        return False, 0.0
+
+    std_dev = variance ** 0.5
+    z_score = (current_score - mean) / std_dev
+
+    is_spike = abs(z_score) > threshold_sigma
+    return is_spike, z_score
+
+
+def _choose(rng: random.Random, items: Sequence[str]) -> str:
+    return items[rng.randrange(len(items))]
+
+
+def build_timing_challenge(nonce: bytes, epoch: int) -> ChallengeSpec:
+    rng = _rng_from_stream(nonce, f"timing:{epoch}")
+    return ChallengeSpec(
+        challenge_type="timing_challenge",
+        layer=CHALLENGE_LAYER_MAP["timing_challenge"],
+        seed=_derive_stream(nonce, f"timing-seed:{epoch}").hex(),
+        interval_slots=rng.randint(3, 11),
+        offset_slots=rng.randint(0, 2),
+        timeout_seconds=rng.randint(20, 90),
+        parameters={
+            "probe": _choose(rng, TIMING_PROBES),
+            "sample_count": rng.randint(8, 32),
+            "burst_count": rng.randint(2, 6),
+            "jitter_budget_ms": rng.randint(15, 180),
+        },
+    )
+
+
+def build_continuity_challenge(nonce: bytes, epoch: int) -> ChallengeSpec:
+    rng = _rng_from_stream(nonce, f"continuity:{epoch}")
+    return ChallengeSpec(
+        challenge_type="continuity_challenge",
+        layer=CHALLENGE_LAYER_MAP["continuity_challenge"],
+        seed=_derive_stream(nonce, f"continuity-seed:{epoch}").hex(),
+        interval_slots=rng.randint(6, 18),
+        offset_slots=rng.randint(0, 5),
+        timeout_seconds=rng.randint(45, 240),
+        parameters={
+            "mode": _choose(rng, CONTINUITY_MODALITIES),
+            "required_depth": rng.randint(2, 6),
+            "lookback_epochs": rng.randint(1, 5),
+            "anchor_count": rng.randint(1, 4),
+        },
+    )
+
+
+def build_coordination_challenge(nonce: bytes, epoch: int) -> ChallengeSpec:
+    rng = _rng_from_stream(nonce, f"coordination:{epoch}")
+    return ChallengeSpec(
+        challenge_type="coordination_challenge",
+        layer=CHALLENGE_LAYER_MAP["coordination_challenge"],
+        seed=_derive_stream(nonce, f"coordination-seed:{epoch}").hex(),
+        interval_slots=rng.randint(9, 27),
+        offset_slots=rng.randint(0, 8),
+        timeout_seconds=rng.randint(60, 300),
+        parameters={
+            "mode": _choose(rng, COORDINATION_MODALITIES),
+            "cohort_size": rng.randint(2, 7),
+            "distinctness_threshold": round(rng.uniform(0.55, 0.95), 3),
+            "response_window_seconds": rng.randint(20, 120),
+        },
+    )
+
+
+def get_epoch_challenge_plan(prev_block_hash: str, epoch: int) -> Dict:
+    """
+    Build the deterministic Phase 4 challenge plan for an epoch.
+
+    This is intentionally a planning/observability layer, not a challenge
+    fulfillment/execution layer.
+    """
+    nonce = derive_epoch_nonce(prev_block_hash)
+    challenges = [
+        build_timing_challenge(nonce, epoch),
+        build_continuity_challenge(nonce, epoch),
+        build_coordination_challenge(nonce, epoch),
+    ]
+
+    challenge_order_rng = _rng_from_stream(nonce, f"challenge-order:{epoch}")
+    challenges = list(challenges)
+    challenge_order_rng.shuffle(challenges)
+
+    return {
+        "epoch": epoch,
+        "nonce": nonce.hex(),
+        "challenge_rotation_version": 1,
+        "challenge_count": len(challenges),
+        "active_challenges": [challenge.to_dict() for challenge in challenges],
+        "layers_covered": [challenge.layer for challenge in challenges],
+    }
+
+
+def persist_epoch_challenge_plan(
+    db_path: str,
+    prev_block_hash: str,
+    epoch: int,
+) -> Dict:
+    """Persist the deterministic challenge plan for auditability."""
+    plan = get_epoch_challenge_plan(prev_block_hash, epoch)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS rip309_epoch_challenges (
+                epoch INTEGER PRIMARY KEY,
+                prev_block_hash TEXT,
+                nonce TEXT NOT NULL,
+                challenge_plan_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO rip309_epoch_challenges (
+                epoch, prev_block_hash, nonce, challenge_plan_json
+            ) VALUES (?, ?, ?, ?)
+            """,
+            (epoch, prev_block_hash, plan["nonce"], json.dumps(plan, sort_keys=True)),
+        )
+        conn.commit()
+
+    return plan
+
+
+def get_epoch_measurement_config(
+    prev_block_hash: str,
+    epoch: int,
+) -> Dict:
+    """Get the complete measurement + challenge configuration for an epoch."""
+    nonce = derive_epoch_nonce(prev_block_hash)
+    active_fp = get_active_fp_checks(nonce)
+    window_hours = get_observation_window_hours(nonce)
+    challenge_rotation = get_epoch_challenge_plan(prev_block_hash, epoch)
+
+    config = {
+        "epoch": epoch,
+        "nonce": nonce.hex(),
+        "active_fingerprints": active_fp,
+        "inactive_fingerprints": sorted(
+            set(ALL_FP_CHECKS) - set(active_fp)
+        ),
+        "observation_window_hours": window_hours,
+        "window_mode": "fast" if window_hours <= 24 else "slow",
+        "challenge_rotation": challenge_rotation,
+    }
+
+    logger.info(
+        "RIP-309 epoch %d: active=%s, window=%dh (%s), challenges=%s, nonce=%s",
+        epoch,
+        active_fp,
+        window_hours,
+        config["window_mode"],
+        [c["challenge_type"] for c in challenge_rotation["active_challenges"]],
+        nonce.hex()[:16],
+    )
+
+    return config
+
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print("RIP-309 Measurement Rotation — Self Test\n")
+
+    print("=== Fingerprint Check Rotation (20 epochs) ===")
+    check_counts = {c: 0 for c in ALL_FP_CHECKS}
+    for i in range(20):
+        fake_hash = hashlib.sha256(f"block_{i}".encode()).hexdigest()
+        config = get_epoch_measurement_config(fake_hash, i)
+        for c in config["active_fingerprints"]:
+            check_counts[c] += 1
+        window = config["observation_window_hours"]
+        mode = config["window_mode"]
+        challenges = [c["challenge_type"] for c in config["challenge_rotation"]["active_challenges"]]
+        print(
+            f"  Epoch {i:2d}: {config['active_fingerprints']} "
+            f"window={window}h ({mode}) challenges={challenges}"
+        )
+
+    print(f"\nCheck activation counts over 20 epochs:")
+    for check, count in sorted(check_counts.items()):
+        bar = "#" * count
+        print(f"  {check:20s}: {count:2d}/20 ({count/20*100:.0f}%) {bar}")
+
+    print("\n=== EMA Scoring ===")
+    scores = [(i, 0.3) for i in range(10)] + [(i, 0.9) for i in range(10, 20)]
+    for epoch in [10, 12, 15, 19]:
+        ema = compute_ema_score(scores[:epoch + 1], epoch)
+        print(f"  Epoch {epoch}: EMA={ema:.3f}")
+
+    print("\n=== Spike Detection ===")
+    honest_scores = [(i, 0.8 + random.Random(42).gauss(0, 0.05)) for i in range(20)]
+    is_spike, z = detect_score_spike(honest_scores, 20, 0.2)
+    print(f"  Honest streak then drop to 0.2: spike={is_spike}, z={z:.2f}")
+    is_spike, z = detect_score_spike(honest_scores, 20, 0.75)
+    print(f"  Honest streak then 0.75:        spike={is_spike}, z={z:.2f}")
+
+    print("\n=== Observation Window Distribution ===")
+    fast = slow = 0
+    for i in range(100):
+        fake_hash = hashlib.sha256(f"window_test_{i}".encode()).hexdigest()
+        nonce = derive_epoch_nonce(fake_hash)
+        hours = get_observation_window_hours(nonce)
+        if hours <= 24:
+            fast += 1
+        else:
+            slow += 1
+    print(f"  Fast (6-24h):   {fast}%")
+    print(f"  Slow (72-168h): {slow}%")
+    print("  (Expected: ~60/40)")

--- a/node/test_rip309_challenge_rotation.py
+++ b/node/test_rip309_challenge_rotation.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Targeted tests for RIP-309 Phase 4 challenge rotation."""
+
+import hashlib
+import unittest
+
+from rip_309_measurement_rotation import (
+    CHALLENGE_TYPES,
+    derive_epoch_nonce,
+    get_epoch_challenge_plan,
+    get_epoch_measurement_config,
+)
+
+
+class Rip309ChallengeRotationTests(unittest.TestCase):
+    def test_nonce_is_deterministic_for_same_prev_hash(self):
+        prev_hash = hashlib.sha256(b"same-block").hexdigest()
+        self.assertEqual(derive_epoch_nonce(prev_hash), derive_epoch_nonce(prev_hash))
+
+    def test_challenge_plan_is_deterministic_with_same_epoch_and_hash(self):
+        prev_hash = hashlib.sha256(b"epoch-10").hexdigest()
+        plan_a = get_epoch_challenge_plan(prev_hash, 10)
+        plan_b = get_epoch_challenge_plan(prev_hash, 10)
+        self.assertEqual(plan_a, plan_b)
+
+    def test_challenge_plan_varies_across_epochs(self):
+        prev_hash_a = hashlib.sha256(b"epoch-10").hexdigest()
+        prev_hash_b = hashlib.sha256(b"epoch-11").hexdigest()
+        plan_a = get_epoch_challenge_plan(prev_hash_a, 10)
+        plan_b = get_epoch_challenge_plan(prev_hash_b, 11)
+        self.assertNotEqual(plan_a["nonce"], plan_b["nonce"])
+        self.assertNotEqual(plan_a["active_challenges"], plan_b["active_challenges"])
+
+    def test_all_three_challenge_types_are_present_each_epoch(self):
+        prev_hash = hashlib.sha256(b"epoch-21").hexdigest()
+        plan = get_epoch_challenge_plan(prev_hash, 21)
+        observed = {entry["challenge_type"] for entry in plan["active_challenges"]}
+        self.assertEqual(observed, set(CHALLENGE_TYPES))
+
+    def test_measurement_config_embeds_challenge_rotation(self):
+        prev_hash = hashlib.sha256(b"epoch-99").hexdigest()
+        config = get_epoch_measurement_config(prev_hash, 99)
+        self.assertIn("challenge_rotation", config)
+        self.assertEqual(config["challenge_rotation"]["epoch"], 99)
+        self.assertEqual(len(config["challenge_rotation"]["active_challenges"]), 3)
+
+    def test_each_challenge_has_stable_required_fields(self):
+        prev_hash = hashlib.sha256(b"epoch-55").hexdigest()
+        plan = get_epoch_challenge_plan(prev_hash, 55)
+        for challenge in plan["active_challenges"]:
+            self.assertIn("challenge_type", challenge)
+            self.assertIn("layer", challenge)
+            self.assertIn("seed", challenge)
+            self.assertIn("interval_slots", challenge)
+            self.assertIn("offset_slots", challenge)
+            self.assertIn("timeout_seconds", challenge)
+            self.assertIn("parameters", challenge)
+            self.assertGreater(challenge["interval_slots"], 0)
+            self.assertGreaterEqual(challenge["offset_slots"], 0)
+            self.assertGreater(challenge["timeout_seconds"], 0)
+            self.assertIsInstance(challenge["parameters"], dict)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR adds a pragmatic first-pass implementation of RIP-309 Phase 4: challenge rotation.

### What changed
- derive deterministic per-epoch challenge rotation from the RIP-309 nonce
- define three challenge families:
  - `timing_challenge`
  - `continuity_challenge`
  - `coordination_challenge`
- embed challenge rotation into the epoch measurement config
- add targeted tests for determinism, challenge shape, and cross-epoch variation

### Important implementation note
This is intentionally a **Phase 4 infrastructure / planning first pass**, not a claim that the repo already has a complete challenge-response executor, answer transport, scoring, or slashing pipeline.

The current repo appears to have challenge-related hooks in attestation/replay-defense areas, but not a complete cross-layer runtime challenge engine for all Phase 4 semantics. This PR therefore focuses on:
- deterministic challenge plan generation,
- stable per-epoch challenge scheduling metadata,
- reviewable observability,
- test coverage.

### Tests
- `python3 -m pytest node/test_rip309_challenge_rotation.py -q`
- Result: `6 passed`

RTC wallet: `RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35`
