### PR TITLE
fix: bind STATE sync sender_id to responder's canonical node_id (Phase 2 regression)

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -880,10 +880,17 @@ class GossipLayer:
                         logger.error(f"Full sync from {peer_url}: no signature on state response")
                         return
                     state_payload = {"state": data["state"]}
+                    # SECURITY (#2256 Phase D follow-up): sender_id must be the
+                    # responder's canonical node_id, not peer_url. Phase A
+                    # signing includes sender_id in the signed content, so
+                    # using peer_url here causes a signature mismatch against
+                    # the content the responder actually signed.
+                    # _handle_get_state returns its node_id in "sender_id".
+                    responder_id = data.get("sender_id") or peer_url
                     state_msg = GossipMessage(
                         msg_type=MessageType.STATE.value,
-                        msg_id=f"sync:{peer_url}:{timestamp}",
-                        sender_id=peer_url,
+                        msg_id=f"sync:{responder_id}:{timestamp}",
+                        sender_id=responder_id,
                         timestamp=timestamp,
                         ttl=0,
                         signature=signature,


### PR DESCRIPTION
Hotfix for regression observed on 4-node flag-day deploy at 2026-04-14 21:03 UTC.

## Symptom
All 4 upgraded P2P nodes logged:
```
WARNING:rustchain_p2p_gossip:Rejected state merge from http://50.28.86.153:8099: invalid signature
```

## Root cause
#2258 Phase A bound `sender_id` into HMAC signed content. `request_full_sync` was still wrapping STATE responses with `sender_id=peer_url` (e.g. `http://50.28.86.153:8099`), but the responder's HMAC was computed over its canonical `node_id` (e.g. `node2`). Mismatch → verify_message fails.

## Fix
`_handle_get_state` already returns responder's `sender_id` in its response. This PR makes `request_full_sync` use that field when wrapping the STATE message, falling back to `peer_url` only if missing.

## Scope
- 9 added / 2 deleted lines in `node/rustchain_p2p_gossip.py` (`request_full_sync` only)
- Does NOT affect epoch vote / propose / attestation paths — those already use `msg.sender_id = self.node_id` via `create_message()`
- Wire-compatible: the fallback preserves old behavior if a responder doesn't return sender_id (none exist after #2258)

## Test plan
- [x] Existing 6 regression tests (`test_p2p_hardening_phase2.py`) still pass
- [ ] Post-deploy: verify 'Rejected state merge' warnings stop appearing in production logs

Closes the Phase 2 regression introduced by #2258.