### PR TITLE
docs: fix two broken documentation links

### DIFF
--- a/README_ES.md
+++ b/README_ES.md
@@ -20,7 +20,7 @@
 
 *Tu PowerPC G4 gana más que un Threadripper moderno. Ese es el punto.*
 
-[Website](https://rustchain.org) • [Manifesto](https://rustchain.org/manifesto.html) • [Principios Boudreaux](docs/BOUDREAUX_COMPUTING_PRINCIPLES.md) • [Live Explorer](https://rustchain.org/explorer) • [Swap wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC Quickstart](docs/wrtc.md) • [Tutorial wRTC](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Ref. Grokipedia](https://grokipedia.com/search?q=RustChain) • [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [Inicio Rápido](#-inicio-rápido) • [Cómo Funciona](#-cómo-funciona-proof-of-antiquity)
+[Website](https://rustchain.org) • [Manifesto](https://rustchain.org/manifesto.html) • [Principios Boudreaux](docs/Boudreaux_COMPUTING_PRINCIPLES.md) • [Live Explorer](https://rustchain.org/explorer) • [Swap wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC Quickstart](docs/wrtc.md) • [Tutorial wRTC](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Ref. Grokipedia](https://grokipedia.com/search?q=RustChain) • [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [Inicio Rápido](#-inicio-rápido) • [Cómo Funciona](#-cómo-funciona-proof-of-antiquity)
 
 </div>
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -716,4 +716,4 @@ get_epoch
 
 ---
 
-**Next**: See [glossary.md](./glossary.md) for terminology reference.
+**Next**: See [GLOSSARY.md](./GLOSSARY.md) for terminology reference.


### PR DESCRIPTION
Summary
- Fixes two broken documentation links caused by filename case mismatches.

Changes
- README_ES.md
  - Update `docs/BOUDREAUX_COMPUTING_PRINCIPLES.md` to `docs/Boudreaux_COMPUTING_PRINCIPLES.md`
- docs/api-reference.md
  - Update `./glossary.md` to `./GLOSSARY.md`

Why
- These links break on case-sensitive filesystems and in GitHub navigation when the target filename casing does not match the actual file.

Related bounty
- Corresponds to the broken-link bounty in Scottcjn/rustchain-bounties#444
