### PR TITLE
docs: fix node URL to 50.28.86.131 in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -152,7 +152,7 @@ tail -f ~/.rustchain/miner.log
 ### Balance Check
 ```bash
 # Note: Using -k flag because node may use self-signed SSL certificate
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sk "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 Example output:
@@ -166,17 +166,17 @@ Example output:
 
 ### Active Miners
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sk https://50.28.86.131/api/miners
 ```
 
 ### Node Health
 ```bash
-curl -sk https://rustchain.org/health
+curl -sk https://50.28.86.131/health
 ```
 
 ### Current Epoch
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sk https://50.28.86.131/epoch
 ```
 
 ## Manual Operation
@@ -304,14 +304,14 @@ cat ~/.rustchain/miner.log
 
 **Check:**
 1. Internet connection is working
-2. Node is accessible: `curl -sk https://rustchain.org/health`
+2. Node is accessible: `curl -sk https://50.28.86.131/health`
 3. Firewall isn't blocking HTTPS (port 443)
 
 ### Miner not earning rewards
 
 **Check:**
 1. Miner is actually running: `systemctl --user status rustchain-miner` or `launchctl list | grep rustchain`
-2. Wallet balance: `curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"`
+2. Wallet balance: `curl -sk "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_NAME"`
 3. Miner logs for errors: `journalctl --user -u rustchain-miner -f` or `tail -f ~/.rustchain/miner.log`
 4. Hardware attestation passes: Look for "fingerprint validation" messages in logs
 
@@ -338,7 +338,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 - **Documentation:** https://github.com/Scottcjn/Rustchain
 - **Issues:** https://github.com/Scottcjn/Rustchain/issues
-- **Explorer:** https://rustchain.org/explorer
+- **Explorer:** https://50.28.86.131/explorer
 - **Bounties:** https://github.com/Scottcjn/rustchain-bounties
 
 ## Security Notes
@@ -348,22 +348,22 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 3. The miner runs as your user (not root)
 4. Services are user-level (systemd --user, ~/Library/LaunchAgents)
 5. All logs are stored in your home directory
-6. **SSL Certificate:** The RustChain node (rustchain.org) may use a self-signed SSL certificate. The `-k` flag in curl commands bypasses certificate verification. This is a known limitation of the current infrastructure. In production, you should verify the node's identity through other means (community consensus, explorer verification, etc.).
+6. **SSL Certificate:** The RustChain node (50.28.86.131) may use a self-signed SSL certificate. The `-k` flag in curl commands bypasses certificate verification. This is a known limitation of the current infrastructure. In production, you should verify the node's identity through other means (community consensus, explorer verification, etc.).
 
 To view the certificate SHA-256 fingerprint:
 
 ```bash
-openssl s_client -connect rustchain.org:443 < /dev/null 2>/dev/null | openssl x509 -fingerprint -sha256 -noout
+openssl s_client -connect 50.28.86.131:443 < /dev/null 2>/dev/null | openssl x509 -fingerprint -sha256 -noout
 ```
 
 If you want to avoid using `-k`, you can save the certificate locally and pin it:
 
 ```bash
 # Save the cert once (overwrite if it changes)
-openssl s_client -connect rustchain.org:443 < /dev/null 2>/dev/null | openssl x509 > ~/.rustchain/rustchain-cert.pem
+openssl s_client -connect 50.28.86.131:443 < /dev/null 2>/dev/null | openssl x509 > ~/.rustchain/rustchain-cert.pem
 
 # Then use it instead of -k
-curl --cacert ~/.rustchain/rustchain-cert.pem "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl --cacert ~/.rustchain/rustchain-cert.pem "https://50.28.86.131/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
Fixed INSTALL.md to use the correct RustChain node IP (50.28.86.131) instead of rustchain.org, which resolves to elyanlabs.ai.

## Changes
- Updated all curl commands to use `https://50.28.86.131` instead of `https://rustchain.org`
- Fixed wallet balance check, active miners, node health, and epoch endpoints
- Updated SSL certificate section to reference the correct node IP

## Why This Matters
The domain rustchain.org currently points to elyanlabs.ai. The actual RustChain node is at 50.28.86.131. Using the wrong URL causes SSL certificate mismatch errors.