### PR TITLE
docs: fix broken RIP-305 and homebrew links

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -2,7 +2,7 @@
 
 Cross-chain bridge endpoints for wRTC (Wrapped RTC) on Solana + Base L2.
 
-Part of [RIP-305: Cross-Chain Airdrop Protocol](../../docs/RIP-305-cross-chain-airdrop.md).
+Part of [RIP-305: Cross-Chain Airdrop Protocol](../docs/RIP-305-cross-chain-airdrop.md).
 
 ## Overview
 

--- a/contracts/base/README.md
+++ b/contracts/base/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Wrapped RTC (wRTC) ERC-20 token implementing [RIP-305](../docs/RIP-305-cross-chain-airdrop.md) for the Base L2 network.
+Wrapped RTC (wRTC) ERC-20 token implementing [RIP-305](../../docs/RIP-305-cross-chain-airdrop.md) for the Base L2 network.
 
 ## Contract: WrappedRTC.sol
 

--- a/cross-chain-airdrop/README.md
+++ b/cross-chain-airdrop/README.md
@@ -273,10 +273,10 @@ cargo test --test integration_tests
 
 ## Related Documentation
 
-- [RIP-305 Specification](../../docs/RIP-305-cross-chain-airdrop.md)
-- [Bridge API](../../bridge/README.md)
-- [Solana SPL Deployment](../../rips/docs/RIP-0305-solana-spl-token-deployment.md)
-- [Airdrop Claim Page](../../airdrop/README.md)
+- [RIP-305 Specification](../docs/RIP-305-cross-chain-airdrop.md)
+- [Bridge API](../bridge/README.md)
+- [Solana SPL Deployment](../rips/docs/RIP-0305-solana-spl-token-deployment.md)
+- [Airdrop Claim Page](../airdrop/README.md)
 
 ## License
 
@@ -289,7 +289,7 @@ at your option.
 
 ## Contributing
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for contribution guidelines.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines.
 
 ## Bounty
 

--- a/homebrew/INSTALL.md
+++ b/homebrew/INSTALL.md
@@ -274,7 +274,7 @@ miners/
 
 - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
 - [RustChain Repository](https://github.com/Scottcjn/Rustchain)
-- [RustChain Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain Whitepaper](../docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
 - [Issue #1612](https://github.com/rustchain-bounties/rustchain-bounties/issues/1612)
 
 ---


### PR DESCRIPTION
Summary
- Fix several broken relative links in RIP-305-related docs and the homebrew install guide.

Changes
- cross-chain-airdrop/README.md
  - Fix links to RIP-305 spec, bridge README, Solana SPL deployment doc, airdrop README, and CONTRIBUTING.md
- bridge/README.md
  - Fix link to the RIP-305 spec
- contracts/base/README.md
  - Fix link to the RIP-305 spec from the Base L2 contract docs
- homebrew/INSTALL.md
  - Fix the whitepaper link to point to the actual docs path

Why
- These links currently resolve to non-existent paths on case-sensitive filesystems and in GitHub navigation, which breaks documentation flow for new contributors and readers.

Validation
- Verified each updated relative path resolves to an existing file locally.