### PR TITLE
Fix #2288: Correct _signed_content arity in _handle_get_state

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -883,7 +883,7 @@ class GossipLayer:
         # Uses the Phase A signed-content shape (msg_type:sender_id:payload)
         # so verify_message() on the requester side accepts it.
         payload = {"state": state_data}
-        content = self._signed_content(MessageType.STATE.value, self.node_id, payload)
+        content = self._signed_content(MessageType.STATE.value, self.node_id, msg.msg_id, msg.ttl, payload)
         signature, timestamp = self._sign_message(content)
         return {
             "status": "ok",

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -880,7 +880,7 @@ class GossipLayer:
             "balances": self.balance_crdt.to_dict()
         }
         # Sign the state response so the requester can verify authenticity.
-        # Uses the Phase A signed-content shape (msg_type:sender_id:payload)
+        # Uses the updated signature shape (msg_type:sender_id:msg_id:ttl:payload) per #2256
         # so verify_message() on the requester side accepts it.
         payload = {"state": state_data}
         content = self._signed_content(MessageType.STATE.value, self.node_id, payload)


### PR DESCRIPTION
Fixes #2288

Updated _handle_get_state to pass msg.msg_id and msg.ttl into _signed_content to match the new signature schema introduced in PR #2256.

GitHub Username: sheerai
RTC Wallet: RTCf3e03dba442d0140b78cf9b76068921e1badcd6b