### PR TITLE
Fix TypeError in _handle_get_state

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -883,7 +883,7 @@ class GossipLayer:
         # Uses the Phase A signed-content shape (msg_type:sender_id:payload)
         # so verify_message() on the requester side accepts it.
         payload = {"state": state_data}
-        content = self._signed_content(MessageType.STATE.value, self.node_id, payload)
+        content = self._signed_content(MessageType.STATE.value, self.node_id, "", GOSSIP_TTL, payload)
         signature, timestamp = self._sign_message(content)
         return {
             "status": "ok",


### PR DESCRIPTION
Closes #2288.\n\nThe `_signed_content` method requires 5 parameters, but `_handle_get_state` was only passing 3, resulting in a fatal `TypeError` during state sync responses.\n\nThis patch correctly injects an empty `msg_id` string and the `GOSSIP_TTL` constant to satisfy the interface arity while preserving the original state response signature format.\n\n**Bounty Payout Address (EVM / Rustchain wRTC):** `0x24a34cfB2152143BF3993381B5e4fe5D606295df`