### PR TITLE
docs(install.sh): fix example referencing missing install-rtc-miner.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@
 #   curl -fsSL https://rustchain.org/install.sh | bash -s -- --wallet MY_WALLET
 #
 # Or manually:
-#   bash install-rtc-miner.sh --wallet my-wallet-name
+#   bash install.sh --wallet my-wallet-name
 #
 # This installs the RTC miner alongside your existing GPU mining setup.
 # CPU overhead: <0.1% | GPU impact: 0% | RAM: <50MB


### PR DESCRIPTION
## Summary

\`install.sh\` line 10 example referenced a file that doesn't exist:

\`\`\`bash
#   bash install-rtc-miner.sh --wallet my-wallet-name
\`\`\`

The script is named \`install.sh\`, so the manual-usage line now reads:

\`\`\`bash
#   bash install.sh --wallet my-wallet-name
\`\`\`

Closes #2302

## Testing

Comment-only change.