### PR TITLE
docs: fix em-dash typography in Quickstart section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ launchctl list | grep rustchain
 tail -f ~/.rustchain/miner.log
 ```
 
-**New to RustChain?** Read the [step-by-step Beginner Quickstart](docs/QUICKSTART.md) -- covers everything from install to your first RTC, with every command explained.
+**New to RustChain?** Read the [step-by-step Beginner Quickstart](docs/QUICKSTART.md) — covers everything from install to your first RTC, with every command explained.
 
 ---
 


### PR DESCRIPTION
Fixes the double dash (--) to proper em-dash (—) in the Quickstart section for better typography.

This is a minor documentation improvement following the bounty issue #2783.