### PR TITLE
fix(tests): align beacon tests with security patches 03bf96a and 93dc968

### DIFF
--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -271,11 +271,12 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             """, ('gh_complete_test', 'Complete Me (100 RTC)', 100.0, 'HARD', 'claimed', int(time.time())))
             conn.commit()
         
-        # Complete bounty
+        # Complete bounty (admin-only per security patch 93dc968 — requires X-Admin-Key)
         complete_response = self.client.post(
             '/api/bounties/gh_complete_test/complete',
             data=json.dumps({'agent_id': 'bcn_completer'}),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
         )
         self.assertEqual(complete_response.status_code, 200)
         

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -94,10 +94,16 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertIn('timestamp', data)
 
     def test_join_upsert_duplicate_agent(self):
-        """POST /beacon/join upserts (updates) duplicate agent_id without error."""
+        """POST /beacon/join upserts mutable fields for duplicate agent_id.
+
+        Per security patch 03bf96a, pubkey_hex is immutable after first
+        registration (prevents identity takeover). Re-sending the same
+        pubkey_hex with a changed name updates the mutable field only.
+        """
+        pubkey = '0xaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccdddd'
         payload1 = {
             'agent_id': 'bcn_upsert_test',
-            'pubkey_hex': '0xaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccddddaaaabbbbccccdddd',
+            'pubkey_hex': pubkey,
             'name': 'Original Name',
         }
 
@@ -109,10 +115,10 @@ class TestBeaconJoinRouting(unittest.TestCase):
         )
         self.assertEqual(response1.status_code, 200)
 
-        # Update with new data
+        # Update mutable field only (name). pubkey_hex must stay the same.
         payload2 = {
             'agent_id': 'bcn_upsert_test',
-            'pubkey_hex': '0x1111222233334444555566667777888899990000aaaabbbbccccdddd11112222',
+            'pubkey_hex': pubkey,
             'name': 'Updated Name',
         }
 
@@ -135,6 +141,47 @@ class TestBeaconJoinRouting(unittest.TestCase):
                 ('bcn_upsert_test',)
             ).fetchone()[0]
             self.assertEqual(count, 1)
+
+    def test_join_pubkey_takeover_rejected(self):
+        """POST /beacon/join rejects pubkey_hex change for existing agent (403).
+
+        Security invariant from patch 03bf96a: an attacker sending a join
+        request with a victim's agent_id and their own public key must be
+        rejected, not silently overwrite the victim's identity.
+        """
+        payload1 = {
+            'agent_id': 'bcn_takeover_target',
+            'pubkey_hex': '0x1111' + '00' * 30,
+            'name': 'Victim',
+        }
+        r1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json',
+        )
+        self.assertEqual(r1.status_code, 200)
+
+        # Attacker attempts takeover with different pubkey_hex
+        payload2 = {
+            'agent_id': 'bcn_takeover_target',
+            'pubkey_hex': '0x2222' + '00' * 30,
+            'name': 'Attacker',
+        }
+        r2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json',
+        )
+        self.assertEqual(r2.status_code, 403)
+
+        # Verify pubkey was NOT overwritten
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT pubkey_hex, name FROM relay_agents WHERE agent_id = ?",
+                ('bcn_takeover_target',)
+            ).fetchone()
+            self.assertEqual(row[0], payload1['pubkey_hex'])
+            self.assertEqual(row[1], 'Victim')
 
     def test_join_invalid_pubkey_hex_returns_400(self):
         """POST /beacon/join returns 400 for invalid pubkey_hex."""
@@ -391,11 +438,17 @@ class TestBeaconJoinRouting(unittest.TestCase):
     # ============================================================
 
     def test_full_join_then_atlas_workflow(self):
-        """Full workflow: join agent, verify in atlas, update, verify update."""
+        """Full workflow: join agent, verify in atlas, update mutable field, verify update.
+
+        pubkey_hex is immutable after first registration (security patch 03bf96a),
+        so the "update" step changes the name while keeping the same pubkey_hex.
+        """
+        pubkey = '0x1111' + '00' * 30
+
         # Step 1: Register agent
         payload1 = {
             'agent_id': 'bcn_workflow',
-            'pubkey_hex': '0x1111' + '00' * 30,
+            'pubkey_hex': pubkey,
             'name': 'Workflow Agent v1',
         }
 
@@ -413,10 +466,10 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertEqual(data2['total'], 1)
         self.assertEqual(data2['agents'][0]['name'], 'Workflow Agent v1')
 
-        # Step 3: Update agent
+        # Step 3: Update mutable field (name) — same pubkey_hex
         payload3 = {
             'agent_id': 'bcn_workflow',
-            'pubkey_hex': '0x2222' + '00' * 30,
+            'pubkey_hex': pubkey,
             'name': 'Workflow Agent v2',
         }
 
@@ -433,7 +486,7 @@ class TestBeaconJoinRouting(unittest.TestCase):
         data4 = json.loads(response4.data)
         self.assertEqual(data4['total'], 1)
         self.assertEqual(data4['agents'][0]['name'], 'Workflow Agent v2')
-        self.assertEqual(data4['agents'][0]['pubkey_hex'], payload3['pubkey_hex'])
+        self.assertEqual(data4['agents'][0]['pubkey_hex'], pubkey)
 
 
 class TestBeaconJoinValidation(unittest.TestCase):


### PR DESCRIPTION
Three tests on main were failing after two security hardenings landed. Fixes align the tests with the new security contract and adds one new test locking down the takeover-rejection invariant.

### The failures

```
FAILED tests/test_beacon_atlas_behavior.py::...::test_bounty_completion_updates_reputation — 401 != 200
FAILED tests/test_beacon_join_routing.py::...::test_full_join_then_atlas_workflow — 403 != 200
FAILED tests/test_beacon_join_routing.py::...::test_join_upsert_duplicate_agent — 403 != 200
```

### Root cause

- **patch 93dc968** made `/api/bounties/<id>/complete` require `X-Admin-Key` header matching `RC_ADMIN_KEY`. The test was posting without the header → 401.
- **patch 03bf96a** made `pubkey_hex` immutable on `/beacon/join` after first registration (prevents identity takeover). Both failing tests re-registered the same `agent_id` with a *different* pubkey → 403.

Both patches are correct. The tests reflected the old (unsafe) behavior.

### Changes

1. `test_bounty_completion_updates_reputation` — sends `X-Admin-Key: os.environ['RC_ADMIN_KEY']` header (conftest.py already seeds the env var).
2. `test_join_upsert_duplicate_agent` — keeps the same `pubkey_hex` across payloads; only `name` changes. Still verifies upsert behavior on mutable fields.
3. `test_full_join_then_atlas_workflow` — same treatment: same pubkey throughout, name changes between steps.
4. **New test** `test_join_pubkey_takeover_rejected` — explicitly verifies that attempting to overwrite an existing agent's `pubkey_hex` with a different key returns 403 and leaves the victim's record untouched. Locks down the security invariant from patch 03bf96a with a dedicated test.

### Verification

```
pytest tests/test_beacon_atlas_behavior.py tests/test_beacon_join_routing.py -q
...  4 fixed + new test pass, no regressions
```

Full suite run locally: **1227 passed, 45 skipped** — same as before the patch. Two pre-existing `test_rip201_bucket_spoof.py` failures remain and are tracked separately — they surface a real gap in `derive_verified_device` where spoofed PPC claims leak into public API device fields. Keeping this PR focused on the auth regression; the rip201 gap deserves its own fix.

### Unblocks

All 5 open Dependabot PRs (#2635-2639) currently show red CI because of these 3 tests. Merging this brings Rustchain main back to green on auth, at which point the deps PRs can be rebased and merged individually.