### PR TITLE
fix(rip201): downgrade spoofed PowerPC claims in derive_verified_device

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1758,15 +1758,39 @@ def derive_verified_device(device: dict, fingerprint: dict, fingerprint_passed: 
         return {"device_family": "ARM", "device_arch": arm_arch}
 
     # PowerPC / POWER detection
-    # Check machine field first — ppc64le/ppc64 is definitive
+    # Check machine field first — ppc64le/ppc64 is suggestive, not definitive.
+    # A spoofer can set machine='ppc' trivially; the cpu brand and SIMD fingerprint
+    # cannot be faked cheaply. Require corroborating evidence before trusting the claim.
+    # RIP-201: spoofed claims must be downgraded to x86_64/default in public APIs,
+    # not just reward-throttled.
     machine_field = str(device.get("machine") or "").lower()
     if machine_field in ("ppc64le", "ppc64", "ppc", "powerpc", "powerpc64"):
+        cpu_brand_lower = cpu_brand.lower()
+        has_x86_tokens = _has_any_token(cpu_brand, X86_CPU_BRANDS)
+        has_ppc_tokens = any(
+            token in cpu_brand_lower
+            for token in ("powerpc", "ppc", "ibm power", "g3", "g4", "g5",
+                          "7447", "7450", "7455", "7448", "970", "power8", "power9", "altivec")
+        )
+        has_ppc_fp = fingerprint_passed and _has_powerpc_simd_evidence(fingerprint)
+
+        # Hard reject: cpu brand is clearly x86 — downgrade regardless of machine claim.
+        if has_x86_tokens and not has_ppc_tokens:
+            print(f"[PPC_DETECT] REJECT spoof: machine={machine_field} but cpu_brand has x86 tokens ({cpu_brand[:40]}) -> x86_64/default")
+            return {"device_family": "x86_64", "device_arch": "default"}
+
+        # Soft reject: no corroborating evidence at all (empty brand + failed fingerprint).
+        # Real PowerPC miners will have either a brand token or a passing SIMD fingerprint.
+        if not has_ppc_tokens and not has_ppc_fp:
+            print(f"[PPC_DETECT] REJECT unverified: machine={machine_field} no brand/fp evidence (brand={cpu_brand[:40]!r}) -> x86_64/default")
+            return {"device_family": "x86_64", "device_arch": "default"}
+
         ppc_arch = arch.upper() if arch.lower() in ("g3", "g4", "g5", "power8", "power9") else "default"
-        if "power8" in cpu_brand.lower() or "8286" in cpu_brand.lower():
+        if "power8" in cpu_brand_lower or "8286" in cpu_brand_lower:
             ppc_arch = "POWER8"
-        elif "power9" in cpu_brand.lower():
+        elif "power9" in cpu_brand_lower:
             ppc_arch = "POWER9"
-        print(f"[PPC_DETECT] machine={machine_field}, brand={cpu_brand[:30]} -> PowerPC/{ppc_arch}")
+        print(f"[PPC_DETECT] VERIFIED: machine={machine_field}, brand={cpu_brand[:30]} -> PowerPC/{ppc_arch}")
         return {"device_family": "PowerPC", "device_arch": ppc_arch}
 
     if _claims_powerpc(device):

--- a/tests/test_rip201_bucket_spoof.py
+++ b/tests/test_rip201_bucket_spoof.py
@@ -295,7 +295,10 @@ def test_public_apis_do_not_expose_spoofed_claim_as_vintage(attest_client):
     assert miner_row["device_family"] == "x86_64"
     assert miner_row["device_arch"] == "default"
     assert miner_row["hardware_type"] == "x86-64 (Modern)"
-    assert miner_row["antiquity_multiplier"] == 1.0
+    # Modern x86_64 baseline multiplier per RIP-200 expanded multiplier table
+    # (rip_200_round_robin_1cpu1vote.py: {"modern": 0.8, "x86_64": 0.8}).
+    # Spoofer claiming G4 (2.5x) is downgraded to this baseline — no vintage bonus.
+    assert miner_row["antiquity_multiplier"] == 0.8
 
 
 def test_verified_server_side_classification_blocks_10x_reward_gain():


### PR DESCRIPTION
Fixes two pre-existing `test_rip201_bucket_spoof` failures that surfaced on main after #2647 unblocked the auth regression.

### The bug

`derive_verified_device` trusted `machine=ppc/ppc64/ppc64le` without corroborating cpu brand or fingerprint evidence. A spoofer setting `machine='ppc'` and claiming G4 with an Intel Xeon cpu brand was caught by the fingerprint layer (correctly getting 1e-09 reward weight) but still had `device_family=PowerPC, device_arch=G4` written to `miner_attest_recent` and exposed via `/api/miners`. Public leaderboards and badges still displayed the machine as vintage PowerPC G4 with a 2.5x antiquity multiplier — exactly what RIP-201 was designed to prevent.

### The fix

`derive_verified_device` now requires corroborating evidence before trusting a `machine=ppc` claim:

- **Hard reject:** cpu_brand contains x86 tokens and no PowerPC tokens → return `x86_64/default`
- **Soft reject:** no PowerPC tokens AND no PowerPC SIMD fingerprint evidence → return `x86_64/default`
- **Verified:** cpu_brand has PowerPC tokens OR fingerprint passes PowerPC SIMD evidence → return `PowerPC/<arch>`

This mirrors the existing `_claims_powerpc()` brand-validation path that ran for non-machine-field PowerPC claims but was unreachable when machine=ppc caught first.

### Test correction

`test_public_apis_do_not_expose_spoofed_claim_as_vintage` expected `antiquity_multiplier == 1.0` for the downgraded x86_64 baseline. Modern x86_64 baseline is actually **0.8** per the RIP-200 expanded multiplier table (`rip_200_round_robin_1cpu1vote.py`: `{'modern': 0.8, 'x86_64': 0.8}`). Updated the assertion to 0.8 with an explanatory comment.

### Verification

```
pytest tests/test_rip201_bucket_spoof.py -v
  5 passed

pytest tests/ -q
  1229 passed, 45 skipped, 0 failures
```

### No-regression check

- Real PowerPC miners with `cpu_brand` containing `powerpc`, `g4`, `7450`, `970`, `power8`, `altivec`, etc. still pass via the brand-token path.
- Real PowerPC miners with sparse `cpu_brand` still pass if their fingerprint includes PowerPC SIMD evidence (`altivec/vsx/vec_perm/has_altivec`).

Both paths are already used by existing production miners — no miner client changes required.