### PR TITLE
docs(security): add Payment-Authority Impersonation appendix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,10 @@ When to pick a tier:
 - `BCOS-L1`: normal features, refactors, non-sensitive changes.
 - `BCOS-L2`: security-sensitive changes, transfer/wallet logic, consensus/rewards, auth/crypto, supply-chain touching changes.
 
+## Payout Authority
+
+Only `@Scottcjn` (or a clearly labeled project automation account speaking on his behalf, with a matching project-issued `pending_id` + `tx_hash`) authorizes RTC bounty disbursements. Anyone else posting "I'll send the RTC" on a bounty issue is not a valid payout notice — see [SECURITY.md § Payment-Authority Impersonation](SECURITY.md#payment-authority-impersonation).
+
 ## Start Mining
 
 Don't just code — mine! Install the miner and earn RTC while you contribute:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -96,3 +96,33 @@ Valid reports may receive:
 - RTC bounty payout
 - optional Hall of Hunters recognition
 - follow-on hardening bounty invitations
+
+
+## Payment-Authority Impersonation
+
+**This appendix documents a contributor-protection abuse pattern. It does not make social-engineering reports bounty-eligible by itself.** Only the project-controlled RustChain payout flow can authorize RTC bounty disbursements. In practice, that means `@Scottcjn`, or a clearly labeled project automation account speaking on his behalf, with a matching project-issued pending transfer record. A comment from anyone else saying "I'll send the RTC," "payment is on the way," or similar is not a valid payout notice.
+
+If you see a comment from anyone outside `@Scottcjn` / `sophiaeagent-beep` / `AutoJanitor` on a bounty issue saying things like:
+
+- *"I'll send the X RTC to your wallet..."*
+- *"Expect the payment within 24 hours..."*
+- *"Transferring now..."*
+- *"Here is the payment confirmation..."*
+
+…on an issue where no authorized project-account comment has first authorized the payment, **treat it as a social-engineering attempt, not a legitimate bounty payout.** Account age, repo count, and unrelated prior commits are not equivalent to payment authority.
+
+### Why this pattern matters
+
+This attack does not need to steal funds. It creates a false expectation that the project promised payment and then failed to deliver, which can damage contributor trust in the real payout pipeline.
+
+### What a real payment looks like
+
+A legitimate RustChain bounty payout notice includes the amount, recipient wallet, and project-issued transfer identifiers needed for public verification, such as `pending_id`, `tx_hash`, and the confirmation timing (`confirms_at` / 24-hour window). If those identifiers are missing, or the comment is not from an authorized project account, do not treat it as payment confirmation.
+
+### How to report an impersonation attempt
+
+1. Tag `@Scottcjn` in a reply on the same issue.
+2. Or open a private report via GitHub Private Vulnerability Reporting on this repo.
+3. Screenshot the impersonating comment — it may later be edited or deleted.
+
+No retaliation against good-faith reporters. See Safe Harbor above.


### PR DESCRIPTION
## Summary
- Adds new appendix to `SECURITY.md` documenting the Payment-Authority Impersonation attack pattern
- Adds `## Payout Authority` pointer section to `CONTRIBUTING.md` linking back to the canonical SECURITY.md entry
- Consensus-reviewed via Claude Opus 4.7 + Codex gpt-5.4 xhigh (two-pass iteration)

## Why
Observed 2026-04-22 in #2150: a 5-year-old `author_association: NONE` account posted *"I'll send the 75 RTC... within 24 hours"* to a legitimate CONTRIBUTOR. No money moved, but if unanswered, the contributor waits 24h, nothing happens, and trust erodes in the **real** payout pipeline (`founder_team_bounty` via admin-keyed `/wallet/transfer`).

Same social-engineering family as the @ghostseven wRTC ETH-drain DMs, routed through public issue threads instead of private messages.

## What the appendix covers
1. **Only `@Scottcjn` (or clearly labeled project automation) authorizes RTC disbursements.** Account age / repo count / unrelated prior commits ≠ payment authority.
2. **Phrases to treat as impersonation**: "I'll send the X RTC", "payment within 24 hours", "transferring now", "here's the payment confirmation" — when posted by any non-authorized account.
3. **What a real payment notice contains**: amount + recipient wallet + `pending_id` + `tx_hash` + confirmation window.
4. **Reporting flow**: tag `@Scottcjn` on-thread, or private vulnerability report.
5. **Not bounty-eligible by itself** — explicit caveat prevents the reporter path from becoming a new farming surface.

## Test plan
- [x] SECURITY.md renders with no merge conflicts
- [x] CONTRIBUTING.md pointer link resolves (SECURITY.md#payment-authority-impersonation)
- [ ] Reviewer confirms tone reads as policy statement, not public callout of any specific contributor

🤖 Generated with [Claude Code](https://claude.com/claude-code)