### PR TITLE
Fix #2291: Upgrade threading.Lock to RLock (rebased from #2308)

### DIFF
--- a/node/rustchain_p2p_sync_secure.py
+++ b/node/rustchain_p2p_sync_secure.py
@@ -134,7 +134,7 @@ class RateLimiter:
 
     def __init__(self):
         self.requests = {}  # {peer_url: [(timestamp, endpoint), ...]}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
 
         # Rate limits per endpoint (requests per minute)
         self.limits = {
@@ -291,7 +291,7 @@ class SybilProtection:
         self.peer_reputation = {}  # {peer_url: score}
         self.banned_peers = set()
         self.whitelist = set()
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
 
     def can_add_peer(self, peer_url: str) -> tuple:
         """Check if peer can be added"""
@@ -344,7 +344,7 @@ class SecurePeerManager:
         self.local_port = local_port
         self.local_url = f"http://{local_host}:{local_port}"
         self.peers: Dict[str, Dict] = {}
-        self.lock = threading.Lock()
+        self.lock = threading.RLock()
 
         # Security components
         self.auth_manager = P2PAuthManager()


### PR DESCRIPTION
Rebased cherry-pick of @sheerai's 27d37c6 onto current main. The #2308 PR had merge conflicts with the #2304 UTXO divergence PoC + Phase F p2p_identity work that landed in parallel.

Author preserved: Ryan Breuker <admin@sheerai.net>. Payment already issued on #2308 (12 RTC, pid 1269, pending).

Closes #2308.