### PR TITLE
docs: add comment to balance check command in START_HERE.md

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -30,6 +30,7 @@ Current `clawrtc` releases do **not** ship `wallet new`, `wallet show`, or `wall
 ### Check Balance
 
 ```bash
+# Check your wallet/miner balance
 curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 ```
 


### PR DESCRIPTION
This PR adds a descriptive comment to the balance check command in START_HERE.md