### PR TITLE
fix: correct miner download URLs in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -23,8 +23,8 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 INSTALL_DIR="$HOME/.rustchain"
-MINER_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_universal_miner.py"
-FINGERPRINT_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/fingerprint_checks.py"
+MINER_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py"
+FINGERPRINT_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py"
 NODE_URL="https://50.28.86.131"
 VERSION="1.0.0"
 


### PR DESCRIPTION
## Summary
Fix incorrect miner download URLs in install.sh that caused installation failures.

## Changes
- Line 26: Changed miner URL from `main/miners/rustchain_universal_miner.py` to `main/miners/linux/rustchain_linux_miner.py`
- Line 27: Changed fingerprint URL from `main/miners/fingerprint_checks.py` to `main/miners/linux/fingerprint_checks.py`

## Root Cause
The files at `main/miners/` root do not exist. The actual files are in `main/miners/linux/`.

## Testing
Verified using `gh api repos/Scottcjn/Rustchain/contents/miners/rustchain_universal_miner.py` returns 404, but `gh api repos/Scottcjn/Rustchain/contents/miners/linux/rustchain_linux_miner.py` returns 200.

## Bounty
Onboard task #2783: Star + Fix a Doc Issue (Your First PR)
Issue filed: Scottcjn/Rustchain#2683 (Bug report for same issue)

**Wallet**: wuxiaobinsh-gif