### PR TITLE
docs: fix broken whitepaper PDF links in README and QUICKSTART

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 [![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
 [![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
-[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.19442753.svg)](https://doi.org/10.5281/zenodo.19442753)
 
 A PowerBook G4 from 2003 earns **2.5x** more than a modern Threadripper.
 A Power Mac G5 earns **2.0x**. A 486 with rusty serial ports earns the most respect of all.
 
-[Explorer](https://rustchain.org/explorer/) · [Machines Preserved](https://rustchain.org/preserved.html) · [Install Miner](#quickstart) · [Beginner Guide](docs/QUICKSTART.md) · [Manifesto](https://rustchain.org/manifesto.html) · [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[Explorer](https://rustchain.org/explorer/) · [Machines Preserved](https://rustchain.org/preserved.html) · [Install Miner](#quickstart) · [Beginner Guide](docs/QUICKSTART.md) · [Manifesto](https://rustchain.org/manifesto.html) · [Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
 
 </div>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -390,7 +390,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 - **Swap RTC for Solana tokens:** [wRTC Guide](wrtc.md)
 - **Run a full node:** [Protocol Docs](PROTOCOL.md)
-- **Deep dive into Proof-of-Antiquity:** [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- **Deep dive into Proof-of-Antiquity:** [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97.pdf)
 - **Contribute code:** [CONTRIBUTING.md](CONTRIBUTING.md)
 - **API reference:** [API Walkthrough](API_WALKTHROUGH.md)
 


### PR DESCRIPTION
## Problem

The README.md and docs/QUICKSTART.md referenced `RustChain_Whitepaper_Flameholder_v0.97-1.pdf`, but the actual file in the repository is `RustChain_Whitepaper_Flameholder_v0.97.pdf` (without the `-1` suffix).

This caused the Whitepaper links in the README badge, navigation bar, and QUICKSTART's Next Steps section to return 404 errors.

## Fix

Updated all three broken links to point to the correct filename:

- **README.md line 15**: Badge link `docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf` → `docs/RustChain_Whitepaper_Flameholder_v0.97.pdf`
- **README.md line 21**: Nav link `docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf` → `docs/RustChain_Whitepaper_Flameholder_v0.97.pdf`
- **docs/QUICKSTART.md line 393**: Next Steps link `RustChain_Whitepaper_Flameholder_v0.97-1.pdf` → `RustChain_Whitepaper_Flameholder_v0.97.pdf`

## Verification

Confirmed that `docs/RustChain_Whitepaper_Flameholder_v0.97.pdf` exists in the repository.

## Checklist

- [x] Real documentation fix (not manufactured)
- [x] Verified the target file exists
- [x] All instances of the broken link fixed
- [x] No other changes

Closes #2783