### PR TITLE
docs: add descriptive comment to balance check command

### DIFF
--- a/START_HERE.md
+++ b/START_HERE.md
@@ -30,6 +30,8 @@ Current `clawrtc` releases do **not** ship `wallet new`, `wallet show`, or `wall
 ### Check Balance
 
 ```bash
+# Query the RustChain network for your wallet's RTC balance
+# Replace YOUR_WALLET with your actual miner/wallet ID
 curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 ```
 


### PR DESCRIPTION
## 📝 Changes

Added a descriptive comment to the balance check command in `START_HERE.md` to help new users understand what the command does and remind them to replace `YOUR_WALLET` with their actual miner/wallet ID.

### Before
```bash
curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
```

### After
```bash
# Query the RustChain network for your wallet's RTC balance
# Replace YOUR_WALLET with your actual miner/wallet ID
curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
```

## ✅ Checklist
- [x] Comment is clear and helpful
- [x] Follows existing markdown formatting
- [x] No code changes, documentation only

## 🔗 Related Issue

Closes #2658