### PR TITLE
docs: fix Homebrew install reference links

### DIFF
--- a/homebrew/INSTALL.md
+++ b/homebrew/INSTALL.md
@@ -274,8 +274,8 @@ miners/
 
 - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
 - [RustChain Repository](https://github.com/Scottcjn/Rustchain)
-- [RustChain Whitepaper](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
-- [Issue #1612](https://github.com/rustchain-bounties/rustchain-bounties/issues/1612)
+- [RustChain Whitepaper](../docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
+- [Issue #1612](https://github.com/Scottcjn/rustchain-bounties/issues/1612)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix the Homebrew install guide whitepaper link so it resolves from the `homebrew/` directory.
- Update the Issue #1612 reference from the 404 `rustchain-bounties/rustchain-bounties` path to `Scottcjn/rustchain-bounties`.

## Verification
- Confirmed `../docs/RustChain_Whitepaper_Flameholder_v0.97.pdf` exists relative to `homebrew/INSTALL.md`.
- Confirmed https://github.com/Scottcjn/rustchain-bounties/issues/1612 returns HTTP 200.

Bounty: Scottcjn/rustchain-bounties#444
