### PR TITLE
fix: replace hardcoded CURRENT_YEAR with dynamic detection

### DIFF
--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -20,7 +20,7 @@ from typing import Tuple, Optional, Dict
 from dataclasses import dataclass
 from datetime import datetime
 
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Replace hardcoded `CURRENT_YEAR = 2025` with `datetime.now().year` to fix systematic underestimation of hardware age and incorrect antiquity multipliers.

## Problem

`cpu_architecture_detection.py` defines `CURRENT_YEAR = 2025` (line 23). As of April 2026, every antiquity multiplier computed by this module is based on 2025 as the baseline year, causing systematic underestimation of hardware age.

## Fix

- Replace `CURRENT_YEAR = 2025` with `CURRENT_YEAR = datetime.now().year`
- `datetime` is already imported at the top of the file

## Impact

- Hardware age calculations will now be accurate for 2026 and beyond
- Antiquity multipliers will be correctly computed
- No breaking changes to existing functionality

---

**Bounty**: #305
**Wallet**: RTC6d1f27d28961279f1034d9561c2403697eb55602