### PR TITLE
fix(security): Auth for bounty claim, SSL verification, remove hardcoded admin key

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -4,6 +4,7 @@ Beacon Atlas API - Flask routes for 3D visualization backend
 Provides endpoints for agents, contracts, bounties, reputation, and chat.
 """
 import json
+import os
 import time
 import hashlib
 import sqlite3
@@ -536,10 +537,13 @@ def sync_bounties():
         
         all_bounties = []
         
-        # Create SSL context that doesn't verify (for demo)
+        # SSL verification: enabled by default, set RC_DISABLE_SSL_VERIFY=1 to skip
         ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
+        if os.environ.get('RC_DISABLE_SSL_VERIFY', '0') == '1':
+            import logging
+            logging.warning('[beacon_api] SSL verification disabled via RC_DISABLE_SSL_VERIFY — not recommended for production')
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
         
         for repo in repos:
             try:
@@ -625,8 +629,16 @@ def sync_bounties():
 
 @beacon_api.route('/api/bounties/<bounty_id>/claim', methods=['POST'])
 def claim_bounty(bounty_id):
-    """Claim a bounty for an agent."""
+    """Claim a bounty for an agent (admin-only)."""
     try:
+        import os, hmac
+        admin_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not admin_key:
+            return jsonify({'error': 'RC_ADMIN_KEY not configured — endpoint disabled'}), 503
+        provided_key = request.headers.get("X-Admin-Key", "")
+        if not hmac.compare_digest(provided_key, admin_key):
+            return jsonify({'error': 'Unauthorized — admin key required to claim bounties'}), 401
+
         data = request.get_json()
         agent_id = data.get('agent_id')
         

--- a/rips/python/rustchain/fleet_immune_system.py
+++ b/rips/python/rustchain/fleet_immune_system.py
@@ -991,9 +991,12 @@ def register_fleet_endpoints(app, DB_PATH):
 
     @app.route('/admin/fleet/report', methods=['GET'])
     def fleet_report():
-        admin_key = request.headers.get("X-Admin-Key", "")
-        import os
-        if admin_key != os.environ.get("RC_ADMIN_KEY", "rustchain_admin_key_2025_secure64"):
+        import os, hmac
+        admin_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not admin_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — endpoint disabled"}), 503
+        provided_key = request.headers.get("X-Admin-Key", "")
+        if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({"error": "Unauthorized"}), 401
 
         epoch = request.args.get('epoch', type=int)
@@ -1007,9 +1010,12 @@ def register_fleet_endpoints(app, DB_PATH):
 
     @app.route('/admin/fleet/scores', methods=['GET'])
     def fleet_scores():
-        admin_key = request.headers.get("X-Admin-Key", "")
-        import os
-        if admin_key != os.environ.get("RC_ADMIN_KEY", "rustchain_admin_key_2025_secure64"):
+        import os, hmac
+        admin_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not admin_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — endpoint disabled"}), 503
+        provided_key = request.headers.get("X-Admin-Key", "")
+        if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({"error": "Unauthorized"}), 401
 
         miner = request.args.get('miner')


### PR DESCRIPTION
## Security Fixes

### 1. Unauthenticated Bounty Claim (`beacon_api.py`)
- **Problem:** `/api/bounties/<id>/claim` had no authentication — anyone could claim any bounty
- **Fix:** Added `X-Admin-Key` header authentication (same pattern as `complete_bounty`)
- **Behavior:** Returns 401 if key missing/wrong, 503 if `RC_ADMIN_KEY` not configured

### 2. SSL Verification Disabled (`beacon_api.py`)
- **Problem:** `sync_bounties` unconditionally disabled SSL certificate verification
- **Fix:** SSL verification enabled by default; opt-out via `RC_DISABLE_SSL_VERIFY=1` env var with a warning log

### 3. Hardcoded Admin Key (`fleet_immune_system.py`)
- **Problem:** `register_fleet_endpoints()` fell back to hardcoded default `rustchain_admin_key_2025_secure64` when `RC_ADMIN_KEY` env var was unset
- **Fix:** Removed default value — endpoints return 503 if `RC_ADMIN_KEY` not set. Also switched to `hmac.compare_digest` for timing-safe comparison.

---

RTC: `RTC4642c5ee8467f61ed91b5775b0eeba984dd776ba`