### PR TITLE
fix(C1): manage_tx undefined in mempool_add() — silent failure of all error-path rollbacks

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -652,6 +652,13 @@ class UtxoDB:
         Returns False if double-spend detected or pool full.
         """
         conn = self._conn()
+        # FIX(#2867 C1): mempool_add() always opens its own connection and
+        # begins its own BEGIN IMMEDIATE transaction below. The 7 ROLLBACK
+        # paths reference manage_tx, which was previously undefined — every
+        # ROLLBACK raised NameError, swallowed by the bare-except at the
+        # bottom, causing ALL mempool admissions to silently fail in error
+        # paths and leak the transaction-in-progress lock.
+        manage_tx = True
         try:
             # Check pool size
             row = conn.execute(


### PR DESCRIPTION
## Closes BossChaos audit finding C1 (Bounty #2867)

### Bug

`mempool_add()` references `manage_tx` 7 times for ROLLBACK control on error paths (lines 687, 698, 707, 714, 736, 742, 775), but `manage_tx` was never defined in scope.

Every error path in `mempool_add()` was raising `NameError` when it reached the `if manage_tx: conn.execute("ROLLBACK")` line. The bare-`except Exception` at the bottom swallowed those NameErrors silently and returned False — so the function appeared to behave correctly from the outside while leaking transaction-in-progress locks under the hood.

Combined with the swallowed-exception masking, the practical impact was:
- All mempool admissions on error paths silently failed (which the caller couldn't distinguish from legitimate validation failures)
- BEGIN IMMEDIATE transactions were left dangling without rollback, eventually expiring

### Fix

`mempool_add()` always opens its own connection (`conn = self._conn()` at line 654) and starts its own transaction (`conn.execute("BEGIN IMMEDIATE")` at line 679), so `manage_tx = True` unconditionally. Set it explicitly at the top of the method.

Compare with `apply_transaction()` (line 364) which correctly sets `manage_tx = own or not conn.in_transaction` because that method can be called with an external connection.

### Verification

```python
db = UtxoDB(':memory:')
result = db.mempool_add({'tx_id': 'test-tx-1', 'tx_type': 'transfer', 'inputs': [{'box_id': 'nonexistent'}], 'outputs': [{'address': 'a', 'value_nrtc': 100}]})
# Before fix: NameError on first ROLLBACK path → swallowed → returns False
# After fix:  Returns False cleanly with proper ROLLBACK
```

### Diff
+7/-0 in `node/utxo_db.py` (1 line of code + 6 lines of comment explaining the bug)

### Audit credit
- Audit finding: @BossChaos via PR #2744 (paid 100 RTC for C1 in #2744)
- Fix: @Scottcjn

### BCOS-L2

Security-sensitive change — ROLLBACK behavior in transaction handling.