### PR TITLE
fix: remove C-style // comment from line 1 of contributor_registry.py (SyntaxError)

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 # SPDX-License-Identifier: MIT
 
 from flask import Flask, request, redirect, url_for, flash


### PR DESCRIPTION
contributor_registry.py had `// SPDX-License-Identifier: MIT` (C-style) on line 1 followed by `# SPDX-License-Identifier: MIT` (correct Python form) on line 2. The C-style line is invalid Python syntax — any `import contributor_registry` raises SyntaxError.

Impact:
- Flask app couldn't be imported in production
- Blocked @FlintLeng's PR #2695 (test_contributor_registry.py) from CI passing — pytest couldn't collect tests for an unimportable module

Fix: delete line 1 (one-line patch).

Verified: `python3 -c 'import ast; ast.parse(open("contributor_registry.py").read())'` now passes.

Found during M1 hmac.compare_digest verification (#2813).