### PR TITLE
fix(docs): repair broken markdown row + add @jaxint to CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,4 +5,7 @@
 | @ryan-the-zilla | RyanX#0000 | AI automation, bounty hunting, and software development |
 | @afu20260324 | 闃跨#0000 | AI automation, bounty hunting, documentation, and open source contributions |
 | @HuiNeng6 | HuiNeng | AI agents, automation, blockchain development |
-| @lam1688 | lam1688#0000 | AI automation, bounty hunting, RustChain ecosystem, Python development || @haoyousun60-create | iKun#0000 | AI automation, bounty hunting, documentation, open source contributions |
+| @lam1688 | lam1688#0000 | AI automation, bounty hunting, RustChain ecosystem, Python development |
+| @haoyousun60-create | iKun#0000 | AI automation, bounty hunting, documentation, open source contributions |
+| @jaxint | jaxint#0000 | AI automation, bounty hunting, and code reviews |
+


### PR DESCRIPTION
Fixes the broken `| ... Python development || @haoyousun60-create | ...` row that landed via #2711 (the source CONTRIBUTORS.md was missing a trailing newline, so appended rows merged into the previous one).

This commit:
1. Splits the corrupt double-row into two clean rows
2. Adds @jaxint's entry (closes the #2689 effort which had the same bug)
3. Adds trailing newline so future appends don't recreate this

Closes #2689 (jaxint's CONTRIBUTORS add — covered here).