### PR TITLE
fix(docs): correct license reference in INSTALL.md (rebased from #2712)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -374,4 +374,4 @@ https://github.com/Scottcjn/Rustchain
 
 ## License
 
-RustChain is licensed under the MIT License. See LICENSE file for details.
+RustChain is licensed under the Apache License 2.0. See LICENSE file for details.


### PR DESCRIPTION
Cleaned-up rebase of @FlintLeng's #2712. Original bundled multiple changes; after rebase against main, only the actual INSTALL.md license fix (`MIT License` → `Apache 2.0`) remains. +1/-1.

Original audit credit @FlintLeng #2712 — 5 RTC paid, wallet on file.