### PR TITLE
fix: replace hardcoded CURRENT_YEAR with dynamic datetime

### DIFF
--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -20,7 +20,7 @@ from typing import Tuple, Optional, Dict
 from dataclasses import dataclass
 from datetime import datetime
 
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 
 @dataclass

--- a/node/rip_200_round_robin_1cpu1vote_v2.py
+++ b/node/rip_200_round_robin_1cpu1vote_v2.py
@@ -20,7 +20,7 @@ from datetime import datetime
 GENESIS_TIMESTAMP = 1764706927  # Production chain launch (Dec 2, 2025)
 BLOCK_TIME = 600  # 10 minutes
 ATTESTATION_TTL = 600  # 10 minutes
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 # =============================================================================
 # ANTIQUITY MULTIPLIER SYSTEM v2

--- a/rips/rustchain-core/validator/setup_validator.py
+++ b/rips/rustchain-core/validator/setup_validator.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, asdict
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -61,7 +62,7 @@ BOOTSTRAP_NODES = [
     "192.168.0.126:9333",  # G4 Mirror Door Secondary
 ]
 
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 # =============================================================================
 # Hardware Detection


### PR DESCRIPTION
## Summary

Fixes hardcoded `CURRENT_YEAR = 2025` across 3 files, replacing it with `datetime.now().year` to prevent stale antiquity multiplier calculations in 2026+.

## Problem

`CURRENT_YEAR` was hardcoded as `2025` in three files, causing incorrect antiquity multiplier calculations once the actual year exceeds 2025. This affects:
- CPU architecture detection and age-based multipliers
- Round-robin consensus device age calculations
- Validator hardware profile setup and vintage classification

## Fix

| File | Change |
|------|--------|
| `cpu_architecture_detection.py` | `CURRENT_YEAR = datetime.now().year` |
| `node/rip_200_round_robin_1cpu1vote_v2.py` | `CURRENT_YEAR = datetime.now().year` |
| `rips/rustchain-core/validator/setup_validator.py` | Added `from datetime import datetime` + dynamic CURRENT_YEAR |

## Impact

- Antiquity multipliers now correctly reflect the current year
- Validator setup correctly classifies hardware as vintage/ancient/etc.
- No breaking changes — only the year resolution is now dynamic

---

**Bounty**: #305
**Wallet**: RTC6d1f27d28961279f1034d9561c2403697eb55602