### PR TITLE
fix(C5): replace hardcoded infrastructure IP with localhost + env var

### DIFF
--- a/cross-chain-airdrop/src/config.rs
+++ b/cross-chain-airdrop/src/config.rs
@@ -72,7 +72,7 @@ pub struct AirdropConfig {
 }
 
 fn default_node_url() -> String {
-    "https://50.28.86.131".to_string()
+    std::env::var("RUSTCHAIN_NODE_URL").unwrap_or_else(|_| "http://localhost:8332".to_string())
 }
 
 fn default_bridge_url() -> String {


### PR DESCRIPTION
## Fix: C5 — Replace hardcoded infrastructure IP with localhost + env var

**Finding:** [CRITICAL] Hardcoded Infrastructure IP in Default Config  
**File:** `cross-chain-airdrop/src/config.rs` (lines 74-76)  
**Reference:** Scottcjn/Rustchain#2867

### What was changed
- Replace hardcoded `"https://50.28.86.131"` with `std::env::var("RUSTCHAIN_NODE_URL")`
- Fallback to `"http://localhost:8332"` (no production IP exposure)

### Why
The default `node_url` was hardcoded to a live IP address, exposing RustChain's production infrastructure to anyone reading the open-source code.

### Verification
```bash
# Confirm no hardcoded production IP remains
grep -rn "50.28.86.131" cross-chain-airdrop/
# (should return nothing)
```

---
**Claim:** 50-100 RTC (Critical fix bounty)  
**Wallet:** RTC6d1f27d28961279f1034d9561c2403697eb55602