### PR TITLE
fix(H4): add field whitelist to prevent SQL injection in _update_reputation

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -195,6 +195,13 @@ def _log_job_action(c: sqlite3.Cursor, job_id: str, action: str,
 def _update_reputation(c: sqlite3.Cursor, wallet_id: str, field: str,
                        increment: int = 1):
     """Increment a reputation field for an agent."""
+    # FIX(#2867 H4): Whitelist allowed fields to prevent SQL injection via f-string
+    ALLOWED_REP_FIELDS = frozenset({
+        "jobs_posted", "jobs_completed_as_poster",
+        "jobs_completed_as_worker", "jobs_disputed", "jobs_expired",
+    })
+    if field not in ALLOWED_REP_FIELDS:
+        return
     now = int(time.time())
     c.execute("""
         INSERT INTO agent_reputation (wallet_id, first_seen, last_active)


### PR DESCRIPTION
## Fix: H4 — Add field whitelist to prevent SQL injection in `_update_reputation`

**Finding:** [HIGH] F-String SQL Injection Risk  
**File:** `rip302_agent_economy.py` (lines 204-206)  
**Reference:** Scottcjn/Rustchain#2867

### What was changed
- Add `ALLOWED_REP_FIELDS` frozenset whitelist with 5 valid reputation column names
- Early return if `field` is not in the whitelist before f-string SQL interpolation

### Why
The `_update_reputation` function constructs SQL using an f-string with the `field` parameter. While current callers use hardcoded constants, any future caller passing user input creates an SQL injection vulnerability.

### Allowed fields
- `jobs_posted`
- `jobs_completed_as_poster`
- `jobs_completed_as_worker`
- `jobs_disputed`
- `jobs_expired`

### Verification
```bash
python3 -c "import ast; ast.parse(open('rip302_agent_economy.py').read()); print('Syntax OK')"
```

---
**Claim:** 25-50 RTC (High fix bounty)  
**Wallet:** RTC6d1f27d28961279f1034d9561c2403697eb55602