### PR TITLE
fix(M1): atomic keystore writes with temp file + fsync + rename

### DIFF
--- a/wallet/rustchain_wallet_secure.py
+++ b/wallet/rustchain_wallet_secure.py
@@ -21,6 +21,7 @@ from tkinter import ttk, messagebox, simpledialog, filedialog
 import requests
 import json
 import os
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 import urllib3
@@ -406,8 +407,17 @@ class SecureFounderWallet:
             encrypted["name"] = name
 
             wallet_path = KEYSTORE_DIR / f"{name}.json"
-            with open(wallet_path, 'w') as f:
-                json.dump(encrypted, f, indent=2)
+            # FIX(#2867 M1): Atomic write — temp file + fsync + rename
+            fd, tmp_path = tempfile.mkstemp(dir=str(KEYSTORE_DIR), suffix='.tmp')
+            try:
+                with os.fdopen(fd, 'w') as f:
+                    json.dump(encrypted, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
+                os.replace(tmp_path, str(wallet_path))
+            except:
+                os.unlink(tmp_path)
+                raise
 
             # Update UI
             self.wallet_name.set(name)
@@ -550,8 +560,17 @@ class SecureFounderWallet:
                 encrypted["name"] = name
 
                 wallet_path = KEYSTORE_DIR / f"{name}.json"
-                with open(wallet_path, 'w') as f:
-                    json.dump(encrypted, f, indent=2)
+                # FIX(#2867 M1): Atomic write — temp file + fsync + rename
+                fd, tmp_path = tempfile.mkstemp(dir=str(KEYSTORE_DIR), suffix='.tmp')
+                try:
+                    with os.fdopen(fd, 'w') as f:
+                        json.dump(encrypted, f, indent=2)
+                        f.flush()
+                        os.fsync(f.fileno())
+                    os.replace(tmp_path, str(wallet_path))
+                except:
+                    os.unlink(tmp_path)
+                    raise
 
                 self.wallet_name.set(name)
                 self.address.set(wallet.address)


### PR DESCRIPTION
## Fix: M1 — Atomic keystore writes with temp file + fsync + rename

**Finding:** [MEDIUM] Non-Atomic Keystore Writes (Wallet File Corruption Risk)  
**File:** `wallet/rustchain_wallet_secure.py` (lines 408-410, 552-554)  
**Reference:** Scottcjn/Rustchain#2867

### What was changed
- Add `tempfile` import
- Replace direct `open() + json.dump()` with atomic write pattern:
  1. `tempfile.mkstemp()` — create temp file in same directory
  2. `os.fdopen()` + `json.dump()` + `f.flush()` + `os.fsync()` — write and sync
  3. `os.replace()` — atomic rename
  4. `except: os.unlink(tmp_path)` — cleanup on failure

### Why
Wallet keystore files were written directly in-place. If the process crashes during write, the wallet file is left truncated with no backup — permanent loss of funds.

### Verification
```bash
python3 -m py_compile wallet/rustchain_wallet_secure.py
```

---
**Claim:** 10-25 RTC (Medium fix bounty)  
**Wallet:** RTC6d1f27d28961279f1034d9561c2403697eb55602