### PR TITLE
fix(M3): add API key authentication to webhook admin endpoints

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -478,6 +478,8 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
     """Simple HTTP handler for managing webhook subscriptions."""
 
     store: SubscriberStore  # injected via class attribute
+    # FIX(#2867 M3): API key for admin endpoints, read from env var
+    ADMIN_API_KEY: str = os.environ.get("WEBHOOK_ADMIN_API_KEY", "")
 
     def log_message(self, fmt, *args):
         log.debug(fmt, *args)
@@ -497,7 +499,19 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
         raw = self.rfile.read(length)
         return json.loads(raw)
 
+    # FIX(#2867 M3): Authenticate admin API requests
+    def _check_api_key(self) -> bool:
+        if not self.ADMIN_API_KEY:
+            return True  # No key configured — allow (development mode)
+        provided = self.headers.get("X-Admin-API-Key", "")
+        if not hmac.compare_digest(provided, self.ADMIN_API_KEY):
+            self._send_json(401, {"error": "invalid or missing API key"})
+            return False
+        return True
+
     def do_GET(self):
+        if not self._check_api_key():
+            return
         if self.path == "/webhooks":
             subs = self.store.list_all()
             self._send_json(200, {
@@ -516,6 +530,8 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": "not found"})
 
     def do_POST(self):
+        if not self._check_api_key():
+            return
         if self.path == "/webhooks/subscribe":
             self._handle_subscribe()
         elif self.path == "/webhooks/unsubscribe":


### PR DESCRIPTION
## Fix: M3 — Add API key authentication to webhook admin endpoints

**Finding:** [MEDIUM] Unauthenticated Webhook Admin API  
**File:** `tools/webhooks/webhook_server.py` (lines 518-584, 619)  
**Reference:** Scottcjn/Rustchain#2867

### What was changed
- Add `ADMIN_API_KEY` class attribute reading from `WEBHOOK_ADMIN_API_KEY` env var
- Add `_check_api_key()` method using `hmac.compare_digest()` for timing-safe comparison
- Gate `do_GET()` and `do_POST()` behind `_check_api_key()`
- Development mode: if no key is configured, all requests are allowed (backward compatible)

### Why
The webhook admin API listens on `0.0.0.0` with no authentication. Anyone can list subscribers, register arbitrary webhook URLs, or unsubscribe legitimate services.

### Usage
```bash
# Production: set the API key
export WEBHOOK_ADMIN_API_KEY="your-secret-key-here"

# Client: include the key in requests
curl -H "X-Admin-API-Key: your-secret-key-here" http://host:9800/webhooks
```

### Verification
```bash
python3 -m py_compile tools/webhooks/webhook_server.py
```

---
**Claim:** 10-25 RTC (Medium fix bounty)  
**Wallet:** RTC6d1f27d28961279f1034d9561c2403697eb55602