### PR TITLE
fix(test): use mkstemp instead of insecure mktemp (B306) in security audit PoC

### DIFF
--- a/tests/security_audit/test_security_findings_2867.py
+++ b/tests/security_audit/test_security_findings_2867.py
@@ -124,7 +124,9 @@ def test_withdrawal_race_condition():
     
     Fix: Use BEGIN IMMEDIATE or conditional UPDATE.
     """
-    db_path = tempfile.mktemp(suffix='.db')
+    # bandit B306: avoid deprecated/insecure mktemp; use mkstemp + close fd.
+    fd, db_path = tempfile.mkstemp(suffix='.db')
+    os.close(fd)
     conn = sqlite3.connect(db_path)
     conn.execute('''CREATE TABLE balances (
         miner_pk TEXT PRIMARY KEY, balance_rtc REAL NOT NULL DEFAULT 0)''')


### PR DESCRIPTION
bandit B306: `tempfile.mktemp()` is deprecated/insecure (race condition between filename creation and file open). Replaced with `mkstemp()` which atomically creates and opens the file, then close the fd we don't need (sqlite3.connect opens its own).

Was failing CI on main since #2744 merged yesterday — blocking all subsequent PRs from green CI.

Affected: `tests/security_audit/test_security_findings_2867.py:127`

+3/-1.