### PR TITLE
fix(test): remove os.chdir at module scope from #2867 PoC (was breaking other tests' collection)

### DIFF
--- a/tests/security_audit/test_security_findings_2867.py
+++ b/tests/security_audit/test_security_findings_2867.py
@@ -21,7 +21,13 @@ import tempfile
 _node_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)),
                             '..', '..', 'node'))
 sys.path.insert(0, _node_dir)
-os.chdir(_node_dir)
+# NOTE: previous version used os.chdir(_node_dir) at module scope which
+# ran during pytest collection, mutating cwd for ALL subsequent test
+# modules collected in the same session. This broke tests that use
+# relative paths after import (e.g., tests/test_vintage_hardware_attestation.py
+# uses sys.path.insert(0, 'vintage_miner') which requires cwd=repo-root).
+# The PoC tests below do not actually need cwd=node — they take db_path
+# arguments and use absolute paths from tempfile.mkstemp().
 
 
 # ============================================================


### PR DESCRIPTION
The audit PoC test (#2744) had `os.chdir(_node_dir)` at module scope, which ran during pytest collection and mutated cwd for ALL subsequent test modules in the same session.

This broke `tests/test_vintage_hardware_attestation.py` which does `sys.path.insert(0, 'vintage_miner')` AFTER import-time — by then cwd was `node/` and 'vintage_miner' didn't exist relative to that.

The PoC tests don't need cwd=node — they take absolute `db_path` arguments from `tempfile.mkstemp()`. Removed the chdir + added a comment explaining why.

Verified: `pytest --collect-only` for both files now collects 43 tests cleanly.

+7/-1 in tests/security_audit/test_security_findings_2867.py.