### PR TITLE
fix: replace hardcoded CURRENT_YEAR with dynamic datetime

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote_v2.py
+++ b/node/rip_200_round_robin_1cpu1vote_v2.py
@@ -20,7 +20,7 @@ from datetime import datetime
 GENESIS_TIMESTAMP = 1764706927  # Production chain launch (Dec 2, 2025)
 BLOCK_TIME = 600  # 10 minutes
 ATTESTATION_TTL = 600  # 10 minutes
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 # =============================================================================
 # ANTIQUITY MULTIPLIER SYSTEM v2

--- a/rips/rustchain-core/validator/setup_validator.py
+++ b/rips/rustchain-core/validator/setup_validator.py
@@ -29,6 +29,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass, asdict
+from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -61,7 +62,7 @@ BOOTSTRAP_NODES = [
     "192.168.0.126:9333",  # G4 Mirror Door Secondary
 ]
 
-CURRENT_YEAR = 2025
+CURRENT_YEAR = datetime.now().year
 
 # =============================================================================
 # Hardware Detection


### PR DESCRIPTION
## Summary

Fixes hardcoded `CURRENT_YEAR = 2025` in 2 files, replacing with `datetime.now().year` to prevent stale antiquity multiplier calculations.

## Files Changed (+3/-2)

| File | Change |
|------|--------|
| `node/rip_200_round_robin_1cpu1vote_v2.py` | `CURRENT_YEAR = datetime.now().year` |
| `rips/rustchain-core/validator/setup_validator.py` | Added `from datetime import datetime` + dynamic CURRENT_YEAR |

## Note on cpu_architecture_detection.py

This file also has `CURRENT_YEAR = 2025` but uses CRLF line endings. Including it in this PR would cause a +733/-732 diff due to git's CRLF→LF normalization. The actual code change is 1 line, but git sees all 730 lines as changed.

**Recommendation:** Normalize CRLF→LF in a separate PR, then apply the CURRENT_YEAR fix. Or apply the fix manually:
```python
# Line 23 of cpu_architecture_detection.py
CURRENT_YEAR = datetime.now().year  # was: CURRENT_YEAR = 2025
```

## Impact

- Antiquity multipliers now correctly reflect the current year
- No breaking changes — only year resolution is dynamic

---

**Bounty**: #305
**Wallet**: RTC6d1f27d28961279f1034d9561c2403697eb55602