### PR TITLE
deps: update python-socketio requirement from >=5.10.0 to >=5.16.1

### DIFF
--- a/explorer/dashboard/requirements.txt
+++ b/explorer/dashboard/requirements.txt
@@ -1,4 +1,4 @@
 flask>=3.0.0
 flask-socketio>=5.3.0
 requests>=2.31.0
-python-socketio>=5.10.0
+python-socketio>=5.16.1

--- a/explorer/requirements.txt
+++ b/explorer/requirements.txt
@@ -11,7 +11,7 @@ flask-cors>=6.0.2
 flask-socketio>=5.6.1
 
 # WebSocket support
-python-socketio>=5.10.0
+python-socketio>=5.16.1
 python-engineio>=4.13.1
 
 # Development


### PR DESCRIPTION
## Summary

Updates python-socketio to latest stable version 5.16.1, which includes bug fixes and performance improvements.

## Changes

- Updated `explorer/requirements.txt`: `python-socketio>=5.10.0` → `python-socketio>=5.16.1`
- Updated `explorer/dashboard/requirements.txt`: `python-socketio>=5.10.0` → `python-socketio>=5.16.1`

## Testing

- [x] Verified requirements.txt syntax
- [x] Confirmed python-socketio 5.16.1 is available on PyPI

## Related Issues

Closes #2830