### PR TITLE
docs: fix broken whitepaper link in zh-CN README

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -20,7 +20,7 @@
 
 *你的 PowerPC G4 比现代 Threadripper 赚得更多。这就是重点。*
 
-[官网](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [兑换 wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC 快速入门](docs/wrtc.md) • [wRTC 教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia 参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
+[官网](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [兑换 wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC 快速入门](docs/wrtc.md) • [wRTC 教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia 参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
 
 </div>
 


### PR DESCRIPTION
## Summary

Fixes broken whitepaper link in `docs/zh-CN/README.md`.

## Changes

- Corrected link from `docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf` to `docs/RustChain_Whitepaper_Flameholder_v0.97.pdf`

## Verification

- Verified the target file `docs/RustChain_Whitepaper_Flameholder_v0.97.pdf` exists in the repository
- Updated only the broken relative path in the Chinese README

This fixes a real broken documentation link for Chinese readers.

## Related Issues

Closes #2277