### PR TITLE
fix: post-audit test regressions (Decimal JSON, admin auth, mempool PoC, RC_P2P_SECRET)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
     - name: Attestation fuzz regression gate
       env:
         RC_ADMIN_KEY: "0123456789abcdef0123456789abcdef"
+        RC_P2P_SECRET: "ci-test-secret-00000000000000000000000000000000"
         DB_PATH: ":memory:"
         ATTEST_FUZZ_CASES: "10000"
       run: python -m pytest tests/test_attestation_fuzz.py -k mutation_regression_no_unhandled_exceptions -v
@@ -44,5 +45,6 @@ jobs:
     - name: Run tests with pytest (blocking)
       env:
         RC_ADMIN_KEY: "0123456789abcdef0123456789abcdef"
+        RC_P2P_SECRET: "ci-test-secret-00000000000000000000000000000000"
         DB_PATH: ":memory:"
       run: pytest tests/ -v --ignore=tests/test_epoch_settlement_formal.py --ignore=tests/test_rip201_bucket_spoof.py

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -360,11 +360,18 @@ def utxo_transfer():
     # FIX(#2202): Include fee in signed data to prevent MITM fee manipulation.
     # Backward-compatible: try new format (with fee) first, fall back to legacy
     # (without fee) with a deprecation warning. Remove fallback after 2026-07-01.
+    #
+    # FIX(#2867 M2 follow-up): the M2 fix parses amount as Decimal internally
+    # for precision-safe int conversion, but Decimal isn't JSON-serializable.
+    # Clients sign with float-shaped amount, so cast back to float here to
+    # keep the signed-payload bytes byte-identical to what the wallet computed.
+    amount_for_sig = float(amount_rtc)
+    fee_for_sig = float(fee_rtc)
     tx_data_v2 = {
         'from': from_address,
         'to': to_address,
-        'amount': amount_rtc,
-        'fee': fee_rtc,
+        'amount': amount_for_sig,
+        'fee': fee_for_sig,
         'memo': memo,
         'nonce': nonce,
     }
@@ -373,7 +380,7 @@ def utxo_transfer():
     tx_data_legacy = {
         'from': from_address,
         'to': to_address,
-        'amount': amount_rtc,
+        'amount': amount_for_sig,
         'memo': memo,
         'nonce': nonce,
     }
@@ -514,8 +521,9 @@ def utxo_transfer():
         'ok': True,
         'from_address': from_address,
         'to_address': to_address,
-        'amount_rtc': amount_rtc,
-        'fee_rtc': fee_rtc,
+        # FIX(#2867 M2 follow-up): Decimal isn't JSON-serializable; cast to float.
+        'amount_rtc': float(amount_rtc),
+        'fee_rtc': float(fee_rtc),
         'inputs_consumed': len(selected),
         'outputs_created': len(outputs),
         'change_nrtc': change_nrtc,

--- a/tests/security_audit/test_security_findings_2867.py
+++ b/tests/security_audit/test_security_findings_2867.py
@@ -37,45 +37,64 @@ sys.path.insert(0, _node_dir)
 
 def test_mempool_add_manage_tx_undefined():
     """
-    CRITICAL: mempool_add() references manage_tx 7 times but never defines it.
-    apply_transaction() (line 364) sets manage_tx = own or not conn.in_transaction,
-    but mempool_add() (line 648) omits this entirely.
-    
-    Fix: Add manage_tx = True at line 654 after conn = self._conn().
+    REGRESSION GUARD: This was the original C1 bug — mempool_add() referenced
+    manage_tx 7 times in error/rollback paths without ever defining it,
+    causing every error path to raise NameError (swallowed by bare-except).
+
+    Fixed via PR #2812 (manage_tx = True at top of mempool_add).
+
+    This test now asserts the FIX is in place, not the bug:
+      - mempool_add MUST define manage_tx (was: must NOT define it)
+      - mempool_add can be called without raising NameError
     """
     from utxo_db import UtxoDB
 
     with open(os.path.join(os.path.dirname(os.path.abspath(__file__)),
                            '..', '..', 'node', 'utxo_db.py')) as f:
         lines = f.readlines()
-    
-    # apply_transaction defines manage_tx
+
+    # apply_transaction defines manage_tx based on conn ownership
     found_define = False
     for i, line in enumerate(lines[350:400], 351):
         if 'manage_tx = ' in line and 'own' in line:
             found_define = True
             break
-    
-    # mempool_add does NOT define it
+
+    # mempool_add MUST now define manage_tx (#2812 fix)
     in_mempool_add = False
     mempool_refs = []
     mempool_define = False
-    for i, line in enumerate(lines[647:782], 648):
+    for i, line in enumerate(lines[647:790], 648):
         if 'def mempool_add' in line:
             in_mempool_add = True
-        if in_mempool_add and 'manage_tx = ' in line and 'own' in line:
+        if in_mempool_add and line.strip().startswith('manage_tx = '):
             mempool_define = True
-        if 'manage_tx' in line:
+        if in_mempool_add and 'manage_tx' in line:
             mempool_refs.append((i, line.strip()))
-    
+
     assert found_define, "apply_transaction should define manage_tx"
-    assert not mempool_define, "mempool_add should NOT define manage_tx (this is the bug)"
-    assert len(mempool_refs) == 7, \
-        f"Expected 7 manage_tx refs in mempool_add, got {len(mempool_refs)}"
-    
-    print(f"[FINDING 1] PASS: manage_tx undefined in mempool_add()")
-    print(f"  {len(mempool_refs)} references at lines: "
-          f"{', '.join(str(r[0]) for r in mempool_refs)}")
+    assert mempool_define, \
+        "mempool_add MUST define manage_tx (#2812 fix); originally undefined → NameError"
+    # Original bug had exactly 7 ROLLBACK refs. After fix we add the assignment
+    # plus a comment; both contain 'manage_tx'. So expect ≥ 7 refs (regression
+    # guard: the 7 ROLLBACK paths must remain intact).
+    assert len(mempool_refs) >= 7, \
+        f"Expected ≥7 manage_tx refs in mempool_add, got {len(mempool_refs)}"
+
+    # Smoke test: instantiate and call mempool_add with invalid input.
+    # Must return False cleanly without raising NameError (the original bug).
+    db = UtxoDB(':memory:')
+    db.init_tables()
+    result = db.mempool_add({
+        'tx_id': 'regression-test',
+        'tx_type': 'transfer',
+        'inputs': [{'box_id': 'nonexistent'}],
+        'outputs': [{'address': 'a', 'value_nrtc': 100}],
+    })
+    assert result is False, "mempool_add should return False on invalid input, not raise"
+
+    print(f"[FINDING 1] PASS: #2812 fix in place — mempool_add defines manage_tx")
+    print(f"  {len(mempool_refs)} references in mempool_add (≥7 ROLLBACK paths intact)")
     return True
 
 

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -164,11 +164,12 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(len(bounties), 1)
         self.assertEqual(bounties[0]['difficulty'], 'MEDIUM')
         
-        # Claim bounty
+        # Claim bounty (admin-only per #2800 — requires X-Admin-Key)
         claim_response = self.client.post(
             '/api/bounties/gh_test_bounty/claim',
             data=json.dumps({'agent_id': 'bcn_claimer'}),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
         )
         self.assertEqual(claim_response.status_code, 200)
         


### PR DESCRIPTION
5 tests on main broken by yesterday's audit-fix merges. This PR brings CI green.

| Test | Broken by | Fix |
|------|-----------|-----|
| test_mempool_add_manage_tx_undefined | #2812 (C1 fix added manage_tx assignment) | Updated PoC to assert FIX (was asserting BUG); added smoke test |
| test_pncounter_max_merge_inflation | RC_P2P_SECRET unset → SystemExit on import | Added RC_P2P_SECRET to ci.yml env |
| test_bounty_lifecycle_workflow | #2800 (auth on /api/bounties/.../claim) | Added X-Admin-Key header to test |
| test_utxo_transfer_rejects_duplicate_nonce | #2814 (M2 Decimal not JSON-serializable) | float() cast on signed payload + response |
| test_utxo_transfer_failed_attempt_does_not_burn_nonce | same | same |

All 6 tests pass locally with the env vars set.

Decimal arithmetic still happens internally (precision-loss + overflow guards intact); the float() casts are only at JSON-boundary points (signed payload to wallets, response back to clients) — preserves byte-identical signature material.

+57/-27 across 4 files.