### PR TITLE
docs: add x402 deployment verification checklist

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -537,12 +537,32 @@ curl -sk -X POST https://rustchain.org/rewards/settle \
 
 These endpoints support the x402 payment protocol (currently free during beta).
 
+### Deployment verification checklist
+
+Use this checklist when testing a live deployment or bounty report. A working
+x402 route should return either a successful JSON response or a payment
+challenge such as `402 Payment Required`. A plain `404` usually means the route
+is not mounted on that host or the public prefix changed.
+
+| Surface | Command | Expected when mounted |
+|---------|---------|-----------------------|
+| BoTTube status | `curl -sk https://bottube.ai/api/x402/status` | JSON status or x402 challenge |
+| BoTTube videos | `curl -sk https://bottube.ai/api/premium/videos` | JSON export or x402 challenge |
+| BoTTube analytics | `curl -sk https://bottube.ai/api/premium/analytics/sophia-elya` | JSON analytics or x402 challenge |
+| Beacon status | `curl -sk https://rustchain.org/beacon/api/x402/status` | JSON status or x402 challenge |
+| Beacon reputation | `curl -sk https://rustchain.org/beacon/api/premium/reputation` | JSON export or x402 challenge |
+| Beacon contracts | `curl -sk https://rustchain.org/beacon/api/premium/contracts/export` | JSON export or x402 challenge |
+| RustChain swap info | `curl -sk https://rustchain.org/wallet/swap-info` | JSON swap guidance |
+
+Keep the raw `curl -skv` output when filing a deployment issue. It shows the
+HTTP status, server headers, and whether the request reached the x402 handler.
+
 ### GET /api/premium/videos
 
 Bulk video export (BoTTube integration).
 
 ```bash
-curl -sk https://rustchain.org/api/premium/videos
+curl -sk https://bottube.ai/api/premium/videos
 ```
 
 ---
@@ -552,7 +572,7 @@ curl -sk https://rustchain.org/api/premium/videos
 Deep agent analytics.
 
 ```bash
-curl -sk https://rustchain.org/api/premium/analytics/scott
+curl -sk https://bottube.ai/api/premium/analytics/scott
 ```
 
 ---


### PR DESCRIPTION
## What changed

- Added a short x402 deployment verification checklist to `docs/api-reference.md`
- Clarified that a working paid route should return JSON or `402`, while a plain `404` usually means the route is not mounted or the public prefix changed
- Updated the BoTTube premium curl examples to use `https://bottube.ai` instead of the RustChain host

## Why

I hit this while retesting the x402 bounty endpoints from raw `curl -skv` logs. The checklist gives future testers a common set of commands and makes deployment drift easier to report.

Bounty context: Scottcjn/rustchain-bounties#2178

Payout wallet: `0x3da59c360cd542de69440189ad7c09b7349ce299` (Base/EVM)
Solana wallet if needed for wRTC: `2KzLaDZ2n8C7xyM62naY6xLAeyFo3xqmT8ivV5o6GQHh`