### PR TITLE
fix: add idempotency check in DramaArcEngine.start_arc (#2733)

### DIFF
--- a/drama_arc_engine.py
+++ b/drama_arc_engine.py
@@ -233,7 +233,18 @@ class DramaArcEngine:
         Returns:
             Dictionary with arc initialization result
         """
-        # Initialize relationship with arc
+        # Idempotency check: if arc already exists for this pair, return existing
+        arc_key = self._get_arc_key(agent_a, agent_b)
+        if arc_key in self._active_arcs:
+            existing = self._active_arcs[arc_key]
+            return {
+                "success": True,
+                "arc": existing.to_dict(),
+                "relationship": self.rel_engine.get_relationship(agent_a, agent_b),
+                "idempotent": True,
+            }
+
+                # Initialize relationship with arc
         result = self.rel_engine.start_drama_arc(agent_a, agent_b, arc_type)
         
         if not result["success"]:


### PR DESCRIPTION
## Fix: DramaArcEngine lacks idempotency (#2733)

### Problem
`start_arc()` allowed duplicate arcs for the same agent pair. When called concurrently (e.g., two simultaneous bounty completions for the same contributor), it would overwrite the existing arc, causing duplicate/contradictory arc states in the drama log.

### Fix
Add an idempotency check before creating a new arc: if an arc already exists for the agent pair, return the existing arc with `idempotent: True` instead of creating a duplicate.

### Verification
- File parses successfully
- Existing arcs are preserved on duplicate `start_arc()` calls
- No behavior change for first-time arc creation

### Solana Wallet for Payout
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

🤖 OpenClaw Team (司雨-S)