### PR TITLE
fix: Python 2 print statement (#2864) and f-string backslash (#2865)

### DIFF
--- a/miners/linux/rustchain_living_museum.py
+++ b/miners/linux/rustchain_living_museum.py
@@ -459,7 +459,8 @@ class LivingMuseumBot(discord.Client):
             for a in archs:
                 arch_counts[a] = arch_counts.get(a, 0) + 1
 
-            arch_summary = ", ".join([f"{ARCH_EMOJIS.get(a, '\U0001F527')}{c}" for a, c in arch_counts.items()])
+            _wrench = '\U0001F527'
+            arch_summary = ", ".join([f"{ARCH_EMOJIS.get(a, _wrench)}{c}" for a, c in arch_counts.items()])
 
             timeline_text += f"**{date}:** +{count} machines\n"
             timeline_text += f"    {arch_summary}\n"

--- a/wallet/rustchain_wallet_ppc.py
+++ b/wallet/rustchain_wallet_ppc.py
@@ -103,7 +103,7 @@ try:
     import tkMessageBox
     import tkSimpleDialog
 except ImportError:
-    print "Error: Tkinter not available"
+    print("Error: Tkinter not available")
     sys.exit(1)
 
 # Configuration


### PR DESCRIPTION
## Summary
- **wallet/rustchain_wallet_ppc.py**: Convert Python 2 `print` statement to Python 3 `print()` function (#2864)
- **miners/linux/rustchain_living_museum.py**: Extract backslash escape from f-string expression to comply with Python 3.12+ (#2865)

## Changes

### #2864 - Python 2 print statement
Line 106: `print "Error: Tkinter not available"` → `print("Error: Tkinter not available")`

This was causing `SyntaxError` on Python 3, making the wallet module crash on startup.

### #2865 - Backslash in f-string expression  
Line 462: Extracted `'\U0001F527'` (🔧 emoji) from inside the f-string `{}` expression to a local variable. Python 3.12+ raises `SyntaxError` for backslashes inside f-string expressions.

```python
# Before
arch_summary = ", ".join([f"{ARCH_EMOJIS.get(a, '\U0001F527')}{c}" for a, c in arch_counts.items()])

# After
_wrench = '\U0001F527'
arch_summary = ", ".join([f"{ARCH_EMOJIS.get(a, _wrench)}{c}" for a, c in arch_counts.items()])
```

Fixes #2864
Fixes #2865