### PR TITLE
security: fix timing-unsafe admin key comparison (timing attack #3200)

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import io
 import json
+import hmac
 import os
 import sqlite3
 import time
@@ -169,7 +170,7 @@ def bcos_attest():
     - Valid Ed25519 signature in the report
     """
     admin_key = request.headers.get("X-Admin-Key", "")
-    is_admin = admin_key and admin_key == _get_admin_key()
+    is_admin = admin_key and hmac.compare_digest(admin_key, _get_admin_key() or "")
 
     data = request.get_json(silent=True)
     if not data:

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -16,6 +16,7 @@ Endpoints:
 
 import sqlite3
 import time
+import hmac
 import hashlib
 import os
 from typing import Optional, Tuple, Dict, Any
@@ -679,7 +680,7 @@ def register_bridge_routes(app):
         
         # Check admin initiation (bypasses balance check)
         admin_key = request.headers.get("X-Admin-Key", "")
-        admin_initiated = admin_key == os.environ.get("RC_ADMIN_KEY", "")
+        admin_initiated = hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
         
         # Create bridge transfer
         req = BridgeTransferRequest(

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4539,7 +4539,7 @@ def register_withdrawal_key():
     # SECURITY: prevent unauthenticated key overwrite (withdrawal takeover).
     # First-time registration is allowed. Rotation requires admin key.
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = admin_key == os.environ.get("RC_ADMIN_KEY", "")
+    is_admin = hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
 
     now = int(time.time())
     with sqlite3.connect(DB_PATH) as c:
@@ -6054,7 +6054,7 @@ def ops_readiness():
     """Single PASS/FAIL aggregator for all go/no-go checks"""
     # SECURITY FIX 2026-02-15: Only show detailed checks to admin
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = admin_key == ADMIN_KEY
+    is_admin = hmac.compare_digest(admin_key, ADMIN_KEY or "")
     out = {"ok": True, "checks": []}
 
     # Health check


### PR DESCRIPTION
## Security Fix: Timing-Unsafe Admin Key Comparison (#3200)

### Problem
Several endpoints use `==` for admin key comparison instead of `hmac.compare_digest()`. Python's `==` operator on strings returns False as soon as it finds a mismatched character, making comparison time proportional to the number of matching prefix characters. This enables timing side-channel attacks to reconstruct the admin key one character at a time.

### Affected Endpoints
- `node/bcos_routes.py:172` — BCOS attestation admin check
- `node/bridge_api.py:682` — Bridge admin check  
- `node/rustchain_v2_integrated_v2.2.1_rip200.py:6057` — Health check admin

### Contrast with Correct Implementation
`node/lock_ledger.py` correctly uses `hmac.compare_digest()` for the same purpose.

### Fix
Replace all `==` comparisons with `hmac.compare_digest()` for constant-time comparison.

### Solana Wallet for Payout
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

🤖 OpenClaw Team (司雨-S)