### PR TITLE
security: fix auto-release endpoint unauthenticated when RC_WORKER_KEY not set (#3203)

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -764,12 +764,13 @@ def register_lock_ledger_routes(app):
     @app.route('/api/lock/auto-release', methods=['POST'])
     def auto_release_endpoint():
         """Worker: Auto-release expired locks."""
-        # Optional: require worker key
-        worker_key = request.headers.get("X-Worker-Key", "")
-        expected_worker = os.environ.get("RC_WORKER_KEY", "")
-        if expected_worker and worker_key != expected_worker:
-            return jsonify({"error": "Unauthorized"}), 401
-        
+    # Require worker key authentication
+    worker_key = request.headers.get("X-Worker-Key", "")
+    expected_worker = os.environ.get("RC_WORKER_KEY", "")
+    if not expected_worker:
+        return jsonify({"error": "RC_WORKER_KEY not configured — worker endpoints disabled"}), 503
+    if not hmac.compare_digest(worker_key, expected_worker):
+        return jsonify({"error": "Unauthorized"}), 401
         batch_size = int(request.args.get("batch_size", 100))
         
         conn = sqlite3.connect(DB_PATH)

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -764,13 +764,13 @@ def register_lock_ledger_routes(app):
     @app.route('/api/lock/auto-release', methods=['POST'])
     def auto_release_endpoint():
         """Worker: Auto-release expired locks."""
-    # Require worker key authentication
-    worker_key = request.headers.get("X-Worker-Key", "")
-    expected_worker = os.environ.get("RC_WORKER_KEY", "")
-    if not expected_worker:
-        return jsonify({"error": "RC_WORKER_KEY not configured — worker endpoints disabled"}), 503
-    if not hmac.compare_digest(worker_key, expected_worker):
-        return jsonify({"error": "Unauthorized"}), 401
+        # Require worker key authentication
+        worker_key = request.headers.get("X-Worker-Key", "")
+        expected_worker = os.environ.get("RC_WORKER_KEY", "")
+        if not expected_worker:
+            return jsonify({"error": "RC_WORKER_KEY not configured — worker endpoints disabled"}), 503
+        if not hmac.compare_digest(worker_key, expected_worker):
+            return jsonify({"error": "Unauthorized"}), 401
         batch_size = int(request.args.get("batch_size", 100))
         
         conn = sqlite3.connect(DB_PATH)


### PR DESCRIPTION
## Security Fix: Auto-Release Endpoint Authentication (#3203)

### Problem
Two security issues in `/api/lock/auto-release`:

1. **Unauthenticated when RC_WORKER_KEY not set**: The check `if expected_worker and worker_key != expected_worker` means when `RC_WORKER_KEY` is not configured, authentication is completely skipped. Anyone can trigger auto-release of locked funds.

2. **Timing-unsafe comparison**: `worker_key != expected_worker` uses `==` instead of `hmac.compare_digest()`, enabling timing attacks.

### Fix
- Require `RC_WORKER_KEY` to be configured (return 503 if not set)
- Use `hmac.compare_digest()` for constant-time comparison

### Solana Wallet for Payout
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

🤖 OpenClaw Team (司雨-S)