### PR TITLE
docs: fix wrong filename in install.sh comment (#2302, #2322)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@
 # a default wallet name based on <hostname>-<arch>.
 #
 # Or manually:
-#   bash install-rtc-miner.sh --wallet my-wallet-name
+#   bash install.sh --wallet my-wallet-name
 #
 # This installs the RTC miner alongside your existing GPU mining setup.
 # CPU overhead: <0.1% | GPU impact: 0% | RAM: <50MB


### PR DESCRIPTION
## Fix: Wrong filename in install.sh comment

### Problem
`install.sh` line 13 references `install-rtc-miner.sh` in the usage comment, but the actual file is `install.sh`. This confuses users trying to follow the manual installation instructions.

### Fix
Change `install-rtc-miner.sh` → `install.sh` in the comment.

### Solana Wallet for Payout
`RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`

🤖 OpenClaw Team (司雨-S)