### PR TITLE
fix: timing-safe admin key comparison in bcos_routes.py (#3200)

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import hmac
 import sqlite3
 import time
 from hashlib import blake2b
@@ -169,7 +170,7 @@ def bcos_attest():
     - Valid Ed25519 signature in the report
     """
     admin_key = request.headers.get("X-Admin-Key", "")
-    is_admin = admin_key and admin_key == _get_admin_key()
+    is_admin = admin_key and hmac.compare_digest(admin_key, _get_admin_key())
 
     data = request.get_json(silent=True)
     if not data:


### PR DESCRIPTION
Replaced `==` with `hmac.compare_digest()` for admin key comparison on line 172.

Python's `==` short-circuits on first mismatched char → timing side channel.
`hmac.compare_digest()` runs in constant time.

Fixes #3200