### PR TITLE
fix: dont leak internal error details via str(e) in api responses (#3202)

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -248,7 +248,7 @@ def bcos_attest():
     except sqlite3.IntegrityError:
         return jsonify({"error": f"Certificate {cert_id} already exists"}), 409
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "internal error"}), 500
 
 
 @bcos_bp.route("/bcos/verify/<cert_id>", methods=["GET"])
@@ -306,7 +306,7 @@ def bcos_verify(cert_id):
             "pdf_url": f"https://50.28.86.131/bcos/cert/{cert_id}.pdf",
         })
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "internal error"}), 500
 
 
 @bcos_bp.route("/bcos/cert/<cert_id>.pdf", methods=["GET"])
@@ -346,7 +346,7 @@ def bcos_certificate_pdf(cert_id):
             download_name=f"{cert_id}.pdf",
         )
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "internal error"}), 500
 
 
 @bcos_bp.route("/bcos/badge/<cert_id>.svg", methods=["GET"])
@@ -431,7 +431,7 @@ def bcos_directory():
             "certificates": certs,
         })
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "internal error"}), 500
 
 
 # ── Registration ──────────────────────────────────────────────────

--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import hmac
 import sqlite3
 import time
 from hashlib import blake2b
@@ -169,7 +170,7 @@ def bcos_attest():
     - Valid Ed25519 signature in the report
     """
     admin_key = request.headers.get("X-Admin-Key", "")
-    is_admin = admin_key and admin_key == _get_admin_key()
+    is_admin = admin_key and hmac.compare_digest(admin_key, _get_admin_key())
 
     data = request.get_json(silent=True)
     if not data:


### PR DESCRIPTION
Multiple endpoints returned `str(e)` in error responses, leaking DB schemas, file paths, and config details.

Changed to generic `"internal error"` messages.

Affected files:
- node/bcos_routes.py
- node/beacon_api.py

Fixes #3202