### PR TITLE
fix(ci): replace JSON `true` with Python `True` in OpenAPI spec

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -926,7 +926,7 @@ OPENAPI = {
                     {
                         "name": "miner_pk",
                         "in": "path",
-                        "required": true,
+                        "required": True,
                         "schema": {"type": "string"},
                         "description": "Miner public key (hex)"
                     }
@@ -957,7 +957,7 @@ OPENAPI = {
                     {
                         "name": "address",
                         "in": "query",
-                        "required": true,
+                        "required": True,
                         "schema": {"type": "string"},
                         "description": "Wallet address (RTC...)"
                     }


### PR DESCRIPTION
## Bug

The OpenAPI spec dictionary in `node/rustchain_v2_integrated_v2.2.1_rip200.py` uses JSON-style `true` (lowercase) instead of Python `True`. This causes a `NameError` at module import time, which makes the entire CI test job fail before any test can actually run.

```
NameError: name 'true' is not defined
```

**Affected lines:** 929 and 960

## Impact
- CI workflow **always fails** at import stage
- All test runs are blocked (pytest can't even collect)
- Every push triggers a red CI regardless of actual code quality

## Fix
- Replace `"required": true` → `"required": True` (capital T, Python boolean)

## Verification
- Local test run: `test_attest_submit_mutation_regression_no_unhandled_exceptions` ✅ PASSED
- Before fix: `NameError` at import
- After fix: tests collect and run normally