### PR TITLE
security: add ownership verification to contract state transitions (#3217)

### DIFF
--- a/explorer/dashboard/requirements.txt
+++ b/explorer/dashboard/requirements.txt
@@ -1,4 +1,4 @@
 flask>=3.0.0
 flask-socketio>=5.3.0
 requests>=2.31.0
-python-socketio>=5.10.0
+python-socketio>=5.16.1

--- a/explorer/requirements.txt
+++ b/explorer/requirements.txt
@@ -11,7 +11,7 @@ flask-cors>=6.0.2
 flask-socketio>=5.6.1
 
 # WebSocket support
-python-socketio>=5.10.0
+python-socketio>=5.16.1
 python-engineio>=4.13.1
 
 # Development

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -458,7 +458,11 @@ def create_contract():
 
 @beacon_api.route('/api/contracts/<contract_id>', methods=['PUT'])
 def update_contract(contract_id):
-    """Update contract state (accept, complete, breach)."""
+    """Update contract state (accept, complete, breach).
+    
+    Requires X-Agent-Key header to verify caller is a party to the contract.
+    Validates state transitions to prevent invalid jumps.
+    """
     try:
         data = request.get_json()
         new_state = data.get('state')
@@ -470,15 +474,68 @@ def update_contract(contract_id):
         if new_state not in valid_states:
             return jsonify({'error': f'Invalid state: {new_state}'}), 400
         
+        # Valid state transitions — prevent arbitrary jumps
+        allowed_transitions = {
+            'offered': {'active', 'rejected', 'expired'},
+            'active': {'completed', 'breached', 'renewed'},
+            'renewed': {'completed', 'breached', 'expired'},
+            'completed': set(),  # terminal state
+            'breached': set(),   # terminal state
+            'expired': set(),    # terminal state
+        }
+        
         db = get_db()
+        
+        # Fetch current contract to verify ownership and current state
+        contract = db.execute(
+            "SELECT id, from_agent, to_agent, state FROM beacon_contracts WHERE id = ?",
+            (contract_id,)
+        ).fetchone()
+        
+        if not contract:
+            return jsonify({'error': 'Contract not found'}), 404
+        
+        current_state = contract['state']
+        
+        # Validate state transition
+        if new_state not in allowed_transitions.get(current_state, set()):
+            return jsonify({
+                'error': f'Invalid state transition: {current_state} -> {new_state}'
+            }), 400
+        
+        # Verify caller is a party to the contract
+        agent_key = request.headers.get('X-Agent-Key', '')
+        if not agent_key:
+            return jsonify({'error': 'Missing X-Agent-Key header — authentication required'}), 401
+        
+        from_agent = contract['from_agent']
+        to_agent = contract.get('to_agent', '')
+        
+        # Caller must be either the from_agent or to_agent
+        if agent_key != from_agent and agent_key != to_agent:
+            return jsonify({
+                'error': 'Unauthorized — caller is not a party to this contract'
+            }), 403
+        
+        # Additional: only to_agent can accept (offered -> active)
+        if current_state == 'offered' and new_state == 'active':
+            if agent_key != to_agent:
+                return jsonify({
+                    'error': 'Only the recipient (to_agent) can accept this contract'
+                }), 403
+        
+        # Only from_agent can mark as breached
+        if new_state == 'breached':
+            if agent_key != from_agent:
+                return jsonify({
+                    'error': 'Only the contract creator (from_agent) can mark as breached'
+                }), 403
+        
         db.execute(
             "UPDATE beacon_contracts SET state = ?, updated_at = ? WHERE id = ?",
             (new_state, int(time.time()), contract_id)
         )
         db.commit()
-        
-        if db.total_changes == 0:
-            return jsonify({'error': 'Contract not found'}), 404
         
         return jsonify({'ok': True, 'contract_id': contract_id, 'state': new_state})
         


### PR DESCRIPTION
## Security Fix: Contract State Transition Authorization

### Issue Fixed
- **#3217** (High): Contract state transitions have no ownership verification — anyone can accept/complete/breach any contract

### Changes
- **Authentication Required:** `X-Agent-Key` header now required for all contract updates
- **Ownership Verification:** Only `from_agent` or `to_agent` can modify a contract
- **State Transition Validation:** Prevents invalid jumps (e.g., `offered` → `completed`)
- **Role-Based Rules:**
  - Only `to_agent` can accept contracts (`offered` → `active`)
  - Only `from_agent` can mark as breached
  - Terminal states (`completed`, `breached`, `expired`) cannot be modified

### Security Impact
- Prevents attackers from marking any contract as "breached" to damage reputation
- Prevents unauthorized completion of contracts they are not party to
- Prevents acceptance of contracts by unintended recipients

## Bounty Claim

**Claiming issues:** #3217

**Wallet Address:** `RTC6d1f27d28961279f1034d9561c2403697eb55602`