### PR TITLE
fix: improve --dry-run help text to mention hardware fingerprint output (Fixes #3267)

### DIFF
--- a/rustchain-miner/src/main.rs
+++ b/rustchain-miner/src/main.rs
@@ -32,7 +32,7 @@ struct Args {
     #[arg(short = 'p', long = "proxy", env = "RUSTCHAIN_PROXY_URL")]
     proxy: Option<String>,
 
-    /// Run preflight checks only (no mining)
+    /// Test mode: run preflight checks and output hardware fingerprint without actual mining
     #[arg(long = "dry-run", env = "RUSTCHAIN_DRY_RUN")]
     dry_run: bool,
 


### PR DESCRIPTION
## Summary
Fixes #3267

The --dry-run flag help text in the miner CLI was too brief. Updated it to clearly explain that it runs in test mode, outputting hardware fingerprint without actual mining.

## Changes
- rustchain-miner/src/main.rs: Updated help text to be more descriptive

## Testing
```
cargo run -- --help | grep dry-run
```

Wallet: RTC4642c5ee8467f61ed91b5775b0eeba984dd776ba