### PR TITLE
docs: fix GPU fingerprinting RIP link

### DIFF
--- a/docs/GPU_FINGERPRINTING.md
+++ b/docs/GPU_FINGERPRINTING.md
@@ -95,6 +95,6 @@ Minimum 3 violations even for same-architecture spoofs.
 
 ## Reference
 
-- [RIP-0308: Proof of Physical AI](rips/docs/RIP-0308-proof-of-physical-ai.md)
+- [RIP-0308: Proof of Physical AI](../rips/docs/RIP-0308-proof-of-physical-ai.md)
 - [DOI: 10.5281/zenodo.19442753](https://doi.org/10.5281/zenodo.19442753)
 - Khattak & Mikaitis, "Accurate Models of NVIDIA Tensor Cores" (arXiv:2512.07004)


### PR DESCRIPTION
﻿## Summary

- Fixes the `docs/GPU_FINGERPRINTING.md` Reference link to RIP-0308.
- The current relative link resolves under `docs/rips/...`, but the target lives at repo root under `rips/docs/...`.

## Verification

- Confirmed `docs/rips/docs/RIP-0308-proof-of-physical-ai.md` does not exist.
- Confirmed `rips/docs/RIP-0308-proof-of-physical-ai.md` exists.
- Ran `git diff --check`.

Fixes #3970.
