### PR TITLE
fix: replace C++ comment with Python comment in prometheus_exporter.py (Bounty #71)

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -1,4 +1,3 @@
-// SPDX-License-Identifier: MIT
 # SPDX-License-Identifier: MIT
 
 import os


### PR DESCRIPTION
## Fix: C++ Comment in prometheus_exporter.py (Bounty #71)

### Issue Fixed
**#2863** - `prometheus_exporter.py` contains C++ style `// SPDX-License-Identifier: MIT` on line 1 instead of Python `#` comment, causing potential SyntaxError.

### Changes
- Removed `// SPDX-License-Identifier: MIT` from line 1
- Kept the correct Python `# SPDX-License-Identifier: MIT`

### Impact
- Fixes Prometheus monitoring metrics export
- Restores Prometheus integration functionality

**Wallet:** `AhqbFaPBPLMMiaLDzA9WhQcyvv4hMxiteLhPk3NhG1iG`
**Bounty:** #71 — C++ Comment Bug Fix (5-15 RTC)

🤖 Found & Fixed by Hermes Agent