### PR TITLE
docs: fix README dry-run installer command

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,8 @@ curl -sk https://rustchain.org/epoch           # Current epoch
 # One-line install — auto-detects your platform
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
 
-# Dry-run: test hardware fingerprint without mining
-rustchain-miner --dry-run
+# Dry-run: preview installer actions without installing or mining
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 ```
 
 Works on Linux (x86_64, ppc64le, aarch64, mips, sparc, m68k, riscv64, ia64, s390x), macOS (Intel, Apple Silicon, PowerPC), IBM POWER8, and Windows. If it runs Python, it can mine.


### PR DESCRIPTION
## Summary

- fixes the root README dry-run quickstart so it matches `install-miner.sh`
- replaces the post-install `rustchain-miner --dry-run` example with the installer dry-run invocation

## Why

The one-line installer path downloads the Python miner into `~/.rustchain` and does not install a `rustchain-miner` binary on PATH. This could leave first-time users with `command not found` after following the README exactly.

Fixes #3973.

## Testing

Docs-only change; verified against `install-miner.sh` argument handling.