### PR TITLE
fix: add input validation to prevent DoS via type conversion errors (#2687)

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -331,10 +331,13 @@ def check_eligibility():
     Returns whether an agent is eligible to claim a job of given value.
     """
     agent_id  = request.args.get("agent_id", "").strip()
-    job_value = float(request.args.get("job_value", 0))
-
     if not agent_id:
         return jsonify({"error": "agent_id required"}), 400
+
+    try:
+        job_value = float(request.args.get("job_value", 0))
+    except (ValueError, TypeError):
+        return jsonify({"error": "job_value must be a number"}), 400
 
     rep = _engine.get(agent_id)
     max_val = rep["max_job_value_rtc"]
@@ -364,7 +367,10 @@ def leaderboard():
     GET /agent/reputation/leaderboard?limit=20
     Returns top agents by reputation (from cache).
     """
-    limit = min(int(request.args.get("limit", 20)), 100)
+    try:
+        limit = min(int(request.args.get("limit", 20)), 100)
+    except (ValueError, TypeError):
+        return jsonify({"error": "limit must be an integer"}), 400
     with _engine._lock:
         entries = [(w, d["reputation_score"]) for w, (d, _) in _engine._cache.items()]
     entries.sort(key=lambda x: x[1], reverse=True)


### PR DESCRIPTION
## 🔧 Bug Fix — Input Validation DoS (#2687, Bounty #71)

### Problem
Two API endpoints crash with `500 Internal Server Error` when given non-numeric query parameters:

1. `GET /agent/reputation/check-eligibility?job_value=abc` → `ValueError: could not convert string to float`
2. `GET /agent/reputation/leaderboard?limit=xyz` → `ValueError: invalid literal for int()`

This allows any user to trigger server errors by sending malformed query strings.

### Fix
Wrapped `float()` and `int()` conversions in `try/except` blocks:

```python
# Before
job_value = float(request.args.get("job_value", 0))  # Crashes on "abc"

# After
try:
    job_value = float(request.args.get("job_value", 0))
except (ValueError, TypeError):
    return jsonify({"error": "job_value must be a number"}), 400
```

### Files Changed
- `agent_reputation.py`: Added validation for `job_value` and `limit` parameters

### Bounty
Linked to **Bounty #71** (Ongoing Bug Bounty Program — 5-15 RTC)

### Testing
```bash
# Should return 400, not 500
curl "http://localhost:5000/agent/reputation/check-eligibility?agent_id=test&job_value=abc"
curl "http://localhost:5000/agent/reputation/leaderboard?limit=xyz"
```
