### PR TITLE
fix: use cryptographically secure nonces for P2P message IDs (#2268)

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -500,8 +500,10 @@ class GossipLayer:
     def create_message(self, msg_type: MessageType, payload: Dict, ttl: int = GOSSIP_TTL) -> GossipMessage:
         """Create a new gossip message"""
         # Generate msg_id first for signature binding (Issue #2272)
+        # Issue #2268: Use cryptographically secure random nonce instead of predictable time.time()
         temp_content = f"{msg_type.value}:{self.node_id}:{json.dumps(payload, sort_keys=True)}"
-        msg_id = hashlib.sha256(f"{temp_content}:{time.time()}".encode()).hexdigest()[:24]
+        secure_nonce = secrets.token_hex(16)  # 128-bit cryptographically secure random value
+        msg_id = hashlib.sha256(f"{temp_content}:{secure_nonce}".encode()).hexdigest()[:24]
         
         content = self._signed_content(msg_type.value, self.node_id, msg_id, ttl, payload)
         sig, ts = self._sign_message(content)
@@ -937,8 +939,10 @@ class GossipLayer:
         # Uses the Phase A signed-content shape (msg_type:sender_id:payload)
         # so verify_message() on the requester side accepts it.
         payload = {"state": state_data}
+        # Issue #2268: Use cryptographically secure random nonce instead of predictable time.time()
+        state_nonce = secrets.token_hex(16)
         state_msg_id = hashlib.sha256(
-            f"STATE:{self.node_id}:{json.dumps(payload, sort_keys=True)}:{time.time()}".encode()
+            f"STATE:{self.node_id}:{json.dumps(payload, sort_keys=True)}:{state_nonce}".encode()
         ).hexdigest()[:24]
         
         content = self._signed_content(MessageType.STATE.value, self.node_id, state_msg_id, 0, payload)

--- a/tests/test_p2p_nonce_security.py
+++ b/tests/test_p2p_nonce_security.py
@@ -1,0 +1,40 @@
+"""
+Tests for P2P Gossip Nonce Security (Issue #2268).
+
+Verifies that message IDs are generated using cryptographically secure 
+random nonces instead of predictable timestamps.
+"""
+import unittest
+import os
+
+class TestP2PNonceSecurity(unittest.TestCase):
+    def test_create_message_uses_secure_nonce(self):
+        """create_message must use secrets.token_hex for nonce generation."""
+        gossip_file = os.path.join(os.path.dirname(__file__), '..', 'node', 'rustchain_p2p_gossip.py')
+        with open(gossip_file, 'r') as f:
+            content = f.read()
+        
+        # Check that secure_nonce is used in message creation
+        self.assertIn("secure_nonce = secrets.token_hex(16)", content, 
+            "create_message must use secrets.token_hex(16) for nonce")
+        
+        # Ensure the vulnerable time.time() pattern in msg_id generation is gone
+        self.assertNotIn("f\"{temp_content}:{time.time()}\"", content,
+            "msg_id must NOT use predictable time.time()")
+
+    def test_state_message_uses_secure_nonce(self):
+        """State messages must also use secure nonces."""
+        gossip_file = os.path.join(os.path.dirname(__file__), '..', 'node', 'rustchain_p2p_gossip.py')
+        with open(gossip_file, 'r') as f:
+            content = f.read()
+            
+        # Check that state_nonce is used
+        self.assertIn("state_nonce = secrets.token_hex(16)", content,
+            "State message generation must use secrets.token_hex(16)")
+        
+        # Ensure the vulnerable pattern in STATE msg_id is gone
+        self.assertNotIn("f\"STATE:{self.node_id}:{json.dumps(payload, sort_keys=True)}:{time.time()}\"", content,
+            "STATE msg_id must NOT use predictable time.time()")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces predictable `time.time()` with `secrets.token_hex(16)` for generating P2P message IDs, preventing message ID prediction and replay attacks.

## Changes
- `node/rustchain_p2p_gossip.py`: Applied secure nonce generation in `create_message()` and `_handle_get_state()`.
- `tests/test_p2p_nonce_security.py`: Added tests to verify nonces are used and predictable patterns are removed.

## Context
This is a clean re-submission of **PR #3997**. The original PR contained unrelated changes (branch pollution). This PR only includes the verified security fix for Issue #2268.

Supersedes #3997.