### PR TITLE
fix: replace direct string comparisons with hmac.compare_digest (#3959)

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -536,7 +536,7 @@ def update_contract(contract_id):
             return jsonify({'error': 'Missing X-Agent-Key header — authentication required'}), 401
         
         from_agent = contract['from_agent']
-        to_agent = contract.get('to_agent', '')
+        to_agent = contract['to_agent']
         
         # Caller must be either the from_agent or to_agent
         if agent_key != from_agent and agent_key != to_agent:

--- a/node/governance.py
+++ b/node/governance.py
@@ -24,6 +24,7 @@ Date: 2026-03-07
 """
 
 import hashlib
+import hmac
 import json
 import logging
 import sqlite3
@@ -553,7 +554,7 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
         # Admin key is validated via environment variable (not hardcoded)
         import os
         expected_key = os.environ.get("RUSTCHAIN_ADMIN_KEY", "")
-        if not expected_key or admin_key != expected_key:
+        if not expected_key or not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "invalid admin_key"}), 403
 
         try:

--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -92,7 +92,7 @@ def register_sync_endpoints(app, db_path, admin_key):
         @wraps(f)
         def decorated(*args, **kwargs):
             key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key")
-            if not key or key != admin_key:
+            if not key or not hmac.compare_digest(key, admin_key):
                 return jsonify({"error": "Unauthorized"}), 401
             return f(*args, **kwargs)
 

--- a/node/sophia_attestation_inspector.py
+++ b/node/sophia_attestation_inspector.py
@@ -15,6 +15,7 @@ import json
 import time
 import sqlite3
 import hashlib
+import hmac
 import argparse
 import logging
 import traceback
@@ -701,7 +702,7 @@ def register_sophia_endpoints(app, db_path: str = None):
     def _is_admin(req):
         need = os.environ.get("RC_ADMIN_KEY", "")
         got = req.headers.get("X-Admin-Key", "") or req.headers.get("X-API-Key", "")
-        return bool(need and got and need == got)
+        return bool(need and got and hmac.compare_digest(got, need))
 
     @app.route("/sophia/status/<miner_id>", methods=["GET"])
     def sophia_status_miner(miner_id):

--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -10,6 +10,7 @@ recommendation, without depending on the full Sophia agent stack.
 
 from __future__ import annotations
 
+import hmac
 import json
 import os
 import re
@@ -142,7 +143,7 @@ def _is_authorized(req) -> bool:
     required_admin = os.getenv("RC_ADMIN_KEY", "").strip()
     if required_admin:
         provided_admin = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
-        if provided_admin == required_admin:
+        if hmac.compare_digest(provided_admin, required_admin):
             return True
 
     auth_header = (req.headers.get("Authorization") or "").strip()

--- a/tests/test_timing_attack_prevention.py
+++ b/tests/test_timing_attack_prevention.py
@@ -1,0 +1,64 @@
+"""
+Tests for timing-attack prevention fixes (Issues #3959 cluster).
+
+Verifies that secret comparisons use hmac.compare_digest() instead of 
+direct == operators, preventing timing side-channel attacks.
+"""
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+class TestTimingAttackPrevention(unittest.TestCase):
+    """Verify all admin/auth comparisons use constant-time comparison."""
+    
+    FILES_TO_CHECK = [
+        ('node/governance.py', 'hmac.compare_digest(admin_key, expected_key)'),
+        ('node/rustchain_sync_endpoints.py', 'hmac.compare_digest(key, admin_key)'),
+        ('node/sophia_attestation_inspector.py', 'hmac.compare_digest(got, need)'),
+        ('node/sophia_governor_review_service.py', 'hmac.compare_digest(provided_admin, required_admin)'),
+    ]
+    
+    def setUp(self):
+        self.base = os.path.join(os.path.dirname(__file__), '..')
+
+    def _read_file(self, filename):
+        with open(os.path.join(self.base, filename), 'r') as f:
+            return f.read()
+
+    def test_governance_uses_hmac(self):
+        """governance.py founder_veto must use hmac.compare_digest."""
+        source = self._read_file('node/governance.py')
+        self.assertIn('hmac.compare_digest(admin_key, expected_key)', source)
+        # Ensure no remaining vulnerable comparison
+        self.assertNotIn('admin_key != expected_key', source)
+
+    def test_sync_endpoints_uses_hmac(self):
+        """rustchain_sync_endpoints.py require_admin must use hmac.compare_digest."""
+        source = self._read_file('node/rustchain_sync_endpoints.py')
+        self.assertIn('hmac.compare_digest(key, admin_key)', source)
+        self.assertNotIn('key != admin_key', source)
+
+    def test_sophia_attestation_uses_hmac(self):
+        """sophia_attestation_inspector.py _is_admin must use hmac.compare_digest."""
+        source = self._read_file('node/sophia_attestation_inspector.py')
+        self.assertIn('hmac.compare_digest(got, need)', source)
+        self.assertNotIn('need == got', source)
+
+    def test_sophia_governor_uses_hmac(self):
+        """sophia_governor_review_service.py _is_authorized must use hmac.compare_digest."""
+        source = self._read_file('node/sophia_governor_review_service.py')
+        self.assertIn('hmac.compare_digest(provided_admin, required_admin)', source)
+        self.assertNotIn('provided_admin == required_admin', source)
+
+    def test_beacon_api_to_agent_required(self):
+        """beacon_api.py update_contract must require to_agent key (no .get default)."""
+        source = self._read_file('node/beacon_api.py')
+        # The fix: to_agent = contract['to_agent'] (not contract.get('to_agent', ''))
+        self.assertIn("to_agent = contract['to_agent']", source)
+        self.assertNotIn("contract.get('to_agent', '')", source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Prevents timing side-channel attacks by replacing `==` string comparisons with `hmac.compare_digest()` in admin key validation across 4 endpoints.

## Changes
- `node/governance.py`: `founder_veto()` admin check
- `node/rustchain_sync_endpoints.py`: `require_admin()` decorator
- `node/sophia_attestation_inspector.py`: `_is_admin()` helper
- `node/sophia_governor_review_service.py`: `_is_authorized()` helper
- `node/beacon_api.py`: Require `to_agent` key in contract updates (no `.get()` bypass)
- `tests/test_timing_attack_prevention.py`: 5 tests verifying constant-time comparisons

## Context
This is a clean re-submission of **PR #3959**. The original PR was held due to branch pollution. This PR contains only the verified security fixes.

Supersedes #3959.