### PR TITLE
fix: prevent timing attacks on x402/Machine Passport admin checks (#4000)

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -9,6 +9,7 @@ Usage in beacon_chat.py:
 
 import json
 import logging
+import hmac
 import os
 import sqlite3
 import time
@@ -176,7 +177,7 @@ def init_app(app, get_db_func):
         expected = os.environ.get("BEACON_ADMIN_KEY", "")
         if not expected:
             return _cors_json({"error": "Admin key not configured"}, 503)
-        if admin_key != expected:
+        if not hmac.compare_digest(admin_key, expected):
             return _cors_json({"error": "Unauthorized — admin key required"}, 401)
 
         data = request.get_json(silent=True) or {}

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -9,6 +9,7 @@ Issue: #2309
 """
 
 import os
+import hmac
 import json
 import time
 from typing import Optional
@@ -188,7 +189,7 @@ def create_passport():
     admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
     expected_admin_key = os.environ.get('ADMIN_KEY', '')
     
-    if expected_admin_key and admin_key != expected_admin_key:
+    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
         return jsonify({
             'ok': False,
             'error': 'unauthorized',
@@ -284,7 +285,7 @@ def update_passport(machine_id: str):
     
     # Check authorization
     if expected_admin_key:
-        if admin_key != expected_admin_key:
+        if not hmac.compare_digest(admin_key, expected_admin_key):
             # Allow owner to update their own passport
             data = request.get_json()
             if data and data.get('owner_miner_id') != passport.owner_miner_id:

--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -8,6 +8,7 @@ Usage in rustchain server:
 """
 
 import logging
+import hmac
 import os
 import sqlite3
 import time
@@ -73,7 +74,7 @@ def init_app(app, db_path):
         expected = os.environ.get("RC_ADMIN_KEY", "")
         if not expected:
             return jsonify({"error": "Admin key not configured"}), 503
-        if admin_key != expected:
+        if not hmac.compare_digest(admin_key, expected):
             return jsonify({"error": "Unauthorized — admin key required"}), 401
 
         data = request.get_json(silent=True) or {}

--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -119,7 +119,9 @@ class Message:
         if not self.timestamp:
             self.timestamp = int(time.time())
         if not self.nonce:
-            self.nonce = int.from_bytes(hashlib.sha256(str(time.time()).encode()).digest()[:4], 'big')
+            # Issue #2268: Use cryptographically secure random nonce instead of predictable time.time()
+            import secrets
+            self.nonce = int.from_bytes(secrets.token_bytes(4), 'big')  # 32-bit cryptographically secure nonce
 
     def to_bytes(self) -> bytes:
         """Serialize message to bytes"""

--- a/tests/test_timing_attack_prevention_x402.py
+++ b/tests/test_timing_attack_prevention_x402.py
@@ -1,0 +1,50 @@
+"""
+Tests for timing-attack prevention fixes (x402 cluster).
+
+Verifies that secret comparisons in x402 and Machine Passport endpoints 
+use hmac.compare_digest() instead of direct == operators.
+"""
+import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+class TestTimingAttackPreventionX402(unittest.TestCase):
+    """Verify admin/auth comparisons in x402-related modules use constant-time comparison."""
+    
+    def setUp(self):
+        self.base = os.path.join(os.path.dirname(__file__), '..')
+
+    def _read_file(self, filename):
+        with open(os.path.join(self.base, filename), 'r') as f:
+            return f.read()
+
+    def test_beacon_x402_uses_hmac(self):
+        """beacon_x402.py set_agent_wallet must use hmac.compare_digest."""
+        source = self._read_file('node/beacon_x402.py')
+        self.assertIn('hmac.compare_digest(admin_key, expected)', source)
+        self.assertNotIn('admin_key != expected', source)
+
+    def test_rustchain_x402_uses_hmac(self):
+        """rustchain_x402.py wallet_link_coinbase must use hmac.compare_digest."""
+        source = self._read_file('node/rustchain_x402.py')
+        self.assertIn('hmac.compare_digest(admin_key, expected)', source)
+        self.assertNotIn('admin_key != expected', source)
+
+    def test_machine_passport_api_uses_hmac(self):
+        """machine_passport_api.py must use hmac.compare_digest for admin checks."""
+        source = self._read_file('node/machine_passport_api.py')
+        self.assertIn('hmac.compare_digest(admin_key, expected_admin_key)', source)
+        # Ensure no remaining vulnerable comparison
+        self.assertNotIn('admin_key != expected_admin_key', source)
+
+    def test_p2p_rips_uses_secure_nonce(self):
+        """rips/rustchain-core/networking/p2p.py must use secrets.token_bytes for nonce."""
+        source = self._read_file('rips/rustchain-core/networking/p2p.py')
+        self.assertIn('secrets.token_bytes(4)', source)
+        self.assertNotIn('hashlib.sha256(str(time.time())', source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Extends timing side-channel protection to x402 and Machine Passport admin endpoints, plus a P2P nonce fix in the RIPS spec.

## Changes
- `node/beacon_x402.py`: `set_agent_wallet` admin key validation
- `node/rustchain_x402.py`: `wallet_link_coinbase` admin key validation
- `node/machine_passport_api.py`: `create_passport` and `update_passport` admin checks
- `rips/rustchain-core/networking/p2p.py`: Secure nonce generation for P2P messages (#2268)
- `tests/test_timing_attack_prevention_x402.py`: 4 tests verifying constant-time comparisons

## Context
This is a clean re-submission of **PR #4000**. The original PR was held due to branch pollution (1141 lines of unrelated social mining code). This PR contains only the verified security fixes.

Supersedes #4000.