### PR TITLE
[UTXO-BUG] Fix Critical Genesis Duplication and Math Bugs

### DIFF
--- a/node/test_utxo_migration_bug.py
+++ b/node/test_utxo_migration_bug.py
@@ -1,0 +1,68 @@
+import os
+import tempfile
+import time
+import unittest
+import sqlite3
+
+from utxo_db import UtxoDB, UNIT
+from utxo_genesis_migration import migrate, rollback_genesis, GENESIS_HEIGHT
+
+class TestGenesisDuplication(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        
+        # Setup account balances
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE balances (miner_id TEXT, amount_i64 INTEGER)")
+        conn.execute("INSERT INTO balances VALUES ('alice', ?)", (100 * UNIT,))
+        conn.commit()
+        conn.close()
+        
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_genesis_duplication_via_rollback(self):
+        # 1. Migrate genesis
+        result = migrate(self.db_path, dry_run=False)
+        self.assertTrue(result['integrity']['ok'])
+        
+        db = UtxoDB(self.db_path)
+        alice_boxes = db.get_unspent_for_address('alice')
+        self.assertEqual(len(alice_boxes), 1)
+        alice_box = alice_boxes[0]
+        
+        # 2. Alice spends her genesis box
+        ok = db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }, block_height=1)
+        self.assertTrue(ok)
+        
+        self.assertEqual(db.get_balance('alice'), 0)
+        self.assertEqual(db.get_balance('bob'), 100 * UNIT)
+        
+        # 3. Admin rolls back genesis
+        # The rollback deletes the genesis box (which is now spent)
+        # But leaves Bob's box intact!
+        deleted = rollback_genesis(self.db_path)
+        self.assertEqual(deleted, 1)
+        
+        # 4. Admin re-runs migration
+        result = migrate(self.db_path, dry_run=False)
+        self.assertTrue(result['integrity']['ok'])
+        
+        # 5. Duplication!
+        # Alice has her genesis box back, AND Bob still has his 100 RTC!
+        self.assertEqual(db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(db.get_balance('bob'), 100 * UNIT)
+        
+        # Total supply is now 200 RTC, even though account balance was 100 RTC
+        self.assertEqual(db.get_balance('alice') + db.get_balance('bob'), 200 * UNIT)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/node/test_utxo_migration_bug.py
+++ b/node/test_utxo_migration_bug.py
@@ -7,7 +7,7 @@ import sqlite3
 from utxo_db import UtxoDB, UNIT
 from utxo_genesis_migration import migrate, rollback_genesis, GENESIS_HEIGHT
 
-class TestGenesisDuplication(unittest.TestCase):
+class TestGenesisDuplicationFix(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
         self.tmp.close()
@@ -23,7 +23,7 @@ class TestGenesisDuplication(unittest.TestCase):
     def tearDown(self):
         os.unlink(self.db_path)
 
-    def test_genesis_duplication_via_rollback(self):
+    def test_genesis_rollback_prevention_on_spend(self):
         # 1. Migrate genesis
         result = migrate(self.db_path, dry_run=False)
         self.assertTrue(result['integrity']['ok'])
@@ -46,23 +46,20 @@ class TestGenesisDuplication(unittest.TestCase):
         self.assertEqual(db.get_balance('alice'), 0)
         self.assertEqual(db.get_balance('bob'), 100 * UNIT)
         
-        # 3. Admin rolls back genesis
-        # The rollback deletes the genesis box (which is now spent)
-        # But leaves Bob's box intact!
-        deleted = rollback_genesis(self.db_path)
-        self.assertEqual(deleted, 1)
+        # 3. Admin attempts to rollback genesis
+        # The rollback MUST FAIL because a genesis box has been spent.
+        # This prevents the duplication bug.
+        with self.assertRaises(ValueError) as cm:
+            rollback_genesis(self.db_path)
+        self.assertIn("Cannot rollback genesis: some genesis boxes have already been spent", str(cm.exception))
         
-        # 4. Admin re-runs migration
-        result = migrate(self.db_path, dry_run=False)
-        self.assertTrue(result['integrity']['ok'])
-        
-        # 5. Duplication!
-        # Alice has her genesis box back, AND Bob still has his 100 RTC!
-        self.assertEqual(db.get_balance('alice'), 100 * UNIT)
+        # 4. Verify that no boxes were deleted and balances are intact
+        # (Alice's spent box is still marked as spent, Bob's box still exists)
+        self.assertEqual(db.get_balance('alice'), 0)
         self.assertEqual(db.get_balance('bob'), 100 * UNIT)
         
-        # Total supply is now 200 RTC, even though account balance was 100 RTC
-        self.assertEqual(db.get_balance('alice') + db.get_balance('bob'), 200 * UNIT)
+        # Total supply remains 100 RTC
+        self.assertEqual(db.get_balance('alice') + db.get_balance('bob'), 100 * UNIT)
 
 if __name__ == '__main__':
     unittest.main()

--- a/node/test_utxo_migration_bug.py
+++ b/node/test_utxo_migration_bug.py
@@ -12,14 +12,14 @@ class TestGenesisDuplicationFix(unittest.TestCase):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
         self.tmp.close()
         self.db_path = self.tmp.name
-        
+
         # Setup account balances
         conn = sqlite3.connect(self.db_path)
         conn.execute("CREATE TABLE balances (miner_id TEXT, amount_i64 INTEGER)")
         conn.execute("INSERT INTO balances VALUES ('alice', ?)", (100 * UNIT,))
         conn.commit()
         conn.close()
-        
+
     def tearDown(self):
         os.unlink(self.db_path)
 
@@ -27,12 +27,12 @@ class TestGenesisDuplicationFix(unittest.TestCase):
         # 1. Migrate genesis
         result = migrate(self.db_path, dry_run=False)
         self.assertTrue(result['integrity']['ok'])
-        
+
         db = UtxoDB(self.db_path)
         alice_boxes = db.get_unspent_for_address('alice')
         self.assertEqual(len(alice_boxes), 1)
         alice_box = alice_boxes[0]
-        
+
         # 2. Alice spends her genesis box
         ok = db.apply_transaction({
             'tx_type': 'transfer',
@@ -42,22 +42,22 @@ class TestGenesisDuplicationFix(unittest.TestCase):
             'timestamp': int(time.time()),
         }, block_height=1)
         self.assertTrue(ok)
-        
+
         self.assertEqual(db.get_balance('alice'), 0)
         self.assertEqual(db.get_balance('bob'), 100 * UNIT)
-        
+
         # 3. Admin attempts to rollback genesis
         # The rollback MUST FAIL because a genesis box has been spent.
         # This prevents the duplication bug.
         with self.assertRaises(ValueError) as cm:
             rollback_genesis(self.db_path)
         self.assertIn("Cannot rollback genesis: some genesis boxes have already been spent", str(cm.exception))
-        
+
         # 4. Verify that no boxes were deleted and balances are intact
         # (Alice's spent box is still marked as spent, Bob's box still exists)
         self.assertEqual(db.get_balance('alice'), 0)
         self.assertEqual(db.get_balance('bob'), 100 * UNIT)
-        
+
         # Total supply remains 100 RTC
         self.assertEqual(db.get_balance('alice') + db.get_balance('bob'), 100 * UNIT)
 

--- a/node/test_utxo_migration_math_bug.py
+++ b/node/test_utxo_migration_math_bug.py
@@ -1,0 +1,43 @@
+import os
+import tempfile
+import unittest
+import sqlite3
+
+from utxo_db import UtxoDB, UNIT
+from utxo_genesis_migration import migrate
+
+class TestGenesisMathBug(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        
+        # Setup account balances using the OLD schema (miner_pk, balance_rtc)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE balances (miner_pk TEXT, balance_rtc REAL)")
+        # 10 RTC = 1_000_000_000 nanoRTC
+        conn.execute("INSERT INTO balances VALUES ('alice', ?)", (10.0,))
+        conn.commit()
+        conn.close()
+        
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_genesis_math_bug(self):
+        # 1. Migrate genesis using fallback query
+        result = migrate(self.db_path, dry_run=False)
+        
+        db = UtxoDB(self.db_path)
+        alice_balance = db.get_balance('alice')
+        
+        # We expected 10 RTC = 1_000_000_000 nanoRTC
+        expected_balance = 10 * UNIT
+        
+        # BUT because of the 1000000 multiplier bug in the fallback query,
+        # it gives 10.0 * 1000000 = 10000000 nanoRTC
+        # Which is 100x smaller!
+        self.assertNotEqual(alice_balance, expected_balance)
+        self.assertEqual(alice_balance, 10_000_000)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/node/test_utxo_migration_math_bug.py
+++ b/node/test_utxo_migration_math_bug.py
@@ -6,7 +6,7 @@ import sqlite3
 from utxo_db import UtxoDB, UNIT
 from utxo_genesis_migration import migrate
 
-class TestGenesisMathBug(unittest.TestCase):
+class TestGenesisMathFix(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
         self.tmp.close()
@@ -23,21 +23,21 @@ class TestGenesisMathBug(unittest.TestCase):
     def tearDown(self):
         os.unlink(self.db_path)
 
-    def test_genesis_math_bug(self):
+    def test_genesis_math_fix(self):
         # 1. Migrate genesis using fallback query
         result = migrate(self.db_path, dry_run=False)
+        self.assertTrue(result['integrity']['ok'])
         
         db = UtxoDB(self.db_path)
         alice_balance = db.get_balance('alice')
         
-        # We expected 10 RTC = 1_000_000_000 nanoRTC
+        # 10 RTC = 1_000_000_000 nanoRTC
         expected_balance = 10 * UNIT
         
-        # BUT because of the 1000000 multiplier bug in the fallback query,
-        # it gives 10.0 * 1000000 = 10000000 nanoRTC
-        # Which is 100x smaller!
-        self.assertNotEqual(alice_balance, expected_balance)
-        self.assertEqual(alice_balance, 10_000_000)
+        # The fix ensures that balance_rtc (REAL) is multiplied by 10^8 (UNIT)
+        # instead of 10^6, ensuring correct fund conservation.
+        self.assertEqual(alice_balance, expected_balance)
+        self.assertEqual(alice_balance, 1_000_000_000)
 
 if __name__ == '__main__':
     unittest.main()

--- a/node/test_utxo_migration_math_bug.py
+++ b/node/test_utxo_migration_math_bug.py
@@ -11,7 +11,7 @@ class TestGenesisMathFix(unittest.TestCase):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
         self.tmp.close()
         self.db_path = self.tmp.name
-        
+
         # Setup account balances using the OLD schema (miner_pk, balance_rtc)
         conn = sqlite3.connect(self.db_path)
         conn.execute("CREATE TABLE balances (miner_pk TEXT, balance_rtc REAL)")
@@ -19,7 +19,7 @@ class TestGenesisMathFix(unittest.TestCase):
         conn.execute("INSERT INTO balances VALUES ('alice', ?)", (10.0,))
         conn.commit()
         conn.close()
-        
+
     def tearDown(self):
         os.unlink(self.db_path)
 
@@ -27,13 +27,13 @@ class TestGenesisMathFix(unittest.TestCase):
         # 1. Migrate genesis using fallback query
         result = migrate(self.db_path, dry_run=False)
         self.assertTrue(result['integrity']['ok'])
-        
+
         db = UtxoDB(self.db_path)
         alice_balance = db.get_balance('alice')
-        
+
         # 10 RTC = 1_000_000_000 nanoRTC
         expected_balance = 10 * UNIT
-        
+
         # The fix ensures that balance_rtc (REAL) is multiplied by 10^8 (UNIT)
         # instead of 10^6, ensuring correct fund conservation.
         self.assertEqual(alice_balance, expected_balance)

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -238,16 +238,20 @@ def rollback_genesis(db_path: str) -> int:
 
         # Prevent rollback if any genesis boxes have already been spent
         spent_count = conn.execute(
-            "SELECT COUNT(*) AS n FROM utxo_boxes WHERE creation_height = ? AND spent_at IS NOT NULL",
-            (GENESIS_HEIGHT,),
+            """SELECT COUNT(b.box_id) AS n
+               FROM utxo_boxes b
+               JOIN utxo_transactions t ON b.transaction_id = t.tx_id
+               WHERE t.tx_type = 'genesis' AND b.spent_at IS NOT NULL"""
         ).fetchone()['n']
         if spent_count > 0:
             raise ValueError("Cannot rollback genesis: some genesis boxes have already been spent.")
 
         # Delete genesis boxes first (child table)
         deleted = conn.execute(
-            "DELETE FROM utxo_boxes WHERE creation_height = ?",
-            (GENESIS_HEIGHT,),
+            """DELETE FROM utxo_boxes
+               WHERE transaction_id IN (
+                   SELECT tx_id FROM utxo_transactions WHERE tx_type = 'genesis'
+               )"""
         ).rowcount
 
         # Delete genesis transactions (parent table)

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -57,7 +57,7 @@ def load_account_balances(db_path: str) -> list:
         # Try alternate column names
         rows = conn.execute(
             """SELECT miner_pk AS miner_id,
-                      CAST(balance_rtc * 1000000 AS INTEGER) AS amount_i64
+                      CAST(balance_rtc * 100000000 AS INTEGER) AS amount_i64
                FROM balances
                WHERE balance_rtc > 0
                ORDER BY miner_pk ASC"""
@@ -234,6 +234,14 @@ def rollback_genesis(db_path: str) -> int:
     conn = sqlite3.connect(db_path, timeout=30)
     try:
         conn.execute("BEGIN IMMEDIATE")
+
+        # Prevent rollback if any genesis boxes have already been spent
+        spent_count = conn.execute(
+            "SELECT COUNT(*) AS n FROM utxo_boxes WHERE creation_height = ? AND spent_at IS NOT NULL",
+            (GENESIS_HEIGHT,),
+        ).fetchone()['n']
+        if spent_count > 0:
+            raise ValueError("Cannot rollback genesis: some genesis boxes have already been spent.")
 
         # Delete genesis boxes first (child table)
         deleted = conn.execute(

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -232,6 +232,7 @@ def rollback_genesis(db_path: str) -> int:
     genesis data exists (returns 0).
     """
     conn = sqlite3.connect(db_path, timeout=30)
+    conn.row_factory = sqlite3.Row
     try:
         conn.execute("BEGIN IMMEDIATE")
 


### PR DESCRIPTION
This PR addresses two critical bugs found during the Red Team UTXO Implementation bounty (#2819).

### 1. Genesis Duplication (Critical)
**Vulnerability Class:** Genesis migration tampering / Double-spend
**Description:** The `rollback_genesis` function blindly deleted genesis boxes based on `creation_height = 0` without checking if they had been spent. If a user spent their genesis box, the new child box remained in the database. When the admin re-ran `migrate`, the genesis box was recreated, resulting in duplicated funds (the user now holds both the recreated genesis box and the child box from the spend).
**Fix:** Added a check in `rollback_genesis` that raises a `ValueError` and prevents the rollback if any genesis boxes have `spent_at IS NOT NULL`.
**Test Case:** Included `test_utxo_migration_bug.py` which demonstrates the duplication via rollback.

### 2. Math Bug in Fallback Migration (High)
**Vulnerability Class:** Fund destruction / Conservation bypass
**Description:** The fallback query in `load_account_balances` (used when the `balances` table uses the older `miner_pk` schema) used a multiplier of `1000000` instead of `UNIT` (`100000000`). This caused all migrated balances to be 100x smaller than their actual value, effectively destroying user funds.
**Fix:** Corrected the multiplier to `100000000` to match `UNIT`.
**Test Case:** Included `test_utxo_migration_math_bug.py` which demonstrates the math discrepancy.

Both tests should now pass, empirically validating the bugs and the provided fixes.