### PR TITLE
fix(ci): unblock test_beacon_atlas_behavior.py + sqlite3.Row.get() prod bug

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -536,7 +536,7 @@ def update_contract(contract_id):
             return jsonify({'error': 'Missing X-Agent-Key header — authentication required'}), 401
         
         from_agent = contract['from_agent']
-        to_agent = contract.get('to_agent', '')
+        to_agent = contract['to_agent'] if 'to_agent' in contract.keys() else ''
         
         # Caller must be either the from_agent or to_agent
         if agent_key != from_agent and agent_key != to_agent:

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -69,6 +69,21 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             conn.execute("DELETE FROM beacon_bounties")
             conn.execute("DELETE FROM beacon_reputation")
             conn.execute("DELETE FROM beacon_chat")
+            conn.execute("DELETE FROM relay_agents")
+            now = int(time.time())
+            conn.executemany(
+                """
+                INSERT INTO relay_agents
+                (agent_id, pubkey_hex, name, status, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    ('bcn_alice_test', '0x' + '11' * 32, 'Alice Test', 'active', now, now),
+                    ('bcn_bob_test', '0x' + '22' * 32, 'Bob Test', 'active', now, now),
+                    ('bcn_test_from', '0x' + '33' * 32, 'From Test', 'active', now, now),
+                    ('bcn_test_to', '0x' + '44' * 32, 'To Test', 'active', now, now),
+                ],
+            )
             conn.commit()
 
     def test_health_endpoint_returns_ok(self):
@@ -95,7 +110,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         create_response = self.client.post(
             '/api/contracts',
             data=json.dumps(contract_data),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_alice_test'},
         )
         self.assertEqual(create_response.status_code, 201)
         
@@ -118,7 +134,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         update_response = self.client.put(
             f'/api/contracts/{contract_id}',
             data=json.dumps({'state': 'active'}),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_bob_test'},
         )
         self.assertEqual(update_response.status_code, 200)
         
@@ -249,7 +266,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         create_response = self.client.post(
             '/api/contracts',
             data=json.dumps(contract_data),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_from'},
         )
         contract_id = json.loads(create_response.data)['id']
         
@@ -257,7 +275,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         update_response = self.client.put(
             f'/api/contracts/{contract_id}',
             data=json.dumps({'state': 'invalid_state'}),
-            content_type='application/json'
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_from'},
         )
         self.assertEqual(update_response.status_code, 400)
 


### PR DESCRIPTION
## Summary

Rustchain `main` CI has been red since **2026-05-04**, blocking 7+ paid PRs across multiple authors. Two related bugs needed fixing — diagnosed with Codex consensus + verified locally.

## Bugs

### 1. Stale test (`tests/test_beacon_atlas_behavior.py`)

`POST /api/contracts` was updated to require:
- `X-Agent-Key` header matching `from` field
- `from_agent` to exist in `relay_agents` table

The two failing tests didn't send the header or seed the table, producing `401 != 201` and downstream `KeyError: 'id'`.

### 2. Production `sqlite3.Row.get()` (`node/beacon_api.py:539`)

`update_contract()` did `contract.get('to_agent', '')` on a `sqlite3.Row`, which doesn't expose `.get()` — `AttributeError` → 500.  
This surfaced after the test fix landed locally (401→201 worked, then PUT 500'd).

Both fixes are needed; neither alone makes CI green.

## Changes

| File | Change |
|---|---|
| `tests/test_beacon_atlas_behavior.py` | Seed 4 test agents into `relay_agents` in `setUp`, add `X-Agent-Key` headers on POST/PUT calls |
| `node/beacon_api.py` | Replace `contract.get('to_agent', '')` with bracket-access via `.keys()` membership check |

PUT to `'active'` (offered → active) authenticates as `to_agent` (`bcn_bob_test`) since that transition is recipient-only — Codex consensus caught that nuance.

## Verification

```
$ python3 -m pytest tests/test_beacon_atlas_behavior.py --tb=short
============================== 15 passed in 0.06s ==============================
```

Both originally-failing tests pass; no regression on the 13 already-passing tests.

## Test plan

- [ ] CI green on this PR
- [ ] Re-run CI on the 7 paid Rustchain PRs after merge → expect green
- [ ] Re-run CI on the bounties PRs after labels propagate

## Why this is urgent

8 transfers totaling 233 RTC are pending (24h void window) for PRs that can't merge until main CI is green. Without this fix, the paid work sits indefinitely in a non-mergeable state and the loop's next tick will keep flagging the same red status.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>