### PR TITLE
fix: replace random with secrets for cryptographically secure validator selection

### DIFF
--- a/rips/rustchain-core/consensus/poa.py
+++ b/rips/rustchain-core/consensus/poa.py
@@ -15,7 +15,7 @@ Formula: AS = (current_year - release_year) * log10(uptime_days + 1)
 
 import hashlib
 import math
-import random
+import secrets
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
@@ -187,10 +187,14 @@ def select_validator(proofs: List[ValidatedProof]) -> Optional[ValidatedProof]:
 
     total_as = sum(p.antiquity_score for p in proofs)
     if total_as == 0:
-        return random.choice(proofs)
+        # Use cryptographically secure random selection
+        idx = secrets.randbelow(len(proofs))
+        return proofs[idx]
 
-    # Weighted random selection
-    r = random.uniform(0, total_as)
+    # Weighted random selection using cryptographically secure randomness.
+    # SECURITY FIX: Previously used random.uniform() which is NOT cryptographically
+    # secure — the sequence is predictable, enabling targeted validator attacks.
+    r = secrets.randbelow(int(total_as * 1_000_000)) / 1_000_000
     cumulative = 0.0
 
     for proof in proofs:

--- a/test_poa_consensus_security.py
+++ b/test_poa_consensus_security.py
@@ -1,0 +1,30 @@
+"""Test for cryptographically secure validator selection fix."""
+
+def test_validator_selection_uses_secrets():
+    """Verify that select_validator uses secrets module, not random."""
+    source = open('/tmp/rustchain-fix/rips/rustchain-core/consensus/poa.py').read()
+    
+    # Check that random module is not imported
+    assert 'import secrets' in source, "secrets module should be imported"
+    
+    # Check that random is not used as an active import/usage (may appear in comments)
+    lines = source.split('\n')
+    code_lines = [l.strip() for l in lines if not l.strip().startswith('#')]
+    code_only = '\n'.join(code_lines)
+    
+    assert 'import random' not in code_only, "random module should NOT be imported in code"
+    assert 'random.uniform(' not in code_only, "random.uniform should not be called"
+    assert 'random.choice(' not in code_only, "random.choice should not be called"
+    
+    # Check that secrets is used
+    assert 'secrets.randbelow' in code_only, "secrets.randbelow should be used"
+    
+    print("PASS: Validator selection uses cryptographically secure randomness (secrets)")
+    print("  - random module removed")
+    print("  - secrets module imported")
+    print("  - secrets.randbelow used for weighted selection")
+    print("  - secrets.randbelow used for zero-AS fallback")
+
+if __name__ == '__main__':
+    test_validator_selection_uses_secrets()
+    print("\nAll POA consensus security tests passed!")


### PR DESCRIPTION
## Summary

**Wallet:** `RTC6d1f27d28961279f1034d9561c2403697eb55602`

## Vulnerability Fixed

### Non-Cryptographic Random in Validator Selection (HIGH)

**File:** `rips/rustchain-core/consensus/poa.py`, `select_validator()`

**Bug:** Uses `random.uniform()` and `random.choice()` for consensus validator selection. Python's `random` module is NOT cryptographically secure — the Mersenne Twister sequence is predictable after observing ~624 outputs.

**Attack:** An attacker monitoring block production can:
1. Observe validator selections over multiple blocks
2. Reconstruct the random seed/state
3. Predict which validator will be selected next
4. Target that validator for DoS, censorship, or MEV extraction

**Fix:** Replace `random` with `secrets` module (cryptographically secure):
- `random.uniform(0, total_as)` → `secrets.randbelow(int(total_as * 1_000_000)) / 1_000_000`
- `random.choice(proofs)` → `proofs[secrets.randbelow(len(proofs))]`

## Local Testing

```bash
python test_poa_consensus_security.py
# PASS: Validator selection uses cryptographically secure randomness (secrets)
```

## Related

- Bug Bounty #71
- Bug #11 reported in #71 comments
