### PR TITLE
docs: fix RTC payout process step numbering in CONTRIBUTING.md

### DIFF
--- a/API_WALKTHROUGH.md
+++ b/API_WALKTHROUGH.md
@@ -68,7 +68,7 @@ POST /wallet/transfer/signed
 ```json
 {
   "from": "sender_wallet_id",
-  "to": "recipient_wallet_id", 
+  "to": "recipient_wallet_id",
   "amount": 10,
   "fee": 0.001,
   "signature": "hex_encoded_signature",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,10 +102,10 @@ curl -sk https://rustchain.org/epoch
 ## RTC Payout Process
 
 1. PR gets reviewed and merged
-3. We comment asking for your wallet address
-4. RTC is transferred from the community fund
-5. Bridge RTC to wRTC (Solana) via [bottube.ai/bridge](https://bottube.ai/bridge)
-6. Trade on [Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X)
+2. We comment asking for your wallet address
+3. RTC is transferred from the community fund
+4. Bridge RTC to wRTC (Solana) via [bottube.ai/bridge](https://bottube.ai/bridge)
+5. Trade on [Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X)
 
 
 ## Documentation Quality Checklist


### PR DESCRIPTION
## Summary

Fix step numbering in the RTC Payout Process section.

The original had steps 1, 3, 4, 5, 6 (missing step 2). This PR renumbers them to 1, 2, 3, 4, 5.

## Bounty

Claiming: #2783 (ONBOARD: 2 RTC - Fix a Doc Issue)

First PR - thanks for the opportunity!