### PR TITLE
fix: use constant-time founder veto admin key check

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -24,6 +24,7 @@ Date: 2026-03-07
 """
 
 import hashlib
+import hmac
 import json
 import logging
 import sqlite3
@@ -553,7 +554,7 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
         # Admin key is validated via environment variable (not hardcoded)
         import os
         expected_key = os.environ.get("RUSTCHAIN_ADMIN_KEY", "")
-        if not expected_key or admin_key != expected_key:
+        if not expected_key or not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "invalid admin_key"}), 403
 
         try:

--- a/node/tests/test_governance.py
+++ b/node/tests/test_governance.py
@@ -392,3 +392,44 @@ def test_abstain_vote(client, active_miner, tmp_db):
     res = client.get(f"/api/governance/results/{pid}")
     data = res.get_json()
     assert data["votes_abstain"] > 0
+
+
+def test_founder_veto_uses_constant_time_admin_key_compare(client, tmp_db, monkeypatch):
+    """Founder veto checks the admin key through hmac.compare_digest."""
+    monkeypatch.setenv("RUSTCHAIN_ADMIN_KEY", "founder-secret")
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(sys.modules["governance"].hmac, "compare_digest", spy_compare_digest)
+
+    now = int(time.time())
+    with sqlite3.connect(tmp_db) as conn:
+        cursor = conn.execute(
+            """INSERT INTO governance_proposals
+               (title, description, proposal_type, proposed_by, created_at, expires_at, status)
+               VALUES (?,?,?,?,?,?,?)""",
+            ("Veto auth test", "Exercise founder veto admin key validation.",
+             "emergency", "alice", now, now + VOTING_WINDOW_SECONDS, STATUS_ACTIVE),
+        )
+        pid = cursor.lastrowid
+
+    denied = client.post(f"/api/governance/veto/{pid}", json={
+        "admin_key": "wrong-secret",
+        "reason": "invalid key should be rejected",
+    })
+    assert denied.status_code == 403
+
+    accepted = client.post(f"/api/governance/veto/{pid}", json={
+        "admin_key": "founder-secret",
+        "reason": "valid key should be accepted",
+    })
+    assert accepted.status_code == 200
+    assert accepted.get_json()["status"] == STATUS_VETOED
+
+    assert calls == [
+        ("wrong-secret", "founder-secret"),
+        ("founder-secret", "founder-secret"),
+    ]


### PR DESCRIPTION
## Summary

Fixes #3227 by replacing the founder veto endpoint's timing-unsafe admin key comparison with `hmac.compare_digest()`.

This is intentionally scoped to one issue and two files, following the branch-contamination closure guidance on earlier broad timing-fix PRs.

## Root cause

`POST /api/governance/veto/<proposal_id>` compared the provided `admin_key` to `RUSTCHAIN_ADMIN_KEY` with `!=`. For a high-privilege founder veto operation, that can leak secret comparison timing.

## Changes

- Adds `hmac` to `node/governance.py`.
- Uses `hmac.compare_digest(admin_key, expected_key)` for founder veto auth.
- Adds focused regression coverage proving the veto path calls `hmac.compare_digest` and still rejects/accepts invalid/valid keys correctly.

## Validation

Passed:

```bash
python3 -m py_compile node/governance.py node/tests/test_governance.py
/tmp/rustchain-bounty-venv/bin/python -m pytest node/tests/test_governance.py::test_founder_veto_uses_constant_time_admin_key_compare -q
/tmp/rustchain-bounty-venv/bin/ruff check node/governance.py node/tests/test_governance.py --select E9,F63,F7,F82
git diff --check
```

Known existing test-suite issue:

```bash
/tmp/rustchain-bounty-venv/bin/python -m pytest node/tests/test_governance.py -q
```

The full governance suite currently fails before and outside this patch because many existing tests do not provide the newer miner signature fields and now receive `401` from proposal/vote auth. The focused veto regression above avoids that unrelated auth fixture drift by seeding the proposal row directly.

## Bounty

Claiming bug bounty for #3227.

RTC wallet: `RTC5268f16391bcdff87c43cd8694fca3be9d995359`
