### PR TITLE
fix: use constant-time sync admin key check

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -91,8 +91,8 @@ def register_sync_endpoints(app, db_path, admin_key):
 
         @wraps(f)
         def decorated(*args, **kwargs):
-            key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key")
-            if not key or key != admin_key:
+            key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
+            if not key or not hmac.compare_digest(key, admin_key):
                 return jsonify({"error": "Unauthorized"}), 401
             return f(*args, **kwargs)
 

--- a/node/tests/test_rustchain_sync_endpoints.py
+++ b/node/tests/test_rustchain_sync_endpoints.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import rustchain_sync_endpoints
+
+
+class DummySyncManager:
+    SYNC_TABLES = []
+
+    def __init__(self, db_path, admin_key):
+        self.db_path = db_path
+        self.admin_key = admin_key
+
+    def get_sync_status(self):
+        return {"merkle_root": "test-root"}
+
+
+def test_require_admin_uses_constant_time_compare(monkeypatch, tmp_path):
+    """Sync admin endpoints check API keys through hmac.compare_digest."""
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(rustchain_sync_endpoints.hmac, "compare_digest", spy_compare_digest)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    denied = client.get("/api/sync/status", headers={"X-Admin-Key": "wrong-secret"})
+    assert denied.status_code == 401
+
+    accepted = client.get("/api/sync/status", headers={"X-API-Key": "sync-secret"})
+    assert accepted.status_code == 200
+    assert accepted.get_json()["merkle_root"] == "test-root"
+
+    assert calls == [
+        ("wrong-secret", "sync-secret"),
+        ("sync-secret", "sync-secret"),
+    ]


### PR DESCRIPTION
## Summary

Fixes #3226 by replacing the sync admin decorator's timing-unsafe API key comparison with `hmac.compare_digest()`.

This is intentionally scoped to one issue and two files, following the branch-contamination closure guidance on earlier broad timing-fix PRs.

## Root cause

`register_sync_endpoints(...).require_admin` compared the provided `X-Admin-Key`/`X-API-Key` to the configured sync admin key with `!=`. The same module already uses `hmac.compare_digest()` for sync signatures, but the admin decorator did not.

## Changes

- Normalizes a missing admin header to an empty string.
- Uses `hmac.compare_digest(key, admin_key)` for sync admin auth.
- Adds focused regression coverage proving `/api/sync/status` calls `hmac.compare_digest` and still rejects/accepts invalid/valid keys correctly.

## Validation

Passed:

```bash
python3 -m py_compile node/rustchain_sync_endpoints.py node/tests/test_rustchain_sync_endpoints.py
/tmp/rustchain-bounty-venv/bin/python -m pytest node/tests/test_rustchain_sync_endpoints.py -q
/tmp/rustchain-bounty-venv/bin/ruff check node/rustchain_sync_endpoints.py node/tests/test_rustchain_sync_endpoints.py --select E9,F63,F7,F82
git diff --check
```

## Bounty

Claiming bug bounty for #3226.

RTC wallet: `RTC5268f16391bcdff87c43cd8694fca3be9d995359`
