### PR TITLE
fix: require admin key for machine passport updates

### DIFF
--- a/node/machine_passport.py
+++ b/node/machine_passport.py
@@ -15,6 +15,7 @@ import json
 import time
 import hashlib
 import sqlite3
+from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass, asdict
 from datetime import datetime
@@ -246,11 +247,19 @@ class MachinePassportLedger:
         self.db_path = db_path
         self._ensure_schema()
     
-    def _get_connection(self) -> sqlite3.Connection:
-        """Get a database connection with row factory."""
+    @contextmanager
+    def _get_connection(self):
+        """Get a database connection with row factory and close it after use."""
         conn = sqlite3.connect(self.db_path)
         conn.row_factory = sqlite3.Row
-        return conn
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
     
     def _ensure_schema(self) -> None:
         """Ensure the database schema is initialized."""

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -11,6 +11,7 @@ Issue: #2309
 import os
 import json
 import time
+import hmac
 from typing import Optional
 from flask import Blueprint, request, jsonify, render_template_string
 
@@ -188,7 +189,7 @@ def create_passport():
     admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
     expected_admin_key = os.environ.get('ADMIN_KEY', '')
     
-    if expected_admin_key and admin_key != expected_admin_key:
+    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
         return jsonify({
             'ok': False,
             'error': 'unauthorized',
@@ -270,8 +271,8 @@ def create_passport():
 def update_passport(machine_id: str):
     """
     Update a machine passport.
-    
-    Requires admin authentication or owner verification.
+
+    Requires admin authentication when ADMIN_KEY is configured.
     """
     admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
     expected_admin_key = os.environ.get('ADMIN_KEY', '')
@@ -282,17 +283,12 @@ def update_passport(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    # Check authorization
-    if expected_admin_key:
-        if admin_key != expected_admin_key:
-            # Allow owner to update their own passport
-            data = request.get_json()
-            if data and data.get('owner_miner_id') != passport.owner_miner_id:
-                return jsonify({
-                    'ok': False,
-                    'error': 'unauthorized',
-                    'message': 'Admin key required or must be owner',
-                }), 401
+    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
     
     data = request.get_json()
     if not data:

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -463,6 +463,9 @@ class TestAPIEndpoints(unittest.TestCase):
         """Set up test Flask app."""
         from flask import Flask
         from machine_passport_api import machine_passport_bp
+
+        self._prev_admin_key = os.environ.get('ADMIN_KEY')
+        os.environ.pop('ADMIN_KEY', None)
         
         self.app = Flask(__name__)
         self.app.config['TESTING'] = True
@@ -470,9 +473,9 @@ class TestAPIEndpoints(unittest.TestCase):
         
         # Set test database
         import machine_passport_api
-        machine_passport_api.PASSPORT_DB_PATH = tempfile.NamedTemporaryFile(
-            delete=False, suffix='.db'
-        ).name
+        temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+        temp_db.close()
+        machine_passport_api.PASSPORT_DB_PATH = temp_db.name
         machine_passport_api._ledger = None
         
         self.client = self.app.test_client()
@@ -480,8 +483,13 @@ class TestAPIEndpoints(unittest.TestCase):
     def tearDown(self):
         """Clean up."""
         import machine_passport_api
+        machine_passport_api._ledger = None
         if os.path.exists(machine_passport_api.PASSPORT_DB_PATH):
             os.unlink(machine_passport_api.PASSPORT_DB_PATH)
+        if self._prev_admin_key is None:
+            os.environ.pop('ADMIN_KEY', None)
+        else:
+            os.environ['ADMIN_KEY'] = self._prev_admin_key
     
     def test_list_passports_empty(self):
         """Test listing passports when empty."""
@@ -512,6 +520,62 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(data['ok'])
         self.assertIn('machine_id', data)
+
+    def test_update_passport_rejects_owner_claim_without_admin_key(self):
+        """Client-supplied owner_miner_id is not proof of ownership."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Owner Claim Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'owner_claim_test',
+            },
+        )
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=False) as compare_digest:
+            resp = self.client.put(
+                '/api/machine-passport/owner_claim_test',
+                headers={'X-Admin-Key': 'wrong-admin-key'},
+                json={
+                    'owner_miner_id': 'miner_owner',
+                    'name': 'Unauthorized Rename',
+                },
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+
+        get_resp = self.client.get('/api/machine-passport/owner_claim_test')
+        passport = json.loads(get_resp.data)['passport']['passport']
+        self.assertEqual(passport['name'], 'Owner Claim Test')
+
+    def test_update_passport_accepts_valid_admin_key(self):
+        """Configured admin key still authorizes passport updates."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Admin Update Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'admin_update_test',
+            },
+        )
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=True) as compare_digest:
+            resp = self.client.put(
+                '/api/machine-passport/admin_update_test',
+                headers={'X-Admin-Key': 'expected-admin-key'},
+                json={'name': 'Authorized Rename'},
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data['ok'])
+        compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""


### PR DESCRIPTION
## Summary

Fixes #4199.

This closes an authorization bypass in `PUT /api/machine-passport/<machine_id>` where a caller could echo the current `owner_miner_id` in the request body and update a passport without a valid admin key.

Changes:
- require a valid admin key for passport updates whenever `ADMIN_KEY` is configured
- use `hmac.compare_digest()` for machine passport admin-key checks
- add regression coverage for the owner-claim bypass and valid-admin path
- close `MachinePassportLedger` SQLite connections after each operation so the full test module can clean up temp DBs reliably on Windows

## Proof

```text
python -m pytest node/tests/test_machine_passport.py -q
..........................                                               [100%]
26 passed in 0.65s

python -m py_compile node\machine_passport.py node\machine_passport_api.py node\tests\test_machine_passport.py

git diff --check
```

`ruff` is not installed in my local environment, so I could not run the repo lint command locally.

## Bounty

Bug report/fix submitted for consideration under #305. Payout details can be provided privately if accepted.
