### PR TITLE
Fix faucet checksum validation

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -26,13 +26,13 @@ import sys
 import json
 import sqlite3
 import logging
-import hashlib
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Tuple
 from contextlib import contextmanager
 
 import yaml
+from Crypto.Hash import keccak
 from flask import Flask, request, jsonify, render_template_string, g
 from flask_cors import CORS
 from functools import wraps
@@ -280,14 +280,19 @@ class RateLimiter:
         conn.close()
         
         if count >= max_requests:
-            # Calculate next available time
-            c = sqlite3.connect(self.config['database']['path']).cursor()
-            c.execute('''
-                SELECT MAX(timestamp) FROM drip_requests
-                WHERE (ip_address = ? OR wallet = ?)
-                AND timestamp > ?
-            ''', (ip_address, wallet, cutoff.isoformat()))
-            last_request = c.fetchone()[0]
+            # Calculate next available time.
+            conn = sqlite3.connect(self.config['database']['path'])
+            try:
+                c = conn.cursor()
+                c.execute('''
+                    SELECT MAX(timestamp) FROM drip_requests
+                    WHERE (ip_address = ? OR wallet = ?)
+                    AND timestamp > ?
+                ''', (ip_address, wallet, cutoff.isoformat()))
+                last_request = c.fetchone()[0]
+            finally:
+                conn.close()
+
             if last_request:
                 last_time = datetime.fromisoformat(last_request)
                 next_available = last_time + timedelta(seconds=window_seconds)
@@ -391,8 +396,10 @@ class FaucetValidator:
         if not all(c in '0123456789abcdefABCDEF' for c in address):
             return False
         
-        # Simple checksum validation
-        hash_lower = hashlib.keccak256(address.lower().encode()).hexdigest()
+        # EIP-55 uses the original Keccak-256, not FIPS SHA3-256.
+        hasher = keccak.new(digest_bits=256)
+        hasher.update(address.lower().encode())
+        hash_lower = hasher.hexdigest()
         for i, c in enumerate(address):
             if c in '0123456789':
                 continue

--- a/faucet_service/requirements.txt
+++ b/faucet_service/requirements.txt
@@ -10,6 +10,9 @@ flask-cors>=6.0.2
 # Configuration
 PyYAML>=6.0.3
 
+# EIP-55 checksum validation
+pycryptodome>=3.23.0
+
 # Optional: Redis for distributed rate limiting
 # redis>=4.5.0
 

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -171,6 +171,24 @@ class TestFaucetValidator(unittest.TestCase):
         self.assertTrue(valid)
         self.assertIsNone(error)
 
+    def test_checksum_validation_accepts_valid_eip55_wallet(self):
+        """Test checksum validation with a known-valid EIP-55 address."""
+        self.config['validation']['require_checksum'] = True
+        validator = FaucetValidator(self.config, self.logger)
+
+        valid, error = validator.validate_wallet('0x52908400098527886E0F7030069857D2E4169EE7')
+        self.assertTrue(valid)
+        self.assertIsNone(error)
+
+    def test_checksum_validation_rejects_invalid_eip55_wallet(self):
+        """Test checksum validation rejects bad casing without raising."""
+        self.config['validation']['require_checksum'] = True
+        validator = FaucetValidator(self.config, self.logger)
+
+        valid, error = validator.validate_wallet('0x52908400098527886e0f7030069857d2e4169ee7')
+        self.assertFalse(valid)
+        self.assertEqual(error, "Invalid wallet checksum")
+
 
 class TestRateLimiter(unittest.TestCase):
     """Test rate limiting."""
@@ -350,6 +368,20 @@ class TestFlaskApp(unittest.TestCase):
         self.assertIn('wallet', data)
         self.assertIn('next_available', data)
     
+    def test_drip_success_with_checksum_validation_enabled(self):
+        """Test checksum validation does not turn drip requests into 500s."""
+        self.config['validation']['require_checksum'] = True
+        app = create_app(self.config)
+        client = app.test_client()
+
+        response = client.post('/faucet/drip',
+                               json={'wallet': '0x52908400098527886E0F7030069857D2E4169EE7'},
+                               content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['ok'])
+
     def test_drip_missing_wallet(self):
         """Test drip request without wallet."""
         response = self.client.post('/faucet/drip',


### PR DESCRIPTION
## Summary

- Fix faucet EIP-55 checksum validation by using Keccak-256 instead of nonexistent `hashlib.keccak256`
- Add `pycryptodome` as the checksum dependency
- Add regression tests for validator-level checksum handling and `/faucet/drip` with checksum validation enabled
- Close a SQLite handle leak in the rate-limit path that kept temporary DB files locked on Windows test runs

## Validation

- `python -m pytest faucet_service/test_faucet_service.py -q`
- `git diff --check`

Bug found while investigating bounty #305.

Fixes #4204.
