### PR TITLE
fix: quantize node payout preflight with Decimal

### DIFF
--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from typing import Any, Dict, Optional, Tuple
+
+
+MICRO_RTC = Decimal("1000000")
 
 
 @dataclass(frozen=True)
@@ -19,14 +21,18 @@ def _as_dict(payload: Any) -> Tuple[Optional[Dict[str, Any]], str]:
     return payload, ""
 
 
-def _safe_float(v: Any) -> Tuple[Optional[float], str]:
+def _safe_decimal(v: Any) -> Tuple[Optional[Decimal], str]:
     try:
-        f = float(v)
-    except (TypeError, ValueError):
+        amount = Decimal(str(v))
+    except (InvalidOperation, TypeError, ValueError):
         return None, "amount_not_number"
-    if not math.isfinite(f):
+    if not amount.is_finite():
         return None, "amount_not_finite"
-    return f, ""
+    return amount, ""
+
+
+def _amount_i64(amount_rtc: Decimal) -> int:
+    return int((amount_rtc * MICRO_RTC).to_integral_value(rounding=ROUND_DOWN))
 
 
 def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
@@ -37,7 +43,7 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
 
     from_miner = data.get("from_miner")
     to_miner = data.get("to_miner")
-    amount_rtc, aerr = _safe_float(data.get("amount_rtc", 0))
+    amount_rtc, aerr = _safe_decimal(data.get("amount_rtc", 0))
 
     if not from_miner or not to_miner:
         return PreflightResult(ok=False, error="missing_from_or_to", details={})
@@ -45,12 +51,12 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
+    amount_i64 = _amount_i64(amount_rtc)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
-            details={"amount_rtc": amount_rtc, "min_rtc": 0.000001},
+            details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
 
     return PreflightResult(
@@ -59,7 +65,7 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         details={
             "from_miner": str(from_miner),
             "to_miner": str(to_miner),
-            "amount_rtc": amount_rtc,
+            "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
         },
     )
@@ -78,17 +84,17 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
 
     from_address = str(data.get("from_address", "")).strip()
     to_address = str(data.get("to_address", "")).strip()
-    amount_rtc, aerr = _safe_float(data.get("amount_rtc", 0))
+    amount_rtc, aerr = _safe_decimal(data.get("amount_rtc", 0))
     if aerr:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
+    amount_i64 = _amount_i64(amount_rtc)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
-            details={"amount_rtc": amount_rtc, "min_rtc": 0.000001},
+            details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
 
     if not (from_address.startswith("RTC") and len(from_address) == 43):
@@ -111,7 +117,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         details={
             "from_address": from_address,
             "to_address": to_address,
-            "amount_rtc": amount_rtc,
+            "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
             "nonce": nonce_int,
         },

--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -44,7 +45,7 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(amount_rtc * 1_000_000)
+    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
@@ -82,7 +83,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(amount_rtc * 1_000_000)
+    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
@@ -115,4 +116,3 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
             "nonce": nonce_int,
         },
     )
-

--- a/node/tests/test_payout_preflight.py
+++ b/node/tests/test_payout_preflight.py
@@ -1,9 +1,12 @@
 import unittest
+from importlib import import_module
 
 try:
     from payout_preflight import validate_wallet_transfer_admin, validate_wallet_transfer_signed
 except ImportError:
     from node.payout_preflight import validate_wallet_transfer_admin, validate_wallet_transfer_signed
+
+node_payout_preflight = import_module("node.payout_preflight")
 
 
 class PayoutPreflightTests(unittest.TestCase):
@@ -34,6 +37,13 @@ class PayoutPreflightTests(unittest.TestCase):
         )
         self.assertTrue(r.ok)
         self.assertEqual(r.details.get("amount_i64"), 1)
+
+    def test_node_module_admin_quantizes_micro_amounts_without_float_loss(self):
+        r = node_payout_preflight.validate_wallet_transfer_admin(
+            {"from_miner": "a", "to_miner": "b", "amount_rtc": "0.000249"}
+        )
+        self.assertTrue(r.ok)
+        self.assertEqual(r.details.get("amount_i64"), 249)
 
     def test_signed_rejects_missing(self):
         r = validate_wallet_transfer_signed({"from_address": "RTC" + "a" * 40})
@@ -90,6 +100,19 @@ class PayoutPreflightTests(unittest.TestCase):
         r = validate_wallet_transfer_signed(payload)
         self.assertTrue(r.ok)
         self.assertEqual(r.details.get("amount_i64"), 1)
+
+    def test_node_module_signed_quantizes_micro_amounts_without_float_loss(self):
+        payload = {
+            "from_address": "RTC" + "a" * 40,
+            "to_address": "RTC" + "b" * 40,
+            "amount_rtc": "0.000489",
+            "nonce": "123",
+            "signature": "00",
+            "public_key": "00",
+        }
+        r = node_payout_preflight.validate_wallet_transfer_signed(payload)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.details.get("amount_i64"), 489)
 
 
 if __name__ == "__main__":

--- a/node/tests/test_payout_preflight.py
+++ b/node/tests/test_payout_preflight.py
@@ -45,6 +45,13 @@ class PayoutPreflightTests(unittest.TestCase):
         self.assertTrue(r.ok)
         self.assertEqual(r.details.get("amount_i64"), 249)
 
+    def test_node_module_admin_quantizes_raw_decimal_before_float_conversion(self):
+        r = node_payout_preflight.validate_wallet_transfer_admin(
+            {"from_miner": "a", "to_miner": "b", "amount_rtc": "0.123456999999999999999999"}
+        )
+        self.assertTrue(r.ok)
+        self.assertEqual(r.details.get("amount_i64"), 123456)
+
     def test_signed_rejects_missing(self):
         r = validate_wallet_transfer_signed({"from_address": "RTC" + "a" * 40})
         self.assertFalse(r.ok)
@@ -113,6 +120,19 @@ class PayoutPreflightTests(unittest.TestCase):
         r = node_payout_preflight.validate_wallet_transfer_signed(payload)
         self.assertTrue(r.ok)
         self.assertEqual(r.details.get("amount_i64"), 489)
+
+    def test_node_module_signed_quantizes_raw_decimal_before_float_conversion(self):
+        payload = {
+            "from_address": "RTC" + "a" * 40,
+            "to_address": "RTC" + "b" * 40,
+            "amount_rtc": "0.000001999999999999999999",
+            "nonce": "123",
+            "signature": "00",
+            "public_key": "00",
+        }
+        r = node_payout_preflight.validate_wallet_transfer_signed(payload)
+        self.assertTrue(r.ok)
+        self.assertEqual(r.details.get("amount_i64"), 1)
 
 
 if __name__ == "__main__":

--- a/payout_preflight.py
+++ b/payout_preflight.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 # single script (no package layout). Keep this module at repo root so
 # `from payout_preflight import ...` works, while tests can still import it.
 
-import math
 import re
 from dataclasses import dataclass
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from typing import Any, Dict, Optional, Tuple
+
+
+MICRO_RTC = Decimal("1000000")
 
 
 @dataclass(frozen=True)
@@ -24,14 +26,18 @@ def _as_dict(payload: Any) -> Tuple[Optional[Dict[str, Any]], str]:
     return payload, ""
 
 
-def _safe_float(v: Any) -> Tuple[Optional[float], str]:
+def _safe_decimal(v: Any) -> Tuple[Optional[Decimal], str]:
     try:
-        f = float(v)
-    except (TypeError, ValueError):
+        amount = Decimal(str(v))
+    except (InvalidOperation, TypeError, ValueError):
         return None, "amount_not_number"
-    if not math.isfinite(f):
+    if not amount.is_finite():
         return None, "amount_not_finite"
-    return f, ""
+    return amount, ""
+
+
+def _amount_i64(amount_rtc: Decimal) -> int:
+    return int((amount_rtc * MICRO_RTC).to_integral_value(rounding=ROUND_DOWN))
 
 
 def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
@@ -42,7 +48,7 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
 
     from_miner = data.get("from_miner")
     to_miner = data.get("to_miner")
-    amount_rtc, aerr = _safe_float(data.get("amount_rtc", 0))
+    amount_rtc, aerr = _safe_decimal(data.get("amount_rtc", 0))
 
     if not from_miner or not to_miner:
         return PreflightResult(ok=False, error="missing_from_or_to", details={})
@@ -50,12 +56,12 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
+    amount_i64 = _amount_i64(amount_rtc)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
-            details={"amount_rtc": amount_rtc, "min_rtc": 0.000001},
+            details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
 
     return PreflightResult(
@@ -64,7 +70,7 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         details={
             "from_miner": str(from_miner),
             "to_miner": str(to_miner),
-            "amount_rtc": amount_rtc,
+            "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
         },
     )
@@ -83,17 +89,17 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
 
     from_address = str(data.get("from_address", "")).strip()
     to_address = str(data.get("to_address", "")).strip()
-    amount_rtc, aerr = _safe_float(data.get("amount_rtc", 0))
+    amount_rtc, aerr = _safe_decimal(data.get("amount_rtc", 0))
     if aerr:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = int(Decimal(str(amount_rtc)) * 1_000_000)
+    amount_i64 = _amount_i64(amount_rtc)
     if amount_i64 <= 0:
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
-            details={"amount_rtc": amount_rtc, "min_rtc": 0.000001},
+            details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
 
     if not (from_address.startswith("RTC") and len(from_address) == 43):
@@ -120,7 +126,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         details={
             "from_address": from_address,
             "to_address": to_address,
-            "amount_rtc": amount_rtc,
+            "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
             "nonce": nonce_int,
             "chain_id": chain_id or None,


### PR DESCRIPTION
## Summary

Fixes #4202.

`node/payout_preflight.py` still used float-based parsing before `amount_i64` quantization even though this preflight path is meant to guard payment amounts. That allowed high-precision decimal strings to round through binary float before Decimal quantization, producing a one micro-RTC overcount or undercount in edge cases.

This PR:
- parses `amount_rtc` directly as `Decimal` before validation in `node/payout_preflight.py`
- keeps the repo-root compatibility shim aligned with the same Decimal parsing behavior
- uses explicit round-down micro-RTC quantization for admin and signed transfer preflight
- adds regression tests that explicitly import `node.payout_preflight`, including the high-precision review cases

## Validation

- `python -m pytest node\\tests\\test_payout_preflight.py -q` => 14 passed
- `python -m py_compile node\\payout_preflight.py payout_preflight.py node\\tests\\test_payout_preflight.py`
- `git diff --check`

`ruff` is not installed in this environment (`No module named ruff`), so I could not run it locally.