### PR TITLE
fix: avoid shell in BIOS hardware probe

### DIFF
--- a/tests/test_bios_pawpaw_detector.py
+++ b/tests/test_bios_pawpaw_detector.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+
+def load_detector_module():
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "bios_pawpaw_detector.py"
+    spec = importlib.util.spec_from_file_location("bios_pawpaw_detector", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_windows_bios_query_uses_argument_list(monkeypatch):
+    detector = load_detector_module()
+    calls = []
+
+    def fake_check_output(args, **kwargs):
+        calls.append((args, kwargs))
+        return b"ReleaseDate\r\n19890304000000.000000+000\r\n"
+
+    monkeypatch.setattr(detector.platform, "system", lambda: "Windows")
+    monkeypatch.setattr(detector.subprocess, "check_output", fake_check_output)
+
+    bios_date = detector.get_bios_date()
+
+    assert bios_date.year == 1989
+    assert calls == [(["wmic", "bios", "get", "releasedate"], {"stderr": detector.subprocess.DEVNULL, "timeout": 10})]
+
+
+def test_linux_bios_query_uses_argument_list(monkeypatch):
+    detector = load_detector_module()
+    calls = []
+
+    def fake_check_output(args, **kwargs):
+        calls.append((args, kwargs))
+        return b"BIOS Information\n\tRelease Date: 03/15/2011\n"
+
+    monkeypatch.setattr(detector.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(detector.subprocess, "check_output", fake_check_output)
+
+    bios_date = detector.get_bios_date()
+
+    assert bios_date.year == 2011
+    assert calls == [(["dmidecode", "-t", "bios"], {"stderr": detector.subprocess.DEVNULL, "timeout": 10})]
+
+
+def test_bios_query_failure_returns_none(monkeypatch):
+    detector = load_detector_module()
+
+    def fake_check_output(args, **kwargs):
+        raise FileNotFoundError(args[0])
+
+    monkeypatch.setattr(detector.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(detector.subprocess, "check_output", fake_check_output)
+
+    assert detector.get_bios_date() is None

--- a/tools/bios_pawpaw_detector.py
+++ b/tools/bios_pawpaw_detector.py
@@ -3,16 +3,25 @@ import platform
 import json
 from datetime import datetime
 
+
+def _run_hardware_query(args):
+    return subprocess.check_output(
+        args,
+        stderr=subprocess.DEVNULL,
+        timeout=10,
+    ).decode().splitlines()
+
+
 def get_bios_date():
     try:
         if platform.system() == "Windows":
-            output = subprocess.check_output("wmic bios get releasedate", shell=True).decode().splitlines()
+            output = _run_hardware_query(["wmic", "bios", "get", "releasedate"])
             for line in output:
-                if line.strip().isdigit() and len(line.strip()) >= 8:
-                    date_str = line.strip()
+                date_str = line.strip()
+                if len(date_str) >= 8 and date_str[:8].isdigit():
                     return datetime.strptime(date_str[:8], "%Y%m%d")
         elif platform.system() == "Linux":
-            output = subprocess.check_output("dmidecode -t bios", shell=True, stderr=subprocess.DEVNULL).decode().splitlines()
+            output = _run_hardware_query(["dmidecode", "-t", "bios"])
             for line in output:
                 if "Release Date" in line:
                     date_str = line.split(":")[1].strip()


### PR DESCRIPTION
Summary:
- replace the fixed `wmic` and `dmidecode` shell commands with argv-based subprocess calls
- add a 10 second timeout so the hardware probe cannot hang indefinitely
- keep the existing BIOS date parsing behavior, with a small fix for normal WMIC timestamps that include fractional/timezone suffixes
- add regression tests for the Windows path, Linux path, and command failure case

Security note:
- Severity: Low
- Scope: one local hardware-detection helper, one matching test file
- The old code passed static commands through a shell even though shell parsing was not needed. The patch keeps the same commands but calls them as argument lists.

Verification:
- `python -m pytest tests\test_bios_pawpaw_detector.py`
- Live-node testing is not applicable here; this code only probes local BIOS metadata. The tests cover the changed subprocess calls directly.

Bounty note:
If this is accepted for the bounty loop, please use my GitHub-login miner_id for payout. I am not posting payment details publicly.