### PR TITLE
fix: avoid shell in miner hardware probes

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -31,6 +31,26 @@ BLOCK_TIME = 600  # 10 minutes
 _CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
 TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 
+
+def _parse_lscpu_model(output):
+    for line in output.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip().lower() == "model name" and value.strip():
+            return value.strip()
+    return ""
+
+
+def _parse_free_memory_gb(output):
+    for line in output.splitlines():
+        parts = line.split()
+        if parts and parts[0].lower().rstrip(":") == "mem" and len(parts) > 1:
+            try:
+                return int(parts[1])
+            except ValueError:
+                return None
+    return None
+
+
 def get_linux_serial():
     """Get hardware serial number for Linux systems"""
     # Try various sources
@@ -119,10 +139,10 @@ class LocalMiner:
         data = f"ryzen5-{uuid.uuid4().hex}-{time.time()}"
         return hashlib.sha256(data.encode()).hexdigest()[:38] + "RTC"
 
-    def _run_cmd(self, cmd):
+    def _run_cmd(self, args):
         try:
-            return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                text=True, timeout=10, shell=True).stdout.strip()
+            return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                text=True, timeout=10).stdout.strip()
         except:
             return ""
 
@@ -240,16 +260,16 @@ class LocalMiner:
             hw["arch"] = machine
 
         # Get CPU
-        cpu = self._run_cmd("lscpu | grep 'Model name' | cut -d: -f2 | xargs")
+        cpu = _parse_lscpu_model(self._run_cmd(["lscpu"]))
         hw["cpu"] = cpu or "Unknown"
 
         # Get cores
-        cores = self._run_cmd("nproc")
+        cores = self._run_cmd(["nproc"])
         hw["cores"] = int(cores) if cores else 6
 
         # Get memory
-        mem = self._run_cmd("free -g | grep Mem | awk '{print $2}'")
-        hw["memory_gb"] = int(mem) if mem else 32
+        mem = _parse_free_memory_gb(self._run_cmd(["free", "-g"]))
+        hw["memory_gb"] = mem if mem is not None else 32
 
         # Get MACs (ensures PoA signal uses real hardware data)
         macs = self._get_mac_addresses()

--- a/miners/power8/rustchain_power8_miner.py
+++ b/miners/power8/rustchain_power8_miner.py
@@ -23,6 +23,34 @@ BLOCK_TIME = 600  # 10 minutes
 
 WALLET_FILE = os.path.expanduser("~/rustchain/power8_wallet.txt")
 
+
+def _parse_lscpu_model(output):
+    for line in output.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip().lower() == "model name" and value.strip():
+            return value.strip()
+    return ""
+
+
+def _parse_proc_cpu_model(output):
+    for line in output.splitlines():
+        key, _, value = line.partition(":")
+        if key.strip().lower() == "cpu" and value.strip():
+            return value.strip()
+    return ""
+
+
+def _parse_free_memory_gb(output):
+    for line in output.splitlines():
+        parts = line.split()
+        if parts and parts[0].lower().rstrip(":") == "mem" and len(parts) > 1:
+            try:
+                return int(parts[1])
+            except ValueError:
+                return None
+    return None
+
+
 class LocalMiner:
     def __init__(self, wallet=None):
         self.node_url = NODE_URL
@@ -86,10 +114,10 @@ class LocalMiner:
         data = f"power8-s824-{uuid.uuid4().hex}-{time.time()}"
         return hashlib.sha256(data.encode()).hexdigest()[:38] + "RTC"
 
-    def _run_cmd(self, cmd):
+    def _run_cmd(self, args):
         try:
-            return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                                text=True, timeout=10, shell=True).stdout.strip()
+            return subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                text=True, timeout=10).stdout.strip()
         except:
             return ""
 
@@ -170,18 +198,22 @@ class LocalMiner:
         }
 
         # Get CPU info for POWER8
-        cpu = self._run_cmd("lscpu | grep 'Model name' | cut -d: -f2 | xargs")
+        cpu = _parse_lscpu_model(self._run_cmd(["lscpu"]))
         if not cpu:
-            cpu = self._run_cmd("cat /proc/cpuinfo | grep 'cpu' | head -1 | cut -d: -f2 | xargs")
+            try:
+                with open("/proc/cpuinfo", "r") as f:
+                    cpu = _parse_proc_cpu_model(f.read())
+            except Exception:
+                cpu = ""
         hw["cpu"] = cpu or "IBM POWER8"
 
         # Get cores (POWER8 has 16 cores, 128 threads with SMT8)
-        cores = self._run_cmd("nproc")
+        cores = self._run_cmd(["nproc"])
         hw["cores"] = int(cores) if cores else 128
 
         # Get memory (576GB on S824)
-        mem = self._run_cmd("free -g | grep Mem | awk '{print $2}'")
-        hw["memory_gb"] = int(mem) if mem else 576
+        mem = _parse_free_memory_gb(self._run_cmd(["free", "-g"]))
+        hw["memory_gb"] = mem if mem is not None else 576
 
         # Get MACs
         macs = self._get_mac_addresses()

--- a/tests/test_miner_hardware_probes.py
+++ b/tests/test_miner_hardware_probes.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+
+def load_module(relative_path, module_name):
+    module_path = Path(__file__).resolve().parents[1] / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_linux_miner_parses_lscpu_and_free_output():
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner")
+
+    assert miner._parse_lscpu_model("Architecture: x86_64\nModel name: AMD Ryzen 5 8645HS\n") == "AMD Ryzen 5 8645HS"
+    assert miner._parse_free_memory_gb("       total used free\nMem:      31    1   30\nSwap:      0    0    0\n") == 31
+
+
+def test_power8_miner_parses_lscpu_proc_cpuinfo_and_free_output():
+    miner = load_module(Path("miners/power8/rustchain_power8_miner.py"), "rustchain_power8_miner")
+
+    assert miner._parse_lscpu_model("Architecture: ppc64le\nModel name: POWER8E\n") == "POWER8E"
+    assert miner._parse_proc_cpu_model("processor\t: 0\ncpu\t\t: POWER8 (raw), altivec supported\n") == "POWER8 (raw), altivec supported"
+    assert miner._parse_free_memory_gb("       total used free\nMem:     576    9  567\n") == 576
+
+
+def test_linux_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_run_cmd")
+    instance = object.__new__(miner.LocalMiner)
+    calls = []
+
+    class Result:
+        stdout = "ok\n"
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return Result()
+
+    monkeypatch.setattr(miner.subprocess, "run", fake_run)
+
+    assert instance._run_cmd(["nproc"]) == "ok"
+    assert calls == [(["nproc"], {"stdout": miner.subprocess.PIPE, "stderr": miner.subprocess.PIPE, "text": True, "timeout": 10})]
+
+
+def test_power8_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
+    miner = load_module(Path("miners/power8/rustchain_power8_miner.py"), "rustchain_power8_miner_run_cmd")
+    instance = object.__new__(miner.LocalMiner)
+    calls = []
+
+    class Result:
+        stdout = "ok\n"
+
+    def fake_run(args, **kwargs):
+        calls.append((args, kwargs))
+        return Result()
+
+    monkeypatch.setattr(miner.subprocess, "run", fake_run)
+
+    assert instance._run_cmd(["nproc"]) == "ok"
+    assert calls == [(["nproc"], {"stdout": miner.subprocess.PIPE, "stderr": miner.subprocess.PIPE, "text": True, "timeout": 10})]


### PR DESCRIPTION
Summary:
- replace shell-based `lscpu | grep ...`, `nproc`, and `free -g | awk ...` probes in the Linux and POWER8 miners with argv-based subprocess calls
- move the old text extraction into small Python parsers so shell pipelines are not needed
- read the POWER8 `/proc/cpuinfo` fallback directly instead of invoking `cat | grep | cut`
- add regression tests for parser behavior and for the subprocess wrapper not passing `shell=True`

Security note:
- Severity: Low
- Scope: miner hardware metadata collection only
- This keeps the same local commands but removes shell interpretation from the probe path.

Verification:
- `python -m pytest tests\test_miner_hardware_probes.py`

Bounty note:
If this is accepted for the bounty loop, please use my GitHub-login miner_id for payout. I am not posting payment details publicly.