### PR TITLE
fix: verify TLS in poller clients

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -4,7 +4,7 @@ Bounty #754: Agent Reputation Score — On-Chain Trust for Agent Economy
 
 Integration:
     from agent_reputation import reputation_bp, ReputationEngine
-    engine = ReputationEngine(db_path="rustchain.db", node_url="https://50.28.86.131")
+    engine = ReputationEngine(db_path="rustchain.db", node_url="https://rustchain.org")
     engine.start_cache_refresh()
     app.register_blueprint(reputation_bp)
 
@@ -21,17 +21,17 @@ import threading
 import sqlite3
 import os
 import json
-import ssl
 import urllib.request
 from flask import Blueprint, jsonify, request
+from node.tls_config import get_ssl_context
 
 # ─── Config ─────────────────────────────────────────────────────────────────── #
 DB_PATH       = os.environ.get("RUSTCHAIN_DB_PATH", "rustchain.db")
-NODE_URL      = os.environ.get("RUSTCHAIN_NODE_URL", "https://50.28.86.131")
+NODE_URL      = os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")
 CACHE_TTL_S   = 3600       # Refresh reputation cache every epoch (~1hr)
 DECAY_DAYS    = 30         # Lose 1 point per 30 days inactive
 
-CTX = ssl._create_unverified_context()
+CTX = get_ssl_context()
 
 # ─── Reputation Levels ───────────────────────────────────────────────────────── #
 LEVELS = [

--- a/explorer/explorer_websocket_server.py
+++ b/explorer/explorer_websocket_server.py
@@ -12,7 +12,7 @@ Features:
 - Nginx proxy compatible
 
 Standalone usage:
-    python3 explorer_websocket_server.py --port 8080 --node https://50.28.86.131
+    python3 explorer_websocket_server.py --port 8080 --node https://rustchain.org
 
 Integration:
     from explorer_websocket_server import socketio, app, start_explorer_poller
@@ -27,10 +27,16 @@ import os
 import json
 import time
 import threading
-import ssl
 import urllib.request
+import sys
 from flask import Flask, Blueprint, jsonify, request
 from datetime import datetime
+
+try:
+    from node.tls_config import get_ssl_context
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+    from node.tls_config import get_ssl_context
 
 try:
     from flask_socketio import SocketIO, emit, join_room, leave_room
@@ -41,14 +47,14 @@ except ImportError:
 
 # ─── Configuration ─────────────────────────────────────────────────────────── #
 EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
-NODE_URL = os.environ.get('RUSTCHAIN_NODE_URL', os.environ.get('RUSTCHAIN_API_BASE', 'https://50.28.86.131'))
+NODE_URL = os.environ.get('RUSTCHAIN_NODE_URL', os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org'))
 API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
 POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds between polls
 HEARTBEAT_S = 30  # ping/pong interval for connection health
 MAX_QUEUE = 100  # max buffered events per client (backpressure)
 
 # SSL context for HTTPS node connections
-CTX = ssl._create_unverified_context()
+CTX = get_ssl_context()
 
 # ─── Explorer State ─────────────────────────────────────────────────────────── #
 class ExplorerState:

--- a/node/tls_config.py
+++ b/node/tls_config.py
@@ -53,3 +53,24 @@ def get_async_tls_verify():
     the same str/bool types as requests.
     """
     return get_tls_verify()
+
+
+def get_ssl_context():
+    """Return an SSL context for urllib/websocket clients.
+
+    Uses the same pinned certificate convention as requests clients.
+    Set RUSTCHAIN_TLS_VERIFY=false only for local development with
+    self-signed endpoints that cannot be verified.
+    """
+    import ssl
+
+    tls_verify_env = os.environ.get("RUSTCHAIN_TLS_VERIFY", "true").strip().lower()
+    ca_bundle = os.environ.get("RUSTCHAIN_CA_BUNDLE", "").strip()
+
+    if tls_verify_env in ("false", "0", "no"):
+        return ssl._create_unverified_context()
+    if ca_bundle:
+        return ssl.create_default_context(cafile=ca_bundle)
+    if os.path.exists(_CERT_PATH):
+        return ssl.create_default_context(cafile=_CERT_PATH)
+    return ssl.create_default_context()

--- a/tests/test_tls_config.py
+++ b/tests/test_tls_config.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+import ssl
+from pathlib import Path
+
+from node import tls_config
+
+
+def test_verified_tls_clients_default_to_certificate_hostname():
+    assert 'os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")' in Path(
+        "agent_reputation.py"
+    ).read_text(encoding="utf-8")
+    assert 'os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")' in Path(
+        "websocket_feed.py"
+    ).read_text(encoding="utf-8")
+    assert (
+        "os.environ.get('RUSTCHAIN_NODE_URL', os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org'))"
+        in Path("explorer/explorer_websocket_server.py").read_text(encoding="utf-8")
+    )
+
+
+def test_ssl_context_verifies_by_default(monkeypatch):
+    monkeypatch.delenv("RUSTCHAIN_TLS_VERIFY", raising=False)
+    monkeypatch.delenv("RUSTCHAIN_CA_BUNDLE", raising=False)
+    monkeypatch.setattr(tls_config.os.path, "exists", lambda path: False)
+
+    context = tls_config.get_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+
+
+def test_ssl_context_can_use_explicit_local_opt_out(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TLS_VERIFY", "false")
+    monkeypatch.delenv("RUSTCHAIN_CA_BUNDLE", raising=False)
+
+    context = tls_config.get_ssl_context()
+
+    assert context.verify_mode == ssl.CERT_NONE
+    assert context.check_hostname is False

--- a/websocket_feed.py
+++ b/websocket_feed.py
@@ -9,7 +9,7 @@ Integration (add to your Flask app):
     start_event_poller()
 
 Standalone:
-    python3 websocket_feed.py --port 5001 --node https://50.28.86.131
+    python3 websocket_feed.py --port 5001 --node https://rustchain.org
 
 Connect with:
     wscat -c ws://localhost:5001/ws/feed
@@ -22,10 +22,10 @@ Wallet: noxventures_rtc
 import time
 import threading
 import json
-import ssl
 import os
 import urllib.request
 from flask import Blueprint
+from node.tls_config import get_ssl_context
 
 try:
     from flask_socketio import SocketIO, emit, disconnect, join_room, leave_room
@@ -41,12 +41,12 @@ except ImportError:
         HAVE_WS = False
 
 # ─── Config ─────────────────────────────────────────────────────────────────── #
-NODE_URL     = os.environ.get("RUSTCHAIN_NODE_URL", "https://50.28.86.131")
+NODE_URL     = os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")
 POLL_INTERVAL = int(os.environ.get("WS_POLL_INTERVAL", "5"))   # seconds between polls
 HEARTBEAT_S  = 30    # ping/pong interval
 MAX_QUEUE    = 100   # max buffered events per client (backpressure)
 
-CTX = ssl._create_unverified_context()
+CTX = get_ssl_context()
 
 # ─── Event Bus ──────────────────────────────────────────────────────────────── #
 class EventBus:


### PR DESCRIPTION
Summary:
- add `get_ssl_context()` to the shared TLS helper for urllib/websocket clients
- switch the agent reputation, websocket feed, and explorer websocket pollers away from unconditional unverified TLS contexts
- keep an explicit local-development escape hatch via `RUSTCHAIN_TLS_VERIFY=false`
- add tests for the verified-by-default behavior and explicit opt-out behavior

Security note:
- Severity: Low
- Scope: three background pollers plus the shared TLS helper
- Previously these clients disabled certificate verification for every HTTPS node request. The new default verifies certificates or a pinned `~/.rustchain/node_cert.pem` certificate.

Verification:
- `python -m pytest tests\test_tls_config.py`
- `python -m pytest explorer\test_explorer_websocket.py::TestWebSocketConfiguration::test_default_configuration`
- `python -m py_compile agent_reputation.py websocket_feed.py explorer\explorer_websocket_server.py node\tls_config.py`

Bounty note:
If this is accepted for the bounty loop, please use my GitHub-login miner_id for payout. I am not posting payment details publicly.