### PR TITLE
fix: use constant-time Sophia inspector admin checks

### DIFF
--- a/node/sophia_attestation_inspector.py
+++ b/node/sophia_attestation_inspector.py
@@ -16,6 +16,7 @@ import time
 import sqlite3
 import hashlib
 import argparse
+import hmac
 import logging
 import traceback
 from typing import Optional, Tuple, Dict, List
@@ -701,7 +702,7 @@ def register_sophia_endpoints(app, db_path: str = None):
     def _is_admin(req):
         need = os.environ.get("RC_ADMIN_KEY", "")
         got = req.headers.get("X-Admin-Key", "") or req.headers.get("X-API-Key", "")
-        return bool(need and got and need == got)
+        return bool(need and got and hmac.compare_digest(got, need))
 
     @app.route("/sophia/status/<miner_id>", methods=["GET"])
     def sophia_status_miner(miner_id):

--- a/node/tests/test_sophia_attestation_inspector.py
+++ b/node/tests/test_sophia_attestation_inspector.py
@@ -1,0 +1,49 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import sophia_attestation_inspector
+
+
+def test_sophia_inspector_admin_auth_uses_constant_time_compare(monkeypatch):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    sophia_attestation_inspector.register_sophia_endpoints(app, ":memory:")
+
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(sophia_attestation_inspector.hmac, "compare_digest", spy_compare_digest)
+    monkeypatch.setattr(
+        sophia_attestation_inspector,
+        "inspect_miner",
+        lambda *args, **kwargs: {"ok": True, "miner": args[0]},
+    )
+
+    client = app.test_client()
+    denied = client.post(
+        "/sophia/inspect",
+        headers={"X-Admin-Key": "wrong-admin"},
+        json={"miner_id": "alice"},
+    )
+    assert denied.status_code == 401
+
+    accepted = client.post(
+        "/sophia/inspect",
+        headers={"X-API-Key": "expected-admin"},
+        json={"miner_id": "alice"},
+    )
+    assert accepted.status_code == 200
+    assert accepted.get_json() == {"ok": True, "miner": "alice"}
+
+    assert calls == [
+        ("wrong-admin", "expected-admin"),
+        ("expected-admin", "expected-admin"),
+    ]

--- a/node/tests/test_sophia_attestation_inspector.py
+++ b/node/tests/test_sophia_attestation_inspector.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 


### PR DESCRIPTION
## Summary

Fixes #3228.

`node/sophia_attestation_inspector.py` used a regular string equality check for admin-key authorization on admin-gated Sophia inspection endpoints. This PR switches the comparison to `hmac.compare_digest()` while preserving the existing fail-closed behavior when `RC_ADMIN_KEY` or a provided key is missing.

## Validation

- `python -m pytest node\\tests\\test_sophia_attestation_inspector.py -q` => 1 passed
- `python -m py_compile node\\sophia_attestation_inspector.py node\\tests\\test_sophia_attestation_inspector.py`
- `git diff --check`

## Bounty

Bug report/fix submitted for consideration under #305. Payout details can be provided privately if accepted.