### PR TITLE
fix: use constant-time Sophia review admin checks

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -16,7 +16,7 @@ import os
 import re
 import sqlite3
 import time
-from typing import Any
+from typing import Any, Iterable
 
 from flask import Flask, jsonify, request
 
@@ -132,24 +132,34 @@ def _env_truthy(name: str, default: str = "false") -> bool:
     return str(os.getenv(name, default)).strip().lower() in TRUE_VALUES
 
 
-def _bearer_tokens() -> set[str]:
+def _bearer_tokens() -> tuple[str, ...]:
     raw = os.getenv("SOPHIA_GOVERNOR_REVIEW_BEARER", "").strip()
     if not raw:
-        return set()
-    return {token.strip() for token in raw.split(",") if token.strip()}
+        return ()
+    return tuple(token.strip() for token in raw.split(",") if token.strip())
+
+
+def _matches_secret(candidate: str, secrets: Iterable[str]) -> bool:
+    if not candidate:
+        return False
+    matched = False
+    for secret in secrets:
+        if secret and hmac.compare_digest(candidate, secret):
+            matched = True
+    return matched
 
 
 def _is_authorized(req) -> bool:
     required_admin = os.getenv("RC_ADMIN_KEY", "").strip()
     if required_admin:
         provided_admin = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
-        if provided_admin and hmac.compare_digest(provided_admin, required_admin):
+        if _matches_secret(provided_admin, (required_admin,)):
             return True
 
     auth_header = (req.headers.get("Authorization") or "").strip()
     if auth_header.lower().startswith("bearer "):
         token = auth_header.split(" ", 1)[1].strip()
-        if token and token in _bearer_tokens():
+        if _matches_secret(token, _bearer_tokens()):
             return True
 
     return False

--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -11,6 +11,7 @@ recommendation, without depending on the full Sophia agent stack.
 from __future__ import annotations
 
 import json
+import hmac
 import os
 import re
 import sqlite3
@@ -142,7 +143,7 @@ def _is_authorized(req) -> bool:
     required_admin = os.getenv("RC_ADMIN_KEY", "").strip()
     if required_admin:
         provided_admin = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
-        if provided_admin == required_admin:
+        if provided_admin and hmac.compare_digest(provided_admin, required_admin):
             return True
 
     auth_header = (req.headers.get("Authorization") or "").strip()

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -1,6 +1,8 @@
+import gc
 import os
 import tempfile
 import sys
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -25,10 +27,15 @@ def client(monkeypatch):
     try:
         yield review_service.app.test_client()
     finally:
-        try:
-            os.unlink(db_path)
-        except FileNotFoundError:
-            pass
+        for _ in range(5):
+            try:
+                os.unlink(db_path)
+                break
+            except FileNotFoundError:
+                break
+            except PermissionError:
+                gc.collect()
+                time.sleep(0.05)
 
 
 def _payload():
@@ -50,6 +57,33 @@ def _payload():
 def test_review_requires_auth(client):
     response = client.post("/review", json=_payload())
     assert response.status_code == 401
+
+
+def test_review_admin_auth_uses_constant_time_compare(client, monkeypatch):
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(review_service.hmac, "compare_digest", spy_compare_digest)
+    monkeypatch.setattr(
+        review_service,
+        "_call_ollama",
+        lambda prompt: ("Assessment: ok.\nRisk: low.\nNext step: approve.", "glm-test"),
+    )
+
+    denied = client.post("/review", headers={"X-Admin-Key": "wrong-admin"}, json=_payload())
+    assert denied.status_code == 401
+
+    accepted = client.post("/review", headers={"X-API-Key": "test-admin"}, json=_payload())
+    assert accepted.status_code == 200
+    assert accepted.get_json()["ok"] is True
+
+    assert calls == [
+        ("wrong-admin", "test-admin"),
+        ("test-admin", "test-admin"),
+    ]
 
 
 def test_review_endpoint_calls_model_and_stores(client, monkeypatch):

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -59,7 +59,7 @@ def test_review_requires_auth(client):
     assert response.status_code == 401
 
 
-def test_review_admin_auth_uses_constant_time_compare(client, monkeypatch):
+def test_review_auth_uses_constant_time_compare(client, monkeypatch):
     calls = []
 
     def spy_compare_digest(provided, expected):
@@ -67,6 +67,7 @@ def test_review_admin_auth_uses_constant_time_compare(client, monkeypatch):
         return provided == expected
 
     monkeypatch.setattr(review_service.hmac, "compare_digest", spy_compare_digest)
+    monkeypatch.setenv("SOPHIA_GOVERNOR_REVIEW_BEARER", "review-token,other-token")
     monkeypatch.setattr(
         review_service,
         "_call_ollama",
@@ -76,12 +77,23 @@ def test_review_admin_auth_uses_constant_time_compare(client, monkeypatch):
     denied = client.post("/review", headers={"X-Admin-Key": "wrong-admin"}, json=_payload())
     assert denied.status_code == 401
 
-    accepted = client.post("/review", headers={"X-API-Key": "test-admin"}, json=_payload())
-    assert accepted.status_code == 200
-    assert accepted.get_json()["ok"] is True
+    denied_bearer = client.post("/review", headers={"Authorization": "Bearer wrong-token"}, json=_payload())
+    assert denied_bearer.status_code == 401
+
+    accepted_bearer = client.post("/review", headers={"Authorization": "Bearer review-token"}, json=_payload())
+    assert accepted_bearer.status_code == 200
+    assert accepted_bearer.get_json()["ok"] is True
+
+    accepted_admin = client.post("/review", headers={"X-API-Key": "test-admin"}, json=_payload())
+    assert accepted_admin.status_code == 200
+    assert accepted_admin.get_json()["ok"] is True
 
     assert calls == [
         ("wrong-admin", "test-admin"),
+        ("wrong-token", "review-token"),
+        ("wrong-token", "other-token"),
+        ("review-token", "review-token"),
+        ("review-token", "other-token"),
         ("test-admin", "test-admin"),
     ]
 


### PR DESCRIPTION
## Summary

Fixes #3229.

This is a clean scoped resubmission for the Sophia governor review service admin-key timing issue. `node/sophia_governor_review_service.py` now uses `hmac.compare_digest()` for configured `RC_ADMIN_KEY` checks while preserving the existing bearer-token fallback behavior.

The regression test exercises both rejected and accepted admin-key requests against `/review` and asserts the admin comparisons use `hmac.compare_digest()`.

## Validation

- `python -m pytest node\\tests\\test_sophia_governor_review_service.py -q` => 14 passed
- `python -m py_compile node\\sophia_governor_review_service.py node\\tests\\test_sophia_governor_review_service.py`
- `git diff --check`

## Bounty

Bug report/fix submitted for consideration under #305. Payout details can be provided privately if accepted.