### PR TITLE
fix: rate limit attestation challenges

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -370,6 +370,15 @@ def attest_ensure_tables(conn):
         """
     )
     conn.execute("CREATE INDEX IF NOT EXISTS idx_used_nonces_expires_at ON used_nonces(expires_at)")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS attest_challenge_rate_limit (
+            client_ip TEXT PRIMARY KEY,
+            window_start INTEGER NOT NULL,
+            request_count INTEGER NOT NULL
+        )
+        """
+    )
 
 
 def attest_cleanup_expired(conn, now_ts: Optional[int] = None):
@@ -2581,6 +2590,60 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
 # -- IP Rate Limiting for Attestations (SQLite-backed, gunicorn-safe) --
 ATTEST_IP_LIMIT = 15      # Max unique miners per IP per hour
 ATTEST_IP_WINDOW = 3600  # 1 hour window
+ATTEST_CHALLENGE_IP_LIMIT = int(os.environ.get("ATTEST_CHALLENGE_IP_LIMIT", "10"))
+ATTEST_CHALLENGE_IP_WINDOW = int(os.environ.get("ATTEST_CHALLENGE_IP_WINDOW", "60"))
+
+
+def check_challenge_rate_limit(client_ip):
+    """Rate limit challenge issuance before allocating a nonce row."""
+    now = int(time.time())
+    window = max(1, int(ATTEST_CHALLENGE_IP_WINDOW))
+    limit = max(1, int(ATTEST_CHALLENGE_IP_LIMIT))
+    window_start = now - (now % window)
+    cutoff = now - window
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute("BEGIN IMMEDIATE")
+        attest_ensure_tables(conn)
+        conn.execute(
+            "DELETE FROM attest_challenge_rate_limit WHERE window_start < ?",
+            (cutoff,),
+        )
+        row = conn.execute(
+            """
+            SELECT window_start, request_count
+            FROM attest_challenge_rate_limit
+            WHERE client_ip = ?
+            """,
+            (client_ip,),
+        ).fetchone()
+        if row and int(row[0]) == window_start:
+            count = int(row[1]) + 1
+            conn.execute(
+                """
+                UPDATE attest_challenge_rate_limit
+                SET request_count = ?
+                WHERE client_ip = ?
+                """,
+                (count, client_ip),
+            )
+        else:
+            count = 1
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO attest_challenge_rate_limit
+                    (client_ip, window_start, request_count)
+                VALUES (?, ?, ?)
+                """,
+                (client_ip, window_start, count),
+            )
+        conn.commit()
+
+    if count > limit:
+        print(f"[RATE_LIMIT] challenge IP {client_ip} has {count} requests in {window}s (limit {limit})")
+        return False, f"challenge_rate_limit:{count}_requests_from_same_ip"
+    return True, "ok"
+
 
 def check_ip_rate_limit(client_ip, miner_id):
     """Rate limit attestations per source IP using SQLite (shared across workers)."""
@@ -2977,6 +3040,17 @@ def get_challenge():
     Deployments with multiple attestation backends should keep submit traffic
     sticky to the issuing node or share the nonce store across nodes.
     """
+    client_ip = get_client_ip()
+    rate_ok, rate_reason = check_challenge_rate_limit(client_ip)
+    if not rate_ok:
+        return jsonify({
+            "ok": False,
+            "error": "rate_limited",
+            "message": "Too many attestation challenge requests from this IP address",
+            "code": "CHALLENGE_RATE_LIMIT",
+            "reason": rate_reason,
+        }), 429
+
     nonce = secrets.token_hex(32)
     expires = int(time.time()) + 300  # 5 minutes
 

--- a/node/tests/test_attest_challenge_rate_limit.py
+++ b/node/tests/test_attest_challenge_rate_limit.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestAttestChallengeRateLimit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        cls._tmp.cleanup()
+
+    def _load_module(self, module_name: str, db_name: str):
+        db_path = str(Path(self._tmp.name) / db_name)
+        os.environ["RUSTCHAIN_DB_PATH"] = db_path
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        with sqlite3.connect(db_path) as conn:
+            mod.attest_ensure_tables(conn)
+        mod.ATTEST_CHALLENGE_IP_LIMIT = 2
+        mod.ATTEST_CHALLENGE_IP_WINDOW = 60
+        return mod, db_path
+
+    def _response_payload(self, resp):
+        if isinstance(resp, tuple):
+            body, status = resp
+            return status, body.get_json()
+        return resp.status_code, resp.get_json()
+
+    def test_challenge_endpoint_limits_repeated_requests_per_ip(self):
+        mod, db_path = self._load_module("rustchain_challenge_limit", "challenge_limit.db")
+
+        statuses = []
+        for _ in range(3):
+            with mod.app.test_request_context(
+                "/attest/challenge",
+                method="POST",
+                json={},
+                environ_base={"REMOTE_ADDR": "203.0.113.10"},
+            ), mock.patch.object(mod.time, "time", return_value=1000):
+                statuses.append(self._response_payload(mod.get_challenge()))
+
+        self.assertEqual(statuses[0][0], 200)
+        self.assertEqual(statuses[1][0], 200)
+        self.assertEqual(statuses[2][0], 429)
+        self.assertEqual(statuses[2][1]["code"], "CHALLENGE_RATE_LIMIT")
+
+        with sqlite3.connect(db_path) as conn:
+            self.assertEqual(conn.execute("SELECT COUNT(*) FROM nonces").fetchone()[0], 2)
+            self.assertEqual(
+                conn.execute(
+                    "SELECT request_count FROM attest_challenge_rate_limit WHERE client_ip = ?",
+                    ("203.0.113.10",),
+                ).fetchone()[0],
+                3,
+            )
+
+    def test_challenge_rate_limit_window_resets(self):
+        mod, db_path = self._load_module("rustchain_challenge_window", "challenge_window.db")
+
+        for _ in range(2):
+            with mod.app.test_request_context(
+                "/attest/challenge",
+                method="POST",
+                json={},
+                environ_base={"REMOTE_ADDR": "203.0.113.11"},
+            ), mock.patch.object(mod.time, "time", return_value=1000):
+                status, _ = self._response_payload(mod.get_challenge())
+                self.assertEqual(status, 200)
+
+        with mod.app.test_request_context(
+            "/attest/challenge",
+            method="POST",
+            json={},
+            environ_base={"REMOTE_ADDR": "203.0.113.11"},
+        ), mock.patch.object(mod.time, "time", return_value=1061):
+            status, body = self._response_payload(mod.get_challenge())
+
+        self.assertEqual(status, 200)
+        self.assertIn("nonce", body)
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT request_count FROM attest_challenge_rate_limit WHERE client_ip = ?",
+                ("203.0.113.11",),
+            ).fetchone()
+            self.assertEqual(row[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #2751.

This adds a SQLite-backed per-IP rate limit to POST /attest/challenge before a nonce row is allocated. Once an IP crosses the challenge limit, the endpoint returns 429 and does not create another nonce, which closes the unbounded nonce-table growth path while keeping normal challenge issuance unchanged.

I used a separate ttest_challenge_rate_limit table instead of reusing ip_rate_limit, because challenge requests do not have a miner id yet. The update runs under BEGIN IMMEDIATE so concurrent workers serialize the per-IP counter instead of undercounting bursts.

Severity: Medium DoS hardening. This is a clean implementation for the existing #2751 report; I am not claiming first-finder credit.

Payment: please use my GitHub-login miner_id for any payout.

## Tests

- python -m pytest node\\tests\\test_attest_challenge_rate_limit.py -q => 2 passed
- python -m py_compile node\\rustchain_v2_integrated_v2.2.1_rip200.py node\\tests\\test_attest_challenge_rate_limit.py
- git diff --check

Live-node test: not run, since this is a write-path rate-limit change and the Flask request-context regression covers the behavior without creating production challenge rows.