### PR TITLE
fix: use constant-time Sophia admin checks

### DIFF
--- a/node/sophia_attestation_inspector.py
+++ b/node/sophia_attestation_inspector.py
@@ -13,6 +13,7 @@ import os
 import sys
 import json
 import time
+import hmac
 import sqlite3
 import hashlib
 import argparse
@@ -701,7 +702,7 @@ def register_sophia_endpoints(app, db_path: str = None):
     def _is_admin(req):
         need = os.environ.get("RC_ADMIN_KEY", "")
         got = req.headers.get("X-Admin-Key", "") or req.headers.get("X-API-Key", "")
-        return bool(need and got and need == got)
+        return bool(need and got and hmac.compare_digest(got, need))
 
     @app.route("/sophia/status/<miner_id>", methods=["GET"])
     def sophia_status_miner(miner_id):

--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -11,6 +11,7 @@ recommendation, without depending on the full Sophia agent stack.
 from __future__ import annotations
 
 import json
+import hmac
 import os
 import re
 import sqlite3
@@ -142,7 +143,7 @@ def _is_authorized(req) -> bool:
     required_admin = os.getenv("RC_ADMIN_KEY", "").strip()
     if required_admin:
         provided_admin = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
-        if provided_admin == required_admin:
+        if provided_admin and hmac.compare_digest(provided_admin, required_admin):
             return True
 
     auth_header = (req.headers.get("Authorization") or "").strip()

--- a/node/tests/test_sophia_attestation_admin_auth.py
+++ b/node/tests/test_sophia_attestation_admin_auth.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+import os
+import sys
+
+from flask import Flask
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import sophia_attestation_inspector as inspector
+
+
+def test_sophia_inspect_admin_auth_uses_compare_digest(monkeypatch):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    monkeypatch.setattr(
+        inspector,
+        "inspect_miner",
+        lambda miner_id, device=None, fingerprint=None, db_path=None: {"miner": miner_id, "ok": True},
+    )
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return True
+
+    monkeypatch.setattr(inspector.hmac, "compare_digest", spy_compare_digest)
+
+    inspector.register_sophia_endpoints(app, db_path=":memory:")
+    response = app.test_client().post(
+        "/sophia/inspect",
+        headers={"X-Admin-Key": "test-admin"},
+        json={"miner_id": "miner-1"},
+    )
+
+    assert response.status_code == 200
+    assert calls == [("test-admin", "test-admin")]

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -52,6 +52,21 @@ def test_review_requires_auth(client):
     assert response.status_code == 401
 
 
+def test_review_admin_auth_uses_compare_digest(client, monkeypatch):
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return True
+
+    monkeypatch.setattr(review_service.hmac, "compare_digest", spy_compare_digest)
+
+    response = client.post("/review", headers={"X-Admin-Key": "test-admin"}, json=_payload())
+
+    assert response.status_code == 200
+    assert calls == [("test-admin", "test-admin")]
+
+
 def test_review_endpoint_calls_model_and_stores(client, monkeypatch):
     monkeypatch.setattr(
         review_service,


### PR DESCRIPTION
## Summary

Fixes #3228 and #3229.

Two Sophia admin paths still compared configured admin keys with plain string equality:
- `node/sophia_attestation_inspector.py` for `/sophia/inspect` and `/sophia/batch`
- `node/sophia_governor_review_service.py` for review-service admin auth

This switches those checks to `hmac.compare_digest()` and adds regression tests that spy on the comparison path so the tests cover the timing-safe behavior, not just the HTTP status.

Severity: Medium timing-side-channel hardening. These are public, already-reported issues; I am claiming clean implementation credit, not first-finder credit.

Payment: please use my GitHub-login miner_id for any payout.

## Tests

- `python -m pytest node\tests\test_sophia_attestation_admin_auth.py node\tests\test_sophia_governor_review_service.py -q` => 15 passed
- `python -m py_compile node\sophia_attestation_inspector.py node\sophia_governor_review_service.py node\tests\test_sophia_attestation_admin_auth.py node\tests\test_sophia_governor_review_service.py`
- `git diff --check`