### PR TITLE
fix: escape beacon chat messages before storage

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -865,6 +865,7 @@ def chat():
         
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400
+        safe_agent_id = html.escape(str(agent_id), quote=True)
         safe_message = html.escape(str(message), quote=True)
         
         # Store user message
@@ -876,7 +877,7 @@ def chat():
         
         # Generate mock response (in production, call LLM)
         responses = [
-            f"Acknowledged. I am {agent_id}. How can I assist?",
+            f"Acknowledged. I am {safe_agent_id}. How can I assist?",
             "Transmission received. Processing request...",
             "Beacon signal strong. Standing by for instructions.",
             "Contract terms acceptable. Ready to proceed.",
@@ -894,7 +895,7 @@ def chat():
         
         return jsonify({
             'response': response,
-            'agent': agent_id,
+            'agent': safe_agent_id,
             'timestamp': int(time.time()),
         })
         

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -4,6 +4,7 @@ Beacon Atlas API - Flask routes for 3D visualization backend
 Provides endpoints for agents, contracts, bounties, reputation, and chat.
 """
 import json
+import html
 import os
 import time
 import hashlib
@@ -864,12 +865,13 @@ def chat():
         
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400
+        safe_message = html.escape(str(message), quote=True)
         
         # Store user message
         db = get_db()
         db.execute(
             "INSERT INTO beacon_chat (agent_id, role, content, created_at) VALUES (?, ?, ?, ?)",
-            (agent_id, 'user', message, int(time.time()))
+            (agent_id, 'user', safe_message, int(time.time()))
         )
         
         # Generate mock response (in production, call LLM)

--- a/tests/test_beacon_chat_xss.py
+++ b/tests/test_beacon_chat_xss.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import sqlite3
+import random
 
 from flask import Flask
 
@@ -44,3 +45,39 @@ def test_chat_endpoint_escapes_user_message_before_storage(tmp_path, monkeypatch
     )
     assert "<script>" not in stored
     assert 'onerror="' not in stored
+
+
+def test_chat_endpoint_escapes_agent_id_in_response(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch)
+    payload = '<img src=x onerror="alert(1)">'
+    monkeypatch.setattr(random, "choice", lambda responses: responses[0])
+
+    response = client.post(
+        "/api/chat",
+        json={"agent_id": payload, "message": "hello"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+
+    assert body["agent"] == '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;'
+    assert body["agent"] in body["response"]
+    assert "<img" not in body["agent"]
+    assert "<img" not in body["response"]
+    assert 'onerror="' not in body["agent"]
+    assert 'onerror="' not in body["response"]
+
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute(
+            """
+            SELECT content
+            FROM beacon_chat
+            WHERE agent_id = ? AND role = ?
+            ORDER BY id
+            LIMIT 1
+            """,
+            (payload, "assistant"),
+        ).fetchone()[0]
+
+    assert body["agent"] in stored
+    assert "<img" not in stored

--- a/tests/test_beacon_chat_xss.py
+++ b/tests/test_beacon_chat_xss.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+
+from flask import Flask
+
+from node import beacon_api as beacon_module
+
+
+def _make_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "beacon_chat.db"
+    monkeypatch.setattr(beacon_module, "DB_PATH", str(db_path))
+    beacon_module.init_beacon_tables(str(db_path))
+
+    app = Flask(__name__)
+    app.register_blueprint(beacon_module.beacon_api)
+    return app.test_client(), db_path
+
+
+def test_chat_endpoint_escapes_user_message_before_storage(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch)
+    payload = '<img src=x onerror="alert(1)"><script>alert(2)</script>'
+
+    response = client.post(
+        "/api/chat",
+        json={"agent_id": "bcn_xss_test", "message": payload},
+    )
+
+    assert response.status_code == 200
+    with sqlite3.connect(db_path) as conn:
+        stored = conn.execute(
+            """
+            SELECT content
+            FROM beacon_chat
+            WHERE agent_id = ? AND role = ?
+            ORDER BY id
+            LIMIT 1
+            """,
+            ("bcn_xss_test", "user"),
+        ).fetchone()[0]
+
+    assert stored == (
+        '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;'
+        '&lt;script&gt;alert(2)&lt;/script&gt;'
+    )
+    assert "<script>" not in stored
+    assert 'onerror="' not in stored


### PR DESCRIPTION
## Summary
- escapes `/api/chat` user messages before persisting them to `beacon_chat`
- adds regression coverage for script and event-handler payloads stored through the chat endpoint

Fixes #3222.

## Validation
- `python -m pytest tests\test_beacon_chat_xss.py -q`
- `python -m py_compile node\beacon_api.py tests\test_beacon_chat_xss.py`
- `git diff --check`

Payout details can be provided privately if accepted.
