### PR TITLE
fix: handle miner SIGTERM shutdown

### DIFF
--- a/rustchain-miner/src/main.rs
+++ b/rustchain-miner/src/main.rs
@@ -3,8 +3,7 @@
 //! Production-ready Rust miner with hardware attestation and RIP-PoA support.
 
 use clap::Parser;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use rustchain_miner::{Config, Miner};
@@ -49,6 +48,25 @@ struct Args {
     attestation_ttl: u64,
 }
 
+#[cfg(unix)]
+async fn wait_for_shutdown_signal() -> anyhow::Result<&'static str> {
+    let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+
+    tokio::select! {
+        result = tokio::signal::ctrl_c() => {
+            result?;
+            Ok("Ctrl+C")
+        }
+        _ = sigterm.recv() => Ok("SIGTERM"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown_signal() -> anyhow::Result<&'static str> {
+    tokio::signal::ctrl_c().await?;
+    Ok("Ctrl+C")
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let args = Args::parse();
@@ -80,28 +98,27 @@ async fn main() -> anyhow::Result<()> {
     // Create miner (async)
     let miner = Miner::new(config).await?;
 
-    // Setup Ctrl+C handler
-    let shutdown_flag = Arc::new(AtomicBool::new(false));
-    let shutdown_flag_clone = shutdown_flag.clone();
-
-    tokio::spawn(async move {
-        match tokio::signal::ctrl_c().await {
-            Ok(()) => {
-                println!("\n\n🛑 Shutdown signal received...");
-                shutdown_flag_clone.store(true, Ordering::Relaxed);
+    // Wire process signals into the miner's shutdown flag so SIGTERM and Ctrl+C
+    // both follow the same graceful shutdown path.
+    let shutdown_flag = miner.shutdown_flag();
+    let signal_task = tokio::spawn(async move {
+        match wait_for_shutdown_signal().await {
+            Ok(signal_name) => {
+                println!("\n\nShutdown signal received ({signal_name}); stopping miner...");
+                shutdown_flag.store(true, Ordering::Relaxed);
             }
             Err(e) => {
-                eprintln!("Error setting up Ctrl+C handler: {}", e);
+                eprintln!("Error setting up shutdown handler: {}", e);
             }
         }
     });
 
-    // Store shutdown flag in miner (we need to modify Miner to support this)
-    // For now, we'll just run the miner and let it handle signals internally
-
     // Run miner
-    if let Err(e) = miner.run().await {
-        eprintln!("❌ Miner error: {}", e);
+    let run_result = miner.run().await;
+    signal_task.abort();
+
+    if let Err(e) = run_result {
+        eprintln!("Miner error: {}", e);
         std::process::exit(1);
     }
 

--- a/rustchain-miner/src/miner.rs
+++ b/rustchain-miner/src/miner.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use ed25519_dalek::Signer;
-use tokio::time::sleep;
+use tokio::time::{sleep, Instant as TokioInstant};
 
 use crate::attestation::{attest_with_key, FingerprintData};
 use crate::config::Config;
@@ -164,6 +164,11 @@ impl Miner {
     /// Get mining statistics
     pub fn stats(&self) -> &MiningStats {
         &self.stats
+    }
+
+    /// Get a clone of the shutdown flag for signal handlers.
+    pub fn shutdown_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.shutdown)
     }
 
     /// Print miner banner
@@ -385,7 +390,7 @@ impl Miner {
                 if let Err(e) = self.do_attestation().await {
                     tracing::error!("[MINER] Attestation failed: {}", e);
                     println!("❌ Attestation failed: {}", e);
-                    sleep(Duration::from_secs(30)).await;
+                    self.sleep_or_shutdown(Duration::from_secs(30)).await;
                     continue;
                 }
             }
@@ -405,7 +410,9 @@ impl Miner {
                             break;
                         }
 
-                        sleep(check_interval).await;
+                        if self.sleep_or_shutdown(check_interval).await {
+                            break;
+                        }
                         elapsed += check_interval;
                         let remaining = block_duration - elapsed;
                         println!(
@@ -425,7 +432,7 @@ impl Miner {
                     tracing::error!("[MINER] Enrollment failed: {}", e);
                     println!("❌ Enrollment failed: {}", e);
                     println!("Retrying in 60s...");
-                    sleep(Duration::from_secs(60)).await;
+                    self.sleep_or_shutdown(Duration::from_secs(60)).await;
                 }
             }
         }
@@ -449,5 +456,22 @@ impl Miner {
     /// Check if shutdown was requested
     pub fn is_shutdown(&self) -> bool {
         self.shutdown.load(Ordering::Relaxed)
+    }
+
+    async fn sleep_or_shutdown(&self, duration: Duration) -> bool {
+        let deadline = TokioInstant::now() + duration;
+
+        loop {
+            if self.is_shutdown() {
+                return true;
+            }
+
+            let now = TokioInstant::now();
+            if now >= deadline {
+                return false;
+            }
+
+            sleep((deadline - now).min(Duration::from_secs(1))).await;
+        }
     }
 }


### PR DESCRIPTION
## Summary\n- handle SIGTERM on Unix/macOS in addition to Ctrl+C\n- wire shutdown signals into the miner's actual shutdown flag instead of an unused local flag\n- make retry/mining waits wake promptly when shutdown is requested\n\nFixes #2745.\n\n## Verification\n- git diff --check\n- Unable to run cargo test locally: this environment does not have cargo/rustc/rustfmt installed.\n\n## Bounty payout\nSolana wallet: CTTqY8B7YihjhhuWXDBqD5sRqR3PY2UQ6fCLuz6ss6WT