### PR TITLE
fix: serialize claims settlement batch IDs

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -306,27 +306,51 @@ def update_claims_failed(
     return updated
 
 
-def generate_batch_id() -> str:
+def generate_batch_id(db_path: str) -> str:
     """
-    Generate unique batch identifier using UUID to prevent TOCTOU race conditions.
-    
-    Previous /tmp file-based approach had TOCTOU vulnerability with concurrent
-    processes reading/writing the same batch counter file.
-    
-    Format: batch_YYYY_MM_DD_<uuid8>
+    Generate a unique settlement batch identifier.
+
+    The settlement database owns the per-day sequence so concurrent settlement
+    workers serialize on SQLite instead of racing through a process-local or
+    filesystem counter.
+
+    Format: batch_YYYY_MM_DD_NNN
     """
     now = datetime.now(timezone.utc)
-    timestamp = now.strftime("%Y_%m_%d")
-    
-    # Use UUID-based batch ID to eliminate race conditions from /tmp file locking
+    batch_day = now.strftime("%Y_%m_%d")
+
+    conn = sqlite3.connect(db_path, timeout=30, isolation_level=None)
     try:
-        import uuid
-        unique_suffix = uuid.uuid4().hex[:8]
-        return f"batch_{timestamp}_{unique_suffix}"
-    except Exception:
-        # Fallback: use microsecond timestamp
-        micro = now.strftime("%H%M%S%f")
-        return f"batch_{timestamp}_{micro}"
+        conn.execute("PRAGMA busy_timeout = 30000")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS settlement_batch_sequence (
+                batch_day TEXT PRIMARY KEY,
+                sequence INTEGER NOT NULL
+            )
+        """)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            conn.execute("""
+                INSERT INTO settlement_batch_sequence (batch_day, sequence)
+                VALUES (?, 1)
+                ON CONFLICT(batch_day) DO UPDATE
+                SET sequence = sequence + 1
+            """, (batch_day,))
+            row = conn.execute("""
+                SELECT sequence FROM settlement_batch_sequence
+                WHERE batch_day = ?
+            """, (batch_day,)).fetchone()
+            if row is None:
+                raise SettlementError("failed to read settlement batch sequence")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+    finally:
+        conn.close()
+
+    return f"batch_{batch_day}_{row[0]:03d}"
 
 
 def process_claims_batch(
@@ -433,7 +457,7 @@ def process_claims_batch(
         return result
     
     # Generate batch ID
-    batch_id = generate_batch_id()
+    batch_id = generate_batch_id(db_path)
     result["batch_id"] = batch_id
     
     # Construct transaction

--- a/test_toctou_batch_fix.py
+++ b/test_toctou_batch_fix.py
@@ -1,12 +1,14 @@
-"""Test TOCTOU batch ID fix - claims_settlement.py uses UUID, not /tmp files."""
+"""Test TOCTOU batch ID fix - claims_settlement.py uses SQLite, not /tmp files."""
 import unittest
 import os
+import sqlite3
 import sys
+import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'node'))
 
 class TestTOCTOUBatchIDFix(unittest.TestCase):
-    """Verify batch ID generation uses UUID instead of /tmp file."""
+    """Verify batch ID generation uses SQLite instead of /tmp file."""
     
     def setUp(self):
         self.base = os.path.dirname(__file__)
@@ -20,30 +22,37 @@ class TestTOCTOUBatchIDFix(unittest.TestCase):
         source = self._read_file('node/claims_settlement.py')
         self.assertNotIn('/tmp/rustchain_settlement_batch', source)
 
-    def test_uses_uuid(self):
-        """claims_settlement.py must use uuid.uuid4() for batch IDs."""
+    def test_uses_sqlite_sequence(self):
+        """claims_settlement.py must use the settlement DB for batch IDs."""
         source = self._read_file('node/claims_settlement.py')
-        self.assertIn('uuid.uuid4()', source)
+        self.assertIn('settlement_batch_sequence', source)
+        self.assertIn('BEGIN IMMEDIATE', source)
 
     def test_batch_id_format(self):
-        """verify batch ID starts with 'batch_' prefix."""
+        """verify batch ID keeps the batch_YYYY_MM_DD_NNN format."""
         source = self._read_file('node/claims_settlement.py')
-        self.assertIn('f"batch_{timestamp}_{unique_suffix}"', source)
+        self.assertIn('f"batch_{batch_day}_{row[0]:03d}"', source)
 
-    def test_fallback_uses_microseconds(self):
-        """Fallback must use microsecond timestamp, not static '001'."""
+    def test_no_static_fallback(self):
+        """Batch IDs must not fall back to a static 001 suffix."""
         source = self._read_file('node/claims_settlement.py')
-        self.assertIn('%H%M%S%f', source)
+        self.assertNotIn('batch_{batch_day}_001', source)
         self.assertNotIn('batch_{timestamp}_001', source)
 
     def test_generate_batch_id_returns_correct_format(self):
-        """generate_batch_id() must return batch_YYYY_MM_DD_<8chars>."""
+        """generate_batch_id() must return batch_YYYY_MM_DD_NNN."""
         from claims_settlement import generate_batch_id
-        batch_id = generate_batch_id()
-        self.assertTrue(batch_id.startswith('batch_'))
-        parts = batch_id.split('_')
-        self.assertEqual(len(parts), 5)  # batch, YYYY, MM, DD, <uuid8>
-        self.assertEqual(len(parts[4]), 8)  # uuid suffix is 8 chars
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = os.path.join(tmpdir, "claims.db")
+            conn = sqlite3.connect(db_path)
+            conn.close()
+
+            batch_id = generate_batch_id(db_path)
+            self.assertTrue(batch_id.startswith('batch_'))
+            parts = batch_id.split('_')
+            self.assertEqual(len(parts), 5)  # batch, YYYY, MM, DD, NNN
+            self.assertEqual(parts[4], "001")
 
 
 if __name__ == '__main__':

--- a/tests/test_claims_settlement_batch_id.py
+++ b/tests/test_claims_settlement_batch_id.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import sqlite3
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
+
+from claims_settlement import generate_batch_id
+
+
+def test_generate_batch_id_uses_database_sequence_under_concurrency(tmp_path):
+    db_path = str(tmp_path / "claims.db")
+
+    conn = sqlite3.connect(db_path)
+    conn.close()
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        batch_ids = list(executor.map(lambda _: generate_batch_id(db_path), range(20)))
+
+    assert len(batch_ids) == 20
+    assert len(set(batch_ids)) == 20
+
+    day_prefix = "_".join(batch_ids[0].split("_")[:4])
+    assert all(batch_id.startswith(f"{day_prefix}_") for batch_id in batch_ids)
+
+    sequences = sorted(int(batch_id.rsplit("_", 1)[1]) for batch_id in batch_ids)
+    assert sequences == list(range(1, 21))
+
+    batch_day = day_prefix.removeprefix("batch_")
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT sequence FROM settlement_batch_sequence WHERE batch_day = ?",
+            (batch_day,),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row == (20,)


### PR DESCRIPTION
## Summary
- replace the settlement batch UUID workaround with a SQLite-backed per-day sequence
- serialize sequence updates with `BEGIN IMMEDIATE` so concurrent settlement workers cannot reuse a batch number
- update the existing TOCTOU test and add a threaded regression that generates 20 IDs concurrently from the same DB

Fixes #3218.

## Verification
- `python -m py_compile node\claims_settlement.py tests\test_claims_settlement_batch_id.py test_toctou_batch_fix.py`
- `python -m pytest tests\test_claims_settlement_batch_id.py test_toctou_batch_fix.py -q` = 6 passed
- `git diff --check`

## Integration note
- `python -m pytest tests\test_claims_integration.py -q` still hits an existing Windows cleanup issue after the first settlement scenario passes: the fixture cannot delete `test_claims_integration.db` because another connection remains open elsewhere in the integration stack. The first scenario did process a settlement with `batch_YYYY_MM_DD_001`, so the changed settlement path was exercised before teardown failed.

## Bounty
Payout details can be provided privately if accepted.