### PR TITLE
fix: require bridge callback API key

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -788,10 +788,11 @@ def register_bridge_routes(app):
     @app.route('/api/bridge/update-external', methods=['POST'])
     def update_external():
         """Update external confirmation data (for bridge service callbacks)."""
-        # Optional: require API key for callbacks
         api_key = request.headers.get("X-API-Key", "")
         expected_key = os.environ.get("RC_BRIDGE_API_KEY", "")
-        if expected_key and not hmac.compare_digest(api_key, expected_key):
+        if not expected_key:
+            return jsonify({"error": "Bridge API key not configured"}), 503
+        if not hmac.compare_digest(api_key, expected_key):
             return jsonify({"error": "Unauthorized"}), 401
         
         data = request.get_json(silent=True)

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import patch, MagicMock
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict, Any, List
+from flask import Flask
 
 # Add node directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "node"))
@@ -662,7 +663,7 @@ class TestIntegration:
         assert locks[0].status == "released"
         
         conn.close()
-    
+
     def test_void_releases_lock(self, setup_test_db, funded_miner):
         """Test that voiding a transfer releases the lock."""
         bridge_api = setup_test_db["bridge_api"]
@@ -693,6 +694,68 @@ class TestIntegration:
         assert locks[0].status == "released"
         
         conn.close()
+
+
+class TestBridgeCallbackAuth:
+    """Test bridge service callback authentication."""
+
+    def _client(self, bridge_api):
+        app = Flask(__name__)
+        bridge_api.register_bridge_routes(app)
+        return app.test_client()
+
+    def test_update_external_fails_closed_when_api_key_unconfigured(
+        self, setup_test_db, monkeypatch
+    ):
+        bridge_api = setup_test_db["bridge_api"]
+        client = self._client(bridge_api)
+        monkeypatch.delenv("RC_BRIDGE_API_KEY", raising=False)
+
+        response = client.post(
+            "/api/bridge/update-external",
+            json={"tx_hash": "bridge_tx", "external_tx_hash": "external_tx"},
+        )
+
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "Bridge API key not configured"
+
+    def test_update_external_uses_constant_time_api_key_compare(
+        self, setup_test_db, monkeypatch
+    ):
+        bridge_api = setup_test_db["bridge_api"]
+        client = self._client(bridge_api)
+        monkeypatch.setenv("RC_BRIDGE_API_KEY", "expected-key")
+        calls = []
+
+        def fake_compare(provided, expected):
+            calls.append((provided, expected))
+            return False
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
+
+        response = client.post(
+            "/api/bridge/update-external",
+            headers={"X-API-Key": "wrong-key"},
+            json={"tx_hash": "bridge_tx", "external_tx_hash": "external_tx"},
+        )
+
+        assert response.status_code == 401
+        assert calls == [("wrong-key", "expected-key")]
+
+    def test_update_external_accepts_configured_api_key_before_payload_validation(
+        self, setup_test_db, monkeypatch
+    ):
+        bridge_api = setup_test_db["bridge_api"]
+        client = self._client(bridge_api)
+        monkeypatch.setenv("RC_BRIDGE_API_KEY", "expected-key")
+
+        response = client.post(
+            "/api/bridge/update-external",
+            headers={"X-API-Key": "expected-key"},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Request body required"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make `/api/bridge/update-external` fail closed when `RC_BRIDGE_API_KEY` is not configured
- keep configured callback authentication on `hmac.compare_digest()`
- add route-level regression coverage for unconfigured, wrong-key, and configured-key paths

Fixes #3225.

## Verification
- `python -m pytest tests\test_bridge_lock_ledger.py::TestBridgeCallbackAuth -q` = 3 passed
- `python -m pytest tests\test_bridge_lock_ledger.py -q` = 30 passed
- `python -m py_compile node\bridge_api.py tests\test_bridge_lock_ledger.py`
- `git diff --check`

## Scope note
This intentionally implements only the bridge callback auth-bypass/timing fix that was validated in the maintainer deep-verify on #4188. It does not include the unrelated bridge balance or payout-worker changes from that unsafe mixed PR.

## Bounty
Payout details can be provided privately if accepted.