### PR TITLE
fix: hide bridge database error details

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -18,6 +18,7 @@ import sqlite3
 import time
 import hmac
 import hashlib
+import logging
 import os
 from typing import Optional, Tuple, Dict, Any
 from decimal import Decimal
@@ -55,6 +56,7 @@ BRIDGE_DEFAULT_CONFIRMATIONS = int(os.environ.get("RC_BRIDGE_DEFAULT_CONFIRMATIO
 BRIDGE_LOCK_EXPIRY_SECONDS = int(os.environ.get("RC_BRIDGE_LOCK_EXPIRY_SECONDS", "604800"))  # 7 days
 BRIDGE_MIN_AMOUNT_RTC = float(os.environ.get("RC_BRIDGE_MIN_AMOUNT_RTC", "1.0"))
 BRIDGE_UNIT = 1000000  # Micro-units per RTC
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -385,11 +387,11 @@ def create_bridge_transfer(
             "amount_rtc": request.amount_rtc
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to create bridge transfer")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 
@@ -568,11 +570,11 @@ def void_bridge_transfer(
             "lock_released": True
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to void bridge transfer")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 
@@ -643,11 +645,11 @@ def update_external_confirmation(
             "required_confirmations": req_conf
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to update bridge external confirmation")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -20,6 +20,7 @@ Functions:
 """
 
 import hmac
+import logging
 import sqlite3
 import time
 import os
@@ -50,6 +51,7 @@ except ImportError:
 # =============================================================================
 
 LOCK_UNIT = UNIT  # Micro-units per RTC
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -209,11 +211,11 @@ def create_lock(
             "status": "locked"
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to create lock")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 
@@ -294,11 +296,11 @@ def release_lock(
             "released_at": now
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to release lock")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 
@@ -368,11 +370,11 @@ def forfeit_lock(
             "note": "Forfeited assets are retained by protocol"
         }
         
-    except sqlite3.Error as e:
+    except sqlite3.Error:
         db_conn.rollback()
+        logger.exception("Failed to forfeit lock")
         return False, {
-            "error": "Database error",
-            "details": str(e)
+            "error": "Database error"
         }
 
 

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -172,6 +172,12 @@ def funded_miner(setup_test_db):
     return "RTC_test_miner"
 
 
+def assert_generic_database_error(result):
+    assert result == {"error": "Database error"}
+    assert "details" not in result
+    assert "no such table" not in str(result).lower()
+
+
 # =============================================================================
 # Bridge API Validation Tests
 # =============================================================================
@@ -415,6 +421,27 @@ class TestBridgeTransferCreation:
         
         conn.close()
 
+    def test_database_errors_do_not_leak_details(self, setup_test_db):
+        """DB failures should not expose SQLite schema details to callers."""
+        bridge_api = setup_test_db["bridge_api"]
+        conn = sqlite3.connect(":memory:")
+
+        req = bridge_api.BridgeTransferRequest(
+            direction="withdraw",
+            source_chain="solana",
+            dest_chain="rustchain",
+            source_address="4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            dest_address="RTC_dest123",
+            amount_rtc=5.0
+        )
+
+        success, result = bridge_api.create_bridge_transfer(conn, req)
+
+        assert success is False
+        assert_generic_database_error(result)
+
+        conn.close()
+
 
 # =============================================================================
 # Bridge Status Query Tests
@@ -489,6 +516,24 @@ class TestLockLedger:
         assert result["lock_id"] > 0
         assert result["amount_rtc"] == 10.0
         
+        conn.close()
+
+    def test_database_errors_do_not_leak_details(self, setup_test_db):
+        """DB failures should not expose SQLite schema details to callers."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(":memory:")
+
+        success, result = lock_ledger.create_lock(
+            conn,
+            miner_id="RTC_test_miner",
+            amount_i64=10 * 1000000,
+            lock_type="bridge_deposit",
+            unlock_at=int(time.time()) + 3600
+        )
+
+        assert success is False
+        assert_generic_database_error(result)
+
         conn.close()
     
     def test_release_lock(self, setup_test_db, funded_miner):


### PR DESCRIPTION
## Summary

Fixes part of #3202 by removing raw SQLite exception strings from the bridge/lock-ledger database error payloads.

Current origin/main still returned details: str(e) from database failure handlers in:
- node/lock_ledger.py: create_lock, release_lock, forfeit_lock
- node/bridge_api.py: create_bridge_transfer, void_bridge_transfer, update_external_confirmation

This PR keeps the full exception server-side via logger.exception(...) but only returns a generic Database error payload to callers.

## Verification

- python -m pytest tests\test_bridge_lock_ledger.py -q => 29 passed
- python -m py_compile node\bridge_api.py node\lock_ledger.py tests\test_bridge_lock_ledger.py
- git diff --check
- rg scan for raw sqlite details in the two modules => no matches
