### PR TITLE
docs: fix vintage pipeline GitHub issues link

### DIFF
--- a/vintage_ai_video_pipeline/PRODUCTION_DEPLOYMENT.md
+++ b/vintage_ai_video_pipeline/PRODUCTION_DEPLOYMENT.md
@@ -557,7 +557,7 @@ def get_miner_info(miner_id: str) -> Dict:
 ### Community
 
 - RustChain Discord: [invite link]
-- GitHub Issues: [rustchain/rustchain/issues](https://github.com/rustchain/rustchain/issues)
+- GitHub Issues: [Scottcjn/Rustchain/issues](https://github.com/Scottcjn/Rustchain/issues)
 - BoTTube API docs: [bottube.ai/api/docs](https://bottube.ai/api/docs)
 
 ### Reporting Issues


### PR DESCRIPTION
## Summary
- Fix a broken GitHub Issues link in the vintage AI video pipeline deployment docs.
- The old target `github.com/rustchain/rustchain` does not resolve; the active repo is `Scottcjn/Rustchain`.

## Test plan
- Verified `gh repo view rustchain/rustchain` fails to resolve.
- Verified `gh repo view Scottcjn/Rustchain` resolves successfully.
- Documentation-only change.

## Bounty
Claiming Scottcjn/rustchain-bounties#444 for the broken-link fix.

Wallet: `RTC4d6fca41e33488153e33bc00cd36e747d337d0f5`