### PR TITLE
docs: fix rustchain-bounties support links

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -494,5 +494,5 @@ curl -sk https://rustchain.org/health
 
 ## Support
 
-- GitHub: https://github.com/rustchain-bounties/rustchain-bounties
+- GitHub: https://github.com/Scottcjn/rustchain-bounties
 - Documentation: https://rustchain.org/docs

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -447,5 +447,5 @@ See CONTRIBUTING.md for contribution guidelines.
 ## Support
 
 - Documentation: https://rustchain.org/docs/faucet
-- Issues: https://github.com/rustchain-bounties/rustchain-bounties/issues
+- Issues: https://github.com/Scottcjn/rustchain-bounties/issues
 - Discord: https://discord.gg/rustchain


### PR DESCRIPTION
## Summary
- Fix two documentation support links that pointed at the non-existent `rustchain-bounties/rustchain-bounties` repository.
- Point them to the active `Scottcjn/rustchain-bounties` repository instead.

## Test plan
- Verified `gh repo view rustchain-bounties/rustchain-bounties` fails to resolve.
- Verified `gh repo view Scottcjn/rustchain-bounties` resolves successfully.
- Documentation-only change.

## Bounty
Claiming Scottcjn/rustchain-bounties#444 for broken-link fixes.

Wallet: `RTC4d6fca41e33488153e33bc00cd36e747d337d0f5`