### PR TITLE
docs: fix BCOS bounty issue link

### DIFF
--- a/homebrew/BCOS-INSTALL.md
+++ b/homebrew/BCOS-INSTALL.md
@@ -421,7 +421,7 @@ jobs:
 - [Homebrew Formula Cookbook](https://docs.brew.sh/Formula-Cookbook)
 - [RustChain Repository](https://github.com/Scottcjn/Rustchain)
 - [BCOS Documentation](../BCOS.md)
-- [Issue #2293](https://github.com/rustchain-bounties/rustchain-bounties/issues/2293)
+- [Issue #2293](https://github.com/Scottcjn/rustchain-bounties/issues/2293)
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix a broken BCOS Homebrew bounty issue link.
- The old target `github.com/rustchain-bounties/rustchain-bounties` does not resolve; the active bounty repo is `Scottcjn/rustchain-bounties`.

## Test plan
- Verified `gh repo view rustchain-bounties/rustchain-bounties` fails to resolve.
- Verified `gh issue view 2293 --repo Scottcjn/rustchain-bounties` resolves successfully.
- Documentation-only change.

## Bounty
Claiming Scottcjn/rustchain-bounties#444 for the broken-link fix.

Wallet: `RTC4d6fca41e33488153e33bc00cd36e747d337d0f5`