### PR TITLE
[UTXO-BUG] Reject ambiguous signed Decimal amounts

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -10,10 +10,14 @@ import os
 import tempfile
 import time
 import unittest
+from decimal import Decimal
 
 from flask import Flask
 
-from utxo_db import UtxoDB, UNIT
+import utxo_endpoints
+from utxo_db import (
+    UtxoDB, UNIT, address_to_proposition, compute_box_id,
+)
 from utxo_endpoints import register_utxo_blueprint
 
 
@@ -69,7 +73,23 @@ class TestUtxoEndpoints(unittest.TestCase):
             'inputs': [],
             'outputs': [{'address': address, 'value_nrtc': value_nrtc}],
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=height)
+
+    def _seed_existing_box(self, address, value_nrtc, height=1):
+        tx_id = '22' * 32
+        prop = address_to_proposition(address)
+        box_id = compute_box_id(value_nrtc, prop, height, tx_id, 0)
+        self.utxo_db.add_box({
+            'box_id': box_id,
+            'value_nrtc': value_nrtc,
+            'proposition': prop,
+            'owner_address': address,
+            'creation_height': height,
+            'transaction_id': tx_id,
+            'output_index': 0,
+        })
+        return box_id
 
     # -- read endpoints ------------------------------------------------------
 
@@ -254,6 +274,53 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(bob_bal, 10_000_000,
                          f"Expected 10_000_000 nanoRTC, got {bob_bal} "
                          f"(float truncation bug)")
+
+    def test_transfer_rejects_decimal_amount_not_preserved_by_signed_float(self):
+        """The signed float amount must match the ledger nanoRTC amount.
+
+        Decimal parsing is exact, but the legacy signed payload serializes
+        amount as a JSON float. These two inputs produce the same signed float
+        while differing by 5 nanoRTC in ledger math.
+        """
+        base_amount = Decimal('1000000000.0')
+        mutated_amount = Decimal('1000000000.00000005')
+        self.assertEqual(float(base_amount), float(mutated_amount))
+
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_existing_box(sender, int(mutated_amount * UNIT))
+
+        signed_message = json.dumps({
+            'from': sender,
+            'to': recipient,
+            'amount': float(base_amount),
+            'fee': 0.0,
+            'memo': '',
+            'nonce': 424242,
+        }, sort_keys=True, separators=(',', ':')).encode()
+
+        old_verify = utxo_endpoints._verify_sig_fn
+
+        def verify_base_amount(pubkey_hex, message, sig_hex):
+            return sig_hex == 'valid-for-base' and message == signed_message
+
+        try:
+            utxo_endpoints._verify_sig_fn = verify_base_amount
+            r = self.client.post('/utxo/transfer', json={
+                'from_address': sender,
+                'to_address': recipient,
+                'amount_rtc': str(mutated_amount),
+                'fee_rtc': '0',
+                'public_key': 'aabbccdd' * 8,
+                'signature': 'valid-for-base',
+                'nonce': 424242,
+            })
+        finally:
+            utxo_endpoints._verify_sig_fn = old_verify
+
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('signed payload', r.get_json()['error'])
+        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
 
 if __name__ == '__main__':

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -72,6 +72,30 @@ def _parse_rtc_amount(raw) -> Decimal:
         raise ValueError(f"amount exceeds maximum ({_MAX_RTC_AMOUNT})")
     return amount
 
+
+def _decimal_to_nrtc(amount: Decimal, field_name: str) -> int:
+    """Convert an RTC Decimal to nanoRTC without silently truncating."""
+    nrtc = amount * UNIT
+    integral = nrtc.to_integral_value()
+    if nrtc != integral:
+        raise ValueError(f"{field_name} supports at most 8 decimal places")
+    return int(integral)
+
+
+def _ensure_signed_float_preserves_nrtc(amount: Decimal, nrtc: int,
+                                        field_name: str) -> None:
+    """
+    The current wallet signature format serializes amounts as JSON numbers.
+    Reject Decimal spellings that collapse to a different float value than the
+    exact nanoRTC amount later applied to the ledger.
+    """
+    signed_amount = Decimal(str(float(amount)))
+    signed_nrtc = signed_amount * UNIT
+    if signed_nrtc != signed_nrtc.to_integral_value() or int(signed_nrtc) != nrtc:
+        raise ValueError(
+            f"{field_name} cannot be represented safely in signed payload"
+        )
+
 # Account-model balances store amount_i64 at 6 decimals (micro-RTC).
 # This MUST match the multiplier used in rustchain_v2_integrated_v2.2.1_rip200.py
 # (e.g. line 2370: amount_i64 = int(amount_decimal * Decimal(1000000))).
@@ -347,6 +371,14 @@ def utxo_transfer():
     if amount_rtc <= 0:
         return jsonify({'error': 'Amount must be positive'}), 400
 
+    try:
+        amount_nrtc = _decimal_to_nrtc(amount_rtc, 'amount_rtc')
+        fee_nrtc = _decimal_to_nrtc(fee_rtc, 'fee_rtc')
+        _ensure_signed_float_preserves_nrtc(amount_rtc, amount_nrtc, 'amount_rtc')
+        _ensure_signed_float_preserves_nrtc(fee_rtc, fee_nrtc, 'fee_rtc')
+    except ValueError as e:
+        return jsonify({'error': f'Invalid amount: {e}'}), 400
+
     # Verify pubkey → address
     expected_addr = _addr_from_pk_fn(public_key)
     if from_address != expected_addr:
@@ -402,8 +434,6 @@ def utxo_transfer():
     # FIX(#2867 M2): Decimal arithmetic preserves precision through quantization.
     # int(Decimal) truncates toward zero (no float-binary noise like 0.29 →
     # 28999999.999... → 28999999 lost-rtc bug).
-    amount_nrtc = int(amount_rtc * UNIT)
-    fee_nrtc = int(fee_rtc * UNIT)
     target_nrtc = amount_nrtc + fee_nrtc
 
     # Select UTXOs


### PR DESCRIPTION
## Summary

Fixes a UTXO transfer signature/accounting mismatch for bounty Scottcjn/rustchain-bounties#2819.

`/utxo/transfer` parses `amount_rtc` and `fee_rtc` as exact `Decimal` values for ledger math, but rebuilds the signed payload by converting those Decimals back to JSON floats. Distinct decimal strings can collapse to the same float-shaped signed payload while producing different nanoRTC ledger amounts.

## Bounty Classification

- Vulnerability class: signed amount mismatch / fee and amount accounting validation
- Suggested severity: Medium under the bounty's UTXO fee/accounting category
- Bounty issue: Scottcjn/rustchain-bounties#2819

## Root Cause

The endpoint uses exact Decimal math for the ledger:

```python
amount_nrtc = int(amount_rtc * UNIT)
fee_nrtc = int(fee_rtc * UNIT)
```

But the signed message is rebuilt using floats:

```python
amount_for_sig = float(amount_rtc)
fee_for_sig = float(fee_rtc)
```

For example, `1000000000.0` and `1000000000.00000005` serialize to the same signed float value, but differ by 5 nanoRTC in exact ledger math. A signature valid for the lower amount could therefore authorize a transfer of the higher exact amount.

## Expected vs Actual

Expected:

- The amount and fee verified by the signature should match the exact nanoRTC values applied to the UTXO ledger.
- Inputs with more precision than nanoRTC or with float-colliding spellings should be rejected.

Actual before this patch:

- The endpoint accepted a decimal string that verified against the signed payload for `1000000000.0`.
- The ledger transferred `1000000000.00000005` RTC, a 5 nanoRTC difference from the signed amount.

## Fix

- Convert Decimal RTC amounts to nanoRTC only when the result is an exact integer.
- Reject Decimal spellings whose float-shaped signed payload does not preserve the same nanoRTC value.
- Add a regression test that proves the float-colliding amount is rejected and no recipient funds move.
- Update the endpoint test coinbase helper to pass the existing internal minting flag so the endpoint suite runs against current UTXO rules.

## Validation

```text
$ git diff --check
$ PYTHONPATH=/tmp/rustchain-flask:node python3 -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py
$ PYTHONPATH=/tmp/rustchain-flask:node python3 -m unittest node.test_utxo_endpoints
.................
----------------------------------------------------------------------
Ran 17 tests in 0.159s

OK
$ PYTHONPATH=node python3 node/test_utxo_db.py
...................................................
----------------------------------------------------------------------
Ran 51 tests in 0.259s

OK
```

Refs Scottcjn/rustchain-bounties#2819
