### PR TITLE
[UTXO-BUG] Reject non-integer fee_nrtc values

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -157,6 +157,29 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
 
+    def test_fractional_fee_rejected(self):
+        """fee_nrtc must be an integer nanoRTC amount.
+
+        A fractional fee can pass conservation by pairing it with a one-nanoRTC
+        output reduction, but SQLite stores the fee in an INTEGER column and
+        truncates it. That silently destroys value without recording the fee.
+        """
+        self._apply_coinbase('alice', 100 * UNIT)
+        alice_boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1}],
+            'fee_nrtc': 0.5,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        # Balances unchanged
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     # -- double-spend --------------------------------------------------------
 
     def test_double_spend_rejected(self):
@@ -530,6 +553,29 @@ class TestUtxoDB(unittest.TestCase):
             'inputs': [{'box_id': boxes[0]['box_id']}],
             'outputs': [{'address': 'bob', 'value_nrtc': 50 * UNIT}],
             'fee_nrtc': -50 * UNIT,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        # Box should NOT be locked
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_rejects_fractional_fee(self):
+        """Mempool must reject non-integer fee_nrtc values.
+
+        Otherwise a transaction can lock inputs with fee accounting that will
+        diverge when persisted to SQLite's INTEGER fee column.
+        """
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'ffee' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1}],
+            'fee_nrtc': 0.5,
         }
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -445,6 +445,8 @@ class UtxoDB:
             if tx_type in MINTING_TX_TYPES and output_total > MAX_COINBASE_OUTPUT_NRTC:
                 return abort()
 
+            if type(fee) is not int:
+                return abort()
             if fee < 0:
                 return abort()
             if inputs and (output_total + fee) > input_total:
@@ -717,6 +719,10 @@ class UtxoDB:
             # Prevent mempool admission of transactions that would fail
             # apply_transaction(), locking UTXOs until expiry (DoS vector).
             fee = tx.get('fee_nrtc', 0)
+            if type(fee) is not int:
+                if manage_tx:
+                        conn.execute("ROLLBACK")
+                return False
             if fee < 0:
                 if manage_tx:
                         conn.execute("ROLLBACK")


### PR DESCRIPTION
## Summary

Fixes a UTXO fee accounting edge case for bounty Scottcjn/rustchain-bounties#2819.

`fee_nrtc` is stored in SQLite as an integer nanoRTC amount, but `UtxoDB.apply_transaction()` and `mempool_add()` accepted non-integer values. A transaction can use a fractional fee such as `0.5` with a one-nanoRTC output reduction, pass the current conservation check, and then persist a different integer fee value in SQLite. That creates divergent accounting between validation-time arithmetic and stored transaction history.

## Bounty Classification

- Vulnerability class: fee calculation exploit / missing validation
- Suggested severity: Medium under the bounty's fee calculation category
- Bounty issue: Scottcjn/rustchain-bounties#2819

## Root Cause

Both code paths read `fee_nrtc` with:

```python
fee = tx.get('fee_nrtc', 0)
```

The code checked only `fee < 0`; it did not require `fee` to be an integer nanoRTC amount before using it in conservation arithmetic and before persisting it to an `INTEGER` column.

## Expected vs Actual

Expected:

- `fee_nrtc` should be an integer nanoRTC amount everywhere it is validated, stored, and used for conservation checks.
- Mempool admission should reject transactions that block application would reject.

Actual before this patch:

- `fee_nrtc: 0.5` could pass validation when paired with a one-nanoRTC output reduction.
- SQLite then persisted the fee into an `INTEGER` column as a different integer value, creating accounting divergence.

## Fix

- Reject `fee_nrtc` values whose exact type is not `int` in `apply_transaction()`.
- Reject the same invalid values in `mempool_add()` so mempool admission matches block application.
- Add regression tests for direct application and mempool admission.

## Validation

```text
$ python3 node/test_utxo_db.py
.....................................................
----------------------------------------------------------------------
Ran 53 tests in 0.214s

OK
```

`python3 -m pytest node/test_utxo_db.py -v` was not available in my local environment because `pytest` is not installed.

Refs Scottcjn/rustchain-bounties#2819
