### PR TITLE
[UTXO-BUG] Bind transfer tx_id to transaction contents

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -124,6 +124,61 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('bob'), 90 * UNIT)
         self.assertEqual(self.db.get_balance('alice'), 9 * UNIT)
 
+    def test_transfer_tx_id_commits_to_outputs(self):
+        """Different transfer outputs must not share the same tx_id.
+
+        Previously transfer tx_id was derived from inputs + timestamp only.
+        Two nodes could apply materially different transactions with the same
+        input and timestamp, record the same tx_id, but produce different UTXO
+        sets and state roots.
+        """
+        def apply_variant(recipient: str) -> tuple:
+            tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+            tmp.close()
+            db = UtxoDB(tmp.name)
+            try:
+                db.init_tables()
+                ok = db.apply_transaction({
+                    'tx_type': 'mining_reward',
+                    'inputs': [],
+                    'outputs': [{'address': 'alice',
+                                 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                    'timestamp': 1234567890,
+                    '_allow_minting': True,
+                }, block_height=1)
+                self.assertTrue(ok)
+
+                box = db.get_unspent_for_address('alice')[0]
+                ok = db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id'],
+                                'spending_proof': 'sig'}],
+                    'outputs': [{'address': recipient,
+                                 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                    'timestamp': 2222222222,
+                }, block_height=10)
+                self.assertTrue(ok)
+
+                conn = db._conn()
+                try:
+                    row = conn.execute(
+                        """SELECT tx_id FROM utxo_transactions
+                           WHERE tx_type = 'transfer'"""
+                    ).fetchone()
+                    return row['tx_id'], db.compute_state_root()
+                finally:
+                    conn.close()
+            finally:
+                os.unlink(tmp.name)
+
+        bob_tx_id, bob_root = apply_variant('bob')
+        eve_tx_id, eve_root = apply_variant('eve')
+
+        self.assertNotEqual(bob_root, eve_root)
+        self.assertNotEqual(bob_tx_id, eve_tx_id)
+
     def test_fee_exceeds_conservation(self):
         """Outputs + fee > inputs should fail."""
         self._apply_coinbase('alice', 100 * UNIT)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -451,20 +451,30 @@ class UtxoDB:
                 return abort()
 
             # -- compute output box IDs and build tx_id ----------------------
-            # We need a preliminary tx_id for box_id computation.
-            # Use SHA256(sorted input box_ids + timestamp) as tx seed.
-            tx_seed_h = hashlib.sha256()
-            for inp in sorted(inputs, key=lambda i: i['box_id']):
-                tx_seed_h.update(bytes.fromhex(inp['box_id']))
-            tx_seed_h.update(ts.to_bytes(8, 'little'))
-            # For coinbase, include tx_type + outputs to differentiate
-            if not inputs:
-                tx_seed_h.update(tx_type.encode())
-                tx_seed_h.update(block_height.to_bytes(8, 'little'))
-                for out in outputs:
-                    tx_seed_h.update(out['address'].encode())
-                    tx_seed_h.update(out['value_nrtc'].to_bytes(8, 'little'))
-            tx_id_hex = tx_seed_h.hexdigest()
+            # We need a preliminary tx_id for box_id computation. Bind it to
+            # the full transaction intent, not just inputs+timestamp, so two
+            # different transfers cannot share one tx_id.
+            tx_identity = {
+                'tx_type': tx_type,
+                'inputs': sorted(i['box_id'] for i in inputs),
+                'data_inputs': sorted(tx.get('data_inputs', [])),
+                'outputs': [
+                    {
+                        'address': out['address'],
+                        'value_nrtc': out['value_nrtc'],
+                        'tokens_json': out.get('tokens_json', '[]'),
+                        'registers_json': out.get('registers_json', '{}'),
+                    }
+                    for out in outputs
+                ],
+                'fee_nrtc': fee,
+                'timestamp': ts,
+                'block_height': block_height,
+            }
+            tx_seed = json.dumps(
+                tx_identity, sort_keys=True, separators=(',', ':')
+            ).encode()
+            tx_id_hex = hashlib.sha256(tx_seed).hexdigest()
 
             # -- assign box_ids to outputs -----------------------------------
             output_records = []


### PR DESCRIPTION
## Summary

Fixes a UTXO transaction identity issue for bounty Scottcjn/rustchain-bounties#2819.

For non-minting transfers, `UtxoDB.apply_transaction()` derived `tx_id` from sorted input box IDs plus timestamp only. The transaction ID did not commit to outputs, fee, transaction type, data inputs, or block height. Two materially different transfers using the same input and timestamp could therefore record the same `tx_id` while producing different output boxes and different state roots.

## Bounty Classification

- Vulnerability class: Merkle/state-root divergence / transaction identity collision
- Suggested severity: Medium under the bounty's Merkle state root manipulation category
- Bounty issue: Scottcjn/rustchain-bounties#2819

## Root Cause

The old transfer tx-id seed used only:

```python
for inp in sorted(inputs, key=lambda i: i['box_id']):
    tx_seed_h.update(bytes.fromhex(inp['box_id']))
tx_seed_h.update(ts.to_bytes(8, 'little'))
```

For coinbase only, it also mixed in `tx_type`, `block_height`, and outputs. Normal transfers did not get that content binding.

## Expected vs Actual

Expected:

- A UTXO transaction ID should identify the transaction contents it records.
- Different outputs or fees should produce different transaction IDs.

Actual before this patch:

- Transfer Alice -> Bob and transfer Alice -> Eve can share the same input and timestamp, record the same `tx_id`, and produce different state roots.
- Reproduced locally with both variants recording `85b9923a27eeadaa0344424288114348c3a283188d73239c4a545f3d7e656e33` while their state roots differed.

## Fix

- Build a canonical `tx_identity` object that includes `tx_type`, sorted input IDs, sorted data inputs, ordered output commitments, `fee_nrtc`, `timestamp`, and `block_height`.
- Hash that canonical JSON to derive `tx_id`.
- Add a regression test proving different recipient outputs no longer share the same `tx_id`.

## Validation

```text
$ git diff --check HEAD~1..HEAD
$ python3 node/test_utxo_db.py
....................................................
----------------------------------------------------------------------
Ran 52 tests in 0.242s

OK
```

`python3 -m pytest node/test_utxo_db.py -v` was not available in my local environment because `pytest` is not installed.

Refs Scottcjn/rustchain-bounties#2819
