### PR TITLE
[UTXO-BUG] Ignore expired UTXO mempool claims

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -316,6 +316,69 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def _expire_mempool_tx(self, tx_id: str):
+        conn = self.db._conn()
+        try:
+            conn.execute(
+                "UPDATE utxo_mempool SET expires_at = ? WHERE tx_id = ?",
+                (int(time.time()) - 1, tx_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_mempool_expired_tx_not_returned_or_locked(self):
+        """Expired mempool rows must not be mined or keep UTXOs locked."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx_id = 'old_' * 16
+        ok = self.db.mempool_add({
+            'tx_id': tx_id,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        })
+        self.assertTrue(ok)
+
+        self._expire_mempool_tx(tx_id)
+
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_add_releases_expired_input_claim(self):
+        """A valid replacement must not be blocked by an expired claim."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+        box_id = boxes[0]['box_id']
+
+        old_tx_id = 'stale' * 16
+        ok = self.db.mempool_add({
+            'tx_id': old_tx_id,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box_id}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        })
+        self.assertTrue(ok)
+        self._expire_mempool_tx(old_tx_id)
+
+        new_tx_id = 'fresh' * 16
+        ok = self.db.mempool_add({
+            'tx_id': new_tx_id,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box_id}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        })
+
+        self.assertTrue(ok)
+        candidates = self.db.mempool_get_block_candidates()
+        self.assertEqual([tx['tx_id'] for tx in candidates], [new_tx_id])
+
     def test_mempool_rejects_user_supplied_mining_reward(self):
         """Public mempool must not admit minting transactions.
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -645,6 +645,29 @@ class UtxoDB:
 
     # -- mempool -------------------------------------------------------------
 
+    def _mempool_clear_expired_locked(
+        self, conn: sqlite3.Connection, now: Optional[int] = None
+    ) -> int:
+        """Remove expired mempool rows using the caller's transaction."""
+        if now is None:
+            now = int(time.time())
+        expired = conn.execute(
+            "SELECT tx_id FROM utxo_mempool WHERE expires_at <= ?",
+            (now,),
+        ).fetchall()
+        count = 0
+        for row in expired:
+            conn.execute(
+                "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
+                (row['tx_id'],),
+            )
+            conn.execute(
+                "DELETE FROM utxo_mempool WHERE tx_id = ?",
+                (row['tx_id'],),
+            )
+            count += 1
+        return count
+
     def mempool_add(self, tx: dict) -> bool:
         """
         Add a transaction to the mempool.
@@ -660,13 +683,6 @@ class UtxoDB:
         # paths and leak the transaction-in-progress lock.
         manage_tx = True
         try:
-            # Check pool size
-            row = conn.execute(
-                "SELECT COUNT(*) AS n FROM utxo_mempool"
-            ).fetchone()
-            if row['n'] >= MAX_POOL_SIZE:
-                return False
-
             tx_id = tx.get('tx_id', '')
             # FIX(#2179): Reject empty/whitespace-only tx_id to prevent
             # INSERT OR IGNORE collisions that create orphan input claims.
@@ -690,6 +706,17 @@ class UtxoDB:
                 return False
 
             conn.execute("BEGIN IMMEDIATE")
+            self._mempool_clear_expired_locked(conn, now)
+
+            # Check pool size after clearing expired entries; stale rows must
+            # not be able to keep the pool full or block valid replacements.
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM utxo_mempool"
+            ).fetchone()
+            if row['n'] >= MAX_POOL_SIZE:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
 
             # Check for double-spend in mempool
             for inp in inputs:
@@ -812,13 +839,22 @@ class UtxoDB:
         """Get highest-fee transactions from mempool for block inclusion."""
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._mempool_clear_expired_locked(conn)
             rows = conn.execute(
                 """SELECT tx_data_json FROM utxo_mempool
                    ORDER BY fee_nrtc DESC
                    LIMIT ?""",
                 (max_count,),
             ).fetchall()
+            conn.execute("COMMIT")
             return [json.loads(r['tx_data_json']) for r in rows]
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         finally:
             conn.close()
 
@@ -826,24 +862,16 @@ class UtxoDB:
         """Remove expired transactions from mempool. Returns count removed."""
         conn = self._conn()
         try:
-            now = int(time.time())
-            expired = conn.execute(
-                "SELECT tx_id FROM utxo_mempool WHERE expires_at <= ?",
-                (now,),
-            ).fetchall()
-            count = 0
-            for row in expired:
-                conn.execute(
-                    "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
-                    (row['tx_id'],),
-                )
-                conn.execute(
-                    "DELETE FROM utxo_mempool WHERE tx_id = ?",
-                    (row['tx_id'],),
-                )
-                count += 1
+            conn.execute("BEGIN IMMEDIATE")
+            count = self._mempool_clear_expired_locked(conn)
             conn.commit()
             return count
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         finally:
             conn.close()
 
@@ -851,11 +879,20 @@ class UtxoDB:
         """Return True if box_id is claimed by a pending mempool TX."""
         conn = self._conn()
         try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._mempool_clear_expired_locked(conn)
             row = conn.execute(
                 "SELECT tx_id FROM utxo_mempool_inputs WHERE box_id = ?",
                 (box_id,),
             ).fetchone()
+            conn.execute("COMMIT")
             return row is not None
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

Fixes an expired UTXO mempool lock issue for bounty Scottcjn/rustchain-bounties#2819.

Expired mempool rows were only removed when callers explicitly invoked `mempool_clear_expired()`. Normal admission, block-candidate selection, and double-spend checks did not clear or ignore expired rows. As a result, an expired transaction could still be returned to block producers and could keep its input marked as claimed, blocking a valid replacement until some separate cleanup path happened to run.

## Bounty Classification

- Vulnerability class: Mempool DoS / lock-unlock expiry logic error
- Suggested severity: Medium under the bounty's mempool DoS category
- Bounty issue: Scottcjn/rustchain-bounties#2819

## Root Cause

`utxo_mempool.expires_at` was written during `mempool_add()`, but the other public mempool boundaries did not enforce it:

- `mempool_get_block_candidates()` selected all rows regardless of `expires_at`.
- `mempool_check_double_spend()` treated expired `utxo_mempool_inputs` claims as active locks.
- `mempool_add()` checked pool size and existing input claims before pruning expired entries.

## Expected vs Actual

Expected:

- Expired mempool transactions should not be eligible block candidates.
- Expired input claims should not block fresh valid transactions.
- Expired rows should not keep the pool full.

Actual before this patch:

- A transaction with `expires_at` in the past was still returned by `mempool_get_block_candidates()`.
- The same expired transaction still made `mempool_check_double_spend(box_id)` return `True`.
- A fresh replacement spending the same input was rejected until cleanup was called separately.

## Fix

- Add a transaction-scoped `_mempool_clear_expired_locked()` helper.
- Prune expired rows under `BEGIN IMMEDIATE` before mempool admission checks.
- Prune expired rows before returning block candidates.
- Prune expired rows before reporting whether a box is locked by the mempool.
- Keep the existing explicit `mempool_clear_expired()` API, now using the shared helper.

## Validation

```text
$ python3 node/test_utxo_db.py
.....................................................
----------------------------------------------------------------------
Ran 53 tests in 0.249s

OK

$ git diff --check HEAD~1..HEAD
$ python3 -m compileall -q node/utxo_db.py node/test_utxo_db.py
```

`python3 -m pytest node/test_utxo_db.py -q` was not available because `pytest` is not installed in this local environment.

Refs Scottcjn/rustchain-bounties#2819
