### PR TITLE
[UTXO-BUG] Convert genesis account balances to nanoRTC

### DIFF
--- a/node/test_utxo_genesis_migration_units.py
+++ b/node/test_utxo_genesis_migration_units.py
@@ -1,0 +1,82 @@
+"""
+Regression tests for UTXO genesis migration account-unit conversion.
+
+Account-model balances use amount_i64 at 6 decimals (micro-RTC), while UTXO
+boxes use nanoRTC at 8 decimals. The genesis migration must convert before
+creating boxes and before comparing integrity totals.
+"""
+
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from utxo_db import UtxoDB, UNIT
+from utxo_genesis_migration import ACCOUNT_UNIT, load_account_balances, migrate
+
+
+class TestGenesisMigrationUnits(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_amount_i64_balances_convert_from_micro_rtc_to_nrtc(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                amount_i64 INTEGER NOT NULL
+            )
+        """)
+        conn.executemany(
+            "INSERT INTO balances VALUES (?, ?)",
+            [
+                ("alice", 1 * ACCOUNT_UNIT),
+                ("bob", 2 * ACCOUNT_UNIT + 500_000),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        balances = load_account_balances(self.db_path)
+        self.assertEqual(balances, [
+            ("alice", 1 * UNIT),
+            ("bob", 250_000_000),
+        ])
+
+        result = migrate(self.db_path, dry_run=False)
+        db = UtxoDB(self.db_path)
+
+        self.assertEqual(result["total_nrtc"], 350_000_000)
+        self.assertEqual(db.get_balance("alice"), 1 * UNIT)
+        self.assertEqual(db.get_balance("bob"), 250_000_000)
+        self.assertTrue(result["integrity"]["ok"])
+        self.assertTrue(result["integrity"]["models_agree"])
+        self.assertEqual(result["integrity"]["expected_total_nrtc"], 350_000_000)
+
+    def test_legacy_balance_rtc_fallback_converts_to_nrtc(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE balances (
+                miner_pk TEXT PRIMARY KEY,
+                balance_rtc REAL NOT NULL
+            )
+        """)
+        conn.execute("INSERT INTO balances VALUES (?, ?)", ("alice", 10.0))
+        conn.commit()
+        conn.close()
+
+        result = migrate(self.db_path, dry_run=False)
+        db = UtxoDB(self.db_path)
+
+        self.assertEqual(result["total_nrtc"], 10 * UNIT)
+        self.assertEqual(db.get_balance("alice"), 10 * UNIT)
+        self.assertTrue(result["integrity"]["models_agree"])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -29,6 +29,8 @@ from utxo_db import (
 
 GENESIS_TX_PREFIX = "rustchain_genesis:"
 GENESIS_HEIGHT = 0
+ACCOUNT_UNIT = 1_000_000  # Account-model amount_i64 is micro-RTC.
+ACCOUNT_TO_UTXO_SCALE = UNIT // ACCOUNT_UNIT
 
 
 def compute_genesis_tx_id(miner_id: str) -> str:
@@ -41,7 +43,7 @@ def compute_genesis_tx_id(miner_id: str) -> str:
 def load_account_balances(db_path: str) -> list:
     """
     Load non-zero balances from the account model.
-    Returns sorted list of (miner_id, amount_i64) tuples.
+    Returns sorted list of (miner_id, amount_nrtc) tuples.
     """
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
@@ -52,17 +54,21 @@ def load_account_balances(db_path: str) -> list:
                WHERE amount_i64 > 0
                ORDER BY miner_id ASC"""
         ).fetchall()
-        return [(r['miner_id'], r['amount_i64']) for r in rows]
+        return [
+            (r['miner_id'], int(r['amount_i64']) * ACCOUNT_TO_UTXO_SCALE)
+            for r in rows
+        ]
     except sqlite3.OperationalError:
         # Try alternate column names
         rows = conn.execute(
             """SELECT miner_pk AS miner_id,
-                      CAST(balance_rtc * 1000000 AS INTEGER) AS amount_i64
+                      CAST(balance_rtc * ? AS INTEGER) AS amount_nrtc
                FROM balances
                WHERE balance_rtc > 0
-               ORDER BY miner_pk ASC"""
+               ORDER BY miner_pk ASC""",
+            (UNIT,),
         ).fetchall()
-        return [(r['miner_id'], r['amount_i64']) for r in rows]
+        return [(r['miner_id'], int(r['amount_nrtc'])) for r in rows]
     finally:
         conn.close()
 
@@ -122,15 +128,15 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
         if not dry_run:
             conn.execute("BEGIN IMMEDIATE")
 
-        for miner_id, amount_i64 in balances:
+        for miner_id, amount_nrtc in balances:
             tx_id = compute_genesis_tx_id(miner_id)
             prop = address_to_proposition(miner_id)
             box_id = compute_box_id(
-                amount_i64, prop, GENESIS_HEIGHT, tx_id, 0
+                amount_nrtc, prop, GENESIS_HEIGHT, tx_id, 0
             )
 
             if dry_run:
-                print(f"  {miner_id:40s} | {amount_i64 / UNIT:>14.6f} RTC | box={box_id[:16]}...")
+                print(f"  {miner_id:40s} | {amount_nrtc / UNIT:>14.6f} RTC | box={box_id[:16]}...")
             else:
                 # Insert box
                 conn.execute(
@@ -140,7 +146,7 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
                         tokens_json, registers_json, created_at)
                        VALUES (?,?,?,?,?,?,?,?,?,?)""",
                     (
-                        box_id, amount_i64, prop, miner_id,
+                        box_id, amount_nrtc, prop, miner_id,
                         GENESIS_HEIGHT, tx_id, 0,
                         '[]',
                         json.dumps({'R4': 'genesis'}),
@@ -160,7 +166,7 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
                         '[]',
                         json.dumps([{
                             'box_id': box_id,
-                            'value_nrtc': amount_i64,
+                            'value_nrtc': amount_nrtc,
                             'owner': miner_id,
                         }]),
                         '[]', 0, now, GENESIS_HEIGHT, 'confirmed',


### PR DESCRIPTION
## Summary

Fixes a UTXO genesis migration unit-conversion issue for bounty Scottcjn/rustchain-bounties#2819.

The account model stores `balances.amount_i64` at 6 decimals (micro-RTC), while UTXO boxes store `value_nrtc` at 8 decimals (nanoRTC). `utxo_genesis_migration.py` loaded `amount_i64` directly into genesis UTXO boxes and passed that same unconverted total into the integrity check. A 1 RTC account balance (`1_000_000` micro-RTC) therefore migrated as a 0.01 RTC UTXO (`1_000_000` nanoRTC), while `models_agree` still reported true.

## Duplicate Check

Open PR Scottcjn/Rustchain#4173 already covers two nearby issues: rollback-after-spend genesis duplication and the legacy `balance_rtc` fallback multiplier. This PR covers the distinct primary schema path (`miner_id`, `amount_i64`) used by the current account model and endpoint dual-write code.

## Bounty Classification

- Vulnerability class: UTXO genesis migration fund destruction / accounting mismatch
- Suggested severity: Medium
- Bounty issue: Scottcjn/rustchain-bounties#2819

## Root Cause

`utxo_endpoints.py` documents and uses:

```python
ACCOUNT_UNIT = 1_000_000
amount_i64 = int(amount_rtc * ACCOUNT_UNIT)
```

But `utxo_genesis_migration.py` treated the same `amount_i64` value as if it were already nanoRTC:

```python
return [(r['miner_id'], r['amount_i64']) for r in rows]
```

## Expected vs Actual

Expected:

- `amount_i64 = 1_000_000` migrates to `value_nrtc = 100_000_000` (1 RTC).
- Integrity compares the UTXO total against the converted nanoRTC account total.

Actual before this patch:

- `amount_i64 = 1_000_000` migrated to `value_nrtc = 1_000_000` (0.01 RTC).
- The migration reported `Integrity OK: True` and `Models agree: True` because both sides used the same unconverted value.

## Fix

- Define the account-model unit used by the migration.
- Convert current-schema `amount_i64` values from micro-RTC to nanoRTC before creating boxes.
- Convert legacy `balance_rtc` values directly to nanoRTC.
- Add regression tests for both schemas and for the integrity total.

## Validation

```text
$ python3 node/test_utxo_genesis_migration_units.py
Ran 2 tests in 0.018s
OK

$ python3 node/test_genesis_race.py
ALL TESTS PASSED

$ python3 node/test_utxo_db.py
Ran 51 tests in 0.199s
OK
```

Refs Scottcjn/rustchain-bounties#2819
