### PR TITLE
docs: fix stale whitepaper links

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,13 +12,13 @@
 [![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
 [![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
-[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/WHITEPAPER.md)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.19442753.svg)](https://doi.org/10.5281/zenodo.19442753)
 
 2003年的 PowerBook G4 比现代 Threadripper **多赚 2.5 倍**。
 Power Mac G5 **多赚 2.0 倍**。带有生锈串口的 486 赢得最多尊重。
 
-[浏览器](https://rustchain.org/explorer/) · [已保存的机器](https://rustchain.org/preserved.html) · [安装矿机](#quickstart) · [新手指南](docs/QUICKSTART.md) · [宣言](https://rustchain.org/manifesto.html) · [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[浏览器](https://rustchain.org/explorer/) · [已保存的机器](https://rustchain.org/preserved.html) · [安装矿机](#quickstart) · [新手指南](docs/QUICKSTART.md) · [宣言](https://rustchain.org/manifesto.html) · [白皮书](docs/WHITEPAPER.md)
 
 </div>
 
@@ -246,7 +246,7 @@ clawrtc mine --wallet=你的钱包地址
 
 ## 文档
 
-- [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [白皮书](docs/WHITEPAPER.md)
 - [新手指南](docs/QUICKSTART.md)
 - [API 参考](docs/API.md)
 - [RIP 文档](rips/)
@@ -279,6 +279,6 @@ MIT License - 查看 [LICENSE](LICENSE) 了解详情。
 
 <div align="center">
 
-**[网站](https://rustchain.org)** · **[浏览器](https://rustchain.org/explorer/)** · **[白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)** · **[Discord](https://discord.gg/VqVVS2CW9Q)**
+**[网站](https://rustchain.org)** · **[浏览器](https://rustchain.org/explorer/)** · **[白皮书](docs/WHITEPAPER.md)** · **[Discord](https://discord.gg/VqVVS2CW9Q)**
 
 </div>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -13,7 +13,7 @@
 
 *你的PowerPC G4比现代Threadripper赚得更多。就是这么硬核。*
 
-[网站](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [交换wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC快速入门](docs/wrtc.md) • [wRTC教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
+[网站](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [交换wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC快速入门](docs/wrtc.md) • [wRTC教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/WHITEPAPER.md) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
 
 </div>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -444,7 +444,7 @@ MIT License
 
 ### 白皮书与技术文档
 
-- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/WHITEPAPER.md)
 - [链架构文档](https://github.com/Scottcjn/Rustchain/blob/main/docs/chain_architecture.md)
 - [开发者牵引报告](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md)
 

--- a/docs/MULTISIG_WALLET_GUIDE.md
+++ b/docs/MULTISIG_WALLET_GUIDE.md
@@ -539,7 +539,7 @@ curl -sk "https://rustchain.org/health"
 
 ### 官方文档
 
-- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain 白皮书](https://github.com/Scottcjn/Rustchain/blob/main/docs/WHITEPAPER.md)
 - [协议规范](https://github.com/Scottcjn/Rustchain/blob/main/docs/PROTOCOL.md)
 - [API 参考](https://github.com/Scottcjn/Rustchain/blob/main/docs/API.md)
 - [钱包用户指南](https://github.com/Scottcjn/Rustchain/blob/main/docs/WALLET_USER_GUIDE.md)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -390,7 +390,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 - **Swap RTC for Solana tokens:** [wRTC Guide](wrtc.md)
 - **Run a full node:** [Protocol Docs](PROTOCOL.md)
-- **Deep dive into Proof-of-Antiquity:** [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- **Deep dive into Proof-of-Antiquity:** [Whitepaper](WHITEPAPER.md)
 - **Contribute code:** [CONTRIBUTING.md](../CONTRIBUTING.md)
 - **API reference:** [API Walkthrough](API_WALKTHROUGH.md)
 

--- a/docs/RUSTCHAIN_PROTOCOL.md
+++ b/docs/RUSTCHAIN_PROTOCOL.md
@@ -398,7 +398,7 @@ New contributors get **10 RTC** for their first merged PR:
 - **GitHub**: https://github.com/Scottcjn/Rustchain
 - **Bounties**: https://github.com/Scottcjn/rustchain-bounties
 - **Explorer**: https://rustchain.org/explorer
-- **Whitepaper**: `docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf`
+- **Whitepaper**: `docs/WHITEPAPER.md`
 - **BoTTube**: https://bottube.ai (AI video platform)
 
 ---

--- a/docs/VINTAGE_MINING_EXPLAINED.md
+++ b/docs/VINTAGE_MINING_EXPLAINED.md
@@ -279,4 +279,4 @@ See [N64 Mining Guide](N64_MINING_GUIDE.md) for setup instructions.
 - [Console Mining Setup](CONSOLE_MINING_SETUP.md) -- mine on NES, SNES, Genesis, PS1, Game Boy, and N64
 - [Protocol Overview](protocol-overview.md) -- attestation protocol specification
 - [Green Tracker](https://rustchain.org/preserved.html) -- live environmental impact dashboard
-- [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf) -- formal specification
+- [Whitepaper](WHITEPAPER.md) -- formal specification

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,7 +341,7 @@
       <p style="margin-top: 12px;">Unlike Proof-of-Work (energy waste) or Proof-of-Stake (rich get richer), RustChain uses <strong style="color:var(--accent2);">Proof-of-Antiquity</strong> &mdash; miners prove they're running on real physical hardware via cryptographic fingerprinting. Vintage machines earn bonus rewards.</p>
       <p style="margin-top: 12px;">The native token is <strong style="color:var(--warn);">RTC (RustChain Token)</strong>. 1.5 RTC is distributed each epoch to active miners, weighted by hardware antiquity multipliers.</p>
       <p style="margin-top: 16px;">
-        <a href="RustChain_Whitepaper_Flameholder_v0.97-1.pdf">Read the Whitepaper (PDF)</a>
+        <a href="WHITEPAPER.md">Read the Whitepaper</a>
       </p>
     </div>
 

--- a/docs/protocol-overview.md
+++ b/docs/protocol-overview.md
@@ -247,7 +247,7 @@ curl -sk https://rustchain.org/api/miners
 
 ## References
 
-- **Whitepaper**: [RustChain_Whitepaper_Flameholder_v0.97-1.pdf](./RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- **Whitepaper**: [WHITEPAPER.md](./WHITEPAPER.md)
 - **API Documentation**: [API.md](./API.md)
 - **Protocol Spec**: [PROTOCOL.md](./PROTOCOL.md)
 - **Glossary**: [GLOSSARY.md](./GLOSSARY.md)

--- a/docs/wrtc.md
+++ b/docs/wrtc.md
@@ -403,7 +403,7 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=my-miner-id"
 
 ## 📚 Additional Resources
 
-- [RustChain Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain Whitepaper](WHITEPAPER.md)
 - [Protocol Specification](./PROTOCOL.md)
 - [API Reference](./API.md)
 - [Wallet User Guide](./WALLET_USER_GUIDE.md)

--- a/integrations/mcp-server/mcp_server.py
+++ b/integrations/mcp-server/mcp_server.py
@@ -1129,7 +1129,7 @@ Visit the [live explorer](https://rustchain.org/explorer) to see your miner!
 ## Resources
 
 - [Full Documentation](https://github.com/Scottcjn/RustChain)
-- [Whitepaper](https://github.com/Scottcjn/RustChain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [Whitepaper](https://github.com/Scottcjn/RustChain/blob/main/docs/WHITEPAPER.md)
 - [Discord](https://discord.gg/rustchain)
 - [Bounties](https://github.com/Scottcjn/rustchain-bounties/issues)
 

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -448,5 +448,5 @@ MIT License
 
 - [RustChain GitHub](https://github.com/Scottcjn/Rustchain)
 - [RustChain Explorer](https://rustchain.org/explorer)
-- [RustChain Whitepaper](https://github.com/Scottcjn/Rustchain/blob/main/docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain Whitepaper](https://github.com/Scottcjn/Rustchain/blob/main/docs/WHITEPAPER.md)
 - [Agent Economy SDK Docs](docs/AGENT_ECONOMY_SDK.md)


### PR DESCRIPTION
## Summary
- Replace user-facing links to the missing `RustChain_Whitepaper_Flameholder_v0.97-1.pdf` file with the current `docs/WHITEPAPER.md` document.
- Update English, Chinese, SDK, and embedded MCP help references so readers land on an existing whitepaper page.

## Test plan
- Ran ripgrep for `RustChain_Whitepaper_Flameholder_v0.97-1.pdf` and confirmed remaining matches are old maintenance scripts, not rendered user docs.

Related: #2696