### PR TITLE
fix: repair Go SDK agent economy doc link

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -458,5 +458,5 @@ MIT License - see [LICENSE](LICENSE) for details.
 
 - [RustChain GitHub](https://github.com/Scottcjn/Rustchain)
 - [RIP-302 Specification](../../rips/docs/)
-- [Agent Economy Documentation](../../docs/agent-economy.md)
+- [Agent Economy Documentation](../docs/AGENT_ECONOMY_SDK.md)
 - [Go Reference](https://pkg.go.dev/github.com/Scottcjn/Rustchain/sdk/go/agenteco)


### PR DESCRIPTION
## Summary
- Fixes the Go SDK README's Agent Economy Documentation link.
- Points the link to the existing `sdk/docs/AGENT_ECONOMY_SDK.md` file instead of the missing `docs/agent-economy.md` path.

## Verification
- Confirmed `docs/agent-economy.md` does not exist.
- Confirmed `sdk/docs/AGENT_ECONOMY_SDK.md` exists.
- Confirmed the README now references `../docs/AGENT_ECONOMY_SDK.md` from `sdk/go/README.md`.

Bounty claim: Scottcjn/rustchain-bounties#444
RTC wallet: `RTC4d6fca41e33488153e33bc00cd36e747d337d0f5`