### PR TITLE
fix: remove duplicate SPDX header

### DIFF
--- a/agent_economy_sdk.py
+++ b/agent_economy_sdk.py
@@ -1,5 +1,4 @@
-# SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
+﻿# SPDX-License-Identifier: MIT
 
 import asyncio
 import aiohttp

--- a/agent_economy_sdk.py
+++ b/agent_economy_sdk.py
@@ -1,4 +1,4 @@
-﻿# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: MIT
 
 import asyncio
 import aiohttp


### PR DESCRIPTION
## Summary
- Remove a duplicated SPDX license identifier from `agent_economy_sdk.py`.

## Test plan
- `python -m py_compile agent_economy_sdk.py`

Fixes #2313