### PR TITLE
[UTXO-BUG] guard epoch reward dual-write settlement

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2871,15 +2871,24 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                     (amount_i64, amount_i64, pk)
                 )
 
-                # Sync to UTXO layer (Atomic Dual-Write)
-                from utxo_db import UtxoDB
-                utxo_tx = {
-                    "tx_type": "mining_reward",
-                    "inputs": [],
-                    "outputs": [{"address": pk, "value_nrtc": amount_i64}],
-                    "_allow_minting": True
-                }
-                UtxoDB().apply_transaction(utxo_tx, epoch * 144, conn=conn)
+                # Sync to UTXO layer only when the dual-write feature is enabled.
+                # A rejected UTXO write must abort the surrounding account-model
+                # settlement or the two ledgers diverge while the epoch is marked
+                # settled.
+                if UTXO_DUAL_WRITE:
+                    utxo_tx = {
+                        "tx_type": "mining_reward",
+                        "inputs": [],
+                        "outputs": [{"address": pk, "value_nrtc": amount_i64}],
+                        "_allow_minting": True
+                    }
+                    utxo_ok = UtxoDB(DB_PATH).apply_transaction(
+                        utxo_tx, epoch * 144, conn=conn
+                    )
+                    if not utxo_ok:
+                        raise RuntimeError(
+                            f"UTXO reward settlement failed for {pk[:20]}..."
+                        )
                 # Update metrics with decimal value for accuracy
                 balance_gauge.labels(miner_pk=pk).set(float(amount_decimal))
 

--- a/node/tests/test_epoch_utxo_dual_write_guard.py
+++ b/node/tests/test_epoch_utxo_dual_write_guard.py
@@ -19,7 +19,7 @@ SERVER_PATH = (
 
 
 def _finalize_epoch_node():
-    source = SERVER_PATH.read_text()
+    source = SERVER_PATH.read_text(encoding="utf-8")
     tree = ast.parse(source)
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name == "finalize_epoch":

--- a/node/tests/test_epoch_utxo_dual_write_guard.py
+++ b/node/tests/test_epoch_utxo_dual_write_guard.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression coverage for epoch reward UTXO dual-write integration.
+
+The integrated server is expensive to import in isolation, so these tests parse
+the source and verify that finalize_epoch() keeps the UTXO reward write behind
+the configured feature gate and treats failed UTXO application as fatal.
+"""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SERVER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rustchain_v2_integrated_v2.2.1_rip200.py"
+)
+
+
+def _finalize_epoch_node():
+    source = SERVER_PATH.read_text()
+    tree = ast.parse(source)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "finalize_epoch":
+            return node, ast.get_source_segment(source, node)
+    raise AssertionError("finalize_epoch() not found")
+
+
+class TestEpochUtxoDualWriteGuard(unittest.TestCase):
+    def test_epoch_reward_utxo_write_respects_feature_gate(self):
+        _, source = _finalize_epoch_node()
+
+        self.assertIn(
+            "if UTXO_DUAL_WRITE",
+            source,
+            "finalize_epoch() must not write UTXOs while UTXO_DUAL_WRITE is off",
+        )
+
+    def test_epoch_reward_utxo_db_uses_configured_db_path(self):
+        node, _ = _finalize_epoch_node()
+        calls = []
+
+        class Visitor(ast.NodeVisitor):
+            def visit_Call(self, call):
+                if isinstance(call.func, ast.Name) and call.func.id == "UtxoDB":
+                    calls.append(call)
+                self.generic_visit(call)
+
+        Visitor().visit(node)
+
+        self.assertTrue(calls, "finalize_epoch() should construct UtxoDB")
+        for call in calls:
+            self.assertEqual(
+                len(call.args),
+                1,
+                "UtxoDB must be constructed with DB_PATH inside finalize_epoch()",
+            )
+            self.assertIsInstance(call.args[0], ast.Name)
+            self.assertEqual(call.args[0].id, "DB_PATH")
+
+    def test_epoch_reward_utxo_apply_failure_aborts_settlement(self):
+        _, source = _finalize_epoch_node()
+
+        self.assertIn(
+            "utxo_ok =",
+            source,
+            "finalize_epoch() should store the UTXO apply result",
+        )
+        self.assertIn(
+            "if not utxo_ok",
+            source,
+            "finalize_epoch() must abort instead of committing account rewards when UTXO apply fails",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#2819

## Finding
`finalize_epoch()` unconditionally tries to sync mining rewards into the UTXO layer, even when `UTXO_DUAL_WRITE` is disabled. The call also constructs `UtxoDB()` without the required `DB_PATH`, so reward settlement rolls back as soon as that path executes. A related atomicity issue is that the UTXO `apply_transaction()` result was ignored, so a future rejected UTXO write could still leave account rewards committed and the epoch marked settled.

## Impact
This can block epoch reward settlement when the integrated server reaches this path, and it can create account/UTXO divergence if the UTXO layer rejects a mining reward while the account-model update continues. That is directly in the pre-production dual-write surface from the bounty brief.

## Fix
- Keep the mining reward UTXO write behind `UTXO_DUAL_WRITE`.
- Construct `UtxoDB(DB_PATH)` with the configured database.
- Treat a false UTXO apply result as fatal so the surrounding transaction rolls back.
- Add regression coverage for the gate, DB path, and apply-result check.

## Verification
- `python3 node/tests/test_epoch_utxo_dual_write_guard.py` fails on the original code and passes after the fix.
- `PYTHONPATH=node python3 -m unittest discover -s node -p test_utxo_db.py` passes: 51 tests.
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_epoch_utxo_dual_write_guard.py` passes.

Payout wallet can be provided after validation.