### PR TITLE
[UTXO-BUG] filter expired mempool block candidates

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -358,6 +358,31 @@ class TestUtxoDB(unittest.TestCase):
         # Highest fee first
         self.assertEqual(candidates[0]['tx_id'], 'high' * 16)
 
+    def test_mempool_block_candidates_ignore_expired_transactions(self):
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+        tx_id = 'expired' * 8
+
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': tx_id,
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }))
+
+        conn = self.db._conn()
+        try:
+            conn.execute(
+                "UPDATE utxo_mempool SET expires_at = ? WHERE tx_id = ?",
+                (int(time.time()) - 1, tx_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
     def test_mempool_nonexistent_input_rejected(self):
         tx = {
             'tx_id': 'cccc' * 16,

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -380,8 +380,16 @@ class TestUtxoDB(unittest.TestCase):
         finally:
             conn.close()
 
-        self.assertEqual(self.db.mempool_get_block_candidates(), [])
-        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': 'replacement' * 6,
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT - 2000}],
+            'fee_nrtc': 2000,
+        }))
+
+        candidates = self.db.mempool_get_block_candidates()
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0]['tx_id'], 'replacement' * 6)
 
     def test_mempool_nonexistent_input_rejected(self):
         tx = {

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -810,13 +810,16 @@ class UtxoDB:
 
     def mempool_get_block_candidates(self, max_count: int = 100) -> List[dict]:
         """Get highest-fee transactions from mempool for block inclusion."""
+        self.mempool_clear_expired()
         conn = self._conn()
         try:
+            now = int(time.time())
             rows = conn.execute(
                 """SELECT tx_data_json FROM utxo_mempool
+                   WHERE expires_at > ?
                    ORDER BY fee_nrtc DESC
                    LIMIT ?""",
-                (max_count,),
+                (now, max_count),
             ).fetchall()
             return [json.loads(r['tx_data_json']) for r in rows]
         finally:

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -651,6 +651,7 @@ class UtxoDB:
         Validates inputs exist and aren't claimed by another pending TX.
         Returns False if double-spend detected or pool full.
         """
+        self.mempool_clear_expired()
         conn = self._conn()
         # FIX(#2867 C1): mempool_add() always opens its own connection and
         # begins its own BEGIN IMMEDIATE transaction below. The 7 ROLLBACK


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#2819

## Finding
`mempool_get_block_candidates()` returns transactions without checking `expires_at`, so an expired transaction can still be selected for block production. Because expired rows also remain in `utxo_mempool_inputs`, the stale transaction keeps its input box locked until a separate cleanup call happens.

## Impact
A stale high-fee transaction can continue to appear as a block candidate after expiry and can block legitimate replacement spends for the same UTXO. This is a mempool DoS / stale candidate bug in the public admission path covered by the bounty brief.

## Fix
- Clear expired mempool entries before selecting candidates.
- Add `WHERE expires_at > now` to the candidate query.
- Add a regression test that forces a transaction expired, asserts it is not returned as a block candidate, and asserts its input lock is released.

## Verification
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db.TestUtxoDB.test_mempool_block_candidates_ignore_expired_transactions` fails on the original code and passes after the fix.
- `PYTHONPATH=node python3 -m unittest discover -s node -p test_utxo_db.py` passes: 52 tests.
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py` passes.

Payout wallet can be provided after validation.