### PR TITLE
Guard attest signature field types

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -270,6 +270,13 @@ def _validate_attestation_payload_shape(data):
         if field_name in data and data[field_name] is not None and not isinstance(data[field_name], str):
             return _attest_field_error("INVALID_MINER", f"Field '{field_name}' must be a non-empty string")
 
+    for field_name, code in (
+        ("signature", "INVALID_SIGNATURE_TYPE"),
+        ("public_key", "INVALID_PUBLIC_KEY_TYPE"),
+    ):
+        if field_name in data and data[field_name] is not None and not isinstance(data[field_name], str):
+            return _attest_field_error(code, f"Field '{field_name}' must be a string")
+
     miner = _attest_valid_miner(data.get("miner")) or _attest_valid_miner(data.get("miner_id"))
     if not miner and not (_attest_text(data.get("miner")) or _attest_text(data.get("miner_id"))):
         return _attest_field_error(

--- a/node/tests/test_attest_signature_verification.py
+++ b/node/tests/test_attest_signature_verification.py
@@ -83,6 +83,15 @@ class TestAttestSignatureVerification(unittest.TestCase):
             conn.commit()
         return mod, db_path
 
+    def _load_module_without_db(self, module_name: str, db_name: str):
+        """Load the route module for pre-DB validation tests."""
+        db_path = self._db_path(db_name)
+        os.environ["RUSTCHAIN_DB_PATH"] = db_path
+        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod, db_path
+
     def _response_payload(self, resp):
         if isinstance(resp, tuple):
             body, status = resp
@@ -98,6 +107,10 @@ class TestAttestSignatureVerification(unittest.TestCase):
     def _submit(self, mod, payload):
         with mod.app.test_request_context("/attest/submit", method="POST", json=payload):
             return self._response_payload(mod._submit_attestation_impl())
+
+    def _submit_route(self, mod, payload):
+        with mod.app.test_request_context("/attest/submit", method="POST", json=payload):
+            return self._response_payload(mod.submit_attestation())
 
     def _base_payload(self, miner, nonce, commitment="deadbeef", sig_hex=None, pubkey_hex=None, miner_id=None):
         """Build a minimal valid attestation payload."""
@@ -233,6 +246,36 @@ class TestAttestSignatureVerification(unittest.TestCase):
         # Should succeed — no signature provided, so no verification attempted
         self.assertEqual(status, 200)
         self.assertTrue(body["ok"])
+
+    def test_non_string_signature_rejected_before_handler_crash(self):
+        """Non-string signature values must be validation failures, not 500s."""
+        mod, _ = self._load_module_without_db("rustchain_attest_sig_type_guard", "sig_type_guard.db")
+
+        payload = self._base_payload(
+            miner="RTC_SIG_TYPE_MINER",
+            nonce="not-a-live-challenge",
+            sig_hex=12345,
+            pubkey_hex="00" * 32,
+        )
+        status, body = self._submit_route(mod, payload)
+
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_SIGNATURE_TYPE")
+
+    def test_non_string_public_key_rejected_before_handler_crash(self):
+        """Non-string public_key values must be validation failures, not 500s."""
+        mod, _ = self._load_module_without_db("rustchain_attest_pubkey_type_guard", "pubkey_type_guard.db")
+
+        payload = self._base_payload(
+            miner="RTC_PUBKEY_TYPE_MINER",
+            nonce="not-a-live-challenge",
+            sig_hex="00" * 64,
+            pubkey_hex=["not", "a", "key"],
+        )
+        status, body = self._submit_route(mod, payload)
+
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_PUBLIC_KEY_TYPE")
 
     def test_signature_rejected_when_pynacl_missing(self):
         """When pynacl is not installed and a signature is provided, reject with 503.

--- a/tests/fuzz/attestation_validators.py
+++ b/tests/fuzz/attestation_validators.py
@@ -132,6 +132,17 @@ def _validate_attestation_payload_shape(data: Any):
                 "INVALID_MINER", f"Field '{field_name}' must be a non-empty string"
             )
 
+    for field_name, code in (
+        ("signature", "INVALID_SIGNATURE_TYPE"),
+        ("public_key", "INVALID_PUBLIC_KEY_TYPE"),
+    ):
+        if (
+            field_name in data
+            and data[field_name] is not None
+            and not isinstance(data[field_name], str)
+        ):
+            return _attest_field_error(code, f"Field '{field_name}' must be a string")
+
     miner = _attest_valid_miner(data.get("miner")) or _attest_valid_miner(data.get("miner_id"))
     if not miner and not (
         _attest_text(data.get("miner")) or _attest_text(data.get("miner_id"))

--- a/tests/fuzz/regression_corpus/crash_10_signature_type_confusion.json
+++ b/tests/fuzz/regression_corpus/crash_10_signature_type_confusion.json
@@ -1,0 +1,12 @@
+{
+  "_class": "SIGNATURE_TYPE_CONFUSION",
+  "_expected_error_code": "INVALID_SIGNATURE_TYPE",
+  "_description": "Regression for /attest/submit 500 when top-level signature is not a string.",
+  "miner": "valid-miner",
+  "report": {
+    "nonce": "challenge-nonce",
+    "commitment": "deadbeef"
+  },
+  "signature": 12345,
+  "public_key": "0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/tests/fuzz/regression_corpus/crash_11_public_key_type_confusion.json
+++ b/tests/fuzz/regression_corpus/crash_11_public_key_type_confusion.json
@@ -1,0 +1,16 @@
+{
+  "_class": "PUBLIC_KEY_TYPE_CONFUSION",
+  "_expected_error_code": "INVALID_PUBLIC_KEY_TYPE",
+  "_description": "Regression for /attest/submit 500 when top-level public_key is not a string.",
+  "miner": "valid-miner",
+  "report": {
+    "nonce": "challenge-nonce",
+    "commitment": "deadbeef"
+  },
+  "signature": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "public_key": [
+    "not",
+    "a",
+    "key"
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes a malformed-input crash path in `POST /attest/submit` by validating top-level signed-attestation fields before the handler calls `.strip().lower()` on them.

This is follow-up work for Scottcjn/rustchain-bounties#1112. Prior public fuzz reports already covered non-string `signature`; this PR keeps that regression covered and adds the adjacent `public_key` type-confusion guard.

## Changes

- Reject non-string `signature` values with `400 INVALID_SIGNATURE_TYPE`.
- Reject non-string `public_key` values with `400 INVALID_PUBLIC_KEY_TYPE`.
- Mirror the production validator change in the extracted fuzz validator.
- Add route-level regression tests for both crash paths.
- Add two replayable fuzz corpus entries.

## Verification

```bash
PYTHONPATH=/tmp/rustchain-flask:node python3 -m unittest \
  node.tests.test_attest_signature_verification.TestAttestSignatureVerification.test_non_string_signature_rejected_before_handler_crash \
  node.tests.test_attest_signature_verification.TestAttestSignatureVerification.test_non_string_public_key_rejected_before_handler_crash
```

```bash
python3 tests/fuzz/run_fuzz.py --corpus-only
```

```bash
PYTHONPATH=/tmp/rustchain-flask:node python3 -m py_compile \
  node/rustchain_v2_integrated_v2.2.1_rip200.py \
  node/tests/test_attest_signature_verification.py \
  tests/fuzz/attestation_validators.py
```

```bash
git diff --check
```

Full Hypothesis fuzzing was not run locally because this environment does not have `pytest` or `hypothesis` installed.
