### PR TITLE
fix: remove duplicate SPDX header

### DIFF
--- a/agent_economy_sdk.py
+++ b/agent_economy_sdk.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
 
 import asyncio
 import aiohttp


### PR DESCRIPTION
## Summary

Fixes #2313 by removing the duplicate SPDX license identifier at the top of `agent_economy_sdk.py`.

## Verification

- `python3 -m py_compile agent_economy_sdk.py`
- Confirmed the file now contains a single SPDX header
