### PR TITLE
Harden explorer dashboard HTML rendering

### DIFF
--- a/explorer/SECURITY_REPORT_BOUNTY_68.md
+++ b/explorer/SECURITY_REPORT_BOUNTY_68.md
@@ -1,0 +1,88 @@
+# Bounty 68 Security Report: Explorer API Response Injection
+
+## Summary
+
+The current explorer renders several API-provided identifiers through `innerHTML` after shortening them, but before HTML escaping the display text. A malicious miner ID, transaction hash, wallet address, block hash, or dashboard field returned by the API could be interpreted as markup in the browser.
+
+The patch escapes shortened values at the sink in:
+
+- `explorer/static/js/explorer.js`
+- `explorer/static/js/dashboard.js`
+- `explorer/dashboard/app.py`
+- `explorer/dashboard/agent-economy.html`
+- `explorer/dashboard/agent-economy-v2.html`
+- `explorer/dashboard/miners.html`
+- `explorer/enhanced-explorer.html`
+- `explorer/miner-dashboard.html`
+- `explorer/realtime-explorer.html`
+- `explorer/templates/dashboard.html`
+- `explorer/templates/ws_explorer.html`
+
+## Finding 1: Main Explorer API Response Injection
+
+Severity: High
+
+Affected file: `explorer/static/js/explorer.js`
+
+Affected sinks included miner IDs, block hashes, transaction hashes, and transaction wallet addresses. These values were placed into template literals assigned to `innerHTML`; `title` attributes were escaped, but the visible cell text was not.
+
+Example vulnerable pattern:
+
+```js
+`${shortenAddress(miner.miner_id || 'unknown')}`
+```
+
+Impact: If a miner-controlled identifier or chain/API response contains HTML with an event handler, the explorer can execute attacker-controlled JavaScript when the table renders.
+
+Fix: Wrap shortened values with `escapeHtml(...)` before inserting them into `innerHTML`.
+
+## Finding 2: Real-Time Dashboard API Response Injection
+
+Severity: High
+
+Affected file: `explorer/static/js/dashboard.js`
+
+The real-time dashboard repeated the same pattern for top miners, recent blocks, recent transactions, and the hardware legend. Values from API/WebSocket state were rendered into HTML without escaping.
+
+Fix: Add a local `escapeHtml` utility and apply it to every API-derived text value that remains in `innerHTML` templates.
+
+## Finding 3: Compact Flask Dashboard Proxy Injection
+
+Severity: High
+
+Affected file: `explorer/dashboard/app.py`
+
+The compact Flask dashboard proxies `/api/dashboard` data and renders miner and transaction fields directly into table rows with `innerHTML`.
+
+Impact: A malicious upstream API response can execute script in a user browser viewing the local dashboard.
+
+Fix: Add an `esc(...)` JavaScript helper and escape all proxied table cells, including timestamps after formatting.
+
+## Finding 4: Legacy Dashboard Template Injection
+
+Severity: High
+
+Affected files:
+
+- `explorer/dashboard/miners.html`
+- `explorer/dashboard/agent-economy.html`
+- `explorer/dashboard/agent-economy-v2.html`
+- `explorer/enhanced-explorer.html`
+- `explorer/miner-dashboard.html`
+- `explorer/realtime-explorer.html`
+- `explorer/templates/dashboard.html`
+- `explorer/templates/ws_explorer.html`
+
+These dashboard views used `innerHTML` to render miner, block, transaction, reward, attestation, notification, and architecture fields directly from fetched or WebSocket-delivered data. The patch adds local escaping helpers, sanitizes CSS class fragments, URL-encodes block links, and replaces one URL share-link `innerHTML` assignment with DOM node construction.
+
+## PoC
+
+Open `explorer/pocs/bounty68_api_response_xss.html` locally. The unsafe table demonstrates the pre-patch sink class; the patched table renders the same payload as text.
+
+## Verification
+
+Run:
+
+```sh
+python3 -m pytest explorer/test_security_hardening.py
+```

--- a/explorer/dashboard/agent-economy-v2.html
+++ b/explorer/dashboard/agent-economy-v2.html
@@ -493,21 +493,21 @@
             return `<div class="job-card">
                 <div style="display:flex; justify-content:space-between; align-items:start;">
                     <div class="job-title">${esc(j.title)}</div>
-                    <span class="badge badge-${j.status}">${j.status}</span>
+                    <span class="badge badge-${safeClass(j.status)}">${esc(j.status)}</span>
                 </div>
                 <div class="job-meta">
-                    <span class="job-reward">${j.reward_rtc} RTC</span>
-                    <span>${j.category}</span>
-                    <span>${age}</span>
-                    ${j.worker_wallet ? `<span>Worker: <span class="activity-wallet">${j.worker_wallet}</span></span>` : ''}
+                    <span class="job-reward">${esc(j.reward_rtc)} RTC</span>
+                    <span>${esc(j.category)}</span>
+                    <span>${esc(age)}</span>
+                    ${j.worker_wallet ? `<span>Worker: <span class="activity-wallet">${esc(j.worker_wallet)}</span></span>` : ''}
                 </div>
                 <div class="job-desc">${esc(j.description || '')}</div>
                 <div class="job-tags">
                     ${tags.map(t => `<span class="tag">${esc(t)}</span>`).join('')}
                 </div>
                 <div style="margin-top:8px; font-size:11px; color:var(--text3);">
-                    Posted by <span class="activity-wallet">${j.poster_wallet}</span>
-                    &bull; ID: ${j.job_id}
+                    Posted by <span class="activity-wallet">${esc(j.poster_wallet)}</span>
+                    &bull; ID: ${esc(j.job_id)}
                 </div>
             </div>`;
         }).join('');
@@ -573,7 +573,7 @@
             const reps = await Promise.all(
                 [...wallets].map(async w => {
                     try {
-                        const rr = await fetch(`${NODE}/agent/reputation/${w}`);
+                        const rr = await fetch(`${NODE}/agent/reputation/${encodeURIComponent(w)}`);
                         const rd = await rr.json();
                         if (rd.reputation) return { wallet: w, ...rd.reputation };
                         return { wallet: w, trust_score: 50, trust_level: 'neutral',
@@ -595,22 +595,24 @@
             body.innerHTML = sorted.map((a, i) => {
                 const rank = i + 1;
                 const rankClass = rank <= 3 ? `rank-${rank}` : 'rank-other';
-                const trustColor = a.trust_score >= 90 ? 'var(--gold)' :
-                                   a.trust_score >= 70 ? 'var(--green)' :
-                                   a.trust_score >= 40 ? 'var(--blue)' : 'var(--red)';
+                const trustScore = Number.isFinite(Number(a.trust_score)) ?
+                    Math.max(0, Math.min(100, Number(a.trust_score))) : 50;
+                const trustColor = trustScore >= 90 ? 'var(--gold)' :
+                                   trustScore >= 70 ? 'var(--green)' :
+                                   trustScore >= 40 ? 'var(--blue)' : 'var(--red)';
                 const jobs = (a.jobs_completed_as_worker || 0) + (a.jobs_completed_as_poster || 0);
 
                 return `<tr>
                     <td><span class="rank-badge ${rankClass}">${rank}</span></td>
-                    <td><span class="activity-wallet">${a.wallet}</span></td>
+                    <td><span class="activity-wallet">${esc(a.wallet)}</span></td>
                     <td>
-                        <span style="color:${trustColor}; font-weight:600;">${a.trust_score || 50}</span>
+                        <span style="color:${trustColor}; font-weight:600;">${trustScore}</span>
                         <div class="trust-bar">
-                            <div class="trust-fill" style="width:${a.trust_score || 50}%; background:${trustColor};"></div>
+                            <div class="trust-fill" style="width:${trustScore}%; background:${trustColor};"></div>
                         </div>
                     </td>
-                    <td><span class="badge badge-${(a.trust_level||'neutral') === 'legendary' ? 'completed' : 'open'}">${a.trust_level || 'neutral'}</span></td>
-                    <td>${jobs}</td>
+                    <td><span class="badge badge-${(a.trust_level||'neutral') === 'legendary' ? 'completed' : 'open'}">${esc(a.trust_level || 'neutral')}</span></td>
+                    <td>${esc(jobs)}</td>
                     <td><span style="color:var(--gold); font-family:monospace;">${(a.total_rtc_earned || 0).toFixed(1)}</span> RTC</td>
                     <td>${a.avg_rating ? `${a.avg_rating.toFixed(1)} ★` : '--'}</td>
                 </tr>`;
@@ -670,13 +672,13 @@
                     <div>
                         <div style="font-weight:600; font-size:13px;">${esc(j.title)}</div>
                         <div style="font-size:11px; color:var(--text3);">
-                            ${j.job_id} &bull; ${j.poster_wallet}
+                            ${esc(j.job_id)} &bull; ${esc(j.poster_wallet)}
                         </div>
                     </div>
                     <div style="text-align:right;">
-                        <span class="badge badge-${j.status}">${j.status}</span>
+                        <span class="badge badge-${safeClass(j.status)}">${esc(j.status)}</span>
                         <div style="color:var(--gold); font-family:monospace; font-size:14px; font-weight:600;">
-                            ${j.reward_rtc} RTC
+                            ${esc(j.reward_rtc)} RTC
                         </div>
                     </div>
                 </div>
@@ -729,9 +731,9 @@
             feed.innerHTML = activities.slice(0, 30).map(a => {
                 const icons = { complete: '&#9989;', deliver: '&#128230;', claim: '&#9997;', post: '&#128203;' };
                 const labels = {
-                    complete: `<span class="activity-wallet">${a.worker}</span> completed "${esc(a.title)}" for <span style="color:var(--gold)">${a.reward} RTC</span>`,
-                    deliver: `<span class="activity-wallet">${a.worker}</span> delivered "${esc(a.title)}"`,
-                    claim: `<span class="activity-wallet">${a.worker}</span> claimed "${esc(a.title)}"`,
+                    complete: `<span class="activity-wallet">${esc(a.worker)}</span> completed "${esc(a.title)}" for <span style="color:var(--gold)">${esc(a.reward)} RTC</span>`,
+                    deliver: `<span class="activity-wallet">${esc(a.worker)}</span> delivered "${esc(a.title)}"`,
+                    claim: `<span class="activity-wallet">${esc(a.worker)}</span> claimed "${esc(a.title)}"`,
                 };
                 return `<div class="activity-item">
                     <div class="activity-icon ${a.type}">${icons[a.type]}</div>
@@ -762,7 +764,7 @@
             document.getElementById('category-chart').innerHTML = cats.map((c, i) => {
                 const pct = (c.jobs / maxJobs * 100).toFixed(0);
                 return `<div class="category-bar">
-                    <span class="category-label">${c.category}</span>
+                    <span class="category-label">${esc(c.category)}</span>
                     <div class="category-track">
                         <div class="category-fill" style="width:${pct}%; background:${colors[i % colors.length]};">
                             ${c.jobs} jobs (${c.total_rtc.toFixed(0)} RTC)
@@ -815,9 +817,17 @@
         return `${Math.floor(s/86400)}d ago`;
     }
     function esc(s) {
+        if (s === null || s === undefined) return '';
         const d = document.createElement('div');
         d.textContent = s;
         return d.innerHTML;
+    }
+
+    function safeClass(value) {
+        return String(value || 'unknown')
+            .toLowerCase()
+            .replace(/[^a-z0-9_-]+/g, '-')
+            .replace(/^-+|-+$/g, '') || 'unknown';
     }
 
     // Init

--- a/explorer/dashboard/agent-economy.html
+++ b/explorer/dashboard/agent-economy.html
@@ -362,13 +362,34 @@
             document.getElementById('activeAgents').textContent = stats.active_agents || 0;
             document.getElementById('lastUpdate').textContent = new Date().toLocaleTimeString();
         }
+
+        function esc(value) {
+            if (value === null || value === undefined) return '';
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function safeClass(value) {
+            return String(value || 'unknown')
+                .toLowerCase()
+                .replace(/[^a-z0-9_-]+/g, '-')
+                .replace(/^-+|-+$/g, '') || 'unknown';
+        }
         
         function renderJobs() {
             const grid = document.getElementById('jobsGrid');
             let filtered = currentCategory === 'all' ? jobs : jobs.filter(j => j.category === currentCategory);
             const searchTerm = document.getElementById('searchInput').value.toLowerCase();
             if (searchTerm) {
-                filtered = filtered.filter(j => j.title.toLowerCase().includes(searchTerm) || j.description.toLowerCase().includes(searchTerm) || j.poster.toLowerCase().includes(searchTerm));
+                filtered = filtered.filter(j =>
+                    String(j.title || '').toLowerCase().includes(searchTerm) ||
+                    String(j.description || '').toLowerCase().includes(searchTerm) ||
+                    String(j.poster || '').toLowerCase().includes(searchTerm)
+                );
             }
             
             if (filtered.length === 0) {
@@ -380,16 +401,16 @@
                 <div class="job-card">
                     <div class="job-header">
                         <div>
-                            <div class="job-title">${job.title}</div>
-                            <div class="job-id">ID: ${job.id}</div>
+                            <div class="job-title">${esc(job.title)}</div>
+                            <div class="job-id">ID: ${esc(job.id)}</div>
                         </div>
-                        <div class="job-reward">${job.reward} RTC</div>
+                        <div class="job-reward">${esc(job.reward)} RTC</div>
                     </div>
-                    <p class="job-description">${job.description}</p>
+                    <p class="job-description">${esc(job.description)}</p>
                     <div class="job-meta">
-                        <span class="category-badge ${job.category}">${job.category}</span>
-                        <span class="job-tag">👤 ${job.poster}</span>
-                        <span class="job-tag">📅 ${formatDate(job.created_at)}</span>
+                        <span class="category-badge ${safeClass(job.category)}">${esc(job.category)}</span>
+                        <span class="job-tag">👤 ${esc(job.poster)}</span>
+                        <span class="job-tag">📅 ${esc(formatDate(job.created_at))}</span>
                     </div>
                     <div class="lifecycle">
                         <div class="lifecycle-step ${getStatusClass(job.status, 'open')}">📝 Posted</div>
@@ -397,7 +418,7 @@
                         <div class="lifecycle-step ${getStatusClass(job.status, 'delivered')}">📤 Delivered</div>
                         <div class="lifecycle-step ${getStatusClass(job.status, 'completed')}">✅ Completed</div>
                     </div>
-                    ${job.status === 'open' ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${job.id}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
+                    ${job.status === 'open' ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${esc(job.id)}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
                 </div>
             `).join('');
         }
@@ -424,7 +445,7 @@
             document.getElementById('repScore').textContent = '--';
             
             try {
-                const response = await fetch(`https://rustchain.org/agent/reputation/${wallet}`);
+                const response = await fetch(`https://rustchain.org/agent/reputation/${encodeURIComponent(wallet)}`);
                 const rep = response.ok ? await response.json() : mockReputation;
                 updateReputation(rep);
             } catch (error) { updateReputation(mockReputation); }

--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -24,6 +24,7 @@ HTML = """
 <script>
 async function j(u){const r=await fetch(u);return await r.json();}
 function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
+function esc(v){return String(v ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 async function load(){
   const d=await j('/api/dashboard');
   document.getElementById('base').textContent=d.base;
@@ -31,8 +32,8 @@ async function load(){
   document.getElementById('miners').textContent=(d.miners||[]).length;
   document.getElementById('epoch').textContent=d.epoch?.epoch ?? '-';
   document.getElementById('txcount').textContent=(d.transactions||[]).length;
-  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${m.miner_id||m.wallet||'-'}</td><td>${m.score||m.attestation_score||'-'}</td><td>${m.multiplier||m.antiquity_multiplier||'-'}</td></tr>`).join('');
-  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${fmtTs(t.timestamp||t.created_at||t.time)}</td><td>${t.from||t.sender||'-'}</td><td>${t.to||t.recipient||'-'}</td><td>${t.amount||t.value||'-'}</td></tr>`).join('');
+  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${esc(m.miner_id??m.wallet??'-')}</td><td>${esc(m.score??m.attestation_score??'-')}</td><td>${esc(m.multiplier??m.antiquity_multiplier??'-')}</td></tr>`).join('');
+  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${esc(fmtTs(t.timestamp??t.created_at??t.time))}</td><td>${esc(t.from??t.sender??'-')}</td><td>${esc(t.to??t.recipient??'-')}</td><td>${esc(t.amount??t.value??'-')}</td></tr>`).join('');
 }
 load(); setInterval(load, 30000);
 </script></body></html>

--- a/explorer/dashboard/miners.html
+++ b/explorer/dashboard/miners.html
@@ -424,6 +424,23 @@
         };
         
         let miners = [];
+
+        function escapeHtml(value) {
+            if (value === null || value === undefined) return '';
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function safeClass(value) {
+            return String(value || 'unknown')
+                .toLowerCase()
+                .replace(/[^a-z0-9_-]+/g, '-')
+                .replace(/^-+|-+$/g, '') || 'unknown';
+        }
         
         async function fetchMiners() {
             try {
@@ -464,36 +481,42 @@
                 return;
             }
             
-            tbody.innerHTML = data.map(miner => `
-                <tr>
-                    <td>
-                        <div class="miner-name">
-                            <strong>${miner.id}</strong>
-                        </div>
-                    </td>
-                    <td>
-                        <span class="arch-badge ${miner.arch.toLowerCase().replace(' ', '-')}">
-                            ${archIcons[miner.arch] || '⚙️'} ${archLabels[miner.arch] || miner.arch}
-                        </span>
-                    </td>
-                    <td>
-                        <span class="status-badge ${miner.status}">
-                            ${miner.status === 'online' ? 'Online' : 'Offline'}
-                        </span>
-                    </td>
-                    <td><span class="multiplier">${miner.multiplier}x</span></td>
-                    <td class="timestamp">${miner.lastAttestation}</td>
-                    <td>${miner.weight.toLocaleString()}</td>
-                </tr>
-            `).join('');
+            tbody.innerHTML = data.map(miner => {
+                const minerId = miner.id ?? miner.miner_id ?? 'unknown';
+                const arch = miner.arch ?? miner.architecture ?? miner.device_arch ?? 'Unknown';
+                const status = miner.status === 'online' ? 'online' : 'offline';
+                const weight = miner.weight ?? miner.score ?? miner.balance ?? 0;
+                return `
+                    <tr>
+                        <td>
+                            <div class="miner-name">
+                                <strong>${escapeHtml(minerId)}</strong>
+                            </div>
+                        </td>
+                        <td>
+                            <span class="arch-badge ${safeClass(arch)}">
+                                ${escapeHtml(archIcons[arch] || 'GPU')} ${escapeHtml(archLabels[arch] || arch)}
+                            </span>
+                        </td>
+                        <td>
+                            <span class="status-badge ${status}">
+                                ${status === 'online' ? 'Online' : 'Offline'}
+                            </span>
+                        </td>
+                        <td><span class="multiplier">${escapeHtml(miner.multiplier ?? '--')}x</span></td>
+                        <td class="timestamp">${escapeHtml(miner.lastAttestation ?? miner.last_seen ?? '--')}</td>
+                        <td>${escapeHtml(weight.toLocaleString())}</td>
+                    </tr>
+                `;
+            }).join('');
         }
         
         // Search functionality
         document.getElementById('searchInput').addEventListener('input', (e) => {
             const query = e.target.value.toLowerCase();
             const filtered = miners.filter(m => 
-                m.id.toLowerCase().includes(query) ||
-                m.arch.toLowerCase().includes(query)
+                String(m.id ?? m.miner_id ?? '').toLowerCase().includes(query) ||
+                String(m.arch ?? m.architecture ?? m.device_arch ?? '').toLowerCase().includes(query)
             );
             renderTable(filtered);
         });

--- a/explorer/enhanced-explorer.html
+++ b/explorer/enhanced-explorer.html
@@ -623,12 +623,12 @@
             if (transactions.transactions && transactions.transactions.length > 0) {
                 table.innerHTML = transactions.transactions.slice(0, 20).map(tx => `
                     <tr>
-                        <td><code>${tx.hash || tx.tx_hash || 'N/A'}</code></td>
-                        <td><code>${tx.from || 'N/A'}</code></td>
-                        <td><code>${tx.to || 'N/A'}</code></td>
+                        <td><code>${esc(tx.hash || tx.tx_hash || 'N/A')}</code></td>
+                        <td><code>${esc(tx.from || 'N/A')}</code></td>
+                        <td><code>${esc(tx.to || 'N/A')}</code></td>
                         <td>${(tx.amount / 1000000 || 0).toFixed(2)} RTC</td>
                         <td>${(tx.fee / 1000000 || 0).toFixed(4)} RTC</td>
-                        <td>${formatTime(tx.timestamp)}</td>
+                        <td>${esc(formatTime(tx.timestamp))}</td>
                         <td><span class="badge badge-success">Confirmed</span></td>
                     </tr>
                 `).join('');

--- a/explorer/miner-dashboard.html
+++ b/explorer/miner-dashboard.html
@@ -321,8 +321,11 @@
         history.replaceState({}, '', url);
 
         // Show share link
-        document.getElementById('share-link').innerHTML =
-            `Share this dashboard: <a href="${url.href}">${url.href}</a>`;
+        const shareLink = document.getElementById('share-link');
+        const link = document.createElement('a');
+        link.href = url.href;
+        link.textContent = url.href;
+        shareLink.replaceChildren('Share this dashboard: ', link);
 
         // Fetch all data in parallel
         const [balanceData, epochData, historyData, activityData] = await Promise.all([
@@ -372,15 +375,15 @@
                 rewardsBody.innerHTML = rewards.slice(0, 20).map(r => `
                     <tr>
                         <td>${escapeHtml(String(r.epoch ?? r.block ?? '--'))}</td>
-                        <td style="color:var(--green);">+${r.amount ?? r.reward ?? r.value ?? '?'} RTC</td>
+                        <td style="color:var(--green);">+${escapeHtml(String(r.amount ?? r.reward ?? r.value ?? '?'))} RTC</td>
                         <td><span class="badge badge-green">${escapeHtml(r.type || 'mining')}</span></td>
-                        <td>${timeAgo(r.timestamp || r.time || r.created_at)}</td>
+                        <td>${escapeHtml(timeAgo(r.timestamp || r.time || r.created_at))}</td>
                     </tr>
                 `).join('');
             } else {
                 rewardsBody.innerHTML = `
                     <tr><td colspan="4" style="text-align:center;color:var(--text-dim);">
-                        No reward data yet. Current epoch: ${epoch.number ?? epoch.id ?? JSON.stringify(epoch).substring(0, 50)}
+                        No reward data yet. Current epoch: ${escapeHtml(String(epoch.number ?? epoch.id ?? JSON.stringify(epoch).substring(0, 50)))}
                     </td></tr>`;
             }
         } else {
@@ -393,8 +396,8 @@
             activityBody.innerHTML = `
                 <tr>
                     <td><span class="badge badge-green">Chain Tip</span></td>
-                    <td>Block ${activityData.height ?? activityData.block_height ?? '--'}</td>
-                    <td>${timeAgo(activityData.timestamp)}</td>
+                    <td>Block ${escapeHtml(String(activityData.height ?? activityData.block_height ?? '--'))}</td>
+                    <td>${escapeHtml(timeAgo(activityData.timestamp))}</td>
                 </tr>`;
         } else {
             activityBody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:var(--text-dim);">No recent activity</td></tr>';
@@ -404,22 +407,22 @@
         const wBody = document.getElementById('withdrawals-body');
         if (historyData && Array.isArray(historyData) && historyData.length > 0) {
             wBody.innerHTML = historyData.slice(0, 10).map(w => `
-                <tr>
-                    <td style="font-size:0.75rem;">${escapeHtml(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
-                    <td>${w.amount ?? '?'} RTC</td>
-                    <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
-                    <td>${timeAgo(w.requested_at || w.created_at || w.timestamp)}</td>
-                </tr>
-            `).join('');
+                    <tr>
+                        <td style="font-size:0.75rem;">${escapeHtml(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
+                        <td>${escapeHtml(String(w.amount ?? '?'))} RTC</td>
+                        <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
+                        <td>${escapeHtml(timeAgo(w.requested_at || w.created_at || w.timestamp))}</td>
+                    </tr>
+                `).join('');
         } else if (historyData?.withdrawals && historyData.withdrawals.length > 0) {
             wBody.innerHTML = historyData.withdrawals.slice(0, 10).map(w => `
-                <tr>
-                    <td style="font-size:0.75rem;">${escapeHtml(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
-                    <td>${w.amount ?? '?'} RTC</td>
-                    <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
-                    <td>${timeAgo(w.requested_at || w.created_at || w.timestamp)}</td>
-                </tr>
-            `).join('');
+                    <tr>
+                        <td style="font-size:0.75rem;">${escapeHtml(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
+                        <td>${escapeHtml(String(w.amount ?? '?'))} RTC</td>
+                        <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
+                        <td>${escapeHtml(timeAgo(w.requested_at || w.created_at || w.timestamp))}</td>
+                    </tr>
+                `).join('');
         } else {
             wBody.innerHTML = '<tr><td colspan="4" style="text-align:center;color:var(--text-dim);">No withdrawals</td></tr>';
         }

--- a/explorer/pocs/bounty68_api_response_xss.html
+++ b/explorer/pocs/bounty68_api_response_xss.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Bounty 68 API response injection PoC</title>
+<h1>Bounty 68 API response injection PoC</h1>
+<p>This local PoC demonstrates the class fixed by escaping shortened API fields before assigning table markup with innerHTML.</p>
+
+<h2>Unsafe renderer</h2>
+<table border="1">
+  <tbody id="unsafe"></tbody>
+</table>
+
+<h2>Patched renderer</h2>
+<table border="1">
+  <tbody id="safe"></tbody>
+</table>
+
+<script>
+const payload = '<svg/onload="document.body.dataset.xss=1">';
+
+function escapeHtml(str) {
+  if (!str) return '';
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function shortenAddress(addr, chars = 64) {
+  if (!addr) return '';
+  if (addr.length <= chars * 2) return addr;
+  return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+}
+
+document.getElementById('unsafe').innerHTML =
+  `<tr><td>${shortenAddress(payload)}</td></tr>`;
+
+document.getElementById('safe').innerHTML =
+  `<tr><td>${escapeHtml(shortenAddress(payload))}</td></tr>`;
+</script>

--- a/explorer/realtime-explorer.html
+++ b/explorer/realtime-explorer.html
@@ -966,16 +966,18 @@
             renderFeed();
         }
 
+        function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+
         function renderFeed() {
             const feed = document.getElementById('live-feed');
             feed.innerHTML = feedItems.map(item => `
                 <div class="feed-item new-entry">
-                    <span class="feed-icon">${item.icon}</span>
+                    <span class="feed-icon">${esc(item.icon)}</span>
                     <div class="feed-content">
-                        <div class="feed-title">${item.title}</div>
-                        <div style="color: var(--text-secondary); font-size: 13px;">${item.subtitle}</div>
+                        <div class="feed-title">${esc(item.title)}</div>
+                        <div style="color: var(--text-secondary); font-size: 13px;">${esc(item.subtitle)}</div>
                     </div>
-                    <span class="feed-time">${item.time}</span>
+                    <span class="feed-time">${esc(item.time)}</span>
                 </div>
             `).join('');
         }
@@ -989,10 +991,10 @@
                     <span aria-hidden="true">🎉</span> Epoch Settlement!
                 </div>
                 <div class="notification-content">
-                    <p>Epoch ${data.epoch} → ${data.new_epoch}</p>
+                    <p>Epoch ${esc(data.epoch)} → ${esc(data.new_epoch)}</p>
                     <p style="margin-top: 8px;">
-                        <strong>Pot:</strong> ${data.total_rtc || 0} RTC<br>
-                        <strong>Miners:</strong> ${data.miners || 0}
+                        <strong>Pot:</strong> ${esc(data.total_rtc || 0)} RTC<br>
+                        <strong>Miners:</strong> ${esc(data.miners || 0)}
                     </p>
                 </div>
             `;
@@ -1128,8 +1130,6 @@
                 return null;
             }
         }
-
-        function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
 
         async function loadHealth() {
             const health = await fetchAPI('/health');

--- a/explorer/static/js/dashboard.js
+++ b/explorer/static/js/dashboard.js
@@ -388,9 +388,9 @@ class DashboardApp {
         tbody.innerHTML = sortedMiners.map((miner, index) => `
             <tr class="${miner.isNew ? 'new' : ''}">
                 <td>${index + 1}</td>
-                <td class="mono">${this.shortenAddress(miner.miner_id || 'unknown')}</td>
-                <td><span class="badge badge-${this.getArchitectureTier(miner.device_arch)}">${miner.device_arch || 'Unknown'}</span></td>
-                <td class="text-accent">${miner.score || 0}</td>
+                <td class="mono">${this.escapeHtml(this.shortenAddress(miner.miner_id || 'unknown'))}</td>
+                <td><span class="badge badge-${this.getArchitectureTier(miner.device_arch)}">${this.escapeHtml(miner.device_arch || 'Unknown')}</span></td>
+                <td class="text-accent">${this.escapeHtml(miner.score || 0)}</td>
                 <td>${(miner.multiplier || 1).toFixed(2)}x</td>
                 <td><span class="badge badge-active">● ACTIVE</span></td>
             </tr>
@@ -440,12 +440,12 @@ class DashboardApp {
             <div class="activity-item ${block.isNew ? 'new' : ''}">
                 <div class="activity-icon">📦</div>
                 <div class="activity-content">
-                    <div class="activity-title">Block #${block.height || 0}</div>
-                    <div class="activity-subtitle mono">${this.shortenHash(block.hash || '0x')}</div>
+                    <div class="activity-title">Block #${this.escapeHtml(block.height || 0)}</div>
+                    <div class="activity-subtitle mono">${this.escapeHtml(this.shortenHash(block.hash || '0x'))}</div>
                 </div>
                 <div class="activity-meta">
                     <div class="activity-time">${this.formatRelativeTime(block.timestamp)}</div>
-                    <div class="activity-value">${block.miners_count || 0} miners</div>
+                    <div class="activity-value">${this.escapeHtml(block.miners_count || 0)} miners</div>
                 </div>
             </div>
         `).join('');
@@ -473,8 +473,8 @@ class DashboardApp {
             <div class="activity-item ${tx.isNew ? 'new' : ''}">
                 <div class="activity-icon">💸</div>
                 <div class="activity-content">
-                    <div class="activity-title">${(tx.type || 'transfer').toUpperCase()}</div>
-                    <div class="activity-subtitle mono">${this.shortenAddress(tx.from || '0x')} → ${this.shortenAddress(tx.to || '0x')}</div>
+                    <div class="activity-title">${this.escapeHtml((tx.type || 'transfer').toUpperCase())}</div>
+                    <div class="activity-subtitle mono">${this.escapeHtml(this.shortenAddress(tx.from || '0x'))} → ${this.escapeHtml(this.shortenAddress(tx.to || '0x'))}</div>
                 </div>
                 <div class="activity-meta">
                     <div class="activity-time">${this.formatRelativeTime(tx.timestamp)}</div>
@@ -518,7 +518,7 @@ class DashboardApp {
             <div class="hardware-legend-item">
                 <div class="hardware-legend-color" style="background: ${item.color}"></div>
                 <div class="hardware-legend-info">
-                    <div class="hardware-legend-label">${item.label}</div>
+                    <div class="hardware-legend-label">${this.escapeHtml(item.label)}</div>
                     <div class="hardware-legend-value">${item.percent}%</div>
                 </div>
                 <div class="hardware-legend-count">${item.value}</div>
@@ -696,6 +696,16 @@ class DashboardApp {
     /**
      * Utility functions
      */
+    escapeHtml(str) {
+        if (str === null || str === undefined) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
     shortenHash(hash, chars = 8) {
         if (!hash) return '';
         if (hash.length <= chars * 2) return hash;

--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -47,7 +47,7 @@ const state = {
 
 // Utility Functions
 function escapeHtml(str) {
-    if (!str) return '';
+    if (str === null || str === undefined) return '';
     return String(str)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -330,7 +330,7 @@ function renderStatusBar() {
             <span>${statusText}</span>
         </div>
         <div class="status-info mono">
-            ${state.health ? `v${state.health.version || '2.2.1'}` : ''}
+            ${state.health ? `v${escapeHtml(state.health.version || '2.2.1')}` : ''}
             ${state.health && state.health.uptime ? `| Uptime: ${formatUptime(state.health.uptime)}` : ''}
             ${state.lastUpdate ? `| Updated: ${formatRelativeTime(state.lastUpdate)}` : ''}
         </div>
@@ -421,7 +421,7 @@ function renderMinersTable() {
         const badgeClass = getArchitectureBadge(miner.device_arch);
         return `
             <tr>
-                <td class="mono" title="${escapeHtml(miner.miner_id)}">${shortenAddress(miner.miner_id || 'unknown')}</td>
+                <td class="mono" title="${escapeHtml(miner.miner_id)}">${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}</td>
                 <td><span class="badge ${badgeClass}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
                 <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                 <td class="text-accent">${formatNumber(miner.multiplier || 1.0, 2)}x</td>
@@ -462,9 +462,9 @@ function renderBlocksTable() {
     container.innerHTML = state.blocks.map(block => `
         <tr>
             <td><strong class="text-accent">#${formatNumber(block.height, 0)}</strong></td>
-            <td class="mono" title="${escapeHtml(block.hash)}">${shortenHash(block.hash || '0x')}</td>
+            <td class="mono" title="${escapeHtml(block.hash)}">${escapeHtml(shortenHash(block.hash || '0x'))}</td>
             <td class="mono">${formatTimestamp(block.timestamp)}</td>
-            <td><span class="badge badge-info">${block.miners_count || 0} miners</span></td>
+            <td><span class="badge badge-info">${escapeHtml(block.miners_count || 0)} miners</span></td>
             <td class="text-success">${formatNumber(block.reward || 0, 2)} RTC</td>
         </tr>
     `).join('');
@@ -498,10 +498,10 @@ function renderTransactionsTable() {
     
     container.innerHTML = state.transactions.map(tx => `
         <tr>
-            <td class="mono" title="${escapeHtml(tx.hash)}">${shortenHash(tx.hash || '0x', 6)}</td>
+            <td class="mono" title="${escapeHtml(tx.hash)}">${escapeHtml(shortenHash(tx.hash || '0x', 6))}</td>
             <td class="mono">${escapeHtml(tx.type || 'transfer')}</td>
-            <td class="mono" title="${escapeHtml(tx.from)}">${shortenAddress(tx.from || '0x')}</td>
-            <td class="mono" title="${escapeHtml(tx.to)}">${shortenAddress(tx.to || '0x')}</td>
+            <td class="mono" title="${escapeHtml(tx.from)}">${escapeHtml(shortenAddress(tx.from || '0x'))}</td>
+            <td class="mono" title="${escapeHtml(tx.to)}">${escapeHtml(shortenAddress(tx.to || '0x'))}</td>
             <td class="text-success">${formatNumber(tx.amount || 0, 6)} RTC</td>
             <td class="mono">${formatRelativeTime(tx.timestamp)}</td>
         </tr>
@@ -582,7 +582,7 @@ function renderHallOfRust() {
                 <span style="font-size: 1.5rem; font-weight: bold; color: ${index === 0 ? '#f59e0b' : index === 1 ? '#94a3b8' : index === 2 ? '#b45309' : '#64748b'};">#${index + 1}</span>
                 <div style="flex: 1;">
                     <div class="mono" style="font-size: 0.9rem;">${machineName}</div>
-                    <div class="text-muted" style="font-size: 0.8rem;">${escapeHtml(machine.device_arch || 'Unknown')} • ${machine.total_attestations || 0} attestations${machine.is_deceased ? ' • <span style="color:#9aa39d">☠ deceased</span>' : ''}</div>
+                    <div class="text-muted" style="font-size: 0.8rem;">${escapeHtml(machine.device_arch || 'Unknown')} • ${escapeHtml(machine.total_attestations || 0)} attestations${machine.is_deceased ? ' • <span style="color:#9aa39d">☠ deceased</span>' : ''}</div>
                 </div>
                 <div class="rust-score">${formatNumber(machine.rust_score || 0, 0)}</div>
                 <span class="rust-badge">${getRustBadge(machine.rust_score)}</span>
@@ -641,7 +641,7 @@ function renderSearchResults() {
                         const badgeClass = getArchitectureBadge(miner.device_arch);
                         return `
                             <tr>
-                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${shortenAddress(miner.miner_id || 'unknown')}</td>
+                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}</td>
                                 <td><span class="badge ${badgeClass}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
                                 <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                                 <td class="text-accent">${formatNumber(miner.multiplier || 1.0, 2)}x</td>

--- a/explorer/templates/dashboard.html
+++ b/explorer/templates/dashboard.html
@@ -319,16 +319,33 @@
             document.getElementById('active-miners').textContent = stats.active_miners;
             document.getElementById('difficulty').textContent = stats.difficulty;
         }
+
+        function escapeHtml(value) {
+            if (value === null || value === undefined) return '';
+            return String(value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function safeClass(value) {
+            return String(value || 'unknown')
+                .toLowerCase()
+                .replace(/[^a-z0-9_-]+/g, '-')
+                .replace(/^-+|-+$/g, '') || 'unknown';
+        }
         
         function updateRecentBlocks(blocks) {
             const tbody = document.getElementById('recent-blocks');
             tbody.innerHTML = blocks.map(block => `
                 <tr>
-                    <td><a href="/block/${block.hash}" class="text-decoration-none">${block.height}</a></td>
-                    <td><code class="text-muted">${block.hash.substring(0, 16)}...</code></td>
-                    <td>${block.tx_count}</td>
-                    <td>${block.miner}</td>
-                    <td class="text-muted">${block.timestamp}</td>
+                    <td><a href="/block/${encodeURIComponent(block.hash || '')}" class="text-decoration-none">${escapeHtml(block.height)}</a></td>
+                    <td><code class="text-muted">${escapeHtml(String(block.hash || '').substring(0, 16))}...</code></td>
+                    <td>${escapeHtml(block.tx_count)}</td>
+                    <td>${escapeHtml(block.miner)}</td>
+                    <td class="text-muted">${escapeHtml(block.timestamp)}</td>
                 </tr>
             `).join('');
         }
@@ -336,29 +353,31 @@
         function updateMiners(miners) {
             const tbody = document.getElementById('miners-tbody');
             tbody.innerHTML = miners.map(miner => {
-                const architectureLower = miner.architecture.toLowerCase().replace('-', '');
+                const architecture = miner.architecture || 'unknown';
+                const architectureClass = safeClass(architecture);
                 const archIcon = miner.architecture === 'x86' ? 'microchip' : 
                                miner.architecture === 'ARM' ? 'mobile-alt' :
                                miner.architecture === 'RISC-V' ? 'cpu' : 'question';
+                const status = miner.status === 'active' ? 'active' : 'inactive';
                 
                 return `
-                    <tr class="miner-row" data-miner-id="${miner.address}">
+                    <tr class="miner-row" data-miner-id="${escapeHtml(miner.address || '')}">
                         <td>
-                            <i class="fas fa-circle ${miner.status === 'active' ? 'status-active' : 'status-inactive'}"></i>
-                            <span class="ms-1">${miner.status.charAt(0).toUpperCase() + miner.status.slice(1)}</span>
+                            <i class="fas fa-circle ${status === 'active' ? 'status-active' : 'status-inactive'}"></i>
+                            <span class="ms-1">${status.charAt(0).toUpperCase() + status.slice(1)}</span>
                         </td>
                         <td>
-                            <code class="text-primary">${miner.address.substring(0, 16)}...</code>
+                            <code class="text-primary">${escapeHtml(String(miner.address || '').substring(0, 16))}...</code>
                         </td>
                         <td>
-                            <span class="badge architecture-badge badge-${architectureLower}">
+                            <span class="badge architecture-badge badge-${architectureClass}">
                                 <i class="fas fa-${archIcon} me-1"></i>
-                                ${miner.architecture}
+                                ${escapeHtml(architecture)}
                             </span>
                         </td>
-                        <td>${miner.hash_rate}</td>
-                        <td>${miner.blocks_mined}</td>
-                        <td class="text-muted">${miner.last_seen}</td>
+                        <td>${escapeHtml(miner.hash_rate)}</td>
+                        <td>${escapeHtml(miner.blocks_mined)}</td>
+                        <td class="text-muted">${escapeHtml(miner.last_seen)}</td>
                     </tr>
                 `;
             }).join('');

--- a/explorer/templates/ws_explorer.html
+++ b/explorer/templates/ws_explorer.html
@@ -145,6 +145,16 @@ function updateEpoch(d) {
   if (epoch) document.getElementById('epoch').textContent = epoch;
 }
 
+function escapeHtml(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 function addBlockFeed(block) {
   const feed = document.getElementById('block-feed');
   if (feed.querySelector('.empty')) feed.innerHTML = '';
@@ -152,7 +162,7 @@ function addBlockFeed(block) {
   const item = document.createElement('div');
   item.className = 'feed-item new';
   item.innerHTML = `<span class="time">${new Date().toLocaleTimeString()}</span> · 
-    Epoch ${block.epoch||'?'} · <span class="hash">${hash}</span>`;
+    Epoch ${escapeHtml(block.epoch||'?')} · <span class="hash">${escapeHtml(hash)}</span>`;
   feed.insertBefore(item, feed.firstChild);
   if (feed.children.length > 50) feed.removeChild(feed.lastChild);
   setTimeout(() => item.classList.remove('new'), 2000);
@@ -171,9 +181,9 @@ function updateMiners(d) {
     const grid = document.getElementById('miner-grid');
     grid.innerHTML = d.miners.slice(0, 12).map(m => `
       <div class="miner-card">
-        <div class="miner-id">${m.miner_id || m.id || '?'}</div>
-        <div class="miner-hw">${m.hardware || m.architecture || '?'}</div>
-        <div class="miner-multi">${m.multiplier || 1.0}x</div>
+        <div class="miner-id">${escapeHtml(m.miner_id || m.id || '?')}</div>
+        <div class="miner-hw">${escapeHtml(m.hardware || m.architecture || '?')}</div>
+        <div class="miner-multi">${escapeHtml(m.multiplier || 1.0)}x</div>
       </div>
     `).join('');
   }
@@ -186,7 +196,7 @@ function updateAttestations(list) {
     const item = document.createElement('div');
     item.className = 'feed-item new';
     item.innerHTML = `<span class="time">${new Date().toLocaleTimeString()}</span> · 
-      ${a.miner_id} · ${a.hardware} · <span class="miner-multi">${a.multiplier}x</span>`;
+      ${escapeHtml(a.miner_id)} · ${escapeHtml(a.hardware)} · <span class="miner-multi">${escapeHtml(a.multiplier)}x</span>`;
     feed.insertBefore(item, feed.firstChild);
     if (feed.children.length > 50) feed.removeChild(feed.lastChild);
     setTimeout(() => item.classList.remove('new'), 2000);

--- a/explorer/test_security_hardening.py
+++ b/explorer/test_security_hardening.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent
+
+
+class SecurityHardeningTests(unittest.TestCase):
+    def test_main_explorer_escapes_shortened_api_values(self):
+        js = (ROOT / "static/js/explorer.js").read_text()
+
+        self.assertIn("${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}", js)
+        self.assertIn("${escapeHtml(shortenHash(block.hash || '0x'))}", js)
+        self.assertIn("${escapeHtml(shortenHash(tx.hash || '0x', 6))}", js)
+        self.assertIn("${escapeHtml(shortenAddress(tx.from || '0x'))}", js)
+        self.assertIn("${escapeHtml(shortenAddress(tx.to || '0x'))}", js)
+        self.assertIn("${escapeHtml(block.miners_count || 0)}", js)
+
+        self.assertNotIn("${shortenAddress(miner.miner_id || 'unknown')}", js)
+        self.assertNotIn("${shortenHash(block.hash || '0x')}", js)
+        self.assertNotIn("${shortenHash(tx.hash || '0x', 6)}", js)
+
+    def test_realtime_dashboard_escapes_api_values(self):
+        js = (ROOT / "static/js/dashboard.js").read_text()
+
+        self.assertIn("escapeHtml(str)", js)
+        self.assertIn("${this.escapeHtml(this.shortenAddress(miner.miner_id || 'unknown'))}", js)
+        self.assertIn("${this.escapeHtml(miner.device_arch || 'Unknown')}", js)
+        self.assertIn("${this.escapeHtml(this.shortenHash(block.hash || '0x'))}", js)
+        self.assertIn("${this.escapeHtml((tx.type || 'transfer').toUpperCase())}", js)
+        self.assertIn("${this.escapeHtml(this.shortenAddress(tx.from || '0x'))}", js)
+        self.assertIn("${this.escapeHtml(this.shortenAddress(tx.to || '0x'))}", js)
+        self.assertIn("${this.escapeHtml(item.label)}", js)
+
+    def test_compact_dashboard_escapes_proxied_table_cells(self):
+        app = (ROOT / "dashboard/app.py").read_text()
+
+        self.assertIn("function esc(v)", app)
+        self.assertIn("${esc(m.miner_id??m.wallet??'-')}", app)
+        self.assertIn("${esc(m.score??m.attestation_score??'-')}", app)
+        self.assertIn("${esc(m.multiplier??m.antiquity_multiplier??'-')}", app)
+        self.assertIn("${esc(t.from??t.sender??'-')}", app)
+        self.assertIn("${esc(t.to??t.recipient??'-')}", app)
+        self.assertIn("${esc(t.amount??t.value??'-')}", app)
+
+    def test_template_dashboards_escape_api_values(self):
+        dashboard = (ROOT / "templates/dashboard.html").read_text()
+        ws_dashboard = (ROOT / "templates/ws_explorer.html").read_text()
+        miners = (ROOT / "dashboard/miners.html").read_text()
+        enhanced = (ROOT / "enhanced-explorer.html").read_text()
+        realtime = (ROOT / "realtime-explorer.html").read_text()
+        miner_dashboard = (ROOT / "miner-dashboard.html").read_text()
+        agent = (ROOT / "dashboard/agent-economy.html").read_text()
+        agent_v2 = (ROOT / "dashboard/agent-economy-v2.html").read_text()
+
+        self.assertIn("function escapeHtml(value)", dashboard)
+        self.assertIn("${escapeHtml(block.miner)}", dashboard)
+        self.assertIn("${escapeHtml(architecture)}", dashboard)
+        self.assertIn("encodeURIComponent(block.hash || '')", dashboard)
+
+        self.assertIn("function escapeHtml(value)", ws_dashboard)
+        self.assertIn("${escapeHtml(m.miner_id || m.id || '?')}", ws_dashboard)
+        self.assertIn("${escapeHtml(a.miner_id)}", ws_dashboard)
+
+        self.assertIn("function escapeHtml(value)", miners)
+        self.assertIn("${escapeHtml(minerId)}", miners)
+        self.assertIn("${escapeHtml(archLabels[arch] || arch)}", miners)
+        self.assertIn("safeClass(arch)", miners)
+
+        self.assertIn("${esc(tx.hash || tx.tx_hash || 'N/A')}", enhanced)
+        self.assertIn("${esc(tx.from || 'N/A')}", enhanced)
+        self.assertIn("${esc(item.subtitle)}", realtime)
+        self.assertIn("${esc(data.total_rtc || 0)}", realtime)
+        self.assertIn("shareLink.replaceChildren('Share this dashboard: ', link)", miner_dashboard)
+        self.assertIn("${escapeHtml(String(r.amount ?? r.reward ?? r.value ?? '?'))}", miner_dashboard)
+        self.assertIn("${esc(job.title)}", agent)
+        self.assertIn("${safeClass(job.category)}", agent)
+        self.assertIn("encodeURIComponent(wallet)", agent)
+        self.assertIn("${esc(j.poster_wallet)}", agent_v2)
+        self.assertIn("${safeClass(j.status)}", agent_v2)
+        self.assertIn("${esc(a.worker)}", agent_v2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Security hardening for rustchain-bounties issue #68: https://github.com/Scottcjn/rustchain-bounties/issues/68

- Escape API/WebSocket-provided values before inserting explorer/dashboard table, feed, card, and notification markup with `innerHTML`.
- Sanitize dynamic CSS class fragments and URL-encode dashboard block/reputation paths where user/API data is interpolated.
- Add a bounty-specific report, local PoC, and stdlib regression test for the API-response injection sink class.

## Files of interest

- `explorer/SECURITY_REPORT_BOUNTY_68.md`
- `explorer/pocs/bounty68_api_response_xss.html`
- `explorer/test_security_hardening.py`

## Validation

- `python3 explorer/test_security_hardening.py`
- `python3 -m unittest discover -s explorer -p 'test_security_hardening.py'`
- `python3 -m py_compile explorer/dashboard/app.py explorer/test_security_hardening.py`
- `node --check explorer/static/js/explorer.js`
- `node --check explorer/static/js/dashboard.js`
- Parsed inline script blocks from changed HTML/PoC files with `new Function(...)`
- `git diff --check`
