### PR TITLE
Fix BCOS action support issues link

### DIFF
--- a/.github/actions/bcos-action/README.md
+++ b/.github/actions/bcos-action/README.md
@@ -191,5 +191,5 @@ MIT License - see [LICENSE](LICENSE) file.
 ## Support
 
 - Documentation: https://rustchain.org/bcos/
-- Issues: https://github.com/Scottcjn/bcos-action/issues
+- Issues: https://github.com/Scottcjn/Rustchain/issues
 - Spec: https://github.com/Scottcjn/Rustchain/blob/main/docs/BEACON_CERTIFIED_OPEN_SOURCE.md


### PR DESCRIPTION
## Summary
- Update the BCOS action README support link from the missing Scottcjn/bcos-action repo to the active Scottcjn/Rustchain issue tracker.

## Verification
- `curl -fsS -o /dev/null -w "%{http_code}" https://github.com/Scottcjn/bcos-action/issues` returns 404.
- `curl -fsS -o /dev/null -w "%{http_code}" https://github.com/Scottcjn/Rustchain/issues` returns 200.