### PR TITLE
fix: keep miner installer dry-run non-mutating

### DIFF
--- a/install-miner.sh
+++ b/install-miner.sh
@@ -79,7 +79,10 @@ setup_python() {
         fi
     fi
     V=$(python3 -c "import sys; print(sys.version_info.minor)")
-    [ "$V" -lt 8 ] && { echo -e "${RED}[!] Python 3.8+ required (Found 3.$V)${NC}"; exit 1; }
+    if [ "$V" -lt 8 ]; then
+        echo -e "${RED}[!] Python 3.8+ required (Found 3.$V)${NC}"
+        exit 1
+    fi
 }
 
 setup_python
@@ -94,7 +97,11 @@ verify_sum() {
 }
 
 download_miner() {
-    cd "$INSTALL_DIR"
+    if [ "$DRY_RUN" = true ]; then
+        echo -e "${CYAN}[DRY-RUN]${NC} Would run: cd $INSTALL_DIR"
+    else
+        cd "$INSTALL_DIR"
+    fi
     case "$PLATFORM" in
         macos) FILE="macos/rustchain_mac_miner_v2.4.py" ;;
         rpi|linux) FILE="linux/rustchain_linux_miner.py" ;;


### PR DESCRIPTION
## Summary

Fixes #2681 by making `install-miner.sh --dry-run` non-mutating end to end.

Two dry-run blockers were present:

- `setup_python()` used `[ $V -lt 8 ] && ...` as the final command in the function. With `set -e`, supported Python versions returned status 1 from the function and aborted the script before dry-run reached later steps.
- `download_miner()` executed `cd $INSTALL_DIR` unconditionally even though dry-run only prints the earlier `mkdir -p $INSTALL_DIR` command and does not create the directory.

The PR converts the Python version guard to an explicit `if` and makes dry-run print the `cd` operation instead of executing it.

## Verification

```text
bash -n install-miner.sh
```

```text
HOME=<temp-empty-home> bash ./install-miner.sh --dry-run
RustChain Miner Installer v1.1.0
>>> DRY-RUN MODE <<<
[+] Platform: linux (x86_64)
[DRY-RUN] Would run: mkdir -p /home/retto/.rustchain
[DRY-RUN] Would run: cd /home/retto/.rustchain
[*] Downloading miner...
[DRY-RUN] Would run: curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py -o rustchain_miner.py
[DRY-RUN] Would run: curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py -o fingerprint_checks.py
[*] Setting up virtual environment...
[DRY-RUN] Would run: python3 -m venv /home/retto/.rustchain/venv
[DRY-RUN] Would run: /home/retto/.rustchain/venv/bin/pip install requests -q
[?] Enter wallet name (or Enter for auto):
[+] Wallet: dry-run
[DRY-RUN] Create systemd unit
[DRY-RUN] Create start.sh

Installation Complete!
Start: /home/retto/.rustchain/start.sh
Wallet: dry-run
```

```text
git diff --check
```

Payout details can be provided privately if accepted.