### PR TITLE
fix: default Rust miner to certificate-valid node URL

### DIFF
--- a/rustchain-miner/README.md
+++ b/rustchain-miner/README.md
@@ -46,7 +46,7 @@ cargo install --path .
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `RUSTCHAIN_NODE_URL` | Node URL (HTTPS) | `https://50.28.86.131` |
+| `RUSTCHAIN_NODE_URL` | Node URL (HTTPS) | `https://rustchain.org` |
 | `RUSTCHAIN_PROXY_URL` | HTTP proxy for legacy systems | (none) |
 | `RUSTCHAIN_WALLET` | Wallet address | (auto-generated) |
 | `RUSTCHAIN_MINER_ID` | Custom miner ID | (auto-generated) |
@@ -61,7 +61,7 @@ cargo install --path .
 Create a `.env` file in the project root:
 
 ```bash
-RUSTCHAIN_NODE_URL=https://50.28.86.131
+RUSTCHAIN_NODE_URL=https://rustchain.org
 RUSTCHAIN_WALLET=my_wallet_RTC
 RUSTCHAIN_VERBOSE=true
 ```

--- a/rustchain-miner/README_RISCV.md
+++ b/rustchain-miner/README_RISCV.md
@@ -125,7 +125,7 @@ scp target/riscv64gc-unknown-linux-gnu/release/rustchain-miner root@visionfive2:
 
 # 2. Configure environment
 echo "RUSTCHAIN_WALLET=your_wallet_address" >> ~/.bashrc
-echo "RUSTCHAIN_NODE_URL=https://50.28.86.131" >> ~/.bashrc
+echo "RUSTCHAIN_NODE_URL=https://rustchain.org" >> ~/.bashrc
 source ~/.bashrc
 
 # 3. Run miner
@@ -153,7 +153,7 @@ Type=simple
 User=miner
 WorkingDirectory=/opt/rustchain
 Environment=RUSTCHAIN_WALLET=your_wallet_address
-Environment=RUSTCHAIN_NODE_URL=https://50.28.86.131
+Environment=RUSTCHAIN_NODE_URL=https://rustchain.org
 ExecStart=/opt/rustchain/rustchain-miner
 Restart=always
 RestartSec=10

--- a/rustchain-miner/src/config.rs
+++ b/rustchain-miner/src/config.rs
@@ -48,7 +48,7 @@ pub struct Config {
 }
 
 fn default_node_url() -> String {
-    "https://50.28.86.131".to_string()
+    "https://rustchain.org".to_string()
 }
 
 fn default_block_time() -> u64 {
@@ -159,7 +159,7 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = Config::default();
-        assert_eq!(config.node_url, "https://50.28.86.131");
+        assert_eq!(config.node_url, "https://rustchain.org");
         assert_eq!(config.block_time_secs, 600);
         assert_eq!(config.attestation_ttl_secs, 580);
         assert!(!config.dry_run);

--- a/rustchain-miner/src/main.rs
+++ b/rustchain-miner/src/main.rs
@@ -25,7 +25,7 @@ struct Args {
     miner_id: Option<String>,
 
     /// Node URL
-    #[arg(short = 'n', long = "node", env = "RUSTCHAIN_NODE_URL", default_value = "https://50.28.86.131")]
+    #[arg(short = 'n', long = "node", env = "RUSTCHAIN_NODE_URL", default_value = "https://rustchain.org")]
     node: String,
 
     /// HTTP proxy URL for legacy systems


### PR DESCRIPTION
## Summary

Fixes #2679 by changing the Rust miner default node URL from the bare IP `https://50.28.86.131` to the certificate-valid public endpoint `https://rustchain.org`.

Updated surfaces:

- `rustchain-miner/src/main.rs` CLI `--node` default
- `rustchain-miner/src/config.rs` config default and unit expectation
- `rustchain-miner/README.md` environment table and `.env` example
- `rustchain-miner/README_RISCV.md` shell and systemd examples

This keeps source builds and docs aligned with the HTTPS endpoint used by the other maintained miner surfaces and avoids hostname-mismatch TLS failures for newcomers who run the Rust miner without an explicit `--node` override.

## Verification

```text
cargo test
# 27 unit tests passed
# 1 doctest passed
```

```text
rg -n 50\.28\.86\.131 rustchain-miner
# no matches
```

```text
git diff --check -- rustchain-miner\src\main.rs rustchain-miner\src\config.rs rustchain-miner\README.md rustchain-miner\README_RISCV.md
# passed
```

I also ran `cargo fmt --check`; it reports pre-existing formatting drift across unrelated Rust files, so I did not run `cargo fmt` or widen this PR beyond the node URL fix.

Payout details can be provided privately if accepted.