### PR TITLE
fix: use platform miner URLs in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,9 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 INSTALL_DIR="$HOME/.rustchain"
-MINER_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_universal_miner.py"
-FINGERPRINT_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/fingerprint_checks.py"
+MINERS_BASE_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners"
+MINER_URL=""
+FINGERPRINT_URL="${MINERS_BASE_URL}/linux/fingerprint_checks.py"
 NODE_URL="https://50.28.86.131"
 VERSION="1.0.0"
 
@@ -81,8 +82,14 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 
 case "$OS" in
-    Linux)  echo "  OS: Linux" ;;
-    Darwin) echo "  OS: macOS" ;;
+    Linux)
+        echo "  OS: Linux"
+        MINER_URL="${MINERS_BASE_URL}/linux/rustchain_linux_miner.py"
+        ;;
+    Darwin)
+        echo "  OS: macOS"
+        MINER_URL="${MINERS_BASE_URL}/macos/rustchain_mac_miner_v2.4.py"
+        ;;
     *)      echo -e "${RED}  Unsupported OS: $OS${NC}"; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary

Fixes #2692 by replacing root `install.sh`'s stale top-level raw miner URLs with platform-specific paths that exist in the current repository layout.

Before this PR, `install.sh` used:

- `https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_universal_miner.py` -> 404
- `https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/fingerprint_checks.py` -> 404

The script already detects Linux vs macOS, so this PR assigns the miner URL from that platform branch:

- Linux: `miners/linux/rustchain_linux_miner.py`
- macOS: `miners/macos/rustchain_mac_miner_v2.4.py`
- Fingerprint helper: `miners/linux/fingerprint_checks.py`, matching the current maintained helper location

## Verification

```text
curl.exe -L -s -o NUL -w %{http_code} https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_universal_miner.py
# 404

curl.exe -L -s -o NUL -w %{http_code} https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/fingerprint_checks.py
# 404

curl.exe -L -s -o NUL -w %{http_code} https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py
# 200

curl.exe -L -s -o NUL -w %{http_code} https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py
# 200

curl.exe -L -s -o NUL -w %{http_code} https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.4.py
# 200
```

```text
bash -n install.sh
bash ./install.sh --dry-run --wallet test-wallet
# dry-run prints the Linux platform URL under the existing OS detection path

git diff --check -- install.sh
```

Payout details can be provided privately if accepted.