### PR TITLE
Fix RustChain branding in Spanish README footer

### DIFF
--- a/README_ES.md
+++ b/README_ES.md
@@ -534,6 +534,6 @@ Esperado: las 6 verificaciones de huella digital de hardware se ejecutan en ARM6
 
 **[Elyan Labs](https://github.com/Scottcjn)** · 1,882 commits · 97 repos · 1,334 stars · $0 recaudados
 
-[⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [📊 Informe de Tracción Q1 2026](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
+[⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [📊 Informe de Tracción Q1 2026](https://github.com/Scottcjn/Rustchain/blob/main/docs/DEVELOPER_TRACTION_Q1_2026.md) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>


### PR DESCRIPTION
## Summary
- update the Spanish README footer link text from `Star Rustchain` to `Star RustChain`

## Validation
- `git diff --check`
- duplicate check: open PR search for `Star Rustchain`, `RustChain branding`, capitalization, and `README_ES` returned no hits
- duplicate check: rustchain-bounties #2178 comments had no `README_ES` or Spanish README submission before this PR