### PR TITLE
fix: align README modern x86 multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Proof-of-Antiquity rewards hardware for *surviving*, not for being fast. Older m
 | PowerPC G4 (2003) | **2.5x** | ANCIENT | Still running, still earning |
 | RISC-V (2014) | **1.4x** | EXOTIC | Open ISA, the future |
 | Apple Silicon M1 (2020) | **1.2x** | MODERN | Efficient, welcome |
-| Modern x86_64 | **0.8x** | MODERN | Baseline — *for now* |
+| Modern x86_64 | **1.0x** | MODERN | Baseline — *for now* |
 | Modern ARM NAS/SBC | **0.0005x** | PENALTY | Cheap, farmable, penalized |
 
 Our fleet of 16+ preserved machines draws roughly the same power as ONE modern GPU mining rig — while preventing 1,300 kg of manufacturing CO2 and 250 kg of e-waste.


### PR DESCRIPTION
## Summary
- align the README modern x86_64 multiplier table with the same README's `1.0x` baseline examples
- closes #2699
- also addresses duplicate report #2690

## Validation
- `git diff --check -- README.md`
- `rg -n "Modern x86_64|Modern PC \\(1\\.0x\\)|1\\.0x|0\\.8x" README.md docs\\hardware.html docs\\VINTAGE_MINING_EXPLAINED.md docs\\WHITEPAPER.md`
