### PR TITLE
fix: retry Sophia Ollama endpoints

### DIFF
--- a/sophia_core.py
+++ b/sophia_core.py
@@ -9,6 +9,7 @@ Rustchain bounty #2261 (150 RTC).
 import json
 import logging
 import requests
+import time
 
 from sophia_db import (
     get_connection, store_inspection, enqueue_review, get_latest_inspection,
@@ -18,6 +19,8 @@ from sophia_db import (
 logger = logging.getLogger("sophia_core")
 
 MODEL = "elyan-sophia:7b-q4_K_M"
+OLLAMA_MAX_ATTEMPTS = 3
+OLLAMA_BACKOFF_BASE_SECONDS = 0.5
 
 OLLAMA_FAILOVER_CHAIN = [
     "http://localhost:11434",
@@ -89,8 +92,12 @@ def _parse_ollama_response(raw_text):
     }
 
 
-def _query_ollama(prompt, endpoint):
+def _query_ollama(prompt, endpoint, max_attempts=OLLAMA_MAX_ATTEMPTS,
+                  backoff_base=OLLAMA_BACKOFF_BASE_SECONDS):
     """Send a generate request to an Ollama endpoint. Returns parsed dict."""
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be at least 1")
+
     url = f"{endpoint}/api/generate"
     payload = {
         "model": MODEL,
@@ -99,12 +106,28 @@ def _query_ollama(prompt, endpoint):
         "options": {"temperature": 0.1, "num_predict": 512},
     }
 
-    resp = requests.post(url, json=payload, timeout=30)
-    resp.raise_for_status()
-    body = resp.json()
-    raw = body.get("response", "")
+    last_exc = None
+    for attempt in range(1, max_attempts + 1):
+        try:
+            resp = requests.post(url, json=payload, timeout=30)
+            resp.raise_for_status()
+            body = resp.json()
+            raw = body.get("response", "")
 
-    return _parse_ollama_response(raw)
+            return _parse_ollama_response(raw)
+        except Exception as exc:
+            last_exc = exc
+            if attempt >= max_attempts:
+                break
+
+            delay = backoff_base * (2 ** (attempt - 1))
+            logger.warning(
+                "Ollama endpoint %s attempt %d/%d failed: %s; retrying in %.1fs",
+                endpoint, attempt, max_attempts, exc, delay
+            )
+            time.sleep(delay)
+
+    raise last_exc
 
 
 def _rule_based_fallback(fingerprint):

--- a/tests/test_sophia_core.py
+++ b/tests/test_sophia_core.py
@@ -34,7 +34,7 @@ from sophia_db import (
 )
 from sophia_core import (
     SophiaCoreInspector, VERDICTS, _build_analysis_prompt,
-    _rule_based_fallback, _parse_ollama_response, MODEL,
+    _rule_based_fallback, _parse_ollama_response, _query_ollama, MODEL,
 )
 
 
@@ -375,24 +375,28 @@ class TestOllamaFailover(unittest.TestCase):
     @patch("sophia_core.requests.post")
     def test_ollama_failover_to_second(self, mock_post):
         """First endpoint fails, second works."""
-        fail_resp = MagicMock()
-        fail_resp.raise_for_status.side_effect = Exception("connection refused")
-
         ok_resp = MagicMock()
         ok_resp.status_code = 200
         ok_resp.json.return_value = {
             "response": "VERDICT: CAUTIOUS\nCONFIDENCE: 0.6\nREASONING: hmm"
         }
 
-        mock_post.side_effect = [Exception("refused"), ok_resp]
+        mock_post.side_effect = [
+            Exception("refused"),
+            Exception("refused"),
+            Exception("refused"),
+            ok_resp,
+        ]
 
         inspector = SophiaCoreInspector(
             db_path=self.db_path,
             ollama_endpoints=["http://bad:11434", "http://good:11434"],
         )
-        result = inspector.inspect("miner_f", _good_fingerprint())
+        with patch("sophia_core.time.sleep") as mock_sleep:
+            result = inspector.inspect("miner_f", _good_fingerprint())
         self.assertEqual(result["verdict"], "CAUTIOUS")
-        self.assertEqual(mock_post.call_count, 2)
+        self.assertEqual(mock_post.call_count, 4)
+        self.assertEqual(mock_sleep.call_count, 2)
 
     @patch("sophia_core.requests.post")
     def test_ollama_all_fail_uses_fallback(self, mock_post):
@@ -403,9 +407,43 @@ class TestOllamaFailover(unittest.TestCase):
             db_path=self.db_path,
             ollama_endpoints=["http://a:11434", "http://b:11434"],
         )
-        result = inspector.inspect("miner_fb", _good_fingerprint())
+        with patch("sophia_core.time.sleep") as mock_sleep:
+            result = inspector.inspect("miner_fb", _good_fingerprint())
         self.assertEqual(result["model_used"], "rule-based-fallback-v1")
         self.assertIn(result["verdict"], VERDICTS)
+        self.assertEqual(mock_post.call_count, 6)
+        self.assertEqual(mock_sleep.call_count, 4)
+
+    @patch("sophia_core.requests.post")
+    def test_query_ollama_retries_endpoint_before_failing(self, mock_post):
+        """One endpoint is retried with exponential backoff before failover."""
+        mock_post.side_effect = Exception("temporary outage")
+
+        with patch("sophia_core.time.sleep") as mock_sleep:
+            with self.assertRaisesRegex(Exception, "temporary outage"):
+                _query_ollama("prompt", "http://down:11434")
+
+        self.assertEqual(mock_post.call_count, 3)
+        mock_sleep.assert_any_call(0.5)
+        mock_sleep.assert_any_call(1.0)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @patch("sophia_core.requests.post")
+    def test_query_ollama_can_recover_on_retry(self, mock_post):
+        """A transient endpoint failure can recover before failover."""
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+        ok_resp.json.return_value = {
+            "response": "VERDICT: APPROVED\nCONFIDENCE: 0.8\nREASONING: retry recovered"
+        }
+        mock_post.side_effect = [Exception("temporary outage"), ok_resp]
+
+        with patch("sophia_core.time.sleep") as mock_sleep:
+            result = _query_ollama("prompt", "http://flaky:11434")
+
+        self.assertEqual(result["verdict"], "APPROVED")
+        self.assertEqual(mock_post.call_count, 2)
+        mock_sleep.assert_called_once_with(0.5)
 
     @patch("sophia_core.requests.post")
     def test_cautious_queued_for_review(self, mock_post):


### PR DESCRIPTION
## Summary
- add bounded retries with exponential backoff for each SophiaCore Ollama endpoint before failover advances to the next endpoint
- keep the existing rule-based fallback when every endpoint still fails
- closes #2730

## Notes
Current `main` already falls back to rule-based analysis after all endpoints fail, so this PR targets the still-valid retry/backoff gap from #2730 without changing the conservative fallback behavior.

## Validation
- `python -m pytest tests\test_sophia_core.py::TestOllamaFailover -q` => 7 passed
- `python -m pytest tests\test_sophia_core.py -q` => 52 passed
- `python -m py_compile sophia_core.py tests\test_sophia_core.py`
- `git diff --check -- sophia_core.py tests\test_sophia_core.py`
