### PR TITLE
fix: migrate payout ledger schema

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -18,6 +18,43 @@ logger = logging.getLogger(__name__)
 
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "rustchain.db")
 
+PAYOUT_LEDGER_COLUMNS = [
+    ("id", "TEXT"),
+    ("bounty_id", "TEXT NOT NULL DEFAULT ''"),
+    ("bounty_title", "TEXT"),
+    ("contributor", "TEXT NOT NULL DEFAULT ''"),
+    ("wallet_address", "TEXT"),
+    ("amount_rtc", "REAL NOT NULL DEFAULT 0"),
+    ("status", "TEXT NOT NULL DEFAULT 'queued'"),
+    ("pr_url", "TEXT"),
+    ("tx_hash", "TEXT"),
+    ("notes", "TEXT"),
+    ("created_at", "INTEGER NOT NULL DEFAULT 0"),
+    ("updated_at", "INTEGER NOT NULL DEFAULT 0"),
+]
+
+
+def _get_columns():
+    return [name for name, _definition in PAYOUT_LEDGER_COLUMNS]
+
+
+def _select_columns_sql():
+    return ", ".join(_get_columns())
+
+
+def _migrate_payout_ledger_schema(conn):
+    """Add missing columns for nodes with older payout_ledger tables."""
+    existing = {
+        row[1] for row in conn.execute("PRAGMA table_info(payout_ledger)").fetchall()
+    }
+    for name, definition in PAYOUT_LEDGER_COLUMNS:
+        if name in existing:
+            continue
+        if name == "id":
+            raise RuntimeError("payout_ledger table is missing required primary key column: id")
+        conn.execute(f"ALTER TABLE payout_ledger ADD COLUMN {name} {definition}")
+        logger.info("Added payout_ledger.%s column", name)
+
 # ── Schema ──────────────────────────────────────────────────────
 def init_payout_ledger_tables():
     """Create the payout_ledger table if it does not exist."""
@@ -38,6 +75,7 @@ def init_payout_ledger_tables():
                 updated_at      INTEGER NOT NULL
             )
         """)
+        _migrate_payout_ledger_schema(c)
         c.execute("""
             CREATE INDEX IF NOT EXISTS idx_ledger_status
             ON payout_ledger(status)
@@ -56,18 +94,10 @@ def _row_to_dict(row, columns):
     return dict(zip(columns, row))
 
 
-def _get_columns():
-    return [
-        "id", "bounty_id", "bounty_title", "contributor",
-        "wallet_address", "amount_rtc", "status", "pr_url",
-        "tx_hash", "notes", "created_at", "updated_at",
-    ]
-
-
 def ledger_list(status=None, contributor=None, limit=100):
     """List payout records, optionally filtered."""
     with sqlite3.connect(DB_PATH) as conn:
-        sql = "SELECT * FROM payout_ledger WHERE 1=1"
+        sql = f"SELECT {_select_columns_sql()} FROM payout_ledger WHERE 1=1"
         params = []
         if status:
             sql += " AND status = ?"
@@ -86,7 +116,7 @@ def ledger_get(record_id):
     """Get a single payout record by ID."""
     with sqlite3.connect(DB_PATH) as conn:
         row = conn.execute(
-            "SELECT * FROM payout_ledger WHERE id = ?", (record_id,)
+            f"SELECT {_select_columns_sql()} FROM payout_ledger WHERE id = ?", (record_id,)
         ).fetchone()
     if row:
         return _row_to_dict(row, _get_columns())

--- a/tests/test_payout_ledger_migration.py
+++ b/tests/test_payout_ledger_migration.py
@@ -1,0 +1,94 @@
+import os
+import gc
+import sqlite3
+import tempfile
+import unittest
+
+import payout_ledger
+
+
+class TestPayoutLedgerMigration(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.original_db_path = payout_ledger.DB_PATH
+        payout_ledger.DB_PATH = self.db_path
+
+    def tearDown(self):
+        payout_ledger.DB_PATH = self.original_db_path
+        gc.collect()
+        try:
+            os.unlink(self.db_path)
+        except PermissionError:
+            # Windows can briefly hold sqlite handles after failed assertions.
+            pass
+
+    def _create_v1_table(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("""
+                CREATE TABLE payout_ledger (
+                    id TEXT PRIMARY KEY,
+                    bounty_id TEXT NOT NULL,
+                    contributor TEXT NOT NULL,
+                    amount_rtc REAL NOT NULL DEFAULT 0,
+                    status TEXT NOT NULL DEFAULT 'queued',
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                )
+            """)
+            conn.execute(
+                "INSERT INTO payout_ledger "
+                "(id, bounty_id, contributor, amount_rtc, status, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("old-1", "bounty-1", "alice", 3.5, "pending", 100, 200),
+            )
+
+    def test_init_migrates_old_table_and_preserves_existing_rows(self):
+        self._create_v1_table()
+
+        payout_ledger.init_payout_ledger_tables()
+
+        with sqlite3.connect(self.db_path) as conn:
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(payout_ledger)")
+            }
+
+        self.assertEqual(columns, set(payout_ledger._get_columns()))
+        row = payout_ledger.ledger_get("old-1")
+        self.assertEqual(row["id"], "old-1")
+        self.assertEqual(row["bounty_id"], "bounty-1")
+        self.assertEqual(row["contributor"], "alice")
+        self.assertEqual(row["amount_rtc"], 3.5)
+        self.assertEqual(row["status"], "pending")
+        self.assertEqual(row["created_at"], 100)
+        self.assertEqual(row["updated_at"], 200)
+        self.assertIn("tx_hash", row)
+        self.assertIn("wallet_address", row)
+
+    def test_init_migration_is_idempotent_and_new_writes_work(self):
+        self._create_v1_table()
+
+        payout_ledger.init_payout_ledger_tables()
+        payout_ledger.init_payout_ledger_tables()
+        new_id = payout_ledger.ledger_create(
+            "bounty-2",
+            "bob",
+            4.25,
+            bounty_title="Schema fix",
+            wallet_address="RTC-private",
+            pr_url="https://example.test/pr/1",
+            notes="created after migration",
+        )
+
+        row = payout_ledger.ledger_get(new_id)
+        self.assertEqual(row["bounty_id"], "bounty-2")
+        self.assertEqual(row["bounty_title"], "Schema fix")
+        self.assertEqual(row["contributor"], "bob")
+        self.assertEqual(row["wallet_address"], "RTC-private")
+        self.assertEqual(row["pr_url"], "https://example.test/pr/1")
+        self.assertEqual(row["notes"], "created after migration")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add idempotent payout ledger column migration for nodes with older local SQLite schemas
- use explicit payout ledger column selection instead of `SELECT *`, so upgraded rows map correctly even when new columns were appended by `ALTER TABLE`
- closes #2731

## Validation
- `python -m pytest tests\test_payout_ledger_migration.py -q` => 2 passed
- `python -m py_compile payout_ledger.py tests\test_payout_ledger_migration.py`
- `git diff --check -- payout_ledger.py tests\test_payout_ledger_migration.py`
