### PR TITLE
docs: align signed transfer examples

### DIFF
--- a/API_WALKTHROUGH.md
+++ b/API_WALKTHROUGH.md
@@ -67,12 +67,14 @@ POST /wallet/transfer/signed
 
 ```json
 {
-  "from": "sender_wallet_id",
-  "to": "recipient_wallet_id",
-  "amount": 10,
-  "fee": 0.001,
-  "signature": "hex_encoded_signature",
-  "timestamp": 1234567890
+  "from_address": "RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "to_address": "RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "amount_rtc": 1.5,
+  "nonce": 12345,
+  "memo": "",
+  "public_key": "ed25519_public_key_hex",
+  "signature": "ed25519_signature_hex",
+  "chain_id": "rustchain-mainnet-v2"
 }
 ```
 
@@ -80,20 +82,22 @@ POST /wallet/transfer/signed
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `from` | string | Sender's RustChain wallet ID |
-| `to` | string | Recipient's RustChain wallet ID |
-| `amount` | integer | Amount in RTC (smallest unit) |
-| `fee` | float | Transaction fee |
-| `signature` | hex string | Ed25519 signature of the transfer payload |
-| `timestamp` | integer | Unix timestamp for replay protection |
+| `from_address` | string | Sender's `RTC...` address |
+| `to_address` | string | Recipient's `RTC...` address |
+| `amount_rtc` | number | Amount to transfer in RTC |
+| `nonce` | integer | Unique nonce for replay protection |
+| `memo` | string | Optional memo included in the signed payload |
+| `public_key` | hex string | Sender Ed25519 public key |
+| `signature` | hex string | Ed25519 signature over the canonical transfer payload |
+| `chain_id` | string | Chain identifier, usually `rustchain-mainnet-v2` |
 
 ### Important Notes
 
-1. **Wallet IDs are NOT external addresses** - RustChain uses its own wallet system (e.g., `Ivan-houzhiwen`), not Ethereum or Solana addresses.
+1. **Use RustChain addresses** - Signed transfers use `RTC...` wallet addresses, not miner IDs like `Ivan-houzhiwen` and not Ethereum or Solana addresses.
 
 2. **TLS certificates** - RustChain nodes use self-signed certificates. For production use, place the node's certificate at `~/.rustchain/node_cert.pem` and the `requests` library will automatically use it (default `verify=True`). For local testing with a self-signed certificate that is not pinned, you may temporarily set `verify=False` but be aware of MITM risks. The recommended pattern is to use the shared `tls_config` module from the RustChain codebase: `from node.tls_config import get_tls_session; session = get_tls_session()`.
 
-3. **Amount is in smallest unit** - 1 RTC = 1,000,000 smallest units.
+3. **Amount is human-readable RTC** - `amount_rtc` is the RTC amount, not the micro-RTC integer balance field.
 
 ---
 
@@ -112,12 +116,14 @@ print(f"Balance: {response.json()['amount_rtc']} RTC")
 
 # Transfer (requires signature)
 transfer_data = {
-    "from": "sender_wallet",
-    "to": "recipient_wallet",
-    "amount": 1000000,  # 1 RTC
-    "fee": 1000,
-    "signature": "...",
-    "timestamp": 1234567890
+    "from_address": "RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "to_address": "RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "amount_rtc": 1.0,
+    "nonce": 12345,
+    "memo": "",
+    "public_key": "ed25519_public_key_hex",
+    "signature": "ed25519_signature_hex",
+    "chain_id": "rustchain-mainnet-v2",
 }
 response = requests.post(
     "https://50.28.86.131/wallet/transfer/signed",
@@ -125,6 +131,8 @@ response = requests.post(
 )
 print(response.json())
 ```
+
+See `docs/API.md` for the full canonical signing rules.
 
 ---
 

--- a/docs/sprint/wallet-user-guide.md
+++ b/docs/sprint/wallet-user-guide.md
@@ -154,10 +154,14 @@ For programmatic use:
 curl -X POST https://rustchain.org/wallet/transfer/signed \
   -H "Content-Type: application/json" \
   -d '{
-    "from": "RTCa3f82...",
-    "to":   "RTCb9e71...",
-    "amount": 10.5,
-    "signature": "<signed-payload>"
+    "from_address": "RTCa3f82d9c1e4b07f5a2d6c8e9b0f1d3e2a4c5b7f8",
+    "to_address": "RTCb9e71c3d2f5a4e8b0c6d1f9a2e4b7c8d3f5a6e2",
+    "amount_rtc": 10.5,
+    "nonce": 12345,
+    "memo": "",
+    "public_key": "<ed25519-public-key-hex>",
+    "signature": "<ed25519-signature-hex>",
+    "chain_id": "rustchain-mainnet-v2"
   }'
 ```
 


### PR DESCRIPTION
## Summary
- updates the root API walkthrough signed-transfer request body to match the live `/wallet/transfer/signed` schema
- updates the sprint wallet guide programmatic transfer example to use `from_address`, `to_address`, `amount_rtc`, `nonce`, `public_key`, and `signature`
- clarifies that signed transfers use `RTC...` addresses and human-readable `amount_rtc`

## Validation
- `rg -n 'from|to|amount|fee|timestamp|from_address|amount_rtc|wallet/transfer/signed' API_WALKTHROUGH.md docs\\sprint\\wallet-user-guide.md`
- `git diff --check -- API_WALKTHROUGH.md docs\\sprint\\wallet-user-guide.md`

Refs #305