### PR TITLE
docs: align installer Python requirements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,26 +38,32 @@ This skips the interactive wallet prompt and uses the specified wallet name.
 - x86_64 (Intel/AMD 64-bit)
 - aarch64 (ARM64, e.g. Raspberry Pi)
 - ppc64le (PowerPC 64-bit Little-Endian)
-- ppc (PowerPC 32-bit)
+
+The one-line installer currently targets 64-bit Linux PowerPC (`ppc64le`). Legacy
+32-bit PowerPC systems may need a manual miner path instead of this installer.
 
 ### macOS
 - ✅ macOS 12 (Monterey) and later
 - ✅ macOS 11 (Big Sur) with limitations
 
+Big Sur support is limited to Intel and Apple Silicon Macs with a working Python
+3.8+ interpreter. Older PowerPC Mac OS X releases are not supported by the
+one-line installer because it creates a Python 3 virtualenv and runs modern
+Python miner code.
+
 **Architectures:**
 - arm64 (Apple Silicon M1/M2/M3)
 - x86_64 (Intel Mac)
-- powerpc (PowerPC G3/G4/G5)
 
 ### Special Hardware
 - ✅ IBM POWER8 systems
-- ✅ PowerPC G4/G5 Macs
+- ✅ 64-bit Linux PowerPC systems (`ppc64le`)
 - ✅ Vintage x86 CPUs (Pentium 4, Core 2 Duo, etc.)
 
 ## Requirements
 
 ### System Requirements
-- Python 3.8+ (or Python 2.5+ for vintage PowerPC systems)
+- Python 3.8+
 - curl or wget
 - 50 MB disk space
 - Internet connection


### PR DESCRIPTION
## Summary
- remove the conflicting Python 2.5 guidance from INSTALL.md
- document that the one-line installer requires Python 3.8+ and only supports macOS arm64/x86_64
- clarify that Linux PowerPC support is ppc64le, while 32-bit PowerPC needs a manual path outside this installer

Fixes #2703

## Verification
- rg confirmed stale Python 2.5 and macOS PowerPC architecture claims are gone from INSTALL.md
- git diff --check -- INSTALL.md
- bash -n install-miner.sh