### PR TITLE
fix: repair deprecated immutable patch proof loop

### DIFF
--- a/deprecated/patches/rustchain_v2_immutable_fixed.py
+++ b/deprecated/patches/rustchain_v2_immutable_fixed.py
@@ -86,8 +86,8 @@ class ImmutableRustChain:
         }
         
         # Proof of Work
-        while not block["hash"] := self._calculate_hash(block), \
-               block["hash"].startswith("0000"):
+        block["hash"] = self._calculate_hash(block)
+        while not block["hash"].startswith("0000"):
             block["nonce"] += 1
             block["hash"] = self._calculate_hash(block)
         


### PR DESCRIPTION
## Summary
- replace the invalid walrus/comma proof-of-work loop in `deprecated/patches/rustchain_v2_immutable_fixed.py`
- compute the initial block hash before looping and continue until it satisfies the existing `0000` prefix target

## Verification
- `python -m py_compile deprecated\patches\rustchain_v2_immutable_fixed.py`
- `git diff --check -- deprecated\patches\rustchain_v2_immutable_fixed.py`
- import smoke test instantiated `ImmutableRustChain` and mined one block with a `0000` hash prefix