### PR TITLE
fix: serialize drama arc creation

### DIFF
--- a/drama_arc_engine.py
+++ b/drama_arc_engine.py
@@ -27,6 +27,7 @@ Usage:
 
 import time
 import random
+import threading
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
@@ -175,6 +176,7 @@ class DramaArcEngine:
         self.rel_engine = relationship_engine
         self.auto_progress = auto_progress
         self._active_arcs: Dict[str, ArcStatus] = {}
+        self._arc_lock = threading.Lock()
         self._event_callbacks: List[Callable] = []
     
     def _get_arc_key(self, agent_a: str, agent_b: str) -> str:
@@ -233,49 +235,48 @@ class DramaArcEngine:
         Returns:
             Dictionary with arc initialization result
         """
-        # Idempotency check: if arc already exists for this pair, return existing
         arc_key = self._get_arc_key(agent_a, agent_b)
-        if arc_key in self._active_arcs:
-            existing = self._active_arcs[arc_key]
-            return {
-                "success": True,
-                "arc": existing.to_dict(),
-                "relationship": self.rel_engine.get_relationship(agent_a, agent_b),
-                "idempotent": True,
-            }
+        with self._arc_lock:
+            if arc_key in self._active_arcs:
+                existing = self._active_arcs[arc_key]
+                return {
+                    "success": True,
+                    "arc": existing.to_dict(),
+                    "relationship": self.rel_engine.get_relationship(agent_a, agent_b),
+                    "idempotent": True,
+                }
 
-                # Initialize relationship with arc
-        result = self.rel_engine.start_drama_arc(agent_a, agent_b, arc_type)
-        
-        if not result["success"]:
-            return result
-        
-        template = DRAMA_ARC_TEMPLATES[arc_type]
-        now = time.time()
-        
-        arc_status = ArcStatus(
-            agent_a=agent_a,
-            agent_b=agent_b,
-            arc_type=arc_type,
-            phase=ArcPhase.INITIATION,
-            start_time=now,
-            last_progress=now,
-            events_triggered=0,
-            expected_duration_days=template["typical_duration_days"],
-            is_expired=False,
-        )
-        
-        self._active_arcs[self._get_arc_key(agent_a, agent_b)] = arc_status
-        
-        # Notify callbacks
+            result = self.rel_engine.start_drama_arc(agent_a, agent_b, arc_type)
+            if not result["success"]:
+                return result
+
+            template = DRAMA_ARC_TEMPLATES[arc_type]
+            now = time.time()
+
+            arc_status = ArcStatus(
+                agent_a=agent_a,
+                agent_b=agent_b,
+                arc_type=arc_type,
+                phase=ArcPhase.INITIATION,
+                start_time=now,
+                last_progress=now,
+                events_triggered=0,
+                expected_duration_days=template["typical_duration_days"],
+                is_expired=False,
+            )
+
+            self._active_arcs[arc_key] = arc_status
+            relationship = result["relationship"]
+
+        # Notify callbacks outside the lock so callback code cannot block arc creation.
         self._notify_callbacks("arc_started", arc_status.to_dict())
-        
+
         return {
             "success": True,
             "arc": arc_status.to_dict(),
-            "relationship": result["relationship"],
+            "relationship": relationship,
         }
-    
+
     def progress_arc(self, agent_a: str, agent_b: str,
                     force_event: Optional[str] = None) -> Dict[str, Any]:
         """

--- a/tests/test_drama_arc_engine_concurrency.py
+++ b/tests/test_drama_arc_engine_concurrency.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+
+import threading
+import time
+
+from agent_relationships import DramaArcType
+from drama_arc_engine import DramaArcEngine
+
+
+class SlowRelationshipEngine:
+    def __init__(self):
+        self.start_count = 0
+        self.relationship = {
+            "agent_a": "alice",
+            "agent_b": "bob",
+            "arc_type": DramaArcType.FRIENDLY_RIVALRY.value,
+            "arc_start_time": time.time(),
+            "state": "rivals",
+            "tension_level": 10,
+            "trust_level": 50,
+        }
+
+    def start_drama_arc(self, agent_a, agent_b, arc_type):
+        time.sleep(0.02)
+        self.start_count += 1
+        return {"success": True, "relationship": dict(self.relationship)}
+
+    def get_relationship(self, agent_a, agent_b):
+        return dict(self.relationship)
+
+
+def test_start_arc_is_idempotent_under_concurrent_calls():
+    rel_engine = SlowRelationshipEngine()
+    engine = DramaArcEngine(rel_engine)
+    callbacks = []
+    barrier = threading.Barrier(8)
+    results = []
+
+    engine.register_callback(lambda event, payload: callbacks.append((event, payload)))
+
+    def start_same_arc():
+        barrier.wait()
+        results.append(
+            engine.start_arc("alice", "bob", DramaArcType.FRIENDLY_RIVALRY)
+        )
+
+    threads = [threading.Thread(target=start_same_arc) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(results) == 8
+    assert all(result["success"] for result in results)
+    assert rel_engine.start_count == 1
+    assert len(engine.get_all_active_arcs()) == 1
+    assert sum(1 for result in results if result.get("idempotent")) == 7
+    assert [event for event, _payload in callbacks] == ["arc_started"]


### PR DESCRIPTION
## Summary
- add a lock around DramaArcEngine.start_arc check-and-create logic
- keep idempotent existing-arc returns while making the check atomic under concurrent callers
- add a regression test where eight threads start the same arc and only one real start is allowed

Fixes #3198

## Verification
- python -m py_compile drama_arc_engine.py tests\test_drama_arc_engine_concurrency.py
- python -m pytest tests\test_drama_arc_engine_concurrency.py -q
- git diff --check -- drama_arc_engine.py tests\test_drama_arc_engine_concurrency.py