### PR TITLE
fix: guard VRF selection for zero weights

### DIFF
--- a/node/tests/test_vrf_zero_weight.py
+++ b/node/tests/test_vrf_zero_weight.py
@@ -1,0 +1,35 @@
+import os
+import sqlite3
+
+os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+os.environ.setdefault("DB_PATH", ":memory:")
+
+import integrated_node
+
+
+def _init_epoch_enroll(db_path, weight):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE epoch_enroll (epoch INTEGER, miner_pk TEXT, weight REAL)"
+        )
+        conn.execute(
+            "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+            (1, "miner-zero", weight),
+        )
+        conn.commit()
+
+
+def test_vrf_selection_returns_false_for_zero_total_weight(tmp_path, monkeypatch):
+    db_path = tmp_path / "zero_weight.db"
+    _init_epoch_enroll(db_path, 0.0)
+    monkeypatch.setitem(integrated_node.vrf_is_selected.__globals__, "DB_PATH", str(db_path))
+
+    assert integrated_node.vrf_is_selected("miner-zero", 144) is False
+
+
+def test_vrf_selection_returns_false_for_sub_fixed_point_total_weight(tmp_path, monkeypatch):
+    db_path = tmp_path / "sub_fixed_point_weight.db"
+    _init_epoch_enroll(db_path, 0.0000000001)
+    monkeypatch.setitem(integrated_node.vrf_is_selected.__globals__, "DB_PATH", str(db_path))
+
+    assert integrated_node.vrf_is_selected("miner-zero", 144) is False

--- a/node/tests/test_vrf_zero_weight.py
+++ b/node/tests/test_vrf_zero_weight.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sqlite3
 


### PR DESCRIPTION
Fixes a remaining zero-weight eligibility crash related to issue #3196.

Summary:
- vrf_is_selected now treats zero, negative, or sub-micro total enrollment weight as no eligible participant and returns False.
- normalizes missing enrollment weights before the deterministic cumulative selection loop.
- adds regression coverage for exactly zero and sub-micro weights, both of which previously made the modulo divisor zero.

Validation:
- python -m pytest node\\tests\\test_vrf_zero_weight.py -q passed, 2 tests.
- python -m py_compile node\\rustchain_v2_integrated_v2.2.1_rip200.py node\\tests\\test_vrf_zero_weight.py passed.
- git diff --check -- node\\rustchain_v2_integrated_v2.2.1_rip200.py node\\tests\\test_vrf_zero_weight.py passed.

Additional check:
- python -m pytest node\\tests\\test_rip309_fingerprint_rotation.py -q reaches expected assertions but fails on Windows temp SQLite cleanup with PermissionError while deleting db files. This appears to be the existing Windows cleanup issue in that test file, not a regression from this PR.