### PR TITLE
fix: use constant-time api nodes admin check

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5429,7 +5429,7 @@ def api_nodes():
     def _is_admin() -> bool:
         need = os.environ.get("RC_ADMIN_KEY", "")
         got = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-        return bool(need and got and need == got)
+        return bool(need and got and hmac.compare_digest(need, got))
 
     def _should_redact_url(u: str) -> bool:
         try:

--- a/node/tests/test_api_nodes_admin_compare.py
+++ b/node/tests/test_api_nodes_admin_compare.py
@@ -1,0 +1,64 @@
+import os
+import sqlite3
+
+os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+os.environ.setdefault("DB_PATH", ":memory:")
+
+import integrated_node
+
+
+def _init_node_registry(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE node_registry (
+                node_id TEXT,
+                wallet_address TEXT,
+                url TEXT,
+                name TEXT,
+                registered_at INTEGER,
+                is_active INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO node_registry
+            (node_id, wallet_address, url, name, registered_at, is_active)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            ("node-1", "RTC_wallet", "http://127.0.0.1:9000", "local", 123, 1),
+        )
+        conn.commit()
+
+
+def test_api_nodes_admin_check_uses_constant_time_compare(tmp_path, monkeypatch):
+    db_path = tmp_path / "nodes.db"
+    _init_node_registry(db_path)
+    api_nodes_globals = integrated_node.api_nodes.__globals__
+    monkeypatch.setitem(api_nodes_globals, "DB_PATH", str(db_path))
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key-0000000000000000")
+
+    calls = []
+    real_compare_digest = api_nodes_globals["hmac"].compare_digest
+
+    def tracking_compare_digest(expected, provided):
+        calls.append((expected, provided))
+        return real_compare_digest(expected, provided)
+
+    monkeypatch.setattr(api_nodes_globals["hmac"], "compare_digest", tracking_compare_digest)
+
+    client = api_nodes_globals["app"].test_client()
+    response = client.get("/api/nodes", headers={"X-Admin-Key": "wrong-admin-key"})
+    assert response.status_code == 200
+    assert calls == [("test-admin-key-0000000000000000", "wrong-admin-key")]
+
+    calls.clear()
+    response = client.get(
+        "/api/nodes",
+        headers={"X-Admin-Key": "test-admin-key-0000000000000000"},
+    )
+    assert response.status_code == 200
+    assert calls == [
+        ("test-admin-key-0000000000000000", "test-admin-key-0000000000000000")
+    ]


### PR DESCRIPTION
Security hardening for the integrated /api/nodes admin path.

Summary:
- Replaces the timing-unsafe 
eed == got admin key comparison inside /api/nodes with hmac.compare_digest().
- Adds a route-level regression test that verifies both invalid and valid admin headers go through the constant-time comparison helper.

Validation:
- python -m pytest node\\tests\\test_api_nodes_admin_compare.py -q passed, 1 test.
- python -m py_compile node\\rustchain_v2_integrated_v2.2.1_rip200.py node\\tests\\test_api_nodes_admin_compare.py passed.
- git diff --check -- node\\rustchain_v2_integrated_v2.2.1_rip200.py node\\tests\\test_api_nodes_admin_compare.py passed.