### PR TITLE
docs: fix dynamic category badge snippets

### DIFF
--- a/.github/scripts/generate_dynamic_badges.py
+++ b/.github/scripts/generate_dynamic_badges.py
@@ -16,9 +16,7 @@ Badge types:
     - total_bounties.json     — Total bounties paid out
     - weekly_growth.json      — Weekly growth percentage
     - top_hunters.json        — Top 3 bounty hunters summary
-    - category_docs.json      — Documentation bounties count
-    - category_outreach.json  — Outreach/community bounties count
-    - category_bugs.json      — Bug bounties count
+    - category_<name>.json    — Per-category bounty count for categories in data
     - hunter_<slug>.json      — Per-hunter badge (collision-safe slug)
 """
 

--- a/docs/DYNAMIC_BADGES_V2.md
+++ b/docs/DYNAMIC_BADGES_V2.md
@@ -29,10 +29,12 @@ Add any of these to your `README.md`:
 
 ## Category Badges
 
+Category badges are generated for categories present in the current bounty data.
+Check `.github/badges/manifest.json` for the generated `category_<name>.json`
+files before embedding one.
+
 ```markdown
-![Docs Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_docs.json)
-![Bug Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_bugs.json)
-![Outreach](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_outreach.json)
+![Feature Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_feature.json)
 ```
 
 ## Per-Hunter Badge


### PR DESCRIPTION
Refs #305.

## Summary
- replace broken category badge snippets in `docs/DYNAMIC_BADGES_V2.md` with the generated category badge currently present in the manifest
- clarify that category badges are emitted only for categories present in the current bounty data
- align the badge generator docstring with the dynamic `category_<name>.json` output

## Bug
The dynamic badge docs currently point users to category badge endpoints that do not exist on `main`:

- `category_docs.json` returns 404
- `category_bugs.json` returns 404
- `category_outreach.json` returns 404

The current manifest lists `category_feature.json`, and that raw badge endpoint returns 200.

## Verification
- `curl -sSIL -o /dev/null -w 'category_docs %{http_code}\\n' https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_docs.json` -> 404\n- `curl -sSIL -o /dev/null -w 'category_bugs %{http_code}\\n' https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_bugs.json` -> 404\n- `curl -sSIL -o /dev/null -w 'category_outreach %{http_code}\\n' https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_outreach.json` -> 404\n- `curl -sSIL -o /dev/null -w 'category_feature %{http_code}\\n' https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_feature.json` -> 200\n- `python3 -m py_compile .github/scripts/generate_dynamic_badges.py`\n- `git diff --check -- docs/DYNAMIC_BADGES_V2.md .github/scripts/generate_dynamic_badges.py`