### PR TITLE
fix: make P2P gossip dedup insert atomic

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -455,7 +455,7 @@ class GossipLayer:
         mode = self._signing_mode
 
         from p2p_identity import unpack_signature, verify_ed25519
-        hmac_sig, ed25519_sig = unpack_signature(signature)
+        hmac_sig, ed25519_sig, _key_version = unpack_signature(signature)
 
         # "strict" mode: only Ed25519 accepted. HMAC-only sigs are rejected
         # even if valid (flag-day enforcement).
@@ -538,7 +538,7 @@ class GossipLayer:
         mode = self._signing_mode
 
         from p2p_identity import unpack_signature, verify_ed25519
-        hmac_sig, ed25519_sig = unpack_signature(msg.signature)
+        hmac_sig, ed25519_sig, _key_version = unpack_signature(msg.signature)
 
         # 1) Try Ed25519 if available AND peer is registered.
         if ed25519_sig and self._peer_registry is not None:
@@ -605,14 +605,20 @@ class GossipLayer:
         # Record as seen (Issue #2271: Persistent storage)
         try:
             with sqlite3.connect(self.db_path) as conn:
-                conn.execute("INSERT OR IGNORE INTO p2p_seen_messages (msg_id, ts) VALUES (?, ?)", 
-                             (msg.msg_id, int(time.time())))
+                now = int(time.time())
+                conn.execute("INSERT OR IGNORE INTO p2p_seen_messages (msg_id, ts) VALUES (?, ?)",
+                             (msg.msg_id, now))
+                if conn.execute("SELECT changes()").fetchone()[0] == 0:
+                    return {"status": "duplicate"}
                 # Prune old messages (> 1 hour)
-                conn.execute("DELETE FROM p2p_seen_messages WHERE ts < ?", (int(time.time()) - 3600,))
+                conn.execute("DELETE FROM p2p_seen_messages WHERE ts < ?", (now - 3600,))
                 conn.commit()
         except Exception as e:
             logger.error(f"P2P save seen DB error: {e}")
-            self.seen_messages.add(msg.msg_id)
+            with self.lock:
+                if self.seen_messages.contains(msg.msg_id):
+                    return {"status": "duplicate"}
+                self.seen_messages.add(msg.msg_id)
 
         # TTLCache handles automatic eviction (TTL + LRU)
 

--- a/node/tests/test_p2p_hardening_phase2.py
+++ b/node/tests/test_p2p_hardening_phase2.py
@@ -81,6 +81,31 @@ def test_phase_a_old_payload_voter_spoof_still_blocked():
     assert result.get("reason") == "voter_identity_mismatch"
 
 
+def test_p2p_dedup_insert_race_returns_duplicate():
+    """A concurrent handler winning the insert after precheck must stop processing."""
+    target = _mk_layer("node1", {"node2": "http://n2"})
+    sender = _mk_layer("node2", db_path=target.db_path)
+    sender.broadcast = lambda *args, **kwargs: None
+
+    msg = sender.create_message(mod.MessageType.PING, {"ping": 1})
+    original_verify = target.verify_message
+
+    def racing_verify(message):
+        verified = original_verify(message)
+        with sqlite3.connect(target.db_path) as conn:
+            conn.execute(
+                "INSERT OR IGNORE INTO p2p_seen_messages (msg_id, ts) VALUES (?, ?)",
+                (message.msg_id, int(time.time())),
+            )
+        return verified
+
+    target.verify_message = racing_verify
+
+    result = target.handle_message(msg)
+    assert result["status"] == "duplicate"
+    assert "pong" not in result
+
+
 # Phase B regression
 def test_phase_b_rr_delegate_gate_rejects_non_leader():
     """Phase B: only the scheduled RR-delegate can propose for an epoch."""


### PR DESCRIPTION
## Summary
- make the post-verification `p2p_seen_messages` insert the authoritative duplicate gate
- return `duplicate` when `INSERT OR IGNORE` reports zero changed rows, preventing TOCTOU duplicate processing
- make the in-memory fallback duplicate check/add atomic under `self.lock`
- update P2P gossip signature callers to ignore the current `unpack_signature()` key-version return value
- add a regression test that simulates another handler winning the insert after the early precheck but before message processing

Fixes #4265.

## Validation
- `python -m pytest node\tests\test_p2p_hardening_phase2.py -q` -> 7 passed
- `python -m pytest node\tests\test_p2p_identity_hardening.py -q` -> 3 passed
- `python -m py_compile node\rustchain_p2p_gossip.py node\tests\test_p2p_hardening_phase2.py` -> passed
- `git diff --check -- node\rustchain_p2p_gossip.py node\tests\test_p2p_hardening_phase2.py` -> passed

## Known unrelated baseline failure
- `python -m pytest node\tests\test_p2p_phase_f_ed25519.py -q` still fails on current main because the tests expect the old two-value/no-version `unpack_signature()` shape and one file-mode assertion observes `0o666`; this PR updates the production gossip caller but does not rewrite that broader Phase F test suite.