### PR TITLE
fix: remove invalid python escape warnings

### DIFF
--- a/miners/power8/fingerprint_checks_power8.py
+++ b/miners/power8/fingerprint_checks_power8.py
@@ -169,7 +169,7 @@ def check_simd_identity() -> Tuple[bool, Dict]:
     if not flags and ("ppc" in arch or "power" in arch):
         try:
             result = subprocess.run(
-                ["grep", "-i", "vsx\|altivec\|dfp", "/proc/cpuinfo"],
+                ["grep", "-i", r"vsx\|altivec\|dfp", "/proc/cpuinfo"],
                 capture_output=True, text=True, timeout=5
             )
             if result.stdout:

--- a/miners/windows/installer/src/config_manager.py
+++ b/miners/windows/installer/src/config_manager.py
@@ -1,4 +1,4 @@
-"""
+r"""
 RustChain Config Manager
 Manages configuration between the installer and the miner.
 Config file location: %APPDATA%\RustChain\config.json

--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -104,7 +104,7 @@ class BountyVerifier:
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
         report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
-        report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
+        report += f"| Wallet `{wallet}` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
             # Mock content fetch


### PR DESCRIPTION
Refs #305.

## Summary
- remove invalid escape sequences from three Python files that emit `SyntaxWarning` during compilation
- keep the generated markdown text and grep pattern behavior unchanged
- mark the Windows config-manager docstring as raw so the documented Windows path is not parsed as Python escapes

## Bug
Running Python compilation on these files emits invalid escape warnings:

- `tools/bounty-bot-pro/verifier.py`: `\`` in an f-string markdown cell
- `miners/power8/fingerprint_checks_power8.py`: `\|` in the grep pattern string
- `miners/windows/installer/src/config_manager.py`: `\R` in the Windows path inside the module docstring

These warnings are easy to miss today, but they are Python parser warnings and can become hard failures under stricter warning settings or future Python versions.

## Verification
- `python3 -W error::SyntaxWarning -m py_compile tools/bounty-bot-pro/verifier.py miners/power8/fingerprint_checks_power8.py miners/windows/installer/src/config_manager.py`
- `python3 -m compileall -f -q tools/bounty-bot-pro/verifier.py miners/power8/fingerprint_checks_power8.py miners/windows/installer/src/config_manager.py`
- `git diff --check -- tools/bounty-bot-pro/verifier.py miners/power8/fingerprint_checks_power8.py miners/windows/installer/src/config_manager.py`