### PR TITLE
fix: handle broken article links in bounty verifier

### DIFF
--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -107,8 +107,11 @@ class BountyVerifier:
         report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
-            # Mock content fetch
-            article_status = "✅ Live" if requests.head(article_url).status_code == 200 else "❌ Broken"
+            try:
+                article_resp = requests.head(article_url, allow_redirects=True, timeout=10)
+                article_status = "✅ Live" if article_resp.status_code == 200 else "❌ Broken"
+            except requests.RequestException:
+                article_status = "❌ Broken"
             report += f"| Article link | {article_status} |\n"
             
         report += f"\n**Suggested payout**: **{payout} RTC**\n"


### PR DESCRIPTION
Refs #305.

## Summary
- add a timeout to the bounty verifier article-link HEAD request
- follow redirects while checking article links
- treat network failures as a broken article link instead of crashing report generation

## Bug
`BountyVerifier.generate_report(..., article_url=...)` currently calls `requests.head(article_url)` without a timeout or `RequestException` handling. A refused connection, DNS failure, invalid URL, or slow endpoint can raise out of report generation or hang the verifier instead of recording the article as broken.

## Verification
- `python3 -m py_compile tools/bounty-bot-pro/verifier.py`
- `python3 - <<'PY'\nimport ast\nfrom pathlib import Path\nast.parse(Path("tools/bounty-bot-pro/verifier.py").read_text())\nprint("parsed")\nPY`\n- `git diff --check -- tools/bounty-bot-pro/verifier.py`\n\nNote: this branch is based on `origin/main`, so it still shows the pre-existing invalid-backtick SyntaxWarning that PR #4268 fixes separately. This PR is scoped only to the article-link request failure path.