### PR TITLE
fix: guard bounty verifier star lookup errors

### DIFF
--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -95,15 +95,16 @@ class BountyVerifier:
         follows = self.verify_following(username)
         wallet_info = self.verify_wallet(wallet)
         
-        payout = stars["count"] * CONFIG["star_reward"]
+        star_count = stars.get("count", 0)
+        payout = star_count * CONFIG["star_reward"]
         if follows: payout += CONFIG["follow_reward"]
-        if stars["is_star_king"]: payout += CONFIG["star_king_bonus"]
+        if stars.get("is_star_king", False): payout += CONFIG["star_king_bonus"]
         
         report = f"## 🤖 Automated Verification for @{username}\n\n"
         report += "| Check | Result |\n"
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
-        report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
+        report += f"| {CONFIG['org']} repos starred | {star_count} |\n"
         report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:


### PR DESCRIPTION
Refs #305.

## Summary
- avoid a `KeyError` when GitHub star lookup fails and `verify_stars()` returns an error payload
- compute payout/report output from a safe `star_count` fallback
- only award the star-king bonus when `is_star_king` is explicitly true

## Bug
`verify_stars()` returns `{ "error": ..., "count": 0 }` on `GithubException`, but `generate_report()` unconditionally reads `stars["is_star_king"]`. If GitHub lookup fails for a missing user, auth/rate-limit issue, or transient API error, the full verification report crashes with `KeyError` instead of producing a zero-star report.

## Verification
- `python3 -m py_compile tools/bounty-bot-pro/verifier.py`
- `git diff --check -- tools/bounty-bot-pro/verifier.py`

Note: this branch is based on `origin/main`, so it still shows the pre-existing invalid-backtick SyntaxWarning that PR #4268 fixes separately. This PR is scoped only to the star lookup error path.