### PR TITLE
fix: encode wallet balance query parameter

### DIFF
--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -7,6 +7,7 @@ import time
 import requests
 import yaml
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlencode
 from github import Github, GithubException
 import google.generativeai as genai
 from dotenv import load_dotenv
@@ -57,8 +58,9 @@ class BountyVerifier:
     def verify_wallet(self, wallet_name: str) -> Dict[str, Any]:
         """Check wallet existence and balance on RustChain node."""
         try:
+            query = urlencode({"miner_id": wallet_name})
             resp = requests.get(
-                f"{CONFIG['miner_node_url']}/wallet/balance?miner_id={wallet_name}",
+                f"{CONFIG['miner_node_url']}/wallet/balance?{query}",
                 verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True,
                 timeout=10
             )


### PR DESCRIPTION
Refs #305.

## Summary
- URL-encode the `miner_id` query parameter before calling `/wallet/balance`
- preserve the existing timeout and TLS verification behavior

## Bug
`verify_wallet()` interpolated `wallet_name` directly into the query string:

```py
/wallet/balance?miner_id={wallet_name}
```

Wallet/miner IDs containing spaces, `+`, `#`, `&`, or `=` are then sent as a different query than intended. For example, `miner one#x&admin=true` becomes a fragment/additional parameter instead of a single `miner_id` value.

## Verification
- `python3 -m py_compile tools/bounty-bot-pro/verifier.py`
- `python3 - <<'PY'\nfrom urllib.parse import urlencode\nwallet = "miner one#x&admin=true"\nprint("/wallet/balance?" + urlencode({"miner_id": wallet}))\nPY`\n- `git diff --check -- tools/bounty-bot-pro/verifier.py`\n\nNote: this branch is based on `origin/main`, so it still shows the pre-existing invalid-backtick SyntaxWarning that PR #4268 fixes separately. This PR is scoped only to wallet query encoding.