### PR TITLE
fix: rate limit public miners endpoint

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2662,6 +2662,8 @@ ATTEST_IP_LIMIT = 15      # Max unique miners per IP per hour
 ATTEST_IP_WINDOW = 3600  # 1 hour window
 ATTEST_CHALLENGE_IP_LIMIT = int(os.environ.get("ATTEST_CHALLENGE_IP_LIMIT", "10"))
 ATTEST_CHALLENGE_IP_WINDOW = int(os.environ.get("ATTEST_CHALLENGE_IP_WINDOW", "60"))
+API_MINERS_RATE_LIMIT = 100
+API_MINERS_RATE_WINDOW = 60
 
 
 def check_challenge_rate_limit(client_ip):
@@ -2737,6 +2739,69 @@ def check_ip_rate_limit(client_ip, miner_id):
             return False, f"ip_rate_limit:{unique_count}_miners_from_same_ip"
     
     return True, "ok"
+
+
+def check_api_miners_rate_limit(client_ip, now_ts=None):
+    """Rate limit public miner enumeration by source IP using SQLite."""
+    now = int(time.time()) if now_ts is None else int(now_ts)
+    cutoff = now - API_MINERS_RATE_WINDOW
+
+    with sqlite3.connect(DB_PATH, timeout=3) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS api_miners_rate_limit (
+                client_ip TEXT NOT NULL,
+                ts INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_api_miners_rate_limit_ip_ts "
+            "ON api_miners_rate_limit(client_ip, ts)"
+        )
+        conn.execute("DELETE FROM api_miners_rate_limit WHERE ts < ?", (cutoff,))
+
+        current_count = conn.execute(
+            "SELECT COUNT(*) FROM api_miners_rate_limit WHERE client_ip = ? AND ts >= ?",
+            (client_ip, cutoff),
+        ).fetchone()[0]
+
+        if current_count >= API_MINERS_RATE_LIMIT:
+            oldest = conn.execute(
+                "SELECT MIN(ts) FROM api_miners_rate_limit WHERE client_ip = ? AND ts >= ?",
+                (client_ip, cutoff),
+            ).fetchone()[0]
+            retry_after = max(1, (oldest + API_MINERS_RATE_WINDOW) - now) if oldest else API_MINERS_RATE_WINDOW
+            return False, {
+                "limit": API_MINERS_RATE_LIMIT,
+                "remaining": 0,
+                "reset": now + retry_after,
+                "retry_after": retry_after,
+            }
+
+        conn.execute(
+            "INSERT INTO api_miners_rate_limit (client_ip, ts) VALUES (?, ?)",
+            (client_ip, now),
+        )
+        conn.commit()
+
+    remaining = max(0, API_MINERS_RATE_LIMIT - current_count - 1)
+    return True, {
+        "limit": API_MINERS_RATE_LIMIT,
+        "remaining": remaining,
+        "reset": now + API_MINERS_RATE_WINDOW,
+        "retry_after": 0,
+    }
+
+
+def add_rate_limit_headers(response, info):
+    """Attach standard rate-limit metadata to a Flask response."""
+    response.headers["X-RateLimit-Limit"] = str(info["limit"])
+    response.headers["X-RateLimit-Remaining"] = str(info["remaining"])
+    response.headers["X-RateLimit-Reset"] = str(info["reset"])
+    if info.get("retry_after"):
+        response.headers["Retry-After"] = str(info["retry_after"])
+    return response
 
 
 def check_vm_signatures_server_side(device: dict, signals: dict) -> tuple:
@@ -5665,6 +5730,16 @@ def api_miners():
     """
     import time as _time
     now = int(_time.time())
+    client_ip = client_ip_from_request(request)
+    rate_ok, rate_info = check_api_miners_rate_limit(client_ip, now_ts=now)
+    if not rate_ok:
+        response = jsonify({
+            "ok": False,
+            "error": "rate_limited",
+            "limit": f"{API_MINERS_RATE_LIMIT}/{API_MINERS_RATE_WINDOW}s",
+        })
+        add_rate_limit_headers(response, rate_info)
+        return response, 429
     
     # Pagination args
     try:
@@ -5736,7 +5811,7 @@ def api_miners():
                 "antiquity_multiplier": mult
             })
     
-    return jsonify({
+    response = jsonify({
         "miners": miners,
         "pagination": {
             "total": total_count,
@@ -5745,6 +5820,8 @@ def api_miners():
             "count": len(miners)
         }
     })
+    add_rate_limit_headers(response, rate_info)
+    return response
 
 
 def _explorer_int_arg(name, default, minimum, maximum):

--- a/node/tests/test_api_miners_rate_limit.py
+++ b/node/tests/test_api_miners_rate_limit.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestApiMinersRateLimit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "api_miners.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        if "integrated_node" in sys.modules:
+            cls.mod = sys.modules["integrated_node"]
+        else:
+            spec = importlib.util.spec_from_file_location("integrated_node", MODULE_PATH)
+            cls.mod = importlib.util.module_from_spec(spec)
+            sys.modules["integrated_node"] = cls.mod
+            spec.loader.exec_module(cls.mod)
+
+        cls._prev_module_db_path = getattr(cls.mod, "DB_PATH", None)
+        cls.mod.DB_PATH = os.environ["RUSTCHAIN_DB_PATH"]
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        if cls._prev_module_db_path is not None:
+            cls.mod.DB_PATH = cls._prev_module_db_path
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.mod.API_MINERS_RATE_LIMIT = 2
+        self.mod.API_MINERS_RATE_WINDOW = 60
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute("DROP TABLE IF EXISTS api_miners_rate_limit")
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS miner_attest_recent "
+                "(miner TEXT PRIMARY KEY, ts_ok INTEGER, device_family TEXT, "
+                "device_arch TEXT, entropy_score REAL)"
+            )
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS miner_attest_history "
+                "(miner TEXT, ts_ok INTEGER)"
+            )
+
+    def test_api_miners_returns_429_after_ip_limit(self):
+        for _ in range(2):
+            resp = self.client.get("/api/miners", environ_base={"REMOTE_ADDR": "203.0.113.10"})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers["X-RateLimit-Limit"], "2")
+
+        resp = self.client.get("/api/miners", environ_base={"REMOTE_ADDR": "203.0.113.10"})
+        self.assertEqual(resp.status_code, 429)
+        self.assertEqual(resp.get_json()["error"], "rate_limited")
+        self.assertEqual(resp.headers["X-RateLimit-Remaining"], "0")
+        self.assertIn("Retry-After", resp.headers)
+
+    def test_api_miners_rate_limit_is_per_ip(self):
+        for _ in range(2):
+            resp = self.client.get("/api/miners", environ_base={"REMOTE_ADDR": "203.0.113.10"})
+            self.assertEqual(resp.status_code, 200)
+
+        resp = self.client.get("/api/miners", environ_base={"REMOTE_ADDR": "203.0.113.11"})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers["X-RateLimit-Remaining"], "1")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import json
+import sqlite3
 from unittest.mock import patch, MagicMock
 import sys
 from pathlib import Path
@@ -65,7 +66,9 @@ def test_api_epoch_admin_sees_full_payload(client):
 
 def test_api_miners_requires_auth(client):
     """Unauthenticated /api/miners endpoint should still return data (no auth required)."""
-    with patch('sqlite3.connect') as mock_connect:
+    rate_info = {"limit": 100, "remaining": 99, "reset": 0, "retry_after": 0}
+    with patch('integrated_node.check_api_miners_rate_limit', return_value=(True, rate_info)), \
+         patch('sqlite3.connect') as mock_connect:
         import sqlite3 as _sqlite3
         mock_conn = mock_connect.return_value.__enter__.return_value
         mock_conn.row_factory = _sqlite3.Row
@@ -82,6 +85,54 @@ def test_api_miners_requires_auth(client):
 
         response = client.get('/api/miners')
         assert response.status_code == 200
+
+
+def _init_api_miners_db(path):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS miner_attest_recent "
+            "(miner TEXT PRIMARY KEY, ts_ok INTEGER, device_family TEXT, "
+            "device_arch TEXT, entropy_score REAL)"
+        )
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS miner_attest_history "
+            "(miner TEXT, ts_ok INTEGER)"
+        )
+
+
+def test_api_miners_returns_429_after_ip_limit(client, monkeypatch, tmp_path):
+    db_path = tmp_path / "api_miners_rate_limit.db"
+    _init_api_miners_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "API_MINERS_RATE_LIMIT", 2)
+    monkeypatch.setattr(integrated_node, "API_MINERS_RATE_WINDOW", 60)
+
+    for _ in range(2):
+        response = client.get('/api/miners', environ_base={"REMOTE_ADDR": "203.0.113.10"})
+        assert response.status_code == 200
+        assert response.headers["X-RateLimit-Limit"] == "2"
+
+    response = client.get('/api/miners', environ_base={"REMOTE_ADDR": "203.0.113.10"})
+    assert response.status_code == 429
+    assert response.get_json()["error"] == "rate_limited"
+    assert response.headers["X-RateLimit-Remaining"] == "0"
+    assert "Retry-After" in response.headers
+
+
+def test_api_miners_rate_limit_is_per_ip(client, monkeypatch, tmp_path):
+    db_path = tmp_path / "api_miners_per_ip.db"
+    _init_api_miners_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "API_MINERS_RATE_LIMIT", 2)
+    monkeypatch.setattr(integrated_node, "API_MINERS_RATE_WINDOW", 60)
+
+    for _ in range(2):
+        response = client.get('/api/miners', environ_base={"REMOTE_ADDR": "203.0.113.10"})
+        assert response.status_code == 200
+
+    response = client.get('/api/miners', environ_base={"REMOTE_ADDR": "203.0.113.11"})
+    assert response.status_code == 200
+    assert response.headers["X-RateLimit-Remaining"] == "1"
 
 
 def test_api_miner_attestations_requires_admin(client):


### PR DESCRIPTION
## Summary
- add a SQLite-backed per-IP sliding-window limiter for the public `/api/miners` endpoint
- return `429 rate_limited` with `Retry-After` and `X-RateLimit-*` headers before running miner enumeration once the IP exceeds `100/60s`
- keep rate-limit records shared across workers through the node DB rather than per-process memory
- add regression coverage for the limit and for per-IP isolation

Fixes #2749.

## Validation
- `python -m pytest node\tests\test_api_miners_rate_limit.py -q` -> 2 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_api_miners_rate_limit.py` -> passed
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_api_miners_rate_limit.py` -> passed

## Known unrelated baseline drift
- `python -m pytest node\tests\test_public_api_disclosure.py -q` fails on current `origin/main` before this patch. The failures are stale expectations around `/api/miners` and `/wallet/history` response shape plus mocked SQLite rows, not the new rate-limit behavior. This PR uses a dedicated temporary SQLite DB test for the changed endpoint behavior.