### PR TITLE
fix: preserve vintage evidence warnings

### DIFF
--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -62,8 +62,9 @@ class SubmissionValidator:
         # - Image content (machine + monitor)
         # - Metadata consistency
         
-        result["status"] = "PASS"
-        result["message"] = "Photo file exists and appears valid"
+        if result["status"] != "WARN":
+            result["status"] = "PASS"
+            result["message"] = "Photo file exists and appears valid"
         result["checks"] = {
             "file_exists": True,
             "file_size_bytes": file_size,
@@ -91,8 +92,9 @@ class SubmissionValidator:
             result["status"] = "WARN"
             result["message"] = f"Screenshot file seems too small: {file_size} bytes"
         
-        result["status"] = "PASS"
-        result["message"] = "Screenshot file exists"
+        if result["status"] != "WARN":
+            result["status"] = "PASS"
+            result["message"] = "Screenshot file exists"
         result["checks"] = {
             "file_exists": True,
             "file_size_bytes": file_size


### PR DESCRIPTION
Refs #305.

## Summary
- preserve `WARN` status for unusually small vintage photo evidence
- preserve `WARN` status for unusual photo formats
- preserve `WARN` status for unusually small screenshots

## Bug
`validate_photo()` and `validate_screenshot()` set `result["status"] = "WARN"` for suspicious evidence, but then unconditionally overwrite the result with `PASS` before returning. This hides weak evidence from the validation report.

## Verification
- `python3 -m py_compile tools/validate_vintage_submission.py`
- smoke test with a 1-byte `.jpg` now returns `WARN Photo file seems too small: 1 bytes`
- `git diff --check -- tools/validate_vintage_submission.py`