### PR TITLE
fix: preserve initial offline miner state

### DIFF
--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -225,7 +225,13 @@ class AlertDB:
             cur.execute("""
                 INSERT INTO miner_state (miner_id, last_attest, balance_rtc, is_online, last_checked)
                 VALUES (?, ?, ?, ?, ?)
-            """, (miner_id, last_attest or 0, balance_rtc or 0, is_online or 1, now))
+            """, (
+                miner_id,
+                last_attest if last_attest is not None else 0,
+                balance_rtc if balance_rtc is not None else 0,
+                is_online if is_online is not None else 1,
+                now,
+            ))
         else:
             updates = ["last_checked = ?"]
             params = [now]


### PR DESCRIPTION
Refs #305.

## Summary
- preserve explicit zero values when inserting the first `miner_state` row
- keep default values only for `None` inputs

## Bug
`AlertDB.update_miner_state()` used `is_online or 1` during the initial insert. Passing `is_online=0` therefore stored `1`, so a miner first recorded as offline/failed was saved as online. The same truthiness pattern also treated explicit zero `last_attest` and `balance_rtc` as defaults.

## Verification
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py`
- DB smoke test with dependency stubs: `update_miner_state("miner-offline", is_online=0)` now stores `0`
- `git diff --check -- tools/miner_alerts/miner_alerts.py`