### PR TITLE
fix: revalidate webhook urls before delivery

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -260,6 +260,12 @@ def _sign_payload(payload_bytes: bytes, secret: str) -> str:
 
 def deliver_webhook(sub: Subscriber, event: WebhookEvent, store: SubscriberStore):
     """POST the event payload to the subscriber URL with retry + backoff."""
+    validation_error = validate_webhook_url(sub.url)
+    if validation_error:
+        log.warning("Skipping webhook delivery to %s: %s", sub.url, validation_error)
+        store.log_delivery(sub.id, event.event_type, "", None, 0, validation_error)
+        return
+
     payload = json.dumps({
         "event": event.event_type,
         "timestamp": event.timestamp,


### PR DESCRIPTION
Refs #305.

## Summary
- re-run webhook URL validation immediately before delivery
- skip and log delivery attempts whose current DNS resolution is blocked

## Bug
Webhook URLs are validated before storage, but delivery later calls `requests.post(sub.url, ...)` directly. If a hostname resolves to a public address during subscription and later changes to localhost/private/link-local metadata space, delivery can still POST to the new internal target. Revalidating at send time closes that DNS-rebinding window.

## Verification
- `python3 -m py_compile tools/webhooks/webhook_server.py`
- dependency-stub smoke check: `validate_webhook_url("http://127.0.0.1:5000")` returns `url resolves to a blocked address (127.0.0.1)`
- `git diff --check -- tools/webhooks/webhook_server.py`