### PR TITLE
fix: handle empty webhook poller lists

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -383,7 +383,7 @@ class RustChainPoller:
 
     def _check_miners(self):
         miners_data = self._get("/api/miners")
-        if not miners_data or not isinstance(miners_data, list):
+        if miners_data is None or not isinstance(miners_data, list):
             return
         current_miners = {m["miner"] for m in miners_data if "miner" in m}
 
@@ -415,7 +415,7 @@ class RustChainPoller:
 
     def _check_large_tx(self):
         balances_data = self._get("/api/balances")
-        if not balances_data or not isinstance(balances_data, list):
+        if balances_data is None or not isinstance(balances_data, list):
             return
 
         current_balances: Dict[str, float] = {}


### PR DESCRIPTION
Refs #305.

## Summary
- distinguish failed/non-list poll responses from valid empty lists
- allow `/api/miners` returning `[]` to emit `miner_left` events for previously seen miners
- allow `/api/balances` returning `[]` to clear the balance snapshot instead of preserving stale balances

## Bug
The webhook poller used `if not miners_data` and `if not balances_data` after fetching list endpoints. A valid empty list is falsy, so a successful `/api/miners` response of `[]` was treated the same as a failed fetch. That prevents the poller from detecting the case where all previously seen miners have left.

## Verification
- `python3 -m py_compile tools/webhooks/webhook_server.py`
- `git diff --check -- tools/webhooks/webhook_server.py`