### PR TITLE
fix: handle unreachable miner bootstrap node

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -26,6 +26,8 @@ except ImportError:
 
 NODE_URL = "https://rustchain.org"  # Use HTTPS via nginx
 BLOCK_TIME = 600  # 10 minutes
+NETWORK_RETRY_ATTEMPTS = 3
+NETWORK_RETRY_BASE_DELAY = 2
 
 # TLS verification: use pinned cert if available, else system CA bundle
 _CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
@@ -48,6 +50,34 @@ def _parse_free_memory_gb(output):
                 return int(parts[1])
             except ValueError:
                 return None
+    return None
+
+
+def _request_with_network_retry(method, url, action, retries=NETWORK_RETRY_ATTEMPTS,
+                                base_delay=NETWORK_RETRY_BASE_DELAY, sleep_func=None,
+                                **kwargs):
+    """Run an HTTP request with bounded retries for transient network failures."""
+    if sleep_func is None:
+        sleep_func = time.sleep
+
+    for attempt in range(1, retries + 1):
+        try:
+            return method(url, **kwargs)
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+            print(
+                "[WARN] Cannot connect to bootstrap node while {} "
+                "(attempt {}/{}): {}".format(action, attempt, retries, exc)
+            )
+            if attempt >= retries:
+                print("[ERROR] Cannot connect to bootstrap node.")
+                print("[ERROR] Check network connectivity and the RustChain node URL, then retry.")
+                return None
+            delay = base_delay * (2 ** (attempt - 1))
+            print("[WARN] Retrying in {}s...".format(delay))
+            sleep_func(delay)
+        except requests.exceptions.RequestException as exc:
+            print("[ERROR] Network request failed while {}: {}".format(action, exc))
+            return None
     return None
 
 
@@ -116,6 +146,32 @@ class LocalMiner:
         # Run initial fingerprint check
         if FINGERPRINT_AVAILABLE:
             self._run_fingerprint_checks()
+
+    def _get(self, path, action, **kwargs):
+        return _request_with_network_retry(
+            requests.get,
+            f"{self.node_url}{path}",
+            action,
+            **kwargs,
+        )
+
+    def _post(self, path, action, **kwargs):
+        return _request_with_network_retry(
+            requests.post,
+            f"{self.node_url}{path}",
+            action,
+            **kwargs,
+        )
+
+    def check_node_connectivity(self):
+        """Verify the configured RustChain node is reachable before mining."""
+        resp = self._get("/health", "checking bootstrap connectivity", timeout=10, verify=TLS_VERIFY)
+        if resp is None:
+            return False
+        if resp.status_code != 200:
+            print(f"[ERROR] Bootstrap node health check failed: HTTP {resp.status_code}")
+            return False
+        return True
 
     def _run_fingerprint_checks(self):
         """Run 6 hardware fingerprint checks for RIP-PoA"""
@@ -287,7 +343,15 @@ class LocalMiner:
 
         try:
             # Get challenge (verify=TLS_VERIFY for self-signed certs)
-            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=TLS_VERIFY)
+            resp = self._post(
+                "/attest/challenge",
+                "requesting attestation challenge",
+                json={},
+                timeout=10,
+                verify=TLS_VERIFY,
+            )
+            if resp is None:
+                return False
             if resp.status_code != 200:
                 print(f"❌ Challenge failed: {resp.status_code}")
                 return False
@@ -342,8 +406,15 @@ class LocalMiner:
         }
 
         try:
-            resp = requests.post(f"{self.node_url}/attest/submit",
-                               json=attestation, timeout=30, verify=TLS_VERIFY)
+            resp = self._post(
+                "/attest/submit",
+                "submitting attestation",
+                json=attestation,
+                timeout=30,
+                verify=TLS_VERIFY,
+            )
+            if resp is None:
+                return False
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -404,8 +475,15 @@ class LocalMiner:
         }
 
         try:
-            resp = requests.post(f"{self.node_url}/epoch/enroll",
-                                json=payload, timeout=30, verify=TLS_VERIFY)
+            resp = self._post(
+                "/epoch/enroll",
+                "enrolling miner",
+                json=payload,
+                timeout=30,
+                verify=TLS_VERIFY,
+            )
+            if resp is None:
+                return False
 
             if resp.status_code == 200:
                 result = resp.json()
@@ -452,14 +530,16 @@ class LocalMiner:
     def check_balance(self):
         """Check balance"""
         try:
-            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10, verify=TLS_VERIFY)
+            resp = self._get(f"/balance/{self.wallet}", "checking wallet balance", timeout=10, verify=TLS_VERIFY)
+            if resp is None:
+                return 0
             if resp.status_code == 200:
                 result = resp.json()
                 balance = result.get('balance_rtc', 0)
                 print(f"\n💰 Balance: {balance} RTC")
                 return balance
-        except:
-            pass
+        except Exception as e:
+            print(f"[WARN] Balance check failed: {e}")
         return 0
 
 
@@ -498,7 +578,9 @@ class LocalMiner:
             if self.verbose:
                 print(f"[DRY-RUN] GET {url}")
                 print(f"[DRY-RUN] Headers: {{'User-Agent': 'RustChain-Miner/2.2.1'}}")
-            r = requests.get(url, timeout=8, verify=TLS_VERIFY)
+            r = self._get("/health", "running dry-run health probe", timeout=8, verify=TLS_VERIFY)
+            if r is None:
+                return True
             print(f"[DRY-RUN] Health probe: HTTP {r.status_code}")
             if self.verbose:
                 print(f"[DRY-RUN] Response headers: {dict(r.headers)}")
@@ -522,6 +604,10 @@ class LocalMiner:
         print(f"\n⛏️  Starting mining...")
         print(f"Block time: {BLOCK_TIME//60} minutes")
         print(f"Press Ctrl+C to stop\n")
+
+        if not self.check_node_connectivity():
+            print("[ERROR] Miner startup aborted before mining began.")
+            return 1
 
         # Save wallet
         with open("/tmp/local_miner_wallet.txt", "w") as f:
@@ -556,6 +642,7 @@ class LocalMiner:
             print(f"\n\n⛔ Mining stopped")
             print(f"   Wallet: {self.wallet}")
             self.check_balance()
+            return 0
 
 if __name__ == "__main__":
     import argparse
@@ -582,6 +669,8 @@ if __name__ == "__main__":
             show_payload=args.show_payload,
     )
     if args.dry_run:
-        miner.dry_run()
+        result = miner.dry_run()
     else:
-        miner.mine()
+        result = miner.mine()
+
+    sys.exit(0 if result in (None, True) else int(result))

--- a/tests/test_linux_miner_network_retry.py
+++ b/tests/test_linux_miner_network_retry.py
@@ -1,0 +1,71 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+MINER_PATH = PROJECT_ROOT / "miners" / "linux" / "rustchain_linux_miner.py"
+
+
+def load_linux_miner():
+    module_name = "rustchain_linux_miner_network_retry_test"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, MINER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_request_with_network_retry_reports_bootstrap_failure(capsys):
+    miner_mod = load_linux_miner()
+    request = Mock(side_effect=requests.exceptions.ConnectionError("refused"))
+    sleeps = []
+
+    response = miner_mod._request_with_network_retry(
+        request,
+        "https://node.invalid/health",
+        "checking bootstrap connectivity",
+        retries=3,
+        base_delay=1,
+        sleep_func=sleeps.append,
+    )
+
+    assert response is None
+    assert request.call_count == 3
+    assert sleeps == [1, 2]
+    output = capsys.readouterr().out
+    assert "Cannot connect to bootstrap node" in output
+    assert "Check network connectivity" in output
+
+
+def test_mine_exits_nonzero_when_bootstrap_unreachable(monkeypatch):
+    miner_mod = load_linux_miner()
+    monkeypatch.setattr(miner_mod, "FINGERPRINT_AVAILABLE", False)
+    monkeypatch.setattr(miner_mod, "get_linux_serial", lambda: "test-serial")
+
+    miner = miner_mod.LocalMiner(wallet="RTC-test-wallet")
+    monkeypatch.setattr(miner, "check_node_connectivity", lambda: False)
+
+    assert miner.mine() == 1
+
+
+def test_attest_returns_false_after_challenge_retries(monkeypatch, capsys):
+    miner_mod = load_linux_miner()
+    monkeypatch.setattr(miner_mod, "FINGERPRINT_AVAILABLE", False)
+    monkeypatch.setattr(miner_mod, "get_linux_serial", lambda: "test-serial")
+    monkeypatch.setattr(miner_mod.time, "sleep", lambda _: None)
+    post = Mock(side_effect=requests.exceptions.Timeout("timed out"))
+    monkeypatch.setattr(miner_mod.requests, "post", post)
+
+    miner = miner_mod.LocalMiner(wallet="RTC-test-wallet")
+    monkeypatch.setattr(miner, "_get_hw_info", lambda: {})
+
+    assert miner.attest() is False
+    assert post.call_count == 3
+    assert "Cannot connect to bootstrap node" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Fixes #4035 by wrapping Linux miner node requests in bounded retry handling for connection and timeout failures.
- Adds a startup health preflight so `rustchain_linux_miner.py` exits with code 1 before entering the mining loop when the bootstrap node is unreachable.
- Reuses the retry wrapper for challenge, attestation submit, epoch enroll, wallet balance, and dry-run health probe paths.

## Verification
- `python -m pytest tests\test_linux_miner_network_retry.py -q` -> 3 passed
- `python -m pytest tests\test_wallet_network_utils.py tests\test_linux_miner_network_retry.py -q` -> 14 passed
- `python -m py_compile miners\linux\rustchain_linux_miner.py tests\test_linux_miner_network_retry.py`
- `git diff --check -- miners\linux\rustchain_linux_miner.py tests\test_linux_miner_network_retry.py`

## Notes
The previous PR for this issue was closed unmerged and included unrelated workflow changes. This PR keeps the fix limited to the Linux miner CLI and tests.