### PR TITLE
fix: reject empty vintage validation requests

### DIFF
--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -290,6 +290,11 @@ class SubmissionValidator:
             "bounty": None,
             "era": None
         }
+
+        if not any([photo_path, screenshot_path, attestation_log_path, writeup_path, wallet_address]):
+            results["valid"] = False
+            results["errors"].append("At least one validation input is required")
+            return results
         
         # Validate each component
         if photo_path:


### PR DESCRIPTION
Refs #305.

## Summary
- make `validate_submission()` return invalid when no evidence inputs are provided
- align the function API with the CLI guard that already rejects empty validation runs

## Bug
The CLI checks that at least one validation input is provided, but the underlying `SubmissionValidator.validate_submission()` API returned `valid=True` when called with all arguments omitted. Any direct caller using the validator class could therefore accept an empty evidence set as valid.

## Verification
- `python3 -m py_compile tools/validate_vintage_submission.py`
- smoke test: `SubmissionValidator().validate_submission()` now returns `False` with `At least one validation input is required`
- `git diff --check -- tools/validate_vintage_submission.py`