### PR TITLE
fix: require core fields in text attestation logs

### DIFF
--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -147,7 +147,7 @@ class SubmissionValidator:
                 
             except json.JSONDecodeError as e:
                 # Not JSON, check for plain text format
-                if "miner_id" in content or "device_arch" in content:
+                if "miner_id" in content and "device_arch" in content:
                     result["status"] = "PASS"
                     result["message"] = "Attestation log appears valid (plain text format)"
                     result["checks"]["format"] = "plain_text"


### PR DESCRIPTION
Refs #305.

## Summary
- require both `miner_id` and `device_arch` before accepting a plain-text attestation log
- keep JSON attestation validation unchanged

## Bug
When an attestation log is not valid JSON, `validate_attestation_log()` falls back to a plain-text heuristic. The heuristic accepted the log if it contained `miner_id` OR `device_arch`, so a partial text file with only one field could pass as a valid attestation log.

## Verification
- `python3 -m py_compile tools/validate_vintage_submission.py`
- smoke test: a plain-text log containing only `miner_id` now returns `WARN` instead of `PASS`
- `git diff --check -- tools/validate_vintage_submission.py`