### PR TITLE
fix: resolve vintage profile path from validator

### DIFF
--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -30,6 +30,12 @@ class SubmissionValidator:
         self.checks: Dict[str, Dict[str, Any]] = {}
         self.errors: list = []
         self.warnings: list = []
+
+    def _add_hardware_profile_path(self) -> None:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        profile_dir = os.path.abspath(os.path.join(script_dir, "..", "vintage_miner"))
+        if profile_dir not in sys.path:
+            sys.path.insert(0, profile_dir)
     
     def validate_photo(self, photo_path: str) -> Dict[str, Any]:
         """Validate photo evidence"""
@@ -260,7 +266,7 @@ class SubmissionValidator:
         """Calculate bounty based on architecture era"""
         # Import from hardware_profiles if available
         try:
-            sys.path.insert(0, 'vintage_miner')
+            self._add_hardware_profile_path()
             from hardware_profiles import get_bounty
             return get_bounty(device_arch)
         except:
@@ -320,6 +326,7 @@ class SubmissionValidator:
                 
                 # Determine era
                 try:
+                    self._add_hardware_profile_path()
                     from hardware_profiles import get_era
                     results["era"] = get_era(device_arch)
                 except:


### PR DESCRIPTION
## Summary
- resolve the vintage hardware profile import path relative to the validator script instead of the caller's current working directory
- reuse the same path setup for bounty and era lookups

## Why
Running the validator from `tools/` or another working directory can make `sys.path.insert(0, "vintage_miner")` point at a non-existent relative directory. That silently falls back to the default bounty and `Unknown` era even when `vintage_miner/hardware_profiles.py` is present in the repo.

## Test plan
- `python3 -m py_compile tools/validate_vintage_submission.py`
- smoke-tested `SubmissionValidator().calculate_bounty("x86_64")` and verified the resolved profile path is added
- `git diff --check`