### PR TITLE
fix: guard miner alert subscription filter

### DIFF
--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -73,6 +73,13 @@ logging.basicConfig(
 )
 logger = logging.getLogger("miner_alerts")
 
+ALERT_TYPE_COLUMNS = {
+    "offline": "alert_offline",
+    "rewards": "alert_rewards",
+    "large_transfer": "alert_large_transfer",
+    "attestation_fail": "alert_attestation_fail",
+}
+
 
 # ─── Database ─────────────────────────────────────────────────────────────────
 
@@ -176,7 +183,9 @@ class AlertDB:
         """Get active subscriptions for a miner, optionally filtered by alert type."""
         cur = self.conn.cursor()
         if alert_type:
-            col = f"alert_{alert_type}"
+            col = ALERT_TYPE_COLUMNS.get(alert_type)
+            if col is None:
+                raise ValueError(f"Unknown alert type: {alert_type}")
             cur.execute(
                 f"SELECT * FROM subscriptions WHERE miner_id = ? AND active = 1 AND {col} = 1",
                 (miner_id,),


### PR DESCRIPTION
## Summary
- add an explicit alert-type to column whitelist for miner alert subscription filtering
- reject unknown alert types before building the SQL query

## Why
`get_subscriptions()` accepted an arbitrary `alert_type` and interpolated `alert_{alert_type}` into the query. Normal internal callers use known constants, but direct or future callers could trigger SQL errors or unsafe column expressions.

## Test plan
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py`
- smoke-tested valid `offline` filtering and invalid alert-type rejection with a temporary SQLite DB
- `git diff --check`