### PR TITLE
fix: skip malformed miner alert entries

### DIFF
--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -527,8 +527,14 @@ def monitor_loop(db: AlertDB):
 
             # Fetch current miner data
             all_miners = fetch_miners()
-            active_miner_ids = set(m["miner"] for m in all_miners)
-            miner_data = {m["miner"]: m for m in all_miners}
+            miner_data = {}
+            for miner in all_miners:
+                miner_id = miner.get("miner") or miner.get("miner_id")
+                if not miner_id:
+                    logger.warning("Skipping miner entry without miner id: %s", miner)
+                    continue
+                miner_data[miner_id] = miner
+            active_miner_ids = set(miner_data)
 
             for miner_id in monitored_miners:
                 prev_state = db.get_miner_state(miner_id)


### PR DESCRIPTION
## Summary
- tolerate miner API entries that use `miner_id` instead of `miner`
- skip and log entries that do not include any miner identifier before building the active miner map

## Why
The monitor loop currently indexes every API entry with `m["miner"]`. A single malformed or differently-shaped entry raises `KeyError` and aborts the poll cycle before subscribed miners can be processed.

## Test plan
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py`
- smoke-tested the miner-map construction with `miner`, `miner_id`, and missing-id entries
- `git diff --check`