### PR TITLE
fix: fall back when balance field is null

### DIFF
--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -495,7 +495,10 @@ def fetch_balance(miner_id: str) -> Optional[float]:
             return None
         resp.raise_for_status()
         data = resp.json()
-        return float(data.get("balance", data.get("balance_rtc", 0)))
+        balance = data.get("balance")
+        if balance is None:
+            balance = data.get("balance_rtc", 0)
+        return float(balance)
     except Exception as e:
         logger.error(f"Failed to fetch balance for {miner_id}: {e}")
         return None


### PR DESCRIPTION
## Summary
- treat a JSON `balance: null` value as missing
- fall back to `balance_rtc` before converting the miner balance to float

## Why
`dict.get("balance", fallback)` does not use the fallback when the key exists with a null value. A response like `{ "balance": null, "balance_rtc": "7.5" }` currently raises `TypeError` and makes balance monitoring return `None`, skipping reward/transfer detection for that poll.

## Test plan
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py`
- smoke-tested `fetch_balance()` with a stubbed response containing `balance: null` and `balance_rtc: "7.5"`
- `git diff --check`