### PR TITLE
fix: ignore malformed webhook tip slots

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -347,7 +347,11 @@ class RustChainPoller:
         tip = self._get("/headers/tip")
         if not tip or tip.get("slot") is None:
             return
-        slot = int(tip["slot"])
+        try:
+            slot = int(tip["slot"])
+        except (TypeError, ValueError):
+            log.debug("Ignoring tip with invalid slot value: %r", tip.get("slot"))
+            return
         if self._prev_tip_slot is not None and slot > self._prev_tip_slot:
             dispatch_event(WebhookEvent(
                 event_type="new_block",


### PR DESCRIPTION
## Summary
- guard webhook block polling against non-integer `slot` values from `/headers/tip`
- skip malformed tip responses instead of raising out of the poll cycle

## Why
`_check_block()` currently calls `int(tip["slot"])` without handling `TypeError` or `ValueError`. A transient malformed node response can abort the poll iteration and delay unrelated webhook checks.

## Test plan
- `python3 -m py_compile tools/webhooks/webhook_server.py`
- smoke-tested `_check_block()` with a stubbed `{ "slot": "not-an-int" }` tip response
- `git diff --check`