### PR TITLE
fix: normalize webhook epoch values

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -368,6 +368,11 @@ class RustChainPoller:
         epoch = stats.get("epoch")
         if epoch is None:
             return
+        try:
+            epoch = int(epoch)
+        except (TypeError, ValueError):
+            log.debug("Ignoring stats response with invalid epoch value: %r", stats.get("epoch"))
+            return
         if self._prev_epoch is not None and epoch != self._prev_epoch:
             dispatch_event(WebhookEvent(
                 event_type="new_epoch",


### PR DESCRIPTION
## Summary
- normalize `/api/stats` epoch values to integers before comparing poll state
- ignore malformed epoch values instead of updating state with inconsistent types

## Why
`_check_epoch()` compares the raw `epoch` value across polls. If the node returns `"7"` in one response and `7` in the next, the poller treats that as a changed epoch and dispatches a false `new_epoch` event.

## Test plan
- `python3 -m py_compile tools/webhooks/webhook_server.py`
- smoke-tested consecutive epoch responses of `"7"` and `7` and verified no event is dispatched
- `git diff --check`