### PR TITLE
fix: tolerate invalid webhook event rows

### DIFF
--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -239,11 +239,17 @@ class SubscriberStore:
 
     @staticmethod
     def _row_to_sub(row) -> Subscriber:
+        try:
+            events = set(json.loads(row["events"]))
+        except (TypeError, json.JSONDecodeError):
+            log.warning("Subscriber %s has invalid events JSON; disabling event delivery", row["id"])
+            events = set()
+
         return Subscriber(
             id=row["id"],
             url=row["url"],
             secret=row["secret"],
-            events=set(json.loads(row["events"])),
+            events=events,
             active=bool(row["active"]),
             created_at=row["created_at"],
         )


### PR DESCRIPTION
## Summary
- handle invalid subscriber `events` JSON while loading webhook subscriptions
- disable delivery for the malformed row instead of crashing list/get operations

## Why
A single corrupted or manually-edited subscriber row currently makes `_row_to_sub()` raise `JSONDecodeError`. That can break admin listing and event dispatch because `list_all()` cannot return any subscribers.

## Test plan
- `python3 -m py_compile tools/webhooks/webhook_server.py`
- smoke-tested a temporary SQLite DB containing a subscriber row with invalid `events` JSON
- `git diff --check`