### PR TITLE
fix: clean expired UTXO mempool transactions

### DIFF
--- a/node/tests/test_utxo_mempool_expiry.py
+++ b/node/tests/test_utxo_mempool_expiry.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression tests for UTXO mempool expiry cleanup."""
+
+import json
+import os
+import sys
+import time
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, NODE_DIR)
+
+import utxo_db
+from utxo_db import UtxoDB
+
+
+def _insert_box(conn, box_id: str, value_nrtc: int = 100_000):
+    conn.execute(
+        """
+        INSERT INTO utxo_boxes (
+            box_id, value_nrtc, proposition, owner_address, creation_height,
+            transaction_id, output_index, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            box_id,
+            value_nrtc,
+            "00",
+            "RTC_TEST_OWNER",
+            1,
+            "ab" * 32,
+            0,
+            int(time.time()),
+        ),
+    )
+
+
+def _insert_mempool_tx(conn, tx_id: str, expires_at: int, fee_nrtc: int = 0):
+    conn.execute(
+        """
+        INSERT INTO utxo_mempool (tx_id, tx_data_json, fee_nrtc, submitted_at, expires_at)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (tx_id, json.dumps({"tx_id": tx_id}), fee_nrtc, int(time.time()), expires_at),
+    )
+
+
+def test_block_candidates_skip_and_remove_expired_transactions(tmp_path):
+    db = UtxoDB(str(tmp_path / "utxo.db"))
+    db.init_tables()
+    now = int(time.time())
+
+    conn = db._conn()
+    try:
+        _insert_mempool_tx(conn, "expired_tx", now - 1, fee_nrtc=10)
+        _insert_mempool_tx(conn, "fresh_tx", now + 60, fee_nrtc=1)
+        conn.execute(
+            "INSERT INTO utxo_mempool_inputs (box_id, tx_id) VALUES (?, ?)",
+            ("cd" * 32, "expired_tx"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    candidates = db.mempool_get_block_candidates()
+
+    assert candidates == [{"tx_id": "fresh_tx"}]
+    conn = db._conn()
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM utxo_mempool WHERE tx_id = 'expired_tx'").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM utxo_mempool_inputs WHERE tx_id = 'expired_tx'").fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_mempool_add_sweeps_expired_rows_before_pool_size_check(tmp_path, monkeypatch):
+    db = UtxoDB(str(tmp_path / "utxo.db"))
+    db.init_tables()
+    now = int(time.time())
+    input_box_id = "ef" * 32
+
+    conn = db._conn()
+    try:
+        _insert_box(conn, input_box_id)
+        _insert_mempool_tx(conn, "expired_tx", now - 1)
+        conn.execute(
+            "INSERT INTO utxo_mempool_inputs (box_id, tx_id) VALUES (?, ?)",
+            ("12" * 32, "expired_tx"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(utxo_db, "MAX_POOL_SIZE", 1)
+    accepted = db.mempool_add(
+        {
+            "tx_id": "fresh_tx",
+            "tx_type": "transfer",
+            "inputs": [{"box_id": input_box_id, "spending_proof": "sig"}],
+            "outputs": [{"value_nrtc": 99_000}],
+            "fee_nrtc": 1_000,
+        }
+    )
+
+    assert accepted is True
+    conn = db._conn()
+    try:
+        rows = conn.execute("SELECT tx_id FROM utxo_mempool ORDER BY tx_id").fetchall()
+        input_rows = conn.execute("SELECT tx_id FROM utxo_mempool_inputs ORDER BY tx_id").fetchall()
+    finally:
+        conn.close()
+
+    assert [row["tx_id"] for row in rows] == ["fresh_tx"]
+    assert [row["tx_id"] for row in input_rows] == ["fresh_tx"]

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -673,6 +673,10 @@ class UtxoDB:
         # paths and leak the transaction-in-progress lock.
         manage_tx = True
         try:
+            now = int(time.time())
+            self._mempool_clear_expired(conn, now=now)
+            conn.commit()
+
             # Check pool size
             row = conn.execute(
                 "SELECT COUNT(*) AS n FROM utxo_mempool"
@@ -688,7 +692,6 @@ class UtxoDB:
 
             inputs = tx.get('inputs', [])
             tx_type = tx.get('tx_type', 'transfer')
-            now = int(time.time())
 
             # Public mempool admission must never accept minting transactions.
             # Coinbase/mining rewards are internally constructed during block
@@ -827,10 +830,11 @@ class UtxoDB:
 
     def mempool_get_block_candidates(self, max_count: int = 100) -> List[dict]:
         """Get highest-fee transactions from mempool for block inclusion."""
-        self.mempool_clear_expired()
         conn = self._conn()
         try:
             now = int(time.time())
+            self._mempool_clear_expired(conn, now=now)
+            conn.commit()
             rows = conn.execute(
                 """SELECT tx_data_json FROM utxo_mempool
                    WHERE expires_at > ?
@@ -839,35 +843,44 @@ class UtxoDB:
                 (now, max_count),
             ).fetchall()
             return [json.loads(r['tx_data_json']) for r in rows]
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return []
+            raise
         finally:
             conn.close()
+
+    def _mempool_clear_expired(self, conn: sqlite3.Connection, now: Optional[int] = None) -> int:
+        """Remove expired mempool rows using the caller's connection."""
+        now = int(time.time()) if now is None else int(now)
+        expired = conn.execute(
+            "SELECT tx_id FROM utxo_mempool WHERE expires_at <= ?",
+            (now,),
+        ).fetchall()
+        count = 0
+        for row in expired:
+            conn.execute(
+                "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
+                (row['tx_id'],),
+            )
+            conn.execute(
+                "DELETE FROM utxo_mempool WHERE tx_id = ?",
+                (row['tx_id'],),
+            )
+            count += 1
+        return count
 
     def mempool_clear_expired(self) -> int:
         """Remove expired transactions from mempool. Returns count removed."""
         conn = self._conn()
         try:
-            now = int(time.time())
             try:
-                expired = conn.execute(
-                    "SELECT tx_id FROM utxo_mempool WHERE expires_at <= ?",
-                    (now,),
-                ).fetchall()
+                count = self._mempool_clear_expired(conn)
             except sqlite3.OperationalError as exc:
                 if "no such table" in str(exc).lower():
                     return 0
                 raise
             else:
-                count = 0
-                for row in expired:
-                    conn.execute(
-                        "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?",
-                        (row['tx_id'],),
-                    )
-                    conn.execute(
-                        "DELETE FROM utxo_mempool WHERE tx_id = ?",
-                        (row['tx_id'],),
-                    )
-                    count += 1
                 conn.commit()
                 return count
         finally:


### PR DESCRIPTION
## Summary
- sweep expired UTXO mempool rows before checking pool capacity in `mempool_add()`
- sweep expired rows before returning block candidates so expired transactions cannot be packed into a block
- share cleanup logic through a same-connection helper to avoid nested SQLite connections during mempool admission
- add regression tests for candidate selection cleanup and pool-full cleanup before admission

Fixes #2738.

## Verification
- `python -m pytest node\tests\test_utxo_mempool_expiry.py -q` -> 2 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed
- `python -m py_compile node\utxo_db.py node\tests\test_utxo_mempool_expiry.py`
- `git diff --check -- node\utxo_db.py node\tests\test_utxo_mempool_expiry.py`