### PR TITLE
fix: require auth for P2P state endpoints

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1064,6 +1064,7 @@ class GossipLayer:
             resp = requests.post(
                 f"{peer_url}/p2p/gossip",
                 json=msg.to_dict(),
+                headers={"X-P2P-Key": P2P_SECRET},
                 timeout=30,
                 verify=TLS_VERIFY
             )
@@ -1315,6 +1316,13 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
                     del _gossip_rate[ip]
             return True
 
+    def _require_p2p_read_auth():
+        """Require the shared P2P secret for sensitive read-only sync endpoints."""
+        provided = request.headers.get("X-P2P-Key", "")
+        if not provided or not hmac.compare_digest(provided, P2P_SECRET):
+            return jsonify({"error": "unauthorized", "message": "valid X-P2P-Key required"}), 401
+        return None
+
     @app.route('/p2p/gossip', methods=['POST'])
     def receive_gossip():
         """Receive and process gossip message"""
@@ -1330,16 +1338,25 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
     @app.route('/p2p/state', methods=['GET'])
     def get_state():
         """Get full CRDT state for sync"""
+        auth_error = _require_p2p_read_auth()
+        if auth_error:
+            return auth_error
         return jsonify(p2p_node.get_full_state())
 
     @app.route('/p2p/attestation_state', methods=['GET'])
     def get_attestation_state():
         """Get attestation timestamps for efficient sync"""
+        auth_error = _require_p2p_read_auth()
+        if auth_error:
+            return auth_error
         return jsonify(p2p_node.get_attestation_state())
 
     @app.route('/p2p/peers', methods=['GET'])
     def get_peers():
         """Get list of known peers"""
+        auth_error = _require_p2p_read_auth()
+        if auth_error:
+            return auth_error
         return jsonify({
             "node_id": p2p_node.node_id,
             "peers": list(p2p_node.peers.keys())

--- a/node/tests/test_p2p_endpoint_auth.py
+++ b/node/tests/test_p2p_endpoint_auth.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Regression tests for P2P read endpoint authentication."""
+
+import importlib
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from flask import Flask
+
+
+P2P_SECRET = "unit-test-secret-0123456789abcdef"
+os.environ["RC_P2P_SECRET"] = P2P_SECRET
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(NODE_DIR))
+
+if "rustchain_p2p_gossip" in sys.modules:
+    del sys.modules["rustchain_p2p_gossip"]
+gossip = importlib.import_module("rustchain_p2p_gossip")
+
+
+def _make_client():
+    app = Flask(__name__)
+    p2p_node = SimpleNamespace(
+        node_id="node-a",
+        peers={"node-b": "https://node-b.example"},
+        running=True,
+        gossip=SimpleNamespace(
+            attestation_crdt=SimpleNamespace(data={"miner-a": (1, {"device_arch": "x86"})}),
+            epoch_crdt=SimpleNamespace(items={}),
+        ),
+        get_full_state=lambda: {
+            "node_id": "node-a",
+            "attestations": {"miner-a": {"ts": 1, "value": {"device_arch": "x86"}}},
+            "epochs": {},
+            "balances": {},
+        },
+        get_attestation_state=lambda: {
+            "node_id": "node-a",
+            "attestations": {"miner-a": 1},
+        },
+    )
+    gossip.register_p2p_endpoints(app, p2p_node)
+    return app.test_client()
+
+
+def test_sensitive_p2p_read_endpoints_reject_missing_or_bad_secret():
+    client = _make_client()
+
+    for path in ("/p2p/state", "/p2p/attestation_state", "/p2p/peers"):
+        assert client.get(path).status_code == 401
+        assert client.get(path, headers={"X-P2P-Key": "wrong"}).status_code == 401
+
+
+def test_sensitive_p2p_read_endpoints_accept_shared_secret():
+    client = _make_client()
+
+    for path in ("/p2p/state", "/p2p/attestation_state", "/p2p/peers"):
+        response = client.get(path, headers={"X-P2P-Key": P2P_SECRET})
+        assert response.status_code == 200
+
+
+def test_p2p_health_remains_public():
+    client = _make_client()
+
+    response = client.get("/p2p/health")
+
+    assert response.status_code == 200
+    assert response.get_json()["node_id"] == "node-a"
+


### PR DESCRIPTION
## Summary
- require `X-P2P-Key` matching `RC_P2P_SECRET` for sensitive P2P read endpoints
- protect `/p2p/state`, `/p2p/attestation_state`, and `/p2p/peers` from unauthenticated scraping
- keep `/p2p/health` public for liveness checks
- include the shared P2P key on peer full-sync requests
- add regression coverage for missing, wrong, and valid P2P read auth headers

Fixes #4293.

## Verification
- `python -m pytest node\tests\test_p2p_endpoint_auth.py -q` -> 3 passed
- `python -m py_compile node\rustchain_p2p_gossip.py node\tests\test_p2p_endpoint_auth.py`
- `git diff --check -- node\rustchain_p2p_gossip.py node\tests\test_p2p_endpoint_auth.py`

Note: `python -m pytest node\tests\test_p2p_phase_f_ed25519.py -q` still fails on existing signature-bundle API expectations and Windows key-file mode assertions unrelated to this endpoint-auth change.