### PR TITLE
fix: restore explorer API routes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5579,6 +5579,270 @@ def api_miners():
     })
 
 
+def _explorer_int_arg(name, default, minimum, maximum):
+    """Parse bounded integer query args for public explorer endpoints."""
+    raw = request.args.get(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None, jsonify({"ok": False, "error": f"{name} must be an integer"}), 400
+    return max(minimum, min(value, maximum)), None, None
+
+
+def _sqlite_table_columns(conn, table_name):
+    try:
+        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+    except sqlite3.Error:
+        return set()
+    return {row[1] for row in rows}
+
+
+def _json_object_or_none(raw):
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _explorer_amount_rtc(amount_i64):
+    return int(amount_i64) / int(globals().get("UNIT", 1_000_000))
+
+
+@app.route("/api/blocks", methods=["GET"])
+def api_explorer_blocks():
+    """Return recent blocks for explorer clients."""
+    limit, error_response, status = _explorer_int_arg("limit", 50, 1, 200)
+    if error_response is not None:
+        return error_response, status
+    offset, error_response, status = _explorer_int_arg("offset", 0, 0, 1_000_000)
+    if error_response is not None:
+        return error_response, status
+
+    with sqlite3.connect(DB_PATH) as db:
+        db.row_factory = sqlite3.Row
+        columns = _sqlite_table_columns(db, "blocks")
+        if not columns:
+            return jsonify({"ok": True, "blocks": [], "count": 0, "total": 0})
+
+        hash_col = "block_hash" if "block_hash" in columns else "hash" if "hash" in columns else None
+        if "height" not in columns or not hash_col:
+            return jsonify({"ok": True, "blocks": [], "count": 0, "total": 0})
+
+        select_columns = ["height", f"{hash_col} AS block_hash"]
+        for optional in (
+            "prev_hash",
+            "timestamp",
+            "merkle_root",
+            "state_root",
+            "attestations_hash",
+            "producer",
+            "tx_count",
+            "attestation_count",
+            "created_at",
+            "body_json",
+            "data",
+        ):
+            if optional in columns:
+                select_columns.append(optional)
+
+        total = db.execute("SELECT COUNT(*) FROM blocks").fetchone()[0]
+        rows = db.execute(
+            f"""
+            SELECT {", ".join(select_columns)}
+            FROM blocks
+            ORDER BY height DESC
+            LIMIT ? OFFSET ?
+            """,
+            (limit, offset),
+        ).fetchall()
+
+    blocks = []
+    for row in rows:
+        block = {
+            "height": int(row["height"]),
+            "hash": row["block_hash"],
+            "block_hash": row["block_hash"],
+        }
+        for field in (
+            "prev_hash",
+            "timestamp",
+            "merkle_root",
+            "state_root",
+            "attestations_hash",
+            "producer",
+            "created_at",
+        ):
+            if field in row.keys():
+                block[field] = row[field]
+        for field in ("tx_count", "attestation_count"):
+            if field in row.keys() and row[field] is not None:
+                block[field] = int(row[field])
+        if "body_json" in row.keys():
+            body = _json_object_or_none(row["body_json"])
+            if body is not None:
+                block["body"] = body
+        elif "data" in row.keys():
+            body = _json_object_or_none(row["data"])
+            if body is not None:
+                block["body"] = body
+        blocks.append(block)
+
+    return jsonify({"ok": True, "blocks": blocks, "count": len(blocks), "total": total})
+
+
+def _pending_ledger_explorer_transactions(db, limit):
+    columns = _sqlite_table_columns(db, "pending_ledger")
+    required = {"from_miner", "to_miner", "amount_i64"}
+    if not required.issubset(columns) or not ({"ts", "created_at"} & columns):
+        return []
+
+    if "created_at" in columns and "ts" in columns:
+        created_expr = "COALESCE(created_at, ts)"
+    elif "created_at" in columns:
+        created_expr = "created_at"
+    else:
+        created_expr = "ts"
+    select_columns = [
+        "from_miner",
+        "to_miner",
+        "amount_i64",
+        f"{created_expr} AS timestamp",
+    ]
+    for optional in ("epoch", "status", "tx_hash", "confirmed_at"):
+        if optional in columns:
+            select_columns.append(optional)
+
+    rows = db.execute(
+        f"""
+        SELECT {", ".join(select_columns)}
+        FROM pending_ledger
+        ORDER BY timestamp DESC{", id DESC" if "id" in columns else ""}
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+
+    transactions = []
+    for row in rows:
+        tx = {
+            "source": "pending_ledger",
+            "tx_hash": row["tx_hash"] if "tx_hash" in row.keys() else None,
+            "from": row["from_miner"],
+            "to": row["to_miner"],
+            "amount_i64": int(row["amount_i64"]),
+            "amount_rtc": _explorer_amount_rtc(row["amount_i64"]),
+            "timestamp": int(row["timestamp"] or 0),
+            "status": row["status"] if "status" in row.keys() else "pending",
+        }
+        if "epoch" in row.keys():
+            tx["epoch"] = int(row["epoch"]) if row["epoch"] is not None else None
+        if "confirmed_at" in row.keys() and row["confirmed_at"]:
+            tx["confirmed_at"] = int(row["confirmed_at"])
+        transactions.append(tx)
+    return transactions
+
+
+def _ledger_explorer_transactions(db, limit):
+    columns = _sqlite_table_columns(db, "ledger")
+    if {"from_miner", "to_miner", "amount_i64", "ts"}.issubset(columns):
+        rows = db.execute(
+            """
+            SELECT from_miner, to_miner, amount_i64, ts
+            FROM ledger
+            ORDER BY ts DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [
+            {
+                "source": "ledger",
+                "tx_hash": None,
+                "from": row["from_miner"],
+                "to": row["to_miner"],
+                "amount_i64": int(row["amount_i64"]),
+                "amount_rtc": _explorer_amount_rtc(row["amount_i64"]),
+                "timestamp": int(row["ts"] or 0),
+                "status": "confirmed",
+            }
+            for row in rows
+        ]
+
+    if not {"miner_id", "delta_i64", "ts"}.issubset(columns):
+        return []
+
+    select_columns = ["miner_id", "delta_i64", "ts"]
+    for optional in ("epoch", "reason"):
+        if optional in columns:
+            select_columns.append(optional)
+
+    rows = db.execute(
+        f"""
+        SELECT {", ".join(select_columns)}
+        FROM ledger
+        ORDER BY ts DESC, rowid DESC
+        LIMIT ?
+        """,
+        (limit,),
+    ).fetchall()
+    transactions = []
+    for row in rows:
+        amount_i64 = int(row["delta_i64"])
+        reason = str(row["reason"] or "") if "reason" in row.keys() else ""
+        counterparty = None
+        tx_hash = None
+        if reason.startswith("transfer_in:") or reason.startswith("transfer_out:"):
+            parts = reason.split(":")
+            counterparty = parts[1] if len(parts) > 1 else None
+            tx_hash = parts[2] if len(parts) > 2 else None
+        tx = {
+            "source": "ledger",
+            "tx_hash": tx_hash,
+            "miner_id": row["miner_id"],
+            "counterparty": counterparty,
+            "amount_i64": abs(amount_i64),
+            "amount_rtc": _explorer_amount_rtc(abs(amount_i64)),
+            "direction": "received" if amount_i64 >= 0 else "sent",
+            "timestamp": int(row["ts"] or 0),
+            "status": "confirmed",
+        }
+        if "epoch" in row.keys():
+            tx["epoch"] = int(row["epoch"]) if row["epoch"] is not None else None
+        transactions.append(tx)
+    return transactions
+
+
+@app.route("/api/transactions", methods=["GET"])
+def api_explorer_transactions():
+    """Return recent ledger transactions for explorer clients."""
+    limit, error_response, status = _explorer_int_arg("limit", 50, 1, 200)
+    if error_response is not None:
+        return error_response, status
+    offset, error_response, status = _explorer_int_arg("offset", 0, 0, 1_000_000)
+    if error_response is not None:
+        return error_response, status
+
+    with sqlite3.connect(DB_PATH) as db:
+        db.row_factory = sqlite3.Row
+        fetch_limit = limit + offset
+        transactions = (
+            _pending_ledger_explorer_transactions(db, fetch_limit)
+            + _ledger_explorer_transactions(db, fetch_limit)
+        )
+
+    transactions.sort(key=lambda tx: tx.get("timestamp", 0), reverse=True)
+    page = transactions[offset:offset + limit]
+    return jsonify({
+        "ok": True,
+        "transactions": page,
+        "count": len(page),
+        "total": len(transactions),
+    })
+
+
 @app.route("/api/miner/<miner_id>/streak", methods=["GET"])
 def api_miner_streak(miner_id: str):
     """Get miner's streak bonus and projected multiplier growth."""

--- a/node/tests/test_explorer_api_routes.py
+++ b/node/tests/test_explorer_api_routes.py
@@ -1,0 +1,191 @@
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestExplorerApiRoutes(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_explorer_api_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.mod.DB_PATH = self.db_path
+        self.mod.app.config["DB_PATH"] = self.db_path
+
+    def tearDown(self):
+        try:
+            os.unlink(self.db_path)
+        except (FileNotFoundError, PermissionError):
+            pass
+
+    def test_blocks_endpoint_returns_recent_blocks(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE blocks (
+                    height INTEGER PRIMARY KEY,
+                    block_hash TEXT NOT NULL,
+                    prev_hash TEXT NOT NULL,
+                    timestamp INTEGER NOT NULL,
+                    merkle_root TEXT NOT NULL,
+                    state_root TEXT NOT NULL,
+                    producer TEXT NOT NULL,
+                    tx_count INTEGER NOT NULL,
+                    body_json TEXT NOT NULL,
+                    created_at INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO blocks
+                (height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                 producer, tx_count, body_json, created_at)
+                VALUES (1, 'hash1', 'prev0', 100, 'm1', 's1', 'miner1', 1, '{"tx_count": 1}', 110)
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO blocks
+                (height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                 producer, tx_count, body_json, created_at)
+                VALUES (2, 'hash2', 'hash1', 200, 'm2', 's2', 'miner2', 0, '{"tx_count": 0}', 210)
+                """
+            )
+
+        resp = self.client.get("/api/blocks?limit=1")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["count"], 1)
+        self.assertEqual(body["total"], 2)
+        self.assertEqual(body["blocks"][0]["height"], 2)
+        self.assertEqual(body["blocks"][0]["hash"], "hash2")
+        self.assertEqual(body["blocks"][0]["block_hash"], "hash2")
+        self.assertEqual(body["blocks"][0]["tx_count"], 0)
+        self.assertEqual(body["blocks"][0]["body"], {"tx_count": 0})
+
+    def test_transactions_endpoint_combines_recent_ledgers(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE pending_ledger (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER NOT NULL,
+                    epoch INTEGER NOT NULL,
+                    from_miner TEXT NOT NULL,
+                    to_miner TEXT NOT NULL,
+                    amount_i64 INTEGER NOT NULL,
+                    reason TEXT,
+                    status TEXT DEFAULT 'pending',
+                    created_at INTEGER NOT NULL,
+                    confirms_at INTEGER NOT NULL,
+                    tx_hash TEXT,
+                    confirmed_at INTEGER
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE ledger (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER NOT NULL,
+                    epoch INTEGER,
+                    miner_id TEXT NOT NULL,
+                    delta_i64 INTEGER NOT NULL,
+                    reason TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO pending_ledger
+                (ts, epoch, from_miner, to_miner, amount_i64, reason, status,
+                 created_at, confirms_at, tx_hash)
+                VALUES (200, 7, 'alice', 'bob', 1500000, 'signed_transfer:coffee',
+                        'pending', 205, 300, 'tx_pending')
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason)
+                VALUES (100, 6, 'carol', 2500000, 'transfer_in:dave:tx_confirmed')
+                """
+            )
+
+        resp = self.client.get("/api/transactions?limit=10")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["count"], 2)
+        self.assertEqual(body["transactions"][0]["source"], "pending_ledger")
+        self.assertEqual(body["transactions"][0]["tx_hash"], "tx_pending")
+        self.assertEqual(body["transactions"][0]["from"], "alice")
+        self.assertEqual(body["transactions"][0]["to"], "bob")
+        self.assertEqual(body["transactions"][0]["status"], "pending")
+        self.assertEqual(body["transactions"][0]["amount_rtc"], 1.5)
+
+        self.assertEqual(body["transactions"][1]["source"], "ledger")
+        self.assertEqual(body["transactions"][1]["tx_hash"], "tx_confirmed")
+        self.assertEqual(body["transactions"][1]["miner_id"], "carol")
+        self.assertEqual(body["transactions"][1]["counterparty"], "dave")
+        self.assertEqual(body["transactions"][1]["direction"], "received")
+        self.assertEqual(body["transactions"][1]["amount_rtc"], 2.5)
+
+    def test_explorer_endpoints_return_empty_without_tables(self):
+        blocks_resp = self.client.get("/api/blocks")
+        tx_resp = self.client.get("/api/transactions")
+
+        self.assertEqual(blocks_resp.status_code, 200)
+        self.assertEqual(blocks_resp.get_json(), {"ok": True, "blocks": [], "count": 0, "total": 0})
+
+        self.assertEqual(tx_resp.status_code, 200)
+        self.assertEqual(tx_resp.get_json(), {"ok": True, "transactions": [], "count": 0, "total": 0})
+
+    def test_explorer_endpoints_reject_invalid_pagination(self):
+        blocks_resp = self.client.get("/api/blocks?limit=bad")
+        tx_resp = self.client.get("/api/transactions?offset=bad")
+
+        self.assertEqual(blocks_resp.status_code, 400)
+        self.assertEqual(blocks_resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+        self.assertEqual(tx_resp.status_code, 400)
+        self.assertEqual(tx_resp.get_json(), {"ok": False, "error": "offset must be an integer"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add public explorer-compatible `GET /api/blocks` route to the integrated node
- add public explorer-compatible `GET /api/transactions` route backed by pending/confirmed ledger data
- tolerate missing or legacy tables so fresh/partially migrated nodes return empty explorer payloads instead of 404/500
- add focused regression tests for blocks, transactions, empty tables, and invalid pagination

Fixes #2676

## Verification
- `python -m pytest node\tests\test_explorer_api_routes.py -q` (4 passed)
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_explorer_api_routes.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_explorer_api_routes.py`

## Notes
- `python -m pytest node\tests\test_public_api_disclosure.py -q` still has pre-existing failures in `/api/miners` mock expectations and `/wallet/history` response-shape expectations; this PR does not touch those routes.