### PR TITLE
Fix broken whitepaper links

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -12,13 +12,13 @@
 [![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
 [![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
-[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
 [![DOI](https://zenodo.org/badge/doi/10.5281/zenodo.19442753.svg)](https://doi.org/10.5281/zenodo.19442753)
 
 2003年的 PowerBook G4 比现代 Threadripper **多赚 2.5 倍**。
 Power Mac G5 **多赚 2.0 倍**。带有生锈串口的 486 赢得最多尊重。
 
-[浏览器](https://rustchain.org/explorer/) · [已保存的机器](https://rustchain.org/preserved.html) · [安装矿机](#quickstart) · [新手指南](docs/QUICKSTART.md) · [宣言](https://rustchain.org/manifesto.html) · [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+[浏览器](https://rustchain.org/explorer/) · [已保存的机器](https://rustchain.org/preserved.html) · [安装矿机](#quickstart) · [新手指南](docs/QUICKSTART.md) · [宣言](https://rustchain.org/manifesto.html) · [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
 
 </div>
 
@@ -246,7 +246,7 @@ clawrtc mine --wallet=你的钱包地址
 
 ## 文档
 
-- [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)
 - [新手指南](docs/QUICKSTART.md)
 - [API 参考](docs/API.md)
 - [RIP 文档](rips/)
@@ -279,6 +279,6 @@ MIT License - 查看 [LICENSE](LICENSE) 了解详情。
 
 <div align="center">
 
-**[网站](https://rustchain.org)** · **[浏览器](https://rustchain.org/explorer/)** · **[白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf)** · **[Discord](https://discord.gg/VqVVS2CW9Q)**
+**[网站](https://rustchain.org)** · **[浏览器](https://rustchain.org/explorer/)** · **[白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf)** · **[Discord](https://discord.gg/VqVVS2CW9Q)**
 
 </div>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -13,7 +13,7 @@
 
 *你的PowerPC G4比现代Threadripper赚得更多。就是这么硬核。*
 
-[网站](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [交换wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC快速入门](docs/wrtc.md) • [wRTC教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97-1.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
+[网站](https://rustchain.org) • [实时浏览器](https://rustchain.org/explorer) • [交换wRTC](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) • [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) • [wRTC快速入门](docs/wrtc.md) • [wRTC教程](docs/WRTC_ONBOARDING_TUTORIAL.md) • [Grokipedia参考](https://grokipedia.com/search?q=RustChain) • [白皮书](docs/RustChain_Whitepaper_Flameholder_v0.97.pdf) • [快速开始](#-快速开始) • [工作原理](#-古董证明如何工作)
 
 </div>
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -390,7 +390,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 - **Swap RTC for Solana tokens:** [wRTC Guide](wrtc.md)
 - **Run a full node:** [Protocol Docs](PROTOCOL.md)
-- **Deep dive into Proof-of-Antiquity:** [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- **Deep dive into Proof-of-Antiquity:** [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97.pdf)
 - **Contribute code:** [CONTRIBUTING.md](../CONTRIBUTING.md)
 - **API reference:** [API Walkthrough](API_WALKTHROUGH.md)
 

--- a/docs/VINTAGE_MINING_EXPLAINED.md
+++ b/docs/VINTAGE_MINING_EXPLAINED.md
@@ -279,4 +279,4 @@ See [N64 Mining Guide](N64_MINING_GUIDE.md) for setup instructions.
 - [Console Mining Setup](CONSOLE_MINING_SETUP.md) -- mine on NES, SNES, Genesis, PS1, Game Boy, and N64
 - [Protocol Overview](protocol-overview.md) -- attestation protocol specification
 - [Green Tracker](https://rustchain.org/preserved.html) -- live environmental impact dashboard
-- [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf) -- formal specification
+- [Whitepaper](RustChain_Whitepaper_Flameholder_v0.97.pdf) -- formal specification

--- a/docs/protocol-overview.md
+++ b/docs/protocol-overview.md
@@ -247,7 +247,7 @@ curl -sk https://rustchain.org/api/miners
 
 ## References
 
-- **Whitepaper**: [RustChain_Whitepaper_Flameholder_v0.97-1.pdf](./RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- **Whitepaper**: [RustChain_Whitepaper_Flameholder_v0.97.pdf](./RustChain_Whitepaper_Flameholder_v0.97.pdf)
 - **API Documentation**: [API.md](./API.md)
 - **Protocol Spec**: [PROTOCOL.md](./PROTOCOL.md)
 - **Glossary**: [GLOSSARY.md](./GLOSSARY.md)

--- a/docs/wrtc.md
+++ b/docs/wrtc.md
@@ -403,7 +403,7 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=my-miner-id"
 
 ## 📚 Additional Resources
 
-- [RustChain Whitepaper](RustChain_Whitepaper_Flameholder_v0.97-1.pdf)
+- [RustChain Whitepaper](RustChain_Whitepaper_Flameholder_v0.97.pdf)
 - [Protocol Specification](./PROTOCOL.md)
 - [API Reference](./API.md)
 - [Wallet User Guide](./WALLET_USER_GUIDE.md)


### PR DESCRIPTION
## Summary
- Update documentation links that pointed at missing RustChain_Whitepaper_Flameholder_v0.97-1.pdf
- Point them to the existing docs/RustChain_Whitepaper_Flameholder_v0.97.pdf file

## Verification
- Confirmed docs/RustChain_Whitepaper_Flameholder_v0.97.pdf exists
- Confirmed no remaining references to RustChain_Whitepaper_Flameholder_v0.97-1.pdf in the touched files

Bounty context: fixes broken documentation links for the recurring typo/broken-link cleanup bounty.