### PR TITLE
fix: make withdrawal debits atomic

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4756,114 +4756,136 @@ def request_withdrawal():
     if amount < MIN_WITHDRAWAL:
         return jsonify({"error": f"Minimum withdrawal is {MIN_WITHDRAWAL} RTC"}), 400
 
-    with sqlite3.connect(DB_PATH) as c:
-        # CRITICAL: Check nonce reuse FIRST (replay protection)
-        nonce_row = c.execute(
-            "SELECT used_at FROM withdrawal_nonces WHERE miner_pk = ? AND nonce = ?",
-            (miner_pk, nonce)
-        ).fetchone()
-
-        if nonce_row:
-            withdrawal_failed.inc()
-            return jsonify({
-                "error": "Nonce already used (replay protection)",
-                "used_at": nonce_row[0]
-            }), 400
-
-        # Check balance
-        row = c.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (miner_pk,)).fetchone()
-        balance = row[0] if row else 0.0
-        total_needed = amount + WITHDRAWAL_FEE
-
-        if balance < total_needed:
-            withdrawal_failed.inc()
-            return jsonify({"error": "Insufficient balance", "balance": balance}), 400
-
-        # Check daily limit
-        today = datetime.now().strftime("%Y-%m-%d")
-        limit_row = c.execute(
-            "SELECT total_withdrawn FROM withdrawal_limits WHERE miner_pk = ? AND date = ?",
-            (miner_pk, today)
-        ).fetchone()
-
-        daily_total = limit_row[0] if limit_row else 0.0
-        if daily_total + amount > MAX_DAILY_WITHDRAWAL:
-            withdrawal_failed.inc()
-            return jsonify({"error": f"Daily limit exceeded"}), 400
-
-        # Verify signature
-        row = c.execute("SELECT pubkey_sr25519 FROM miner_keys WHERE miner_pk = ?", (miner_pk,)).fetchone()
-        if not row:
-            return jsonify({"error": "Miner not registered"}), 404
-
-        pubkey_hex = row[0]
-        message = f"{miner_pk}:{destination}:{amount}:{nonce}".encode()
-
-        # Try base64 first, then hex
+    with sqlite3.connect(DB_PATH, timeout=10) as c:
         try:
+            c.execute("BEGIN IMMEDIATE")
+
+            def rollback_json(payload, status):
+                c.rollback()
+                return jsonify(payload), status
+
+            # CRITICAL: Check nonce reuse FIRST (replay protection)
+            nonce_row = c.execute(
+                "SELECT used_at FROM withdrawal_nonces WHERE miner_pk = ? AND nonce = ?",
+                (miner_pk, nonce)
+            ).fetchone()
+
+            if nonce_row:
+                withdrawal_failed.inc()
+                return rollback_json({
+                    "error": "Nonce already used (replay protection)",
+                    "used_at": nonce_row[0]
+                }, 400)
+
+            # Check balance
+            row = c.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (miner_pk,)).fetchone()
+            balance = row[0] if row else 0.0
+            total_needed = amount + WITHDRAWAL_FEE
+
+            if balance < total_needed:
+                withdrawal_failed.inc()
+                return rollback_json({"error": "Insufficient balance", "balance": balance}, 400)
+
+            # Check daily limit
+            today = datetime.now().strftime("%Y-%m-%d")
+            limit_row = c.execute(
+                "SELECT total_withdrawn FROM withdrawal_limits WHERE miner_pk = ? AND date = ?",
+                (miner_pk, today)
+            ).fetchone()
+
+            daily_total = limit_row[0] if limit_row else 0.0
+            if daily_total + amount > MAX_DAILY_WITHDRAWAL:
+                withdrawal_failed.inc()
+                return rollback_json({"error": f"Daily limit exceeded"}, 400)
+
+            # Verify signature
+            row = c.execute("SELECT pubkey_sr25519 FROM miner_keys WHERE miner_pk = ?", (miner_pk,)).fetchone()
+            if not row:
+                return rollback_json({"error": "Miner not registered"}, 404)
+
+            pubkey_hex = row[0]
+            message = f"{miner_pk}:{destination}:{amount}:{nonce}".encode()
+
+            # Try base64 first, then hex
             try:
-                sig_bytes = base64.b64decode(signature)
-            except:
-                sig_bytes = bytes.fromhex(signature)
+                try:
+                    sig_bytes = base64.b64decode(signature)
+                except:
+                    sig_bytes = bytes.fromhex(signature)
 
-            pubkey_bytes = bytes.fromhex(pubkey_hex)
+                pubkey_bytes = bytes.fromhex(pubkey_hex)
 
-            if len(sig_bytes) != 64:
+                if len(sig_bytes) != 64:
+                    withdrawal_failed.inc()
+                    return rollback_json({"error": "Invalid signature length"}, 400)
+
+                if not verify_sr25519_signature(message, sig_bytes, pubkey_bytes):
+                    withdrawal_failed.inc()
+                    return rollback_json({"error": "Invalid signature"}, 401)
+            except Exception as e:
                 withdrawal_failed.inc()
-                return jsonify({"error": "Invalid signature length"}), 400
+                logging.warning(f"Withdrawal signature error for {miner_pk}: {e}")
+                return rollback_json({"error": "Signature verification failed"}, 400)
 
-            if not verify_sr25519_signature(message, sig_bytes, pubkey_bytes):
+            # Create withdrawal
+            withdrawal_id = f"WD_{int(time.time() * 1000000)}_{secrets.token_hex(8)}"
+
+            # ATOMIC TRANSACTION: Record nonce FIRST to prevent replay
+            c.execute("""
+                INSERT INTO withdrawal_nonces (miner_pk, nonce, used_at)
+                VALUES (?, ?, ?)
+            """, (miner_pk, nonce, int(time.time())))
+
+            # Deduct balance only if the row still has enough funds inside this transaction.
+            debit = c.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ? AND balance_rtc >= ?",
+                (total_needed, miner_pk, total_needed)
+            )
+            if debit.rowcount != 1:
                 withdrawal_failed.inc()
-                return jsonify({"error": "Invalid signature"}), 401
-        except Exception as e:
-            withdrawal_failed.inc()
-            logging.warning(f"Withdrawal signature error for {miner_pk}: {e}")
-            return jsonify({"error": "Signature verification failed"}), 400
+                latest = c.execute(
+                    "SELECT balance_rtc FROM balances WHERE miner_pk = ?",
+                    (miner_pk,)
+                ).fetchone()
+                latest_balance = latest[0] if latest else 0.0
+                return rollback_json({"error": "Insufficient balance", "balance": latest_balance}, 400)
 
-        # Create withdrawal
-        withdrawal_id = f"WD_{int(time.time() * 1000000)}_{secrets.token_hex(8)}"
+            # RIP-301: Route fee to mining pool (founder_community) instead of burning
+            fee_urtc = int(WITHDRAWAL_FEE * UNIT)
+            fee_rtc = WITHDRAWAL_FEE
+            # Ensure founder_community row exists before crediting
+            c.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
+                      ("founder_community",))
+            c.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+                (fee_rtc, "founder_community")
+            )
+            c.execute(
+                """INSERT INTO fee_events (source, source_id, miner_pk, fee_rtc, fee_urtc, destination, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                ("withdrawal", withdrawal_id, miner_pk, WITHDRAWAL_FEE, fee_urtc, "founder_community", int(time.time()))
+            )
 
-        # ATOMIC TRANSACTION: Record nonce FIRST to prevent replay
-        c.execute("""
-            INSERT INTO withdrawal_nonces (miner_pk, nonce, used_at)
-            VALUES (?, ?, ?)
-        """, (miner_pk, nonce, int(time.time())))
+            # Create withdrawal record
+            c.execute("""
+                INSERT INTO withdrawals (
+                    withdrawal_id, miner_pk, amount, fee, destination,
+                    signature, status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+            """, (withdrawal_id, miner_pk, amount, WITHDRAWAL_FEE, destination, signature, int(time.time())))
 
-        # Deduct balance
-        c.execute("UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?",
-                  (total_needed, miner_pk))
+            # Update daily limit
+            c.execute("""
+                INSERT INTO withdrawal_limits (miner_pk, date, total_withdrawn)
+                VALUES (?, ?, ?)
+                ON CONFLICT(miner_pk, date) DO UPDATE SET
+                total_withdrawn = total_withdrawn + ?
+            """, (miner_pk, today, amount, amount))
 
-        # RIP-301: Route fee to mining pool (founder_community) instead of burning
-        fee_urtc = int(WITHDRAWAL_FEE * UNIT)
-        fee_rtc = WITHDRAWAL_FEE
-        # Ensure founder_community row exists before crediting
-        c.execute("INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
-                  ("founder_community",))
-        c.execute(
-            "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
-            (fee_rtc, "founder_community")
-        )
-        c.execute(
-            """INSERT INTO fee_events (source, source_id, miner_pk, fee_rtc, fee_urtc, destination, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?)""",
-            ("withdrawal", withdrawal_id, miner_pk, WITHDRAWAL_FEE, fee_urtc, "founder_community", int(time.time()))
-        )
-
-        # Create withdrawal record
-        c.execute("""
-            INSERT INTO withdrawals (
-                withdrawal_id, miner_pk, amount, fee, destination,
-                signature, status, created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
-        """, (withdrawal_id, miner_pk, amount, WITHDRAWAL_FEE, destination, signature, int(time.time())))
-
-        # Update daily limit
-        c.execute("""
-            INSERT INTO withdrawal_limits (miner_pk, date, total_withdrawn)
-            VALUES (?, ?, ?)
-            ON CONFLICT(miner_pk, date) DO UPDATE SET
-            total_withdrawn = total_withdrawn + ?
-        """, (miner_pk, today, amount, amount))
+            c.commit()
+        except Exception:
+            c.rollback()
+            raise
 
         balance_gauge.labels(miner_pk=miner_pk).set(balance - total_needed)
         withdrawal_queue_size.inc()

--- a/node/tests/test_withdrawal_atomic_debit.py
+++ b/node/tests/test_withdrawal_atomic_debit.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+import base64
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestWithdrawalAtomicDebit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_withdraw_atomic_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.mod.UNIT = getattr(cls.mod, "UNIT", 1_000_000)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        try:
+            cls._tmp.cleanup()
+        except OSError:
+            pass
+
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.mod.DB_PATH = self.db_path
+        self._orig_verify = self.mod.verify_sr25519_signature
+        self._create_schema()
+
+    def tearDown(self):
+        self.mod.verify_sr25519_signature = self._orig_verify
+        try:
+            os.unlink(self.db_path)
+        except (FileNotFoundError, PermissionError):
+            pass
+
+    def _create_schema(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                "CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL NOT NULL DEFAULT 0)"
+            )
+            conn.execute(
+                "CREATE TABLE withdrawal_nonces (miner_pk TEXT NOT NULL, nonce TEXT NOT NULL, used_at INTEGER NOT NULL, PRIMARY KEY (miner_pk, nonce))"
+            )
+            conn.execute(
+                "CREATE TABLE withdrawal_limits (miner_pk TEXT NOT NULL, date TEXT NOT NULL, total_withdrawn REAL DEFAULT 0, PRIMARY KEY (miner_pk, date))"
+            )
+            conn.execute(
+                "CREATE TABLE miner_keys (miner_pk TEXT PRIMARY KEY, pubkey_sr25519 TEXT NOT NULL, registered_at INTEGER NOT NULL)"
+            )
+            conn.execute(
+                """
+                CREATE TABLE withdrawals (
+                    withdrawal_id TEXT PRIMARY KEY,
+                    miner_pk TEXT NOT NULL,
+                    amount REAL NOT NULL,
+                    fee REAL NOT NULL,
+                    destination TEXT NOT NULL,
+                    signature TEXT NOT NULL,
+                    status TEXT DEFAULT 'pending',
+                    created_at INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE fee_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    source TEXT NOT NULL,
+                    source_id TEXT,
+                    miner_pk TEXT,
+                    fee_rtc REAL NOT NULL,
+                    fee_urtc INTEGER NOT NULL,
+                    destination TEXT NOT NULL,
+                    created_at INTEGER NOT NULL
+                )
+                """
+            )
+            conn.execute("INSERT INTO balances VALUES ('miner-test', 50.01)")
+            conn.execute("INSERT INTO balances VALUES ('founder_community', 0)")
+            conn.execute(
+                "INSERT INTO miner_keys VALUES ('miner-test', ?, ?)",
+                ("00" * 32, int(time.time())),
+            )
+
+    def _payload(self, nonce):
+        return {
+            "miner_pk": "miner-test",
+            "amount": 50.0,
+            "destination": "rtc-destination",
+            "signature": base64.b64encode(b"\x00" * 64).decode("ascii"),
+            "nonce": nonce,
+        }
+
+    def test_concurrent_withdrawals_cannot_overdraw_balance(self):
+        def slow_valid_signature(*_args, **_kwargs):
+            time.sleep(0.05)
+            return True
+
+        self.mod.verify_sr25519_signature = slow_valid_signature
+        results = []
+        lock = threading.Lock()
+
+        def post_withdrawal(nonce):
+            with self.mod.app.test_client() as client:
+                resp = client.post("/withdraw/request", json=self._payload(nonce))
+            with lock:
+                results.append((resp.status_code, resp.get_json()))
+
+        t1 = threading.Thread(target=post_withdrawal, args=("nonce-1",))
+        t2 = threading.Thread(target=post_withdrawal, args=("nonce-2",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        statuses = sorted(status for status, _body in results)
+        self.assertEqual(statuses, [200, 400])
+
+        with sqlite3.connect(self.db_path) as conn:
+            balance = conn.execute(
+                "SELECT balance_rtc FROM balances WHERE miner_pk = 'miner-test'"
+            ).fetchone()[0]
+            founder_balance = conn.execute(
+                "SELECT balance_rtc FROM balances WHERE miner_pk = 'founder_community'"
+            ).fetchone()[0]
+            withdrawal_count = conn.execute("SELECT COUNT(*) FROM withdrawals").fetchone()[0]
+
+        self.assertGreaterEqual(balance, 0)
+        self.assertAlmostEqual(balance, 0.0, places=6)
+        self.assertAlmostEqual(founder_balance, self.mod.WITHDRAWAL_FEE, places=6)
+        self.assertEqual(withdrawal_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- wrap `/withdraw/request` validation and mutation in `BEGIN IMMEDIATE`
- replace the unconditional balance debit with a conditional atomic debit guarded by `balance_rtc >= total_needed`
- rollback cleanly on replay, insufficient balance, daily limit, registration, and signature failures
- add a concurrent regression test proving two simultaneous withdrawals cannot overdraw the same balance

Fixes #4296

## Verification
- `python -m pytest node\tests\test_withdrawal_atomic_debit.py -q` (1 passed)
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_withdrawal_atomic_debit.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_withdrawal_atomic_debit.py`

## Notes
- `python -m pytest node\tests\test_withdraw_amount_validation.py -q` still fails on pre-existing amount/JSON validation expectations and Windows temp cleanup behavior; this PR is intentionally scoped to withdrawal debit atomicity.