### PR TITLE
Fix machine passport write authentication

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,33 @@ def get_optional_json_object():
     return data, None
 
 
+def require_admin(req):
+    """Validate admin authentication for machine passport write endpoints."""
+    expected_admin_key = os.environ.get('ADMIN_KEY', '').strip()
+    provided_admin_key = (
+        req.headers.get('X-Admin-Key', '') or req.headers.get('X-API-Key', '')
+    ).strip()
+
+    if not expected_admin_key:
+        return jsonify({
+            'ok': False,
+            'error': 'admin_key_not_configured',
+            'message': 'ADMIN_KEY not configured - write endpoints disabled',
+        }), 503
+
+    if not provided_admin_key or not hmac.compare_digest(
+        provided_admin_key,
+        expected_admin_key,
+    ):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -199,16 +226,9 @@ def create_passport():
         "provenance": "eBay lot #12345"
     }
     """
-    # Admin authentication
-    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
-    expected_admin_key = os.environ.get('ADMIN_KEY', '')
-    
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
-        return jsonify({
-            'ok': False,
-            'error': 'unauthorized',
-            'message': 'Admin key required',
-        }), 401
+    auth_error = require_admin(request)
+    if auth_error:
+        return auth_error
     
     data = request.get_json()
     if not data:
@@ -286,23 +306,17 @@ def update_passport(machine_id: str):
     """
     Update a machine passport.
 
-    Requires admin authentication when ADMIN_KEY is configured.
+    Requires admin authentication.
     """
-    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
-    expected_admin_key = os.environ.get('ADMIN_KEY', '')
-    
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
-        return jsonify({
-            'ok': False,
-            'error': 'unauthorized',
-            'message': 'Admin key required',
-        }), 401
+    auth_error = require_admin(request)
+    if auth_error:
+        return auth_error
     
     data = request.get_json()
     if not data:

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -502,6 +502,7 @@ class TestAPIEndpoints(unittest.TestCase):
     
     def test_create_passport(self):
         """Test creating a passport via API."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
         passport_data = {
             'name': 'API Test',
             'owner_miner_id': 'miner_api',
@@ -512,26 +513,63 @@ class TestAPIEndpoints(unittest.TestCase):
         resp = self.client.post(
             '/api/machine-passport',
             json=passport_data,
-            # No admin key needed if ADMIN_KEY env var not set
+            headers={'X-Admin-Key': 'expected-admin-key'},
         )
         data = json.loads(resp.data)
 
-        # Should succeed (no admin key required if ADMIN_KEY not set)
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(data['ok'])
         self.assertIn('machine_id', data)
 
+    def test_create_passport_requires_configured_admin_key(self):
+        """Write endpoints fail closed when ADMIN_KEY is unset."""
+        resp = self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'No Auth',
+                'owner_miner_id': 'miner_api',
+                'machine_id': 'api_test_no_auth',
+            },
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'admin_key_not_configured')
+
+    def test_create_passport_rejects_wrong_admin_key(self):
+        """Invalid admin credentials cannot create passports."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=False) as compare_digest:
+            resp = self.client.post(
+                '/api/machine-passport',
+                headers={'X-Admin-Key': 'wrong-admin-key'},
+                json={
+                    'name': 'Wrong Auth',
+                    'owner_miner_id': 'miner_api',
+                    'machine_id': 'api_test_wrong_auth',
+                },
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+
     def test_update_passport_rejects_owner_claim_without_admin_key(self):
         """Client-supplied owner_miner_id is not proof of ownership."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
         self.client.post(
             '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
             json={
                 'name': 'Owner Claim Test',
                 'owner_miner_id': 'miner_owner',
                 'machine_id': 'owner_claim_test',
             },
         )
-        os.environ['ADMIN_KEY'] = 'expected-admin-key'
 
         with patch('hmac.compare_digest', return_value=False) as compare_digest:
             resp = self.client.put(
@@ -555,15 +593,16 @@ class TestAPIEndpoints(unittest.TestCase):
 
     def test_update_passport_accepts_valid_admin_key(self):
         """Configured admin key still authorizes passport updates."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
         self.client.post(
             '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
             json={
                 'name': 'Admin Update Test',
                 'owner_miner_id': 'miner_owner',
                 'machine_id': 'admin_update_test',
             },
         )
-        os.environ['ADMIN_KEY'] = 'expected-admin-key'
 
         with patch('hmac.compare_digest', return_value=True) as compare_digest:
             resp = self.client.put(


### PR DESCRIPTION
## Summary
- fail closed on machine passport write endpoints when `ADMIN_KEY` is not configured
- centralize machine passport admin auth and use `hmac.compare_digest()` for configured key checks
- require real admin auth for passport updates instead of trusting `owner_miner_id` supplied in the request body
- add regression coverage for unset admin key, wrong admin key, forged owner-body updates, and valid admin updates

Fixes #4300

## Validation
- `python -m pytest node\tests\test_machine_passport.py::TestAPIEndpoints -q`
- `python -m pytest node\tests\test_machine_passport.py -q`
- `python -m py_compile node\machine_passport_api.py node\tests\test_machine_passport.py`
- `git diff --check -- node\machine_passport_api.py node\tests\test_machine_passport.py`
