### PR TITLE
docs: fix installation walkthrough relative link

### DIFF
--- a/docs/INSTALLATION_WALKTHROUGH.md
+++ b/docs/INSTALLATION_WALKTHROUGH.md
@@ -158,7 +158,7 @@ Add to your README.md:
 ```markdown
 ## Installation
 
-See the [Installation Walkthrough](docs/INSTALLATION_WALKTHROUGH.md) for a 
+See the [Installation Walkthrough](INSTALLATION_WALKTHROUGH.md) for a 
 visual guide with asciinema recordings.
 
 Quick preview:


### PR DESCRIPTION
## Summary\n- Fix a relative link in docs/INSTALLATION_WALKTHROUGH.md so it resolves correctly from the docs directory.\n\n## Validation\n- Verified the target file exists at docs/INSTALLATION_WALKTHROUGH.md.\n\nRelated to Scottcjn/rustchain-bounties#2178.