### PR TITLE
fix: harden prometheus exporter metrics

### DIFF
--- a/prometheus_exporter.py
+++ b/prometheus_exporter.py
@@ -3,12 +3,12 @@
 
 import os
 import time
-import json
 import sqlite3
 import requests
 from flask import Flask, Response
 from threading import Thread
 import logging
+from math import isfinite
 
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -16,12 +16,16 @@ logger = logging.getLogger(__name__)
 
 # Configuration from environment
 NODE_URL = os.getenv('RUSTCHAIN_NODE_URL', 'http://localhost:8080')
+EXPORTER_HOST = os.getenv(
+    'PROMETHEUS_EXPORTER_HOST',
+    '0.0.0.0' if os.getenv('RUSTCHAIN_AUTH') else '127.0.0.1'
+)
 EXPORTER_PORT = int(os.getenv('PROMETHEUS_EXPORTER_PORT', '9100'))
 SCRAPE_INTERVAL = int(os.getenv('SCRAPE_INTERVAL', '15'))
 DB_PATH = os.getenv('DB_PATH', 'rustchain.db')
 
 # Metrics storage
-metrics_data = {
+METRIC_DEFAULTS = {
     'node_up': 0,
     'current_epoch': 0,
     'epoch_progress': 0.0,
@@ -34,6 +38,44 @@ metrics_data = {
     'difficulty': 0.0,
     'last_scrape_timestamp': 0
 }
+
+INTEGER_METRICS = {
+    'node_up',
+    'current_epoch',
+    'total_miners',
+    'active_miners',
+    'chain_height',
+    'total_transactions',
+    'pending_transactions',
+    'last_scrape_timestamp',
+}
+
+# Metrics storage
+metrics_data = dict(METRIC_DEFAULTS)
+
+def coerce_metric_value(name, value):
+    """Return a finite numeric metric value, or the metric's safe default."""
+    default = METRIC_DEFAULTS[name]
+    try:
+        numeric_value = float(value)
+    except (TypeError, ValueError):
+        return default
+
+    if not isfinite(numeric_value):
+        return default
+
+    if name in INTEGER_METRICS:
+        return int(numeric_value)
+    return numeric_value
+
+def update_metrics_from_source(source):
+    """Apply only known numeric metrics from a scraped API/database payload."""
+    if not isinstance(source, dict):
+        return
+
+    for name in METRIC_DEFAULTS:
+        if name in source:
+            metrics_data[name] = coerce_metric_value(name, source[name])
 
 def fetch_node_api_data():
     """Fetch data from RustChain node API"""
@@ -105,13 +147,14 @@ def scrape_metrics():
             api_data = fetch_node_api_data()
             if api_data:
                 metrics_data['node_up'] = 1
-                metrics_data.update(api_data)
+                update_metrics_from_source(api_data)
+                metrics_data['node_up'] = 1
             else:
                 metrics_data['node_up'] = 0
                 # Fallback to database
                 db_data = fetch_db_metrics()
                 if db_data:
-                    metrics_data.update(db_data)
+                    update_metrics_from_source(db_data)
             
             metrics_data['last_scrape_timestamp'] = int(time.time())
             logger.info(f"Metrics updated: node_up={metrics_data['node_up']}, epoch={metrics_data['current_epoch']}")
@@ -180,11 +223,11 @@ def health_check():
 
 if __name__ == '__main__':
     logger.info(f"Starting Prometheus exporter for RustChain node at {NODE_URL}")
-    logger.info(f"Metrics will be available at http://localhost:{EXPORTER_PORT}/metrics")
+    logger.info(f"Metrics will be available at http://{EXPORTER_HOST}:{EXPORTER_PORT}/metrics")
     
     # Start metrics scraping in background thread
     scraper_thread = Thread(target=scrape_metrics, daemon=True)
     scraper_thread.start()
     
     # Run Flask app
-    app.run(host='0.0.0.0', port=EXPORTER_PORT, debug=False)
+    app.run(host=EXPORTER_HOST, port=EXPORTER_PORT, debug=False)

--- a/tests/test_prometheus_exporter_security.py
+++ b/tests/test_prometheus_exporter_security.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "prometheus_exporter.py"
+
+
+def load_exporter(monkeypatch, *, auth=None, host=None):
+    if auth is None:
+        monkeypatch.delenv("RUSTCHAIN_AUTH", raising=False)
+    else:
+        monkeypatch.setenv("RUSTCHAIN_AUTH", auth)
+
+    if host is None:
+        monkeypatch.delenv("PROMETHEUS_EXPORTER_HOST", raising=False)
+    else:
+        monkeypatch.setenv("PROMETHEUS_EXPORTER_HOST", host)
+
+    module_name = "prometheus_exporter_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_metrics_update_ignores_private_key_payload(monkeypatch):
+    exporter = load_exporter(monkeypatch)
+
+    exporter.update_metrics_from_source(
+        {
+            "current_epoch": 42,
+            "node_private_key": "0xsupersecret",
+            "private_key": "also-secret",
+            "difficulty": "not-a-number",
+            "network_hashrate": math.inf,
+        }
+    )
+
+    response = exporter.app.test_client().get("/metrics")
+    body = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert "rustchain_current_epoch 42" in body
+    assert "node_private_key" not in body
+    assert "0xsupersecret" not in body
+    assert "also-secret" not in body
+    assert "rustchain_difficulty 0.0" in body
+    assert "rustchain_network_hashrate 0.0" in body
+
+
+def test_exporter_binds_localhost_without_auth_by_default(monkeypatch):
+    exporter = load_exporter(monkeypatch)
+
+    assert exporter.EXPORTER_HOST == "127.0.0.1"
+
+
+def test_exporter_host_can_be_explicitly_configured(monkeypatch):
+    exporter = load_exporter(monkeypatch, host="0.0.0.0")
+
+    assert exporter.EXPORTER_HOST == "0.0.0.0"


### PR DESCRIPTION
## Summary
- bind the standalone Prometheus exporter to localhost by default when `RUSTCHAIN_AUTH` is unset, with `PROMETHEUS_EXPORTER_HOST` as an explicit override
- whitelist/coerce scraped API/database metric values before rendering `/metrics`, so unknown or non-numeric fields such as private keys cannot be emitted
- add regression tests for private-key payload redaction and default bind behavior
- include the existing `utxo_mempool` missing-table guard needed for current security-audit CI on fresh `main`

Fixes #2732.

## Validation
- `python -m pytest tests\test_prometheus_exporter_security.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile prometheus_exporter.py tests\test_prometheus_exporter_security.py node\utxo_db.py`
- `git diff --check -- prometheus_exporter.py tests\test_prometheus_exporter_security.py node\utxo_db.py`