### PR TITLE
fix: repair installer miner download urls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,8 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 INSTALL_DIR="$HOME/.rustchain"
-MINER_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_universal_miner.py"
-FINGERPRINT_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/fingerprint_checks.py"
+MINER_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py"
+FINGERPRINT_URL="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py"
 NODE_URL="https://50.28.86.131"
 VERSION="1.0.0"
 


### PR DESCRIPTION
## Summary
- updates `install.sh` to download the Linux miner from `miners/linux/rustchain_linux_miner.py`
- updates the fingerprint helper URL to `miners/linux/fingerprint_checks.py`
- keeps the local installed filenames unchanged

Fixes #2683.

## Validation
- verified both raw GitHub URLs return HTTP 200
- `bash install.sh --wallet test-miner --dry-run`
- `git diff --check -- install.sh`