### PR TITLE
docs: add local development guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,19 @@ tail -f ~/.rustchain/miner.log
 
 ---
 
+## Local Development
+
+Developers can build and run RustChain locally from a fresh checkout:
+
+1. Install prerequisites and run Python/Rust checks with the [Build Guide](docs/BUILD.md).
+2. Start a single-node local devnet with [Local Devnet](docs/DEVNET.md).
+3. Create a development wallet and simulate a transfer with the [CLI Wallet Walkthrough](docs/CLI.md).
+
+These guides keep local state in `.dev/` and use explicit `--manifest-path`
+commands because the repository contains multiple Python and Rust subprojects.
+
+---
+
 ## How Proof-of-Antiquity Works
 
 ### 1 CPU = 1 Vote

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,105 @@
+# RustChain Build Guide
+
+Use this guide when you want a local development checkout for the Python node
+and the Rust command-line components.
+
+## System prerequisites
+
+| Tool | Minimum | Used for |
+| --- | --- | --- |
+| Python | 3.11+ recommended | Node, tests, wallet GUI, scripts |
+| pip | Bundled with Python | Python dependency installation |
+| Rust | 1.70+ | Rust miner and native wallet crates |
+| Cargo | Bundled with Rust | Rust builds and checks |
+| curl | Any recent version | API smoke tests |
+| Git | Any recent version | Checkout and contribution workflow |
+
+Protocol Buffers are not required for the checked-in Python node, Rust miner, or
+Rust wallet paths documented here. Install `protoc` only if a specific future
+subproject or integration README asks for it.
+
+## Clone the repository
+
+```bash
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain
+```
+
+## Python development setup
+
+Linux and macOS:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-node.txt
+```
+
+Windows PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-node.txt
+```
+
+Verify the key entry points parse correctly:
+
+```bash
+python -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py wallet/__main__.py
+```
+
+## Rust component builds
+
+RustChain has multiple Rust subprojects, not one top-level Cargo workspace. Build
+or check the component you are changing with `--manifest-path`.
+
+Check the miner:
+
+```bash
+cargo check --manifest-path rustchain-miner/Cargo.toml
+```
+
+Build the miner:
+
+```bash
+cargo build --release --manifest-path rustchain-miner/Cargo.toml
+```
+
+Check the native wallet:
+
+```bash
+cargo check --manifest-path rustchain-wallet/Cargo.toml
+```
+
+Build the native wallet:
+
+```bash
+cargo build --release --manifest-path rustchain-wallet/Cargo.toml --bin rtc-wallet
+```
+
+## Fast validation before opening a PR
+
+For docs-only changes:
+
+```bash
+git diff --check
+```
+
+For Python node or wallet changes:
+
+```bash
+python -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py wallet/__main__.py
+```
+
+For Rust miner or wallet changes:
+
+```bash
+cargo check --manifest-path rustchain-miner/Cargo.toml
+cargo check --manifest-path rustchain-wallet/Cargo.toml
+```
+
+Run narrower tests for the files you touched when possible. The repository is
+large, so prefer focused validation plus any maintainer-requested CI checks.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,103 @@
+# RustChain CLI Wallet Walkthrough
+
+This walkthrough uses the native Rust wallet in `rustchain-wallet/`. It shows
+wallet creation, local devnet connectivity, and a simulated transaction.
+
+## Build the wallet
+
+```bash
+cargo build --manifest-path rustchain-wallet/Cargo.toml --bin rtc-wallet
+```
+
+You can also run commands through Cargo while developing:
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- --help
+```
+
+## Create a development wallet
+
+Use a local wallet directory so test wallets stay out of your default wallet
+storage.
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  create --name alice
+```
+
+The command prompts for a password and stores the encrypted key in the wallet
+directory. Save the printed RTC address if you want to use it in examples.
+
+## Show the receive address
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  receive --name alice
+```
+
+## Check balance on a local node
+
+Start the local node from [`DEVNET.md`](DEVNET.md), then run:
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  balance --wallet alice \
+  --rpc http://127.0.0.1:8099
+```
+
+You can also check a raw RTC address:
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  balance --wallet RTC_EXAMPLE_ADDRESS \
+  --rpc http://127.0.0.1:8099
+```
+
+## Simulate a transaction
+
+Use `--simulate` first. It signs and prints the transaction without broadcasting
+it to the node.
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  send \
+  --from alice \
+  --to RTC_RECIPIENT_ADDRESS \
+  --amount 1000 \
+  --fee 1000 \
+  --memo "local devnet test" \
+  --rpc http://127.0.0.1:8099 \
+  --simulate
+```
+
+Remove `--simulate` only after the local node is running, the recipient address
+is correct, and you intentionally want to submit the transfer.
+
+## Useful wallet commands
+
+```bash
+# List local wallets
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --wallet-dir .dev/wallets list
+
+# Show public wallet details
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --wallet-dir .dev/wallets show --name alice
+
+# Query local network information
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet network --rpc http://127.0.0.1:8099
+```
+
+Never commit files from `.dev/wallets`, exported private keys, seed phrases, or
+terminal logs containing secrets.

--- a/docs/DEVNET.md
+++ b/docs/DEVNET.md
@@ -1,0 +1,108 @@
+# Local Single-Node Devnet
+
+This page shows how to start the RustChain node locally for development and
+connect examples to it. The local node uses SQLite and listens on port `8099`.
+
+## 1. Prepare the Python environment
+
+From the repository root, follow the Python setup in [`BUILD.md`](BUILD.md):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-node.txt
+```
+
+On Windows PowerShell, activate the environment with:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+```
+
+## 2. Start the node
+
+Use a throwaway SQLite database so local experiments do not reuse production or
+shared state.
+
+Linux and macOS:
+
+```bash
+export RUSTCHAIN_DB_PATH=.dev/rustchain-devnet.db
+mkdir -p .dev
+python node/wsgi.py
+```
+
+Windows PowerShell:
+
+```powershell
+$env:RUSTCHAIN_DB_PATH = ".dev\rustchain-devnet.db"
+New-Item -ItemType Directory -Force .dev
+python node\wsgi.py
+```
+
+The development server listens at:
+
+```text
+http://127.0.0.1:8099
+```
+
+## 3. Smoke test the local node
+
+In a second terminal:
+
+```bash
+curl http://127.0.0.1:8099/health
+curl http://127.0.0.1:8099/epoch
+curl http://127.0.0.1:8099/api/miners
+```
+
+If the node cannot start because port `8099` is already in use, stop the other
+process first. The current WSGI entry point hard-codes port `8099` for direct
+development runs.
+
+## 4. Connect a miner in dry-run mode
+
+After building the Rust miner, point it at the local node:
+
+```bash
+cargo run --manifest-path rustchain-miner/Cargo.toml -- \
+  --node http://127.0.0.1:8099 \
+  --wallet dev-miner \
+  --miner-id dev-miner \
+  --dry-run
+```
+
+Remove `--dry-run` only when you intentionally want the miner to submit to the
+local node.
+
+## 5. Connect the native wallet
+
+The native wallet accepts an RPC override on commands that talk to the network:
+
+```bash
+cargo run --manifest-path rustchain-wallet/Cargo.toml -- \
+  --network devnet \
+  --wallet-dir .dev/wallets \
+  network \
+  --rpc http://127.0.0.1:8099
+```
+
+See [`CLI.md`](CLI.md) for wallet creation, balance, and transaction examples.
+
+## 6. Reset local state
+
+Stop the node, then delete the throwaway database:
+
+```bash
+rm -f .dev/rustchain-devnet.db
+```
+
+Windows PowerShell:
+
+```powershell
+Remove-Item .dev\rustchain-devnet.db -ErrorAction SilentlyContinue
+```
+
+Do not run destructive cleanup commands against any database path you did not
+create for local development.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,9 @@
 | [Protocol Specification](./PROTOCOL.md) | Full RIP-200 consensus protocol |
 | [Mechanism Spec + Falsification Matrix](./MECHANISM_SPEC_AND_FALSIFICATION_MATRIX.md) | One-page claim-to-test map with break conditions |
 | [API Reference](./API.md) | All endpoints with curl examples |
+| [Build Guide](./BUILD.md) | Local Python and Rust build commands |
+| [Local Devnet](./DEVNET.md) | Run a single-node development server |
+| [CLI Wallet Walkthrough](./CLI.md) | Create a wallet and simulate a transaction |
 | [Glossary](./GLOSSARY.md) | Terms and definitions |
 | [Tokenomics](./tokenomics_v1.md) | RTC supply and distribution |
 | [FAQ & Troubleshooting](./FAQ_TROUBLESHOOTING.md) | Common setup/runtime issues and recovery steps |
@@ -69,4 +72,3 @@ Active bounties: [github.com/Scottcjn/rustchain-bounties](https://github.com/Sco
 
 ---
 *Documentation maintained by the RustChain community.*
-


### PR DESCRIPTION
## Summary

- add build, local devnet, and CLI wallet walkthrough docs for new contributors
- link the new local development path from the root README and docs index
- document the Python node setup and explicit Cargo manifest paths for the Rust miner and wallet crates

Fixes #2728

## Validation

- `git diff --check -- README.md docs\README.md docs\BUILD.md docs\DEVNET.md docs\CLI.md`
- `python -m py_compile node\wsgi.py node\rustchain_v2_integrated_v2.2.1_rip200.py wallet\__main__.py`
- `cargo check --manifest-path rustchain-miner\Cargo.toml`
- `cargo check --manifest-path rustchain-wallet\Cargo.toml`
- `cargo run --manifest-path rustchain-wallet\Cargo.toml -- --help`
