### PR TITLE
fix: recover interrupted tx balance migrations

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -109,6 +109,8 @@ class TransactionPool:
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.cursor()
 
+            self._recover_interrupted_balances_migration(cursor)
+
             # Base case: create the balances table if it doesn't exist at all.
             # The migration steps below assume the table already exists (ALTER TABLE,
             # PRAGMA table_info, etc.), so a fresh empty DB would fail without this.
@@ -169,6 +171,27 @@ class TransactionPool:
                             logger.warning(f"Schema statement failed: {e}")
 
             conn.commit()
+
+    def _recover_interrupted_balances_migration(self, cursor) -> None:
+        """Recover balances after a crash between SQLite table renames."""
+        cursor.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name IN ('balances', 'balances_old', 'balances_new')"
+        )
+        tables = {row[0] for row in cursor.fetchall()}
+
+        if "balances" in tables:
+            return
+
+        if "balances_new" in tables:
+            cursor.execute("ALTER TABLE balances_new RENAME TO balances")
+            cursor.execute("DROP TABLE IF EXISTS balances_old")
+            logger.warning("Recovered interrupted balances migration from balances_new")
+            return
+
+        if "balances_old" in tables:
+            cursor.execute("ALTER TABLE balances_old RENAME TO balances")
+            logger.warning("Recovered interrupted balances migration from balances_old")
 
     @contextmanager
     def _get_connection(self):

--- a/tests/test_tx_handler_migration_recovery.py
+++ b/tests/test_tx_handler_migration_recovery.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import sys
+
+import pytest
+
+
+tx_handler = sys.modules["tx_handler"]
+
+
+def test_recovers_balances_old_when_migration_crashed_before_new_rename(tmp_path):
+    db_path = str(tmp_path / "tx_recover_old.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE balances_old "
+            "(wallet TEXT PRIMARY KEY, balance_urtc INTEGER NOT NULL, wallet_nonce INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO balances_old (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)",
+            ("alice", 1234, 7),
+        )
+
+    pool = tx_handler.TransactionPool(db_path)
+
+    assert pool.get_balance("alice") == 1234
+    assert pool.get_wallet_nonce("alice") == 7
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert "balances" in tables
+    assert "balances_old" not in tables
+
+
+def test_completes_balances_new_when_migration_crashed_after_old_rename(tmp_path):
+    db_path = str(tmp_path / "tx_recover_new.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE balances_old "
+            "(wallet TEXT PRIMARY KEY, balance_urtc INTEGER NOT NULL, wallet_nonce INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO balances_old (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)",
+            ("old-copy", 5000, 2),
+        )
+        conn.execute(
+            "CREATE TABLE balances_new "
+            "(wallet TEXT PRIMARY KEY, balance_urtc INTEGER NOT NULL CHECK(balance_urtc >= 0), "
+            "wallet_nonce INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO balances_new (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)",
+            ("alice", 1234, 7),
+        )
+
+    pool = tx_handler.TransactionPool(db_path)
+
+    assert pool.get_balance("alice") == 1234
+    assert pool.get_wallet_nonce("alice") == 7
+    assert pool.get_balance("old-copy") == 0
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO balances (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)",
+                ("negative", -1, 0),
+            )
+    assert "balances" in tables
+    assert "balances_old" not in tables
+    assert "balances_new" not in tables


### PR DESCRIPTION
## Summary

Fixes the `rustchain_tx_handler.py` schema migration crash-safety gap from #2811.

- detects interrupted `balances` migrations before creating a fresh table
- restores `balances_old` when the crash happened before `balances_new` was promoted
- completes the `balances_new` promotion and drops `balances_old` when the crash happened after the old table rename
- preserves the existing `CHECK(balance_urtc >= 0)` migration behavior
- includes the minimal `utxo_db.mempool_clear_expired()` missing-table guard needed for the current CI baseline

Wallet: `cerredz`

## Validation

- `python -m pytest tests\test_tx_handler_migration_recovery.py tests\test_ledger.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_tx_handler.py node\utxo_db.py tests\test_tx_handler_migration_recovery.py`
- `git diff --check -- node\rustchain_tx_handler.py node\utxo_db.py tests\test_tx_handler_migration_recovery.py`

Fixes #2811