### PR TITLE
fix: fail closed when payout broadcast is unconfigured

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -21,6 +21,11 @@ POLL_INTERVAL = 30  # seconds
 MAX_RETRIES = 3
 MOCK_MODE = os.environ.get("RUSTCHAIN_MOCK_MODE", "0") == "1"  # Default: production (False)
 
+
+class ProductionWithdrawalNotConfigured(RuntimeError):
+    """Raised when the worker is asked to broadcast without an implementation."""
+
+
 class PayoutWorker:
     def __init__(self):
         self.db_path = DB_PATH
@@ -77,7 +82,10 @@ class PayoutWorker:
             # tx = build_transaction(withdrawal)
             # tx_hash = broadcast_transaction(tx)
             # wait_for_confirmation(tx_hash)
-            pass
+            raise ProductionWithdrawalNotConfigured(
+                "Production withdrawal execution is not configured; refusing to "
+                "complete withdrawal without a broadcast transaction hash"
+            )
 
     def process_withdrawal(self, withdrawal: Dict) -> bool:
         """Process a single withdrawal with balance deduction before execution."""
@@ -87,6 +95,20 @@ class PayoutWorker:
             logger.info(f"Processing withdrawal {withdrawal_id}")
             logger.info(f"  Amount: {withdrawal['amount']} RTC")
             logger.info(f"  Destination: {withdrawal['destination']}")
+
+            if not MOCK_MODE:
+                message = (
+                    "Production withdrawal execution is not configured; leaving "
+                    "withdrawal pending for retry"
+                )
+                with sqlite3.connect(self.db_path) as conn:
+                    conn.execute(
+                        "UPDATE withdrawals SET error_msg = ? "
+                        "WHERE withdrawal_id = ? AND status = 'pending'",
+                        (message, withdrawal_id),
+                    )
+                logger.error(f"✗ Withdrawal {withdrawal_id}: {message}")
+                return False
 
             # ── Atomic balance check + deduction + status update ─────────
             # All three operations MUST happen in a single transaction so

--- a/tests/test_payout_worker_production_noop.py
+++ b/tests/test_payout_worker_production_noop.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+
+import pytest
+
+from node import payout_worker
+
+
+def withdrawal():
+    return {
+        "withdrawal_id": "wd-1",
+        "miner_pk": "miner-pubkey",
+        "amount": 10,
+        "fee": 1,
+        "destination": "RTCdest",
+        "created_at": 1234567890,
+    }
+
+
+def test_production_execute_withdrawal_raises_instead_of_returning_none(monkeypatch):
+    monkeypatch.setattr(payout_worker, "MOCK_MODE", False)
+    worker = payout_worker.PayoutWorker()
+
+    with pytest.raises(payout_worker.ProductionWithdrawalNotConfigured) as exc:
+        worker.execute_withdrawal(withdrawal())
+
+    assert "not configured" in str(exc.value)
+    assert "transaction hash" in str(exc.value)
+
+
+def test_process_withdrawal_leaves_pending_when_production_broadcast_is_not_configured(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(payout_worker, "MOCK_MODE", False)
+    db_path = str(tmp_path / "payout_worker.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE accounts (public_key TEXT PRIMARY KEY, balance INTEGER)")
+        conn.execute(
+            "CREATE TABLE withdrawals ("
+            "withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT, amount INTEGER, fee INTEGER, "
+            "destination TEXT, status TEXT, error_msg TEXT, processed_at INTEGER, "
+            "tx_hash TEXT, created_at INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO accounts (public_key, balance) VALUES (?, ?)",
+            ("miner-pubkey", 100),
+        )
+        conn.execute(
+            "INSERT INTO withdrawals "
+            "(withdrawal_id, miner_pk, amount, fee, destination, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("wd-1", "miner-pubkey", 10, 1, "RTCdest", "pending", 1234567890),
+        )
+
+    worker = payout_worker.PayoutWorker()
+    worker.db_path = db_path
+
+    assert worker.process_withdrawal(withdrawal()) is False
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT balance FROM accounts WHERE public_key = ?",
+            ("miner-pubkey",),
+        ).fetchone()[0]
+        status, error_msg, tx_hash = conn.execute(
+            "SELECT status, error_msg, tx_hash FROM withdrawals WHERE withdrawal_id = ?",
+            ("wd-1",),
+        ).fetchone()
+
+    assert balance == 100
+    assert status == "pending"
+    assert "not configured" in error_msg
+    assert tx_hash is None


### PR DESCRIPTION
## Summary

Fixes the `payout_worker.py` production withdrawal no-op finding from #2811.

When `RUSTCHAIN_MOCK_MODE` is disabled, `execute_withdrawal()` currently falls through `pass` and returns `None`. The caller later converts that into a generic failure after temporarily deducting and refunding balance. This PR makes the production path fail closed explicitly with a named exception so the worker never silently treats an unimplemented broadcast path as a possible transaction execution path.

- adds `ProductionWithdrawalNotConfigured`
- raises it from production `execute_withdrawal()` instead of returning `None`
- covers the direct execution path and the `process_withdrawal()` refund/fail path

Wallet/miner ID: `cerredz`

## Validation

- `python -m pytest tests\test_payout_worker_production_noop.py -q`
- `python -m py_compile node\payout_worker.py tests\test_payout_worker_production_noop.py`
- `git diff --check -- node\payout_worker.py tests\test_payout_worker_production_noop.py`

Follow-up for #2811