### PR TITLE
feat: add miner state backup import export

### DIFF
--- a/rustchain-miner/src/lib.rs
+++ b/rustchain-miner/src/lib.rs
@@ -26,6 +26,7 @@ pub mod hardware;
 pub mod transport;
 pub mod attestation;
 pub mod miner;
+pub mod state_backup;
 
 #[cfg(test)]
 mod arch_tests;
@@ -36,3 +37,4 @@ pub use hardware::HardwareInfo;
 pub use transport::NodeTransport;
 pub use attestation::AttestationReport;
 pub use miner::Miner;
+pub use state_backup::{export_state, import_state, MinerStateBackup};

--- a/rustchain-miner/src/main.rs
+++ b/rustchain-miner/src/main.rs
@@ -3,10 +3,11 @@
 //! Production-ready Rust miner with hardware attestation and RIP-PoA support.
 
 use clap::Parser;
+use std::path::PathBuf;
 use std::sync::atomic::Ordering;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use rustchain_miner::{Config, Miner};
+use rustchain_miner::{export_state, import_state, Config, Miner};
 
 /// RustChain Miner - Production-ready CLI with hardware attestation
 #[derive(Parser, Debug)]
@@ -24,7 +25,12 @@ struct Args {
     miner_id: Option<String>,
 
     /// Node URL
-    #[arg(short = 'n', long = "node", env = "RUSTCHAIN_NODE_URL", default_value = "https://50.28.86.131")]
+    #[arg(
+        short = 'n',
+        long = "node",
+        env = "RUSTCHAIN_NODE_URL",
+        default_value = "https://50.28.86.131"
+    )]
     node: String,
 
     /// HTTP proxy URL for legacy systems
@@ -40,12 +46,44 @@ struct Args {
     verbose: bool,
 
     /// Block time in seconds
-    #[arg(long = "block-time", env = "RUSTCHAIN_BLOCK_TIME", default_value = "600")]
+    #[arg(
+        long = "block-time",
+        env = "RUSTCHAIN_BLOCK_TIME",
+        default_value = "600"
+    )]
     block_time: u64,
 
     /// Attestation TTL in seconds
-    #[arg(long = "attestation-ttl", env = "RUSTCHAIN_ATTESTATION_TTL", default_value = "580")]
+    #[arg(
+        long = "attestation-ttl",
+        env = "RUSTCHAIN_ATTESTATION_TTL",
+        default_value = "580"
+    )]
     attestation_ttl: u64,
+
+    /// Export local miner state to a portable JSON backup and exit
+    #[arg(
+        long = "export-state",
+        conflicts_with = "import_state",
+        requires = "output"
+    )]
+    export_state: bool,
+
+    /// Backup file to write when using --export-state
+    #[arg(long = "output", value_name = "FILE")]
+    output: Option<PathBuf>,
+
+    /// Import miner state from a JSON backup before starting
+    #[arg(
+        long = "import-state",
+        conflicts_with = "export_state",
+        requires = "input"
+    )]
+    import_state: bool,
+
+    /// Backup file to read when using --import-state
+    #[arg(long = "input", value_name = "FILE")]
+    input: Option<PathBuf>,
 }
 
 #[cfg(unix)]
@@ -94,6 +132,34 @@ async fn main() -> anyhow::Result<()> {
     config.verbose = args.verbose;
     config.block_time_secs = args.block_time;
     config.attestation_ttl_secs = args.attestation_ttl;
+
+    if args.import_state {
+        let input = args
+            .input
+            .as_ref()
+            .expect("--input is required by clap when --import-state is set");
+        let backup = import_state(input)?;
+        backup.apply_to_config(&mut config)?;
+        println!(
+            "Imported miner state for miner_id={} wallet={}",
+            backup.miner_id, backup.wallet
+        );
+    }
+
+    if args.export_state {
+        let output = args
+            .output
+            .as_ref()
+            .expect("--output is required by clap when --export-state is set");
+        let backup = export_state(output, &config)?;
+        println!(
+            "Exported miner state for miner_id={} wallet={} to {}",
+            backup.miner_id,
+            backup.wallet,
+            output.display()
+        );
+        return Ok(());
+    }
 
     // Create miner (async)
     let miner = Miner::new(config).await?;

--- a/rustchain-miner/src/state_backup.rs
+++ b/rustchain-miner/src/state_backup.rs
@@ -1,0 +1,185 @@
+//! Miner state backup import/export helpers.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+use crate::config::Config;
+use crate::error::{MinerError, Result};
+use crate::hardware::HardwareInfo;
+
+const BACKUP_VERSION: u32 = 1;
+
+/// Portable miner state snapshot for backup or machine migration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MinerStateBackup {
+    /// Backup schema version.
+    pub version: u32,
+
+    /// RFC3339 export timestamp.
+    pub exported_at: String,
+
+    /// Wallet address used by the miner.
+    pub wallet: String,
+
+    /// Miner identity used for attestation and enrollment.
+    pub miner_id: String,
+
+    /// Node URL used when the backup was created.
+    pub node_url: String,
+
+    /// Optional HTTP proxy URL used when the backup was created.
+    #[serde(default)]
+    pub proxy_url: Option<String>,
+
+    /// Mining block interval.
+    pub block_time_secs: u64,
+
+    /// Attestation TTL.
+    pub attestation_ttl_secs: u64,
+
+    /// Last known sync checkpoint, reserved for future node-backed exports.
+    #[serde(default)]
+    pub last_sync_checkpoint: Option<String>,
+
+    /// Attestation history, reserved for future node-backed exports.
+    #[serde(default)]
+    pub attestation_records: Vec<serde_json::Value>,
+
+    /// Pending reward records, reserved for future node-backed exports.
+    #[serde(default)]
+    pub pending_rewards: Vec<serde_json::Value>,
+}
+
+impl MinerStateBackup {
+    /// Build a backup from local miner configuration and detected hardware.
+    pub fn from_config(config: &Config, hardware: &HardwareInfo) -> Self {
+        let miner_id = config
+            .miner_id
+            .clone()
+            .unwrap_or_else(|| hardware.generate_miner_id());
+        let wallet = config
+            .wallet
+            .clone()
+            .unwrap_or_else(|| hardware.generate_wallet(&miner_id));
+
+        Self {
+            version: BACKUP_VERSION,
+            exported_at: Utc::now().to_rfc3339(),
+            wallet,
+            miner_id,
+            node_url: config.node_url.clone(),
+            proxy_url: config.proxy_url.clone(),
+            block_time_secs: config.block_time_secs,
+            attestation_ttl_secs: config.attestation_ttl_secs,
+            last_sync_checkpoint: None,
+            attestation_records: Vec::new(),
+            pending_rewards: Vec::new(),
+        }
+    }
+
+    /// Validate and apply imported state to a miner configuration.
+    pub fn apply_to_config(&self, config: &mut Config) -> Result<()> {
+        self.validate()?;
+        config.wallet = Some(self.wallet.clone());
+        config.miner_id = Some(self.miner_id.clone());
+        config.node_url = self.node_url.clone();
+        config.proxy_url = self.proxy_url.clone();
+        config.block_time_secs = self.block_time_secs;
+        config.attestation_ttl_secs = self.attestation_ttl_secs;
+        Ok(())
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.version != BACKUP_VERSION {
+            return Err(MinerError::Config(format!(
+                "unsupported miner state backup version {}",
+                self.version
+            )));
+        }
+        if self.wallet.trim().is_empty() {
+            return Err(MinerError::Config(
+                "miner state backup is missing wallet".to_string(),
+            ));
+        }
+        if self.miner_id.trim().is_empty() {
+            return Err(MinerError::Config(
+                "miner state backup is missing miner_id".to_string(),
+            ));
+        }
+        if self.node_url.trim().is_empty() {
+            return Err(MinerError::Config(
+                "miner state backup is missing node_url".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Write local miner state to a JSON backup file.
+pub fn export_state(path: &Path, config: &Config) -> Result<MinerStateBackup> {
+    let hardware = HardwareInfo::collect()?;
+    let backup = MinerStateBackup::from_config(config, &hardware);
+    let encoded = serde_json::to_string_pretty(&backup)?;
+    std::fs::write(path, encoded)?;
+    Ok(backup)
+}
+
+/// Read and validate a JSON backup file.
+pub fn import_state(path: &Path) -> Result<MinerStateBackup> {
+    let raw = std::fs::read_to_string(path)?;
+    let backup: MinerStateBackup = serde_json::from_str(&raw)?;
+    backup.validate()?;
+    Ok(backup)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_hardware() -> HardwareInfo {
+        HardwareInfo {
+            platform: "linux".to_string(),
+            machine: "x86_64".to_string(),
+            hostname: "miner-host".to_string(),
+            family: "x86_64".to_string(),
+            arch: "modern".to_string(),
+            cpu: "test cpu".to_string(),
+            cores: 4,
+            memory_gb: 8,
+            serial: Some("serial-1".to_string()),
+            macs: vec!["00:11:22:33:44:55".to_string()],
+            mac: "00:11:22:33:44:55".to_string(),
+        }
+    }
+
+    #[test]
+    fn backup_roundtrip_applies_identity_to_config() {
+        let mut config = Config::default();
+        config.wallet = Some("RTCbackupwallet".to_string());
+        config.miner_id = Some("miner-backup".to_string());
+        config.node_url = "https://node.example".to_string();
+        config.proxy_url = Some("http://proxy.example".to_string());
+
+        let backup = MinerStateBackup::from_config(&config, &sample_hardware());
+        let encoded = serde_json::to_string(&backup).unwrap();
+        let decoded: MinerStateBackup = serde_json::from_str(&encoded).unwrap();
+
+        let mut restored = Config::default();
+        decoded.apply_to_config(&mut restored).unwrap();
+
+        assert_eq!(restored.wallet.as_deref(), Some("RTCbackupwallet"));
+        assert_eq!(restored.miner_id.as_deref(), Some("miner-backup"));
+        assert_eq!(restored.node_url, "https://node.example");
+        assert_eq!(restored.proxy_url.as_deref(), Some("http://proxy.example"));
+    }
+
+    #[test]
+    fn rejects_missing_wallet() {
+        let mut backup = MinerStateBackup::from_config(&Config::default(), &sample_hardware());
+        backup.wallet.clear();
+
+        let err = backup.validate().unwrap_err().to_string();
+        assert!(err.contains("missing wallet"));
+    }
+}


### PR DESCRIPTION
## Summary
- adds `rustchain-miner --export-state --output <file>` to write a portable JSON backup of the miner wallet, miner ID, node/proxy settings, timing config, and reserved attestation/reward fields
- adds `rustchain-miner --import-state --input <file>` to validate a backup and apply the wallet/miner identity before startup
- includes unit coverage for backup round-trip/import validation
- carries the existing mempool missing-table CI guard so the full repository test job can run on current main

Fixes #2659

## Validation
- `cargo test` in `rustchain-miner`
- `cargo run -- --wallet RTCdemo --miner-id miner-demo --export-state --output ..\miner-state-demo.json`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\utxo_db.py`
- `git diff --check -- rustchain-miner\src\main.rs rustchain-miner\src\lib.rs rustchain-miner\src\state_backup.rs node\utxo_db.py`

Wallet/miner ID: `cerredz`