### PR TITLE
fix: reject negative BoTTube feed limits

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -59,6 +59,20 @@ def _get_db_connection():
     return conn
 
 
+def _parse_limit_arg(default: int = 20, max_value: int = 100) -> int:
+    """Parse and clamp a non-negative feed limit query parameter."""
+    raw_limit = request.args.get("limit", default)
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("limit must be an integer") from exc
+
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+
+    return min(limit, max_value)
+
+
 def _fetch_videos(
     limit: int = 20,
     agent: Optional[str] = None,
@@ -224,7 +238,7 @@ def rss_feed():
     """
     try:
         # Parse parameters
-        limit = min(int(request.args.get("limit", 20)), 100)
+        limit = _parse_limit_arg()
         agent = request.args.get("agent")
         cursor = request.args.get("cursor")
         
@@ -278,7 +292,7 @@ def atom_feed():
     """
     try:
         # Parse parameters
-        limit = min(int(request.args.get("limit", 20)), 100)
+        limit = _parse_limit_arg()
         agent = request.args.get("agent")
         cursor = request.args.get("cursor")
         
@@ -340,7 +354,7 @@ def feed_index():
     
     # Parse parameters
     try:
-        limit = min(int(request.args.get("limit", 20)), 100)
+        limit = _parse_limit_arg()
     except ValueError:
         return jsonify({"error": "Invalid limit parameter"}), 400
     

--- a/tests/test_bottube_feed_routes.py
+++ b/tests/test_bottube_feed_routes.py
@@ -73,6 +73,11 @@ class TestFeedRoutes(unittest.TestCase):
         self.assertIn("rss", data["_links"])
         self.assertIn("atom", data["_links"])
 
+    def test_feed_index_negative_limit(self):
+        """Test JSON feed rejects negative limit."""
+        response = self.client.get("/api/feed?limit=-1")
+        self.assertEqual(response.status_code, 400)
+
     def test_feed_index_rss_accept_header(self):
         """Test feed index returns RSS with Accept header."""
         response = self.client.get(
@@ -103,6 +108,11 @@ class TestFeedRoutes(unittest.TestCase):
         response = self.client.get("/api/feed/rss?limit=invalid")
         self.assertEqual(response.status_code, 400)
 
+    def test_rss_feed_negative_limit(self):
+        """Test RSS feed rejects negative limit."""
+        response = self.client.get("/api/feed/rss?limit=-1")
+        self.assertEqual(response.status_code, 400)
+
     def test_rss_feed_excessive_limit(self):
         """Test RSS feed caps limit to 100."""
         response = self.client.get("/api/feed/rss?limit=999")
@@ -121,6 +131,11 @@ class TestFeedRoutes(unittest.TestCase):
         """Test Atom feed respects limit parameter."""
         response = self.client.get("/api/feed/atom?limit=5")
         self.assertEqual(response.status_code, 200)
+
+    def test_atom_feed_negative_limit(self):
+        """Test Atom feed rejects negative limit."""
+        response = self.client.get("/api/feed/atom?limit=-1")
+        self.assertEqual(response.status_code, 400)
 
     def test_atom_feed_agent_filter(self):
         """Test Atom feed with agent filter."""


### PR DESCRIPTION
## Summary
- rejects negative `limit` values on BoTTube JSON, RSS, and Atom feed routes
- keeps existing behavior for non-integer limits and large-limit clamping at 100
- adds regression coverage for all three feed entrypoints
- carries the current-main mempool missing-table CI guard so the full test job can run cleanly

Fixes #4313

## Validation
- `python -m pytest tests\test_bottube_feed_routes.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\bottube_feed_routes.py node\utxo_db.py tests\test_bottube_feed_routes.py`
- `git diff --check -- node\bottube_feed_routes.py node\utxo_db.py tests\test_bottube_feed_routes.py`

Wallet/miner ID: `cerredz`