### PR TITLE
fix: validate machine passport pagination

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,23 @@ def get_optional_json_object():
     return data, None
 
 
+def _parse_non_negative_int_arg(name: str, default: int, max_value: Optional[int] = None):
+    """Parse a non-negative integer query parameter."""
+    raw_value = request.args.get(name, default)
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, jsonify({'ok': False, 'error': f'{name} must be an integer'}), 400
+
+    if value < 0:
+        return None, jsonify({'ok': False, 'error': f'{name} must be non-negative'}), 400
+
+    if max_value is not None:
+        value = min(value, max_value)
+
+    return value, None, None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -96,8 +113,13 @@ def list_passports():
     
     owner = request.args.get('owner')
     architecture = request.args.get('architecture')
-    limit = min(int(request.args.get('limit', 100)), 500)
-    offset = int(request.args.get('offset', 0))
+    limit, error_response, status = _parse_non_negative_int_arg('limit', 100, max_value=500)
+    if error_response is not None:
+        return error_response, status
+
+    offset, error_response, status = _parse_non_negative_int_arg('offset', 0)
+    if error_response is not None:
+        return error_response, status
     
     passports = ledger.list_passports(
         owner_miner_id=owner,

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -499,6 +499,33 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
         self.assertEqual(data['count'], 0)
+
+    def test_list_passports_rejects_non_integer_limit(self):
+        """Non-integer limits are invalid for list pagination."""
+        resp = self.client.get('/api/machine-passport?limit=abc')
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'limit must be an integer')
+
+    def test_list_passports_rejects_negative_offset(self):
+        """Negative offsets are invalid for list pagination."""
+        resp = self.client.get('/api/machine-passport?offset=-1')
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'offset must be non-negative')
+
+    def test_list_passports_clamps_large_limit(self):
+        """Large list limits are clamped to the documented maximum."""
+        resp = self.client.get('/api/machine-passport?limit=999')
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['limit'], 500)
     
     def test_create_passport(self):
         """Test creating a passport via API."""


### PR DESCRIPTION
## Summary
- adds shared non-negative integer parsing for machine passport list pagination
- returns 400 for malformed or negative `limit`/`offset` values instead of raising server errors
- preserves the documented `limit` cap at 500
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4315

## Validation
- `python -m pytest node\tests\test_machine_passport.py::TestAPIEndpoints tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\machine_passport_api.py node\utxo_db.py node\tests\test_machine_passport.py`
- `git diff --check -- node\machine_passport_api.py node\utxo_db.py node\tests\test_machine_passport.py`

## Bounty proof
Wallet/miner ID: `cerredz`