### PR TITLE
fix: validate coalition pagination

### DIFF
--- a/node/coalition.py
+++ b/node/coalition.py
@@ -48,7 +48,11 @@ def _parse_bounded_int_arg(name: str, default: int, minimum: int, maximum: int):
         value = int(raw)
     except (TypeError, ValueError):
         return None, jsonify({"error": f"{name} must be an integer"}), 400
-    return max(minimum, min(value, maximum)), None, None
+
+    if value < minimum:
+        return None, jsonify({"error": f"{name} must be at least {minimum}"}), 400
+
+    return min(value, maximum), None, None
 
 
 def _verify_miner_signature(miner_id: str, action: str, data: dict) -> bool:

--- a/node/tests/test_coalition.py
+++ b/node/tests/test_coalition.py
@@ -639,13 +639,15 @@ def test_list_coalitions_rejects_non_integer_pagination(client):
     assert res.get_json() == {"error": "offset must be an integer"}
 
 
-def test_list_coalitions_clamps_negative_pagination(client):
-    """Negative pagination values are clamped to safe public bounds."""
-    res = client.get("/api/coalition/list?limit=-5&offset=-10")
-    assert res.status_code == 200
-    data = res.get_json()
-    assert data["count"] == 1
-    assert data["coalitions"][0]["name"] == FLAMEBUND_COALITION_NAME
+def test_list_coalitions_rejects_negative_pagination(client):
+    """Negative pagination values are invalid."""
+    res = client.get("/api/coalition/list?limit=-5")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "limit must be at least 1"}
+
+    res = client.get("/api/coalition/list?offset=-10")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "offset must be at least 0"}
 
 
 def test_get_coalition_details(client, test_coalition, rich_miner, poor_miner):
@@ -716,6 +718,17 @@ def test_list_proposals_rejects_non_integer_pagination(client, test_coalition):
     res = client.get(f"/api/coalition/{test_coalition}/proposals?offset=NaN")
     assert res.status_code == 400
     assert res.get_json() == {"error": "offset must be an integer"}
+
+
+def test_list_proposals_rejects_negative_pagination(client, test_coalition):
+    """Proposal listing rejects negative pagination before querying SQLite."""
+    res = client.get(f"/api/coalition/{test_coalition}/proposals?limit=-1")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "limit must be at least 1"}
+
+    res = client.get(f"/api/coalition/{test_coalition}/proposals?offset=-1")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "offset must be at least 0"}
 
 
 def test_list_proposals_nonexistent_coalition(client, rich_miner):


### PR DESCRIPTION
## Summary
- adds shared non-negative integer parsing for coalition list pagination
- returns 400 for malformed or negative `limit`/`offset` values on `/api/coalition/list`
- applies the same validation to `/api/coalition/<id>/proposals`
- preserves the existing max `limit` cap of 200
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4317

## Validation
- process-level Flask assertions for:
  - `/api/coalition/list?limit=abc`
  - `/api/coalition/list?offset=-1`
  - `/api/coalition/<id>/proposals?limit=abc`
  - `/api/coalition/<id>/proposals?offset=-1`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\coalition.py node\utxo_db.py node\tests\test_coalition.py`
- `git diff --check -- node\coalition.py node\utxo_db.py node\tests\test_coalition.py`

Note: running `node\tests\test_coalition.py` directly on Windows currently hits a pre-existing temp SQLite cleanup issue (`PermissionError` during fixture teardown). The route assertions above passed in a separate process, and CI runs the normal suite on Linux.

## Bounty proof
Wallet/miner ID: `cerredz`