### PR TITLE
fix: validate governance proposal pagination

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -193,6 +193,21 @@ def _is_within_founder_veto_period() -> bool:
     return (time.time() - GENESIS_TIMESTAMP) < FOUNDER_VETO_DURATION
 
 
+def _parse_non_negative_int_arg(name: str, default: int, max_value: Optional[int] = None):
+    raw_value = request.args.get(name)
+    if raw_value is None:
+        return default, None
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": f"{name} must be an integer"}), 400)
+    if value < 0:
+        return None, (jsonify({"error": f"{name} must be non-negative"}), 400)
+    if max_value is not None:
+        value = min(value, max_value)
+    return value, None
+
+
 def _settle_expired_proposals(db_path: str):
     """Settle any proposals whose voting window has closed."""
     now = int(time.time())
@@ -343,8 +358,12 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
     def list_proposals():
         _settle_expired_proposals(db_path)
         status_filter = request.args.get("status")
-        limit = min(int(request.args.get("limit", 50)), 200)
-        offset = int(request.args.get("offset", 0))
+        limit, error_response = _parse_non_negative_int_arg("limit", 50, max_value=200)
+        if error_response:
+            return error_response
+        offset, error_response = _parse_non_negative_int_arg("offset", 0)
+        if error_response:
+            return error_response
 
         try:
             with sqlite3.connect(db_path) as conn:

--- a/node/tests/test_governance.py
+++ b/node/tests/test_governance.py
@@ -262,6 +262,22 @@ def test_list_proposals_empty(client):
     assert data["count"] == 0
 
 
+def test_list_proposals_rejects_non_integer_limit(client):
+    """Malformed pagination returns a client error instead of a 500."""
+    res = client.get("/api/governance/proposals?limit=abc")
+
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "limit must be an integer"
+
+
+def test_list_proposals_rejects_negative_offset(client):
+    """Negative offsets are invalid for proposal pagination."""
+    res = client.get("/api/governance/proposals?offset=-1")
+
+    assert res.status_code == 400
+    assert res.get_json()["error"] == "offset must be non-negative"
+
+
 def test_list_proposals_with_filter(client, active_miner, tmp_db):
     """Proposals can be filtered by status."""
     client.post("/api/governance/propose", json={


### PR DESCRIPTION
## Summary
- adds shared non-negative integer parsing for governance proposal pagination
- returns 400 for malformed or negative `limit`/`offset` values on `/api/governance/proposals`
- preserves the existing max `limit` cap of 200
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4319

## Validation
- process-level Flask assertions for:
  - `/api/governance/proposals?limit=abc`
  - `/api/governance/proposals?offset=-1`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\governance.py node\utxo_db.py node\tests\test_governance.py`
- `git diff --check -- node\governance.py node\utxo_db.py node\tests\test_governance.py`

Note: running the targeted `node\tests\test_governance.py` tests directly on Windows currently hits a pre-existing temp SQLite cleanup issue (`PermissionError` during fixture teardown). The route assertions passed in a separate process, and CI runs the normal suite on Linux.

## Bounty proof
Wallet/miner ID: `cerredz`