### PR TITLE
fix: validate passport viewer limit

### DIFF
--- a/node/machine_passport_viewer.py
+++ b/node/machine_passport_viewer.py
@@ -8,7 +8,7 @@ Includes vintage computer aesthetic styling.
 Issue: #2309
 """
 
-from flask import Blueprint, render_template_string, abort
+from flask import Blueprint, render_template_string, abort, request
 from machine_passport import MachinePassportLedger
 import os
 
@@ -25,6 +25,19 @@ def get_ledger():
     if _ledger is None:
         _ledger = MachinePassportLedger(PASSPORT_DB_PATH)
     return _ledger
+
+
+def _parse_limit_arg(default: int = 100, max_value: int = 500):
+    raw_value = request.args.get('limit')
+    if raw_value is None:
+        return default, None
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError):
+        return None, ("limit must be an integer", 400)
+    if limit < 0:
+        return None, ("limit must be non-negative", 400)
+    return min(limit, max_value), None
 
 
 # HTML Template with vintage computer aesthetic
@@ -597,14 +610,14 @@ def view_passport(machine_id: str):
 @passport_viewer_bp.route('/')
 def list_passports():
     """List all machine passports."""
-    from flask import request, jsonify
-    
     ledger = get_ledger()
     
     # Get query parameters
     owner = request.args.get('owner')
     architecture = request.args.get('architecture')
-    limit = min(int(request.args.get('limit', 100)), 500)
+    limit, error_response = _parse_limit_arg()
+    if error_response:
+        return error_response
     
     passports = ledger.list_passports(
         owner_miner_id=owner,

--- a/node/tests/test_machine_passport_viewer.py
+++ b/node/tests/test_machine_passport_viewer.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _make_client(tmp_path):
+    import machine_passport_viewer
+    from machine_passport_viewer import passport_viewer_bp
+
+    machine_passport_viewer.PASSPORT_DB_PATH = str(tmp_path / "passports.db")
+    machine_passport_viewer._ledger = None
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(passport_viewer_bp)
+    return app.test_client()
+
+
+def test_passport_viewer_rejects_non_integer_limit(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/passport/?limit=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_data(as_text=True) == "limit must be an integer"
+
+
+def test_passport_viewer_rejects_negative_limit(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/passport/?limit=-1")
+
+    assert resp.status_code == 400
+    assert resp.get_data(as_text=True) == "limit must be non-negative"
+
+
+def test_passport_viewer_clamps_large_limit(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/passport/?limit=999")
+
+    assert resp.status_code == 200
+    assert "0 passport(s) found" in resp.get_data(as_text=True)
+


### PR DESCRIPTION
## Summary
- validates the passport viewer `limit` query parameter before listing passports
- returns 400 for non-integer or negative `limit` values instead of raising server errors
- preserves the existing max `limit` cap of 500
- adds focused Flask regression tests for malformed, negative, and oversized limits
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4321

## Validation
- `python -m pytest node\tests\test_machine_passport_viewer.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\machine_passport_viewer.py node\utxo_db.py node\tests\test_machine_passport_viewer.py`
- `git diff --check -- node\machine_passport_viewer.py node\utxo_db.py node\tests\test_machine_passport_viewer.py`

## Bounty proof
Wallet/miner ID: `cerredz`