### PR TITLE
fix: validate bridge list limit

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -513,6 +513,20 @@ def list_bridge_transfers(
     ]
 
 
+def _parse_non_negative_int_arg(value: Optional[str], name: str, default: int, max_value: Optional[int] = None):
+    if value is None or value == "":
+        return default, None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None, f"{name} must be an integer"
+    if parsed < 0:
+        return None, f"{name} must be non-negative"
+    if max_value is not None:
+        parsed = min(parsed, max_value)
+    return parsed, None
+
+
 def void_bridge_transfer(
     db_conn: sqlite3.Connection,
     tx_hash: str,
@@ -744,7 +758,9 @@ def register_bridge_routes(app):
         source = request.args.get("source_address")
         dest = request.args.get("dest_address")
         direction = request.args.get("direction")
-        limit = int(request.args.get("limit", 100))
+        limit, error = _parse_non_negative_int_arg(request.args.get("limit"), "limit", 100, max_value=500)
+        if error:
+            return jsonify({"error": error}), 400
         
         conn = sqlite3.connect(DB_PATH)
         try:

--- a/node/tests/test_bridge_api_limit_validation.py
+++ b/node/tests/test_bridge_api_limit_validation.py
@@ -1,0 +1,52 @@
+import os
+import sqlite3
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+def _make_client(tmp_path):
+    import bridge_api
+
+    db_path = str(tmp_path / "bridge.db")
+    bridge_api.DB_PATH = db_path
+    with sqlite3.connect(db_path) as conn:
+        bridge_api.init_bridge_schema(conn.cursor())
+        conn.commit()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    bridge_api.register_bridge_routes(app)
+    return app.test_client()
+
+
+def test_bridge_list_rejects_non_integer_limit(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/api/bridge/list?limit=abc")
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "limit must be an integer"
+
+
+def test_bridge_list_rejects_negative_limit(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/api/bridge/list?limit=-1")
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "limit must be non-negative"
+
+
+def test_bridge_list_accepts_empty_limit_default(tmp_path):
+    client = _make_client(tmp_path)
+
+    resp = client.get("/api/bridge/list?limit=")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["count"] == 0
+


### PR DESCRIPTION
## Summary
- validates the bridge list `limit` query parameter before listing transfers
- returns 400 for non-integer or negative `limit` values instead of raising server errors
- preserves the existing max `limit` cap of 500
- adds focused Flask regression tests for malformed, negative, and empty/default limits
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4323

## Validation
- `python -m pytest node\tests\test_bridge_api_limit_validation.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\bridge_api.py node\utxo_db.py node\tests\test_bridge_api_limit_validation.py`
- `git diff --check -- node\bridge_api.py node\utxo_db.py node\tests\test_bridge_api_limit_validation.py`

## Bounty proof
Wallet/miner ID: `cerredz`