### PR TITLE
fix: validate lock ledger query params

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -630,6 +630,20 @@ def auto_release_expired_locks(
     }
 
 
+def _parse_non_negative_int_arg(value: Optional[str], name: str, default=None, max_value: Optional[int] = None):
+    if value is None or value == "":
+        return default, None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None, f"{name} must be an integer"
+    if parsed < 0:
+        return None, f"{name} must be non-negative"
+    if max_value is not None:
+        parsed = min(parsed, max_value)
+    return parsed, None
+
+
 # =============================================================================
 # Flask Routes (to be integrated into main node)
 # =============================================================================
@@ -642,7 +656,9 @@ def register_lock_ledger_routes(app):
     def get_miner_locks(miner_id: str):
         """Get locks for a specific miner."""
         status = request.args.get("status")
-        limit = int(request.args.get("limit", 100))
+        limit, error = _parse_non_negative_int_arg(request.args.get("limit"), "limit", 100, max_value=500)
+        if error:
+            return jsonify({"error": error}), 400
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -703,9 +719,12 @@ def register_lock_ledger_routes(app):
     def get_pending_unlocks():
         """Get locks ready to be released."""
         before = request.args.get("before")
-        limit = int(request.args.get("limit", 100))
-        
-        before_ts = int(before) if before else None
+        limit, error = _parse_non_negative_int_arg(request.args.get("limit"), "limit", 100, max_value=500)
+        if error:
+            return jsonify({"error": error}), 400
+        before_ts, error = _parse_non_negative_int_arg(before, "before", None)
+        if error:
+            return jsonify({"error": error}), 400
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -807,7 +826,14 @@ def register_lock_ledger_routes(app):
             return jsonify({"error": "RC_WORKER_KEY not configured — worker endpoints disabled"}), 503
         if not hmac.compare_digest(worker_key, expected_worker):
             return jsonify({"error": "Unauthorized"}), 401
-        batch_size = int(request.args.get("batch_size", 100))
+        batch_size, error = _parse_non_negative_int_arg(
+            request.args.get("batch_size"),
+            "batch_size",
+            100,
+            max_value=500,
+        )
+        if error:
+            return jsonify({"error": error}), 400
         
         conn = sqlite3.connect(DB_PATH)
         try:

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -727,6 +727,58 @@ class TestLockLedger:
         assert len(locks) == 3
         
         conn.close()
+
+    def test_miner_locks_rejects_non_integer_limit(self, setup_test_db):
+        """Miner lock list pagination returns 400 for malformed limits."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        app = Flask(__name__)
+        lock_ledger.register_lock_ledger_routes(app)
+        client = app.test_client()
+
+        resp = client.get("/api/lock/miner/RTC_test_miner?limit=abc")
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit must be an integer"
+
+    def test_pending_unlocks_rejects_negative_limit(self, setup_test_db):
+        """Pending unlock pagination rejects negative limits."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        app = Flask(__name__)
+        lock_ledger.register_lock_ledger_routes(app)
+        client = app.test_client()
+
+        resp = client.get("/api/lock/pending-unlock?limit=-1")
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit must be non-negative"
+
+    def test_pending_unlocks_rejects_non_integer_before(self, setup_test_db):
+        """Pending unlock filters reject malformed before timestamps."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        app = Flask(__name__)
+        lock_ledger.register_lock_ledger_routes(app)
+        client = app.test_client()
+
+        resp = client.get("/api/lock/pending-unlock?before=soon")
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "before must be an integer"
+
+    def test_auto_release_rejects_non_integer_batch_size(self, setup_test_db, monkeypatch):
+        """Worker auto-release rejects malformed batch sizes after auth."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        monkeypatch.setenv("RC_WORKER_KEY", "worker-secret")
+        app = Flask(__name__)
+        lock_ledger.register_lock_ledger_routes(app)
+        client = app.test_client()
+
+        resp = client.post(
+            "/api/lock/auto-release?batch_size=abc",
+            headers={"X-Worker-Key": "worker-secret"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "batch_size must be an integer"
     
     def test_get_miner_locked_balance(self, setup_test_db, funded_miner):
         """Test getting miner's total locked balance."""


### PR DESCRIPTION
## Summary
- adds shared non-negative integer parsing for lock ledger query parameters
- returns 400 for malformed or negative `limit` on miner locks and pending unlocks
- returns 400 for malformed `before` timestamps on pending unlocks
- returns 400 for malformed worker `batch_size` after worker auth
- caps list/batch sizes at 500
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4325

## Validation
- `python -m pytest tests\test_bridge_lock_ledger.py::TestLockLedger::test_miner_locks_rejects_non_integer_limit tests\test_bridge_lock_ledger.py::TestLockLedger::test_pending_unlocks_rejects_negative_limit tests\test_bridge_lock_ledger.py::TestLockLedger::test_pending_unlocks_rejects_non_integer_before tests\test_bridge_lock_ledger.py::TestLockLedger::test_auto_release_rejects_non_integer_batch_size tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\lock_ledger.py node\utxo_db.py tests\test_bridge_lock_ledger.py`
- `git diff --check -- node\lock_ledger.py node\utxo_db.py tests\test_bridge_lock_ledger.py`

## Bounty proof
Wallet/miner ID: `cerredz`