### PR TITLE
docs: fix MCP integration relative links

### DIFF
--- a/integrations/rustchain-mcp/IMPLEMENTATION_REPORT.md
+++ b/integrations/rustchain-mcp/IMPLEMENTATION_REPORT.md
@@ -341,8 +341,8 @@ Potential additions for future versions:
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
-- [RustChain API Walkthrough](../../../API_WALKTHROUGH.md)
-- [RustChain API Reference](../../../docs/api-reference.md)
+- [RustChain API Walkthrough](../../API_WALKTHROUGH.md)
+- [RustChain API Reference](../../docs/api-reference.md)
 
 ---
 

--- a/integrations/rustchain-mcp/README.md
+++ b/integrations/rustchain-mcp/README.md
@@ -2,7 +2,7 @@
 
 [![MCP Server](https://img.shields.io/badge/MCP-Server-blue)](https://modelcontextprotocol.io)
 [![Python](https://img.shields.io/badge/Python-3.10+-yellow.svg)](https://www.python.org)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](../../../LICENSE)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 
 **Model Context Protocol (MCP) server for RustChain blockchain** — Provides AI assistants with tools to interact with RustChain's core endpoints: health, epoch, balance, and queries.
 
@@ -339,16 +339,16 @@ tests/test_mcp_server.py::TestRustChainMCP::test_tool_health PASSED
 ## 📚 API Reference
 
 For detailed API documentation, see:
-- [API Walkthrough](../../../API_WALKTHROUGH.md)
-- [API Reference](../../../docs/api-reference.md)
+- [API Walkthrough](../../API_WALKTHROUGH.md)
+- [API Reference](../../docs/api-reference.md)
 
 ## 🤝 Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines.
+Contributions welcome! See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
 
 ## 📄 License
 
-MIT License — See [LICENSE](../../../LICENSE) for details.
+MIT License — See [LICENSE](../../LICENSE) for details.
 
 ---
 

--- a/integrations/rustchain-mcp/USAGE.md
+++ b/integrations/rustchain-mcp/USAGE.md
@@ -510,6 +510,6 @@ async def query_with_backoff(client, query_type):
 
 <div align="center">
 
-**RustChain MCP Server** | [Documentation](README.md) | [API Reference](../../../docs/api-reference.md)
+**RustChain MCP Server** | [Documentation](README.md) | [API Reference](../../docs/api-reference.md)
 
 </div>


### PR DESCRIPTION
## Summary
- Fix broken relative links in RustChain MCP integration documentation
- Correct links to the API walkthrough, API reference, contributing guide, and license from `integrations/rustchain-mcp/`

## Verification
- Verified the updated targets exist locally:
  - `API_WALKTHROUGH.md`
  - `docs/api-reference.md`
  - `CONTRIBUTING.md`
  - `LICENSE`

Related to Scottcjn/rustchain-bounties#2178.