### PR TITLE
fix: validate hall of rust leaderboard limit

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -439,6 +439,19 @@ def _table_exists(cursor, table_name):
     return row is not None
 
 
+def _parse_limit_arg(default=50, max_value=500):
+    raw_value = request.args.get('limit')
+    if raw_value is None or raw_value == '':
+        return default, None
+    try:
+        limit = int(raw_value)
+    except (TypeError, ValueError):
+        return None, ("limit must be an integer", 400)
+    if limit < 0:
+        return None, ("limit must be non-negative", 400)
+    return min(limit, max_value), None
+
+
 def _internal_error_response(context):
     logger.exception("Hall of Rust endpoint failed: %s", context)
     return jsonify({'error': 'internal_error'}), 500
@@ -451,7 +464,9 @@ def api_hall_of_fame_leaderboard():
     GET /api/hall_of_fame/leaderboard?limit=50&deceased=0|1
     Returns machines ordered by rust_score DESC with badge decoration.
     """
-    limit = min(int(request.args.get('limit', 50) or 50), 500)
+    limit, error_response = _parse_limit_arg()
+    if error_response:
+        return error_response
     deceased_filter = request.args.get('deceased')  # '0', '1', or omitted (all)
 
     try:

--- a/node/tests/test_hall_of_rust_limit_validation.py
+++ b/node/tests/test_hall_of_rust_limit_validation.py
@@ -1,0 +1,41 @@
+from flask import Flask
+
+from node.hall_of_rust import hall_bp, init_hall_tables
+
+
+def _app_with_hall_db(tmp_path):
+    db_path = tmp_path / "hall.db"
+    init_hall_tables(str(db_path))
+
+    app = Flask(__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(hall_bp)
+    return app
+
+
+def test_leaderboard_rejects_non_integer_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "limit must be an integer"
+
+
+def test_leaderboard_rejects_negative_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=-1")
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "limit must be non-negative"
+
+
+def test_leaderboard_uses_default_for_empty_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=")
+
+    assert response.status_code == 200
+    assert response.get_json()["leaderboard"] == []
+    assert response.get_json()["total_machines"] == 0


### PR DESCRIPTION
## Summary
- validates the Hall of Rust leaderboard `limit` query parameter before querying SQLite
- returns 400 for non-integer or negative `limit` values instead of raising server errors or passing negative limits through
- preserves the existing max `limit` cap of 500
- adds focused Flask regression tests for malformed, negative, and empty/default limits
- includes the current main-branch mempool missing-table guard needed by CI

Fixes #4329

## Validation
- `python -m pytest node\tests\test_hall_of_rust_limit_validation.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\hall_of_rust.py node\utxo_db.py node\tests\test_hall_of_rust_limit_validation.py`
- `git diff --check -- node\hall_of_rust.py node\utxo_db.py node\tests\test_hall_of_rust_limit_validation.py`

## Bounty proof
Wallet/miner ID: `cerredz`