### PR TITLE
docs: fix RIP-302 bounty links

### DIFF
--- a/bounties/issue-684/README.md
+++ b/bounties/issue-684/README.md
@@ -207,7 +207,7 @@ To submit for bounty #684:
 
 ## 📚 Documentation
 
-- [RIP-302 Specification](../docs/RIP-302-agent-to-agent-test-challenge.md) - Full technical specification
+- [RIP-302 Specification](../../rips/docs/RIP-302-agent-to-agent-test-challenge.md) - Full technical specification
 - [Evidence Schema](#-evidence-schema) - Evidence format documentation
 - [CI/CD Guide](#-ci-integration) - Automated validation guide
 

--- a/bounties/issue-684/docs/CHALLENGE_GUIDE.md
+++ b/bounties/issue-684/docs/CHALLENGE_GUIDE.md
@@ -454,7 +454,7 @@ python scripts/run_challenge.py --all
 ### Getting Help
 
 1. Check the [main README](../README.md)
-2. Review the [RIP-302 specification](../docs/RIP-302-agent-to-agent-test-challenge.md)
+2. Review the [RIP-302 specification](../../../rips/docs/RIP-302-agent-to-agent-test-challenge.md)
 3. Open an issue on GitHub
 4. Ask in RustChain Discord
 


### PR DESCRIPTION
## Summary
- Fix broken RIP-302 links in the issue 684 bounty documentation
- Point both links to the existing `rips/docs/RIP-302-agent-to-agent-test-challenge.md` file

## Verification
- Verified the updated relative links resolve locally from both markdown files

Related to Scottcjn/rustchain-bounties#2178.