### PR TITLE
fix: validate integrated admin limits

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6178,7 +6178,10 @@ def api_miner_attestations(miner_id: str):
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
     if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
-    limit = int(request.args.get("limit", "120") or 120)
+    try:
+        limit = int(request.args.get("limit", "120") or 120)
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 500))
 
     with sqlite3.connect(DB_PATH) as conn:
@@ -6221,7 +6224,10 @@ def api_balances():
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
     if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
-    limit = int(request.args.get("limit", "2000") or 2000)
+    try:
+        limit = int(request.args.get("limit", "2000") or 2000)
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 5000))
 
     with sqlite3.connect(DB_PATH) as conn:
@@ -6964,7 +6970,11 @@ def list_pending():
         return jsonify({"error": "Unauthorized"}), 401
 
     status_filter = request.args.get('status', 'pending')
-    limit = min(int(request.args.get('limit', 100)), 500)
+    try:
+        limit = int(request.args.get('limit', 100))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 500))
     
     with sqlite3.connect(DB_PATH) as db:
         if status_filter == 'all':

--- a/node/tests/test_limit_validation.py
+++ b/node/tests/test_limit_validation.py
@@ -3,6 +3,7 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import MagicMock, patch
 
 
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -37,22 +38,48 @@ class TestLimitValidation(unittest.TestCase):
             os.environ.pop("RC_ADMIN_KEY", None)
         else:
             os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
-        cls._tmp.cleanup()
+        try:
+            cls._tmp.cleanup()
+        except OSError:
+            pass
 
     def test_api_miner_attestations_rejects_non_integer_limit(self):
-        resp = self.client.get("/api/miner/alice/attestations?limit=abc")
+        resp = self.client.get(
+            "/api/miner/alice/attestations?limit=abc",
+            headers={"X-Admin-Key": ADMIN_KEY},
+        )
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
 
     def test_api_balances_rejects_non_integer_limit(self):
-        resp = self.client.get("/api/balances?limit=abc")
+        resp = self.client.get(
+            "/api/balances?limit=abc",
+            headers={"X-Admin-Key": ADMIN_KEY},
+        )
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+    def test_admin_limit_validation_preserves_auth_boundary(self):
+        resp = self.client.get("/api/balances?limit=abc")
+        self.assertEqual(resp.status_code, 401)
 
     def test_pending_list_rejects_non_integer_limit(self):
         resp = self.client.get("/pending/list?limit=abc", headers={"X-Admin-Key": ADMIN_KEY})
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+    def test_pending_list_clamps_negative_limit(self):
+        mock_db = MagicMock()
+        mock_db.__enter__.return_value = mock_db
+        mock_db.__exit__.return_value = False
+        mock_db.execute.return_value.fetchall.return_value = []
+
+        with patch.object(self.mod.sqlite3, "connect", return_value=mock_db):
+            resp = self.client.get("/pending/list?limit=-1", headers={"X-Admin-Key": ADMIN_KEY})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"ok": True, "count": 0, "pending": []})
+        self.assertEqual(mock_db.execute.call_args.args[1], ("pending", 1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- return structured 400 responses for authenticated non-integer `limit` values on integrated admin endpoints
- clamp `/pending/list` limits to `1..500` so negative values cannot bypass the row cap
- update regression coverage to use admin headers and preserve the 401 auth boundary
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4332

## Validation
- `python -m pytest node\tests\test_limit_validation.py -q`
- `python -m pytest tests\test_api.py::test_api_miner_attestations_requires_admin tests\test_api.py::test_api_balances_requires_admin tests\test_api.py::test_pending_list_requires_admin -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\utxo_db.py node\tests\test_limit_validation.py tests\test_api.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\utxo_db.py node\tests\test_limit_validation.py tests\test_api.py`

Wallet/miner ID for bounty credit: `cerredz`
