### PR TITLE
fix: validate bridge dashboard transaction filters

### DIFF
--- a/bridge/dashboard_api.py
+++ b/bridge/dashboard_api.py
@@ -242,11 +242,15 @@ def get_dashboard_transactions():
     }
     """
     tx_type = request.args.get("type", "all").lower()
+    if tx_type not in ("all", "wrap", "unwrap"):
+        return jsonify({"error": "type must be one of: all, wrap, unwrap"}), 400
+
     state_filter = request.args.get("state", "").strip() or None
     try:
-        limit = min(int(request.args.get("limit", 50)), 200)
-    except ValueError:
-        limit = 50
+        limit = int(request.args.get("limit", 50))
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 200))
 
     now = int(time.time())
     day_ago = now - 86400
@@ -259,6 +263,12 @@ def get_dashboard_transactions():
         if state_filter:
             where_clauses.append("state = ?")
             params.append(state_filter)
+        if tx_type == "wrap":
+            where_clauses.append("target_chain = ?")
+            params.append("solana")
+        elif tx_type == "unwrap":
+            where_clauses.append("target_chain = ?")
+            params.append("base")
 
         # Calculate 24h volume
         volume_row = conn.execute(

--- a/bridge/test_dashboard_api.py
+++ b/bridge/test_dashboard_api.py
@@ -236,6 +236,75 @@ class TestDashboardTransactions:
         # Should cap at 200
         assert len(data['transactions']) <= 200
 
+    def test_transactions_rejects_non_integer_limit(self, client):
+        """Test transactions limit rejects malformed values."""
+        response = client.get('/bridge/dashboard/transactions?limit=abc')
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data['error'] == 'limit must be an integer'
+
+    def test_transactions_clamps_negative_limit(self, app, client):
+        """Test transactions limit clamps negative values to one row."""
+        import uuid
+
+        for idx in range(2):
+            insert_sample_lock(app.config['BRIDGE_DB_PATH'], {
+                'lock_id': f'lock_neg_{idx}_{uuid.uuid4().hex[:8]}',
+                'sender_wallet': f'wallet-neg-{idx}',
+                'amount_rtc': 100.0 + idx,
+                'target_chain': 'solana',
+                'target_wallet': '7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU',
+                'tx_hash': f'tx-neg-{uuid.uuid4().hex[:8]}',
+                'state': STATE_COMPLETE,
+            })
+
+        response = client.get('/bridge/dashboard/transactions?limit=-1')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert len(data['transactions']) == 1
+
+    def test_transactions_type_filter_wrap_and_unwrap(self, app, client):
+        """Test transactions type filter applies wrap/unwrap query parameter."""
+        import uuid
+
+        insert_sample_lock(app.config['BRIDGE_DB_PATH'], {
+            'lock_id': f'lock_wrap_{uuid.uuid4().hex[:8]}',
+            'sender_wallet': 'wallet-wrap',
+            'amount_rtc': 100.0,
+            'target_chain': 'solana',
+            'target_wallet': '7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU',
+            'tx_hash': f'tx-wrap-{uuid.uuid4().hex[:8]}',
+            'state': STATE_COMPLETE,
+        })
+        insert_sample_lock(app.config['BRIDGE_DB_PATH'], {
+            'lock_id': f'lock_unwrap_{uuid.uuid4().hex[:8]}',
+            'sender_wallet': 'wallet-unwrap',
+            'amount_rtc': 75.0,
+            'target_chain': 'base',
+            'target_wallet': '0x1111111111111111111111111111111111111111',
+            'tx_hash': f'tx-unwrap-{uuid.uuid4().hex[:8]}',
+            'state': STATE_COMPLETE,
+        })
+
+        wrap_response = client.get('/bridge/dashboard/transactions?type=wrap')
+        unwrap_response = client.get('/bridge/dashboard/transactions?type=unwrap')
+
+        assert wrap_response.status_code == 200
+        assert unwrap_response.status_code == 200
+        wrap_data = json.loads(wrap_response.data)
+        unwrap_data = json.loads(unwrap_response.data)
+        assert wrap_data['transactions']
+        assert unwrap_data['transactions']
+        assert {tx['type'] for tx in wrap_data['transactions']} == {'wrap'}
+        assert {tx['type'] for tx in unwrap_data['transactions']} == {'unwrap'}
+
+    def test_transactions_rejects_unknown_type(self, client):
+        """Test transactions type filter rejects unsupported values."""
+        response = client.get('/bridge/dashboard/transactions?type=sideways')
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data['error'] == 'type must be one of: all, wrap, unwrap'
+
     def test_transactions_format(self, client):
         """Test transaction format."""
         response = client.get('/bridge/dashboard/transactions')


### PR DESCRIPTION
## Summary
- enforce the documented `type=wrap|unwrap|all` filter for bridge dashboard transactions
- reject unsupported transaction type filters
- reject malformed `limit` values and clamp numeric limits to `1..200`
- add dashboard regression tests for filtering and limit validation
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4338

## Validation
- `python -m pytest bridge\test_dashboard_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile bridge\dashboard_api.py bridge\test_dashboard_api.py node\utxo_db.py`
- `git diff --check -- bridge\dashboard_api.py bridge\test_dashboard_api.py node\utxo_db.py`

Wallet/miner ID for bounty credit: `cerredz`
