### PR TITLE
fix: validate bridge ledger pagination

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -467,10 +467,12 @@ def get_ledger():
     chain_filter  = request.args.get("chain", "").strip() or None
     sender_filter = request.args.get("sender", "").strip() or None
     try:
-        limit  = min(int(request.args.get("limit", 50)), 200)
-        offset = max(int(request.args.get("offset", 0)), 0)
-    except ValueError:
-        limit, offset = 50, 0
+        limit  = int(request.args.get("limit", 50))
+        offset = int(request.args.get("offset", 0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit and offset must be integers"}), 400
+    limit = max(1, min(limit, 200))
+    offset = max(offset, 0)
 
     where_clauses, params = [], []
     if state_filter:

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -707,6 +707,41 @@ class TestLedgerEndpoint:
         for lock in data["locks"]:
             assert lock["state"] == "confirmed"
 
+    def test_ledger_rejects_malformed_pagination(self, client):
+        resp = client.get("/bridge/ledger?limit=abc")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit and offset must be integers"
+
+        resp = client.get("/bridge/ledger?offset=abc")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit and offset must be integers"
+
+    def test_ledger_clamps_negative_limit_and_offset(self, client):
+        tx_hash = f"rtc-lock-ledger-limit-{int(time.time())}"
+        payload = {
+            "sender_wallet": "ledger-limit-wallet",
+            "amount": 100.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "ledger-limit-wallet",
+                100.0,
+                "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                tx_hash,
+            ),
+        }
+        resp_create = client.post("/bridge/lock", json=payload)
+        assert resp_create.status_code == 201
+
+        resp = client.get("/bridge/ledger?limit=-1&offset=-10")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["limit"] == 1
+        assert data["offset"] == 0
+        assert len(data["locks"]) <= 1
+
 
 class TestStatsEndpoint:
     def test_stats_structure(self, client):


### PR DESCRIPTION
## Summary
- return 400 for malformed bridge ledger `limit` or `offset`
- clamp `limit` to `1..200` so negative values cannot bypass the row cap
- clamp negative offsets back to zero
- add bridge ledger pagination regression coverage
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4340

## Validation
- `python -m pytest bridge\test_bridge_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile bridge\bridge_api.py bridge\test_bridge_api.py node\utxo_db.py`
- `git diff --check -- bridge\bridge_api.py bridge\test_bridge_api.py node\utxo_db.py`

Wallet/miner ID for bounty credit: `cerredz`
