### PR TITLE
fix: validate legacy p2p sync endpoints

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -11,6 +11,7 @@ import json
 import threading
 from datetime import datetime
 from typing import List, Dict, Optional
+from flask import jsonify, request
 
 # ============================================================================
 # PEER DISCOVERY & MANAGEMENT
@@ -408,7 +409,9 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
     @app.route('/p2p/announce', methods=['POST'])
     def announce_peer():
         """Endpoint for peer nodes to announce themselves"""
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "JSON object required"}), 400
         peer_url = data.get('peer_url')
 
         if peer_url:
@@ -426,8 +429,13 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
     @app.route('/api/blocks', methods=['GET'])
     def get_blocks():
         """Get blocks for sync (start height, limit)"""
-        start = request.args.get('start', 0, type=int)
-        limit = request.args.get('limit', 100, type=int)
+        try:
+            start = int(request.args.get('start', 0))
+            limit = int(request.args.get('limit', 100))
+        except (TypeError, ValueError):
+            return jsonify({"ok": False, "error": "start and limit must be integers"}), 400
+        start = max(0, start)
+        limit = max(1, min(limit, 1000))
 
         # Fetch blocks from database
         with sqlite3.connect(peer_manager.db_path) as conn:

--- a/node/tests/test_rustchain_p2p_sync_endpoints.py
+++ b/node/tests/test_rustchain_p2p_sync_endpoints.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: MIT
+import json
+import os
+import sqlite3
+import sys
+from types import SimpleNamespace
+
+from flask import Flask
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+from rustchain_p2p_sync import add_p2p_endpoints
+
+
+class DummyPeerManager:
+    def __init__(self, db_path):
+        self.db_path = db_path
+        self.peers = []
+
+    def add_peer(self, peer_url):
+        self.peers.append(peer_url)
+        return True
+
+    def get_active_peers(self):
+        return list(self.peers)
+
+
+def _client(tmp_path):
+    db_path = tmp_path / "p2p.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE blocks (height INTEGER, hash TEXT, data TEXT)")
+        conn.executemany(
+            "INSERT INTO blocks (height, hash, data) VALUES (?, ?, ?)",
+            [
+                (1, "hash-1", json.dumps({"height": 1})),
+                (2, "hash-2", json.dumps({"height": 2})),
+            ],
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    add_p2p_endpoints(app, DummyPeerManager(str(db_path)), SimpleNamespace(), SimpleNamespace())
+    return app.test_client()
+
+
+def test_announce_rejects_non_object_json(tmp_path):
+    client = _client(tmp_path)
+
+    response = client.post("/p2p/announce", data="null", content_type="application/json")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "JSON object required"}
+
+
+def test_announce_requires_peer_url(tmp_path):
+    client = _client(tmp_path)
+
+    response = client.post("/p2p/announce", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "peer_url required"}
+
+
+def test_get_blocks_rejects_malformed_pagination(tmp_path):
+    client = _client(tmp_path)
+
+    response = client.get("/api/blocks?start=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "start and limit must be integers"}
+
+    response = client.get("/api/blocks?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "start and limit must be integers"}
+
+
+def test_get_blocks_clamps_negative_pagination(tmp_path):
+    client = _client(tmp_path)
+
+    response = client.get("/api/blocks?start=-10&limit=-1")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["count"] == 1
+    assert data["blocks"][0]["height"] == 1


### PR DESCRIPTION
## Summary
- import Flask `request`/`jsonify` symbols used by legacy P2P sync routes
- reject non-object `/p2p/announce` JSON bodies before calling `.get()`
- reject malformed `/api/blocks` pagination with HTTP 400
- clamp block sync `start` and `limit` before querying SQLite
- add endpoint regression tests
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4342

## Validation
- `python -m pytest node\tests\test_rustchain_p2p_sync_endpoints.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_p2p_sync.py node\tests\test_rustchain_p2p_sync_endpoints.py node\utxo_db.py`
- `git diff --check -- node\rustchain_p2p_sync.py node\tests\test_rustchain_p2p_sync_endpoints.py node\utxo_db.py`

Wallet/miner ID for bounty credit: `cerredz`
