### PR TITLE
fix: validate beacon contract json bodies

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -419,7 +419,9 @@ def create_contract():
     Validates that the from_agent exists in the relay_agents table.
     """
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'JSON object required'}), 400
         
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
@@ -491,7 +493,9 @@ def update_contract(contract_id):
     Validates state transitions to prevent invalid jumps.
     """
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'JSON object required'}), 400
         new_state = data.get('state')
         
         if not new_state:

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -168,6 +168,47 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         data = json.loads(response.data)
         self.assertIn('error', data)
 
+    def test_contract_create_rejects_non_object_json(self):
+        """Contract creation rejects valid JSON that is not an object."""
+        response = self.client.post(
+            '/api/contracts',
+            data='null',
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual(data['error'], 'JSON object required')
+
+    def test_contract_update_rejects_non_object_json(self):
+        """Contract update rejects valid JSON that is not an object."""
+        contract_data = {
+            'from': 'bcn_alice_test',
+            'to': 'bcn_bob_test',
+            'type': 'rent',
+            'amount': 100.0,
+            'term': '30d',
+        }
+        create_response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(contract_data),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_alice_test'},
+        )
+        self.assertEqual(create_response.status_code, 201)
+        contract_id = json.loads(create_response.data)['id']
+
+        response = self.client.put(
+            f'/api/contracts/{contract_id}',
+            data='null',
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_bob_test'},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual(data['error'], 'JSON object required')
+
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
         # Insert a test bounty directly


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on Beacon contract create/update paths
- prevent those requests from falling through to generic `internal_error` responses
- add regression coverage for both contract endpoints
- tolerate Windows SQLite teardown locks in the existing Beacon behavior test
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4344

## Validation
- `python -m pytest tests\test_beacon_atlas_behavior.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py`
- `git diff --check -- node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py`

Wallet/miner ID for bounty credit: `cerredz`
