### PR TITLE
fix: validate profile badge json bodies

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -126,7 +126,9 @@ def badge_generator():
 @app.route('/api/badge/create', methods=['POST'])
 def create_badge():
     init_badge_db()
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'error': 'JSON object required'}), 400
     
     username = data.get('username', '').strip()
     wallet = data.get('wallet', '').strip()

--- a/tests/test_profile_badge_generator.py
+++ b/tests/test_profile_badge_generator.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+import os
+import sys
+
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+import profile_badge_generator
+
+
+def _client(tmp_path, monkeypatch):
+    monkeypatch.setattr(profile_badge_generator, "DB_PATH", str(tmp_path / "badges.db"))
+    profile_badge_generator.app.config["TESTING"] = True
+    return profile_badge_generator.app.test_client()
+
+
+def test_badge_create_rejects_non_object_json(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.post("/api/badge/create", data="null", content_type="application/json")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"success": False, "error": "JSON object required"}
+
+
+def test_badge_create_rejects_malformed_json(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.post("/api/badge/create", data="{", content_type="application/json")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"success": False, "error": "JSON object required"}
+
+
+def test_badge_create_preserves_valid_request(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/badge/create",
+        json={
+            "username": "cerredz",
+            "wallet": "",
+            "badge_type": "developer",
+            "custom_message": "Audit Fixer",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert "markdown" in data
+    assert "Audit%20Fixer" in data["shield_url"]


### PR DESCRIPTION
## Summary
- reject malformed or non-object JSON bodies on `POST /api/badge/create`
- preserve valid profile badge creation behavior
- add focused profile badge endpoint regression tests
- carry the mempool missing-table guard needed by the existing security regression test

Fixes #4346

## Validation
- `python -m pytest tests\test_profile_badge_generator.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile profile_badge_generator.py tests\test_profile_badge_generator.py node\utxo_db.py`
- `git diff --check -- profile_badge_generator.py tests\test_profile_badge_generator.py node\utxo_db.py`

Wallet/miner ID for bounty credit: `cerredz`
