### PR TITLE
fix: validate agent reputation queries

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -338,6 +338,8 @@ def check_eligibility():
         job_value = float(request.args.get("job_value", 0))
     except (ValueError, TypeError):
         return jsonify({"error": "job_value must be a number"}), 400
+    if not math.isfinite(job_value) or job_value < 0:
+        return jsonify({"error": "job_value must be a finite non-negative number"}), 400
 
     rep = _engine.get(agent_id)
     max_val = rep["max_job_value_rtc"]
@@ -371,6 +373,8 @@ def leaderboard():
         limit = min(int(request.args.get("limit", 20)), 100)
     except (ValueError, TypeError):
         return jsonify({"error": "limit must be an integer"}), 400
+    if limit < 1:
+        return jsonify({"error": "limit must be between 1 and 100"}), 400
     with _engine._lock:
         entries = [(w, d["reputation_score"]) for w, (d, _) in _engine._cache.items()]
     entries.sort(key=lambda x: x[1], reverse=True)

--- a/tests/test_agent_reputation.py
+++ b/tests/test_agent_reputation.py
@@ -1,4 +1,5 @@
 import math
+import threading
 
 import pytest
 from flask import Flask
@@ -9,6 +10,11 @@ import agent_reputation
 class StubReputationEngine:
     def __init__(self, levels):
         self._levels = levels
+        self._lock = threading.Lock()
+        self._cache = {
+            "veteran-agent": ({"reputation_score": 90}, 0),
+            "trusted-agent": ({"reputation_score": 60}, 0),
+        }
 
     def get(self, agent_id):
         level, score, max_value = self._levels[agent_id]
@@ -72,3 +78,25 @@ def test_veteran_agent_can_claim_high_value_jobs(reputation_client):
     assert payload["eligible"] is True
     assert payload["can_post_high_value"] is True
     assert payload["reason"] is None
+
+
+@pytest.mark.parametrize("job_value", ["-1", "nan", "inf", "-inf"])
+def test_check_eligibility_rejects_invalid_job_values(reputation_client, job_value):
+    response = reputation_client.get(
+        "/agent/reputation/check-eligibility",
+        query_string={"agent_id": "trusted-agent", "job_value": job_value},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "job_value must be a finite non-negative number"
+
+
+@pytest.mark.parametrize("limit", ["0", "-1"])
+def test_leaderboard_rejects_non_positive_limits(reputation_client, limit):
+    response = reputation_client.get(
+        "/agent/reputation/leaderboard",
+        query_string={"limit": limit},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be between 1 and 100"


### PR DESCRIPTION
## Summary
- Reject non-finite or negative `job_value` inputs on `/agent/reputation/check-eligibility`.
- Reject non-positive leaderboard limits before slicing cached reputation entries.
- Add focused regression coverage for invalid job values and leaderboard limits.
- Preserve the mempool missing-table guard needed by the existing security regression on fresh branches.

Fixes #4350

## Validation
- `python -m pytest tests\test_agent_reputation.py -q` -> 9 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile agent_reputation.py tests\test_agent_reputation.py node\utxo_db.py`
- `git diff --check -- agent_reputation.py tests\test_agent_reputation.py node\utxo_db.py`

Wallet/miner ID: `cerredz`