### PR TITLE
fix: validate relationship json bodies

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1035,6 +1035,16 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     from flask import Blueprint, jsonify, request
     
     bp = Blueprint("relationships", __name__)
+
+    def _get_json_object():
+        data = request.get_json(silent=True)
+        if data is None:
+            if request.get_data(cache=True):
+                return None, (jsonify({"error": "JSON object required"}), 400)
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
     
     @bp.route("/api/relationships", methods=["GET"])
     def list_relationships():
@@ -1059,7 +1069,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/disagree", methods=["POST"])
     def disagree(agent_a: str, agent_b: str):
-        data = request.json or {}
+        data, error = _get_json_object()
+        if error:
+            return error
         try:
             result = engine.record_disagreement(
                 agent_a, agent_b,
@@ -1072,7 +1084,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/collaborate", methods=["POST"])
     def collaborate(agent_a: str, agent_b: str):
-        data = request.json or {}
+        data, error = _get_json_object()
+        if error:
+            return error
         try:
             result = engine.record_collaboration(
                 agent_a, agent_b,
@@ -1085,7 +1099,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/reconcile", methods=["POST"])
     def reconcile(agent_a: str, agent_b: str):
-        data = request.json or {}
+        data, error = _get_json_object()
+        if error:
+            return error
         try:
             result = engine.record_reconciliation(
                 agent_a, agent_b,
@@ -1097,7 +1113,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/intervene", methods=["POST"])
     def admin_intervene(agent_a: str, agent_b: str):
-        data = request.json or {}
+        data, error = _get_json_object()
+        if error:
+            return error
         try:
             result = engine.admin_intervene(
                 agent_a, agent_b,

--- a/test_agent_relationships.py
+++ b/test_agent_relationships.py
@@ -18,9 +18,11 @@ import os
 import tempfile
 from typing import Dict, Any
 
+from flask import Flask
+
 from agent_relationships import (
     RelationshipEngine, RelationshipState, DramaArcType, EventType,
-    GUARDRAILS, DRAMA_ARC_TEMPLATES
+    GUARDRAILS, DRAMA_ARC_TEMPLATES, create_relationship_blueprint
 )
 from drama_arc_engine import (
     DramaArcEngine, ArcPhase, run_five_day_rivalry_scenario
@@ -638,6 +640,65 @@ class TestEdgeCases(unittest.TestCase):
         stats = self.engine.get_relationship_stats()
         self.assertEqual(stats["total_relationships"], 0)
         self.assertEqual(stats["total_events"], 0)
+
+class TestRelationshipBlueprintJsonValidation(unittest.TestCase):
+    """Test JSON parsing for relationship API write endpoints."""
+
+    def setUp(self):
+        self.test_db = tempfile.NamedTemporaryFile(
+            suffix=".db", delete=False
+        )
+        self.test_db.close()
+        self.engine = RelationshipEngine(db_path=self.test_db.name)
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        app = Flask(__name__)
+        app.register_blueprint(create_relationship_blueprint(self.engine))
+        self.client = app.test_client()
+
+    def tearDown(self):
+        if os.path.exists(self.test_db.name):
+            os.unlink(self.test_db.name)
+
+    def test_write_endpoints_reject_non_object_json(self):
+        endpoints = [
+            "/api/relationships/agent_a/agent_b/disagree",
+            "/api/relationships/agent_a/agent_b/collaborate",
+            "/api/relationships/agent_a/agent_b/reconcile",
+            "/api/relationships/agent_a/agent_b/intervene",
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(endpoint, json=["not", "an", "object"])
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    "JSON object required",
+                )
+
+    def test_write_endpoints_reject_malformed_json(self):
+        endpoints = [
+            "/api/relationships/agent_a/agent_b/disagree",
+            "/api/relationships/agent_a/agent_b/collaborate",
+            "/api/relationships/agent_a/agent_b/reconcile",
+            "/api/relationships/agent_a/agent_b/intervene",
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    endpoint,
+                    data="{",
+                    content_type="application/json",
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    "JSON object required",
+                )
 
 
 # ─── Test Runner ────────────────────────────────────────────────────────────── #


### PR DESCRIPTION
## Summary
- Add a shared JSON-object parser for the BoTTube relationship blueprint write routes.
- Preserve omitted-body behavior while rejecting malformed or non-object JSON bodies with a 400 error.
- Add Flask client regressions for all four relationship write endpoints.
- Preserve the mempool missing-table guard needed by the existing security regression on fresh branches.

Fixes #4352

## Validation
- `python -m pytest test_agent_relationships.py -q` -> 42 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile agent_relationships.py test_agent_relationships.py node\utxo_db.py`
- `git diff --check -- agent_relationships.py test_agent_relationships.py node\utxo_db.py`

Wallet/miner ID: `cerredz`
