### PR TITLE
fix: validate passport json bodies

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -864,6 +864,10 @@ class UtxoDB:
                 count += 1
             conn.commit()
             return count
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return 0
+            raise
         finally:
             conn.close()
 

--- a/passport/passport_server.py
+++ b/passport/passport_server.py
@@ -18,6 +18,17 @@ app = Flask(__name__, template_folder="templates", static_folder="static")
 ledger = PassportLedger(data_dir=os.environ.get("PASSPORT_DATA_DIR", "/tmp/passport-ledger"))
 
 
+def _json_object_body(allow_empty=False):
+    data = request.get_json(silent=True)
+    if data is None:
+        if allow_empty and not request.get_data(cache=True):
+            return {}, None
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 # ── Web Routes ────────────────────────────────────────────────────
 
 @app.route("/")
@@ -69,7 +80,9 @@ def api_get(machine_id):
 @app.route("/api/passport", methods=["POST"])
 def api_create():
     """Create or update a machine passport."""
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     if not data or "machine_id" not in data:
         return jsonify({"error": "machine_id required"}), 400
 
@@ -100,7 +113,9 @@ def api_add_repair(machine_id):
     if not p:
         return jsonify({"error": "Passport not found"}), 404
 
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     if not data or "date" not in data or "description" not in data:
         return jsonify({"error": "date and description required"}), 400
 
@@ -116,7 +131,9 @@ def api_add_benchmark(machine_id):
     if not p:
         return jsonify({"error": "Passport not found"}), 404
 
-    data = request.get_json() or {}
+    data, error = _json_object_body(allow_empty=True)
+    if error:
+        return error
     sig = BenchmarkSignature(**{k: v for k, v in data.items() if k in BenchmarkSignature.__dataclass_fields__})
     p.add_benchmark(sig)
     ledger.save(p)

--- a/passport/test_passport.py
+++ b/passport/test_passport.py
@@ -249,6 +249,57 @@ class TestAPI:
         resp = client.post("/api/passport", json={"name": "No ID"})
         assert resp.status_code == 400
 
+    @pytest.mark.parametrize("payload", [["machine_id"], "machine_id", None])
+    def test_api_create_rejects_non_object_json(self, client, payload):
+        resp = client.post("/api/passport", json=payload)
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object required"
+
+    def test_api_create_rejects_malformed_json(self, client):
+        resp = client.post(
+            "/api/passport",
+            data="{",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object required"
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/passport/shape-test/repair",
+            "/api/passport/shape-test/benchmark",
+        ],
+    )
+    def test_passport_child_routes_reject_non_object_json(self, client, endpoint):
+        client.post("/api/passport", json={"machine_id": "shape-test", "name": "Shape"})
+
+        resp = client.post(endpoint, json=["not", "an", "object"])
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object required"
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/passport/shape-test/repair",
+            "/api/passport/shape-test/benchmark",
+        ],
+    )
+    def test_passport_child_routes_reject_malformed_json(self, client, endpoint):
+        client.post("/api/passport", json={"machine_id": "shape-test", "name": "Shape"})
+
+        resp = client.post(
+            endpoint,
+            data="{",
+            content_type="application/json",
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object required"
+
     def test_passport_view_page(self, client):
         resp = client.get("/passport/test123")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- Add a shared JSON-object parser for the legacy passport API.
- Reject present malformed, null, scalar, and array JSON bodies with `400` before route logic assumes a dict.
- Preserve the benchmark endpoint's omitted-body behavior.
- Add passport API regression coverage for create, repair, and benchmark routes.
- Preserve the mempool missing-table guard needed by the existing security regression on fresh branches.

Fixes #4354

## Validation
- `python -m pytest test_passport.py -q` from `passport/` -> 39 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile passport\passport_server.py passport\test_passport.py node\utxo_db.py`
- `git diff --check -- passport\passport_server.py passport\test_passport.py node\utxo_db.py`

Wallet/miner ID: `cerredz`
