### PR TITLE
fix: validate bottube mood json bodies

### DIFF
--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -924,6 +924,20 @@ def get_mood_engine() -> MoodEngine:
     return MoodEngine(db_path=db_path)
 
 
+def _get_json_object(allow_empty: bool = False):
+    data = request.get_json(silent=True)
+    has_body = bool(request.get_data(cache=True))
+    if data is None:
+        if allow_empty and not has_body:
+            return {}, None
+        if not has_body:
+            return None, (jsonify({"error": "Request body required"}), 400)
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 @mood_bp.route("/<agent_name>/mood", methods=["GET"])
 def get_agent_mood_endpoint(agent_name: str):
     """
@@ -964,10 +978,9 @@ def record_mood_signal(agent_name: str):
     """
     try:
         engine = get_mood_engine()
-        data = request.get_json()
-
-        if not data:
-            return jsonify({"error": "Request body required"}), 400
+        data, error = _get_json_object()
+        if error:
+            return error
 
         signal_type = data.get("signal_type")
         value = data.get("value", {})
@@ -995,10 +1008,9 @@ def generate_mood_title(agent_name: str):
     """
     try:
         engine = get_mood_engine()
-        data = request.get_json()
-
-        if not data:
-            return jsonify({"error": "Request body required"}), 400
+        data, error = _get_json_object()
+        if error:
+            return error
 
         topic = data.get("topic", "New Video")
         title = engine.generate_title(agent_name, topic)
@@ -1026,7 +1038,9 @@ def generate_mood_comment(agent_name: str):
     """
     try:
         engine = get_mood_engine()
-        data = request.get_json() or {}
+        data, error = _get_json_object(allow_empty=True)
+        if error:
+            return error
         base_comment = data.get("base_comment", "")
 
         comment = engine.generate_comment(agent_name, base_comment)

--- a/tests/test_bottube_mood.py
+++ b/tests/test_bottube_mood.py
@@ -17,6 +17,8 @@ import json
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 
+from flask import Flask
+
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -29,6 +31,7 @@ from bottube_mood_engine import (
     COMMENT_MODIFIERS,
     TRANSITION_PROBABILITIES,
     DEFAULT_MOOD,
+    mood_bp,
 )
 
 
@@ -551,6 +554,85 @@ class TestDatabasePersistence(unittest.TestCase):
         
         # History should be preserved
         self.assertEqual(len(history1), len(history2))
+
+
+class TestMoodBlueprintJsonValidation(unittest.TestCase):
+    """Test JSON body validation for mood API write endpoints."""
+
+    def setUp(self):
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
+        self.temp_db.close()
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+        app.config["DB_PATH"] = self.temp_db.name
+        app.register_blueprint(mood_bp)
+        self.client = app.test_client()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.temp_db.name)
+        except Exception:
+            pass
+
+    def test_write_endpoints_reject_non_object_json(self):
+        endpoints = [
+            "/api/v1/agents/test-agent/mood/signal",
+            "/api/v1/agents/test-agent/mood/title",
+            "/api/v1/agents/test-agent/mood/comment",
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(endpoint, json=["not", "an", "object"])
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    "JSON object required",
+                )
+
+    def test_write_endpoints_reject_malformed_json(self):
+        endpoints = [
+            "/api/v1/agents/test-agent/mood/signal",
+            "/api/v1/agents/test-agent/mood/title",
+            "/api/v1/agents/test-agent/mood/comment",
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    endpoint,
+                    data="{",
+                    content_type="application/json",
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    "JSON object required",
+                )
+
+    def test_required_write_endpoints_still_reject_missing_body(self):
+        endpoints = [
+            "/api/v1/agents/test-agent/mood/signal",
+            "/api/v1/agents/test-agent/mood/title",
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(endpoint)
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    "Request body required",
+                )
+
+    def test_comment_endpoint_still_allows_missing_body(self):
+        response = self.client.post("/api/v1/agents/test-agent/mood/comment")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("generated_comment", response.get_json())
 
 
 def run_demo():


### PR DESCRIPTION
## Summary
- Add a shared JSON-object parser for the BoTTube mood write endpoints.
- Return deterministic 400s for malformed or non-object JSON instead of routing those cases into broad 500 handling.
- Preserve existing missing-body behavior for required signal/title routes and omitted-body behavior for the comment route.
- Add Flask client regression coverage for all affected routes.
- Preserve the mempool missing-table guard needed by the existing security regression on fresh branches.

Fixes #4356

## Validation
- `python -m pytest tests\test_bottube_mood.py -q` -> 30 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile bottube_mood_engine.py tests\test_bottube_mood.py node\utxo_db.py`
- `git diff --check -- bottube_mood_engine.py tests\test_bottube_mood.py node\utxo_db.py`

Wallet/miner ID: `cerredz`
