### PR TITLE
Fix legacy faucet JSON body validation

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -305,12 +305,19 @@ def drip():
     Response:
         {"ok": true, "amount": 0.5, "next_available": "2026-03-08T12:00:00Z"}
     """
-    data = request.get_json()
-    
-    if not data or 'wallet' not in data:
+    data = request.get_json(silent=True)
+
+    if not isinstance(data, dict):
+        return jsonify({'ok': False, 'error': 'Invalid JSON body'}), 400
+
+    if 'wallet' not in data:
         return jsonify({'ok': False, 'error': 'Wallet address required'}), 400
-    
-    wallet = data['wallet'].strip()
+
+    wallet_value = data['wallet']
+    if not isinstance(wallet_value, str):
+        return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400
+
+    wallet = wallet_value.strip()
     
     # Basic wallet validation (should start with 0x and be reasonably long)
     if not wallet.startswith('0x') or len(wallet) < 10:

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -1,0 +1,36 @@
+import pytest
+
+import faucet
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setattr(faucet, "DATABASE", str(tmp_path / "faucet.db"))
+    faucet.init_db()
+    faucet.app.config.update(TESTING=True)
+    return faucet.app.test_client()
+
+
+def test_legacy_faucet_rejects_malformed_json(client):
+    response = client.post(
+        "/faucet/drip",
+        data="{",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid JSON body"}
+
+
+def test_legacy_faucet_rejects_non_object_json(client):
+    response = client.post("/faucet/drip", json=["wallet"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid JSON body"}
+
+
+def test_legacy_faucet_rejects_non_string_wallet(client):
+    response = client.post("/faucet/drip", json={"wallet": ["0x123456789"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}


### PR DESCRIPTION
## Summary

- reject malformed JSON in the legacy faucet drip endpoint with a structured `400` response
- reject non-object JSON payloads before wallet lookup
- reject non-string wallet values before calling `.strip()`
- add regression tests for malformed JSON, array JSON, and non-string wallet payloads

## Validation

- Added focused pytest coverage in `tests/test_legacy_faucet_json_validation.py`
- Not run locally: this environment does not have `python`/`py` available on PATH
