### PR TITLE
fix: validate relic market requests

### DIFF
--- a/bounties/issue-2312/src/relic_market_api.py
+++ b/bounties/issue-2312/src/relic_market_api.py
@@ -911,6 +911,28 @@ mcp = MCPIntegration(reservation_manager)
 beacon = BeaconIntegration(reservation_manager)
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        if request.get_data(cache=True):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return None, (jsonify({"error": "Request body required"}), 400)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _positive_limit(default: int = 10):
+    raw = request.args.get('limit', str(default))
+    try:
+        limit = int(raw)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "limit must be an integer"}), 400)
+    if limit < 1:
+        return None, (jsonify({"error": "limit must be positive"}), 400)
+    return limit, None
+
+
 # ============== API Endpoints ==============
 
 @app.route('/health', methods=['GET'])
@@ -956,7 +978,9 @@ def get_machine_details(machine_id: str):
 @app.route('/relic/reserve', methods=['POST'])
 def reserve_machine():
     """POST /relic/reserve - Reserve a machine"""
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     
     required = ["machine_id", "agent_id", "duration_hours", "payment_rtc"]
     if not all(k in data for k in required):
@@ -1011,7 +1035,9 @@ def start_reservation_session(reservation_id: str):
 @app.route('/relic/reservation/<reservation_id>/complete', methods=['POST'])
 def complete_reservation_session(reservation_id: str):
     """Complete session and get provenance receipt"""
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     
     required = ["compute_hash", "hardware_attestation"]
     if not all(k in data for k in required):
@@ -1056,7 +1082,9 @@ def get_receipt(session_id: str):
 @app.route('/relic/leaderboard', methods=['GET'])
 def get_leaderboard():
     """Get most-rented machines leaderboard"""
-    limit = int(request.args.get('limit', '10'))
+    limit, error = _positive_limit()
+    if error:
+        return error
     leaderboard = reservation_manager.get_most_rented_machines(limit)
     
     machines_data = []
@@ -1099,7 +1127,9 @@ def get_mcp_manifest():
 @app.route('/mcp/tool', methods=['POST'])
 def call_mcp_tool():
     """Call an MCP tool"""
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     
     tool_name = data.get("tool")
     arguments = data.get("arguments", {})
@@ -1116,7 +1146,9 @@ def call_mcp_tool():
 @app.route('/beacon/message', methods=['POST'])
 def handle_beacon_message():
     """Handle Beacon protocol message"""
-    data = request.get_json()
+    data, error = _json_object_body()
+    if error:
+        return error
     
     message_type = data.get("type")
     payload = data.get("payload", {})

--- a/bounties/issue-2312/tests/test_relic_market.py
+++ b/bounties/issue-2312/tests/test_relic_market.py
@@ -580,6 +580,62 @@ class TestAPIEndpoints(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data['status'], 'confirmed')
 
+    def test_json_write_endpoints_reject_non_object_bodies(self):
+        endpoints = [
+            '/relic/reserve',
+            '/relic/reservation/missing/complete',
+            '/mcp/tool',
+            '/beacon/message',
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(endpoint, json=["not", "an", "object"])
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json()['error'], "JSON object required")
+
+    def test_json_write_endpoints_reject_malformed_bodies(self):
+        endpoints = [
+            '/relic/reserve',
+            '/relic/reservation/missing/complete',
+            '/mcp/tool',
+            '/beacon/message',
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(
+                    endpoint,
+                    data="{",
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json()['error'], "JSON object required")
+
+    def test_json_write_endpoints_reject_missing_bodies(self):
+        endpoints = [
+            '/relic/reserve',
+            '/relic/reservation/missing/complete',
+            '/mcp/tool',
+            '/beacon/message',
+        ]
+
+        for endpoint in endpoints:
+            with self.subTest(endpoint=endpoint):
+                response = self.client.post(endpoint)
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json()['error'], "Request body required")
+
+    def test_leaderboard_rejects_invalid_limits(self):
+        for limit in ['abc', '0', '-1']:
+            with self.subTest(limit=limit):
+                response = self.client.get(f'/relic/leaderboard?limit={limit}')
+
+                self.assertEqual(response.status_code, 400)
+
 
 class TestAccessDuration(unittest.TestCase):
     """Test AccessDuration enum"""


### PR DESCRIPTION
## Summary
- Add shared JSON-object validation for Rent-a-Relic POST endpoints.
- Return deterministic 400 responses for missing bodies, malformed JSON, and non-object JSON.
- Validate `/relic/leaderboard` limits before calling into leaderboard slicing.
- Add Flask client regressions for all affected routes.
- Preserve the mempool missing-table guard needed by the existing security regression on fresh branches.

Fixes #4359

## Validation
- Installed missing local test dependency: `python -m pip install PyNaCl`
- `python -m pytest tests\test_relic_market.py -q` from `bounties/issue-2312/` -> 54 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile bounties\issue-2312\src\relic_market_api.py bounties\issue-2312\tests\test_relic_market.py node\utxo_db.py`
- `git diff --check -- bounties\issue-2312\src\relic_market_api.py bounties\issue-2312\tests\test_relic_market.py node\utxo_db.py`

Wallet/miner ID: `cerredz`
