### PR TITLE
fix: validate faucet service wallet values

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -531,11 +531,16 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         
         # Parse request
         data = request.get_json(silent=True)
-        if not data or 'wallet' not in data:
+        if not isinstance(data, dict) or 'wallet' not in data:
             logger.warning(f"Invalid request from {request.remote_addr}: missing wallet")
             return jsonify({'ok': False, 'error': 'Wallet address required'}), 400
         
-        wallet = data['wallet'].strip()
+        wallet_value = data['wallet']
+        if not isinstance(wallet_value, str) or not wallet_value.strip():
+            logger.warning(f"Invalid request from {request.remote_addr}: invalid wallet type")
+            return jsonify({'ok': False, 'error': 'Wallet address required'}), 400
+
+        wallet = wallet_value.strip()
         ip = get_client_ip(request)
         
         logger.info(f"Drip request: wallet={wallet}, ip={ip}")

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -392,7 +392,31 @@ class TestFlaskApp(unittest.TestCase):
         data = json.loads(response.data)
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'Wallet address required')
-    
+
+    def test_drip_rejects_non_object_json(self):
+        """Test drip request rejects non-object JSON."""
+        response = self.client.post('/faucet/drip',
+                                    json=['wallet'],
+                                    content_type='application/json')
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Wallet address required')
+
+    def test_drip_rejects_non_string_wallet(self):
+        """Test drip request rejects structured wallet values."""
+        for wallet in (['0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E'], {'address': '0xabc'}, 123):
+            with self.subTest(wallet=wallet):
+                response = self.client.post('/faucet/drip',
+                                            json={'wallet': wallet},
+                                            content_type='application/json')
+
+                self.assertEqual(response.status_code, 400)
+                data = json.loads(response.data)
+                self.assertFalse(data['ok'])
+                self.assertEqual(data['error'], 'Wallet address required')
+
     def test_drip_invalid_wallet(self):
         """Test drip request with invalid wallet."""
         response = self.client.post('/faucet/drip',


### PR DESCRIPTION
## Summary

Fixes #4362.

The production faucet service `/faucet/drip` route now validates that the parsed JSON body is an object and that `wallet` is a non-empty string before calling `.strip()`.

This keeps malformed client input on the 400 path instead of allowing list/object/numeric wallet values to raise a server error.

## Changes

- reject non-object JSON bodies for `/faucet/drip`
- reject non-string or blank `wallet` values before address validation and rate limiting
- add focused regression tests for array bodies and list/object/numeric wallet values
- keep the mempool missing-table guard required by the security audit regression test

## Validation

Installed missing local test dependency:

- `python -m pip install pycryptodome`

Commands run:

- from `faucet_service/`: `python -m pytest test_faucet_service.py -q` -> 35 passed
- from repo root: `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile faucet_service\faucet_service.py faucet_service\test_faucet_service.py node\utxo_db.py`
- `git diff --check -- faucet_service\faucet_service.py faucet_service\test_faucet_service.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
