### PR TITLE
fix: validate bridge json requests

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -172,6 +172,28 @@ def _require_admin(fn):
     return wrapper
 
 
+def _json_object_body():
+    """Return the parsed JSON body only when it is an object."""
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object body is required"}), 400)
+    return data, None
+
+
+def _clean_string_field(data, field_name, *, optional=False, lower=False):
+    value = data.get(field_name)
+    if value is None:
+        return None if optional else ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    value = value.strip()
+    if lower:
+        value = value.lower()
+    if optional and not value:
+        return None
+    return value
+
+
 # ─── Blueprint ────────────────────────────────────────────────────────────────
 bridge_bp = Blueprint("bridge", __name__, url_prefix="/bridge")
 
@@ -200,15 +222,19 @@ def lock_rtc():
       - Rejects requests with invalid proof signatures
       - Validates proof before accepting lock into ledger
     """
-    data = request.get_json(force=True, silent=True) or {}
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
 
     # ── Validate inputs ──
-    sender = data.get("sender_wallet", "").strip()
-    target_chain = data.get("target_chain", "").lower().strip()
-    target_wallet = data.get("target_wallet", "").strip()
-    tx_hash = data.get("tx_hash", "").strip() or None
-    receipt_signature_raw = data.get("receipt_signature")
-    receipt_signature = receipt_signature_raw.strip().lower() if receipt_signature_raw else None
+    try:
+        sender = _clean_string_field(data, "sender_wallet")
+        target_chain = _clean_string_field(data, "target_chain", lower=True)
+        target_wallet = _clean_string_field(data, "target_wallet")
+        tx_hash = _clean_string_field(data, "tx_hash", optional=True)
+        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     try:
         amount_float = float(data.get("amount", 0))
@@ -344,10 +370,15 @@ def lock_rtc():
 @_require_admin
 def confirm_lock():
     """Admin: confirm a requested lock after reviewing proof."""
-    data = request.get_json(force=True, silent=True) or {}
-    lock_id = data.get("lock_id", "").strip()
-    proof_ref = data.get("proof_ref", "").strip()
-    notes = data.get("notes", "").strip() or None
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    try:
+        lock_id = _clean_string_field(data, "lock_id")
+        proof_ref = _clean_string_field(data, "proof_ref")
+        notes = _clean_string_field(data, "notes", optional=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     if not lock_id:
         return jsonify({"error": "lock_id is required"}), 400
@@ -405,10 +436,15 @@ def release_wrtc():
 
     Returns success/error.
     """
-    data = request.get_json(force=True, silent=True) or {}
-    lock_id = data.get("lock_id", "").strip()
-    release_tx = data.get("release_tx", "").strip()
-    notes = data.get("notes", "").strip() or None
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    try:
+        lock_id = _clean_string_field(data, "lock_id")
+        release_tx = _clean_string_field(data, "release_tx")
+        notes = _clean_string_field(data, "notes", optional=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     if not lock_id:
         return jsonify({"error": "lock_id is required"}), 400

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -580,6 +580,69 @@ class TestLockEndpoint:
         assert "tx_hash is required" in resp.get_json()["error"]
 
 
+class TestBridgeRequestValidation:
+    def test_lock_rejects_non_object_json(self, client):
+        resp = client.post("/bridge/lock", json=["sender_wallet"])
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object body is required"
+
+    def test_lock_rejects_non_string_fields(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": ["test-miner"],
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": "rtc-lock-bad-sender-type",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "sender_wallet must be a string"
+
+    def test_lock_rejects_non_string_receipt_signature(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": "rtc-lock-bad-sig-type",
+            "receipt_signature": {"sig": "bad"},
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "receipt_signature must be a string"
+
+    def test_confirm_rejects_non_object_json(self, client):
+        resp = client.post(
+            "/bridge/confirm",
+            json=["lock_id"],
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object body is required"
+
+    def test_confirm_rejects_non_string_notes(self, client):
+        resp = client.post(
+            "/bridge/confirm",
+            json={"lock_id": "lock_fake", "proof_ref": "manual:proof", "notes": {"admin": "note"}},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "notes must be a string"
+
+    def test_release_rejects_non_string_fields(self, client):
+        resp = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": ["0xabc"]},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "release_tx must be a string"
+
+
 class TestReleaseEndpoint:
     def test_release_requires_admin_key(self, client):
         resp = client.post("/bridge/release", json={


### PR DESCRIPTION
## Summary

Fixes #4364.

The bridge API now rejects malformed request shapes before string normalization:

- non-object JSON bodies return HTTP 400
- non-string text fields return HTTP 400
- omitted fields still flow through the existing missing-field validation messages

This covers the public lock route and the admin confirm/release routes, preventing list/object/numeric field values from reaching `.strip()` and returning 500s.

## Changes

- add shared JSON-object body validation for bridge POST routes
- add shared string-field normalization with optional lowercasing
- validate `/bridge/lock` sender, target chain, target wallet, tx hash, and receipt signature types
- validate `/bridge/confirm` lock/proof/notes types
- validate `/bridge/release` lock/release/notes types
- add focused regression tests for lock, confirm, and release request validation
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- from `bridge/`: `python -m pytest test_bridge_api.py -q` -> 37 passed
- from repo root: `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile bridge\bridge_api.py bridge\test_bridge_api.py node\utxo_db.py`
- `git diff --check -- bridge\bridge_api.py bridge\test_bridge_api.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
