### PR TITLE
fix: validate bcos badge json fields

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -418,10 +418,66 @@ class TestFlaskIntegration(unittest.TestCase):
                     content_type='application/json',
                 )
 
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, 400)
                 data = json.loads(response.data)
                 self.assertFalse(data['success'])
-                self.assertEqual(data['error'], 'Trust score must be a number')
+                self.assertEqual(data['error'], 'trust_score must be a number')
+
+    def test_generate_badge_rejects_non_object_json(self):
+        """Test badge generation rejects non-object JSON bodies."""
+        response = self.client.post(
+            '/api/badge/generate',
+            json=['repo_name'],
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'JSON object body is required')
+
+    def test_generate_badge_rejects_non_string_fields(self):
+        """Test badge generation rejects structured string fields."""
+        for field, value in (
+            ('repo_name', ['test/repo']),
+            ('tier', {'tier': 'L1'}),
+            ('cert_id', ['BCOS-test']),
+        ):
+            with self.subTest(field=field):
+                payload = {
+                    'repo_name': 'test/repo',
+                    'tier': 'L1',
+                    'trust_score': 75,
+                }
+                payload[field] = value
+
+                response = self.client.post(
+                    '/api/badge/generate',
+                    json=payload,
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 400)
+                data = json.loads(response.data)
+                self.assertFalse(data['success'])
+                self.assertEqual(data['error'], f'{field} must be a string')
+
+    def test_generate_badge_rejects_non_numeric_trust_score(self):
+        """Test badge generation rejects structured trust scores."""
+        response = self.client.post(
+            '/api/badge/generate',
+            json={
+                'repo_name': 'test/repo',
+                'tier': 'L1',
+                'trust_score': {'score': 75},
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'trust_score must be a number')
 
     def test_stats_endpoint(self):
         """Test stats endpoint."""

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1057,16 +1057,44 @@ def index():
     return render_template_string(MAIN_TEMPLATE)
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({'success': False, 'error': 'JSON object body is required'}), 400)
+    return data, None
+
+
+def _string_field(data, field_name, default=''):
+    value = data.get(field_name, default)
+    if value is None:
+        return ''
+    if not isinstance(value, str):
+        raise ValueError(f'{field_name} must be a string')
+    return value.strip()
+
+
+def _trust_score_field(data):
+    value = data.get('trust_score', 75)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError('trust_score must be a number')
+    return value
+
+
 @app.route('/api/badge/generate', methods=['POST'])
 def generate_badge():
     """Generate a BCOS badge."""
-    data = request.get_json()
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
 
-    repo_name = data.get('repo_name', '').strip()
-    tier = data.get('tier', 'L1').upper()
-    raw_trust_score = data.get('trust_score', 75)
-    cert_id = data.get('cert_id', '')
-    include_qr = data.get('include_qr', False)
+    try:
+        repo_name = _string_field(data, 'repo_name')
+        tier = _string_field(data, 'tier', 'L1').upper()
+        raw_trust_score = _trust_score_field(data)
+        cert_id = _string_field(data, 'cert_id')
+    except ValueError as exc:
+        return jsonify({'success': False, 'error': str(exc)}), 400
+    include_qr = bool(data.get('include_qr', False))
 
     # Validation
     if not repo_name:


### PR DESCRIPTION
## Summary

Fixes #4367.

The BCOS badge generator now validates `/api/badge/generate` request shape and field types before string normalization, trust-score range checks, SVG generation, or database recording.

## Changes

- reject non-object JSON bodies with HTTP 400
- reject non-string `repo_name`, `tier`, and `cert_id` values with HTTP 400
- reject non-numeric `trust_score` values with HTTP 400
- preserve the existing validation behavior for missing repo names, invalid tiers, and out-of-range numeric scores
- add focused route tests for malformed JSON field types
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- `python -m pytest tests\test_bcos_badge_generator.py -q` -> 37 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py node\utxo_db.py`
- `git diff --check -- tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
