### PR TITLE
fix: validate beacon x402 wallet json

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -97,6 +97,22 @@ def _cors_json(data, status=200):
     return resp, status
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, _cors_json({"error": "JSON object body is required"}, 400)
+    return data, None
+
+
+def _json_string_field(data, field_name, default=""):
+    value = data.get(field_name, default)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value.strip()
+
+
 # ---------------------------------------------------------------------------
 # x402 payment check
 # ---------------------------------------------------------------------------
@@ -183,8 +199,13 @@ def init_app(app, get_db_func):
         if not hmac.compare_digest(admin_key, expected):
             return _cors_json({"error": "Unauthorized — admin key required"}, 401)
 
-        data = request.get_json(silent=True) or {}
-        address = data.get("coinbase_address", "").strip()
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            address = _json_string_field(data, "coinbase_address")
+        except ValueError as exc:
+            return _cors_json({"error": str(exc)}, 400)
         if not address or not address.startswith("0x") or len(address) != 42:
             return _cors_json({"error": "Invalid Base address"}, 400)
 

--- a/tests/test_beacon_x402_wallet.py
+++ b/tests/test_beacon_x402_wallet.py
@@ -1,0 +1,65 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from node import beacon_x402
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "beacon.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(beacon_x402.X402_BEACON_SCHEMA)
+
+    monkeypatch.setenv("BEACON_ADMIN_KEY", "test-admin-key")
+    monkeypatch.setattr(beacon_x402, "_run_migrations", lambda _db_path: None)
+
+    def get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    beacon_x402.init_app(app, get_db)
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def test_set_agent_wallet_rejects_non_object_json(client):
+    response = client.post(
+        "/api/agents/agent-1/wallet",
+        json=["coinbase_address"],
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object body is required"
+
+
+def test_set_agent_wallet_rejects_non_string_coinbase_address(client):
+    response = client.post(
+        "/api/agents/agent-1/wallet",
+        json={"coinbase_address": {"address": "0x1234567890123456789012345678901234567890"}},
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "coinbase_address must be a string"
+
+
+def test_set_agent_wallet_preserves_valid_address(client):
+    response = client.post(
+        "/api/agents/agent-1/wallet",
+        json={"coinbase_address": " 0x1234567890123456789012345678901234567890 "},
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["coinbase_address"] == "0x1234567890123456789012345678901234567890"


### PR DESCRIPTION
## Summary

Fixes #4371.

The Beacon x402 wallet-link route now validates the parsed JSON body and `coinbase_address` type before trimming and Base-address validation.

## Changes

- reject non-object JSON bodies with HTTP 400
- reject non-string `coinbase_address` values with HTTP 400
- preserve valid address trimming and existing Base-address validation
- add focused route tests for malformed and valid wallet-link requests
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- `python -m pytest tests\test_beacon_x402_wallet.py -q` -> 3 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile node\beacon_x402.py tests\test_beacon_x402_wallet.py node\utxo_db.py`
- `git diff --check -- node\beacon_x402.py tests\test_beacon_x402_wallet.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
