### PR TITLE
fix: validate rustchain x402 wallet json

### DIFF
--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -54,6 +54,22 @@ def _run_migration(db_path):
     conn.close()
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object body is required"}), 400)
+    return data, None
+
+
+def _json_string_field(data, field_name, default=""):
+    value = data.get(field_name, default)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    return value.strip()
+
+
 def init_app(app, db_path):
     """Register x402 routes on the RustChain Flask app."""
 
@@ -77,9 +93,14 @@ def init_app(app, db_path):
         if not hmac.compare_digest(admin_key, expected):
             return jsonify({"error": "Unauthorized — admin key required"}), 401
 
-        data = request.get_json(silent=True) or {}
-        miner_id = data.get("miner_id", "").strip()
-        coinbase_address = data.get("coinbase_address", "").strip()
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            miner_id = _json_string_field(data, "miner_id")
+            coinbase_address = _json_string_field(data, "coinbase_address")
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
 
         if not miner_id:
             return jsonify({"error": "miner_id is required"}), 400

--- a/tests/test_rustchain_x402_wallet.py
+++ b/tests/test_rustchain_x402_wallet.py
@@ -1,0 +1,83 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from node import rustchain_x402
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "wallets.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, miner_pk TEXT)")
+        conn.execute(
+            "INSERT INTO balances (miner_id, miner_pk) VALUES (?, ?)",
+            ("miner-1", "pk-1"),
+        )
+        conn.commit()
+
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    rustchain_x402.init_app(app, str(db_path))
+    with app.test_client() as test_client:
+        yield test_client
+
+
+def test_link_coinbase_rejects_non_object_json(client):
+    response = client.post(
+        "/wallet/link-coinbase",
+        json=["miner_id"],
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object body is required"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("miner_id", ["miner-1"]),
+        ("coinbase_address", {"address": "0x1234567890123456789012345678901234567890"}),
+    ],
+)
+def test_link_coinbase_rejects_non_string_fields(client, field, value):
+    payload = {
+        "miner_id": "miner-1",
+        "coinbase_address": "0x1234567890123456789012345678901234567890",
+    }
+    payload[field] = value
+
+    response = client.post(
+        "/wallet/link-coinbase",
+        json=payload,
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == f"{field} must be a string"
+
+
+def test_link_coinbase_preserves_valid_request(client):
+    response = client.post(
+        "/wallet/link-coinbase",
+        json={
+            "miner_id": " miner-1 ",
+            "coinbase_address": " 0x1234567890123456789012345678901234567890 ",
+        },
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["miner_id"] == "miner-1"
+    assert body["coinbase_address"] == "0x1234567890123456789012345678901234567890"


### PR DESCRIPTION
## Summary

Fixes #4373.

The RustChain x402 wallet-link route now validates JSON body shape and string field types before trimming `miner_id` / `coinbase_address` and before database mutation.

## Changes

- reject non-object JSON bodies with HTTP 400
- reject non-string `miner_id` and `coinbase_address` values with HTTP 400
- preserve valid request trimming, miner lookup, and Base-address validation
- add focused route tests for malformed body shape, malformed field types, and valid trimmed input
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- `python -m pytest tests\test_rustchain_x402_wallet.py -q` -> 4 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile node\rustchain_x402.py tests\test_rustchain_x402_wallet.py node\utxo_db.py`
- `git diff --check -- node\rustchain_x402.py tests\test_rustchain_x402_wallet.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
