### PR TITLE
fix: validate beacon join field types

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -219,7 +219,7 @@ def beacon_join():
 
     try:
         data = request.get_json(silent=True)
-        if not data:
+        if not isinstance(data, dict):
             return jsonify({'error': 'Invalid or missing JSON body'}), 400
 
         # Validate required fields
@@ -230,6 +230,10 @@ def beacon_join():
             return jsonify({'error': 'Missing required field: agent_id'}), 400
         if not pubkey_hex:
             return jsonify({'error': 'Missing required field: pubkey_hex'}), 400
+        if not isinstance(agent_id, str):
+            return jsonify({'error': 'Invalid agent_id: must be a string'}), 400
+        if not isinstance(pubkey_hex, str):
+            return jsonify({'error': 'Invalid pubkey_hex: must be a string'}), 400
 
         # Validate pubkey_hex format (must be valid hex string, optionally with 0x prefix)
         pubkey_clean = pubkey_hex.strip()
@@ -248,6 +252,10 @@ def beacon_join():
         # Optional fields
         name = data.get('name')
         coinbase_address = data.get('coinbase_address')
+        if name is not None and not isinstance(name, str):
+            return jsonify({'error': 'Invalid name: must be a string'}), 400
+        if coinbase_address is not None and not isinstance(coinbase_address, str):
+            return jsonify({'error': 'Invalid coinbase_address: must be a string'}), 400
         
         # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
         if coinbase_address:

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -4,6 +4,7 @@ Test suite for Issue #2127 - Beacon Join Routing
 Tests POST /beacon/join and GET /beacon/atlas endpoints.
 """
 import unittest
+import gc
 import json
 import time
 import sys
@@ -60,7 +61,13 @@ class TestBeaconJoinRouting(unittest.TestCase):
     def tearDownClass(cls):
         """Clean up after all tests."""
         os.close(cls.test_db_fd)
-        os.unlink(cls.test_db_path)
+        cls.client = None
+        cls.app = None
+        gc.collect()
+        try:
+            os.unlink(cls.test_db_path)
+        except PermissionError:
+            pass
 
     def setUp(self):
         """Reset database state before each test."""
@@ -250,6 +257,66 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         data = json.loads(response.data)
         self.assertIn('error', data)
+
+    def test_join_rejects_non_object_json(self):
+        """POST /beacon/join returns 400 for non-object JSON bodies."""
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(['agent_id']),
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertEqual(data['error'], 'Invalid or missing JSON body')
+
+    def test_join_rejects_non_string_required_fields(self):
+        """POST /beacon/join returns 400 for structured required fields."""
+        cases = [
+            (
+                {'agent_id': ['bcn_test'], 'pubkey_hex': '0x1234'},
+                'Invalid agent_id: must be a string',
+            ),
+            (
+                {'agent_id': 'bcn_test', 'pubkey_hex': ['0x1234']},
+                'Invalid pubkey_hex: must be a string',
+            ),
+        ]
+
+        for payload, expected_error in cases:
+            response = self.client.post(
+                '/beacon/join',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
+
+            self.assertEqual(response.status_code, 400)
+            data = json.loads(response.data)
+            self.assertEqual(data['error'], expected_error)
+
+    def test_join_rejects_non_string_optional_fields(self):
+        """POST /beacon/join returns 400 for structured optional string fields."""
+        cases = [
+            (
+                {'agent_id': 'bcn_test', 'pubkey_hex': '0x1234', 'name': {'display': 'agent'}},
+                'Invalid name: must be a string',
+            ),
+            (
+                {'agent_id': 'bcn_test', 'pubkey_hex': '0x1234', 'coinbase_address': ['0x123']},
+                'Invalid coinbase_address: must be a string',
+            ),
+        ]
+
+        for payload, expected_error in cases:
+            response = self.client.post(
+                '/beacon/join',
+                data=json.dumps(payload),
+                content_type='application/json'
+            )
+
+            self.assertEqual(response.status_code, 400)
+            data = json.loads(response.data)
+            self.assertEqual(data['error'], expected_error)
 
     def test_join_with_coinbase_address(self):
         """POST /beacon/join accepts valid coinbase_address."""


### PR DESCRIPTION
## Summary

Fixes #4375.

The Beacon join route now validates JSON body shape and field types before string normalization, pubkey parsing, Base-address validation, or database writes.

## Changes

- reject non-object JSON bodies with HTTP 400
- reject non-string `agent_id` and `pubkey_hex` values with HTTP 400
- reject non-string optional `name` and `coinbase_address` values with HTTP 400
- preserve existing missing-field, invalid-hex, and invalid-Base-address validation
- add regression coverage to the existing Beacon join routing suite
- make the test DB cleanup release Flask test-client references before unlinking on Windows
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- `python -m pytest tests\test_beacon_join_routing.py -q` -> 21 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile node\beacon_api.py tests\test_beacon_join_routing.py node\utxo_db.py`
- `git diff --check -- node\beacon_api.py tests\test_beacon_join_routing.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
