### PR TITLE
fix: validate utxo transfer field types

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -206,6 +206,40 @@ class TestUtxoEndpoints(unittest.TestCase):
         })
         self.assertEqual(r.status_code, 400)
 
+    def test_transfer_rejects_non_object_json(self):
+        r = self.client.post('/utxo/transfer', json=['from_address'])
+
+        self.assertEqual(r.status_code, 400)
+        data = r.get_json()
+        self.assertEqual(data['error'], 'JSON body required')
+
+    def test_transfer_rejects_non_string_fields(self):
+        base_payload = {
+            'from_address': 'RTC_test_aabbccdd',
+            'to_address': 'bob',
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': 123,
+        }
+
+        for field, value in (
+            ('from_address', ['RTC_test_aabbccdd']),
+            ('to_address', {'address': 'bob'}),
+            ('public_key', ['aabbccdd' * 8]),
+            ('signature', {'sig': 'abc'}),
+            ('memo', ['note']),
+        ):
+            with self.subTest(field=field):
+                payload = dict(base_payload)
+                payload[field] = value
+
+                r = self.client.post('/utxo/transfer', json=payload)
+
+                self.assertEqual(r.status_code, 400)
+                data = r.get_json()
+                self.assertEqual(data['error'], f'{field} must be a string')
+
     def test_transfer_zero_amount(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -96,6 +96,23 @@ def _ensure_signed_float_preserves_nrtc(amount: Decimal, nrtc: int,
             f"{field_name} cannot be represented safely in signed payload"
         )
 
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'JSON body required'}), 400)
+    return data, None
+
+
+def _json_string_field(data, field_name, default=''):
+    value = data.get(field_name, default)
+    if value is None:
+        return ''
+    if not isinstance(value, str):
+        raise ValueError(f'{field_name} must be a string')
+    return value.strip()
+
+
 # Account-model balances store amount_i64 at 6 decimals (micro-RTC).
 # This MUST match the multiplier used in rustchain_v2_integrated_v2.2.1_rip200.py
 # (e.g. line 2370: amount_i64 = int(amount_decimal * Decimal(1000000))).
@@ -342,16 +359,19 @@ def utxo_transfer():
     4. Apply atomically
     5. If dual_write: also update account model
     """
-    data = request.get_json()
-    if not data:
-        return jsonify({'error': 'JSON body required'}), 400
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
 
-    from_address = (data.get('from_address') or '').strip()
-    to_address = (data.get('to_address') or '').strip()
-    public_key = (data.get('public_key') or '').strip()
-    signature = (data.get('signature') or '').strip()
+    try:
+        from_address = _json_string_field(data, 'from_address')
+        to_address = _json_string_field(data, 'to_address')
+        public_key = _json_string_field(data, 'public_key')
+        signature = _json_string_field(data, 'signature')
+        memo = _json_string_field(data, 'memo')
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
     nonce = data.get('nonce')
-    memo = data.get('memo', '')
     # FIX(#2867 M2): exact Decimal parsing with bounds check (was float()).
     try:
         amount_rtc = _parse_rtc_amount(data.get('amount_rtc', 0))


### PR DESCRIPTION
## Summary

Fixes #4377.

The UTXO transfer route now validates JSON body shape and string field types before signature verification, nonce handling, UTXO selection, or ledger mutation.

## Changes

- reject non-object JSON bodies with HTTP 400
- reject non-string `from_address`, `to_address`, `public_key`, `signature`, and optional `memo` values with HTTP 400
- preserve existing missing-field, amount, signature, and balance validation behavior
- add regression coverage to the existing UTXO endpoint suite
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- from `node/`: `python -m pytest test_utxo_endpoints.py -q` -> 19 passed
- from repo root: `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile node\utxo_endpoints.py node\test_utxo_endpoints.py node\utxo_db.py`
- `git diff --check -- node\utxo_endpoints.py node\test_utxo_endpoints.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
