### PR TITLE
Fix broken relative documentation links

### DIFF
--- a/bounties/issue-684/README.md
+++ b/bounties/issue-684/README.md
@@ -207,7 +207,7 @@ To submit for bounty #684:
 
 ## 📚 Documentation
 
-- [RIP-302 Specification](../docs/RIP-302-agent-to-agent-test-challenge.md) - Full technical specification
+- [RIP-302 Specification](../../rips/docs/RIP-302-agent-to-agent-test-challenge.md) - Full technical specification
 - [Evidence Schema](#-evidence-schema) - Evidence format documentation
 - [CI/CD Guide](#-ci-integration) - Automated validation guide
 

--- a/bounties/issue-684/docs/CHALLENGE_GUIDE.md
+++ b/bounties/issue-684/docs/CHALLENGE_GUIDE.md
@@ -454,7 +454,7 @@ python scripts/run_challenge.py --all
 ### Getting Help
 
 1. Check the [main README](../README.md)
-2. Review the [RIP-302 specification](../docs/RIP-302-agent-to-agent-test-challenge.md)
+2. Review the [RIP-302 specification](../../../rips/docs/RIP-302-agent-to-agent-test-challenge.md)
 3. Open an issue on GitHub
 4. Ask in RustChain Discord
 

--- a/bounties/issue-729/README.md
+++ b/bounties/issue-729/README.md
@@ -397,7 +397,7 @@ chrome.runtime.sendMessage({
 
 ## 📄 License
 
-MIT License - See [LICENSE](../../../LICENSE) for details.
+MIT License - See [LICENSE](../../LICENSE) for details.
 
 ## 🙏 Acknowledgments
 

--- a/bounties/issue-755/README.md
+++ b/bounties/issue-755/README.md
@@ -315,7 +315,7 @@ python scripts/verify_backup.py backup.db --format json | jq .
 
 ## 📄 License
 
-MIT License - See [LICENSE](../../../LICENSE) for details.
+MIT License - See [LICENSE](../../LICENSE) for details.
 
 ## 🙏 Acknowledgments
 

--- a/docs/CLAIMS_GUIDE.md
+++ b/docs/CLAIMS_GUIDE.md
@@ -433,7 +433,7 @@ Rewards are calculated based on:
 2. **Antiquity Multiplier** - Bonus for vintage hardware (1.0x - 3.0x)
 3. **Fleet Adjustments** - Penalties for suspicious fleet activity
 
-See [RIP-0200](/rips/docs/RIP-0200-round-robin-consensus.md) for full details.
+See [RIP-200](WHITEPAPER.md#3-rip-200-round-robin-consensus) for full details.
 
 ### Settlement Process
 

--- a/docs/CONSOLE_MINING_SETUP.md
+++ b/docs/CONSOLE_MINING_SETUP.md
@@ -369,7 +369,7 @@ Develop attestation ROMs for additional consoles:
 
 ## References
 
-- [RIP-0683 Specification](../rips/docs/RIP-0683-console-bridge-integration.md)
+- [RIP-0683 Implementation Summary](../IMPLEMENTATION_SUMMARY.md)
 - [RIP-0304: Retro Console Mining](../rips/docs/RIP-0304-retro-console-mining.md)
 - [RIP-201: Fleet Immune System](../rips/docs/RIP-0201-fleet-immune-system.md)
 - [Legend of Elya](https://github.com/ilya-kh/legend-of-elya) - N64 neural network demo

--- a/integrations/rustchain-mcp/IMPLEMENTATION_REPORT.md
+++ b/integrations/rustchain-mcp/IMPLEMENTATION_REPORT.md
@@ -341,8 +341,8 @@ Potential additions for future versions:
 
 - [Model Context Protocol](https://modelcontextprotocol.io)
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
-- [RustChain API Walkthrough](../../../API_WALKTHROUGH.md)
-- [RustChain API Reference](../../../docs/api-reference.md)
+- [RustChain API Walkthrough](../../API_WALKTHROUGH.md)
+- [RustChain API Reference](../../docs/api-reference.md)
 
 ---
 

--- a/integrations/rustchain-mcp/README.md
+++ b/integrations/rustchain-mcp/README.md
@@ -339,16 +339,16 @@ tests/test_mcp_server.py::TestRustChainMCP::test_tool_health PASSED
 ## 📚 API Reference
 
 For detailed API documentation, see:
-- [API Walkthrough](../../../API_WALKTHROUGH.md)
-- [API Reference](../../../docs/api-reference.md)
+- [API Walkthrough](../../API_WALKTHROUGH.md)
+- [API Reference](../../docs/api-reference.md)
 
 ## 🤝 Contributing
 
-Contributions welcome! See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for guidelines.
+Contributions welcome! See [CONTRIBUTING.md](../../CONTRIBUTING.md) for guidelines.
 
 ## 📄 License
 
-MIT License — See [LICENSE](../../../LICENSE) for details.
+MIT License — See [LICENSE](../../LICENSE) for details.
 
 ---
 

--- a/integrations/rustchain-mcp/USAGE.md
+++ b/integrations/rustchain-mcp/USAGE.md
@@ -510,6 +510,6 @@ async def query_with_backoff(client, query_type):
 
 <div align="center">
 
-**RustChain MCP Server** | [Documentation](README.md) | [API Reference](../../../docs/api-reference.md)
+**RustChain MCP Server** | [Documentation](README.md) | [API Reference](../../docs/api-reference.md)
 
 </div>


### PR DESCRIPTION
Fixes several broken local documentation links that resolved to non-existent paths on GitHub.

Changes include:
- Correct RIP-302 links from `bounties/issue-684` to the root `rips/docs` file.
- Correct license links from nested bounty README files.
- Replace the missing RIP-0200 document link with the existing RIP-200 whitepaper section.
- Replace the missing RIP-0683 spec link with the existing implementation summary.
- Correct `integrations/rustchain-mcp` links to API docs, contributing guide, and license.

Validation:
- Ran a local markdown-link resolver against all edited files.
- `git diff --check` passed.