### PR TITLE
fix: validate beacon write json bodies

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -4,6 +4,7 @@ Beacon Atlas API - Flask routes for 3D visualization backend
 Provides endpoints for agents, contracts, bounties, reputation, and chat.
 """
 import json
+import math
 import os
 import time
 import hashlib
@@ -27,6 +28,35 @@ contract_store = []
 
 # Chat session store
 chat_sessions = {}
+
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'Invalid or missing JSON body'}), 400)
+    return data, None
+
+
+def _string_field(data, field):
+    value = data.get(field)
+    if value is None or value == '':
+        return ''
+    if not isinstance(value, str):
+        raise ValueError(f'{field} must be a string')
+    return value
+
+
+def _contract_amount(data):
+    raw_amount = data.get('amount')
+    if isinstance(raw_amount, bool):
+        raise ValueError('amount must be a number')
+    try:
+        amount = float(raw_amount)
+    except (TypeError, ValueError):
+        raise ValueError('amount must be a number')
+    if not math.isfinite(amount):
+        raise ValueError('amount must be finite')
+    return amount
 
 
 def get_db():
@@ -419,7 +449,9 @@ def create_contract():
     Validates that the from_agent exists in the relay_agents table.
     """
     try:
-        data = request.get_json()
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
         
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
@@ -427,7 +459,15 @@ def create_contract():
             if field not in data:
                 return jsonify({'error': f'Missing field: {field}'}), 400
         
-        from_agent = data['from']
+        try:
+            from_agent = _string_field(data, 'from')
+            to_agent = _string_field(data, 'to')
+            contract_type = _string_field(data, 'type')
+            term = _string_field(data, 'term')
+            currency = _string_field(data, 'currency') if 'currency' in data else 'RTC'
+            amount = _contract_amount(data)
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         
         # Authentication: require X-Agent-Key header matching from_agent
         agent_key = request.headers.get('X-Agent-Key', '')
@@ -455,12 +495,12 @@ def create_contract():
         
         contract = {
             'id': contract_id,
-            'from': data['from'],
-            'to': data['to'],
-            'type': data['type'],
-            'amount': float(data['amount']),
-            'currency': data.get('currency', 'RTC'),
-            'term': data['term'],
+            'from': from_agent,
+            'to': to_agent,
+            'type': contract_type,
+            'amount': amount,
+            'currency': currency,
+            'term': term,
             'state': 'offered',  # Initial state
             'created_at': int(time.time()),
         }
@@ -491,8 +531,13 @@ def update_contract(contract_id):
     Validates state transitions to prevent invalid jumps.
     """
     try:
-        data = request.get_json()
-        new_state = data.get('state')
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            new_state = _string_field(data, 'state')
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         
         if not new_state:
             return jsonify({'error': 'Missing state field'}), 400
@@ -742,8 +787,13 @@ def claim_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to claim bounties'}), 401
 
-        data = request.get_json()
-        agent_id = data.get('agent_id')
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            agent_id = _string_field(data, 'agent_id')
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         
         if not agent_id:
             return jsonify({'error': 'Missing agent_id'}), 400
@@ -776,8 +826,13 @@ def complete_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to complete bounties'}), 401
 
-        data = request.get_json()
-        agent_id = data.get('agent_id')
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            agent_id = _string_field(data, 'agent_id')
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         
         if not agent_id:
             return jsonify({'error': 'Missing agent_id'}), 400
@@ -877,9 +932,14 @@ def get_agent_reputation(agent_id):
 def chat():
     """Send message to an agent (mock response for demo)."""
     try:
-        data = request.get_json()
-        agent_id = data.get('agent_id')
-        message = data.get('message')
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        try:
+            agent_id = _string_field(data, 'agent_id')
+            message = _string_field(data, 'message')
+        except ValueError as e:
+            return jsonify({'error': str(e)}), 400
         
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -168,6 +168,130 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         data = json.loads(response.data)
         self.assertIn('error', data)
 
+    def test_write_routes_reject_non_object_json(self):
+        """Beacon write routes reject non-object JSON bodies before dereference."""
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            endpoints = [
+                ('post', '/api/contracts', {'X-Agent-Key': 'bcn_alice_test'}),
+                ('put', '/api/contracts/ctr_missing', {'X-Agent-Key': 'bcn_alice_test'}),
+                ('post', '/api/bounties/gh_missing/claim', {'X-Admin-Key': 'test-admin'}),
+                ('post', '/api/bounties/gh_missing/complete', {'X-Admin-Key': 'test-admin'}),
+                ('post', '/api/chat', {}),
+            ]
+
+            for method, path, headers in endpoints:
+                with self.subTest(path=path):
+                    response = getattr(self.client, method)(
+                        path,
+                        data=json.dumps(['not-an-object']),
+                        content_type='application/json',
+                        headers=headers,
+                    )
+
+                    self.assertEqual(response.status_code, 400)
+                    data = json.loads(response.data)
+                    self.assertEqual(data['error'], 'Invalid or missing JSON body')
+
+    def test_create_contract_rejects_non_string_fields(self):
+        """Contract creation rejects structured string fields."""
+        base_payload = {
+            'from': 'bcn_alice_test',
+            'to': 'bcn_bob_test',
+            'type': 'rent',
+            'amount': 100.0,
+            'term': '30d',
+        }
+
+        for field, value in (
+            ('from', ['bcn_alice_test']),
+            ('to', {'agent': 'bcn_bob_test'}),
+            ('type', ['rent']),
+            ('term', {'duration': '30d'}),
+            ('currency', ['RTC']),
+        ):
+            with self.subTest(field=field):
+                payload = dict(base_payload)
+                payload[field] = value
+
+                response = self.client.post(
+                    '/api/contracts',
+                    data=json.dumps(payload),
+                    content_type='application/json',
+                    headers={'X-Agent-Key': 'bcn_alice_test'},
+                )
+
+                self.assertEqual(response.status_code, 400)
+                data = json.loads(response.data)
+                self.assertEqual(data['error'], f'{field} must be a string')
+
+    def test_create_contract_rejects_boolean_amount(self):
+        """Contract creation rejects JSON booleans instead of coercing them to 1.0/0.0."""
+        payload = {
+            'from': 'bcn_alice_test',
+            'to': 'bcn_bob_test',
+            'type': 'rent',
+            'amount': True,
+            'term': '30d',
+        }
+
+        response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(payload),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_alice_test'},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data)['error'], 'amount must be a number')
+
+    def test_contract_and_chat_reject_malformed_field_types(self):
+        """Contract update and chat reject structured string fields."""
+        create_response = self.client.post(
+            '/api/contracts',
+            data=json.dumps({
+                'from': 'bcn_alice_test',
+                'to': 'bcn_bob_test',
+                'type': 'rent',
+                'amount': 100.0,
+                'term': '30d',
+            }),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_alice_test'},
+        )
+        contract_id = json.loads(create_response.data)['id']
+
+        update_response = self.client.put(
+            f'/api/contracts/{contract_id}',
+            data=json.dumps({'state': ['active']}),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_bob_test'},
+        )
+        self.assertEqual(update_response.status_code, 400)
+        self.assertEqual(json.loads(update_response.data)['error'], 'state must be a string')
+
+        chat_response = self.client.post(
+            '/api/chat',
+            data=json.dumps({'agent_id': {'id': 'bcn_chat_test'}, 'message': 'hello'}),
+            content_type='application/json',
+        )
+        self.assertEqual(chat_response.status_code, 400)
+        self.assertEqual(json.loads(chat_response.data)['error'], 'agent_id must be a string')
+
+    def test_bounty_actions_reject_non_string_agent_id(self):
+        """Bounty admin actions reject structured agent IDs."""
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            for action in ('claim', 'complete'):
+                with self.subTest(action=action):
+                    response = self.client.post(
+                        f'/api/bounties/gh_test_bounty/{action}',
+                        data=json.dumps({'agent_id': ['bcn_agent']}),
+                        content_type='application/json',
+                        headers={'X-Admin-Key': 'test-admin'},
+                    )
+
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(json.loads(response.data)['error'], 'agent_id must be a string')
+
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
         # Insert a test bounty directly


### PR DESCRIPTION
## Summary

Fixes #4380.

The Beacon Atlas write routes now validate JSON body shape and string field types before contract creation/update, bounty state mutation, chat storage, or reputation updates.

## Changes

- add shared JSON-object and string-field validation helpers in `node/beacon_api.py`
- reject non-object JSON bodies with HTTP 400 for contract, bounty, and chat write routes
- reject structured contract fields (`from`, `to`, `type`, `term`, optional `currency`) with HTTP 400
- reject structured contract `state` values with HTTP 400
- reject structured bounty `agent_id` values with HTTP 400
- reject structured chat `agent_id` / `message` values with HTTP 400
- add regression coverage to `tests/test_beacon_atlas_behavior.py`
- make the Beacon behavior test DB cleanup release Flask test-client references before unlinking on Windows
- keep the mempool missing-table guard required by the security audit regression test

## Validation

- `python -m pytest tests\test_beacon_atlas_behavior.py -q` -> 19 passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, 1 warning
- `python -m py_compile node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py`
- `git diff --check -- node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py`

Miner/wallet ID: `cerredz`
