### PR TITLE
fix: validate airdrop v2 json fields

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -34,6 +34,7 @@ import hashlib
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -1236,17 +1237,67 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
             return jsonify({"ok": False, "error": "unauthorized"}), 401
         return None
 
+    def _json_object_body(required: bool = True):
+        data = request.get_json(silent=True)
+        if data is None and not required:
+            return {}, None
+        if not isinstance(data, dict) or (required and not data):
+            return None, (jsonify({"ok": False, "error": "invalid_json"}), 400)
+        return data, None
+
+    def _field_type_error(field: str, expected: str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_field_type",
+            "field": field,
+            "expected": expected,
+        }), 400
+
+    def _string_field(data: Dict[str, Any], field: str, default: str = ""):
+        value = data.get(field, default)
+        if value is None:
+            value = default
+        if not isinstance(value, str):
+            return None, _field_type_error(field, "string")
+        return value.strip(), None
+
+    def _optional_string_field(data: Dict[str, Any], field: str):
+        value = data.get(field)
+        if value is not None and not isinstance(value, str):
+            return None, _field_type_error(field, "string")
+        return value, None
+
+    def _amount_uwrtc_field(data: Dict[str, Any], field: str):
+        value = data.get(field, 0)
+        if isinstance(value, bool):
+            return None, (jsonify({"ok": False, "error": "invalid_amount"}), 400)
+        try:
+            amount_wrtc = float(value)
+        except (TypeError, ValueError):
+            return None, (jsonify({"ok": False, "error": "invalid_amount"}), 400)
+        if not math.isfinite(amount_wrtc):
+            return None, (jsonify({"ok": False, "error": "invalid_amount"}), 400)
+        return int(amount_wrtc * 1_000_000), None
+
     @app.route("/api/airdrop/eligibility", methods=["POST"])
     def check_airdrop_eligibility():
         """Check airdrop eligibility."""
-        data = request.get_json(silent=True)
-        if not data:
-            return jsonify({"ok": False, "error": "invalid_json"}), 400
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        github_username = data.get("github_username", "").strip()
-        wallet_address = data.get("wallet_address", "").strip()
-        chain = data.get("chain", "").strip()
-        github_token = data.get("github_token")
+        github_username, error_response = _string_field(data, "github_username")
+        if error_response:
+            return error_response
+        wallet_address, error_response = _string_field(data, "wallet_address")
+        if error_response:
+            return error_response
+        chain, error_response = _string_field(data, "chain")
+        if error_response:
+            return error_response
+        github_token, error_response = _optional_string_field(data, "github_token")
+        if error_response:
+            return error_response
         # SECURITY: skip_antisybil must NEVER be settable from API requests.
         # It exists only for internal testing via direct Python calls.
 
@@ -1266,15 +1317,25 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
     @app.route("/api/airdrop/claim", methods=["POST"])
     def claim_airdrop():
         """Submit airdrop claim."""
-        data = request.get_json(silent=True)
-        if not data:
-            return jsonify({"ok": False, "error": "invalid_json"}), 400
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        github_username = data.get("github_username", "").strip()
-        wallet_address = data.get("wallet_address", "").strip()
-        chain = data.get("chain", "").strip()
-        tier = data.get("tier", "").strip()
-        github_token = data.get("github_token")
+        github_username, error_response = _string_field(data, "github_username")
+        if error_response:
+            return error_response
+        wallet_address, error_response = _string_field(data, "wallet_address")
+        if error_response:
+            return error_response
+        chain, error_response = _string_field(data, "chain")
+        if error_response:
+            return error_response
+        tier, error_response = _string_field(data, "tier")
+        if error_response:
+            return error_response
+        github_token, error_response = _optional_string_field(data, "github_token")
+        if error_response:
+            return error_response
 
         if not all([github_username, wallet_address, chain, tier]):
             return (
@@ -1313,15 +1374,25 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
     @app.route("/api/bridge/lock", methods=["POST"])
     def create_bridge_lock():
         """Create bridge lock."""
-        data = request.get_json(silent=True)
-        if not data:
-            return jsonify({"ok": False, "error": "invalid_json"}), 400
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        from_address = data.get("from_address", "").strip()
-        to_address = data.get("to_address", "").strip()
-        from_chain = data.get("from_chain", "").strip()
-        to_chain = data.get("to_chain", "").strip()
-        amount_wrtc = data.get("amount_wrtc", 0)
+        from_address, error_response = _string_field(data, "from_address")
+        if error_response:
+            return error_response
+        to_address, error_response = _string_field(data, "to_address")
+        if error_response:
+            return error_response
+        from_chain, error_response = _string_field(data, "from_chain")
+        if error_response:
+            return error_response
+        to_chain, error_response = _string_field(data, "to_chain")
+        if error_response:
+            return error_response
+        amount_uwrtc, error_response = _amount_uwrtc_field(data, "amount_wrtc")
+        if error_response:
+            return error_response
 
         if not all([from_address, to_address, from_chain, to_chain]):
             return (
@@ -1334,8 +1405,6 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
                 ),
                 400,
             )
-
-        amount_uwrtc = int(float(amount_wrtc) * 1_000_000)
 
         success, message, lock = airdrop.create_bridge_lock(
             from_address, to_address, from_chain, to_chain, amount_uwrtc
@@ -1353,8 +1422,12 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
-        source_tx = data.get("source_tx", "").strip()
+        data, error_response = _json_object_body(required=False)
+        if error_response:
+            return error_response
+        source_tx, error_response = _string_field(data, "source_tx")
+        if error_response:
+            return error_response
 
         if not source_tx:
             return jsonify({"ok": False, "error": "missing_source_tx"}), 400
@@ -1373,8 +1446,12 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
-        dest_tx = data.get("dest_tx", "").strip()
+        data, error_response = _json_object_body(required=False)
+        if error_response:
+            return error_response
+        dest_tx, error_response = _string_field(data, "dest_tx")
+        if error_response:
+            return error_response
 
         if not dest_tx:
             return jsonify({"ok": False, "error": "missing_dest_tx"}), 400

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -11,6 +11,7 @@ Tests cover:
 - Database persistence
 """
 import json
+import gc
 import os
 import sqlite3
 import tempfile
@@ -30,7 +31,13 @@ from airdrop_v2 import (
     AIRDROP_SCHEMA,
     TOTAL_SOLANA_ALLOCATION,
     TOTAL_BASE_ALLOCATION,
+    init_airdrop_routes,
 )
+
+try:
+    from flask import Flask
+except ImportError:
+    Flask = None
 
 
 class TestEligibilityTier(unittest.TestCase):
@@ -405,6 +412,129 @@ class TestBridgeOperations(unittest.TestCase):
         updated_lock = self.airdrop.get_lock(lock.lock_id)
         self.assertEqual(updated_lock.status, "released")
         self.assertEqual(updated_lock.dest_tx, "base_tx_signature_abcdef")
+
+
+@unittest.skipIf(Flask is None, "Flask is not installed")
+class TestAirdropRoutes(unittest.TestCase):
+    """Test Flask route request validation."""
+
+    def setUp(self):
+        """Create a test app and temp database."""
+        self.temp_db = tempfile.NamedTemporaryFile(delete=False, suffix=".db")
+        self.temp_db.close()
+        self.airdrop = AirdropV2(db_path=self.temp_db.name)
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        init_airdrop_routes(self.app, self.airdrop, self.temp_db.name)
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        """Clean up temp database."""
+        self.client = None
+        self.app = None
+        self.airdrop = None
+        gc.collect()
+        os.unlink(self.temp_db.name)
+
+    def test_write_routes_reject_non_object_json(self):
+        """Write routes should reject JSON arrays instead of raising."""
+        routes = [
+            ("/api/airdrop/eligibility", {}),
+            ("/api/airdrop/claim", {}),
+            ("/api/bridge/lock", {}),
+            ("/api/bridge/lock/test-lock/confirm", {"X-Admin-Key": "test-admin"}),
+            ("/api/bridge/lock/test-lock/release", {"X-Admin-Key": "test-admin"}),
+        ]
+
+        with patch.dict(os.environ, {"RC_ADMIN_KEY": "test-admin"}):
+            for route, headers in routes:
+                with self.subTest(route=route):
+                    response = self.client.post(
+                        route,
+                        json=["not", "an", "object"],
+                        headers=headers,
+                    )
+
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(response.get_json()["error"], "invalid_json")
+
+    def test_write_routes_reject_non_string_fields(self):
+        """Text fields should be strings before they are stripped."""
+        cases = [
+            (
+                "/api/airdrop/eligibility",
+                {
+                    "github_username": {"name": "octo"},
+                    "wallet_address": "RTC1234567890123456789012345678901234567890",
+                    "chain": "base",
+                },
+                "github_username",
+                {},
+            ),
+            (
+                "/api/airdrop/claim",
+                {
+                    "github_username": "octo",
+                    "wallet_address": "RTC1234567890123456789012345678901234567890",
+                    "chain": "base",
+                    "tier": ["builder"],
+                },
+                "tier",
+                {},
+            ),
+            (
+                "/api/bridge/lock",
+                {
+                    "from_address": "RTC1234567890123456789012345678901234567890",
+                    "to_address": {"address": "0x1234567890123456789012345678901234567890"},
+                    "from_chain": "rustchain",
+                    "to_chain": "base",
+                    "amount_wrtc": "1.5",
+                },
+                "to_address",
+                {},
+            ),
+            (
+                "/api/bridge/lock/test-lock/confirm",
+                {"source_tx": {"tx": "abc"}},
+                "source_tx",
+                {"X-Admin-Key": "test-admin"},
+            ),
+            (
+                "/api/bridge/lock/test-lock/release",
+                {"dest_tx": ["abc"]},
+                "dest_tx",
+                {"X-Admin-Key": "test-admin"},
+            ),
+        ]
+
+        with patch.dict(os.environ, {"RC_ADMIN_KEY": "test-admin"}):
+            for route, body, field, headers in cases:
+                with self.subTest(route=route, field=field):
+                    response = self.client.post(route, json=body, headers=headers)
+                    payload = response.get_json()
+
+                    self.assertEqual(response.status_code, 400)
+                    self.assertEqual(payload["error"], "invalid_field_type")
+                    self.assertEqual(payload["field"], field)
+
+    def test_bridge_lock_rejects_invalid_amount_type(self):
+        """Bridge amount conversion errors should be handled as 400s."""
+        for amount in ({"value": "1.5"}, True, False):
+            with self.subTest(amount=amount):
+                response = self.client.post(
+                    "/api/bridge/lock",
+                    json={
+                        "from_address": "RTC1234567890123456789012345678901234567890",
+                        "to_address": "0x1234567890123456789012345678901234567890",
+                        "from_chain": "rustchain",
+                        "to_chain": "base",
+                        "amount_wrtc": amount,
+                    },
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json()["error"], "invalid_amount")
 
 
 class TestAllocationTracking(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add shared request parsing helpers for the airdrop v2 Flask routes
- reject non-object JSON bodies and non-string text fields with 400 responses before calling `.get()`/`.strip()`
- handle invalid bridge amount conversion as a client error
- add route-level regressions for airdrop and bridge malformed JSON requests

Fixes #4384

## Tests
- `python -m pytest test_airdrop_v2.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\airdrop_v2.py node\test_airdrop_v2.py node\utxo_db.py`
- `git diff --check -- node\airdrop_v2.py node\test_airdrop_v2.py node\utxo_db.py`