### PR TITLE
Replace missing dashboard preview images with links

### DIFF
--- a/bridge-dashboard/README.md
+++ b/bridge-dashboard/README.md
@@ -11,7 +11,7 @@
 
 Real-time monitoring dashboard for the wRTC (Wrapped RustChain Token) Solana Bridge. Tracks wrap/unwrap transactions, locked RTC, wRTC circulating supply, bridge fees, and provides comprehensive health monitoring with 30-second auto-refresh.
 
-![Dashboard Preview](./screenshot.png)
+[Open the dashboard](./index.html)
 
 ---
 

--- a/dashboards/grafana-rustchain/README.md
+++ b/dashboards/grafana-rustchain/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive Grafana dashboard for monitoring RustChain network metrics, including node health, miner activity, epoch statistics, and hardware distribution.
 
-![Dashboard Preview](./screenshot.png)
+[Open the Grafana dashboard JSON](./rustchain-network-dashboard.json)
 
 ## Overview
 

--- a/dashboards/miner-dashboard/README.md
+++ b/dashboards/miner-dashboard/README.md
@@ -70,11 +70,7 @@ All API calls are made directly from the browser (client-side only).
 
 ## 📱 Screenshots
 
-### Desktop View
-![Desktop Dashboard](./screenshot-desktop.png)
-
-### Mobile View
-![Mobile Dashboard](./screenshot-mobile.png)
+Open the live dashboard preview in [index.html](./index.html).
 
 ## 🔧 Customization
 

--- a/dashboards/rustchain-stats/README.md
+++ b/dashboards/rustchain-stats/README.md
@@ -2,7 +2,7 @@
 
 A live web dashboard displaying core RustChain network statistics with auto-refresh.
 
-![Dashboard Preview](./preview.png)
+[Open the dashboard](./index.html)
 
 ## Features
 

--- a/fossils/README.md
+++ b/fossils/README.md
@@ -4,7 +4,7 @@
 
 A visual timeline showing every attestation from every miner since genesis, color-coded by architecture family. G4s as ancient amber strata, G5s layered above in copper, POWER8 in deep blue, modern x86 as pale recent sediment.
 
-![Fossil Record Preview](preview.png)
+[Open the visualizer](./index.html)
 
 ## 🎯 Overview
 


### PR DESCRIPTION
Fixes broken README preview image references where the referenced screenshots are not present in the repository.

Instead of leaving broken image placeholders, the READMEs now link to the existing local dashboard or visualizer files:
- `bridge-dashboard/index.html`
- `dashboards/grafana-rustchain/rustchain-network-dashboard.json`
- `dashboards/miner-dashboard/index.html`
- `dashboards/rustchain-stats/index.html`
- `fossils/index.html`

Validation:
- Ran a local markdown-link resolver against all edited files.
- `git diff --check` passed.