### PR TITLE
fix: validate coalition json fields

### DIFF
--- a/node/coalition.py
+++ b/node/coalition.py
@@ -32,7 +32,7 @@ import hmac
 import os
 import sqlite3
 import time
-from typing import Optional
+from typing import Any, Optional
 from flask import Blueprint, request, jsonify
 
 log = logging.getLogger("rip0278_coalition")
@@ -72,7 +72,10 @@ def _verify_miner_signature(miner_id: str, action: str, data: dict) -> bool:
     except ValueError:
         return True
 
-    signature_hex = data.get("signature", "").strip()
+    signature_value = data.get("signature", "")
+    if not isinstance(signature_value, str):
+        return False
+    signature_hex = signature_value.strip()
     timestamp = data.get("timestamp")
 
     if not signature_hex or not timestamp:
@@ -357,6 +360,53 @@ def _admin_key_authorized() -> tuple[bool, tuple[dict, int] | None]:
     return True, None
 
 
+def _field_type_error(field: str, expected: str):
+    return (
+        jsonify(
+            {
+                "error": "invalid_field_type",
+                "field": field,
+                "expected": expected,
+            }
+        ),
+        400,
+    )
+
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "invalid_json"}), 400)
+    return data, None
+
+
+def _string_field(data: dict[str, Any], field: str, default: str = ""):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, _field_type_error(field, "string")
+    return value.strip(), None
+
+
+def _integer_field(data: dict[str, Any], field: str):
+    value = data.get(field)
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, _field_type_error(field, "integer")
+    if isinstance(value, int):
+        return value, None
+    if isinstance(value, str):
+        try:
+            return int(value.strip()), None
+        except ValueError:
+            return None, _field_type_error(field, "integer")
+    return None, _field_type_error(field, "integer")
+
+
 # ---------------------------------------------------------------------------
 # Flask Blueprint
 # ---------------------------------------------------------------------------
@@ -370,11 +420,19 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     # -- POST /api/coalition/create ------------------------------------------
     @bp.route("/create", methods=["POST"])
     def create_coalition():
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        name = data.get("name", "").strip()
-        description = data.get("description", "").strip()
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        name, error_response = _string_field(data, "name")
+        if error_response:
+            return error_response
+        description, error_response = _string_field(data, "description")
+        if error_response:
+            return error_response
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -415,10 +473,16 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     # -- POST /api/coalition/join --------------------------------------------
     @bp.route("/join", methods=["POST"])
     def join_coalition():
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        coalition_id = data.get("coalition_id")
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        coalition_id, error_response = _integer_field(data, "coalition_id")
+        if error_response:
+            return error_response
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -468,10 +532,16 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     # -- POST /api/coalition/leave -------------------------------------------
     @bp.route("/leave", methods=["POST"])
     def leave_coalition():
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        coalition_id = data.get("coalition_id")
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        coalition_id, error_response = _integer_field(data, "coalition_id")
+        if error_response:
+            return error_response
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -506,13 +576,25 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     @bp.route("/propose", methods=["POST"])
     def create_proposal():
         _settle_expired_proposals(db_path)
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        coalition_id = data.get("coalition_id")
-        title = data.get("title", "").strip()
-        description = data.get("description", "").strip()
-        rip_number = data.get("rip_number")
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        coalition_id, error_response = _integer_field(data, "coalition_id")
+        if error_response:
+            return error_response
+        title, error_response = _string_field(data, "title")
+        if error_response:
+            return error_response
+        description, error_response = _string_field(data, "description")
+        if error_response:
+            return error_response
+        rip_number, error_response = _integer_field(data, "rip_number")
+        if error_response:
+            return error_response
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -558,11 +640,20 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     @bp.route("/vote", methods=["POST"])
     def cast_vote():
         _settle_expired_proposals(db_path)
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        proposal_id = data.get("proposal_id")
-        vote_choice = data.get("vote", "").strip().lower()
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        proposal_id, error_response = _integer_field(data, "proposal_id")
+        if error_response:
+            return error_response
+        vote_choice, error_response = _string_field(data, "vote")
+        if error_response:
+            return error_response
+        vote_choice = vote_choice.lower()
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -670,12 +761,23 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
             body, status = error
             return jsonify(body), status
 
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        proposal_id = data.get("proposal_id")
-        decision = data.get("decision", "").strip().lower()
-        reason = data.get("reason", "").strip()
-        reviewer = data.get("reviewer", FLAMEBUND_MINER_ID).strip()
+        proposal_id, error_response = _integer_field(data, "proposal_id")
+        if error_response:
+            return error_response
+        decision, error_response = _string_field(data, "decision")
+        if error_response:
+            return error_response
+        decision = decision.lower()
+        reason, error_response = _string_field(data, "reason")
+        if error_response:
+            return error_response
+        reviewer, error_response = _string_field(data, "reviewer", FLAMEBUND_MINER_ID)
+        if error_response:
+            return error_response
 
         if proposal_id is None:
             return jsonify({"error": "proposal_id required"}), 400

--- a/node/tests/test_coalition.py
+++ b/node/tests/test_coalition.py
@@ -159,6 +159,114 @@ def test_create_coalition_no_miner_id_rejected(client):
     assert res.status_code == 400
 
 
+def test_coalition_write_routes_reject_non_object_json(client):
+    """Write routes reject JSON arrays before accessing request fields."""
+    routes = [
+        ("/api/coalition/create", {}),
+        ("/api/coalition/join", {}),
+        ("/api/coalition/leave", {}),
+        ("/api/coalition/propose", {}),
+        ("/api/coalition/vote", {}),
+        ("/api/coalition/flamebound-review", {"X-Admin-Key": "test-admin-key"}),
+    ]
+
+    for route, headers in routes:
+        res = client.post(route, json=["not", "an", "object"], headers=headers)
+
+        assert res.status_code == 400
+        assert res.get_json()["error"] == "invalid_json"
+
+
+def test_coalition_write_routes_reject_malformed_field_types(client):
+    """Write route text and ID fields are validated before business logic."""
+    cases = [
+        (
+            "/api/coalition/create",
+            {"miner_id": {"id": "alice"}, "name": "Alpha", "description": ""},
+            "miner_id",
+            "string",
+            {},
+        ),
+        (
+            "/api/coalition/join",
+            {"miner_id": "alice", "coalition_id": {"id": 1}},
+            "coalition_id",
+            "integer",
+            {},
+        ),
+        (
+            "/api/coalition/leave",
+            {"miner_id": ["alice"], "coalition_id": 1},
+            "miner_id",
+            "string",
+            {},
+        ),
+        (
+            "/api/coalition/propose",
+            {"miner_id": "alice", "coalition_id": 1, "title": ["RIP"], "description": ""},
+            "title",
+            "string",
+            {},
+        ),
+        (
+            "/api/coalition/vote",
+            {"miner_id": "alice", "proposal_id": 1, "vote": {"choice": "for"}},
+            "vote",
+            "string",
+            {},
+        ),
+        (
+            "/api/coalition/flamebound-review",
+            {"proposal_id": ["1"], "decision": "approve", "reason": ""},
+            "proposal_id",
+            "integer",
+            {"X-Admin-Key": "test-admin-key"},
+        ),
+    ]
+
+    for route, body, field, expected, headers in cases:
+        res = client.post(route, json=body, headers=headers)
+        payload = res.get_json()
+
+        assert res.status_code == 400
+        assert payload["error"] == "invalid_field_type"
+        assert payload["field"] == field
+        assert payload["expected"] == expected
+
+
+def test_coalition_proposal_rejects_malformed_rip_number(client):
+    """rip_number is optional, but provided values must be integer-like."""
+    for rip_number in ({"id": 101}, [101], True, False):
+        res = client.post("/api/coalition/propose", json={
+            "miner_id": "alice",
+            "coalition_id": 1,
+            "title": "RIP object",
+            "description": "bad rip_number",
+            "rip_number": rip_number,
+        })
+        payload = res.get_json()
+
+        assert res.status_code == 400
+        assert payload["error"] == "invalid_field_type"
+        assert payload["field"] == "rip_number"
+        assert payload["expected"] == "integer"
+
+
+def test_hex_miner_signature_field_type_returns_unauthorized(client):
+    """Malformed signature fields should fail auth instead of raising."""
+    hex_miner_id = "a" * 64
+    res = client.post("/api/coalition/create", json={
+        "miner_id": hex_miner_id,
+        "name": "Hex Miner Coalition",
+        "description": "signature type regression",
+        "signature": ["not", "hex"],
+        "timestamp": int(time.time()),
+    })
+
+    assert res.status_code == 401
+    assert "invalid or missing signature" in res.get_json()["error"]
+
+
 def test_create_coalition_creator_is_auto_member(client, rich_miner):
     """Creator should automatically be a member."""
     res = client.post("/api/coalition/create", json={


### PR DESCRIPTION
## Summary
- add shared coalition request validators for JSON object bodies, string fields, and integer ID fields
- reject malformed coalition write requests with 400s before route logic, SQLite lookups, or `.strip()` calls
- make malformed signature field types fail authorization instead of raising for hex miner IDs
- add regression coverage for all coalition write routes and the signature validation path
- make the coalition test fixture close/collect SQLite handles before deleting temp DBs on Windows

Fixes #4387

## Tests
- `python -m pytest tests\test_coalition.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\coalition.py node\tests\test_coalition.py node\utxo_db.py`
- `git diff --check -- node\coalition.py node\tests\test_coalition.py node\utxo_db.py`