### PR TITLE
fix: validate governance json fields

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -29,7 +29,7 @@ import json
 import logging
 import sqlite3
 import time
-from typing import Optional
+from typing import Any, Optional
 from flask import Blueprint, request, jsonify
 
 log = logging.getLogger("rip0002_governance")
@@ -47,7 +47,10 @@ def _verify_miner_signature(miner_id: str, action: str, data: dict) -> bool:
 
     The signed payload is: f"{action}:{miner_id}:{timestamp}"
     """
-    signature_hex = data.get("signature", "").strip()
+    signature_value = data.get("signature", "")
+    if not isinstance(signature_value, str):
+        return False
+    signature_hex = signature_value.strip()
     timestamp = data.get("timestamp")
 
     if not signature_hex or not timestamp:
@@ -253,6 +256,48 @@ def _sophia_evaluate(proposal: dict) -> str:
     return "\n".join(analysis_lines)
 
 
+def _field_type_error(field: str, expected: str):
+    return jsonify({
+        "error": "invalid_field_type",
+        "field": field,
+        "expected": expected,
+    }), 400
+
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "invalid_json"}), 400)
+    return data, None
+
+
+def _string_field(data: dict[str, Any], field: str, default: str = ""):
+    value = data.get(field, default)
+    if value is None:
+        value = default
+    if not isinstance(value, str):
+        return None, _field_type_error(field, "string")
+    return value.strip(), None
+
+
+def _integer_field(data: dict[str, Any], field: str):
+    value = data.get(field)
+    if value is None:
+        return None, None
+    if isinstance(value, bool):
+        return None, _field_type_error(field, "integer")
+    if isinstance(value, int):
+        return value, None
+    if isinstance(value, str):
+        try:
+            return int(value.strip()), None
+        except ValueError:
+            return None, _field_type_error(field, "integer")
+    return None, _field_type_error(field, "integer")
+
+
 # ---------------------------------------------------------------------------
 # Flask Blueprint
 # ---------------------------------------------------------------------------
@@ -264,13 +309,26 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
     @bp.route("/api/governance/propose", methods=["POST"])
     def create_proposal():
         _settle_expired_proposals(db_path)
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        title = data.get("title", "").strip()
-        description = data.get("description", "").strip()
-        proposal_type = data.get("proposal_type", "").strip()
-        parameter_key = data.get("parameter_key", "").strip() or None
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        title, error_response = _string_field(data, "title")
+        if error_response:
+            return error_response
+        description, error_response = _string_field(data, "description")
+        if error_response:
+            return error_response
+        proposal_type, error_response = _string_field(data, "proposal_type")
+        if error_response:
+            return error_response
+        parameter_key, error_response = _string_field(data, "parameter_key")
+        if error_response:
+            return error_response
+        parameter_key = parameter_key or None
         parameter_value = str(data.get("parameter_value", "")).strip() or None
 
         # Validation
@@ -401,11 +459,20 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
     @bp.route("/api/governance/vote", methods=["POST"])
     def cast_vote():
         _settle_expired_proposals(db_path)
-        data = request.get_json(silent=True) or {}
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
 
-        miner_id = data.get("miner_id", "").strip()
-        proposal_id = data.get("proposal_id")
-        vote_choice = data.get("vote", "").strip().lower()
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
+        proposal_id, error_response = _integer_field(data, "proposal_id")
+        if error_response:
+            return error_response
+        vote_choice, error_response = _string_field(data, "vote")
+        if error_response:
+            return error_response
+        vote_choice = vote_choice.lower()
 
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
@@ -547,9 +614,15 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
         if not _is_within_founder_veto_period():
             return jsonify({"error": "Founder veto period has expired"}), 403
 
-        data = request.get_json(silent=True) or {}
-        admin_key = data.get("admin_key", "").strip()
-        reason = data.get("reason", "Security-critical change").strip()
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        admin_key, error_response = _string_field(data, "admin_key")
+        if error_response:
+            return error_response
+        reason, error_response = _string_field(data, "reason", "Security-critical change")
+        if error_response:
+            return error_response
 
         # Admin key is validated via environment variable (not hardcoded)
         import os

--- a/node/tests/test_governance.py
+++ b/node/tests/test_governance.py
@@ -9,6 +9,7 @@ Run with:
 Author: NOX Ventures
 """
 
+import gc
 import pytest
 import sqlite3
 import tempfile
@@ -40,7 +41,8 @@ def tmp_db():
     init_governance_tables(db_path)
 
     # Seed schema that governance references (miners, attestations)
-    with sqlite3.connect(db_path) as conn:
+    conn = sqlite3.connect(db_path)
+    try:
         conn.executescript("""
             CREATE TABLE IF NOT EXISTS miners (
                 wallet_name TEXT PRIMARY KEY,
@@ -52,8 +54,11 @@ def tmp_db():
                 timestamp INTEGER NOT NULL
             );
         """)
+    finally:
+        conn.close()
 
     yield db_path
+    gc.collect()
     os.unlink(db_path)
 
 
@@ -158,6 +163,73 @@ def test_create_proposal_missing_parameter_key(client, active_miner):
         "proposal_type": "parameter_change",
     })
     assert res.status_code == 400
+
+
+def test_governance_write_routes_reject_non_object_json(client):
+    """Governance write routes reject JSON arrays before field access."""
+    propose = client.post("/api/governance/propose", json=["not", "an", "object"])
+    assert propose.status_code == 400
+    assert propose.get_json() == {"error": "invalid_json"}
+
+    vote = client.post("/api/governance/vote", json=["not", "an", "object"])
+    assert vote.status_code == 400
+    assert vote.get_json() == {"error": "invalid_json"}
+
+    veto = client.post("/api/governance/veto/1", json=["not", "an", "object"])
+    assert veto.status_code == 400
+    assert veto.get_json() == {"error": "invalid_json"}
+
+
+def test_governance_write_routes_reject_malformed_field_types(client, active_miner):
+    """Governance write routes reject malformed fields without server errors."""
+    propose = client.post("/api/governance/propose", json={
+        "miner_id": active_miner,
+        "title": ["not", "a", "string"],
+        "description": "Malformed title should be rejected.",
+        "proposal_type": "feature_activation",
+    })
+    assert propose.status_code == 400
+    assert propose.get_json() == {
+        "error": "invalid_field_type",
+        "field": "title",
+        "expected": "string",
+    }
+
+    vote = client.post("/api/governance/vote", json={
+        "miner_id": active_miner,
+        "proposal_id": {"not": "an integer"},
+        "vote": "for",
+    })
+    assert vote.status_code == 400
+    assert vote.get_json() == {
+        "error": "invalid_field_type",
+        "field": "proposal_id",
+        "expected": "integer",
+    }
+
+    veto = client.post("/api/governance/veto/1", json={
+        "admin_key": ["not", "a", "string"],
+        "reason": "Malformed admin key should be rejected.",
+    })
+    assert veto.status_code == 400
+    assert veto.get_json() == {
+        "error": "invalid_field_type",
+        "field": "admin_key",
+        "expected": "string",
+    }
+
+
+def test_governance_signature_field_type_returns_unauthorized(client, active_miner):
+    """Malformed signature fields fail authentication instead of crashing."""
+    res = client.post("/api/governance/propose", json={
+        "miner_id": active_miner,
+        "title": "Malformed signature",
+        "description": "Signature is the wrong JSON type.",
+        "proposal_type": "feature_activation",
+        "signature": {"not": "a string"},
+        "timestamp": int(time.time()),
+    })
+    assert res.status_code == 401
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add governance request validators for JSON object bodies, string fields, and integer IDs
- reject malformed propose/vote/veto requests before field stripping, auth, or SQL paths
- make malformed signature field types fail authorization instead of raising
- add focused malformed-input regressions for governance write routes
- close/collect SQLite handles in the governance test fixture before Windows temp DB cleanup

Fixes #4389

## Tests
- python -m pytest tests\test_governance.py -q -k governance_write_routes_reject
- python -m pytest tests\test_governance.py -q -k governance_signature_field_type
- python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q
- python -m py_compile node\governance.py node\tests\test_governance.py node\utxo_db.py
- git diff --check -- node\governance.py node\tests\test_governance.py node\utxo_db.py

Note: the broader tests/test_governance.py suite has pre-existing auth expectations that fail on current upstream main; this PR validates the new malformed-input coverage directly.
