### PR TITLE
Fix bridge API documentation links

### DIFF
--- a/docs/bridge-api.md
+++ b/docs/bridge-api.md
@@ -567,5 +567,5 @@ status = check_bridge_status("abc123def456...")
 ## Related Documentation
 
 - [RIP-0305 Specification](../rips/docs/RIP-0305-bridge-lock-ledger.md)
-- [Bridge Integration Guide](../bridge/README.md)
-- [Lock Ledger Architecture](../rips/docs/RIP-0305-bridge-lock-ledger.md#12-lock-ledger-table)
+- [Bridge Integration Guide](../contracts/erc20/docs/BRIDGE_INTEGRATION.md)
+- [Lock Ledger Architecture](../rips/docs/RIP-0305-bridge-lock-ledger.md)

--- a/sdk/docs/BOTTUBE_SDK.md
+++ b/sdk/docs/BOTTUBE_SDK.md
@@ -629,6 +629,6 @@ MIT License - See main repository license for details.
 
 ## Support
 
-- Documentation: [sdk/docs/BOTTUBE_SDK.md](BOTTUBE_SDK.md)
+- Documentation: [BOTTUBE_SDK.md](BOTTUBE_SDK.md)
 - BoTTube Platform: https://bottube.ai
 - Issues: Tag with `bottube`, `sdk`, `issue-1603`


### PR DESCRIPTION
## Summary
- Fix two broken relative links in docs/bridge-api.md
- Point the bridge integration reference to the existing ERC-20 bridge integration guide
- Point the lock ledger architecture reference to the existing RIP-0305 bridge lock ledger spec
- Fix the BoTTube SDK support link so it resolves from sdk/docs/BOTTUBE_SDK.md instead of sdk/docs/sdk/docs/BOTTUBE_SDK.md

## Validation
- Verified docs/bridge-api.md has no missing relative Markdown links
- Verified sdk/docs/BOTTUBE_SDK.md has no missing relative Markdown links
- Ran git diff --check

Bounty reference: Scottcjn/rustchain-bounties#444