### PR TITLE
fix: validate gpu render protocol routes

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -406,11 +406,49 @@ def register_routes(app):
     """Register GPU Render Protocol routes with a Flask app."""
     protocol = GPURenderProtocol()
 
+    def _field_type_error(field, expected):
+        from flask import jsonify
+        return (
+            jsonify(
+                {
+                    "error": "invalid_field_type",
+                    "field": field,
+                    "expected": expected,
+                }
+            ),
+            400,
+        )
+
+    def _json_object_body():
+        from flask import request, jsonify
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "invalid_json"}), 400)
+        return data, None
+
+    def _string_field(data, field, default=""):
+        value = data.get(field, default)
+        if value is None:
+            value = default
+        if not isinstance(value, str):
+            return None, _field_type_error(field, "string")
+        return value, None
+
+    def _number_field(data, field, default=0):
+        value = data.get(field, default)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None, _field_type_error(field, "number")
+        return value, None
+
     @app.route("/gpu/attest", methods=["POST"])
     def gpu_attest():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
-        miner_id = data.get("miner_id")
+        from flask import jsonify
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response:
+            return error_response
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
         result = protocol.attest_gpu(miner_id, data)
@@ -430,21 +468,39 @@ def register_routes(app):
     @app.route("/llm/escrow", methods=["POST"])
     def create_escrow():
         from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
         # Infer job_type from path
         path = request.path
         if path.startswith("/voice"):
-            job_type = data.get("job_type", "tts")  # tts or stt
+            job_type, error_response = _string_field(
+                data,
+                "job_type",
+                "tts",
+            )  # tts or stt
         elif path.startswith("/llm"):
             job_type = "llm"
+            error_response = None
         else:
-            job_type = data.get("job_type", "render")
+            job_type, error_response = _string_field(data, "job_type", "render")
+        if error_response:
+            return error_response
+        from_wallet, error_response = _string_field(data, "from_wallet")
+        if error_response:
+            return error_response
+        to_wallet, error_response = _string_field(data, "to_wallet")
+        if error_response:
+            return error_response
+        amount_rtc, error_response = _number_field(data, "amount_rtc")
+        if error_response:
+            return error_response
 
         result = protocol.create_escrow(
             job_type=job_type,
-            from_wallet=data.get("from_wallet", ""),
-            to_wallet=data.get("to_wallet", ""),
-            amount_rtc=data.get("amount_rtc", 0),
+            from_wallet=from_wallet,
+            to_wallet=to_wallet,
+            amount_rtc=amount_rtc,
             metadata=data.get("metadata"),
         )
         status_code = 201 if "error" not in result else 400
@@ -454,17 +510,27 @@ def register_routes(app):
     @app.route("/voice/release", methods=["POST"])
     @app.route("/llm/release", methods=["POST"])
     def release_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
-        result = protocol.release_escrow(data.get("job_id", ""))
+        from flask import jsonify
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        job_id, error_response = _string_field(data, "job_id")
+        if error_response:
+            return error_response
+        result = protocol.release_escrow(job_id)
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
     @app.route("/render/refund", methods=["POST"])
     def refund_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
-        result = protocol.refund_escrow(data.get("job_id", ""))
+        from flask import jsonify
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        job_id, error_response = _string_field(data, "job_id")
+        if error_response:
+            return error_response
+        result = protocol.refund_escrow(job_id)
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
@@ -484,11 +550,19 @@ def register_routes(app):
 
     @app.route("/render/pricing/check", methods=["POST"])
     def check_pricing():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        from flask import jsonify
+        data, error_response = _json_object_body()
+        if error_response:
+            return error_response
+        job_type, error_response = _string_field(data, "job_type", "render")
+        if error_response:
+            return error_response
+        price, error_response = _number_field(data, "price")
+        if error_response:
+            return error_response
         result = protocol.detect_price_manipulation(
-            data.get("job_type", "render"),
-            data.get("price", 0),
+            job_type,
+            price,
         )
         return jsonify(result)
 

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -3,8 +3,12 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
+
+from flask import Flask
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from node import gpu_render_protocol as gpu_module
 from node.gpu_render_protocol import GPURenderProtocol
 
 
@@ -133,6 +137,92 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertEqual(result["status"], "locked")
         status = self.proto.get_escrow(result["job_id"])
         self.assertEqual(status["metadata"]["model"], "llama-70b")
+
+
+class TestGPURenderProtocolRoutes(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "test_gpu_routes.db")
+        self.app = Flask(__name__)
+        with patch.object(
+            gpu_module,
+            "GPURenderProtocol",
+            lambda: GPURenderProtocol(db_path=self.db),
+        ):
+            gpu_module.register_routes(self.app)
+        self.app.config["TESTING"] = True
+        self.client = self.app.test_client()
+
+    def test_write_routes_reject_non_object_json(self):
+        routes = [
+            "/gpu/attest",
+            "/render/escrow",
+            "/voice/escrow",
+            "/llm/escrow",
+            "/render/release",
+            "/voice/release",
+            "/llm/release",
+            "/render/refund",
+            "/render/pricing/check",
+        ]
+
+        for route in routes:
+            with self.subTest(route=route):
+                response = self.client.post(route, json=["not", "an", "object"])
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json()["error"], "invalid_json")
+
+    def test_write_routes_reject_malformed_field_types(self):
+        cases = [
+            ("/gpu/attest", {"miner_id": {"id": "miner"}}, "miner_id", "string"),
+            (
+                "/render/escrow",
+                {
+                    "job_type": ["render"],
+                    "from_wallet": "a",
+                    "to_wallet": "b",
+                    "amount_rtc": 1,
+                },
+                "job_type",
+                "string",
+            ),
+            (
+                "/voice/escrow",
+                {
+                    "job_type": "tts",
+                    "from_wallet": {"wallet": "a"},
+                    "to_wallet": "b",
+                    "amount_rtc": 1,
+                },
+                "from_wallet",
+                "string",
+            ),
+            (
+                "/llm/escrow",
+                {"from_wallet": "a", "to_wallet": "b", "amount_rtc": "1.0"},
+                "amount_rtc",
+                "number",
+            ),
+            ("/render/release", {"job_id": ["job-1"]}, "job_id", "string"),
+            ("/render/refund", {"job_id": {"id": "job-1"}}, "job_id", "string"),
+            (
+                "/render/pricing/check",
+                {"job_type": "render", "price": {"value": 1}},
+                "price",
+                "number",
+            ),
+        ]
+
+        for route, body, field, expected in cases:
+            with self.subTest(route=route, field=field):
+                response = self.client.post(route, json=body)
+                payload = response.get_json()
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(payload["error"], "invalid_field_type")
+                self.assertEqual(payload["field"], field)
+                self.assertEqual(payload["expected"], expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add GPU render protocol route validators for JSON object bodies, string fields, and numeric fields
- reject malformed route payloads before protocol calls for attest, escrow, release, refund, and pricing checks
- add Flask route regressions covering non-object JSON and malformed field types

Fixes #4396

## Tests
- `python -m pytest tests\test_gpu_render_protocol.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\gpu_render_protocol.py tests\test_gpu_render_protocol.py node\utxo_db.py`
- `git diff --check -- node\gpu_render_protocol.py tests\test_gpu_render_protocol.py node\utxo_db.py`
