### PR TITLE
fix: validate sophia governor route inputs

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -940,23 +940,44 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
         provided = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
         return bool(provided and provided == required)
 
+    def _json_object_body():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "invalid_json"}), 400)
+        return data, None
+
+    def _parse_recent_limit(raw_limit):
+        try:
+            limit = int(raw_limit)
+        except (TypeError, ValueError):
+            return None, (jsonify({"error": "invalid_limit"}), 400)
+        if limit < 1:
+            return None, (jsonify({"error": "invalid_limit"}), 400)
+        return min(limit, _max_recent_rows()), None
+
     @app.route("/sophia/governor/status", methods=["GET"])
     def sophia_governor_status():
         return jsonify(get_governor_status(db))
 
     @app.route("/sophia/governor/recent", methods=["GET"])
     def sophia_governor_recent():
-        limit = request.args.get("limit", 20)
+        limit, error = _parse_recent_limit(request.args.get("limit", 20))
+        if error:
+            return error
         return jsonify({
             "ok": True,
-            "events": get_recent_governor_events(db_path=db, limit=int(limit)),
+            "events": get_recent_governor_events(db_path=db, limit=limit),
         })
 
     @app.route("/sophia/governor/review", methods=["POST"])
     def sophia_governor_review():
         if not _is_admin(request):
             return jsonify({"error": "Unauthorized -- admin key required"}), 401
-        data = request.get_json(silent=True) or {}
+        data, error = _json_object_body()
+        if error:
+            return error
         event_type = str(data.get("event_type", "")).strip()
         source = str(data.get("source", "manual")).strip() or "manual"
         payload = data.get("payload") if isinstance(data.get("payload"), dict) else {}

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import sqlite3
 import tempfile
@@ -37,6 +38,7 @@ def tmp_db():
         db_path = handle.name
     init_sophia_governor_schema(db_path)
     yield db_path
+    gc.collect()
     os.unlink(db_path)
 
 
@@ -175,6 +177,31 @@ def test_governor_endpoints_require_admin_for_manual_review(client):
         },
     )
     assert response.status_code == 401
+
+
+def test_governor_recent_rejects_invalid_limit(client):
+    response = client.get("/sophia/governor/recent?limit=not-an-int")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_limit"
+
+
+def test_governor_recent_rejects_non_positive_limit(client):
+    response = client.get("/sophia/governor/recent?limit=0")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_limit"
+
+
+def test_governor_review_rejects_non_object_json(client):
+    response = client.post(
+        "/sophia/governor/review",
+        headers={"X-Admin-Key": "test-admin"},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_json"
 
 
 def test_governor_endpoints_report_status_and_recent(client):


### PR DESCRIPTION
## Summary
- validate `/sophia/governor/recent` limits before converting them to integers
- reject authenticated `/sophia/governor/review` JSON bodies that are not objects
- add regression tests for both malformed input cases
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4398.

## Tests
- `python -m pytest node\tests\test_sophia_governor.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\sophia_governor.py node\tests\test_sophia_governor.py node\utxo_db.py`
- `git diff --check -- node\sophia_governor.py node\tests\test_sophia_governor.py node\utxo_db.py`