### PR TITLE
fix: validate sophia review maintenance limits

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -154,6 +154,22 @@ def _is_authorized(req) -> bool:
     return False
 
 
+def _parse_route_limit(
+    value: Any,
+    default: int = 25,
+    max_limit: int = 200,
+) -> tuple[int | None, dict[str, str] | None]:
+    if value is None:
+        return default, None
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        return None, {"error": "invalid_limit"}
+    if limit < 1:
+        return None, {"error": "invalid_limit"}
+    return min(limit, max_limit), None
+
+
 def _relay_scott_notification(payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
     if requests is None:
         return 503, {"status": "error", "error": "requests_unavailable"}
@@ -619,7 +635,10 @@ def backfill_missing():
     if not _is_authorized(request):
         return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
     data = request.get_json(silent=True) or {}
-    limit = data.get("limit", 25) if isinstance(data, dict) else 25
+    raw_limit = data.get("limit") if isinstance(data, dict) else None
+    limit, error = _parse_route_limit(raw_limit)
+    if error:
+        return jsonify(error), 400
     results = backfill_missing_reviews(limit=limit)
     return jsonify({"ok": True, "updated": results, "count": len(results)})
 
@@ -630,7 +649,10 @@ def normalize_existing():
     if not _is_authorized(request):
         return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
     data = request.get_json(silent=True) or {}
-    limit = data.get("limit", 25) if isinstance(data, dict) else 25
+    raw_limit = data.get("limit") if isinstance(data, dict) else None
+    limit, error = _parse_route_limit(raw_limit)
+    if error:
+        return jsonify(error), 400
     results = normalize_existing_reviews(limit=limit)
     return jsonify({"ok": True, "updated": results, "count": len(results)})
 

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import tempfile
 import sys
@@ -26,6 +27,7 @@ def client(monkeypatch):
         yield review_service.app.test_client()
     finally:
         try:
+            gc.collect()
             os.unlink(db_path)
         except FileNotFoundError:
             pass
@@ -152,6 +154,18 @@ def test_backfill_missing_updates_blank_reviews(client, monkeypatch):
     assert "Assessment: repaired." in repaired["review_text"]
 
 
+def test_backfill_missing_rejects_invalid_limit(client):
+    for limit in ("bad", 0, -1):
+        response = client.post(
+            "/api/sophia/governor/review/backfill-missing",
+            headers={"X-Admin-Key": "test-admin"},
+            json={"limit": limit},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_limit"
+
+
 def test_review_normalizes_verbose_action_reasoning(client, monkeypatch):
     monkeypatch.setattr(
         review_service,
@@ -196,6 +210,18 @@ def test_normalize_existing_route_rewrites_recent_rows(client, monkeypatch):
     assert "\nRisk:" in normalized["review_text"]
     assert "\nNext step:" in normalized["review_text"]
     assert normalized["recommended_resolution"]["target_inbox_status"] == "resolved"
+
+
+def test_normalize_existing_rejects_invalid_limit(client):
+    for limit in ("bad", 0, -1):
+        response = client.post(
+            "/api/sophia/governor/review/normalize-existing",
+            headers={"X-Admin-Key": "test-admin"},
+            json={"limit": limit},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "invalid_limit"
 
 
 def test_normalize_review_text_compacts_numbered_reasoning():


### PR DESCRIPTION
## Summary
- validate JSON `limit` values before running Sophia review maintenance jobs
- return HTTP 400 for non-integer or less-than-one limits on backfill and normalize routes
- add regression coverage for both invalid-limit cases
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4400.

## Tests
- `python -m pytest node\tests\test_sophia_governor_review_service.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\sophia_governor_review_service.py node\tests\test_sophia_governor_review_service.py node\utxo_db.py`
- `git diff --check -- node\sophia_governor_review_service.py node\tests\test_sophia_governor_review_service.py node\utxo_db.py`