### PR TITLE
fix: validate sophia inbox action json

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -1088,6 +1088,14 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
     db = db_path or DB_PATH
     init_sophia_governor_inbox_schema(db)
 
+    def _json_object_body():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
+
     @app.route("/api/sophia/governor/bridge/status", methods=["GET"])
     def sophia_governor_bridge_status():
         return jsonify(get_governor_inbox_status(db))
@@ -1153,7 +1161,9 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
         if not _is_authorized(request):
             return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
 
-        data = request.get_json(silent=True) or {}
+        data, error = _json_object_body()
+        if error:
+            return error
         try:
             updated = update_governor_inbox_entry(
                 inbox_id,
@@ -1175,7 +1185,9 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
         if not _is_authorized(request):
             return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
 
-        data = request.get_json(silent=True) or {}
+        data, error = _json_object_body()
+        if error:
+            return error
         targets = data.get("targets")
         if targets is not None and not isinstance(targets, list):
             return jsonify({"error": "targets must be a list of URLs"}), 400

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -202,6 +202,24 @@ def test_update_status_endpoint(client):
     assert updated_body["entry"]["recommended_resolution"]["resolution_type"] == "watch"
 
 
+def test_update_status_rejects_non_object_json(client):
+    ingest = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=_sample_envelope(),
+    )
+    inbox_id = ingest.get_json()["inbox"]["inbox_id"]
+
+    response = client.post(
+        f"/api/sophia/governor/inbox/{inbox_id}/status",
+        headers={"X-Admin-Key": "test-admin"},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
 def test_status_helper_reports_totals(tmp_db):
     ingest_governor_envelope(_sample_envelope(), db_path=tmp_db)
     status = get_governor_inbox_status(tmp_db)
@@ -354,6 +372,24 @@ def test_manual_forward_endpoint_records_attempt(client, monkeypatch):
     assert len(body["entry"]["forward_attempts"]) == 1
     assert body["result"]["scott_notification"]["status"] == "queued"
     assert body["result"]["scott_notification"]["notification_id"] == "SN-GOV-REVIEW-1"
+
+
+def test_manual_forward_rejects_non_object_json(client):
+    ingest = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=_sample_envelope(),
+    )
+    inbox_id = ingest.get_json()["inbox"]["inbox_id"]
+
+    response = client.post(
+        f"/api/sophia/governor/inbox/{inbox_id}/forward",
+        headers={"X-Admin-Key": "test-admin"},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
 
 
 def test_auto_forward_on_ingest_uses_configured_targets(client, monkeypatch):


### PR DESCRIPTION
## Summary
- add JSON-object validation for Sophia governor inbox status and forward actions
- return HTTP 400 for non-object request bodies instead of raising on `data.get(...)`
- add regression tests for both affected admin routes
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4402.

## Tests
- `python -m pytest node\tests\test_sophia_governor_inbox.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\sophia_governor_inbox.py node\tests\test_sophia_governor_inbox.py node\utxo_db.py`
- `git diff --check -- node\sophia_governor_inbox.py node\tests\test_sophia_governor_inbox.py node\utxo_db.py`