### PR TITLE
fix: validate bcos attest json objects

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -205,9 +205,13 @@ def bcos_attest():
     data = request.get_json(silent=True)
     if not data:
         return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     # Extract fields from report or from wrapper
     report = data.get("report", data)
+    if not isinstance(report, dict):
+        return jsonify({"error": "report must be an object"}), 400
     cert_id = report.get("cert_id")
     commitment = report.get("commitment")
     repo = report.get("repo_name", report.get("repo", ""))

--- a/node/tests/test_bcos_routes.py
+++ b/node/tests/test_bcos_routes.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bcos_routes import register_bcos_routes
+
+
+def test_bcos_attest_rejects_non_object_json(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    app = Flask(__name__)
+    register_bcos_routes(app, str(tmp_path / "bcos.db"))
+    app.config["TESTING"] = True
+
+    response = app.test_client().post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
+def test_bcos_attest_rejects_non_object_report(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    app = Flask(__name__)
+    register_bcos_routes(app, str(tmp_path / "bcos.db"))
+    app.config["TESTING"] = True
+
+    response = app.test_client().post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json={"report": ["not", "an", "object"]},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "report must be an object"

--- a/node/tests/test_bcos_routes.py
+++ b/node/tests/test_bcos_routes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies in `/bcos/attest`
- reject non-object wrapped `report` values before field extraction
- add direct route regression tests for both malformed request shapes
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4404.

## Tests
- `python -m pytest node\tests\test_bcos_routes.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\bcos_routes.py node\tests\test_bcos_routes.py node\utxo_db.py`
- `git diff --check -- node\bcos_routes.py node\tests\test_bcos_routes.py node\utxo_db.py`