### PR TITLE
fix: validate rewards settle json body

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -280,7 +280,11 @@ def register_rewards_rip200(app, DB_PATH):
         if not hmac.compare_digest(provided_key, settle_key):
             return jsonify({"error": "Unauthorized — valid X-Admin-Key header required"}), 401
 
-        data = request.json or {}
+        data = request.get_json(silent=True)
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            return jsonify({"error": "JSON object required"}), 400
         epoch = data.get('epoch')
 
         if epoch is None:
@@ -288,6 +292,10 @@ def register_rewards_rip200(app, DB_PATH):
             current = current_slot()
             current_epoch = slot_to_epoch(current)
             epoch = current_epoch - 1
+        elif isinstance(epoch, bool) or not isinstance(epoch, int):
+            return jsonify({"error": "epoch must be an integer"}), 400
+        elif epoch < 0:
+            return jsonify({"error": "epoch must be non-negative"}), 400
 
         result = settle_epoch_rip200(DB_PATH, epoch)
         return jsonify(result)

--- a/node/tests/test_rewards_settle_endpoint.py
+++ b/node/tests/test_rewards_settle_endpoint.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 

--- a/node/tests/test_rewards_settle_endpoint.py
+++ b/node/tests/test_rewards_settle_endpoint.py
@@ -1,0 +1,81 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import rewards_implementation_rip200 as rewards
+
+
+def _app(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_SETTLE_KEY", "test-settle")
+    app = Flask(__name__)
+    rewards.register_rewards_rip200(app, str(tmp_path / "rewards.db"))
+    app.config["TESTING"] = True
+    return app
+
+
+def test_settle_rewards_rejects_non_object_json(tmp_path, monkeypatch):
+    app = _app(tmp_path, monkeypatch)
+
+    response = app.test_client().post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "test-settle"},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
+def test_settle_rewards_rejects_non_integer_epoch(tmp_path, monkeypatch):
+    app = _app(tmp_path, monkeypatch)
+
+    response = app.test_client().post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "test-settle"},
+        json={"epoch": "bad"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "epoch must be an integer"
+
+
+def test_settle_rewards_rejects_object_epoch(tmp_path, monkeypatch):
+    app = _app(tmp_path, monkeypatch)
+
+    response = app.test_client().post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "test-settle"},
+        json={"epoch": {"value": 1}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "epoch must be an integer"
+
+
+def test_settle_rewards_rejects_negative_epoch(tmp_path, monkeypatch):
+    app = _app(tmp_path, monkeypatch)
+
+    response = app.test_client().post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "test-settle"},
+        json={"epoch": -1},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "epoch must be non-negative"
+
+
+def test_settle_rewards_rejects_boolean_epoch(tmp_path, monkeypatch):
+    app = _app(tmp_path, monkeypatch)
+
+    response = app.test_client().post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "test-settle"},
+        json={"epoch": True},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "epoch must be an integer"


### PR DESCRIPTION
## Summary
- parse `/rewards/settle` JSON silently and require object bodies
- preserve the existing no-body auto-settle behavior
- add a direct regression test for authenticated non-object JSON
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4406.

## Tests
- `python -m pytest node\tests\test_rewards_settle_endpoint.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rewards_implementation_rip200.py node\tests\test_rewards_settle_endpoint.py node\utxo_db.py`
- `git diff --check -- node\rewards_implementation_rip200.py node\tests\test_rewards_settle_endpoint.py node\utxo_db.py`