### PR TITLE
fix: clamp bottube oembed dimensions

### DIFF
--- a/node/bottube_embed.py
+++ b/node/bottube_embed.py
@@ -899,6 +899,10 @@ def oembed():
     except (ValueError, TypeError):
         maxwidth = 854
         maxheight = 480
+    if maxwidth < 1:
+        maxwidth = 854
+    if maxheight < 1:
+        maxheight = 480
     
     # Maintain 16:9 aspect ratio
     width = min(maxwidth, 854)

--- a/tests/test_bottube_embed.py
+++ b/tests/test_bottube_embed.py
@@ -170,6 +170,17 @@ class TestOEmbedEndpoint(unittest.TestCase):
         data = response.get_json()
         self.assertLessEqual(data["height"], 360)
 
+    def test_oembed_rejects_non_positive_dimensions(self):
+        """Test that non-positive dimensions do not produce invalid iframe sizes."""
+        response = self.client.get(
+            "/oembed?url=https://bottube.ai/watch/demo-001&maxwidth=-1&maxheight=0"
+        )
+        data = response.get_json()
+        self.assertGreater(data["width"], 0)
+        self.assertGreater(data["height"], 0)
+        self.assertNotIn('width="-', data["html"])
+        self.assertNotIn('height="0"', data["html"])
+
     def test_oembed_thumbnail(self):
         """Test that oEmbed includes thumbnail URL."""
         response = self.client.get("/oembed?url=https://bottube.ai/watch/demo-001")


### PR DESCRIPTION
## Summary
- clamp oEmbed `maxwidth` and `maxheight` values to defaults when callers send zero or negative values
- add regression coverage to ensure generated iframe dimensions stay positive
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4408.

## Tests
- `python -m pytest tests\test_bottube_embed.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\bottube_embed.py tests\test_bottube_embed.py node\utxo_db.py`
- `git diff --check -- node\bottube_embed.py tests\test_bottube_embed.py node\utxo_db.py`