### PR TITLE
fix: validate hall of rust json bodies

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -25,6 +25,16 @@ RUST_WEIGHTS = {
     'first_attestation': 50,   # Bonus for being among first 100 miners
 }
 
+
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'JSON object required'}), 400)
+    return data, None
+
+
 # Capacitor plague era models (infamous bad electrolytic caps)
 CAPACITOR_PLAGUE_MODELS = [
     'PowerMac3,',      # G4 Quicksilver/MDD 2001-2003
@@ -148,7 +158,9 @@ def estimate_manufacture_year(model, arch):
 @hall_bp.route('/hall/induct', methods=['POST'])
 def induct_machine():
     """Automatically induct a machine into the Hall of Rust on first attestation."""
-    data = request.json or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     
     # Generate fingerprint hash from hardware identifiers
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
@@ -301,7 +313,9 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
-    data = request.json or {}
+    data, error = _json_object_body()
+    if error:
+        return error
     
     try:
         from flask import current_app

--- a/node/tests/test_hall_of_rust_routes.py
+++ b/node/tests/test_hall_of_rust_routes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 
@@ -27,4 +29,3 @@ def test_hall_eulogy_rejects_non_object_json():
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "JSON object required"
-

--- a/node/tests/test_hall_of_rust_routes.py
+++ b/node/tests/test_hall_of_rust_routes.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from hall_of_rust import hall_bp
+
+
+def _client():
+    app = Flask(__name__)
+    app.register_blueprint(hall_bp)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_hall_induct_rejects_non_object_json():
+    response = _client().post("/hall/induct", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
+def test_hall_eulogy_rejects_non_object_json():
+    response = _client().post("/hall/eulogy/deadbeef", json=["nickname"])
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+


### PR DESCRIPTION
## Summary
- validate JSON object bodies for Hall of Rust induction and eulogy routes
- return HTTP 400 for array/scalar JSON instead of assuming `.get(...)`
- add direct blueprint regression tests for both affected write routes
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4410.

## Tests
- `python -m pytest node\tests\test_hall_of_rust_routes.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\hall_of_rust.py node\tests\test_hall_of_rust_routes.py node\utxo_db.py`
- `git diff --check -- node\hall_of_rust.py node\tests\test_hall_of_rust_routes.py node\utxo_db.py`