### PR TITLE
fix: validate integrated governance json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5181,7 +5181,11 @@ def gov_rotate_commit():
 
 @app.route('/governance/propose', methods=['POST'])
 def governance_propose():
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "JSON object required"}), 400
     proposer_wallet = str(data.get('wallet', '')).strip()
     title = str(data.get('title', '')).strip()
     description = str(data.get('description', '')).strip()
@@ -5330,8 +5334,15 @@ def governance_proposal_detail(proposal_id: int):
 
 @app.route('/governance/vote', methods=['POST'])
 def governance_vote():
-    data = request.get_json(silent=True) or {}
-    proposal_id = int(data.get('proposal_id') or 0)
+    data = request.get_json(silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "JSON object required"}), 400
+    try:
+        proposal_id = int(data.get('proposal_id') or 0)
+    except (TypeError, ValueError):
+        proposal_id = 0
     wallet = str(data.get('wallet', '')).strip()
     vote = str(data.get('vote', '')).strip().lower()
     nonce = str(data.get('nonce', '')).strip()

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -1,12 +1,30 @@
+import gc
 import json
+import shutil
 import sqlite3
 import sys
 import tempfile
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
 integrated_node = sys.modules["integrated_node"]
+
+
+@contextmanager
+def _temporary_directory():
+    path = tempfile.mkdtemp()
+    try:
+        yield path
+    finally:
+        for _ in range(5):
+            try:
+                shutil.rmtree(path)
+                break
+            except PermissionError:
+                gc.collect()
+                time.sleep(0.05)
 
 
 def _vote_payload(proposal_id: int, wallet: str, vote: str, nonce: str):
@@ -20,7 +38,7 @@ def _vote_payload(proposal_id: int, wallet: str, vote: str, nonce: str):
 
 
 def test_governance_propose_requires_gt_10_rtc_balance():
-    with tempfile.TemporaryDirectory() as td:
+    with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")
         integrated_node.DB_PATH = db_path
         integrated_node.app.config["DB_PATH"] = db_path
@@ -40,8 +58,47 @@ def test_governance_propose_requires_gt_10_rtc_balance():
             assert resp.get_json()["error"] == "insufficient_balance_to_propose"
 
 
+def test_governance_propose_rejects_non_object_json():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/governance/propose", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_governance_vote_rejects_non_object_json():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/governance/vote", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_governance_vote_rejects_invalid_proposal_id():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/governance/vote",
+            json={
+                "proposal_id": "not-an-int",
+                "wallet": "RTC-test",
+                "vote": "yes",
+                "nonce": "n-1",
+                "signature": "ab",
+                "public_key": "11" * 32,
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == (
+        "proposal_id, wallet, vote(yes/no), nonce, signature, public_key are required"
+    )
+
+
 def test_governance_vote_flow_and_lifecycle_finalization():
-    with tempfile.TemporaryDirectory() as td:
+    with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")
         integrated_node.DB_PATH = db_path
         integrated_node.app.config["DB_PATH"] = db_path


### PR DESCRIPTION
## Summary
- require JSON object bodies for integrated `/governance/propose` and `/governance/vote`
- handle non-integer `proposal_id` values with the existing 400 validation response instead of raising
- add governance API regression tests for non-object bodies and invalid proposal IDs
- make governance API temp DB cleanup reliable on Windows
- keep the mempool cleanup helper tolerant of missing mempool tables for the shared security regression

Fixes #4412.

## Tests
- `python -m pytest tests\test_governance_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_governance_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_governance_api.py node\utxo_db.py`