### PR TITLE
fix: validate integrated oui deny json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6282,18 +6282,35 @@ def list_oui_deny():
         "entries": [{"oui": r[0], "vendor": r[1], "added_ts": r[2], "enforce": r[3]} for r in rows]
     })
 
+def _admin_json_object_body():
+    """Return an admin JSON object body or a response tuple for malformed JSON."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"ok": False, "error": "JSON object required"}), 400)
+    return data, None
+
 @app.route('/admin/oui_deny/add', methods=['POST'])
 def add_oui_deny():
     """Add OUI to denylist"""
     if not is_admin(request):
         return jsonify({"ok": False, "error": "forbidden"}), 403
-    data = request.get_json()
+    data, error = _admin_json_object_body()
+    if error:
+        return error
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()
-    oui = data.get('oui', '').lower().replace(':', '').replace('-', '')
+    raw_oui = data.get('oui', '')
+    if not isinstance(raw_oui, str):
+        return jsonify({"error": "Invalid OUI (must be 6 hex chars)"}), 400
+    oui = raw_oui.lower().replace(':', '').replace('-', '')
     vendor = data.get('vendor', 'Unknown')
-    enforce = int(data.get('enforce', 0))
+    try:
+        enforce = int(data.get('enforce', 0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "Invalid enforce value"}), 400
 
     if len(oui) != 6 or not all(c in '0123456789abcdef' for c in oui):
         return jsonify({"error": "Invalid OUI (must be 6 hex chars)"}), 400
@@ -6312,11 +6329,16 @@ def remove_oui_deny():
     """Remove OUI from denylist"""
     if not is_admin(request):
         return jsonify({"ok": False, "error": "forbidden"}), 403
-    data = request.get_json()
+    data, error = _admin_json_object_body()
+    if error:
+        return error
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()
-    oui = data.get('oui', '').lower().replace(':', '').replace('-', '')
+    raw_oui = data.get('oui', '')
+    if not isinstance(raw_oui, str):
+        return jsonify({"error": "Invalid OUI (must be 6 hex chars)"}), 400
+    oui = raw_oui.lower().replace(':', '').replace('-', '')
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("DELETE FROM oui_deny WHERE oui = ?", (oui,))

--- a/tests/test_integrated_oui_deny_api.py
+++ b/tests/test_integrated_oui_deny_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sys
 
 integrated_node = sys.modules["integrated_node"]

--- a/tests/test_integrated_oui_deny_api.py
+++ b/tests/test_integrated_oui_deny_api.py
@@ -1,0 +1,82 @@
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def _admin_headers():
+    return {"X-Admin-Key": "test-admin-key"}
+
+
+def test_oui_deny_add_requires_json_object(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/admin/oui_deny/add",
+            headers=_admin_headers(),
+            json=["not", "an", "object"],
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_oui_deny_add_rejects_non_string_oui(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/admin/oui_deny/add",
+            headers=_admin_headers(),
+            json={"oui": {"nested": "value"}},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid OUI (must be 6 hex chars)"
+
+
+def test_oui_deny_add_rejects_invalid_enforce(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/admin/oui_deny/add",
+            headers=_admin_headers(),
+            json={"oui": "aa:bb:cc", "enforce": "yes"},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid enforce value"
+
+
+def test_oui_deny_remove_requires_json_object(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/admin/oui_deny/remove",
+            headers=_admin_headers(),
+            json=["not", "an", "object"],
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_oui_deny_remove_rejects_non_string_oui(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/admin/oui_deny/remove",
+            headers=_admin_headers(),
+            json={"oui": ["aa", "bb", "cc"]},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid OUI (must be 6 hex chars)"


### PR DESCRIPTION
## Summary
- validate OUI deny admin JSON bodies before using them as dictionaries
- reject non-string `oui` values and invalid `enforce` coercions with 400 responses
- add regression coverage for malformed `/admin/oui_deny/add` and `/admin/oui_deny/remove` requests
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4414.

## Tests
- `python -m pytest tests\test_integrated_oui_deny_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_integrated_oui_deny_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_integrated_oui_deny_api.py node\utxo_db.py`