### PR TITLE
fix: validate pending void json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6999,6 +6999,15 @@ def list_pending():
     return jsonify({"ok": True, "count": len(items), "pending": items})
 
 
+def _pending_json_object_body():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 @app.route('/pending/void', methods=['POST'])
 def void_pending():
     """Admin: Void a pending transfer before confirmation"""
@@ -7006,7 +7015,9 @@ def void_pending():
     if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
         return jsonify({"error": "Unauthorized"}), 401
     
-    data = request.get_json()
+    data, error = _pending_json_object_body()
+    if error:
+        return error
     pending_id = data.get('pending_id')
     tx_hash = data.get('tx_hash')
     reason = data.get('reason', 'admin_void')
@@ -7014,6 +7025,12 @@ def void_pending():
     
     if not pending_id and not tx_hash:
         return jsonify({"error": "Provide pending_id or tx_hash"}), 400
+
+    if pending_id is not None and not isinstance(pending_id, (int, str)):
+        return jsonify({"error": "pending_id must be a string or integer"}), 400
+
+    if tx_hash is not None and not isinstance(tx_hash, str):
+        return jsonify({"error": "tx_hash must be a string"}), 400
     
     conn = sqlite3.connect(DB_PATH)
     try:

--- a/tests/test_pending_void_api.py
+++ b/tests/test_pending_void_api.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sys
 
 integrated_node = sys.modules["integrated_node"]

--- a/tests/test_pending_void_api.py
+++ b/tests/test_pending_void_api.py
@@ -1,0 +1,52 @@
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def _admin_headers():
+    return {"X-Admin-Key": "test-admin-key"}
+
+
+def test_pending_void_requires_json_object(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/pending/void",
+            headers=_admin_headers(),
+            json=["not", "an", "object"],
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_pending_void_rejects_non_scalar_pending_id(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/pending/void",
+            headers=_admin_headers(),
+            json={"pending_id": ["not", "scalar"]},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "pending_id must be a string or integer"
+
+
+def test_pending_void_rejects_non_string_tx_hash(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/pending/void",
+            headers=_admin_headers(),
+            json={"tx_hash": {"not": "scalar"}},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "tx_hash must be a string"


### PR DESCRIPTION
## Summary
- validate `/pending/void` JSON bodies before using dictionary methods
- reject non-scalar `pending_id` and non-string `tx_hash` before database lookup
- add regression tests for malformed authenticated pending void requests
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4416.

## Tests
- `python -m pytest tests\test_pending_void_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_pending_void_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_pending_void_api.py node\utxo_db.py`