### PR TITLE
fix: validate epoch enroll json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3708,7 +3708,9 @@ def get_epoch():
 @app.route('/epoch/enroll', methods=['POST'])
 def enroll_epoch():
     """Enroll in current epoch"""
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()

--- a/tests/test_epoch_enroll_api.py
+++ b/tests/test_epoch_enroll_api.py
@@ -1,0 +1,23 @@
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_epoch_enroll_requires_json_object():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/epoch/enroll", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_epoch_enroll_missing_body_uses_json_validation():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/epoch/enroll")
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"


### PR DESCRIPTION
## Summary
- require `POST /epoch/enroll` to receive a JSON object before reading payload fields
- return 400 for missing or non-object JSON instead of raising during enrollment parsing
- add regression tests for malformed epoch enrollment requests
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4418.

## Tests
- `python -m pytest tests\test_epoch_enroll_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_epoch_enroll_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_epoch_enroll_api.py node\utxo_db.py`