### PR TITLE
fix: validate withdraw request json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4740,12 +4740,22 @@ def request_withdrawal():
     """Request RTC withdrawal"""
     withdrawal_requests.inc()
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        withdrawal_failed.inc()
+        return jsonify({"error": "JSON object required"}), 400
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()
     miner_pk = data.get('miner_pk')
-    amount = float(data.get('amount', 0))
+    try:
+        amount = float(data.get('amount', 0))
+    except (TypeError, ValueError):
+        withdrawal_failed.inc()
+        return jsonify({"error": "Invalid amount"}), 400
+    if not math.isfinite(amount):
+        withdrawal_failed.inc()
+        return jsonify({"error": "Invalid amount"}), 400
     destination = data.get('destination')
     signature = data.get('signature')
     nonce = data.get('nonce')

--- a/tests/test_withdraw_request_api.py
+++ b/tests/test_withdraw_request_api.py
@@ -1,0 +1,70 @@
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_withdraw_request_requires_json_object():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/withdraw/request", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_withdraw_request_rejects_invalid_amount_before_database():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/withdraw/request",
+            json={
+                "miner_pk": "miner-a",
+                "amount": "not-a-number",
+                "destination": "dest",
+                "signature": "sig",
+                "nonce": "nonce-1",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid amount"
+
+
+def test_withdraw_request_rejects_nan_amount_before_database():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/withdraw/request",
+            json={
+                "miner_pk": "miner-a",
+                "amount": "nan",
+                "destination": "dest",
+                "signature": "sig",
+                "nonce": "nonce-2",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid amount"
+
+
+def test_withdraw_request_rejects_infinite_amount_before_database():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/withdraw/request",
+            json={
+                "miner_pk": "miner-a",
+                "amount": "inf",
+                "destination": "dest",
+                "signature": "sig",
+                "nonce": "nonce-3",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Invalid amount"


### PR DESCRIPTION
## Summary
- require `/withdraw/request` to receive a JSON object before reading request fields
- reject non-float-coercible withdrawal amounts with 400 responses
- add regression tests for malformed withdrawal request payloads
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4420.

## Tests
- `python -m pytest tests\test_withdraw_request_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_withdraw_request_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_withdraw_request_api.py node\utxo_db.py`