### PR TITLE
fix: validate gov rotation json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5035,20 +5035,38 @@ def _rotation_message(epoch:int, threshold:int, members_json:str)->bytes:
     h = hashlib.sha256(members_json.encode()).hexdigest()
     return f"ROTATE|{epoch}|{threshold}|{h}".encode()
 
+
+def _gov_rotation_json_body():
+    b = request.get_json(silent=True)
+    if not isinstance(b, dict):
+        return None, (jsonify({"ok": False, "reason": "json_object_required"}), 400)
+    return b, None
+
+
 @app.route('/gov/rotate/stage', methods=['POST'])
 @admin_required
 def gov_rotate_stage():
     """Stage governance rotation (admin only) - returns canonical message to sign"""
-    b = request.get_json() or {}
-    if not b:
-        return jsonify({"ok": False, "reason": "invalid_json"}), 400
-    epoch = int(b.get("epoch_effective") or -1)
+    b, error = _gov_rotation_json_body()
+    if error:
+        return error
+    try:
+        epoch = int(b.get("epoch_effective", -1))
+        thr = int(b.get("threshold", 3))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "reason": "bad_args"}), 400
     members = b.get("members") or []
-    thr = int(b.get("threshold") or 3)
-    if epoch < 0 or not members:
+    if epoch < 0 or not isinstance(members, list) or not members:
         return jsonify({"ok": False, "reason": "epoch_or_members_missing"}), 400
 
-    members = _canon_members(members)
+    try:
+        members = _canon_members(members)
+    except (KeyError, TypeError, ValueError):
+        return jsonify({"ok": False, "reason": "bad_members"}), 400
+    if thr < 1:
+        return jsonify({"ok": False, "reason": "invalid_threshold"}), 400
+    if thr > len(members):
+        return jsonify({"ok": False, "reason": "threshold_exceeds_members"}), 400
     members_json = json.dumps(members, separators=(',',':'))
 
     with sqlite3.connect(DB_PATH) as c:
@@ -5091,11 +5109,14 @@ def gov_rotate_message(epoch:int):
 @app.route('/gov/rotate/approve', methods=['POST'])
 def gov_rotate_approve():
     """Submit governance rotation approval signature"""
-    b = request.get_json() or {}
-    if not b:
-        return jsonify({"ok": False, "reason": "invalid_json"}), 400
-    epoch = int(b.get("epoch_effective") or -1)
-    signer_id = int(b.get("signer_id") or -1)
+    b, error = _gov_rotation_json_body()
+    if error:
+        return error
+    try:
+        epoch = int(b.get("epoch_effective", -1))
+        signer_id = int(b.get("signer_id", -1))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "reason": "bad_args"}), 400
     sig_hex = str(b.get("sig_hex") or "")
 
     if epoch < 0 or signer_id < 0 or not sig_hex:
@@ -5143,10 +5164,13 @@ def gov_rotate_approve():
 @app.route('/gov/rotate/commit', methods=['POST'])
 def gov_rotate_commit():
     """Commit governance rotation (requires threshold approvals)"""
-    b = request.get_json() or {}
-    if not b:
-        return jsonify({"ok": False, "reason": "invalid_json"}), 400
-    epoch = int(b.get("epoch_effective") or -1)
+    b, error = _gov_rotation_json_body()
+    if error:
+        return error
+    try:
+        epoch = int(b.get("epoch_effective", -1))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "reason": "bad_args"}), 400
     if epoch < 0:
         return jsonify({"ok": False, "reason": "epoch_missing"}), 400
 

--- a/tests/test_gov_rotate_api.py
+++ b/tests/test_gov_rotate_api.py
@@ -1,0 +1,106 @@
+import sys
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def _admin_headers():
+    return {"X-API-Key": "test-admin-key"}
+
+
+def _member(signer_id=1):
+    return {"signer_id": signer_id, "pubkey_hex": "aa"}
+
+
+def test_gov_rotate_stage_requires_json_object(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/stage",
+            headers=_admin_headers(),
+            json=["not", "an", "object"],
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "json_object_required"
+
+
+def test_gov_rotate_stage_rejects_bad_integer_fields(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/stage",
+            headers=_admin_headers(),
+            json={
+                "epoch_effective": "bad",
+                "threshold": 3,
+                "members": [_member()],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "bad_args"
+
+
+def test_gov_rotate_stage_rejects_non_positive_threshold(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/stage",
+            headers=_admin_headers(),
+            json={
+                "epoch_effective": 1,
+                "threshold": 0,
+                "members": [_member()],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "invalid_threshold"
+
+
+def test_gov_rotate_stage_rejects_threshold_above_members(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/stage",
+            headers=_admin_headers(),
+            json={
+                "epoch_effective": 1,
+                "threshold": 2,
+                "members": [_member()],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "threshold_exceeds_members"
+
+
+def test_gov_rotate_approve_rejects_bad_integer_fields():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/approve",
+            json={"epoch_effective": "bad", "signer_id": 1, "sig_hex": "aa"},
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "bad_args"
+
+
+def test_gov_rotate_commit_requires_json_object():
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post("/gov/rotate/commit", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "json_object_required"


### PR DESCRIPTION
## Summary
- require governance rotation stage/approve/commit requests to use JSON object bodies
- return 400 for invalid rotation integer fields and malformed member lists
- add regression tests for malformed governance rotation payloads
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4422.

## Tests
- `python -m pytest tests\test_gov_rotate_api.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_gov_rotate_api.py node\utxo_db.py`
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_gov_rotate_api.py node\utxo_db.py`