### PR TITLE
fix: validate bft propose json

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -1078,10 +1078,19 @@ def create_bft_routes(app, bft: BFTConsensus):
     def bft_propose():
         """Manually trigger epoch proposal (admin)"""
         try:
-            data = request.get_json()
+            data = request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({'error': 'JSON object required'}), 400
             epoch = data.get('epoch')
             miners = data.get('miners', [])
             distribution = data.get('distribution', {})
+
+            if epoch is None:
+                return jsonify({'error': 'Missing epoch field'}), 400
+            if not isinstance(miners, list):
+                return jsonify({'error': 'miners must be a list'}), 400
+            if not isinstance(distribution, dict):
+                return jsonify({'error': 'distribution must be an object'}), 400
 
             msg = bft.propose_epoch_settlement(epoch, miners, distribution)
             if msg:

--- a/node/tests/test_bft_routes.py
+++ b/node/tests/test_bft_routes.py
@@ -1,0 +1,59 @@
+from flask import Flask
+
+from node.rustchain_bft_consensus import create_bft_routes
+
+
+class _FakeBft:
+    def get_status(self):
+        return {"ok": True}
+
+    def receive_message(self, msg_data):
+        return None
+
+    def handle_view_change(self, msg_data):
+        return None
+
+    def propose_epoch_settlement(self, epoch, miners, distribution):
+        return None
+
+
+def _client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    create_bft_routes(app, _FakeBft())
+    return app.test_client()
+
+
+def test_bft_propose_requires_json_object():
+    resp = _client().post("/bft/propose", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+
+
+def test_bft_propose_requires_epoch_field():
+    resp = _client().post(
+        "/bft/propose",
+        json={"miners": [], "distribution": {}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "Missing epoch field"
+
+
+def test_bft_propose_rejects_invalid_collection_fields():
+    client = _client()
+
+    miners_resp = client.post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": {"bad": "shape"}, "distribution": {}},
+    )
+    distribution_resp = client.post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": [], "distribution": ["bad", "shape"]},
+    )
+
+    assert miners_resp.status_code == 400
+    assert miners_resp.get_json()["error"] == "miners must be a list"
+    assert distribution_resp.status_code == 400
+    assert distribution_resp.get_json()["error"] == "distribution must be an object"


### PR DESCRIPTION
## Summary
- require `/bft/propose` to receive a JSON object before reading fields
- reject missing `epoch`, non-list `miners`, and non-object `distribution` payloads with 400 responses
- add focused Flask route regression tests using a fake BFT object
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4424.

## Tests
- `python -m pytest node\tests\test_bft_routes.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_bft_consensus.py node\tests\test_bft_routes.py node\utxo_db.py`
- `git diff --check -- node\rustchain_bft_consensus.py node\tests\test_bft_routes.py node\utxo_db.py`