### PR TITLE
fix: validate p2p gossip json

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1377,7 +1377,9 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
         if not _gossip_rate_check(remote_ip):
             return jsonify({"error": "rate_limited", "limit": f"{GOSSIP_RATE_LIMIT}/{GOSSIP_RATE_WINDOW_S}s"}), 429
 
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"error": "JSON object required"}), 400
         result = p2p_node.handle_gossip(data)
         return jsonify(result)
 

--- a/node/tests/test_p2p_gossip_routes.py
+++ b/node/tests/test_p2p_gossip_routes.py
@@ -1,0 +1,64 @@
+import os
+
+from flask import Flask
+
+os.environ.setdefault("RC_P2P_SECRET", "a" * 64)
+
+from node.rustchain_p2p_gossip import register_p2p_endpoints
+
+
+class _FakeP2PNode:
+    def __init__(self):
+        self.handled = []
+        self.node_id = "node-test"
+        self.running = True
+        self.peers = {}
+        self.gossip = type(
+            "FakeGossip",
+            (),
+            {
+                "attestation_crdt": type("FakeAttest", (), {"data": {}})(),
+                "epoch_crdt": type("FakeEpoch", (), {"items": set()})(),
+            },
+        )()
+
+    def handle_gossip(self, data):
+        self.handled.append(data)
+        return {"status": "ok"}
+
+    def get_full_state(self):
+        return {"node_id": self.node_id}
+
+    def get_attestation_state(self):
+        return {"node_id": self.node_id, "attestations": {}}
+
+
+def _app_and_node():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    node = _FakeP2PNode()
+    register_p2p_endpoints(app, node)
+    return app, node
+
+
+def test_p2p_gossip_requires_json_object():
+    app, node = _app_and_node()
+
+    with app.test_client() as client:
+        resp = client.post("/p2p/gossip", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "JSON object required"
+    assert node.handled == []
+
+
+def test_p2p_gossip_forwards_valid_object_body():
+    app, node = _app_and_node()
+    payload = {"msg_type": "ping"}
+
+    with app.test_client() as client:
+        resp = client.post("/p2p/gossip", json=payload)
+
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "ok"
+    assert node.handled == [payload]


### PR DESCRIPTION
## Summary
- require `/p2p/gossip` request bodies to be JSON objects before invoking gossip processing
- add route tests that verify malformed bodies are rejected and valid object bodies still forward
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4427.

## Tests
- `python -m pytest node\tests\test_p2p_gossip_routes.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `$env:RC_P2P_SECRET='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'; python -m py_compile node\rustchain_p2p_gossip.py node\tests\test_p2p_gossip_routes.py node\utxo_db.py`
- `git diff --check -- node\rustchain_p2p_gossip.py node\tests\test_p2p_gossip_routes.py node\utxo_db.py`