### PR TITLE
fix: validate sophia elya json shapes

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -186,12 +186,18 @@ def get_epoch():
 @app.post("/epoch/enroll")
 def epoch_enroll():
     """Enroll miner in current epoch"""
-    data = request.get_json(force=True) or {}
+    data, error = _json_object_body()
+    if error:
+        return error
 
     miner_pk = data.get("miner_pubkey", "")
-    weights = data.get("weights", {}) or {}
-    device = data.get("device", {}) or {}
+    weights = data.get("weights", {})
+    device = data.get("device", {})
     ticket_id = data.get("ticket_id", "")
+    if not isinstance(weights, dict):
+        return jsonify({"ok": False, "reason": "invalid_weights"}), 400
+    if not isinstance(device, dict):
+        return jsonify({"ok": False, "reason": "invalid_device"}), 400
 
     if not miner_pk or not ticket_id:
         return jsonify({"ok": False, "reason": "missing_params"}), 400
@@ -230,15 +236,25 @@ def balance(miner_pk):
         "balance_rtc": bal
     })
 
+
+def _json_object_body():
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "json_object_required"}), 400)
+    return data, None
+
+
 @app.post("/api/register")
 def api_register():
     """Register node with hardware fingerprint"""
-    data = request.get_json(force=True)
+    data, error = _json_object_body()
+    if error:
+        return error
 
     system_id = data.get("system_id")
     fingerprint = data.get("fingerprint", {})
 
-    if not system_id or not fingerprint:
+    if not system_id or not isinstance(fingerprint, dict) or not fingerprint:
         return jsonify({"error": "missing_data"}), 400
 
     # Check blacklist
@@ -272,8 +288,12 @@ def attest_challenge():
 @app.post("/attest/submit")
 def attest_submit():
     """Submit Silicon Ticket attestation"""
-    data = request.get_json(force=True)
+    data, error = _json_object_body()
+    if error:
+        return error
     report = data.get("report", {})
+    if not isinstance(report, dict):
+        return jsonify({"error": "invalid_report"}), 400
 
     # Basic validation
     if not report.get("commitment"):
@@ -282,6 +302,8 @@ def attest_submit():
     # Create ticket
     ticket_id = secrets.token_hex(8)
     device = report.get("device", {})
+    if not isinstance(device, dict):
+        return jsonify({"error": "invalid_device"}), 400
     hw_weight = get_hardware_weight(device)
     ticket = {
         "ticket_id": ticket_id,
@@ -316,9 +338,15 @@ def api_submit_block():
     """Submit block with VRF proof and Silicon Ticket"""
     global LAST_HASH_B3, LAST_EPOCH
 
-    data = request.get_json(force=True)
+    data, error = _json_object_body()
+    if error:
+        return error
     header = data.get("header", {})
     ext = data.get("header_ext", {})
+    if not isinstance(header, dict):
+        return jsonify({"error": "invalid_header"}), 400
+    if not isinstance(ext, dict):
+        return jsonify({"error": "invalid_header_ext"}), 400
 
     # Check previous hash
     if header.get("prev_hash_b3") != LAST_HASH_B3:

--- a/node/tests/test_sophia_elya_service.py
+++ b/node/tests/test_sophia_elya_service.py
@@ -1,0 +1,85 @@
+from node import sophia_elya_service as elya
+
+
+def _client():
+    elya.app.config["TESTING"] = True
+    return elya.app.test_client()
+
+
+def test_elya_register_requires_json_object():
+    resp = _client().post("/api/register", json=["not", "an", "object"])
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "json_object_required"
+
+
+def test_elya_epoch_enroll_rejects_invalid_nested_shapes():
+    client = _client()
+
+    weights_resp = client.post(
+        "/epoch/enroll",
+        json={
+            "miner_pubkey": "miner-a",
+            "ticket_id": "ticket-a",
+            "weights": ["not", "object"],
+        },
+    )
+    falsey_weights_resp = client.post(
+        "/epoch/enroll",
+        json={
+            "miner_pubkey": "miner-a",
+            "ticket_id": "ticket-a",
+            "weights": [],
+        },
+    )
+    device_resp = client.post(
+        "/epoch/enroll",
+        json={
+            "miner_pubkey": "miner-a",
+            "ticket_id": "ticket-a",
+            "weights": {},
+            "device": [],
+        },
+    )
+
+    assert weights_resp.status_code == 400
+    assert weights_resp.get_json()["reason"] == "invalid_weights"
+    assert falsey_weights_resp.status_code == 400
+    assert falsey_weights_resp.get_json()["reason"] == "invalid_weights"
+    assert device_resp.status_code == 400
+    assert device_resp.get_json()["reason"] == "invalid_device"
+
+
+def test_elya_attest_submit_rejects_non_object_report():
+    resp = _client().post("/attest/submit", json={"report": ["not", "object"]})
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_report"
+
+
+def test_elya_attest_submit_rejects_non_object_report_device():
+    resp = _client().post(
+        "/attest/submit",
+        json={"report": {"commitment": "abc", "device": []}},
+    )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_device"
+
+
+def test_elya_submit_block_rejects_invalid_header_shapes():
+    client = _client()
+
+    header_resp = client.post(
+        "/api/submit_block",
+        json={"header": ["not", "object"], "header_ext": {}},
+    )
+    ext_resp = client.post(
+        "/api/submit_block",
+        json={"header": {"prev_hash_b3": elya.LAST_HASH_B3}, "header_ext": ["bad"]},
+    )
+
+    assert header_resp.status_code == 400
+    assert header_resp.get_json()["error"] == "invalid_header"
+    assert ext_resp.status_code == 400
+    assert ext_resp.get_json()["error"] == "invalid_header_ext"


### PR DESCRIPTION
## Summary
- require Sophia Elya POST routes to receive JSON object bodies
- reject malformed nested `weights`, `device`, `report`, `header`, and `header_ext` shapes before business logic
- add focused Flask client regression tests for malformed Elya payloads
- include the mempool empty-table guard needed by the existing security regression test

Fixes #4429.

## Tests
- `python -m pytest node\tests\test_sophia_elya_service.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\sophia_elya_service.py node\tests\test_sophia_elya_service.py node\utxo_db.py`
- `git diff --check -- node\sophia_elya_service.py node\tests\test_sophia_elya_service.py node\utxo_db.py`