### PR TITLE
fix: validate tx submit json

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -674,7 +674,13 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
     def submit_transaction():
         """Submit a signed transaction"""
         try:
-            data = request.get_json()
+            data = request.get_json(silent=True)
+
+            if data is None:
+                return jsonify({"error": "No JSON data provided"}), 400
+
+            if not isinstance(data, dict):
+                return jsonify({"error": "JSON object required"}), 400
 
             if not data:
                 return jsonify({"error": "No JSON data provided"}), 400

--- a/tests/test_tx_submit_route.py
+++ b/tests/test_tx_submit_route.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for /tx/submit request validation.
+"""
+
+import tempfile
+from pathlib import Path
+
+from flask import Flask
+
+from node.rustchain_tx_handler import TransactionPool, create_tx_api_routes
+
+
+def _client_for_tx_routes(db_path: Path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    pool = TransactionPool(str(db_path))
+    create_tx_api_routes(app, pool)
+    return app.test_client()
+
+
+def test_tx_submit_rejects_non_object_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with _client_for_tx_routes(Path(tmpdir) / "tx.db") as client:
+            response = client.post("/tx/submit", json=["not", "an", "object"])
+
+            assert response.status_code == 400
+            assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_tx_submit_rejects_malformed_json_without_500():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with _client_for_tx_routes(Path(tmpdir) / "tx.db") as client:
+            response = client.post(
+                "/tx/submit",
+                data="{",
+                content_type="application/json",
+            )
+
+            assert response.status_code == 400
+            assert response.get_json() == {"error": "No JSON data provided"}

--- a/tests/test_tx_submit_route.py
+++ b/tests/test_tx_submit_route.py
@@ -4,7 +4,6 @@
 Regression tests for /tx/submit request validation.
 """
 
-import tempfile
 from pathlib import Path
 
 from flask import Flask
@@ -20,23 +19,21 @@ def _client_for_tx_routes(db_path: Path):
     return app.test_client()
 
 
-def test_tx_submit_rejects_non_object_json():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with _client_for_tx_routes(Path(tmpdir) / "tx.db") as client:
-            response = client.post("/tx/submit", json=["not", "an", "object"])
+def test_tx_submit_rejects_non_object_json(tmp_path):
+    with _client_for_tx_routes(tmp_path / "tx.db") as client:
+        response = client.post("/tx/submit", json=["not", "an", "object"])
 
-            assert response.status_code == 400
-            assert response.get_json() == {"error": "JSON object required"}
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "JSON object required"}
 
 
-def test_tx_submit_rejects_malformed_json_without_500():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        with _client_for_tx_routes(Path(tmpdir) / "tx.db") as client:
-            response = client.post(
-                "/tx/submit",
-                data="{",
-                content_type="application/json",
-            )
+def test_tx_submit_rejects_malformed_json_without_500(tmp_path):
+    with _client_for_tx_routes(tmp_path / "tx.db") as client:
+        response = client.post(
+            "/tx/submit",
+            data="{",
+            content_type="application/json",
+        )
 
-            assert response.status_code == 400
-            assert response.get_json() == {"error": "No JSON data provided"}
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "No JSON data provided"}


### PR DESCRIPTION
## Summary
- decode `/tx/submit` JSON bodies with `silent=True`
- reject missing/malformed bodies and non-object JSON before transaction parsing
- add regression coverage for array-shaped JSON and malformed JSON
- carry the mempool expiry missing-table guard required by the security regression suite

Fixes #4432

## Verification
- `python -m pytest tests\test_tx_submit_route.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_tx_handler.py tests\test_tx_submit_route.py node\utxo_db.py`
- `git diff --check -- node\rustchain_tx_handler.py tests\test_tx_submit_route.py node\utxo_db.py`