### PR TITLE
fix: validate anchor list pagination

### DIFF
--- a/node/rustchain_ergo_anchor.py
+++ b/node/rustchain_ergo_anchor.py
@@ -542,7 +542,8 @@ def create_anchor_api_routes(app, anchor_service: AnchorService):
         if error:
             return jsonify({"error": error}), 400
 
-        with sqlite3.connect(anchor_service.db_path) as conn:
+        conn = sqlite3.connect(anchor_service.db_path)
+        try:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
 
@@ -553,6 +554,8 @@ def create_anchor_api_routes(app, anchor_service: AnchorService):
             """, (limit, offset))
 
             anchors = [dict(row) for row in cursor.fetchall()]
+        finally:
+            conn.close()
 
         return jsonify({
             "count": len(anchors),

--- a/node/tests/test_ergo_anchor_routes.py
+++ b/node/tests/test_ergo_anchor_routes.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """Route tests for RustChain Ergo anchor API pagination."""
 
 import sqlite3

--- a/node/tests/test_ergo_anchor_routes.py
+++ b/node/tests/test_ergo_anchor_routes.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Route tests for RustChain Ergo anchor API pagination."""
+
+import sqlite3
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+from flask import Flask
+
+mock_crypto = types.ModuleType("rustchain_crypto")
+mock_crypto.blake2b256_hex = lambda data: "00" * 32
+mock_crypto.canonical_json = lambda data: "{}"
+mock_crypto.MerkleTree = object
+sys.modules["rustchain_crypto"] = mock_crypto
+
+from node.rustchain_ergo_anchor import create_anchor_api_routes
+
+
+class _DummyErgo:
+    def get_height(self):
+        return 0
+
+
+class _DummyAnchorService:
+    interval_blocks = 144
+    ergo = _DummyErgo()
+
+    def __init__(self, db_path: Path):
+        self.db_path = str(db_path)
+
+    def get_last_anchor(self):
+        return None
+
+    def get_anchor_proof(self, height: int):
+        return None
+
+
+def _seed_anchor_db(db_path: Path):
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE ergo_anchors (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                rustchain_height INTEGER NOT NULL,
+                rustchain_hash TEXT NOT NULL,
+                commitment_hash TEXT NOT NULL,
+                ergo_tx_id TEXT NOT NULL,
+                ergo_height INTEGER,
+                confirmations INTEGER DEFAULT 0,
+                status TEXT DEFAULT 'pending',
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        for height in range(3):
+            conn.execute(
+                """
+                INSERT INTO ergo_anchors (
+                    rustchain_height, rustchain_hash, commitment_hash,
+                    ergo_tx_id, ergo_height, confirmations, status, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    height,
+                    f"hash-{height}",
+                    f"commitment-{height}",
+                    f"ergo-{height}",
+                    height + 100,
+                    6,
+                    "confirmed",
+                    height + 1000,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _client(db_path: Path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    create_anchor_api_routes(app, _DummyAnchorService(db_path))
+    return app.test_client()
+
+
+def test_anchor_list_rejects_negative_limit():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "anchors.db"
+        _seed_anchor_db(db_path)
+        response = _client(db_path).get("/anchor/list?limit=-1")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "limit_must_be_at_least_1"}
+
+
+def test_anchor_list_rejects_invalid_offset():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "anchors.db"
+        _seed_anchor_db(db_path)
+        response = _client(db_path).get("/anchor/list?offset=abc")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "offset_must_be_integer"}
+
+
+def test_anchor_list_keeps_valid_pagination():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "anchors.db"
+        _seed_anchor_db(db_path)
+        response = _client(db_path).get("/anchor/list?limit=2&offset=1")
+
+    body = response.get_json()
+    assert response.status_code == 200
+    assert body["count"] == 2
+    assert [anchor["rustchain_height"] for anchor in body["anchors"]] == [1, 0]
+
+
+def test_anchor_list_clamps_oversized_limit():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = Path(tmpdir) / "anchors.db"
+        _seed_anchor_db(db_path)
+        response = _client(db_path).get("/anchor/list?limit=500")
+
+    assert response.status_code == 200
+    assert response.get_json()["count"] == 3


### PR DESCRIPTION
## Summary
- validate `/anchor/list` pagination with explicit integer parsing
- reject negative, zero, and oversized limits before SQLite sees them
- reject negative or non-integer offsets
- close the route SQLite connection explicitly after fetching anchors
- add route-level regression coverage for invalid and valid pagination
- carry the mempool expiry missing-table guard required by the security regression suite

Fixes #4434

## Verification
- `python -m pytest node\tests\test_ergo_anchor_routes.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_ergo_anchor.py node\tests\test_ergo_anchor_routes.py node\utxo_db.py`
- `git diff --check -- node\rustchain_ergo_anchor.py node\tests\test_ergo_anchor_routes.py node\utxo_db.py`