### PR TITLE
fix: validate bft consensus routes

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -798,7 +798,7 @@ class BFTConsensus:
             # Check if we have quorum for view change
             self._check_view_change_quorum(new_view)
 
-    def handle_view_change(self, msg_data: Dict):
+    def handle_view_change(self, msg_data: Dict) -> Tuple[bool, str, int]:
         """Handle received VIEW-CHANGE message"""
         with self.lock:
             new_view = msg_data.get('view')
@@ -808,9 +808,17 @@ class BFTConsensus:
             epoch = msg_data.get('epoch', 0)
 
             # -- Validation: reject garbage / missing fields -----------------
-            if not all([new_view, node_id, signature, timestamp]):
+            required_fields = (
+                'view',
+                'epoch',
+                'node_id',
+                'prepared_cert',
+                'signature',
+                'timestamp',
+            )
+            if any(field not in msg_data for field in required_fields):
                 logging.warning("[VIEW-CHANGE] Rejected: missing required fields")
-                return
+                return False, "missing required fields", 400
 
             # Must be requesting a *higher* view than current
             if new_view <= self.current_view:
@@ -818,7 +826,7 @@ class BFTConsensus:
                     f"[VIEW-CHANGE] Rejected stale view {new_view} "
                     f"(<= current {self.current_view})"
                 )
-                return
+                return False, "stale view", 400
 
             # -- Verify HMAC signature (same format as _trigger_view_change) --
             sign_data = (
@@ -828,7 +836,7 @@ class BFTConsensus:
                 logging.warning(
                     f"[VIEW-CHANGE] Invalid signature from {node_id}"
                 )
-                return
+                return False, "invalid signature", 401
 
             # -- Timestamp freshness -----------------------------------------
             if abs(time.time() - timestamp) > CONSENSUS_MESSAGE_TTL:
@@ -836,7 +844,7 @@ class BFTConsensus:
                     f"[VIEW-CHANGE] Stale message from {node_id} "
                     f"(age={int(time.time()) - timestamp}s)"
                 )
-                return
+                return False, "stale message", 400
 
             # -- Passed all checks, store ------------------------------------
             if new_view not in self.view_change_log:
@@ -847,6 +855,7 @@ class BFTConsensus:
                 logging.info(f"[VIEW-CHANGE] Received from {node_id} for view {new_view}")
 
             self._check_view_change_quorum(new_view)
+            return True, "", 200
 
     def _check_view_change_quorum(self, new_view: int):
         """Check if we have quorum for view change"""
@@ -1063,12 +1072,14 @@ def create_bft_routes(app, bft: BFTConsensus):
 
             missing = _missing_fields(
                 msg_data,
-                ('view', 'epoch', 'node_id', 'signature', 'timestamp'),
+                ('view', 'epoch', 'node_id', 'prepared_cert', 'signature', 'timestamp'),
             )
             if missing:
                 return jsonify({'error': f"missing required fields: {', '.join(missing)}"}), 400
 
-            bft.handle_view_change(msg_data)
+            ok, error, status_code = bft.handle_view_change(msg_data)
+            if not ok:
+                return jsonify({'error': error}), status_code
             return jsonify({'status': 'ok'})
         except Exception as e:
             logging.error(f"BFT view change error: {e}")

--- a/node/tests/test_bft_route_validation.py
+++ b/node/tests/test_bft_route_validation.py
@@ -1,3 +1,7 @@
+import hashlib
+import hmac
+import time
+
 import pytest
 from flask import Flask
 
@@ -5,16 +9,42 @@ from node.rustchain_bft_consensus import BFTConsensus, create_bft_routes
 
 
 @pytest.fixture
-def bft_client():
+def bft_context():
     app = Flask(__name__)
     app.config["TESTING"] = True
     bft = BFTConsensus("node-a", ":memory:", "test-secret")
     create_bft_routes(app, bft)
 
     try:
-        yield app.test_client()
+        with app.test_client() as client:
+            yield client, bft
     finally:
         bft._cancel_view_change_timer()
+
+
+@pytest.fixture
+def bft_client(bft_context):
+    client, _ = bft_context
+    return client
+
+
+def _signed_view_change(bft, *, view=1, epoch=0):
+    timestamp = int(time.time())
+    sign_data = f"view_change:{view}:{epoch}:{timestamp}"
+    node_key = bft._derive_node_key("peer-a")
+    signature = hmac.new(
+        node_key.encode(),
+        sign_data.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "view": view,
+        "epoch": epoch,
+        "node_id": "peer-a",
+        "prepared_cert": None,
+        "signature": signature,
+        "timestamp": timestamp,
+    }
 
 
 @pytest.mark.parametrize("payload", (None, [], "not-object"))
@@ -49,5 +79,36 @@ def test_bft_view_change_rejects_missing_required_fields(bft_client):
 
     assert response.status_code == 400
     assert response.get_json() == {
-        "error": "missing required fields: epoch, signature, timestamp"
+        "error": "missing required fields: epoch, prepared_cert, signature, timestamp"
     }
+
+
+def test_bft_view_change_rejects_invalid_signature(bft_context):
+    client, bft = bft_context
+
+    response = client.post(
+        "/bft/view_change",
+        json={
+            "view": 1,
+            "epoch": 0,
+            "node_id": "peer-a",
+            "prepared_cert": None,
+            "signature": "not-a-valid-signature",
+            "timestamp": int(time.time()),
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "invalid signature"}
+    assert bft.view_change_log == {}
+
+
+def test_bft_view_change_accepts_valid_signature(bft_context):
+    client, bft = bft_context
+    payload = _signed_view_change(bft)
+
+    response = client.post("/bft/view_change", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "ok"}
+    assert bft.view_change_log[payload["view"]]["peer-a"].node_id == "peer-a"


### PR DESCRIPTION
## Summary
- reject non-object JSON on BFT consensus message routes
- reject unknown `/bft/message` message types before dispatch
- reject `/bft/view_change` requests missing required fields before acknowledging them
- add route-level regression coverage for invalid and valid BFT request shapes
- carry the mempool expiry missing-table guard required by the security regression suite

Fixes #4436

## Verification
- `python -m pytest node\tests\test_bft_route_validation.py -q`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node\rustchain_bft_consensus.py node\tests\test_bft_route_validation.py node\utxo_db.py`
- `git diff --check -- node\rustchain_bft_consensus.py node\tests\test_bft_route_validation.py node\utxo_db.py`