### PR TITLE
fix: verify windows miner bootstrap

### DIFF
--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,6 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
+set "MINER_SHA256=51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===
@@ -42,10 +43,11 @@ echo Installing miner dependencies...
 python -m pip install -r "%REQUIREMENTS%"
 
 if exist "%MINER_SCRIPT%" (
-    echo Keeping existing miner script (%MINER_SCRIPT%).
+    echo Keeping existing miner script: "%MINER_SCRIPT%"
 ) else (
     echo Downloading the latest miner script...
-    powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%MINER_URL%' -OutFile '%MINER_SCRIPT%'"
+    call :download_miner
+    if errorlevel 1 exit /b 1
 )
 
 echo.
@@ -54,3 +56,9 @@ echo    python "%MINER_SCRIPT%"
 echo If you still get a tkinter error, run headless:
 echo    python "%MINER_SCRIPT%" --headless --wallet YOUR_WALLET_ID --node https://rustchain.org
 echo You can create a scheduled task or shortcut to keep it running.
+
+exit /b 0
+
+:download_miner
+powershell -NoProfile -ExecutionPolicy Bypass -Command "$ErrorActionPreference='Stop'; Invoke-WebRequest -UseBasicParsing -Uri '%MINER_URL%' -OutFile '%MINER_SCRIPT%'; $actual=(Get-FileHash -Algorithm SHA256 -Path '%MINER_SCRIPT%').Hash.ToLowerInvariant(); if ($actual -ne '%MINER_SHA256%') { Remove-Item -LiteralPath '%MINER_SCRIPT%' -ErrorAction SilentlyContinue; throw ('Miner checksum mismatch: expected %MINER_SHA256% got ' + $actual) }"
+exit /b %ERRORLEVEL%

--- a/tests/test_windows_miner_setup_security.py
+++ b/tests/test_windows_miner_setup_security.py
@@ -1,0 +1,42 @@
+import hashlib
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = ROOT / "miners" / "windows" / "rustchain_miner_setup.bat"
+MINER = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+
+
+def test_windows_bootstrap_pins_current_miner_hash():
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+    match = re.search(r'set "MINER_SHA256=([a-f0-9]{64})"', script)
+
+    assert match, "Windows bootstrap must pin a SHA-256 for the downloaded miner"
+    assert match.group(1) == hashlib.sha256(MINER.read_bytes()).hexdigest()
+
+
+def test_windows_bootstrap_verifies_downloaded_miner():
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    assert "Get-FileHash -Algorithm SHA256" in script
+    assert "$actual -ne '%MINER_SHA256%'" in script
+    assert "Remove-Item -LiteralPath '%MINER_SCRIPT%'" in script
+    assert "if errorlevel 1 exit /b 1" in script
+
+
+def test_windows_bootstrap_runs_powershell_verification_outside_else_block():
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    else_block = script.split('if exist "%MINER_SCRIPT%" (', 1)[1].split("echo.", 1)[0]
+    assert "call :download_miner" in else_block
+    assert "Get-FileHash" not in else_block
+    assert ":download_miner" in script
+
+
+def test_windows_bootstrap_existing_file_message_does_not_close_if_block():
+    script = BOOTSTRAP.read_text(encoding="utf-8")
+
+    existing_branch = script.split('if exist "%MINER_SCRIPT%" (', 1)[1].split(") else (", 1)[0]
+    assert "Keeping existing miner script:" in existing_branch
+    assert "(%MINER_SCRIPT%)" not in existing_branch


### PR DESCRIPTION
## Summary
- Fixes #4445 by pinning the expected SHA-256 of the Windows miner downloaded by `rustchain_miner_setup.bat`.
- Verifies the downloaded miner with `Get-FileHash -Algorithm SHA256` before leaving it in place.
- Deletes the downloaded miner and exits non-zero if the digest does not match.
- Adds regression tests that recompute the committed miner hash and check the bootstrap verification path.

## Verification
- `python -m pytest tests\test_windows_miner_setup_security.py -q`
- fetched the current raw Windows miner and confirmed its SHA-256 matches the pinned value
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile tests\test_windows_miner_setup_security.py node\utxo_db.py`
- `git diff --check`