### PR TITLE
fix: verify install-miner fingerprint helper

### DIFF
--- a/install-miner.sh
+++ b/install-miner.sh
@@ -95,6 +95,7 @@ verify_sum() {
 
 download_miner() {
     cd "$INSTALL_DIR"
+    FINGERPRINT_FILE="linux/fingerprint_checks.py"
     case "$PLATFORM" in
         macos) FILE="macos/rustchain_mac_miner_v2.4.py" ;;
         rpi|linux) FILE="linux/rustchain_linux_miner.py" ;;
@@ -103,11 +104,18 @@ download_miner() {
     
     echo -e "${CYAN}[*] Downloading miner...${NC}"
     run_cmd curl -sSL "$REPO_BASE/$FILE" -o rustchain_miner.py
-    run_cmd curl -sSL "$REPO_BASE/linux/fingerprint_checks.py" -o fingerprint_checks.py
+    run_cmd curl -sSL "$REPO_BASE/$FINGERPRINT_FILE" -o fingerprint_checks.py
     
     if [ "$SKIP_CHECKSUM" != true ] && [ "$DRY_RUN" != true ]; then
-        curl -sSL "$CHECKSUM_URL" -o sums 2>/dev/null || true
-        [ -f sums ] && { SUM=$(grep "$(basename $FILE)" sums | awk '{print $1}'); [ -n "$SUM" ] && verify_sum "rustchain_miner.py" "$SUM"; rm sums; }
+        curl -sSL "$CHECKSUM_URL" -o sums
+        for artifact in "$FILE:rustchain_miner.py" "$FINGERPRINT_FILE:fingerprint_checks.py"; do
+            manifest_path="${artifact%%:*}"
+            local_path="${artifact#*:}"
+            SUM=$(awk -v path="$manifest_path" '$2 == path { print $1; exit }' sums)
+            [ -n "$SUM" ] || { echo -e "${RED}[!] Missing checksum for: $manifest_path${NC}"; rm -f sums; exit 1; }
+            verify_sum "$local_path" "$SUM"
+        done
+        rm sums
     fi
 }
 

--- a/miners/windows/install-miner.sh
+++ b/miners/windows/install-miner.sh
@@ -93,6 +93,7 @@ verify_sum() {
 
 download_miner() {
     cd "$INSTALL_DIR"
+    FINGERPRINT_FILE="linux/fingerprint_checks.py"
     case "$PLATFORM" in
         macos) FILE="macos/rustchain_mac_miner_v2.4.py" ;;
         rpi|linux) FILE="linux/rustchain_linux_miner.py" ;;
@@ -101,11 +102,18 @@ download_miner() {
     
     echo -e "${CYAN}[*] Downloading miner...${NC}"
     run_cmd curl -sSL "$REPO_BASE/$FILE" -o rustchain_miner.py
-    run_cmd curl -sSL "$REPO_BASE/linux/fingerprint_checks.py" -o fingerprint_checks.py
+    run_cmd curl -sSL "$REPO_BASE/$FINGERPRINT_FILE" -o fingerprint_checks.py
     
     if [ "$SKIP_CHECKSUM" != true ] && [ "$DRY_RUN" != true ]; then
-        curl -sSL "$CHECKSUM_URL" -o sums 2>/dev/null || true
-        [ -f sums ] && { SUM=$(grep "$(basename $FILE)" sums | awk '{print $1}'); [ -n "$SUM" ] && verify_sum "rustchain_miner.py" "$SUM"; rm sums; }
+        curl -sSL "$CHECKSUM_URL" -o sums
+        for artifact in "$FILE:rustchain_miner.py" "$FINGERPRINT_FILE:fingerprint_checks.py"; do
+            manifest_path="${artifact%%:*}"
+            local_path="${artifact#*:}"
+            SUM=$(awk -v path="$manifest_path" '$2 == path { print $1; exit }' sums)
+            [ -n "$SUM" ] || { echo -e "${RED}[!] Missing checksum for: $manifest_path${NC}"; rm -f sums; exit 1; }
+            verify_sum "$local_path" "$SUM"
+        done
+        rm sums
     fi
 }
 

--- a/tests/test_install_miner_checksums.py
+++ b/tests/test_install_miner_checksums.py
@@ -1,0 +1,39 @@
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _installer_paths():
+    return (
+        ROOT / "install-miner.sh",
+        ROOT / "miners" / "windows" / "install-miner.sh",
+    )
+
+
+def test_install_miners_verify_fingerprint_helper_checksum():
+    for installer in _installer_paths():
+        text = installer.read_text()
+        assert 'FINGERPRINT_FILE="linux/fingerprint_checks.py"' in text
+        assert 'run_cmd curl -sSL "$REPO_BASE/$FINGERPRINT_FILE" -o fingerprint_checks.py' in text
+        assert '"$FINGERPRINT_FILE:fingerprint_checks.py"' in text
+        assert 'verify_sum "$local_path" "$SUM"' in text
+
+
+def test_install_miners_require_manifest_entries_before_verification():
+    for installer in _installer_paths():
+        text = installer.read_text()
+        checksum_block = text.partition('curl -sSL "$CHECKSUM_URL" -o sums')[2].partition("fi")[0]
+        assert 'curl -sSL "$CHECKSUM_URL" -o sums' in text
+        assert 'Missing checksum for: $manifest_path' in text
+        assert 'grep "$(basename $FILE)"' not in text
+        assert "|| true" not in checksum_block
+
+
+def test_checksum_manifest_covers_installer_downloads():
+    manifest = (ROOT / "miners" / "checksums.sha256").read_text()
+    assert "linux/fingerprint_checks.py" in manifest
+    for installer in _installer_paths():
+        for miner_path in re.findall(r'\)\s+FILE="([^"]+)"\s+;;', installer.read_text()):
+            assert miner_path in manifest


### PR DESCRIPTION
## Summary
- require `install-miner.sh` checksum verification to cover both downloaded Python artifacts
- verify `fingerprint_checks.py` against the existing `linux/fingerprint_checks.py` manifest entry in both installer copies
- fail installation when the checksum manifest is unavailable, missing an artifact entry, or a downloaded digest mismatches
- add static regression coverage for installer checksum behavior

Closes #4449

## Validation
- `python -m pytest tests/test_install_miner_checksums.py tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `bash -n install-miner.sh; bash -n miners/windows/install-miner.sh`
- `python -m py_compile node/utxo_db.py tests/test_install_miner_checksums.py`
- `git diff --check`
