### PR TITLE
fix: escape bridge dashboard transactions

### DIFF
--- a/static/bridge/dashboard.html
+++ b/static/bridge/dashboard.html
@@ -1067,12 +1067,12 @@
 
             body.innerHTML = filtered.map(tx => `
                 <tr>
-                    <td><span class="tx-id">${tx.lock_id.substring(0, 16)}...</span></td>
-                    <td><span class="tx-type ${tx.type}">${tx.type.toUpperCase()}</span></td>
-                    <td>${tx.sender_wallet}</td>
+                    <td><span class="tx-id">${escapeHtml(String(tx.lock_id || '').substring(0, 16))}...</span></td>
+                    <td><span class="tx-type ${safeCssToken(tx.type)}">${escapeHtml(String(tx.type || '').toUpperCase())}</span></td>
+                    <td>${escapeHtml(tx.sender_wallet)}</td>
                     <td><span class="tx-amount">${formatNumber(tx.amount_rtc)} ${tx.type === 'wrap' ? 'RTC' : 'wRTC'}</span></td>
-                    <td><span class="chain-badge ${tx.target_chain}">${tx.target_chain.toUpperCase()}</span></td>
-                    <td><span class="tx-state ${tx.state}">${tx.state.toUpperCase()}</span></td>
+                    <td><span class="chain-badge ${safeCssToken(tx.target_chain)}">${escapeHtml(String(tx.target_chain || '').toUpperCase())}</span></td>
+                    <td><span class="tx-state ${safeCssToken(tx.state)}">${escapeHtml(String(tx.state || '').toUpperCase())}</span></td>
                     <td>${formatTime(tx.created_at || tx.timestamp)}</td>
                 </tr>
             `).join('');
@@ -1087,6 +1087,20 @@
         }
 
         // 鈹€鈹€鈹€ Utility Functions 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, char => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[char]));
+        }
+
+        function safeCssToken(value) {
+            return String(value ?? '').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+        }
+
         function formatNumber(num) {
             return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(num || 0);
         }

--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -125,6 +125,20 @@
 </div>
 
 <script>
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        }[char]));
+    }
+
+    function safeCssToken(value) {
+        return String(value ?? '').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+    }
+
     async function refresh() {
         try {
             const resp = await fetch('bridge_status.json');
@@ -149,11 +163,11 @@
             data.recent_transactions.forEach(tx => {
                 const row = document.createElement('tr');
                 row.innerHTML = `
-                    <td style="font-family:monospace; color:#888">${tx.lock_id.substring(0,12)}...</td>
-                    <td>${tx.sender_wallet}</td>
-                    <td style="color:white; font-weight:bold">${tx.amount_rtc}</td>
-                    <td><span style="color:var(--solana)">${tx.target_chain.toUpperCase()}</span></td>
-                    <td><span class="state-tag ${tx.state}">${tx.state.toUpperCase()}</span></td>
+                    <td style="font-family:monospace; color:#888">${escapeHtml(String(tx.lock_id || '').substring(0, 12))}...</td>
+                    <td>${escapeHtml(tx.sender_wallet)}</td>
+                    <td style="color:white; font-weight:bold">${escapeHtml(tx.amount_rtc)}</td>
+                    <td><span style="color:var(--solana)">${escapeHtml(String(tx.target_chain || '').toUpperCase())}</span></td>
+                    <td><span class="state-tag ${safeCssToken(tx.state)}">${escapeHtml(String(tx.state || '').toUpperCase())}</span></td>
                 `;
                 body.appendChild(row);
             });

--- a/tests/test_bridge_dashboard_dom_xss.py
+++ b/tests/test_bridge_dashboard_dom_xss.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 
@@ -35,4 +37,3 @@ def test_bridge_transaction_fields_are_escaped_before_inner_html_injection():
     assert "${escapeHtml(String(tx.target_chain || '').toUpperCase())}" in index
     assert "${escapeHtml(String(tx.state || '').toUpperCase())}" in index
     assert "${safeCssToken(tx.state)}" in index
-

--- a/tests/test_bridge_dashboard_dom_xss.py
+++ b/tests/test_bridge_dashboard_dom_xss.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_PAGES = (
+    ROOT / "static" / "bridge" / "index.html",
+    ROOT / "static" / "bridge" / "dashboard.html",
+)
+
+
+def test_bridge_pages_define_html_and_css_token_escaping():
+    for page in BRIDGE_PAGES:
+        text = page.read_text(encoding="utf-8")
+        assert "function escapeHtml(value)" in text
+        assert "function safeCssToken(value)" in text
+        assert "replace(/[&<>\"']/g" in text
+        assert "replace(/[^a-z0-9_-]/g, '-')" in text
+
+
+def test_bridge_transaction_fields_are_escaped_before_inner_html_injection():
+    dashboard = (ROOT / "static" / "bridge" / "dashboard.html").read_text(encoding="utf-8")
+    assert "${escapeHtml(tx.sender_wallet)}" in dashboard
+    assert "${escapeHtml(String(tx.lock_id || '').substring(0, 16))}" in dashboard
+    assert "${escapeHtml(String(tx.type || '').toUpperCase())}" in dashboard
+    assert "${escapeHtml(String(tx.target_chain || '').toUpperCase())}" in dashboard
+    assert "${escapeHtml(String(tx.state || '').toUpperCase())}" in dashboard
+    assert "${safeCssToken(tx.type)}" in dashboard
+    assert "${safeCssToken(tx.target_chain)}" in dashboard
+    assert "${safeCssToken(tx.state)}" in dashboard
+
+    index = (ROOT / "static" / "bridge" / "index.html").read_text(encoding="utf-8")
+    assert "${escapeHtml(tx.sender_wallet)}" in index
+    assert "${escapeHtml(tx.amount_rtc)}" in index
+    assert "${escapeHtml(String(tx.lock_id || '').substring(0, 12))}" in index
+    assert "${escapeHtml(String(tx.target_chain || '').toUpperCase())}" in index
+    assert "${escapeHtml(String(tx.state || '').toUpperCase())}" in index
+    assert "${safeCssToken(tx.state)}" in index
+


### PR DESCRIPTION
## Summary
- escape bridge transaction text before static bridge pages insert rows via `innerHTML`
- sanitize bridge transaction values used as CSS class tokens
- add static regression tests for the bridge dashboard DOM XSS guard

Closes #4452

## Validation
- `python -m pytest tests/test_bridge_dashboard_dom_xss.py tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node/utxo_db.py tests/test_bridge_dashboard_dom_xss.py`
- `git diff --check`
