### PR TITLE
Fix issue 729 license link

### DIFF
--- a/bounties/issue-729/README.md
+++ b/bounties/issue-729/README.md
@@ -397,7 +397,7 @@ chrome.runtime.sendMessage({
 
 ## 📄 License
 
-MIT License - See [LICENSE](../../../LICENSE) for details.
+MIT License - See [LICENSE](../../LICENSE) for details.
 
 ## 🙏 Acknowledgments
 


### PR DESCRIPTION
## Summary
- Fixes a broken relative LICENSE link in `bounties/issue-729/README.md`.
- The file lives at `bounties/issue-729/`, so the repo root is `../../`, not `../../../`.

## Validation
- `Test-Path bounties/issue-729/../../LICENSE` resolves successfully.
- `Test-Path bounties/issue-729/../../../LICENSE` fails because it points outside the repository.
- `git diff --check` passed.

Bounty context: Scottcjn/rustchain-bounties#444