### PR TITLE
Fix rustchainnode homepage URL

### DIFF
--- a/rustchainnode/pyproject.toml
+++ b/rustchainnode/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = []
 dev = ["pytest>=7.0", "flask>=3.0"]
 
 [project.urls]
-Homepage = "https://rustchain.ai"
+Homepage = "https://rustchain.org"
 Repository = "https://github.com/Scottcjn/Rustchain"
 Issues = "https://github.com/Scottcjn/rustchain-bounties/issues/757"
 


### PR DESCRIPTION
## Summary
- Fixes the `rustchainnode` package homepage metadata to use the live RustChain site.
- `https://rustchain.ai` no longer resolves, while `https://rustchain.org` is the active project homepage used elsewhere in the repository.

## Validation
- `Invoke-WebRequest -Uri https://rustchain.ai -Method Head` fails with DNS resolution error.
- `Invoke-WebRequest -Uri https://rustchain.org -Method Head` returns `200`.
- `git diff --check` passed.

Bounty context: Scottcjn/rustchain-bounties#444