### PR TITLE
fix: reject legacy UTXO signatures with fees

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -322,6 +322,47 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertIn('signed payload', r.get_json()['error'])
         self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
+    def test_legacy_signature_rejects_nonzero_fee(self):
+        """Legacy signatures omit fee_rtc, so they cannot authorize fees."""
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        signed_message = json.dumps({
+            'from': sender,
+            'to': recipient,
+            'amount': 10.0,
+            'memo': '',
+            'nonce': 515151,
+        }, sort_keys=True, separators=(',', ':')).encode()
+
+        old_verify = utxo_endpoints._verify_sig_fn
+
+        def verify_legacy_only(pubkey_hex, message, sig_hex):
+            return sig_hex == 'legacy-sig' and message == signed_message
+
+        try:
+            utxo_endpoints._verify_sig_fn = verify_legacy_only
+            r = self.client.post('/utxo/transfer', json={
+                'from_address': sender,
+                'to_address': recipient,
+                'amount_rtc': 10.0,
+                'fee_rtc': 1.0,
+                'public_key': 'aabbccdd' * 8,
+                'signature': 'legacy-sig',
+                'nonce': 515151,
+            })
+        finally:
+            utxo_endpoints._verify_sig_fn = old_verify
+
+        self.assertEqual(r.status_code, 401)
+        self.assertEqual(
+            r.get_json()['code'],
+            'LEGACY_SIGNATURE_FEE_UNBOUND',
+        )
+        self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -421,6 +421,11 @@ def utxo_transfer():
     if _verify_sig_fn(public_key, message_v2, signature):
         pass  # New client — fee is signed, MITM-resistant
     elif _verify_sig_fn(public_key, message_legacy, signature):
+        if fee_nrtc != 0:
+            return jsonify({
+                'error': 'Legacy signature format cannot authorize nonzero fee',
+                'code': 'LEGACY_SIGNATURE_FEE_UNBOUND',
+            }), 401
         logging.warning(
             "[UTXO/SIG] DEPRECATED: signature without fee accepted for %s... "
             "Upgrade client to include fee in signed message.",


### PR DESCRIPTION
## Summary

Follow-up hardening for the UTXO legacy-signature compatibility path discussed in #2811 and relevant to the red-team bounty in Scottcjn/rustchain-bounties#2819.

`/utxo/transfer` currently prefers the v2 signed payload that includes `fee_rtc`, then falls back to a legacy signed payload that omits the fee for compatibility. During that compatibility window, a legacy signature can still be accepted with a nonzero fee even though the fee is not bound by the signature.

This patch rejects legacy-signature transfers whenever `fee_rtc` is nonzero, while preserving zero-fee legacy compatibility and the v2 fee-bound path.

## Validation

- `/tmp/earn-micro-bounties-rustchain/.venv/bin/python node/test_utxo_endpoints.py`
- `/tmp/earn-micro-bounties-rustchain/.venv/bin/python -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py`
- `git diff --check -- node/utxo_endpoints.py node/test_utxo_endpoints.py`

No public payment details included; please use a private channel if payout information is needed.