### PR TITLE
Fix agent SDK demo documentation URL

### DIFF
--- a/agent_sdk_demo.py
+++ b/agent_sdk_demo.py
@@ -101,7 +101,7 @@ def demo_full_lifecycle():
     print("\nStep 4: Delivering work...")
     delivery = client.deliver_work(
         job_id,
-        "https://docs.rustchain.ai/agent-economy",
+        "https://github.com/Scottcjn/Rustchain/blob/main/sdk/docs/AGENT_ECONOMY_SDK.md",
         "Complete technical documentation with API examples and integration guides"
     )
     print("✓ Work delivered with URL and summary")


### PR DESCRIPTION
## Summary
- Fixes the Agent Economy SDK demo delivery URL so it points to live documentation.
- Replaces the non-resolving `docs.rustchain.ai` link with the existing Agent Economy SDK docs in this repository.

## Validation
- `Invoke-WebRequest -Uri https://docs.rustchain.ai/agent-economy -Method Head` fails with DNS resolution error.
- `Invoke-WebRequest -Uri https://github.com/Scottcjn/Rustchain/blob/main/sdk/docs/AGENT_ECONOMY_SDK.md -Method Head` returns `200`.
- `git diff --check` passed.

Bounty context: Scottcjn/rustchain-bounties#444