### PR TITLE
fix: escape mining dashboard api fields

### DIFF
--- a/node/rustchain_dashboard.py
+++ b/node/rustchain_dashboard.py
@@ -189,6 +189,28 @@ DASHBOARD_HTML = """
         .sys-stat .value { font-size: 1.8em; font-weight: bold; }
     </style>
     <script>
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, char => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            }[char]));
+        }
+
+        function safeCssToken(value) {
+            return String(value ?? '').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'unknown';
+        }
+
+        function formatNumber(value, fractionDigits = null) {
+            const number = Number(value);
+            if (!Number.isFinite(number)) {
+                return '0';
+            }
+            return fractionDigits === null ? String(number) : number.toFixed(fractionDigits);
+        }
+
         function updateDashboard() {
             fetch('/api/stats')
                 .then(r => r.json())
@@ -212,12 +234,12 @@ DASHBOARD_HTML = """
                     const minersTable = document.getElementById('miners-tbody');
                     minersTable.innerHTML = data.active_miners.map(m => `
                         <tr>
-                            <td class="mono">${m.wallet_short}...</td>
-                            <td><span class="badge badge-${m.arch}">${m.arch.toUpperCase()}</span></td>
-                            <td><strong>${m.weight}x</strong></td>
-                            <td class="green">${m.balance.toFixed(6)} RTC</td>
-                            <td class="mono">${m.last_seen}</td>
-                            <td class="blue">${m.age_on_network || 'New'}</td>
+                            <td class="mono">${escapeHtml(m.wallet_short)}...</td>
+                            <td><span class="badge badge-${safeCssToken(m.arch)}">${escapeHtml(String(m.arch || '').toUpperCase())}</span></td>
+                            <td><strong>${formatNumber(m.weight)}x</strong></td>
+                            <td class="green">${formatNumber(m.balance, 6)} RTC</td>
+                            <td class="mono">${escapeHtml(m.last_seen)}</td>
+                            <td class="blue">${escapeHtml(m.age_on_network || 'New')}</td>
                             <td><span class="badge badge-active pulse">ACTIVE</span></td>
                         </tr>
                     `).join('');
@@ -226,11 +248,11 @@ DASHBOARD_HTML = """
                     const blocksTable = document.getElementById('blocks-tbody');
                     blocksTable.innerHTML = data.recent_blocks.map(b => `
                         <tr>
-                            <td><strong>${b.height}</strong></td>
-                            <td class="mono">${b.hash_short}...</td>
-                            <td>${b.timestamp}</td>
-                            <td><span class="badge">${b.miners_count} miners</span></td>
-                            <td class="green">${b.reward} RTC</td>
+                            <td><strong>${formatNumber(b.height)}</strong></td>
+                            <td class="mono">${escapeHtml(b.hash_short)}...</td>
+                            <td>${escapeHtml(b.timestamp)}</td>
+                            <td><span class="badge">${formatNumber(b.miners_count)} miners</span></td>
+                            <td class="green">${formatNumber(b.reward)} RTC</td>
                         </tr>
                     `).join('');
 
@@ -242,30 +264,30 @@ DASHBOARD_HTML = """
             const wallet = document.getElementById('wallet-search').value.trim();
             if (!wallet) return;
 
-            fetch(`/api/wallet/${wallet}`)
+            fetch(`/api/wallet/${encodeURIComponent(wallet)}`)
                 .then(r => r.json())
                 .then(data => {
                     const resultDiv = document.getElementById('search-result');
                     if (data.found) {
                         resultDiv.innerHTML = `
                             <h3>✅ Wallet Found</h3>
-                            <p><strong>Address:</strong> <span class="mono">${data.wallet}</span></p>
-                            <p><strong>Balance:</strong> <span class="green">${data.balance} RTC</span></p>
-                            <p><strong>Weight:</strong> ${data.weight}x (${data.tier})</p>
-                            <p><strong>Age on Network:</strong> ${data.age_on_network || 'Unknown'}</p>
+                            <p><strong>Address:</strong> <span class="mono">${escapeHtml(data.wallet)}</span></p>
+                            <p><strong>Balance:</strong> <span class="green">${formatNumber(data.balance)} RTC</span></p>
+                            <p><strong>Weight:</strong> ${formatNumber(data.weight)}x (${escapeHtml(data.tier)})</p>
+                            <p><strong>Age on Network:</strong> ${escapeHtml(data.age_on_network || 'Unknown')}</p>
                             <p><strong>Status:</strong> ${data.enrolled ? '✅ Enrolled in current epoch' : '⏸️ Not currently enrolled'}</p>
-                            <p><strong>Last Seen:</strong> ${data.last_seen || 'Never'}</p>
+                            <p><strong>Last Seen:</strong> ${escapeHtml(data.last_seen || 'Never')}</p>
                         `;
                     } else {
                         resultDiv.innerHTML = `
                             <h3>❌ Wallet Not Found</h3>
-                            <p>No miner found with address: <span class="mono">${wallet}</span></p>
+                            <p>No miner found with address: <span class="mono">${escapeHtml(wallet)}</span></p>
                         `;
                     }
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
-                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
+                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${escapeHtml(err)}</p>`;
                     document.getElementById('search-result').style.display = 'block';
                 });
         }

--- a/tests/test_mining_dashboard_dom_xss.py
+++ b/tests/test_mining_dashboard_dom_xss.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD = ROOT / "node" / "rustchain_dashboard.py"
+
+
+def _source() -> str:
+    return DASHBOARD.read_text(encoding="utf-8")
+
+
+def test_mining_dashboard_defines_escape_helpers():
+    source = _source()
+    assert "function escapeHtml(value)" in source
+    assert "function safeCssToken(value)" in source
+    assert "function formatNumber(value, fractionDigits = null)" in source
+    assert "replace(/[&<>\"']/g" in source
+    assert "replace(/[^a-z0-9_-]/g, '-')" in source
+    assert "Number.isFinite(number)" in source
+
+
+def test_mining_dashboard_escapes_miner_and_block_rows_before_inner_html():
+    source = _source()
+    assert "${escapeHtml(m.wallet_short)}" in source
+    assert "${safeCssToken(m.arch)}" in source
+    assert "${escapeHtml(String(m.arch || '').toUpperCase())}" in source
+    assert "${formatNumber(m.weight)}" in source
+    assert "${formatNumber(m.balance, 6)}" in source
+    assert "${escapeHtml(m.last_seen)}" in source
+    assert "${escapeHtml(m.age_on_network || 'New')}" in source
+
+    assert "${formatNumber(b.height)}" in source
+    assert "${escapeHtml(b.hash_short)}" in source
+    assert "${escapeHtml(b.timestamp)}" in source
+    assert "${formatNumber(b.miners_count)}" in source
+    assert "${formatNumber(b.reward)}" in source
+
+
+def test_mining_dashboard_escapes_wallet_search_rendering_and_encodes_route():
+    source = _source()
+    assert "fetch(`/api/wallet/${encodeURIComponent(wallet)}`)" in source
+    assert "${escapeHtml(data.wallet)}" in source
+    assert "${formatNumber(data.balance)}" in source
+    assert "${formatNumber(data.weight)}" in source
+    assert "${escapeHtml(data.tier)}" in source
+    assert "${escapeHtml(data.age_on_network || 'Unknown')}" in source
+    assert "${escapeHtml(data.last_seen || 'Never')}" in source
+    assert "${escapeHtml(wallet)}" in source
+    assert "${escapeHtml(err)}" in source
+
+
+def test_mining_dashboard_no_longer_uses_raw_reviewed_interpolations():
+    source = _source()
+    raw_interpolations = (
+        "${m.weight}x",
+        "${m.balance.toFixed(6)}",
+        "${b.height}",
+        "${b.miners_count}",
+        "${b.reward}",
+        "${data.balance}",
+        "${data.weight}",
+        "fetch(`/api/wallet/${wallet}`)",
+    )
+    for interpolation in raw_interpolations:
+        assert interpolation not in source
+

--- a/tests/test_mining_dashboard_dom_xss.py
+++ b/tests/test_mining_dashboard_dom_xss.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 
@@ -63,4 +65,3 @@ def test_mining_dashboard_no_longer_uses_raw_reviewed_interpolations():
     )
     for interpolation in raw_interpolations:
         assert interpolation not in source
-


### PR DESCRIPTION
## Summary
- escape API-provided mining dashboard fields before inserting them via `innerHTML`
- sanitize dynamic miner architecture badge class suffixes
- URL-encode wallet lookup paths and escape wallet search result/error text
- add a static regression test for the dashboard DOM XSS guard

Closes #4458

## Validation
- `python -m pytest tests/test_mining_dashboard_dom_xss.py tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node/rustchain_dashboard.py node/utxo_db.py tests/test_mining_dashboard_dom_xss.py`
- `git diff --check`
