### PR TITLE
fix: escape status dashboard node fields

### DIFF
--- a/static/status/index.html
+++ b/static/status/index.html
@@ -102,6 +102,16 @@
 </div>
 
 <script>
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        }[char]));
+    }
+
     async function updateStatus() {
         try {
             const resp = await fetch('node_status.json');
@@ -130,29 +140,29 @@
                 card.innerHTML = `
                     <div class="node-name">
                         <span class="status-dot ${node.status === 'up' ? 'up' : 'down'}"></span>
-                        ${node.name}
+                        ${escapeHtml(node.name)}
                     </div>
-                    <div class="location">${node.location}</div>
+                    <div class="location">${escapeHtml(node.location)}</div>
                     
                     <div class="stat-row">
                         <span class="stat-label">STATUS</span>
-                        <span style="color: ${node.status === 'up' ? 'var(--green)' : 'var(--red)'}">${node.status.toUpperCase()}</span>
+                        <span style="color: ${node.status === 'up' ? 'var(--green)' : 'var(--red)'}">${escapeHtml(String(node.status || '').toUpperCase())}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">LATENCY</span>
-                        <span>${node.latency_ms || '--'}ms</span>
+                        <span>${escapeHtml(node.latency_ms || '--')}ms</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">VERSION</span>
-                        <span>${node.version || 'unknown'}</span>
+                        <span>${escapeHtml(node.version || 'unknown')}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">EPOCH</span>
-                        <span>${node.epoch || '--'}</span>
+                        <span>${escapeHtml(node.epoch || '--')}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">MINERS</span>
-                        <span>${node.miners || 0}</span>
+                        <span>${escapeHtml(node.miners || 0)}</span>
                     </div>
                     
                     ${uptimeHtml}

--- a/tests/test_status_dashboard_dom_xss.py
+++ b/tests/test_status_dashboard_dom_xss.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+STATUS_PAGE = ROOT / "static" / "status" / "index.html"
+
+
+def _source() -> str:
+    return STATUS_PAGE.read_text(encoding="utf-8")
+
+
+def test_status_dashboard_defines_html_escaping():
+    source = _source()
+    assert "function escapeHtml(value)" in source
+    assert "replace(/[&<>\"']/g" in source
+    assert "'&': '&amp;'" in source
+    assert "'<': '&lt;'" in source
+    assert "'>': '&gt;'" in source
+    assert "'\"': '&quot;'" in source
+    assert '"\'": \'&#39;\'' in source
+
+
+def test_status_dashboard_escapes_node_status_fields_before_inner_html():
+    source = _source()
+    assert "${escapeHtml(node.name)}" in source
+    assert "${escapeHtml(node.location)}" in source
+    assert "${escapeHtml(String(node.status || '').toUpperCase())}" in source
+    assert "${escapeHtml(node.latency_ms || '--')}ms" in source
+    assert "${escapeHtml(node.version || 'unknown')}" in source
+    assert "${escapeHtml(node.epoch || '--')}" in source
+    assert "${escapeHtml(node.miners || 0)}" in source
+

--- a/tests/test_status_dashboard_dom_xss.py
+++ b/tests/test_status_dashboard_dom_xss.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 
@@ -29,4 +31,3 @@ def test_status_dashboard_escapes_node_status_fields_before_inner_html():
     assert "${escapeHtml(node.version || 'unknown')}" in source
     assert "${escapeHtml(node.epoch || '--')}" in source
     assert "${escapeHtml(node.miners || 0)}" in source
-


### PR DESCRIPTION
## Summary
- escape `node_status.json` fields before the status dashboard inserts node cards via `innerHTML`
- preserve local uptime-bar markup while treating remote node health values as text
- add static regression coverage for the status dashboard DOM XSS guard

Closes #4460

## Validation
- `python -m pytest tests/test_status_dashboard_dom_xss.py tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node/utxo_db.py tests/test_status_dashboard_dom_xss.py`
- `git diff --check`
