### PR TITLE
fix: use public host for bcos links

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -47,10 +47,15 @@ bcos_bp = Blueprint("bcos", __name__)
 
 # Module-level ref to DB_PATH, set by register_bcos_routes
 _DB_PATH = None
+BCOS_PUBLIC_BASE_URL = os.environ.get("BCOS_PUBLIC_BASE_URL", "https://rustchain.org").rstrip("/")
 
 
 def _get_admin_key():
     return os.environ.get("RC_ADMIN_KEY", "")
+
+
+def _bcos_url(path: str) -> str:
+    return f"{BCOS_PUBLIC_BASE_URL}{path}"
 
 
 def _parse_trust_score(raw_score) -> int:
@@ -277,8 +282,8 @@ def bcos_attest():
             "tier": tier,
             "trust_score": trust_score,
             "anchored_epoch": epoch,
-            "verify_url": f"https://rustchain.org/bcos/verify/{cert_id}",
-            "badge_url": f"https://50.28.86.131/bcos/badge/{cert_id}.svg",
+            "verify_url": _bcos_url(f"/bcos/verify/{cert_id}"),
+            "badge_url": _bcos_url(f"/bcos/badge/{cert_id}.svg"),
         })
     except sqlite3.IntegrityError:
         return jsonify({"error": f"Certificate {cert_id} already exists"}), 409
@@ -339,8 +344,8 @@ def bcos_verify(cert_id):
             "score_breakdown": report.get("score_breakdown", {}),
             "checks": report.get("checks", {}),
             "engine_version": report.get("engine_version", "unknown"),
-            "badge_url": f"https://50.28.86.131/bcos/badge/{cert_id}.svg",
-            "pdf_url": f"https://50.28.86.131/bcos/cert/{cert_id}.pdf",
+            "badge_url": _bcos_url(f"/bcos/badge/{cert_id}.svg"),
+            "pdf_url": _bcos_url(f"/bcos/cert/{cert_id}.pdf"),
         })
     except Exception as e:
         import logging
@@ -464,8 +469,8 @@ def bcos_directory():
                 "reviewer": row["reviewer"],
                 "anchored_epoch": row["anchored_epoch"],
                 "created_at": row["created_at"],
-                "verify_url": f"https://rustchain.org/bcos/verify/{row['cert_id']}",
-                "badge_url": f"https://50.28.86.131/bcos/badge/{row['cert_id']}.svg",
+                "verify_url": _bcos_url(f"/bcos/verify/{row['cert_id']}"),
+                "badge_url": _bcos_url(f"/bcos/badge/{row['cert_id']}.svg"),
             })
 
         return jsonify({

--- a/tests/test_bcos_public_urls.py
+++ b/tests/test_bcos_public_urls.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BCOS_ROUTES = ROOT / "node" / "bcos_routes.py"
+
+
+def _source() -> str:
+    return BCOS_ROUTES.read_text(encoding="utf-8")
+
+
+def test_bcos_routes_use_certificate_valid_public_base_url():
+    source = _source()
+    assert (
+        'BCOS_PUBLIC_BASE_URL = os.environ.get("BCOS_PUBLIC_BASE_URL", '
+        '"https://rustchain.org").rstrip("/")'
+    ) in source
+    assert "def _bcos_url(path: str) -> str:" in source
+    assert "https://50.28.86.131/bcos" not in source
+
+
+def test_bcos_response_links_use_shared_url_helper():
+    source = _source()
+    assert '"verify_url": _bcos_url(f"/bcos/verify/{cert_id}")' in source
+    assert '"badge_url": _bcos_url(f"/bcos/badge/{cert_id}.svg")' in source
+    assert '"pdf_url": _bcos_url(f"/bcos/cert/{cert_id}.pdf")' in source
+    assert '"verify_url": _bcos_url(f"/bcos/verify/{row[\'cert_id\']}")' in source
+    assert '"badge_url": _bcos_url(f"/bcos/badge/{row[\'cert_id\']}.svg")' in source
+


### PR DESCRIPTION
## Summary
- centralize BCOS public URL generation behind a certificate-valid public base URL
- return `https://rustchain.org` badge/PDF links by default instead of bare-IP HTTPS links
- add static regression coverage for BCOS public URL generation

Closes #4462

## Validation
- `python -m pytest tests/test_bcos_public_urls.py tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile node/bcos_routes.py node/utxo_db.py tests/test_bcos_public_urls.py`
- `git diff --check`
