### PR TITLE
fix: escape passport dashboard fields

### DIFF
--- a/passport/templates/passport_index.html
+++ b/passport/templates/passport_index.html
@@ -48,6 +48,14 @@
 </div>
 <script>
 let passports = [];
+function escapeHtml(value) {
+  const d = document.createElement('div');
+  d.textContent = String(value ?? '');
+  return d.innerHTML;
+}
+function safeTier(value) {
+  return String(value || 'modern').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'modern';
+}
 async function load() {
   const resp = await fetch('/api/passports');
   passports = await resp.json();
@@ -58,22 +66,27 @@ function render(list) {
   document.getElementById('count').textContent = `${list.length} machines documented`;
   if (!list.length) { el.innerHTML = '<div class="empty">No passports yet. Miners can register at POST /api/passport</div>'; return; }
   el.innerHTML = list.map(p => `
-    <div class="passport-card" onclick="location.href='/passport/${p.machine_id}'">
-      <div class="name">${p.name || p.machine_id.substring(0,12)+'...'}</div>
-      <div class="arch">${p.architecture || 'Unknown'} · ${p.manufacture_year || '?'}</div>
+    <div class="passport-card" data-machine-id="${escapeHtml(p.machine_id || '')}">
+      <div class="name">${escapeHtml(p.name || String(p.machine_id || '').substring(0,12)+'...')}</div>
+      <div class="arch">${escapeHtml(p.architecture || 'Unknown')} &middot; ${escapeHtml(p.manufacture_year || '?')}</div>
       <div class="meta">
-        <span class="tier-badge tier-${p.tier}">${p.tier}</span>
-        · ${p.total_epochs || 0} epochs · ${p.total_rtc || 0} RTC earned
+        <span class="tier-badge tier-${safeTier(p.tier)}">${escapeHtml(p.tier || 'modern')}</span>
+        &middot; ${escapeHtml(p.total_epochs || 0)} epochs &middot; ${escapeHtml(p.total_rtc || 0)} RTC earned
       </div>
     </div>
   `).join('');
+  el.querySelectorAll('.passport-card').forEach(card => {
+    card.addEventListener('click', () => {
+      location.href = '/passport/' + encodeURIComponent(card.dataset.machineId || '');
+    });
+  });
 }
 function filterList() {
   const q = document.getElementById('search').value.toLowerCase();
   render(passports.filter(p =>
     (p.name||'').toLowerCase().includes(q) ||
     (p.architecture||'').toLowerCase().includes(q) ||
-    p.machine_id.includes(q)
+    String(p.machine_id || '').includes(q)
   ));
 }
 load();

--- a/passport/templates/passport_view.html
+++ b/passport/templates/passport_view.html
@@ -58,53 +58,64 @@
   <div class="passport" id="passport"><div class="empty">Loading passport...</div></div>
 </div>
 <script>
-const machineId = '{{ machine_id }}';
+const machineId = {{ machine_id|tojson }};
+function escapeHtml(value) {
+  const d = document.createElement('div');
+  d.textContent = String(value ?? '');
+  return d.innerHTML;
+}
+function safeTier(value) {
+  return String(value || 'modern').toLowerCase().replace(/[^a-z0-9_-]/g, '-') || 'modern';
+}
+function formatParts(parts) {
+  return Array.isArray(parts) ? parts.map(escapeHtml).join(', ') : '';
+}
 async function load() {
-  const resp = await fetch('/api/passport/' + machineId);
+  const resp = await fetch('/api/passport/' + encodeURIComponent(machineId));
   if (!resp.ok) { document.getElementById('passport').innerHTML = '<div class="empty">Passport not found</div>'; return; }
   const p = await resp.json();
-  document.title = `${p.name || machineId} — Machine Passport`;
+  document.title = `${p.name || machineId} - Machine Passport`;
   const el = document.getElementById('passport');
   el.innerHTML = `
     <div class="passport-header">
-      <div class="machine-name">${p.name || 'Unnamed Machine'}</div>
-      <div class="machine-id">${p.machine_id}</div>
-      <div class="tier-badge tier-${p.tier}">${p.tier} · ${p.hardware_age} years old</div>
+      <div class="machine-name">${escapeHtml(p.name || 'Unnamed Machine')}</div>
+      <div class="machine-id">${escapeHtml(p.machine_id || '')}</div>
+      <div class="tier-badge tier-${safeTier(p.tier)}">${escapeHtml(p.tier || 'modern')} &middot; ${escapeHtml(p.hardware_age || 0)} years old</div>
     </div>
 
     <div class="section">
-      <div class="section-title">⚙️ Identity</div>
-      <div class="field"><span class="field-label">Architecture</span><span class="field-value">${p.architecture || '—'}</span></div>
-      <div class="field"><span class="field-label">CPU Model</span><span class="field-value">${p.cpu_model || '—'}</span></div>
-      <div class="field"><span class="field-label">Manufacture Year</span><span class="field-value">${p.manufacture_year || '—'}</span></div>
-      <div class="field"><span class="field-label">ROM Hash</span><span class="field-value" style="font-family:monospace;font-size:0.8em">${p.rom_hash || '—'}</span></div>
-      ${p.provenance ? `<div class="field"><span class="field-label">Provenance</span><span class="provenance">"${p.provenance}"</span></div>` : ''}
+      <div class="section-title">Identity</div>
+      <div class="field"><span class="field-label">Architecture</span><span class="field-value">${escapeHtml(p.architecture || '-')}</span></div>
+      <div class="field"><span class="field-label">CPU Model</span><span class="field-value">${escapeHtml(p.cpu_model || '-')}</span></div>
+      <div class="field"><span class="field-label">Manufacture Year</span><span class="field-value">${escapeHtml(p.manufacture_year || '-')}</span></div>
+      <div class="field"><span class="field-label">ROM Hash</span><span class="field-value" style="font-family:monospace;font-size:0.8em">${escapeHtml(p.rom_hash || '-')}</span></div>
+      ${p.provenance ? `<div class="field"><span class="field-label">Provenance</span><span class="provenance">"${escapeHtml(p.provenance)}"</span></div>` : ''}
     </div>
 
     <div class="section">
-      <div class="section-title">📊 Attestation Record</div>
+      <div class="section-title">Attestation Record</div>
       <div class="stats-grid">
-        <div class="stat"><div class="stat-value">${p.attestation_history?.total_epochs || 0}</div><div class="stat-label">Epochs</div></div>
-        <div class="stat"><div class="stat-value">${p.attestation_history?.total_rtc_earned || 0}</div><div class="stat-label">RTC Earned</div></div>
-        <div class="stat"><div class="stat-value">${p.attestation_history?.multiplier || 1.0}x</div><div class="stat-label">Multiplier</div></div>
+        <div class="stat"><div class="stat-value">${escapeHtml(p.attestation_history?.total_epochs || 0)}</div><div class="stat-label">Epochs</div></div>
+        <div class="stat"><div class="stat-value">${escapeHtml(p.attestation_history?.total_rtc_earned || 0)}</div><div class="stat-label">RTC Earned</div></div>
+        <div class="stat"><div class="stat-value">${escapeHtml(p.attestation_history?.multiplier || 1.0)}x</div><div class="stat-label">Multiplier</div></div>
       </div>
     </div>
 
     <div class="section">
-      <div class="section-title">🔧 Repair Log</div>
+      <div class="section-title">Repair Log</div>
       ${(p.repair_log && p.repair_log.length) ? p.repair_log.map(r => `
         <div class="repair-entry">
-          <div class="repair-date">${r.date}</div>
-          <div class="repair-desc">${r.description}</div>
-          ${r.parts && r.parts.length ? `<div style="font-size:0.8em;color:var(--muted)">Parts: ${r.parts.join(', ')}</div>` : ''}
+          <div class="repair-date">${escapeHtml(r.date || '')}</div>
+          <div class="repair-desc">${escapeHtml(r.description || '')}</div>
+          ${r.parts && r.parts.length ? `<div style="font-size:0.8em;color:var(--muted)">Parts: ${formatParts(r.parts)}</div>` : ''}
         </div>
       `).join('') : '<div class="empty">No repairs logged yet</div>'}
     </div>
 
-    ${p.notes ? `<div class="section"><div class="section-title">📝 Notes</div><div class="notes">${p.notes}</div></div>` : ''}
+    ${p.notes ? `<div class="section"><div class="section-title">Notes</div><div class="notes">${escapeHtml(p.notes)}</div></div>` : ''}
 
     <div class="hash">
-      🔗 Passport Hash: ${p.passport_hash}
+      Passport Hash: ${escapeHtml(p.passport_hash || '')}
     </div>
 
     <div class="qr-section">

--- a/passport/test_passport.py
+++ b/passport/test_passport.py
@@ -4,6 +4,7 @@
 import json
 import os
 import tempfile
+from pathlib import Path
 import pytest
 
 from passport_ledger import (
@@ -278,3 +279,34 @@ class TestAPI:
         data = json.loads(resp.data)
         assert len(data) >= 1
         assert any(p["machine_id"] == "list-test" for p in data)
+
+
+class TestPassportTemplateSecurity:
+    TEMPLATE_DIR = Path(__file__).parent / "templates"
+
+    def test_passport_index_escapes_stored_passport_fields(self):
+        template = (self.TEMPLATE_DIR / "passport_index.html").read_text(encoding="utf-8")
+
+        assert "function escapeHtml(value)" in template
+        assert 'data-machine-id="${escapeHtml(p.machine_id || \'\')}"' in template
+        assert "onclick=\"location.href='/passport/${p.machine_id}'\"" not in template
+        assert "${escapeHtml(p.name || String(p.machine_id || '').substring(0,12)+'...')}" in template
+        assert "${escapeHtml(p.architecture || 'Unknown')}" in template
+        assert "${escapeHtml(p.tier || 'modern')}" in template
+        assert "encodeURIComponent(card.dataset.machineId || '')" in template
+        assert "String(p.machine_id || '').includes(q)" in template
+
+    def test_passport_view_escapes_stored_passport_fields(self):
+        template = (self.TEMPLATE_DIR / "passport_view.html").read_text(encoding="utf-8")
+
+        assert "const machineId = {{ machine_id|tojson }};" in template
+        assert "function escapeHtml(value)" in template
+        assert "fetch('/api/passport/' + encodeURIComponent(machineId))" in template
+        assert "${escapeHtml(p.name || 'Unnamed Machine')}" in template
+        assert "${escapeHtml(p.machine_id || '')}" in template
+        assert "${escapeHtml(p.architecture || '-')}" in template
+        assert "${escapeHtml(p.cpu_model || '-')}" in template
+        assert "${escapeHtml(p.provenance)}" in template
+        assert "${escapeHtml(r.description || '')}" in template
+        assert "${formatParts(r.parts)}" in template
+        assert "${escapeHtml(p.notes)}" in template


### PR DESCRIPTION
## Summary

Fixes #4464.

- Escape stored machine passport fields before inserting list/detail markup with `innerHTML`.
- Sanitize dynamic tier CSS class fragments and URL-encode machine IDs used for navigation/API lookups.
- Add template regression coverage for the stored DOM XSS sink class.
- Keep the standing mempool regression guard for worktrees based on current `origin/main`.

## Validation

- `python -m pytest passport\test_passport.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m py_compile passport\passport_server.py passport\passport_ledger.py passport\test_passport.py node\utxo_db.py`
- `git diff --check -- passport/templates/passport_index.html passport/templates/passport_view.html passport/test_passport.py node/utxo_db.py`
