### PR TITLE
fix: fail closed on unverified Beacon x402 payments

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -8,14 +8,12 @@ Usage in beacon_chat.py:
 """
 
 import hmac
-import json
 import logging
 import os
 import sqlite3
 import time
 
-from flask import g, jsonify, request
-from functools import wraps
+from flask import jsonify, request
 
 log = logging.getLogger("beacon.x402")
 
@@ -127,20 +125,25 @@ def _check_x402_payment(price_str, action_name):
             }
         }, 402)
 
-    # Log payment
-    try:
-        db = g.get("db")
-        if db:
-            db.execute(
-                "INSERT INTO x402_beacon_payments (payer_address, action, amount_usdc, created_at) "
-                "VALUES (?, ?, ?, ?)",
-                ("unknown", action_name, price_str, time.time()),
-            )
-            db.commit()
-    except Exception as e:
-        log.debug(f"Payment logging failed: {e}")
-
-    return True, None
+    log.warning(
+        "Rejected unverified x402 payment header for action=%s price=%s",
+        action_name,
+        price_str,
+    )
+    return False, _cors_json({
+        "error": "Payment verification unavailable",
+        "message": "Beacon x402 payments must fail closed until a verifier is configured.",
+        "x402": {
+            "version": "1",
+            "network": X402_NETWORK,
+            "facilitator": FACILITATOR_URL,
+            "payTo": BEACON_TREASURY,
+            "maxAmountRequired": price_str,
+            "asset": USDC_BASE,
+            "resource": request.url,
+            "description": f"Beacon Atlas: {action_name}",
+        }
+    }, 503)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_beacon_x402_payment_gate.py
+++ b/tests/test_beacon_x402_payment_gate.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+from flask import Flask
+
+import beacon_x402
+
+
+def _make_paid_beacon_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "beacon.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(beacon_x402.X402_BEACON_SCHEMA)
+        conn.execute("CREATE TABLE reputation (agent_id TEXT, score REAL)")
+        conn.execute("INSERT INTO reputation VALUES (?, ?)", ("agent-victim", 99.9))
+
+    monkeypatch.setattr(beacon_x402, "X402_CONFIG_OK", True)
+    monkeypatch.setattr(beacon_x402, "PRICE_REPUTATION_EXPORT", "0.01", raising=False)
+    monkeypatch.setattr(beacon_x402, "PRICE_BEACON_CONTRACT", "0.05", raising=False)
+    monkeypatch.setattr(beacon_x402, "X402_NETWORK", "base-sepolia", raising=False)
+    monkeypatch.setattr(
+        beacon_x402,
+        "FACILITATOR_URL",
+        "https://facilitator.invalid",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        beacon_x402,
+        "BEACON_TREASURY",
+        "0x1111111111111111111111111111111111111111",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        beacon_x402,
+        "USDC_BASE",
+        "0x2222222222222222222222222222222222222222",
+        raising=False,
+    )
+    monkeypatch.setattr(beacon_x402, "SWAP_INFO", {"network": "Base"}, raising=False)
+    monkeypatch.setattr(beacon_x402, "has_cdp_credentials", lambda: True, raising=False)
+    monkeypatch.setattr(
+        beacon_x402,
+        "is_free",
+        lambda price: str(price) in ("0", "0.0", "0.00", ""),
+        raising=False,
+    )
+    monkeypatch.setattr(beacon_x402, "_run_migrations", lambda _db_path: None)
+
+    def get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    beacon_x402.init_app(app, get_db)
+    return app.test_client(), db_path
+
+
+def test_paid_beacon_reputation_without_payment_returns_x402_challenge(tmp_path, monkeypatch):
+    client, _db_path = _make_paid_beacon_client(tmp_path, monkeypatch)
+
+    response = client.get("/api/premium/reputation")
+
+    body = response.get_json()
+    assert response.status_code == 402
+    assert body["error"] == "Payment Required"
+    assert body["x402"]["maxAmountRequired"] == "0.01"
+    assert body["x402"]["payTo"] == "0x1111111111111111111111111111111111111111"
+
+
+def test_paid_beacon_reputation_rejects_unverified_payment_header(tmp_path, monkeypatch):
+    client, db_path = _make_paid_beacon_client(tmp_path, monkeypatch)
+
+    response = client.get(
+        "/api/premium/reputation",
+        headers={"X-PAYMENT": "bogus-not-json-not-signed-not-facilitated"},
+    )
+
+    body = response.get_json()
+    assert response.status_code == 503
+    assert body["error"] == "Payment verification unavailable"
+    assert "reputation" not in body
+
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM x402_beacon_payments").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L2` requested for security-sensitive x402/payment logic
- [x] If adding new code files, include SPDX header near the top
- [x] Provide test evidence (commands + output below)

## What Changed

- Fail closed when a paid Beacon endpoint receives an `X-PAYMENT` header but no verifier is wired in.
- Stop treating header presence as successful payment and stop writing fake `payer_address = unknown` payment rows before verification.
- Add regression coverage for the paid `/api/premium/reputation` path:
  - no payment header still returns the x402 `402 Payment Required` challenge
  - garbage/unverified payment headers return `503` and do not expose premium data or log a payment

This patches the Beacon x402 bypass documented in `audits/beacon_x402_header_presence_bypass_66.md` and relates to `Scottcjn/rustchain-bounties#66`.

No live node or production testing was performed; this was verified locally in line with the #66 bounty rule to test locally or on a test node only.

## Testing / Evidence

```text
PYTHONPATH=node uv run --no-project --with pytest --with flask python -m pytest node/tests/test_x402_admin_key_compare.py tests/test_beacon_x402_payment_gate.py -q
....                                                                     [100%]
4 passed in 0.08s
```

```text
python3 -m py_compile node/beacon_x402.py tests/test_beacon_x402_payment_gate.py
```

```text
git diff --check -- node/beacon_x402.py tests/test_beacon_x402_payment_gate.py
```
