### PR TITLE
test: cover legacy OS badge detection

### DIFF
--- a/tools/test_os_detector.py
+++ b/tools/test_os_detector.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "os_detector.py"
+spec = importlib.util.spec_from_file_location("os_detector", MODULE_PATH)
+os_detector = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(os_detector)
+
+
+class FixedDateTime:
+    @staticmethod
+    def utcnow():
+        class FixedNow:
+            @staticmethod
+            def isoformat():
+                return "2026-05-11T12:00:00"
+
+        return FixedNow()
+
+
+def test_detect_legacy_os_badges_detects_multiple_matching_environments():
+    directory_listing = "System Folder\nFinder\nwin.ini\nprogman.exe\n"
+
+    with patch.object(
+        os_detector.subprocess,
+        "check_output",
+        return_value=directory_listing.encode(),
+    ), patch.object(os_detector, "datetime", FixedDateTime):
+        result = os_detector.detect_legacy_os_badges()
+
+    assert [badge["title"] for badge in result["badges"]] == [
+        "MacInitiate",
+        "Progman Pioneer",
+    ]
+    assert all(badge["class"] == "OS Relic" for badge in result["badges"])
+    assert result["badges"][0]["rarity"] == "Legendary"
+    assert result["badges"][1]["emotional_resonance"]["timestamp"] == (
+        "2026-05-11T12:00:00Z"
+    )
+
+
+def test_detect_legacy_os_badges_returns_empty_list_when_directory_probe_fails():
+    with patch.object(
+        os_detector.subprocess,
+        "check_output",
+        side_effect=OSError("dir unavailable"),
+    ):
+        result = os_detector.detect_legacy_os_badges()
+
+    assert result == {"badges": []}


### PR DESCRIPTION
## Summary
- Adds pytest coverage for `tools/os_detector.py` legacy badge detection.
- Covers multiple matching legacy environments in one directory probe.
- Covers the edge case where the directory probe fails and no badges are emitted.

## Bounty
Refs Scottcjn/rustchain-bounties#1589.

## Test Plan
- `python -m pytest tools/test_os_detector.py -q`
