### PR TITLE
fix: keep account reward units in micro rtc

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2889,8 +2889,10 @@ def current_slot():
 
 def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
     """Finalize epoch and distribute rewards with security hardening"""
+    from contextlib import closing
+    from decimal import Decimal, ROUND_DOWN
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with closing(sqlite3.connect(DB_PATH)) as conn:
         c = conn.cursor()
 
         # REPLAY PROTECTION: Check if epoch already settled

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1028,6 +1028,8 @@ PER_EPOCH_RTC = 1.5  # Total RTC distributed per epoch across all miners
 PER_BLOCK_RTC = PER_EPOCH_RTC / EPOCH_SLOTS  # ~0.0104 RTC per block
 TOTAL_SUPPLY_RTC = 8_388_608  # Exactly 2**23 — pure binary, immutable
 TOTAL_SUPPLY_URTC = int(TOTAL_SUPPLY_RTC * 1_000_000)  # 8,388,608,000,000 uRTC
+ACCOUNT_UNIT = 1_000_000  # balances.amount_i64 uses micro-RTC.
+UTXO_UNIT = 100_000_000   # UTXO values use nano-RTC.
 ENFORCE = False  # Start with enforcement off
 CHAIN_ID = "rustchain-mainnet-v2"
 MIN_WITHDRAWAL = 0.1  # RTC
@@ -2990,15 +2992,17 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
 
             # Distribute rewards with precision
             for pk, weight in miners:
-                amount_decimal = Decimal(0) if total_weight == 0 else total_reward * Decimal(weight) / Decimal(total_weight)
-                amount_i64 = int(amount_decimal * Decimal(100000000))
+                # Use Decimal arithmetic to avoid float precision loss
+                amount_decimal = Decimal(0) if Decimal(total_weight) == 0 else total_reward * Decimal(weight) / Decimal(total_weight)
+                amount_i64 = int(amount_decimal * Decimal(ACCOUNT_UNIT))
+                amount_nrtc = int(amount_decimal * Decimal(UTXO_UNIT))
 
-                # OVERFLOW PROTECTION: Ensure amount_i64 fits in signed 64-bit int
-                if amount_i64 >= 2**63:
+                # OVERFLOW PROTECTION: Ensure stored reward units fit in signed 64-bit int
+                if amount_i64 >= 2**63 or amount_nrtc >= 2**63:
                     raise ValueError(f"Reward overflow for miner {pk}: {amount_i64}")
 
                 c.execute(
-                    "UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 100000000.0 WHERE miner_id = ?",
+                    "UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?",
                     (amount_i64, amount_i64, pk)
                 )
 
@@ -3010,7 +3014,7 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                     utxo_tx = {
                         "tx_type": "mining_reward",
                         "inputs": [],
-                        "outputs": [{"address": pk, "value_nrtc": amount_i64}],
+                        "outputs": [{"address": pk, "value_nrtc": amount_nrtc}],
                         "_allow_minting": True
                     }
                     utxo_ok = UtxoDB(DB_PATH).apply_transaction(
@@ -5537,7 +5541,7 @@ def bounty_multiplier():
             ("founder_community",)
         ).fetchone()
         total_paid_urtc = row[0] if row else 0
-        total_paid_rtc = total_paid_urtc / 100000000.0
+        total_paid_rtc = total_paid_urtc / ACCOUNT_UNIT
 
         # Current balance
         bal_row = c.execute(
@@ -7107,7 +7111,7 @@ def confirm_pending():
                 # Execute the actual transfer
                 c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (to_m,))
                 c.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?", (amount, from_m))
-                c.execute("UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 100000000.0 WHERE miner_id = ?", (amount, amount, to_m))
+                c.execute("UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?", (amount, amount, to_m))
                 
                 # Log to IMMUTABLE ledger (the real chain!)
                 c.execute("""
@@ -7245,7 +7249,7 @@ def wallet_transfer_OLD():
 
         c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (to_miner,))
         c.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?", (amount_i64, from_miner))
-        c.execute("UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 100000000.0 WHERE miner_id = ?", (amount_i64, amount_i64, to_miner))
+        c.execute("UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?", (amount_i64, amount_i64, to_miner))
 
         sender_new = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (from_miner,)).fetchone()[0]
         recipient_new = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (to_miner,)).fetchone()[0]

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -1,0 +1,180 @@
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class _NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+class TestIntegratedBalanceScale(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._import_tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._import_tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0" * 32
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        import prometheus_client
+
+        prev_metrics = (
+            prometheus_client.Counter,
+            prometheus_client.Gauge,
+            prometheus_client.Histogram,
+        )
+        prometheus_client.Counter = _NoopMetric
+        prometheus_client.Gauge = _NoopMetric
+        prometheus_client.Histogram = _NoopMetric
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_balance_scale_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(cls.mod)
+        finally:
+            (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            ) = prev_metrics
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._import_tmp.cleanup()
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self._tmp.name, "scale.db")
+        self._prev_module_db = self.mod.DB_PATH
+        self._prev_utxo_dual_write = self.mod.UTXO_DUAL_WRITE
+        self._prev_utxo_db = self.mod.UtxoDB
+        self.mod.DB_PATH = self.db_path
+        self.mod.UTXO_DUAL_WRITE = False
+        self._init_db()
+
+    def tearDown(self):
+        self.mod.DB_PATH = self._prev_module_db
+        self.mod.UTXO_DUAL_WRITE = self._prev_utxo_dual_write
+        self.mod.UtxoDB = self._prev_utxo_db
+        self._tmp.cleanup()
+
+    def _init_db(self):
+        with sqlite3.connect(self.db_path) as db:
+            db.executescript(
+                """
+                CREATE TABLE epoch_state (
+                    epoch INTEGER PRIMARY KEY,
+                    settled INTEGER DEFAULT 0,
+                    settled_ts INTEGER
+                );
+                CREATE TABLE epoch_enroll (
+                    epoch INTEGER,
+                    miner_pk TEXT,
+                    weight REAL,
+                    PRIMARY KEY (epoch, miner_pk)
+                );
+                CREATE TABLE miner_attest_recent (
+                    miner TEXT PRIMARY KEY,
+                    fingerprint_checks_json TEXT
+                );
+                CREATE TABLE balances (
+                    miner_id TEXT PRIMARY KEY,
+                    amount_i64 INTEGER DEFAULT 0,
+                    balance_rtc REAL DEFAULT 0
+                );
+                """
+            )
+            db.execute(
+                "INSERT INTO epoch_state (epoch, settled) VALUES (?, 0)",
+                (7,),
+            )
+            db.execute(
+                "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                (7, "miner-scale", 1.0),
+            )
+            db.execute(
+                "INSERT INTO miner_attest_recent (miner, fingerprint_checks_json) VALUES (?, ?)",
+                ("miner-scale", "{}"),
+            )
+            db.execute(
+                "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
+                ("miner-scale",),
+            )
+
+    def _stored_balance(self):
+        with sqlite3.connect(self.db_path) as db:
+            return db.execute(
+                "SELECT amount_i64, balance_rtc FROM balances WHERE miner_id = ?",
+                ("miner-scale",),
+            ).fetchone()
+
+    def test_finalize_epoch_writes_account_rewards_in_micro_rtc(self):
+        self.mod.finalize_epoch(7, 0.01, b"")
+
+        amount_i64, balance_rtc = self._stored_balance()
+        self.assertEqual(amount_i64, 1_440_000)
+        self.assertEqual(amount_i64, int(1.44 * self.mod.ACCOUNT_UNIT))
+        self.assertAlmostEqual(balance_rtc, 1.44)
+
+    def test_finalize_epoch_keeps_utxo_rewards_in_nano_rtc(self):
+        calls = []
+
+        class FakeUtxoDB:
+            def __init__(self, db_path):
+                self.db_path = db_path
+
+            def apply_transaction(self, tx, height, conn=None):
+                calls.append((self.db_path, tx, height, conn))
+                return True
+
+        self.mod.UTXO_DUAL_WRITE = True
+        self.mod.UtxoDB = FakeUtxoDB
+
+        self.mod.finalize_epoch(7, 0.01, b"")
+
+        amount_i64, balance_rtc = self._stored_balance()
+        self.assertEqual(amount_i64, 1_440_000)
+        self.assertAlmostEqual(balance_rtc, 1.44)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], 144_000_000)
+        self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], int(1.44 * self.mod.UTXO_UNIT))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -160,7 +160,7 @@ class TestIntegratedBalanceScale(unittest.TestCase):
                 self.db_path = db_path
 
             def apply_transaction(self, tx, height, conn=None):
-                calls.append((self.db_path, tx, height, conn))
+                calls.append((self.db_path, tx, height, conn is not None))
                 return True
 
         self.mod.UTXO_DUAL_WRITE = True
@@ -174,6 +174,7 @@ class TestIntegratedBalanceScale(unittest.TestCase):
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], 144_000_000)
         self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], int(1.44 * self.mod.UTXO_UNIT))
+        self.assertTrue(calls[0][3])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #4488.

## Summary
- defines separate account and UTXO unit constants for integrated node reward settlement
- credits `balances.amount_i64` mining rewards in micro-RTC, matching wallet/governance/account-model reads
- preserves UTXO dual-write reward outputs in nano-RTC and aligns related `balance_rtc` mirror math

## Validation
- `uv run --no-project --with pytest --with flask --with prometheus-client --with requests --with PyNaCl python -m pytest node/tests/test_integrated_balance_scale.py node/tests/test_epoch_utxo_dual_write_guard.py -q` -> 5 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_balance_scale.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_balance_scale.py`

## Security impact
Before this change, `finalize_epoch()` wrote account balances at the UTXO nano-RTC scale while account-model readers divide `amount_i64` by 1,000,000. A 1.44 RTC epoch reward could therefore appear as 144 RTC in governance/account paths. The regression test now verifies the same reward stores `amount_i64 = 1_440_000` while the optional UTXO output remains `144_000_000` nRTC.
