### PR TITLE
fix: hide Hall of Rust error details

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -10,8 +10,10 @@ import sqlite3
 import hashlib
 import time
 import json
+import logging
 
 hall_bp = Blueprint('hall_of_rust', __name__)
+logger = logging.getLogger(__name__)
 
 # Rust Score calculation weights
 RUST_WEIGHTS = {
@@ -233,8 +235,8 @@ def induct_machine():
             'capacitor_plague': is_plague
         })
         
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("induct_machine")
 
 @hall_bp.route('/hall/machine/<fingerprint>', methods=['GET'])
 def get_machine(fingerprint):
@@ -254,8 +256,8 @@ def get_machine(fingerprint):
             return jsonify({'error': 'Machine not found in Hall of Rust'}), 404
         
         return jsonify(dict(row))
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("get_machine")
 
 @hall_bp.route('/hall/leaderboard', methods=['GET'])
 def rust_leaderboard():
@@ -293,8 +295,8 @@ def rust_leaderboard():
             'total_machines': len(leaderboard),
             'generated_at': int(time.time())
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("rust_leaderboard")
 
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
@@ -330,8 +332,8 @@ def set_eulogy(fingerprint):
         
         conn.close()
         return jsonify({'ok': True, 'message': 'Memorial updated'})
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("set_eulogy")
 
 @hall_bp.route('/hall/stats', methods=['GET'])
 def hall_stats():
@@ -370,8 +372,8 @@ def hall_stats():
         
         conn.close()
         return jsonify(stats)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("hall_stats")
 
 def get_rust_badge(score):
     """Get a badge based on Rust Score."""
@@ -437,6 +439,11 @@ def _table_exists(cursor, table_name):
     return row is not None
 
 
+def _internal_error_response(context):
+    logger.exception("Hall of Rust endpoint failed: %s", context)
+    return jsonify({'error': 'internal_error'}), 500
+
+
 @hall_bp.route('/api/hall_of_fame/leaderboard', methods=['GET'])
 def api_hall_of_fame_leaderboard():
     """Leaderboard endpoint for Hall of Fame index page.
@@ -492,8 +499,8 @@ def api_hall_of_fame_leaderboard():
             'total_machines': len(leaderboard),
             'generated_at': int(time.time()),
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("api_hall_of_fame_leaderboard")
 
 
 @hall_bp.route('/api/hall_of_fame/machine', methods=['GET'])
@@ -616,8 +623,8 @@ def api_hall_of_fame_machine():
             'reward_participation': reward_participation,
             'generated_at': now,
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("api_hall_of_fame_machine")
 
 def register_hall_endpoints(app, db_path):
     """Register Hall of Rust endpoints with Flask app."""
@@ -685,8 +692,8 @@ def machine_of_the_day():
         machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
         
         return jsonify(machine)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("machine_of_the_day")
 
 @hall_bp.route('/hall/fleet_breakdown', methods=['GET'])
 def fleet_breakdown():
@@ -725,8 +732,8 @@ def fleet_breakdown():
             'total_architectures': len(breakdown),
             'generated_at': int(time.time())
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("fleet_breakdown")
 
 @hall_bp.route('/hall/timeline', methods=['GET'])
 def hall_timeline():
@@ -761,5 +768,5 @@ def hall_timeline():
             'timeline': timeline,
             'generated_at': int(time.time())
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        return _internal_error_response("hall_timeline")

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+import sqlite3
+import sys
+
+from flask import Flask
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "node"))
+
+import hall_of_rust  # noqa: E402
+
+
+def _client_for(db_path):
+    app = Flask(__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(hall_of_rust.hall_bp)
+    return app.test_client()
+
+
+def test_hall_stats_hides_sqlite_error_details(tmp_path):
+    db_path = tmp_path / "missing_schema.db"
+    sqlite3.connect(db_path).close()
+    client = _client_for(db_path)
+
+    response = client.get("/hall/stats")
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "internal_error"}
+    body = response.get_data(as_text=True)
+    assert "no such table" not in body
+    assert "hall_of_rust" not in body
+
+
+def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    client = _client_for(db_path)
+
+    response = client.get("/hall/stats")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["total_machines"] == 0
+    assert body["total_attestations"] == 0
+    assert body["average_rust_score"] == 0


### PR DESCRIPTION
## Summary
- replace Hall of Rust user-facing `str(e)` responses with a logged generic `internal_error` payload
- cover the missing-table SQLite repro so schema details like `no such table: hall_of_rust` are not returned to callers
- preserve normal empty Hall stats behavior

Related to #3202. This is intentionally scoped to `node/hall_of_rust.py` and avoids overlap with the open Beacon/BFT info-leak PR.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_hall_of_rust_error_responses.py -q` -> 2 passed
- `python3 -m py_compile node/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py`
- `rg -n "jsonify\(\{'error': str\(e\)\}\)|jsonify\(\{\"error\": str\(e\)\}\)" node/hall_of_rust.py` -> no matches
- `git diff --check -- node/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py`

## Security impact
Before this change, Hall of Rust endpoints could return raw exception text to API callers. The regression test forces a missing-table SQLite error and verifies the response is only `{"error": "internal_error"}` without schema names or SQLite exception text.

Bounty handling: please use GitHub contributor identity; no payment details are included in this PR.
