### PR TITLE
fix: guard mock signatures outside test runtimes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -68,6 +68,15 @@ except Exception as _e:
 # Ed25519 signature verification
 TESTNET_ALLOW_INLINE_PUBKEY = False  # PRODUCTION: Disabled
 TESTNET_ALLOW_MOCK_SIG = False  # PRODUCTION: Disabled
+_MOCK_SIG_ALLOWED_ENVS = {"test", "testing", "dev", "development", "local", "testnet"}
+
+
+def enforce_mock_signature_runtime_guard():
+    runtime_env = (os.environ.get("RC_RUNTIME_ENV") or os.environ.get("RUSTCHAIN_ENV") or "production").strip().lower()
+    if TESTNET_ALLOW_MOCK_SIG and runtime_env not in _MOCK_SIG_ALLOWED_ENVS:
+        raise RuntimeError(
+            "TESTNET_ALLOW_MOCK_SIG must not be enabled outside test/dev runtimes"
+        )
 
 try:
     from nacl.signing import VerifyKey
@@ -7608,6 +7617,8 @@ def beacon_envelopes_list():
     return jsonify({"ok": True, "count": len(envelopes), "envelopes": envelopes})
 
 if __name__ == "__main__":
+    enforce_mock_signature_runtime_guard()
+
     # CRITICAL: SR25519 library is REQUIRED for production
     if not SR25519_AVAILABLE:
         print("=" * 70, file=sys.stderr)


### PR DESCRIPTION
## Summary
- add the missing `enforce_mock_signature_runtime_guard()` expected by the existing mock-signature regression tests
- fail closed if `TESTNET_ALLOW_MOCK_SIG` is enabled outside explicit test/dev runtimes
- call the guard during normal node startup before DB initialization

## Security impact
This preserves the intended BuilderFred audit fix for mock signature mode: even if the testnet mock-signature flag is accidentally flipped in a production runtime, startup aborts instead of allowing mock header signatures.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_mock_signature_guard.py -q` -> 2 passed
- `uv run --no-project --with flask python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_mock_signature_guard.py && git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_mock_signature_guard.py` -> passed

Related to Scottcjn/rustchain-bounties#398 Step 2 and the mock-signature-mode hardening item.
