### PR TITLE
fix: register real header pubkeys during signed enrollment

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -182,6 +182,7 @@ def _attest_mapping(value):
 
 
 _ATTEST_MINER_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_ED25519_PUBKEY_HEX_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
 def _attest_text(value):
@@ -198,6 +199,14 @@ def _attest_valid_miner(value):
     text = _attest_text(value)
     if text and _ATTEST_MINER_RE.fullmatch(text):
         return text
+    return None
+
+
+def _valid_ed25519_pubkey_hex(value):
+    """Return normalized Ed25519 public key hex or None."""
+    text = _attest_text(value)
+    if text and _ED25519_PUBKEY_HEX_RE.fullmatch(text):
+        return text.lower()
     return None
 
 
@@ -3556,10 +3565,12 @@ def _submit_attestation_impl():
                 "INSERT OR IGNORE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
                 (epoch, miner, enroll_weight)
             )
-            enroll_conn.execute(
-                "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
-                (miner_id, miner)
-            )
+            header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner)
+            if header_pubkey:
+                enroll_conn.execute(
+                    "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
+                    (miner_id, header_pubkey)
+                )
             enroll_conn.commit()
 
         # Issue #19 temporal consistency only sets a review flag (no hard-fail).
@@ -3785,11 +3796,13 @@ def enroll_epoch():
             (epoch, miner_pk, weight)
         )
 
-        # FIX: Register pubkey in miner_header_keys for block submission
-        c.execute(
-            "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
-            (miner_id, miner_pk)
-        )
+        # Register a real Ed25519 pubkey for block-header verification when available.
+        header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner_pk)
+        if header_pubkey:
+            c.execute(
+                "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
+                (miner_id, header_pubkey)
+            )
 
     app.logger.info(
         f"[RIP-309] epoch={epoch} miner={miner_pk[:20]}... nonce={rotation_eval['measurement_nonce'][:16]} "

--- a/node/tests/test_enroll_signature_verification.py
+++ b/node/tests/test_enroll_signature_verification.py
@@ -170,6 +170,33 @@ class TestEnrollSignatureVerification(unittest.TestCase):
         self.assertTrue(body["ok"])
         self.assertEqual(body["miner_pk"], miner)
 
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id = ?",
+                (miner_id,),
+            ).fetchone()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], pubkey_hex)
+
+    @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
+    def test_auto_enroll_registers_attestation_pubkey(self):
+        """Signed attestation auto-enroll must register the Ed25519 pubkey, not wallet text."""
+        mod, db_path = self._load_module("rustchain_auto_enroll_pubkey", "auto_enroll_pubkey.db")
+
+        miner = "RTC_AUTO_ENROLL_MINER"
+        miner_id = "miner_auto_001"
+        _, pubkey_hex = self._attest_and_get_signing_key(mod, miner, miner_id)
+
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id = ?",
+                (miner_id,),
+            ).fetchone()
+
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], pubkey_hex)
+
     @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
     def test_enrollment_with_wrong_key_rejected(self):
         """Enrollment signed with a different keypair than the attestation must be rejected."""


### PR DESCRIPTION
## Summary
- preserve the Ed25519 public key from signed attestation/enrollment when writing `miner_header_keys`
- stop writing wallet/miner identifiers into the `pubkey_hex` column when they are not real 64-hex public keys
- add regression coverage for signed auto-enroll and explicit signed enrollment header-key registration

## Bug / Impact
Signed attestation auto-enroll and explicit `/epoch/enroll` currently write the wallet/miner string into `miner_header_keys.pubkey_hex`. Later `/headers/ingest_signed` resolves that row when inline pubkeys are unavailable and tries to use the wallet text as an Ed25519 public key, causing legitimate signed header ingestion to fail.

## Validation
- `uv run --no-project --with pytest --with flask --with pynacl python -m pytest node/tests/test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_auto_enroll_registers_attestation_pubkey -q` -> 1 passed
- `uv run --no-project --with pytest --with flask --with pynacl python -m pytest node/tests/test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_signed_enrollment_accepted -q` -> 1 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_enroll_signature_verification.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_enroll_signature_verification.py`

Bounty context: security/bug bounty candidate under #305 / #71.