### PR TITLE
Fix BoTTube feed forwarded-host link poisoning

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -32,6 +32,20 @@ from bottube_feed import (
 feed_bp = Blueprint("bottube_feed", __name__, url_prefix="/api/feed")
 
 
+def _get_base_url() -> str:
+    """Return the public base URL without trusting arbitrary forwarded hosts."""
+    configured_base_url = current_app.config.get("BOTTUBE_PUBLIC_BASE_URL")
+    if configured_base_url:
+        return str(configured_base_url).rstrip("/")
+
+    forwarded_host = request.headers.get("X-Forwarded-Host", "").strip()
+    trusted_hosts = current_app.config.get("TRUSTED_FORWARD_HOSTS") or []
+    if forwarded_host and forwarded_host in trusted_hosts:
+        return f"https://{forwarded_host}"
+
+    return request.host_url.rstrip("/")
+
+
 def _get_db_connection():
     """Get database connection from Flask app config."""
     db_path = current_app.config.get("DB_PATH")
@@ -218,9 +232,7 @@ def rss_feed():
         videos, next_cursor = _fetch_videos(limit=limit, agent=agent, cursor=cursor)
         
         # Get base URL
-        base_url = request.host_url.rstrip("/")
-        if request.headers.get("X-Forwarded-Host"):
-            base_url = f"https://{request.headers['X-Forwarded-Host']}"
+        base_url = _get_base_url()
         
         # Build RSS feed
         feed_title = "BoTTube Videos"
@@ -274,9 +286,7 @@ def atom_feed():
         videos, next_cursor = _fetch_videos(limit=limit, agent=agent, cursor=cursor)
         
         # Get base URL
-        base_url = request.host_url.rstrip("/")
-        if request.headers.get("X-Forwarded-Host"):
-            base_url = f"https://{request.headers['X-Forwarded-Host']}"
+        base_url = _get_base_url()
         
         # Build Atom feed
         feed_title = "BoTTube Videos"
@@ -341,9 +351,7 @@ def feed_index():
     videos, next_cursor = _fetch_videos(limit=limit, agent=agent, cursor=cursor)
     
     # Get base URL
-    base_url = request.host_url.rstrip("/")
-    if request.headers.get("X-Forwarded-Host"):
-        base_url = f"https://{request.headers['X-Forwarded-Host']}"
+    base_url = _get_base_url()
     
     # Auto-detect format
     if "application/rss+xml" in accept_header:

--- a/tests/test_bottube_feed_routes.py
+++ b/tests/test_bottube_feed_routes.py
@@ -193,17 +193,37 @@ class TestFeedRoutes(unittest.TestCase):
             self.assertIn("id", item)
             self.assertIn("title", item)
 
-    def test_forwarded_host_header(self):
-        """Test feed respects X-Forwarded-Host header."""
+    def test_forwarded_host_header_ignored_by_default(self):
+        """Untrusted X-Forwarded-Host values must not poison feed links."""
         response = self.client.get(
             "/api/feed/rss",
-            headers={"X-Forwarded-Host": "custom-domain.com"}
+            headers={"X-Forwarded-Host": "attacker.example"}
         )
         
         self.assertEqual(response.status_code, 200)
         data = response.data.decode("utf-8")
-        # Should use the forwarded host in feed links
-        self.assertIn("custom-domain.com", data)
+        self.assertNotIn("attacker.example", data)
+
+    def test_configured_public_base_url_used_for_feed_links(self):
+        """Deployments can set an explicit public feed base URL."""
+        self.app.config["BOTTUBE_PUBLIC_BASE_URL"] = "https://feeds.example/"
+        response = self.client.get("/api/feed/rss")
+
+        self.assertEqual(response.status_code, 200)
+        data = response.data.decode("utf-8")
+        self.assertIn("https://feeds.example", data)
+
+    def test_forwarded_host_requires_trusted_allowlist(self):
+        """Forwarded host is only honored when explicitly allowlisted."""
+        self.app.config["TRUSTED_FORWARD_HOSTS"] = ["feeds.example"]
+        response = self.client.get(
+            "/api/feed/rss",
+            headers={"X-Forwarded-Host": "feeds.example"}
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = response.data.decode("utf-8")
+        self.assertIn("https://feeds.example", data)
 
 
 class TestFeedRoutesWithDatabase(unittest.TestCase):


### PR DESCRIPTION
Fixes Scottcjn/Rustchain#4521
Bounty claim: Scottcjn/rustchain-bounties#71
Wallet: RTC253255d034065a839cd421811ec589ae5b694ffc

## Summary
- centralize BoTTube feed base URL selection in `_get_base_url()`
- keep a configured `BOTTUBE_PUBLIC_BASE_URL` as the preferred canonical feed URL
- ignore arbitrary `X-Forwarded-Host` values by default, only allowing explicit `TRUSTED_FORWARD_HOSTS`
- add regression coverage for the untrusted forwarded-host case and configured/trusted host cases

## Verification
- `python -m pytest tests\test_bottube_feed_routes.py -q` -> 25 passed
- `python -m py_compile node\bottube_feed_routes.py tests\test_bottube_feed_routes.py`