### PR TITLE
fix: accept simd_identity in RIP-309 rotation

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1478,7 +1478,14 @@ def _fingerprint_checks_map(fingerprint: dict) -> dict:
     if not isinstance(fingerprint, dict):
         return {}
     checks = fingerprint.get("checks", {})
-    return checks if isinstance(checks, dict) else {}
+    if not isinstance(checks, dict):
+        return {}
+    checks = dict(checks)
+    if "simd_bias" not in checks and "simd_identity" in checks:
+        checks["simd_bias"] = checks["simd_identity"]
+    if "simd_identity" not in checks and "simd_bias" in checks:
+        checks["simd_identity"] = checks["simd_bias"]
+    return checks
 
 
 def _fingerprint_check_data(fingerprint: dict, check_name: str) -> dict:

--- a/node/tests/test_rip309_integrated_simd_alias.py
+++ b/node/tests/test_rip309_integrated_simd_alias.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def _load_module():
+    fd, db_path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    os.environ["RUSTCHAIN_DB_PATH"] = db_path
+    os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_rip309_simd_alias_test",
+        MODULE_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod, db_path
+
+
+def test_rip309_accepts_miner_simd_identity_for_simd_bias_rotation():
+    mod, db_path = _load_module()
+    try:
+        fingerprint = {
+            "checks": {
+                "clock_drift": {"passed": True, "data": {"cv": 0.04}},
+                "cache_timing": {"passed": True, "data": {"L1": 2.1, "L2": 8.4}},
+                "simd_identity": {"passed": True, "data": {"simd_type": "neon"}},
+                "thermal_drift": {"passed": True, "data": {"thermal_drift_pct": 2.0}},
+                "instruction_jitter": {"passed": True, "data": {"cv": 0.03}},
+                "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+            }
+        }
+
+        with sqlite3.connect(":memory:") as conn:
+            rotation = mod.get_epoch_fingerprint_rotation(conn, 0)
+            assert "simd_bias" in rotation["active_checks"]
+            result = mod.evaluate_rotating_fingerprint_checks(conn, 0, fingerprint)
+
+        assert result["active_ratio"] == 1.0
+        assert result["failed_active_checks"] == []
+        assert result["active_results"]["simd_bias"] is True
+    finally:
+        os.unlink(db_path)


### PR DESCRIPTION
## Summary
- fixes a RIP-309 name mismatch where rotation selects `simd_bias` but miner fingerprints store the check as `simd_identity`
- aliases the two names in the integrated node fingerprint normalizer so valid SIMD evidence is not scored as missing
- adds a regression covering epoch 0, where the deterministic active set includes `simd_bias`

## Security impact
Without this alias, an otherwise valid fingerprint can be underweighted whenever `simd_bias` is one of the active RIP-309 checks. In the attestation enrollment path that drops the active check ratio from 1.0 to 0.75, weakening reward correctness and creating a false-negative penalty for miners that emit the current `simd_identity` field.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_rip309_integrated_simd_alias.py -q`
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_rip309_integrated_simd_alias.py node/tests/test_rip309_fingerprint_rotation.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_rip309_integrated_simd_alias.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_rip309_integrated_simd_alias.py`

## Bounty
Claiming under the ongoing security/bug bounty for a reward-accounting correctness bug in the RIP-309 integrated attestation path.

Wallet: `RTCe11828a58518480960023f571842abadeeeb943d`
