### PR TITLE
fix: require Beacon signatures for contract writes

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -11,9 +11,15 @@ import sqlite3
 from datetime import datetime
 from flask import Blueprint, jsonify, request, g
 
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+except Exception:  # pragma: no cover
+    Ed25519PublicKey = None
+
 beacon_api = Blueprint('beacon_api', __name__)
 
 DB_PATH = 'rustchain_v2.db'
+BEACON_AUTH_WINDOW_SECONDS = 300
 
 # In-memory cache for bounties (synced from GitHub)
 bounty_cache = {
@@ -123,6 +129,15 @@ def init_beacon_tables(db_path=DB_PATH):
             )
         """)
 
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS beacon_agent_nonces (
+                agent_id TEXT NOT NULL,
+                nonce TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY (agent_id, nonce)
+            )
+        """)
+
         # Create indexes
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_from ON beacon_contracts(from_agent)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_to ON beacon_contracts(to_agent)")
@@ -130,8 +145,97 @@ def init_beacon_tables(db_path=DB_PATH):
         conn.execute("CREATE INDEX IF NOT EXISTS idx_bounties_state ON beacon_bounties(state)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_chat_agent ON beacon_chat(agent_id)")
         conn.execute("CREATE INDEX IF NOT EXISTS idx_relay_agents_status ON relay_agents(status)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_beacon_agent_nonces_created ON beacon_agent_nonces(created_at)")
 
         conn.commit()
+
+
+def _clean_pubkey_hex(pubkey_hex):
+    pubkey_clean = str(pubkey_hex or '').strip()
+    if pubkey_clean.startswith(('0x', '0X')):
+        pubkey_clean = pubkey_clean[2:]
+    return pubkey_clean
+
+
+def _canonical_agent_request(agent_id, timestamp, nonce, body_bytes):
+    body_hash = hashlib.sha256(body_bytes or b'').hexdigest()
+    return '\n'.join([
+        request.method.upper(),
+        request.path,
+        body_hash,
+        str(timestamp),
+        str(nonce),
+        str(agent_id),
+    ]).encode('utf-8')
+
+
+def _verify_agent_signature(pubkey_hex, signature_hex, message):
+    if Ed25519PublicKey is None:
+        return False
+    try:
+        pubkey = Ed25519PublicKey.from_public_bytes(bytes.fromhex(_clean_pubkey_hex(pubkey_hex)))
+        pubkey.verify(bytes.fromhex(str(signature_hex or '').strip()), message)
+        return True
+    except Exception:
+        return False
+
+
+def _authenticate_contract_agent(db, allowed_agents, body_bytes):
+    allowed = {str(agent) for agent in allowed_agents if agent}
+
+    if os.environ.get('BEACON_ALLOW_LEGACY_AGENT_KEY') == '1':
+        legacy_key = request.headers.get('X-Agent-Key', '')
+        if legacy_key in allowed:
+            return legacy_key, None
+
+    agent_id = request.headers.get('X-Agent-Id', '')
+    timestamp_raw = request.headers.get('X-Agent-Timestamp', '')
+    nonce = request.headers.get('X-Agent-Nonce', '')
+    signature = request.headers.get('X-Agent-Signature', '')
+
+    if not all([agent_id, timestamp_raw, nonce, signature]):
+        return None, (jsonify({
+            'error': 'Missing Beacon signature headers: X-Agent-Id, X-Agent-Timestamp, X-Agent-Nonce, X-Agent-Signature'
+        }), 401)
+
+    if agent_id not in allowed:
+        return None, (jsonify({'error': 'Unauthorized — caller is not an allowed contract party'}), 403)
+
+    try:
+        timestamp = int(timestamp_raw)
+    except (TypeError, ValueError):
+        return None, (jsonify({'error': 'Invalid X-Agent-Timestamp'}), 400)
+
+    now = int(time.time())
+    if abs(now - timestamp) > BEACON_AUTH_WINDOW_SECONDS:
+        return None, (jsonify({'error': 'Stale Beacon signature timestamp'}), 401)
+
+    if not isinstance(nonce, str) or not nonce.strip() or len(nonce) > 128:
+        return None, (jsonify({'error': 'Invalid X-Agent-Nonce'}), 400)
+
+    row = db.execute(
+        "SELECT pubkey_hex FROM relay_agents WHERE agent_id = ?",
+        (agent_id,)
+    ).fetchone()
+    if not row:
+        return None, (jsonify({'error': f'agent not found: {agent_id}'}), 400)
+
+    message = _canonical_agent_request(agent_id, timestamp, nonce, body_bytes)
+    if not _verify_agent_signature(row['pubkey_hex'], signature, message):
+        return None, (jsonify({'error': 'Invalid Beacon agent signature'}), 401)
+
+    cutoff = now - BEACON_AUTH_WINDOW_SECONDS
+    db.execute("DELETE FROM beacon_agent_nonces WHERE created_at < ?", (cutoff,))
+    try:
+        db.execute(
+            "INSERT INTO beacon_agent_nonces (agent_id, nonce, created_at) VALUES (?, ?, ?)",
+            (agent_id, nonce, now)
+        )
+        db.commit()
+    except sqlite3.IntegrityError:
+        return None, (jsonify({'error': 'Replay detected for Beacon agent nonce'}), 401)
+
+    return agent_id, None
 
 
 # ============================================================
@@ -415,11 +519,14 @@ def get_contracts():
 def create_contract():
     """Create a new contract between agents.
     
-    Requires X-Agent-Key header to authenticate the contract creator (from_agent).
+    Requires Beacon Ed25519 signature headers to authenticate the contract creator.
     Validates that the from_agent exists in the relay_agents table.
     """
     try:
-        data = request.get_json()
+        body_bytes = request.get_data(cache=True)
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'Invalid or missing JSON body'}), 400
         
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
@@ -428,16 +535,6 @@ def create_contract():
                 return jsonify({'error': f'Missing field: {field}'}), 400
         
         from_agent = data['from']
-        
-        # Authentication: require X-Agent-Key header matching from_agent
-        agent_key = request.headers.get('X-Agent-Key', '')
-        if not agent_key:
-            return jsonify({'error': 'Missing X-Agent-Key header — authentication required'}), 401
-        
-        if agent_key != from_agent:
-            return jsonify({
-                'error': 'Unauthorized — X-Agent-Key does not match from_agent'
-            }), 403
         
         # Verify from_agent exists in relay_agents table
         db = get_db()
@@ -449,6 +546,10 @@ def create_contract():
             return jsonify({
                 'error': f'from_agent not found: {from_agent}'
             }), 400
+
+        _, auth_error = _authenticate_contract_agent(db, [from_agent], body_bytes)
+        if auth_error:
+            return auth_error
         
         # Generate contract ID
         contract_id = f"ctr_{int(time.time())}_{hashlib.blake2b(str(time.time()).encode(), digest_size=4).hexdigest()}"
@@ -487,11 +588,14 @@ def create_contract():
 def update_contract(contract_id):
     """Update contract state (accept, complete, breach).
     
-    Requires X-Agent-Key header to verify caller is a party to the contract.
+    Requires Beacon Ed25519 signature headers to verify caller is a party to the contract.
     Validates state transitions to prevent invalid jumps.
     """
     try:
-        data = request.get_json()
+        body_bytes = request.get_data(cache=True)
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'Invalid or missing JSON body'}), 400
         new_state = data.get('state')
         
         if not new_state:
@@ -530,30 +634,23 @@ def update_contract(contract_id):
                 'error': f'Invalid state transition: {current_state} -> {new_state}'
             }), 400
         
-        # Verify caller is a party to the contract
-        agent_key = request.headers.get('X-Agent-Key', '')
-        if not agent_key:
-            return jsonify({'error': 'Missing X-Agent-Key header — authentication required'}), 401
-        
         from_agent = contract['from_agent']
         to_agent = contract['to_agent'] if 'to_agent' in contract.keys() else ''
-        
-        # Caller must be either the from_agent or to_agent
-        if agent_key != from_agent and agent_key != to_agent:
-            return jsonify({
-                'error': 'Unauthorized — caller is not a party to this contract'
-            }), 403
+
+        caller_agent, auth_error = _authenticate_contract_agent(db, [from_agent, to_agent], body_bytes)
+        if auth_error:
+            return auth_error
         
         # Additional: only to_agent can accept (offered -> active)
         if current_state == 'offered' and new_state == 'active':
-            if agent_key != to_agent:
+            if caller_agent != to_agent:
                 return jsonify({
                     'error': 'Only the recipient (to_agent) can accept this contract'
                 }), 403
         
         # Only from_agent can mark as breached
         if new_state == 'breached':
-            if agent_key != from_agent:
+            if caller_agent != from_agent:
                 return jsonify({
                     'error': 'Only the contract creator (from_agent) can mark as breached'
                 }), 403

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -12,6 +12,10 @@ import tempfile
 import sqlite3
 import gc
 from unittest.mock import Mock, patch
+import hashlib
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -57,6 +61,15 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         init_beacon_tables(cls.test_db_path)
         
         cls.client = cls.app.test_client()
+        cls.agent_keys = {
+            agent_id: Ed25519PrivateKey.generate()
+            for agent_id in [
+                'bcn_alice_test',
+                'bcn_bob_test',
+                'bcn_test_from',
+                'bcn_test_to',
+            ]
+        }
 
     @classmethod
     def tearDownClass(cls):
@@ -83,13 +96,43 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
                 VALUES (?, ?, ?, ?, ?, ?)
                 """,
                 [
-                    ('bcn_alice_test', '0x' + '11' * 32, 'Alice Test', 'active', now, now),
-                    ('bcn_bob_test', '0x' + '22' * 32, 'Bob Test', 'active', now, now),
-                    ('bcn_test_from', '0x' + '33' * 32, 'From Test', 'active', now, now),
-                    ('bcn_test_to', '0x' + '44' * 32, 'To Test', 'active', now, now),
+                    (agent_id, self._pubkey_hex(agent_id), name, 'active', now, now)
+                    for agent_id, name in [
+                        ('bcn_alice_test', 'Alice Test'),
+                        ('bcn_bob_test', 'Bob Test'),
+                        ('bcn_test_from', 'From Test'),
+                        ('bcn_test_to', 'To Test'),
+                    ]
                 ],
             )
             conn.commit()
+
+    @classmethod
+    def _pubkey_hex(cls, agent_id):
+        pubkey = cls.agent_keys[agent_id].public_key()
+        return pubkey.public_bytes(Encoding.Raw, PublicFormat.Raw).hex()
+
+    @classmethod
+    def _signed_headers(cls, agent_id, method, path, body):
+        body_bytes = body.encode('utf-8') if isinstance(body, str) else body
+        timestamp = str(int(time.time()))
+        nonce = hashlib.blake2b(f"{agent_id}:{timestamp}:{body}".encode(), digest_size=16).hexdigest()
+        body_hash = hashlib.sha256(body_bytes or b'').hexdigest()
+        message = '\n'.join([
+            method.upper(),
+            path,
+            body_hash,
+            timestamp,
+            nonce,
+            agent_id,
+        ]).encode('utf-8')
+        signature = cls.agent_keys[agent_id].sign(message).hex()
+        return {
+            'X-Agent-Id': agent_id,
+            'X-Agent-Timestamp': timestamp,
+            'X-Agent-Nonce': nonce,
+            'X-Agent-Signature': signature,
+        }
 
     def test_health_endpoint_returns_ok(self):
         """Health check endpoint returns status ok."""
@@ -112,11 +155,12 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             'term': '30d'
         }
         
+        create_body = json.dumps(contract_data)
         create_response = self.client.post(
             '/api/contracts',
-            data=json.dumps(contract_data),
+            data=create_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_alice_test'},
+            headers=self._signed_headers('bcn_alice_test', 'POST', '/api/contracts', create_body),
         )
         self.assertEqual(create_response.status_code, 201)
         
@@ -136,11 +180,17 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(contracts[0]['id'], contract_id)
         
         # Update contract state to active
+        update_body = json.dumps({'state': 'active'})
         update_response = self.client.put(
             f'/api/contracts/{contract_id}',
-            data=json.dumps({'state': 'active'}),
+            data=update_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_bob_test'},
+            headers=self._signed_headers(
+                'bcn_bob_test',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                update_body,
+            ),
         )
         self.assertEqual(update_response.status_code, 200)
         
@@ -148,6 +198,25 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         list_response2 = self.client.get('/api/contracts')
         contracts2 = json.loads(list_response2.data)
         self.assertEqual(contracts2[0]['state'], 'active')
+
+    def test_public_agent_id_bearer_rejected_for_contract_create(self):
+        """A public agent ID in X-Agent-Key is not enough to create contracts."""
+        contract_data = {
+            'from': 'bcn_alice_test',
+            'to': 'bcn_bob_test',
+            'type': 'rent',
+            'amount': 100.0,
+            'term': '30d'
+        }
+
+        response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(contract_data),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_alice_test'},
+        )
+
+        self.assertEqual(response.status_code, 401)
 
     def test_contract_validation_rejects_invalid(self):
         """Contract creation rejects invalid/missing fields."""
@@ -268,20 +337,27 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             'term': '7d'
         }
         
+        create_body = json.dumps(contract_data)
         create_response = self.client.post(
             '/api/contracts',
-            data=json.dumps(contract_data),
+            data=create_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
         )
         contract_id = json.loads(create_response.data)['id']
         
         # Try invalid state
+        update_body = json.dumps({'state': 'invalid_state'})
         update_response = self.client.put(
             f'/api/contracts/{contract_id}',
-            data=json.dumps({'state': 'invalid_state'}),
+            data=update_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers(
+                'bcn_test_from',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                update_body,
+            ),
         )
         self.assertEqual(update_response.status_code, 400)
 


### PR DESCRIPTION
Fixes #4520.

## Summary
- replaces public `X-Agent-Key == agent_id` checks on Beacon contract write routes with Ed25519 signed request authentication
- verifies caller identity against the registered `relay_agents.pubkey_hex`
- binds signatures to method, path, body hash, timestamp, nonce, and agent id
- stores used nonces in `beacon_agent_nonces` to reject replay inside the auth window
- keeps an explicit `BEACON_ALLOW_LEGACY_AGENT_KEY=1` compatibility escape hatch, disabled by default

## Security impact
Before this change, public agent ids from `/beacon/atlas` were accepted as bearer credentials for `POST /api/contracts` and `PUT /api/contracts/<id>`. Any caller who knew a public agent id could create contracts as that agent or move contract state when the public id matched a party. This PR requires proof of control of the registered Ed25519 key instead.

## Validation
- `uv run --no-project --with pytest --with flask --with cryptography python -m pytest tests/test_beacon_atlas_behavior.py -q` -> 16 passed
- `python3 -m py_compile node/beacon_api.py tests/test_beacon_atlas_behavior.py`
- `git diff --check -- node/beacon_api.py tests/test_beacon_atlas_behavior.py`

## Bounty
Claiming under the ongoing security/bug bounty for #4520 / rustchain-bounties#71.

Wallet: `RTCe11828a58518480960023f571842abadeeeb943d`
