### PR TITLE
fix: use constant-time compare for bridge admin key

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -166,7 +166,7 @@ def _require_admin(fn):
         key = request.headers.get("X-Admin-Key", "")
         if not BRIDGE_ADMIN_KEY:
             return jsonify({"error": "admin key not configured on server"}), 500
-        if key != BRIDGE_ADMIN_KEY:
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
             return jsonify({"error": "unauthorized"}), 403
         return fn(*args, **kwargs)
     return wrapper

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -377,6 +377,39 @@ class TestLegacyMode_ProofNotRequired:
 
 
 # =============================================================================
+# Admin Authentication Tests
+# =============================================================================
+
+class TestAdminAuthentication:
+    """Tests for bridge admin endpoint authentication."""
+
+    def test_admin_key_uses_constant_time_compare(self, monkeypatch):
+        """Admin-gated endpoints compare configured keys with hmac.compare_digest."""
+        import bridge_api
+
+        app = Flask(__name__)
+        bridge_api.register_bridge_routes(app)
+        app.config["TESTING"] = True
+        calls = []
+
+        def fake_compare(provided, expected):
+            calls.append((provided, expected))
+            return False
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
+
+        with app.test_client() as c:
+            resp = c.post(
+                "/bridge/release",
+                json={"lock_id": "missing-lock", "release_tx": "release-tx"},
+                headers={"X-Admin-Key": "wrong-admin-key"},
+            )
+
+        assert resp.status_code == 403
+        assert calls == [("wrong-admin-key", "test-admin-key-12345")]
+
+
+# =============================================================================
 # Integration Tests - Full Flow with Valid Proof
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- replace the `bridge/bridge_api.py` admin decorator direct key comparison with `hmac.compare_digest`
- add a regression that spies on `compare_digest` for an admin-gated endpoint

## Security impact

The standalone RIP-305 bridge API still compared `X-Admin-Key` to `BRIDGE_ADMIN_KEY` with `!=`. Other admin/auth paths in the repo already use constant-time comparison; this closes the residual timing-leak pattern for `/bridge/release` and `/bridge/confirm`.

## Validation

- `uv run --no-project --with pytest --with flask python -m pytest bridge/test_bridge_api.py::TestAdminAuthentication::test_admin_key_uses_constant_time_compare -q` -> 1 passed
- `uv run --no-project --with pytest --with flask python -m pytest bridge/test_bridge_api.py -q` -> 32 passed
- `python3 -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py` -> passed
- `git diff --check -- bridge/bridge_api.py bridge/test_bridge_api.py` -> passed