### PR TITLE
Fix BCOS badge verification cache

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -73,6 +73,22 @@ def _parse_non_negative_query_int(name: str, default: int, max_value: int | None
     return parsed
 
 
+def _parse_trust_score(raw_score) -> int:
+    """Validate BCOS trust scores before they are stored or rendered."""
+    if isinstance(raw_score, bool):
+        raise ValueError("trust_score must be a number")
+
+    try:
+        score = int(raw_score)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("trust_score must be a number") from exc
+
+    if not (0 <= score <= 100):
+        raise ValueError("trust_score must be between 0 and 100")
+
+    return score
+
+
 def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
     """Recompute BLAKE2b commitment and compare."""
     try:
@@ -203,7 +219,7 @@ def bcos_attest():
     repo = report.get("repo_name", report.get("repo", ""))
     commit_sha = report.get("commit_sha", "")
     tier = report.get("tier", "L1")
-    trust_score = report.get("trust_score", 0)
+    raw_trust_score = report.get("trust_score", 0)
     reviewer = report.get("reviewer", "")
     signature = data.get("signature", report.get("signature", ""))
     signer_pubkey = data.get("signer_pubkey", report.get("signer_pubkey", ""))
@@ -213,6 +229,11 @@ def bcos_attest():
         return jsonify({"error": "cert_id and commitment required"}), 400
     if not repo:
         return jsonify({"error": "repo_name or repo required"}), 400
+    try:
+        trust_score = _parse_trust_score(raw_trust_score)
+    except ValueError as e:
+        return jsonify({"error": "invalid_trust_score", "message": str(e)}), 400
+    report["trust_score"] = trust_score
 
     # Auth: admin key OR valid Ed25519 signature
     sig_valid = False

--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -53,6 +53,26 @@ def _get_admin_key():
     return os.environ.get("RC_ADMIN_KEY", "")
 
 
+def _parse_non_negative_query_int(name: str, default: int, max_value: int | None = None) -> int:
+    """Parse pagination query params without letting malformed input become a 500."""
+    raw_value = request.args.get(name)
+    if raw_value is None:
+        parsed = default
+    else:
+        try:
+            parsed = int(raw_value, 10)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{name} must be an integer") from exc
+
+    if parsed < 0:
+        raise ValueError(f"{name} must be non-negative")
+
+    if max_value is not None:
+        parsed = min(parsed, max_value)
+
+    return parsed
+
+
 def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
     """Recompute BLAKE2b commitment and compare."""
     try:
@@ -388,8 +408,11 @@ def bcos_badge_svg(cert_id):
 def bcos_directory():
     """List all BCOS-certified repos with latest attestation."""
     tier_filter = request.args.get("tier", "").upper()
-    limit = min(int(request.args.get("limit", 100)), 500)
-    offset = int(request.args.get("offset", 0))
+    try:
+        limit = _parse_non_negative_query_int("limit", 100, max_value=500)
+        offset = _parse_non_negative_query_int("offset", 0)
+    except ValueError as e:
+        return jsonify({"error": "invalid_pagination", "message": str(e)}), 400
 
     try:
         with sqlite3.connect(_DB_PATH) as conn:

--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -228,6 +228,27 @@ class TestDatabaseOperations(unittest.TestCase):
         self.assertEqual(result['data']['tier'], 'L1')
         self.assertEqual(result['data']['trust_score'], 75)
 
+    def test_verify_certificate_cache_returns_response_data(self):
+        """Cached certificate verification should return the cached response data."""
+        init_db()
+        record_badge_generation(
+            cert_id='BCOS-CACHED',
+            repo_name='cache/repo',
+            tier='L2',
+            metadata={'trust_score': 90},
+        )
+
+        first = verify_certificate('BCOS-CACHED')
+        second = verify_certificate('BCOS-CACHED')
+
+        self.assertTrue(first['valid'])
+        self.assertFalse(first['cached'])
+        self.assertTrue(second['valid'])
+        self.assertTrue(second['cached'])
+        self.assertEqual(second['data']['repo_name'], 'cache/repo')
+        self.assertEqual(second['data']['tier'], 'L2')
+        self.assertEqual(second['data']['trust_score'], 90)
+
     def test_verify_certificate_invalid(self):
         """Test verifying an invalid certificate."""
         init_db()

--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -402,6 +402,27 @@ class TestFlaskIntegration(unittest.TestCase):
         self.assertFalse(data['success'])
         self.assertIn('error', data)
 
+    def test_generate_badge_rejects_non_numeric_score(self):
+        """Test badge generation rejects non-numeric trust scores without 500s."""
+        invalid_scores = ['high', None, True]
+
+        for score in invalid_scores:
+            with self.subTest(score=score):
+                response = self.client.post(
+                    '/api/badge/generate',
+                    json={
+                        'repo_name': 'test/repo',
+                        'tier': 'L1',
+                        'trust_score': score,
+                    },
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 200)
+                data = json.loads(response.data)
+                self.assertFalse(data['success'])
+                self.assertEqual(data['error'], 'Trust score must be a number')
+
     def test_stats_endpoint(self):
         """Test stats endpoint."""
         # Generate a badge first

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -65,3 +65,55 @@ def test_bcos_directory_clamps_large_limit(bcos_client):
     body = response.get_json()
     assert body["ok"] is True
     assert body["count"] == 1
+
+
+@pytest.mark.parametrize(
+    "trust_score,message",
+    [
+        ("high", "trust_score must be a number"),
+        (None, "trust_score must be a number"),
+        (True, "trust_score must be a number"),
+        (-1, "trust_score must be between 0 and 100"),
+        (101, "trust_score must be between 0 and 100"),
+    ],
+)
+def test_bcos_attest_rejects_invalid_trust_score(bcos_client, trust_score, message):
+    response = bcos_client.post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "0" * 32},
+        json={
+            "cert_id": "cert-bad-score",
+            "commitment": "commitment",
+            "repo": "Scottcjn/Rustchain",
+            "commit_sha": "abcdef1234567890",
+            "tier": "L1",
+            "trust_score": trust_score,
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "invalid_trust_score"
+    assert body["message"] == message
+
+
+def test_bcos_attest_stores_numeric_trust_score(bcos_client):
+    response = bcos_client.post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "0" * 32},
+        json={
+            "cert_id": "cert-good-score",
+            "commitment": "commitment",
+            "repo": "Scottcjn/Rustchain",
+            "commit_sha": "abcdef1234567890",
+            "tier": "L1",
+            "trust_score": "81",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["trust_score"] == 81
+
+    verify_response = bcos_client.get("/bcos/verify/cert-good-score")
+    assert verify_response.status_code == 200
+    assert verify_response.get_json()["trust_score"] == 81

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -1,0 +1,67 @@
+import sqlite3
+
+import pytest
+from flask import Flask
+
+from bcos_routes import init_bcos_table, register_bcos_routes
+
+
+@pytest.fixture
+def bcos_client(tmp_path):
+    db_path = tmp_path / "bcos.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        init_bcos_table(conn)
+        conn.execute(
+            """
+            INSERT INTO bcos_attestations (
+                cert_id, commitment, repo, commit_sha, tier, trust_score,
+                reviewer, report_json, signature, signer_pubkey, anchored_epoch, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "cert-1",
+                "commitment",
+                "Scottcjn/Rustchain",
+                "abcdef1234567890",
+                "L1",
+                80,
+                "reviewer",
+                "{}",
+                None,
+                None,
+                1,
+                1234567890,
+            ),
+        )
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_bcos_routes(app, str(db_path))
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "query,message",
+    [
+        ("limit=abc", "limit must be an integer"),
+        ("offset=abc", "offset must be an integer"),
+        ("limit=-1", "limit must be non-negative"),
+        ("offset=-1", "offset must be non-negative"),
+    ],
+)
+def test_bcos_directory_rejects_invalid_pagination(bcos_client, query, message):
+    response = bcos_client.get(f"/bcos/directory?{query}")
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "invalid_pagination"
+    assert body["message"] == message
+
+
+def test_bcos_directory_clamps_large_limit(bcos_client):
+    response = bcos_client.get("/bcos/directory?limit=999999")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["count"] == 1

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -362,7 +362,7 @@ def verify_certificate(cert_id: str, use_cache: bool = True) -> Dict:
                 'valid': bool(cached[0]),
                 'cached': True,
                 'verified_at': cached[2],
-                'data': json.loads(cached[3]) if cached[3] else {},
+                'data': json.loads(cached[1]) if cached[1] else {},
             }
 
     # Check local database

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1064,7 +1064,7 @@ def generate_badge():
 
     repo_name = data.get('repo_name', '').strip()
     tier = data.get('tier', 'L1').upper()
-    trust_score = data.get('trust_score', 75)
+    raw_trust_score = data.get('trust_score', 75)
     cert_id = data.get('cert_id', '')
     include_qr = data.get('include_qr', False)
 
@@ -1077,6 +1077,13 @@ def generate_badge():
 
     if tier not in ['L0', 'L1', 'L2']:
         return jsonify({'success': False, 'error': 'Invalid tier. Must be L0, L1, or L2'})
+
+    if isinstance(raw_trust_score, bool):
+        return jsonify({'success': False, 'error': 'Trust score must be a number'})
+    try:
+        trust_score = int(raw_trust_score)
+    except (TypeError, ValueError):
+        return jsonify({'success': False, 'error': 'Trust score must be a number'})
 
     if not (0 <= trust_score <= 100):
         return jsonify({'success': False, 'error': 'Trust score must be between 0 and 100'})


### PR DESCRIPTION
## Summary

Fixes four BCOS request/verification bugs.

- The first `verify_certificate()` call stores `response_data` in `verification_cache`, but the cached read path parsed the `ttl` column as JSON instead of the cached response payload. A second verification of the same certificate could therefore crash with `TypeError: the JSON object must be str, bytes or bytearray, not int`.
- `POST /api/badge/generate` compared `trust_score` directly against integers. Non-numeric JSON values such as `"high"`, `null`, or `true` raised 500-class errors instead of returning a controlled validation response.
- `GET /bcos/directory` parsed `limit` and `offset` with raw `int(...)` before route error handling. Malformed pagination raised a 500, and negative limits could bypass the intended cap. The route now returns a controlled 400 and keeps oversized limits capped.
- `POST /bcos/attest` accepted non-numeric or out-of-range `trust_score` values into `bcos_attestations`. Follow-up verification/badge paths could then crash when comparing/rendering the stored score. The route now validates and normalizes scores before persistence.

## Bounty

Bug-fix bounty claim for Scottcjn/Rustchain#305.

## Validation

- `uv run --no-project --with pytest --with flask --with qrcode --with pillow python -m pytest tests\test_bcos_badge_generator.py::TestDatabaseOperations::test_verify_certificate_cache_returns_response_data -q` -> 1 passed
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow python -m pytest tests\test_bcos_badge_generator.py::TestFlaskIntegration::test_generate_badge_rejects_non_numeric_score tests\test_bcos_badge_generator.py::TestDatabaseOperations::test_verify_certificate_cache_returns_response_data -q` -> 2 passed, 3 subtests passed
- `python -m py_compile tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py` -> passed
- `git diff --check -- tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py` -> passed
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow --with requests python -m pytest tests\test_bcos_badge_generator.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 37 passed, 1 existing pytest return-value warning, 3 subtests passed
- `uv run --no-project --with pytest --with flask python -m pytest tests\test_bcos_routes_query_validation.py -q` -> 5 passed
- `python -m py_compile node\bcos_routes.py tests\test_bcos_routes_query_validation.py` -> passed
- `git diff --check -- node\bcos_routes.py tests\test_bcos_routes_query_validation.py` -> passed
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow --with requests python -m pytest tests\test_bcos_routes_query_validation.py tests\test_bcos_badge_generator.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 42 passed, 1 existing pytest return-value warning, 3 subtests passed
- `uv run --no-project --with pytest --with flask python -m pytest tests\test_bcos_routes_query_validation.py -q` -> 11 passed
- `python -m py_compile node\bcos_routes.py tests\test_bcos_routes_query_validation.py` -> passed
- `git diff --check -- node\bcos_routes.py tests\test_bcos_routes_query_validation.py` -> passed
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow --with requests python -m pytest tests\test_bcos_routes_query_validation.py tests\test_bcos_badge_generator.py tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 48 passed, 1 existing pytest return-value warning, 3 subtests passed
