### PR TITLE
Require admin auth for airdrop bridge state changes

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -1223,6 +1223,19 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         db_path: Database path for persistence
     """
 
+    def require_admin_key():
+        required = os.environ.get("RC_ADMIN_KEY", "").strip()
+        if not required:
+            return jsonify({"ok": False, "error": "admin_key_not_configured"}), 503
+        provided = (
+            request.headers.get("X-Admin-Key")
+            or request.headers.get("X-API-Key")
+            or ""
+        ).strip()
+        if not hmac.compare_digest(provided, required):
+            return jsonify({"ok": False, "error": "unauthorized"}), 401
+        return None
+
     @app.route("/api/airdrop/eligibility", methods=["POST"])
     def check_airdrop_eligibility():
         """Check airdrop eligibility."""
@@ -1336,6 +1349,10 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
     @app.route("/api/bridge/lock/<lock_id>/confirm", methods=["POST"])
     def confirm_lock(lock_id: str):
         """Confirm bridge lock with source tx."""
+        auth_error = require_admin_key()
+        if auth_error:
+            return auth_error
+
         data = request.get_json(silent=True) or {}
         source_tx = data.get("source_tx", "").strip()
 
@@ -1352,6 +1369,10 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
     @app.route("/api/bridge/lock/<lock_id>/release", methods=["POST"])
     def release_lock(lock_id: str):
         """Release bridge lock with dest tx."""
+        auth_error = require_admin_key()
+        if auth_error:
+            return auth_error
+
         data = request.get_json(silent=True) or {}
         dest_tx = data.get("dest_tx", "").strip()
 

--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+from flask import Flask
+
+from node.airdrop_v2 import AirdropV2, init_airdrop_routes
+
+
+def _make_client(tmp_path):
+    db_path = tmp_path / "airdrop.db"
+    airdrop = AirdropV2(str(db_path))
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    init_airdrop_routes(app, airdrop, str(db_path))
+    return app.test_client(), db_path
+
+
+def _create_pending_lock(client):
+    response = client.post(
+        "/api/bridge/lock",
+        json={
+            "from_address": "solana-source",
+            "to_address": "base-destination",
+            "from_chain": "solana",
+            "to_chain": "base",
+            "amount_wrtc": 1,
+        },
+    )
+    assert response.status_code == 200
+    return response.get_json()["lock"]["lock_id"]
+
+
+def _lock_status(db_path, lock_id):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT status, source_tx, dest_tx FROM bridge_locks WHERE lock_id = ?",
+            (lock_id,),
+        ).fetchone()
+
+
+def test_bridge_confirm_requires_admin_key(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path)
+    lock_id = _create_pending_lock(client)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+    response = client.post(
+        f"/api/bridge/lock/{lock_id}/confirm",
+        json={"source_tx": "attacker-source-tx"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"
+    assert _lock_status(db_path, lock_id) == ("pending", None, None)
+
+
+def test_bridge_release_requires_admin_key(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path)
+    lock_id = _create_pending_lock(client)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+    authorized = client.post(
+        f"/api/bridge/lock/{lock_id}/confirm",
+        headers={"X-Admin-Key": "expected-admin"},
+        json={"source_tx": "real-source-tx"},
+    )
+    assert authorized.status_code == 200
+
+    response = client.post(
+        f"/api/bridge/lock/{lock_id}/release",
+        json={"dest_tx": "attacker-dest-tx"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"
+    assert _lock_status(db_path, lock_id) == ("locked", "real-source-tx", None)
+
+
+def test_bridge_confirm_and_release_accept_valid_admin_key(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path)
+    lock_id = _create_pending_lock(client)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+    confirmed = client.post(
+        f"/api/bridge/lock/{lock_id}/confirm",
+        headers={"X-Admin-Key": "expected-admin"},
+        json={"source_tx": "real-source-tx"},
+    )
+    released = client.post(
+        f"/api/bridge/lock/{lock_id}/release",
+        headers={"X-Admin-Key": "expected-admin"},
+        json={"dest_tx": "real-dest-tx"},
+    )
+
+    assert confirmed.status_code == 200
+    assert released.status_code == 200
+    assert _lock_status(db_path, lock_id) == (
+        "released",
+        "real-source-tx",
+        "real-dest-tx",
+    )


### PR DESCRIPTION
## Summary

Fixes #4528.

Adds an admin-key gate to the Airdrop V2 bridge state-changing routes:

- `POST /api/bridge/lock/<lock_id>/confirm`
- `POST /api/bridge/lock/<lock_id>/release`

The routes now fail closed when `RC_ADMIN_KEY` is not configured and accept the configured key via `X-Admin-Key` or `X-API-Key` using `hmac.compare_digest()`.

## Security impact

Before this patch, any caller who knew a bridge `lock_id` could move it from `pending` to `locked` and then `released` with arbitrary transaction IDs. That corrupts the bridge/payment ledger and can create false wRTC release records.

## Tests

- `python -m pytest tests\test_airdrop_bridge_admin_auth.py -q` -> 3 passed
- `python -m py_compile node\airdrop_v2.py tests\test_airdrop_bridge_admin_auth.py` -> passed
- `git diff --check -- node\airdrop_v2.py tests\test_airdrop_bridge_admin_auth.py` -> passed