### PR TITLE
Prevent airdrop claim double dipping

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -660,16 +660,16 @@ class AirdropV2:
     def _has_claimed(
         self, github_username: str, wallet_address: str, chain: str
     ) -> bool:
-        """Check if user already claimed airdrop."""
+        """Check if a GitHub account or wallet already claimed an airdrop."""
         conn = self._get_conn()
         cursor = conn.cursor()
         cursor.execute(
             """
             SELECT 1 FROM airdrop_claims
-            WHERE github_username = ? AND wallet_address = ? AND chain = ?
+            WHERE (github_username = ? OR wallet_address = ?)
             AND status IN ('pending', 'completed')
             """,
-            (github_username, wallet_address, chain),
+            (github_username, wallet_address),
         )
         result = cursor.fetchone() is not None
         self._close_conn(conn)

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -190,6 +190,49 @@ class TestEligibilityChecks(unittest.TestCase):
         self.assertFalse(result.eligible)
         self.assertIn("Already claimed", result.reason)
 
+    def test_same_github_cannot_claim_with_different_wallet(self):
+        """A GitHub account cannot bypass claim limits by changing wallets."""
+        success, _, _ = self.airdrop.claim_airdrop(
+            github_username="testuser",
+            wallet_address="RTC1111111111111111111111111111111111111111",
+            chain="base",
+            tier="contributor",
+            skip_antisybil=True,
+        )
+        self.assertTrue(success)
+
+        result = self.airdrop.check_eligibility(
+            github_username="testuser",
+            wallet_address="RTC2222222222222222222222222222222222222222",
+            chain="base",
+            skip_antisybil=True,
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIn("Already claimed", result.reason)
+
+    def test_same_wallet_cannot_claim_with_different_github(self):
+        """A wallet cannot bypass claim limits by changing GitHub accounts."""
+        wallet = "RTC3333333333333333333333333333333333333333"
+        success, _, _ = self.airdrop.claim_airdrop(
+            github_username="firstuser",
+            wallet_address=wallet,
+            chain="base",
+            tier="contributor",
+            skip_antisybil=True,
+        )
+        self.assertTrue(success)
+
+        result = self.airdrop.check_eligibility(
+            github_username="seconduser",
+            wallet_address=wallet,
+            chain="base",
+            skip_antisybil=True,
+        )
+
+        self.assertFalse(result.eligible)
+        self.assertIn("Already claimed", result.reason)
+
 
 class TestClaimProcessing(unittest.TestCase):
     """Test claim creation and finalization."""


### PR DESCRIPTION
## Summary

Fixes #4531.

Tightens RIP-305 airdrop duplicate-claim detection so a prior pending/completed claim by either the same GitHub account or the same wallet address blocks another eligibility result.

## Why

The protocol docs require one claim per GitHub account and one claim per wallet address. The previous `_has_claimed()` query only blocked the exact `(github_username, wallet_address, chain)` tuple, so a claimant could reuse the same GitHub with a new wallet or reuse the same wallet with a new GitHub account.

## Changes

- Update `_has_claimed()` to match prior claims where `github_username = ? OR wallet_address = ?` for pending/completed claims.
- Add regression coverage for:
  - same GitHub account with a different wallet
  - same wallet address with a different GitHub account

## Tests

- `python -m pytest node\test_airdrop_v2.py -q` -> 23 passed
- `python -m py_compile node\airdrop_v2.py node\test_airdrop_v2.py` -> passed
- `git diff --check -- node\airdrop_v2.py node\test_airdrop_v2.py` -> passed