### PR TITLE
fix: cap transactions explorer offset

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5773,6 +5773,9 @@ def _explorer_amount_rtc(amount_i64):
     return int(amount_i64) / int(globals().get("UNIT", 1_000_000))
 
 
+EXPLORER_TRANSACTIONS_MAX_OFFSET = 10_000
+
+
 @app.route("/api/blocks", methods=["GET"])
 def api_explorer_blocks():
     """Return recent blocks for explorer clients."""
@@ -5983,7 +5986,9 @@ def api_explorer_transactions():
     limit, error_response, status = _explorer_int_arg("limit", 50, 1, 200)
     if error_response is not None:
         return error_response, status
-    offset, error_response, status = _explorer_int_arg("offset", 0, 0, 1_000_000)
+    offset, error_response, status = _explorer_int_arg(
+        "offset", 0, 0, EXPLORER_TRANSACTIONS_MAX_OFFSET
+    )
     if error_response is not None:
         return error_response, status
 

--- a/node/tests/test_explorer_api_routes.py
+++ b/node/tests/test_explorer_api_routes.py
@@ -166,6 +166,30 @@ class TestExplorerApiRoutes(unittest.TestCase):
         self.assertEqual(body["transactions"][1]["direction"], "received")
         self.assertEqual(body["transactions"][1]["amount_rtc"], 2.5)
 
+    def test_transactions_endpoint_caps_offset_before_materializing_rows(self):
+        calls = []
+
+        def fake_pending_transactions(db, limit):
+            calls.append(("pending", limit))
+            return []
+
+        def fake_ledger_transactions(db, limit):
+            calls.append(("ledger", limit))
+            return []
+
+        previous_pending = self.mod._pending_ledger_explorer_transactions
+        previous_ledger = self.mod._ledger_explorer_transactions
+        self.mod._pending_ledger_explorer_transactions = fake_pending_transactions
+        self.mod._ledger_explorer_transactions = fake_ledger_transactions
+        try:
+            resp = self.client.get("/api/transactions?limit=10&offset=1000000")
+        finally:
+            self.mod._pending_ledger_explorer_transactions = previous_pending
+            self.mod._ledger_explorer_transactions = previous_ledger
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(calls, [("pending", 10010), ("ledger", 10010)])
+
     def test_explorer_endpoints_return_empty_without_tables(self):
         blocks_resp = self.client.get("/api/blocks")
         tx_resp = self.client.get("/api/transactions")


### PR DESCRIPTION
## Summary

Fixes the post-merge vulnerability audit finding on `/api/transactions`.

The endpoint already capped `limit`, but it still accepted `offset` values up to 1,000,000 and then fetched `limit + offset` rows from both `pending_ledger` and `ledger` before sorting/slicing in Python. An unauthenticated caller could force multi-million-row reads and in-memory sorting on a public, financially relevant endpoint.

This PR caps transaction explorer offset at 10,000 before any ledger helper materializes rows. With the existing max `limit=200`, each backing query can now request at most 10,200 rows rather than 1,000,200.

## Bounty

Follow-up fix for the audit note on PR #4295 and bounty claim under Scottcjn/rustchain-bounties#71.

## Validation

- `uv run --no-project --with pytest --with flask python -m pytest node\tests\test_explorer_api_routes.py::TestExplorerApiRoutes::test_transactions_endpoint_caps_offset_before_materializing_rows -q` -> 1 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_explorer_api_routes.py` -> passed
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_explorer_api_routes.py` -> passed
- `uv run --no-project --with pytest --with flask python -m pytest node\tests\test_explorer_api_routes.py -q` -> 5 passed
