### PR TITLE
fix: enforce mock signature guard in WSGI

### DIFF
--- a/node/tests/test_wsgi_mock_signature_guard.py
+++ b/node/tests/test_wsgi_mock_signature_guard.py
@@ -1,0 +1,48 @@
+import importlib.machinery
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+class WsgiMockSignatureGuardTests(unittest.TestCase):
+    def test_wsgi_invokes_mock_signature_guard_before_db_init(self):
+        calls = []
+
+        class FakeRustChainLoader:
+            def create_module(self, spec):
+                return types.ModuleType(spec.name)
+
+            def exec_module(self, module):
+                module.app = object()
+                module.DB_PATH = ":memory:"
+                module.enforce_mock_signature_runtime_guard = lambda: calls.append("guard")
+                module.init_db = lambda: calls.append("init_db")
+
+        node_dir = Path(__file__).resolve().parents[1]
+        wsgi_path = node_dir / "wsgi.py"
+        wsgi_spec = importlib.util.spec_from_file_location(
+            "rustchain_wsgi_guard_test", str(wsgi_path)
+        )
+        wsgi_module = importlib.util.module_from_spec(wsgi_spec)
+        main_spec = importlib.machinery.ModuleSpec(
+            "rustchain_main", FakeRustChainLoader()
+        )
+
+        with mock.patch(
+            "importlib.util.spec_from_file_location", return_value=main_spec
+        ), mock.patch.dict(
+            sys.modules,
+            {"rustchain_p2p_init": None, "sophia_attestation_inspector": None},
+        ):
+            wsgi_spec.loader.exec_module(wsgi_module)
+
+        self.assertIn("guard", calls)
+        self.assertIn("init_db", calls)
+        self.assertLess(calls.index("guard"), calls.index("init_db"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/wsgi.py
+++ b/node/wsgi.py
@@ -22,6 +22,7 @@ spec = importlib.util.spec_from_file_location(
 )
 rustchain_main = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(rustchain_main)
+rustchain_main.enforce_mock_signature_runtime_guard()
 
 # Get the Flask app
 app = rustchain_main.app


### PR DESCRIPTION
## Summary

Fixes the post-merge vulnerability audit finding on the mock-signature runtime guard.

`enforce_mock_signature_runtime_guard()` existed, but it was only called under `if __name__ == "__main__"`. The documented gunicorn entrypoint loads `node/wsgi.py`, which imports the main RustChain module without taking that `__main__` path. That made the guard ineffective for the production WSGI startup path.

This PR calls `rustchain_main.enforce_mock_signature_runtime_guard()` immediately after the WSGI loader imports the main module and before database/app startup continues.

## Bounty

Follow-up fix for the audit note on PR #4519 and bounty claim under Scottcjn/rustchain-bounties#71.

## Validation

- `uv run --no-project --with pytest python -m pytest node\tests\test_wsgi_mock_signature_guard.py -q` -> 1 passed
- `python -m py_compile node\wsgi.py node\tests\test_wsgi_mock_signature_guard.py` -> passed
- `git diff --check -- node\wsgi.py node\tests\test_wsgi_mock_signature_guard.py` -> passed
- `uv run --no-project --with pytest --with flask python -m pytest node\tests\test_wsgi_mock_signature_guard.py node\tests\test_mock_signature_guard.py -q` -> 3 passed
