### PR TITLE
fix: enforce mock signature guard during WSGI startup

### DIFF
--- a/node/tests/test_mock_signature_guard.py
+++ b/node/tests/test_mock_signature_guard.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
+import shutil
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -58,6 +60,38 @@ class MockSignatureGuardTests(unittest.TestCase):
         os.environ.pop("RUSTCHAIN_ENV", None)
 
         integrated_node.enforce_mock_signature_runtime_guard()
+
+    def test_wsgi_startup_enforces_mock_signature_guard(self):
+        project_root = Path(__file__).resolve().parents[2]
+        node_dir = project_root / "node"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_node = Path(temp_dir)
+            shutil.copy2(node_dir / "wsgi.py", temp_node / "wsgi.py")
+            (temp_node / "rustchain_v2_integrated_v2.2.1_rip200.py").write_text(
+                "\n".join(
+                    [
+                        "TESTNET_ALLOW_MOCK_SIG = True",
+                        "app = object()",
+                        "DB_PATH = ':memory:'",
+                        "def init_db():",
+                        "    raise AssertionError('init_db should not run before guard')",
+                        "def enforce_mock_signature_runtime_guard():",
+                        "    raise RuntimeError('TESTNET_ALLOW_MOCK_SIG blocked by WSGI guard')",
+                        "",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            spec = importlib.util.spec_from_file_location(
+                "wsgi_mock_guard_test",
+                str(temp_node / "wsgi.py"),
+            )
+            module = importlib.util.module_from_spec(spec)
+
+            with self.assertRaisesRegex(RuntimeError, "TESTNET_ALLOW_MOCK_SIG"):
+                spec.loader.exec_module(module)
 
 
 if __name__ == "__main__":

--- a/node/wsgi.py
+++ b/node/wsgi.py
@@ -22,6 +22,7 @@ spec = importlib.util.spec_from_file_location(
 )
 rustchain_main = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(rustchain_main)
+rustchain_main.enforce_mock_signature_runtime_guard()
 
 # Get the Flask app
 app = rustchain_main.app


### PR DESCRIPTION
## Summary
- calls the existing mock-signature runtime guard during `node/wsgi.py` startup immediately after loading the integrated server module
- adds a WSGI-specific regression test that proves startup fails before `init_db()` when mock signatures are enabled

## Security impact
This closes the production WSGI gap noted in the post-merge audit on #4519: gunicorn imports `node/wsgi.py`, so the guard now runs before the Flask app is exposed or database/P2P startup continues.

## Validation
- `uv run --no-project --with pytest --with flask --with prometheus-client --with pynacl python -m pytest node/tests/test_mock_signature_guard.py -q` -> 3 passed
- `uv run --no-project --with flask --with prometheus-client --with pynacl python -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_mock_signature_guard.py`
- `git diff --check`

Bounty context: follow-up to the owner audit comment on #4519, which suggested the WSGI-path enforcement as a Medium-tier fix.