### PR TITLE
fix: require admin auth for Flamebound coalition reviews

### DIFF
--- a/node/coalition.py
+++ b/node/coalition.py
@@ -28,6 +28,8 @@ Date: 2026-05-04
 """
 
 import logging
+import hmac
+import os
 import sqlite3
 import time
 from typing import Optional
@@ -331,6 +333,18 @@ def _coalition_exists(coalition_id: int, db_path: str) -> bool:
             return bool(row and row[0] == COALITION_STATUS_ACTIVE)
     except Exception:
         return False
+
+
+def _admin_key_authorized() -> tuple[bool, tuple[dict, int] | None]:
+    admin_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key:
+        return False, ({"error": "RC_ADMIN_KEY not configured - endpoint disabled"}, 503)
+
+    provided = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
+    if not hmac.compare_digest(provided, admin_key):
+        return False, ({"error": "Unauthorized - admin key required"}, 401)
+
+    return True, None
 
 
 # ---------------------------------------------------------------------------
@@ -641,6 +655,11 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     # -- POST /api/coalition/flamebound-review -------------------------------
     @bp.route("/flamebound-review", methods=["POST"])
     def flamebound_review():
+        authorized, error = _admin_key_authorized()
+        if not authorized:
+            body, status = error
+            return jsonify(body), status
+
         data = request.get_json(silent=True) or {}
 
         proposal_id = data.get("proposal_id")

--- a/node/tests/test_coalition.py
+++ b/node/tests/test_coalition.py
@@ -60,7 +60,8 @@ def tmp_db():
 
 
 @pytest.fixture
-def app(tmp_db):
+def app(tmp_db, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
     app = Flask(__name__)
     bp = create_coalition_blueprint(tmp_db)
     app.register_blueprint(bp)
@@ -501,7 +502,7 @@ def test_flamebound_approve(client, test_coalition, tmp_db, rich_miner, poor_min
         "proposal_id": pid,
         "decision": "approve",
         "reason": "Proposal is well-structured and aligns with protocol goals.",
-    })
+    }, headers={"X-Admin-Key": "test-admin-key"})
     assert res.status_code == 200
     data = res.get_json()
     assert data["decision"] == "approve"
@@ -516,7 +517,7 @@ def test_flamebound_veto(client, test_coalition, tmp_db, rich_miner, poor_miner,
         "proposal_id": pid,
         "decision": "veto",
         "reason": "Proposal contains security risks.",
-    })
+    }, headers={"X-Admin-Key": "test-admin-key"})
     assert res.status_code == 200
     data = res.get_json()
     assert data["decision"] == "veto"
@@ -532,7 +533,7 @@ def test_flamebound_veto_prevents_voting(client, test_coalition, tmp_db, rich_mi
         "proposal_id": pid,
         "decision": "veto",
         "reason": "Security risk.",
-    })
+    }, headers={"X-Admin-Key": "test-admin-key"})
     assert res.status_code == 200
 
     # Vote on vetoed proposal should fail
@@ -552,7 +553,7 @@ def test_flamebound_invalid_decision_rejected(client, test_coalition, tmp_db, ri
         "proposal_id": pid,
         "decision": "maybe",
         "reason": "Unclear.",
-    })
+    }, headers={"X-Admin-Key": "test-admin-key"})
     assert res.status_code == 400
 
 
@@ -562,8 +563,27 @@ def test_flamebound_nonexistent_proposal_rejected(client, rich_miner):
         "proposal_id": 99999,
         "decision": "approve",
         "reason": "N/A",
-    })
+    }, headers={"X-Admin-Key": "test-admin-key"})
     assert res.status_code == 404
+
+
+def test_flamebound_review_requires_admin_key(client, test_coalition, tmp_db, rich_miner, poor_miner, medium_miner):
+    """Unauthenticated callers cannot approve or veto coalition proposals."""
+    pid = _create_proposal_and_add_members(client, test_coalition, tmp_db, rich_miner, poor_miner, medium_miner)
+
+    res = client.post("/api/coalition/flamebound-review", json={
+        "proposal_id": pid,
+        "decision": "veto",
+        "reason": "Attacker should not be able to veto.",
+    })
+    assert res.status_code == 401
+
+    with sqlite3.connect(tmp_db) as conn:
+        status = conn.execute(
+            "SELECT status FROM coalition_proposals WHERE id = ?",
+            (pid,),
+        ).fetchone()[0]
+    assert status == PROPOSAL_STATUS_ACTIVE
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require a configured `RC_ADMIN_KEY` for `/api/coalition/flamebound-review`
- accept `X-Admin-Key` or `X-API-Key` and compare with `hmac.compare_digest()`
- fail closed when the admin key is unset
- update Flamebound review tests and add an unauthenticated veto regression

Fixes #4536.

/claim #4536

## Security impact
Before this change, any caller that could reach the coalition API could send `decision: "veto"` and move an active proposal to `vetoed`, blocking further voting. The endpoint now requires operator authorization before it evaluates or mutates proposal state.

## Validation
- `python -m pytest node\tests\test_coalition.py::test_flamebound_review_requires_admin_key node\tests\test_coalition.py::test_flamebound_veto node\tests\test_coalition.py::test_flamebound_approve -q` -> assertions passed, but existing Windows teardown hit `PermissionError` while unlinking temporary SQLite DB files after the tests completed
- `python -m py_compile node\coalition.py node\tests\test_coalition.py` -> passed
- `git diff --check -- node\coalition.py node\tests\test_coalition.py` -> passed
