### PR TITLE
[UTXO-BUG] Fix automatic epoch reward scale

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4091,7 +4091,7 @@ def ingest_signed_header():
                         (slot,)
                     ).fetchone()
                     prev_block_hash = hashlib.sha256((prev_msg[0] if prev_msg else str(slot)).encode()).digest() if prev_msg else b""
-                    finalize_epoch(current_epoch, PER_EPOCH_RTC, prev_block_hash)
+                    finalize_epoch(current_epoch, PER_BLOCK_RTC, prev_block_hash)
                     print(f"[EPOCH] Auto-settled epoch {current_epoch} after {blocks_in_epoch} blocks")
                 except Exception as e:
                     print(f"[EPOCH] Settlement failed for epoch {current_epoch}: {e}")

--- a/node/tests/test_epoch_reward_settlement_parameter.py
+++ b/node/tests/test_epoch_reward_settlement_parameter.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression guard for automatic epoch settlement reward scale.
+
+PER_EPOCH_RTC is already the whole epoch pot. finalize_epoch() accepts a
+per-block reward and multiplies it by EPOCH_SLOTS internally, so the automatic
+settlement path must pass PER_BLOCK_RTC. Passing PER_EPOCH_RTC pays the epoch
+pot once per slot and inflates both account rewards and UTXO dual-write mints.
+"""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+SERVER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rustchain_v2_integrated_v2.2.1_rip200.py"
+)
+
+
+def _integrated_source_tree():
+    source = SERVER_PATH.read_text(encoding="utf-8")
+    return source, ast.parse(source)
+
+
+class TestEpochRewardSettlementParameter(unittest.TestCase):
+    def test_auto_settlement_passes_per_block_reward_to_finalize_epoch(self):
+        source, tree = _integrated_source_tree()
+        calls = []
+
+        class Visitor(ast.NodeVisitor):
+            def visit_Call(self, call):
+                if isinstance(call.func, ast.Name) and call.func.id == "finalize_epoch":
+                    calls.append(call)
+                self.generic_visit(call)
+
+        Visitor().visit(tree)
+
+        self.assertEqual(
+            len(calls),
+            1,
+            "expected one automatic finalize_epoch() call in the integrated node",
+        )
+        call = calls[0]
+        rendered_call = ast.get_source_segment(source, call)
+        self.assertGreaterEqual(len(call.args), 2, rendered_call)
+        reward_arg = call.args[1]
+
+        self.assertIsInstance(reward_arg, ast.Name, rendered_call)
+        self.assertEqual(
+            reward_arg.id,
+            "PER_BLOCK_RTC",
+            "auto-settlement must pass PER_BLOCK_RTC because finalize_epoch() "
+            f"multiplies its reward argument by EPOCH_SLOTS; found {rendered_call}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿﻿## Summary
- Fixes automatic epoch settlement passing the wrong reward scale into `finalize_epoch()`.
- `PER_EPOCH_RTC` is already the whole epoch pot, while `finalize_epoch()` multiplies its reward argument by `EPOCH_SLOTS` internally.
- Passing `PER_EPOCH_RTC` therefore pays the epoch pot once per slot: `1.5 * 144 = 216 RTC` instead of the intended `1.5 RTC` per epoch, and UTXO dual-write mints the same inflated amount when enabled.
- Adds a regression guard so the automatic settlement path must call `finalize_epoch(..., PER_BLOCK_RTC, ...)`.

## Proof
Current control flow before this patch:

```python
PER_EPOCH_RTC = 1.5
PER_BLOCK_RTC = PER_EPOCH_RTC / EPOCH_SLOTS
...
total_reward = Decimal(str(per_block_rtc)) * Decimal(EPOCH_SLOTS)
...
finalize_epoch(current_epoch, PER_EPOCH_RTC, prev_block_hash)
```

With `EPOCH_SLOTS = 144`, the automatic path distributes `216 RTC` per settled epoch instead of `1.5 RTC`. The fix passes `PER_BLOCK_RTC`, preserving the existing `finalize_epoch()` contract.

## Tests
- `python -m pytest node/tests/test_epoch_reward_settlement_parameter.py node/tests/test_epoch_utxo_dual_write_guard.py -q` -> `4 passed`
- `python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_epoch_reward_settlement_parameter.py`
- `git diff --check`

## Bounty
Submission for the UTXO/security bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2819

Public RTC wallet/miner ID for payout: `RTCfc0b72ca793ea72a2ba593e7d918d786e4350364`

This is a public receive reference only; no seed phrase, private key, wallet password, bank details, email, or payment token is being shared.

wallet: RTCfc0b72ca793ea72a2ba593e7d918d786e4350364
