### PR TITLE
fix: escape wallet tracker wallet labels

### DIFF
--- a/tests/test_wallet_tracker_frontend_security.py
+++ b/tests/test_wallet_tracker_frontend_security.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+TRACKER_HTML = Path(__file__).resolve().parents[1] / "wallet-tracker" / "rtc-wallet-tracker.html"
+
+
+def test_wallet_tracker_escapes_wallet_ids_and_founder_labels():
+    html = TRACKER_HTML.read_text(encoding="utf-8")
+
+    assert "function escapeHtml(value)" in html
+    assert "<strong>${escapeHtml(w.id)}</strong>" in html
+    assert "${escapeHtml(w.id)}" in html
+    assert "'<span class=\"badge-founder\">' + escapeHtml(w.founderLabel) + '</span>'" in html
+    assert "'<span class=\"badge badge-founder\">' + escapeHtml(w.founderLabel) + '</span>'" in html
+
+    assert "<strong>${w.id}</strong>" not in html
+    assert "${w.id}\n" not in html
+    assert "+ w.founderLabel +" not in html

--- a/wallet-tracker/rtc-wallet-tracker.html
+++ b/wallet-tracker/rtc-wallet-tracker.html
@@ -367,6 +367,12 @@
         let supplyChart = null;
         let refreshInterval = null;
 
+        function escapeHtml(value) {
+            const el = document.createElement('div');
+            el.textContent = String(value ?? '');
+            return el.innerHTML;
+        }
+
         async function getBalance(minerId) {
             try {
                 const response = await fetch(`${BALANCE_API_URL}?miner_id=${encodeURIComponent(minerId)}`);
@@ -476,9 +482,9 @@
                 whaleAlert.classList.add('active');
                 whaleList.innerHTML = whales.map(w => `
                     <li>
-                        <strong>${w.id}</strong><br>
+                        <strong>${escapeHtml(w.id)}</strong><br>
                         Balance: ${formatNumber(w.balance)} (${(w.balance / TOTAL_SUPPLY * 100).toFixed(2)}%)
-                        ${w.founder ? '<span class="badge-founder">' + w.founderLabel + '</span>' : ''}
+                        ${w.founder ? '<span class="badge-founder">' + escapeHtml(w.founderLabel) + '</span>' : ''}
                     </li>
                 `).join('');
             } else {
@@ -494,8 +500,8 @@
                     <tr class="${w.founder ? 'founder' : ''} ${isWhale ? 'whale-row' : ''}">
                         <td>${i + 1}</td>
                         <td>
-                            ${w.id}
-                            ${w.founder ? '<span class="badge badge-founder">' + w.founderLabel + '</span>' : ''}
+                            ${escapeHtml(w.id)}
+                            ${w.founder ? '<span class="badge badge-founder">' + escapeHtml(w.founderLabel) + '</span>' : ''}
                             ${isWhale ? '<span class="badge badge-whale">WHALE</span>' : ''}
                         </td>
                         <td>${formatNumber(w.balance)}</td>


### PR DESCRIPTION
## Summary
- fixes #4468 by escaping wallet/miner IDs and founder labels before they are inserted into the wallet tracker whale alert and holders table
- keeps the existing static badge markup intact while treating API-derived labels as text
- adds a static frontend regression test so raw wallet IDs and founder labels are not reintroduced into the `innerHTML` templates

## Security impact
A miner-controlled wallet ID can no longer be interpreted as HTML in the wallet distribution tracker whale alert or top holders table.

## Validation
- `python -m pytest tests\test_wallet_tracker_frontend_security.py -q` -> 1 passed
- `python -m py_compile tests\test_wallet_tracker_frontend_security.py` -> passed
- `git diff --check -- wallet-tracker\rtc-wallet-tracker.html tests\test_wallet_tracker_frontend_security.py` -> passed

/claim #4468