### PR TITLE
fix: validate BCOS and coalition pagination

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -53,26 +53,6 @@ def _get_admin_key():
     return os.environ.get("RC_ADMIN_KEY", "")
 
 
-def _parse_non_negative_query_int(name: str, default: int, max_value: int | None = None) -> int:
-    """Parse pagination query params without letting malformed input become a 500."""
-    raw_value = request.args.get(name)
-    if raw_value is None:
-        parsed = default
-    else:
-        try:
-            parsed = int(raw_value, 10)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(f"{name} must be an integer") from exc
-
-    if parsed < 0:
-        raise ValueError(f"{name} must be non-negative")
-
-    if max_value is not None:
-        parsed = min(parsed, max_value)
-
-    return parsed
-
-
 def _parse_trust_score(raw_score) -> int:
     """Validate BCOS trust scores before they are stored or rendered."""
     if isinstance(raw_score, bool):
@@ -87,6 +67,20 @@ def _parse_trust_score(raw_score) -> int:
         raise ValueError("trust_score must be between 0 and 100")
 
     return score
+
+
+def _parse_bounded_int_arg(name: str, default: int, maximum: int):
+    """Parse a bounded integer query arg for public BCOS endpoints."""
+    raw = request.args.get(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None, jsonify({"error": "invalid_pagination", "message": f"{name} must be an integer"}), 400
+
+    if value < 0:
+        return None, jsonify({"error": "invalid_pagination", "message": f"{name} must be non-negative"}), 400
+
+    return min(value, maximum), None, None
 
 
 def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
@@ -429,11 +423,12 @@ def bcos_badge_svg(cert_id):
 def bcos_directory():
     """List all BCOS-certified repos with latest attestation."""
     tier_filter = request.args.get("tier", "").upper()
-    try:
-        limit = _parse_non_negative_query_int("limit", 100, max_value=500)
-        offset = _parse_non_negative_query_int("offset", 0)
-    except ValueError as e:
-        return jsonify({"error": "invalid_pagination", "message": str(e)}), 400
+    limit, error_response, status = _parse_bounded_int_arg("limit", 100, 500)
+    if error_response is not None:
+        return error_response, status
+    offset, error_response, status = _parse_bounded_int_arg("offset", 0, 10_000)
+    if error_response is not None:
+        return error_response, status
 
     try:
         with sqlite3.connect(_DB_PATH) as conn:

--- a/node/coalition.py
+++ b/node/coalition.py
@@ -39,6 +39,16 @@ log = logging.getLogger("rip0278_coalition")
 _SIGNATURE_MAX_AGE_SECONDS = 300  # 5 minutes
 
 
+def _parse_bounded_int_arg(name: str, default: int, minimum: int, maximum: int):
+    """Parse a bounded integer query arg for public coalition endpoints."""
+    raw = request.args.get(name, str(default))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None, jsonify({"error": f"{name} must be an integer"}), 400
+    return max(minimum, min(value, maximum)), None, None
+
+
 def _verify_miner_signature(miner_id: str, action: str, data: dict) -> bool:
     """Verify ed25519 signature proving the caller controls miner_id.
 
@@ -700,8 +710,12 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
     @bp.route("/list", methods=["GET"])
     def list_coalitions():
         status_filter = request.args.get("status")
-        limit = min(int(request.args.get("limit", 50)), 200)
-        offset = int(request.args.get("offset", 0))
+        limit, error_response, status = _parse_bounded_int_arg("limit", 50, 1, 200)
+        if error_response is not None:
+            return error_response, status
+        offset, error_response, status = _parse_bounded_int_arg("offset", 0, 0, 10_000)
+        if error_response is not None:
+            return error_response, status
 
         try:
             with sqlite3.connect(db_path) as conn:
@@ -774,8 +788,12 @@ def create_coalition_blueprint(db_path: str) -> Blueprint:
             return jsonify({"error": "coalition not found or inactive"}), 404
 
         status_filter = request.args.get("status")
-        limit = min(int(request.args.get("limit", 50)), 200)
-        offset = int(request.args.get("offset", 0))
+        limit, error_response, status = _parse_bounded_int_arg("limit", 50, 1, 200)
+        if error_response is not None:
+            return error_response, status
+        offset, error_response, status = _parse_bounded_int_arg("offset", 0, 0, 10_000)
+        if error_response is not None:
+            return error_response, status
 
         try:
             with sqlite3.connect(db_path) as conn:

--- a/node/tests/test_bcos_routes_pagination.py
+++ b/node/tests/test_bcos_routes_pagination.py
@@ -1,0 +1,87 @@
+"""Regression tests for BCOS public pagination validation."""
+
+import gc
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from bcos_routes import register_bcos_routes
+
+
+def _unlink_temp_db(db_path):
+    gc.collect()
+    for _ in range(5):
+        try:
+            os.unlink(db_path)
+            return
+        except PermissionError:
+            time.sleep(0.05)
+    # Windows can keep Flask/SQLite test handles alive until process teardown.
+
+
+@pytest.fixture
+def tmp_db():
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE bcos_attestations (
+                cert_id TEXT PRIMARY KEY,
+                repo TEXT NOT NULL,
+                commit_sha TEXT NOT NULL,
+                tier TEXT NOT NULL,
+                trust_score INTEGER NOT NULL,
+                reviewer TEXT NOT NULL,
+                anchored_epoch INTEGER NOT NULL,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.executemany(
+            """
+            INSERT INTO bcos_attestations (
+                cert_id, repo, commit_sha, tier, trust_score,
+                reviewer, anchored_epoch, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                ("BCOS-ONE", "owner/repo-one", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "L1", 80, "alice", 1, "2026-05-01T00:00:00Z"),
+                ("BCOS-TWO", "owner/repo-two", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "L2", 95, "bob", 2, "2026-05-02T00:00:00Z"),
+            ],
+        )
+
+    yield db_path
+    _unlink_temp_db(db_path)
+
+
+@pytest.fixture
+def client(tmp_db):
+    app = Flask(__name__)
+    register_bcos_routes(app, tmp_db)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_bcos_directory_rejects_non_integer_pagination(client):
+    limit_response = client.get("/bcos/directory?limit=not-an-int")
+    assert limit_response.status_code == 400
+    assert limit_response.get_json() == {"error": "invalid_pagination", "message": "limit must be an integer"}
+
+    offset_response = client.get("/bcos/directory?offset=not-an-int")
+    assert offset_response.status_code == 400
+    assert offset_response.get_json() == {"error": "invalid_pagination", "message": "offset must be an integer"}
+
+
+def test_bcos_directory_rejects_negative_pagination(client):
+    response = client.get("/bcos/directory?limit=-10&offset=-20")
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid_pagination", "message": "limit must be non-negative"}

--- a/node/tests/test_coalition.py
+++ b/node/tests/test_coalition.py
@@ -11,6 +11,7 @@ Author: Claude (via Nous Hermes)
 """
 
 import pytest
+import gc
 import sqlite3
 import tempfile
 import time
@@ -31,6 +32,17 @@ from coalition import (
     FLAMEBUND_MINER_ID, FLAMEBUND_COALITION_NAME,
 )
 from flask import Flask
+
+
+def _unlink_temp_db(db_path):
+    gc.collect()
+    for _ in range(5):
+        try:
+            os.unlink(db_path)
+            return
+        except PermissionError:
+            time.sleep(0.05)
+    # Windows can keep Flask/SQLite test handles alive until process teardown.
 
 
 # ---------------------------------------------------------------------------
@@ -56,7 +68,7 @@ def tmp_db():
         """)
 
     yield db_path
-    os.unlink(db_path)
+    _unlink_temp_db(db_path)
 
 
 @pytest.fixture
@@ -596,6 +608,26 @@ def test_list_coalitions_with_status_filter(client, rich_miner):
         assert c["status"] == COALITION_STATUS_ACTIVE
 
 
+def test_list_coalitions_rejects_non_integer_pagination(client):
+    """Malformed pagination returns 400 instead of an internal error."""
+    res = client.get("/api/coalition/list?limit=not-an-int")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "limit must be an integer"}
+
+    res = client.get("/api/coalition/list?offset=not-an-int")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "offset must be an integer"}
+
+
+def test_list_coalitions_clamps_negative_pagination(client):
+    """Negative pagination values are clamped to safe public bounds."""
+    res = client.get("/api/coalition/list?limit=-5&offset=-10")
+    assert res.status_code == 200
+    data = res.get_json()
+    assert data["count"] == 1
+    assert data["coalitions"][0]["name"] == FLAMEBUND_COALITION_NAME
+
+
 def test_get_coalition_details(client, test_coalition, rich_miner, poor_miner):
     """Get coalition details with members."""
     # Add a member
@@ -653,6 +685,17 @@ def test_list_proposals_status_filter(client, test_coalition, rich_miner):
     assert res.status_code == 200
     data = res.get_json()
     assert data["count"] == 1
+
+
+def test_list_proposals_rejects_non_integer_pagination(client, test_coalition):
+    """Proposal listing validates pagination before querying SQLite."""
+    res = client.get(f"/api/coalition/{test_coalition}/proposals?limit=NaN")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "limit must be an integer"}
+
+    res = client.get(f"/api/coalition/{test_coalition}/proposals?offset=NaN")
+    assert res.status_code == 400
+    assert res.get_json() == {"error": "offset must be an integer"}
 
 
 def test_list_proposals_nonexistent_coalition(client, rich_miner):


### PR DESCRIPTION
## Summary

- add bounded integer parsing for public BCOS directory pagination
- add bounded integer parsing for coalition list/proposal pagination
- add regression tests for malformed and negative pagination inputs

## Security impact

This prevents unauthenticated malformed `limit`/`offset` values from falling into internal-error paths on public list endpoints, and clamps negative or oversized pagination to safe bounds before SQLite queries.

Fixes #4545.

## Tests

- `python -m pytest node\tests\test_bcos_routes_pagination.py node\tests\test_coalition.py::test_list_coalitions_rejects_non_integer_pagination node\tests\test_coalition.py::test_list_coalitions_clamps_negative_pagination node\tests\test_coalition.py::test_list_proposals_rejects_non_integer_pagination -q`
- `python -m pytest node\tests\test_coalition.py node\tests\test_bcos_routes_pagination.py -q`
- `python -m py_compile node\bcos_routes.py node\coalition.py node\tests\test_bcos_routes_pagination.py node\tests\test_coalition.py`
- `git diff --check`

/claim #71
