### PR TITLE
fix: validate memory route inputs

### DIFF
--- a/bounties/issue-2285/src/memory_routes.py
+++ b/bounties/issue-2285/src/memory_routes.py
@@ -57,6 +57,31 @@ def _validate_agent_id(agent_id: Optional[str]) -> str:
     return agent_id
 
 
+def _get_json_object() -> Dict[str, Any]:
+    """Return the request JSON body when it is an object."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        raise ValueError("JSON object required")
+    return data
+
+
+def _get_positive_int_arg(name: str, default: int, max_value: int) -> int:
+    """Parse a positive integer query argument with an upper bound."""
+    raw_value = request.args.get(name)
+    if raw_value is None:
+        return default
+
+    try:
+        value = int(raw_value)
+    except ValueError:
+        raise ValueError(f"Invalid {name} parameter") from None
+
+    if value < 1:
+        raise ValueError(f"{name} must be positive")
+
+    return min(value, max_value)
+
+
 @memory_bp.route("/record", methods=["POST"])
 def record_content() -> tuple:
     """
@@ -80,7 +105,7 @@ def record_content() -> tuple:
         }
     """
     try:
-        data = request.get_json() or {}
+        data = _get_json_object()
 
         agent_id = _validate_agent_id(data.get("agent_id"))
         content_id = data.get("content_id")
@@ -133,10 +158,7 @@ def get_recent() -> tuple:
         agent_id = _validate_agent_id(request.args.get("agent_id"))
         content_type = request.args.get("content_type")
 
-        try:
-            limit = min(int(request.args.get("limit", 10)), 100)
-        except ValueError:
-            return jsonify({"error": "Invalid limit parameter"}), 400
+        limit = _get_positive_int_arg("limit", 10, 100)
 
         engine = _get_engine()
         recalls = engine.recall_recent(
@@ -180,10 +202,7 @@ def search_topic() -> tuple:
         if not topic:
             return jsonify({"error": "topic is required"}), 400
 
-        try:
-            limit = min(int(request.args.get("limit", 10)), 100)
-        except ValueError:
-            return jsonify({"error": "Invalid limit parameter"}), 400
+        limit = _get_positive_int_arg("limit", 10, 100)
 
         engine = _get_engine()
         recalls = engine.recall_by_topic(
@@ -234,10 +253,7 @@ def search_tags() -> tuple:
 
         match_all = request.args.get("match_all", "false").lower() == "true"
 
-        try:
-            limit = min(int(request.args.get("limit", 10)), 100)
-        except ValueError:
-            return jsonify({"error": "Invalid limit parameter"}), 400
+        limit = _get_positive_int_arg("limit", 10, 100)
 
         engine = _get_engine()
         recalls = engine.recall_by_tags(
@@ -293,10 +309,7 @@ def get_context() -> tuple:
         if tags_param:
             tags = [t.strip() for t in tags_param.split(",") if t.strip()]
 
-        try:
-            max_items = min(int(request.args.get("max_items", 5)), 20)
-        except ValueError:
-            return jsonify({"error": "Invalid max_items parameter"}), 400
+        max_items = _get_positive_int_arg("max_items", 5, 20)
 
         include_summary = request.args.get("include_summary", "true").lower() != "false"
 
@@ -338,7 +351,7 @@ def generate_reference() -> tuple:
         }
     """
     try:
-        data = request.get_json() or {}
+        data = _get_json_object()
 
         agent_id = _validate_agent_id(data.get("agent_id"))
         topic = data.get("topic")
@@ -386,7 +399,7 @@ def link_content() -> tuple:
         }
     """
     try:
-        data = request.get_json() or {}
+        data = _get_json_object()
 
         agent_id = _validate_agent_id(data.get("agent_id"))
         source_id = data.get("source_content_id")

--- a/bounties/issue-2285/tests/test_memory_routes.py
+++ b/bounties/issue-2285/tests/test_memory_routes.py
@@ -98,6 +98,25 @@ class MemoryRoutesTestCase(unittest.TestCase):
         data = response.get_json()
         self.assertIn("error", data)
 
+    def test_json_routes_reject_non_object_bodies(self) -> None:
+        """Test JSON mutation routes reject arrays and other non-object bodies."""
+        routes = (
+            ("post", "/api/memory/record"),
+            ("post", "/api/memory/reference"),
+            ("post", "/api/memory/link"),
+        )
+
+        for method, path in routes:
+            with self.subTest(path=path):
+                response = getattr(self.client, method)(
+                    path,
+                    json=["not", "an", "object"],
+                    content_type="application/json"
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "JSON object required"})
+
     def test_get_recent(self) -> None:
         """Test getting recent content."""
         # First record some content
@@ -132,6 +151,16 @@ class MemoryRoutesTestCase(unittest.TestCase):
             "/api/memory/recent?agent_id=test-agent&limit=invalid"
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_get_recent_rejects_non_positive_limit(self) -> None:
+        """Test recent content rejects zero and negative limits."""
+        for limit in ("0", "-1"):
+            with self.subTest(limit=limit):
+                response = self.client.get(
+                    f"/api/memory/recent?agent_id=test-agent&limit={limit}"
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "limit must be positive"})
 
     def test_search_topic(self) -> None:
         """Test searching by topic."""
@@ -174,6 +203,16 @@ class MemoryRoutesTestCase(unittest.TestCase):
             "/api/memory/search?agent_id=test-agent"
         )
         self.assertEqual(response.status_code, 400)
+
+    def test_search_topic_rejects_non_positive_limit(self) -> None:
+        """Test topic search rejects zero and negative limits."""
+        for limit in ("0", "-1"):
+            with self.subTest(limit=limit):
+                response = self.client.get(
+                    f"/api/memory/search?agent_id=test-agent&topic=mining&limit={limit}"
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "limit must be positive"})
 
     def test_search_by_tags(self) -> None:
         """Test searching by tags."""
@@ -238,6 +277,16 @@ class MemoryRoutesTestCase(unittest.TestCase):
         data = response.get_json()
         self.assertEqual(len(data["recalls"]), 1)
 
+    def test_search_by_tags_rejects_non_positive_limit(self) -> None:
+        """Test tag search rejects zero and negative limits."""
+        for limit in ("0", "-1"):
+            with self.subTest(limit=limit):
+                response = self.client.get(
+                    f"/api/memory/tags?agent_id=test-agent&tags=mining&limit={limit}"
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "limit must be positive"})
+
     def test_get_context(self) -> None:
         """Test building memory context."""
         # Record content
@@ -273,6 +322,16 @@ class MemoryRoutesTestCase(unittest.TestCase):
         """Test context without agent_id."""
         response = self.client.get("/api/memory/context")
         self.assertEqual(response.status_code, 400)
+
+    def test_get_context_rejects_non_positive_max_items(self) -> None:
+        """Test context rejects zero and negative max_items values."""
+        for max_items in ("0", "-1"):
+            with self.subTest(max_items=max_items):
+                response = self.client.get(
+                    f"/api/memory/context?agent_id=test-agent&max_items={max_items}"
+                )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "max_items must be positive"})
 
     def test_generate_reference_casual(self) -> None:
         """Test generating casual self-reference."""


### PR DESCRIPTION
## Summary
- require JSON object bodies for memory mutation routes instead of allowing arrays/scalars to raise route exceptions
- validate memory route limit/max_items query parameters as positive integers while preserving existing caps
- extend issue-2285 route tests for non-object JSON and non-positive pagination values

## Verification
- `python -m pytest bounties\issue-2285\tests\test_memory_routes.py -q`
- `python -m pytest bounties\issue-2285\tests -q`
- `python -m py_compile bounties\issue-2285\src\memory_routes.py bounties\issue-2285\tests\test_memory_routes.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `git diff --check -- bounties\issue-2285\src\memory_routes.py bounties\issue-2285\tests\test_memory_routes.py`