### PR TITLE
fix: require admin key for bounty sync

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -611,6 +611,14 @@ def sync_bounties():
     try:
         import urllib.request
         import ssl
+        import hmac
+
+        admin_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not admin_key:
+            return jsonify({'error': 'RC_ADMIN_KEY not configured — endpoint disabled'}), 503
+        provided_key = request.headers.get("X-Admin-Key", "")
+        if not hmac.compare_digest(provided_key, admin_key):
+            return jsonify({'error': 'Unauthorized — admin key required to sync bounties'}), 401
         
         # GitHub repos to scan
         repos = [

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -163,6 +163,14 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         data = json.loads(response.data)
         self.assertIn('error', data)
 
+    def test_bounty_sync_requires_admin_key(self):
+        """Bounty sync is admin-only because it mutates local bounty state."""
+        response = self.client.post('/api/bounties/sync')
+        self.assertEqual(response.status_code, 401)
+        data = json.loads(response.data)
+        self.assertIn('admin key required', data['error'])
+
+
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
         # Insert a test bounty directly


### PR DESCRIPTION
## Summary
- require `X-Admin-Key` on `POST /api/bounties/sync` before fetching or writing bounty rows
- return the same disabled/unauthorized style used by adjacent claim and complete bounty routes
- add a regression test that unauthenticated sync requests are rejected

Fixes #4549

## Verification
- `python3 -m py_compile node/beacon_api.py tests/test_beacon_atlas_behavior.py`
- `git diff --check -- node/beacon_api.py tests/test_beacon_atlas_behavior.py`

Note: targeted pytest could not run in this local checkout because the test bootstrap imports Flask from `node/rustchain_v2_integrated_v2.2.1_rip200.py`, and Flask is not installed in the local environment.