### PR TITLE
fix: validate boot chime json bodies

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -51,6 +51,18 @@ audio_capture = BootChimeCapture(config=capture_config)
 fingerprint_extractor = AcousticFingerprint()
 
 
+class JsonBodyError(ValueError):
+    """Raised when a JSON endpoint receives a non-object body."""
+
+
+def get_json_object() -> Dict[str, Any]:
+    """Return the request JSON body when it is an object."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        raise JsonBodyError("JSON object required")
+    return data
+
+
 # ============= Health & Info =============
 
 @app.route('/health', methods=['GET'])
@@ -102,7 +114,7 @@ def issue_challenge():
         }
     """
     try:
-        data = request.get_json() or {}
+        data = get_json_object()
         miner_id = data.get('miner_id')
         
         if not miner_id:
@@ -118,6 +130,8 @@ def issue_challenge():
             'ttl_seconds': challenge.expires_at - challenge.issued_at
         })
         
+    except JsonBodyError as e:
+        return jsonify({'error': str(e)}), 400
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -300,7 +314,7 @@ def revoke_attestation():
         { "success": true, "message": "..." }
     """
     try:
-        data = request.get_json() or {}
+        data = get_json_object()
         miner_id = data.get('miner_id')
         reason = data.get('reason', '')
         
@@ -314,6 +328,8 @@ def revoke_attestation():
         else:
             return jsonify({'error': 'Miner not found'}), 404
             
+    except JsonBodyError as e:
+        return jsonify({'error': str(e)}), 400
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -1,0 +1,106 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ChallengeStub:
+    challenge_id = "challenge-1"
+    nonce = "nonce-1"
+    issued_at = 100
+    expires_at = 400
+
+
+class ProofOfIronStub:
+    def __init__(self, *args, **kwargs):
+        self.issued_for = None
+        self.revoked = None
+
+    def issue_challenge(self, miner_id):
+        self.issued_for = miner_id
+        return ChallengeStub()
+
+    def revoke_attestation(self, miner_id, reason):
+        self.revoked = (miner_id, reason)
+        return True
+
+
+def install_dependency_stubs(monkeypatch):
+    flask_cors = types.ModuleType("flask_cors")
+    flask_cors.CORS = lambda app: app
+    monkeypatch.setitem(sys.modules, "flask_cors", flask_cors)
+
+    acoustic_fingerprint = types.ModuleType("acoustic_fingerprint")
+    acoustic_fingerprint.AcousticFingerprint = type("AcousticFingerprint", (), {})
+    monkeypatch.setitem(sys.modules, "acoustic_fingerprint", acoustic_fingerprint)
+
+    boot_chime_capture = types.ModuleType("boot_chime_capture")
+    boot_chime_capture.AudioCaptureConfig = type(
+        "AudioCaptureConfig",
+        (),
+        {"__init__": lambda self, **kwargs: None},
+    )
+    boot_chime_capture.BootChimeCapture = type(
+        "BootChimeCapture",
+        (),
+        {"__init__": lambda self, *args, **kwargs: None},
+    )
+    monkeypatch.setitem(sys.modules, "boot_chime_capture", boot_chime_capture)
+
+    proof_of_iron = types.ModuleType("proof_of_iron")
+    proof_of_iron.ProofOfIron = ProofOfIronStub
+    proof_of_iron.ProofOfIronError = Exception
+    proof_of_iron.AttestationStatus = type(
+        "AttestationStatus",
+        (),
+        {"VERIFIED": "verified"},
+    )
+    monkeypatch.setitem(sys.modules, "proof_of_iron", proof_of_iron)
+
+
+@pytest.fixture
+def api_module(monkeypatch):
+    install_dependency_stubs(monkeypatch)
+    module_path = REPO_ROOT / "issue2307_boot_chime" / "boot_chime_api.py"
+    spec = importlib.util.spec_from_file_location("boot_chime_api_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def client(api_module):
+    api_module.app.config["TESTING"] = True
+    return api_module.app.test_client()
+
+
+@pytest.mark.parametrize("path", ("/api/v1/challenge", "/api/v1/revoke"))
+def test_json_endpoints_reject_non_object_bodies(client, path):
+    response = client.post(path, json=["not", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_challenge_accepts_valid_json_body(client, api_module):
+    response = client.post("/api/v1/challenge", json={"miner_id": "miner-1"})
+
+    assert response.status_code == 200
+    assert api_module.poi_system.issued_for == "miner-1"
+    assert response.get_json()["challenge_id"] == "challenge-1"
+
+
+def test_revoke_accepts_valid_json_body(client, api_module):
+    response = client.post(
+        "/api/v1/revoke",
+        json={"miner_id": "miner-1", "reason": "retired"},
+    )
+
+    assert response.status_code == 200
+    assert api_module.poi_system.revoked == ("miner-1", "retired")
+    assert response.get_json() == {"success": True, "message": "Attestation revoked"}


### PR DESCRIPTION
## Summary
- require JSON object bodies on boot chime challenge and revoke endpoints
- return 400 for arrays/scalars instead of letting route logic fail against non-dict payloads
- add focused Flask API tests with dependency stubs so validation runs without audio hardware/native services

## Verification
- `python -m pytest tests\test_boot_chime_api_json_validation.py -q`
- `python -m py_compile tests\test_boot_chime_api_json_validation.py issue2307_boot_chime\boot_chime_api.py node\utxo_db.py`
- `git diff --check -- issue2307_boot_chime\boot_chime_api.py tests\test_boot_chime_api_json_validation.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `python -m pytest issue2307_boot_chime\tests\test_boot_chime.py -q`