### PR TITLE
fix: reject malformed bft route payloads

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -27,7 +27,7 @@ import threading
 import time
 from dataclasses import dataclass, asdict
 from enum import Enum
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, Iterable, List, Optional, Set, Tuple
 import requests
 
 # Configure logging
@@ -1016,6 +1016,15 @@ def create_bft_routes(app, bft: BFTConsensus):
     """Add BFT consensus routes to Flask app"""
     from flask import request, jsonify
 
+    def _json_object():
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return None, ({'error': 'JSON object required'}, 400)
+        return data, None
+
+    def _missing_fields(data: Dict, required: Iterable[str]) -> List[str]:
+        return [field for field in required if field not in data]
+
     @app.route('/bft/status', methods=['GET'])
     def bft_status():
         """Get BFT consensus status"""
@@ -1025,7 +1034,19 @@ def create_bft_routes(app, bft: BFTConsensus):
     def bft_receive_message():
         """Receive consensus message from peer"""
         try:
-            msg_data = request.get_json()
+            msg_data, error = _json_object()
+            if error:
+                return jsonify(error[0]), error[1]
+
+            msg_type = msg_data.get('msg_type')
+            valid_types = {
+                MessageType.PRE_PREPARE.value,
+                MessageType.PREPARE.value,
+                MessageType.COMMIT.value,
+            }
+            if msg_type not in valid_types:
+                return jsonify({'error': 'invalid msg_type'}), 400
+
             bft.receive_message(msg_data)
             return jsonify({'status': 'ok'})
         except Exception as e:
@@ -1036,7 +1057,17 @@ def create_bft_routes(app, bft: BFTConsensus):
     def bft_view_change():
         """Receive view change message"""
         try:
-            msg_data = request.get_json()
+            msg_data, error = _json_object()
+            if error:
+                return jsonify(error[0]), error[1]
+
+            missing = _missing_fields(
+                msg_data,
+                ('view', 'epoch', 'node_id', 'signature', 'timestamp'),
+            )
+            if missing:
+                return jsonify({'error': f"missing required fields: {', '.join(missing)}"}), 400
+
             bft.handle_view_change(msg_data)
             return jsonify({'status': 'ok'})
         except Exception as e:

--- a/node/tests/test_bft_route_validation.py
+++ b/node/tests/test_bft_route_validation.py
@@ -1,0 +1,53 @@
+import pytest
+from flask import Flask
+
+from node.rustchain_bft_consensus import BFTConsensus, create_bft_routes
+
+
+@pytest.fixture
+def bft_client():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    bft = BFTConsensus("node-a", ":memory:", "test-secret")
+    create_bft_routes(app, bft)
+
+    try:
+        yield app.test_client()
+    finally:
+        bft._cancel_view_change_timer()
+
+
+@pytest.mark.parametrize("payload", (None, [], "not-object"))
+def test_bft_message_requires_json_object(bft_client, payload):
+    response = bft_client.post("/bft/message", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+@pytest.mark.parametrize("payload", ({}, {"msg_type": "unknown"}))
+def test_bft_message_rejects_invalid_message_type(bft_client, payload):
+    response = bft_client.post("/bft/message", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid msg_type"}
+
+
+@pytest.mark.parametrize("payload", (None, [], "not-object"))
+def test_bft_view_change_requires_json_object(bft_client, payload):
+    response = bft_client.post("/bft/view_change", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_bft_view_change_rejects_missing_required_fields(bft_client):
+    response = bft_client.post(
+        "/bft/view_change",
+        json={"view": 2, "node_id": "peer-a"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "missing required fields: epoch, signature, timestamp"
+    }


### PR DESCRIPTION
## Summary
- require JSON object bodies on `/bft/message` and `/bft/view_change`
- reject unknown or missing `msg_type` values before dispatching consensus messages
- reject incomplete view-change payloads before the handler can silently drop them
- add focused Flask route tests for malformed BFT message and view-change requests

Fixes #4436

## Verification
- `python -m pytest node\tests\test_bft_route_validation.py -q`
- `python -m py_compile node\rustchain_bft_consensus.py node\tests\test_bft_route_validation.py`
- `git diff --check -- node\rustchain_bft_consensus.py node\tests\test_bft_route_validation.py`