### PR TITLE
fix: validate passport json bodies

### DIFF
--- a/passport/passport_server.py
+++ b/passport/passport_server.py
@@ -10,12 +10,21 @@ Deployable at rustchain.org/passport/<machine_id>
 import json
 import os
 from datetime import datetime
+from typing import Any, Dict
 
 from flask import Flask, render_template, jsonify, request, Response
 from passport_ledger import MachinePassport, PassportLedger, RepairEntry, BenchmarkSignature
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
 ledger = PassportLedger(data_dir=os.environ.get("PASSPORT_DATA_DIR", "/tmp/passport-ledger"))
+
+
+def get_json_object() -> Dict[str, Any]:
+    """Return the request JSON body when it is an object."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        raise ValueError("JSON object required")
+    return data
 
 
 # ── Web Routes ────────────────────────────────────────────────────
@@ -69,8 +78,12 @@ def api_get(machine_id):
 @app.route("/api/passport", methods=["POST"])
 def api_create():
     """Create or update a machine passport."""
-    data = request.get_json()
-    if not data or "machine_id" not in data:
+    try:
+        data = get_json_object()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if "machine_id" not in data:
         return jsonify({"error": "machine_id required"}), 400
 
     # Check if exists (update) or new (create)
@@ -100,8 +113,12 @@ def api_add_repair(machine_id):
     if not p:
         return jsonify({"error": "Passport not found"}), 404
 
-    data = request.get_json()
-    if not data or "date" not in data or "description" not in data:
+    try:
+        data = get_json_object()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if "date" not in data or "description" not in data:
         return jsonify({"error": "date and description required"}), 400
 
     p.add_repair(**{k: v for k, v in data.items() if k in RepairEntry.__dataclass_fields__})
@@ -116,7 +133,11 @@ def api_add_benchmark(machine_id):
     if not p:
         return jsonify({"error": "Passport not found"}), 404
 
-    data = request.get_json() or {}
+    try:
+        data = get_json_object()
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
     sig = BenchmarkSignature(**{k: v for k, v in data.items() if k in BenchmarkSignature.__dataclass_fields__})
     p.add_benchmark(sig)
     ledger.save(p)

--- a/passport/test_passport.py
+++ b/passport/test_passport.py
@@ -249,6 +249,20 @@ class TestAPI:
         resp = client.post("/api/passport", json={"name": "No ID"})
         assert resp.status_code == 400
 
+    def test_api_json_routes_reject_non_object_bodies(self, client):
+        client.post("/api/passport", json={"machine_id": "json-test", "name": "JSON Test"})
+
+        routes = (
+            "/api/passport",
+            "/api/passport/json-test/repair",
+            "/api/passport/json-test/benchmark",
+        )
+
+        for route in routes:
+            resp = client.post(route, json=["not", "object"])
+            assert resp.status_code == 400
+            assert resp.get_json() == {"error": "JSON object required"}
+
     def test_passport_view_page(self, client):
         resp = client.get("/passport/test123")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- require JSON object bodies for machine passport create, repair, and benchmark API routes
- return 400 for arrays/scalars instead of letting benchmark handling call `.items()` on non-dict payloads
- extend the existing passport API tests for non-object JSON bodies

## Verification
- `python -m pytest test_passport.py -q` from `passport\`
- `python -m py_compile passport\passport_server.py passport\test_passport.py node\utxo_db.py`
- `git diff --check -- passport\passport_server.py passport\test_passport.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`