### PR TITLE
docs: fix RIP-305 claims guide link

### DIFF
--- a/docs/CLAIMS_GUIDE.md
+++ b/docs/CLAIMS_GUIDE.md
@@ -444,7 +444,7 @@ Claims are settled in batches:
 3. **Maximum Batch** - 100 claims
 4. **Transaction** - Multi-output transfer to all claimants
 
-See [RIP-305](/rips/docs/RIP-0305-reward-claim-system.md) for full specification.
+See [RIP-305](../rips/docs/RIP-0305-reward-claim-system.md) for full specification.
 
 ---
 


### PR DESCRIPTION
## Summary
- fixes the RIP-305 link in docs/CLAIMS_GUIDE.md so it resolves from the docs directory
- replaces the root-relative /rips/... URL with the repository-relative ../rips/... path

Bounty: Scottcjn/rustchain-bounties#9018
- 地址：RTC6a5325fd2708469d4625ad15e70a807b127846bc
## Verification
- direct link assertion: docs/CLAIMS_GUIDE.md points at an existing ../rips/docs/RIP-0305-reward-claim-system.md file
- git diff --check -- docs/CLAIMS_GUIDE.md

