### PR TITLE
fix: use local RTC award workflow

### DIFF
--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -248,6 +248,8 @@ class TestMainFlow(unittest.TestCase):
 
     def _env(self, **overrides):
         """Set up environment for main()."""
+        output_file = tempfile.NamedTemporaryFile(delete=False)
+        output_file.close()
         env = {
             "INPUT_RTC_AMOUNT": "75",
             "INPUT_RTC_VPS_HOST": "1.2.3.4",
@@ -265,7 +267,7 @@ class TestMainFlow(unittest.TestCase):
             "PR_BODY": "wallet: RTCcontributor123\n",
             "PR_HEAD_SHA": "abc123",
             "PR_TITLE": "Test PR",
-            "GITHUB_OUTPUT": "/dev/null",
+            "GITHUB_OUTPUT": output_file.name,
         }
         env.update(overrides)
         return patch.dict(os.environ, env, clear=True)

--- a/.github/workflows/award-rtc.yml
+++ b/.github/workflows/award-rtc.yml
@@ -5,7 +5,9 @@ on:
     types: [closed]
 
 permissions:
-  pull-requests: write
+  contents: read
+  issues: write
+  pull-requests: read
 
 jobs:
   award-rtc:
@@ -16,12 +18,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Award RTC to Contributor
-        uses: BossChaos/rtc-award-action@main
+        uses: ./.github/actions/rtc-auto-bounty
         with:
-          wallet_file: '.rtc-wallet'
-          amount: '5'
-          api_url: 'https://bulbous-bouffant.metalseed.net/transfer'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Store wallet as secret: Settings > Secrets > RTC_WALLET_JSON
-          # The action will read from the secret instead of a file
+          rtc-amount: '5'
+          rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
+          rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
+          from-wallet: 'founder_community'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-path: ${{ github.workspace }}

--- a/tests/test_award_rtc_workflow.py
+++ b/tests/test_award_rtc_workflow.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "award-rtc.yml"
+
+
+def test_award_rtc_workflow_uses_local_action() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "uses: ./.github/actions/rtc-auto-bounty" in workflow
+    assert "BossChaos/rtc-award-action" not in workflow
+
+
+def test_award_rtc_workflow_no_longer_requires_wallet_file() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "wallet_file" not in workflow
+    assert "api_url" not in workflow
+
+
+def test_award_rtc_workflow_passes_live_transfer_secrets() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}" in workflow
+    assert "rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}" in workflow
+    assert "github-token: ${{ secrets.GITHUB_TOKEN }}" in workflow

--- a/tests/test_award_rtc_workflow.py
+++ b/tests/test_award_rtc_workflow.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 


### PR DESCRIPTION
## Summary

- Switch `award-rtc.yml` from the external `BossChaos/rtc-award-action` to the repository's local `./.github/actions/rtc-auto-bounty` action.
- Pass the existing RTC VPS/admin secrets into the local action and remove the hard dependency on a repository-root `.rtc-wallet` file.
- Add workflow regression tests so future changes do not reintroduce the external action or `.rtc-wallet` requirement.
- Make the RTC action's existing main-flow tests portable on Windows by using a real temporary `GITHUB_OUTPUT` file instead of `/dev/null`.

## Why

Merged bounty PRs were running the `award-rtc` workflow but failing before payment because the external action expected `.rtc-wallet` in the checkout. The local action already supports the repo's desired behavior: resolve a wallet from the PR body or `.rtc-wallet`, then fall back to the PR author when no wallet directive is present.

## Verification

```text
python -m pytest tests\test_award_rtc_workflow.py .github\actions\rtc-auto-bounty\test_award_rtc.py -q
# 38 passed

python -m py_compile .github\actions\rtc-auto-bounty\award_rtc.py .github\actions\rtc-auto-bounty\test_award_rtc.py tests\test_award_rtc_workflow.py
git diff --check -- .github\workflows\award-rtc.yml .github\actions\rtc-auto-bounty\test_award_rtc.py tests\test_award_rtc_workflow.py
# both passed
```
