### PR TITLE
fix: validate rent relic json bodies

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -153,6 +153,17 @@ class TestReservationFlow:
         assert cr.status_code == 200
         assert cr.json["status"] == "completed"
 
+    def test_complete_rejects_non_object_json(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_bad_complete", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+
+        cr = app.post(f"/relic/complete/{r.json['session_id']}", json=["not", "object"])
+        assert cr.status_code == 400
+        assert cr.json["error"] == "JSON object required"
+
     def test_status_endpoint(self, app):
         r = app.post("/relic/reserve", json={
             "agent_id": "agent_stat", "machine_id": "g4-quicksilver",
@@ -169,6 +180,11 @@ class TestReservationFlow:
             "machine_id": "g3-beige", "duration_hours": 1, "rtc_amount": 4.0,
         })
         assert resp.status_code == 400
+
+    def test_reserve_rejects_non_object_json(self, app):
+        resp = app.post("/relic/reserve", json=["not", "object"])
+        assert resp.status_code == 400
+        assert resp.json["error"] == "JSON object required"
 
     def test_unknown_machine_returns_404(self, app):
         resp = app.post("/relic/reserve", json={

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -45,6 +45,16 @@ def get_db_path() -> str:
     return app.config.get("DB_PATH", DB_PATH)
 
 
+def _get_json_object_or_empty() -> dict:
+    """Return an object JSON body, preserving empty-body behavior."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        abort(400, description="JSON object required")
+    return data
+
+
 @contextmanager
 def db_conn():
     conn = sqlite3.connect(get_db_path())
@@ -224,7 +234,7 @@ def get_available():
 @app.post("/relic/reserve")
 def post_reserve():
     """Reserve a machine and lock RTC in escrow."""
-    data = request.get_json(silent=True) or {}
+    data = _get_json_object_or_empty()
 
     agent_id       = data.get("agent_id", "").strip()
     machine_id     = data.get("machine_id", "").strip()
@@ -415,7 +425,7 @@ def get_reservation(session_id: str):
 @app.post("/relic/complete/<session_id>")
 def post_complete(session_id: str):
     """Mark a session as completed and release escrow."""
-    data        = request.get_json(silent=True) or {}
+    data        = _get_json_object_or_empty()
     output_hash = data.get("output_hash") or hashlib.sha256(session_id.encode()).hexdigest()
 
     with db_conn() as conn:


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on Rent-a-Relic reservation and completion POST routes
- preserve existing empty-body behavior for `/relic/complete/<session_id>` while preventing array/scalar payloads from reaching `.get()`
- add route coverage for invalid JSON shape on reserve and complete flows

## Verification
- `python -m pytest tests\test_rent_a_relic.py -q`
- `python -m py_compile tools\rent_a_relic\server.py tests\test_rent_a_relic.py node\utxo_db.py`
- `git diff --check -- tools\rent_a_relic\server.py tests\test_rent_a_relic.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`