### PR TITLE
fix: validate machine passport event json

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -41,6 +41,20 @@ def get_ledger() -> MachinePassportLedger:
     return _ledger
 
 
+def get_optional_json_object():
+    """Return an optional JSON object body or an error response."""
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({
+            'ok': False,
+            'error': 'invalid_request',
+            'message': 'JSON object required',
+        }), 400)
+    return data, None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -374,7 +388,9 @@ def add_attestation(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json() or {}
+    data, error = get_optional_json_object()
+    if error:
+        return error
     
     success, msg = ledger.add_attestation(
         machine_id=machine_id,
@@ -418,7 +434,9 @@ def add_benchmark(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json() or {}
+    data, error = get_optional_json_object()
+    if error:
+        return error
     
     success, msg = ledger.add_benchmark(
         machine_id=machine_id,

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -1,0 +1,89 @@
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "node"))
+
+import machine_passport_api
+
+
+class LedgerStub:
+    def __init__(self):
+        self.attestation_payload = None
+        self.benchmark_payload = None
+
+    def get_passport(self, machine_id):
+        return True
+
+    def add_attestation(self, **kwargs):
+        self.attestation_payload = kwargs
+        return True, "attestation added"
+
+    def add_benchmark(self, **kwargs):
+        self.benchmark_payload = kwargs
+        return True, "benchmark added"
+
+
+@pytest.fixture
+def ledger(monkeypatch):
+    stub = LedgerStub()
+    monkeypatch.setattr(machine_passport_api, "_ledger", stub)
+    return stub
+
+
+@pytest.fixture
+def client(ledger):
+    app = Flask(__name__)
+    app.register_blueprint(machine_passport_api.machine_passport_bp)
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/api/machine-passport/machine-1/attestations",
+        "/api/machine-passport/machine-1/benchmarks",
+    ),
+)
+def test_event_routes_reject_non_object_json(client, path):
+    response = client.post(path, json=["not", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }
+
+
+def test_attestation_route_preserves_empty_body_defaults(client, ledger):
+    response = client.post("/api/machine-passport/machine-1/attestations")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "attestation added"}
+    assert ledger.attestation_payload["machine_id"] == "machine-1"
+    assert ledger.attestation_payload["epoch"] is None
+
+
+def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
+    response = client.post("/api/machine-passport/machine-1/benchmarks")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "benchmark added"}
+    assert ledger.benchmark_payload["machine_id"] == "machine-1"
+    assert ledger.benchmark_payload["compute_score"] is None
+
+
+def test_benchmark_route_accepts_object_json(client, ledger):
+    response = client.post(
+        "/api/machine-passport/machine-1/benchmarks",
+        json={"compute_score": 1250.0, "memory_bandwidth": 3200.5},
+    )
+
+    assert response.status_code == 200
+    assert ledger.benchmark_payload["compute_score"] == 1250.0
+    assert ledger.benchmark_payload["memory_bandwidth"] == 3200.5


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on machine passport attestation and benchmark event routes
- preserve existing empty-body behavior for both routes while preventing arrays/scalars from reaching `.get()` calls
- add focused Flask route tests for rejection, empty-body defaults, and valid benchmark payloads

## Verification
- `python -m pytest tests\test_machine_passport_event_json_validation.py -q`
- `python -m py_compile tests\test_machine_passport_event_json_validation.py node\machine_passport_api.py node\utxo_db.py`
- `git diff --check -- tests\test_machine_passport_event_json_validation.py node\machine_passport_api.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`