### PR TITLE
fix: require admin for passport event writes

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,30 @@ def get_optional_json_object():
     return data, None
 
 
+def _require_admin(req):
+    """Validate admin authentication for machine passport write endpoints."""
+    expected_admin_key = os.environ.get('ADMIN_KEY', '').strip()
+    provided_admin_key = (
+        req.headers.get('X-Admin-Key', '') or req.headers.get('X-API-Key', '')
+    ).strip()
+
+    if not expected_admin_key:
+        return jsonify({
+            'ok': False,
+            'error': 'admin_key_not_configured',
+            'message': 'ADMIN_KEY not configured - write endpoint disabled',
+        }), 503
+
+    if not provided_admin_key or not hmac.compare_digest(provided_admin_key, expected_admin_key):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -345,6 +369,10 @@ def add_repair_entry(machine_id: str):
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
+
+    auth_error = _require_admin(request)
+    if auth_error:
+        return auth_error
     
     data = request.get_json()
     if not data or 'repair_type' not in data or 'description' not in data:
@@ -387,6 +415,10 @@ def add_attestation(machine_id: str):
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
+
+    auth_error = _require_admin(request)
+    if auth_error:
+        return auth_error
     
     data, error = get_optional_json_object()
     if error:
@@ -433,6 +465,10 @@ def add_benchmark(machine_id: str):
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
+
+    auth_error = _require_admin(request)
+    if auth_error:
+        return auth_error
     
     data, error = get_optional_json_object()
     if error:
@@ -478,6 +514,10 @@ def add_lineage_note(machine_id: str):
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
+
+    auth_error = _require_admin(request)
+    if auth_error:
+        return auth_error
     
     data = request.get_json()
     if not data or 'event_type' not in data:

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -576,6 +576,111 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
         compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
+
+    def test_subresource_writes_require_configured_admin_key(self):
+        """Passport event writes fail closed when ADMIN_KEY is unset."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Subresource Auth Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'subresource_auth_test',
+            },
+        )
+
+        endpoints = [
+            ('/api/machine-passport/subresource_auth_test/repair-log', {
+                'repair_type': 'recap',
+                'description': 'forged repair entry',
+            }),
+            ('/api/machine-passport/subresource_auth_test/attestations', {
+                'epoch': 42,
+                'total_rtc_earned': 999,
+            }),
+            ('/api/machine-passport/subresource_auth_test/benchmarks', {
+                'compute_score': 9999,
+            }),
+            ('/api/machine-passport/subresource_auth_test/lineage', {
+                'event_type': 'transfer',
+                'to_owner': 'attacker_miner',
+            }),
+        ]
+
+        for endpoint, payload in endpoints:
+            with self.subTest(endpoint=endpoint):
+                resp = self.client.post(endpoint, json=payload)
+                data = json.loads(resp.data)
+                self.assertEqual(resp.status_code, 503)
+                self.assertFalse(data['ok'])
+                self.assertEqual(data['error'], 'admin_key_not_configured')
+
+        get_resp = self.client.get('/api/machine-passport/subresource_auth_test')
+        passport = json.loads(get_resp.data)['passport']['passport']
+        self.assertEqual(passport['owner_miner_id'], 'miner_owner')
+
+    def test_subresource_writes_reject_wrong_admin_key(self):
+        """Forged event writes cannot mutate passport history or ownership."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Wrong Subresource Auth Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'subresource_wrong_auth_test',
+            },
+        )
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=False) as compare_digest:
+            resp = self.client.post(
+                '/api/machine-passport/subresource_wrong_auth_test/lineage',
+                headers={'X-Admin-Key': 'wrong-admin-key'},
+                json={
+                    'event_type': 'transfer',
+                    'to_owner': 'attacker_miner',
+                },
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+
+        get_resp = self.client.get('/api/machine-passport/subresource_wrong_auth_test')
+        passport = json.loads(get_resp.data)['passport']['passport']
+        self.assertEqual(passport['owner_miner_id'], 'miner_owner')
+
+    def test_subresource_writes_accept_valid_admin_key(self):
+        """Configured admin key still authorizes passport event writes."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Valid Subresource Auth Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'subresource_valid_auth_test',
+            },
+        )
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=True) as compare_digest:
+            resp = self.client.post(
+                '/api/machine-passport/subresource_valid_auth_test/lineage',
+                headers={'X-Admin-Key': 'expected-admin-key'},
+                json={
+                    'event_type': 'transfer',
+                    'to_owner': 'new_owner',
+                    'description': 'authorized transfer',
+                },
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(data['ok'])
+        compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
+
+        get_resp = self.client.get('/api/machine-passport/subresource_valid_auth_test')
+        passport = json.loads(get_resp.data)['passport']['passport']
+        self.assertEqual(passport['owner_miner_id'], 'new_owner')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -11,6 +11,9 @@ sys.path.insert(0, str(REPO_ROOT / "node"))
 import machine_passport_api
 
 
+ADMIN_HEADERS = {"X-Admin-Key": "expected-admin"}
+
+
 class LedgerStub:
     def __init__(self):
         self.attestation_payload = None
@@ -36,7 +39,8 @@ def ledger(monkeypatch):
 
 
 @pytest.fixture
-def client(ledger):
+def client(ledger, monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin")
     app = Flask(__name__)
     app.register_blueprint(machine_passport_api.machine_passport_bp)
     return app.test_client()
@@ -50,7 +54,7 @@ def client(ledger):
     ),
 )
 def test_event_routes_reject_non_object_json(client, path):
-    response = client.post(path, json=["not", "object"])
+    response = client.post(path, headers=ADMIN_HEADERS, json=["not", "object"])
 
     assert response.status_code == 400
     assert response.get_json() == {
@@ -61,7 +65,10 @@ def test_event_routes_reject_non_object_json(client, path):
 
 
 def test_attestation_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/attestations")
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers=ADMIN_HEADERS,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "attestation added"}
@@ -70,7 +77,10 @@ def test_attestation_route_preserves_empty_body_defaults(client, ledger):
 
 
 def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/benchmarks")
+    response = client.post(
+        "/api/machine-passport/machine-1/benchmarks",
+        headers=ADMIN_HEADERS,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "benchmark added"}
@@ -81,6 +91,7 @@ def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
 def test_benchmark_route_accepts_object_json(client, ledger):
     response = client.post(
         "/api/machine-passport/machine-1/benchmarks",
+        headers=ADMIN_HEADERS,
         json={"compute_score": 1250.0, "memory_bandwidth": 3200.5},
     )
 


### PR DESCRIPTION
## Summary
- require configured `ADMIN_KEY` for machine passport repair, attestation, benchmark, and lineage event writes
- fail closed with `admin_key_not_configured` when the admin key is absent
- add API regressions covering unset admin key, wrong admin key, and valid admin lineage transfer

Fixes #4562.

## Security impact
`POST /api/machine-passport/<machine_id>/lineage` could previously change `owner_miner_id` with no admin or owner proof. The same unauthenticated write gap existed for repair-log, attestation, and benchmark event history.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_machine_passport.py::TestAPIEndpoints -q` -> 8 passed, 4 subtests passed
- `uv run --no-project --with pytest --with flask --with qrcode --with reportlab python -m pytest node/tests/test_machine_passport.py -q` -> 29 passed, 4 subtests passed
- `python3 -m py_compile node/machine_passport_api.py node/tests/test_machine_passport.py` -> passed
- `git diff --check -- node/machine_passport_api.py node/tests/test_machine_passport.py` -> passed
