### PR TITLE
fix: validate agent economy json bodies

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -247,6 +247,17 @@ def _parse_non_negative_float_arg(name: str, default: float):
     return value, None
 
 
+def _get_json_object(required: bool = True):
+    data = request.get_json(silent=True)
+    if data is None:
+        if required:
+            return None, (jsonify({"error": "JSON body required"}), 400)
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 # ---------------------------------------------------------------------------
 # Route Registration
 # ---------------------------------------------------------------------------
@@ -261,9 +272,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs", methods=["POST"])
     def agent_post_job():
-        data = request.get_json(silent=True)
-        if not data:
-            return jsonify({"error": "JSON body required"}), 400
+        data, error = _get_json_object(required=True)
+        if error:
+            return error
 
         poster = str(data.get("poster_wallet", "")).strip()
         title = str(data.get("title", "")).strip()
@@ -376,7 +387,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs/<job_id>/claim", methods=["POST"])
     def agent_claim_job(job_id):
-        data = request.get_json(silent=True) or {}
+        data, error = _get_json_object(required=False)
+        if error:
+            return error
         worker = str(data.get("worker_wallet", "")).strip()
 
         if not worker:
@@ -447,7 +460,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs/<job_id>/deliver", methods=["POST"])
     def agent_deliver_job(job_id):
-        data = request.get_json(silent=True) or {}
+        data, error = _get_json_object(required=False)
+        if error:
+            return error
         worker = str(data.get("worker_wallet", "")).strip()
         deliverable_url = str(data.get("deliverable_url", "")).strip()
         deliverable_hash = str(data.get("deliverable_hash", "")).strip()
@@ -504,7 +519,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs/<job_id>/accept", methods=["POST"])
     def agent_accept_delivery(job_id):
-        data = request.get_json(silent=True) or {}
+        data, error = _get_json_object(required=False)
+        if error:
+            return error
         poster = str(data.get("poster_wallet", "")).strip()
         rating = data.get("rating")  # 1-5 optional
 
@@ -619,7 +636,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs/<job_id>/dispute", methods=["POST"])
     def agent_dispute_job(job_id):
-        data = request.get_json(silent=True) or {}
+        data, error = _get_json_object(required=False)
+        if error:
+            return error
         poster = str(data.get("poster_wallet", "")).strip()
         reason = str(data.get("reason", "")).strip()
 
@@ -673,7 +692,9 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     @app.route("/agent/jobs/<job_id>/cancel", methods=["POST"])
     def agent_cancel_job(job_id):
-        data = request.get_json(silent=True) or {}
+        data, error = _get_json_object(required=False)
+        if error:
+            return error
         poster = str(data.get("poster_wallet", "")).strip()
 
         if not poster:

--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -258,6 +258,32 @@ def _get_json_object(required: bool = True):
     return data, None
 
 
+def _parse_job_reward(raw):
+    if isinstance(raw, bool):
+        return None, "reward_rtc must be a finite number"
+    try:
+        reward = float(raw)
+    except (TypeError, ValueError):
+        return None, "reward_rtc must be a finite number"
+    if not math.isfinite(reward):
+        return None, "reward_rtc must be a finite number"
+    if reward < 0.01:
+        return None, "Minimum reward is 0.01 RTC"
+    if reward > 10000:
+        return None, "Maximum reward is 10,000 RTC"
+    return reward, None
+
+
+def _parse_ttl_seconds(raw):
+    if isinstance(raw, bool):
+        return None, "ttl_seconds must be an integer"
+    try:
+        ttl_seconds = int(raw)
+    except (TypeError, ValueError):
+        return None, "ttl_seconds must be an integer"
+    return min(max(ttl_seconds, 3600), JOB_TTL_MAX), None
+
+
 # ---------------------------------------------------------------------------
 # Route Registration
 # ---------------------------------------------------------------------------
@@ -281,7 +307,7 @@ def register_agent_economy(app: Flask, db_path: str):
         description = str(data.get("description", "")).strip()
         category = str(data.get("category", "other")).strip().lower()
         reward_rtc = data.get("reward_rtc", 0)
-        ttl_seconds = int(data.get("ttl_seconds", JOB_TTL_DEFAULT))
+        ttl_seconds = data.get("ttl_seconds", JOB_TTL_DEFAULT)
         tags = data.get("tags", [])
 
         # Validation
@@ -294,17 +320,13 @@ def register_agent_economy(app: Flask, db_path: str):
         if category not in VALID_CATEGORIES:
             return jsonify({"error": f"category must be one of: {VALID_CATEGORIES}"}), 400
 
-        try:
-            reward_rtc = float(reward_rtc)
-        except (TypeError, ValueError):
-            return jsonify({"error": "reward_rtc must be a number"}), 400
+        reward_rtc, error = _parse_job_reward(reward_rtc)
+        if error:
+            return jsonify({"error": error}), 400
 
-        if reward_rtc < 0.01:
-            return jsonify({"error": "Minimum reward is 0.01 RTC"}), 400
-        if reward_rtc > 10000:
-            return jsonify({"error": "Maximum reward is 10,000 RTC"}), 400
-
-        ttl_seconds = min(max(ttl_seconds, 3600), JOB_TTL_MAX)  # 1h to 30d
+        ttl_seconds, error = _parse_ttl_seconds(ttl_seconds)
+        if error:
+            return jsonify({"error": error}), 400
 
         reward_i64 = int(reward_rtc * 1000000)
         platform_fee_i64 = int(reward_i64 * PLATFORM_FEE_RATE)

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 from flask import Flask
 
 from rip302_agent_economy import register_agent_economy
@@ -49,3 +50,23 @@ def test_agent_jobs_clamps_large_limit_and_preserves_empty_listing(tmp_path):
     assert payload["jobs"] == []
     assert payload["limit"] == 100
     assert payload["offset"] == 0
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/agent/jobs",
+        "/agent/jobs/job-1/claim",
+        "/agent/jobs/job-1/deliver",
+        "/agent/jobs/job-1/accept",
+        "/agent/jobs/job-1/dispute",
+        "/agent/jobs/job-1/cancel",
+    ),
+)
+def test_agent_job_post_routes_reject_non_object_json(tmp_path, path):
+    client = make_client(tmp_path)
+
+    response = client.post(path, json=["not", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -70,3 +70,35 @@ def test_agent_job_post_routes_reject_non_object_json(tmp_path, path):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "JSON object required"}
+
+
+def _valid_job_payload(**overrides):
+    payload = {
+        "poster_wallet": "poster-1",
+        "title": "Build integration",
+        "description": "Build a complete test integration",
+        "category": "other",
+        "reward_rtc": 1,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.parametrize("reward", ["nan", "inf", True, "not-a-number"])
+def test_agent_job_post_rejects_invalid_reward_values(tmp_path, reward):
+    client = make_client(tmp_path)
+
+    response = client.post("/agent/jobs", json=_valid_job_payload(reward_rtc=reward))
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "reward_rtc must be a finite number"}
+
+
+@pytest.mark.parametrize("ttl", ["soon", True, None])
+def test_agent_job_post_rejects_invalid_ttl_values(tmp_path, ttl):
+    client = make_client(tmp_path)
+
+    response = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=ttl))
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "ttl_seconds must be an integer"}


### PR DESCRIPTION
## Summary
- validate JSON body shape on all agent job mutation routes
- preserve empty-body behavior on job lifecycle routes while preventing arrays/scalars from reaching `.get()` calls
- extend existing agent job validation tests to cover non-object JSON payloads across post/claim/deliver/accept/dispute/cancel

## Verification
- `python -m pytest tests\test_agent_jobs_query_validation.py -q`
- `python -m py_compile tests\test_agent_jobs_query_validation.py rip302_agent_economy.py node\utxo_db.py`
- `git diff --check -- tests\test_agent_jobs_query_validation.py rip302_agent_economy.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`