### PR TITLE
fix: validate payout ledger requests

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -12,11 +12,29 @@ import sqlite3
 import uuid
 import json
 import logging
+import math
 from flask import request, jsonify, render_template_string
 
 logger = logging.getLogger(__name__)
 
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "rustchain.db")
+
+
+def _get_json_object():
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def _parse_amount_rtc(value):
+    try:
+        amount = float(value)
+    except (TypeError, ValueError):
+        return None, (jsonify({"error": "amount_rtc must be a finite number"}), 400)
+    if not math.isfinite(amount):
+        return None, (jsonify({"error": "amount_rtc must be a finite number"}), 400)
+    return amount, None
 
 PAYOUT_LEDGER_COLUMNS = [
     ("id", "TEXT"),
@@ -198,15 +216,20 @@ def register_ledger_routes(app):
     @app.route("/api/ledger", methods=["POST"])
     def api_ledger_create():
         init_payout_ledger_tables()
-        data = request.get_json(force=True)
+        data, error = _get_json_object()
+        if error:
+            return error
         required = ["bounty_id", "contributor", "amount_rtc"]
         for field in required:
             if field not in data:
                 return jsonify({"error": f"missing {field}"}), 400
+        amount_rtc, error = _parse_amount_rtc(data["amount_rtc"])
+        if error:
+            return error
         record_id = ledger_create(
             bounty_id=data["bounty_id"],
             contributor=data["contributor"],
-            amount_rtc=float(data["amount_rtc"]),
+            amount_rtc=amount_rtc,
             bounty_title=data.get("bounty_title", ""),
             wallet_address=data.get("wallet_address", ""),
             pr_url=data.get("pr_url", ""),
@@ -217,7 +240,9 @@ def register_ledger_routes(app):
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
     def api_ledger_update(record_id):
         init_payout_ledger_tables()
-        data = request.get_json(force=True)
+        data, error = _get_json_object()
+        if error:
+            return error
         new_status = data.get("status")
         if not new_status:
             return jsonify({"error": "missing status"}), 400

--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -28,12 +28,14 @@ def _get_json_object():
 
 
 def _parse_amount_rtc(value):
+    if isinstance(value, bool):
+        return None, (jsonify({"error": "amount_rtc must be a finite positive number"}), 400)
     try:
         amount = float(value)
     except (TypeError, ValueError):
-        return None, (jsonify({"error": "amount_rtc must be a finite number"}), 400)
-    if not math.isfinite(amount):
-        return None, (jsonify({"error": "amount_rtc must be a finite number"}), 400)
+        return None, (jsonify({"error": "amount_rtc must be a finite positive number"}), 400)
+    if not math.isfinite(amount) or amount <= 0:
+        return None, (jsonify({"error": "amount_rtc must be a finite positive number"}), 400)
     return amount, None
 
 PAYOUT_LEDGER_COLUMNS = [

--- a/tests/test_payout_ledger_request_validation.py
+++ b/tests/test_payout_ledger_request_validation.py
@@ -34,8 +34,8 @@ def test_create_rejects_non_object_json(client):
     assert response.get_json() == {"error": "JSON object required"}
 
 
-@pytest.mark.parametrize("amount", ["not-a-number", "nan", "inf"])
-def test_create_rejects_non_finite_amounts(client, amount):
+@pytest.mark.parametrize("amount", ["not-a-number", "nan", "inf", True, False, 0, -1, "-0.0"])
+def test_create_rejects_invalid_amounts(client, amount):
     response = client.post(
         "/api/ledger",
         json={
@@ -46,7 +46,7 @@ def test_create_rejects_non_finite_amounts(client, amount):
     )
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "amount_rtc must be a finite number"}
+    assert response.get_json() == {"error": "amount_rtc must be a finite positive number"}
 
 
 def test_status_update_rejects_non_object_json(client):

--- a/tests/test_payout_ledger_request_validation.py
+++ b/tests/test_payout_ledger_request_validation.py
@@ -1,0 +1,86 @@
+import gc
+import sqlite3
+
+import pytest
+from flask import Flask
+
+import payout_ledger
+
+
+@pytest.fixture
+def client(tmp_path):
+    db_path = tmp_path / "payout-ledger.db"
+    original_db_path = payout_ledger.DB_PATH
+    payout_ledger.DB_PATH = str(db_path)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    payout_ledger.register_ledger_routes(app)
+
+    with app.test_client() as test_client:
+        yield test_client
+
+    payout_ledger.DB_PATH = original_db_path
+    gc.collect()
+
+
+def test_create_rejects_non_object_json(client):
+    response = client.post(
+        "/api/ledger",
+        data="42",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+@pytest.mark.parametrize("amount", ["not-a-number", "nan", "inf"])
+def test_create_rejects_non_finite_amounts(client, amount):
+    response = client.post(
+        "/api/ledger",
+        json={
+            "bounty_id": "bounty-1",
+            "contributor": "alice",
+            "amount_rtc": amount,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "amount_rtc must be a finite number"}
+
+
+def test_status_update_rejects_non_object_json(client):
+    response = client.patch(
+        "/api/ledger/example/status",
+        data="[]",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_valid_create_and_status_update_still_work(client):
+    created = client.post(
+        "/api/ledger",
+        json={
+            "bounty_id": "bounty-1",
+            "contributor": "alice",
+            "amount_rtc": "2.5",
+            "bounty_title": "Validation fix",
+        },
+    )
+    assert created.status_code == 201
+    record_id = created.get_json()["id"]
+
+    updated = client.patch(f"/api/ledger/{record_id}/status", json={"status": "pending"})
+    assert updated.status_code == 200
+    assert updated.get_json() == {"id": record_id, "status": "pending"}
+
+    with sqlite3.connect(payout_ledger.DB_PATH) as conn:
+        amount, status = conn.execute(
+            "SELECT amount_rtc, status FROM payout_ledger WHERE id = ?",
+            (record_id,),
+        ).fetchone()
+    assert amount == 2.5
+    assert status == "pending"

--- a/tests/test_payout_ledger_request_validation.py
+++ b/tests/test_payout_ledger_request_validation.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import gc
 import sqlite3
 


### PR DESCRIPTION
## Summary
- require payout ledger write endpoints to receive JSON objects instead of scalars/arrays/null
- reject non-numeric and non-finite `amount_rtc` values before inserting ledger rows
- cover invalid request bodies plus the existing create/status happy path

## Verification
- `python -m pytest tests\test_payout_ledger_request_validation.py -q`
- `python -m pytest tests\test_payout_ledger_migration.py tests\test_payout_ledger_request_validation.py -q`
- `python -m py_compile tests\test_payout_ledger_request_validation.py payout_ledger.py node\utxo_db.py`
- `git diff --check -- tests\test_payout_ledger_request_validation.py payout_ledger.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`