### PR TITLE
fix: validate testnet faucet json bodies

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -34,6 +34,21 @@ def test_github_user_drip_success(app):
     assert data["amount"] == 1.0
 
 
+@pytest.mark.parametrize("body", ["[]", '"wallet"', "42"])
+def test_drip_rejects_non_object_json(app, body):
+    c = app.test_client()
+    r = c.post("/faucet/drip", data=body, content_type="application/json")
+    assert r.status_code == 400
+    assert r.get_json() == {"ok": False, "error": "json_object_required"}
+
+
+def test_drip_accepts_form_payload(app):
+    c = app.test_client()
+    r = c.post("/faucet/drip", data={"wallet": "form_wallet"})
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+
+
 def test_ip_only_limit(app):
     c = app.test_client()
     h = {"X-Forwarded-For": "1.2.3.4"}

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -84,6 +84,15 @@ def _limit_for_identity(github_username: str | None, account_age_days: int | Non
     return 1.0
 
 
+def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
+    data = request.get_json(silent=True)
+    if data is None:
+        return request.form.to_dict() or {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({"ok": False, "error": "json_object_required"}), 400)
+    return data, None
+
+
 def _sum_last_24h(conn: sqlite3.Connection, github_username: str | None, ip: str) -> float:
     since = (_utcnow() - timedelta(hours=24)).isoformat()
     if github_username:
@@ -161,7 +170,9 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
 
     @app.post("/faucet/drip")
     def faucet_drip():
-        data = request.get_json(silent=True) or request.form.to_dict() or {}
+        data, error = _request_data()
+        if error:
+            return error
         wallet = (data.get("wallet") or "").strip()
         github_username = (data.get("github_username") or "").strip() or None
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()


### PR DESCRIPTION
## Summary
- reject scalar and array JSON bodies on `/faucet/drip` before route logic dereferences `.get`
- keep existing form submissions and JSON object requests working
- add focused regression coverage for non-object JSON and form fallback behavior

## Verification
- `python -m pytest tests\test_faucet.py -q`
- `python -m py_compile tests\test_faucet.py tools\testnet_faucet.py node\utxo_db.py`
- `git diff --check -- tests\test_faucet.py tools\testnet_faucet.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`