### PR TITLE
[UTXO-BUG] Fix dual-write fee accounting divergence

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -364,5 +364,126 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
 
+class TestUtxoDualWrite(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ledger (ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)"
+        )
+        conn.commit()
+        conn.close()
+
+        self.utxo_db = UtxoDB(self.db_path)
+        self.utxo_db.init_tables()
+
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        register_utxo_blueprint(
+            self.app, self.utxo_db, self.db_path,
+            verify_sig_fn=mock_verify_sig,
+            addr_from_pk_fn=mock_addr_from_pk,
+            current_slot_fn=mock_current_slot,
+            dual_write=True,
+        )
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def _seed_sender(self, address, rtc_amount=100):
+        self.utxo_db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': address, 'value_nrtc': rtc_amount * UNIT}],
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            (address, rtc_amount * utxo_endpoints.ACCOUNT_UNIT),
+        )
+        conn.commit()
+        conn.close()
+
+    def _account_balance(self, address):
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+                (address,),
+            ).fetchone()
+            return row[0] if row else 0
+        finally:
+            conn.close()
+
+    def test_dual_write_debits_fee_from_sender_shadow_balance(self):
+        """dual_write must mirror UTXO fees in the account model.
+
+        Before the fix, the UTXO transaction spent amount + fee, but the
+        shadow account model only debited amount. A 90 RTC transfer with a
+        1 RTC fee left the sender at 10 RTC in balances while their UTXO
+        balance was 9 RTC, letting the legacy model retain spendable value.
+        """
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_sender(sender, rtc_amount=100)
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 90.0,
+            'fee_rtc': 1.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(self.utxo_db.get_balance(sender), 9 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 90 * UNIT)
+        self.assertEqual(
+            self._account_balance(sender),
+            9 * utxo_endpoints.ACCOUNT_UNIT,
+        )
+        self.assertEqual(
+            self._account_balance(recipient),
+            90 * utxo_endpoints.ACCOUNT_UNIT,
+        )
+
+    def test_dual_write_rejects_sub_micro_amounts(self):
+        """dual_write cannot safely mirror nanoRTC values below 1 microRTC."""
+        sender = 'RTC_test_aabbccdd'
+        self._seed_sender(sender, rtc_amount=100)
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': 'bob',
+            'amount_rtc': '0.00000001',
+            'fee_rtc': 0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+
+        self.assertEqual(r.status_code, 400)
+        self.assertIn('dual-write', r.get_json()['error'])
+        self.assertEqual(self.utxo_db.get_balance('bob'), 0)
+        self.assertEqual(
+            self._account_balance(sender),
+            100 * utxo_endpoints.ACCOUNT_UNIT,
+        )
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -101,6 +101,19 @@ def _ensure_signed_float_preserves_nrtc(amount: Decimal, nrtc: int,
 # (e.g. line 2370: amount_i64 = int(amount_decimal * Decimal(1000000))).
 ACCOUNT_UNIT = 1_000_000  # 1 RTC = 1,000,000 uRTC (6 decimals)
 
+
+def _decimal_to_account_i64(amount: Decimal, field_name: str) -> int:
+    """Convert an RTC Decimal to the legacy 6-decimal account unit exactly."""
+    units = amount * ACCOUNT_UNIT
+    integral = units.to_integral_value()
+    if units != integral:
+        raise ValueError(
+            f"{field_name} cannot be mirrored by dual-write account model "
+            "(max 6 decimal places)"
+        )
+    return int(integral)
+
+
 utxo_bp = Blueprint('utxo', __name__, url_prefix='/utxo')
 
 # These get set by register_utxo_blueprint() from the main server
@@ -376,6 +389,15 @@ def utxo_transfer():
         fee_nrtc = _decimal_to_nrtc(fee_rtc, 'fee_rtc')
         _ensure_signed_float_preserves_nrtc(amount_rtc, amount_nrtc, 'amount_rtc')
         _ensure_signed_float_preserves_nrtc(fee_rtc, fee_nrtc, 'fee_rtc')
+        amount_i64_for_dual_write = None
+        fee_i64_for_dual_write = None
+        if _dual_write:
+            amount_i64_for_dual_write = _decimal_to_account_i64(
+                amount_rtc, 'amount_rtc'
+            )
+            fee_i64_for_dual_write = _decimal_to_account_i64(
+                fee_rtc, 'fee_rtc'
+            )
     except ValueError as e:
         return jsonify({'error': f'Invalid amount: {e}'}), 400
 
@@ -505,7 +527,9 @@ def utxo_transfer():
         try:
             conn = sqlite3.connect(_db_path)
             c = conn.cursor()
-            amount_i64 = int(amount_rtc * ACCOUNT_UNIT)
+            amount_i64 = amount_i64_for_dual_write
+            fee_i64 = fee_i64_for_dual_write
+            debit_i64 = amount_i64 + fee_i64
 
             # Re-check sender shadow-balance before debit (security: prevent
             # negative-balance minting when account-model diverges from UTXO
@@ -514,26 +538,26 @@ def utxo_transfer():
                       (from_address,))
             shadow_row = c.fetchone()
             shadow_balance = shadow_row[0] if shadow_row else 0
-            if shadow_balance < amount_i64:
+            if shadow_balance < debit_i64:
                 conn.close()
                 print(
                     f"[UTXO] WARNING: dual-write skipped — insufficient "
                     f"shadow balance for {from_address[:20]}... "
-                    f"(have {shadow_balance}, need {amount_i64})"
+                    f"(have {shadow_balance}, need {debit_i64})"
                 )
             else:
                 c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
                           (to_address,))
                 c.execute("UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
-                          (amount_i64, from_address))
+                          (debit_i64, from_address))
                 c.execute("UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
                           (amount_i64, to_address))
                 now = int(time.time())
                 slot = _current_slot_fn()
                 c.execute(
                     "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",
-                    (now, slot, from_address, -amount_i64,
-                     f"utxo_transfer_out:{to_address[:20]}:{memo[:30]}")
+                    (now, slot, from_address, -debit_i64,
+                     f"utxo_transfer_out:{to_address[:20]}:fee={fee_i64}:{memo[:30]}")
                 )
                 c.execute(
                     "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?,?,?,?,?)",


### PR DESCRIPTION
## Summary

Fixes a dual-write accounting bug found while working through the UTXO red-team bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2819

When `/utxo/transfer` ran with `dual_write=True`, the UTXO ledger consumed `amount + fee`, but the legacy `balances` shadow model only debited `amount`. A transfer such as `90 RTC` with a `1 RTC` fee left the sender with `9 RTC` in UTXO state but `10 RTC` in the account model, preserving spendable value on the legacy side and making the models diverge.

## Changes

- Convert dual-write amounts with an exact 6-decimal account-model helper instead of truncating `Decimal` values with `int(...)`.
- Reject dual-write transfers that cannot be mirrored by the legacy `amount_i64` precision, while leaving pure UTXO mode unchanged.
- Debit `amount + fee` from the sender shadow balance and credit only `amount` to the recipient, matching UTXO fee burn semantics.
- Add regression coverage for fee debiting and sub-micro precision rejection.

## Validation

- `python -m unittest test_utxo_endpoints.TestUtxoDualWrite`
- `python -m unittest test_utxo_db test_utxo_endpoints`
- `python -B -m unittest test_utxo_db test_utxo_endpoints`
- `python -B -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding='utf-8-sig'), filename=p) for p in ['utxo_endpoints.py','test_utxo_endpoints.py']]; print('syntax ok')"`
- `git diff --check`

Note: `python -m py_compile utxo_endpoints.py test_utxo_endpoints.py` hit a Windows `__pycache__` access-denied rename error in this local checkout, so I used AST parsing plus the unit suites above for syntax/runtime validation.