### PR TITLE
fix: require participant auth for GPU escrow transitions

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -363,6 +363,8 @@ class GPURenderProtocol:
             if not row:
                 return {"error": "Job not found"}
             result = dict(row)
+            result.pop("escrow_secret_hash", None)
+            result.pop("escrow_secret", None)
             result["metadata"] = json.loads(result.get("metadata") or "{}")
             return result
         finally:

--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -27,6 +27,9 @@ import uuid
 import json
 import os
 import logging
+import hashlib
+import hmac
+import secrets
 from functools import wraps
 
 logger = logging.getLogger("gpu_render_protocol")
@@ -46,6 +49,7 @@ CREATE TABLE IF NOT EXISTS render_escrow (
     status TEXT DEFAULT 'locked' CHECK(status IN ('locked', 'released', 'refunded')),
     created_at INTEGER NOT NULL,
     released_at INTEGER,
+    escrow_secret_hash TEXT,
     metadata TEXT  -- JSON blob for job-specific params
 );
 
@@ -114,9 +118,32 @@ class GPURenderProtocol:
     def _init_db(self):
         conn = self._get_conn()
         conn.executescript(SCHEMA_SQL)
+        self._ensure_escrow_secret_column(conn)
         conn.commit()
         conn.close()
         logger.info("GPU Render Protocol DB initialized at %s", self.db_path)
+
+    def _ensure_escrow_secret_column(self, conn):
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
+        if "escrow_secret_hash" not in columns:
+            conn.execute("ALTER TABLE render_escrow ADD COLUMN escrow_secret_hash TEXT")
+
+    @staticmethod
+    def _hash_escrow_secret(secret: str) -> str:
+        return hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
+
+    def _authorize_escrow_transition(self, row, actor_wallet: str, escrow_secret: str, expected_wallet: str):
+        if not actor_wallet or not escrow_secret:
+            return {"error": "actor_wallet and escrow_secret are required"}
+        if actor_wallet != expected_wallet:
+            return {"error": "actor_wallet is not authorized for this transition"}
+
+        expected_hash = row["escrow_secret_hash"] or ""
+        if not expected_hash:
+            return {"error": "escrow secret unavailable for this job"}
+        if not hmac.compare_digest(self._hash_escrow_secret(escrow_secret), expected_hash):
+            return {"error": "invalid escrow_secret"}
+        return None
 
     # -------------------------------------------------------------------
     # GPU Attestation
@@ -223,7 +250,8 @@ class GPURenderProtocol:
     # -------------------------------------------------------------------
 
     def create_escrow(self, job_type: str, from_wallet: str, to_wallet: str,
-                      amount_rtc: float, metadata: dict = None) -> dict:
+                      amount_rtc: float, metadata: dict = None,
+                      escrow_secret: str = None) -> dict:
         """Lock RTC in escrow for a compute job."""
         valid_types = ("render", "tts", "stt", "llm")
         if job_type not in valid_types:
@@ -234,15 +262,17 @@ class GPURenderProtocol:
             return {"error": "from_wallet and to_wallet must differ"}
 
         job_id = f"{job_type}-{uuid.uuid4().hex[:12]}"
+        escrow_secret = escrow_secret or secrets.token_hex(16)
         conn = self._get_conn()
         try:
             conn.execute(
                 """INSERT INTO render_escrow
                    (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                    status, created_at, metadata)
-                   VALUES (?,?,?,?,?,'locked',?,?)""",
+                    status, created_at, escrow_secret_hash, metadata)
+                   VALUES (?,?,?,?,?,'locked',?,?,?)""",
                 (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                 int(time.time()), json.dumps(metadata or {})),
+                 int(time.time()), self._hash_escrow_secret(escrow_secret),
+                 json.dumps(metadata or {})),
             )
             conn.commit()
             return {
@@ -252,11 +282,12 @@ class GPURenderProtocol:
                 "amount_rtc": amount_rtc,
                 "from_wallet": from_wallet,
                 "to_wallet": to_wallet,
+                "escrow_secret": escrow_secret,
             }
         finally:
             conn.close()
 
-    def release_escrow(self, job_id: str) -> dict:
+    def release_escrow(self, job_id: str, actor_wallet: str = "", escrow_secret: str = "") -> dict:
         """Release escrowed RTC to the GPU provider on job completion."""
         conn = self._get_conn()
         try:
@@ -267,6 +298,11 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             if row["status"] != "locked":
                 return {"error": f"Job already {row['status']}"}
+            error = self._authorize_escrow_transition(
+                row, actor_wallet, escrow_secret, row["from_wallet"]
+            )
+            if error:
+                return error
 
             now = int(time.time())
             conn.execute(
@@ -284,7 +320,7 @@ class GPURenderProtocol:
         finally:
             conn.close()
 
-    def refund_escrow(self, job_id: str) -> dict:
+    def refund_escrow(self, job_id: str, actor_wallet: str = "", escrow_secret: str = "") -> dict:
         """Refund escrowed RTC to the requester on job failure."""
         conn = self._get_conn()
         try:
@@ -295,6 +331,11 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             if row["status"] != "locked":
                 return {"error": f"Job already {row['status']}"}
+            error = self._authorize_escrow_transition(
+                row, actor_wallet, escrow_secret, row["to_wallet"]
+            )
+            if error:
+                return error
 
             now = int(time.time())
             conn.execute(
@@ -446,6 +487,7 @@ def register_routes(app):
             to_wallet=data.get("to_wallet", ""),
             amount_rtc=data.get("amount_rtc", 0),
             metadata=data.get("metadata"),
+            escrow_secret=data.get("escrow_secret"),
         )
         status_code = 201 if "error" not in result else 400
         return jsonify(result), status_code
@@ -456,7 +498,11 @@ def register_routes(app):
     def release_escrow():
         from flask import request, jsonify
         data = request.get_json(force=True)
-        result = protocol.release_escrow(data.get("job_id", ""))
+        result = protocol.release_escrow(
+            data.get("job_id", ""),
+            actor_wallet=data.get("actor_wallet", ""),
+            escrow_secret=data.get("escrow_secret", ""),
+        )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
@@ -464,7 +510,11 @@ def register_routes(app):
     def refund_escrow():
         from flask import request, jsonify
         data = request.get_json(force=True)
-        result = protocol.refund_escrow(data.get("job_id", ""))
+        result = protocol.refund_escrow(
+            data.get("job_id", ""),
+            actor_wallet=data.get("actor_wallet", ""),
+            escrow_secret=data.get("escrow_secret", ""),
+        )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -59,6 +59,7 @@ class TestGPURenderProtocol(unittest.TestCase):
         result = self.proto.create_escrow("render", "wallet-a", "wallet-b", 10.0)
         self.assertEqual(result["status"], "locked")
         job_id = result["job_id"]
+        escrow_secret = result["escrow_secret"]
 
         # Check
         status = self.proto.get_escrow(job_id)
@@ -66,19 +67,45 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertEqual(status["amount_rtc"], 10.0)
 
         # Release
-        release = self.proto.release_escrow(job_id)
+        release = self.proto.release_escrow(job_id, "wallet-a", escrow_secret)
         self.assertEqual(release["status"], "released")
         self.assertEqual(release["amount_rtc"], 10.0)
 
         # Double release fails
-        double = self.proto.release_escrow(job_id)
+        double = self.proto.release_escrow(job_id, "wallet-a", escrow_secret)
         self.assertIn("error", double)
 
     def test_escrow_refund(self):
         result = self.proto.create_escrow("tts", "wallet-a", "wallet-b", 5.0)
         job_id = result["job_id"]
 
-        refund = self.proto.refund_escrow(job_id)
+        refund = self.proto.refund_escrow(job_id, "wallet-b", result["escrow_secret"])
+        self.assertEqual(refund["status"], "refunded")
+
+    def test_escrow_release_requires_payer_secret(self):
+        result = self.proto.create_escrow("render", "payer", "provider", 10.0)
+        job_id = result["job_id"]
+
+        missing_auth = self.proto.release_escrow(job_id)
+        self.assertIn("error", missing_auth)
+
+        wrong_actor = self.proto.release_escrow(job_id, "provider", result["escrow_secret"])
+        self.assertEqual(wrong_actor["error"], "actor_wallet is not authorized for this transition")
+
+        wrong_secret = self.proto.release_escrow(job_id, "payer", "wrong-secret")
+        self.assertEqual(wrong_secret["error"], "invalid escrow_secret")
+
+        status = self.proto.get_escrow(job_id)
+        self.assertEqual(status["status"], "locked")
+
+    def test_escrow_refund_requires_provider_secret(self):
+        result = self.proto.create_escrow("render", "payer", "provider", 10.0)
+        job_id = result["job_id"]
+
+        wrong_actor = self.proto.refund_escrow(job_id, "payer", result["escrow_secret"])
+        self.assertEqual(wrong_actor["error"], "actor_wallet is not authorized for this transition")
+
+        refund = self.proto.refund_escrow(job_id, "provider", result["escrow_secret"])
         self.assertEqual(refund["status"], "refunded")
 
     def test_escrow_invalid_type(self):

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -108,6 +108,16 @@ class TestGPURenderProtocol(unittest.TestCase):
         refund = self.proto.refund_escrow(job_id, "provider", result["escrow_secret"])
         self.assertEqual(refund["status"], "refunded")
 
+    def test_get_escrow_redacts_secret_material(self):
+        result = self.proto.create_escrow(
+            "render", "payer", "provider", 10.0, escrow_secret="weak"
+        )
+
+        status = self.proto.get_escrow(result["job_id"])
+
+        self.assertNotIn("escrow_secret", status)
+        self.assertNotIn("escrow_secret_hash", status)
+
     def test_escrow_invalid_type(self):
         result = self.proto.create_escrow("invalid", "a", "b", 1.0)
         self.assertIn("error", result)


### PR DESCRIPTION
## Summary
- store a hashed one-time escrow secret for GPU render protocol escrows
- require the payer wallet plus secret before release and provider wallet plus secret before refund
- wire the Flask release/refund routes to require `actor_wallet` and `escrow_secret`
- add regression coverage for missing auth, wrong participant, wrong secret, and valid release/refund

Security issue: #4568
Bounty: Scottcjn/rustchain-bounties#71
Requested severity: High

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_gpu_render_protocol.py -q` -> 14 passed
- `python3 -m py_compile node/gpu_render_protocol.py tests/test_gpu_render_protocol.py` -> passed
- `git diff --check -- node/gpu_render_protocol.py tests/test_gpu_render_protocol.py` -> passed
