### PR TITLE
fix: validate comment webhook payload shape

### DIFF
--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -21,6 +21,19 @@ from .moderation_service import ModerationService
 logger = logging.getLogger(__name__)
 
 
+def _payload_object(
+    payload: dict[str, Any],
+    field: str,
+) -> Optional[dict[str, Any]]:
+    """Return an optional webhook payload field when it is a JSON object."""
+    value = payload.get(field)
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError(f"{field} must be a JSON object")
+    return value
+
+
 def create_app(config: Optional[BotConfig] = None) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -174,19 +187,34 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
                 detail="Webhook payload must be a JSON object",
             )
 
+        try:
+            repository = _payload_object(payload, "repository") or {}
+            comment = _payload_object(payload, "comment") or {}
+            issue = _payload_object(payload, "issue") or {}
+            installation = _payload_object(payload, "installation") or {}
+            comment_user = _payload_object(comment, "user") or {}
+        except ValueError as e:
+            audit_logger.log_error(
+                error_type="invalid_payload",
+                message=str(e),
+                delivery_id=x_github_delivery,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
+
         # Log webhook receipt
-        repo = payload.get("repository", {}).get("full_name", "unknown")
+        repo = repository.get("full_name", "unknown")
         audit_logger.log_webhook_event(
             event_type=x_github_event,
             delivery_id=x_github_delivery,
             repo=repo,
             action=payload.get("action", "unknown"),
             payload_summary={
-                "comment_id": payload.get("comment", {}).get("id"),
-                "issue_number": payload.get("issue", {}).get("number"),
-                "author": payload.get("comment", {})
-                .get("user", {})
-                .get("login"),
+                "comment_id": comment.get("id"),
+                "issue_number": issue.get("number"),
+                "author": comment_user.get("login"),
             },
         )
 
@@ -219,10 +247,6 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
 
         # Extract required data
         try:
-            comment = payload.get("comment", {})
-            issue = payload.get("issue", {})
-            installation = payload.get("installation", {})
-
             if not comment or not issue:
                 raise ValueError("Missing comment or issue data")
 

--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -163,6 +163,16 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid JSON payload",
             )
+        if not isinstance(payload, dict):
+            audit_logger.log_error(
+                error_type="invalid_payload",
+                message="Webhook payload must be a JSON object",
+                delivery_id=x_github_delivery,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Webhook payload must be a JSON object",
+            )
 
         # Log webhook receipt
         repo = payload.get("repository", {}).get("full_name", "unknown")

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -429,3 +429,23 @@ class TestWebhookProcessing:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_webhook_rejects_non_object_json(
+        self, app: TestClient, mock_config: MagicMock
+    ) -> None:
+        """Test webhook with valid JSON that is not an object."""
+        body = json.dumps(["not", "an", "object"]).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        response = app.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Webhook payload must be a JSON object"

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -449,3 +449,38 @@ class TestWebhookProcessing:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["detail"] == "Webhook payload must be a JSON object"
+
+    @pytest.mark.parametrize(
+        ("field", "expected_detail"),
+        [
+            ("repository", "repository must be a JSON object"),
+            ("comment", "comment must be a JSON object"),
+            ("issue", "issue must be a JSON object"),
+            ("installation", "installation must be a JSON object"),
+        ],
+    )
+    def test_webhook_rejects_non_object_nested_payload_fields(
+        self,
+        app: TestClient,
+        sample_webhook_payload: dict,
+        mock_config: MagicMock,
+        field: str,
+        expected_detail: str,
+    ) -> None:
+        """Test webhook with malformed nested payload objects."""
+        sample_webhook_payload[field] = "not-an-object"
+        body = json.dumps(sample_webhook_payload).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        response = app.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == expected_detail


### PR DESCRIPTION
## Summary
- reject signed webhook payloads that parse as non-object JSON before `.get` access
- return a controlled 400 response and audit log entry for invalid payload shape
- add regression coverage for valid JSON arrays sent to the webhook endpoint

## Verification
- `python -m pytest tools\comment-moderation-bot\tests\test_webhook.py -q -o addopts=`
- `python -m py_compile tools\comment-moderation-bot\tests\test_webhook.py tools\comment-moderation-bot\src\webhook.py node\utxo_db.py`
- `git diff --check -- tools\comment-moderation-bot\tests\test_webhook.py tools\comment-moderation-bot\src\webhook.py node\utxo_db.py`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`

Note: running the nested webhook pytest without `-o addopts=` fails in this environment before collection because the nested project config enables `pytest-cov`, which is not installed here.