### PR TITLE
docs: clarify BCOS exemption in welcome message

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -32,7 +32,8 @@ jobs:
             Welcome to RustChain\! Thanks for your first pull request.
 
             **Before we review**, please make sure:
-            - [ ] Your PR has a `BCOS-L1` or `BCOS-L2` label
+            - [ ] Non-doc PRs have a `BCOS-L1` or `BCOS-L2` label
+            - [ ] Doc-only PRs are exempt from BCOS tier labels when they only touch `docs/**`, `*.md`, or common image/PDF files
             - [ ] New code files include an SPDX license header
             - [ ] You've tested your changes against the live node
 


### PR DESCRIPTION
## Summary
- Clarifies the first-PR welcome message so doc-only contributors are not told they always need a BCOS tier label.
- Aligns the bot comment with `CONTRIBUTING.md`, which already says doc-only PRs are exempt when they only touch `docs/**`, `*.md`, or common image/PDF files.

Fixes #3177

Bounty: Scottcjn/rustchain-bounties#444
- 地址：RTC6a5325fd2708469d4625ad15e70a807b127846bc
## Validation
- Direct assertion that `.github/workflows/welcome.yml` contains the non-doc label requirement and the doc-only exemption note.
- `git diff --check -- .github/workflows/welcome.yml`

