### PR TITLE
fix: validate webhook nested payload objects

### DIFF
--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -247,6 +247,12 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             installation_id = installation.get("id")
             if not installation_id:
                 raise ValueError("Missing installation ID")
+            if "id" not in comment or "body" not in comment:
+                raise ValueError("Missing comment id or body")
+            if not comment_user.get("login"):
+                raise ValueError("Missing comment user login")
+            if "number" not in issue:
+                raise ValueError("Missing issue number")
 
         except Exception as e:
             audit_logger.log_error(

--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -21,6 +21,13 @@ from .moderation_service import ModerationService
 logger = logging.getLogger(__name__)
 
 
+def _payload_object(payload: dict[str, Any], field: str, parent: str = "payload") -> dict[str, Any]:
+    value = payload.get(field, {})
+    if isinstance(value, dict):
+        return value
+    raise ValueError(f"{parent}.{field} must be a JSON object")
+
+
 def create_app(config: Optional[BotConfig] = None) -> FastAPI:
     """
     Create and configure the FastAPI application.
@@ -163,20 +170,45 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Invalid JSON payload",
             )
+        if not isinstance(payload, dict):
+            audit_logger.log_error(
+                error_type="invalid_payload",
+                message="Webhook payload must be a JSON object",
+                delivery_id=x_github_delivery,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Webhook payload must be a JSON object",
+            )
+
+        try:
+            repository = _payload_object(payload, "repository")
+            comment = _payload_object(payload, "comment")
+            issue = _payload_object(payload, "issue")
+            installation = _payload_object(payload, "installation")
+            comment_user = _payload_object(comment, "user", parent="payload.comment")
+        except ValueError as e:
+            audit_logger.log_error(
+                error_type="invalid_payload",
+                message=str(e),
+                delivery_id=x_github_delivery,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(e),
+            )
 
         # Log webhook receipt
-        repo = payload.get("repository", {}).get("full_name", "unknown")
+        repo = repository.get("full_name", "unknown")
         audit_logger.log_webhook_event(
             event_type=x_github_event,
             delivery_id=x_github_delivery,
             repo=repo,
             action=payload.get("action", "unknown"),
             payload_summary={
-                "comment_id": payload.get("comment", {}).get("id"),
-                "issue_number": payload.get("issue", {}).get("number"),
-                "author": payload.get("comment", {})
-                .get("user", {})
-                .get("login"),
+                "comment_id": comment.get("id"),
+                "issue_number": issue.get("number"),
+                "author": comment_user.get("login"),
             },
         )
 
@@ -209,10 +241,6 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
 
         # Extract required data
         try:
-            comment = payload.get("comment", {})
-            issue = payload.get("issue", {})
-            installation = payload.get("installation", {})
-
             if not comment or not issue:
                 raise ValueError("Missing comment or issue data")
 

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -489,3 +489,50 @@ class TestWebhookProcessing:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["detail"] == expected_detail
+
+    @pytest.mark.parametrize(
+        ("mutate_payload", "expected_detail"),
+        [
+            (
+                lambda payload: payload["comment"].pop("user"),
+                "Missing comment user login",
+            ),
+            (
+                lambda payload: payload["comment"]["user"].pop("login"),
+                "Missing comment user login",
+            ),
+            (
+                lambda payload: payload["comment"].pop("body"),
+                "Missing comment id or body",
+            ),
+            (
+                lambda payload: payload["issue"].pop("number"),
+                "Missing issue number",
+            ),
+        ],
+    )
+    def test_webhook_rejects_missing_required_nested_fields(
+        self,
+        app: TestClient,
+        sample_webhook_payload: dict,
+        mock_config: MagicMock,
+        mutate_payload,
+        expected_detail: str,
+    ) -> None:
+        """Test signed issue_comment payloads with missing nested required fields."""
+        mutate_payload(sample_webhook_payload)
+        body = json.dumps(sample_webhook_payload).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        response = app.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == expected_detail

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -429,3 +429,63 @@ class TestWebhookProcessing:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_webhook_rejects_non_object_json(
+        self, app: TestClient, mock_config: MagicMock
+    ) -> None:
+        """Test webhook with valid JSON that is not an object."""
+        body = json.dumps(["not", "an", "object"]).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        response = app.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "Webhook payload must be a JSON object"
+
+    @pytest.mark.parametrize(
+        ("field_path", "expected_detail"),
+        [
+            (("repository",), "payload.repository must be a JSON object"),
+            (("comment",), "payload.comment must be a JSON object"),
+            (("comment", "user"), "payload.comment.user must be a JSON object"),
+            (("issue",), "payload.issue must be a JSON object"),
+            (("installation",), "payload.installation must be a JSON object"),
+        ],
+    )
+    def test_webhook_rejects_malformed_nested_objects(
+        self,
+        app: TestClient,
+        sample_webhook_payload: dict,
+        mock_config: MagicMock,
+        field_path: tuple[str, ...],
+        expected_detail: str,
+    ) -> None:
+        """Test webhook with signed payloads containing non-object nested sections."""
+        target = sample_webhook_payload
+        for field in field_path[:-1]:
+            target = target[field]
+        target[field_path[-1]] = "not-an-object"
+
+        body = json.dumps(sample_webhook_payload).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        response = app.post(
+            "/webhook",
+            content=body,
+            headers={
+                "X-GitHub-Event": "issue_comment",
+                "X-GitHub-Delivery": "test-delivery-id",
+                "X-Hub-Signature-256": signature,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == expected_detail


### PR DESCRIPTION
## Summary
- Reject signed webhook payloads that parse as non-object JSON before any `.get()` access.
- Validate nested `repository`, `comment`, `comment.user`, `issue`, and `installation` sections are JSON objects before audit logging or moderation processing.
- Add regression coverage for top-level arrays plus malformed nested sections returning controlled 400 responses.

Fixes #4575

## Responsible testing
Static review and local FastAPI `TestClient` regressions only; no production probing was performed.

## Verification
- `.\.review-venv-webhook-fix\Scripts\python.exe -m pytest tools\comment-moderation-bot\tests\test_webhook.py -q -o addopts=` -> 22 passed
- `.\.review-venv-webhook-fix\Scripts\python.exe -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed with existing return-value warning
- `python -m py_compile tools\comment-moderation-bot\tests\test_webhook.py tools\comment-moderation-bot\src\webhook.py node\utxo_db.py` -> passed
- `git diff --check -- tools/comment-moderation-bot/tests/test_webhook.py tools/comment-moderation-bot/src/webhook.py node/utxo_db.py` -> passed

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
