### PR TITLE
fix: reject mismatched BCOS attest commitments

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -83,18 +83,23 @@ def _parse_bounded_int_arg(name: str, default: int, maximum: int):
     return min(value, maximum), None, None
 
 
+def _compute_report_commitment(report: dict) -> str:
+    """Return the BLAKE2b commitment digest for a BCOS report payload."""
+    report_copy = {
+        key: value
+        for key, value in report.items()
+        if key not in ("cert_id", "commitment")
+    }
+    canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
+    return blake2b(canonical.encode(), digest_size=32).hexdigest()
+
+
 def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
     """Recompute BLAKE2b commitment and compare."""
     try:
-        # Reparse and re-serialize to canonical form
         report = json.loads(report_json_str)
-        # Remove cert_id and commitment before recomputing
-        # (they were added after the commitment was computed)
-        report_copy = {k: v for k, v in report.items()
-                       if k not in ("cert_id", "commitment")}
-        canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
-        computed = blake2b(canonical.encode(), digest_size=32).hexdigest()
-        return computed == claimed_commitment
+        computed = _compute_report_commitment(report)
+        return hmac.compare_digest(computed, str(claimed_commitment))
     except Exception:
         return False
 
@@ -229,6 +234,13 @@ def bcos_attest():
         return jsonify({"error": "invalid_trust_score", "message": str(e)}), 400
     report["trust_score"] = trust_score
 
+    report_json_str = json.dumps(report, sort_keys=True, separators=(",", ":"))
+    if not _verify_commitment(report_json_str, commitment):
+        return jsonify({
+            "error": "invalid_commitment",
+            "message": "commitment does not match report",
+        }), 400
+
     # Auth: admin key OR valid Ed25519 signature
     sig_valid = False
     if signature and signer_pubkey:
@@ -239,9 +251,6 @@ def bcos_attest():
             "error": "Unauthorized - admin key or valid Ed25519 signature required",
             "hint": "Use X-Admin-Key header or sign the commitment with Ed25519",
         }), 401
-
-    # Verify commitment matches report
-    report_json_str = json.dumps(report, sort_keys=True, separators=(",", ":"))
 
     # Store
     now = int(time.time())
@@ -308,10 +317,7 @@ def bcos_verify(cert_id):
 
         # Recompute commitment from stored report
         report = json.loads(row["report_json"])
-        report_copy = {k: v for k, v in report.items()
-                       if k not in ("cert_id", "commitment")}
-        canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
-        recomputed = blake2b(canonical.encode(), digest_size=32).hexdigest()
+        recomputed = _compute_report_commitment(report)
         commitment_valid = recomputed == row["commitment"]
 
         # Verify Ed25519 signature if present

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -1,9 +1,21 @@
 import sqlite3
+import json
+from hashlib import blake2b
 
 import pytest
 from flask import Flask
 
 from bcos_routes import init_bcos_table, register_bcos_routes
+
+
+def _commitment_for(report):
+    report_copy = {
+        key: value
+        for key, value in report.items()
+        if key not in ("cert_id", "commitment")
+    }
+    canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
+    return blake2b(canonical.encode(), digest_size=32).hexdigest()
 
 
 @pytest.fixture
@@ -98,17 +110,19 @@ def test_bcos_attest_rejects_invalid_trust_score(bcos_client, trust_score, messa
 
 
 def test_bcos_attest_stores_numeric_trust_score(bcos_client):
+    report = {
+        "cert_id": "cert-good-score",
+        "repo": "Scottcjn/Rustchain",
+        "commit_sha": "abcdef1234567890",
+        "tier": "L1",
+        "trust_score": "81",
+    }
+    report["commitment"] = _commitment_for({**report, "trust_score": 81})
+
     response = bcos_client.post(
         "/bcos/attest",
         headers={"X-Admin-Key": "0" * 32},
-        json={
-            "cert_id": "cert-good-score",
-            "commitment": "commitment",
-            "repo": "Scottcjn/Rustchain",
-            "commit_sha": "abcdef1234567890",
-            "tier": "L1",
-            "trust_score": "81",
-        },
+        json=report,
     )
 
     assert response.status_code == 200
@@ -117,3 +131,22 @@ def test_bcos_attest_stores_numeric_trust_score(bcos_client):
     verify_response = bcos_client.get("/bcos/verify/cert-good-score")
     assert verify_response.status_code == 200
     assert verify_response.get_json()["trust_score"] == 81
+
+
+def test_bcos_attest_rejects_mismatched_commitment(bcos_client):
+    response = bcos_client.post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "0" * 32},
+        json={
+            "cert_id": "cert-stale-commitment",
+            "commitment": "stale-commitment",
+            "repo": "Scottcjn/Rustchain",
+            "commit_sha": "abcdef1234567890",
+            "tier": "L1",
+            "trust_score": 81,
+        },
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "invalid_commitment"


### PR DESCRIPTION
## Summary
- reject BCOS attest submissions when the supplied commitment does not match the normalized report payload
- share the digest helper with verify so POST and GET use the same canonical report rules
- add route coverage for stale commitments and keep numeric trust score storage coverage

Fixes #4579.
Bounty: Scottcjn/rustchain-bounties#71.

## Validation
- PYTHONPATH=(repo root);(repo root)/node py -3 -m pytest tests/test_bcos_routes_query_validation.py node/tests/test_bcos_routes_pagination.py -q
- py -3 -m py_compile node/bcos_routes.py tests/test_bcos_routes_query_validation.py node/tests/test_bcos_routes_pagination.py
- git diff --check --cached
Bounty payout:
- RTC address: RTCbe08538ae955ed694c5bc87314eff89b3b850627