### PR TITLE
fix: validate RustChain core RPC json bodies

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -21,6 +21,10 @@ from urllib.parse import urlparse, parse_qs
 import threading
 
 
+JSON_BODY_OBJECT_ERROR = "JSON body must be an object"
+RPC_PARAMS_OBJECT_ERROR = "RPC params must be an object"
+
+
 # =============================================================================
 # API Response
 # =============================================================================
@@ -65,6 +69,8 @@ class RpcRegistry:
         handler = self.methods.get(name)
         if not handler:
             return ApiResponse(success=False, error=f"Method not found: {name}")
+        if not isinstance(params, dict):
+            return ApiResponse(success=False, error=RPC_PARAMS_OBJECT_ERROR)
 
         try:
             result = handler(params)
@@ -279,8 +285,11 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         response = self._route_request(parsed.path, params)
         self._send_response(response)
 
-    def _route_request(self, path: str, params: Dict[str, Any]) -> ApiResponse:
+    def _route_request(self, path: str, params: Any) -> ApiResponse:
         """Route request to appropriate handler"""
+        if not isinstance(params, dict):
+            return ApiResponse(success=False, error=JSON_BODY_OBJECT_ERROR)
+
         # REST endpoints
         routes = {
             "/api/stats": ("getStats", {}),
@@ -326,6 +335,8 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         if path == "/rpc":
             method = params.get("method", "")
             rpc_params = params.get("params", {})
+            if not isinstance(rpc_params, dict):
+                return ApiResponse(success=False, error=RPC_PARAMS_OBJECT_ERROR)
             return self.api.rpc.call(method, rpc_params)
 
         return ApiResponse(success=False, error=f"Unknown endpoint: {path}")

--- a/tests/test_rustchain_core_rpc_request_validation.py
+++ b/tests/test_rustchain_core_rpc_request_validation.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for RustChain core RPC request shape validation."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+RPC_PATH = PROJECT_ROOT / "rips" / "rustchain-core" / "api" / "rpc.py"
+
+
+def load_rpc_module():
+    spec = importlib.util.spec_from_file_location("rustchain_core_rpc", RPC_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def rpc_handler():
+    rpc = load_rpc_module()
+    handler = object.__new__(rpc.ApiRequestHandler)
+    handler.api = rpc.RustChainApi(rpc.MockNode())
+    return rpc, handler
+
+
+@pytest.mark.parametrize("payload", [[], "not-an-object", 1, None])
+def test_route_request_rejects_non_object_post_bodies(rpc_handler, payload):
+    rpc, handler = rpc_handler
+
+    response = handler._route_request("/rpc", payload)
+
+    assert response.success is False
+    assert response.error == rpc.JSON_BODY_OBJECT_ERROR
+
+
+@pytest.mark.parametrize("params", [[], "not-an-object", 1, None])
+def test_rpc_endpoint_rejects_non_object_params(rpc_handler, params):
+    rpc, handler = rpc_handler
+
+    response = handler._route_request(
+        "/rpc",
+        {"method": "getWallet", "params": params},
+    )
+
+    assert response.success is False
+    assert response.error == rpc.RPC_PARAMS_OBJECT_ERROR
+
+
+def test_rpc_endpoint_accepts_object_params(rpc_handler):
+    _rpc, handler = rpc_handler
+
+    response = handler._route_request(
+        "/rpc",
+        {"method": "getWallet", "params": {"address": "RTC1Test"}},
+    )
+
+    assert response.success is True
+    assert response.data["address"] == "RTC1Test"


### PR DESCRIPTION
## Summary
- Reject decoded POST bodies that are not JSON objects before RPC route dispatch.
- Reject non-object `/rpc.params` before method handlers assume `.get()` is available.
- Add regression coverage for array, scalar, and null payload shapes while preserving valid object params.

## Responsible testing
Static review and local unit tests only; no production probing was performed.

## Verification
- `python -m pytest tests\test_rustchain_core_rpc_request_validation.py -q` -> 9 passed
- `python -m py_compile tests\test_rustchain_core_rpc_request_validation.py rips\rustchain-core\api\rpc.py node\utxo_db.py` -> passed
- `git diff --check -- tests\test_rustchain_core_rpc_request_validation.py rips\rustchain-core\api\rpc.py node\utxo_db.py` -> passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed with the existing return-value warning