### PR TITLE
test: cover payout preflight CLI

### DIFF
--- a/tools/tests/test_payout_preflight_check.py
+++ b/tools/tests/test_payout_preflight_check.py
@@ -1,0 +1,77 @@
+import io
+import json
+
+from tools import payout_preflight_check
+
+
+def test_read_payload_loads_json_file(tmp_path):
+    payload_path = tmp_path / "payload.json"
+    payload_path.write_text('{"from_miner": "alice", "amount_rtc": 1.25}', encoding="utf-8")
+
+    assert payout_preflight_check.read_payload(str(payload_path)) == {
+        "from_miner": "alice",
+        "amount_rtc": 1.25,
+    }
+
+
+def test_read_payload_reads_stdin_when_path_is_dash(monkeypatch):
+    monkeypatch.setattr(payout_preflight_check.sys, "stdin", io.StringIO('{"ok": true}'))
+
+    assert payout_preflight_check.read_payload("-") == {"ok": True}
+
+
+def test_main_returns_success_for_valid_admin_payload(tmp_path, monkeypatch, capsys):
+    payload_path = tmp_path / "admin.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "from_miner": "alice",
+                "to_miner": "bob",
+                "amount_rtc": "2.5",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        payout_preflight_check.sys,
+        "argv",
+        ["payout_preflight_check.py", "--mode", "admin", "--input", str(payload_path)],
+    )
+
+    assert payout_preflight_check.main() == 0
+    body = json.loads(capsys.readouterr().out)
+    assert body["ok"] is True
+    assert body["details"]["amount_i64"] == 2500000
+
+
+def test_main_returns_validation_error_for_signed_payload(capsys, monkeypatch):
+    monkeypatch.setattr(payout_preflight_check.sys, "stdin", io.StringIO('{"from_address": "RTCbad"}'))
+    monkeypatch.setattr(
+        payout_preflight_check.sys,
+        "argv",
+        ["payout_preflight_check.py", "--mode", "signed", "--input", "-"],
+    )
+
+    assert payout_preflight_check.main() == 1
+    body = json.loads(capsys.readouterr().out)
+    assert body == {
+        "ok": False,
+        "error": "missing_required_fields",
+        "details": {"missing": ["to_address", "amount_rtc", "nonce", "signature", "public_key"]},
+    }
+
+
+def test_main_returns_invalid_json_error(tmp_path, monkeypatch, capsys):
+    payload_path = tmp_path / "bad.json"
+    payload_path.write_text("{not-json", encoding="utf-8")
+    monkeypatch.setattr(
+        payout_preflight_check.sys,
+        "argv",
+        ["payout_preflight_check.py", "--mode", "admin", "--input", str(payload_path)],
+    )
+
+    assert payout_preflight_check.main() == 2
+    body = json.loads(capsys.readouterr().out)
+    assert body["ok"] is False
+    assert body["error"] == "invalid_json"
+    assert "details" in body


### PR DESCRIPTION
## Summary
- Adds offline pytest coverage for `tools/payout_preflight_check.py`.
- Covers JSON file loading, stdin loading, valid admin CLI success, signed-payload validation failure, and invalid JSON handling.

Bounty: Scottcjn/rustchain-bounties#1589
wallet: CTTqY8B7YihjhhuWXDBqD5sRqR3PY2UQ6fCLuz6ss6WT
Solana/wRTC payout wallet: CTTqY8B7YihjhhuWXDBqD5sRqR3PY2UQ6fCLuz6ss6WT

## Validation
- `python -m pytest tools\tests\test_payout_preflight_check.py -q` -> 5 passed
- `python -m py_compile tools\payout_preflight_check.py tools\tests\test_payout_preflight_check.py` -> passed
- `git diff --check -- tools\payout_preflight_check.py tools\tests\test_payout_preflight_check.py` -> passed