### PR TITLE
fix: require admin auth for GPU endpoint escrow

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -2,6 +2,7 @@
 # Author: @createkr (RayBot AI)
 # BCOS-Tier: L1
 import hashlib
+import hmac
 import math
 import secrets
 import sqlite3
@@ -29,6 +30,14 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
 
     def _hash_job_secret(secret):
         return hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
+
+    def _require_admin_key():
+        if not admin_key:
+            return jsonify({"error": "Admin key not configured"}), 503
+        provided = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
+        if not hmac.compare_digest(provided, admin_key):
+            return jsonify({"error": "Unauthorized - admin key required"}), 401
+        return None
 
     def _ensure_escrow_secret_column(db):
         """Best-effort migration for older DBs."""
@@ -87,6 +96,10 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
     # 2. Escrow: Lock funds for a job
     @app.route("/api/gpu/escrow", methods=["POST"])
     def gpu_escrow():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
+
         data = request.get_json(silent=True) or {}
         job_id = data.get("job_id") or f"job_{secrets.token_hex(8)}"
         job_type = data.get("job_type")  # render, tts, stt, llm
@@ -134,6 +147,10 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
     # 3. Release: Job finished successfully (payer authorizes provider payout)
     @app.route("/api/gpu/release", methods=["POST"])
     def gpu_release():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
+
         data = request.get_json(silent=True) or {}
         job_id = data.get("job_id")
         actor_wallet = data.get("actor_wallet")
@@ -178,6 +195,10 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
     # 4. Refund: Job failed (provider authorizes refund to payer)
     @app.route("/api/gpu/refund", methods=["POST"])
     def gpu_refund():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
+
         data = request.get_json(silent=True) or {}
         job_id = data.get("job_id")
         actor_wallet = data.get("actor_wallet")

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -1,0 +1,137 @@
+import sqlite3
+
+from flask import Flask
+
+from node.gpu_render_endpoints import register_gpu_render_endpoints
+
+
+ADMIN_KEY = "test-admin-key"
+
+
+def _create_app(db_path, admin_key=ADMIN_KEY):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_gpu_render_endpoints(app, str(db_path), admin_key)
+    return app
+
+
+def _init_db(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE balances (
+                miner_pk TEXT PRIMARY KEY,
+                balance_rtc REAL NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE render_escrow (
+                job_id TEXT PRIMARY KEY,
+                job_type TEXT,
+                from_wallet TEXT,
+                to_wallet TEXT,
+                amount_rtc REAL,
+                status TEXT,
+                created_at INTEGER,
+                released_at INTEGER,
+                escrow_secret_hash TEXT
+            )
+            """
+        )
+        conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("victim", 25.0))
+        conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("attacker", 0.0))
+
+
+def _balance(db_path, wallet):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (wallet,)).fetchone()[0]
+
+
+def _escrow_payload():
+    return {
+        "job_id": "job-1",
+        "job_type": "render",
+        "from_wallet": "victim",
+        "to_wallet": "attacker",
+        "amount_rtc": 5,
+    }
+
+
+def test_gpu_escrow_rejects_unauthenticated_wallet_lock(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post("/api/gpu/escrow", json=_escrow_payload())
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized - admin key required"}
+    assert _balance(db_path, "victim") == 25.0
+    assert _balance(db_path, "attacker") == 0.0
+
+
+def test_gpu_settlement_rejects_unauthenticated_secret_replay(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    created = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+    assert created.status_code == 200
+    escrow_secret = created.get_json()["escrow_secret"]
+
+    release = client.post(
+        "/api/gpu/release",
+        json={"job_id": "job-1", "actor_wallet": "victim", "escrow_secret": escrow_secret},
+    )
+
+    assert release.status_code == 401
+    assert release.get_json() == {"error": "Unauthorized - admin key required"}
+    assert _balance(db_path, "victim") == 20.0
+    assert _balance(db_path, "attacker") == 0.0
+
+
+def test_gpu_admin_can_create_and_release_escrow(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    created = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-API-Key": ADMIN_KEY},
+    )
+    assert created.status_code == 200
+    escrow_secret = created.get_json()["escrow_secret"]
+
+    released = client.post(
+        "/api/gpu/release",
+        json={"job_id": "job-1", "actor_wallet": "victim", "escrow_secret": escrow_secret},
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert released.status_code == 200
+    assert released.get_json() == {"ok": True, "status": "released"}
+    assert _balance(db_path, "victim") == 20.0
+    assert _balance(db_path, "attacker") == 5.0
+
+
+def test_gpu_admin_endpoints_fail_closed_without_configured_key(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path, admin_key="").test_client()
+
+    response = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "Admin key not configured"}
+    assert _balance(db_path, "victim") == 25.0

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sqlite3
 
 from flask import Flask


### PR DESCRIPTION
## Summary

This closes an unauthenticated GPU escrow fund-movement path in `node/gpu_render_endpoints.py`.

Before this change, any caller could:
1. create `/api/gpu/escrow` with `from_wallet` set to a victim wallet and `to_wallet` set to an attacker wallet;
2. receive the returned `escrow_secret`;
3. call `/api/gpu/release` with `actor_wallet` set to the victim wallet and the returned secret;
4. move the locked amount into the attacker wallet without proving control of the payer wallet.

The endpoint registration already receives `admin_key`, so this patch gates escrow creation, release, and refund behind that configured key using constant-time comparison. Both `X-Admin-Key` and `X-API-Key` are accepted to match neighboring admin endpoints. The routes fail closed when the key is not configured.

## Validation

- `uv run --no-project --with pytest --with flask python -m pytest tests/test_gpu_render_endpoints_security.py -q` -> 4 passed
- `python3 -m py_compile node/gpu_render_endpoints.py tests/test_gpu_render_endpoints_security.py` -> passed
- `git diff --check -- node/gpu_render_endpoints.py tests/test_gpu_render_endpoints_security.py` -> passed
