### PR TITLE
fix: fail closed for integrated admin endpoints

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4683,8 +4683,7 @@ def reject_v1_mine():
 @app.route('/withdraw/register', methods=['POST'])
 def register_withdrawal_key():
     # SECURITY: Registering withdrawal keys allows fund extraction; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     """Register sr25519 public key for withdrawals"""
     data = request.get_json(silent=True)
@@ -4706,8 +4705,7 @@ def register_withdrawal_key():
 
     # SECURITY: prevent unauthenticated key overwrite (withdrawal takeover).
     # First-time registration is allowed. Rotation requires admin key.
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
+    admin_ok = is_admin(request)
 
     now = int(time.time())
     with sqlite3.connect(DB_PATH) as c:
@@ -4717,7 +4715,7 @@ def register_withdrawal_key():
         ).fetchone()
 
         if row and row[0] and row[0] != pubkey_sr25519:
-            if not is_admin:
+            if not admin_ok:
                 return jsonify({"error": "pubkey already registered; admin required to rotate"}), 409
             c.execute(
                 "UPDATE miner_keys SET pubkey_sr25519 = ?, registered_at = ? WHERE miner_pk = ?",
@@ -4958,8 +4956,7 @@ def withdrawal_status(withdrawal_id):
 def withdrawal_history(miner_pk):
     """Get withdrawal history for miner"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes withdrawal history
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     limit = request.args.get('limit', 50, type=int)
 
@@ -5013,8 +5010,7 @@ def admin_required(f):
     from functools import wraps
     @wraps(f)
     def decorated(*args, **kwargs):
-        key = request.headers.get("X-API-Key") or ""
-        if not hmac.compare_digest(key, ADMIN_KEY or ""):
+        if not is_admin(request):
             return jsonify({"ok": False, "reason": "admin_required"}), 401
         return f(*args, **kwargs)
     return decorated
@@ -6175,8 +6171,7 @@ def api_miner_dashboard(miner_id):
 def api_miner_attestations(miner_id: str):
     """Best-effort attestation history for a single miner (museum detail view)."""
     # SECURITY FIX 2026-02-15: Require admin key - exposes miner attestation history/timing
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     limit = int(request.args.get("limit", "120") or 120)
     limit = max(1, min(limit, 500))
@@ -6218,8 +6213,7 @@ def api_miner_attestations(miner_id: str):
 def api_balances():
     """Return wallet balances (best-effort across schema variants)."""
     # SECURITY FIX 2026-02-15: Require admin key - dumps all wallet balances
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     limit = int(request.args.get("limit", "2000") or 2000)
     limit = max(1, min(limit, 5000))
@@ -6373,8 +6367,7 @@ def metrics_mac():
 def attest_debug():
     """Debug endpoint: show miner's enrollment eligibility"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes internal config + MAC hashes
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     data = request.get_json()
 
@@ -6490,8 +6483,7 @@ METRICS_SNAPSHOT = {}
 def ops_readiness():
     """Single PASS/FAIL aggregator for all go/no-go checks"""
     # SECURITY FIX 2026-02-15: Only show detailed checks to admin
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = hmac.compare_digest(admin_key, ADMIN_KEY or "")
+    admin_ok = is_admin(request)
     out = {"ok": True, "checks": []}
 
     # Health check
@@ -6547,7 +6539,7 @@ def ops_readiness():
         out["ok"] = False
 
     # Strip detailed checks for non-admin requests
-    if not is_admin:
+    if not admin_ok:
         return jsonify({"ok": out["ok"]}), (200 if out["ok"] else 503)
     return jsonify(out), (200 if out["ok"] else 503)
 
@@ -6586,8 +6578,7 @@ def metrics():
 def api_rewards_settle():
     """Settle rewards for a specific epoch (admin/cron callable)"""
     # SECURITY: settling rewards mutates chain state; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     body = request.get_json(force=True, silent=True) or {}
@@ -6860,8 +6851,7 @@ def send_sophiacheck_alert(alert_type, message, data):
 def wallet_transfer_v2():
     """Transfer RTC between miner wallets - NOW WITH 2-PHASE COMMIT"""
     # SECURITY: Require admin key for internal transfers
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({
             "error": "Unauthorized - admin key required",
             "hint": "Use /wallet/transfer/signed for user transfers"
@@ -6959,8 +6949,7 @@ def wallet_transfer_v2():
 @app.route('/pending/list', methods=['GET'])
 def list_pending():
     """List all pending transfers"""
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized"}), 401
 
     status_filter = request.args.get('status', 'pending')
@@ -7002,8 +6991,7 @@ def list_pending():
 @app.route('/pending/void', methods=['POST'])
 def void_pending():
     """Admin: Void a pending transfer before confirmation"""
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized"}), 401
     
     data = request.get_json()
@@ -7076,8 +7064,7 @@ def void_pending():
 @app.route('/pending/confirm', methods=['POST'])
 def confirm_pending():
     """Worker: Confirm pending transfers that have passed the delay period"""
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized"}), 401
     
     now = int(time.time())
@@ -7166,8 +7153,7 @@ def confirm_pending():
 @app.route('/pending/integrity', methods=['GET'])
 def check_integrity():
     """Check balance integrity: sum of ledger should match balances"""
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized"}), 401
 
     with sqlite3.connect(DB_PATH) as db:
@@ -7221,8 +7207,7 @@ def check_integrity():
 @app.route('/wallet/transfer_OLD_DISABLED', methods=['POST'])
 def wallet_transfer_OLD():
     # SECURITY FIX: Require admin key for internal transfers
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required", "hint": "Use /wallet/transfer/signed for user transfers"}), 401
     """Transfer RTC between miner wallets"""
     data = request.get_json()
@@ -7277,8 +7262,7 @@ def wallet_transfer_OLD():
 def api_wallet_ledger():
     """Get transaction ledger (optionally filtered by miner)"""
     # SECURITY: ledger entries include transfer reasons + wallet identifiers; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     miner_id = request.args.get("miner_id", "").strip()
@@ -7323,8 +7307,7 @@ def api_wallet_ledger():
 def api_wallet_balances_all():
     """Get all miner balances"""
     # SECURITY: exporting all balances is sensitive; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not is_admin(request):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     with sqlite3.connect(DB_PATH) as db:

--- a/tests/test_integrated_admin_fail_closed.py
+++ b/tests/test_integrated_admin_fail_closed.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import os
 import sqlite3
 import sys

--- a/tests/test_integrated_admin_fail_closed.py
+++ b/tests/test_integrated_admin_fail_closed.py
@@ -1,0 +1,121 @@
+import os
+import sqlite3
+import sys
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def _init_wallet_db(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                amount_i64 INTEGER NOT NULL,
+                balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE pending_ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER,
+                epoch INTEGER,
+                from_miner TEXT,
+                to_miner TEXT,
+                amount_i64 INTEGER,
+                reason TEXT,
+                status TEXT,
+                created_at INTEGER,
+                confirms_at INTEGER,
+                confirmed_at INTEGER,
+                voided_by TEXT,
+                voided_reason TEXT,
+                tx_hash TEXT
+            );
+            CREATE TABLE ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER,
+                epoch INTEGER,
+                miner_id TEXT,
+                delta_i64 INTEGER,
+                reason TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, ?, ?)",
+            ("victim", 10_000_000, 10.0),
+        )
+
+
+def _pending_count(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM pending_ledger").fetchone()[0]
+
+
+def test_wallet_transfer_fails_closed_when_admin_key_unset(tmp_path, monkeypatch):
+    db_path = tmp_path / "wallet.db"
+    _init_wallet_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", None, raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    monkeypatch.setattr(integrated_node, "send_sophiacheck_alert", lambda *args, **kwargs: None)
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
+
+    integrated_node.app.config["TESTING"] = True
+    client = integrated_node.app.test_client()
+
+    response = client.post(
+        "/wallet/transfer",
+        json={
+            "from_miner": "victim",
+            "to_miner": "attacker",
+            "amount_rtc": 5,
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Unauthorized - admin key required"
+    assert _pending_count(db_path) == 0
+
+
+def test_pending_confirm_fails_closed_when_admin_key_unset(tmp_path, monkeypatch):
+    db_path = tmp_path / "wallet.db"
+    _init_wallet_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", None, raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    integrated_node.app.config["TESTING"] = True
+    client = integrated_node.app.test_client()
+
+    response = client.post("/pending/confirm")
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Unauthorized"
+
+
+def test_wallet_transfer_still_accepts_configured_admin_key(tmp_path, monkeypatch):
+    db_path = tmp_path / "wallet.db"
+    _init_wallet_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "expected-admin-key", raising=False)
+    monkeypatch.setattr(integrated_node, "send_sophiacheck_alert", lambda *args, **kwargs: None)
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
+
+    integrated_node.app.config["TESTING"] = True
+    client = integrated_node.app.test_client()
+
+    response = client.post(
+        "/wallet/transfer",
+        headers={"X-Admin-Key": "expected-admin-key"},
+        json={
+            "from_miner": "victim",
+            "to_miner": "recipient",
+            "amount_rtc": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["phase"] == "pending"
+    assert _pending_count(db_path) == 1


### PR DESCRIPTION
## Summary

This hardens the integrated node admin checks so sensitive wallet, pending-transfer, reward-settlement, withdrawal, balance, ledger, and ops/debug endpoints consistently use the existing `is_admin(request)` helper.

Several routes compared the submitted key directly against `os.environ.get("RC_ADMIN_KEY", "")` or `ADMIN_KEY or ""`. If the runtime key was absent after startup in a loaded test/deployment process, an empty header could compare equal to an empty expected key and reach privileged logic. The focused regression demonstrates `/wallet/transfer` creating a pending transfer and `/pending/confirm` returning success before this change when `RC_ADMIN_KEY` is unset at request time.

## Changed

- Route direct admin comparisons through `is_admin(request)`, which already requires both configured expected key and submitted key before `hmac.compare_digest()`.
- Preserve both `X-Admin-Key` and `X-API-Key` support through the shared helper.
- Add regression coverage proving wallet transfer and pending confirmation fail closed when `RC_ADMIN_KEY` is absent, while configured admin transfer still works.

## Validation

- `uv run --no-project --with pytest --with flask python -m pytest tests/test_integrated_admin_fail_closed.py -q` -> 3 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_integrated_admin_fail_closed.py` -> passed
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_integrated_admin_fail_closed.py` -> passed
- `rg -n 'compare_digest\\([^\\n]*(os\\.environ\\.get\\(\"RC_ADMIN_KEY\", \"\"\\)|ADMIN_KEY or \"\"\\))' node/rustchain_v2_integrated_v2.2.1_rip200.py` -> no matches

Note: I also tried `node/tests/test_api_nodes_admin_compare.py` and `node/tests/test_wallet_history.py` in the same local environment. Those fail for pre-existing reasons unrelated to this patch: missing optional `requests` in the uv env for the node-admin test, and existing wallet-history response-shape expectations that do not match current `main`.
