### PR TITLE
fix: preserve beacon join wallet ownership

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -261,13 +261,14 @@ def beacon_join():
                 bytes.fromhex(cb_hex)
             except ValueError:
                 return jsonify({'error': 'Invalid coinbase_address: must be valid hexadecimal'}), 400
+            coinbase_address = cb_clean.lower()
 
         now = int(time.time())
 
         # Check if agent already exists
         db = get_db()
         existing = db.execute(
-            "SELECT pubkey_hex FROM relay_agents WHERE agent_id = ?",
+            "SELECT pubkey_hex, coinbase_address FROM relay_agents WHERE agent_id = ?",
             (agent_id,)
         ).fetchone()
 
@@ -282,15 +283,22 @@ def beacon_join():
                              'public key is immutable after registration'
                 }), 403
 
-            # Update mutable fields only
+            existing_coinbase = existing['coinbase_address']
+            existing_coinbase = existing_coinbase.strip().lower() if existing_coinbase else None
+            if coinbase_address and coinbase_address != existing_coinbase:
+                return jsonify({
+                    'error': 'Cannot change coinbase_address for existing agent; '
+                             f'use POST /api/agents/{agent_id}/wallet with an admin key'
+                }), 403
+
+            # Update mutable fields only. Wallet changes require the admin endpoint.
             db.execute("""
                 UPDATE relay_agents
                 SET name = COALESCE(?, name),
-                    coinbase_address = COALESCE(?, coinbase_address),
                     status = 'active',
                     updated_at = ?
                 WHERE agent_id = ?
-            """, (name, coinbase_address, now, agent_id))
+            """, (name, now, agent_id))
         else:
             # New agent — insert with pubkey_hex
             db.execute("""

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -8,6 +8,7 @@ import json
 import time
 import sys
 import os
+import gc
 import tempfile
 import sqlite3
 
@@ -59,6 +60,9 @@ class TestBeaconJoinRouting(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         """Clean up after all tests."""
+        cls.client = None
+        cls.app = None
+        gc.collect()
         os.close(cls.test_db_fd)
         os.unlink(cls.test_db_path)
 
@@ -274,6 +278,85 @@ class TestBeaconJoinRouting(unittest.TestCase):
                 ('bcn_wallet_test',)
             ).fetchone()
             self.assertEqual(row[0], '0x1234567890123456789012345678901234567890')
+
+    def test_join_allows_same_coinbase_with_case_and_spacing(self):
+        """POST /beacon/join treats the same normalized wallet as unchanged."""
+        pubkey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+        payload1 = {
+            'agent_id': 'bcn_wallet_normalized',
+            'pubkey_hex': pubkey,
+            'name': 'Wallet Owner',
+            'coinbase_address': '  0xABCDEFabcdefABCDEFabcdefABCDEFabcdefABCD  ',
+        }
+        r1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json',
+        )
+        self.assertEqual(r1.status_code, 200)
+
+        payload2 = {
+            'agent_id': 'bcn_wallet_normalized',
+            'pubkey_hex': pubkey,
+            'name': 'Renamed Owner',
+            'coinbase_address': '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+        }
+        r2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json',
+        )
+        self.assertEqual(r2.status_code, 200)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT coinbase_address, name FROM relay_agents WHERE agent_id = ?",
+                ('bcn_wallet_normalized',),
+            ).fetchone()
+            self.assertEqual(row[0], '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd')
+            self.assertEqual(row[1], 'Renamed Owner')
+
+    def test_join_rejects_coinbase_change_for_existing_agent(self):
+        """POST /beacon/join cannot replace an existing agent wallet."""
+        pubkey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+        original_wallet = '0x1111111111111111111111111111111111111111'
+        attacker_wallet = '0x2222222222222222222222222222222222222222'
+        payload1 = {
+            'agent_id': 'bcn_wallet_takeover_target',
+            'pubkey_hex': pubkey,
+            'name': 'Wallet Owner',
+            'coinbase_address': original_wallet,
+        }
+        r1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json',
+        )
+        self.assertEqual(r1.status_code, 200)
+
+        payload2 = {
+            'agent_id': 'bcn_wallet_takeover_target',
+            'pubkey_hex': pubkey,
+            'name': 'Renamed Owner',
+            'coinbase_address': attacker_wallet,
+        }
+        r2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json',
+        )
+        self.assertEqual(r2.status_code, 403)
+        data = json.loads(r2.data)
+        self.assertIn('/api/agents/bcn_wallet_takeover_target/wallet', data['error'])
+        self.assertIn('admin key', data['error'])
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT coinbase_address, name FROM relay_agents WHERE agent_id = ?",
+                ('bcn_wallet_takeover_target',),
+            ).fetchone()
+            self.assertEqual(row[0], original_wallet)
+            self.assertEqual(row[1], 'Wallet Owner')
 
     def test_join_invalid_coinbase_address_returns_400(self):
         """POST /beacon/join returns 400 for invalid coinbase_address."""


### PR DESCRIPTION
## Summary
- reject coinbase_address changes when /beacon/join is called for an existing relay agent
- keep the existing public-key immutability check and idempotent name/status refresh path
- add a regression that proves a same-pubkey rejoin cannot replace the stored payment address

Fixes #4589.
Bounty: Scottcjn/rustchain-bounties#71.

## Validation
- PYTHONPATH=(repo root);(repo root)/node py -3 -m pytest tests/test_beacon_join_routing.py -q
- py -3 -m py_compile node/beacon_api.py tests/test_beacon_join_routing.py
- git diff --check
Bounty payout:
- RTC address: RTCbe08538ae955ed694c5bc87314eff89b3b850627