### PR TITLE
fix: validate beacon api json bodies

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -4,6 +4,7 @@ Beacon Atlas API - Flask routes for 3D visualization backend
 Provides endpoints for agents, contracts, bounties, reputation, and chat.
 """
 import json
+import math
 import os
 import time
 import hashlib
@@ -35,6 +36,14 @@ def get_db():
         g.db = sqlite3.connect(DB_PATH)
         g.db.row_factory = sqlite3.Row
     return g.db
+
+
+def _json_object():
+    """Decode a request body that must be a JSON object."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'JSON object required'}), 400)
+    return data, None
 
 
 @beacon_api.teardown_request
@@ -419,7 +428,9 @@ def create_contract():
     Validates that the from_agent exists in the relay_agents table.
     """
     try:
-        data = request.get_json()
+        data, error = _json_object()
+        if error:
+            return error
         
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
@@ -449,6 +460,14 @@ def create_contract():
             return jsonify({
                 'error': f'from_agent not found: {from_agent}'
             }), 400
+
+        try:
+            amount = float(data['amount'])
+        except (TypeError, ValueError):
+            return jsonify({'error': 'Invalid amount'}), 400
+
+        if not math.isfinite(amount) or amount <= 0:
+            return jsonify({'error': 'Invalid amount'}), 400
         
         # Generate contract ID
         contract_id = f"ctr_{int(time.time())}_{hashlib.blake2b(str(time.time()).encode(), digest_size=4).hexdigest()}"
@@ -458,7 +477,7 @@ def create_contract():
             'from': data['from'],
             'to': data['to'],
             'type': data['type'],
-            'amount': float(data['amount']),
+            'amount': amount,
             'currency': data.get('currency', 'RTC'),
             'term': data['term'],
             'state': 'offered',  # Initial state
@@ -491,7 +510,9 @@ def update_contract(contract_id):
     Validates state transitions to prevent invalid jumps.
     """
     try:
-        data = request.get_json()
+        data, error = _json_object()
+        if error:
+            return error
         new_state = data.get('state')
         
         if not new_state:
@@ -742,7 +763,9 @@ def claim_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to claim bounties'}), 401
 
-        data = request.get_json()
+        data, error = _json_object()
+        if error:
+            return error
         agent_id = data.get('agent_id')
         
         if not agent_id:
@@ -776,7 +799,9 @@ def complete_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to complete bounties'}), 401
 
-        data = request.get_json()
+        data, error = _json_object()
+        if error:
+            return error
         agent_id = data.get('agent_id')
         
         if not agent_id:
@@ -877,7 +902,9 @@ def get_agent_reputation(agent_id):
 def chat():
     """Send message to an agent (mock response for demo)."""
     try:
-        data = request.get_json()
+        data, error = _json_object()
+        if error:
+            return error
         agent_id = data.get('agent_id')
         message = data.get('message')
         

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -168,6 +168,65 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         data = json.loads(response.data)
         self.assertIn('error', data)
 
+    def test_mutating_routes_require_json_object_body(self):
+        """Routes that read JSON fields reject non-object JSON bodies."""
+        routes = [
+            ('post', '/api/contracts', {}),
+            ('put', '/api/contracts/ctr_test', {}),
+            ('post', '/api/chat', {}),
+            (
+                'post',
+                '/api/bounties/gh_test_bounty/claim',
+                {'X-Admin-Key': 'test-admin'},
+            ),
+            (
+                'post',
+                '/api/bounties/gh_test_bounty/complete',
+                {'X-Admin-Key': 'test-admin'},
+            ),
+        ]
+
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            for method, path, headers in routes:
+                response = getattr(self.client, method)(
+                    path,
+                    data=json.dumps([]),
+                    content_type='application/json',
+                    headers=headers,
+                )
+
+                self.assertEqual(response.status_code, 400, path)
+                self.assertEqual(
+                    json.loads(response.data),
+                    {'error': 'JSON object required'},
+                    path,
+                )
+
+    def test_contract_creation_rejects_invalid_amount(self):
+        """Contract creation rejects malformed amount fields with 400."""
+        invalid_amounts = ['not-a-number', 'nan', 0, -1]
+
+        for amount in invalid_amounts:
+            with self.subTest(amount=amount):
+                response = self.client.post(
+                    '/api/contracts',
+                    data=json.dumps({
+                        'from': 'bcn_alice_test',
+                        'to': 'bcn_bob_test',
+                        'type': 'rent',
+                        'amount': amount,
+                        'term': '30d',
+                    }),
+                    content_type='application/json',
+                    headers={'X-Agent-Key': 'bcn_alice_test'},
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    json.loads(response.data),
+                    {'error': 'Invalid amount'},
+                )
+
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
         # Insert a test bounty directly


### PR DESCRIPTION
## Summary
- add a shared JSON-object decoder for Beacon Atlas mutating routes
- reject valid JSON arrays/scalars with `400 {"error":"JSON object required"}` before field access
- cover contract, contract update, chat, bounty claim, and bounty completion routes in the existing Beacon Atlas behavior suite

## Verification
- `python -m pytest tests\test_beacon_atlas_behavior.py -q` -> 19 passed
- `python -m py_compile node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py` -> passed
- `git diff --check -- node\beacon_api.py tests\test_beacon_atlas_behavior.py node\utxo_db.py` -> passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, existing pytest return warning
