### PR TITLE
fix: bind claims to registered payout wallets

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -487,6 +487,11 @@ def submit_claim(
     if not eligibility["eligible"]:
         result["error"] = f"ineligible: {eligibility['reason']}"
         return result
+
+    registered_wallet = eligibility.get("wallet_address")
+    if not registered_wallet or registered_wallet.lower() != wallet_address.lower():
+        result["error"] = "wallet_mismatch"
+        return result
     
     # Verify signature (unless skipped for testing)
     if not skip_signature_verify:

--- a/node/test_claims_security.py
+++ b/node/test_claims_security.py
@@ -61,5 +61,33 @@ class TestClaimsUnitConsistency(unittest.TestCase):
         self.assertAlmostEqual(wrong_rtc, 0.01)  # 100x too small
 
 
+class TestClaimsWalletBinding(unittest.TestCase):
+    """Claim payouts must stay bound to the miner's registered wallet."""
+
+    def test_submit_claim_rejects_unregistered_payout_wallet(self):
+        import claims_submission as cs
+
+        with patch.object(cs, "check_claim_eligibility", return_value={
+            "eligible": True,
+            "reason": None,
+            "wallet_address": "RTC1RegisteredWallet123456789",
+            "reward_urtc": 1_000_000,
+        }):
+            result = cs.submit_claim(
+                db_path="unused.db",
+                miner_id="wallet-bound-claimer",
+                epoch=123,
+                wallet_address="RTC1AttackerWallet9999999999",
+                signature="mock_signature",
+                public_key="mock_public_key",
+                current_slot=20000,
+                current_ts=1766000000,
+                skip_signature_verify=True,
+            )
+
+        self.assertFalse(result["success"])
+        self.assertEqual(result["error"], "wallet_mismatch")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/node/test_claims_security.py
+++ b/node/test_claims_security.py
@@ -64,7 +64,8 @@ class TestClaimsUnitConsistency(unittest.TestCase):
 class TestClaimsWalletBinding(unittest.TestCase):
     """Claim payouts must stay bound to the miner's registered wallet."""
 
-    def test_submit_claim_rejects_payout_wallet_mismatch(self):
+    def test_submit_claim_rejects_registered_wallet_mismatch(self):
+        """Reject claims when submitted wallet differs from the registered wallet."""
         import claims_submission as cs
 
         with patch.object(cs, "check_claim_eligibility", return_value={

--- a/node/test_claims_security.py
+++ b/node/test_claims_security.py
@@ -64,7 +64,7 @@ class TestClaimsUnitConsistency(unittest.TestCase):
 class TestClaimsWalletBinding(unittest.TestCase):
     """Claim payouts must stay bound to the miner's registered wallet."""
 
-    def test_submit_claim_rejects_unregistered_payout_wallet(self):
+    def test_submit_claim_rejects_payout_wallet_mismatch(self):
         import claims_submission as cs
 
         with patch.object(cs, "check_claim_eligibility", return_value={
@@ -87,6 +87,46 @@ class TestClaimsWalletBinding(unittest.TestCase):
 
         self.assertFalse(result["success"])
         self.assertEqual(result["error"], "wallet_mismatch")
+
+    def test_submit_claim_accepts_case_variant_of_registered_wallet(self):
+        import claims_submission as cs
+
+        registered_wallet = "rtc1registeredwallet123456789"
+        submitted_wallet = "RTC1REGISTEREDWALLET123456789"
+
+        with (
+            patch.object(cs, "check_claim_eligibility", return_value={
+                "eligible": True,
+                "reason": None,
+                "wallet_address": registered_wallet,
+                "reward_urtc": 1_000_000,
+            }),
+            patch.object(cs, "create_claim_record", return_value={
+                "status": "pending",
+                "submitted_at": 1766000000,
+                "estimated_settlement": 1766001800,
+            }) as create_claim_record,
+        ):
+            result = cs.submit_claim(
+                db_path="unused.db",
+                miner_id="wallet-bound-claimer",
+                epoch=123,
+                wallet_address=submitted_wallet,
+                signature="mock_signature",
+                public_key="mock_public_key",
+                current_slot=20000,
+                current_ts=1766000000,
+                skip_signature_verify=True,
+            )
+
+        self.assertTrue(result["success"])
+        self.assertIsNone(result["error"])
+        self.assertEqual(result["reward_rtc"], 1.0)
+        create_claim_record.assert_called_once()
+        self.assertEqual(
+            create_claim_record.call_args.kwargs["wallet_address"],
+            submitted_wallet,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #4592
Bounty: Scottcjn/rustchain-bounties#71

Summary:
- reject claim submissions when the requested payout wallet differs from the wallet returned by eligibility
- add a regression test for the mismatch path

Validation:
- `py -3 -m pytest node/test_claims_security.py -q -W ignore::ResourceWarning`
- `py -3 -m py_compile node/claims_submission.py node/test_claims_security.py`
- `git diff --check`
Bounty payout:
- RTC address: RTCbe08538ae955ed694c5bc87314eff89b3b850627