### PR TITLE
Fix Hall of Rust current-year age calculations

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -37,6 +37,10 @@ CAPACITOR_PLAGUE_MODELS = [
     'Dell GX280',
 ]
 
+def current_utc_year():
+    """Return the current UTC year for hardware age calculations."""
+    return time.gmtime().tm_year
+
 def init_hall_tables(db_path):
     """Create Hall of Rust tables if they don't exist."""
     conn = sqlite3.connect(db_path)
@@ -88,7 +92,7 @@ def calculate_rust_score(machine):
     
     # Age bonus (estimated from model/arch)
     if machine.get('manufacture_year'):
-        age = 2025 - machine['manufacture_year']
+        age = max(0, current_utc_year() - int(machine['manufacture_year']))
         score += age * RUST_WEIGHTS['age_years']
     
     # Attestation loyalty
@@ -485,7 +489,7 @@ def api_hall_of_fame_leaderboard():
         conn.close()
 
         leaderboard = []
-        now_year = time.gmtime().tm_year
+        now_year = current_utc_year()
         for idx, row in enumerate(rows, 1):
             entry = dict(row)
             entry['rank'] = idx
@@ -531,7 +535,7 @@ def api_hall_of_fame_machine():
             machine.get('device_model'),
         )
         mfg = machine.get('manufacture_year')
-        current_year = time.gmtime(now).tm_year
+        current_year = current_utc_year()
         machine['age_years'] = max(0, current_year - int(mfg)) if mfg else None
 
         # Last 30 days timeline from attestation history (best-effort).
@@ -689,7 +693,8 @@ def machine_of_the_day():
         machine = dict(row)
         machine['badge'] = get_rust_badge(machine['rust_score'])
         machine['fun_fact'] = random.choice(VINTAGE_FACTS)
-        machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
+        mfg = machine.get('manufacture_year')
+        machine['age_years'] = max(0, current_utc_year() - int(mfg)) if mfg else None
         
         return jsonify(machine)
     except Exception:

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -44,3 +44,45 @@ def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
     assert body["total_machines"] == 0
     assert body["total_attestations"] == 0
     assert body["average_rust_score"] == 0
+
+
+def test_rust_score_uses_current_year_for_age_bonus(monkeypatch):
+    monkeypatch.setattr(hall_of_rust, "current_utc_year", lambda: 2026)
+
+    score = hall_of_rust.calculate_rust_score(
+        {
+            "manufacture_year": 2001,
+            "device_arch": "modern",
+            "device_model": "Generic",
+            "total_attestations": 0,
+            "id": 999,
+        }
+    )
+
+    assert score == 250
+
+
+def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    monkeypatch.setattr(hall_of_rust, "current_utc_year", lambda: 2026)
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO hall_of_rust (
+            fingerprint_hash, miner_id, device_arch, device_model,
+            manufacture_year, first_attestation, last_attestation,
+            rust_score, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("fp-1", "miner-1", "G4", "PowerMac3,6", 2003, 1, 1, 101, 1),
+    )
+    conn.commit()
+    conn.close()
+    client = _client_for(db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 23


### PR DESCRIPTION
## Summary
- replace Hall of Rust's hardcoded 2025 age baseline with a shared current UTC year helper
- keep rust score, Hall of Fame API, and machine-of-the-day age calculations consistent
- add regression coverage for rust-score age bonus and machine-of-the-day `age_years`

Fixes #4594

## Verification
- `python -m pytest node\tests\test_hall_of_rust_error_responses.py -q`
- `python -m py_compile node\hall_of_rust.py node\tests\test_hall_of_rust_error_responses.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`