### PR TITLE
fix: validate cross-node attestation payloads

### DIFF
--- a/bounties/issue-2296/src/cross_node_replay_defense.py
+++ b/bounties/issue-2296/src/cross_node_replay_defense.py
@@ -650,8 +650,14 @@ def create_defense_middleware(db_path: str = DB_PATH):
                 
                 try:
                     data = request.get_json(silent=True)
-                    if not data:
+                    if data is None:
                         return None
+                    if not isinstance(data, dict):
+                        return jsonify({
+                            "ok": False,
+                            "error": "JSON object required",
+                            "code": "INVALID_ATTESTATION_PAYLOAD"
+                        }), 400
                     
                     nonce = data.get('nonce')
                     miner = data.get('miner') or data.get('miner_id')
@@ -688,7 +694,9 @@ def create_defense_middleware(db_path: str = DB_PATH):
                 
                 try:
                     data = request.get_json(silent=True)
-                    if not data:
+                    if data is None:
+                        return response
+                    if not isinstance(data, dict):
                         return response
                     
                     nonce = data.get('nonce')

--- a/bounties/issue-2296/tests/test_cross_node_replay_defense.py
+++ b/bounties/issue-2296/tests/test_cross_node_replay_defense.py
@@ -25,6 +25,7 @@ import json
 import os
 import sqlite3
 import sys
+import tempfile
 import time
 import uuid
 from pathlib import Path
@@ -46,6 +47,7 @@ from cross_node_replay_defense import (
     get_cross_node_nonce_stats,
     get_replay_attack_report,
     NonceCleanupService,
+    create_defense_middleware,
     CROSS_NODE_NONCE_TTL,
     NODE_ID,
 )
@@ -514,6 +516,42 @@ class TestCleanupService:
             # Should stop without error
             service.stop()
             assert service.running is False
+
+
+# =============================================================================
+# Tests: Flask Middleware Payload Validation
+# =============================================================================
+
+class TestDefenseMiddlewarePayloadValidation:
+    """Tests for request-shape handling in the Flask middleware."""
+
+    def test_attestation_middleware_rejects_non_object_json(self):
+        """Non-object JSON must not bypass nonce validation middleware."""
+        from flask import Flask, jsonify
+
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            app = Flask(__name__)
+            app.config["TESTING"] = True
+
+            middleware = create_defense_middleware(db_path=db_path)
+            middleware.init_app(app)
+
+            @app.route("/attest/submit", methods=["POST"])
+            def attest_submit():
+                return jsonify({"ok": True})
+
+            response = app.test_client().post("/attest/submit", json=[])
+
+            assert response.status_code == 400
+            assert response.get_json() == {
+                "ok": False,
+                "error": "JSON object required",
+                "code": "INVALID_ATTESTATION_PAYLOAD",
+            }
+        finally:
+            os.unlink(db_path)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- reject non-object JSON payloads in the cross-node replay defense middleware for `/attest/*` POSTs
- keep missing/invalid JSON behavior unchanged, but prevent valid JSON arrays/scalars from bypassing nonce validation
- add a Flask middleware regression showing an array body is blocked before the attestation route can accept it

## Verification
- `python -m pytest bounties\issue-2296\tests\test_cross_node_replay_defense.py::TestDefenseMiddlewarePayloadValidation::test_attestation_middleware_rejects_non_object_json -q` -> 1 passed
- `python -m pytest bounties\issue-2296\tests\test_cross_node_replay_defense.py -q` -> 34 passed
- `python -m py_compile bounties\issue-2296\src\cross_node_replay_defense.py bounties\issue-2296\tests\test_cross_node_replay_defense.py node\utxo_db.py` -> passed
- `git diff --check -- bounties\issue-2296\src\cross_node_replay_defense.py bounties\issue-2296\tests\test_cross_node_replay_defense.py node\utxo_db.py` -> passed
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q` -> 1 passed, existing pytest return warning
