### PR TITLE
Fix hardware fingerprint device-age current year

### DIFF
--- a/node/hardware_fingerprint.py
+++ b/node/hardware_fingerprint.py
@@ -22,6 +22,11 @@ JITTER_SAMPLES = 500
 THERMAL_SAMPLES = 50
 
 
+def current_utc_year() -> int:
+    """Return the current UTC year for device age calculations."""
+    return time.gmtime().tm_year
+
+
 class HardwareFingerprint:
     """Collects comprehensive hardware fingerprints for attestation"""
     
@@ -433,7 +438,7 @@ class HardwareFingerprint:
             release_year = 2023
         
         oracle["estimated_release_year"] = release_year
-        oracle["estimated_age_years"] = 2025 - release_year
+        oracle["estimated_age_years"] = max(0, current_utc_year() - release_year)
         oracle["valid"] = "cpu_model" in oracle or "processor" in oracle
         
         return oracle

--- a/node/tests/test_hardware_fingerprint_device_oracle.py
+++ b/node/tests/test_hardware_fingerprint_device_oracle.py
@@ -1,0 +1,28 @@
+import builtins
+import os
+import sys
+from unittest import mock
+
+
+try:
+    import hardware_fingerprint
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+    import hardware_fingerprint
+
+
+def test_device_oracle_uses_current_year_for_estimated_age():
+    cpuinfo = "model name\t: PowerPC G4 7447A\n"
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/cpuinfo":
+            return mock.mock_open(read_data=cpuinfo)()
+        return builtins.open(path, *args, **kwargs)
+
+    with mock.patch.object(hardware_fingerprint.platform, "system", return_value="Linux"), mock.patch.object(
+        hardware_fingerprint, "current_utc_year", return_value=2026
+    ), mock.patch.object(builtins, "open", side_effect=fake_open):
+        oracle = hardware_fingerprint.HardwareFingerprint.collect_device_oracle()
+
+    assert oracle["estimated_release_year"] == 2003
+    assert oracle["estimated_age_years"] == 23

--- a/node/tests/test_hardware_fingerprint_device_oracle.py
+++ b/node/tests/test_hardware_fingerprint_device_oracle.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import builtins
 import os
 import sys


### PR DESCRIPTION
## Summary
- replace the hardware fingerprint device-age oracle's hardcoded 2025 age baseline with current UTC year
- clamp negative estimated ages to zero for future/default release-year data
- add focused regression coverage for a vintage CPU model in 2026

Fixes #4597

## Verification
- `python -m pytest node\tests\test_hardware_fingerprint_device_oracle.py -q`
- `python -m py_compile node\hardware_fingerprint.py node\tests\test_hardware_fingerprint_device_oracle.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`