### PR TITLE
Fix integrated Hall score current-year age bonus

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1990,6 +1990,10 @@ def _mac_hash(mac: str) -> str:
     digest = hmac.new(salt, norm.encode(), hashlib.sha256).hexdigest()
     return digest[:12]
 
+def current_utc_year():
+    """Return the current UTC year for hardware age calculations."""
+    return time.gmtime().tm_year
+
 def record_macs(miner: str, macs: list):
     now = int(time.time())
     with sqlite3.connect(DB_PATH) as conn:
@@ -2008,7 +2012,7 @@ def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id):
     """Calculate rust score for a machine."""
     score = 0
     if mfg_year:
-        score += (2025 - mfg_year) * 10  # age bonus
+        score += max(0, current_utc_year() - int(mfg_year)) * 10  # age bonus
     score += attestations * 0.001  # attestation bonus
     if machine_id <= 100:
         score += 50  # early adopter

--- a/node/tests/test_integrated_hall_score_year.py
+++ b/node/tests/test_integrated_hall_score_year.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def _load_integrated_node(monkeypatch, tmp_path):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key-000000000000000000")
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", str(tmp_path / "rustchain.db"))
+    spec = importlib.util.spec_from_file_location("integrated_hall_score_year_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_inline_rust_score_uses_current_year_for_age_bonus(monkeypatch, tmp_path):
+    module = _load_integrated_node(monkeypatch, tmp_path)
+    monkeypatch.setattr(module, "current_utc_year", lambda: 2026)
+
+    score = module.calculate_rust_score_inline(2001, "modern", 0, 999)
+
+    assert score == 250


### PR DESCRIPTION
## Summary
- replace the integrated node Hall score helper's hardcoded 2025 age baseline with current UTC year
- clamp future-year age bonuses to zero
- add focused regression coverage for `calculate_rust_score_inline()`

Fixes #4599

## Verification
- `python -m pytest node\tests\test_integrated_hall_score_year.py -q`
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_integrated_hall_score_year.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`