### PR TITLE
Harden bridge admin key comparison

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -166,7 +166,7 @@ def _require_admin(fn):
         key = request.headers.get("X-Admin-Key", "")
         if not BRIDGE_ADMIN_KEY:
             return jsonify({"error": "admin key not configured on server"}), 500
-        if key != BRIDGE_ADMIN_KEY:
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
             return jsonify({"error": "unauthorized"}), 403
         return fn(*args, **kwargs)
     return wrapper

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -26,6 +26,7 @@ if os.path.exists("/tmp/bridge_test_727.db"):
 
 # Import after env setup
 sys.path.insert(0, os.path.dirname(__file__))
+import bridge_api
 from bridge_api import Flask, register_bridge_routes, STATE_REQUESTED, STATE_CONFIRMED
 
 
@@ -587,6 +588,32 @@ class TestReleaseEndpoint:
             "release_tx": "0xabc",
         })
         assert resp.status_code == 403
+
+    def test_release_admin_key_uses_constant_time_compare(self, client, monkeypatch):
+        calls = []
+        real_compare_digest = bridge_api.hmac.compare_digest
+
+        def compare_digest_spy(left, right):
+            calls.append((left, right))
+            return real_compare_digest(left, right)
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", compare_digest_spy)
+
+        invalid = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": "0xabc"},
+            headers={"X-Admin-Key": "wrong-admin-key"},
+        )
+        assert invalid.status_code == 403
+        assert calls[-1] == ("wrong-admin-key", "test-admin-key-12345")
+
+        valid = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": "0xabc"},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+        assert valid.status_code == 404
+        assert calls[-1] == ("test-admin-key-12345", "test-admin-key-12345")
 
     def test_release_requires_confirmed_lock(self, client):
         # Create lock without proof (legacy mode test)


### PR DESCRIPTION
## Summary

- Harden the bridge admin-key guard by using `hmac.compare_digest()` instead of a normal string equality check.
- Add a focused regression test that verifies the `/bridge/release` admin path calls the constant-time comparison for both invalid and valid keys.

Fixes #4605.

## Security

This touches bridge admin authentication and should be treated as `BCOS-L2`.

## Validation

- `/private/tmp/rustchain-audit-venv/bin/python -m pytest bridge/test_bridge_api.py -q`
- `python3 -m compileall bridge/bridge_api.py bridge/test_bridge_api.py`
- `git diff --check`

Result: `32 passed`
