### PR TITLE
Fix validator proof current-year age weighting

### DIFF
--- a/tools/tests/test_validator_core_with_badge.py
+++ b/tools/tests/test_validator_core_with_badge.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(TOOLS_DIR))
+
+import validator_core_with_badge  # noqa: E402
+
+
+def test_entropy_score_uses_current_year_for_bios_age(monkeypatch):
+    monkeypatch.setattr(validator_core_with_badge, "current_utc_year", lambda: 2026)
+
+    score = validator_core_with_badge.simulate_entropy_score("Pentium III", "1998-12-01")
+
+    assert score == 7.55

--- a/tools/validator_core_with_badge.py
+++ b/tools/validator_core_with_badge.py
@@ -1,10 +1,13 @@
 import json
 import hashlib
-from datetime import datetime
+from datetime import datetime, timezone
+
+def current_utc_year():
+    return datetime.now(timezone.utc).year
 
 def simulate_entropy_score(cpu_model, bios_date):
     year = int(bios_date.split("-")[0])
-    age_weight = max(0, 2025 - year)
+    age_weight = max(0, current_utc_year() - year)
     entropy_score = round((age_weight * 0.25) + (len(cpu_model) * 0.05), 2)
     return entropy_score
 


### PR DESCRIPTION
## Summary
- replace validator proof entropy age weighting's hardcoded 2025 baseline with current UTC year
- clamp future BIOS/release years to zero age weight
- add focused regression coverage for the entropy score calculation

Fixes #4603

## Verification
- `python -m pytest tools\tests\test_validator_core_with_badge.py -q`
- `python -m py_compile tools\validator_core_with_badge.py tools\tests\test_validator_core_with_badge.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`