### PR TITLE
Restrict public JSON-RPC method dispatch

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -73,6 +73,22 @@ class RpcRegistry:
             return ApiResponse(success=False, error=str(e))
 
 
+JSON_RPC_ALLOWED_METHODS = {
+    "getStats",
+    "getBlock",
+    "getBlockByHash",
+    "getWallet",
+    "getBalance",
+    "getMiningStatus",
+    "getAntiquityScore",
+    "getProposals",
+    "getProposal",
+    "getNodeInfo",
+    "getPeers",
+    "getEntropyProfile",
+}
+
+
 # =============================================================================
 # API Server
 # =============================================================================
@@ -325,6 +341,8 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         # JSON-RPC endpoint
         if path == "/rpc":
             method = params.get("method", "")
+            if method not in JSON_RPC_ALLOWED_METHODS:
+                return ApiResponse(success=False, error=f"Method not allowed: {method}")
             rpc_params = params.get("params", {})
             return self.api.rpc.call(method, rpc_params)
 

--- a/tests/test_rustchain_core_rpc_method_allowlist.py
+++ b/tests/test_rustchain_core_rpc_method_allowlist.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "rips" / "rustchain-core" / "api" / "rpc.py"
+
+
+def _load_rpc_module():
+    spec = importlib.util.spec_from_file_location("rustchain_core_rpc_allowlist_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rpc_endpoint_rejects_state_changing_methods():
+    rpc = _load_rpc_module()
+    api = rpc.RustChainApi(rpc.MockNode())
+    handler = object.__new__(rpc.ApiRequestHandler)
+    handler.api = api
+
+    response = handler._route_request(
+        "/rpc",
+        {
+            "method": "createProposal",
+            "params": {
+                "title": "malicious",
+                "description": "should not be created",
+                "proposer": "attacker",
+            },
+        },
+    )
+
+    assert response.success is False
+    assert response.error == "Method not allowed: createProposal"
+
+
+def test_rpc_endpoint_allows_read_only_methods():
+    rpc = _load_rpc_module()
+    api = rpc.RustChainApi(rpc.MockNode())
+    handler = object.__new__(rpc.ApiRequestHandler)
+    handler.api = api
+
+    response = handler._route_request("/rpc", {"method": "getStats", "params": {}})
+
+    assert response.success is True
+    assert response.data["chain_id"] == 2718


### PR DESCRIPTION
## Summary
- add a read-only allowlist for the public `/rpc` JSON-RPC endpoint
- block state-changing RPC methods such as `submitProof`, `createProposal`, and `vote` from unauthenticated generic dispatch
- add focused regression tests for blocked mutating methods and allowed read-only methods

Fixes #4601

## Verification
- `python -m pytest tests\test_rustchain_core_rpc_method_allowlist.py -q`
- `python -m py_compile rips\rustchain-core\api\rpc.py tests\test_rustchain_core_rpc_method_allowlist.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`