### PR TITLE
fix: load Moltbook agent keys from env

### DIFF
--- a/scripts/moltbook_solver.py
+++ b/scripts/moltbook_solver.py
@@ -36,12 +36,12 @@ log = logging.getLogger("moltbook_solver")
 # ─── Agent Registry ──────────────────────────────────────────────────────────
 
 AGENTS = {
-    "sophia":          {"key": "moltbook_sk_nuTK8FxFHuUtknLGrXUJKxcgBsTJ0zP7",  "persona": "warm_tech"},
-    "boris":           {"key": "moltbook_sk_mACTltXU55x6s1mYqDuWkeEcuDQ9feMB",  "persona": "soviet_enthusiast"},
-    "janitor":         {"key": "moltbook_sk_yWpLPPIp1MxWAlbgiCEdamHodyClGg08",  "persona": "sysadmin"},
-    "bottube":         {"key": "moltbook_sk_CJgvb5ecA9ZnutcmmaFy2Scm_X4SQgcz",  "persona": "platform_bot"},
-    "msgoogletoggle":  {"key": "moltbook_sk_-zuaZPUGMVoC_tdQJA-YaLVlj-VnUMdw",  "persona": "gracious_socialite"},
-    "oneo":            {"key": "moltbook_sk_BeO3rZoBKuleNwSX3sZeBNQRYhOBK436",  "persona": "minimalist"},
+    "sophia":          {"env": "MOLTBOOK_SOPHIA_API_KEY",          "persona": "warm_tech"},
+    "boris":           {"env": "MOLTBOOK_BORIS_API_KEY",           "persona": "soviet_enthusiast"},
+    "janitor":         {"env": "MOLTBOOK_JANITOR_API_KEY",         "persona": "sysadmin"},
+    "bottube":         {"env": "MOLTBOOK_BOTTUBE_API_KEY",         "persona": "platform_bot"},
+    "msgoogletoggle":  {"env": "MOLTBOOK_MSGOOGLETOGGLE_API_KEY",  "persona": "gracious_socialite"},
+    "oneo":            {"env": "MOLTBOOK_ONEO_API_KEY",            "persona": "minimalist"},
 }
 
 # Gemini for LLM solving
@@ -124,12 +124,15 @@ def get_available_agents() -> List[str]:
     # Preference order: msgoogletoggle first (it's our best solver host),
     # then sophia, boris, janitor, bottube, oneo
     preferred = ["msgoogletoggle", "sophia", "boris", "janitor", "bottube", "oneo"]
-    return [a for a in preferred if a in AGENTS and a not in suspended]
+    return [a for a in preferred if a in AGENTS and a not in suspended and get_agent_key(a)]
 
 
 def get_agent_key(agent: str) -> Optional[str]:
     """Get API key for an agent."""
-    return AGENTS.get(agent, {}).get("key")
+    env_name = AGENTS.get(agent, {}).get("env")
+    if not env_name:
+        return None
+    return os.environ.get(env_name) or None
 
 
 # ─── Content Uniqueness ─────────────────────────────────────────────────────

--- a/scripts/tests/test_moltbook_solver.py
+++ b/scripts/tests/test_moltbook_solver.py
@@ -114,17 +114,25 @@ class TestContentHash:
 class TestAgentFunctions:
     """Tests for agent functions."""
 
-    def test_get_available_agents(self):
+    def test_get_available_agents(self, monkeypatch):
+        for config in AGENTS.values():
+            monkeypatch.delenv(config["env"], raising=False)
+        monkeypatch.setenv("MOLTBOOK_MSGOOGLETOGGLE_API_KEY", "test-token-msgoogletoggle")
         agents = get_available_agents()
-        assert isinstance(agents, list) and len(agents) > 0
+        assert agents == ["msgoogletoggle"]
 
-    def test_get_agent_key(self):
+    def test_get_agent_key(self, monkeypatch):
+        monkeypatch.setenv("MOLTBOOK_SOPHIA_API_KEY", "test-token-sophia")
         key = get_agent_key("sophia")
-        assert key is not None and key.startswith("moltbook_sk_")
+        assert key == "test-token-sophia"
+
+    def test_get_agent_key_missing_env(self, monkeypatch):
+        monkeypatch.delenv("MOLTBOOK_SOPHIA_API_KEY", raising=False)
+        assert get_agent_key("sophia") is None
 
     def test_agents_have_required_fields(self):
         for agent_name, config in AGENTS.items():
-            assert "key" in config and "persona" in config
+            assert "env" in config and "persona" in config
 
 
 class TestRecordPost:


### PR DESCRIPTION
## Summary
- replace committed Moltbook bearer-token values with per-agent environment variable names
- only return available Moltbook agents when their credential env var is configured
- update solver tests to use non-secret-shaped dummy tokens

Fixes #4609.

## Security note
The previously committed Moltbook credentials should be rotated out of band. This PR avoids repeating the raw token values and removes secret-shaped Moltbook literals from the source/test paths.

## Validation
- `rg -n "moltbook_sk_[A-Za-z0-9_-]+" scripts node tests tools integrations --glob "!**/get-pip.py" --glob "!**/package-lock.json"` -> no matches
- `python3 -m py_compile scripts/moltbook_solver.py scripts/tests/test_moltbook_solver.py`
- `uv run --no-project --with pytest --with requests python -m pytest scripts/tests/test_moltbook_solver.py -q` -> 23 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK
