### PR TITLE
Fix bridge admin key timing-sensitive comparison

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -166,7 +166,7 @@ def _require_admin(fn):
         key = request.headers.get("X-Admin-Key", "")
         if not BRIDGE_ADMIN_KEY:
             return jsonify({"error": "admin key not configured on server"}), 500
-        if key != BRIDGE_ADMIN_KEY:
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
             return jsonify({"error": "unauthorized"}), 403
         return fn(*args, **kwargs)
     return wrapper

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -26,6 +26,7 @@ if os.path.exists("/tmp/bridge_test_727.db"):
 
 # Import after env setup
 sys.path.insert(0, os.path.dirname(__file__))
+import bridge_api
 from bridge_api import Flask, register_bridge_routes, STATE_REQUESTED, STATE_CONFIRMED
 
 
@@ -587,6 +588,24 @@ class TestReleaseEndpoint:
             "release_tx": "0xabc",
         })
         assert resp.status_code == 403
+
+    def test_release_uses_constant_time_admin_key_compare(self, client, monkeypatch):
+        calls = []
+
+        def fake_compare(provided, expected):
+            calls.append((provided, expected))
+            return False
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
+
+        resp = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": "0xabc"},
+            headers={"X-Admin-Key": "wrong-key"},
+        )
+
+        assert resp.status_code == 403
+        assert calls == [("wrong-key", "test-admin-key-12345")]
 
     def test_release_requires_confirmed_lock(self, client):
         # Create lock without proof (legacy mode test)


### PR DESCRIPTION
Fixes #4605

## Summary
- Replaces the bridge admin key equality check with `hmac.compare_digest()` in `_require_admin()`.
- Adds a regression test that monkeypatches `hmac.compare_digest` and verifies `/bridge/release` uses it for bad admin keys.

## Verification
- `python -m pytest bridge/test_bridge_api.py -q` - 32 passed
- `git diff --check`

wallet: minyanyi