### PR TITLE
Validate P2P message deserialization

### DIFF
--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -32,6 +32,11 @@ from ..config.chain_params import (
 )
 
 
+MAX_MESSAGE_BYTES = 1024 * 1024
+MAX_PAYLOAD_BYTES = 256 * 1024
+MAX_CLOCK_SKEW_SECONDS = 300
+
+
 # =============================================================================
 # Message Types
 # =============================================================================
@@ -135,13 +140,52 @@ class Message:
     @classmethod
     def from_bytes(cls, data: bytes, sender: PeerId) -> 'Message':
         """Deserialize message from bytes"""
-        parsed = json.loads(data.decode())
+        if not isinstance(data, (bytes, bytearray)):
+            raise ValueError("message data must be bytes")
+        if len(data) > MAX_MESSAGE_BYTES:
+            raise ValueError("message too large")
+
+        try:
+            parsed = json.loads(data.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("invalid message encoding") from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError("message must be a JSON object")
+
+        missing = {"type", "payload", "timestamp", "nonce"} - parsed.keys()
+        if missing:
+            raise ValueError(f"missing message fields: {', '.join(sorted(missing))}")
+
+        try:
+            msg_type = MessageType[parsed["type"]]
+        except KeyError as exc:
+            raise ValueError("unknown message type") from exc
+
+        payload = parsed["payload"]
+        if not isinstance(payload, dict):
+            raise ValueError("payload must be a JSON object")
+        payload_size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        if payload_size > MAX_PAYLOAD_BYTES:
+            raise ValueError("payload too large")
+
+        timestamp = parsed["timestamp"]
+        if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+            raise ValueError("timestamp must be an integer")
+        now = int(time.time())
+        if timestamp <= 0 or timestamp > now + MAX_CLOCK_SKEW_SECONDS:
+            raise ValueError("timestamp outside accepted range")
+
+        nonce = parsed["nonce"]
+        if not isinstance(nonce, int) or isinstance(nonce, bool) or nonce <= 0 or nonce > 2**64 - 1:
+            raise ValueError("nonce must be a positive 64-bit integer")
+
         return cls(
-            msg_type=MessageType[parsed["type"]],
+            msg_type=msg_type,
             sender=sender,
-            payload=parsed["payload"],
-            timestamp=parsed["timestamp"],
-            nonce=parsed["nonce"],
+            payload=payload,
+            timestamp=timestamp,
+            nonce=nonce,
         )
 
     def compute_hash(self) -> str:

--- a/tests/test_rustchain_core_p2p_message_validation.py
+++ b/tests/test_rustchain_core_p2p_message_validation.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import json
+import sys
+import time
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = REPO_ROOT / "rips" / "rustchain-core"
+
+
+def load_p2p_module():
+    package = types.ModuleType("rustchain_core")
+    package.__path__ = [str(CORE_ROOT)]
+    networking_package = types.ModuleType("rustchain_core.networking")
+    networking_package.__path__ = [str(CORE_ROOT / "networking")]
+    config_package = types.ModuleType("rustchain_core.config")
+    config_package.__path__ = [str(CORE_ROOT / "config")]
+
+    sys.modules.setdefault("rustchain_core", package)
+    sys.modules.setdefault("rustchain_core.networking", networking_package)
+    sys.modules.setdefault("rustchain_core.config", config_package)
+
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_core.networking.p2p",
+        CORE_ROOT / "networking" / "p2p.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+p2p = load_p2p_module()
+
+
+def encode_message(**overrides):
+    message = {
+        "type": "HELLO",
+        "payload": {"version": "1.0.0"},
+        "timestamp": int(time.time()),
+        "nonce": 12345,
+    }
+    message.update(overrides)
+    return json.dumps(message).encode("utf-8")
+
+
+def test_from_bytes_accepts_valid_message():
+    sender = p2p.PeerId("127.0.0.1", 2718)
+
+    message = p2p.Message.from_bytes(encode_message(), sender)
+
+    assert message.msg_type is p2p.MessageType.HELLO
+    assert message.sender == sender
+    assert message.payload == {"version": "1.0.0"}
+    assert message.nonce == 12345
+
+
+@pytest.mark.parametrize(
+    ("raw_message", "error"),
+    [
+        (b"{", "invalid message encoding"),
+        (json.dumps(["not", "object"]).encode(), "message must be a JSON object"),
+        (encode_message(type="NOT_A_MESSAGE_TYPE"), "unknown message type"),
+        (encode_message(timestamp=-1), "timestamp outside accepted range"),
+        (encode_message(timestamp=int(time.time()) + 301), "timestamp outside accepted range"),
+        (encode_message(nonce="abc"), "nonce must be a positive 64-bit integer"),
+        (encode_message(payload=[]), "payload must be a JSON object"),
+    ],
+)
+def test_from_bytes_rejects_malformed_messages(raw_message, error):
+    sender = p2p.PeerId("127.0.0.1", 2718)
+
+    with pytest.raises(ValueError, match=error):
+        p2p.Message.from_bytes(raw_message, sender)
+
+
+def test_from_bytes_rejects_missing_fields():
+    sender = p2p.PeerId("127.0.0.1", 2718)
+    raw_message = json.dumps({"type": "HELLO", "payload": {}}).encode("utf-8")
+
+    with pytest.raises(ValueError, match="missing message fields"):
+        p2p.Message.from_bytes(raw_message, sender)
+
+
+def test_from_bytes_rejects_oversized_payload():
+    sender = p2p.PeerId("127.0.0.1", 2718)
+    payload = {"blob": "x" * (p2p.MAX_PAYLOAD_BYTES + 1)}
+
+    with pytest.raises(ValueError, match="payload too large"):
+        p2p.Message.from_bytes(encode_message(payload=payload), sender)
+

--- a/tests/test_rustchain_core_p2p_message_validation.py
+++ b/tests/test_rustchain_core_p2p_message_validation.py
@@ -68,7 +68,7 @@ def test_from_bytes_accepts_valid_message():
         (json.dumps(["not", "object"]).encode(), "message must be a JSON object"),
         (encode_message(type="NOT_A_MESSAGE_TYPE"), "unknown message type"),
         (encode_message(timestamp=-1), "timestamp outside accepted range"),
-        (encode_message(timestamp=int(time.time()) + 301), "timestamp outside accepted range"),
+        (encode_message(timestamp=2**63 - 1), "timestamp outside accepted range"),
         (encode_message(nonce="abc"), "nonce must be a positive 64-bit integer"),
         (encode_message(payload=[]), "payload must be a JSON object"),
     ],
@@ -94,4 +94,3 @@ def test_from_bytes_rejects_oversized_payload():
 
     with pytest.raises(ValueError, match="payload too large"):
         p2p.Message.from_bytes(encode_message(payload=payload), sender)
-


### PR DESCRIPTION
Fixes #4607.\n\n## Summary\n- add bounded validation to Message.from_bytes() before constructing P2P messages\n- reject oversized frames, malformed JSON, non-object messages, missing fields, unknown message types, invalid timestamps, invalid nonces, non-object payloads, and oversized payloads\n- add focused regression coverage for valid messages and malformed peer input\n\n## Validation\n- python -m pytest tests\\test_rustchain_core_p2p_message_validation.py -q -> 10 passed\n- python -m py_compile rips\\rustchain-core\\networking\\p2p.py tests\\test_rustchain_core_p2p_message_validation.py -> passed\n- git diff --check -> passed\n- python tools\\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK\n\nNo live network probing was performed; validation used local unit tests only.