### PR TITLE
Validate P2P message deserialization

### DIFF
--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -69,6 +69,12 @@ class MessageType(Enum):
 # Data Structures
 # =============================================================================
 
+MAX_MESSAGE_BYTES = 128 * 1024
+MAX_PAYLOAD_BYTES = 64 * 1024
+MAX_CLOCK_SKEW_SECONDS = 300
+MAX_NONCE = 0xFFFFFFFF
+
+
 @dataclass
 class PeerId:
     """Unique peer identifier"""
@@ -135,13 +141,56 @@ class Message:
     @classmethod
     def from_bytes(cls, data: bytes, sender: PeerId) -> 'Message':
         """Deserialize message from bytes"""
-        parsed = json.loads(data.decode())
+        if not isinstance(data, (bytes, bytearray)):
+            raise ValueError("invalid message encoding: expected bytes")
+
+        if len(data) > MAX_MESSAGE_BYTES:
+            raise ValueError("invalid message size")
+
+        try:
+            parsed = json.loads(data.decode("utf-8"))
+        except UnicodeDecodeError as exc:
+            raise ValueError("invalid message encoding") from exc
+        except json.JSONDecodeError as exc:
+            raise ValueError("invalid message json") from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError("invalid message: expected object")
+
+        required_fields = ("type", "payload", "timestamp", "nonce")
+        for field_name in required_fields:
+            if field_name not in parsed:
+                raise ValueError(f"missing required field: {field_name}")
+
+        msg_type_name = parsed["type"]
+        if not isinstance(msg_type_name, str) or msg_type_name not in MessageType.__members__:
+            raise ValueError("invalid message type")
+
+        payload = parsed["payload"]
+        if not isinstance(payload, dict):
+            raise ValueError("invalid payload")
+        if len(json.dumps(payload).encode("utf-8")) > MAX_PAYLOAD_BYTES:
+            raise ValueError("invalid payload size")
+
+        timestamp = parsed["timestamp"]
+        now = int(time.time())
+        if not isinstance(timestamp, int) or isinstance(timestamp, bool):
+            raise ValueError("invalid timestamp")
+        if timestamp <= 0 or abs(now - timestamp) > MAX_CLOCK_SKEW_SECONDS:
+            raise ValueError("invalid timestamp")
+
+        nonce = parsed["nonce"]
+        if not isinstance(nonce, int) or isinstance(nonce, bool):
+            raise ValueError("invalid nonce")
+        if nonce <= 0 or nonce > MAX_NONCE:
+            raise ValueError("invalid nonce")
+
         return cls(
-            msg_type=MessageType[parsed["type"]],
+            msg_type=MessageType[msg_type_name],
             sender=sender,
-            payload=parsed["payload"],
-            timestamp=parsed["timestamp"],
-            nonce=parsed["nonce"],
+            payload=payload,
+            timestamp=timestamp,
+            nonce=nonce,
         )
 
     def compute_hash(self) -> str:

--- a/test_p2p_message_validation.py
+++ b/test_p2p_message_validation.py
@@ -1,0 +1,150 @@
+"""
+Regression tests for defensive P2P Message.from_bytes() validation.
+
+The production module uses package-relative imports, so this standalone test
+loads p2p.py with the chain parameter constants supplied in a small namespace.
+"""
+
+import hashlib
+import json
+import os
+import queue
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from typing import Any, Callable, Dict, List, Optional, Set
+
+import pytest
+
+
+def _load_p2p_namespace():
+    import re
+
+    p2p_path = os.path.join(
+        os.path.dirname(__file__),
+        "rips",
+        "rustchain-core",
+        "networking",
+        "p2p.py",
+    )
+    with open(p2p_path) as f:
+        source = f.read()
+
+    source = re.sub(
+        r"from \.\.config\.chain_params import \(.*?\)\n",
+        "",
+        source,
+        flags=re.DOTALL,
+    )
+
+    ns = {
+        "DEFAULT_PORT": 8085,
+        "MTLS_PORT": 4443,
+        "PROTOCOL_VERSION": "1.0.0",
+        "MAX_PEERS": 50,
+        "PEER_TIMEOUT_SECONDS": 30,
+        "SYNC_BATCH_SIZE": 100,
+        "time": time,
+        "hashlib": hashlib,
+        "json": json,
+        "threading": threading,
+        "queue": queue,
+        "socket": socket,
+        "Dict": Dict,
+        "List": List,
+        "Optional": Optional,
+        "Set": Set,
+        "Any": Any,
+        "Callable": Callable,
+        "dataclass": dataclass,
+        "field": field,
+        "Enum": Enum,
+        "auto": auto,
+        "__name__": "__not_main__",
+    }
+
+    exec(compile(source, p2p_path, "exec"), ns)
+    return ns
+
+
+P2P = _load_p2p_namespace()
+Message = P2P["Message"]
+MessageType = P2P["MessageType"]
+PeerId = P2P["PeerId"]
+
+
+def _sender():
+    return PeerId("127.0.0.1", 8085)
+
+
+def _encoded_message(**overrides):
+    data = {
+        "type": "NEW_TX",
+        "payload": {"tx_id": "abc123"},
+        "timestamp": int(time.time()),
+        "nonce": 1,
+    }
+    data.update(overrides)
+    return json.dumps(data).encode()
+
+
+def test_from_bytes_accepts_valid_message():
+    message = Message.from_bytes(_encoded_message(), _sender())
+
+    assert message.msg_type is MessageType.NEW_TX
+    assert message.payload == {"tx_id": "abc123"}
+    assert message.nonce == 1
+
+
+@pytest.mark.parametrize("missing_field", ["type", "payload", "timestamp", "nonce"])
+def test_from_bytes_rejects_missing_required_fields(missing_field):
+    data = {
+        "type": "NEW_TX",
+        "payload": {"tx_id": "abc123"},
+        "timestamp": int(time.time()),
+        "nonce": 1,
+    }
+    data.pop(missing_field)
+
+    with pytest.raises(ValueError, match=missing_field):
+        Message.from_bytes(json.dumps(data).encode(), _sender())
+
+
+@pytest.mark.parametrize(
+    ("raw_data", "message"),
+    [
+        (b"\xff", "encoding"),
+        (b"{not-json", "json"),
+    ],
+)
+def test_from_bytes_rejects_malformed_bytes(raw_data, message):
+    with pytest.raises(ValueError, match=message):
+        Message.from_bytes(raw_data, _sender())
+
+
+@pytest.mark.parametrize(
+    ("override", "message"),
+    [
+        ({"type": "NOT_A_MESSAGE_TYPE"}, "type"),
+        ({"type": 7}, "type"),
+        ({"payload": ["not", "a", "dict"]}, "payload"),
+        ({"timestamp": "now"}, "timestamp"),
+        ({"timestamp": 0}, "timestamp"),
+        ({"timestamp": int(time.time()) + 600}, "timestamp"),
+        ({"nonce": "abc"}, "nonce"),
+        ({"nonce": 0}, "nonce"),
+        ({"nonce": 0x100000000}, "nonce"),
+    ],
+)
+def test_from_bytes_rejects_invalid_fields(override, message):
+    with pytest.raises(ValueError, match=message):
+        Message.from_bytes(_encoded_message(**override), _sender())
+
+
+def test_from_bytes_rejects_oversized_payload():
+    oversized_payload = {"blob": "x" * (64 * 1024 + 1)}
+
+    with pytest.raises(ValueError, match="payload"):
+        Message.from_bytes(_encoded_message(payload=oversized_payload), _sender())

--- a/test_p2p_message_validation.py
+++ b/test_p2p_message_validation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """
 Regression tests for defensive P2P Message.from_bytes() validation.
 

--- a/test_p2p_message_validation.py
+++ b/test_p2p_message_validation.py
@@ -3,77 +3,61 @@
 Regression tests for defensive P2P Message.from_bytes() validation.
 
 The production module uses package-relative imports, so this standalone test
-loads p2p.py with the chain parameter constants supplied in a small namespace.
+loads p2p.py through importlib with the chain parameter constants supplied as a
+temporary in-memory package.
 """
 
-import hashlib
+import importlib.util
 import json
-import os
-import queue
-import socket
-import threading
+import sys
 import time
-from dataclasses import dataclass, field
-from enum import Enum, auto
-from typing import Any, Callable, Dict, List, Optional, Set
+import types
+from pathlib import Path
 
 import pytest
 
 
-def _load_p2p_namespace():
-    import re
+def _module(name: str, package_path: Path | None = None):
+    module = types.ModuleType(name)
+    if package_path:
+        module.__path__ = [str(package_path)]
+    sys.modules[name] = module
+    return module
 
-    p2p_path = os.path.join(
-        os.path.dirname(__file__),
-        "rips",
-        "rustchain-core",
-        "networking",
-        "p2p.py",
+
+def _install_chain_params_package(root: Path):
+    _module("rustchain_core", root)
+    _module("rustchain_core.config", root / "config")
+    _module("rustchain_core.networking", root / "networking")
+
+    chain_params = _module("rustchain_core.config.chain_params")
+    chain_params.DEFAULT_PORT = 8085
+    chain_params.MTLS_PORT = 4443
+    chain_params.PROTOCOL_VERSION = "1.0.0"
+    chain_params.MAX_PEERS = 50
+    chain_params.PEER_TIMEOUT_SECONDS = 30
+    chain_params.SYNC_BATCH_SIZE = 100
+
+
+def _load_p2p_module():
+    root = Path(__file__).resolve().parent / "rips" / "rustchain-core"
+    _install_chain_params_package(root)
+
+    p2p_path = root / "networking" / "p2p.py"
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_core.networking.p2p_test_target",
+        p2p_path,
     )
-    with open(p2p_path) as f:
-        source = f.read()
-
-    source = re.sub(
-        r"from \.\.config\.chain_params import \(.*?\)\n",
-        "",
-        source,
-        flags=re.DOTALL,
-    )
-
-    ns = {
-        "DEFAULT_PORT": 8085,
-        "MTLS_PORT": 4443,
-        "PROTOCOL_VERSION": "1.0.0",
-        "MAX_PEERS": 50,
-        "PEER_TIMEOUT_SECONDS": 30,
-        "SYNC_BATCH_SIZE": 100,
-        "time": time,
-        "hashlib": hashlib,
-        "json": json,
-        "threading": threading,
-        "queue": queue,
-        "socket": socket,
-        "Dict": Dict,
-        "List": List,
-        "Optional": Optional,
-        "Set": Set,
-        "Any": Any,
-        "Callable": Callable,
-        "dataclass": dataclass,
-        "field": field,
-        "Enum": Enum,
-        "auto": auto,
-        "__name__": "__not_main__",
-    }
-
-    exec(compile(source, p2p_path, "exec"), ns)
-    return ns
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
-P2P = _load_p2p_namespace()
-Message = P2P["Message"]
-MessageType = P2P["MessageType"]
-PeerId = P2P["PeerId"]
+P2P = _load_p2p_module()
+Message = P2P.Message
+MessageType = P2P.MessageType
+PeerId = P2P.PeerId
 
 
 def _sender():


### PR DESCRIPTION
Fixes #4607.

Summary:
- Add defensive validation to `Message.from_bytes()` before constructing a `Message`.
- Convert malformed input, missing fields, invalid message types, bad timestamps, bad nonces, and oversized payloads into `ValueError`.
- Add standalone regression tests for valid messages and invalid deserialization inputs.

Verification:
- `python -m pytest test_p2p_message_validation.py -q` -> 17 passed
- `python -m pytest test_p2p_replay_fix.py test_p2p_message_validation.py -q` -> 20 passed
- `git diff --check` -> clean

wallet: minyanyi
payout address: 0x2E4380d2e1668Ca9fA3Ef91fF776FDc140Cf3fE8