### PR TITLE
fix: require configured Sophia notification token

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -561,7 +561,7 @@ def _scott_notification_headers() -> dict[str, str]:
     }
     bearer = (
         os.getenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", "").strip()
-        or os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "elya2025").strip()
+        or os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "").strip()
     )
     if bearer:
         headers["Authorization"] = f"Bearer {bearer}"
@@ -681,6 +681,8 @@ def _queue_scott_notification_for_entry(
     queue_url = _scott_notification_queue_url()
     if not queue_url:
         return {"status": "not_configured", "phase": phase}
+    if "Authorization" not in _scott_notification_headers():
+        return {"status": "token_not_configured", "phase": phase}
 
     sent_column = _phase_notify_column(phase)
     if entry.get(sent_column):

--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -30,7 +30,7 @@ DB_PATH = os.getenv("SOPHIA_GOVERNOR_REVIEW_DB", "/tmp/sophia_governor_review.db
 OLLAMA_URL = os.getenv("SOPHIA_GOVERNOR_OLLAMA_URL", "http://192.168.0.160:11434")
 OLLAMA_MODEL = os.getenv("SOPHIA_GOVERNOR_REVIEW_MODEL", "glm-4.7-flash:latest")
 SCOTT_NOTIFICATION_QUEUE_URL = os.getenv("SCOTT_NOTIFICATION_QUEUE_URL", "").strip()
-SCOTT_NOTIFICATION_SERVICE_TOKEN = os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "elya2025").strip()
+SCOTT_NOTIFICATION_SERVICE_TOKEN = os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "").strip()
 TRUE_VALUES = {"1", "true", "yes", "on"}
 SECTION_PATTERN = re.compile(
     r"(?is)(?:\*\*|\b)(assessment|analysis(?: of the event)?|reasoning|risk|next step|next steps|recommended action|action|decision)\s*:\s*"
@@ -159,6 +159,8 @@ def _relay_scott_notification(payload: dict[str, Any]) -> tuple[int, dict[str, A
         return 503, {"status": "error", "error": "requests_unavailable"}
     if not SCOTT_NOTIFICATION_QUEUE_URL:
         return 503, {"status": "error", "error": "scott_notification_queue_not_configured"}
+    if not SCOTT_NOTIFICATION_SERVICE_TOKEN:
+        return 503, {"status": "error", "error": "scott_notification_service_token_not_configured"}
     try:
         response = requests.post(
             SCOTT_NOTIFICATION_QUEUE_URL,

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -260,6 +260,7 @@ def test_ingest_can_queue_scott_notification(client, monkeypatch):
         return DummyResponse()
 
     monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.setenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "relay-token")
     monkeypatch.setattr(
         "sophia_governor_inbox.requests",
         type("DummyRequests", (), {"post": staticmethod(fake_post)}),
@@ -276,8 +277,37 @@ def test_ingest_can_queue_scott_notification(client, monkeypatch):
     assert body["scott_notification"]["status"] == "queued"
     assert body["scott_notification"]["notification_id"] == "SN-GOV-INBOX-1"
     assert calls[0]["url"] == "https://example.com/scott-notifications/queue"
+    assert calls[0]["headers"]["Authorization"] == "Bearer relay-token"
     assert calls[0]["json"]["related_type"] == "rustchain_governor_inbox"
     assert calls[0]["json"]["related_id"] == str(body["inbox"]["inbox_id"])
+
+
+def test_ingest_does_not_queue_scott_notification_without_token(client, monkeypatch):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError("notification queue should not be called without a token")
+
+    monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.delenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", raising=False)
+    monkeypatch.delenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", raising=False)
+    monkeypatch.setattr(
+        "sophia_governor_inbox.requests",
+        type("DummyRequests", (), {"post": staticmethod(fake_post)}),
+        raising=False,
+    )
+
+    response = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=_sample_envelope(),
+    )
+
+    assert response.status_code == 202
+    body = response.get_json()
+    assert body["scott_notification"]["status"] == "token_not_configured"
+    assert calls == []
 
 
 def test_manual_forward_endpoint_records_attempt(client, monkeypatch):
@@ -322,6 +352,7 @@ def test_manual_forward_endpoint_records_attempt(client, monkeypatch):
 
     monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_TARGETS", "https://example.com/sophia/review")
     monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.setenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "relay-token")
     monkeypatch.setattr(
         "sophia_governor_inbox.requests",
         type("DummyRequests", (), {"post": staticmethod(fake_post)}),

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -20,7 +20,7 @@ def client(monkeypatch):
     monkeypatch.delenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", raising=False)
     review_service.DB_PATH = db_path
     review_service.SCOTT_NOTIFICATION_QUEUE_URL = ""
-    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = "elya2025"
+    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = ""
     review_service.app.config["TESTING"] = True
     try:
         yield review_service.app.test_client()
@@ -300,3 +300,32 @@ def test_scott_notification_queue_relay_endpoint(client, monkeypatch):
     assert body["notification"]["notification_id"] == "SN-RELAY0001"
     assert captured["url"] == "http://100.121.203.9:18790/scott-notifications/queue"
     assert captured["headers"]["Authorization"] == "Bearer relay-token"
+
+
+def test_scott_notification_queue_relay_requires_configured_token(client, monkeypatch):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError("notification queue should not be called without a token")
+
+    monkeypatch.setattr(review_service, "requests", SimpleNamespace(post=fake_post))
+    review_service.SCOTT_NOTIFICATION_QUEUE_URL = "http://100.121.203.9:18790/scott-notifications/queue"
+    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = ""
+
+    response = client.post(
+        "/api/sophia/governor/scott-notifications/queue",
+        headers={"X-Admin-Key": "test-admin"},
+        json={
+            "title": "RustChain inbox 7 needs review",
+            "summary": "pending_transfer came in at high risk.",
+            "related_type": "rustchain_governor_inbox",
+            "related_id": "7",
+        },
+    )
+
+    assert response.status_code == 503
+    body = response.get_json()
+    assert body["status"] == "error"
+    assert body["error"] == "scott_notification_service_token_not_configured"
+    assert calls == []


### PR DESCRIPTION
## Summary
- closes #4616
- removes the hardcoded Scott notification bearer-token fallback from Sophia governor notification paths
- fails closed when a notification queue URL is configured without an explicit token
- adds regression coverage for both inbox queueing and review-service relay behavior

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest node/tests/test_sophia_governor_review_service.py node/tests/test_sophia_governor_inbox.py -q`
- `python3 -m py_compile node/sophia_governor_review_service.py node/sophia_governor_inbox.py node/tests/test_sophia_governor_review_service.py node/tests/test_sophia_governor_inbox.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
- `rg -n "elya2025" node tests docs -S`