### PR TITLE
FIX(#4601): restrict JSON-RPC /rpc endpoint to safe methods only

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -325,6 +325,14 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         # JSON-RPC endpoint
         if path == "/rpc":
             method = params.get("method", "")
+            # FIX(#4601): Restrict to read-only methods to prevent arbitrary invocation
+            RPC_SAFE_METHODS = {
+                "getStats", "getNodeInfo", "getPeers", "getWallet",
+                "getBlock", "getBlockByHash", "getProposal", "getProposals",
+                "getEntropyProfile",
+            }
+            if method not in RPC_SAFE_METHODS:
+                return ApiResponse(success=False, error=f"Method not allowed: {method}")
             rpc_params = params.get("params", {})
             return self.api.rpc.call(method, rpc_params)
 


### PR DESCRIPTION
## Fix for #4601

Restricts the `/rpc` JSON-RPC endpoint to a whitelist of safe read-only methods, preventing arbitrary method invocation.

### Changes
- Added `RPC_SAFE_METHODS` whitelist (getStats, getNodeInfo, getPeers, getWallet, getBlock, getBlockByHash, getProposal, getProposals, getEntropyProfile)
- Returns error for non-whitelisted methods

### Testing
- Verified the whitelist covers all existing read-only routes
- Write operations (createProposal, vote, submitProof) must use their dedicated endpoints

## Wallet
RTC9d7caca3039130d3b26d41f7343d8f4ef4592360