### PR TITLE
Return 400 for malformed RPC JSON

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -273,7 +273,8 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         try:
             params = json.loads(body) if body else {}
         except json.JSONDecodeError:
-            params = {}
+            self._send_response(ApiResponse(success=False, error="Invalid JSON body"))
+            return
 
         parsed = urlparse(self.path)
         response = self._route_request(parsed.path, params)

--- a/test_rpc_malformed_json.py
+++ b/test_rpc_malformed_json.py
@@ -5,35 +5,26 @@ Regression tests for malformed POST bodies in rips/rustchain-core/api/rpc.py.
 The API module is loaded directly because the package path contains a hyphen.
 """
 
+import importlib.util
 import json
-import os
 import threading
-import time
+from http.client import HTTPConnection
 from http.server import HTTPServer
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+from pathlib import Path
 
 
-def _load_rpc_namespace():
-    rpc_path = os.path.join(
-        os.path.dirname(__file__),
-        "rips",
-        "rustchain-core",
-        "api",
-        "rpc.py",
-    )
-    with open(rpc_path) as f:
-        source = f.read()
-
-    ns = {"__name__": "__not_main__"}
-    exec(compile(source, rpc_path, "exec"), ns)
-    return ns
+def _load_rpc_module():
+    rpc_path = Path(__file__).resolve().parent / "rips" / "rustchain-core" / "api" / "rpc.py"
+    spec = importlib.util.spec_from_file_location("rustchain_rpc_json_test_target", rpc_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-RPC = _load_rpc_namespace()
-ApiRequestHandler = RPC["ApiRequestHandler"]
-RustChainApi = RPC["RustChainApi"]
-MockNode = RPC["MockNode"]
+RPC = _load_rpc_module()
+ApiRequestHandler = RPC.ApiRequestHandler
+RustChainApi = RPC.RustChainApi
+MockNode = RPC.MockNode
 
 
 class _ApiServerFixture:
@@ -43,7 +34,6 @@ class _ApiServerFixture:
         self.server = HTTPServer(("127.0.0.1", 0), ApiRequestHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
-        self.url = f"http://127.0.0.1:{self.server.server_port}"
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -51,17 +41,18 @@ class _ApiServerFixture:
         self.thread.join(timeout=5)
 
     def post(self, path, body):
-        request = Request(
-            f"{self.url}{path}",
-            data=body,
-            method="POST",
-            headers={"Content-Type": "application/json"},
-        )
+        connection = HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
         try:
-            with urlopen(request, timeout=5) as response:
-                return response.status, json.loads(response.read().decode())
-        except HTTPError as error:
-            return error.code, json.loads(error.read().decode())
+            connection.request(
+                "POST",
+                path,
+                body=body,
+                headers={"Content-Type": "application/json"},
+            )
+            response = connection.getresponse()
+            return response.status, json.loads(response.read().decode())
+        finally:
+            connection.close()
 
 
 def test_malformed_json_post_returns_400_before_routing():

--- a/test_rpc_malformed_json.py
+++ b/test_rpc_malformed_json.py
@@ -1,0 +1,81 @@
+"""
+Regression tests for malformed POST bodies in rips/rustchain-core/api/rpc.py.
+
+The API module is loaded directly because the package path contains a hyphen.
+"""
+
+import json
+import os
+import threading
+import time
+from http.server import HTTPServer
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def _load_rpc_namespace():
+    rpc_path = os.path.join(
+        os.path.dirname(__file__),
+        "rips",
+        "rustchain-core",
+        "api",
+        "rpc.py",
+    )
+    with open(rpc_path) as f:
+        source = f.read()
+
+    ns = {"__name__": "__not_main__"}
+    exec(compile(source, rpc_path, "exec"), ns)
+    return ns
+
+
+RPC = _load_rpc_namespace()
+ApiRequestHandler = RPC["ApiRequestHandler"]
+RustChainApi = RPC["RustChainApi"]
+MockNode = RPC["MockNode"]
+
+
+class _ApiServerFixture:
+    def __enter__(self):
+        self.node = MockNode()
+        ApiRequestHandler.api = RustChainApi(self.node)
+        self.server = HTTPServer(("127.0.0.1", 0), ApiRequestHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}"
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+
+    def post(self, path, body):
+        request = Request(
+            f"{self.url}{path}",
+            data=body,
+            method="POST",
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with urlopen(request, timeout=5) as response:
+                return response.status, json.loads(response.read().decode())
+        except HTTPError as error:
+            return error.code, json.loads(error.read().decode())
+
+
+def test_malformed_json_post_returns_400_before_routing():
+    with _ApiServerFixture() as server:
+        status, body = server.post("/api/mine", b'{"wallet":')
+
+    assert status == 400
+    assert body["success"] is False
+    assert body["error"] == "Invalid JSON body"
+
+
+def test_malformed_json_rpc_returns_invalid_json_error():
+    with _ApiServerFixture() as server:
+        status, body = server.post("/rpc", b'{"method":')
+
+    assert status == 400
+    assert body["success"] is False
+    assert body["error"] == "Invalid JSON body"

--- a/test_rpc_malformed_json.py
+++ b/test_rpc_malformed_json.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """
 Regression tests for malformed POST bodies in rips/rustchain-core/api/rpc.py.
 


### PR DESCRIPTION
Fixes #4615.

Summary:
- Return a 400 API response immediately when POST JSON parsing fails.
- Prevent malformed request bodies from falling through to route handlers with default params.
- Add HTTP-level regression tests for `/api/mine` and `/rpc` malformed JSON bodies.

Verification:
- `python -m pytest test_rpc_malformed_json.py -q` -> 2 passed
- `git diff --check` -> clean

wallet: minyanyi
payout address: 0x2E4380d2e1668Ca9fA3Ef91fF776FDc140Cf3fE8