### PR TITLE
Restrict API CORS and require CSRF tokens

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -12,15 +12,21 @@ Endpoints:
 - /api/governance/* - Governance operations
 """
 
+import hmac
 import json
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, Callable
+from typing import Dict, Any, Optional, Callable, Set
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 import threading
 
+
+ALLOWED_ORIGINS_ENV = "RUSTCHAIN_API_ALLOWED_ORIGINS"
+CSRF_TOKEN_ENV = "RUSTCHAIN_API_CSRF_TOKEN"
+CSRF_HEADER = "X-RustChain-CSRF-Token"
+LEGACY_CSRF_HEADER = "X-CSRF-Token"
 
 RPC_PUBLIC_METHODS = frozenset({
     "getStats",
@@ -281,21 +287,40 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
 
     @staticmethod
     def _allowed_cors_origins() -> set[str]:
-        raw = os.getenv("RUSTCHAIN_API_ALLOWED_ORIGINS", "")
+        raw = os.getenv(ALLOWED_ORIGINS_ENV, "")
         return {origin.strip() for origin in raw.split(",") if origin.strip() and origin.strip() != "*"}
 
     @staticmethod
     def _configured_csrf_token() -> str:
-        return os.getenv("RUSTCHAIN_API_CSRF_TOKEN", "").strip()
+        return os.getenv(CSRF_TOKEN_ENV, "").strip()
+
+    def _is_allowed_origin(self, origin: Optional[str]) -> bool:
+        """Check whether a request Origin is explicitly allowed."""
+        return bool(origin and origin in self._allowed_cors_origins())
 
     def _send_cors_headers(self):
         """Emit CORS headers only for explicitly allowed origins."""
-        origin = self.headers.get("Origin", "")
-        if origin and origin in self._allowed_cors_origins():
+        origin = self.headers.get("Origin")
+        if self._is_allowed_origin(origin):
             self.send_header("Access-Control-Allow-Origin", origin)
             self.send_header("Vary", "Origin")
-            self.send_header("Access-Control-Allow-Headers", "Content-Type, X-CSRF-Token")
+            self.send_header(
+                "Access-Control-Allow-Headers",
+                f"Content-Type, {CSRF_HEADER}, {LEGACY_CSRF_HEADER}",
+            )
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight requests"""
+        origin = self.headers.get("Origin")
+        if not self._is_allowed_origin(origin):
+            self.send_response(403)
+            self.end_headers()
+            return
+
+        self.send_response(204)
+        self._send_cors_headers()
+        self.end_headers()
 
     def do_GET(self):
         """Handle GET requests"""
@@ -320,17 +345,14 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         csrf_error = self._csrf_error(parsed.path, params)
         if csrf_error:
-            self._send_response(ApiResponse(success=False, error=csrf_error))
+            self._send_response(
+                ApiResponse(success=False, error="CSRF token required"),
+                status_code=403,
+            )
             return
 
         response = self._route_request(parsed.path, params)
         self._send_response(response)
-
-    def do_OPTIONS(self):
-        """Handle CORS preflight without wildcard access."""
-        self.send_response(204)
-        self._send_cors_headers()
-        self.end_headers()
 
     def _route_request(self, path: str, params: Dict[str, Any]) -> ApiResponse:
         """Route request to appropriate handler"""
@@ -404,15 +426,18 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         if not expected:
             return "RUSTCHAIN_API_CSRF_TOKEN not configured"
 
-        provided = self.headers.get("X-CSRF-Token", "").strip()
-        if not provided or provided != expected:
+        provided = (
+            self.headers.get(CSRF_HEADER, "").strip()
+            or self.headers.get(LEGACY_CSRF_HEADER, "").strip()
+        )
+        if not provided or not hmac.compare_digest(provided, expected):
             return "invalid or missing CSRF token"
 
         return None
 
-    def _send_response(self, response: ApiResponse):
+    def _send_response(self, response: ApiResponse, status_code: Optional[int] = None):
         """Send HTTP response"""
-        self.send_response(200 if response.success else 400)
+        self.send_response(status_code or (200 if response.success else 400))
         self.send_header("Content-Type", "application/json")
         self._send_cors_headers()
         self.end_headers()

--- a/test_rpc_cors_csrf.py
+++ b/test_rpc_cors_csrf.py
@@ -5,35 +5,28 @@ Regression tests for API CORS and CSRF handling in rips/rustchain-core/api/rpc.p
 The API module is loaded directly because the package path contains a hyphen.
 """
 
+import importlib.util
 import json
 import os
 import threading
+from http.client import HTTPConnection
 from http.server import HTTPServer
+from pathlib import Path
 from unittest.mock import patch
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 
 
-def _load_rpc_namespace():
-    rpc_path = os.path.join(
-        os.path.dirname(__file__),
-        "rips",
-        "rustchain-core",
-        "api",
-        "rpc.py",
-    )
-    with open(rpc_path) as f:
-        source = f.read()
-
-    ns = {"__name__": "__not_main__"}
-    exec(compile(source, rpc_path, "exec"), ns)
-    return ns
+def _load_rpc_module():
+    rpc_path = Path(__file__).resolve().parent / "rips" / "rustchain-core" / "api" / "rpc.py"
+    spec = importlib.util.spec_from_file_location("rustchain_rpc_test_target", rpc_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-RPC = _load_rpc_namespace()
-ApiRequestHandler = RPC["ApiRequestHandler"]
-RustChainApi = RPC["RustChainApi"]
-MockNode = RPC["MockNode"]
+RPC = _load_rpc_module()
+ApiRequestHandler = RPC.ApiRequestHandler
+RustChainApi = RPC.RustChainApi
+MockNode = RPC.MockNode
 
 
 class _ApiServerFixture:
@@ -42,7 +35,6 @@ class _ApiServerFixture:
         self.server = HTTPServer(("127.0.0.1", 0), ApiRequestHandler)
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
         self.thread.start()
-        self.url = f"http://127.0.0.1:{self.server.server_port}"
         return self
 
     def __exit__(self, exc_type, exc, tb):
@@ -50,25 +42,27 @@ class _ApiServerFixture:
         self.thread.join(timeout=5)
 
     def get(self, path, headers=None):
-        request = Request(f"{self.url}{path}", method="GET", headers=headers or {})
+        connection = HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
         try:
-            with urlopen(request, timeout=5) as response:
-                return response.status, json.loads(response.read().decode()), response.headers
-        except HTTPError as error:
-            return error.code, json.loads(error.read().decode()), error.headers
+            connection.request("GET", path, headers=headers or {})
+            response = connection.getresponse()
+            return response.status, json.loads(response.read().decode()), response.headers
+        finally:
+            connection.close()
 
     def post(self, path, body, headers=None):
-        request = Request(
-            f"{self.url}{path}",
-            data=json.dumps(body).encode(),
-            method="POST",
-            headers={"Content-Type": "application/json", **(headers or {})},
-        )
+        connection = HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
         try:
-            with urlopen(request, timeout=5) as response:
-                return response.status, json.loads(response.read().decode()), response.headers
-        except HTTPError as error:
-            return error.code, json.loads(error.read().decode()), error.headers
+            connection.request(
+                "POST",
+                path,
+                body=json.dumps(body).encode(),
+                headers={"Content-Type": "application/json", **(headers or {})},
+            )
+            response = connection.getresponse()
+            return response.status, json.loads(response.read().decode()), response.headers
+        finally:
+            connection.close()
 
 
 def test_default_response_does_not_send_wildcard_cors():

--- a/test_rpc_cors_csrf.py
+++ b/test_rpc_cors_csrf.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """
 Regression tests for API CORS and CSRF handling in rips/rustchain-core/api/rpc.py.
 

--- a/test_rpc_cors_csrf.py
+++ b/test_rpc_cors_csrf.py
@@ -1,0 +1,147 @@
+"""
+Regression tests for API CORS and CSRF handling in rips/rustchain-core/api/rpc.py.
+
+The API module is loaded directly because the package path contains a hyphen.
+"""
+
+import json
+import os
+import threading
+from http.server import HTTPServer
+from unittest.mock import patch
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def _load_rpc_namespace():
+    rpc_path = os.path.join(
+        os.path.dirname(__file__),
+        "rips",
+        "rustchain-core",
+        "api",
+        "rpc.py",
+    )
+    with open(rpc_path) as f:
+        source = f.read()
+
+    ns = {"__name__": "__not_main__"}
+    exec(compile(source, rpc_path, "exec"), ns)
+    return ns
+
+
+RPC = _load_rpc_namespace()
+ApiRequestHandler = RPC["ApiRequestHandler"]
+RustChainApi = RPC["RustChainApi"]
+MockNode = RPC["MockNode"]
+
+
+class _ApiServerFixture:
+    def __enter__(self):
+        ApiRequestHandler.api = RustChainApi(MockNode())
+        self.server = HTTPServer(("127.0.0.1", 0), ApiRequestHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        self.url = f"http://127.0.0.1:{self.server.server_port}"
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+
+    def get(self, path, headers=None):
+        request = Request(f"{self.url}{path}", method="GET", headers=headers or {})
+        try:
+            with urlopen(request, timeout=5) as response:
+                return response.status, json.loads(response.read().decode()), response.headers
+        except HTTPError as error:
+            return error.code, json.loads(error.read().decode()), error.headers
+
+    def post(self, path, body, headers=None):
+        request = Request(
+            f"{self.url}{path}",
+            data=json.dumps(body).encode(),
+            method="POST",
+            headers={"Content-Type": "application/json", **(headers or {})},
+        )
+        try:
+            with urlopen(request, timeout=5) as response:
+                return response.status, json.loads(response.read().decode()), response.headers
+        except HTTPError as error:
+            return error.code, json.loads(error.read().decode()), error.headers
+
+
+def test_default_response_does_not_send_wildcard_cors():
+    with patch.dict(os.environ, {}, clear=True):
+        with _ApiServerFixture() as server:
+            status, body, headers = server.get(
+                "/api/stats",
+                headers={"Origin": "https://evil.example"},
+            )
+
+    assert status == 200
+    assert body["success"] is True
+    assert headers.get("Access-Control-Allow-Origin") is None
+
+
+def test_configured_origin_is_reflected_in_cors_response():
+    with patch.dict(
+        os.environ,
+        {"RUSTCHAIN_API_ALLOWED_ORIGINS": "https://wallet.example"},
+        clear=True,
+    ):
+        with _ApiServerFixture() as server:
+            status, body, headers = server.get(
+                "/api/stats",
+                headers={"Origin": "https://wallet.example"},
+            )
+
+    assert status == 200
+    assert body["success"] is True
+    assert headers.get("Access-Control-Allow-Origin") == "https://wallet.example"
+    assert headers.get("Vary") == "Origin"
+
+
+def test_browser_state_changing_post_requires_csrf_token():
+    with patch.dict(
+        os.environ,
+        {
+            "RUSTCHAIN_API_ALLOWED_ORIGINS": "https://wallet.example",
+            "RUSTCHAIN_API_CSRF_TOKEN": "known-token",
+        },
+        clear=True,
+    ):
+        with _ApiServerFixture() as server:
+            status, body, headers = server.post(
+                "/api/mine",
+                {"wallet": "RTC1Test"},
+                headers={"Origin": "https://wallet.example"},
+            )
+
+    assert status == 403
+    assert body["success"] is False
+    assert body["error"] == "CSRF token required"
+    assert headers.get("Access-Control-Allow-Origin") == "https://wallet.example"
+
+
+def test_browser_state_changing_post_accepts_valid_csrf_token():
+    with patch.dict(
+        os.environ,
+        {
+            "RUSTCHAIN_API_ALLOWED_ORIGINS": "https://wallet.example",
+            "RUSTCHAIN_API_CSRF_TOKEN": "known-token",
+        },
+        clear=True,
+    ):
+        with _ApiServerFixture() as server:
+            status, body, headers = server.post(
+                "/api/mine",
+                {"wallet": "RTC1Test"},
+                headers={
+                    "Origin": "https://wallet.example",
+                    "X-RustChain-CSRF-Token": "known-token",
+                },
+            )
+
+    assert status == 200
+    assert body["success"] is True
+    assert headers.get("Access-Control-Allow-Origin") == "https://wallet.example"


### PR DESCRIPTION
Fixes #4614.

Summary:
- Remove the default wildcard `Access-Control-Allow-Origin: *` API response.
- Reflect CORS only for origins listed in `RUSTCHAIN_API_ALLOWED_ORIGINS`.
- Require `X-RustChain-CSRF-Token` to match `RUSTCHAIN_API_CSRF_TOKEN` for browser-origin state-changing POST paths.
- Add preflight handling and HTTP-level regression tests for CORS/CSRF behavior.

Verification:
- `python -m pytest test_rpc_cors_csrf.py -q` -> 4 passed
- `git diff --check` -> clean

wallet: minyanyi
payout address: 0x2E4380d2e1668Ca9fA3Ef91fF776FDc140Cf3fE8