### PR TITLE
fix: restrict core API CORS origins

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -13,6 +13,7 @@ Endpoints:
 """
 
 import json
+import os
 import time
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, Callable
@@ -256,6 +257,20 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
 
     api: RustChainApi = None  # Set by server
 
+    @staticmethod
+    def _allowed_cors_origins() -> set[str]:
+        raw = os.getenv("RUSTCHAIN_API_ALLOWED_ORIGINS", "")
+        return {origin.strip() for origin in raw.split(",") if origin.strip() and origin.strip() != "*"}
+
+    def _send_cors_headers(self):
+        """Emit CORS headers only for explicitly allowed origins."""
+        origin = self.headers.get("Origin", "")
+        if origin and origin in self._allowed_cors_origins():
+            self.send_header("Access-Control-Allow-Origin", origin)
+            self.send_header("Vary", "Origin")
+            self.send_header("Access-Control-Allow-Headers", "Content-Type, X-CSRF-Token")
+            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
     def do_GET(self):
         """Handle GET requests"""
         parsed = urlparse(self.path)
@@ -278,6 +293,12 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         response = self._route_request(parsed.path, params)
         self._send_response(response)
+
+    def do_OPTIONS(self):
+        """Handle CORS preflight without wildcard access."""
+        self.send_response(204)
+        self._send_cors_headers()
+        self.end_headers()
 
     def _route_request(self, path: str, params: Dict[str, Any]) -> ApiResponse:
         """Route request to appropriate handler"""
@@ -334,7 +355,7 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         """Send HTTP response"""
         self.send_response(200 if response.success else 400)
         self.send_header("Content-Type", "application/json")
-        self.send_header("Access-Control-Allow-Origin", "*")
+        self._send_cors_headers()
         self.end_headers()
         self.wfile.write(response.to_json().encode())
 

--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -256,11 +256,21 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
     """HTTP request handler for API"""
 
     api: RustChainApi = None  # Set by server
+    MUTATING_RPC_METHODS = {"submitProof", "createProposal", "vote"}
+    MUTATING_REST_PATHS = {
+        "/api/mine",
+        "/api/governance/create",
+        "/api/governance/vote",
+    }
 
     @staticmethod
     def _allowed_cors_origins() -> set[str]:
         raw = os.getenv("RUSTCHAIN_API_ALLOWED_ORIGINS", "")
         return {origin.strip() for origin in raw.split(",") if origin.strip() and origin.strip() != "*"}
+
+    @staticmethod
+    def _configured_csrf_token() -> str:
+        return os.getenv("RUSTCHAIN_API_CSRF_TOKEN", "").strip()
 
     def _send_cors_headers(self):
         """Emit CORS headers only for explicitly allowed origins."""
@@ -291,6 +301,11 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
             params = {}
 
         parsed = urlparse(self.path)
+        csrf_error = self._csrf_error(parsed.path, params)
+        if csrf_error:
+            self._send_response(ApiResponse(success=False, error=csrf_error))
+            return
+
         response = self._route_request(parsed.path, params)
         self._send_response(response)
 
@@ -350,6 +365,28 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
             return self.api.rpc.call(method, rpc_params)
 
         return ApiResponse(success=False, error=f"Unknown endpoint: {path}")
+
+    def _requires_csrf(self, path: str, params: Dict[str, Any]) -> bool:
+        """Return true for state-changing REST endpoints and mutating RPC methods."""
+        if path in self.MUTATING_REST_PATHS:
+            return True
+        if path == "/rpc" and params.get("method", "") in self.MUTATING_RPC_METHODS:
+            return True
+        return False
+
+    def _csrf_error(self, path: str, params: Dict[str, Any]) -> Optional[str]:
+        if not self._requires_csrf(path, params):
+            return None
+
+        expected = self._configured_csrf_token()
+        if not expected:
+            return "RUSTCHAIN_API_CSRF_TOKEN not configured"
+
+        provided = self.headers.get("X-CSRF-Token", "").strip()
+        if not provided or provided != expected:
+            return "invalid or missing CSRF token"
+
+        return None
 
     def _send_response(self, response: ApiResponse):
         """Send HTTP response"""

--- a/tests/test_rustchain_core_api_cors.py
+++ b/tests/test_rustchain_core_api_cors.py
@@ -1,0 +1,72 @@
+import importlib.util
+from io import BytesIO
+from pathlib import Path
+
+
+def _load_rpc_module():
+    path = Path(__file__).resolve().parents[1] / "rips" / "rustchain-core" / "api" / "rpc.py"
+    spec = importlib.util.spec_from_file_location("rustchain_core_rpc_api", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_handler(rpc, origin=None):
+    handler = object.__new__(rpc.ApiRequestHandler)
+    handler.headers = {}
+    if origin:
+        handler.headers["Origin"] = origin
+    handler.sent_headers = []
+    handler.responses = []
+    handler.wfile = BytesIO()
+
+    def send_response(status):
+        handler.responses.append(status)
+
+    def send_header(name, value):
+        handler.sent_headers.append((name, value))
+
+    handler.send_response = send_response
+    handler.send_header = send_header
+    handler.end_headers = lambda: None
+    return handler
+
+
+def _header_values(handler, name):
+    return [value for header, value in handler.sent_headers if header.lower() == name.lower()]
+
+
+def test_core_api_does_not_emit_wildcard_cors_by_default(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.delenv("RUSTCHAIN_API_ALLOWED_ORIGINS", raising=False)
+    handler = _make_handler(rpc, origin="https://evil.example")
+
+    rpc.ApiRequestHandler._send_response(handler, rpc.ApiResponse(success=True, data={"ok": True}))
+
+    assert _header_values(handler, "Access-Control-Allow-Origin") == []
+    assert handler.responses == [200]
+
+
+def test_core_api_ignores_wildcard_allowed_origin(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.setenv("RUSTCHAIN_API_ALLOWED_ORIGINS", "*")
+    handler = _make_handler(rpc, origin="https://evil.example")
+
+    rpc.ApiRequestHandler._send_response(handler, rpc.ApiResponse(success=True, data={"ok": True}))
+
+    assert _header_values(handler, "Access-Control-Allow-Origin") == []
+
+
+def test_core_api_reflects_only_explicitly_allowed_origin(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.setenv(
+        "RUSTCHAIN_API_ALLOWED_ORIGINS",
+        "https://wallet.example, https://dashboard.example",
+    )
+    handler = _make_handler(rpc, origin="https://dashboard.example")
+
+    rpc.ApiRequestHandler._send_response(handler, rpc.ApiResponse(success=True, data={"ok": True}))
+
+    assert _header_values(handler, "Access-Control-Allow-Origin") == ["https://dashboard.example"]
+    assert _header_values(handler, "Vary") == ["Origin"]

--- a/tests/test_rustchain_core_api_cors.py
+++ b/tests/test_rustchain_core_api_cors.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 from io import BytesIO
 from pathlib import Path
@@ -12,11 +14,13 @@ def _load_rpc_module():
     return module
 
 
-def _make_handler(rpc, origin=None):
+def _make_handler(rpc, origin=None, csrf_token=None):
     handler = object.__new__(rpc.ApiRequestHandler)
     handler.headers = {}
     if origin:
         handler.headers["Origin"] = origin
+    if csrf_token:
+        handler.headers["X-CSRF-Token"] = csrf_token
     handler.sent_headers = []
     handler.responses = []
     handler.wfile = BytesIO()
@@ -70,3 +74,57 @@ def test_core_api_reflects_only_explicitly_allowed_origin(monkeypatch):
 
     assert _header_values(handler, "Access-Control-Allow-Origin") == ["https://dashboard.example"]
     assert _header_values(handler, "Vary") == ["Origin"]
+
+
+def test_state_changing_rest_endpoint_requires_configured_csrf_token(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.delenv("RUSTCHAIN_API_CSRF_TOKEN", raising=False)
+    handler = _make_handler(rpc)
+
+    error = rpc.ApiRequestHandler._csrf_error(handler, "/api/mine", {"wallet": "alice"})
+
+    assert error == "RUSTCHAIN_API_CSRF_TOKEN not configured"
+
+
+def test_state_changing_rest_endpoint_rejects_missing_csrf_token(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.setenv("RUSTCHAIN_API_CSRF_TOKEN", "csrf-secret")
+    handler = _make_handler(rpc)
+
+    error = rpc.ApiRequestHandler._csrf_error(handler, "/api/governance/vote", {"proposal_id": "1"})
+
+    assert error == "invalid or missing CSRF token"
+
+
+def test_state_changing_rest_endpoint_accepts_matching_csrf_token(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.setenv("RUSTCHAIN_API_CSRF_TOKEN", "csrf-secret")
+    handler = _make_handler(rpc, csrf_token="csrf-secret")
+
+    error = rpc.ApiRequestHandler._csrf_error(handler, "/api/governance/create", {"title": "T"})
+
+    assert error is None
+
+
+def test_mutating_rpc_method_requires_csrf_token(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.setenv("RUSTCHAIN_API_CSRF_TOKEN", "csrf-secret")
+    handler = _make_handler(rpc)
+
+    error = rpc.ApiRequestHandler._csrf_error(
+        handler,
+        "/rpc",
+        {"method": "createProposal", "params": {"title": "T"}},
+    )
+
+    assert error == "invalid or missing CSRF token"
+
+
+def test_read_only_rpc_method_does_not_require_csrf_token(monkeypatch):
+    rpc = _load_rpc_module()
+    monkeypatch.delenv("RUSTCHAIN_API_CSRF_TOKEN", raising=False)
+    handler = _make_handler(rpc)
+
+    error = rpc.ApiRequestHandler._csrf_error(handler, "/rpc", {"method": "getStats"})
+
+    assert error is None


### PR DESCRIPTION
## Summary
- closes #4614
- removes the default `Access-Control-Allow-Origin: *` header from the core JSON-RPC/API handler
- adds explicit origin allowlisting via `RUSTCHAIN_API_ALLOWED_ORIGINS`
- ignores wildcard `*` in the allowlist so operators cannot re-enable broad browser access by accident
- handles CORS preflight without granting cross-origin access unless the request origin is explicitly allowed
- requires configured `RUSTCHAIN_API_CSRF_TOKEN` plus matching `X-CSRF-Token` for state-changing REST endpoints (`/api/mine`, `/api/governance/create`, `/api/governance/vote`)
- requires the same CSRF token for mutating JSON-RPC methods (`submitProof`, `createProposal`, `vote`) while leaving read-only RPC methods unchanged

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_rustchain_core_api_cors.py -q` -> 8 passed
- `python3 -m py_compile rips/rustchain-core/api/rpc.py tests/test_rustchain_core_api_cors.py` -> passed
- `git diff --check -- rips/rustchain-core/api/rpc.py tests/test_rustchain_core_api_cors.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK