### PR TITLE
fix: reject malformed rpc json bodies

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -273,7 +273,18 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         try:
             params = json.loads(body) if body else {}
         except json.JSONDecodeError:
-            params = {}
+            self._send_response(ApiResponse(
+                success=False,
+                error="Invalid JSON request body",
+            ))
+            return
+
+        if not isinstance(params, dict):
+            self._send_response(ApiResponse(
+                success=False,
+                error="JSON request body must be an object",
+            ))
+            return
 
         parsed = urlparse(self.path)
         response = self._route_request(parsed.path, params)

--- a/rips/rustchain-core/api/test_rpc.py
+++ b/rips/rustchain-core/api/test_rpc.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+from io import BytesIO
+from pathlib import Path
+import sys
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api.rpc import ApiRequestHandler, ApiResponse
+
+
+def _post_response(body, path="/rpc"):
+    handler = object.__new__(ApiRequestHandler)
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = BytesIO(body)
+    handler.path = path
+
+    responses = []
+    routed = []
+
+    def route_request(route_path, params):
+        routed.append((route_path, params))
+        return ApiResponse(success=True, data={"routed": True})
+
+    handler._route_request = route_request
+    handler._send_response = responses.append
+    handler.do_POST()
+    return responses, routed
+
+
+def test_post_rejects_malformed_json_without_routing():
+    responses, routed = _post_response(b'{"method":')
+
+    assert routed == []
+    assert len(responses) == 1
+    assert responses[0].success is False
+    assert responses[0].error == "Invalid JSON request body"
+
+
+def test_post_rejects_non_object_json_without_routing():
+    responses, routed = _post_response(b'[]')
+
+    assert routed == []
+    assert len(responses) == 1
+    assert responses[0].success is False
+    assert responses[0].error == "JSON request body must be an object"
+
+
+def test_post_routes_valid_json_object():
+    responses, routed = _post_response(
+        b'{"method": "getStats", "params": {"limit": 1}}'
+    )
+
+    assert routed == [("/rpc", {"method": "getStats", "params": {"limit": 1}})]
+    assert len(responses) == 1
+    assert responses[0].success is True


### PR DESCRIPTION
## Summary
- reject malformed JSON POST bodies before the RPC router sees them
- reject syntactically valid non-object JSON bodies instead of calling object-only handlers
- add focused coverage for malformed JSON, non-object JSON, and valid request routing

Fixes #4615.

## Validation
- py -3 -m pytest rips/rustchain-core/api/test_rpc.py -q
- py -3 -m py_compile rips/rustchain-core/api/rpc.py rips/rustchain-core/api/test_rpc.py
- git diff --check

Bounty payout:
- RTC address: RTCbe08538ae955ed694c5bc87314eff89b3b850627