### PR TITLE
fix: use current year for hall age calculations

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -35,6 +35,15 @@ CAPACITOR_PLAGUE_MODELS = [
     'Dell GX280',
 ]
 
+
+def _current_year():
+    return time.gmtime().tm_year
+
+
+def _age_years(manufacture_year):
+    return max(0, _current_year() - int(manufacture_year))
+
+
 def init_hall_tables(db_path):
     """Create Hall of Rust tables if they don't exist."""
     conn = sqlite3.connect(db_path)
@@ -85,8 +94,9 @@ def calculate_rust_score(machine):
     score = 0
     
     # Age bonus (estimated from model/arch)
-    if machine.get('manufacture_year'):
-        age = 2025 - machine['manufacture_year']
+    manufacture_year = machine.get('manufacture_year')
+    if manufacture_year is not None:
+        age = _age_years(manufacture_year)
         score += age * RUST_WEIGHTS['age_years']
     
     # Attestation loyalty
@@ -622,7 +632,10 @@ def machine_of_the_day():
         machine = dict(row)
         machine['badge'] = get_rust_badge(machine['rust_score'])
         machine['fun_fact'] = random.choice(VINTAGE_FACTS)
-        machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
+        mfg = machine.get('manufacture_year')
+        if mfg is None:
+            mfg = 2020
+        machine['age_years'] = _age_years(mfg)
         
         return jsonify(machine)
     except Exception as e:

--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -474,8 +474,7 @@ def api_hall_of_fame_machine():
             machine.get('device_model'),
         )
         mfg = machine.get('manufacture_year')
-        current_year = time.gmtime(now).tm_year
-        machine['age_years'] = max(0, current_year - int(mfg)) if mfg else None
+        machine['age_years'] = _age_years(mfg) if mfg is not None else None
 
         # Last 30 days timeline from attestation history (best-effort).
         start_ts = now - 30 * 86400

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -495,13 +495,12 @@ def api_hall_of_fame_leaderboard():
         conn.close()
 
         leaderboard = []
-        now_year = time.gmtime().tm_year
         for idx, row in enumerate(rows, 1):
             entry = dict(row)
             entry['rank'] = idx
             entry['badge'] = get_rust_badge(float(entry.get('rust_score') or 0))
             mfg = entry.get('manufacture_year')
-            entry['age_years'] = max(0, now_year - int(mfg)) if mfg else None
+            entry['age_years'] = _age_years(mfg) if mfg is not None else None
             leaderboard.append(entry)
 
         return jsonify({
@@ -541,8 +540,7 @@ def api_hall_of_fame_machine():
             machine.get('device_model'),
         )
         mfg = machine.get('manufacture_year')
-        current_year = time.gmtime(now).tm_year
-        machine['age_years'] = max(0, current_year - int(mfg)) if mfg else None
+        machine['age_years'] = _age_years(mfg) if mfg is not None else None
 
         # Last 30 days timeline from attestation history (best-effort).
         start_ts = now - 30 * 86400

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -37,6 +37,15 @@ CAPACITOR_PLAGUE_MODELS = [
     'Dell GX280',
 ]
 
+
+def _current_year():
+    return time.gmtime().tm_year
+
+
+def _age_years(manufacture_year):
+    return max(0, _current_year() - int(manufacture_year))
+
+
 def init_hall_tables(db_path):
     """Create Hall of Rust tables if they don't exist."""
     conn = sqlite3.connect(db_path)
@@ -87,8 +96,9 @@ def calculate_rust_score(machine):
     score = 0
     
     # Age bonus (estimated from model/arch)
-    if machine.get('manufacture_year'):
-        age = 2025 - machine['manufacture_year']
+    manufacture_year = machine.get('manufacture_year')
+    if manufacture_year is not None:
+        age = _age_years(manufacture_year)
         score += age * RUST_WEIGHTS['age_years']
     
     # Attestation loyalty
@@ -689,7 +699,10 @@ def machine_of_the_day():
         machine = dict(row)
         machine['badge'] = get_rust_badge(machine['rust_score'])
         machine['fun_fact'] = random.choice(VINTAGE_FACTS)
-        machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
+        mfg = machine.get('manufacture_year')
+        if mfg is None:
+            mfg = 2020
+        machine['age_years'] = _age_years(mfg)
         
         return jsonify(machine)
     except Exception:

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 import sqlite3
 import sys

--- a/tests/test_hall_of_rust_age.py
+++ b/tests/test_hall_of_rust_age.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+from flask import Flask
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, ROOT / path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _client_for(module, db_path):
+    app = Flask(module.__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(module.hall_bp)
+    return app.test_client()
+
+
+def _insert_hall_machine(module, db_path, manufacture_year):
+    module.init_hall_tables(str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO hall_of_rust (
+            fingerprint_hash, miner_id, device_arch, device_model,
+            manufacture_year, first_attestation, rust_score, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("fp", "miner", "G5", "PowerMac7,2", manufacture_year, 1, 150, 1),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_node_hall_calculate_rust_score_uses_current_year(monkeypatch):
+    module = _load_module("node_hall_of_rust_age", "node/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+
+    score = module.calculate_rust_score({
+        "manufacture_year": 2001,
+        "device_arch": "modern",
+        "device_model": "Generic",
+        "total_attestations": 0,
+        "id": 999,
+    })
+
+    assert score == 250
+
+
+def test_node_hall_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    module = _load_module("node_hall_of_rust_route_age", "node/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "node_hall.db"
+    _insert_hall_machine(module, db_path, 2003)
+    client = _client_for(module, db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 23
+
+
+def test_node_hall_machine_of_the_day_preserves_default_age(tmp_path, monkeypatch):
+    module = _load_module("node_hall_of_rust_route_default_age", "node/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "node_hall_default.db"
+    _insert_hall_machine(module, db_path, None)
+    client = _client_for(module, db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 6
+
+
+def test_explorer_hall_calculate_rust_score_uses_current_year(monkeypatch):
+    module = _load_module("explorer_hall_of_rust_age", "explorer/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+
+    score = module.calculate_rust_score({
+        "manufacture_year": 2001,
+        "device_arch": "modern",
+        "device_model": "Generic",
+        "total_attestations": 0,
+        "id": 999,
+    })
+
+    assert score == 250
+
+
+def test_explorer_hall_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    module = _load_module("explorer_hall_of_rust_route_age", "explorer/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "explorer_hall.db"
+    _insert_hall_machine(module, db_path, 2003)
+    client = _client_for(module, db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 23
+
+
+def test_explorer_hall_machine_of_the_day_preserves_default_age(tmp_path, monkeypatch):
+    module = _load_module(
+        "explorer_hall_of_rust_route_default_age",
+        "explorer/hall_of_rust.py",
+    )
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "explorer_hall_default.db"
+    _insert_hall_machine(module, db_path, None)
+    client = _client_for(module, db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 6

--- a/tests/test_hall_of_rust_age.py
+++ b/tests/test_hall_of_rust_age.py
@@ -82,6 +82,22 @@ def test_node_hall_machine_of_the_day_preserves_default_age(tmp_path, monkeypatc
     assert response.get_json()["age_years"] == 6
 
 
+def test_node_hall_api_routes_treat_zero_year_as_known(tmp_path, monkeypatch):
+    module = _load_module("node_hall_of_rust_api_zero_age", "node/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "node_hall_zero.db"
+    _insert_hall_machine(module, db_path, 0)
+    client = _client_for(module, db_path)
+
+    leaderboard = client.get("/api/hall_of_fame/leaderboard")
+    machine = client.get("/api/hall_of_fame/machine?id=fp")
+
+    assert leaderboard.status_code == 200
+    assert leaderboard.get_json()["leaderboard"][0]["age_years"] == 2026
+    assert machine.status_code == 200
+    assert machine.get_json()["machine"]["age_years"] == 2026
+
+
 def test_explorer_hall_calculate_rust_score_uses_current_year(monkeypatch):
     module = _load_module("explorer_hall_of_rust_age", "explorer/hall_of_rust.py")
     monkeypatch.setattr(module, "_current_year", lambda: 2026)
@@ -124,3 +140,16 @@ def test_explorer_hall_machine_of_the_day_preserves_default_age(tmp_path, monkey
 
     assert response.status_code == 200
     assert response.get_json()["age_years"] == 6
+
+
+def test_explorer_hall_machine_route_treats_zero_year_as_known(tmp_path, monkeypatch):
+    module = _load_module("explorer_hall_of_rust_machine_zero_age", "explorer/hall_of_rust.py")
+    monkeypatch.setattr(module, "_current_year", lambda: 2026)
+    db_path = tmp_path / "explorer_hall_zero.db"
+    _insert_hall_machine(module, db_path, 0)
+    client = _client_for(module, db_path)
+
+    response = client.get("/api/hall_of_fame/machine?id=fp")
+
+    assert response.status_code == 200
+    assert response.get_json()["machine"]["age_years"] == 2026


### PR DESCRIPTION
## Summary
- replace stale Hall of Rust 2025 age baselines with the current UTC year in both node and explorer Hall implementations
- preserve the machine-of-the-day default-age fallback while using the current year
- cover rust-score age bonuses and machine-of-the-day age output for both implementations

Fixes #4594.

## Validation
- py -3 -m pytest tests/test_hall_of_rust_age.py node/tests/test_hall_of_rust_error_responses.py -q
- py -3 -m py_compile node/hall_of_rust.py explorer/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py tests/test_hall_of_rust_age.py
- git diff --check

Bounty payout:
- RTC address: RTCbe08538ae955ed694c5bc87314eff89b3b850627