### PR TITLE
FIX(#4627): add null check to all Flask POST endpoints

### DIFF
--- a/rips/python/rustchain/node.py
+++ b/rips/python/rustchain/node.py
@@ -384,6 +384,8 @@ def create_api_server(node: RustChainNode):
     @app.route("/api/mine", methods=["POST"])
     def mine():
         data = request.json
+        if data is None:
+            return jsonify({"error": "Invalid or missing JSON body"}), 400
         wallet = WalletAddress(data["wallet"])
         hardware = HardwareInfo(
             cpu_model=data["hardware"],
@@ -396,6 +398,8 @@ def create_api_server(node: RustChainNode):
     @app.route("/api/node/antiquity", methods=["POST"])
     def antiquity():
         data = request.json
+        if data is None:
+            return jsonify({"error": "Invalid or missing JSON body"}), 400
         wallet = WalletAddress(data["wallet"])
         hardware = HardwareInfo(
             cpu_model=data["hardware"],
@@ -411,6 +415,8 @@ def create_api_server(node: RustChainNode):
     @app.route("/api/governance/create", methods=["POST"])
     def create_proposal():
         data = request.json
+        if data is None:
+            return jsonify({"error": "Invalid or missing JSON body"}), 400
         result = node.create_proposal(
             title=data["title"],
             description=data["description"],
@@ -423,6 +429,8 @@ def create_api_server(node: RustChainNode):
     @app.route("/api/governance/vote", methods=["POST"])
     def vote():
         data = request.json
+        if data is None:
+            return jsonify({"error": "Invalid or missing JSON body"}), 400
         result = node.vote_proposal(
             proposal_id=data["proposal_id"],
             voter=WalletAddress(data["voter"]),


### PR DESCRIPTION
## Fix for #4627

All Flask POST endpoints (`/api/mine`, `/api/node/antiquity`, `/api/governance/create`, `/api/governance/vote`) now validate `request.json` is not None before accessing fields.

Previously, sending a POST with empty body or wrong Content-Type caused `TypeError: NoneType is not subscriptable` → 500 Internal Server Error.

Now returns 400 with clear error message: `Invalid or missing JSON body`.

## Wallet
RTC9d7caca3039130d3b26d41f7343d8f4ef4592360