### PR TITLE
Fix core current-year constant

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -52,8 +52,6 @@ FOUNDER_WALLETS = [
 # Consensus Parameters
 # =============================================================================
 
-CURRENT_YEAR: int = 2025
-
 # Antiquity Score parameters
 AS_MAX: float = 100.0  # Maximum for reward capping
 AS_MIN: float = 1.0    # Minimum to participate

--- a/tests/test_rustchain_core_current_year.py
+++ b/tests/test_rustchain_core_current_year.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+
+import datetime
+import importlib.util
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHAIN_PARAMS_PATH = REPO_ROOT / "rips" / "rustchain-core" / "config" / "chain_params.py"
+
+
+def load_chain_params():
+    spec = importlib.util.spec_from_file_location("rustchain_core_chain_params", CHAIN_PARAMS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_current_year_uses_runtime_year():
+    chain_params = load_chain_params()
+
+    assert chain_params.CURRENT_YEAR == datetime.datetime.now().year
+
+
+def test_current_year_has_single_assignment():
+    source = CHAIN_PARAMS_PATH.read_text(encoding="utf-8")
+
+    assignments = re.findall(r"^CURRENT_YEAR\s*:\s*int\s*=", source, flags=re.MULTILINE)
+    assert len(assignments) == 1
+    assert "CURRENT_YEAR: int = 2025" not in source


### PR DESCRIPTION
## Summary
- remove the second hardcoded `CURRENT_YEAR = 2025` assignment from `rips/rustchain-core/config/chain_params.py`
- keep the dynamic runtime year as the only source of truth for core Antiquity Score calculations
- add regression coverage that verifies `CURRENT_YEAR` equals the runtime year and has only one assignment

## Verification
- `python -m pytest tests\test_rustchain_core_current_year.py -q`
- `python -m py_compile rips\rustchain-core\config\chain_params.py tests\test_rustchain_core_current_year.py`
- `git diff --check origin/main...HEAD -- rips/rustchain-core/config/chain_params.py tests/test_rustchain_core_current_year.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Fixes #4631
