### PR TITLE
FIX(#4631): remove hardcoded CURRENT_YEAR=2025 that shadows dynamic value

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -52,7 +52,6 @@ FOUNDER_WALLETS = [
 # Consensus Parameters
 # =============================================================================
 
-CURRENT_YEAR: int = 2025
 
 # Antiquity Score parameters
 AS_MAX: float = 100.0  # Maximum for reward capping


### PR DESCRIPTION
## Fix for #4631

`chain_params.py` had `CURRENT_YEAR` defined twice:
1. Line 38: `CURRENT_YEAR: int = datetime.now().year` (correct, dynamic)
2. Line 55: `CURRENT_YEAR: int = 2025` (hardcoded override)

Python uses the last assignment, so all Antiquity Score calculations were stuck at 2025 regardless of the actual year.

This fix removes the hardcoded override, allowing `datetime.now().year` to work correctly.

## Impact
- Without this fix, all hardware age calculations are 1 year short in 2026, 2 in 2027, etc.
- Affects: `calculate_antiquity_score()`, `HardwareInfo.__post_init__()`, hardware tier assignments

## Wallet
RTC9d7caca3039130d3b26d41f7343d8f4ef4592360