### PR TITLE
Fix explorer Hall of Rust current-year age calculations

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -35,6 +35,10 @@ CAPACITOR_PLAGUE_MODELS = [
     'Dell GX280',
 ]
 
+def current_utc_year():
+    """Return the current UTC year for hardware age calculations."""
+    return time.gmtime().tm_year
+
 def init_hall_tables(db_path):
     """Create Hall of Rust tables if they don't exist."""
     conn = sqlite3.connect(db_path)
@@ -86,7 +90,7 @@ def calculate_rust_score(machine):
     
     # Age bonus (estimated from model/arch)
     if machine.get('manufacture_year'):
-        age = 2025 - machine['manufacture_year']
+        age = max(0, current_utc_year() - int(machine['manufacture_year']))
         score += age * RUST_WEIGHTS['age_years']
     
     # Attestation loyalty
@@ -622,7 +626,8 @@ def machine_of_the_day():
         machine = dict(row)
         machine['badge'] = get_rust_badge(machine['rust_score'])
         machine['fun_fact'] = random.choice(VINTAGE_FACTS)
-        machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
+        mfg = machine.get('manufacture_year')
+        machine['age_years'] = max(0, current_utc_year() - int(mfg)) if mfg else None
         
         return jsonify(machine)
     except Exception as e:

--- a/tests/test_explorer_hall_of_rust_current_year.py
+++ b/tests/test_explorer_hall_of_rust_current_year.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "explorer" / "hall_of_rust.py"
+
+
+def load_explorer_hall():
+    spec = importlib.util.spec_from_file_location("explorer_hall_of_rust_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def client_for(module, db_path):
+    app = Flask(__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(module.hall_bp)
+    return app.test_client()
+
+
+def test_explorer_rust_score_uses_current_year_for_age_bonus(monkeypatch):
+    hall = load_explorer_hall()
+    monkeypatch.setattr(hall, "current_utc_year", lambda: 2026)
+
+    score = hall.calculate_rust_score(
+        {
+            "manufacture_year": 2001,
+            "device_arch": "modern",
+            "device_model": "Generic",
+            "total_attestations": 0,
+            "id": 999,
+        }
+    )
+
+    assert score == 250
+
+
+def test_explorer_rust_score_clamps_future_manufacture_year(monkeypatch):
+    hall = load_explorer_hall()
+    monkeypatch.setattr(hall, "current_utc_year", lambda: 2026)
+
+    score = hall.calculate_rust_score(
+        {
+            "manufacture_year": 2027,
+            "device_arch": "modern",
+            "device_model": "Generic",
+            "total_attestations": 0,
+            "id": 999,
+        }
+    )
+
+    assert score == 0
+
+
+def test_explorer_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    hall = load_explorer_hall()
+    monkeypatch.setattr(hall, "current_utc_year", lambda: 2026)
+    db_path = tmp_path / "hall.db"
+    hall.init_hall_tables(str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO hall_of_rust (
+            fingerprint_hash, miner_id, device_arch, device_model,
+            manufacture_year, first_attestation, last_attestation,
+            rust_score, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("fp-1", "miner-1", "G4", "PowerMac3,6", 2003, 1, 1, 101, 1),
+    )
+    conn.commit()
+    conn.close()
+    client = client_for(hall, db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 23


### PR DESCRIPTION
## Summary
- replace the explorer Hall of Rust copy's hardcoded 2025 age baseline with a current UTC year helper
- clamp future manufacture years to zero age in explorer rust-score calculations
- update machine-of-the-day age output to use the current year instead of 2025
- add focused regression coverage for rust score, future-year clamping, and machine-of-the-day `age_years`

## Verification
- `python -m pytest tests\test_explorer_hall_of_rust_current_year.py -q`
- `python -m py_compile explorer\hall_of_rust.py tests\test_explorer_hall_of_rust_current_year.py`
- `git diff --check origin/main...HEAD -- explorer/hall_of_rust.py tests/test_explorer_hall_of_rust_current_year.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Fixes #4634
