### PR TITLE
FIX(#4636): reject negative block height in calculate_block_reward()

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -144,6 +144,8 @@ def get_multiplier_for_tier(tier: str) -> float:
 
 def calculate_block_reward(height: int) -> Decimal:
     """Calculate block reward at a given height"""
+    if height < 0:
+        raise ValueError(f"Block height cannot be negative: {height}")
     halvings = height // HALVING_INTERVAL_BLOCKS
     if halvings >= HALVING_COUNT:
         # Tail emission after 4 halvings


### PR DESCRIPTION
## Fix for #4636

`calculate_block_reward()` now raises `ValueError` for negative heights instead of returning inflated rewards.

Previously, `calculate_block_reward(-1)` returned 3.0 RTC (2x normal) due to Python floor division and `2**-1 = 0.5`.

## Wallet
RTC9d7caca3039130d3b26d41f7343d8f4ef4592360