### PR TITLE
[UTXO-BUG] Reject unmineable mempool outputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -596,29 +596,6 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('attacker'), 0)
 
-    def test_disallowed_mining_reward_releases_db_connection(self):
-        """Rejected minting txs must not leak SQLite handles.
-
-        The early public mining_reward guard runs before transaction setup.
-        It must still close the owned connection or Windows checkouts keep the
-        database file locked after a rejected minting attempt.
-        """
-        tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
-        tmp.close()
-        db = UtxoDB(tmp.name)
-        try:
-            db.init_tables()
-            ok = db.apply_transaction({
-                'tx_type': 'mining_reward',
-                'inputs': [],
-                'outputs': [{'address': 'attacker', 'value_nrtc': UNIT}],
-                'fee_nrtc': 0,
-                'timestamp': int(time.time()),
-            }, block_height=10)
-            self.assertFalse(ok)
-        finally:
-            os.unlink(tmp.name)
-
     def test_mempool_empty_inputs_rejected_for_transfer(self):
         """Mempool must also reject non-minting txs with empty inputs."""
         tx = {

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -596,6 +596,29 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('attacker'), 0)
 
+    def test_disallowed_mining_reward_releases_db_connection(self):
+        """Rejected minting txs must not leak SQLite handles.
+
+        The early public mining_reward guard runs before transaction setup.
+        It must still close the owned connection or Windows checkouts keep the
+        database file locked after a rejected minting attempt.
+        """
+        tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        tmp.close()
+        db = UtxoDB(tmp.name)
+        try:
+            db.init_tables()
+            ok = db.apply_transaction({
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': 'attacker', 'value_nrtc': UNIT}],
+                'fee_nrtc': 0,
+                'timestamp': int(time.time()),
+            }, block_height=10)
+            self.assertFalse(ok)
+        finally:
+            os.unlink(tmp.name)
+
     def test_mempool_empty_inputs_rejected_for_transfer(self):
         """Mempool must also reject non-minting txs with empty inputs."""
         tx = {
@@ -668,6 +691,29 @@ class TestUtxoDB(unittest.TestCase):
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
         # Box should NOT be locked
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_rejects_output_missing_address(self):
+        """Mempool must reject outputs that apply_transaction() cannot mine.
+
+        Without this guard a transaction with a positive value but no address
+        is admitted, locks the input box, and later raises KeyError("address")
+        when block production tries to apply the candidate.
+        """
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'noad' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
         self.assertFalse(
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -380,8 +380,6 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
-            if own:
-                conn.close()
             return False
 
         try:
@@ -759,17 +757,17 @@ class UtxoDB:
 
             outputs = tx.get('outputs', [])
 
-            # FIX(#2179): Mirror apply_transaction() output validation.
-            # Reject outputs with missing, non-int, zero, or negative value_nrtc.
-            # Without this, unmineable transactions enter the mempool and lock
-            # UTXOs until expiry (DoS vector).
+            # Mirror apply_transaction() output validation. Reject outputs with
+            # missing, non-int, or below-dust value_nrtc. Without this,
+            # unmineable transactions enter the mempool and lock UTXOs until
+            # expiry (DoS vector).
             for o in outputs:
                 if not isinstance(o.get('address'), str):
                     if manage_tx:
                         conn.execute("ROLLBACK")
                     return False
                 val = o.get('value_nrtc')
-                if not isinstance(val, int) or val <= 0:
+                if isinstance(val, bool) or not isinstance(val, int) or val < DUST_THRESHOLD:
                     if manage_tx:
                         conn.execute("ROLLBACK")
                     return False

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -380,6 +380,8 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
+            if own:
+                conn.close()
             return False
 
         try:
@@ -762,6 +764,10 @@ class UtxoDB:
             # Without this, unmineable transactions enter the mempool and lock
             # UTXOs until expiry (DoS vector).
             for o in outputs:
+                if not isinstance(o.get('address'), str):
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
+                    return False
                 val = o.get('value_nrtc')
                 if not isinstance(val, int) or val <= 0:
                     if manage_tx:


### PR DESCRIPTION
## Summary
- reject mempool outputs that are missing an `address` before they can lock input UTXOs
- close the owned SQLite connection on the early public `mining_reward` rejection path
- add focused regression coverage for both UTXO bounty findings

## UTXO bounty impact
Submission for Scottcjn/rustchain-bounties#2819.

Finding 1: `mempool_add()` accepted a transaction whose output had a positive `value_nrtc` but no `address`. That candidate locks the input box in `utxo_mempool_inputs`, appears in block candidates, and then `apply_transaction()` raises `KeyError(address)` when block production tries to apply it. This is a mempool DoS / unmineable-candidate admission bug.

Finding 2: `apply_transaction()` returned from the public `mining_reward` guard before the `try/finally` close path. On Windows this leaves the SQLite DB handle open after a rejected minting attempt, which the existing over-cap test exposed as a locked temp DB file.

## Validation
- `python -m pytest node\test_utxo_db.py::TestUtxoDB::test_mempool_rejects_output_missing_address node\test_utxo_db.py::TestUtxoDB::test_disallowed_mining_reward_releases_db_connection node\test_utxo_db.py::TestUtxoDB::test_mining_reward_over_cap_rejected -q` -> 3 passed
- `python -m pytest node\test_utxo_db.py -q` -> 57 passed
- `python -m py_compile node\utxo_db.py node\test_utxo_db.py` -> passed
- `git diff --check origin/main...HEAD -- node/utxo_db.py node/test_utxo_db.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Payout details can be provided privately if accepted.