### PR TITLE
fix: reject negative block rewards

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -144,6 +144,9 @@ def get_multiplier_for_tier(tier: str) -> float:
 
 def calculate_block_reward(height: int) -> Decimal:
     """Calculate block reward at a given height"""
+    if height < 0:
+        raise ValueError(f"Block height cannot be negative: {height}")
+
     halvings = height // HALVING_INTERVAL_BLOCKS
     if halvings >= HALVING_COUNT:
         # Tail emission after 4 halvings

--- a/tests/test_chain_params_block_reward.py
+++ b/tests/test_chain_params_block_reward.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+
+from decimal import Decimal
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHAIN_PARAMS_PATH = REPO_ROOT / "rips" / "rustchain-core" / "config" / "chain_params.py"
+
+
+def load_chain_params():
+    spec = importlib.util.spec_from_file_location("chain_params_under_test", CHAIN_PARAMS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_block_reward_rejects_negative_height():
+    chain_params = load_chain_params()
+
+    with pytest.raises(ValueError, match="Block height cannot be negative: -1"):
+        chain_params.calculate_block_reward(-1)
+
+
+def test_block_reward_rejects_negative_halving_boundary():
+    chain_params = load_chain_params()
+
+    with pytest.raises(ValueError, match="Block height cannot be negative: -210000"):
+        chain_params.calculate_block_reward(-chain_params.HALVING_INTERVAL_BLOCKS)
+
+
+def test_block_reward_keeps_genesis_and_halving_outputs():
+    chain_params = load_chain_params()
+
+    assert chain_params.calculate_block_reward(0) == Decimal("1.5")
+    assert chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS) == Decimal("0.75")
+    assert chain_params.calculate_block_reward(
+        chain_params.HALVING_INTERVAL_BLOCKS * chain_params.HALVING_COUNT
+    ) == Decimal("0.09375")


### PR DESCRIPTION
## Summary
- reject negative heights in calculate_block_reward() before halving math
- add regression coverage for negative heights, negative halving boundaries, and existing genesis/halving/tail reward outputs

Fixes #4636

## Verification
- python -m pytest tests\\test_chain_params_block_reward.py -q
- python -m py_compile rips\\rustchain-core\\config\\chain_params.py tests\\test_chain_params_block_reward.py
- git diff --check
- python tools\\bcos_spdx_check.py --base-ref origin/main