### PR TITLE
fix: secure deep entropy challenge randomness

### DIFF
--- a/rips/python/rustchain/deep_entropy.py
+++ b/rips/python/rustchain/deep_entropy.py
@@ -14,10 +14,9 @@ Layers:
 5. Architectural Quirk Entropy - Known hardware bugs/quirks
 """
 
-import hashlib
 import math
+import secrets
 import time
-import random
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Any
 from enum import Enum
@@ -262,16 +261,19 @@ class DeepEntropyVerifier:
 
     def generate_challenge(self) -> Dict[str, Any]:
         """Generate a challenge for hardware to solve"""
-        nonce = hashlib.sha256(str(time.time()).encode()).digest()
-        # Multiply the 4-op template by 25 to produce 100 total operations.
-        # The randomised values ensure each challenge is unique, preventing
+        nonce = secrets.token_bytes(32)
+        strides = [1, 4, 16, 64, 256]
+        # Build 100 total operations from cryptographically secure randomness.
+        # The randomized values ensure each challenge is unique, preventing
         # a cached replay attack where an attacker pre-records a real machine's response.
-        operations = [
-            {"op": "mul", "value": random.randint(1, 1000000)},
-            {"op": "div", "value": random.randint(1, 1000)},
-            {"op": "fadd", "value": random.uniform(0, 1000)},
-            {"op": "memory", "stride": random.choice([1, 4, 16, 64, 256])},
-        ] * 25  # 100 operations
+        operations = []
+        for _ in range(25):
+            operations.extend([
+                {"op": "mul", "value": secrets.randbelow(1_000_000) + 1},
+                {"op": "div", "value": secrets.randbelow(1_000) + 1},
+                {"op": "fadd", "value": secrets.randbelow(1_000_000) / 1000.0},
+                {"op": "memory", "stride": strides[secrets.randbelow(len(strides))]},
+            ])
 
         return {
             "nonce": nonce.hex(),

--- a/tests/test_deep_entropy_challenge_security.py
+++ b/tests/test_deep_entropy_challenge_security.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEEP_ENTROPY_PATH = REPO_ROOT / "rips" / "python" / "rustchain" / "deep_entropy.py"
+
+
+def load_deep_entropy():
+    spec = importlib.util.spec_from_file_location("deep_entropy_under_test", DEEP_ENTROPY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_challenge_uses_secrets_for_nonce_and_operations(monkeypatch):
+    deep_entropy = load_deep_entropy()
+    randbelow_bounds = []
+
+    def fake_randbelow(bound):
+        randbelow_bounds.append(bound)
+        return 0
+
+    monkeypatch.setattr(deep_entropy.secrets, "token_bytes", lambda size: b"\xab" * size)
+    monkeypatch.setattr(deep_entropy.secrets, "randbelow", fake_randbelow)
+
+    challenge = deep_entropy.DeepEntropyVerifier().generate_challenge()
+
+    assert challenge["nonce"] == "ab" * 32
+    assert len(challenge["operations"]) == 100
+    assert randbelow_bounds.count(1_000_000) == 50
+    assert randbelow_bounds.count(1_000) == 25
+    assert randbelow_bounds.count(5) == 25
+    assert challenge["operations"][:4] == [
+        {"op": "mul", "value": 1},
+        {"op": "div", "value": 1},
+        {"op": "fadd", "value": 0.0},
+        {"op": "memory", "stride": 1},
+    ]


### PR DESCRIPTION
## Summary
- replace time-derived deep entropy challenge nonces with secrets.token_bytes(32)
- generate challenge operation values and memory strides with secrets.randbelow()
- add focused regression coverage proving nonce and operation generation use the secrets module

Fixes #4640

## Verification
- python -m pytest tests\\test_deep_entropy_challenge_security.py -q
- python -m py_compile rips\\python\\rustchain\\deep_entropy.py tests\\test_deep_entropy_challenge_security.py
- git diff --check
- python tools\\bcos_spdx_check.py --base-ref origin/main