### PR TITLE
fix: secure Proof of Antiquity validator selection

### DIFF
--- a/rips/python/rustchain/proof_of_antiquity.py
+++ b/rips/python/rustchain/proof_of_antiquity.py
@@ -410,11 +410,11 @@ def select_block_validator(proofs: List[ValidatedProof]) -> Optional[ValidatedPr
         return proofs[secrets.randbelow(len(proofs))]
 
     # Weighted random selection via cumulative distribution: pick a random point
-    # on [0, total_as] and return the proof whose range contains it.
+    # on [0, total_as) and return the proof whose range contains it.
     # The last proof is returned as a fallback for floating-point rounding where
     # cumulative may fall just short of total_as.
-    precision = 1_000_000
-    r = secrets.randbelow(int(total_as * precision)) / float(precision)
+    secure_unit = secrets.randbelow(2**53) / float(2**53)
+    r = secure_unit * total_as
     cumulative = 0
 
     for proof in proofs:

--- a/rips/python/rustchain/proof_of_antiquity.py
+++ b/rips/python/rustchain/proof_of_antiquity.py
@@ -14,6 +14,7 @@ Formula: AS = (current_year - release_year) * log10(uptime_days + 1)
 
 import hashlib
 import math
+import secrets
 import time
 from datetime import datetime
 from dataclasses import dataclass, field
@@ -404,17 +405,16 @@ def select_block_validator(proofs: List[ValidatedProof]) -> Optional[ValidatedPr
     if not proofs:
         return None
 
-    import random
-
     total_as = sum(p.antiquity_score for p in proofs)
     if total_as == 0:
-        return random.choice(proofs)
+        return proofs[secrets.randbelow(len(proofs))]
 
     # Weighted random selection via cumulative distribution: pick a random point
     # on [0, total_as] and return the proof whose range contains it.
     # The last proof is returned as a fallback for floating-point rounding where
     # cumulative may fall just short of total_as.
-    r = random.uniform(0, total_as)
+    precision = 1_000_000
+    r = secrets.randbelow(int(total_as * precision)) / float(precision)
     cumulative = 0
 
     for proof in proofs:

--- a/tests/test_proof_of_antiquity_validator_selection.py
+++ b/tests/test_proof_of_antiquity_validator_selection.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+
+import importlib
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTHON_RIPS_PATH = REPO_ROOT / "rips" / "python"
+
+
+def load_proof_of_antiquity():
+    if str(PYTHON_RIPS_PATH) not in sys.path:
+        sys.path.insert(0, str(PYTHON_RIPS_PATH))
+    return importlib.import_module("rustchain.proof_of_antiquity")
+
+
+def proof(score):
+    return SimpleNamespace(antiquity_score=score)
+
+
+def test_select_block_validator_uses_secrets_for_zero_score_fallback(monkeypatch):
+    poa = load_proof_of_antiquity()
+    proofs = [proof(0), proof(0), proof(0)]
+    calls = []
+
+    def fake_randbelow(bound):
+        calls.append(bound)
+        return 1
+
+    monkeypatch.setattr(poa.secrets, "randbelow", fake_randbelow)
+
+    assert poa.select_block_validator(proofs) is proofs[1]
+    assert calls == [3]
+
+
+def test_select_block_validator_uses_secrets_for_weighted_selection(monkeypatch):
+    poa = load_proof_of_antiquity()
+    proofs = [proof(1.0), proof(2.0)]
+    calls = []
+
+    def fake_randbelow(bound):
+        calls.append(bound)
+        return 1_500_000
+
+    monkeypatch.setattr(poa.secrets, "randbelow", fake_randbelow)
+
+    assert poa.select_block_validator(proofs) is proofs[1]
+    assert calls == [3_000_000]
+
+
+def test_select_block_validator_returns_none_for_empty_proofs():
+    poa = load_proof_of_antiquity()
+
+    assert poa.select_block_validator([]) is None

--- a/tests/test_proof_of_antiquity_validator_selection.py
+++ b/tests/test_proof_of_antiquity_validator_selection.py
@@ -42,12 +42,27 @@ def test_select_block_validator_uses_secrets_for_weighted_selection(monkeypatch)
 
     def fake_randbelow(bound):
         calls.append(bound)
-        return 1_500_000
+        return 2**52
 
     monkeypatch.setattr(poa.secrets, "randbelow", fake_randbelow)
 
     assert poa.select_block_validator(proofs) is proofs[1]
-    assert calls == [3_000_000]
+    assert calls == [2**53]
+
+
+def test_select_block_validator_handles_tiny_positive_scores(monkeypatch):
+    poa = load_proof_of_antiquity()
+    proofs = [proof(1e-9)]
+    calls = []
+
+    def fake_randbelow(bound):
+        calls.append(bound)
+        return 0
+
+    monkeypatch.setattr(poa.secrets, "randbelow", fake_randbelow)
+
+    assert poa.select_block_validator(proofs) is proofs[0]
+    assert calls == [2**53]
 
 
 def test_select_block_validator_returns_none_for_empty_proofs():


### PR DESCRIPTION
## Summary
- replace predictable random.choice/random.uniform validator selection with secrets.randbelow()
- keep the zero-score fallback and weighted selection behavior deterministic under mocked secure randomness
- add focused regression coverage for empty, zero-score, and weighted validator selection paths

Fixes #4643

## Verification
- python -m pytest tests\\test_proof_of_antiquity_validator_selection.py -q
- python -m py_compile rips\\python\\rustchain\\proof_of_antiquity.py tests\\test_proof_of_antiquity_validator_selection.py
- git diff --check
- python tools\\bcos_spdx_check.py --base-ref origin/main