### PR TITLE
[UTXO-BUG] Reject non-object transfer JSON

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -206,6 +206,12 @@ class TestUtxoEndpoints(unittest.TestCase):
         })
         self.assertEqual(r.status_code, 400)
 
+    def test_transfer_rejects_non_object_json_body(self):
+        for payload in ([{'from_address': 'alice'}], ['bad'], 'bad'):
+            r = self.client.post('/utxo/transfer', json=payload)
+            self.assertEqual(r.status_code, 400)
+            self.assertEqual(r.get_json()['error'], 'JSON object body required')
+
     def test_transfer_zero_amount(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -342,9 +342,11 @@ def utxo_transfer():
     4. Apply atomically
     5. If dual_write: also update account model
     """
-    data = request.get_json()
-    if not data:
+    data = request.get_json(silent=True)
+    if data is None or data == {}:
         return jsonify({'error': 'JSON body required'}), 400
+    if not isinstance(data, dict):
+        return jsonify({'error': 'JSON object body required'}), 400
 
     from_address = (data.get('from_address') or '').strip()
     to_address = (data.get('to_address') or '').strip()


### PR DESCRIPTION
## Summary

`/utxo/transfer` assumed every parsed JSON body was an object. A non-empty JSON array or string reached `data.get(...)` and raised `AttributeError`, turning malformed machine-client input into an internal server error instead of a deterministic contract rejection.

This patch makes the endpoint parse JSON silently, keeps the existing empty-body response, and rejects non-object JSON with a machine-readable 400 response.

## Why this matters

The UTXO bounty scope includes code quality, unchecked error paths, and mempool/API DoS edges. External clients can send syntactically valid JSON that is not an object. The transfer endpoint should fail closed before signature, coin-selection, nonce, or database work.

## Validation

- `python -m pytest node\test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_rejects_non_object_json_body -q` -> 1 passed
- `python -m pytest node\test_utxo_endpoints.py -q` -> 19 passed
- `python -m py_compile node\utxo_endpoints.py node\test_utxo_endpoints.py` -> passed
- `git diff --check origin/main...HEAD -- node\utxo_endpoints.py node\test_utxo_endpoints.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Note: I also ran `python -m pytest node\test_utxo_endpoints.py tests\test_utxo_transfer_replay.py -q`; the endpoint tests passed, while the replay file hit existing Windows temp-DB unlink locks in its teardown. This patch does not touch that replay test harness.
