### PR TITLE
fix: use public BCOS response URLs

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -53,6 +53,16 @@ def _get_admin_key():
     return os.environ.get("RC_ADMIN_KEY", "")
 
 
+def _bcos_public_url(path: str) -> str:
+    """Build certificate-valid public BCOS URLs for API responses."""
+    base_url = (
+        os.environ.get("RUSTCHAIN_BCOS_PUBLIC_BASE_URL")
+        or os.environ.get("RUSTCHAIN_PUBLIC_BASE_URL")
+        or "https://rustchain.org"
+    )
+    return f"{base_url.rstrip('/')}{path}"
+
+
 def _parse_trust_score(raw_score) -> int:
     """Validate BCOS trust scores before they are stored or rendered."""
     if isinstance(raw_score, bool):
@@ -277,8 +287,8 @@ def bcos_attest():
             "tier": tier,
             "trust_score": trust_score,
             "anchored_epoch": epoch,
-            "verify_url": f"https://rustchain.org/bcos/verify/{cert_id}",
-            "badge_url": f"https://50.28.86.131/bcos/badge/{cert_id}.svg",
+            "verify_url": _bcos_public_url(f"/bcos/verify/{cert_id}"),
+            "badge_url": _bcos_public_url(f"/bcos/badge/{cert_id}.svg"),
         })
     except sqlite3.IntegrityError:
         return jsonify({"error": f"Certificate {cert_id} already exists"}), 409
@@ -339,8 +349,8 @@ def bcos_verify(cert_id):
             "score_breakdown": report.get("score_breakdown", {}),
             "checks": report.get("checks", {}),
             "engine_version": report.get("engine_version", "unknown"),
-            "badge_url": f"https://50.28.86.131/bcos/badge/{cert_id}.svg",
-            "pdf_url": f"https://50.28.86.131/bcos/cert/{cert_id}.pdf",
+            "badge_url": _bcos_public_url(f"/bcos/badge/{cert_id}.svg"),
+            "pdf_url": _bcos_public_url(f"/bcos/cert/{cert_id}.pdf"),
         })
     except Exception as e:
         import logging
@@ -464,8 +474,8 @@ def bcos_directory():
                 "reviewer": row["reviewer"],
                 "anchored_epoch": row["anchored_epoch"],
                 "created_at": row["created_at"],
-                "verify_url": f"https://rustchain.org/bcos/verify/{row['cert_id']}",
-                "badge_url": f"https://50.28.86.131/bcos/badge/{row['cert_id']}.svg",
+                "verify_url": _bcos_public_url(f"/bcos/verify/{row['cert_id']}"),
+                "badge_url": _bcos_public_url(f"/bcos/badge/{row['cert_id']}.svg"),
             })
 
         return jsonify({

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -117,3 +117,40 @@ def test_bcos_attest_stores_numeric_trust_score(bcos_client):
     verify_response = bcos_client.get("/bcos/verify/cert-good-score")
     assert verify_response.status_code == 200
     assert verify_response.get_json()["trust_score"] == 81
+
+
+def test_bcos_public_urls_default_to_certificate_valid_host(bcos_client):
+    verify_response = bcos_client.get("/bcos/verify/cert-1")
+    assert verify_response.status_code == 200
+    verify_body = verify_response.get_json()
+    assert verify_body["badge_url"] == "https://rustchain.org/bcos/badge/cert-1.svg"
+    assert verify_body["pdf_url"] == "https://rustchain.org/bcos/cert/cert-1.pdf"
+
+    directory_response = bcos_client.get("/bcos/directory")
+    assert directory_response.status_code == 200
+    cert = directory_response.get_json()["certificates"][0]
+    assert cert["verify_url"] == "https://rustchain.org/bcos/verify/cert-1"
+    assert cert["badge_url"] == "https://rustchain.org/bcos/badge/cert-1.svg"
+
+
+def test_bcos_attest_uses_configured_public_url(monkeypatch, bcos_client):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    monkeypatch.setenv("RUSTCHAIN_BCOS_PUBLIC_BASE_URL", "https://bcos.example/")
+
+    response = bcos_client.post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json={
+            "cert_id": "cert-custom-host",
+            "commitment": "commitment",
+            "repo": "Scottcjn/Rustchain",
+            "commit_sha": "abcdef1234567890",
+            "tier": "L1",
+            "trust_score": 82,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["verify_url"] == "https://bcos.example/bcos/verify/cert-custom-host"
+    assert body["badge_url"] == "https://bcos.example/bcos/badge/cert-custom-host.svg"


### PR DESCRIPTION
## Summary
- centralize BCOS public response URLs behind a certificate-valid public base helper
- default BCOS verify, badge, and PDF links to `https://rustchain.org` instead of the bare IP host
- support `RUSTCHAIN_BCOS_PUBLIC_BASE_URL` / `RUSTCHAIN_PUBLIC_BASE_URL` overrides for deployments using a different public host
- add route-level regression coverage for attest, verify, and directory responses

Closes #4462

## Validation
- `python -m pytest tests\test_bcos_routes_query_validation.py -q` -> 13 passed
- `python -m py_compile node\bcos_routes.py tests\test_bcos_routes_query_validation.py` -> passed
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK