### PR TITLE
docs: fix RTC balance endpoint examples

### DIFF
--- a/rtc-balance-extension/README.md
+++ b/rtc-balance-extension/README.md
@@ -42,9 +42,9 @@ A lightweight browser extension that displays RTC (RustChain Token) balance for 
 
 The extension supports various endpoint formats:
 
-- `https://api.rustchain.io/balance` - Wallet ID appended automatically
-- `https://api.rustchain.io/balance/{walletId}` - Include wallet ID in URL
-- `https://api.rustchain.io/balance?address={walletId}` - Query parameter format
+- `https://rustchain.org/wallet/balance` - Wallet ID appended automatically as a query parameter
+- `https://rustchain.org/wallet/balance?miner_id={walletId}` - Miner ID query parameter format
+- `https://rustchain.org/wallet/balance?address={walletId}` - Address query parameter format
 
 The extension will automatically adapt to your endpoint format.
 


### PR DESCRIPTION
## Summary
- replace the non-resolving `api.rustchain.io` balance endpoint examples with the live `rustchain.org/wallet/balance` endpoint formats
- keep the README scoped to the browser extension configuration guidance

## Bounty
- Scottcjn/rustchain-bounties#9018
- Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation
- `https://api.rustchain.io/balance` -> DNS resolution failure
- `https://rustchain.org/wallet/balance?miner_id=RTC253255d034065a839cd421811ec589ae5b694ffc` -> HTTP 200
- `https://rustchain.org/wallet/balance?address=RTC253255d034065a839cd421811ec589ae5b694ffc` -> HTTP 200
- `git diff --check -- rtc-balance-extension/README.md` -> passed
