### PR TITLE
security: prevent double-apply race in pending confirmations

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7088,6 +7088,10 @@ def confirm_pending():
     conn = sqlite3.connect(DB_PATH)
     try:
         c = conn.cursor()
+        # Serialize the read-check-update confirmation loop. Without taking a
+        # write lock before selecting ready rows, two workers can both read the
+        # same pending transfer, then each debit/credit and ledger-log it.
+        c.execute("BEGIN IMMEDIATE")
         
         # Get all pending transfers ready for confirmation
         ready = c.execute("""

--- a/node/tests/audit_pending_confirm_race.py
+++ b/node/tests/audit_pending_confirm_race.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+
+ADMIN_KEY = "a" * 32
+SERVER_PATH = Path(__file__).resolve().parents[1] / "rustchain_v2_integrated_v2.2.1_rip200.py"
+_SERVER_MODULE = None
+_IMPORT_DB_PATH = str(Path(tempfile.mkdtemp(prefix="rustchain-pending-import-")) / "import.db")
+
+
+def load_server(db_path: str):
+    global _SERVER_MODULE
+
+    os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+    os.environ["RUSTCHAIN_DB_PATH"] = db_path
+    os.environ["DB_PATH"] = db_path
+
+    server_dir = str(SERVER_PATH.parent)
+    if server_dir not in sys.path:
+        sys.path.insert(0, server_dir)
+
+    if _SERVER_MODULE is None:
+        os.environ["RUSTCHAIN_DB_PATH"] = _IMPORT_DB_PATH
+        os.environ["DB_PATH"] = _IMPORT_DB_PATH
+        spec = importlib.util.spec_from_file_location("rustchain_pending_confirm_audit", SERVER_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        _SERVER_MODULE = mod
+
+    _SERVER_MODULE.DB_PATH = db_path
+    _SERVER_MODULE.app.config["DB_PATH"] = db_path
+    os.environ["RUSTCHAIN_DB_PATH"] = db_path
+    os.environ["DB_PATH"] = db_path
+    return _SERVER_MODULE
+
+
+def seed_db(db_path: str):
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS balances (
+                miner_id TEXT PRIMARY KEY,
+                amount_i64 INTEGER NOT NULL DEFAULT 0,
+                balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS pending_ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER NOT NULL,
+                epoch INTEGER NOT NULL,
+                from_miner TEXT NOT NULL,
+                to_miner TEXT NOT NULL,
+                amount_i64 INTEGER NOT NULL,
+                reason TEXT,
+                status TEXT DEFAULT 'pending',
+                created_at INTEGER NOT NULL,
+                confirms_at INTEGER NOT NULL,
+                tx_hash TEXT,
+                voided_by TEXT,
+                voided_reason TEXT,
+                confirmed_at INTEGER
+            );
+            CREATE TABLE IF NOT EXISTS ledger (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                ts INTEGER,
+                epoch INTEGER,
+                miner_id TEXT,
+                delta_i64 INTEGER,
+                reason TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, ?, ?)",
+            ("alice", 1_000_000, 1.0),
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, ?, ?)",
+            ("bob", 0, 0.0),
+        )
+        now = int(time.time())
+        conn.execute(
+            """
+            INSERT INTO pending_ledger
+            (ts, epoch, from_miner, to_miner, amount_i64, reason, status, created_at, confirms_at, tx_hash)
+            VALUES (?, 1, 'alice', 'bob', 400000, 'race-test', 'pending', ?, ?, 'racehash')
+            """,
+            (now, now, now - 1),
+        )
+
+
+class ReadySelectCursor:
+    def __init__(self, cursor, barrier):
+        self._cursor = cursor
+        self._barrier = barrier
+        self._ready_select = False
+
+    def execute(self, sql, params=()):
+        normalized = " ".join(sql.split())
+        self._ready_select = (
+            normalized.startswith("SELECT id, from_miner, to_miner, amount_i64, reason, epoch, tx_hash")
+            and "FROM pending_ledger" in normalized
+            and "status = 'pending'" in normalized
+        )
+        self._cursor.execute(sql, params)
+        return self
+
+    def fetchall(self):
+        rows = self._cursor.fetchall()
+        if self._ready_select:
+            try:
+                self._barrier.wait(timeout=2)
+            except threading.BrokenBarrierError:
+                # After the fix, BEGIN IMMEDIATE serializes the second worker
+                # before it reaches this SELECT. Continue so the first request
+                # can commit and the second can observe no pending rows.
+                pass
+        return rows
+
+    def fetchone(self):
+        return self._cursor.fetchone()
+
+    @property
+    def lastrowid(self):
+        return self._cursor.lastrowid
+
+
+class ReadySelectConnection:
+    def __init__(self, conn, barrier):
+        self._conn = conn
+        self._barrier = barrier
+
+    def cursor(self):
+        return ReadySelectCursor(self._conn.cursor(), self._barrier)
+
+    def commit(self):
+        return self._conn.commit()
+
+    def close(self):
+        return self._conn.close()
+
+    def rollback(self):
+        return self._conn.rollback()
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+
+def test_pending_confirm_concurrent_requests_do_not_double_apply(monkeypatch, tmp_path):
+    db_path = str(tmp_path / "race.db")
+    seed_db(db_path)
+    mod = load_server(db_path)
+    barrier = threading.Barrier(2)
+    real_connect = sqlite3.connect
+
+    def connect_with_barrier(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        if args and args[0] == db_path:
+            return ReadySelectConnection(conn, barrier)
+        return conn
+
+    monkeypatch.setattr(mod.sqlite3, "connect", connect_with_barrier)
+
+    responses = []
+
+    def call_confirm():
+        with mod.app.test_client() as client:
+            resp = client.post("/pending/confirm", headers={"X-Admin-Key": ADMIN_KEY})
+            responses.append(resp.get_json())
+
+    t1 = threading.Thread(target=call_confirm)
+    t2 = threading.Thread(target=call_confirm)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    with real_connect(db_path) as conn:
+        balances = dict(conn.execute("SELECT miner_id, amount_i64 FROM balances"))
+        ledger_rows = conn.execute(
+            "SELECT miner_id, delta_i64, reason FROM ledger ORDER BY id"
+        ).fetchall()
+        status = conn.execute(
+            "SELECT status FROM pending_ledger WHERE tx_hash='racehash'"
+        ).fetchone()[0]
+
+    print("responses=", responses)
+    print("balances=", balances)
+    print("ledger_rows=", ledger_rows)
+    print("status=", status)
+
+    assert status == "confirmed"
+    assert balances["alice"] == 600_000
+    assert balances["bob"] == 400_000
+    assert len(ledger_rows) == 2
+
+
+def test_pending_confirm_single_request_still_confirms_once(tmp_path):
+    db_path = str(tmp_path / "single.db")
+    seed_db(db_path)
+    mod = load_server(db_path)
+
+    with mod.app.test_client() as client:
+        resp = client.post("/pending/confirm", headers={"X-Admin-Key": ADMIN_KEY})
+        assert resp.status_code == 200
+        assert resp.get_json()["confirmed_count"] == 1
+
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute("SELECT miner_id, amount_i64 FROM balances"))
+        ledger_count = conn.execute("SELECT COUNT(*) FROM ledger").fetchone()[0]
+        status = conn.execute(
+            "SELECT status FROM pending_ledger WHERE tx_hash='racehash'"
+        ).fetchone()[0]
+
+    assert status == "confirmed"
+    assert balances["alice"] == 600_000
+    assert balances["bob"] == 400_000
+    assert ledger_count == 2

--- a/node/tests/audit_pending_confirm_race.py
+++ b/node/tests/audit_pending_confirm_race.py
@@ -174,7 +174,7 @@ def test_pending_confirm_concurrent_requests_do_not_double_apply(monkeypatch, tm
     def call_confirm():
         with mod.app.test_client() as client:
             resp = client.post("/pending/confirm", headers={"X-Admin-Key": ADMIN_KEY})
-            responses.append(resp.get_json())
+            responses.append((resp.status_code, resp.get_json()))
 
     t1 = threading.Thread(target=call_confirm)
     t2 = threading.Thread(target=call_confirm)
@@ -192,11 +192,16 @@ def test_pending_confirm_concurrent_requests_do_not_double_apply(monkeypatch, tm
             "SELECT status FROM pending_ledger WHERE tx_hash='racehash'"
         ).fetchone()[0]
 
+    status_codes = [status_code for status_code, _ in responses]
+    confirmed_counts = sorted(payload["confirmed_count"] for _, payload in responses)
+
     print("responses=", responses)
     print("balances=", balances)
     print("ledger_rows=", ledger_rows)
     print("status=", status)
 
+    assert status_codes == [200, 200]
+    assert confirmed_counts == [0, 1]
     assert status == "confirmed"
     assert balances["alice"] == 600_000
     assert balances["bob"] == 400_000


### PR DESCRIPTION
## Summary

Adds a regression test and fix for a pending-ledger confirmation race where two concurrent `/pending/confirm` workers can both process the same ready `pending_ledger` row.

## Impact

Two concurrent confirmation requests can both read the same `status='pending'` transfer before either request marks it confirmed. Each worker then debits the sender, credits the recipient, inserts both ledger rows, and returns `confirmed_count=1` for the same `pending_id`.

Local reproduction before the fix:

- One pending transfer: `alice -> bob` for `400000` microRTC.
- Two concurrent `/pending/confirm` calls.
- Both responses report `confirmed_ids: [1]`.
- Final balances become `alice=200000`, `bob=800000` instead of `alice=600000`, `bob=400000`.
- Ledger contains four rows instead of two.

This is a significant ledger integrity issue in the 2-phase pending transfer system. It is local-only reproduced; no production exploitation was performed.

## Root cause

`confirm_pending()` selected ready rows before acquiring a SQLite write lock. The loop used a read-check-update sequence and only changed `pending_ledger.status` after balance updates and ledger inserts, so another worker could read and process the same pending row concurrently.

## Fix

Acquire `BEGIN IMMEDIATE` before selecting ready pending transfers. This serializes confirmation workers at the database write boundary. A second concurrent worker waits until the first commits, then observes no ready pending row and returns `confirmed_count=0`.

## Tests

```bash
PYTHONPATH=node .venv/bin/python -m pytest node/tests/audit_pending_confirm_race.py node/test_utxo_db.py node/test_utxo_endpoints.py node/test_rollback_atomicity.py node/test_utxo_genesis_migration_units.py -q
```

Result:

```text
83 passed in 14.71s
```

Additional checks:

```bash
.venv/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/audit_pending_confirm_race.py
```

## Bounty / Disclosure

Related to the ongoing bug bounty `Scottcjn/rustchain-bounties#71` and the pending transfer exploit class from `Scottcjn/rustchain-bounties#59`.

- Severity: High, significant ledger logic error affecting pending transfer confirmation integrity.
- Wallet ID: `RTCc068d2850639325b847e09fc6b8c01b0b88d7be8`
- Local-only reproduction.
- No production exploitation.
- No funds moved.
- No private data accessed.
