### PR TITLE
security: require quorum for P2P epoch state sync

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1052,7 +1052,10 @@ class GossipLayer:
                 except Exception as e:
                     logger.warning(f"State from {sender}: attestation merge failed: {e}")
 
-        # Phase D.2: Validate + merge epochs (GSet is additive-only; schema check only)
+        # Phase D.2: Validate + merge epochs. A signed STATE message proves
+        # which peer sent the state, but it is not quorum evidence by itself.
+        # Only accept a remote settled epoch if this node already has persisted
+        # accept votes reaching quorum for that epoch/proposal hash.
         if "epochs" in state:
             raw = state["epochs"]
             if not isinstance(raw, dict):
@@ -1060,7 +1063,27 @@ class GossipLayer:
             else:
                 try:
                     remote_epochs = GSet.from_dict(raw)
-                    self.epoch_crdt.merge(remote_epochs)
+                    total_nodes = len(self.peers) + 1
+                    quorum = max(3, (total_nodes // 2) + 1)
+                    verified_epochs = GSet()
+                    for epoch in remote_epochs.items:
+                        meta = remote_epochs.metadata.get(epoch) or remote_epochs.metadata.get(str(epoch)) or {}
+                        proposal_hash = meta.get("proposal_hash") if isinstance(meta, dict) else None
+                        if not proposal_hash:
+                            logger.warning(
+                                f"State from {sender}: rejecting epoch {epoch} without proposal_hash"
+                            )
+                            continue
+                        votes = self._epoch_votes.get((epoch, proposal_hash), {})
+                        accept_count = sum(1 for v in votes.values() if v == "accept")
+                        if accept_count < quorum:
+                            logger.warning(
+                                f"State from {sender}: rejecting epoch {epoch} without local quorum "
+                                f"for proposal {proposal_hash[:12]} ({accept_count}/{quorum})"
+                            )
+                            continue
+                        verified_epochs.add(epoch, meta)
+                    self.epoch_crdt.merge(verified_epochs)
                 except Exception as e:
                     logger.warning(f"State from {sender}: epochs merge failed: {e}")
 

--- a/node/tests/test_p2p_hardening_phase2.py
+++ b/node/tests/test_p2p_hardening_phase2.py
@@ -180,6 +180,69 @@ def test_epoch_votes_survive_restart_and_reject_retransmit():
     assert restarted._epoch_votes[key] == {"node2": "accept"}
 
 
+def test_phase_d_state_sync_cannot_settle_epoch_without_local_quorum():
+    """Phase D: one signed peer STATE cannot bypass epoch vote quorum."""
+    target = _mk_layer("node1", {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"})
+    peer = _mk_layer("node2", db_path=target.db_path)
+    peer.broadcast = lambda *args, **kwargs: None
+
+    forged_epoch = 424242
+    proposal_hash = "forged-proposal"
+    state_msg = peer.create_message(
+        mod.MessageType.STATE,
+        {
+            "state": {
+                "epochs": {
+                    "epochs": [forged_epoch],
+                    "metadata": {
+                        str(forged_epoch): {
+                            "proposal_hash": proposal_hash,
+                            "finalized": True,
+                        }
+                    },
+                }
+            }
+        },
+    )
+
+    assert target.handle_message(state_msg)["status"] == "ok"
+    assert not target.epoch_crdt.contains(forged_epoch)
+
+
+def test_phase_d_state_sync_accepts_epoch_with_local_quorum_votes():
+    """Phase D: state sync may restore epochs only when local quorum evidence exists."""
+    target = _mk_layer("node1", {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"})
+    peer = _mk_layer("node2", db_path=target.db_path)
+    peer.broadcast = lambda *args, **kwargs: None
+
+    epoch = 15
+    proposal_hash = "locally-quorum-backed"
+    target._epoch_votes[(epoch, proposal_hash)] = {
+        "node1": "accept",
+        "node2": "accept",
+        "node3": "accept",
+    }
+    state_msg = peer.create_message(
+        mod.MessageType.STATE,
+        {
+            "state": {
+                "epochs": {
+                    "epochs": [epoch],
+                    "metadata": {
+                        str(epoch): {
+                            "proposal_hash": proposal_hash,
+                            "finalized": True,
+                        }
+                    },
+                }
+            }
+        },
+    )
+
+    assert target.handle_message(state_msg)["status"] == "ok"
+    assert target.epoch_crdt.contains(epoch)
+
+
 # Phase E regression
 def test_phase_e_future_timestamp_attestation_rejected():
     """Phase E: attestations with ts_ok far in the future are rejected."""


### PR DESCRIPTION
## Summary

Prevents a signed P2P `STATE` response from marking remote epochs as settled unless this node already has local quorum evidence for that `(epoch, proposal_hash)`.

## Impact

Before this patch, `_handle_state()` treated a signed peer state blob as sufficient authority to merge the remote `epochs` GSet. A single authenticated peer could send a valid `MessageType.STATE` containing an arbitrary settled epoch and the receiver would add it to `epoch_crdt` without going through `_handle_epoch_vote()` quorum.

This is a cross-node consensus state poisoning issue: the signature proves who sent the state, but it is not quorum proof.

## Root Cause

`GossipLayer._handle_state()` validated the message signature and basic schema, then directly merged `GSet.from_dict(raw)` into `self.epoch_crdt`. Unlike vote handling, this path did not check whether the receiver had enough local accept votes for the proposal hash.

## Fix

Remote epoch state sync now filters every epoch from the incoming GSet:

- requires a `proposal_hash` in metadata
- checks local persisted votes for `(epoch, proposal_hash)`
- requires the same quorum threshold used by epoch voting
- skips and logs remote epochs that do not have local quorum evidence

The patch still allows state sync to restore an epoch when local quorum votes already exist.

## Tests

```bash
PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_p2p_hardening_phase2.py -q
# 10 passed

PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_p2p_hardening_phase2.py node/tests/test_p2p_endpoint_auth.py node/tests/test_epoch_proposal_merkle_validation.py -q
# 21 passed

.venv/bin/python -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_hardening_phase2.py

git diff --check origin/main...HEAD -- node/rustchain_p2p_gossip.py node/tests/test_p2p_hardening_phase2.py

.venv/bin/python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```

Note: `node/tests/test_p2p_phase_f_ed25519.py` has an existing baseline mismatch with `p2p_identity.unpack_signature()` returning three values and packed signatures including `v`; this PR does not touch that path.

## Bounty / Disclosure

Related to the Cross-Node Consensus red-team bounty (#58) and the ongoing bug bounty (#71). Reproduction was local only. No production infrastructure was accessed and no funds were moved.
