### PR TITLE
fix: use constant-time Sophia governor admin auth

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -16,6 +16,7 @@ events that deserve a larger mind.
 
 from __future__ import annotations
 
+import hmac
 import json
 import logging
 import os
@@ -938,7 +939,7 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
         if not required:
             return False
         provided = (req.headers.get("X-Admin-Key") or req.headers.get("X-API-Key") or "").strip()
-        return bool(provided and provided == required)
+        return bool(provided and hmac.compare_digest(provided, required))
 
     @app.route("/sophia/governor/status", methods=["GET"])
     def sophia_governor_status():

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -1,6 +1,8 @@
+import gc
 import os
 import sqlite3
 import tempfile
+import time
 import types
 
 import pytest
@@ -10,6 +12,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+import sophia_governor
 from sophia_governor import (
     ROUTE_IMMEDIATE_PHONE_HOME,
     ROUTE_LOCAL_ONLY,
@@ -37,7 +40,13 @@ def tmp_db():
         db_path = handle.name
     init_sophia_governor_schema(db_path)
     yield db_path
-    os.unlink(db_path)
+    for _ in range(5):
+        try:
+            os.unlink(db_path)
+            break
+        except PermissionError:
+            gc.collect()
+            time.sleep(0.05)
 
 
 @pytest.fixture
@@ -175,6 +184,43 @@ def test_governor_endpoints_require_admin_for_manual_review(client):
         },
     )
     assert response.status_code == 401
+
+
+def test_governor_admin_auth_uses_constant_time_compare(client, monkeypatch):
+    """Admin-gated governor endpoints compare configured keys with hmac.compare_digest."""
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(sophia_governor.hmac, "compare_digest", spy_compare_digest)
+
+    denied = client.post(
+        "/sophia/governor/review",
+        headers={"X-Admin-Key": "wrong-admin"},
+        json={
+            "event_type": "pending_transfer",
+            "payload": {"amount_rtc": 50},
+        },
+    )
+    assert denied.status_code == 401
+
+    accepted = client.post(
+        "/sophia/governor/review",
+        headers={"X-API-Key": "test-admin"},
+        json={
+            "event_type": "pending_transfer",
+            "source": "pytest.manual",
+            "payload": {"amount_rtc": 50},
+        },
+    )
+    assert accepted.status_code == 200
+
+    assert calls == [
+        ("wrong-admin", "test-admin"),
+        ("test-admin", "test-admin"),
+    ]
 
 
 def test_governor_endpoints_report_status_and_recent(client):


### PR DESCRIPTION
Fixes #4656. Reporter credit remains with @RJamieKelly. This patch replaces direct Sophia governor admin key equality with hmac.compare_digest, preserves existing X-Admin-Key/X-API-Key behavior, and adds regression coverage for both denied and accepted admin requests. Validation: python -m pytest node\tests\test_sophia_governor.py -q; python tools\bcos_spdx_check.py --base-ref origin/main; git diff --check.