### PR TITLE
fix: preserve non-json server proxy responses

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -4,14 +4,34 @@ RustChain Server Proxy - Port 8089
 Allows G4 to connect via different port
 """
 
-from flask import Flask, request, jsonify
+from flask import Flask, Response, request, jsonify
 import requests
-import json
 
 app = Flask(__name__)
 
 # Local server on same machine
 LOCAL_SERVER = "http://localhost:8088"
+
+
+def _forward_upstream_response(response):
+    """Return upstream responses without crashing on non-JSON bodies."""
+    content_type = response.headers.get('Content-Type', '')
+    if 'application/json' in content_type.lower():
+        try:
+            return jsonify(response.json()), response.status_code
+        except ValueError:
+            return Response(
+                response.text,
+                status=response.status_code,
+                content_type='text/plain; charset=utf-8',
+            )
+
+    return Response(
+        response.text,
+        status=response.status_code,
+        content_type=content_type or 'text/plain; charset=utf-8',
+    )
+
 
 @app.route('/api/<path:path>', methods=['GET', 'POST'])
 def proxy(path):
@@ -32,23 +52,15 @@ def proxy(path):
             # Forward GET requests
             response = requests.get(url, timeout=10)
 
-        # Return the response from local server
-        # Safely handle non-JSON responses from upstream
-        content_type = response.headers.get('Content-Type', '')
-        if 'application/json' in content_type:
-            try:
-                return response.json(), response.status_code
-            except (ValueError, Exception):
-                # JSON parse failed, fall back to text
-                return response.text, response.status_code
-        else:
-            # Non-JSON response (e.g., HTML error page), return as-is with text
-            return response.text, response.status_code
+        return _forward_upstream_response(response)
 
     except requests.exceptions.Timeout:
         return jsonify({'error': 'Local server timeout'}), 504
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except requests.exceptions.RequestException:
+        return jsonify({'error': 'Local server request failed'}), 502
+    except Exception:
+        app.logger.exception("Proxy request failed")
+        return jsonify({'error': 'Proxy request failed'}), 500
 
 @app.route('/status')
 def status():

--- a/node/tests/test_server_proxy.py
+++ b/node/tests/test_server_proxy.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import server_proxy
+
+
+class DummyResponse:
+    def __init__(self, text, status_code=200, content_type="text/plain"):
+        self.text = text
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type} if content_type is not None else {}
+
+    def json(self):
+        raise ValueError("not json")
+
+
+class JsonResponse(DummyResponse):
+    def __init__(self, payload, status_code=200):
+        super().__init__("", status_code, "application/json")
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+def test_proxy_preserves_non_json_upstream_response(monkeypatch):
+    upstream = DummyResponse("<h1>upstream failed</h1>", status_code=502, content_type="text/html")
+    monkeypatch.setattr(server_proxy.requests, "get", lambda *args, **kwargs: upstream)
+
+    server_proxy.app.config["TESTING"] = True
+    response = server_proxy.app.test_client().get("/api/stats")
+
+    assert response.status_code == 502
+    assert response.get_data(as_text=True) == "<h1>upstream failed</h1>"
+    assert response.content_type == "text/html"
+
+
+def test_proxy_json_response_still_uses_json_body(monkeypatch):
+    upstream = JsonResponse({"ok": True}, status_code=201)
+    monkeypatch.setattr(server_proxy.requests, "get", lambda *args, **kwargs: upstream)
+
+    server_proxy.app.config["TESTING"] = True
+    response = server_proxy.app.test_client().get("/api/stats")
+
+    assert response.status_code == 201
+    assert response.get_json() == {"ok": True}
+
+
+def test_proxy_request_exception_does_not_leak_internal_details(monkeypatch):
+    def fail(*args, **kwargs):
+        raise server_proxy.requests.exceptions.ConnectionError("secret upstream path")
+
+    monkeypatch.setattr(server_proxy.requests, "get", fail)
+
+    server_proxy.app.config["TESTING"] = True
+    response = server_proxy.app.test_client().get("/api/stats")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Local server request failed"}
+    assert "secret upstream path" not in response.get_data(as_text=True)


### PR DESCRIPTION
Fixes #1996. This hardens node/server_proxy.py so upstream non-JSON responses are returned without Flask reinterpreting them, preserves the upstream Content-Type for non-JSON bodies, and replaces raw request exception text with a generic proxy error so internal upstream details are not leaked. Validation: python -m pytest node\tests\test_server_proxy.py -q; python -m py_compile node\server_proxy.py node\tests\test_server_proxy.py; python tools\bcos_spdx_check.py --base-ref origin/main; git diff --check.