### PR TITLE
fix: require admin auth for machine passport event writes

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,21 @@ def get_optional_json_object():
     return data, None
 
 
+def require_admin_key():
+    """Require the configured admin key for machine passport write events."""
+    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
+    expected_admin_key = os.environ.get('ADMIN_KEY', '')
+
+    if not expected_admin_key or not hmac.compare_digest(admin_key, expected_admin_key):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -340,6 +355,10 @@ def add_repair_entry(machine_id: str):
         "notes": "Machine now stable at 1.2V"
     }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -382,6 +401,10 @@ def add_attestation(machine_id: str):
     
     Typically called automatically during mining attestation.
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -428,6 +451,10 @@ def add_benchmark(machine_id: str):
         "entropy_throughput": 500.0
     }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -473,6 +500,10 @@ def add_lineage_note(machine_id: str):
         "tx_hash": "0x..."  # Optional blockchain transaction
     }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -576,6 +576,62 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
         compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
+
+    def test_lineage_rejects_owner_tampering_without_admin_key(self):
+        """Lineage writes cannot transfer passport ownership without admin auth."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Lineage Auth Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'lineage_auth_test',
+            },
+        )
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        with patch('hmac.compare_digest', return_value=False) as compare_digest:
+            resp = self.client.post(
+                '/api/machine-passport/lineage_auth_test/lineage',
+                headers={'X-Admin-Key': 'wrong-admin-key'},
+                json={
+                    'event_type': 'transfer',
+                    'to_owner': 'attacker_miner',
+                },
+            )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+
+        get_resp = self.client.get('/api/machine-passport/lineage_auth_test')
+        passport = json.loads(get_resp.data)['passport']['passport']
+        self.assertEqual(passport['owner_miner_id'], 'miner_owner')
+
+    def test_event_writes_fail_closed_when_admin_key_unset(self):
+        """Subresource event writes require an explicitly configured admin key."""
+        self.client.post(
+            '/api/machine-passport',
+            json={
+                'name': 'Fail Closed Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'fail_closed_test',
+            },
+        )
+
+        resp = self.client.post(
+            '/api/machine-passport/fail_closed_test/repair-log',
+            json={
+                'repair_type': 'capacitor_replacement',
+                'description': 'recapped PSU',
+            },
+        )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -13,11 +13,17 @@ import machine_passport_api
 
 class LedgerStub:
     def __init__(self):
+        self.repair_payload = None
         self.attestation_payload = None
         self.benchmark_payload = None
+        self.lineage_payload = None
 
     def get_passport(self, machine_id):
         return True
+
+    def add_repair_entry(self, **kwargs):
+        self.repair_payload = kwargs
+        return True, "repair added"
 
     def add_attestation(self, **kwargs):
         self.attestation_payload = kwargs
@@ -27,11 +33,16 @@ class LedgerStub:
         self.benchmark_payload = kwargs
         return True, "benchmark added"
 
+    def add_lineage_note(self, **kwargs):
+        self.lineage_payload = kwargs
+        return True, "lineage added"
+
 
 @pytest.fixture
 def ledger(monkeypatch):
     stub = LedgerStub()
     monkeypatch.setattr(machine_passport_api, "_ledger", stub)
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
     return stub
 
 
@@ -50,7 +61,11 @@ def client(ledger):
     ),
 )
 def test_event_routes_reject_non_object_json(client, path):
-    response = client.post(path, json=["not", "object"])
+    response = client.post(
+        path,
+        headers={"X-Admin-Key": "expected-admin-key"},
+        json=["not", "object"],
+    )
 
     assert response.status_code == 400
     assert response.get_json() == {
@@ -61,7 +76,10 @@ def test_event_routes_reject_non_object_json(client, path):
 
 
 def test_attestation_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/attestations")
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers={"X-Admin-Key": "expected-admin-key"},
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "attestation added"}
@@ -70,7 +88,10 @@ def test_attestation_route_preserves_empty_body_defaults(client, ledger):
 
 
 def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/benchmarks")
+    response = client.post(
+        "/api/machine-passport/machine-1/benchmarks",
+        headers={"X-Admin-Key": "expected-admin-key"},
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "benchmark added"}
@@ -81,9 +102,53 @@ def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
 def test_benchmark_route_accepts_object_json(client, ledger):
     response = client.post(
         "/api/machine-passport/machine-1/benchmarks",
+        headers={"X-Admin-Key": "expected-admin-key"},
         json={"compute_score": 1250.0, "memory_bandwidth": 3200.5},
     )
 
     assert response.status_code == 200
     assert ledger.benchmark_payload["compute_score"] == 1250.0
     assert ledger.benchmark_payload["memory_bandwidth"] == 3200.5
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    (
+        (
+            "/api/machine-passport/machine-1/repair-log",
+            {"repair_type": "capacitor_replacement", "description": "recapped PSU"},
+        ),
+        ("/api/machine-passport/machine-1/attestations", {}),
+        ("/api/machine-passport/machine-1/benchmarks", {}),
+        (
+            "/api/machine-passport/machine-1/lineage",
+            {"event_type": "transfer", "to_owner": "attacker_miner"},
+        ),
+    ),
+)
+def test_event_routes_reject_wrong_admin_key(client, ledger, path, payload):
+    response = client.post(path, headers={"X-Admin-Key": "wrong-key"}, json=payload)
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "message": "Admin key required",
+    }
+    assert ledger.repair_payload is None
+    assert ledger.attestation_payload is None
+    assert ledger.benchmark_payload is None
+    assert ledger.lineage_payload is None
+
+
+def test_event_routes_fail_closed_when_admin_key_unset(client, monkeypatch):
+    monkeypatch.delenv("ADMIN_KEY", raising=False)
+
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers={"X-Admin-Key": "anything"},
+        json={},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"


### PR DESCRIPTION
## Summary
- require a configured admin key for machine passport repair-log, attestation, benchmark, and lineage event writes
- fail closed when `ADMIN_KEY` is unset on those persistent event-write endpoints
- add regressions for wrong-key rejection, unset-key rejection, and lineage owner-tampering prevention

Fixes #4562

## Validation
- `PYTHONPATH=node uv run --no-project --with pytest --with flask python -m pytest tests/test_machine_passport_event_json_validation.py node/tests/test_machine_passport.py -q` -> 38 passed
- `python3 -m py_compile node/machine_passport_api.py tests/test_machine_passport_event_json_validation.py node/tests/test_machine_passport.py` -> passed
- `git diff --check origin/main...HEAD -- node/machine_passport_api.py tests/test_machine_passport_event_json_validation.py node/tests/test_machine_passport.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Bounty / Disclosure
Related security bounty issue: #4562.

Wallet: `RTCe11828a58518480960023f571842abadeeeb943d`
Contact: `doug.lance@gmail.com`

Local-only validation; no production probing performed.