### PR TITLE
security: bind epoch enroll weight to attested state

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2769,20 +2769,58 @@ def check_vm_signatures_server_side(device: dict, signals: dict) -> tuple:
 
 def check_enrollment_requirements(miner: str) -> tuple:
     """Check if miner meets enrollment requirements including fingerprint validation."""
+    attested_context = {
+        "attested_device_family": "x86",
+        "attested_device_arch": "default",
+        "attested_fingerprint": {"checks": {}},
+    }
     with sqlite3.connect(DB_PATH) as conn:
         if ENROLL_REQUIRE_TICKET:
-            # RIP-PoA: Also fetch fingerprint_passed status
-            row = conn.execute("SELECT ts_ok, fingerprint_passed FROM miner_attest_recent WHERE miner = ?", (miner,)).fetchone()
+            # RIP-PoA: Fetch the verified attestation snapshot used for enrollment weight.
+            columns = {
+                str(col[1])
+                for col in conn.execute("PRAGMA table_info(miner_attest_recent)").fetchall()
+            }
+            select_fields = [
+                "ts_ok",
+                "fingerprint_passed" if "fingerprint_passed" in columns else "1 AS fingerprint_passed",
+                "device_family" if "device_family" in columns else "'x86' AS device_family",
+                "device_arch" if "device_arch" in columns else "'default' AS device_arch",
+                "fingerprint_checks_json" if "fingerprint_checks_json" in columns else "'{}' AS fingerprint_checks_json",
+            ]
+            row = conn.execute(
+                f"SELECT {', '.join(select_fields)} FROM miner_attest_recent WHERE miner = ?",
+                (miner,),
+            ).fetchone()
             if not row:
                 return False, {"error": "no_recent_attestation", "ttl_s": ENROLL_TICKET_TTL_S}
             if (int(time.time()) - row[0]) > ENROLL_TICKET_TTL_S:
                 return False, {"error": "attestation_expired", "ttl_s": ENROLL_TICKET_TTL_S}
-            
+
+            fingerprint_checks = {}
+            if len(row) > 4 and row[4]:
+                try:
+                    parsed_checks = json.loads(row[4])
+                    if isinstance(parsed_checks, dict):
+                        fingerprint_checks = parsed_checks
+                except Exception:
+                    fingerprint_checks = {}
+            attested_context = {
+                "attested_device_family": row[2] if len(row) > 2 and row[2] else "x86",
+                "attested_device_arch": row[3] if len(row) > 3 and row[3] else "default",
+                "attested_fingerprint": {"checks": fingerprint_checks},
+            }
+
             # RIP-PoA Phase 2: Check fingerprint passed (returns status for weight calculation)
             fingerprint_passed = row[1] if len(row) > 1 else 1  # Default to passed for legacy
             if not fingerprint_passed:
                 # Don't reject - but flag for zero weight
-                return True, {"ok": True, "fingerprint_failed": True, "reason": "vm_or_emulator_detected"}
+                return True, {
+                    "ok": True,
+                    "fingerprint_failed": True,
+                    "reason": "vm_or_emulator_detected",
+                    **attested_context,
+                }
         if ENROLL_REQUIRE_MAC:
             row = conn.execute(
                 "SELECT COUNT(*) as c FROM miner_macs WHERE miner = ? AND last_ts >= ?",
@@ -2793,7 +2831,7 @@ def check_enrollment_requirements(miner: str) -> tuple:
                 return False, {"error": "mac_required", "hint": "Submit attestation with signals.macs"}
             if unique_count > MAC_MAX_UNIQUE_PER_DAY:
                 return False, {"error": "mac_churn", "unique_24h": unique_count, "limit": MAC_MAX_UNIQUE_PER_DAY}
-    return True, {"ok": True}
+    return True, {"ok": True, **attested_context}
 
 # RIP-0147a: VM-OUI Denylist (warn mode)
 # Process-local counters
@@ -3813,9 +3851,12 @@ def enroll_epoch():
         ENROLL_REJ[reason] = ENROLL_REJ.get(reason, 0) + 1
         return jsonify(check_result), 412
 
-    # Calculate weight based on hardware
-    family = device.get('family', 'x86')
-    arch = device.get('arch', 'default')
+    # Calculate weight from the last accepted attestation, not request fields.
+    # /epoch/enroll remains backward-compatible for legacy unsigned miners, but
+    # callers must not be able to upgrade reward weight by submitting a spoofed
+    # device or fingerprint only at enrollment time.
+    family = check_result.get('attested_device_family') or 'x86'
+    arch = check_result.get('attested_device_arch') or 'default'
     hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
 
     # RIP-PoA Phase 2: VM miners get minimal (but non-zero) weight
@@ -3826,7 +3867,7 @@ def enroll_epoch():
         rotation_eval = evaluate_rotating_fingerprint_checks(
             c,
             epoch,
-            data.get('fingerprint') if isinstance(data.get('fingerprint'), dict) else {},
+            check_result.get('attested_fingerprint') if isinstance(check_result.get('attested_fingerprint'), dict) else {},
         )
         if fingerprint_failed:
             weight_units = MIN_FAILED_FINGERPRINT_WEIGHT_UNITS

--- a/node/tests/test_enroll_signature_verification.py
+++ b/node/tests/test_enroll_signature_verification.py
@@ -15,6 +15,8 @@ import os
 import sqlite3
 import sys
 import tempfile
+import time
+import types
 import unittest
 from pathlib import Path
 
@@ -41,6 +43,64 @@ EXTRA_SCHEMA = [
 ]
 
 
+def _install_p2p_stub():
+    previous = sys.modules.get("rustchain_p2p_sync_secure")
+    stub = types.ModuleType("rustchain_p2p_sync_secure")
+
+    class DummyPeerManager:
+        def get_network_stats(self):
+            return {}
+
+        def add_peer(self, peer_url):
+            return True
+
+    class DummyBlockSync:
+        running = False
+
+        def start(self):
+            self.running = True
+
+        def get_blocks_for_sync(self, start_height, limit):
+            return []
+
+    def initialize_secure_p2p(*args, **kwargs):
+        def require_peer_auth(func):
+            return func
+
+        return DummyPeerManager(), DummyBlockSync(), require_peer_auth
+
+    stub.initialize_secure_p2p = initialize_secure_p2p
+    sys.modules["rustchain_p2p_sync_secure"] = stub
+    return previous
+
+
+def _release_integrated_module(mod):
+    block_sync = getattr(mod, "block_sync", None)
+    if block_sync is not None:
+        block_sync.running = False
+
+    try:
+        from prometheus_client import REGISTRY
+    except Exception:
+        return
+
+    for metric_name in (
+        "withdrawal_requests",
+        "withdrawal_completed",
+        "withdrawal_failed",
+        "balance_gauge",
+        "epoch_gauge",
+        "withdrawal_queue_size",
+    ):
+        metric = getattr(mod, metric_name, None)
+        if metric is None:
+            continue
+        try:
+            REGISTRY.unregister(metric)
+        except (KeyError, ValueError):
+            pass
+
+
 def _sign_message(miner_id: str, wallet: str, nonce: str, commitment: str):
     """Sign an attestation message using Ed25519, return (signature_hex, public_key_hex)."""
     signing_key = nacl.signing.SigningKey.generate()
@@ -63,9 +123,11 @@ def _sign_enrollment(miner_pk: str, miner_id: str, epoch: int, signing_key):
 class TestEnrollSignatureVerification(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._tmp = tempfile.TemporaryDirectory()
+        cls._tmp_dir = tempfile.mkdtemp(prefix="rustchain-enroll-sig-")
         cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
         cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_p2p_module = _install_p2p_stub()
+        cls._loaded_modules = []
         os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
 
         if NODE_DIR not in sys.path:
@@ -81,18 +143,44 @@ class TestEnrollSignatureVerification(unittest.TestCase):
             os.environ.pop("RUSTCHAIN_DB_PATH", None)
         else:
             os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
-        cls._tmp.cleanup()
+        cls._release_loaded_modules()
+        if cls._prev_p2p_module is None:
+            sys.modules.pop("rustchain_p2p_sync_secure", None)
+        else:
+            sys.modules["rustchain_p2p_sync_secure"] = cls._prev_p2p_module
+
+    @classmethod
+    def _release_loaded_modules(cls):
+        for mod in cls._loaded_modules:
+            _release_integrated_module(mod)
+        cls._loaded_modules = []
+
+    def tearDown(self):
+        self._release_loaded_modules()
 
     def _db_path(self, name: str) -> str:
-        return str(Path(self._tmp.name) / name)
+        return str(Path(self._tmp_dir) / name)
 
     def _load_module(self, module_name: str, db_name: str):
+        self._release_loaded_modules()
         db_path = self._db_path(db_name)
         os.environ["RUSTCHAIN_DB_PATH"] = db_path
         spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        mod.init_db()
+        self._loaded_modules.append(mod)
+        # These tests target /epoch/enroll signature behavior, not the replay
+        # defense package. Disabling that optional init avoids cross-import
+        # SQLite locks from its module-level schema setup in integrated tests.
+        mod.HAVE_REPLAY_DEFENSE = False
+        for attempt in range(5):
+            try:
+                mod.init_db()
+                break
+            except sqlite3.OperationalError as exc:
+                if "locked" not in str(exc).lower() or attempt == 4:
+                    raise
+                time.sleep(0.2)
         with sqlite3.connect(db_path) as conn:
             for stmt in EXTRA_SCHEMA:
                 conn.execute(stmt)

--- a/node/tests/test_epoch_enroll_attested_weight.py
+++ b/node/tests/test_epoch_enroll_attested_weight.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestEpochEnrollAttestedWeight(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls.db_path = os.path.join(cls._tmp.name, "enroll_attested_weight.db")
+        os.environ["RUSTCHAIN_DB_PATH"] = cls.db_path
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_epoch_enroll_attested_weight_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executescript(
+                """
+                DROP TABLE IF EXISTS miner_attest_recent;
+                DROP TABLE IF EXISTS miner_macs;
+                DROP TABLE IF EXISTS epoch_enroll;
+                DROP TABLE IF EXISTS balances;
+                DROP TABLE IF EXISTS miner_header_keys;
+                DROP TABLE IF EXISTS epoch_fingerprint_rotation;
+
+                CREATE TABLE miner_attest_recent (
+                    miner TEXT PRIMARY KEY,
+                    ts_ok INTEGER NOT NULL,
+                    device_family TEXT,
+                    device_arch TEXT,
+                    entropy_score REAL DEFAULT 0,
+                    fingerprint_passed INTEGER DEFAULT 0,
+                    source_ip TEXT,
+                    fingerprint_checks_json TEXT
+                );
+                CREATE TABLE miner_macs (
+                    miner TEXT NOT NULL,
+                    mac_hash TEXT NOT NULL,
+                    first_ts INTEGER NOT NULL,
+                    last_ts INTEGER NOT NULL,
+                    count INTEGER NOT NULL DEFAULT 1,
+                    PRIMARY KEY (miner, mac_hash)
+                );
+                CREATE TABLE epoch_enroll (
+                    epoch INTEGER,
+                    miner_pk TEXT,
+                    weight INTEGER,
+                    PRIMARY KEY (epoch, miner_pk)
+                );
+                CREATE TABLE balances (
+                    miner_pk TEXT PRIMARY KEY,
+                    balance_rtc REAL NOT NULL DEFAULT 0
+                );
+                CREATE TABLE miner_header_keys (
+                    miner_id TEXT PRIMARY KEY,
+                    pubkey_hex TEXT NOT NULL
+                );
+                """
+            )
+
+    def _enroll(self, payload):
+        with self.mod.app.test_request_context("/epoch/enroll", method="POST", json=payload):
+            resp = self.mod.enroll_epoch()
+        if isinstance(resp, tuple):
+            body, status = resp
+            return status, body.get_json()
+        return resp.status_code, resp.get_json()
+
+    def test_enrollment_uses_attested_device_and_fingerprint_not_request_payload(self):
+        miner = "RTC_WEIGHT_SPOOF_MINER"
+        now = int(time.time())
+        attested_checks = {
+            "clock_drift": True,
+            "cache_timing": True,
+            "simd_bias": True,
+            "thermal_drift": True,
+            "instruction_jitter": True,
+            "anti_emulation": True,
+        }
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO miner_attest_recent
+                    (miner, ts_ok, device_family, device_arch, fingerprint_passed,
+                     source_ip, fingerprint_checks_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    miner,
+                    now,
+                    "x86_64",
+                    "default",
+                    1,
+                    "127.0.0.1",
+                    json.dumps(attested_checks),
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO miner_macs
+                    (miner, mac_hash, first_ts, last_ts, count)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (miner, "mac-hash", now, now, 1),
+            )
+
+        request_controlled_checks = {
+            name: {"passed": True, "data": {"request_controlled": True}}
+            for name in attested_checks
+        }
+        status, body = self._enroll(
+            {
+                "miner_pubkey": miner,
+                "miner_id": miner,
+                "device": {"family": "PowerPC", "arch": "G4"},
+                "fingerprint": {"checks": request_controlled_checks},
+            }
+        )
+
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+        self.assertEqual(body["hw_weight"], 0.8)
+        self.assertEqual(body["weight"], 0.8)
+
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT weight FROM epoch_enroll WHERE epoch = ? AND miner_pk = ?",
+                (body["epoch"], miner),
+            ).fetchone()
+        self.assertIsNotNone(row)
+        self.assertEqual(int(row[0]), self.mod.epoch_weight_to_units(0.8))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_epoch_enroll_attested_weight.py
+++ b/node/tests/test_epoch_enroll_attested_weight.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 import tempfile
 import time
+import types
 import unittest
 
 
@@ -14,13 +15,48 @@ NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
 
 
+def _install_p2p_stub():
+    previous = sys.modules.get("rustchain_p2p_sync_secure")
+    stub = types.ModuleType("rustchain_p2p_sync_secure")
+
+    class DummyPeerManager:
+        def get_network_stats(self):
+            return {}
+
+        def add_peer(self, peer_url):
+            return True
+
+    class DummyBlockSync:
+        running = False
+
+        def start(self):
+            self.running = True
+
+        def get_blocks_for_sync(self, start_height, limit):
+            return []
+
+    def initialize_secure_p2p(*args, **kwargs):
+        def require_peer_auth(func):
+            return func
+
+        return DummyPeerManager(), DummyBlockSync(), require_peer_auth
+
+    stub.initialize_secure_p2p = initialize_secure_p2p
+    sys.modules["rustchain_p2p_sync_secure"] = stub
+    return previous
+
+
 class TestEpochEnrollAttestedWeight(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._tmp = tempfile.TemporaryDirectory()
         cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
         cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
-        cls.db_path = os.path.join(cls._tmp.name, "enroll_attested_weight.db")
+        cls._prev_p2p_module = _install_p2p_stub()
+        # Leave the temp directory for pytest/OS cleanup instead of deleting it
+        # in tearDownClass. The integrated node import can keep SQLite handles
+        # alive briefly on Windows, which makes eager directory cleanup flaky.
+        cls._tmp_dir = tempfile.mkdtemp(prefix="rustchain-enroll-attested-")
+        cls.db_path = os.path.join(cls._tmp_dir, "enroll_attested_weight.db")
         os.environ["RUSTCHAIN_DB_PATH"] = cls.db_path
         os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
 
@@ -44,7 +80,36 @@ class TestEpochEnrollAttestedWeight(unittest.TestCase):
             os.environ.pop("RC_ADMIN_KEY", None)
         else:
             os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
-        cls._tmp.cleanup()
+
+        block_sync = getattr(cls.mod, "block_sync", None)
+        if block_sync is not None:
+            block_sync.running = False
+
+        try:
+            from prometheus_client import REGISTRY
+
+            for metric_name in (
+                "withdrawal_requests",
+                "withdrawal_completed",
+                "withdrawal_failed",
+                "balance_gauge",
+                "epoch_gauge",
+                "withdrawal_queue_size",
+            ):
+                metric = getattr(cls.mod, metric_name, None)
+                if metric is None:
+                    continue
+                try:
+                    REGISTRY.unregister(metric)
+                except (KeyError, ValueError):
+                    pass
+        except Exception:
+            pass
+        finally:
+            if cls._prev_p2p_module is None:
+                sys.modules.pop("rustchain_p2p_sync_secure", None)
+            else:
+                sys.modules["rustchain_p2p_sync_secure"] = cls._prev_p2p_module
 
     def setUp(self):
         with sqlite3.connect(self.db_path) as conn:


### PR DESCRIPTION
## Summary

Prevents `/epoch/enroll` from calculating epoch reward weight from request-controlled `device` and `fingerprint` fields. Enrollment now derives its reward inputs from the most recent accepted attestation snapshot in `miner_attest_recent`: attested device family, attested device arch, and stored `fingerprint_checks_json`.

## Impact

Before this patch, the endpoint checked that a miner had a fresh attestation, but then used the enroll request body to calculate weight. A miner with a fresh low-tier attestation could make the first explicit enrollment for an epoch with a spoofed high-tier device, for example `PowerPC/G4`, plus request-controlled passing fingerprint checks. Because first enrollment wins, that inflated weight could be locked for the epoch.

Local PoC before the fix:

- stored attestation: `x86_64/default`, `fingerprint_passed=1`
- enroll request: `device={"family":"PowerPC","arch":"G4"}` plus all-passing request fingerprint checks
- observed stored `epoch_enroll.weight`: `2500000000` (`2.5x`)
- expected from attested device: `800000000` (`0.8x`)

## Fix

- `check_enrollment_requirements()` now returns an attested enrollment context from `miner_attest_recent`.
- `/epoch/enroll` uses that attested context for `HARDWARE_WEIGHTS` lookup and RIP-309 rotating fingerprint evaluation.
- The legacy unsigned enrollment path remains accepted for compatibility, but it can no longer upgrade reward weight by changing request-only device/fingerprint fields.

## Duplicate Check

Searches run:

- `epoch enroll device weight`
- `unauthorized enrollment weight downgrade device`
- `epoch enroll fingerprint request controlled`
- `epoch enroll device family arch weight spoof`

Related but different:

- PR #2110 fixed external weight downgrade by changing `epoch_enroll` from `INSERT OR REPLACE` to `INSERT OR IGNORE`.

Novel delta:

- #2110 prevents later overwrites, but the first explicit enrollment could still choose inflated request-controlled weight inputs. This patch binds that first enrollment to the attested snapshot.

## Tests

```bash
PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_epoch_enroll_attested_weight.py -q
# 1 passed

PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_epoch_enroll_attested_weight.py node/tests/test_attest_nonce_replay.py -q
# 7 passed

PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_unsigned_enrollment_accepted_backward_compat -q
# 1 passed

PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_signed_enrollment_accepted -q
# 1 passed

.venv/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_epoch_enroll_attested_weight.py

git diff --check origin/main...HEAD -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_epoch_enroll_attested_weight.py

.venv/bin/python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```

## Bounty / Disclosure

Related to reward manipulation under the ongoing bug bounty (#71). Reproduction was local only. No production infrastructure was accessed and no funds were moved.