### PR TITLE
fix: raise CLI API fetch errors

### DIFF
--- a/tests/test_wallet_show_regression.py
+++ b/tests/test_wallet_show_regression.py
@@ -8,10 +8,12 @@ import pytest
 from unittest.mock import patch, MagicMock
 import sys
 import os
+import urllib.error
 
 # Add tools to path for importing cli module
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools', 'cli'))
-from rustchain_cli import fetch_api, get_node_url
+import rustchain_cli
+from rustchain_cli import RustChainAPIError, fetch_api, get_node_url
 
 
 class TestWalletBalanceEndpoint:
@@ -46,22 +48,42 @@ class TestWalletBalanceEndpoint:
             balance = resp.get("amount_rtc", resp.get("balance_rtc", resp.get("balance", 0)))
             assert isinstance(balance, (int, float))
 
-    @patch('urllib.request.urlopen')
+    @patch('rustchain_cli.urlopen')
     def test_wallet_show_handles_network_error_gracefully(self, mock_urlopen):
         """Test that wallet show handles network errors without crashing."""
-        import urllib.error
-        
         # Simulate network timeout
         mock_urlopen.side_effect = urllib.error.URLError("timeout")
-        
-        # Should not raise exception, should handle gracefully
-        # This is the behavior we want to preserve
-        try:
-            # Test the balance fetch logic directly
-            result = fetch_api("/wallet/balance?miner_id=test")
-        except Exception as e:
-            # Expected to fail with network error
-            assert "timeout" in str(e).lower() or "network" in str(e).lower()
+
+        with pytest.raises(RustChainAPIError, match="Cannot connect to node: timeout"):
+            fetch_api("/wallet/balance?miner_id=test")
+
+    @patch('rustchain_cli.urlopen')
+    def test_wallet_show_handles_http_error_gracefully(self, mock_urlopen):
+        """Test that API HTTP failures raise a catchable CLI API error."""
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="https://rustchain.org/wallet/balance?miner_id=test",
+            code=503,
+            msg="Service Unavailable",
+            hdrs=None,
+            fp=None,
+        )
+
+        with pytest.raises(RustChainAPIError, match="API returned 503"):
+            fetch_api("/wallet/balance?miner_id=test")
+
+    def test_main_reports_api_errors_at_cli_boundary(self, capsys):
+        """Test that main preserves CLI error printing and exit behavior."""
+        with patch.object(sys, "argv", ["rustchain-cli", "status"]):
+            with patch.object(
+                rustchain_cli,
+                "cmd_status",
+                side_effect=RustChainAPIError("sentinel-main-error"),
+            ):
+                with pytest.raises(SystemExit) as exc_info:
+                    rustchain_cli.main()
+
+        assert exc_info.value.code == 1
+        assert "Error: sentinel-main-error" in capsys.readouterr().err
 
     def test_balance_endpoint_returns_valid_json(self):
         """Integration test: verify /wallet/balance returns valid JSON."""

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -43,6 +43,11 @@ DEFAULT_NODE = "https://rustchain.org"
 TIMEOUT = 10
 __version__ = "0.2.0"
 
+
+class RustChainAPIError(Exception):
+    """Raised when the CLI cannot fetch or decode node API data."""
+
+
 def get_node_url():
     """Get node URL from env var or default."""
     return os.environ.get("RUSTCHAIN_NODE", DEFAULT_NODE)
@@ -55,14 +60,11 @@ def fetch_api(endpoint):
         with urlopen(req, timeout=TIMEOUT) as response:
             return json.loads(response.read().decode())
     except HTTPError as e:
-        print(f"Error: API returned {e.code}", file=sys.stderr)
-        sys.exit(1)
+        raise RustChainAPIError(f"API returned {e.code}") from e
     except URLError as e:
-        print(f"Error: Cannot connect to node: {e.reason}", file=sys.stderr)
-        sys.exit(1)
+        raise RustChainAPIError(f"Cannot connect to node: {e.reason}") from e
     except Exception as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(1)
+        raise RustChainAPIError(str(e)) from e
 
 def format_table(headers, rows):
     """Format data as a simple table."""
@@ -775,7 +777,12 @@ def main():
     if args.node:
         os.environ["RUSTCHAIN_NODE"] = args.node
 
-    result = args.func(args)
+    try:
+        result = args.func(args)
+    except RustChainAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
     if result is not None:
         sys.exit(result)
 


### PR DESCRIPTION
## Summary
- make `fetch_api()` raise a normal `RustChainAPIError` instead of calling `sys.exit()` directly
- keep CLI process behavior unchanged by catching that error in `main()` and exiting with the same error message style
- makes wallet/network regression tests deterministic because patched API calls now surface as catchable exceptions

## Verification
- `python -m pytest tests\test_wallet_show_regression.py -q` (5 passed)
- `python -m py_compile tools\cli\rustchain_cli.py node\utxo_db.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
- `python -m pytest tests\security_audit\test_security_findings_2867.py::test_mempool_add_manage_tx_undefined -q`
- `git diff --check -- tools\cli\rustchain_cli.py`

Wallet/miner ID: `cerredz`
