### PR TITLE
fix: use secure rng for PoA validator selection

### DIFF
--- a/rips/python/rustchain/proof_of_antiquity.py
+++ b/rips/python/rustchain/proof_of_antiquity.py
@@ -14,6 +14,7 @@ Formula: AS = (current_year - release_year) * log10(uptime_days + 1)
 
 import hashlib
 import math
+import secrets
 import time
 from datetime import datetime
 from dataclasses import dataclass, field
@@ -40,6 +41,7 @@ AS_MAX: float = 100.0  # Maximum Antiquity Score for reward capping
 AS_MIN: float = 1.0    # Minimum AS to participate in validation
 MAX_MINERS_PER_BLOCK: int = 100
 BLOCK_REWARD_AMOUNT: TokenAmount = TokenAmount.from_rtc(float(BLOCK_REWARD))
+_SECURE_RANDOM = secrets.SystemRandom()
 
 
 # =============================================================================
@@ -404,17 +406,15 @@ def select_block_validator(proofs: List[ValidatedProof]) -> Optional[ValidatedPr
     if not proofs:
         return None
 
-    import random
-
     total_as = sum(p.antiquity_score for p in proofs)
     if total_as == 0:
-        return random.choice(proofs)
+        return _SECURE_RANDOM.choice(proofs)
 
     # Weighted random selection via cumulative distribution: pick a random point
     # on [0, total_as] and return the proof whose range contains it.
     # The last proof is returned as a fallback for floating-point rounding where
     # cumulative may fall just short of total_as.
-    r = random.uniform(0, total_as)
+    r = _SECURE_RANDOM.uniform(0, total_as)
     cumulative = 0
 
     for proof in proofs:

--- a/tests/test_proof_of_antiquity_validator_selection.py
+++ b/tests/test_proof_of_antiquity_validator_selection.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+
+from rustchain.core_types import HardwareInfo, WalletAddress
+from rustchain import proof_of_antiquity
+
+
+def _proof(wallet_suffix, antiquity_score):
+    return proof_of_antiquity.ValidatedProof(
+        wallet=WalletAddress(f"RTC{wallet_suffix}"),
+        hardware=HardwareInfo(cpu_model="PowerMac G4", release_year=2002),
+        antiquity_score=antiquity_score,
+        anti_emulation_hash=f"hash-{wallet_suffix}",
+        validated_at=1,
+    )
+
+
+class TrackingSecureRandom:
+    def __init__(self, weighted_pick):
+        self.weighted_pick = weighted_pick
+        self.choice_calls = []
+        self.uniform_calls = []
+
+    def choice(self, values):
+        self.choice_calls.append(list(values))
+        return values[-1]
+
+    def uniform(self, start, end):
+        self.uniform_calls.append((start, end))
+        return self.weighted_pick
+
+
+def test_select_block_validator_uses_secure_choice_for_zero_scores(monkeypatch):
+    rng = TrackingSecureRandom(weighted_pick=0)
+    monkeypatch.setattr(proof_of_antiquity, "_SECURE_RANDOM", rng)
+    proofs = [_proof("zeroA", 0), _proof("zeroB", 0)]
+
+    selected = proof_of_antiquity.select_block_validator(proofs)
+
+    assert selected is proofs[-1]
+    assert rng.choice_calls == [proofs]
+    assert rng.uniform_calls == []
+
+
+def test_select_block_validator_uses_secure_weighted_pick(monkeypatch):
+    rng = TrackingSecureRandom(weighted_pick=6.0)
+    monkeypatch.setattr(proof_of_antiquity, "_SECURE_RANDOM", rng)
+    proofs = [_proof("low", 5.0), _proof("high", 10.0)]
+
+    selected = proof_of_antiquity.select_block_validator(proofs)
+
+    assert selected is proofs[1]
+    assert rng.choice_calls == []
+    assert rng.uniform_calls == [(0, 15.0)]


### PR DESCRIPTION
## Summary\n- Fixes #4643 by replacing predictable random.choice/random.uniform in PoA validator selection with a secrets.SystemRandom-backed selector.\n- Covers both zero-score tie selection and weighted lottery selection.\n- Adds focused regression tests that monkeypatch the secure RNG path to prove selection no longer depends on the standard random module.\n\n## Validation\n- PYTHONPATH=rips\\python python -m pytest tests\\test_proof_of_antiquity_validator_selection.py -q -> 2 passed\n- python -m py_compile rips\\python\\rustchain\\proof_of_antiquity.py tests\\test_proof_of_antiquity_validator_selection.py\n- git diff --check origin/main...HEAD -- rips/python/rustchain/proof_of_antiquity.py tests/test_proof_of_antiquity_validator_selection.py\n- python tools\\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK\n\n## Notes\nThis is an alternative to PR #4644, which currently only adds a misplaced import and leaves the random-based selection logic unchanged.