### PR TITLE
test: cover exact UTXO nanoRTC conversion

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -275,6 +275,27 @@ class TestUtxoEndpoints(unittest.TestCase):
                          f"Expected 10_000_000 nanoRTC, got {bob_bal} "
                          f"(float truncation bug)")
 
+    def test_transfer_preserves_three_nanortc_amount(self):
+        """Issue #4671: 0.00000003 RTC must transfer exactly 3 nanoRTC."""
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_coinbase(sender, UNIT)
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 0.00000003,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 200, data)
+        self.assertTrue(data['ok'])
+        self.assertEqual(self.utxo_db.get_balance(recipient), 3)
+        self.assertEqual(self.utxo_db.get_balance(sender), UNIT - 3)
+
     def test_transfer_rejects_decimal_amount_not_preserved_by_signed_float(self):
         """The signed float amount must match the ledger nanoRTC amount.
 

--- a/node/tests/test_utxo_float_precision_bug.py
+++ b/node/tests/test_utxo_float_precision_bug.py
@@ -1,57 +1,44 @@
-"""
-PoC Test: UTXO Transfer Float Precision Bug
-=============================================
-Finding: utxo_endpoints.py uses `float(data.get('amount_rtc', 0))` before
-converting to nanoRTC. This causes systematic precision loss for common
-decimal amounts like 0.1, 0.3, 123.456, etc.
+# SPDX-License-Identifier: MIT
+"""Regression coverage for exact RTC-to-nanoRTC conversion.
 
-Severity: High
-Target: utxo_endpoints.py::utxo_transfer()
+Issue #4671 identified that the old endpoint conversion path effectively did
+``int(float(amount_rtc) * UNIT)``. Very small valid amounts such as 3 nanoRTC
+could then truncate to 2 nanoRTC. The production parser/converter must preserve
+the exact integer nanoRTC value.
 """
 
-UNIT = 100_000_000  # 1 RTC = 100,000,000 nanoRTC
+import pytest
+
+from utxo_db import UNIT
+from utxo_endpoints import _decimal_to_nrtc, _parse_rtc_amount
 
 
-def current_buggy_conversion(amount_rtc):
-    """Replica of current code path in utxo_endpoints.py"""
+def old_float_conversion(amount_rtc):
+    """Replica of the historical bug for documentation."""
     amount = float(amount_rtc)
     return int(amount * UNIT)
 
 
-def test_float_precision_loss():
-    """Demonstrate precision loss for amounts that are not exactly
-    representable in IEEE-754 double precision."""
+@pytest.mark.parametrize(
+    ("amount_rtc", "expected_nrtc"),
+    [
+        ("0.1", 10_000_000),
+        ("0.3", 30_000_000),
+        ("0.00000003", 3),
+        ("0.00000006", 6),
+        ("0.00000012", 12),
+        ("0.00000029", 29),
+        ("0.00000058", 58),
+        ("0.00000105", 105),
+        (0.00000003, 3),
+    ],
+)
+def test_decimal_conversion_preserves_nanortc(amount_rtc, expected_nrtc):
+    amount = _parse_rtc_amount(amount_rtc)
 
-    test_cases = [
-        # (amount_rtc, expected_nrtc) — values known to trigger IEEE-754 precision loss
-        (0.1,     10_000_000),       # safe baseline
-        (0.3,     30_000_000),       # safe baseline
-        (0.000_000_03, 3),           # 3 nanoRTC  -> float gives 2
-        (0.000_000_06, 6),           # 6 nanoRTC  -> float gives 5
-        (0.000_000_12, 12),          # 12 nanoRTC -> float gives 11
-        (0.000_000_29, 29),          # 29 nanoRTC -> float gives 28
-        (0.000_000_58, 58),          # 58 nanoRTC -> float gives 57
-        (0.000_001_05, 105),         # 105 nanoRTC -> float gives 104
-    ]
-
-    failures = []
-    for amount_rtc, expected_nrtc in test_cases:
-        actual = current_buggy_conversion(amount_rtc)
-        diff = expected_nrtc - actual
-        status = "PASS" if diff == 0 else "FAIL"
-        print(f"  amount_rtc={amount_rtc:>12} -> expected={expected_nrtc:>16} actual={actual:>16} diff={diff:>6} [{status}]")
-        if diff != 0:
-            failures.append((amount_rtc, expected_nrtc, actual, diff))
-
-    print()
-    if failures:
-        print(f"❌ PRECISION LOSS CONFIRMED on {len(failures)} test cases.")
-        for amount_rtc, expected, actual, diff in failures:
-            print(f"   - {amount_rtc} RTC loses {diff} nanoRTC (expected {expected}, got {actual})")
-        assert False, f"Float precision bug reproduced on {len(failures)} cases."
-    else:
-        print("✅ No precision loss detected.")
+    assert _decimal_to_nrtc(amount, "amount_rtc") == expected_nrtc
 
 
-if __name__ == "__main__":
-    test_float_precision_loss()
+def test_old_float_conversion_would_undercount_three_nanortc():
+    assert old_float_conversion(0.00000003) == 2
+    assert _decimal_to_nrtc(_parse_rtc_amount("0.00000003"), "amount_rtc") == 3


### PR DESCRIPTION
## Summary
- Convert the stale float-precision PoC into a passing regression against the production Decimal parser/converter
- Add endpoint-level coverage for the exact issue #4671 case: 0.00000003 RTC must transfer as 3 nanoRTC
- Keep the historical float under-count assertion documented so the regression proves why Decimal conversion matters

Closes #4671

## Validation
- PYTHONPATH=node python -m pytest node\\tests\\test_utxo_float_precision_bug.py node\\test_utxo_endpoints.py -q -> 29 passed
- python -m py_compile node\\utxo_endpoints.py node\\test_utxo_endpoints.py node\\tests\\test_utxo_float_precision_bug.py -> passed
- git diff --check -- node/test_utxo_endpoints.py node/tests/test_utxo_float_precision_bug.py -> passed
- python tools\\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK

## Bounty / payout
Wallet/miner ID: godd-ctrl-codex-earner
Wallet declaration: https://github.com/Scottcjn/rustchain-bounties/issues/6885#issuecomment-4419070614
