### PR TITLE
fix: validate lock ledger route queries

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -490,7 +490,7 @@ def get_pending_unlocks(
     """
     params = [now]
     
-    if before_timestamp:
+    if before_timestamp is not None:
         query += " AND unlock_at <= ?"
         params.append(before_timestamp)
     

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -637,12 +637,33 @@ def auto_release_expired_locks(
 def register_lock_ledger_routes(app):
     """Register lock ledger API routes with Flask app."""
     from flask import request, jsonify
+
+    def parse_bounded_int_arg(
+        name: str,
+        default: Optional[int],
+        minimum: int,
+        maximum: int,
+        *,
+        required: bool = False,
+    ):
+        raw = request.args.get(name)
+        if raw is None:
+            if required:
+                return None, (jsonify({"error": f"{name} required"}), 400)
+            return default, None
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return None, (jsonify({"error": f"{name} must be an integer"}), 400)
+        return max(minimum, min(value, maximum)), None
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):
         """Get locks for a specific miner."""
         status = request.args.get("status")
-        limit = int(request.args.get("limit", 100))
+        limit, error_response = parse_bounded_int_arg("limit", 100, 1, 500)
+        if error_response is not None:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -700,12 +721,14 @@ def register_lock_ledger_routes(app):
             conn.close()
     
     @app.route('/api/lock/pending-unlock', methods=['GET'])
-    def get_pending_unlocks():
+    def get_pending_unlocks_endpoint():
         """Get locks ready to be released."""
-        before = request.args.get("before")
-        limit = int(request.args.get("limit", 100))
-        
-        before_ts = int(before) if before else None
+        limit, error_response = parse_bounded_int_arg("limit", 100, 1, 500)
+        if error_response is not None:
+            return error_response
+        before_ts, error_response = parse_bounded_int_arg("before", None, 0, 4_102_444_800)
+        if error_response is not None:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -807,7 +830,9 @@ def register_lock_ledger_routes(app):
             return jsonify({"error": "RC_WORKER_KEY not configured — worker endpoints disabled"}), 503
         if not hmac.compare_digest(worker_key, expected_worker):
             return jsonify({"error": "Unauthorized"}), 401
-        batch_size = int(request.args.get("batch_size", 100))
+        batch_size, error_response = parse_bounded_int_arg("batch_size", 100, 1, 500)
+        if error_response is not None:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -746,6 +746,64 @@ class TestLockLedger:
         conn.close()
 
 
+class TestLockLedgerRoutes:
+    """Test lock ledger route-level validation and helper dispatch."""
+
+    def _client(self, lock_ledger, db_path):
+        lock_ledger.DB_PATH = db_path
+        app = Flask(__name__)
+        lock_ledger.register_lock_ledger_routes(app)
+        return app.test_client()
+
+    def test_miner_locks_rejects_malformed_limit(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+
+        response = client.get(f"/api/lock/miner/{funded_miner}?limit=abc")
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "limit must be an integer"}
+
+    def test_pending_unlock_rejects_malformed_before(self, setup_test_db):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+
+        response = client.get("/api/lock/pending-unlock?before=not-a-timestamp")
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "before must be an integer"}
+
+    def test_pending_unlock_route_calls_database_helper(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        now = int(time.time())
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    funded_miner,
+                    5 * 1000000,
+                    "bridge_deposit",
+                    now - 3600,
+                    now - 60,
+                    "locked",
+                    now - 3600,
+                ),
+            )
+
+        client = self._client(lock_ledger, db_path)
+
+        response = client.get("/api/lock/pending-unlock?limit=10")
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["ok"] is True
+        assert body["count"] == 1
+        assert body["locks"][0]["miner_id"] == funded_miner
+
+
 # =============================================================================
 # Integration Tests
 # =============================================================================

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -803,6 +803,36 @@ class TestLockLedgerRoutes:
         assert body["count"] == 1
         assert body["locks"][0]["miner_id"] == funded_miner
 
+    def test_pending_unlock_before_zero_applies_cutoff(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        now = int(time.time())
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    funded_miner,
+                    5 * 1000000,
+                    "bridge_deposit",
+                    now - 3600,
+                    now - 60,
+                    "locked",
+                    now - 3600,
+                ),
+            )
+
+        client = self._client(lock_ledger, db_path)
+
+        response = client.get("/api/lock/pending-unlock?before=0&limit=10")
+
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["ok"] is True
+        assert body["count"] == 0
+        assert body["locks"] == []
+
 
 # =============================================================================
 # Integration Tests


### PR DESCRIPTION
## Summary
- add bounded integer parsing for lock ledger route query parameters
- return clear 400 JSON errors for malformed public lock route values
- rename the pending-unlock route handler so it dispatches to the database helper instead of shadowing it
- cover miner lock limit validation, pending-unlock before validation, and the pending-unlock helper dispatch path

Fixes #4680
Claims #305

## Validation
- C:\Users\hamza\.local\bin\uv.exe run --no-project --with pytest --with flask python -m pytest tests\test_bridge_lock_ledger.py::TestLockLedgerRoutes -q -> 3 passed
- C:\Users\hamza\.local\bin\uv.exe run --no-project --with pytest --with flask python -m pytest tests\test_bridge_lock_ledger.py -q -> 38 passed
- python -m py_compile node\lock_ledger.py tests\test_bridge_lock_ledger.py -> passed
- git diff --check origin/main...HEAD -> passed