### PR TITLE
fix: validate attestation miner_id alias

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -279,6 +279,12 @@ def _validate_attestation_payload_shape(data):
     for field_name in ("miner", "miner_id"):
         if field_name in data and data[field_name] is not None and not isinstance(data[field_name], str):
             return _attest_field_error("INVALID_MINER", f"Field '{field_name}' must be a non-empty string")
+        if field_name in data and _attest_text(data[field_name]) and not _attest_valid_miner(data[field_name]):
+            return _attest_field_error(
+                "INVALID_MINER",
+                "Fields 'miner' and 'miner_id' must use only letters, numbers, '.', '_', ':' or '-' "
+                "and be at most 128 characters",
+            )
 
     for field_name, code in (
         ("signature", "INVALID_SIGNATURE_TYPE"),
@@ -3269,7 +3275,7 @@ def _submit_attestation_impl():
     # in transit and claiming another miner's hardware rewards (wallet hijack).
     sig_hex = (data.get('signature') or '').strip().lower()
     pubkey_hex = (data.get('public_key') or '').strip().lower()
-    miner_id_raw = _attest_text(data.get('miner_id')) or miner
+    miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
     if sig_hex and pubkey_hex:
         if HAVE_NACL:
@@ -3599,7 +3605,7 @@ def _submit_attestation_impl():
         family = verified_device["device_family"]
         arch_for_weight = verified_device["device_arch"]
         hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch_for_weight, HARDWARE_WEIGHTS.get(family, {}).get("default", 1.0))
-        miner_id = data.get("miner_id", miner)
+        miner_id = _attest_valid_miner(data.get("miner_id")) or miner
 
         with sqlite3.connect(DB_PATH) as enroll_conn:
             rotation_eval = evaluate_rotating_fingerprint_checks(

--- a/tests/fuzz/attestation_validators.py
+++ b/tests/fuzz/attestation_validators.py
@@ -131,6 +131,16 @@ def _validate_attestation_payload_shape(data: Any):
             return _attest_field_error(
                 "INVALID_MINER", f"Field '{field_name}' must be a non-empty string"
             )
+        if (
+            field_name in data
+            and _attest_text(data[field_name])
+            and not _attest_valid_miner(data[field_name])
+        ):
+            return _attest_field_error(
+                "INVALID_MINER",
+                "Fields 'miner' and 'miner_id' must use only letters, numbers, '.', '_', ':' or '-' "
+                "and be at most 128 characters",
+            )
 
     for field_name, code in (
         ("signature", "INVALID_SIGNATURE_TYPE"),

--- a/tests/test_attestation_fuzz.py
+++ b/tests/test_attestation_fuzz.py
@@ -243,6 +243,17 @@ def test_attest_submit_sql_like_miner_does_not_mutate_schema(client):
     assert response.get_json()["code"] == "INVALID_MINER"
 
 
+def test_attest_submit_rejects_invalid_miner_id_even_when_miner_is_valid(client):
+    payload = _attach_live_challenge(client, _base_payload())
+    payload["miner"] = "valid-miner"
+    payload["miner_id"] = "../../invalid"
+
+    response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "INVALID_MINER"
+
+
 def test_validate_fingerprint_data_rejects_non_dict_input():
     passed, reason = integrated_node.validate_fingerprint_data(["not", "a", "dict"])
 


### PR DESCRIPTION
## Summary
- reject malformed present miner_id values even when miner is valid
- use the validated miner_id alias in the attestation signing/storage paths
- mirror the validator update in the extracted fuzz validator
- add a regression test proving miner_id=../../invalid no longer returns 200 when miner is valid

## Validation
- PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests --with pynacl python -m pytest tests\\test_attestation_fuzz.py::test_attest_submit_rejects_invalid_miner_id_even_when_miner_is_valid -q -> 1 passed
- PYTHONPATH=. ATTEST_FUZZ_CASES=500 ATTEST_FUZZ_SEED=20260512 uv run --no-project --with pytest --with flask --with requests --with pynacl python -m pytest tests\\test_attestation_fuzz.py -q -> 35 passed
- PYTHONPATH=. uv run --no-project --with pytest --with flask --with requests --with pynacl python -m pytest tests\\test_attestation_regression.py -q -> 64 passed, 18 skipped
- python -m py_compile node\\rustchain_v2_integrated_v2.2.1_rip200.py tests\\test_attestation_fuzz.py tests\\fuzz\\attestation_validators.py -> passed
- git diff --check -> passed
- python tools\\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK

Bounty context: follows up on rustchain-bounties#1112 with a non-duplicate validation bypass found while fuzzing the attestation submit path.