### PR TITLE
fix: import asyncio for digest miner lookup

### DIFF
--- a/bottube_digest_bot/bottube_digest_bot.py
+++ b/bottube_digest_bot/bottube_digest_bot.py
@@ -20,6 +20,7 @@ Features:
 """
 
 import argparse
+import asyncio
 import json
 import logging
 import smtplib
@@ -223,8 +224,6 @@ class DigestGenerator:
 
     async def _fetch_all_data(self) -> Tuple[Dict, Dict, List, List]:
         """Fetch all data in parallel."""
-        import asyncio
-
         health_task = self.rustchain_client.health()
         epoch_task = self.rustchain_client.epoch()
         miners_task = self.rustchain_client.miners()

--- a/bottube_digest_bot/tests/test_bottube_digest_bot.py
+++ b/bottube_digest_bot/tests/test_bottube_digest_bot.py
@@ -317,6 +317,30 @@ class TestIntegration(unittest.TestCase):
         self.assertIsNotNone(generator.rustchain_client)
         self.assertIsNotNone(generator.bottube_client)
 
+    def test_top_miners_uses_async_rate_limit_delay(self):
+        """Top-miner balance lookup should not crash on the async delay."""
+        generator = DigestGenerator(self.config)
+        generator.rustchain_client.wallet_balance = AsyncMock(
+            return_value={"ok": True, "amount_rtc": 42.5}
+        )
+
+        top_miners = asyncio.run(
+            generator._get_top_miners(
+                [{"miner_id": "miner-1", "architecture": "powerpc"}]
+            )
+        )
+
+        self.assertEqual(
+            top_miners,
+            [
+                {
+                    "miner_id": "miner-1",
+                    "balance_rtc": 42.5,
+                    "architecture": "powerpc",
+                }
+            ],
+        )
+
     def test_formatter_chain(self):
         """Test formatting chain for all channels."""
         content = DigestContent(


### PR DESCRIPTION
## Summary
- import `asyncio` at module scope so both digest async helpers can use it
- keep `_fetch_all_data()` behavior unchanged after removing the local import
- add a regression test for `_get_top_miners()` with miner data so the rate-limit delay path is covered

Fixes #4686
Claims #305

## Verification
- `python -m pytest bottube_digest_bot\tests\test_bottube_digest_bot.py -q` -> 27 passed
- `python -m py_compile bottube_digest_bot\bottube_digest_bot.py bottube_digest_bot\tests\test_bottube_digest_bot.py` -> passed
- `python -m ruff check bottube_digest_bot\bottube_digest_bot.py --select F821` -> All checks passed
- `git diff --check -- bottube_digest_bot\bottube_digest_bot.py bottube_digest_bot\tests\test_bottube_digest_bot.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
