### PR TITLE
fix: repair bottube onboarding welcome CLI

### DIFF
--- a/integrations/bottube_onboarding/__init__.py
+++ b/integrations/bottube_onboarding/__init__.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -441,6 +442,10 @@ def get_empty_state_display(agent_id: str = "Creator") -> str:
     """Get formatted empty-state display for UI."""
     return EMPTY_STATE_TEMPLATE
 
+def get_welcome_message(agent_id: str = "Creator") -> str:
+    """Get formatted welcome message for an agent."""
+    return OnboardingState(agent_id=agent_id).get_welcome_message()
+
 def get_checklist_complete_display() -> str:
     """Get formatted checklist complete display."""
     return CHECKLIST_COMPLETE_TEMPLATE
@@ -454,11 +459,19 @@ def get_first_upload_success_display(agent_id: str, video_title: str, video_url:
     )
 
 
+def _configure_cli_stdout() -> None:
+    """Use UTF-8 for CLI templates that include box drawing and emoji."""
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
+
 # ============================================================================
 # CLI Interface
 # ============================================================================
 
 if __name__ == "__main__":
+    _configure_cli_stdout()
+
     import argparse
     
     parser = argparse.ArgumentParser(

--- a/tests/test_bottube_onboarding_cli.py
+++ b/tests/test_bottube_onboarding_cli.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the BoTTube onboarding CLI."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_welcome_template_cli_does_not_crash():
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "integrations"
+        / "bottube_onboarding"
+        / "__init__.py"
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--show-template", "welcome"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "demo_agent" in result.stdout


### PR DESCRIPTION
## Summary
- add the missing module-level `get_welcome_message()` helper used by `--show-template welcome`
- configure CLI stdout as UTF-8 before printing Unicode templates on Windows
- add a subprocess regression covering the welcome-template CLI path

Fixes #4688
Claims #305

## Verification
- `python integrations\bottube_onboarding\__init__.py --show-template welcome` -> printed welcome template and exited 0
- `python -m pytest tests\test_bottube_onboarding_cli.py -q` -> 1 passed
- `python -m py_compile integrations\bottube_onboarding\__init__.py tests\test_bottube_onboarding_cli.py` -> passed
- `python -m ruff check integrations\bottube_onboarding\__init__.py --select F821` -> All checks passed
- `git diff --check -- integrations\bottube_onboarding\__init__.py tests\test_bottube_onboarding_cli.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
