### PR TITLE
fix: repair bottube parasocial package import

### DIFF
--- a/integrations/bottube_parasocial/__init__.py
+++ b/integrations/bottube_parasocial/__init__.py
@@ -66,6 +66,8 @@ from .description_generator import (
     DescriptionValidator,
 )
 
+from typing import Dict
+
 __version__ = "1.0.0"
 __author__ = "RustChain Bounty Contributors"
 __bounty__ = "#2286"

--- a/integrations/bottube_parasocial/comment_responder.py
+++ b/integrations/bottube_parasocial/comment_responder.py
@@ -28,13 +28,22 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from datetime import datetime
 
-from audience_tracker import (
-    AudienceTracker, 
-    ViewerProfile, 
-    ViewerStatus, 
-    SentimentType,
-    SentimentAnalyzer,
-)
+try:
+    from .audience_tracker import (
+        AudienceTracker,
+        ViewerProfile,
+        ViewerStatus,
+        SentimentType,
+        SentimentAnalyzer,
+    )
+except ImportError:  # pragma: no cover - supports direct script-style imports
+    from audience_tracker import (
+        AudienceTracker,
+        ViewerProfile,
+        ViewerStatus,
+        SentimentType,
+        SentimentAnalyzer,
+    )
 
 
 class ResponseStyle(Enum):

--- a/integrations/bottube_parasocial/description_generator.py
+++ b/integrations/bottube_parasocial/description_generator.py
@@ -26,7 +26,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from audience_tracker import AudienceTracker, ViewerProfile
+try:
+    from .audience_tracker import AudienceTracker, ViewerProfile
+except ImportError:  # pragma: no cover - supports direct script-style imports
+    from audience_tracker import AudienceTracker, ViewerProfile
 
 
 @dataclass

--- a/tests/test_bottube_parasocial_import.py
+++ b/tests/test_bottube_parasocial_import.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for importing the BoTTube parasocial package."""
+
+import sys
+from pathlib import Path
+
+
+def test_bottube_parasocial_package_import_and_factory():
+    integrations_dir = Path(__file__).resolve().parents[1] / "integrations"
+    sys.path.insert(0, str(integrations_dir))
+    original_module = sys.modules.pop("bottube_parasocial", None)
+    try:
+        import bottube_parasocial
+
+        agent = bottube_parasocial.create_parasocial_agent("agent-1")
+    finally:
+        sys.modules.pop("bottube_parasocial", None)
+        if original_module is not None:
+            sys.modules["bottube_parasocial"] = original_module
+        sys.path.remove(str(integrations_dir))
+
+    assert set(agent) == {"tracker", "responder", "description_generator"}


### PR DESCRIPTION
## Summary
- use package-relative sibling imports for BoTTube parasocial modules, with direct-script fallback
- import `Dict` for the public `create_parasocial_agent()` return annotation
- add regression coverage for package import plus factory construction

Fixes #4690
Claims #305

## Verification
- `python -c "import sys; sys.path.insert(0, 'integrations'); import bottube_parasocial; print(sorted(bottube_parasocial.create_parasocial_agent('agent-1')))"` -> `['description_generator', 'responder', 'tracker']`
- `python -m pytest tests\test_bottube_parasocial_import.py -q` -> 1 passed
- `python -m py_compile integrations\bottube_parasocial\__init__.py integrations\bottube_parasocial\comment_responder.py integrations\bottube_parasocial\description_generator.py tests\test_bottube_parasocial_import.py` -> passed
- `python -m ruff check integrations\bottube_parasocial\__init__.py integrations\bottube_parasocial\comment_responder.py integrations\bottube_parasocial\description_generator.py --select F821` -> All checks passed
- `git diff --check -- integrations\bottube_parasocial\__init__.py integrations\bottube_parasocial\comment_responder.py integrations\bottube_parasocial\description_generator.py tests\test_bottube_parasocial_import.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
