### PR TITLE
fix: repair agent economy bounty creation

### DIFF
--- a/sdk/rustchain/agent_economy/bounties.py
+++ b/sdk/rustchain/agent_economy/bounties.py
@@ -6,7 +6,7 @@ Manages bounty discovery, claims, and automated payments.
 
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 
 

--- a/sdk/tests/test_agent_economy.py
+++ b/sdk/tests/test_agent_economy.py
@@ -539,6 +539,36 @@ class TestBountyClient(unittest.TestCase):
         self.assertTrue(expired_bounty.is_expired)
         self.assertFalse(active_bounty.is_expired)
 
+    def test_create_bounty_sets_deadline_and_payload(self):
+        """Test creating a bounty includes a computed deadline"""
+        self.mock_client._request.return_value = {"bounty_id": "bounty_new"}
+
+        bounty = self.bounties.create_bounty(
+            title="Fix SDK bug",
+            description="Repair bounty creation",
+            reward=12.5,
+            tier=BountyTier.MINOR,
+            requirements=["regression test"],
+            tags=["sdk"],
+            deadline_days=7,
+        )
+
+        self.assertEqual(bounty.bounty_id, "bounty_new")
+        self.assertEqual(bounty.issuer, "bounty-hunter")
+        self.assertEqual(bounty.tier, BountyTier.MINOR)
+        self.assertEqual(bounty.reward, 12.5)
+        self.assertIsNotNone(bounty.deadline)
+
+        self.mock_client._request.assert_called_once()
+        _, _, kwargs = self.mock_client._request.mock_calls[0]
+        payload = kwargs["json_payload"]
+        self.assertEqual(payload["issuer_id"], "bounty-hunter")
+        self.assertEqual(payload["title"], "Fix SDK bug")
+        self.assertEqual(payload["tier"], "minor")
+        self.assertEqual(payload["requirements"], ["regression test"])
+        self.assertEqual(payload["tags"], ["sdk"])
+        self.assertIn("deadline", payload)
+
 
 class TestIntegration(unittest.TestCase):
     """Integration tests mocking HTTP requests"""


### PR DESCRIPTION
## Summary
- import `timedelta` for Agent Economy bounty deadline creation
- add a regression for `BountyClient.create_bounty()` covering deadline payload creation and returned `Bounty` fields

Fixes #4693.

## Verification
- `python -c "import importlib.util; from unittest.mock import Mock; spec=importlib.util.spec_from_file_location('bounties','sdk/rustchain/agent_economy/bounties.py'); mod=importlib.util.module_from_spec(spec); spec.loader.exec_module(mod); client=Mock(); client.config.agent_id='issuer-1'; client._request.return_value={'bounty_id':'bounty-1'}; bounty=mod.BountyClient(client).create_bounty('Title','Description',5.0); print(bounty.bounty_id, client._request.call_args.kwargs['json_payload']['deadline'][:4])"` -> `bounty-1 2026`
- `PYTHONPATH=sdk python -m pytest sdk\tests\test_agent_economy.py::TestBountyClient::test_create_bounty_sets_deadline_and_payload sdk\tests\test_agent_economy.py::TestBountyClient::test_bounty_is_expired -q` -> 2 passed
- `python -m py_compile sdk\rustchain\agent_economy\bounties.py sdk\tests\test_agent_economy.py` -> passed
- `python -m ruff check sdk\rustchain\agent_economy\bounties.py --select F821` -> All checks passed
- `git diff --check -- sdk\rustchain\agent_economy\bounties.py sdk\tests\test_agent_economy.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
