### PR TITLE
fix: repair mac miner v2.4 optional helper fallback

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/rustchain_mac_miner_v2.4.py
@@ -18,6 +18,14 @@ import statistics
 import re
 from datetime import datetime
 
+try:
+    from color_logs import error, info, success, warning
+except ImportError:
+    def info(msg): return msg
+    def warning(msg): return msg
+    def success(msg): return msg
+    def error(msg): return msg
+
 # Import fingerprint checks
 try:
     from fingerprint_checks import validate_all_checks

--- a/tests/test_mac_miner_v24_cli.py
+++ b/tests/test_mac_miner_v24_cli.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/test_mac_miner_v24_cli.py
+++ b/tests/test_mac_miner_v24_cli.py
@@ -1,0 +1,20 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_mac_miner_v24_version_does_not_require_optional_helpers():
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "miners" / "macos" / "rustchain_mac_miner_v2.4.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--version"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert "RustChain Mac Miner v2.4.0" in result.stdout
+    assert "NameError" not in result.stderr


### PR DESCRIPTION
## Summary
- import Mac miner v2.4 color helper functions before optional helper fallback logging uses them
- keep plain-text fallback helpers if `color_logs.py` is unavailable
- add a subprocess regression for `--version` so optional helper imports cannot crash before argparse

Fixes #4695.

## Verification
- `python miners\macos\rustchain_mac_miner_v2.4.py --version` -> printed optional-helper warnings and `RustChain Mac Miner v2.4.0`
- `python -m pytest tests\test_mac_miner_v24_cli.py -q` -> 1 passed
- `python -m py_compile miners\macos\rustchain_mac_miner_v2.4.py tests\test_mac_miner_v24_cli.py` -> passed
- `python -m ruff check miners\macos\rustchain_mac_miner_v2.4.py --select F821` -> All checks passed
- `git diff --check -- miners\macos\rustchain_mac_miner_v2.4.py tests\test_mac_miner_v24_cli.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
