### PR TITLE
fix: repair bottube uploader JSON requests

### DIFF
--- a/tests/test_bottube_uploader_request.py
+++ b/tests/test_bottube_uploader_request.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_bottube_uploader_request.py
+++ b/tests/test_bottube_uploader_request.py
@@ -1,0 +1,42 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_uploader_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "vintage_ai_video_pipeline" / "bottube_uploader.py"
+    spec = importlib.util.spec_from_file_location("bottube_uploader", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def read(self):
+        return b'{"ok": true}'
+
+
+def test_json_post_uses_urllib_request(monkeypatch):
+    module = load_uploader_module()
+    captured = {}
+
+    def fake_urlopen(req, context=None, timeout=None):
+        captured["request"] = req
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(module.urllib.request, "urlopen", fake_urlopen)
+    uploader = module.BoTTubeUploader(api_key=None, base_url="https://example.test")
+
+    result = uploader._request("POST", "/api/videos", data={"title": "demo"})
+
+    assert result == {"ok": True}
+    assert captured["request"].full_url == "https://example.test/api/videos"
+    assert captured["request"].data == b'{"title": "demo"}'
+    assert captured["request"].headers["Content-type"] == "application/json"

--- a/vintage_ai_video_pipeline/bottube_uploader.py
+++ b/vintage_ai_video_pipeline/bottube_uploader.py
@@ -102,7 +102,7 @@ class BoTTubeUploader:
                     )
                 elif data and method in ("POST", "PUT", "PATCH"):
                     headers["Content-Type"] = "application/json"
-                    req = Request(
+                    req = urllib.request.Request(
                         url,
                         data=json.dumps(data).encode("utf-8"),
                         headers=headers,


### PR DESCRIPTION
## Summary
- use `urllib.request.Request` for JSON body requests in the vintage BoTTube uploader
- add a local fake-`urlopen` regression for JSON POST request construction

Fixes #4697.

## Verification
- `python -m pytest tests\test_bottube_uploader_request.py -q` -> 1 passed
- `python -m py_compile vintage_ai_video_pipeline\bottube_uploader.py tests\test_bottube_uploader_request.py` -> passed
- `python -m ruff check vintage_ai_video_pipeline\bottube_uploader.py --select F821` -> All checks passed
- `git diff --check -- vintage_ai_video_pipeline\bottube_uploader.py tests\test_bottube_uploader_request.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
