### PR TITLE
fix: repair proof of antiquity demo year reference

### DIFF
--- a/rips/python/rustchain/proof_of_antiquity.py
+++ b/rips/python/rustchain/proof_of_antiquity.py
@@ -456,7 +456,7 @@ if __name__ == "__main__":
         tier = HardwareTier.from_release_year(year)
 
         print(f"📟 {model} ({year})")
-        print(f"   Age: {CURRENT_YEAR - year} years")
+        print(f"   Age: {current_year - year} years")
         print(f"   Uptime: {uptime} days")
         print(f"   Tier: {tier.value.upper()} ({tier.multiplier}x)")
         print(f"   Antiquity Score: {as_score:.2f}")

--- a/tests/test_poa_demo_cli.py
+++ b/tests/test_poa_demo_cli.py
@@ -1,0 +1,25 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_proof_of_antiquity_demo_runs():
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root / "rips" / "python")
+    env["PYTHONIOENCODING"] = "utf-8"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "rustchain.proof_of_antiquity"],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert "RUSTCHAIN PROOF OF ANTIQUITY" in result.stdout
+    assert "Ryzen 9 7950X" in result.stdout
+    assert "NameError" not in result.stderr


### PR DESCRIPTION
## Summary
- use the demo's computed `current_year` when printing Proof of Antiquity example ages
- add a subprocess regression for `python -m rustchain.proof_of_antiquity`

Fixes #4699.

## Verification
- `PYTHONPATH=rips/python PYTHONIOENCODING=utf-8 python -m rustchain.proof_of_antiquity` -> printed all demo examples through `Ryzen 9 7950X`
- `python -m pytest tests\test_poa_demo_cli.py -q` -> 1 passed
- `python -m py_compile rips\python\rustchain\proof_of_antiquity.py tests\test_poa_demo_cli.py` -> passed
- `python -m ruff check rips\python\rustchain\proof_of_antiquity.py --select F821` -> All checks passed
- `git diff --check -- rips\python\rustchain\proof_of_antiquity.py tests\test_poa_demo_cli.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
