### PR TITLE
fix: repair faucet metrics database path

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -658,6 +658,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         @app.route(metrics_path)
         def metrics():
             """Prometheus metrics endpoint."""
+            db_path = config.get('database', {}).get('path', 'faucet.db')
             conn = sqlite3.connect(db_path)
             c = conn.cursor()
             

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -382,6 +382,20 @@ class TestFlaskApp(unittest.TestCase):
         data = json.loads(response.data)
         self.assertTrue(data['ok'])
 
+    def test_metrics_endpoint_uses_configured_database_path(self):
+        """Test metrics endpoint reads the configured faucet database."""
+        self.config['monitoring']['metrics_enabled'] = True
+        app = create_app(self.config)
+        client = app.test_client()
+
+        response = client.get('/metrics')
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_data(as_text=True)
+        self.assertIn('faucet_drips_total 0', body)
+        self.assertIn('faucet_amount_total 0', body)
+        self.assertEqual(response.content_type, 'text/plain')
+
     def test_drip_missing_wallet(self):
         """Test drip request without wallet."""
         response = self.client.post('/faucet/drip',


### PR DESCRIPTION
## Summary
- fix the optional faucet `/metrics` route so it resolves the configured database path before opening SQLite
- add regression coverage with `monitoring.metrics_enabled = True`
- keep behavior aligned with the existing `/faucet/status` database lookup

Fixes #4705.

## Validation
- `python -m pytest faucet_service\test_faucet_service.py::TestFlaskApp::test_metrics_endpoint_uses_configured_database_path -q` -> 1 passed
- `python -m pytest faucet_service\test_faucet_service.py::TestFlaskApp -q` -> 11 passed
- `python -m pytest faucet_service\test_faucet_service.py -q` -> 34 passed
- `python -m py_compile faucet_service\faucet_service.py faucet_service\test_faucet_service.py` -> passed
- `python -m ruff check faucet_service\faucet_service.py --select F821` -> passed
- `git diff --check -- faucet_service\faucet_service.py faucet_service\test_faucet_service.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

## Bounty
Bug bounty claim under #305 for #4705.

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`