### PR TITLE
fix: restore integrated request logging

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -547,7 +547,7 @@ def _after(resp):
             "ip": get_client_ip(),
             "dur_ms": int(dur * 1000),
         }
-        log.info(json.dumps(rec, separators=(",", ":")))
+        app.logger.info(json.dumps(rec, separators=(",", ":")))
     except Exception:
         pass
     resp.headers["X-Request-Id"] = getattr(g, "request_id", "-")

--- a/node/tests/test_integrated_request_logging.py
+++ b/node/tests/test_integrated_request_logging.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def load_integrated_module():
+    spec = importlib.util.spec_from_file_location("rustchain_integrated_request_logging_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_after_request_emits_structured_request_log(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key-for-request-logging")
+    module = load_integrated_module()
+    info = Mock()
+    monkeypatch.setattr(module.app.logger, "info", info)
+
+    response = module.app.test_client().get("/definitely-missing", headers={"X-Request-Id": "req-test-1"})
+
+    assert response.status_code == 404
+    assert response.headers["X-Request-Id"] == "req-test-1"
+    info.assert_called()
+    payload = json.loads(info.call_args.args[0])
+    assert payload["req_id"] == "req-test-1"
+    assert payload["method"] == "GET"
+    assert payload["path"] == "/definitely-missing"
+    assert payload["status"] == 404


### PR DESCRIPTION
## Summary
- restore structured request logging in the integrated node after-request hook
- use the existing Flask app logger instead of an undefined `log` name
- add regression coverage that asserts a request emits a JSON log record and preserves `X-Request-Id`

Fixes #4707.

## Validation
- `python -m pytest node\tests\test_integrated_request_logging.py -q` -> 1 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_integrated_request_logging.py` -> passed
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_integrated_request_logging.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed
- `python -m ruff check node\rustchain_v2_integrated_v2.2.1_rip200.py --select F821 --output-format=concise` -> the fixed `log` F821 is gone; remaining `miners` and `status` F821s are unrelated/open-branch issues already submitted separately

## Bounty
Bug bounty claim under #305 for #4707.

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`