### PR TITLE
Guard lock ledger public query parsing

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -490,7 +490,7 @@ def get_pending_unlocks(
     """
     params = [now]
     
-    if before_timestamp:
+    if before_timestamp is not None:
         query += " AND unlock_at <= ?"
         params.append(before_timestamp)
     

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -637,12 +637,38 @@ def auto_release_expired_locks(
 def register_lock_ledger_routes(app):
     """Register lock ledger API routes with Flask app."""
     from flask import request, jsonify
+
+    pending_unlock_query = get_pending_unlocks
+
+    def parse_bounded_int_arg(
+        name: str,
+        default: Optional[int] = None,
+        *,
+        min_value: Optional[int] = None,
+        max_value: Optional[int] = None,
+    ) -> Tuple[Optional[int], Optional[Tuple[Any, int]]]:
+        raw_value = request.args.get(name)
+        if raw_value is None:
+            return default, None
+
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None, (jsonify({"error": f"Invalid {name} query parameter"}), 400)
+
+        if min_value is not None:
+            value = max(min_value, value)
+        if max_value is not None:
+            value = min(max_value, value)
+        return value, None
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):
         """Get locks for a specific miner."""
         status = request.args.get("status")
-        limit = int(request.args.get("limit", 100))
+        limit, error_response = parse_bounded_int_arg("limit", 100, min_value=1, max_value=500)
+        if error_response:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -700,16 +726,18 @@ def register_lock_ledger_routes(app):
             conn.close()
     
     @app.route('/api/lock/pending-unlock', methods=['GET'])
-    def get_pending_unlocks():
+    def get_pending_unlocks_route():
         """Get locks ready to be released."""
-        before = request.args.get("before")
-        limit = int(request.args.get("limit", 100))
-        
-        before_ts = int(before) if before else None
+        before_ts, error_response = parse_bounded_int_arg("before", None, min_value=0)
+        if error_response:
+            return error_response
+        limit, error_response = parse_bounded_int_arg("limit", 100, min_value=1, max_value=500)
+        if error_response:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:
-            locks = get_pending_unlocks(conn, before_timestamp=before_ts, limit=limit)
+            locks = pending_unlock_query(conn, before_timestamp=before_ts, limit=limit)
             
             return jsonify({
                 "ok": True,

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -746,6 +746,66 @@ class TestLockLedger:
         conn.close()
 
 
+class TestLockLedgerRoutes:
+    """Test lock ledger Flask routes."""
+
+    def _client(self, lock_ledger, db_path: str):
+        app = Flask(__name__)
+        lock_ledger.DB_PATH = db_path
+        lock_ledger.register_lock_ledger_routes(app)
+        return app.test_client()
+
+    def test_get_miner_locks_returns_400_for_invalid_limit(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+
+        response = client.get(f"/api/lock/miner/{funded_miner}?limit=abc")
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Invalid limit query parameter"
+
+    def test_get_pending_unlocks_returns_400_for_invalid_before(self, setup_test_db):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+
+        response = client.get("/api/lock/pending-unlock?before=not-a-timestamp")
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Invalid before query parameter"
+
+    def test_get_pending_unlocks_route_returns_expired_locks(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        conn = sqlite3.connect(setup_test_db["db_path"])
+        now = int(time.time())
+
+        conn.execute(
+            """
+            INSERT INTO lock_ledger (
+                bridge_transfer_id,
+                miner_id,
+                amount_i64,
+                lock_type,
+                locked_at,
+                unlock_at,
+                status,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'locked', ?)
+            """,
+            (None, funded_miner, 5 * 1000000, "bridge_deposit", now - 60, now - 5, now - 60),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.get("/api/lock/pending-unlock")
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["ok"] is True
+        assert payload["count"] == 1
+        assert payload["locks"][0]["miner_id"] == funded_miner
+
+
 # =============================================================================
 # Integration Tests
 # =============================================================================

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -773,6 +773,38 @@ class TestLockLedgerRoutes:
         assert response.status_code == 400
         assert response.get_json()["error"] == "Invalid before query parameter"
 
+    def test_get_pending_unlocks_honors_zero_before_cutoff(self, setup_test_db, funded_miner):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        conn = sqlite3.connect(setup_test_db["db_path"])
+        now = int(time.time())
+
+        conn.execute(
+            """
+            INSERT INTO lock_ledger (
+                bridge_transfer_id,
+                miner_id,
+                amount_i64,
+                lock_type,
+                locked_at,
+                unlock_at,
+                status,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, 'locked', ?)
+            """,
+            (None, funded_miner, 5 * 1000000, "bridge_deposit", now - 60, now - 5, now - 60),
+        )
+        conn.commit()
+        conn.close()
+
+        response = client.get("/api/lock/pending-unlock?before=0")
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["ok"] is True
+        assert payload["count"] == 0
+        assert payload["locks"] == []
+
     def test_get_pending_unlocks_route_returns_expired_locks(self, setup_test_db, funded_miner):
         lock_ledger = setup_test_db["lock_ledger"]
         client = self._client(lock_ledger, setup_test_db["db_path"])


### PR DESCRIPTION
Fixes #4680.

## Summary
- return explicit 400 JSON errors when `limit` or `before` query parameters are malformed
- clamp public lock-ledger query limits before they reach the DB helpers
- avoid the `/api/lock/pending-unlock` route shadowing the `get_pending_unlocks` query helper
- add route regression tests for invalid query values and the pending-unlock happy path

## Verification
- `python -m pytest tests/test_bridge_lock_ledger.py -q`
- `python -m py_compile node/lock_ledger.py tests/test_bridge_lock_ledger.py`
- `python -m ruff check node/lock_ledger.py tests/test_bridge_lock_ledger.py --select E9,F821`
- `git diff --check`
- `python tools/bcos_spdx_check.py --base-ref origin/main`