### PR TITLE
fix: avoid audit logger file locks

### DIFF
--- a/tools/comment-moderation-bot/src/audit_logger.py
+++ b/tools/comment-moderation-bot/src/audit_logger.py
@@ -6,7 +6,6 @@ Provides JSONL-based audit logging for moderation actions.
 
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -49,8 +48,9 @@ class AuditLogger:
         self._logger.setLevel(self.log_level)
         self._logger.handlers = []  # Clear existing handlers
 
-        # File handler for JSONL output
-        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        # File handler for JSONL output. This opens the file only while
+        # writing each record so test temp directories are not locked on Windows.
+        file_handler = JSONLFileHandler(log_file)
         file_handler.setLevel(self.log_level)
 
         # Custom formatter for JSONL
@@ -240,3 +240,25 @@ class JSONLFormatter(logging.Formatter):
         }
 
         return json.dumps(data, ensure_ascii=False)
+
+
+class JSONLFileHandler(logging.Handler):
+    """Write JSONL records without keeping the log file open."""
+
+    terminator = "\n"
+
+    def __init__(self, filename: Path, encoding: str = "utf-8"):
+        super().__init__()
+        self.filename = Path(filename)
+        self.encoding = encoding
+
+    def emit(self, record: logging.LogRecord) -> None:
+        """Append a formatted record to the JSONL log file."""
+        try:
+            message = self.format(record)
+            self.filename.parent.mkdir(parents=True, exist_ok=True)
+            with self.filename.open("a", encoding=self.encoding) as log_file:
+                log_file.write(message)
+                log_file.write(self.terminator)
+        except Exception:
+            self.handleError(record)

--- a/tools/comment-moderation-bot/tests/test_audit_logger_auth.py
+++ b/tools/comment-moderation-bot/tests/test_audit_logger_auth.py
@@ -5,12 +5,16 @@ Tests for Audit Logger and GitHub Auth modules.
 import json
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.audit_logger import AuditLogger, JSONLFormatter
 from src.scorer import ScoreBreakdown
+
+if TYPE_CHECKING:
+    from src.github_auth import GitHubAuth
 
 
 class TestAuditLogger:


### PR DESCRIPTION
## Summary

Fixes #4710.

The comment moderation audit logger used a persistent `logging.FileHandler` on a process-global logger. On Windows, that keeps the JSONL audit file open after each test, so temporary log directories cannot be removed during teardown.

This PR replaces the persistent file handler with a small append-on-emit JSONL handler. Each audit record is written with a short-lived file handle, preserving the existing JSONL output while avoiding leaked/locked handles. It also adds a type-only `GitHubAuth` import so the auth test annotations are visible to Ruff without runtime import side effects.

/claim #305

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation

- `python -m pytest tools\comment-moderation-bot\tests\test_audit_logger_auth.py -q -o addopts=` -> 13 passed, 3 skipped
- `python -m ruff check tools\comment-moderation-bot\src\audit_logger.py tools\comment-moderation-bot\tests\test_audit_logger_auth.py --select F821` -> passed
- `python -m py_compile tools\comment-moderation-bot\src\audit_logger.py tools\comment-moderation-bot\tests\test_audit_logger_auth.py` -> passed
- `git diff --check -- tools\comment-moderation-bot\src\audit_logger.py tools\comment-moderation-bot\tests\test_audit_logger_auth.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

Note: full `tools\comment-moderation-bot\tests` collection is blocked in this local environment by missing optional dependency `fastapi` from the package's dev stack.