### PR TITLE
fix: import flask globals in p2p sync

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -9,8 +9,9 @@ import sqlite3
 import time
 import json
 import threading
-from datetime import datetime
-from typing import List, Dict, Optional
+from typing import List, Dict
+
+from flask import jsonify, request
 
 # ============================================================================
 # PEER DISCOVERY & MANAGEMENT

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import sqlite3
+import sys
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import rustchain_p2p_sync
+
+
+def test_p2p_sync_flask_routes_use_flask_request_and_jsonify(tmp_path):
+    """P2P route handlers should not crash on missing Flask globals."""
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER,
+                hash TEXT,
+                data TEXT
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO blocks (height, hash, data) VALUES (?, ?, ?)",
+            (1, "block-hash", '{"ok": true}'),
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    announce = client.post("/p2p/announce", json={"peer_url": "http://10.0.0.2:8088"})
+    assert announce.status_code == 200
+    assert announce.get_json() == {"ok": True, "peers": 1}
+
+    peers = client.get("/p2p/peers")
+    assert peers.status_code == 200
+    assert peers.get_json()["peers"] == ["http://10.0.0.2:8088"]
+
+    blocks = client.get("/api/blocks?start=1&limit=1")
+    assert blocks.status_code == 200
+    assert blocks.get_json()["blocks"] == [
+        {"height": 1, "hash": "block-hash", "data": {"ok": True}}
+    ]


### PR DESCRIPTION
## Summary

Fixes #4712.

`node/rustchain_p2p_sync.py` registers Flask handlers that use `request` and `jsonify`, but neither name was imported. Calling the P2P endpoints through a Flask app crashed with `NameError` before returning a response.

This PR imports the Flask globals and adds a regression test that exercises all three affected routes through Flask's test client:
- `POST /p2p/announce`
- `GET /p2p/peers`
- `GET /api/blocks`

/claim #305

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation

- `python -m pytest node\tests\test_p2p_sync_flask_imports.py -q` -> 1 passed
- `python -m ruff check node\rustchain_p2p_sync.py --select F821` -> passed
- `python -m py_compile node\rustchain_p2p_sync.py node\tests\test_p2p_sync_flask_imports.py` -> passed
- `git diff --check -- node\rustchain_p2p_sync.py node\tests\test_p2p_sync_flask_imports.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed