### PR TITLE
fix: remove duplicate balance openapi schema

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -945,37 +945,6 @@ OPENAPI = {
                 }
             }
         },
-        "/balance/{miner_pk}": {
-            "get": {
-                "summary": "Get miner balance by public key",
-                "parameters": [
-                    {
-                        "name": "miner_pk",
-                        "in": "path",
-                        "required": True,
-                        "schema": {"type": "string"},
-                        "description": "Miner public key (hex)"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Miner balance",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "miner_pk": {"type": "string"},
-                                        "balance": {"type": "number"},
-                                        "pending_rewards": {"type": "number"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/wallet/balance": {
             "get": {
                 "summary": "Get wallet balance (requires wallet address)",

--- a/node/tests/test_integrated_openapi_balance_schema.py
+++ b/node/tests/test_integrated_openapi_balance_schema.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+NODE_PATH = Path(__file__).resolve().parents[1] / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def test_openapi_balance_path_is_not_shadowed_by_duplicate_schema():
+    """The OpenAPI balance path should expose the balance_rtc schema."""
+    source = NODE_PATH.read_text(encoding="utf-8")
+    assert source.count('"/balance/{miner_pk}"') == 1
+
+    balance_path = source[source.index('"/balance/{miner_pk}"'):]
+    wallet_path = balance_path.index('"/wallet/balance"')
+    balance_entry = balance_path[:wallet_path]
+
+    assert '"balance_rtc": {"type": "number"}' in balance_entry
+    assert '"pending_rewards": {"type": "number"}' not in balance_entry


### PR DESCRIPTION
## Summary

Fixes #4715.

`OPENAPI[paths]` defined `/balance/{miner_pk}` twice. Python kept only the later duplicate entry, so `/openapi.json` exposed the stale balance schema (`balance`, `pending_rewards`) and silently discarded the earlier `balance_rtc` schema.

This PR removes the duplicate stale entry and adds a regression test that verifies the integrated-node source contains exactly one `/balance/{miner_pk}` OpenAPI path and that the retained schema exposes `balance_rtc`.

## Validation

- `python -m pytest node\tests\test_integrated_openapi_balance_schema.py -q` -> 1 passed
- `python -m ruff check node\rustchain_v2_integrated_v2.2.1_rip200.py --select F601` -> passed
- `python -m ruff check node\tests\test_integrated_openapi_balance_schema.py --select F821,F401,F811` -> passed
- `python -m py_compile node\tests\test_integrated_openapi_balance_schema.py` -> passed
- `git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_integrated_openapi_balance_schema.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

Note: `python -m ruff check node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_integrated_openapi_balance_schema.py --select F601,F821` is still blocked by pre-existing unrelated F821 findings in the integrated node (`log`, `miners`, `status`), each already covered by separate open submissions. The fixed F601 duplicate-key finding is gone.