### PR TITLE
fix: remove verifier invalid markdown escapes

### DIFF
--- a/tests/test_bounty_verifier_py_compile.py
+++ b/tests/test_bounty_verifier_py_compile.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+import py_compile
+import warnings
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+VERIFIER_PATH = PROJECT_ROOT / "tools" / "bounty-bot-pro" / "verifier.py"
+
+
+def test_bounty_verifier_compiles_with_syntax_warnings_as_errors():
+    """Invalid escape sequences should not break strict bytecode compilation."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SyntaxWarning)
+        py_compile.compile(str(VERIFIER_PATH), doraise=True)

--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -104,7 +104,7 @@ class BountyVerifier:
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
         report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
-        report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
+        report += f"| Wallet `{wallet}` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
             # Mock content fetch


### PR DESCRIPTION
## Summary

Fixes #4717.

`tools/bounty-bot-pro/verifier.py` escaped Markdown inline-code backticks as `\`` inside an f-string. Modern Python reports that as an invalid escape sequence, and strict environments that promote `SyntaxWarning` to errors fail bytecode compilation before the verifier can run.

This PR removes the unnecessary backslash escapes and adds a regression test that compiles the verifier with `SyntaxWarning` treated as an error.

## Validation

- `python -W error::SyntaxWarning -m py_compile tools\bounty-bot-pro\verifier.py` -> passed
- `python -m pytest tests\test_bounty_verifier_py_compile.py -q` -> 1 passed
- `python -m ruff check tools\bounty-bot-pro\verifier.py tests\test_bounty_verifier_py_compile.py --select F821` -> passed
- `git diff --check -- tools\bounty-bot-pro\verifier.py tests\test_bounty_verifier_py_compile.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

Note: broader Ruff unused-import checks in `verifier.py` still report unrelated pre-existing unused imports (`time`, `yaml`, `List`). This PR keeps the fix scoped to the compile break.

/claim #4717
