### PR TITLE
fix: apply Warthog bonus in RIP-200 rewards

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -598,17 +598,17 @@ def calculate_epoch_rewards_time_aged(
                 "miner_attest_recent time-window query (may drop miners "
                 "if settlement is delayed)", epoch
             )
+            bonus_expr = "COALESCE(warthog_bonus, 1.0)" if has_warthog_col else "1.0"
             if has_checks_col:
-                cursor.execute("""
+                cursor.execute(f"""
                     SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp,
                            NULL as enrolled_weight,
-                           COALESCE(fingerprint_checks_json, '{}') as checks_json,
-                           COALESCE(warthog_bonus, 1.0) as warthog_bonus
+                           COALESCE(fingerprint_checks_json, '{{}}') as checks_json,
+                           {bonus_expr} as warthog_bonus
                     FROM miner_attest_recent
                     WHERE ts_ok >= ? AND ts_ok <= ?
                 """, (epoch_start_ts - ATTESTATION_TTL, epoch_end_ts))
             else:
-                bonus_expr = "COALESCE(warthog_bonus, 1.0)" if has_warthog_col else "1.0"
                 cursor.execute(f"""
                     SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp,
                            NULL as enrolled_weight,

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -1,6 +1,3 @@
-import json
-import random
-import hashlib
 #!/usr/bin/env python3
 """
 RIP-200: Round-Robin Consensus (1 CPU = 1 Vote)
@@ -17,7 +14,9 @@ Key Changes:
 """
 
 import hashlib
+import json
 import logging
+import random
 import sqlite3
 import time
 from typing import List, Tuple, Dict
@@ -548,6 +547,8 @@ def calculate_epoch_rewards_time_aged(
         # Schema compatibility: detect whether fingerprint_checks_json column exists
         cols = cursor.execute("PRAGMA table_info(miner_attest_recent)").fetchall()
         has_checks_col = any(col[1] == 'fingerprint_checks_json' for col in cols)
+        has_warthog_col = any(col[1] == 'warthog_bonus' for col in cols)
+        wart_sql = ", COALESCE(warthog_bonus, 1.0) " if has_warthog_col else ", 1.0 "
 
         # Primary source: epoch_enroll (per-epoch snapshot, matches finalize_epoch).
         try:
@@ -568,20 +569,24 @@ def calculate_epoch_rewards_time_aged(
             )
             for miner_pk, enrolled_weight in enrolled:
                 arch_row = cursor.execute(
-                    "SELECT device_arch, COALESCE(fingerprint_passed, 1)" + check_sql +
-                    "FROM miner_attest_recent WHERE miner = ? LIMIT 1",
+                    "SELECT device_arch, COALESCE(fingerprint_passed, 1)"
+                    + check_sql
+                    + wart_sql
+                    + "FROM miner_attest_recent WHERE miner = ? LIMIT 1",
                     (miner_pk,)
                 ).fetchone()
                 if arch_row:
                     device_arch = arch_row[0] or "unknown"
                     fp = arch_row[1]
                     checks_json = arch_row[2] or '{}' if has_checks_col else '{}'
+                    warthog_bonus = arch_row[3]
                 else:
                     # No attestation record — treat as unknown arch, fingerprint ok.
                     device_arch = "unknown"
                     fp = 1
                     checks_json = '{}'
-                epoch_miners.append((miner_pk, device_arch, fp, enrolled_weight, checks_json))
+                    warthog_bonus = 1.0
+                epoch_miners.append((miner_pk, device_arch, fp, enrolled_weight, checks_json, warthog_bonus))
         else:
             # SECURITY FIX #2159: Fallback for epochs without enrollment
             # records.  This path is vulnerable to the stale-attestation
@@ -597,15 +602,18 @@ def calculate_epoch_rewards_time_aged(
                 cursor.execute("""
                     SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp,
                            NULL as enrolled_weight,
-                           COALESCE(fingerprint_checks_json, '{}') as checks_json
+                           COALESCE(fingerprint_checks_json, '{}') as checks_json,
+                           COALESCE(warthog_bonus, 1.0) as warthog_bonus
                     FROM miner_attest_recent
                     WHERE ts_ok >= ? AND ts_ok <= ?
                 """, (epoch_start_ts - ATTESTATION_TTL, epoch_end_ts))
             else:
-                cursor.execute("""
+                bonus_expr = "COALESCE(warthog_bonus, 1.0)" if has_warthog_col else "1.0"
+                cursor.execute(f"""
                     SELECT DISTINCT miner, device_arch, COALESCE(fingerprint_passed, 1) as fp,
                            NULL as enrolled_weight,
-                           '{}' as checks_json
+                           '{{}}' as checks_json,
+                           {bonus_expr} as warthog_bonus
                     FROM miner_attest_recent
                     WHERE ts_ok >= ? AND ts_ok <= ?
                 """, (epoch_start_ts - ATTESTATION_TTL, epoch_end_ts))
@@ -623,6 +631,7 @@ def calculate_epoch_rewards_time_aged(
         fingerprint_ok = row[2] if len(row) > 2 else 1
         enrolled_weight = row[3] if len(row) > 3 else None
         checks_json = row[4] if len(row) > 4 else '{}'
+        warthog_bonus = row[5] if len(row) > 5 else 1.0
 
         # RIP-309: Only active checks count toward reward weight.
         # Inactive checks still run and log, but their pass/fail does not affect reward.
@@ -648,12 +657,8 @@ def calculate_epoch_rewards_time_aged(
         # Double-gated: fingerprint must pass (weight>0) AND fingerprint_ok==1
         if weight > 0 and fingerprint_ok == 1:
             try:
-                wart_row = cursor.execute(
-                    "SELECT warthog_bonus FROM miner_attest_recent WHERE miner=?",
-                    (miner_id,)
-                ).fetchone()
-                if wart_row and wart_row[0] and wart_row[0] > 1.0:
-                    weight *= wart_row[0]
+                if warthog_bonus and warthog_bonus > 1.0:
+                    weight *= warthog_bonus
             except Exception:
                 pass  # Column may not exist on older schemas
 

--- a/node/tests/test_rip200_warthog_bonus.py
+++ b/node/tests/test_rip200_warthog_bonus.py
@@ -57,3 +57,37 @@ def test_epoch_rewards_apply_warthog_bonus_from_enrollment_path(tmp_path):
         "miner_bonus": bonus_share,
         "miner_plain": total_reward - bonus_share,
     }
+
+
+def test_epoch_rewards_fallback_allows_checks_without_warthog_bonus(tmp_path):
+    db_path = tmp_path / "legacy_rewards.db"
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE miner_attest_recent (
+                miner TEXT NOT NULL,
+                device_arch TEXT,
+                ts_ok INTEGER NOT NULL,
+                fingerprint_passed INTEGER DEFAULT 1,
+                fingerprint_checks_json TEXT
+            );
+            """
+        )
+        db.executemany(
+            """
+            INSERT INTO miner_attest_recent(
+                miner, device_arch, ts_ok, fingerprint_passed, fingerprint_checks_json
+            )
+            VALUES (?, 'x86_64', ?, 1, '{}')
+            """,
+            [("legacy_a", rip200.GENESIS_TIMESTAMP), ("legacy_b", rip200.GENESIS_TIMESTAMP)],
+        )
+
+    rewards = rip200.calculate_epoch_rewards_time_aged(
+        str(db_path),
+        epoch=0,
+        total_reward_urtc=100,
+        current_slot=0,
+    )
+
+    assert rewards == {"legacy_a": 50, "legacy_b": 50}

--- a/node/tests/test_rip200_warthog_bonus.py
+++ b/node/tests/test_rip200_warthog_bonus.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+import rip_200_round_robin_1cpu1vote as rip200
+
+
+def test_epoch_rewards_apply_warthog_bonus_from_enrollment_path(tmp_path):
+    db_path = tmp_path / "rewards.db"
+    with sqlite3.connect(db_path) as db:
+        db.executescript(
+            """
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL,
+                weight REAL NOT NULL
+            );
+            CREATE TABLE miner_attest_recent (
+                miner TEXT NOT NULL,
+                device_arch TEXT,
+                fingerprint_passed INTEGER DEFAULT 1,
+                fingerprint_checks_json TEXT,
+                warthog_bonus REAL DEFAULT 1.0
+            );
+            """
+        )
+        db.executemany(
+            "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (0, ?, 1.0)",
+            [("miner_bonus",), ("miner_plain",)],
+        )
+        db.executemany(
+            """
+            INSERT INTO miner_attest_recent(
+                miner, device_arch, fingerprint_passed, fingerprint_checks_json, warthog_bonus
+            )
+            VALUES (?, 'x86_64', 1, '{}', ?)
+            """,
+            [("miner_bonus", 1.15), ("miner_plain", 1.0)],
+        )
+
+    total_reward = 2_150_000
+    rewards = rip200.calculate_epoch_rewards_time_aged(
+        str(db_path),
+        epoch=0,
+        total_reward_urtc=total_reward,
+        current_slot=0,
+    )
+
+    bonus_share = int((1.15 / 2.15) * total_reward)
+    assert rewards == {
+        "miner_bonus": bonus_share,
+        "miner_plain": total_reward - bonus_share,
+    }


### PR DESCRIPTION
/claim #4720

## Summary

Fixes the RIP-200 reward calculator so Warthog dual-mining bonuses are read while the SQLite connection is still open and then applied during reward weight calculation.

Previously, `calculate_epoch_rewards_time_aged()` closed the `sqlite3` connection before the later `cursor.execute("SELECT warthog_bonus ...")` lookup. That raised on the closed cursor and was swallowed by `except Exception: pass`, silently treating Warthog-qualified miners as if their bonus were `1.0`.

## Validation

- `python -m pytest node\tests\test_rip200_warthog_bonus.py -q` -> 1 passed
- `python -m py_compile node\rip_200_round_robin_1cpu1vote.py node\tests\test_rip200_warthog_bonus.py` -> passed
- `python -m ruff check node\rip_200_round_robin_1cpu1vote.py node\tests\test_rip200_warthog_bonus.py --select F821,F601,F811 --output-format=concise` -> passed
- `git diff --check -- node\rip_200_round_robin_1cpu1vote.py node\tests\test_rip200_warthog_bonus.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
