### PR TITLE
fix: require admin key for contributor approval

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
 
 from flask import Flask, request, redirect, url_for, flash
+from contextlib import closing
+import hmac
 import sqlite3
 import os
 import secrets
-from datetime import datetime
 
 app = Flask(__name__)
 
@@ -35,7 +36,7 @@ app.secret_key = SECRET_KEY
 DB_PATH = 'contributors.db'
 
 def init_db():
-    with sqlite3.connect(DB_PATH) as conn:
+    with closing(sqlite3.connect(DB_PATH)) as conn:
         conn.execute('''
             CREATE TABLE IF NOT EXISTS contributors (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -126,7 +127,7 @@ def index():
     </html>
     '''
     
-    with sqlite3.connect(DB_PATH) as conn:
+    with closing(sqlite3.connect(DB_PATH)) as conn:
         contributors = conn.execute(
             'SELECT * FROM contributors ORDER BY registration_date DESC'
         ).fetchall()
@@ -142,7 +143,7 @@ def register():
     contribution_history = request.form.get('contribution_history', '')
     
     try:
-        with sqlite3.connect(DB_PATH) as conn:
+        with closing(sqlite3.connect(DB_PATH)) as conn:
             conn.execute(
                 'INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history) VALUES (?, ?, ?, ?)',
                 (github_username, contributor_type, rtc_wallet, contribution_history)
@@ -156,7 +157,7 @@ def register():
 
 @app.route('/api/contributors')
 def api_contributors():
-    with sqlite3.connect(DB_PATH) as conn:
+    with closing(sqlite3.connect(DB_PATH)) as conn:
         contributors = conn.execute(
             'SELECT github_username, contributor_type, rtc_wallet, registration_date, status FROM contributors ORDER BY registration_date DESC'
         ).fetchall()
@@ -174,9 +175,26 @@ def api_contributors():
         ]
     }
 
-@app.route('/approve/<username>')
+def _require_admin_key():
+    expected_key = os.environ.get('CONTRIBUTOR_ADMIN_KEY', '')
+    if not expected_key:
+        return False, ('Contributor approval is disabled until CONTRIBUTOR_ADMIN_KEY is configured.', 503)
+
+    provided_key = request.headers.get('X-Admin-Key') or request.headers.get('X-API-Key') or ''
+    if not hmac.compare_digest(provided_key, expected_key):
+        return False, ('Invalid contributor admin key.', 403)
+
+    return True, None
+
+
+@app.route('/approve/<username>', methods=['POST'])
 def approve_contributor(username):
-    with sqlite3.connect(DB_PATH) as conn:
+    ok, error = _require_admin_key()
+    if not ok:
+        message, status_code = error
+        return message, status_code
+
+    with closing(sqlite3.connect(DB_PATH)) as conn:
         conn.execute(
             'UPDATE contributors SET status = "approved" WHERE github_username = ?',
             (username,)

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -1,8 +1,8 @@
 import pytest
+from contextlib import closing
 import sqlite3
 import os
 import tempfile
-from unittest.mock import patch, MagicMock
 
 # Module under test
 import contributor_registry as cr
@@ -29,7 +29,7 @@ def client(app):
 @pytest.fixture
 def seed_contributor(app):
     """Insert a test contributor into the database."""
-    with sqlite3.connect(cr.DB_PATH) as conn:
+    with closing(sqlite3.connect(cr.DB_PATH)) as conn:
         conn.execute(
             "INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history, status) "
             "VALUES (?, ?, ?, ?, ?)",
@@ -41,7 +41,7 @@ def seed_contributor(app):
 class TestInitDb:
     def test_creates_table(self, app):
         """init_db should create the contributors table."""
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
             result = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='contributors'"
             ).fetchone()
@@ -77,7 +77,7 @@ class TestRegisterRoute:
             "contribution_history": "Mining and staking",
         }, follow_redirects=True)
         assert response.status_code == 200
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
             row = conn.execute(
                 "SELECT contributor_type, status FROM contributors WHERE github_username='newuser'"
             ).fetchone()
@@ -122,17 +122,84 @@ class TestApiContributors:
 
 
 class TestApproveRoute:
-    def test_approve_pending_contributor(self, client):
-        """GET /approve/<username> should set status to approved."""
+    def test_approve_rejects_get_requests(self, client, monkeypatch):
+        """GET /approve/<username> should not mutate contributor status."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "secret-admin-key")
         client.post("/register", data={
             "github_username": "pendinguser",
             "contributor_type": "bot",
             "rtc_wallet": "RTC0pending",
             "contribution_history": "",
         }, follow_redirects=True)
-        response = client.get("/approve/pendinguser", follow_redirects=True)
+        response = client.get(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "secret-admin-key"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 405
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_fails_closed_without_configured_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> should fail when no admin key is configured."""
+        monkeypatch.delenv("CONTRIBUTOR_ADMIN_KEY", raising=False)
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+        response = client.post("/approve/pendinguser", follow_redirects=True)
+        assert response.status_code == 503
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_rejects_missing_or_wrong_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> should require the configured admin key."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "secret-admin-key")
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+
+        missing_response = client.post("/approve/pendinguser", follow_redirects=True)
+        wrong_response = client.post(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "wrong-key"},
+            follow_redirects=True,
+        )
+        assert missing_response.status_code == 403
+        assert wrong_response.status_code == 403
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_pending_contributor_with_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> should approve when the admin key is valid."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "secret-admin-key")
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+        response = client.post(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "secret-admin-key"},
+            follow_redirects=True,
+        )
         assert response.status_code == 200
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='pendinguser'"
             ).fetchone()
@@ -142,7 +209,7 @@ class TestApproveRoute:
 class TestDatabaseConstraints:
     def test_unique_username_constraint(self, app):
         """Inserting duplicate github_username should raise IntegrityError."""
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
             conn.execute(
                 "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
                 ("unique_test", "human", "RTC0unique"),
@@ -160,9 +227,8 @@ class TestDatabaseConstraints:
             "contributor_type": "human",
             "rtc_wallet": "RTC0default",
         }, follow_redirects=True)
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with closing(sqlite3.connect(cr.DB_PATH)) as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"
             ).fetchone()
         assert row[0] == "pending"
-


### PR DESCRIPTION
/claim #4714

## Summary

Fixes the public contributor registry approval authorization issue reported in #4714.

The approval route now:
- accepts only `POST /approve/<username>` instead of state-changing GET requests,
- fails closed unless `CONTRIBUTOR_ADMIN_KEY` is configured,
- requires the configured key through `X-Admin-Key` or `X-API-Key`,
- uses `hmac.compare_digest()` for key comparison,
- keeps pending contributors unchanged for unconfigured, missing, wrong, and GET approval attempts.

I also changed the contributor registry DB access and focused tests to explicitly close SQLite connections. That keeps the regression suite reliable on Windows, where open handles prevent temporary DB cleanup.

## Validation

- `python -m pytest tests\test_contributor_registry.py -q` -> 15 passed, 1 warning
- `python -m py_compile contributor_registry.py tests\test_contributor_registry.py` -> passed
- `python -m ruff check contributor_registry.py tests\test_contributor_registry.py --select F821,F401,F811 --output-format=concise` -> passed
- `git diff --check -- contributor_registry.py tests\test_contributor_registry.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> passed

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`
