### PR TITLE
fix: preserve keeper explorer ascii template escapes

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -13,15 +13,12 @@ Features:
 """
 
 import os
-import sys
-import json
 import time
 import hashlib
 import sqlite3
 import requests
-from flask import Flask, request, jsonify, render_template_string, send_from_directory
+from flask import Flask, request, jsonify, render_template_string
 from flask_cors import CORS
-from datetime import datetime
 
 # Configuration
 NODE_API = os.environ.get("RUSTCHAIN_NODE_API", "http://localhost:8000")
@@ -120,7 +117,7 @@ def faucet_drip():
 
 # --- Fossil-punk UI Template ---
 
-RETRO_HTML = """
+RETRO_HTML = r"""
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/test_keeper_explorer_py_compile.py
+++ b/tests/test_keeper_explorer_py_compile.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_keeper_explorer_compiles_with_syntax_warnings_as_errors():
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::SyntaxWarning",
+            "-m",
+            "py_compile",
+            "keeper_explorer.py",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- fix #4725 by making the embedded keeper explorer HTML template a raw string so ASCII-art backslashes are preserved without invalid escape warnings
- remove unused imports from the same file
- add a regression that compiles `keeper_explorer.py` with `SyntaxWarning` promoted to an error

## Validation
- `python -m pytest tests\test_keeper_explorer_py_compile.py -q`
- `python -W error::SyntaxWarning -m py_compile keeper_explorer.py tests\test_keeper_explorer_py_compile.py`
- `python -m ruff check keeper_explorer.py tests\test_keeper_explorer_py_compile.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- keeper_explorer.py tests\test_keeper_explorer_py_compile.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
