### PR TITLE
fix: preserve windows config path docstring

### DIFF
--- a/miners/windows/installer/src/config_manager.py
+++ b/miners/windows/installer/src/config_manager.py
@@ -1,4 +1,4 @@
-"""
+r"""
 RustChain Config Manager
 Manages configuration between the installer and the miner.
 Config file location: %APPDATA%\RustChain\config.json

--- a/tests/test_windows_config_manager_py_compile.py
+++ b/tests/test_windows_config_manager_py_compile.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_windows_config_manager_compiles_with_syntax_warnings_as_errors():
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::SyntaxWarning",
+            "-m",
+            "py_compile",
+            "miners/windows/installer/src/config_manager.py",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- fix #4727 by making the Windows installer config manager module docstring raw, preserving `%APPDATA%\RustChain\config.json` without invalid escape warnings
- add a strict `py_compile` regression for the installer config module

## Validation
- `python -m pytest tests\test_windows_config_manager_py_compile.py -q`
- `python -W error::SyntaxWarning -m py_compile miners\windows\installer\src\config_manager.py tests\test_windows_config_manager_py_compile.py`
- `python -m ruff check miners\windows\installer\src\config_manager.py tests\test_windows_config_manager_py_compile.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- miners\windows\installer\src\config_manager.py tests\test_windows_config_manager_py_compile.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
