### PR TITLE
fix: compile legacy v3 fingerprint miner

### DIFF
--- a/deprecated/old_miners/rustchain_miner_v3_fingerprint.py
+++ b/deprecated/old_miners/rustchain_miner_v3_fingerprint.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """
 RustChain Universal Miner v3.0 - With Full Hardware Fingerprinting
 ===================================================================
 Runs all 6 RIP-PoA fingerprint checks to prove real hardware.
 Emulators/VMs will FAIL these checks and be denied RTC rewards.
 """
-import os, sys, json, time, hashlib, platform, subprocess, statistics, requests
+import os, sys, json, time, hashlib, platform, statistics, requests
 from datetime import datetime
 from typing import Dict, Tuple
 
@@ -235,7 +236,8 @@ def run_all_fingerprint_checks() -> Tuple[bool, Dict]:
         print(f"  Result: {status}")
     
     print("\n" + "=" * 50)
-    print(f"OVERALL: {[PASS] ALL CHECKS PASSED if all_passed else [FAIL] FAILED}")
+    overall_status = "[PASS] ALL CHECKS PASSED" if all_passed else "[FAIL] FAILED"
+    print(f"OVERALL: {overall_status}")
     
     return all_passed, results
 

--- a/tests/test_v3_fingerprint_miner_py_compile.py
+++ b/tests/test_v3_fingerprint_miner_py_compile.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: MIT
+import py_compile
+from pathlib import Path
+
+
+def test_deprecated_v3_fingerprint_miner_compiles():
+    repo_root = Path(__file__).resolve().parents[1]
+    py_compile.compile(
+        str(repo_root / "deprecated" / "old_miners" / "rustchain_miner_v3_fingerprint.py"),
+        doraise=True,
+    )


### PR DESCRIPTION
## Summary
- fix #4729 by converting the invalid overall-status f-string expression into an explicit status string
- remove the unused `subprocess` import from the same file
- add SPDX to the touched legacy miner file and add a compile regression

## Validation
- `python -m pytest tests\test_v3_fingerprint_miner_py_compile.py -q`
- `python -m py_compile deprecated\old_miners\rustchain_miner_v3_fingerprint.py tests\test_v3_fingerprint_miner_py_compile.py`
- `python -m ruff check deprecated\old_miners\rustchain_miner_v3_fingerprint.py tests\test_v3_fingerprint_miner_py_compile.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- deprecated\old_miners\rustchain_miner_v3_fingerprint.py tests\test_v3_fingerprint_miner_py_compile.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
