### PR TITLE
fix: compile entropy enforcement patch helper

### DIFF
--- a/deprecated/patches/rustchain_entropy_enforcement_patch.py
+++ b/deprecated/patches/rustchain_entropy_enforcement_patch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """
 RustChain Server-Side Entropy Enforcement Patch
 ================================================
@@ -24,7 +25,7 @@ MIN_ENTROPY_SCORE = 0.15  # Phase 1: Start low
 MIN_ENTROPY_WARNING = 0.20  # Warn if below this
 MIN_ENTROPY_STRICT = 0.30  # Phase 2: Future strict enforcement
 
-PATCH_INSTRUCTIONS = """
+PATCH_INSTRUCTIONS = r'''
 ================================================================================
 RUSTCHAIN ENTROPY ENFORCEMENT PATCH
 ================================================================================
@@ -143,7 +144,7 @@ In the final success response of submit_attestation(), add entropy data:
     })
 
 ================================================================================
-"""
+'''
 
 
 def check_prerequisites(node_path="/root/rustchain"):

--- a/tests/test_entropy_patch_py_compile.py
+++ b/tests/test_entropy_patch_py_compile.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+import py_compile
+from pathlib import Path
+
+
+def test_entropy_enforcement_patch_compiles():
+    repo_root = Path(__file__).resolve().parents[1]
+    py_compile.compile(
+        str(
+            repo_root
+            / "deprecated"
+            / "patches"
+            / "rustchain_entropy_enforcement_patch.py"
+        ),
+        doraise=True,
+    )


### PR DESCRIPTION
## Summary
- fix #4731 by changing `PATCH_INSTRUCTIONS` to a raw triple-single-quoted string so the embedded SQL triple-double-quoted snippet no longer terminates the outer string
- add SPDX to the touched patch helper
- add a compile regression for the entropy enforcement patch helper

## Validation
- `python -m pytest tests\test_entropy_patch_py_compile.py -q`
- `python -m py_compile deprecated\patches\rustchain_entropy_enforcement_patch.py tests\test_entropy_patch_py_compile.py`
- `python -m ruff check deprecated\patches\rustchain_entropy_enforcement_patch.py tests\test_entropy_patch_py_compile.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- deprecated\patches\rustchain_entropy_enforcement_patch.py tests\test_entropy_patch_py_compile.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
