### PR TITLE
fix: preserve power8 grep pattern escapes

### DIFF
--- a/miners/power8/fingerprint_checks_power8.py
+++ b/miners/power8/fingerprint_checks_power8.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """
 RIP-PoA Hardware Fingerprint Validation - POWER8 Optimized
 ===========================================================
@@ -18,7 +19,7 @@ import random
 import statistics
 import subprocess
 import time
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Tuple
 
 
 def check_clock_drift(samples: int = 200) -> Tuple[bool, Dict]:
@@ -169,7 +170,7 @@ def check_simd_identity() -> Tuple[bool, Dict]:
     if not flags and ("ppc" in arch or "power" in arch):
         try:
             result = subprocess.run(
-                ["grep", "-i", "vsx\|altivec\|dfp", "/proc/cpuinfo"],
+                ["grep", "-i", r"vsx\|altivec\|dfp", "/proc/cpuinfo"],
                 capture_output=True, text=True, timeout=5
             )
             if result.stdout:

--- a/tests/test_power8_fingerprint_py_compile.py
+++ b/tests/test_power8_fingerprint_py_compile.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_power8_fingerprint_checks_compile_with_syntax_warnings_as_errors():
+    repo_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::SyntaxWarning",
+            "-m",
+            "py_compile",
+            "miners/power8/fingerprint_checks_power8.py",
+        ],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- fix #4733 by making the POWER8 grep alternation pattern a raw string, preserving the intended `vsx\|altivec\|dfp` behavior without invalid escape warnings
- remove unused typing imports from the touched file
- add SPDX to the touched POWER8 helper and add a strict `py_compile` regression

## Validation
- `python -m pytest tests\test_power8_fingerprint_py_compile.py -q`
- `python -W error::SyntaxWarning -m py_compile miners\power8\fingerprint_checks_power8.py tests\test_power8_fingerprint_py_compile.py`
- `python -m ruff check miners\power8\fingerprint_checks_power8.py tests\test_power8_fingerprint_py_compile.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- miners\power8\fingerprint_checks_power8.py tests\test_power8_fingerprint_py_compile.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
