### PR TITLE
docs: fix BCOS comparison links

### DIFF
--- a/docs/bcos/compare.html
+++ b/docs/bcos/compare.html
@@ -660,7 +660,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> Anchors verification to RustChain using BLAKE2b-256 commitments. Immutable, timestamped proof.</div>
                   <div><strong>Nucleus:</strong> No blockchain integration.</div>
-                  <a href="../BCOS.md" class="evidence-link">📄 Evidence: BCOS Methodology Spec</a>
+                  <a href="../../BCOS.md" class="evidence-link">📄 Evidence: BCOS Methodology Spec</a>
                   <a href="https://github.com/Scottcjn/rustchain-bounties/blob/main/bcos_directory.py" class="evidence-link">📄 Evidence: bcos_directory.py</a>
                 </div>
               </td>
@@ -689,7 +689,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> L2 tier requires human maintainer approval + Beacon identity signature (Ed25519).</div>
                   <div><strong>Nucleus:</strong> Fully automated, no human attestation.</div>
-                  <a href="../BOUNTY_2275_FORMAL_VERIFICATION.md" class="evidence-link">📄 Evidence: L2 Review Specification</a>
+                  <a href="../../BOUNTY_2275_FORMAL_VERIFICATION.md" class="evidence-link">📄 Evidence: L2 Review Specification</a>
                 </div>
               </td>
             </tr>
@@ -703,7 +703,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> Public formula: (License×20) + (Vuln×25) + (Static×20) + (Test×15) + (Review) + (Deps×10) + (Community×10)</div>
                   <div><strong>Nucleus:</strong> Proprietary scoring, formula not disclosed.</div>
-                  <a href="../BCOS.md#trust-score-calculation" class="evidence-link">📄 Evidence: Trust Score Formula</a>
+                  <a href="../../BCOS.md#trust-score-calculation" class="evidence-link">📄 Evidence: Trust Score Formula</a>
                 </div>
               </td>
             </tr>
@@ -746,7 +746,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> Exports SBOM in industry-standard SPDX and CycloneDX formats.</div>
                   <div><strong>Nucleus:</strong> Uses proprietary format, limited export options.</div>
-                  <a href="agent_economy_sdk.py" class="evidence-link">📄 Evidence: SBOM Implementation</a>
+                  <a href="../../agent_economy_sdk.py" class="evidence-link">📄 Evidence: SBOM Implementation</a>
                 </div>
               </td>
             </tr>
@@ -802,7 +802,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> L0 (auto), L1 (agent+evidence), L2 (human+signature).</div>
                   <div><strong>Nucleus:</strong> Single verification tier.</div>
-                  <a href="../BCOS.md#review-tiers" class="evidence-link">📄 Evidence: Review Tiers Documentation</a>
+                  <a href="../../BCOS.md#review-tiers" class="evidence-link">📄 Evidence: Review Tiers Documentation</a>
                 </div>
               </td>
             </tr>
@@ -830,7 +830,7 @@
                 <div class="detail-content">
                   <div><strong>BCOS:</strong> Ed25519 signatures from Beacon identities for L2 reviews.</div>
                   <div><strong>Nucleus:</strong> No cryptographic attestation.</div>
-                  <a href="agent_reputation.py" class="evidence-link">📄 Evidence: Attestation Implementation</a>
+                  <a href="../../agent_reputation.py" class="evidence-link">📄 Evidence: Attestation Implementation</a>
                 </div>
               </td>
             </tr>
@@ -846,10 +846,10 @@
           <li><strong>BCOS MIT License:</strong> Full license terms at <a href="https://github.com/Scottcjn/rustchain-bounties/blob/main/LICENSE" target="_blank">github.com/rustchain-bounties/LICENSE</a></li>
           <li><strong>Nucleus Pricing:</strong> Current pricing at <a href="https://altermenta.com/nucleus/pricing" target="_blank">altermenta.com/nucleus/pricing</a></li>
           <li><strong>BCOS Repository:</strong> Source code at <a href="https://github.com/Scottcjn/rustchain-bounties" target="_blank">github.com/Scottcjn/rustchain-bounties</a></li>
-          <li><strong>BCOS Methodology:</strong> Technical specification in <a href="../BCOS.md">docs/BCOS.md</a></li>
+          <li><strong>BCOS Methodology:</strong> Technical specification in <a href="../../BCOS.md">BCOS.md</a></li>
           <li><strong>clawrtc CLI:</strong> Package at <a href="https://pypi.org/project/clawrtc/" target="_blank">pypi.org/project/clawrtc</a></li>
-          <li><strong>L2 Review Spec:</strong> Human review requirements in <a href="../BOUNTY_2275_FORMAL_VERIFICATION.md">BOUNTY_2275_FORMAL_VERIFICATION.md</a></li>
-          <li><strong>Trust Score Formula:</strong> Calculation details in <a href="../BCOS.md#trust-score-calculation">BCOS.md</a></li>
+          <li><strong>L2 Review Spec:</strong> Human review requirements in <a href="../../BOUNTY_2275_FORMAL_VERIFICATION.md">BOUNTY_2275_FORMAL_VERIFICATION.md</a></li>
+          <li><strong>Trust Score Formula:</strong> Calculation details in <a href="../../BCOS.md#trust-score-calculation">BCOS.md</a></li>
           <li><strong>GitHub Stars:</strong> BCOS: <a href="https://github.com/Scottcjn/rustchain-bounties/stargazers" target="_blank">183 stars</a> | Nucleus: <a href="https://github.com/altermenta/nucleus-verify/stargazers" target="_blank">0 stars</a></li>
           <li><strong>OSV Database:</strong> Open source CVE database at <a href="https://osv.dev/" target="_blank">osv.dev</a></li>
           <li><strong>Semgrep:</strong> Static analysis engine at <a href="https://semgrep.dev/" target="_blank">semgrep.dev</a></li>
@@ -1007,7 +1007,7 @@ clawrtc bcos report --format html --output report.html</code></pre>
 
       <h3>Technical References</h3>
       <ul>
-        <li><a href="../BCOS.md" target="_blank">BCOS Certification Overview</a></li>
+        <li><a href="../../BCOS.md" target="_blank">BCOS Certification Overview</a></li>
         <li><code>bcos_directory.py</code> - Directory backend implementation</li>
         <li><code>clawrtc bcos</code> - CLI tool source code</li>
       </ul>


### PR DESCRIPTION
## Summary
- Fix broken relative links in docs/bcos/compare.html so BCOS evidence references resolve from docs/bcos/ to the repository root.
- Update the visible BCOS methodology reference text to match the root-level BCOS.md target.

## Validation
- `rg -n 'href="(../BCOS.md|../BOUNTY_2275_FORMAL_VERIFICATION.md|agent_economy_sdk.py|agent_reputation.py)' docs/bcos/compare.html || true` returned no old broken hrefs.
- Parsed the page and verified the new href targets resolve to existing files: BCOS.md, BOUNTY_2275_FORMAL_VERIFICATION.md, agent_economy_sdk.py, and agent_reputation.py.
- `git diff --check`

Bounty: Scottcjn/rustchain-bounties#9018
RTC receive address: RTC991843db74121688c427d42ad7799a21e9d8adc2
