### PR TITLE
fix: add missing timedelta import in bounties.py

### DIFF
--- a/sdk/rustchain/agent_economy/bounties.py
+++ b/sdk/rustchain/agent_economy/bounties.py
@@ -6,7 +6,7 @@ Manages bounty discovery, claims, and automated payments.
 
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 
 


### PR DESCRIPTION
## Summary
`bounties.py` uses `timedelta(days=deadline_days)` on line 504 but only imports `datetime` from `datetime`, causing a `NameError` crash when any SDK caller tries to create a bounty.

## Fix
Added `timedelta` to the existing import: `from datetime import datetime, timedelta`

## Testing
- `python -W error::SyntaxWarning -m py_compile sdk/rustchain/agent_economy/bounties.py` passes

Fixes #4693

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>