### PR TITLE
fix: replace invalid escape sequences in verifier.py f-strings

### DIFF
--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -104,7 +104,7 @@ class BountyVerifier:
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
         report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
-        report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
+        report += f"| Wallet \\`{wallet}\\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
             # Mock content fetch


### PR DESCRIPTION
## Summary
`verifier.py` uses `\`` (backslash-backtick) in an f-string on line 107, which is not a valid Python escape sequence. With `SyntaxWarning` promoted to errors, the bytecode compilation fails before the verifier can run.

## Fix
Doubled the backslash to `\\`` which produces the intended markdown output (literal backslash + backtick).

## Testing
- `python -W error::SyntaxWarning -m py_compile tools/bounty-bot-pro/verifier.py` passes (previously failed)

Fixes #4717

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>