### PR TITLE
fix: add timedelta import and fix markdown backtick escape

### DIFF
--- a/sdk/rustchain/agent_economy/bounties.py
+++ b/sdk/rustchain/agent_economy/bounties.py
@@ -6,7 +6,7 @@ Manages bounty discovery, claims, and automated payments.
 
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 
 

--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -104,7 +104,7 @@ class BountyVerifier:
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
         report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
-        report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
+        report += f"| Wallet `{wallet}` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
             # Mock content fetch


### PR DESCRIPTION
Fixes two small bugs found in issues #4693 and #4717.

## Changes

**sdk/rustchain/agent_economy/bounties.py** (fixes #4693)
- Added `timedelta` to `from datetime import datetime, timedelta`
- Without this, any call to `BountyClient.create_bounty()` raises `NameError: name timedelta is not defined`

**tools/bounty-bot-pro/verifier.py** (fixes #4717)
- Replaced `\\`{wallet}\\`` with ``{wallet}`` in the f-string
- Backslash-escaped backticks are an invalid escape sequence; Python raises SyntaxWarning which becomes SyntaxError under `-W error::SyntaxWarning` or strict CI

Both files pass `python3 -W error::SyntaxWarning -m py_compile` after the fix.