### PR TITLE
fix: repair CRT validation imports on Windows

### DIFF
--- a/bounties/issue-2310/src/__init__.py
+++ b/bounties/issue-2310/src/__init__.py
@@ -7,10 +7,16 @@ This package provides practical CRT-based hardware attestation for RustChain.
 __version__ = '1.0.0'
 __author__ = 'RustChain Bounty Program'
 
-from crt_pattern_generator import CRTPatternGenerator
-from crt_capture import CRTCapture, CaptureConfig, CaptureMethod
-from crt_analyzer import CRTAnalyzer, CRTFingerprint
-from crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
+if __package__:
+    from .crt_pattern_generator import CRTPatternGenerator
+    from .crt_capture import CRTCapture, CaptureConfig, CaptureMethod
+    from .crt_analyzer import CRTAnalyzer, CRTFingerprint
+    from .crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
+else:
+    from crt_pattern_generator import CRTPatternGenerator
+    from crt_capture import CRTCapture, CaptureConfig, CaptureMethod
+    from crt_analyzer import CRTAnalyzer, CRTFingerprint
+    from crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
 
 __all__ = [
     'CRTPatternGenerator',

--- a/bounties/issue-2310/validate_bounty_2310.py
+++ b/bounties/issue-2310/validate_bounty_2310.py
@@ -25,13 +25,13 @@ def print_header(text):
     print(f"{BLUE}{'=' * 60}{RESET}\n")
 
 def print_success(text):
-    print(f"{GREEN}✅ {text}{RESET}")
+    print(f"{GREEN}[OK] {text}{RESET}")
 
 def print_error(text):
-    print(f"{RED}❌ {text}{RESET}")
+    print(f"{RED}[FAIL] {text}{RESET}")
 
 def print_info(text):
-    print(f"{YELLOW}ℹ️  {text}{RESET}")
+    print(f"{YELLOW}[INFO] {text}{RESET}")
 
 def check_file_exists(filepath, description):
     """Check if a file exists"""
@@ -48,7 +48,7 @@ def check_file_content(filepath, patterns, description):
         print_error(f"{description} missing: {filepath}")
         return False
     
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_found = True
@@ -66,7 +66,7 @@ def count_lines(filepath):
     """Count lines in a file"""
     if not os.path.exists(filepath):
         return 0
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         return sum(1 for _ in f)
 
 def get_file_hash(filepath):
@@ -242,7 +242,7 @@ def validate_tests():
         'pytest'
     ]
     
-    with open(test_file, 'r') as f:
+    with open(test_file, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_valid = True
@@ -271,7 +271,7 @@ def validate_evidence():
         print_error("Evidence file missing: proof.json")
         return False
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     required_fields = [
@@ -306,7 +306,7 @@ def validate_requirements():
     base_dir = Path(__file__).parent / 'evidence'
     proof_file = base_dir / 'proof.json'
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     req_verify = proof.get('requirements_verification', {})
@@ -404,10 +404,10 @@ def main():
     print(f"  Total source lines: {total_lines}")
     
     if passed == total:
-        print(f"\n{GREEN}✅ VALIDATION PASSED - Implementation is complete!{RESET}\n")
+        print(f"\n{GREEN}[OK] VALIDATION PASSED - Implementation is complete!{RESET}\n")
         return 0
     else:
-        print(f"\n{RED}❌ VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
+        print(f"\n{RED}[FAIL] VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
         return 1
 
 if __name__ == '__main__':

--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ISSUE_DIR = ROOT / "bounties" / "issue-2310"
+
+
+def test_crt_attestation_package_imports_from_parent_path():
+    pytest.importorskip("numpy")
+
+    code = (
+        "import sys; "
+        f"sys.path.insert(0, {str(ISSUE_DIR)!r}); "
+        "import src; "
+        "assert src.CRTAttestationSubmitter; "
+        "assert src.CRTPatternGenerator"
+    )
+
+    subprocess.run([sys.executable, "-c", code], check=True, cwd=ROOT)
+
+
+def test_issue2310_validator_does_not_crash_under_cp1252_stdout():
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+
+    result = subprocess.run(
+        [sys.executable, "validate_bounty_2310.py"],
+        cwd=ISSUE_DIR,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    combined_output = result.stdout + result.stderr
+    assert "UnicodeEncodeError" not in combined_output
+    assert "Final Results" in combined_output


### PR DESCRIPTION
Closes #4749.

## Summary
- make the CRT light attestation package importable from the parent bounty directory by using package-relative imports with a source-path fallback
- make the issue #2310 validator safe under Windows-style CP1252 output by replacing Unicode status glyphs with ASCII labels
- read validator text inputs as UTF-8 explicitly so README/test/evidence scans do not depend on the platform default codec
- add regression coverage for both the parent-path package import and CP1252 validator execution path

## Validation
- `python -m pytest bounties\issue-2310\tests\test_crt_attestation.py tests\test_issue2310_package_validation.py -q` -> 54 passed
- `python -m py_compile bounties\issue-2310\src\__init__.py bounties\issue-2310\validate_bounty_2310.py tests\test_issue2310_package_validation.py`
- `python -m ruff check bounties\issue-2310\src\__init__.py bounties\issue-2310\validate_bounty_2310.py tests\test_issue2310_package_validation.py --select F821,F401,F811 --output-format=concise`
- `git diff --check -- bounties\issue-2310\src\__init__.py bounties\issue-2310\validate_bounty_2310.py tests\test_issue2310_package_validation.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Wallet/miner ID for #305 bounty consideration: `RTC253255d034065a839cd421811ec589ae5b694ffc`