### PR TITLE
Secure relationship intervention route

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -28,6 +28,7 @@ Author: BoTTube Team
 import sqlite3
 import os
 import json
+import hmac
 import time
 import random
 import threading
@@ -1133,6 +1134,10 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/intervene", methods=["POST"])
     def admin_intervene(agent_a: str, agent_b: str):
+        auth_error = _require_mutation_admin()
+        if auth_error:
+            return auth_error
+
         data = request.json or {}
         try:
             result = engine.admin_intervene(

--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1046,6 +1046,15 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             or ""
         ).strip()
 
+    def _constant_time_key_match(provided_key: str, required_key: str) -> bool:
+        try:
+            return hmac.compare_digest(
+                provided_key.encode("utf-8"),
+                required_key.encode("utf-8"),
+            )
+        except UnicodeError:
+            return False
+
     def _require_mutation_admin():
         required_key = _required_mutation_admin_key()
         if not required_key:
@@ -1056,7 +1065,7 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             or request.headers.get("X-API-Key")
             or ""
         ).strip()
-        if not provided_key or not hmac.compare_digest(provided_key, required_key):
+        if not provided_key or not _constant_time_key_match(provided_key, required_key):
             return jsonify({"error": "Unauthorized relationship mutation"}), 401
 
         return None

--- a/tests/test_agent_relationships_admin_auth.py
+++ b/tests/test_agent_relationships_admin_auth.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+import pytest
+from flask import Flask
+
+from agent_relationships import RelationshipEngine, create_relationship_blueprint
+
+
+def _make_client(tmp_path):
+    engine = RelationshipEngine(db_path=str(tmp_path / "relationships.db"))
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(create_relationship_blueprint(engine))
+    return app.test_client(), engine
+
+
+def _create_rivalry(engine):
+    engine.initialize_relationship("alice", "bob")
+    for topic in ("formats", "timing", "editing"):
+        engine.record_disagreement("alice", "bob", topic)
+    relationship = engine.get_relationship("alice", "bob")
+    assert relationship["state"] == "rivals"
+    return relationship
+
+
+def _relationship_state(engine):
+    relationship = engine.get_relationship("alice", "bob")
+    return {
+        "state": relationship["state"],
+        "tension_level": relationship["tension_level"],
+        "trust_level": relationship["trust_level"],
+        "disagreement_count": relationship["disagreement_count"],
+    }
+
+
+def _intervention_count(engine):
+    with sqlite3.connect(engine.db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM admin_interventions").fetchone()[0]
+
+
+def test_intervention_fails_closed_when_admin_key_unconfigured(tmp_path, monkeypatch):
+    client, engine = _make_client(tmp_path)
+    _create_rivalry(engine)
+    expected_state = _relationship_state(engine)
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    response = client.post(
+        "/api/relationships/alice/bob/intervene",
+        json={"reason": "moderation reset"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Relationship mutation admin key is not configured"
+    assert _relationship_state(engine) == expected_state
+    assert _intervention_count(engine) == 0
+
+
+@pytest.mark.parametrize("headers", [{}, {"X-Admin-Key": "wrong-admin-key"}])
+def test_intervention_requires_valid_admin_key(tmp_path, monkeypatch, headers):
+    client, engine = _make_client(tmp_path)
+    _create_rivalry(engine)
+    expected_state = _relationship_state(engine)
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(
+        "/api/relationships/alice/bob/intervene",
+        headers=headers,
+        json={"reason": "attacker reset"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Unauthorized relationship mutation"
+    assert _relationship_state(engine) == expected_state
+    assert _intervention_count(engine) == 0
+
+
+def test_intervention_accepts_valid_admin_key(tmp_path, monkeypatch):
+    client, engine = _make_client(tmp_path)
+    _create_rivalry(engine)
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(
+        "/api/relationships/alice/bob/intervene",
+        headers={"X-Admin-Key": "expected-admin-key"},
+        json={
+            "admin_id": "ops",
+            "reason": "moderation reset",
+            "action": "reset_to_neutral",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["success"] is True
+    assert body["previous_state"] == "rivals"
+    assert body["new_state"] == "neutral"
+    assert _relationship_state(engine) == {
+        "state": "neutral",
+        "tension_level": 0,
+        "trust_level": 50,
+        "disagreement_count": 3,
+    }
+    assert _intervention_count(engine) == 1
+
+
+def test_intervention_accepts_legacy_api_key_header(tmp_path, monkeypatch):
+    client, engine = _make_client(tmp_path)
+    _create_rivalry(engine)
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(
+        "/api/relationships/alice/bob/intervene",
+        headers={"X-API-Key": "expected-admin-key"},
+        json={"reason": "moderation reset"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["new_state"] == "neutral"
+    assert _intervention_count(engine) == 1

--- a/tests/test_agent_relationships_admin_auth.py
+++ b/tests/test_agent_relationships_admin_auth.py
@@ -58,7 +58,10 @@ def test_intervention_fails_closed_when_admin_key_unconfigured(tmp_path, monkeyp
     assert _intervention_count(engine) == 0
 
 
-@pytest.mark.parametrize("headers", [{}, {"X-Admin-Key": "wrong-admin-key"}])
+@pytest.mark.parametrize(
+    "headers",
+    [{}, {"X-Admin-Key": "wrong-admin-key"}, {"X-Admin-Key": "\u00e9"}],
+)
 def test_intervention_requires_valid_admin_key(tmp_path, monkeypatch, headers):
     client, engine = _make_client(tmp_path)
     _create_rivalry(engine)


### PR DESCRIPTION
Fixes #4751.

## Summary
- Require `RC_ADMIN_KEY` before the optional relationship intervention route can call `admin_intervene`.
- Accept `X-Admin-Key` and the existing legacy `X-API-Key` header, compared with `hmac.compare_digest`.
- Add Flask route tests proving unset, missing, and wrong keys fail without mutating relationship state or inserting intervention rows.

## Validation
- `python -m pytest tests\test_agent_relationships_admin_auth.py -q` -> 5 passed
- `python -m pytest test_agent_relationships.py tests\test_agent_relationships_admin_auth.py -q` -> 45 passed
- `python -m py_compile agent_relationships.py tests\test_agent_relationships_admin_auth.py` -> passed
- `git diff --check -- agent_relationships.py tests\test_agent_relationships_admin_auth.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive action was performed.