### PR TITLE
fix: add missing timedelta import in agent_economy/bounties.py

### DIFF
--- a/sdk/rustchain/agent_economy/bounties.py
+++ b/sdk/rustchain/agent_economy/bounties.py
@@ -6,7 +6,7 @@ Manages bounty discovery, claims, and automated payments.
 
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 
 


### PR DESCRIPTION
## Summary

Fixes `NameError: name 'timedelta' is not defined` in `BountyClient.create_bounty()`.

## Problem

`sdk/rustchain/agent_economy/bounties.py` line 504 uses:
```python
deadline = datetime.utcnow() + timedelta(days=deadline_days)
```

But the module only imports `datetime` (line 9):
```python
from datetime import datetime
```

`timedelta` is not imported, causing a `NameError` every time `create_bounty()` is called.

## Fix

Added `timedelta` to the existing import:
```python
from datetime import datetime, timedelta
```

## Verification

- ✅ Module loads without error
- ✅ `create_bounty()` executes successfully and returns a `Bounty` object
- ✅ No other code changes needed

Fixes #4693

---
*This fix was generated with AI assistance (WorkBuddy Bounty Hunter).*