### PR TITLE
fix: resolve Windows encoding and package import issues in CRT attestation

### DIFF
--- a/bounties/issue-2310/src/__init__.py
+++ b/bounties/issue-2310/src/__init__.py
@@ -7,10 +7,10 @@ This package provides practical CRT-based hardware attestation for RustChain.
 __version__ = '1.0.0'
 __author__ = 'RustChain Bounty Program'
 
-from crt_pattern_generator import CRTPatternGenerator
-from crt_capture import CRTCapture, CaptureConfig, CaptureMethod
-from crt_analyzer import CRTAnalyzer, CRTFingerprint
-from crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
+from .crt_pattern_generator import CRTPatternGenerator
+from .crt_capture import CRTCapture, CaptureConfig, CaptureMethod
+from .crt_analyzer import CRTAnalyzer, CRTFingerprint
+from .crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
 
 __all__ = [
     'CRTPatternGenerator',

--- a/bounties/issue-2310/validate_bounty_2310.py
+++ b/bounties/issue-2310/validate_bounty_2310.py
@@ -25,13 +25,13 @@ def print_header(text):
     print(f"{BLUE}{'=' * 60}{RESET}\n")
 
 def print_success(text):
-    print(f"{GREEN}✅ {text}{RESET}")
+    print(f"{GREEN}[PASS] {text}{RESET}")
 
 def print_error(text):
-    print(f"{RED}❌ {text}{RESET}")
+    print(f"{RED}[FAIL] {text}{RESET}")
 
 def print_info(text):
-    print(f"{YELLOW}ℹ️  {text}{RESET}")
+    print(f"{YELLOW}[INFO] {text}{RESET}")
 
 def check_file_exists(filepath, description):
     """Check if a file exists"""
@@ -48,7 +48,7 @@ def check_file_content(filepath, patterns, description):
         print_error(f"{description} missing: {filepath}")
         return False
     
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_found = True
@@ -66,7 +66,7 @@ def count_lines(filepath):
     """Count lines in a file"""
     if not os.path.exists(filepath):
         return 0
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         return sum(1 for _ in f)
 
 def get_file_hash(filepath):
@@ -242,7 +242,7 @@ def validate_tests():
         'pytest'
     ]
     
-    with open(test_file, 'r') as f:
+    with open(test_file, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_valid = True
@@ -271,7 +271,7 @@ def validate_evidence():
         print_error("Evidence file missing: proof.json")
         return False
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     required_fields = [
@@ -306,7 +306,7 @@ def validate_requirements():
     base_dir = Path(__file__).parent / 'evidence'
     proof_file = base_dir / 'proof.json'
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     req_verify = proof.get('requirements_verification', {})
@@ -404,10 +404,10 @@ def main():
     print(f"  Total source lines: {total_lines}")
     
     if passed == total:
-        print(f"\n{GREEN}✅ VALIDATION PASSED - Implementation is complete!{RESET}\n")
+        print(f"\n{GREEN}[PASS] VALIDATION PASSED - Implementation is complete!{RESET}\n")
         return 0
     else:
-        print(f"\n{RED}❌ VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
+        print(f"\n{RED}[FAIL] VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
         return 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Fixes two failures in `bounties/issue-2310/` that break local validation on Windows and prevent package-style imports.

## Problem 1: Package Import Failure

`src/__init__.py` uses absolute sibling imports:
```python
from crt_pattern_generator import CRTPatternGenerator
```

This fails with `ModuleNotFoundError` when importing from the parent directory (`import src`).

## Fix 1: Relative Imports

Changed to package-relative imports:
```python
from .crt_pattern_generator import CRTPatternGenerator
```

## Problem 2: Windows Encoding Crash

`validate_bounty_2310.py` prints Unicode emoji (✅❌ℹ️) and reads UTF-8 files without specifying encoding. On Windows CP1252 consoles this crashes with `UnicodeEncodeError` / `UnicodeDecodeError`.

## Fix 2: ASCII-Safe Output + Explicit Encoding

- Replaced emoji with ASCII labels: `[PASS]`, `[FAIL]`, `[INFO]`
- Added `encoding='utf-8'` to all `open(..., 'r')` calls

## Verification

- ✅ `python -m py_compile` passes for both files
- ✅ No Unicode emoji remaining in output functions
- ✅ All text reads use explicit UTF-8 encoding
- ✅ Relative imports allow package-style import from parent dir

Fixes #4749

---
*This fix was generated with AI assistance (WorkBuddy Bounty Hunter).*