### PR TITLE
fix: reject negative block reward heights

### DIFF
--- a/rips/rustchain-core/config/chain_params.py
+++ b/rips/rustchain-core/config/chain_params.py
@@ -144,6 +144,9 @@ def get_multiplier_for_tier(tier: str) -> float:
 
 def calculate_block_reward(height: int) -> Decimal:
     """Calculate block reward at a given height"""
+    if height < 0:
+        raise ValueError(f"Block height cannot be negative: {height}")
+
     halvings = height // HALVING_INTERVAL_BLOCKS
     if halvings >= HALVING_COUNT:
         # Tail emission after 4 halvings

--- a/tests/test_chain_params_block_reward.py
+++ b/tests/test_chain_params_block_reward.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+
+CHAIN_PARAMS_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rips"
+    / "rustchain-core"
+    / "config"
+    / "chain_params.py"
+)
+
+
+def load_chain_params():
+    spec = importlib.util.spec_from_file_location("chain_params_under_test", CHAIN_PARAMS_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_calculate_block_reward_rejects_negative_heights():
+    chain_params = load_chain_params()
+
+    with pytest.raises(ValueError, match="Block height cannot be negative: -1"):
+        chain_params.calculate_block_reward(-1)
+
+    with pytest.raises(ValueError, match="Block height cannot be negative: -210000"):
+        chain_params.calculate_block_reward(-210000)
+
+
+def test_calculate_block_reward_preserves_halving_schedule():
+    chain_params = load_chain_params()
+
+    assert chain_params.calculate_block_reward(0) == Decimal("1.5")
+    assert (
+        chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS - 1)
+        == Decimal("1.5")
+    )
+    assert (
+        chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS)
+        == Decimal("0.75")
+    )
+    assert (
+        chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS * 2)
+        == Decimal("0.375")
+    )
+    assert (
+        chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS * 4)
+        == Decimal("0.09375")
+    )
+    assert (
+        chain_params.calculate_block_reward(chain_params.HALVING_INTERVAL_BLOCKS * 5)
+        == Decimal("0.09375")
+    )


### PR DESCRIPTION
﻿## Summary
- reject negative heights in the live `rips/rustchain-core/config/chain_params.py::calculate_block_reward()` path
- add focused regression coverage for `-1` and `-210000`, the cases that previously inflated rewards through Python floor division
- preserve the existing halving and tail-emission schedule for valid heights

Fixes #4636.

## Validation
```powershell
python -m pytest tests\test_chain_params_block_reward.py -q
# 2 passed

$env:PYTHONUTF8='1'; python -m pytest tests\test_epoch_window_consistency.py tests\test_chain_params_block_reward.py -q
# 7 passed

python -m py_compile rips\rustchain-core\config\chain_params.py tests\test_chain_params_block_reward.py
git diff --check -- rips/rustchain-core/config/chain_params.py tests/test_chain_params_block_reward.py
# both passed
```

## Notes
`tests/test_epoch_window_consistency.py` needs UTF-8 mode on this Windows host because the existing source scan hits non-CP1252 bytes in a large integrated-node file. The focused reward regression itself passes without that environment override.
