### PR TITLE
Secure Rent-a-Relic completion

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -35,16 +35,24 @@ from tools.rent_a_relic.models import (
 )
 from tools.rent_a_relic.provenance import generate_receipt, verify_receipt
 
+ADMIN_KEY = "test-rent-relic-admin"
+
 
 @pytest.fixture()
-def app(tmp_path):
+def app(tmp_path, monkeypatch):
     from tools.rent_a_relic import server
     db_file = str(tmp_path / "test_relic.db")
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     server.app.config["TESTING"] = True
     server.app.config["DB_PATH"]  = db_file
     server.init_db()
     with server.app.test_client() as client:
         yield client
+
+
+def complete_session(client, session_id: str, payload: dict | list | None = None, admin_key: str | None = ADMIN_KEY):
+    headers = {"X-Admin-Key": admin_key} if admin_key else {}
+    return client.post(f"/relic/complete/{session_id}", headers=headers, json=payload)
 
 
 @pytest.fixture()
@@ -148,10 +156,59 @@ class TestReservationFlow:
             "duration_hours": 1, "rtc_amount": 15.0,
         })
         assert r.status_code == 201
-        cr = app.post(f"/relic/complete/{r.json['session_id']}",
-                      json={"output_hash": hashlib.sha256(b"output").hexdigest()})
+        cr = complete_session(
+            app,
+            r.json["session_id"],
+            {"output_hash": hashlib.sha256(b"output").hexdigest()},
+        )
         assert cr.status_code == 200
         assert cr.json["status"] == "completed"
+
+    def test_complete_requires_admin_key(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_auth_complete", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+
+        cr = complete_session(app, r.json["session_id"], admin_key=None)
+
+        assert cr.status_code == 401
+        assert cr.json["error"] == "unauthorized"
+        sr = app.get(f"/relic/reservation/{r.json['session_id']}")
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
+    def test_complete_rejects_wrong_admin_key(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_wrong_key", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+
+        cr = complete_session(app, r.json["session_id"], admin_key="wrong-key")
+
+        assert cr.status_code == 401
+        assert cr.json["error"] == "unauthorized"
+        sr = app.get(f"/relic/reservation/{r.json['session_id']}")
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
+    def test_complete_fails_closed_when_admin_key_unconfigured(self, app, monkeypatch):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_no_key", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+        monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+        cr = complete_session(app, r.json["session_id"])
+
+        assert cr.status_code == 503
+        assert cr.json["error"] == "RC_ADMIN_KEY not configured"
+        sr = app.get(f"/relic/reservation/{r.json['session_id']}")
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
 
     def test_complete_rejects_non_object_json(self, app):
         r = app.post("/relic/reserve", json={
@@ -160,7 +217,7 @@ class TestReservationFlow:
         })
         assert r.status_code == 201
 
-        cr = app.post(f"/relic/complete/{r.json['session_id']}", json=["not", "object"])
+        cr = complete_session(app, r.json["session_id"], ["not", "object"])
         assert cr.status_code == 400
         assert cr.json["error"] == "JSON object required"
 
@@ -218,7 +275,7 @@ class TestEscrow:
             "duration_hours": 1, "rtc_amount": 10.0,
         })
         sid = r.json["session_id"]
-        app.post(f"/relic/complete/{sid}")
+        complete_session(app, sid)
         sr = app.get(f"/relic/reservation/{sid}")
         assert sr.json["escrow"]["status"] == "released"
         assert sr.json["escrow"]["release_reason"] == "completed"
@@ -327,7 +384,7 @@ class TestLeaderboard:
                 "duration_hours": 1, "rtc_amount": 5.0,
             })
             if r.status_code == 201:
-                app.post(f"/relic/complete/{r.json['session_id']}")
+                complete_session(app, r.json["session_id"])
         ranks = [e["rank"] for e in app.get("/relic/leaderboard").json["leaderboard"]]
         assert ranks == sorted(ranks)
 

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -18,6 +18,8 @@ RTC escrow: locked on reserve, released on completion or timeout.
 from __future__ import annotations
 
 import hashlib
+import hmac
+import os
 import sqlite3
 import time
 import uuid
@@ -53,6 +55,17 @@ def _get_json_object_or_empty() -> dict:
     if not isinstance(data, dict):
         abort(400, description="JSON object required")
     return data
+
+
+def _require_admin_key() -> None:
+    """Require the shared RustChain admin key for escrow-releasing actions."""
+    expected_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not expected_key:
+        abort(503, description="RC_ADMIN_KEY not configured")
+
+    provided_key = request.headers.get("X-Admin-Key", "")
+    if not provided_key or not hmac.compare_digest(provided_key, expected_key):
+        abort(401, description="unauthorized")
 
 
 @contextmanager
@@ -425,6 +438,7 @@ def get_reservation(session_id: str):
 @app.post("/relic/complete/<session_id>")
 def post_complete(session_id: str):
     """Mark a session as completed and release escrow."""
+    _require_admin_key()
     data        = _get_json_object_or_empty()
     output_hash = data.get("output_hash") or hashlib.sha256(session_id.encode()).hexdigest()
 
@@ -457,9 +471,11 @@ def post_complete(session_id: str):
 
 
 @app.errorhandler(400)
+@app.errorhandler(401)
 @app.errorhandler(404)
 @app.errorhandler(409)
 @app.errorhandler(500)
+@app.errorhandler(503)
 def handle_error(e):
     return jsonify({"error": str(e.description), "code": e.code}), e.code
 


### PR DESCRIPTION
Fixes #4762.

## Summary
- Require `RC_ADMIN_KEY` before `POST /relic/complete/<session_id>` can release escrow.
- Compare `X-Admin-Key` with `hmac.compare_digest` and fail closed when the server key is not configured.
- Extend Rent-a-Relic tests so missing, wrong, and unconfigured admin keys leave reservations active and escrow locked.

## Validation
- `python -m pytest tests\test_rent_a_relic.py -q` -> 36 passed
- `python -m py_compile tools\rent_a_relic\server.py tests\test_rent_a_relic.py` -> passed
- `git diff --check -- tools\rent_a_relic\server.py tests\test_rent_a_relic.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive action was performed.