### PR TITLE
Secure payout ledger routes

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -7,6 +7,7 @@ See: node/rustchain_v2_integrated_v2.2.1_rip200.py for DB conventions.
 Statuses: queued → pending → confirmed | voided
 """
 import os
+import hmac
 import time
 import sqlite3
 import uuid
@@ -167,12 +168,28 @@ def ledger_summary():
     return {r[0]: {"count": r[1], "total_rtc": r[2]} for r in rows}
 
 
+def _require_admin_key():
+    """Return an error response unless X-Admin-Key matches RC_ADMIN_KEY."""
+    expected_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not expected_key:
+        return jsonify({"error": "RC_ADMIN_KEY not configured"}), 503
+
+    provided_key = request.headers.get("X-Admin-Key", "")
+    if not provided_key or not hmac.compare_digest(provided_key, expected_key):
+        return jsonify({"error": "unauthorized"}), 401
+
+    return None
+
+
 # ── Flask route registration ───────────────────────────────────
 def register_ledger_routes(app):
     """Register /ledger/* routes on the given Flask app."""
 
     @app.route("/ledger")
     def ledger_page():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         status_filter = request.args.get("status")
         records = ledger_list(status=status_filter)
@@ -181,6 +198,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["GET"])
     def api_ledger_list():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         status = request.args.get("status")
         contributor = request.args.get("contributor")
@@ -189,6 +209,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>", methods=["GET"])
     def api_ledger_get(record_id):
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         record = ledger_get(record_id)
         if not record:
@@ -197,6 +220,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["POST"])
     def api_ledger_create():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         required = ["bounty_id", "contributor", "amount_rtc"]
@@ -216,6 +242,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
     def api_ledger_update(record_id):
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         new_status = data.get("status")
@@ -233,6 +262,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/summary", methods=["GET"])
     def api_ledger_summary():
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         init_payout_ledger_tables()
         return jsonify(ledger_summary())
 

--- a/tests/test_payout_ledger_admin_auth.py
+++ b/tests/test_payout_ledger_admin_auth.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+import sqlite3
+
+from flask import Flask
+
+import payout_ledger
+
+
+ADMIN_KEY = "ledger-admin-secret"
+
+
+def _make_client(tmp_path, monkeypatch, admin_key=ADMIN_KEY):
+    db_path = tmp_path / "ledger.db"
+    monkeypatch.setattr(payout_ledger, "DB_PATH", str(db_path))
+    if admin_key is None:
+        monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    else:
+        monkeypatch.setenv("RC_ADMIN_KEY", admin_key)
+
+    app = Flask(__name__)
+    payout_ledger.register_ledger_routes(app)
+    return app.test_client(), db_path
+
+
+def _table_exists(db_path):
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='payout_ledger'"
+        ).fetchone()
+    return row is not None
+
+
+def _create_payload():
+    return {
+        "bounty_id": "bug-1",
+        "contributor": "alice",
+        "amount_rtc": 25,
+        "wallet_address": "RTC-alice",
+        "notes": "queued by admin",
+    }
+
+
+def test_ledger_routes_fail_closed_when_admin_key_unconfigured(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch, admin_key=None)
+
+    response = client.post("/api/ledger", json=_create_payload())
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "RC_ADMIN_KEY not configured"
+    assert not _table_exists(db_path)
+
+
+def test_ledger_create_requires_admin_key_before_mutation(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch)
+
+    missing = client.post("/api/ledger", json=_create_payload())
+    wrong = client.post(
+        "/api/ledger",
+        headers={"X-Admin-Key": "wrong"},
+        json=_create_payload(),
+    )
+
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert not _table_exists(db_path)
+
+
+def test_ledger_reads_require_admin_key(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path, monkeypatch)
+    payout_ledger.init_payout_ledger_tables()
+    record_id = payout_ledger.ledger_create("bug-1", "alice", 25)
+
+    assert client.get("/ledger").status_code == 401
+    assert client.get("/api/ledger").status_code == 401
+    assert client.get(f"/api/ledger/{record_id}").status_code == 401
+    assert client.get("/api/ledger/summary").status_code == 401
+
+
+def test_ledger_status_update_requires_admin_key_before_mutation(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path, monkeypatch)
+    payout_ledger.init_payout_ledger_tables()
+    record_id = payout_ledger.ledger_create("bug-1", "alice", 25)
+
+    missing = client.patch(
+        f"/api/ledger/{record_id}/status",
+        json={"status": "confirmed", "tx_hash": "tx-1"},
+    )
+    wrong = client.patch(
+        f"/api/ledger/{record_id}/status",
+        headers={"X-Admin-Key": "wrong"},
+        json={"status": "confirmed", "tx_hash": "tx-1"},
+    )
+
+    record = payout_ledger.ledger_get(record_id)
+    assert missing.status_code == 401
+    assert wrong.status_code == 401
+    assert record["status"] == "queued"
+    assert record["tx_hash"] == ""
+
+
+def test_admin_key_allows_create_read_summary_and_status_update(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path, monkeypatch)
+    headers = {"X-Admin-Key": ADMIN_KEY}
+
+    create = client.post("/api/ledger", headers=headers, json=_create_payload())
+    record_id = create.get_json()["id"]
+    list_response = client.get("/api/ledger", headers=headers)
+    get_response = client.get(f"/api/ledger/{record_id}", headers=headers)
+    summary = client.get("/api/ledger/summary", headers=headers)
+    page = client.get("/ledger", headers=headers)
+    update = client.patch(
+        f"/api/ledger/{record_id}/status",
+        headers=headers,
+        json={"status": "confirmed", "tx_hash": "tx-1"},
+    )
+
+    assert create.status_code == 201
+    assert list_response.status_code == 200
+    assert get_response.status_code == 200
+    assert summary.status_code == 200
+    assert page.status_code == 200
+    assert update.status_code == 200
+    assert payout_ledger.ledger_get(record_id)["status"] == "confirmed"


### PR DESCRIPTION
﻿## Summary
- Require `X-Admin-Key` matching `RC_ADMIN_KEY` for `/ledger` and every `/api/ledger*` route.
- Fail closed when `RC_ADMIN_KEY` is unset and reject missing/wrong keys before DB initialization, JSON parsing, or state mutation.
- Add Flask client regressions covering unauthorized create/read/status-update attempts and the valid admin workflow.

Fixes #4766

## Validation
- `python -m pytest tests\test_payout_ledger_admin_auth.py tests\test_payout_ledger_migration.py -q` -> 7 passed
- `python -m py_compile payout_ledger.py tests\test_payout_ledger_admin_auth.py tests\test_payout_ledger_migration.py`
- `git diff --check -- payout_ledger.py tests\test_payout_ledger_admin_auth.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID: `SimoneMariaRomeo-codex-earner`
