### PR TITLE
fix: add missing Flask imports (request, jsonify) in rustchain_p2p_sync.py (closes #4712)

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -1,3 +1,5 @@
+from flask import request, jsonify
+
 #!/usr/bin/env python3
 """
 RustChain v2 - P2P Synchronization Module


### PR DESCRIPTION
## Summary
Fixes #4712 - P2P sync Flask endpoints crash on missing request/jsonify imports.

## Changes
- Added `request` and `jsonify` to the Flask imports in `node/rustchain_p2p_sync.py`
- The `add_p2p_endpoints()` function registers Flask routes but the module didn't import `request` and `jsonify`

## Testing
- [x] `py_compile` passes
- [x] Routes can be registered without ImportError

## Type
- [x] Bug fix (non-breaking change which fixes an issue)
