### PR TITLE
fix: add missing warning/info helpers in mac miner v2.4 (closes #4695)

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/rustchain_mac_miner_v2.4.py
@@ -18,6 +18,15 @@ import statistics
 import re
 from datetime import datetime
 
+def warning(msg):
+    """Fallback warning function"""
+    print(f"WARNING: {msg}")
+
+def info(msg):
+    """Fallback info function"""
+    print(f"INFO: {msg}")
+
+
 # Import fingerprint checks
 try:
     from fingerprint_checks import validate_all_checks


### PR DESCRIPTION
## Summary
Fixes #4695 - Mac miner v2.4 crashes before CLI when optional helpers are missing.

## Changes
- Added `warning()` and `info()` helper functions to `miners/macos/rustchain_mac_miner_v2.4.py`
- These are called in optional-import fallback paths but were not defined

## Testing
- [x] `py_compile` passes
- [x] Miner can be imported without NameError