### PR TITLE
Secure GPU escrow release and refund transitions

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -27,7 +27,9 @@ import uuid
 import json
 import os
 import logging
-from functools import wraps
+import hashlib
+import hmac
+import secrets
 
 logger = logging.getLogger("gpu_render_protocol")
 
@@ -46,6 +48,7 @@ CREATE TABLE IF NOT EXISTS render_escrow (
     status TEXT DEFAULT 'locked' CHECK(status IN ('locked', 'released', 'refunded')),
     created_at INTEGER NOT NULL,
     released_at INTEGER,
+    escrow_secret_hash TEXT,
     metadata TEXT  -- JSON blob for job-specific params
 );
 
@@ -114,9 +117,16 @@ class GPURenderProtocol:
     def _init_db(self):
         conn = self._get_conn()
         conn.executescript(SCHEMA_SQL)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
+        if "escrow_secret_hash" not in cols:
+            conn.execute("ALTER TABLE render_escrow ADD COLUMN escrow_secret_hash TEXT")
         conn.commit()
         conn.close()
         logger.info("GPU Render Protocol DB initialized at %s", self.db_path)
+
+    @staticmethod
+    def _hash_job_secret(secret: str) -> str:
+        return hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
 
     # -------------------------------------------------------------------
     # GPU Attestation
@@ -234,15 +244,16 @@ class GPURenderProtocol:
             return {"error": "from_wallet and to_wallet must differ"}
 
         job_id = f"{job_type}-{uuid.uuid4().hex[:12]}"
+        escrow_secret = secrets.token_hex(16)
         conn = self._get_conn()
         try:
             conn.execute(
                 """INSERT INTO render_escrow
                    (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                    status, created_at, metadata)
-                   VALUES (?,?,?,?,?,'locked',?,?)""",
+                    status, created_at, escrow_secret_hash, metadata)
+                   VALUES (?,?,?,?,?,'locked',?,?,?)""",
                 (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                 int(time.time()), json.dumps(metadata or {})),
+                 int(time.time()), self._hash_job_secret(escrow_secret), json.dumps(metadata or {})),
             )
             conn.commit()
             return {
@@ -252,12 +263,20 @@ class GPURenderProtocol:
                 "amount_rtc": amount_rtc,
                 "from_wallet": from_wallet,
                 "to_wallet": to_wallet,
+                "escrow_secret": escrow_secret,
             }
         finally:
             conn.close()
 
-    def release_escrow(self, job_id: str) -> dict:
+    def release_escrow(
+        self,
+        job_id: str,
+        actor_wallet: str = "",
+        escrow_secret: str = "",
+    ) -> dict:
         """Release escrowed RTC to the GPU provider on job completion."""
+        if not actor_wallet or not escrow_secret:
+            return {"error": "actor_wallet and escrow_secret are required"}
         conn = self._get_conn()
         try:
             row = conn.execute(
@@ -267,6 +286,14 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             if row["status"] != "locked":
                 return {"error": f"Job already {row['status']}"}
+            if actor_wallet != row["from_wallet"]:
+                return {"error": "only payer can release escrow"}
+            if not row["escrow_secret_hash"]:
+                return {"error": "escrow_secret required for this job"}
+            if not hmac.compare_digest(
+                self._hash_job_secret(escrow_secret), row["escrow_secret_hash"]
+            ):
+                return {"error": "invalid escrow_secret"}
 
             now = int(time.time())
             conn.execute(
@@ -284,8 +311,15 @@ class GPURenderProtocol:
         finally:
             conn.close()
 
-    def refund_escrow(self, job_id: str) -> dict:
+    def refund_escrow(
+        self,
+        job_id: str,
+        actor_wallet: str = "",
+        escrow_secret: str = "",
+    ) -> dict:
         """Refund escrowed RTC to the requester on job failure."""
+        if not actor_wallet or not escrow_secret:
+            return {"error": "actor_wallet and escrow_secret are required"}
         conn = self._get_conn()
         try:
             row = conn.execute(
@@ -295,6 +329,14 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             if row["status"] != "locked":
                 return {"error": f"Job already {row['status']}"}
+            if actor_wallet != row["to_wallet"]:
+                return {"error": "only provider can request refund"}
+            if not row["escrow_secret_hash"]:
+                return {"error": "escrow_secret required for this job"}
+            if not hmac.compare_digest(
+                self._hash_job_secret(escrow_secret), row["escrow_secret_hash"]
+            ):
+                return {"error": "invalid escrow_secret"}
 
             now = int(time.time())
             conn.execute(
@@ -322,6 +364,7 @@ class GPURenderProtocol:
             if not row:
                 return {"error": "Job not found"}
             result = dict(row)
+            result.pop("escrow_secret_hash", None)
             result["metadata"] = json.loads(result.get("metadata") or "{}")
             return result
         finally:
@@ -456,7 +499,11 @@ def register_routes(app):
     def release_escrow():
         from flask import request, jsonify
         data = request.get_json(force=True)
-        result = protocol.release_escrow(data.get("job_id", ""))
+        result = protocol.release_escrow(
+            data.get("job_id", ""),
+            actor_wallet=data.get("actor_wallet", ""),
+            escrow_secret=data.get("escrow_secret", ""),
+        )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
@@ -464,7 +511,11 @@ def register_routes(app):
     def refund_escrow():
         from flask import request, jsonify
         data = request.get_json(force=True)
-        result = protocol.refund_escrow(data.get("job_id", ""))
+        result = protocol.refund_escrow(
+            data.get("job_id", ""),
+            actor_wallet=data.get("actor_wallet", ""),
+            escrow_secret=data.get("escrow_secret", ""),
+        )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -3,8 +3,12 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest import mock
+
+from flask import Flask
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+import node.gpu_render_protocol as gpu_render_protocol
 from node.gpu_render_protocol import GPURenderProtocol
 
 
@@ -59,26 +63,56 @@ class TestGPURenderProtocol(unittest.TestCase):
         result = self.proto.create_escrow("render", "wallet-a", "wallet-b", 10.0)
         self.assertEqual(result["status"], "locked")
         job_id = result["job_id"]
+        escrow_secret = result["escrow_secret"]
 
         # Check
         status = self.proto.get_escrow(job_id)
         self.assertEqual(status["status"], "locked")
         self.assertEqual(status["amount_rtc"], 10.0)
 
-        # Release
-        release = self.proto.release_escrow(job_id)
+        # Bare job_id should not be enough to release funds
+        bare_release = self.proto.release_escrow(job_id)
+        self.assertIn("error", bare_release)
+        self.assertEqual(self.proto.get_escrow(job_id)["status"], "locked")
+
+        # Provider cannot release payer escrow
+        wrong_actor = self.proto.release_escrow(
+            job_id, actor_wallet="wallet-b", escrow_secret=escrow_secret
+        )
+        self.assertIn("error", wrong_actor)
+        self.assertEqual(self.proto.get_escrow(job_id)["status"], "locked")
+
+        # Payer can release with the escrow secret
+        release = self.proto.release_escrow(
+            job_id, actor_wallet="wallet-a", escrow_secret=escrow_secret
+        )
         self.assertEqual(release["status"], "released")
         self.assertEqual(release["amount_rtc"], 10.0)
 
         # Double release fails
-        double = self.proto.release_escrow(job_id)
+        double = self.proto.release_escrow(
+            job_id, actor_wallet="wallet-a", escrow_secret=escrow_secret
+        )
         self.assertIn("error", double)
 
     def test_escrow_refund(self):
         result = self.proto.create_escrow("tts", "wallet-a", "wallet-b", 5.0)
         job_id = result["job_id"]
+        escrow_secret = result["escrow_secret"]
 
-        refund = self.proto.refund_escrow(job_id)
+        bare_refund = self.proto.refund_escrow(job_id)
+        self.assertIn("error", bare_refund)
+        self.assertEqual(self.proto.get_escrow(job_id)["status"], "locked")
+
+        wrong_actor = self.proto.refund_escrow(
+            job_id, actor_wallet="wallet-a", escrow_secret=escrow_secret
+        )
+        self.assertIn("error", wrong_actor)
+        self.assertEqual(self.proto.get_escrow(job_id)["status"], "locked")
+
+        refund = self.proto.refund_escrow(
+            job_id, actor_wallet="wallet-b", escrow_secret=escrow_secret
+        )
         self.assertEqual(refund["status"], "refunded")
 
     def test_escrow_invalid_type(self):
@@ -133,6 +167,46 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertEqual(result["status"], "locked")
         status = self.proto.get_escrow(result["job_id"])
         self.assertEqual(status["metadata"]["model"], "llama-70b")
+
+
+class TestGPURenderProtocolRoutes(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.db = os.path.join(self.tmp, "test_gpu_routes.db")
+        self.proto = GPURenderProtocol(db_path=self.db)
+        app = Flask(__name__)
+        with mock.patch.object(gpu_render_protocol, "GPURenderProtocol", return_value=self.proto):
+            gpu_render_protocol.register_routes(app)
+        self.client = app.test_client()
+
+    def test_release_route_requires_participant_and_secret(self):
+        create = self.client.post(
+            "/render/escrow",
+            json={
+                "from_wallet": "wallet-a",
+                "to_wallet": "wallet-b",
+                "amount_rtc": 7.5,
+            },
+        )
+        self.assertEqual(create.status_code, 201)
+        payload = create.get_json()
+        job_id = payload["job_id"]
+        escrow_secret = payload["escrow_secret"]
+
+        bare_release = self.client.post("/render/release", json={"job_id": job_id})
+        self.assertEqual(bare_release.status_code, 400)
+        self.assertEqual(self.proto.get_escrow(job_id)["status"], "locked")
+
+        release = self.client.post(
+            "/render/release",
+            json={
+                "job_id": job_id,
+                "actor_wallet": "wallet-a",
+                "escrow_secret": escrow_secret,
+            },
+        )
+        self.assertEqual(release.status_code, 200)
+        self.assertEqual(release.get_json()["status"], "released")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #4568

## Summary
- bind GPU render protocol escrow transitions to an actor wallet plus one-time escrow secret instead of accepting bare `job_id` values
- store only `escrow_secret_hash` in `render_escrow`, return the raw secret once at creation, and reject legacy rows without a secret hash
- add protocol and route regressions covering bare `job_id` attempts, wrong-participant attempts, and successful participant-authorized transitions

## Validation
- `python -m pytest tests/test_gpu_render_protocol.py -q`
- `python -m py_compile node/gpu_render_protocol.py tests/test_gpu_render_protocol.py`
- `python -m ruff check node/gpu_render_protocol.py tests/test_gpu_render_protocol.py --select E9,F821`
- `git diff --check -- node/gpu_render_protocol.py tests/test_gpu_render_protocol.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main`