### PR TITLE
fix: escape markdown backticks in verifier.py (closes #4717)

### DIFF
--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -104,7 +104,7 @@ class BountyVerifier:
         report += "|-------|--------|\n"
         report += f"| Follows @{CONFIG['org']} | {'✅ Yes' if follows else '❌ No'} |\n"
         report += f"| {CONFIG['org']} repos starred | {stars['count']} |\n"
-        report += f"| Wallet \`{wallet}\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
+        report += f"| Wallet \\`{wallet}\\` exists | {'✅ Balance: ' + str(wallet_info['balance']) + ' RTC' if wallet_info['exists'] else '❌ Not found'} |\n"
         
         if article_url:
             # Mock content fetch


### PR DESCRIPTION
## Summary
Fixes #4717 - Bounty verifier fails strict py_compile due invalid markdown escapes.

## Changes
- Double-escaped backslashes in f-strings containing backticks
- `py_compile` now passes without warnings/errors

## Testing
- [x] `py_compile` passes
- [x] No SyntaxWarning