### PR TITLE
fix: escape Windows path backslashes in docstring (closes #4727)

### DIFF
--- a/miners/windows/installer/src/config_manager.py
+++ b/miners/windows/installer/src/config_manager.py
@@ -1,7 +1,7 @@
 """
 RustChain Config Manager
 Manages configuration between the installer and the miner.
-Config file location: %APPDATA%\RustChain\config.json
+Config file location: %APPDATA%\\RustChain\\config.json
 """
 
 import os


### PR DESCRIPTION
## Summary
Fixes #4727 - Windows installer config manager fails strict py_compile on path docstring.

## Changes
- Escaped backslashes in Windows path `%APPDATA%` in docstring
- `py_compile` now passes without errors

## Testing
- [x] `py_compile` passes