### PR TITLE
Expose Prometheus metrics at /api/metrics

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6,7 +6,7 @@ Includes RIP-0005 (Epoch Rewards), RIP-0008 (Withdrawals), RIP-0009 (Finality)
 import os, time, json, secrets, hashlib, hmac, sqlite3, base64, struct, uuid, glob, logging, sys, binascii, math, re, statistics
 import ipaddress
 from urllib.parse import urlparse
-from flask import Flask, request, jsonify, g, send_from_directory, send_file, abort, render_template_string, redirect
+from flask import Flask, request, jsonify, g, send_from_directory, send_file, abort, render_template_string, redirect, Response
 import json
 from decimal import Decimal, ROUND_HALF_UP
 from beacon_anchor import init_beacon_table, store_envelope, compute_beacon_digest, get_recent_envelopes, VALID_KINDS
@@ -6577,9 +6577,10 @@ def api_ready():
         return jsonify({"ready": False, "version": APP_VERSION}), 503
 
 @app.route('/metrics', methods=['GET'])
+@app.route('/api/metrics', methods=['GET'])
 def metrics():
     """Prometheus metrics endpoint"""
-    return generate_latest()
+    return Response(generate_latest(), content_type=CONTENT_TYPE_LATEST)
 
 
 @app.route('/rewards/settle', methods=['POST'])

--- a/node/tests/test_integrated_metrics_route.py
+++ b/node/tests/test_integrated_metrics_route.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class _NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+class TestIntegratedMetricsRoute(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._import_tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._import_tmp.name, "import.db")
+        os.environ["RC_ADMIN_KEY"] = "0" * 32
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        prometheus_client = None
+        prev_metrics = None
+        try:
+            import prometheus_client
+
+            prev_metrics = (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            )
+            prometheus_client.Counter = _NoopMetric
+            prometheus_client.Gauge = _NoopMetric
+            prometheus_client.Histogram = _NoopMetric
+        except ModuleNotFoundError:
+            pass
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_metrics_route_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(cls.mod)
+        finally:
+            if prometheus_client is not None and prev_metrics is not None:
+                (
+                    prometheus_client.Counter,
+                    prometheus_client.Gauge,
+                    prometheus_client.Histogram,
+                ) = prev_metrics
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._import_tmp.cleanup()
+
+    def test_api_metrics_alias_returns_prometheus_text(self):
+        client = self.mod.app.test_client()
+
+        legacy = client.get("/metrics")
+        api = client.get("/api/metrics")
+
+        self.assertEqual(legacy.status_code, 200)
+        self.assertEqual(api.status_code, 200)
+        self.assertEqual(api.data, legacy.data)
+        self.assertIn("text/plain", api.content_type)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #2756

## Summary
- expose the existing Prometheus metrics endpoint at `/api/metrics` in addition to `/metrics`
- return metrics through Flask `Response` with the Prometheus content type
- add a regression test proving `/api/metrics` returns the same Prometheus text as the legacy route

## Validation
- `python -m pytest node/tests/test_integrated_metrics_route.py -q`
- `python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_metrics_route.py`
- `python -m ruff check node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_metrics_route.py --select E9`
- `python -m ruff check node/tests/test_integrated_metrics_route.py --select E9,F821`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_metrics_route.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

Note: a broader `ruff --select E9,F821` over the integrated node still reports pre-existing unrelated F821 findings outside this diff; this change keeps validation scoped to syntax for the large existing file and F821 for the new test.