### PR TITLE
Fail closed for webhook admin API

### DIFF
--- a/tests/test_webhook_admin_auth.py
+++ b/tests/test_webhook_admin_auth.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+"""Regression tests for webhook admin API authentication."""
 
 import json
 import sys
@@ -10,27 +11,23 @@ from http.server import HTTPServer
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO_ROOT / "tools" / "webhooks"))
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "tools" / "webhooks"))
 
-import webhook_server
+import webhook_server  # noqa: E402
 
 
 @contextmanager
 def webhook_admin_server(tmp_path, admin_key):
-    store = webhook_server.SubscriberStore(str(tmp_path / "webhooks.db"))
+    handler = type("TestWebhookAdminHandler", (webhook_server.WebhookAdminHandler,), {})
+    handler.store = webhook_server.SubscriberStore(str(tmp_path / "webhooks.db"))
+    handler.ADMIN_API_KEY = admin_key
 
-    class TestWebhookAdminHandler(webhook_server.WebhookAdminHandler):
-        pass
-
-    TestWebhookAdminHandler.store = store
-    TestWebhookAdminHandler.ADMIN_API_KEY = admin_key
-
-    server = HTTPServer(("127.0.0.1", 0), TestWebhookAdminHandler)
+    server = HTTPServer(("127.0.0.1", 0), handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        yield f"http://127.0.0.1:{server.server_port}", store
+        yield f"http://127.0.0.1:{server.server_port}", handler.store
     finally:
         server.shutdown()
         thread.join(timeout=5)
@@ -38,68 +35,102 @@ def webhook_admin_server(tmp_path, admin_key):
 
 
 def request_json(base_url, method, path, body=None, headers=None):
-    data = None if body is None else json.dumps(body).encode()
-    req = urllib.request.Request(
-        base_url + path,
-        data=data,
-        method=method,
-        headers={
-            "Content-Type": "application/json",
-            **(headers or {}),
-        },
-    )
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+
+    req = urllib.request.Request(f"{base_url}{path}", data=data, method=method)
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+    for key, value in (headers or {}).items():
+        req.add_header(key, value)
+
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
         with opener.open(req, timeout=5) as response:
-            payload = json.loads(response.read().decode())
-            return response.status, payload
+            payload = response.read().decode("utf-8")
+            return response.status, json.loads(payload)
     except urllib.error.HTTPError as exc:
-        payload = json.loads(exc.read().decode())
-        return exc.code, payload
+        payload = exc.read().decode("utf-8")
+        return exc.code, json.loads(payload)
 
 
-def test_webhook_admin_fails_closed_when_key_unconfigured(tmp_path):
+def test_management_fails_closed_when_admin_key_is_unset(tmp_path):
     with webhook_admin_server(tmp_path, admin_key="") as (base_url, store):
-        status, payload = request_json(
+        status, body = request_json(
             base_url,
             "POST",
             "/webhooks/subscribe",
-            {"id": "sub-1", "url": "https://hooks.example/event"},
+            body={"id": "attacker", "url": "https://example.com/hook"},
         )
 
         assert status == 503
-        assert payload == {"error": "WEBHOOK_ADMIN_API_KEY not configured"}
+        assert body["error"] == "WEBHOOK_ADMIN_API_KEY not configured"
         assert store.list_all() == []
 
 
-def test_webhook_health_remains_public_when_key_unconfigured(tmp_path):
+def test_health_remains_public_when_admin_key_is_unset(tmp_path):
     with webhook_admin_server(tmp_path, admin_key="") as (base_url, _store):
-        status, payload = request_json(base_url, "GET", "/health")
+        status, body = request_json(base_url, "GET", "/health")
 
         assert status == 200
-        assert payload == {"status": "ok"}
+        assert body == {"status": "ok"}
 
 
-def test_webhook_admin_requires_configured_key(tmp_path, monkeypatch):
+def test_management_rejects_missing_or_wrong_key(tmp_path):
+    with webhook_admin_server(tmp_path, admin_key="expected-key") as (base_url, _store):
+        missing_status, missing_body = request_json(base_url, "GET", "/webhooks")
+        wrong_status, wrong_body = request_json(
+            base_url,
+            "GET",
+            "/webhooks",
+            headers={"X-Admin-API-Key": "wrong-key"},
+        )
+
+        assert missing_status == 401
+        assert missing_body["error"] == "invalid or missing API key"
+        assert wrong_status == 401
+        assert wrong_body["error"] == "invalid or missing API key"
+
+
+def test_management_rejects_non_ascii_admin_key_header(tmp_path):
+    with webhook_admin_server(tmp_path, admin_key="expected-key") as (base_url, _store):
+        status, body = request_json(
+            base_url,
+            "GET",
+            "/webhooks",
+            headers={"X-Admin-API-Key": "e\u00e9"},
+        )
+
+        assert status == 401
+        assert body["error"] == "invalid or missing API key"
+
+
+def test_management_accepts_valid_admin_key(tmp_path):
+    with webhook_admin_server(tmp_path, admin_key="expected-key") as (base_url, _store):
+        status, body = request_json(
+            base_url,
+            "GET",
+            "/webhooks",
+            headers={"X-Admin-API-Key": "expected-key"},
+        )
+
+        assert status == 200
+        assert body == {"subscribers": []}
+
+
+def test_management_accepts_authenticated_subscribe(tmp_path, monkeypatch):
     monkeypatch.setattr(webhook_server, "validate_webhook_url", lambda _url: None)
 
-    with webhook_admin_server(tmp_path, admin_key="expected-admin") as (base_url, store):
-        status, payload = request_json(
+    with webhook_admin_server(tmp_path, admin_key="expected-key") as (base_url, store):
+        status, body = request_json(
             base_url,
             "POST",
             "/webhooks/subscribe",
-            {"id": "sub-1", "url": "https://hooks.example/event"},
+            body={"id": "sub-1", "url": "https://hooks.example/event"},
+            headers={"X-Admin-API-Key": "expected-key"},
         )
-        assert status == 401
-        assert payload == {"error": "invalid or missing API key"}
 
-        status, payload = request_json(
-            base_url,
-            "POST",
-            "/webhooks/subscribe",
-            {"id": "sub-1", "url": "https://hooks.example/event"},
-            headers={"X-Admin-API-Key": "expected-admin"},
-        )
         assert status == 201
-        assert payload["message"] == "subscribed"
+        assert body["message"] == "subscribed"
         assert [sub.id for sub in store.list_all()] == ["sub-1"]

--- a/tools/webhooks/README.md
+++ b/tools/webhooks/README.md
@@ -21,6 +21,7 @@ The webhook system polls the RustChain node API, detects state changes, and disp
 ### 1. Start the dispatcher
 
 ```bash
+export WEBHOOK_ADMIN_API_KEY="local-dev-admin-key"
 python webhook_server.py --node http://localhost:5000 --port 9800
 ```
 
@@ -35,6 +36,7 @@ python webhook_client.py --port 9801
 ```bash
 curl -X POST http://localhost:9800/webhooks/subscribe \
   -H "Content-Type: application/json" \
+  -H "X-Admin-API-Key: $WEBHOOK_ADMIN_API_KEY" \
   -d '{
     "url": "http://localhost:9801/hook",
     "events": ["new_block", "miner_joined", "miner_left"]
@@ -42,6 +44,9 @@ curl -X POST http://localhost:9800/webhooks/subscribe \
 ```
 
 ## Dispatcher API
+
+Management routes require `WEBHOOK_ADMIN_API_KEY` on the dispatcher and the matching
+`X-Admin-API-Key` request header. `/health` is the only public dispatcher route.
 
 ### Subscribe
 

--- a/tools/webhooks/webhook_client.py
+++ b/tools/webhooks/webhook_client.py
@@ -11,8 +11,10 @@ Usage:
   python webhook_client.py --port 9801
 
   # 2. Register it with the dispatcher
+  export WEBHOOK_ADMIN_API_KEY="local-dev-admin-key"
   curl -X POST http://localhost:9800/webhooks/subscribe \
        -H "Content-Type: application/json" \
+       -H "X-Admin-API-Key: $WEBHOOK_ADMIN_API_KEY" \
        -d '{"url": "http://localhost:9801/hook", "events": ["new_block", "miner_joined"]}'
 
   # 3. Watch events stream in
@@ -154,8 +156,10 @@ def main():
         log.info("Signature verification disabled (no --secret provided)")
 
     log.info("Register this receiver with the dispatcher:")
+    log.info('  export WEBHOOK_ADMIN_API_KEY="local-dev-admin-key"')
     log.info('  curl -X POST http://localhost:9800/webhooks/subscribe \\')
     log.info('    -H "Content-Type: application/json" \\')
+    log.info('    -H "X-Admin-API-Key: $WEBHOOK_ADMIN_API_KEY" \\')
     log.info('    -d \'{"url": "http://localhost:%d/hook"}\'', args.port)
 
     try:

--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -525,7 +525,10 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
             self._send_json(503, {"error": "WEBHOOK_ADMIN_API_KEY not configured"})
             return False
         provided = self.headers.get("X-Admin-API-Key", "")
-        if not hmac.compare_digest(provided, self.ADMIN_API_KEY):
+        if not hmac.compare_digest(
+            provided.encode("utf-8"),
+            self.ADMIN_API_KEY.encode("utf-8"),
+        ):
             self._send_json(401, {"error": "invalid or missing API key"})
             return False
         return True
@@ -533,9 +536,11 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         if self.path == "/health":
             self._send_json(200, {"status": "ok"})
-        elif not self._check_api_key():
             return
-        elif self.path == "/webhooks":
+
+        if not self._check_api_key():
+            return
+        if self.path == "/webhooks":
             subs = self.store.list_all()
             self._send_json(200, {
                 "subscribers": [


### PR DESCRIPTION
﻿## Summary
- fail closed when `WEBHOOK_ADMIN_API_KEY` is not configured for webhook management routes
- keep `/health` public for uptime checks
- add local HTTP regression coverage for unset, missing/wrong, and valid admin keys

Fixes #4785.

## Validation
- `python -m pytest tests\test_webhook_admin_auth.py -q` -> 4 passed
- `python -m py_compile tools\webhooks\webhook_server.py tests\test_webhook_admin_auth.py` -> passed
- `git diff --check -- tools\webhooks\webhook_server.py tests\test_webhook_admin_auth.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive action was performed.
