### PR TITLE
Reject non-scalar UTXO transfer nonces

### DIFF
--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -141,6 +141,16 @@ def _reserve_transfer_nonce(conn: sqlite3.Connection, from_address: str, nonce) 
     return conn.execute("SELECT changes()").fetchone()[0] == 1
 
 
+def _normalize_transfer_nonce(nonce) -> str:
+    """Return the replay-key representation for accepted transfer nonces."""
+    if isinstance(nonce, bool) or not isinstance(nonce, (int, str)):
+        raise ValueError("nonce must be a string or integer")
+    nonce_key = str(nonce).strip()
+    if not nonce_key:
+        raise ValueError("nonce cannot be empty")
+    return nonce_key
+
+
 def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
                             verify_sig_fn, addr_from_pk_fn,
                             current_slot_fn, dual_write: bool = False):
@@ -361,12 +371,17 @@ def utxo_transfer():
 
     # --- validation ---------------------------------------------------------
 
-    if not all([from_address, to_address, public_key, signature, nonce]):
+    if not all([from_address, to_address, public_key, signature]) or nonce is None:
         return jsonify({
             'error': 'Missing required fields',
             'required': ['from_address', 'to_address', 'public_key',
                          'signature', 'nonce']
         }), 400
+
+    try:
+        nonce_key = _normalize_transfer_nonce(nonce)
+    except ValueError as e:
+        return jsonify({'error': f'Invalid nonce: {e}'}), 400
 
     if amount_rtc <= 0:
         return jsonify({'error': 'Amount must be positive'}), 400
@@ -476,12 +491,12 @@ def utxo_transfer():
     try:
         conn.execute("BEGIN IMMEDIATE")
 
-        if not _reserve_transfer_nonce(conn, from_address, nonce):
+        if not _reserve_transfer_nonce(conn, from_address, nonce_key):
             conn.rollback()
             return jsonify({
                 'error': 'Nonce already used (replay attack detected)',
                 'code': 'REPLAY_DETECTED',
-                'nonce': str(nonce),
+                'nonce': nonce_key,
             }), 400
 
         ok = _utxo_db.apply_transaction(tx, block_height, conn=conn)

--- a/tests/test_utxo_transfer_replay.py
+++ b/tests/test_utxo_transfer_replay.py
@@ -1,4 +1,6 @@
 import os
+import json
+import gc
 import sqlite3
 import sys
 import tempfile
@@ -12,6 +14,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "node"))
 
 from utxo_db import UtxoDB, UNIT
+import utxo_endpoints
 from utxo_endpoints import register_utxo_blueprint
 
 
@@ -82,6 +85,32 @@ def payload(nonce=1733420000000, amount_rtc=10.0):
     }
 
 
+def cleanup_db(client, db_path):
+    try:
+        client.__exit__(None, None, None)
+    except Exception:
+        pass
+    try:
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            conn.execute("PRAGMA journal_mode=DELETE")
+    except sqlite3.Error:
+        pass
+    utxo_endpoints._utxo_db = None
+    utxo_endpoints._db_path = None
+    gc.collect()
+    for path in (db_path, f"{db_path}-wal", f"{db_path}-shm"):
+        for attempt in range(20):
+            try:
+                if os.path.exists(path):
+                    os.unlink(path)
+                break
+            except PermissionError:
+                if attempt == 19:
+                    break
+                time.sleep(0.05)
+
+
 def test_utxo_transfer_rejects_duplicate_nonce():
     client, utxo_db, db_path = build_client()
     try:
@@ -104,7 +133,61 @@ def test_utxo_transfer_rejects_duplicate_nonce():
 
         assert nonce_count == 1
     finally:
-        os.unlink(db_path)
+        cleanup_db(client, db_path)
+
+
+def test_utxo_transfer_rejects_non_scalar_nonce_replay_bypass():
+    """Object nonces must not bypass replay protection via key order.
+
+    JSON signing uses sort_keys=True, so {"a":1,"b":2} and {"b":2,"a":1}
+    produce the same signed bytes. The replay table previously stored
+    str(nonce), whose order follows the submitted JSON object, allowing the
+    same signature to drain another UTXO with a reordered nonce object.
+    """
+    client, utxo_db, db_path = build_client()
+    try:
+        sender = "RTC_test_aabbccdd"
+        recipient = "bob"
+        seed_coinbase(utxo_db, sender, 20 * UNIT)
+
+        signed_message = json.dumps(
+            {
+                "from": sender,
+                "to": recipient,
+                "amount": 10.0,
+                "fee": 0.0,
+                "memo": "replay-test",
+                "nonce": {"a": 1, "b": 2},
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+
+        old_verify = utxo_endpoints._verify_sig_fn
+
+        def verify_object_nonce(pubkey_hex, message, sig_hex):
+            return sig_hex == "object-nonce-sig" and message == signed_message
+
+        try:
+            utxo_endpoints._verify_sig_fn = verify_object_nonce
+            first = payload(nonce={"a": 1, "b": 2})
+            first["signature"] = "object-nonce-sig"
+            first_response = client.post("/utxo/transfer", json=first)
+        finally:
+            utxo_endpoints._verify_sig_fn = old_verify
+
+        assert first_response.status_code == 400
+        assert "Invalid nonce" in first_response.get_json()["error"]
+        assert utxo_db.get_balance(sender) == 20 * UNIT
+        assert utxo_db.get_balance(recipient) == 0
+
+        with sqlite3.connect(db_path) as conn:
+            nonce_count = conn.execute(
+                "SELECT COUNT(*) FROM transfer_nonces"
+            ).fetchone()[0]
+        assert nonce_count == 0
+    finally:
+        cleanup_db(client, db_path)
 
 
 def test_utxo_transfer_failed_attempt_does_not_burn_nonce():
@@ -131,4 +214,4 @@ def test_utxo_transfer_failed_attempt_does_not_burn_nonce():
         assert nonce_count == 1
         assert utxo_db.get_balance("bob") == 10 * UNIT
     finally:
-        os.unlink(db_path)
+        cleanup_db(client, db_path)


### PR DESCRIPTION
﻿## Summary
- Reject boolean/object/array/null UTXO transfer nonces before signature or coin selection.
- Normalize accepted integer/string nonces to one scalar replay key.
- Add regression coverage for a same-signature object-nonce replay bypass caused by JSON key-order differences.

## Bounty context
Targets Scottcjn/rustchain-bounties#2819. This is distinct from the earlier "no nonce protection" reports: replay protection exists, but it keyed `str(nonce)` while the signed transfer payload canonicalizes JSON with `sort_keys=True`. A caller could sign one object nonce, reorder that object in a second request, produce the same signed bytes, and get a different replay-table key.

## Validation
- `python -m pytest node\test_utxo_endpoints.py tests\test_utxo_transfer_replay.py -q` -> 21 passed
- `python -m py_compile node\utxo_endpoints.py tests\test_utxo_transfer_replay.py`
- `git diff --check -- node\utxo_endpoints.py tests\test_utxo_transfer_replay.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet: `RTC7f251390e4a9c382224e1cbb682810c99cedd898`

