### PR TITLE
Fix bounty creation deadline import

### DIFF
--- a/sdk/rustchain/agent_economy/bounties.py
+++ b/sdk/rustchain/agent_economy/bounties.py
@@ -4,10 +4,10 @@ Bounty System Client
 Manages bounty discovery, claims, and automated payments.
 """
 
-from typing import Dict, List, Optional, Any
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
+from typing import Any, Dict, List, Optional
 
 
 class BountyStatus(Enum):

--- a/tests/test_agent_economy_bounties.py
+++ b/tests/test_agent_economy_bounties.py
@@ -1,16 +1,25 @@
 # SPDX-License-Identifier: MIT
 
 from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
 
+BOUNTIES_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "sdk"
+    / "rustchain"
+    / "agent_economy"
+    / "bounties.py"
+)
+
 
 def load_bounties_module():
     spec = spec_from_file_location(
         "agent_economy_bounties",
-        "sdk/rustchain/agent_economy/bounties.py",
+        BOUNTIES_MODULE_PATH,
     )
     module = module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/tests/test_agent_economy_bounties.py
+++ b/tests/test_agent_economy_bounties.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from importlib.util import module_from_spec, spec_from_file_location
 from types import SimpleNamespace
 from unittest.mock import Mock

--- a/tests/test_agent_economy_bounties.py
+++ b/tests/test_agent_economy_bounties.py
@@ -1,0 +1,80 @@
+from importlib.util import module_from_spec, spec_from_file_location
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+def load_bounties_module():
+    spec = spec_from_file_location(
+        "agent_economy_bounties",
+        "sdk/rustchain/agent_economy/bounties.py",
+    )
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_bounty_computes_deadline_and_posts_payload():
+    bounties = load_bounties_module()
+    client = Mock()
+    client.config = SimpleNamespace(agent_id="issuer-1")
+    client._request.return_value = {"bounty_id": "bounty-1"}
+
+    bounty = bounties.BountyClient(client).create_bounty(
+        "Title",
+        "Description",
+        5.0,
+        requirements=["tests"],
+        tags=["sdk"],
+        deadline_days=7,
+    )
+
+    client._request.assert_called_once()
+    method, path = client._request.call_args.args
+    payload = client._request.call_args.kwargs["json_payload"]
+
+    assert method == "POST"
+    assert path == "/api/bounty/create"
+    assert payload["issuer_id"] == "issuer-1"
+    assert payload["title"] == "Title"
+    assert payload["description"] == "Description"
+    assert payload["reward"] == 5.0
+    assert payload["tier"] == bounties.BountyTier.MEDIUM.value
+    assert payload["requirements"] == ["tests"]
+    assert payload["tags"] == ["sdk"]
+    assert payload["deadline"]
+
+    assert bounty.bounty_id == "bounty-1"
+    assert bounty.issuer == "issuer-1"
+    assert bounty.deadline is not None
+
+
+def test_create_bounty_defaults_optional_lists_to_empty_payload_values():
+    bounties = load_bounties_module()
+    client = Mock()
+    client.config = SimpleNamespace(agent_id="issuer-1")
+    client._request.return_value = {"bounty_id": "bounty-2"}
+
+    bounty = bounties.BountyClient(client).create_bounty(
+        "Default lists",
+        "Description",
+        3.0,
+    )
+
+    payload = client._request.call_args.kwargs["json_payload"]
+    assert payload["requirements"] == []
+    assert payload["tags"] == []
+    assert bounty.requirements == []
+    assert bounty.tags == []
+
+
+def test_create_bounty_requires_configured_agent_id():
+    bounties = load_bounties_module()
+    client = Mock()
+    client.config = SimpleNamespace(agent_id="")
+
+    with pytest.raises(ValueError, match="client must have agent_id configured"):
+        bounties.BountyClient(client).create_bounty("Title", "Description", 5.0)
+
+    client._request.assert_not_called()


### PR DESCRIPTION
## Summary
- import `timedelta` in the Agent Economy bounty client so `create_bounty()` can compute deadlines
- add a regression test that verifies `create_bounty()` posts the expected payload and returns a `Bounty`

Fixes #4693

wallet: RTC79b77545eeac126b85ff0ee56784e5e412f3d82a

## Verification
- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_agent_economy_bounties.py -q`
- `/tmp/rustchain-bounty-venv/bin/python -m ruff check --select F,I sdk/rustchain/agent_economy/bounties.py tests/test_agent_economy_bounties.py`
- `python3 -m py_compile sdk/rustchain/agent_economy/bounties.py tests/test_agent_economy_bounties.py`
- `git diff --check`
- `graphify update .`

Bounty payout wallet can be provided after maintainer review if needed.
