### PR TITLE
Require participant authorization for GPU escrow transitions

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -50,6 +50,8 @@ CREATE TABLE IF NOT EXISTS render_escrow (
     created_at INTEGER NOT NULL,
     released_at INTEGER,
     escrow_secret_hash TEXT,
+    release_secret_hash TEXT,
+    refund_secret_hash TEXT,
     metadata TEXT  -- JSON blob for job-specific params
 );
 
@@ -118,29 +120,39 @@ class GPURenderProtocol:
     def _init_db(self):
         conn = self._get_conn()
         conn.executescript(SCHEMA_SQL)
-        self._ensure_escrow_secret_column(conn)
+        self._ensure_escrow_secret_columns(conn)
         conn.commit()
         conn.close()
         logger.info("GPU Render Protocol DB initialized at %s", self.db_path)
 
-    def _ensure_escrow_secret_column(self, conn):
+    def _ensure_escrow_secret_columns(self, conn):
         """Add escrow secret storage for databases created before this guard."""
         cols = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
         if "escrow_secret_hash" not in cols:
             conn.execute("ALTER TABLE render_escrow ADD COLUMN escrow_secret_hash TEXT")
+        if "release_secret_hash" not in cols:
+            conn.execute("ALTER TABLE render_escrow ADD COLUMN release_secret_hash TEXT")
+        if "refund_secret_hash" not in cols:
+            conn.execute("ALTER TABLE render_escrow ADD COLUMN refund_secret_hash TEXT")
 
     @staticmethod
     def _hash_escrow_secret(secret: str) -> str:
         return hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
 
-    def _authorize_escrow_action(self, row, actor_wallet: str, escrow_secret: str, required_wallet: str):
+    def _authorize_escrow_action(
+        self,
+        row,
+        actor_wallet: str,
+        escrow_secret: str,
+        required_wallet: str,
+        expected_hash: str,
+    ):
         if not actor_wallet or not escrow_secret:
             return {"error": "actor_wallet and escrow_secret are required"}
         if actor_wallet not in {row["from_wallet"], row["to_wallet"]}:
             return {"error": "actor_wallet must be escrow participant"}
         if actor_wallet != required_wallet:
             return {"error": "actor_wallet is not allowed for this escrow action"}
-        expected_hash = row["escrow_secret_hash"]
         if not expected_hash:
             return {"error": "escrow_secret missing for existing escrow"}
         if not hmac.compare_digest(self._hash_escrow_secret(escrow_secret), expected_hash):
@@ -252,7 +264,8 @@ class GPURenderProtocol:
     # -------------------------------------------------------------------
 
     def create_escrow(self, job_type: str, from_wallet: str, to_wallet: str,
-                      amount_rtc: float, metadata: dict = None) -> dict:
+                      amount_rtc: float, metadata: dict = None,
+                      refund_secret_hash: str = None) -> dict:
         """Lock RTC in escrow for a compute job."""
         valid_types = ("render", "tts", "stt", "llm")
         if job_type not in valid_types:
@@ -263,16 +276,18 @@ class GPURenderProtocol:
             return {"error": "from_wallet and to_wallet must differ"}
 
         job_id = f"{job_type}-{uuid.uuid4().hex[:12]}"
-        escrow_secret = secrets.token_hex(16)
+        release_secret = secrets.token_urlsafe(32)
         conn = self._get_conn()
         try:
             conn.execute(
                 """INSERT INTO render_escrow
-                   (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                    status, created_at, escrow_secret_hash, metadata)
-                   VALUES (?,?,?,?,?,'locked',?,?,?)""",
+                    (job_id, job_type, from_wallet, to_wallet, amount_rtc,
+                     status, created_at, escrow_secret_hash, release_secret_hash,
+                     refund_secret_hash, metadata)
+                   VALUES (?,?,?,?,?,'locked',?,?,?,?,?)""",
                 (job_id, job_type, from_wallet, to_wallet, amount_rtc,
-                 int(time.time()), self._hash_escrow_secret(escrow_secret),
+                 int(time.time()), self._hash_escrow_secret(release_secret),
+                 self._hash_escrow_secret(release_secret), refund_secret_hash,
                  json.dumps(metadata or {})),
             )
             conn.commit()
@@ -283,7 +298,9 @@ class GPURenderProtocol:
                 "amount_rtc": amount_rtc,
                 "from_wallet": from_wallet,
                 "to_wallet": to_wallet,
-                "escrow_secret": escrow_secret,
+                "escrow_secret": release_secret,
+                "release_secret": release_secret,
+                "refund_secret_configured": bool(refund_secret_hash),
             }
         finally:
             conn.close()
@@ -304,6 +321,7 @@ class GPURenderProtocol:
                 actor_wallet=actor_wallet,
                 escrow_secret=escrow_secret,
                 required_wallet=row["from_wallet"],
+                expected_hash=row["release_secret_hash"] or row["escrow_secret_hash"],
             )
             if auth_error:
                 return auth_error
@@ -335,11 +353,14 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             if row["status"] != "locked":
                 return {"error": f"Job already {row['status']}"}
+            if not row["refund_secret_hash"]:
+                return {"error": "provider refund secret not configured"}
             auth_error = self._authorize_escrow_action(
                 row,
                 actor_wallet=actor_wallet,
                 escrow_secret=escrow_secret,
                 required_wallet=row["to_wallet"],
+                expected_hash=row["refund_secret_hash"],
             )
             if auth_error:
                 return auth_error
@@ -371,6 +392,9 @@ class GPURenderProtocol:
                 return {"error": "Job not found"}
             result = dict(row)
             result["metadata"] = json.loads(result.get("metadata") or "{}")
+            result.pop("escrow_secret_hash", None)
+            result.pop("release_secret_hash", None)
+            result.pop("refund_secret_hash", None)
             return result
         finally:
             conn.close()
@@ -494,6 +518,8 @@ def register_routes(app):
             to_wallet=data.get("to_wallet", ""),
             amount_rtc=data.get("amount_rtc", 0),
             metadata=data.get("metadata"),
+            refund_secret_hash=data.get("refund_secret_hash")
+            or data.get("provider_refund_secret_hash"),
         )
         status_code = 201 if "error" not in result else 400
         return jsonify(result), status_code

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -3,8 +3,11 @@ import os
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from flask import Flask
+from node import gpu_render_protocol
 from node.gpu_render_protocol import GPURenderProtocol
 
 
@@ -13,6 +16,10 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.db = os.path.join(self.tmp, "test_gpu.db")
         self.proto = GPURenderProtocol(db_path=self.db)
+
+    def refund_secret_pair(self):
+        secret = "provider-refund-secret"
+        return secret, GPURenderProtocol._hash_escrow_secret(secret)
 
     def test_attest_gpu(self):
         result = self.proto.attest_gpu("miner-1", {
@@ -76,10 +83,17 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertIn("error", double)
 
     def test_escrow_refund(self):
-        result = self.proto.create_escrow("tts", "wallet-a", "wallet-b", 5.0)
+        refund_secret, refund_secret_hash = self.refund_secret_pair()
+        result = self.proto.create_escrow(
+            "tts",
+            "wallet-a",
+            "wallet-b",
+            5.0,
+            refund_secret_hash=refund_secret_hash,
+        )
         job_id = result["job_id"]
 
-        refund = self.proto.refund_escrow(job_id, "wallet-b", result["escrow_secret"])
+        refund = self.proto.refund_escrow(job_id, "wallet-b", refund_secret)
         self.assertEqual(refund["status"], "refunded")
 
     def test_release_requires_payer_and_secret(self):
@@ -99,20 +113,132 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertEqual(status["status"], "locked")
 
     def test_refund_requires_provider_and_secret(self):
-        result = self.proto.create_escrow("tts", "wallet-a", "wallet-b", 5.0)
+        refund_secret, refund_secret_hash = self.refund_secret_pair()
+        result = self.proto.create_escrow(
+            "tts",
+            "wallet-a",
+            "wallet-b",
+            5.0,
+            refund_secret_hash=refund_secret_hash,
+        )
         job_id = result["job_id"]
 
-        wrong_actor = self.proto.refund_escrow(job_id, "wallet-a", result["escrow_secret"])
+        wrong_actor = self.proto.refund_escrow(job_id, "wallet-a", refund_secret)
         self.assertIn("error", wrong_actor)
 
-        outsider = self.proto.refund_escrow(job_id, "wallet-c", result["escrow_secret"])
+        outsider = self.proto.refund_escrow(job_id, "wallet-c", refund_secret)
         self.assertIn("error", outsider)
 
-        wrong_secret = self.proto.refund_escrow(job_id, "wallet-b", "wrong-secret")
+        wrong_secret = self.proto.refund_escrow(job_id, "wallet-b", result["escrow_secret"])
         self.assertIn("error", wrong_secret)
 
         status = self.proto.get_escrow(job_id)
         self.assertEqual(status["status"], "locked")
+
+        refunded = self.proto.refund_escrow(job_id, "wallet-b", refund_secret)
+        self.assertEqual(refunded["status"], "refunded")
+
+    def test_refund_requires_configured_provider_secret(self):
+        result = self.proto.create_escrow("tts", "wallet-a", "wallet-b", 5.0)
+
+        refund = self.proto.refund_escrow(
+            result["job_id"],
+            "wallet-b",
+            result["escrow_secret"],
+        )
+
+        self.assertEqual(refund["error"], "provider refund secret not configured")
+        self.assertEqual(self.proto.get_escrow(result["job_id"])["status"], "locked")
+
+    def test_creator_release_secret_cannot_refund_as_provider(self):
+        refund_secret, refund_secret_hash = self.refund_secret_pair()
+        result = self.proto.create_escrow(
+            "render",
+            "payer",
+            "provider",
+            10.0,
+            refund_secret_hash=refund_secret_hash,
+        )
+
+        refund = self.proto.refund_escrow(
+            result["job_id"],
+            "provider",
+            result["escrow_secret"],
+        )
+
+        self.assertIn("error", refund)
+        self.assertEqual(refund["error"], "invalid escrow_secret")
+        self.assertEqual(self.proto.get_escrow(result["job_id"])["status"], "locked")
+
+    def test_get_escrow_does_not_expose_secret_hashes(self):
+        _, refund_secret_hash = self.refund_secret_pair()
+        result = self.proto.create_escrow(
+            "render",
+            "payer",
+            "provider",
+            10.0,
+            refund_secret_hash=refund_secret_hash,
+        )
+
+        status = self.proto.get_escrow(result["job_id"])
+
+        self.assertNotIn("escrow_secret_hash", status)
+        self.assertNotIn("release_secret_hash", status)
+        self.assertNotIn("refund_secret_hash", status)
+
+    def test_release_route_rejects_bare_job_id(self):
+        result = self.proto.create_escrow("render", "payer", "provider", 10.0)
+        app = Flask(__name__)
+
+        with patch.object(gpu_render_protocol, "GPURenderProtocol", return_value=self.proto):
+            gpu_render_protocol.register_routes(app)
+
+        client = app.test_client()
+        response = client.post("/render/release", json={"job_id": result["job_id"]})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error", response.get_json())
+        self.assertEqual(self.proto.get_escrow(result["job_id"])["status"], "locked")
+
+    def test_refund_route_rejects_creator_release_secret_as_provider(self):
+        provider_secret, provider_secret_hash = self.refund_secret_pair()
+        result = self.proto.create_escrow(
+            "render",
+            "payer",
+            "provider",
+            10.0,
+            refund_secret_hash=provider_secret_hash,
+        )
+        app = Flask(__name__)
+
+        with patch.object(gpu_render_protocol, "GPURenderProtocol", return_value=self.proto):
+            gpu_render_protocol.register_routes(app)
+
+        client = app.test_client()
+        spoofed = client.post(
+            "/render/refund",
+            json={
+                "job_id": result["job_id"],
+                "actor_wallet": "provider",
+                "escrow_secret": result["escrow_secret"],
+            },
+        )
+
+        self.assertEqual(spoofed.status_code, 400)
+        self.assertEqual(spoofed.get_json()["error"], "invalid escrow_secret")
+        self.assertEqual(self.proto.get_escrow(result["job_id"])["status"], "locked")
+
+        valid = client.post(
+            "/render/refund",
+            json={
+                "job_id": result["job_id"],
+                "actor_wallet": "provider",
+                "escrow_secret": provider_secret,
+            },
+        )
+
+        self.assertEqual(valid.status_code, 200)
+        self.assertEqual(valid.get_json()["status"], "refunded")
 
     def test_escrow_invalid_type(self):
         result = self.proto.create_escrow("invalid", "a", "b", 1.0)


### PR DESCRIPTION
﻿## Summary
- Store a one-time escrow secret hash for GPU render protocol escrow records.
- Return the raw secret only at escrow creation.
- Require the payer wallet plus secret for release, and the provider wallet plus secret for refund.
- Add regression coverage proving bare `job_id` release/refund attempts leave escrow locked.

## Security context
Addresses the existing report in Scottcjn/Rustchain#4568. Before this change, `/render/release`, `/voice/release`, `/llm/release`, and `/render/refund` accepted only `job_id` and could transition any locked escrow without proving payer/provider authorization.

## Validation
- `python -m pytest tests\test_gpu_render_protocol.py -q` -> 15 passed
- `python -m py_compile node\gpu_render_protocol.py tests\test_gpu_render_protocol.py`
- `git diff --check -- node\gpu_render_protocol.py tests\test_gpu_render_protocol.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID: `SimoneMariaRomeo-codex-earner`
