### PR TITLE
fix: require admin auth for Hall eulogies

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -8,6 +8,8 @@ This is the emotional core of RustChain.
 from flask import Blueprint, jsonify, request
 import sqlite3
 import hashlib
+import hmac
+import os
 import time
 import json
 
@@ -144,6 +146,24 @@ def estimate_manufacture_year(model, arch):
         if key.lower() in arch.lower():
             return year
     return 2020  # Modern default
+
+
+def _require_hall_admin():
+    expected = os.environ.get("RC_ADMIN_KEY", "").strip()
+    if not expected:
+        return jsonify({'ok': False, 'error': 'RC_ADMIN_KEY not configured'}), 503
+
+    provided = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+    expected_bytes = expected.encode("utf-8")
+    provided_bytes = provided.encode("utf-8") if provided else b""
+    if not provided_bytes or not hmac.compare_digest(provided_bytes, expected_bytes):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
 
 # ============== API ENDPOINTS ==============
 
@@ -303,6 +323,10 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
+    auth_error = _require_hall_admin()
+    if auth_error:
+        return auth_error
+
     data = request.json or {}
     
     try:

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -11,6 +11,8 @@ from flask import Blueprint, jsonify, request
 from datetime import datetime, timezone
 import sqlite3
 import hashlib
+import hmac
+import os
 import time
 import json
 import logging
@@ -151,6 +153,24 @@ def estimate_manufacture_year(model, arch):
         if key.lower() in arch.lower():
             return year
     return 2020  # Modern default
+
+
+def _require_hall_admin():
+    expected = os.environ.get("RC_ADMIN_KEY", "").strip()
+    if not expected:
+        return jsonify({'ok': False, 'error': 'RC_ADMIN_KEY not configured'}), 503
+
+    provided = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+    expected_bytes = expected.encode("utf-8")
+    provided_bytes = provided.encode("utf-8") if provided else b""
+    if not provided_bytes or not hmac.compare_digest(provided_bytes, expected_bytes):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
 
 # ============== API ENDPOINTS ==============
 
@@ -310,6 +330,10 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
+    auth_error = _require_hall_admin()
+    if auth_error:
+        return auth_error
+
     data = request.json or {}
     
     try:

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -1,8 +1,10 @@
 from pathlib import Path
+import importlib.util
 import sqlite3
 import sys
 
 from flask import Flask
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -10,12 +12,48 @@ sys.path.insert(0, str(ROOT / "node"))
 
 import hall_of_rust  # noqa: E402
 
+EXPLORER_HALL_SPEC = importlib.util.spec_from_file_location(
+    "explorer_hall_of_rust",
+    ROOT / "explorer" / "hall_of_rust.py",
+)
+explorer_hall_of_rust = importlib.util.module_from_spec(EXPLORER_HALL_SPEC)
+EXPLORER_HALL_SPEC.loader.exec_module(explorer_hall_of_rust)
 
-def _client_for(db_path):
+FINGERPRINT = "f" * 32
+
+
+def _client_for(db_path, module=hall_of_rust):
     app = Flask(__name__)
     app.config["DB_PATH"] = str(db_path)
-    app.register_blueprint(hall_of_rust.hall_bp)
+    app.register_blueprint(module.hall_bp)
     return app.test_client()
+
+
+def _seed_machine(module, db_path):
+    module.init_hall_tables(str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO hall_of_rust (
+                fingerprint_hash, miner_id, first_attestation, created_at,
+                nickname, eulogy, is_deceased
+            )
+            VALUES (?, 'miner-original', 1, 1, 'original', 'still alive', 0)
+            """,
+            (FINGERPRINT,),
+        )
+
+
+def _memorial_row(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        return dict(conn.execute(
+            """
+            SELECT nickname, eulogy, is_deceased, deceased_at
+            FROM hall_of_rust WHERE fingerprint_hash = ?
+            """,
+            (FINGERPRINT,),
+        ).fetchone())
 
 
 def test_hall_stats_hides_sqlite_error_details(tmp_path):
@@ -82,3 +120,93 @@ def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json()["age_years"] == 23
+
+
+@pytest.mark.parametrize("module", (hall_of_rust, explorer_hall_of_rust))
+def test_hall_eulogy_fails_closed_when_admin_key_unconfigured(tmp_path, monkeypatch, module):
+    db_path = tmp_path / f"{module.__name__}.db"
+    _seed_machine(module, db_path)
+    client = _client_for(db_path, module)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    response = client.post(
+        f"/hall/eulogy/{FINGERPRINT}",
+        json={"nickname": "owned", "eulogy": "changed", "is_deceased": True},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "RC_ADMIN_KEY not configured"
+    assert _memorial_row(db_path) == {
+        "nickname": "original",
+        "eulogy": "still alive",
+        "is_deceased": 0,
+        "deceased_at": None,
+    }
+
+
+@pytest.mark.parametrize("module", (hall_of_rust, explorer_hall_of_rust))
+@pytest.mark.parametrize("headers", ({}, {"X-Admin-Key": "wrong"}))
+def test_hall_eulogy_requires_admin_key_before_mutation(tmp_path, monkeypatch, module, headers):
+    db_path = tmp_path / f"{module.__name__}.db"
+    _seed_machine(module, db_path)
+    client = _client_for(db_path, module)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-secret")
+
+    response = client.post(
+        f"/hall/eulogy/{FINGERPRINT}",
+        json={"nickname": "owned", "eulogy": "changed", "is_deceased": True},
+        headers=headers,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"
+    assert _memorial_row(db_path) == {
+        "nickname": "original",
+        "eulogy": "still alive",
+        "is_deceased": 0,
+        "deceased_at": None,
+    }
+
+
+@pytest.mark.parametrize("module", (hall_of_rust, explorer_hall_of_rust))
+def test_hall_eulogy_accepts_valid_admin_key(tmp_path, monkeypatch, module):
+    db_path = tmp_path / f"{module.__name__}.db"
+    _seed_machine(module, db_path)
+    client = _client_for(db_path, module)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-secret")
+
+    response = client.post(
+        f"/hall/eulogy/{FINGERPRINT}",
+        json={"nickname": "restored", "eulogy": "kept online", "is_deceased": True},
+        headers={"X-Admin-Key": "expected-secret"},
+    )
+
+    assert response.status_code == 200
+    row = _memorial_row(db_path)
+    assert row["nickname"] == "restored"
+    assert row["eulogy"] == "kept online"
+    assert row["is_deceased"] == 1
+    assert row["deceased_at"] is not None
+
+
+@pytest.mark.parametrize("module", (hall_of_rust, explorer_hall_of_rust))
+def test_hall_eulogy_rejects_non_ascii_admin_key_without_500(tmp_path, monkeypatch, module):
+    db_path = tmp_path / f"{module.__name__}.db"
+    _seed_machine(module, db_path)
+    client = _client_for(db_path, module)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-secret")
+
+    response = client.post(
+        f"/hall/eulogy/{FINGERPRINT}",
+        json={"nickname": "owned", "eulogy": "changed", "is_deceased": True},
+        headers={"X-Admin-Key": "é"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "unauthorized"
+    assert _memorial_row(db_path) == {
+        "nickname": "original",
+        "eulogy": "still alive",
+        "is_deceased": 0,
+        "deceased_at": None,
+    }


### PR DESCRIPTION
﻿## Summary
- Implements the unresolved Hall of Rust eulogy authorization finding from merged audit PR #3182.
- Requires configured `RC_ADMIN_KEY` plus `X-Admin-Key` or legacy `X-API-Key` before `/hall/eulogy/<fingerprint>` can edit nickname, eulogy, or deceased state.
- Applies the same fail-closed guard to both `node/hall_of_rust.py` and the duplicated `explorer/hall_of_rust.py` implementation.
- Adds regression coverage proving unset, missing, and wrong keys leave memorial rows unchanged while a valid admin key still updates the record.

## Validation
- `python -m pytest node\\tests\\test_hall_of_rust_error_responses.py -q` -> 10 passed
- `python -m py_compile node\\hall_of_rust.py explorer\\hall_of_rust.py node\\tests\\test_hall_of_rust_error_responses.py` -> passed
- `git diff --check -- node\\hall_of_rust.py explorer\\hall_of_rust.py node\\tests\\test_hall_of_rust_error_responses.py` -> passed
- `python tools\\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive action was performed.
