### PR TITLE
fix: bind reward claims to registered wallet

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -99,6 +99,16 @@ def validate_wallet_address_format(wallet_address: str) -> bool:
     return bool(re.match(pattern, wallet_address, re.IGNORECASE))
 
 
+def wallet_addresses_match(submitted_wallet: str, registered_wallet: str) -> bool:
+    """
+    Compare RustChain wallet addresses using the same case-insensitive
+    semantics as the address format validator.
+    """
+    if not isinstance(submitted_wallet, str) or not isinstance(registered_wallet, str):
+        return False
+    return submitted_wallet.casefold() == registered_wallet.casefold()
+
+
 def create_claim_payload(
     miner_id: str,
     epoch: int,
@@ -486,6 +496,11 @@ def submit_claim(
     
     if not eligibility["eligible"]:
         result["error"] = f"ineligible: {eligibility['reason']}"
+        return result
+
+    registered_wallet = eligibility.get("wallet_address")
+    if not wallet_addresses_match(wallet_address, registered_wallet):
+        result["error"] = "wallet_address_mismatch"
         return result
     
     # Verify signature (unless skipped for testing)

--- a/tests/test_claims_integration.py
+++ b/tests/test_claims_integration.py
@@ -597,6 +597,58 @@ class TestEdgeCases:
         
         assert result2["success"] is False
         assert "pending_claim_exists" in result2["error"] or "already exists" in result2["error"] or "Duplicate" in result2["error"]
+
+    def test_rejects_unregistered_payout_wallet_for_eligible_miner(self, integration_db, current_ts, current_slot):
+        """Eligible miners cannot redirect claims to a different payout wallet"""
+
+        test_epoch = max(0, current_slot // 144 - 3)
+
+        miner_id = "wallet-spoof-target"
+        registered_wallet = "RTC1RegisteredWallet1234567890"
+        attacker_wallet = "RTC1AttackerWallet123456789012"
+        setup_test_miner(integration_db, miner_id, "g4", registered_wallet, current_ts, epoch=test_epoch)
+
+        result = submit_claim(
+            db_path=integration_db,
+            miner_id=miner_id,
+            epoch=test_epoch,
+            wallet_address=attacker_wallet,
+            signature="mock_signature",
+            public_key="mock_public_key",
+            current_slot=current_slot,
+            current_ts=current_ts,
+            skip_signature_verify=True
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "wallet_address_mismatch"
+        assert get_claim_status(integration_db, f"claim_{test_epoch}_{miner_id}") is None
+
+    def test_wallet_match_is_case_insensitive(self, integration_db, current_ts, current_slot):
+        """Wallet comparison follows the existing case-insensitive address format"""
+
+        test_epoch = max(0, current_slot // 144 - 3)
+
+        miner_id = "case-wallet-miner"
+        registered_wallet = "RTC1CaseWalletABC1234567890"
+        submitted_wallet = registered_wallet.lower()
+        setup_test_miner(integration_db, miner_id, "g4", registered_wallet, current_ts, epoch=test_epoch)
+
+        result = submit_claim(
+            db_path=integration_db,
+            miner_id=miner_id,
+            epoch=test_epoch,
+            wallet_address=submitted_wallet,
+            signature="mock_signature",
+            public_key="mock_public_key",
+            current_slot=current_slot,
+            current_ts=current_ts,
+            skip_signature_verify=True
+        )
+
+        assert result["success"] is True
+        status = get_claim_status(integration_db, result["claim_id"])
+        assert status["wallet_address"] == submitted_wallet
     
     def test_wallet_address_change(self, integration_db, current_ts, current_slot):
         """Test that wallet address can be updated between claims"""


### PR DESCRIPTION
## Summary
- reject reward claim submissions whose payout wallet differs from the wallet returned by `check_claim_eligibility`
- compare RustChain wallet addresses case-insensitively, matching the existing address validator
- add regression coverage for victim-miner payout redirection and accepted case-only wallet variants

Closes #4592
Bounty: Scottcjn/rustchain-bounties#71
Miner/wallet ID: `lampten-codex-earner`
wallet: lampten-codex-earner

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_claims_integration.py -q` -> 13 passed
- `python -m py_compile node/claims_submission.py tests/test_claims_integration.py` -> passed
- `git diff --check -- node/claims_submission.py tests/test_claims_integration.py` -> passed
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive action was performed.
