### PR TITLE
fix: require admin key for machine passport events

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,31 @@ def get_optional_json_object():
     return data, None
 
 
+def require_configured_admin_key():
+    """Require ADMIN_KEY for protected write routes and fail closed if unset."""
+    expected_admin_key = os.environ.get('ADMIN_KEY', '').strip()
+    if not expected_admin_key:
+        return jsonify({
+            'ok': False,
+            'error': 'admin_key_not_configured',
+            'message': 'Admin key is not configured',
+        }), 503
+
+    admin_key = (
+        request.headers.get('X-Admin-Key')
+        or request.headers.get('X-API-Key')
+        or ''
+    ).strip()
+    if not admin_key or not hmac.compare_digest(admin_key, expected_admin_key):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -340,6 +365,10 @@ def add_repair_entry(machine_id: str):
         "notes": "Machine now stable at 1.2V"
     }
     """
+    auth_error = require_configured_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -382,6 +411,10 @@ def add_attestation(machine_id: str):
     
     Typically called automatically during mining attestation.
     """
+    auth_error = require_configured_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -428,6 +461,10 @@ def add_benchmark(machine_id: str):
         "entropy_throughput": 500.0
     }
     """
+    auth_error = require_configured_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -473,6 +510,10 @@ def add_lineage_note(machine_id: str):
         "tx_hash": "0x..."  # Optional blockchain transaction
     }
     """
+    auth_error = require_configured_admin_key()
+    if auth_error:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,19 @@ def get_optional_json_object():
     return data, None
 
 
+def admin_key_matches(admin_key: str, expected_admin_key: str) -> bool:
+    """Constant-time admin key comparison that treats malformed text as no match."""
+    if not admin_key or not expected_admin_key:
+        return False
+    try:
+        return hmac.compare_digest(
+            admin_key.encode('utf-8'),
+            expected_admin_key.encode('utf-8'),
+        )
+    except UnicodeError:
+        return False
+
+
 def require_configured_admin_key():
     """Require ADMIN_KEY for protected write routes and fail closed if unset."""
     expected_admin_key = os.environ.get('ADMIN_KEY', '').strip()
@@ -70,7 +83,7 @@ def require_configured_admin_key():
         or request.headers.get('X-API-Key')
         or ''
     ).strip()
-    if not admin_key or not hmac.compare_digest(admin_key, expected_admin_key):
+    if not admin_key_matches(admin_key, expected_admin_key):
         return jsonify({
             'ok': False,
             'error': 'unauthorized',
@@ -228,7 +241,7 @@ def create_passport():
     admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
     expected_admin_key = os.environ.get('ADMIN_KEY', '')
     
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
+    if expected_admin_key and not admin_key_matches(admin_key, expected_admin_key):
         return jsonify({
             'ok': False,
             'error': 'unauthorized',
@@ -322,7 +335,7 @@ def update_passport(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
+    if expected_admin_key and not admin_key_matches(admin_key, expected_admin_key):
         return jsonify({
             'ok': False,
             'error': 'unauthorized',

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -547,7 +547,7 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 401)
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'unauthorized')
-        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+        compare_digest.assert_called_once_with(b'wrong-admin-key', b'expected-admin-key')
 
         get_resp = self.client.get('/api/machine-passport/owner_claim_test')
         passport = json.loads(get_resp.data)['passport']['passport']
@@ -575,7 +575,7 @@ class TestAPIEndpoints(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
-        compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
+        compare_digest.assert_called_once_with(b'expected-admin-key', b'expected-admin-key')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -13,11 +13,18 @@ import machine_passport_api
 
 class LedgerStub:
     def __init__(self):
+        self.repair_payload = None
         self.attestation_payload = None
         self.benchmark_payload = None
+        self.lineage_payload = None
+        self.update_payload = None
 
     def get_passport(self, machine_id):
         return True
+
+    def add_repair_entry(self, **kwargs):
+        self.repair_payload = kwargs
+        return True, "repair added"
 
     def add_attestation(self, **kwargs):
         self.attestation_payload = kwargs
@@ -26,6 +33,21 @@ class LedgerStub:
     def add_benchmark(self, **kwargs):
         self.benchmark_payload = kwargs
         return True, "benchmark added"
+
+    def add_lineage_note(self, **kwargs):
+        self.lineage_payload = kwargs
+        return True, "lineage added"
+
+    def update_passport(self, machine_id, data):
+        self.update_payload = {"machine_id": machine_id, "data": data}
+        return True, "updated"
+
+    def assert_no_writes(self):
+        assert self.repair_payload is None
+        assert self.attestation_payload is None
+        assert self.benchmark_payload is None
+        assert self.lineage_payload is None
+        assert self.update_payload is None
 
 
 @pytest.fixture
@@ -42,6 +64,12 @@ def client(ledger):
     return app.test_client()
 
 
+@pytest.fixture
+def auth_headers(monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
+    return {"X-Admin-Key": "expected-admin-key"}
+
+
 @pytest.mark.parametrize(
     "path",
     (
@@ -49,8 +77,8 @@ def client(ledger):
         "/api/machine-passport/machine-1/benchmarks",
     ),
 )
-def test_event_routes_reject_non_object_json(client, path):
-    response = client.post(path, json=["not", "object"])
+def test_event_routes_reject_non_object_json(client, path, auth_headers):
+    response = client.post(path, json=["not", "object"], headers=auth_headers)
 
     assert response.status_code == 400
     assert response.get_json() == {
@@ -60,8 +88,102 @@ def test_event_routes_reject_non_object_json(client, path):
     }
 
 
-def test_attestation_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/attestations")
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/api/machine-passport/machine-1/repair-log",
+        "/api/machine-passport/machine-1/attestations",
+        "/api/machine-passport/machine-1/benchmarks",
+        "/api/machine-passport/machine-1/lineage",
+    ),
+)
+def test_event_write_routes_fail_closed_when_admin_key_unset(
+    client,
+    ledger,
+    monkeypatch,
+    path,
+):
+    monkeypatch.delenv("ADMIN_KEY", raising=False)
+
+    response = client.post(path, json={"event_type": "transfer"})
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "ok": False,
+        "error": "admin_key_not_configured",
+        "message": "Admin key is not configured",
+    }
+    ledger.assert_no_writes()
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        {},
+        {"X-Admin-Key": "wrong-admin-key"},
+        {"X-API-Key": "wrong-admin-key"},
+    ),
+)
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/api/machine-passport/machine-1/repair-log",
+        "/api/machine-passport/machine-1/attestations",
+        "/api/machine-passport/machine-1/benchmarks",
+        "/api/machine-passport/machine-1/lineage",
+    ),
+)
+def test_event_write_routes_reject_missing_or_wrong_admin_key(
+    client,
+    ledger,
+    monkeypatch,
+    path,
+    headers,
+):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(path, json={"event_type": "transfer"}, headers=headers)
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "message": "Admin key required",
+    }
+    ledger.assert_no_writes()
+
+
+def test_repair_route_accepts_admin_key_header(client, ledger, auth_headers):
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        json={"repair_type": "capacitor_replacement", "description": "recapped board"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "repair added"}
+    assert ledger.repair_payload["machine_id"] == "machine-1"
+    assert ledger.repair_payload["repair_type"] == "capacitor_replacement"
+
+
+def test_event_write_routes_accept_legacy_api_key_header(client, ledger, monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers={"X-API-Key": "expected-admin-key"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "attestation added"}
+    assert ledger.attestation_payload["machine_id"] == "machine-1"
+
+
+def test_attestation_route_preserves_empty_body_defaults(client, ledger, auth_headers):
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers=auth_headers,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "attestation added"}
@@ -69,8 +191,11 @@ def test_attestation_route_preserves_empty_body_defaults(client, ledger):
     assert ledger.attestation_payload["epoch"] is None
 
 
-def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/benchmarks")
+def test_benchmark_route_preserves_empty_body_defaults(client, ledger, auth_headers):
+    response = client.post(
+        "/api/machine-passport/machine-1/benchmarks",
+        headers=auth_headers,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "benchmark added"}
@@ -78,12 +203,30 @@ def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
     assert ledger.benchmark_payload["compute_score"] is None
 
 
-def test_benchmark_route_accepts_object_json(client, ledger):
+def test_benchmark_route_accepts_object_json(client, ledger, auth_headers):
     response = client.post(
         "/api/machine-passport/machine-1/benchmarks",
         json={"compute_score": 1250.0, "memory_bandwidth": 3200.5},
+        headers=auth_headers,
     )
 
     assert response.status_code == 200
     assert ledger.benchmark_payload["compute_score"] == 1250.0
     assert ledger.benchmark_payload["memory_bandwidth"] == 3200.5
+
+
+def test_lineage_route_updates_owner_with_admin_key(client, ledger, auth_headers):
+    response = client.post(
+        "/api/machine-passport/machine-1/lineage",
+        json={"event_type": "transfer", "to_owner": "new-owner"},
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "lineage added"}
+    assert ledger.lineage_payload["machine_id"] == "machine-1"
+    assert ledger.lineage_payload["event_type"] == "transfer"
+    assert ledger.update_payload == {
+        "machine_id": "machine-1",
+        "data": {"owner_miner_id": "new-owner"},
+    }

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -153,6 +153,28 @@ def test_event_write_routes_reject_missing_or_wrong_admin_key(
     ledger.assert_no_writes()
 
 
+def test_event_write_routes_reject_malformed_admin_key_without_500(
+    client,
+    ledger,
+    monkeypatch,
+):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
+
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        json={"event_type": "transfer"},
+        headers={"X-Admin-Key": "é"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {
+        "ok": False,
+        "error": "unauthorized",
+        "message": "Admin key required",
+    }
+    ledger.assert_no_writes()
+
+
 def test_repair_route_accepts_admin_key_header(client, ledger, auth_headers):
     response = client.post(
         "/api/machine-passport/machine-1/repair-log",


### PR DESCRIPTION
## Summary
- fail closed on machine passport repair, attestation, benchmark, and lineage writes when `ADMIN_KEY` is unset
- require `X-Admin-Key` or legacy `X-API-Key` before passport lookup, JSON parsing, or mutation
- add regression coverage for unauthorized writes plus valid repair, attestation, benchmark, and lineage updates

Closes #4562
Bounty: Scottcjn/rustchain-bounties#71
Miner/wallet ID: `lampten-codex-earner`
wallet: lampten-codex-earner

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_machine_passport_event_json_validation.py -q`
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_machine_passport.py tests/test_machine_passport_event_json_validation.py -q`
- `python -m py_compile node/machine_passport_api.py tests/test_machine_passport_event_json_validation.py`
- `git diff --check -- node/machine_passport_api.py tests/test_machine_passport_event_json_validation.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main`

No production testing or destructive actions performed.
