### PR TITLE
fix: keep beacon join payment address immutable

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -29,6 +29,11 @@ contract_store = []
 chat_sessions = {}
 
 
+def _coinbase_addresses_match(left, right):
+    """Compare optional EVM-style payment addresses without case sensitivity."""
+    return (left or '').strip().casefold() == (right or '').strip().casefold()
+
+
 def get_db():
     """Get database connection for current request context."""
     if 'db' not in g:
@@ -267,7 +272,7 @@ def beacon_join():
         # Check if agent already exists
         db = get_db()
         existing = db.execute(
-            "SELECT pubkey_hex FROM relay_agents WHERE agent_id = ?",
+            "SELECT pubkey_hex, coinbase_address FROM relay_agents WHERE agent_id = ?",
             (agent_id,)
         ).fetchone()
 
@@ -281,16 +286,23 @@ def beacon_join():
                     'error': 'Cannot change pubkey_hex for existing agent — '
                              'public key is immutable after registration'
                 }), 403
+            if coinbase_address and not _coinbase_addresses_match(
+                coinbase_address,
+                existing['coinbase_address'],
+            ):
+                return jsonify({
+                    'error': 'Cannot change coinbase_address for existing agent — '
+                             'payment address is immutable after registration'
+                }), 403
 
             # Update mutable fields only
             db.execute("""
                 UPDATE relay_agents
                 SET name = COALESCE(?, name),
-                    coinbase_address = COALESCE(?, coinbase_address),
                     status = 'active',
                     updated_at = ?
                 WHERE agent_id = ?
-            """, (name, coinbase_address, now, agent_id))
+            """, (name, now, agent_id))
         else:
             # New agent — insert with pubkey_hex
             db.execute("""

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -275,6 +275,83 @@ class TestBeaconJoinRouting(unittest.TestCase):
             ).fetchone()
             self.assertEqual(row[0], '0x1234567890123456789012345678901234567890')
 
+    def test_join_rejects_existing_agent_coinbase_address_change(self):
+        """POST /beacon/join cannot overwrite payment address for an existing agent."""
+        pubkey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+        original_coinbase = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+        attacker_coinbase = '0x9999999999999999999999999999999999999999'
+        payload1 = {
+            'agent_id': 'bcn_wallet_takeover_target',
+            'pubkey_hex': pubkey,
+            'name': 'Victim Agent',
+            'coinbase_address': original_coinbase,
+        }
+        response1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json',
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        payload2 = {
+            'agent_id': 'bcn_wallet_takeover_target',
+            'pubkey_hex': pubkey,
+            'name': 'Attacker Rename',
+            'coinbase_address': attacker_coinbase,
+        }
+        response2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json',
+        )
+        self.assertEqual(response2.status_code, 403)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT name, coinbase_address FROM relay_agents WHERE agent_id = ?",
+                ('bcn_wallet_takeover_target',)
+            ).fetchone()
+            self.assertEqual(row[0], 'Victim Agent')
+            self.assertEqual(row[1], original_coinbase)
+
+    def test_join_allows_idempotent_existing_coinbase_address(self):
+        """POST /beacon/join accepts the same payment address for an existing agent."""
+        pubkey = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
+        original_coinbase = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+        payload1 = {
+            'agent_id': 'bcn_wallet_idempotent',
+            'pubkey_hex': pubkey,
+            'name': 'Original Name',
+            'coinbase_address': original_coinbase,
+        }
+        response1 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload1),
+            content_type='application/json',
+        )
+        self.assertEqual(response1.status_code, 200)
+
+        payload2 = {
+            'agent_id': 'bcn_wallet_idempotent',
+            'pubkey_hex': pubkey,
+            'name': 'Updated Name',
+            'coinbase_address': original_coinbase.upper().replace('X', 'x', 1),
+        }
+        response2 = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload2),
+            content_type='application/json',
+        )
+        self.assertEqual(response2.status_code, 200)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT name, coinbase_address FROM relay_agents WHERE agent_id = ?",
+                ('bcn_wallet_idempotent',)
+            ).fetchone()
+            self.assertEqual(row[0], 'Updated Name')
+            self.assertEqual(row[1], original_coinbase)
+
     def test_join_invalid_coinbase_address_returns_400(self):
         """POST /beacon/join returns 400 for invalid coinbase_address."""
         invalid_cases = [


### PR DESCRIPTION
## Summary
- reject `/beacon/join` replays that try to change `coinbase_address` for an existing agent
- keep existing same-address joins idempotent, including case-only address variants
- continue allowing display-name updates while preserving the originally registered payment address

Closes #4589
Bounty: Scottcjn/rustchain-bounties#71
Miner/wallet ID: `lampten-codex-earner`
wallet: lampten-codex-earner

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_beacon_join_routing.py -q`
- `python -m py_compile node/beacon_api.py tests/test_beacon_join_routing.py`
- `git diff --check -- node/beacon_api.py tests/test_beacon_join_routing.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main`

No production testing or destructive actions performed.
