### PR TITLE
Escape mining dashboard rendered fields

### DIFF
--- a/node/rustchain_dashboard.py
+++ b/node/rustchain_dashboard.py
@@ -189,6 +189,21 @@ DASHBOARD_HTML = """
         .sys-stat .value { font-size: 1.8em; font-weight: bold; }
     </style>
     <script>
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, ch => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            }[ch]));
+        }
+
+        function safeToken(value, allowed, fallback = 'unknown') {
+            const token = String(value ?? '').toLowerCase();
+            return allowed.includes(token) ? token : fallback;
+        }
+
         function updateDashboard() {
             fetch('/api/stats')
                 .then(r => r.json())
@@ -210,27 +225,32 @@ DASHBOARD_HTML = """
 
                     // Update miners table
                     const minersTable = document.getElementById('miners-tbody');
-                    minersTable.innerHTML = data.active_miners.map(m => `
-                        <tr>
-                            <td class="mono">${m.wallet_short}...</td>
-                            <td><span class="badge badge-${m.arch}">${m.arch.toUpperCase()}</span></td>
-                            <td><strong>${m.weight}x</strong></td>
-                            <td class="green">${m.balance.toFixed(6)} RTC</td>
-                            <td class="mono">${m.last_seen}</td>
-                            <td class="blue">${m.age_on_network || 'New'}</td>
-                            <td><span class="badge badge-active pulse">ACTIVE</span></td>
-                        </tr>
-                    `).join('');
+                    const archTokens = ['active', 'classic', 'retro', 'ancient', 'modern'];
+                    minersTable.innerHTML = data.active_miners.map(m => {
+                        const archToken = safeToken(m.arch, archTokens, 'modern');
+                        const balance = Number(m.balance || 0).toFixed(6);
+                        return `
+                            <tr>
+                                <td class="mono">${escapeHtml(m.wallet_short)}...</td>
+                                <td><span class="badge badge-${archToken}">${escapeHtml(m.arch || 'unknown').toUpperCase()}</span></td>
+                                <td><strong>${escapeHtml(m.weight)}x</strong></td>
+                                <td class="green">${balance} RTC</td>
+                                <td class="mono">${escapeHtml(m.last_seen)}</td>
+                                <td class="blue">${escapeHtml(m.age_on_network || 'New')}</td>
+                                <td><span class="badge badge-active pulse">ACTIVE</span></td>
+                            </tr>
+                        `;
+                    }).join('');
 
                     // Update recent blocks
                     const blocksTable = document.getElementById('blocks-tbody');
                     blocksTable.innerHTML = data.recent_blocks.map(b => `
                         <tr>
-                            <td><strong>${b.height}</strong></td>
-                            <td class="mono">${b.hash_short}...</td>
-                            <td>${b.timestamp}</td>
-                            <td><span class="badge">${b.miners_count} miners</span></td>
-                            <td class="green">${b.reward} RTC</td>
+                            <td><strong>${escapeHtml(b.height)}</strong></td>
+                            <td class="mono">${escapeHtml(b.hash_short)}...</td>
+                            <td>${escapeHtml(b.timestamp)}</td>
+                            <td><span class="badge">${escapeHtml(b.miners_count)} miners</span></td>
+                            <td class="green">${escapeHtml(b.reward)} RTC</td>
                         </tr>
                     `).join('');
 
@@ -242,29 +262,31 @@ DASHBOARD_HTML = """
             const wallet = document.getElementById('wallet-search').value.trim();
             if (!wallet) return;
 
-            fetch(`/api/wallet/${wallet}`)
+            fetch(`/api/wallet/${encodeURIComponent(wallet)}`)
                 .then(r => r.json())
                 .then(data => {
                     const resultDiv = document.getElementById('search-result');
                     if (data.found) {
+                        const tierToken = safeToken(data.tier, ['classic', 'retro', 'ancient', 'modern'], 'modern');
                         resultDiv.innerHTML = `
                             <h3>✅ Wallet Found</h3>
-                            <p><strong>Address:</strong> <span class="mono">${data.wallet}</span></p>
-                            <p><strong>Balance:</strong> <span class="green">${data.balance} RTC</span></p>
-                            <p><strong>Weight:</strong> ${data.weight}x (${data.tier})</p>
-                            <p><strong>Age on Network:</strong> ${data.age_on_network || 'Unknown'}</p>
+                            <p><strong>Address:</strong> <span class="mono">${escapeHtml(data.wallet)}</span></p>
+                            <p><strong>Balance:</strong> <span class="green">${escapeHtml(data.balance)} RTC</span></p>
+                            <p><strong>Weight:</strong> ${escapeHtml(data.weight)}x (<span class="badge badge-${tierToken}">${escapeHtml(data.tier)}</span>)</p>
+                            <p><strong>Age on Network:</strong> ${escapeHtml(data.age_on_network || 'Unknown')}</p>
                             <p><strong>Status:</strong> ${data.enrolled ? '✅ Enrolled in current epoch' : '⏸️ Not currently enrolled'}</p>
-                            <p><strong>Last Seen:</strong> ${data.last_seen || 'Never'}</p>
+                            <p><strong>Last Seen:</strong> ${escapeHtml(data.last_seen || 'Never')}</p>
                         `;
                     } else {
                         resultDiv.innerHTML = `
                             <h3>❌ Wallet Not Found</h3>
-                            <p>No miner found with address: <span class="mono">${wallet}</span></p>
+                            <p>No miner found with address: <span class="mono">${escapeHtml(wallet)}</span></p>
                         `;
                     }
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
+                    err = escapeHtml(err.message || err);
                     document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
                     document.getElementById('search-result').style.display = 'block';
                 });

--- a/tests/test_rustchain_dashboard_frontend_security.py
+++ b/tests/test_rustchain_dashboard_frontend_security.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 
 

--- a/tests/test_rustchain_dashboard_frontend_security.py
+++ b/tests/test_rustchain_dashboard_frontend_security.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+
+RUSTCHAIN_DASHBOARD = (
+    Path(__file__).resolve().parents[1] / "node" / "rustchain_dashboard.py"
+)
+
+
+def _source() -> str:
+    return RUSTCHAIN_DASHBOARD.read_text(encoding="utf-8")
+
+
+def test_dashboard_escapes_api_fields_before_inner_html_rendering():
+    source = _source()
+
+    assert "function escapeHtml(value)" in source
+    assert "${escapeHtml(m.wallet_short)}" in source
+    assert "${escapeHtml(m.arch || 'unknown').toUpperCase()}" in source
+    assert "${escapeHtml(m.last_seen)}" in source
+    assert "${escapeHtml(m.age_on_network || 'New')}" in source
+    assert "${escapeHtml(b.hash_short)}" in source
+    assert "${escapeHtml(b.timestamp)}" in source
+
+    assert "${m.wallet_short}" not in source
+    assert "badge-${m.arch}" not in source
+    assert "${b.hash_short}" not in source
+    assert "${b.timestamp}" not in source
+
+
+def test_dashboard_sanitizes_dynamic_class_tokens_and_wallet_search():
+    source = _source()
+
+    assert "function safeToken(value, allowed" in source
+    assert "const archToken = safeToken(m.arch, archTokens, 'modern');" in source
+    assert "badge-${archToken}" in source
+    assert "const tierToken = safeToken(data.tier" in source
+    assert "badge-${tierToken}" in source
+    assert "fetch(`/api/wallet/${encodeURIComponent(wallet)}`)" in source
+    assert "fetch(`/api/wallet/${wallet}`)" not in source
+
+
+def test_dashboard_escapes_search_result_and_error_text():
+    source = _source()
+
+    assert "${escapeHtml(data.wallet)}" in source
+    assert "${escapeHtml(data.balance)}" in source
+    assert "${escapeHtml(data.weight)}" in source
+    assert "${escapeHtml(data.tier)}" in source
+    assert "${escapeHtml(wallet)}" in source
+    assert "err = escapeHtml(err.message || err);" in source
+
+    assert "${data.wallet}" not in source
+    assert "${data.balance}" not in source
+    assert "${data.weight}" not in source
+    assert "${data.tier}" not in source
+    assert '<span class="mono">${wallet}</span>' not in source


### PR DESCRIPTION
Fixes #4458.

## Summary
- Add `escapeHtml()` for mining dashboard values rendered through template-string `innerHTML`.
- Sanitize dynamic badge class suffixes for miner architecture and wallet tier.
- URL-encode wallet search requests and escape wallet search/error output.
- Add regression coverage for raw API/search values no longer being inserted directly.

## Validation
- `python -m pytest tests\test_rustchain_dashboard_frontend_security.py -q` -> 3 passed
- `python -m pytest tests\test_miner_dashboard_frontend_security.py tests\test_rustchain_dashboard_frontend_security.py -q` -> 6 passed
- `python -m py_compile node\rustchain_dashboard.py tests\test_rustchain_dashboard_frontend_security.py` -> passed
- `git diff --check -- node\rustchain_dashboard.py tests\test_rustchain_dashboard_frontend_security.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID: `SimoneMariaRomeo-codex-earner`