### PR TITLE
fix: verify windows miner bootstrap download

### DIFF
--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,6 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
+set "MINER_SHA256=51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===
@@ -47,6 +48,8 @@ if exist "%MINER_SCRIPT%" (
     echo Downloading the latest miner script...
     powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%MINER_URL%' -OutFile '%MINER_SCRIPT%'"
 )
+call :verify_miner
+if errorlevel 1 exit /b 1
 
 echo.
 echo Miner is ready. Run:
@@ -54,3 +57,21 @@ echo    python "%MINER_SCRIPT%"
 echo If you still get a tkinter error, run headless:
 echo    python "%MINER_SCRIPT%" --headless --wallet YOUR_WALLET_ID --node https://rustchain.org
 echo You can create a scheduled task or shortcut to keep it running.
+goto :eof
+
+:verify_miner
+if not exist "%MINER_SCRIPT%" (
+    echo ERROR: Miner script was not downloaded.
+    exit /b 1
+)
+set "ACTUAL_MINER_SHA256="
+for /f "usebackq delims=" %%H in (`powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -Path '%MINER_SCRIPT%').Hash.ToLowerInvariant()"`) do set "ACTUAL_MINER_SHA256=%%H"
+if /I not "!ACTUAL_MINER_SHA256!"=="%MINER_SHA256%" (
+    echo ERROR: Miner script SHA-256 mismatch.
+    echo Expected: %MINER_SHA256%
+    echo Actual:   !ACTUAL_MINER_SHA256!
+    del /f /q "%MINER_SCRIPT%" >nul 2>&1
+    exit /b 1
+)
+echo Miner script checksum verified.
+exit /b 0

--- a/tests/test_windows_miner_setup_checksum.py
+++ b/tests/test_windows_miner_setup_checksum.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+import hashlib
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SETUP_SCRIPT = ROOT / "miners" / "windows" / "rustchain_miner_setup.bat"
+MINER_SCRIPT = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+
+
+def _setup_text():
+    return SETUP_SCRIPT.read_text(encoding="utf-8", errors="replace")
+
+
+def test_windows_miner_setup_pins_current_miner_hash():
+    text = _setup_text()
+
+    match = re.search(r'set "MINER_SHA256=([0-9a-f]{64})"', text, re.IGNORECASE)
+
+    assert match is not None
+    assert match.group(1).lower() == hashlib.sha256(MINER_SCRIPT.read_bytes()).hexdigest()
+
+
+def test_windows_miner_setup_verifies_miner_before_run_instructions():
+    text = _setup_text()
+
+    assert "call :verify_miner" in text
+    assert text.index("call :verify_miner") < text.index("Miner is ready. Run:")
+    assert "Get-FileHash -Algorithm SHA256" in text
+    assert "Hash.ToLowerInvariant()" in text
+    assert 'if /I not "!ACTUAL_MINER_SHA256!"=="%MINER_SHA256%"' in text
+    assert 'del /f /q "%MINER_SCRIPT%"' in text
+    assert "Miner script SHA-256 mismatch." in text


### PR DESCRIPTION
## Summary
- pin the expected SHA-256 for `miners/windows/rustchain_windows_miner.py` in the Windows bootstrap
- verify the existing or downloaded miner script before printing run instructions
- delete mismatched miner scripts and fail setup instead of leaving unverified code in place
- add regression coverage for the pinned hash and verification flow

Closes #4445
Bounty: Scottcjn/Rustchain#305
Miner/wallet ID: `lampten-codex-earner`
wallet: lampten-codex-earner

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_windows_miner_setup_checksum.py -q` -> 2 passed
- `python -m py_compile tests/test_windows_miner_setup_checksum.py`
- `git diff --check -- miners/windows/rustchain_miner_setup.bat tests/test_windows_miner_setup_checksum.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production testing or destructive actions performed.
