### PR TITLE
fix: disable public Flask debug mode by default

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -11,6 +11,7 @@ app = Flask(__name__)
 app.config['SECRET_KEY'] = 'bcos-directory-dev-key'
 
 DATABASE = 'bcos_directory.db'
+FLASK_DEBUG = os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes'}
 
 def init_db():
     """Initialize the database with projects table"""
@@ -482,4 +483,4 @@ def serve_dist(filename):
 if __name__ == '__main__':
     init_db()
     load_projects_from_json()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=FLASK_DEBUG, host='0.0.0.0', port=5000)

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -29,6 +29,7 @@ BRIDGE_RECEIPT_SECRET = os.environ.get("BRIDGE_RECEIPT_SECRET", "")
 
 # Security: require proof for all bridge locks (Issue #727)
 BRIDGE_REQUIRE_PROOF = os.environ.get("BRIDGE_REQUIRE_PROOF", "true").lower() == "true"
+FLASK_DEBUG = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes"}
 
 # Target chain identifiers
 CHAIN_SOLANA = "solana"
@@ -621,4 +622,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=FLASK_DEBUG)

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -33,6 +33,7 @@ elif SECRET_KEY == 'rustchain_contributor_secret_2024':
 app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
+FLASK_DEBUG = os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes'}
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -188,4 +189,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=FLASK_DEBUG, host='0.0.0.0', port=5000)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, jsonify
+import os
 import requests
 import json
 from datetime import datetime
@@ -8,6 +9,7 @@ app = Flask(__name__)
 # Configuration
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
+FLASK_DEBUG = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes"}
 
 @app.route('/')
 def dashboard():
@@ -134,4 +136,4 @@ def internal_error(error):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=FLASK_DEBUG)

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -27,6 +27,7 @@ from datetime import datetime
 NODE_API = os.environ.get("RUSTCHAIN_NODE_API", "http://localhost:8000")
 FAUCET_DB = "faucet_service/faucet.db"
 PORT = 8095
+FLASK_DEBUG = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes"}
 
 app = Flask(__name__)
 CORS(app)
@@ -377,4 +378,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=FLASK_DEBUG)

--- a/security_test_payment_widget.py
+++ b/security_test_payment_widget.py
@@ -13,6 +13,7 @@ app = Flask(__name__)
 app.secret_key = 'test_key_for_security_testing_only'
 
 DB_PATH = 'rustchain.db'
+FLASK_DEBUG = os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes'}
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -272,4 +273,4 @@ def admin_login():
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=FLASK_DEBUG, host='0.0.0.0', port=5000)

--- a/tests/test_flask_debug_defaults.py
+++ b/tests/test_flask_debug_defaults.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+
+import ast
+from pathlib import Path
+
+
+PUBLIC_FLASK_ENTRYPOINTS = [
+    Path("bcos_directory.py"),
+    Path("bridge/bridge_api.py"),
+    Path("contributor_registry.py"),
+    Path("explorer/app.py"),
+    Path("keeper_explorer.py"),
+    Path("security_test_payment_widget.py"),
+]
+
+
+def test_public_flask_entrypoints_do_not_force_debug_true():
+    for path in PUBLIC_FLASK_ENTRYPOINTS:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            if not isinstance(call.func, ast.Attribute) or call.func.attr != "run":
+                continue
+
+            debug_keywords = [kw for kw in call.keywords if kw.arg == "debug"]
+            assert debug_keywords, f"{path} should pass debug explicitly"
+            for keyword in debug_keywords:
+                assert not (
+                    isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is True
+                ), f"{path} must not force Flask debug mode on"


### PR DESCRIPTION
## Summary
- stop six standalone Flask entrypoints from forcing debug mode on while binding to `0.0.0.0`
- keep local opt-in behavior via `FLASK_DEBUG=1`, `true`, or `yes`
- add an AST regression test so public Flask entrypoints do not hard-code `debug=True` again

Fixes #4810.
Bounty reference: #305. Public payment details intentionally omitted.

## Validation
- `python -m py_compile bcos_directory.py bridge\bridge_api.py contributor_registry.py explorer\app.py keeper_explorer.py security_test_payment_widget.py tests\test_flask_debug_defaults.py`
- Manual run of `tests/test_flask_debug_defaults.py::test_public_flask_entrypoints_do_not_force_debug_true` using Python 3.11.7
- `rg app\.run\(.*debug=True|debug=True` on the touched entrypoints returns no matches
- `git diff --check -- bcos_directory.py bridge\bridge_api.py contributor_registry.py explorer\app.py keeper_explorer.py security_test_payment_widget.py tests\test_flask_debug_defaults.py`

Note: full `pytest` was not run locally because this Windows host only has Python 2.7 globally; validation used the bundled Blender Python 3.11.7 interpreter available on the machine.