### PR TITLE
fix: avoid shell invocation in detector tools

### DIFF
--- a/tests/test_tool_shell_invocations.py
+++ b/tests/test_tool_shell_invocations.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: MIT
+
+import ast
+from pathlib import Path
+
+
+TOOL_FILES = [
+    Path("tools/gpu_display_detector.py"),
+    Path("tools/os_detector.py"),
+]
+
+
+def test_tool_detectors_do_not_use_shell_true():
+    for path in TOOL_FILES:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for call in (node for node in ast.walk(tree) if isinstance(node, ast.Call)):
+            for keyword in call.keywords:
+                assert not (
+                    keyword.arg == "shell"
+                    and isinstance(keyword.value, ast.Constant)
+                    and keyword.value.value is True
+                ), f"{path} must not invoke subprocesses through a shell"

--- a/tools/gpu_display_detector.py
+++ b/tools/gpu_display_detector.py
@@ -7,8 +7,8 @@ def detect_gpu_and_display():
     badges = []
 
     try:
-        output = subprocess.check_output("lspci", shell=True).decode().lower()
-    except Exception:
+        output = subprocess.check_output(["lspci"], stderr=subprocess.DEVNULL).decode().lower()
+    except (OSError, subprocess.SubprocessError):
         output = ""
 
     gpu_flags = {

--- a/tools/os_detector.py
+++ b/tools/os_detector.py
@@ -1,5 +1,5 @@
 import platform
-import subprocess
+import os
 import json
 from datetime import datetime
 
@@ -45,11 +45,11 @@ def detect_legacy_os_badges():
 
     detected_keywords = []
     try:
-        output = subprocess.check_output("dir", shell=True).decode().lower()
+        output = "\n".join(os.listdir(".")).lower()
         for system_key, terms in simulated_os_data.items():
             if any(term.lower() in output for term in terms):
                 detected_keywords.append(system_key)
-    except:
+    except OSError:
         pass
 
     for key in detected_keywords:


### PR DESCRIPTION
## Summary
- remove `shell=True` from the GPU/display detector's fixed `lspci` call
- replace the OS detector's shell `dir` call with `os.listdir(.)`
- add an AST regression test that prevents these detector tools from reintroducing `shell=True`

Fixes #4813.
Bounty reference: #305. Public payment details intentionally omitted.

## Validation
- `python -m py_compile tools\gpu_display_detector.py tools\os_detector.py tests\test_tool_shell_invocations.py`
- Manual run of `tests/test_tool_shell_invocations.py::test_tool_detectors_do_not_use_shell_true` using Python 3.11.7
- `rg -n 'shell=True' tools\gpu_display_detector.py tools\os_detector.py tests\test_tool_shell_invocations.py` returns no matches
- `git diff --check -- tools\gpu_display_detector.py tools\os_detector.py tests\test_tool_shell_invocations.py`

Note: full `pytest` was not run locally because this Windows host only has Python 2.7 globally; validation used the bundled Blender Python 3.11.7 interpreter available on the machine.