### PR TITLE
fix: escape profile badge preview labels

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -7,10 +7,15 @@ import json
 import urllib.parse
 import hashlib
 from datetime import datetime
+from html import escape as escape_html
 
 app = Flask(__name__)
 
 DB_PATH = "rustchain.db"
+
+
+def escape_markdown_alt_text(value):
+    return value.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
 
 def init_badge_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -109,7 +114,12 @@ def badge_generator():
             .then(response => response.json())
             .then(data => {
                 if (data.success) {
-                    document.getElementById('badgePreview').innerHTML = data.preview_html;
+                    const badgePreview = document.getElementById('badgePreview');
+                    badgePreview.replaceChildren();
+                    const previewImage = document.createElement('img');
+                    previewImage.src = data.shield_url;
+                    previewImage.alt = data.alt_text || 'RustChain badge';
+                    badgePreview.appendChild(previewImage);
                     document.getElementById('markdownCode').textContent = data.markdown;
                     document.getElementById('htmlCode').textContent = data.html;
                     document.getElementById('result').style.display = 'block';
@@ -145,13 +155,16 @@ def create_badge():
     
     color = badge_colors.get(badge_type, 'blue')
     label = custom_message if custom_message else badge_type.replace('-', ' ').title()
+    shield_label = urllib.parse.quote(label, safe="")
+    escaped_label = escape_html(label, quote=True)
+    markdown_label = escape_markdown_alt_text(label)
     
-    shield_url = f"https://img.shields.io/badge/RustChain-{urllib.parse.quote(label)}-{color}"
+    shield_url = f"https://img.shields.io/badge/RustChain-{shield_label}-{color}"
     repo_url = "https://github.com/Scottcjn/Rustchain"
     
-    markdown = f"[![RustChain {label}]({shield_url})]({repo_url})"
-    html = f'<a href="{repo_url}"><img src="{shield_url}" alt="RustChain {label}"></a>'
-    preview_html = f'<img src="{shield_url}" alt="RustChain {label}">'
+    markdown = f"[![RustChain {markdown_label}]({shield_url})]({repo_url})"
+    html = f'<a href="{repo_url}"><img src="{shield_url}" alt="RustChain {escaped_label}"></a>'
+    preview_html = f'<img src="{shield_url}" alt="RustChain {escaped_label}">'
     
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
@@ -167,7 +180,8 @@ def create_badge():
         'markdown': markdown,
         'html': html,
         'preview_html': preview_html,
-        'shield_url': shield_url
+        'shield_url': shield_url,
+        'alt_text': f"RustChain {label}"
     })
 
 @app.route('/api/badge/stats')

--- a/tests/test_profile_badge_generator_frontend_security.py
+++ b/tests/test_profile_badge_generator_frontend_security.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+PROFILE_BADGE_GENERATOR = Path(__file__).resolve().parents[1] / "profile_badge_generator.py"
+
+
+def test_profile_badge_preview_escapes_custom_message_labels():
+    source = PROFILE_BADGE_GENERATOR.read_text(encoding="utf-8")
+
+    assert "from html import escape as escape_html" in source
+    assert 'urllib.parse.quote(label, safe="")' in source
+    assert "escaped_label = escape_html(label, quote=True)" in source
+    assert "markdown_label = escape_markdown_alt_text(label)" in source
+    assert 'alt="RustChain {escaped_label}"' in source
+    assert 'alt="RustChain {label}"' not in source
+
+    assert "const previewImage = document.createElement('img');" in source
+    assert "previewImage.src = data.shield_url;" in source
+    assert "previewImage.alt = data.alt_text || 'RustChain badge';" in source
+    assert "badgePreview.replaceChildren();" in source
+    assert "document.getElementById('badgePreview').innerHTML" not in source


### PR DESCRIPTION
## Summary

Fixes #4815.

- escapes the user-controlled badge label before placing it in generated HTML attributes
- encodes the Shields.io label path component with `safe=""`
- escapes Markdown alt text in the generated README snippet
- renders the live preview with DOM APIs instead of assigning returned HTML to `innerHTML`
- adds a focused regression test for the profile badge preview/generator path

## Validation

- `python -m py_compile profile_badge_generator.py tests\test_profile_badge_generator_frontend_security.py`
- manual execution of `test_profile_badge_preview_escapes_custom_message_labels`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Submitted for consideration under #305. Public payout/payment details are intentionally omitted.
