### PR TITLE
fix: add silent=True and validation to /epoch/enroll JSON parsing

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3708,7 +3708,9 @@ def get_epoch():
 @app.route('/epoch/enroll', methods=['POST'])
 def enroll_epoch():
     """Enroll in current epoch"""
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "Invalid JSON body"}), 400
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()


### PR DESCRIPTION
## Security Fix

The `/epoch/enroll` endpoint used `request.get_json()` without `silent=True`, causing a `400 BadRequest` on non-JSON Content-Type headers.
Additionally, there was no `isinstance` check to validate the parsed data is a dict before calling `.get()` on it.

### Impact
- Sending `Content-Type: text/plain` with `POST /epoch/enroll` causes 400
- Sending a JSON array `[]` crashes with `AttributeError` on `.get()`

### Fix
- Added `silent=True` to `request.get_json()`
- Added `isinstance(data, dict)` check with proper 400 response

### Testing
Verified that the endpoint now returns a proper 400 error for invalid Content-Types and JSON arrays instead of raising unhandled exceptions.

---
RTC Wallet: `RTC6d1f27d28961279f1034d9561c2403697eb55602`