### PR TITLE
fix: prevent admin key leak via URL query parameters

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4178,7 +4178,7 @@ def _wallet_review_ui_authorized(req):
     if is_admin(req):
         return True
     need = os.environ.get("RC_ADMIN_KEY", "")
-    got = str(req.values.get("admin_key") or "").strip()
+    got = str(req.form.get("admin_key") or "").strip()
     return bool(need and got and hmac.compare_digest(need, got))
 
 


### PR DESCRIPTION
## Security Hardening

The `_wallet_review_ui_authorized` function accepted `admin_key` from `req.values`, which includes both query string parameters and form data.
This means admin keys passed via URL query strings (`?admin_key=xxx`) would be logged in server access logs, browser history, and Referer headers.

### Fix
Changed `req.values.get('admin_key')` to `req.form.get('admin_key')` so admin keys are only accepted from POST form bodies, never from URLs.

### Impact
Low — requires admin to have previously used URL-based auth. But this is defense-in-depth hardening to prevent accidental key exposure.

---
RTC Wallet: `RTC6d1f27d28961279f1034d9561c2403697eb55602`