### PR TITLE
fix: add BEGIN IMMEDIATE to /wallet/transfer to prevent race condition

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6891,6 +6891,10 @@ def wallet_transfer_v2():
     try:
         c = conn.cursor()
         
+        # SECURITY: Acquire write lock BEFORE reading balance to prevent
+        # concurrent transfers from both passing the balance check.
+        c.execute("BEGIN IMMEDIATE")
+        
         # Check sender balance
         row = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (from_miner,)).fetchone()
         sender_balance = row[0] if row else 0


### PR DESCRIPTION
## Security Fix

The `/wallet/transfer` endpoint read the sender balance and pending debits without acquiring a write lock first. This allowed concurrent requests to both pass the balance check simultaneously, resulting in pending transfers exceeding the actual balance.

### Attack Scenario
1. Attacker sends 2 concurrent `POST /wallet/transfer` requests
2. Both requests read the same balance (e.g., 100 RTC)
3. Both check `available_balance >= amount` (e.g., 80 RTC each)
4. Both insert `pending_ledger` entries
5. Total pending debits = 160 RTC > 100 RTC actual balance

### Fix
Added `BEGIN IMMEDIATE` before the balance `SELECT` to acquire an exclusive write lock, preventing concurrent reads from seeing stale balance data.

### Impact
**High** — allows overspending via concurrent transfer requests.

---
RTC Wallet: `RTC6d1f27d28961279f1034d9561c2403697eb55602`