### PR TITLE
fix: submit stable linux miner hardware signals

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -34,6 +34,52 @@ _CERT_PATH = os.path.expanduser("~/.rustchain/node_cert.pem")
 TLS_VERIFY = _CERT_PATH if os.path.exists(_CERT_PATH) else True
 
 
+def _safe_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coefficient_of_variation(mean_value, stdev_value):
+    mean = _safe_float(mean_value)
+    if mean <= 0:
+        return 0.0
+    return _safe_float(stdev_value) / mean
+
+
+def _add_hardware_binding_entropy_aliases(results):
+    """Add field aliases consumed by the node's hardware_binding_v2 profile extractor."""
+    clock = results.get("clock_drift", {}).get("data", {})
+    cache = results.get("cache_timing", {}).get("data", {})
+    thermal = results.get("thermal_drift", {}).get("data", {})
+    jitter = results.get("instruction_jitter", {}).get("data", {})
+
+    if "L1" not in cache and "l1_ns" in cache:
+        cache["L1"] = cache["l1_ns"]
+    if "L2" not in cache and "l2_ns" in cache:
+        cache["L2"] = cache["l2_ns"]
+    if "ratio" not in thermal and "drift_ratio" in thermal:
+        thermal["ratio"] = thermal["drift_ratio"]
+    if "cv" not in jitter:
+        cvs = [
+            _coefficient_of_variation(jitter.get("int_avg_ns"), jitter.get("int_stdev")),
+            _coefficient_of_variation(jitter.get("fp_avg_ns"), jitter.get("fp_stdev")),
+            _coefficient_of_variation(jitter.get("branch_avg_ns"), jitter.get("branch_stdev")),
+        ]
+        nonzero_cvs = [cv for cv in cvs if cv > 0]
+        if nonzero_cvs:
+            jitter["cv"] = round(sum(nonzero_cvs) / len(nonzero_cvs), 6)
+
+    return {
+        "clock_cv": _safe_float(clock.get("cv")),
+        "cache_l1": _safe_float(cache.get("L1")),
+        "cache_l2": _safe_float(cache.get("L2")),
+        "thermal_ratio": _safe_float(thermal.get("ratio")),
+        "jitter_cv": _safe_float(jitter.get("cv")),
+    }
+
+
 def _parse_lscpu_model(output):
     for line in output.splitlines():
         key, _, value = line.partition(":")
@@ -62,6 +108,55 @@ def _miner_id_from_hw(hw_info):
     arch = _safe_id_part(hw_info.get("arch") or hw_info.get("machine") or "linux")
     hostname = _safe_id_part(hw_info.get("hostname") or socket.gethostname())
     return f"{arch}-{hostname}"
+
+
+VIRTUAL_IFACE_PREFIXES = (
+    "br-",
+    "cni",
+    "docker",
+    "flannel",
+    "lo",
+    "tap",
+    "tailscale",
+    "tun",
+    "veth",
+    "virbr",
+    "vnet",
+    "wg",
+)
+
+
+def _is_virtual_iface(name):
+    base_name = name.split("@", 1)[0].lower()
+    return any(base_name == prefix or base_name.startswith(prefix) for prefix in VIRTUAL_IFACE_PREFIXES)
+
+
+def _parse_ip_link_macs(output):
+    physical = []
+    active = []
+    current_iface = None
+    current_flags = set()
+    for line in output.splitlines():
+        header = re.search(
+            r"^\d+:\s+([^:]+):\s+<([^>]*)>",
+            line,
+            re.IGNORECASE,
+        )
+        if header:
+            current_iface, flags = header.groups()
+            current_flags = {flag.strip().upper() for flag in flags.split(",")}
+
+        mac_match = re.search(r"\blink/ether\s+([0-9a-f:]{17})", line, re.IGNORECASE)
+        if not mac_match or not current_iface:
+            continue
+        mac = mac_match.group(1).lower()
+        if mac == "00:00:00:00:00:00" or _is_virtual_iface(current_iface):
+            continue
+        physical.append(mac)
+        if "LOWER_UP" in current_flags:
+            active.append(mac)
+
+    return active or physical
 
 
 def _request_with_network_retry(method, url, action, retries=NETWORK_RETRY_ATTEMPTS,
@@ -190,7 +285,12 @@ class LocalMiner:
         try:
             passed, results = validate_all_checks()
             self.fingerprint_passed = passed
-            self.fingerprint_data = {"checks": results, "all_passed": passed}
+            entropy_profile = _add_hardware_binding_entropy_aliases(results)
+            self.fingerprint_data = {
+                "checks": results,
+                "all_passed": passed,
+                "data": entropy_profile,
+            }
             if passed:
                 print("[FINGERPRINT] All checks PASSED - eligible for full rewards")
             else:
@@ -227,13 +327,8 @@ class LocalMiner:
                 stderr=subprocess.DEVNULL,
                 text=True,
                 timeout=5,
-            ).stdout.splitlines()
-            for line in output:
-                m = re.search(r"link/(?:ether|loopback)\s+([0-9a-f:]{17})", line, re.IGNORECASE)
-                if m:
-                    mac = m.group(1).lower()
-                    if mac != "00:00:00:00:00:00":
-                        macs.append(mac)
+            ).stdout
+            macs.extend(_parse_ip_link_macs(output))
         except Exception:
             pass
 

--- a/tests/test_miner_hardware_probes.py
+++ b/tests/test_miner_hardware_probes.py
@@ -44,6 +44,52 @@ def test_linux_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
     assert calls == [(["nproc"], {"stdout": miner.subprocess.PIPE, "stderr": miner.subprocess.PIPE, "text": True, "timeout": 10})]
 
 
+def test_linux_miner_adds_hardware_binding_entropy_aliases():
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_entropy_aliases")
+    results = {
+        "clock_drift": {"data": {"cv": 0.022}},
+        "cache_timing": {"data": {"l1_ns": 11.5, "l2_ns": 18.75}},
+        "thermal_drift": {"data": {"drift_ratio": 1.034}},
+        "instruction_jitter": {
+            "data": {
+                "int_avg_ns": 1000,
+                "int_stdev": 50,
+                "fp_avg_ns": 2000,
+                "fp_stdev": 40,
+                "branch_avg_ns": 1500,
+                "branch_stdev": 30,
+            }
+        },
+    }
+
+    profile = miner._add_hardware_binding_entropy_aliases(results)
+
+    assert profile == {
+        "clock_cv": 0.022,
+        "cache_l1": 11.5,
+        "cache_l2": 18.75,
+        "thermal_ratio": 1.034,
+        "jitter_cv": 0.03,
+    }
+    assert results["cache_timing"]["data"]["L1"] == 11.5
+    assert results["cache_timing"]["data"]["L2"] == 18.75
+    assert results["thermal_drift"]["data"]["ratio"] == 1.034
+    assert results["instruction_jitter"]["data"]["cv"] == 0.03
+
+
+def test_linux_miner_filters_virtual_macs_and_prefers_active_physical_iface():
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_macs")
+    output = """
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 88:a2:9e:a6:58:ce brd ff:ff:ff:ff:ff:ff
+3: wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DORMANT group default qlen 1000\\    link/ether 88:a2:9e:a6:58:cf brd ff:ff:ff:ff:ff:ff
+5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default \\    link/ether 02:42:a7:e5:ff:ff brd ff:ff:ff:ff:ff:ff
+8: vethf5058cc@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-c6f6f37bad09 state UP mode DEFAULT group default \\    link/ether 0a:e2:34:f6:e2:0a brd ff:ff:ff:ff:ff:ff link-netnsid 0
+"""
+
+    assert miner._parse_ip_link_macs(output) == ["88:a2:9e:a6:58:ce"]
+
+
 def test_power8_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
     miner = load_module(Path("miners/power8/rustchain_power8_miner.py"), "rustchain_power8_miner_run_cmd")
     instance = object.__new__(miner.LocalMiner)

--- a/tests/test_miner_hardware_probes.py
+++ b/tests/test_miner_hardware_probes.py
@@ -80,11 +80,26 @@ def test_linux_miner_adds_hardware_binding_entropy_aliases():
 def test_linux_miner_filters_virtual_macs_and_prefers_active_physical_iface():
     miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_macs")
     output = """
-1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000\\    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000
+    link/ether 88:a2:9e:a6:58:ce brd ff:ff:ff:ff:ff:ff
+3: wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DORMANT group default qlen 1000
+    link/ether 88:a2:9e:a6:58:cf brd ff:ff:ff:ff:ff:ff
+5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default
+    link/ether 02:42:a7:e5:ff:ff brd ff:ff:ff:ff:ff:ff
+8: vethf5058cc@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-c6f6f37bad09 state UP mode DEFAULT group default
+    link/ether 0a:e2:34:f6:e2:0a brd ff:ff:ff:ff:ff:ff link-netnsid 0
+"""
+
+    assert miner._parse_ip_link_macs(output) == ["88:a2:9e:a6:58:ce"]
+
+
+def test_linux_miner_supports_one_line_ip_link_output():
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_one_line_macs")
+    output = """
 2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP mode DEFAULT group default qlen 1000\\    link/ether 88:a2:9e:a6:58:ce brd ff:ff:ff:ff:ff:ff
 3: wlan0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc fq_codel state DOWN mode DORMANT group default qlen 1000\\    link/ether 88:a2:9e:a6:58:cf brd ff:ff:ff:ff:ff:ff
-5: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default \\    link/ether 02:42:a7:e5:ff:ff brd ff:ff:ff:ff:ff:ff
-8: vethf5058cc@if7: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-c6f6f37bad09 state UP mode DEFAULT group default \\    link/ether 0a:e2:34:f6:e2:0a brd ff:ff:ff:ff:ff:ff link-netnsid 0
 """
 
     assert miner._parse_ip_link_macs(output) == ["88:a2:9e:a6:58:ce"]


### PR DESCRIPTION
Fixes #4820

Bounty reference: #305
wallet: RTCc15ec7690277ab7a0b6951e326e192512b95896a

## Summary

- add Linux miner fingerprint field aliases consumed by `node/hardware_binding_v2.py::extract_entropy_profile()`
- include a compact `fingerprint.data` entropy profile alongside the existing check payload
- filter loopback, Docker, veth, bridge, Tailscale, tun/tap, WireGuard, and other virtual MAC interfaces before submitting hardware signals

## Live reproduction

On this local ARM Linux host, the unpatched miner ran all six fingerprint checks successfully but the live node could still reject or under-quality the binding because the Linux checker emits `l1_ns`, `l2_ns`, `drift_ratio`, and avg/stdev jitter values while the node extractor expects `L1`, `L2`, `ratio`, and `cv`.

After applying the entropy alias fix locally, `/attest/submit` accepted the attestation:

```text
[PASS] Attestation accepted!
   CPU: Cortex-A76
   Arch: aarch64/aarch64
   Fingerprint: PASSED
```

The same host then exposed the second issue: `/epoch/enroll` returned `HTTP 412: mac_churn` because the existing Linux MAC collector had submitted virtual/container/VPN interfaces in addition to the real NIC. The MAC filter in this PR keeps active physical interfaces first and avoids recording local virtual interfaces as hardware churn.

The wallet appears in live `/api/miners` as `RTCc15ec7690277ab7a0b6951e326e192512b95896a`.

## Validation

```text
uv run --no-project --with pytest --with requests --with psutil --with flask python -m pytest tests/test_miner_hardware_probes.py -q
# 6 passed

python -m py_compile miners/linux/rustchain_linux_miner.py tests/test_miner_hardware_probes.py

git diff --check -- miners/linux/rustchain_linux_miner.py tests/test_miner_hardware_probes.py

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```