### PR TITLE
fix: credit welcome bonus on current ledger schema

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2210,8 +2210,10 @@ def _record_welcome_bonus_ledger(conn, miner: str, bonus_i64: int, source_charge
 
 def _check_welcome_bonus(miner: str):
     """Award welcome bonus on first-ever attestation. Funded from founder_community."""
+    from contextlib import closing
+
     try:
-        with sqlite3.connect(DB_PATH) as conn:
+        with closing(sqlite3.connect(DB_PATH)) as conn:
             # Check if this miner has ever attested before
             history_count = conn.execute(
                 "SELECT COUNT(*) FROM miner_attest_history WHERE miner = ?", (miner,)

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2075,6 +2075,139 @@ def auto_induct_to_hall(miner: str, device: dict):
     except Exception as e:
         print(f"[HALL] Auto-induct error: {e}")
 
+def _table_columns(conn, table_name: str) -> set:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def _welcome_bonus_epoch() -> int:
+    try:
+        return slot_to_epoch(current_slot())
+    except Exception:
+        return 0
+
+
+def _welcome_bonus_already_paid(conn, miner: str, ledger_cols: set) -> bool:
+    if {"miner_id", "delta_i64", "reason"}.issubset(ledger_cols):
+        return conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM ledger
+            WHERE miner_id = ?
+              AND delta_i64 > 0
+              AND reason LIKE 'welcome_bonus:%'
+            """,
+            (miner,),
+        ).fetchone()[0] > 0
+
+    if {"to_miner", "memo"}.issubset(ledger_cols):
+        return conn.execute(
+            "SELECT COUNT(*) FROM ledger WHERE to_miner = ? AND memo LIKE '%welcome%'",
+            (miner,),
+        ).fetchone()[0] > 0
+
+    return False
+
+
+def _apply_welcome_bonus_balance(conn, miner: str, bonus_i64: int) -> bool:
+    balances_cols = _table_columns(conn, "balances")
+    bonus_rtc = bonus_i64 / ACCOUNT_UNIT
+
+    if {"miner_id", "amount_i64"}.issubset(balances_cols):
+        source_exists = conn.execute(
+            "SELECT 1 FROM balances WHERE miner_id = ?",
+            (WELCOME_BONUS_SOURCE,),
+        ).fetchone() is not None
+
+        if source_exists:
+            if "balance_rtc" in balances_cols:
+                conn.execute(
+                    """
+                    UPDATE balances
+                    SET amount_i64 = amount_i64 - ?,
+                        balance_rtc = (amount_i64 - ?) / ?
+                    WHERE miner_id = ?
+                    """,
+                    (bonus_i64, bonus_i64, float(ACCOUNT_UNIT), WELCOME_BONUS_SOURCE),
+                )
+            else:
+                conn.execute(
+                    "UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
+                    (bonus_i64, WELCOME_BONUS_SOURCE),
+                )
+
+        conn.execute(
+            "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
+            (miner,),
+        )
+        if "balance_rtc" in balances_cols:
+            conn.execute(
+                """
+                UPDATE balances
+                SET amount_i64 = amount_i64 + ?,
+                    balance_rtc = (amount_i64 + ?) / ?
+                WHERE miner_id = ?
+                """,
+                (bonus_i64, bonus_i64, float(ACCOUNT_UNIT), miner),
+            )
+        else:
+            conn.execute(
+                "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
+                (bonus_i64, miner),
+            )
+        return source_exists
+
+    if {"miner_pk", "balance_rtc"}.issubset(balances_cols):
+        source_exists = conn.execute(
+            "SELECT 1 FROM balances WHERE miner_pk = ?",
+            (WELCOME_BONUS_SOURCE,),
+        ).fetchone() is not None
+
+        if source_exists:
+            conn.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?",
+                (bonus_rtc, WELCOME_BONUS_SOURCE),
+            )
+        conn.execute(
+            "INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0)",
+            (miner,),
+        )
+        conn.execute(
+            "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+            (bonus_rtc, miner),
+        )
+        return source_exists
+
+    raise RuntimeError("Unsupported balances schema for welcome bonus")
+
+
+def _record_welcome_bonus_ledger(conn, miner: str, bonus_i64: int, source_charged: bool):
+    ledger_cols = _table_columns(conn, "ledger")
+    now = int(time.time())
+    reason = f"welcome_bonus:{WELCOME_BONUS_RTC}_rtc"
+
+    if {"ts", "epoch", "miner_id", "delta_i64", "reason"}.issubset(ledger_cols):
+        epoch = _welcome_bonus_epoch()
+        if source_charged:
+            conn.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+                (now, epoch, WELCOME_BONUS_SOURCE, -bonus_i64, reason),
+            )
+        conn.execute(
+            "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+            (now, epoch, miner, bonus_i64, reason),
+        )
+        return
+
+    if {"from_miner", "to_miner", "amount_i64", "memo", "ts"}.issubset(ledger_cols):
+        conn.execute(
+            "INSERT INTO ledger (from_miner, to_miner, amount_i64, memo, ts) VALUES (?, ?, ?, ?, ?)",
+            (WELCOME_BONUS_SOURCE, miner, bonus_i64, reason, now),
+        )
+        return
+
+    raise RuntimeError("Unsupported ledger schema for welcome bonus")
+
+
 def _check_welcome_bonus(miner: str):
     """Award welcome bonus on first-ever attestation. Funded from founder_community."""
     try:
@@ -2085,29 +2218,14 @@ def _check_welcome_bonus(miner: str):
             ).fetchone()[0]
             
             if history_count <= 1:  # First attestation (just recorded)
+                ledger_cols = _table_columns(conn, "ledger")
                 # Check if welcome bonus already paid
-                already_paid = conn.execute(
-                    "SELECT COUNT(*) FROM ledger WHERE to_miner = ? AND memo LIKE '%welcome%'", (miner,)
-                ).fetchone()[0]
+                already_paid = _welcome_bonus_already_paid(conn, miner, ledger_cols)
                 
-                if already_paid == 0:
+                if not already_paid:
                     bonus_i64 = int(WELCOME_BONUS_RTC * 1_000_000)
-                    # Transfer from founder_community
-                    conn.execute(
-                        "UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
-                        (bonus_i64, WELCOME_BONUS_SOURCE)
-                    )
-                    conn.execute(
-                        "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (miner,)
-                    )
-                    conn.execute(
-                        "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
-                        (bonus_i64, miner)
-                    )
-                    conn.execute(
-                        "INSERT INTO ledger (from_miner, to_miner, amount_i64, memo, ts) VALUES (?, ?, ?, ?, ?)",
-                        (WELCOME_BONUS_SOURCE, miner, bonus_i64, f"welcome_bonus:{WELCOME_BONUS_RTC}_rtc", int(time.time()))
-                    )
+                    source_charged = _apply_welcome_bonus_balance(conn, miner, bonus_i64)
+                    _record_welcome_bonus_ledger(conn, miner, bonus_i64, source_charged)
                     conn.commit()
                     print(f"[WELCOME] {miner} received {WELCOME_BONUS_RTC} RTC welcome bonus!")
     except Exception as e:

--- a/node/tests/test_welcome_bonus_ledger_schema.py
+++ b/node/tests/test_welcome_bonus_ledger_schema.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+def load_node_module():
+    os.environ.setdefault("RC_ADMIN_KEY", "test-admin-key-000000000000000000")
+    spec = importlib.util.spec_from_file_location("rustchain_welcome_bonus_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestWelcomeBonusLedgerSchema(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = load_node_module()
+
+    def setUp(self):
+        fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        self.original_db_path = self.mod.DB_PATH
+        self.mod.DB_PATH = self.db_path
+
+    def tearDown(self):
+        self.mod.DB_PATH = self.original_db_path
+        if os.path.exists(self.db_path):
+            os.unlink(self.db_path)
+
+    def _seed_current_schema(self, miner="RTC-new-miner"):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE miner_attest_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    miner TEXT NOT NULL,
+                    ts_ok INTEGER NOT NULL
+                );
+
+                CREATE TABLE balances (
+                    miner_id TEXT PRIMARY KEY,
+                    amount_i64 INTEGER DEFAULT 0,
+                    balance_rtc REAL DEFAULT 0
+                );
+
+                CREATE TABLE ledger (
+                    ts INTEGER,
+                    epoch INTEGER,
+                    miner_id TEXT,
+                    delta_i64 INTEGER,
+                    reason TEXT
+                );
+                """
+            )
+            conn.execute(
+                "INSERT INTO miner_attest_history (miner, ts_ok) VALUES (?, 100)",
+                (miner,),
+            )
+            conn.execute(
+                "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, ?, ?)",
+                (self.mod.WELCOME_BONUS_SOURCE, 2_000_000, 2.0),
+            )
+            conn.commit()
+
+    def _seed_legacy_schema(self, miner="RTC-legacy-miner"):
+        with sqlite3.connect(self.db_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE miner_attest_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    miner TEXT NOT NULL,
+                    ts_ok INTEGER NOT NULL
+                );
+
+                CREATE TABLE balances (
+                    miner_pk TEXT PRIMARY KEY,
+                    balance_rtc REAL DEFAULT 0
+                );
+
+                CREATE TABLE ledger (
+                    from_miner TEXT,
+                    to_miner TEXT,
+                    amount_i64 INTEGER,
+                    memo TEXT,
+                    ts INTEGER
+                );
+                """
+            )
+            conn.execute(
+                "INSERT INTO miner_attest_history (miner, ts_ok) VALUES (?, 100)",
+                (miner,),
+            )
+            conn.execute(
+                "INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
+                (self.mod.WELCOME_BONUS_SOURCE, 2.0),
+            )
+            conn.commit()
+
+    def test_welcome_bonus_uses_current_account_ledger_schema(self):
+        miner = "RTC-new-miner"
+        self._seed_current_schema(miner)
+
+        self.mod._check_welcome_bonus(miner)
+        self.mod._check_welcome_bonus(miner)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows = dict(
+                (miner_id, (amount_i64, balance_rtc))
+                for miner_id, amount_i64, balance_rtc in conn.execute(
+                    "SELECT miner_id, amount_i64, balance_rtc FROM balances"
+                ).fetchall()
+            )
+            ledger_rows = conn.execute(
+                "SELECT miner_id, delta_i64, reason FROM ledger ORDER BY delta_i64"
+            ).fetchall()
+
+        bonus_i64 = int(self.mod.WELCOME_BONUS_RTC * self.mod.ACCOUNT_UNIT)
+        self.assertEqual(
+            rows,
+            {
+                self.mod.WELCOME_BONUS_SOURCE: (2_000_000 - bonus_i64, 1.5),
+                miner: (bonus_i64, self.mod.WELCOME_BONUS_RTC),
+            },
+        )
+        self.assertEqual(
+            ledger_rows,
+            [
+                (self.mod.WELCOME_BONUS_SOURCE, -bonus_i64, "welcome_bonus:0.5_rtc"),
+                (miner, bonus_i64, "welcome_bonus:0.5_rtc"),
+            ],
+        )
+
+    def test_welcome_bonus_preserves_legacy_transfer_ledger_schema(self):
+        miner = "RTC-legacy-miner"
+        self._seed_legacy_schema(miner)
+
+        self.mod._check_welcome_bonus(miner)
+        self.mod._check_welcome_bonus(miner)
+
+        with sqlite3.connect(self.db_path) as conn:
+            rows = dict(
+                conn.execute("SELECT miner_pk, balance_rtc FROM balances").fetchall()
+            )
+            ledger_rows = conn.execute(
+                "SELECT from_miner, to_miner, amount_i64, memo FROM ledger"
+            ).fetchall()
+
+        bonus_i64 = int(self.mod.WELCOME_BONUS_RTC * self.mod.ACCOUNT_UNIT)
+        self.assertEqual(
+            rows,
+            {
+                self.mod.WELCOME_BONUS_SOURCE: 1.5,
+                miner: self.mod.WELCOME_BONUS_RTC,
+            },
+        )
+        self.assertEqual(
+            ledger_rows,
+            [
+                (
+                    self.mod.WELCOME_BONUS_SOURCE,
+                    miner,
+                    bonus_i64,
+                    "welcome_bonus:0.5_rtc",
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_welcome_bonus_ledger_schema.py
+++ b/node/tests/test_welcome_bonus_ledger_schema.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import tempfile
 import unittest
+from contextlib import closing
 
 
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
@@ -35,7 +36,7 @@ class TestWelcomeBonusLedgerSchema(unittest.TestCase):
             os.unlink(self.db_path)
 
     def _seed_current_schema(self, miner="RTC-new-miner"):
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.executescript(
                 """
                 CREATE TABLE miner_attest_history (
@@ -70,7 +71,7 @@ class TestWelcomeBonusLedgerSchema(unittest.TestCase):
             conn.commit()
 
     def _seed_legacy_schema(self, miner="RTC-legacy-miner"):
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.executescript(
                 """
                 CREATE TABLE miner_attest_history (
@@ -110,7 +111,7 @@ class TestWelcomeBonusLedgerSchema(unittest.TestCase):
         self.mod._check_welcome_bonus(miner)
         self.mod._check_welcome_bonus(miner)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             rows = dict(
                 (miner_id, (amount_i64, balance_rtc))
                 for miner_id, amount_i64, balance_rtc in conn.execute(
@@ -144,7 +145,7 @@ class TestWelcomeBonusLedgerSchema(unittest.TestCase):
         self.mod._check_welcome_bonus(miner)
         self.mod._check_welcome_bonus(miner)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             rows = dict(
                 conn.execute("SELECT miner_pk, balance_rtc FROM balances").fetchall()
             )


### PR DESCRIPTION
Fixes #4822

Bounty reference: #305
Wallet: `RTCc15ec7690277ab7a0b6951e326e192512b95896a`

## Summary

- make `_check_welcome_bonus()` detect the active `balances` and `ledger` schemas before writing
- credit current account-ledger deployments through `balances(miner_id, amount_i64, balance_rtc)` and `ledger(ts, epoch, miner_id, delta_i64, reason)`
- preserve the legacy transfer-ledger path for deployments that still expose `from_miner/to_miner/memo`
- keep the welcome bonus idempotent by checking the matching ledger format before crediting

## Why

The welcome-bonus path still assumed the old transfer ledger shape and queried `ledger.to_miner` / `ledger.memo`. Current node code and reward settlement use `ledger.miner_id`, `ledger.delta_i64`, and `ledger.reason`. On that schema, a first successful attestation can return OK while `_check_welcome_bonus()` catches and prints the schema error, leaving the wallet balance at 0.

I hit this after a live first attestation from this machine: `/attest/submit` accepted wallet `RTCc15ec7690277ab7a0b6951e326e192512b95896a`, `/api/miners` listed the miner, but `/wallet/balance?miner_id=...` stayed `0`.

## Validation

```text
uv run --no-project --with pytest --with flask python -m pytest node/tests/test_welcome_bonus_ledger_schema.py -q
# 2 passed

python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_welcome_bonus_ledger_schema.py

git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_welcome_bonus_ledger_schema.py

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```