### PR TITLE
fix: allow beacon wallets through signed transfer preflight

### DIFF
--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -8,6 +8,14 @@ from typing import Any, Dict, Optional, Tuple
 MICRO_RTC = Decimal("1000000")
 
 
+def _is_rtc_address(value: str) -> bool:
+    return value.startswith("RTC") and len(value) == 43
+
+
+def _is_bcn_address(value: str) -> bool:
+    return value.startswith("bcn_") and len(value) >= 8
+
+
 @dataclass(frozen=True)
 class PreflightResult:
     ok: bool
@@ -77,7 +85,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
     if err:
         return PreflightResult(ok=False, error=err, details={})
 
-    required = ["from_address", "to_address", "amount_rtc", "nonce", "signature", "public_key"]
+    required = ["from_address", "to_address", "amount_rtc", "nonce", "signature"]
     missing = [k for k in required if not data.get(k)]
     if missing:
         return PreflightResult(ok=False, error="missing_required_fields", details={"missing": missing})
@@ -97,12 +105,14 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
             details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
 
-    if not (from_address.startswith("RTC") and len(from_address) == 43):
+    if not (_is_rtc_address(from_address) or _is_bcn_address(from_address)):
         return PreflightResult(ok=False, error="invalid_from_address_format", details={})
-    if not (to_address.startswith("RTC") and len(to_address) == 43):
+    if not (_is_rtc_address(to_address) or _is_bcn_address(to_address)):
         return PreflightResult(ok=False, error="invalid_to_address_format", details={})
     if from_address == to_address:
         return PreflightResult(ok=False, error="from_to_must_differ", details={})
+    if _is_rtc_address(from_address) and not data.get("public_key"):
+        return PreflightResult(ok=False, error="missing_required_fields", details={"missing": ["public_key"]})
 
     try:
         nonce_int = int(str(data.get("nonce")))

--- a/node/tests/test_payout_preflight.py
+++ b/node/tests/test_payout_preflight.py
@@ -82,6 +82,42 @@ class PayoutPreflightTests(unittest.TestCase):
         r = validate_wallet_transfer_signed(payload)
         self.assertTrue(r.ok)
 
+    def test_signed_requires_public_key_for_rtc_sender(self):
+        payload = {
+            "from_address": "RTC" + "a" * 40,
+            "to_address": "RTC" + "b" * 40,
+            "amount_rtc": 1.25,
+            "nonce": "123",
+            "signature": "00",
+        }
+        r = validate_wallet_transfer_signed(payload)
+        self.assertFalse(r.ok)
+        self.assertEqual(r.error, "missing_required_fields")
+        self.assertEqual(r.details.get("missing"), ["public_key"])
+
+    def test_signed_accepts_bcn_sender_without_public_key(self):
+        payload = {
+            "from_address": "bcn_sender001",
+            "to_address": "RTC" + "b" * 40,
+            "amount_rtc": 1.25,
+            "nonce": "123",
+            "signature": "00",
+        }
+        r = validate_wallet_transfer_signed(payload)
+        self.assertTrue(r.ok)
+
+    def test_signed_accepts_bcn_recipient(self):
+        payload = {
+            "from_address": "RTC" + "a" * 40,
+            "to_address": "bcn_receiver001",
+            "amount_rtc": 1.25,
+            "nonce": "123",
+            "signature": "00",
+            "public_key": "00",
+        }
+        r = validate_wallet_transfer_signed(payload)
+        self.assertTrue(r.ok)
+
     def test_signed_rejects_sub_micro_amount(self):
         payload = {
             "from_address": "RTC" + "a" * 40,


### PR DESCRIPTION
Fixes #4824

Bounty reference: #305
Wallet: `RTCc15ec7690277ab7a0b6951e326e192512b95896a`

## Summary

- let signed-transfer preflight accept documented `bcn_` Beacon wallet senders and recipients
- keep `public_key` required for normal RTC senders
- allow `bcn_` senders to omit `public_key` so `wallet_transfer_signed()` can resolve the Beacon Atlas public key as intended
- preserve amount, nonce, and same-address validation

## Why

`/wallet/transfer/signed` contains Beacon-specific route logic, but preflight ran first and rejected anything that was not exactly `RTC` + 40 characters. It also required `public_key` before the route could resolve the Atlas key for `bcn_` senders. This made the documented Beacon wallet support unreachable.

## Validation

```text
uv run --no-project --with pytest python -m pytest node/tests/test_payout_preflight.py -q
# 17 passed

python -m py_compile node/payout_preflight.py node/tests/test_payout_preflight.py

git diff --check -- node/payout_preflight.py node/tests/test_payout_preflight.py

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```