### PR TITLE
security: require admin key for relationship interventions

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -31,6 +31,7 @@ import json
 import time
 import random
 import threading
+import hmac
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any, Tuple
 from enum import Enum
@@ -186,6 +187,17 @@ GUARDRAILS = {
     "admin_override_enabled": True,
     "cooling_period_days": 7,  # After beef ends, can't start new beef immediately
 }
+
+
+def _get_relationship_admin_key() -> str:
+    """Return the configured admin key for relationship interventions."""
+    return os.environ.get("RELATIONSHIP_ADMIN_KEY") or os.environ.get("RC_ADMIN_KEY", "")
+
+
+def _verify_relationship_admin_key(candidate_key: str) -> bool:
+    """Constant-time verification for relationship admin operations."""
+    configured_key = _get_relationship_admin_key()
+    return bool(configured_key and hmac.compare_digest(candidate_key or "", configured_key))
 
 
 # ─── Relationship Engine ────────────────────────────────────────────────────── #
@@ -787,7 +799,8 @@ class RelationshipEngine:
         }
     
     def admin_intervene(self, agent_a: str, agent_b: str, admin_id: str,
-                       reason: str, action: str = "reset_to_neutral") -> Dict[str, Any]:
+                       reason: str, action: str = "reset_to_neutral",
+                       admin_key: Optional[str] = None) -> Dict[str, Any]:
         """
         Admin intervention to reset or modify a relationship.
         
@@ -797,12 +810,16 @@ class RelationshipEngine:
             admin_id: Admin user ID
             reason: Reason for intervention
             action: Action to take (default: reset_to_neutral)
+            admin_key: Secret admin key for authorizing intervention
             
         Returns:
             Dictionary with intervention result
         """
         if not GUARDRAILS["admin_override_enabled"]:
             raise ValueError("Admin override is disabled")
+
+        if not _verify_relationship_admin_key(admin_key or ""):
+            raise PermissionError("Unauthorized admin intervention")
         
         agent_a, agent_b = self._normalize_pair(agent_a, agent_b)
         now = time.time()
@@ -1103,9 +1120,12 @@ def create_relationship_blueprint(engine: RelationshipEngine):
                 agent_a, agent_b,
                 admin_id=data.get("admin_id", "admin"),
                 reason=data.get("reason", "Admin intervention"),
-                action=data.get("action", "reset_to_neutral")
+                action=data.get("action", "reset_to_neutral"),
+                admin_key=request.headers.get("X-Admin-Key", "")
             )
             return jsonify(result)
+        except PermissionError as e:
+            return jsonify({"error": str(e)}), 403
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
     

--- a/test_agent_relationships.py
+++ b/test_agent_relationships.py
@@ -16,11 +16,12 @@ import time
 import sqlite3
 import os
 import tempfile
+import importlib.util
 from typing import Dict, Any
 
 from agent_relationships import (
     RelationshipEngine, RelationshipState, DramaArcType, EventType,
-    GUARDRAILS, DRAMA_ARC_TEMPLATES
+    GUARDRAILS, DRAMA_ARC_TEMPLATES, create_relationship_blueprint
 )
 from drama_arc_engine import (
     DramaArcEngine, ArcPhase, run_five_day_rivalry_scenario
@@ -172,6 +173,8 @@ class TestRelationshipEngine(unittest.TestCase):
     
     def test_admin_intervention(self):
         """Test admin intervention to reset relationship."""
+        os.environ["RELATIONSHIP_ADMIN_KEY"] = "test-admin-key"
+        self.addCleanup(os.environ.pop, "RELATIONSHIP_ADMIN_KEY", None)
         self.engine.initialize_relationship("agent_a", "agent_b")
         
         # Create beef
@@ -184,7 +187,8 @@ class TestRelationshipEngine(unittest.TestCase):
         result = self.engine.admin_intervene(
             "agent_a", "agent_b",
             admin_id="admin_user",
-            reason="Too much drama"
+            reason="Too much drama",
+            admin_key="test-admin-key"
         )
         
         self.assertTrue(result["success"])
@@ -194,6 +198,93 @@ class TestRelationshipEngine(unittest.TestCase):
         rel = self.engine.get_relationship("agent_a", "agent_b")
         self.assertEqual(rel["state"], "neutral")
         self.assertEqual(rel["tension_level"], 0)
+
+    def test_admin_intervention_requires_valid_admin_key(self):
+        """Test admin intervention rejects missing or invalid admin keys."""
+        os.environ["RELATIONSHIP_ADMIN_KEY"] = "test-admin-key"
+        self.addCleanup(os.environ.pop, "RELATIONSHIP_ADMIN_KEY", None)
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        with self.assertRaises(PermissionError):
+            self.engine.admin_intervene(
+                "agent_a", "agent_b",
+                admin_id="admin_user",
+                reason="Too much drama"
+            )
+
+        with self.assertRaises(PermissionError):
+            self.engine.admin_intervene(
+                "agent_a", "agent_b",
+                admin_id="admin_user",
+                reason="Too much drama",
+                admin_key="wrong-key"
+            )
+
+    def test_admin_intervention_uses_rc_admin_key_fallback(self):
+        """Test admin intervention accepts RC_ADMIN_KEY when no relationship key is set."""
+        os.environ.pop("RELATIONSHIP_ADMIN_KEY", None)
+        os.environ["RC_ADMIN_KEY"] = "fallback-admin-key"
+        self.addCleanup(os.environ.pop, "RC_ADMIN_KEY", None)
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        result = self.engine.admin_intervene(
+            "agent_a", "agent_b",
+            admin_id="admin_user",
+            reason="Too much drama",
+            admin_key="fallback-admin-key"
+        )
+
+        self.assertTrue(result["success"])
+        self.assertEqual(result["new_state"], "neutral")
+
+    def test_admin_intervention_fails_closed_without_configured_key(self):
+        """Test admin intervention is disabled when no admin key is configured."""
+        os.environ.pop("RELATIONSHIP_ADMIN_KEY", None)
+        os.environ.pop("RC_ADMIN_KEY", None)
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        with self.assertRaises(PermissionError):
+            self.engine.admin_intervene(
+                "agent_a", "agent_b",
+                admin_id="admin_user",
+                reason="Too much drama",
+                admin_key="any-key"
+            )
+
+    def test_admin_intervention_endpoint_requires_admin_key(self):
+        """Test HTTP admin intervention endpoint enforces X-Admin-Key."""
+        if importlib.util.find_spec("flask") is None:
+            self.skipTest("flask is not installed")
+
+        os.environ["RELATIONSHIP_ADMIN_KEY"] = "test-admin-key"
+        self.addCleanup(os.environ.pop, "RELATIONSHIP_ADMIN_KEY", None)
+        self.engine.initialize_relationship("agent_a", "agent_b")
+
+        from flask import Flask
+        app = Flask(__name__)
+        app.register_blueprint(create_relationship_blueprint(self.engine))
+        client = app.test_client()
+
+        response = client.post(
+            "/api/relationships/agent_a/agent_b/intervene",
+            json={"admin_id": "admin_user", "reason": "Too much drama"}
+        )
+        self.assertEqual(response.status_code, 403)
+
+        response = client.post(
+            "/api/relationships/agent_a/agent_b/intervene",
+            json={"admin_id": "admin_user", "reason": "Too much drama"},
+            headers={"X-Admin-Key": "wrong-key"}
+        )
+        self.assertEqual(response.status_code, 403)
+
+        response = client.post(
+            "/api/relationships/agent_a/agent_b/intervene",
+            json={"admin_id": "admin_user", "reason": "Too much drama"},
+            headers={"X-Admin-Key": "test-admin-key"}
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()["success"])
     
     def test_get_all_relationships(self):
         """Test retrieving all relationships."""
@@ -591,11 +682,14 @@ class TestEdgeCases(unittest.TestCase):
     
     def test_admin_intervention_without_relationship(self):
         """Test that admin intervention fails without existing relationship."""
+        os.environ["RELATIONSHIP_ADMIN_KEY"] = "test-admin-key"
+        self.addCleanup(os.environ.pop, "RELATIONSHIP_ADMIN_KEY", None)
         with self.assertRaises(ValueError):
             self.engine.admin_intervene(
                 "unknown_a", "unknown_b",
                 admin_id="admin",
-                reason="Testing"
+                reason="Test",
+                admin_key="test-admin-key"
             )
     
     def test_tension_clamping(self):


### PR DESCRIPTION
## Summary

This PR hardens the relationship admin intervention path by requiring an admin key before a caller can reset or modify a relationship state.

## Security issue

`agent_relationships.py` exposed `RelationshipEngine.admin_intervene()` through the Flask route:

`POST /api/relationships/<agent_a>/<agent_b>/intervene`

Before this change, the route accepted caller-provided JSON (`admin_id`, `reason`, `action`) and invoked the admin intervention directly. That meant any client able to reach the endpoint could reset a relationship to neutral or force-end beef without proving admin authorization.

## Fix

- Added `RELATIONSHIP_ADMIN_KEY` / `RC_ADMIN_KEY` based authorization for relationship admin interventions.
- Uses `hmac.compare_digest()` for constant-time key comparison.
- The Flask route now reads `X-Admin-Key` and returns HTTP 403 for unauthorized intervention attempts.
- Interventions fail closed when no admin key is configured.

## Tests

Added/updated tests for:

- Valid admin intervention with `RELATIONSHIP_ADMIN_KEY`
- Missing and wrong admin keys rejected with `PermissionError`
- `RC_ADMIN_KEY` fallback behavior
- Fail-closed behavior when no admin key is configured
- HTTP endpoint missing/wrong/valid `X-Admin-Key` behavior

Test command run locally:

```bash
python3 -m pytest test_agent_relationships.py -q
```

Result:

```text
43 passed, 1 skipped in 1.50s
```

## Notes

This is a focused security hardening PR. It does not change normal relationship/disagreement/collaboration behavior.

First PR / security fix.
