### PR TITLE
Validate BCOS badge certificate IDs

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -509,11 +509,7 @@ class TestFlaskIntegration(unittest.TestCase):
             'cert_id': 'BCOS-abc" onerror="alert(1)',
         }
 
-        response = self.client.post(
-            '/api/badge/generate',
-            json=payload,
-            content_type='application/json',
-        )
+        response = self.post_generate_badge(payload)
 
         self.assertEqual(response.status_code, 200)
         data = json.loads(response.data)
@@ -527,15 +523,13 @@ class TestFlaskIntegration(unittest.TestCase):
 
         for cert_id in invalid_ids:
             with self.subTest(cert_id=cert_id):
-                response = self.client.post(
-                    '/api/badge/generate',
-                    json={
+                response = self.post_generate_badge(
+                    {
                         'repo_name': 'test/repo',
                         'tier': 'L1',
                         'trust_score': 75,
                         'cert_id': cert_id,
-                    },
-                    content_type='application/json',
+                    }
                 )
 
                 self.assertEqual(response.status_code, 200)
@@ -546,15 +540,13 @@ class TestFlaskIntegration(unittest.TestCase):
 
     def test_generate_badge_accepts_safe_custom_cert_id(self):
         """Safe custom cert IDs remain supported."""
-        response = self.client.post(
-            '/api/badge/generate',
-            json={
+        response = self.post_generate_badge(
+            {
                 'repo_name': 'test/repo',
                 'tier': 'L1',
                 'trust_score': 75,
                 'cert_id': 'BCOS-safe_ID-123',
-            },
-            content_type='application/json',
+            }
         )
 
         self.assertEqual(response.status_code, 200)

--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -29,6 +29,7 @@ from tools.bcos_badge_generator import (
     record_badge_generation,
     increment_download_count,
     load_secret_key,
+    is_valid_cert_id,
 )
 
 
@@ -498,6 +499,47 @@ class TestFlaskIntegration(unittest.TestCase):
                 data = json.loads(response.data)
                 self.assertFalse(data['success'])
                 self.assertEqual(data['error'], 'Trust score must be a number')
+
+    def test_generate_badge_rejects_attribute_breaking_cert_id(self):
+        """User-supplied cert IDs must not break generated embed attributes."""
+        payload = {
+            'repo_name': 'test/repo',
+            'tier': 'L1',
+            'trust_score': 75,
+            'cert_id': 'BCOS-abc" onerror="alert(1)',
+        }
+
+        response = self.client.post(
+            '/api/badge/generate',
+            json=payload,
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertIn('Invalid certificate ID', data['error'])
+        self.assertFalse(is_valid_cert_id(payload['cert_id']))
+
+    def test_generate_badge_accepts_safe_custom_cert_id(self):
+        """Safe custom cert IDs remain supported."""
+        response = self.client.post(
+            '/api/badge/generate',
+            json={
+                'repo_name': 'test/repo',
+                'tier': 'L1',
+                'trust_score': 75,
+                'cert_id': 'BCOS-safe_ID-123',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['success'])
+        self.assertEqual(data['cert_id'], 'BCOS-safe_ID-123')
+        self.assertIn('https://rustchain.org/bcos/badge/BCOS-safe_ID-123.svg', data['html'])
+        self.assertNotIn('onerror=', data['html'])
 
     def test_stats_endpoint(self):
         """Test stats endpoint."""

--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -521,6 +521,29 @@ class TestFlaskIntegration(unittest.TestCase):
         self.assertIn('Invalid certificate ID', data['error'])
         self.assertFalse(is_valid_cert_id(payload['cert_id']))
 
+    def test_generate_badge_rejects_non_string_cert_id(self):
+        """Non-string cert IDs should fail validation instead of raising 500."""
+        invalid_ids = [123, True, ['BCOS-safe'], {'id': 'BCOS-safe'}]
+
+        for cert_id in invalid_ids:
+            with self.subTest(cert_id=cert_id):
+                response = self.client.post(
+                    '/api/badge/generate',
+                    json={
+                        'repo_name': 'test/repo',
+                        'tier': 'L1',
+                        'trust_score': 75,
+                        'cert_id': cert_id,
+                    },
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 200)
+                data = json.loads(response.data)
+                self.assertFalse(data['success'])
+                self.assertIn('Invalid certificate ID', data['error'])
+                self.assertFalse(is_valid_cert_id(cert_id))
+
     def test_generate_badge_accepts_safe_custom_cert_id(self):
         """Safe custom cert IDs remain supported."""
         response = self.client.post(

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -98,6 +98,13 @@ BADGE_CONFIG = {
     'font_size': 11,
 }
 
+CERT_ID_PATTERN = re.compile(r'^BCOS-[A-Za-z0-9_-]{1,64}$')
+
+
+def is_valid_cert_id(cert_id: str) -> bool:
+    """Return True for cert IDs that are safe to store and embed in badge URLs."""
+    return bool(CERT_ID_PATTERN.fullmatch(cert_id))
+
 # ── Database Functions ──────────────────────────────────────────────
 
 
@@ -1141,6 +1148,13 @@ def generate_badge():
         hash_input = f"{repo_name}{tier}{trust_score}{time.time()}"
         cert_hash = hashlib.blake2b(hash_input.encode(), digest_size=32).hexdigest()
         cert_id = f"BCOS-{cert_hash[:8]}"
+    elif not is_valid_cert_id(cert_id):
+        return jsonify({
+            'success': False,
+            'error': 'Invalid certificate ID. Use BCOS- followed by letters, numbers, underscores, or hyphens.',
+        })
+
+    cert_path = urllib.parse.quote(cert_id, safe='')
 
     # Generate SVG
     svg = generate_badge_svg(
@@ -1149,7 +1163,7 @@ def generate_badge():
         trust_score=trust_score,
         cert_id=cert_id,
         include_qr=include_qr,
-        verification_url=f"https://rustchain.org/bcos/verify/{cert_id}",
+        verification_url=f"https://rustchain.org/bcos/verify/{cert_path}",
     )
 
     # Record in database
@@ -1162,8 +1176,8 @@ def generate_badge():
         app.logger.error(f"Failed to record badge generation: {e}")
 
     # Generate embed codes
-    verification_url = f"https://rustchain.org/bcos/verify/{cert_id}"
-    svg_url = f"https://rustchain.org/bcos/badge/{cert_id}.svg"
+    verification_url = f"https://rustchain.org/bcos/verify/{cert_path}"
+    svg_url = f"https://rustchain.org/bcos/badge/{cert_path}.svg"
 
     markdown = f'[![BCOS {tier} Certified]({svg_url})]({verification_url})'
     html = f'<a href="{verification_url}"><img src="{svg_url}" alt="BCOS {tier} Certified"></a>'

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -101,8 +101,10 @@ BADGE_CONFIG = {
 CERT_ID_PATTERN = re.compile(r'^BCOS-[A-Za-z0-9_-]{1,64}$')
 
 
-def is_valid_cert_id(cert_id: str) -> bool:
+def is_valid_cert_id(cert_id: object) -> bool:
     """Return True for cert IDs that are safe to store and embed in badge URLs."""
+    if not isinstance(cert_id, str):
+        return False
     return bool(CERT_ID_PATTERN.fullmatch(cert_id))
 
 # ── Database Functions ──────────────────────────────────────────────

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -102,7 +102,14 @@ CERT_ID_PATTERN = re.compile(r'^BCOS-[A-Za-z0-9_-]{1,64}$')
 
 
 def is_valid_cert_id(cert_id: object) -> bool:
-    """Return True for cert IDs that are safe to store and embed in badge URLs."""
+    """Return True for safe custom BCOS certificate IDs.
+
+    Rules:
+    - Must be a string.
+    - Must start with ``BCOS-``.
+    - May contain only ASCII letters, numbers, underscores, and hyphens after the prefix.
+    - The suffix must be 1 to 64 characters long.
+    """
     if not isinstance(cert_id, str):
         return False
     return bool(CERT_ID_PATTERN.fullmatch(cert_id))


### PR DESCRIPTION
﻿## Summary
- validate caller-supplied BCOS certificate IDs before storing or embedding them
- encode the certificate ID as a URL path component when building verification and badge URLs
- add regressions for quote-breaking custom IDs and safe custom IDs

Fixes #4827.

## Validation
- `python -m pytest tests\test_bcos_badge_generator.py -q` -> 38 passed, 3 subtests passed
- `python -m py_compile tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py`
- `git diff --check -- tools\bcos_badge_generator.py tests\test_bcos_badge_generator.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`
