### PR TITLE
Fix UTXO genesis migration atomicity

### DIFF
--- a/node/test_genesis_race.py
+++ b/node/test_genesis_race.py
@@ -110,10 +110,8 @@ def test_genesis_migration_race():
         if count > len(test_balances):
             print("🔴 CRITICAL BUG DETECTED: Genesis boxes duplicated!")
             print(f"   Duplication factor: {count / len(test_balances):.2f}x")
-            return False
-        else:
-            print("✅ PASS: Genesis migration is atomic")
-            return True
+            raise AssertionError("Genesis boxes duplicated")
+        print("✅ PASS: Genesis migration is atomic")
             
     finally:
         # Cleanup
@@ -138,7 +136,7 @@ def test_genesis_migration_rollback():
                 amount_i64 INTEGER NOT NULL
             )
         """)
-        conn.execute("INSERT INTO balances VALUES ('miner_001', 100_000_000)")
+        conn.execute("INSERT INTO balances VALUES (?, ?)", ("miner_001", 100_000_000))
         conn.commit()
         conn.close()
         
@@ -159,10 +157,8 @@ def test_genesis_migration_rollback():
         
         if count != 0:
             print("🔴 BUG: Rollback incomplete!")
-            return False
-        else:
-            print("✅ PASS: Rollback is complete")
-            return True
+            raise AssertionError("Rollback left genesis boxes behind")
+        print("✅ PASS: Rollback is complete")
             
     finally:
         if os.path.exists(db_path):
@@ -175,19 +171,15 @@ if __name__ == '__main__':
     print("=" * 60)
     
     # Test 1: Race condition
-    result1 = test_genesis_migration_race()
+    test_genesis_migration_race()
     
     print("\n" + "=" * 60)
     print("Testing Genesis Migration Rollback")
     print("=" * 60)
     
     # Test 2: Rollback
-    result2 = test_genesis_migration_rollback()
+    test_genesis_migration_rollback()
     
     print("\n" + "=" * 60)
-    if result1 and result2:
-        print("✅ ALL TESTS PASSED")
-        sys.exit(0)
-    else:
-        print("🔴 SOME TESTS FAILED")
-        sys.exit(1)
+    print("✅ ALL TESTS PASSED")
+    sys.exit(0)

--- a/node/test_rollback_atomicity.py
+++ b/node/test_rollback_atomicity.py
@@ -14,6 +14,7 @@ import shutil
 import sqlite3
 import sys
 import tempfile
+import threading
 import unittest
 
 # Add parent directory to path for imports
@@ -25,7 +26,7 @@ from utxo_genesis_migration import (
     check_existing_genesis,
     GENESIS_HEIGHT,
 )
-from utxo_db import UtxoDB, UNIT
+from utxo_db import UtxoDB, UNIT, address_to_proposition
 
 
 class TestRollbackAtomicity(unittest.TestCase):
@@ -68,6 +69,61 @@ class TestRollbackAtomicity(unittest.TestCase):
                 os.unlink(path)
         if os.path.exists(self.tmpdir):
             shutil.rmtree(self.tmpdir)
+
+    def _insert_non_genesis_height_zero_box(self):
+        """Insert a confirmed height-0 transfer box that is not genesis."""
+        UtxoDB(self.db_path).init_tables()
+        tx_id = "1" * 64
+        box_id = "2" * 64
+        owner = "sentinel_wallet"
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            conn.execute(
+                """INSERT INTO utxo_transactions
+                   (tx_id, tx_type, inputs_json, outputs_json,
+                    data_inputs_json, fee_nrtc, timestamp,
+                    block_height, status)
+                   VALUES (?,?,?,?,?,?,?,?,?)""",
+                (
+                    tx_id,
+                    "transfer",
+                    "[]",
+                    '[{"box_id":"%s","value_nrtc":1000,"owner":"%s"}]' % (
+                        box_id,
+                        owner,
+                    ),
+                    "[]",
+                    0,
+                    1,
+                    GENESIS_HEIGHT,
+                    "confirmed",
+                ),
+            )
+            conn.execute(
+                """INSERT INTO utxo_boxes
+                   (box_id, value_nrtc, proposition, owner_address,
+                    creation_height, transaction_id, output_index,
+                    tokens_json, registers_json, created_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    box_id,
+                    1000,
+                    address_to_proposition(owner),
+                    owner,
+                    GENESIS_HEIGHT,
+                    tx_id,
+                    0,
+                    "[]",
+                    "{}",
+                    1,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        return box_id
 
     def test_01_migrate_creates_genesis(self):
         """Verify migration creates genesis boxes."""
@@ -184,6 +240,80 @@ class TestRollbackAtomicity(unittest.TestCase):
         try:
             mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
             self.assertIn(mode, ["wal", "WAL"], "WAL mode not active after rollback")
+        finally:
+            conn.close()
+
+    def test_07_height_zero_transfer_is_not_genesis(self):
+        """Verify height-0 non-genesis boxes do not block or get rolled back."""
+        box_id = self._insert_non_genesis_height_zero_box()
+
+        self.assertFalse(check_existing_genesis(UtxoDB(self.db_path)))
+
+        deleted = rollback_genesis(self.db_path)
+        self.assertEqual(deleted, 0)
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            box_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_boxes WHERE box_id = ?",
+                (box_id,),
+            ).fetchone()[0]
+            transfer_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_transactions WHERE tx_type = 'transfer'",
+            ).fetchone()[0]
+
+            self.assertEqual(box_count, 1)
+            self.assertEqual(transfer_count, 1)
+        finally:
+            conn.close()
+
+    def test_08_concurrent_migrations_serialize_cleanly(self):
+        """Verify concurrent migration attempts cannot both create genesis."""
+        barrier = threading.Barrier(2)
+        lock = threading.Lock()
+        results = []
+        errors = []
+
+        def run_migration():
+            try:
+                barrier.wait()
+                result = migrate(self.db_path, dry_run=False)
+                with lock:
+                    results.append(result)
+            except Exception as exc:
+                with lock:
+                    errors.append(exc)
+
+        threads = [
+            threading.Thread(target=run_migration),
+            threading.Thread(target=run_migration),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(errors, [])
+        successes = [r for r in results if 'error' not in r]
+        duplicates = [
+            r for r in results
+            if r.get('error') == 'genesis_already_exists'
+        ]
+        self.assertEqual(len(successes), 1)
+        self.assertEqual(len(duplicates), 1)
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            tx_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_transactions WHERE tx_type = 'genesis'",
+            ).fetchone()[0]
+            box_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_boxes WHERE creation_height = ?",
+                (GENESIS_HEIGHT,),
+            ).fetchone()[0]
+
+            self.assertEqual(tx_count, 3)
+            self.assertEqual(box_count, 3)
         finally:
             conn.close()
 

--- a/node/test_rollback_atomicity.py
+++ b/node/test_rollback_atomicity.py
@@ -317,6 +317,28 @@ class TestRollbackAtomicity(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_09_migrate_rejects_existing_non_genesis_utxo_state(self):
+        """Verify migration fails before writing when UTXO state exists."""
+        box_id = self._insert_non_genesis_height_zero_box()
+
+        result = migrate(self.db_path, dry_run=False)
+        self.assertEqual(result['error'], 'utxo_state_already_exists')
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            box_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_boxes WHERE box_id = ?",
+                (box_id,),
+            ).fetchone()[0]
+            genesis_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_transactions WHERE tx_type = 'genesis'",
+            ).fetchone()[0]
+
+            self.assertEqual(box_count, 1)
+            self.assertEqual(genesis_count, 0)
+        finally:
+            conn.close()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -140,6 +140,14 @@ CREATE TABLE IF NOT EXISTS utxo_mempool_inputs (
 """
 
 
+def _execute_schema(conn: sqlite3.Connection):
+    """Execute schema statements without implicitly committing a transaction."""
+    for statement in SCHEMA_SQL.split(";"):
+        statement = statement.strip()
+        if statement:
+            conn.execute(statement)
+
+
 # ---------------------------------------------------------------------------
 # UtxoDB
 # ---------------------------------------------------------------------------
@@ -168,19 +176,28 @@ class UtxoDB:
 
     def _conn(self) -> sqlite3.Connection:
         c = sqlite3.connect(self.db_path, timeout=30)
-        c.row_factory = sqlite3.Row
-        c.execute("PRAGMA journal_mode=WAL")
-        c.execute("PRAGMA foreign_keys=ON")
-        return c
+        try:
+            c.row_factory = sqlite3.Row
+            c.execute("PRAGMA journal_mode=WAL")
+            c.execute("PRAGMA foreign_keys=ON")
+            return c
+        except Exception:
+            c.close()
+            raise
 
     def init_tables(self, conn: Optional[sqlite3.Connection] = None):
         """Create UTXO tables if they don't exist."""
         own = conn is None
         if own:
             conn = self._conn()
-        conn.executescript(SCHEMA_SQL)
-        if own:
-            conn.close()
+        try:
+            if own:
+                conn.executescript(SCHEMA_SQL)
+            else:
+                _execute_schema(conn)
+        finally:
+            if own:
+                conn.close()
 
     # -- box operations ------------------------------------------------------
 
@@ -380,6 +397,8 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
+            if own:
+                conn.close()
             return False
 
         try:

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -105,6 +105,29 @@ def check_existing_genesis(utxo_db: UtxoDB, conn=None) -> bool:
             conn.close()
 
 
+def check_existing_non_genesis_utxo_state(utxo_db: UtxoDB, conn=None) -> bool:
+    """Check whether the UTXO tables already contain non-genesis state."""
+    own = conn is None
+    if own:
+        conn = utxo_db._conn()
+    try:
+        box_row = conn.execute(
+            """SELECT COUNT(*) AS n
+               FROM utxo_boxes AS b
+               LEFT JOIN utxo_transactions AS t ON t.tx_id = b.transaction_id
+               WHERE COALESCE(t.tx_type, '') <> 'genesis'"""
+        ).fetchone()
+        tx_row = conn.execute(
+            """SELECT COUNT(*) AS n
+               FROM utxo_transactions
+               WHERE tx_type <> 'genesis'"""
+        ).fetchone()
+        return (box_row['n'] + tx_row['n']) > 0
+    finally:
+        if own:
+            conn.close()
+
+
 def migrate(db_path: str, dry_run: bool = False) -> dict:
     """
     Run the genesis migration.
@@ -138,6 +161,13 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
             print("ERROR: Genesis boxes already exist. Aborting.")
             print("To re-run, use rollback_genesis() first.")
             return {'error': 'genesis_already_exists'}
+
+        if check_existing_non_genesis_utxo_state(utxo_db, conn=conn):
+            if not dry_run:
+                conn.execute("ROLLBACK")
+            print("ERROR: Non-genesis UTXO state already exists. Aborting.")
+            print("Run migration only on an empty UTXO set.")
+            return {'error': 'utxo_state_already_exists'}
 
         # Non-dry-run migrations load balances on the transaction connection
         # so the migrated snapshot is consistent with the acquired lock.

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -33,6 +33,20 @@ ACCOUNT_UNIT = 1_000_000  # Account-model amount_i64 is micro-RTC.
 ACCOUNT_TO_UTXO_SCALE = UNIT // ACCOUNT_UNIT
 
 
+def _is_locked_error(exc: Exception) -> bool:
+    return isinstance(exc, sqlite3.OperationalError) and "locked" in str(exc).lower()
+
+
+def _retry_locked(operation, attempts: int = 50, delay_seconds: float = 0.1):
+    for attempt in range(attempts):
+        try:
+            return operation()
+        except sqlite3.OperationalError as exc:
+            if not _is_locked_error(exc) or attempt == attempts - 1:
+                raise
+            time.sleep(delay_seconds)
+
+
 def compute_genesis_tx_id(miner_id: str) -> str:
     """Deterministic transaction ID for a genesis box."""
     return hashlib.sha256(
@@ -40,13 +54,15 @@ def compute_genesis_tx_id(miner_id: str) -> str:
     ).hexdigest()
 
 
-def load_account_balances(db_path: str) -> list:
+def load_account_balances(db_path: str, conn=None) -> list:
     """
     Load non-zero balances from the account model.
     Returns sorted list of (miner_id, amount_nrtc) tuples.
     """
-    conn = sqlite3.connect(db_path)
-    conn.row_factory = sqlite3.Row
+    own = conn is None
+    if own:
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
             """SELECT miner_id, amount_i64
@@ -70,20 +86,23 @@ def load_account_balances(db_path: str) -> list:
         ).fetchall()
         return [(r['miner_id'], int(r['amount_nrtc'])) for r in rows]
     finally:
-        conn.close()
+        if own:
+            conn.close()
 
 
-def check_existing_genesis(utxo_db: UtxoDB) -> bool:
-    """Check if genesis boxes already exist."""
-    conn = utxo_db._conn()
+def check_existing_genesis(utxo_db: UtxoDB, conn=None) -> bool:
+    """Check if genesis migration transactions already exist."""
+    own = conn is None
+    if own:
+        conn = utxo_db._conn()
     try:
         row = conn.execute(
-            "SELECT COUNT(*) AS n FROM utxo_boxes WHERE creation_height = ?",
-            (GENESIS_HEIGHT,),
+            "SELECT COUNT(*) AS n FROM utxo_transactions WHERE tx_type = 'genesis'",
         ).fetchone()
         return row['n'] > 0
     finally:
-        conn.close()
+        if own:
+            conn.close()
 
 
 def migrate(db_path: str, dry_run: bool = False) -> dict:
@@ -94,39 +113,46 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
         wallets_migrated, total_nrtc, state_root, boxes_created
     """
     utxo_db = UtxoDB(db_path)
-    utxo_db.init_tables()
-
-    # Safety check
-    if check_existing_genesis(utxo_db):
-        print("ERROR: Genesis boxes already exist. Aborting.")
-        print("To re-run, first delete genesis boxes:")
-        print(f"  DELETE FROM utxo_boxes WHERE creation_height = {GENESIS_HEIGHT};")
-        return {'error': 'genesis_already_exists'}
-
-    # Load balances
-    balances = load_account_balances(db_path)
-    if not balances:
-        print("WARNING: No non-zero balances found.")
-        return {'error': 'no_balances'}
-
-    total_account = sum(amt for _, amt in balances)
-
-    print(f"Found {len(balances)} wallets with non-zero balance")
-    print(f"Total account balance: {total_account} nrtc ({total_account / UNIT:.6f} RTC)")
-    print()
 
     if dry_run:
+        _retry_locked(utxo_db.init_tables)
         print("=== DRY RUN — computing what would be created ===")
         print()
 
     # Create genesis boxes
-    conn = utxo_db._conn()
+    conn = None
     now = int(time.time())
     boxes_created = 0
 
     try:
         if not dry_run:
+            conn = _retry_locked(utxo_db._conn)
             conn.execute("BEGIN IMMEDIATE")
+            utxo_db.init_tables(conn=conn)
+
+        # For real migrations, this check runs under the same write
+        # transaction that will insert the genesis boxes.
+        if check_existing_genesis(utxo_db, conn=conn):
+            if not dry_run:
+                conn.execute("ROLLBACK")
+            print("ERROR: Genesis boxes already exist. Aborting.")
+            print("To re-run, use rollback_genesis() first.")
+            return {'error': 'genesis_already_exists'}
+
+        # Non-dry-run migrations load balances on the transaction connection
+        # so the migrated snapshot is consistent with the acquired lock.
+        balances = load_account_balances(db_path, conn=conn)
+        if not balances:
+            if not dry_run:
+                conn.execute("ROLLBACK")
+            print("WARNING: No non-zero balances found.")
+            return {'error': 'no_balances'}
+
+        total_account = sum(amt for _, amt in balances)
+
+        print(f"Found {len(balances)} wallets with non-zero balance")
+        print(f"Total account balance: {total_account} nrtc ({total_account / UNIT:.6f} RTC)")
+        print()
 
         for miner_id, amount_nrtc in balances:
             tx_id = compute_genesis_tx_id(miner_id)
@@ -179,7 +205,7 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
             conn.execute("COMMIT")
 
     except Exception as e:
-        if not dry_run:
+        if not dry_run and conn is not None:
             try:
                 conn.execute("ROLLBACK")
             except Exception:
@@ -187,7 +213,8 @@ def migrate(db_path: str, dry_run: bool = False) -> dict:
         print(f"ERROR: Migration failed: {e}")
         raise
     finally:
-        conn.close()
+        if conn is not None:
+            conn.close()
 
     # Compute and verify state root
     state_root = utxo_db.compute_state_root()
@@ -237,14 +264,18 @@ def rollback_genesis(db_path: str) -> int:
     deletion state is possible. Idempotent: safe to call when no
     genesis data exists (returns 0).
     """
-    conn = sqlite3.connect(db_path, timeout=30)
+    utxo_db = UtxoDB(db_path)
+    conn = utxo_db._conn()
     try:
         conn.execute("BEGIN IMMEDIATE")
 
-        # Delete genesis boxes first (child table)
+        # Delete only boxes produced by genesis transactions. A non-genesis
+        # box can legitimately have creation_height=0.
         deleted = conn.execute(
-            "DELETE FROM utxo_boxes WHERE creation_height = ?",
-            (GENESIS_HEIGHT,),
+            """DELETE FROM utxo_boxes
+               WHERE transaction_id IN (
+                   SELECT tx_id FROM utxo_transactions WHERE tx_type = 'genesis'
+               )""",
         ).rowcount
 
         # Delete genesis transactions (parent table)

--- a/tests/test_utxo_transfer_replay.py
+++ b/tests/test_utxo_transfer_replay.py
@@ -82,6 +82,14 @@ def payload(nonce=1733420000000, amount_rtc=10.0):
     }
 
 
+def nonce_count(db_path):
+    conn = sqlite3.connect(db_path)
+    try:
+        return conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
+    finally:
+        conn.close()
+
+
 def test_utxo_transfer_rejects_duplicate_nonce():
     client, utxo_db, db_path = build_client()
     try:
@@ -99,10 +107,7 @@ def test_utxo_transfer_rejects_duplicate_nonce():
 
         assert utxo_db.get_balance("bob") == 10 * UNIT
 
-        with sqlite3.connect(db_path) as conn:
-            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
-
-        assert nonce_count == 1
+        assert nonce_count(db_path) == 1
     finally:
         os.unlink(db_path)
 
@@ -117,18 +122,14 @@ def test_utxo_transfer_failed_attempt_does_not_burn_nonce():
         assert rejected.status_code == 400
         assert rejected.get_json()["error"] == "Insufficient UTXO balance"
 
-        with sqlite3.connect(db_path) as conn:
-            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
-        assert nonce_count == 0
+        assert nonce_count(db_path) == 0
 
         seed_coinbase(utxo_db, "RTC_test_aabbccdd", 20 * UNIT, height=2)
         accepted = client.post("/utxo/transfer", json=req)
         assert accepted.status_code == 200
         assert accepted.get_json()["ok"] is True
 
-        with sqlite3.connect(db_path) as conn:
-            nonce_count = conn.execute("SELECT COUNT(*) FROM transfer_nonces").fetchone()[0]
-        assert nonce_count == 1
+        assert nonce_count(db_path) == 1
         assert utxo_db.get_balance("bob") == 10 * UNIT
     finally:
         os.unlink(db_path)


### PR DESCRIPTION
/claim #2819

## Summary
- Move UTXO genesis table setup, duplicate detection, balance loading, and writes under one `BEGIN IMMEDIATE` transaction.
- Detect existing genesis data by `utxo_transactions.tx_type = 'genesis'` instead of treating every height-0 box as genesis.
- Make `rollback_genesis()` delete only boxes created by genesis transactions, preserving legitimate non-genesis height-0 boxes.
- Keep external-connection schema setup inside the caller's transaction, close failed UTXO connections, and fix Windows SQLite cleanup leaks in related tests.

## Validation
- `python -m pytest node\test_rollback_atomicity.py node\test_utxo_genesis_migration_units.py node\test_genesis_race.py node\test_utxo_db.py tests\test_utxo_transfer_replay.py -q` -> 69 passed
- `python -m py_compile node\utxo_genesis_migration.py node\test_rollback_atomicity.py node\utxo_db.py node\test_genesis_race.py tests\test_utxo_transfer_replay.py`
- `git diff --check -- node\utxo_genesis_migration.py node\test_rollback_atomicity.py node\utxo_db.py node\test_genesis_race.py tests\test_utxo_transfer_replay.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK