### PR TITLE
[UTXO-BUG] Reject non-string transfer memo before dual-write

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -363,6 +363,71 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
         self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
+    def test_dual_write_rejects_non_string_memo_before_utxo_commit(self):
+        """Non-string memo must not commit UTXO state then break shadow writes."""
+        import sqlite3
+
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+                (sender, 100_000_000),
+            )
+            conn.execute(
+                """CREATE TABLE ledger (
+                   ts INTEGER, epoch INTEGER, miner_id TEXT,
+                   delta_i64 INTEGER, reason TEXT
+                )"""
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        dual_app = Flask(__name__ + '_dual_write')
+        dual_app.config['TESTING'] = True
+        register_utxo_blueprint(
+            dual_app, self.utxo_db, self.db_path,
+            verify_sig_fn=mock_verify_sig,
+            addr_from_pk_fn=mock_addr_from_pk,
+            current_slot_fn=mock_current_slot,
+            dual_write=True,
+        )
+        client = dual_app.test_client()
+
+        r = client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': 616161,
+            'memo': {'not': 'a string'},
+        })
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json()['error'], 'memo must be a string')
+        self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            balances = dict(conn.execute(
+                "SELECT miner_id, amount_i64 FROM balances"
+            ).fetchall())
+            ledger_count = conn.execute(
+                "SELECT COUNT(*) FROM ledger"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        self.assertEqual(balances[sender], 100_000_000)
+        self.assertNotIn(recipient, balances)
+        self.assertEqual(ledger_count, 0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -398,35 +398,41 @@ class TestUtxoEndpoints(unittest.TestCase):
         )
         client = dual_app.test_client()
 
-        r = client.post('/utxo/transfer', json={
-            'from_address': sender,
-            'to_address': recipient,
-            'amount_rtc': 10.0,
-            'public_key': 'aabbccdd' * 8,
-            'signature': 'sig' * 22,
-            'nonce': 616161,
-            'memo': {'not': 'a string'},
-        })
+        for nonce, bad_memo in (
+            (616161, {'not': 'a string'}),
+            (616162, None),
+            (616163, ['not', 'a', 'string']),
+        ):
+            with self.subTest(memo=bad_memo):
+                r = client.post('/utxo/transfer', json={
+                    'from_address': sender,
+                    'to_address': recipient,
+                    'amount_rtc': 10.0,
+                    'public_key': 'aabbccdd' * 8,
+                    'signature': 'sig' * 22,
+                    'nonce': nonce,
+                    'memo': bad_memo,
+                })
 
-        self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.get_json()['error'], 'memo must be a string')
-        self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
-        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
+                self.assertEqual(r.status_code, 400)
+                self.assertEqual(r.get_json()['error'], 'memo must be a string')
+                self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
+                self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
-        conn = sqlite3.connect(self.db_path)
-        try:
-            balances = dict(conn.execute(
-                "SELECT miner_id, amount_i64 FROM balances"
-            ).fetchall())
-            ledger_count = conn.execute(
-                "SELECT COUNT(*) FROM ledger"
-            ).fetchone()[0]
-        finally:
-            conn.close()
+                conn = sqlite3.connect(self.db_path)
+                try:
+                    balances = dict(conn.execute(
+                        "SELECT miner_id, amount_i64 FROM balances"
+                    ).fetchall())
+                    ledger_count = conn.execute(
+                        "SELECT COUNT(*) FROM ledger"
+                    ).fetchone()[0]
+                finally:
+                    conn.close()
 
-        self.assertEqual(balances[sender], 100_000_000)
-        self.assertNotIn(recipient, balances)
-        self.assertEqual(ledger_count, 0)
+                self.assertEqual(balances[sender], 100_000_000)
+                self.assertNotIn(recipient, balances)
+                self.assertEqual(ledger_count, 0)
 
 
 if __name__ == '__main__':

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -352,6 +352,8 @@ def utxo_transfer():
     signature = (data.get('signature') or '').strip()
     nonce = data.get('nonce')
     memo = data.get('memo', '')
+    if not isinstance(memo, str):
+        return jsonify({'error': 'memo must be a string'}), 400
     # FIX(#2867 M2): exact Decimal parsing with bounds check (was float()).
     try:
         amount_rtc = _parse_rtc_amount(data.get('amount_rtc', 0))


### PR DESCRIPTION
/claim #2819

## Summary
- Reject non-string `/utxo/transfer` `memo` values before signature verification, nonce reservation, UTXO commit, or dual-write shadow writes.
- Add a dual-write regression proving a malformed memo cannot commit UTXO state and then skip account/ledger updates.

## Bug / Impact
With `dual_write=True`, the current endpoint accepts a JSON object memo. The UTXO transaction commits first, then the account-model shadow write tries to slice `memo[:30]`, raises `TypeError`, catches it in the broad dual-write exception handler, and still returns HTTP 200.

That leaves the UTXO model debited/credited while `balances` and `ledger` remain unchanged. In the local repro, a 10 RTC transfer with `memo: {bad:memo}` returned 200, moved UTXO balances to sender=90 RTC and recipient=10 RTC, but left `balances` at sender=100 RTC and inserted zero ledger rows.

## Validation
- `git diff --check -- node/utxo_endpoints.py node/test_utxo_endpoints.py` -> passed
- `python -m py_compile node\utxo_endpoints.py node\test_utxo_endpoints.py` -> passed
- `python -m pytest node\test_utxo_endpoints.py -q` -> 19 passed
- `python -m ruff check node\utxo_endpoints.py node\test_utxo_endpoints.py --select E9,F821,F811 --output-format=concise` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Note: `python -m pytest node\test_utxo_endpoints.py tests\test_utxo_transfer_replay.py -q` runs my focused suite successfully, then hits existing Windows cleanup locks in `tests/test_utxo_transfer_replay.py` while unlinking temp DB files. I did not bundle that unrelated cleanup here because it is outside this fix.

Wallet/miner ID: `RTC253255d034065a839cd421811ec589ae5b694ffc`