### PR TITLE
fix: emit integrated request logs

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -547,7 +547,7 @@ def _after(resp):
             "ip": get_client_ip(),
             "dur_ms": int(dur * 1000),
         }
-        log.info(json.dumps(rec, separators=(",", ":")))
+        app.logger.info(json.dumps(rec, separators=(",", ":")))
     except Exception:
         pass
     resp.headers["X-Request-Id"] = getattr(g, "request_id", "-")

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -1,0 +1,31 @@
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        yield client
+
+
+def test_after_request_emits_structured_request_log(client):
+    with patch.object(integrated_node.app.logger, "info") as logger_info:
+        response = client.get("/definitely-missing", headers={"X-Request-Id": "req-test-1"})
+
+    assert response.status_code == 404
+    assert response.headers["X-Request-Id"] == "req-test-1"
+    logger_info.assert_called_once()
+
+    payload = json.loads(logger_info.call_args.args[0])
+    assert payload["req_id"] == "req-test-1"
+    assert payload["method"] == "GET"
+    assert payload["path"] == "/definitely-missing"
+    assert payload["status"] == 404
+    assert isinstance(payload["dur_ms"], int)

--- a/tests/test_request_logging.py
+++ b/tests/test_request_logging.py
@@ -1,3 +1,4 @@
+﻿# SPDX-License-Identifier: MIT
 import json
 import sys
 from unittest.mock import patch


### PR DESCRIPTION
## Summary
- route the integrated node after-request JSON record through Flask's app logger instead of an undefined \\log\\ name
- add a regression test that verifies a request emits a structured log and preserves \\X-Request-Id\\

Closes #4707.

## Testing
- \\PYTHONPATH=.testdeps python -m pytest tests/test_request_logging.py -q\\ -> 1 passed
- \\python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_request_logging.py\\
- \\git diff --check\\

Note: local Windows Python was missing pytest/flask, so I installed CI-equivalent dependencies into a temporary local \\.testdeps\\ directory for the test run and removed it before committing.