### PR TITLE
docs: clarify contributing setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,16 +79,23 @@ New to RustChain? Get 10 RTC for your **first merged PR** — even for small imp
 git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
 
+# Verify you are in the expected checkout
+test -f CONTRIBUTING.md && test -f pyproject.toml && test -f requirements.txt
+
 # Python environment
-python3 -m venv venv && source venv/bin/activate
-pip install -r requirements.txt
+python3 -m venv .venv && source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-node.txt
+
+# Verify key Python entry points parse correctly
+python -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py wallet/__main__.py
 
 # Run the main Python test suite configured in pyproject.toml
-pytest
+python -m pytest
 
 # Or run a scoped test while working on one area
-pytest node/tests/test_balance_endpoint.py
-pytest sdk/tests/test_client_unit.py
+python -m pytest node/tests/test_balance_endpoint.py
+python -m pytest sdk/tests/test_client_unit.py
 
 # Test against live node
 curl -sk https://rustchain.org/health
@@ -100,11 +107,12 @@ For package-specific work, use the closest local manifest or test folder:
 
 | Area | Example command |
 |------|-----------------|
-| Node API | `pytest node/tests` |
-| SDK | `pytest sdk/tests` |
-| Bridge | `pytest bridge/test_bridge_api.py` |
-| Rust miners | `cd miners/rust && cargo test` |
-| Frontend/package work | `cd onboard && npm test` |
+| Node API | `python -m pytest node/tests` |
+| SDK | `python -m pytest sdk/tests` |
+| Bridge | `python -m pytest bridge/test_bridge_api.py` |
+| Rust miner crate | `cargo check --manifest-path rustchain-miner/Cargo.toml` |
+| Native wallet crate | `cargo check --manifest-path rustchain-wallet/Cargo.toml` |
+| Onboarding script | `node --check onboard/index.js` |
 
 ## Live Infrastructure
 
@@ -148,7 +156,7 @@ This keeps bounty-quality docs usable by new contributors and operators.
 
 ## Code Style
 
-- Python 3.8+ compatible
+- Python 3.11+ recommended for the main node and repository-level checks
 - Type hints appreciated but not yet enforced
 - Keep PRs focused — one issue per PR
 - Test against the live node, not just local mocks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ python -m pip install -r requirements.txt -r requirements-node.txt
 # Verify key Python entry points parse correctly
 python -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py wallet/__main__.py
 
-# Run the main Python test suite configured in pyproject.toml
-python -m pytest
+# Run focused tests for the area you changed
+python -m pytest node/tests/test_mock_signature_guard.py
 
-# Or run a scoped test while working on one area
-python -m pytest node/tests/test_balance_endpoint.py
+# SDK tests need the local SDK package dependencies first
+python -m pip install -e ./sdk
 python -m pytest sdk/tests/test_client_unit.py
 
 # Test against live node
@@ -107,8 +107,8 @@ For package-specific work, use the closest local manifest or test folder:
 
 | Area | Example command |
 |------|-----------------|
-| Node API | `python -m pytest node/tests` |
-| SDK | `python -m pytest sdk/tests` |
+| Node API | `python -m pytest node/tests/test_mock_signature_guard.py` |
+| SDK | `python -m pip install -e ./sdk && python -m pytest sdk/tests/test_client_unit.py` |
 | Bridge | `python -m pytest bridge/test_bridge_api.py` |
 | Rust miner crate | `cargo check --manifest-path rustchain-miner/Cargo.toml` |
 | Native wallet crate | `cargo check --manifest-path rustchain-wallet/Cargo.toml` |


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Doc-only change: `CONTRIBUTING.md` only, so the BCOS tier/SPDX requirements do not apply.
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- First PR contribution for #2286.
- Closes #2286.
- Aligns the contributor setup commands with the current repo layout and `docs/BUILD.md`.
- Adds a quick checkout verification step before dependency installation.
- Uses `.venv`, `python -m pip`, and `python -m pytest` so commands run against the active environment.
- Installs both `requirements.txt` and `requirements-node.txt` for node-oriented checks.
- Uses focused test examples that pass against the current checkout instead of broad or stale test targets.
- Adds the local editable SDK install before the SDK unit-test example, because those tests import SDK dependencies such as `aiohttp`.
- Replaces `cd onboard && npm test`, which has no matching script, with `node --check onboard/index.js`.
- Updates the main repo Python guidance from Python 3.8+ to Python 3.11+ recommended.

Prepared with AI assistance in Codex and manually verified before submission.

RTC wallet: will provide through the bounty claim flow after merge.

## Testing / Evidence

- `git diff --check`
- `test -f CONTRIBUTING.md && test -f pyproject.toml && test -f requirements.txt`
- `python3 -m venv .venv && source .venv/bin/activate`
- `python -m pip install --upgrade pip`
- `python -m pip install -r requirements.txt -r requirements-node.txt`
- `python3 -m py_compile node/wsgi.py node/rustchain_v2_integrated_v2.2.1_rip200.py wallet/__main__.py`
- `node --check onboard/index.js`
- `python -m pytest node/tests/test_mock_signature_guard.py` -> 3 passed
- `python -m pip install -e ./sdk`
- `python -m pytest sdk/tests/test_client_unit.py` -> 24 passed
- `curl -sk --max-time 15 https://rustchain.org/health`
- `curl -sk --max-time 15 https://rustchain.org/api/miners`
- `curl -sk --max-time 15 https://rustchain.org/epoch`
