### PR TITLE
Fix Beacon contract rejected state

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -497,7 +497,7 @@ def update_contract(contract_id):
         if not new_state:
             return jsonify({'error': 'Missing state field'}), 400
         
-        valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired'}
+        valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired', 'rejected'}
         if new_state not in valid_states:
             return jsonify({'error': f'Invalid state: {new_state}'}), 400
         
@@ -509,6 +509,7 @@ def update_contract(contract_id):
             'completed': set(),  # terminal state
             'breached': set(),   # terminal state
             'expired': set(),    # terminal state
+            'rejected': set(),   # terminal state
         }
         
         db = get_db()

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -545,11 +545,16 @@ def update_contract(contract_id):
                 'error': 'Unauthorized — caller is not a party to this contract'
             }), 403
         
-        # Additional: only to_agent can accept (offered -> active)
+        # Only to_agent can accept or reject an offered contract
         if current_state == 'offered' and new_state == 'active':
             if agent_key != to_agent:
                 return jsonify({
                     'error': 'Only the recipient (to_agent) can accept this contract'
+                }), 403
+        if current_state == 'offered' and new_state == 'rejected':
+            if agent_key != to_agent:
+                return jsonify({
+                    'error': 'Only the recipient (to_agent) can reject this contract'
                 }), 403
         
         # Only from_agent can mark as breached

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -317,6 +317,46 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         contracts = json.loads(list_response.data)
         self.assertEqual(contracts[0]['state'], 'rejected')
 
+        for terminal_attempt in ('active', 'expired', 'completed'):
+            update_response = self.client.put(
+                f'/api/contracts/{contract_id}',
+                data=json.dumps({'state': terminal_attempt}),
+                content_type='application/json',
+                headers={'X-Agent-Key': 'bcn_test_to'},
+            )
+            self.assertEqual(update_response.status_code, 400)
+
+    def test_creator_cannot_reject_offered_contract(self):
+        """Only the recipient can reject an offered contract."""
+        contract_data = {
+            'from': 'bcn_test_from',
+            'to': 'bcn_test_to',
+            'type': 'service',
+            'amount': 25.0,
+            'term': '7d'
+        }
+
+        create_response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(contract_data),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_from'},
+        )
+        self.assertEqual(create_response.status_code, 201)
+        contract_id = json.loads(create_response.data)['id']
+
+        reject_response = self.client.put(
+            f'/api/contracts/{contract_id}',
+            data=json.dumps({'state': 'rejected'}),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_from'},
+        )
+        self.assertEqual(reject_response.status_code, 403)
+
+        list_response = self.client.get('/api/contracts')
+        contracts = json.loads(list_response.data)
+        self.assertEqual(contracts[0]['state'], 'offered')
+
     def test_bounty_completion_updates_reputation(self):
         """Completing a bounty increases agent reputation."""
         # Insert test bounty

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -285,6 +285,38 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         )
         self.assertEqual(update_response.status_code, 400)
 
+    def test_recipient_can_reject_offered_contract(self):
+        """Offered contracts can move to the documented rejected terminal state."""
+        contract_data = {
+            'from': 'bcn_test_from',
+            'to': 'bcn_test_to',
+            'type': 'service',
+            'amount': 25.0,
+            'term': '7d'
+        }
+
+        create_response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(contract_data),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_from'},
+        )
+        self.assertEqual(create_response.status_code, 201)
+        contract_id = json.loads(create_response.data)['id']
+
+        reject_response = self.client.put(
+            f'/api/contracts/{contract_id}',
+            data=json.dumps({'state': 'rejected'}),
+            content_type='application/json',
+            headers={'X-Agent-Key': 'bcn_test_to'},
+        )
+        self.assertEqual(reject_response.status_code, 200)
+        self.assertEqual(json.loads(reject_response.data)['state'], 'rejected')
+
+        list_response = self.client.get('/api/contracts')
+        contracts = json.loads(list_response.data)
+        self.assertEqual(contracts[0]['state'], 'rejected')
+
     def test_bounty_completion_updates_reputation(self):
         """Completing a bounty increases agent reputation."""
         # Insert test bounty
@@ -456,7 +488,7 @@ class TestBeaconAtlasDataValidation(unittest.TestCase):
 
     def test_contract_state_machine(self):
         """Contract states follow valid transitions."""
-        valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired'}
+        valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired', 'rejected'}
         
         # Valid state transitions
         valid_transitions = {
@@ -466,6 +498,7 @@ class TestBeaconAtlasDataValidation(unittest.TestCase):
             'completed': set(),  # Terminal state
             'breached': set(),  # Terminal state
             'expired': set(),  # Terminal state
+            'rejected': set(),  # Terminal state
         }
         
         # Verify all states have transitions defined


### PR DESCRIPTION
## Summary
- Allows Beacon contracts to enter the documented `rejected` terminal state.
- Keeps `offered -> rejected` aligned with the existing transition table.
- Adds a route-level regression proving the recipient can reject an offered contract and the persisted state becomes `rejected`.

Fixes #4836
Bounty reference: #305
Wallet/miner ID: `SimoneMariaRomeo-codex-earner`

## Validation
- `python -m pytest tests\test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_recipient_can_reject_offered_contract tests\test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_create_contract_workflow tests\test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_invalid_state_update_rejected -q` -> 3 passed
- `python -m pytest tests\test_beacon_atlas_behavior.py -q` -> 19 passed
- `python -m py_compile node\beacon_api.py tests\test_beacon_atlas_behavior.py`
- `git diff --check -- node\beacon_api.py tests\test_beacon_atlas_behavior.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK