### PR TITLE
FIX(#4840): add cryptographic nonce to proposal execution hash

### DIFF
--- a/rips/rustchain-core/governance/proposals.py
+++ b/rips/rustchain-core/governance/proposals.py
@@ -13,6 +13,7 @@ Lifecycle:
 """
 
 import hashlib
+import secrets
 import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Callable
@@ -386,7 +387,7 @@ class GovernanceEngine:
             raise ValueError("Vetoed proposals cannot be executed")
 
         now = int(time.time())
-        tx_hash = hashlib.sha256(f"{proposal_id}:{now}".encode()).hexdigest()
+        tx_hash = hashlib.sha256(f"{proposal_id}:{now}".encode() + secrets.token_bytes(32)).hexdigest()
 
         proposal.status = ProposalStatus.EXECUTED
         proposal.executed_at = now


### PR DESCRIPTION
## Fix for #4840: Proposal execution hash is deterministic and predictable

**Problem:** `execute_proposal()` generates tx_hash from only `proposal_id + timestamp`, both publicly known. Attackers can pre-compute execution hashes.

**Fix:**
- Added `secrets.token_bytes(32)` to hash computation
- Now: `sha256(proposal_id + timestamp + 32_random_bytes)`
- Makes execution hash unpredictable

**Testing:** AST parse verified ✅

**Wallet:** `RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`