### PR TITLE
fix: disable public Flask debug by default

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -621,4 +621,5 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    app.run(host="0.0.0.0", port=8096, debug=debug)

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -186,4 +186,5 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    app.run(debug=debug, host='0.0.0.0', port=5000)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template, jsonify
+import os
 import requests
 import json
 from datetime import datetime
@@ -134,4 +135,5 @@ def internal_error(error):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    app.run(host='0.0.0.0', port=5000, debug=debug)

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -401,4 +401,5 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    app.run(host='0.0.0.0', port=PORT, debug=debug)

--- a/security_test_payment_widget.py
+++ b/security_test_payment_widget.py
@@ -272,4 +272,5 @@ def admin_login():
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    debug = os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+    app.run(debug=debug, host='0.0.0.0', port=5000)

--- a/tests/test_public_flask_debug.py
+++ b/tests/test_public_flask_debug.py
@@ -1,3 +1,4 @@
+﻿# SPDX-License-Identifier: MIT
 import ast
 from pathlib import Path
 

--- a/tests/test_public_flask_debug.py
+++ b/tests/test_public_flask_debug.py
@@ -1,0 +1,50 @@
+import ast
+from pathlib import Path
+
+
+PUBLIC_FLASK_ENTRYPOINTS = [
+    "bcos_directory.py",
+    "bridge/bridge_api.py",
+    "contributor_registry.py",
+    "explorer/app.py",
+    "keeper_explorer.py",
+    "security_test_payment_widget.py",
+]
+
+
+def _literal_keyword(call: ast.Call, keyword_name: str):
+    for keyword in call.keywords:
+        if keyword.arg == keyword_name:
+            return keyword.value
+    return None
+
+
+def _is_app_run(call: ast.Call) -> bool:
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "run"
+        and isinstance(call.func.value, ast.Name)
+        and call.func.value.id == "app"
+    )
+
+
+def test_public_flask_entrypoints_do_not_hardcode_debug_true():
+    repo_root = Path(__file__).resolve().parents[1]
+
+    for relative_path in PUBLIC_FLASK_ENTRYPOINTS:
+        source_path = repo_root / relative_path
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=relative_path)
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_app_run(node):
+                continue
+
+            host = _literal_keyword(node, "host")
+            debug = _literal_keyword(node, "debug")
+
+            binds_public_interface = isinstance(host, ast.Constant) and host.value == "0.0.0.0"
+            hardcodes_debug_true = isinstance(debug, ast.Constant) and debug.value is True
+
+            assert not (
+                binds_public_interface and hardcodes_debug_true
+            ), f"{relative_path} binds 0.0.0.0 with debug=True"


### PR DESCRIPTION
﻿Closes #4810
/claim #4810

## Summary
- Default the affected public Flask entrypoints to `debug=False` by deriving debug mode from `FLASK_DEBUG` instead of hard-coding `debug=True`.
- Keep local development opt-in available with values like `FLASK_DEBUG=1`.
- Add an AST regression test that fails if the listed public entrypoints bind `0.0.0.0` while hard-coding `debug=True`.

## Security impact
Flask/Werkzeug debug mode is no longer enabled by default on helper services that bind to a public interface, reducing stack trace disclosure and debugger exposure risk if these scripts are run on a reachable host.

## Validation
- `python -m pytest tests\test_public_flask_debug.py -q`
- `python -m py_compile bcos_directory.py bridge\bridge_api.py contributor_registry.py explorer\app.py keeper_explorer.py security_test_payment_widget.py tests\test_public_flask_debug.py`
- `git diff --check`

## Payout
RTC wallet: RTCd84b6e2d917d0272ecaae49f2f0dfe2f5474d585
