### PR TITLE
FIX(#4847): default unknown CPU release_year to CURRENT_YEAR

### DIFF
--- a/rips/rustchain-core/validator/setup_validator.py
+++ b/rips/rustchain-core/validator/setup_validator.py
@@ -200,8 +200,8 @@ def estimate_release_year(cpu_model: str, cpu_vendor: str) -> int:
     if "8086" in model_lower or "8088" in model_lower:
         return 1978
 
-    # Default to somewhat recent
-    return 2020
+    # Default to current year for unknown CPUs (minimum antiquity)
+    return CURRENT_YEAR
 
 
 def determine_tier(release_year: int) -> Tuple[str, float]:


### PR DESCRIPTION
## Fix for #4847: estimate_release_year() defaults unknown CPUs to 2020

**Problem:** Unknown CPU models get `release_year=2020` as default, giving them 6 free years of antiquity — more than real modern hardware.

**Fix:**
- Changed default from 2020 to CURRENT_YEAR
- Unknown CPUs now get age=0 (minimum antiquity)
- Prevents inflated scores from unrecognized hardware claims

**Testing:** AST parse verified ✅

**Wallet:** `RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`