### PR TITLE
Validate antiquity score inputs

### DIFF
--- a/rips/python/rustchain/proof_of_antiquity.py
+++ b/rips/python/rustchain/proof_of_antiquity.py
@@ -40,6 +40,7 @@ AS_MAX: float = 100.0  # Maximum Antiquity Score for reward capping
 AS_MIN: float = 1.0    # Minimum AS to participate in validation
 MAX_MINERS_PER_BLOCK: int = 100
 BLOCK_REWARD_AMOUNT: TokenAmount = TokenAmount.from_rtc(float(BLOCK_REWARD))
+MIN_RELEASE_YEAR: int = 1970
 
 
 # =============================================================================
@@ -71,6 +72,7 @@ def calculate_antiquity_score(release_year: int, uptime_days: int) -> float:
     """
     # Calculate age using current year to ensure calculations remain accurate
     current_year = datetime.now().year
+    _validate_antiquity_inputs(release_year, uptime_days, current_year)
     age = max(0, current_year - release_year)
 
     # log10 gives diminishing returns on uptime: day 1→0, day 10→1, day 100→2,
@@ -79,6 +81,27 @@ def calculate_antiquity_score(release_year: int, uptime_days: int) -> float:
     uptime_factor = math.log10(uptime_days + 1)
 
     return age * uptime_factor
+
+
+def _validate_antiquity_inputs(
+    release_year: int,
+    uptime_days: int,
+    current_year: int,
+) -> None:
+    if (
+        not isinstance(release_year, int)
+        or isinstance(release_year, bool)
+        or release_year < MIN_RELEASE_YEAR
+        or release_year > current_year
+    ):
+        raise ValueError(
+            f"release_year must be an integer between {MIN_RELEASE_YEAR} "
+            f"and {current_year}"
+        )
+    if not isinstance(uptime_days, int) or isinstance(uptime_days, bool):
+        raise ValueError("uptime_days must be an integer")
+    if uptime_days < 0:
+        raise ValueError("uptime_days must be greater than or equal to 0")
 
 
 def calculate_reward(antiquity_score: float, total_reward: TokenAmount) -> TokenAmount:

--- a/rips/rustchain-core/consensus/poa.py
+++ b/rips/rustchain-core/consensus/poa.py
@@ -33,6 +33,8 @@ from ..config.chain_params import (
     calculate_block_reward,
 )
 
+MIN_RELEASE_YEAR = 1970
+
 
 # =============================================================================
 # Data Structures
@@ -143,9 +145,27 @@ def compute_antiquity_score(release_year: int, uptime_days: int) -> float:
         >>> compute_antiquity_score(2023, 30)   # Modern CPU
         2.96   # (2025-2023) * log10(31)
     """
+    _validate_antiquity_inputs(release_year, uptime_days)
     age = max(0, CURRENT_YEAR - release_year)
     uptime_factor = math.log10(uptime_days + 1)
     return age * uptime_factor
+
+
+def _validate_antiquity_inputs(release_year: int, uptime_days: int) -> None:
+    if (
+        not isinstance(release_year, int)
+        or isinstance(release_year, bool)
+        or release_year < MIN_RELEASE_YEAR
+        or release_year > CURRENT_YEAR
+    ):
+        raise ValueError(
+            f"release_year must be an integer between {MIN_RELEASE_YEAR} "
+            f"and {CURRENT_YEAR}"
+        )
+    if not isinstance(uptime_days, int) or isinstance(uptime_days, bool):
+        raise ValueError("uptime_days must be an integer")
+    if uptime_days < 0:
+        raise ValueError("uptime_days must be greater than or equal to 0")
 
 
 def compute_reward(antiquity_score: float, base_reward: int) -> int:

--- a/rips/rustchain-core/validator/score.py
+++ b/rips/rustchain-core/validator/score.py
@@ -30,6 +30,8 @@ from ..config.chain_params import (
     MIN_ENTROPY_SCORE,
 )
 
+MIN_RELEASE_YEAR = 1970
+
 
 # =============================================================================
 # Hardware Database
@@ -127,6 +129,14 @@ def validate_hardware_claim(model: str, claimed_year: int) -> Tuple[bool, str]:
     Returns:
         (valid, message) tuple
     """
+    if not isinstance(model, str) or not model.strip():
+        return False, "Hardware model must be a non-empty string"
+    if not _is_valid_release_year(claimed_year):
+        return False, (
+            f"Release year must be between {MIN_RELEASE_YEAR} and "
+            f"{CURRENT_YEAR}: {claimed_year}"
+        )
+
     # Check if model is in database
     for known_model, info in HARDWARE_DATABASE.items():
         if known_model.lower() in model.lower():
@@ -137,13 +147,32 @@ def validate_hardware_claim(model: str, claimed_year: int) -> Tuple[bool, str]:
             else:
                 return False, f"Year mismatch: claimed {claimed_year}, actual {actual_year}"
 
-    # Unknown hardware - allow with warning
-    return True, f"Unknown hardware: {model} - accepting claimed year {claimed_year}"
+    return False, f"Unknown hardware: {model} - refusing unverified claimed year"
 
 
 # =============================================================================
 # Antiquity Score Calculator
 # =============================================================================
+
+def _is_valid_release_year(release_year: int) -> bool:
+    return (
+        isinstance(release_year, int)
+        and not isinstance(release_year, bool)
+        and MIN_RELEASE_YEAR <= release_year <= CURRENT_YEAR
+    )
+
+
+def _validate_antiquity_inputs(release_year: int, uptime_days: int) -> None:
+    if not _is_valid_release_year(release_year):
+        raise ValueError(
+            f"release_year must be an integer between {MIN_RELEASE_YEAR} "
+            f"and {CURRENT_YEAR}"
+        )
+    if not isinstance(uptime_days, int) or isinstance(uptime_days, bool):
+        raise ValueError("uptime_days must be an integer")
+    if uptime_days < 0:
+        raise ValueError("uptime_days must be greater than or equal to 0")
+
 
 def calculate_antiquity_score(release_year: int, uptime_days: int) -> float:
     """
@@ -156,6 +185,7 @@ def calculate_antiquity_score(release_year: int, uptime_days: int) -> float:
     - Node reliability (uptime)
     - NOT computational speed
     """
+    _validate_antiquity_inputs(release_year, uptime_days)
     age = max(0, CURRENT_YEAR - release_year)
     uptime_factor = math.log10(uptime_days + 1)
     return age * uptime_factor

--- a/rips/rustchain-core/validator/setup_validator.py
+++ b/rips/rustchain-core/validator/setup_validator.py
@@ -63,6 +63,7 @@ BOOTSTRAP_NODES = [
 ]
 
 CURRENT_YEAR = datetime.now().year
+MIN_RELEASE_YEAR = 1970
 
 # =============================================================================
 # Hardware Detection
@@ -369,8 +370,26 @@ def calculate_antiquity_score(release_year: int, uptime_days: int = 1) -> float:
     AS = (current_year - release_year) * log10(uptime_days + 1)
     """
     import math
+    _validate_antiquity_inputs(release_year, uptime_days)
     age = CURRENT_YEAR - release_year
     return age * math.log10(uptime_days + 1)
+
+
+def _validate_antiquity_inputs(release_year: int, uptime_days: int) -> None:
+    if (
+        not isinstance(release_year, int)
+        or isinstance(release_year, bool)
+        or release_year < MIN_RELEASE_YEAR
+        or release_year > CURRENT_YEAR
+    ):
+        raise ValueError(
+            f"release_year must be an integer between {MIN_RELEASE_YEAR} "
+            f"and {CURRENT_YEAR}"
+        )
+    if not isinstance(uptime_days, int) or isinstance(uptime_days, bool):
+        raise ValueError("uptime_days must be an integer")
+    if uptime_days < 0:
+        raise ValueError("uptime_days must be greater than or equal to 0")
 
 
 def register_validator(hardware: HardwareProfile, genesis: Dict) -> ValidatorConfig:

--- a/tests/test_antiquity_score_validation.py
+++ b/tests/test_antiquity_score_validation.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE_ROOT = ROOT / "rips" / "rustchain-core"
+PYTHON_ROOT = ROOT / "rips" / "python" / "rustchain"
+
+
+def _namespace_package(name: str, path: Path):
+    package = sys.modules.get(name)
+    if package is None:
+        package = types.ModuleType(name)
+        package.__path__ = [str(path)]
+        sys.modules[name] = package
+    return package
+
+
+def _core_module(module_name: str):
+    _namespace_package("rustchain_core", CORE_ROOT)
+    if str(CORE_ROOT) not in sys.path:
+        sys.path.insert(0, str(CORE_ROOT))
+    return importlib.import_module(f"rustchain_core.{module_name}")
+
+
+def _setup_validator_module():
+    if str(CORE_ROOT) not in sys.path:
+        sys.path.insert(0, str(CORE_ROOT))
+    chain_params = importlib.import_module("config.chain_params")
+    chain_params.NETWORK_NAME = getattr(chain_params, "NETWORK_NAME", "testnet")
+    chain_params.ANCIENT_THRESHOLD = getattr(chain_params, "ANCIENT_THRESHOLD", 30)
+    chain_params.SACRED_THRESHOLD = getattr(chain_params, "SACRED_THRESHOLD", 25)
+    chain_params.VINTAGE_THRESHOLD = getattr(chain_params, "VINTAGE_THRESHOLD", 20)
+    chain_params.CLASSIC_THRESHOLD = getattr(chain_params, "CLASSIC_THRESHOLD", 15)
+    chain_params.RETRO_THRESHOLD = getattr(chain_params, "RETRO_THRESHOLD", 10)
+    chain_params.MODERN_THRESHOLD = getattr(chain_params, "MODERN_THRESHOLD", 5)
+    return _core_module("validator.setup_validator")
+
+
+def _python_module(module_name: str):
+    _namespace_package("rustchain_pkg", PYTHON_ROOT)
+    return importlib.import_module(f"rustchain_pkg.{module_name}")
+
+
+SCORE_FUNCTIONS = [
+    (
+        "validator.score.calculate_antiquity_score",
+        _core_module("validator.score").calculate_antiquity_score,
+    ),
+    (
+        "consensus.poa.compute_antiquity_score",
+        _core_module("consensus.poa").compute_antiquity_score,
+    ),
+    (
+        "validator.setup_validator.calculate_antiquity_score",
+        _setup_validator_module().calculate_antiquity_score,
+    ),
+    (
+        "python.proof_of_antiquity.calculate_antiquity_score",
+        _python_module("proof_of_antiquity").calculate_antiquity_score,
+    ),
+]
+
+
+@pytest.mark.parametrize("name,score_func", SCORE_FUNCTIONS, ids=[name for name, _ in SCORE_FUNCTIONS])
+@pytest.mark.parametrize("release_year", [0, 1969, 3000, True, 1992.5, "1992"])
+def test_antiquity_scores_reject_invalid_release_years(name, score_func, release_year):
+    with pytest.raises(ValueError, match="release_year"):
+        score_func(release_year, 365)
+
+
+@pytest.mark.parametrize("name,score_func", SCORE_FUNCTIONS, ids=[name for name, _ in SCORE_FUNCTIONS])
+@pytest.mark.parametrize("uptime_days", [-1, True, 1.5, "365"])
+def test_antiquity_scores_reject_invalid_uptime(name, score_func, uptime_days):
+    with pytest.raises(ValueError, match="uptime_days"):
+        score_func(1992, uptime_days)
+
+
+@pytest.mark.parametrize("name,score_func", SCORE_FUNCTIONS, ids=[name for name, _ in SCORE_FUNCTIONS])
+def test_antiquity_scores_preserve_valid_hardware_scoring(name, score_func):
+    assert score_func(1992, 276) > 0
+
+
+def test_validator_rejects_unknown_hardware_claims():
+    score_module = _core_module("validator.score")
+
+    valid, message = score_module.validate_hardware_claim("QuantumCPU-9000", 1970)
+
+    assert valid is False
+    assert "Unknown hardware" in message
+
+
+def test_validator_rejects_impossible_claimed_years_before_model_lookup():
+    score_module = _core_module("validator.score")
+
+    valid, message = score_module.validate_hardware_claim("486DX2", 0)
+
+    assert valid is False
+    assert "Release year" in message
+
+
+def test_validator_accepts_known_hardware_with_matching_year():
+    score_module = _core_module("validator.score")
+
+    valid, message = score_module.validate_hardware_claim("486DX2", 1992)
+
+    assert valid is True
+    assert "Hardware validated" in message


### PR DESCRIPTION
﻿## Summary
- Reject impossible antiquity score inputs before scoring: non-integer years, years before 1970, future years, non-integer uptime, and negative uptime.
- Reject unknown hardware claims instead of accepting arbitrary claimed years.
- Apply the same input guard to the sibling PoA scoring implementations and add focused regressions.

Closes #4844
Closes #4845

## Validation
- `python -m pytest tests\test_antiquity_score_validation.py -q` -> 47 passed
- `python -m py_compile rips\rustchain-core\validator\score.py rips\rustchain-core\consensus\poa.py rips\rustchain-core\validator\setup_validator.py rips\python\rustchain\proof_of_antiquity.py tests\test_antiquity_score_validation.py`
- `git diff --check -- rips\rustchain-core\validator\score.py rips\rustchain-core\consensus\poa.py rips\rustchain-core\validator\setup_validator.py rips\python\rustchain\proof_of_antiquity.py tests\test_antiquity_score_validation.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `python -m ruff ...` could not run locally: `No module named ruff`

## Payout
Wallet: `RTC7f251390e4a9c382224e1cbb682810c99cedd898`
