### PR TITLE
FIX(#4850): use random signing key instead of deterministic pubkey hash in challenge protocol

### DIFF
--- a/rips/rustchain-core/src/anti_spoof/network_challenge.py
+++ b/rips/rustchain-core/src/anti_spoof/network_challenge.py
@@ -441,6 +441,8 @@ class NetworkChallengeProtocol:
     def __init__(self, validator_pubkey: str, hardware_profile: Dict):
         self.pubkey = validator_pubkey
         self.hardware = hardware_profile
+        # Generate a random signing key instead of deriving from pubkey
+        self._signing_key = secrets.token_bytes(32)
         self.validator = AntiSpoofValidator()
         self.pending_challenges: Dict[str, Challenge] = {}
         self.failure_count = 0
@@ -458,8 +460,8 @@ class NetworkChallengeProtocol:
 
     def create_challenge(self, target_pubkey: str, target_hardware: Dict) -> Challenge:
         """Create a challenge for another validator"""
-        # Use pubkey as signing key for demo (use real keys in production)
-        privkey = hashlib.sha256(self.pubkey.encode()).digest()
+        # Use randomly-generated signing key (not derivable from public key)
+        privkey = self._signing_key
 
         challenge = self.validator.generate_challenge(
             target_pubkey=target_pubkey,


### PR DESCRIPTION
## Fix for #4850: Deterministic private key from public key

**Problem:** `NetworkChallengeProtocol.create_challenge()` derives the signing key as `hashlib.sha256(pubkey.encode()).digest()`. Since the pubkey is public, anyone can compute the same key and forge challenge signatures.

**Fix:**
- Generate a random signing key (`secrets.token_bytes(32)`) per validator instance in `__init__`
- Use `self._signing_key` instead of deterministic hash of pubkey
- Signatures now cannot be forged by observers

**Testing:** AST parse verified ✅

**Wallet:** `RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`