### PR TITLE
Fix multi-arch oracle HMAC ring signature import

### DIFF
--- a/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
+++ b/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Set
 from enum import Enum, auto
 import hashlib
+import hmac
 import struct
 import secrets
 import time
@@ -289,7 +290,7 @@ class MultiArchOracleRing:
             final_seed,
             b''.join(a.encode() for a in sorted(contributions.keys())),
             hashlib.sha256
-        ).digest() if 'hmac' in dir() else hashlib.sha256(final_seed).digest()
+        ).digest()
 
         seed = MultiArchMutationSeed(
             seed=final_seed,
@@ -478,5 +479,4 @@ def demo_multi_arch_network():
 
 
 if __name__ == "__main__":
-    import hmac  # Import for ring signature
     demo_multi_arch_network()

--- a/tests/test_multi_arch_oracles_hmac.py
+++ b/tests/test_multi_arch_oracles_hmac.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Regression tests for multi-architecture oracle ring signatures."""
+
+import contextlib
+import hashlib
+import hmac
+import io
+import sys
+from pathlib import Path
+
+
+MODULE_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "rips"
+    / "rustchain-core"
+    / "src"
+    / "mutator_oracle"
+)
+sys.path.insert(0, str(MODULE_DIR))
+
+from multi_arch_oracles import (  # noqa: E402
+    ArchitectureOracle,
+    CPUArchitecture,
+    MultiArchOracleRing,
+)
+
+
+def test_library_import_uses_hmac_for_ring_signature():
+    ring = MultiArchOracleRing()
+
+    with contextlib.redirect_stdout(io.StringIO()):
+        assert ring.register_oracle(
+            ArchitectureOracle(
+                node_id="ppc",
+                hostname="ppc.local",
+                ip_address="127.0.0.1",
+                architecture=CPUArchitecture.POWERPC_G4,
+                cpu_model="PowerMac G4",
+                simd_enabled=True,
+            )
+        )
+        assert ring.register_oracle(
+            ArchitectureOracle(
+                node_id="x86",
+                hostname="x86.local",
+                ip_address="127.0.0.2",
+                architecture=CPUArchitecture.INTEL_X86_64,
+                cpu_model="x86_64",
+                simd_enabled=True,
+            )
+        )
+        seed = ring.generate_mutation_seed(block_height=123)
+
+    assert seed is not None
+    arch_message = b"".join(
+        arch.encode() for arch in sorted(seed.architecture_contributions)
+    )
+    expected_hmac = hmac.new(seed.seed, arch_message, hashlib.sha256).digest()
+    fallback_sha256 = hashlib.sha256(seed.seed).digest()
+
+    assert seed.ring_signature == expected_hmac
+    assert seed.ring_signature != fallback_sha256


### PR DESCRIPTION
﻿## Summary
- Import `hmac` at module load time for the multi-architecture mutator oracle.
- Remove the dead `sha256(final_seed)` fallback so generated mutation seeds always carry the intended HMAC ring signature.
- Add a library-import regression test that proves `generate_mutation_seed()` returns an HMAC over the final seed and architecture contribution set.

## Root Cause
`hmac` was only imported inside the `__main__` demo block. When `multi_arch_oracles.py` is imported as a library, `generate_mutation_seed()` silently takes the fallback branch and returns `sha256(final_seed)` instead of the intended HMAC ring signature. The issue body describes this as a crash, but the production-relevant failure is that the HMAC path is bypassed outside the demo entrypoint.

Fixes #4852.

## Validation
- `python -m pytest tests\test_multi_arch_oracles_hmac.py -q` -> 1 passed
- `python -m py_compile rips\rustchain-core\src\mutator_oracle\multi_arch_oracles.py tests\test_multi_arch_oracles_hmac.py` -> passed
- `git diff --check -- rips\rustchain-core\src\mutator_oracle\multi_arch_oracles.py tests\test_multi_arch_oracles_hmac.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `python -m ruff check ... --select E9,F821,F811 --output-format=concise` -> unavailable locally: `No module named ruff`

## Payout
Nomad-Syndiode-Worker. Payout details can be provided privately if needed.
