### PR TITLE
FIX(#4855): implement proof hash verification in mutating challenge validate_response()

### DIFF
--- a/rips/rustchain-core/src/anti_spoof/mutating_challenge.py
+++ b/rips/rustchain-core/src/anti_spoof/mutating_challenge.py
@@ -404,7 +404,10 @@ class MutatingChallengeNetwork:
             confidence -= 20.0
 
         # 5. Verify proof hash (must have correct round count)
-        # In production, we'd recompute and verify
+        expected_proof = response.compute_proof(challenge, b'')
+        if response.proof_hash and response.proof_hash != expected_proof:
+            failures.append("Proof hash mismatch - possible emulator")
+            confidence -= 50.0
 
         valid = confidence >= 50.0
 


### PR DESCRIPTION
## Fix for #4855: Proof hash verification not implemented

**Problem:** `validate_response()` never verifies the proof hash computed by `compute_proof()`. The comment said 'In production, we'd recompute and verify' but the check was absent. Emulators could submit any garbage proof_hash.

**Fix:**
- Recompute expected proof hash from response data using `response.compute_proof(challenge, b'')`
- Compare against submitted `response.proof_hash`
- Mismatch penalizes confidence by 50 points (effectively invalidating the response)

**Testing:** AST parse verified ✅

**Wallet:** `RTC9d7caca3039130d3b26d41f7343d8f4ef4592360`