### PR TITLE
Fix: Remove hardcoded debug=True in Flask entrypoints (#4810)

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -482,4 +482,4 @@ def serve_dist(filename):
 if __name__ == '__main__':
     init_db()
     load_projects_from_json()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=os.environ.get('FLASK_DEBUG') == '1', host='0.0.0.0', port=5000)

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -621,4 +621,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=os.environ.get('FLASK_DEBUG') == '1')

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -188,4 +188,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=os.environ.get('FLASK_DEBUG') == '1', host='0.0.0.0', port=5000)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, render_template, jsonify
 import requests
 import json
@@ -134,4 +135,4 @@ def internal_error(error):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=os.environ.get('FLASK_DEBUG') == '1')

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -377,4 +377,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=os.environ.get('FLASK_DEBUG') == '1')

--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -1,3 +1,4 @@
+import os
 # SPDX-License-Identifier: MIT
 # SPDX-License-Identifier: MIT
 
@@ -216,4 +217,4 @@ def list_badges():
 
 if __name__ == '__main__':
     init_badge_db()
-    app.run(debug=True, port=5003)
+    app.run(debug=os.environ.get('FLASK_DEBUG') == '1', port=5003)

--- a/security_test_payment_widget.py
+++ b/security_test_payment_widget.py
@@ -272,4 +272,4 @@ def admin_login():
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=os.environ.get('FLASK_DEBUG') == '1', host='0.0.0.0', port=5000)

--- a/tests/test_flask_debug_security.py
+++ b/tests/test_flask_debug_security.py
@@ -1,0 +1,39 @@
+import os
+import re
+
+def test_no_hardcoded_flask_debug():
+    """
+    Regression test to ensure no Flask entrypoints hardcode debug=True.
+    Safe practice is to use an environment variable.
+    """
+    base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    affected_files = [
+        'security_test_payment_widget.py',
+        'profile_badge_generator.py',
+        'xss_poc_templates.py',
+        'keeper_explorer.py',
+        'contributor_registry.py',
+        'bridge/bridge_api.py',
+        'explorer/app.py'
+    ]
+
+    pattern = re.compile(r'app\.run\(.*debug\s*=\s*True', re.IGNORECASE)
+
+    errors = []
+    for rel_path in affected_files:
+        full_path = os.path.join(base_dir, rel_path)
+        if not os.path.exists(full_path):
+            continue
+
+        with open(full_path, 'r', encoding='utf-8') as f:
+            content = f.read()
+            if pattern.search(content):
+                errors.append(f"Hardcoded debug=True found in {rel_path}")
+
+    if errors:
+        print("\n".join(errors))
+        exit(1)
+
+if __name__ == "__main__":
+    test_no_hardcoded_flask_debug()
+    print("Test passed: No hardcoded debug=True found.")

--- a/xss_poc_templates.py
+++ b/xss_poc_templates.py
@@ -418,4 +418,4 @@ def payload_tester():
     return template
 
 if __name__ == '__main__':
-    app.run(debug=True, port=5001)
+    app.run(debug=os.environ.get('FLASK_DEBUG') == '1', port=5001)


### PR DESCRIPTION
Fixed hardcoded debug=True in multiple Flask entrypoints to prevent security exposure. Added a regression test in tests/test_flask_debug_security.py to ensure this doesn't recur. Part of the security hardening bounty.