### PR TITLE
Fix Atom feed thumbnail XML

### DIFF
--- a/node/bottube_feed.py
+++ b/node/bottube_feed.py
@@ -595,7 +595,7 @@ class AtomFeedBuilder:
         # Thumbnail
         if entry.get("thumbnail_url"):
             lines.append(
-                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}/>'
+                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}"/>'
             )
         
         lines.append("</entry>")

--- a/tests/test_bottube_feed.py
+++ b/tests/test_bottube_feed.py
@@ -11,6 +11,7 @@ Run with:
 import sys
 import time
 import unittest
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -324,6 +325,19 @@ class TestAtomFeedBuilder(unittest.TestCase):
         xml = self.builder.build()
         self.assertIn("media:content", xml)
         self.assertIn("video.mp4", xml)
+
+    def test_thumbnail_is_valid_xml(self):
+        """Test Atom media thumbnail extension produces valid XML."""
+        self.builder.add_entry(
+            title="Test",
+            entry_id="urn:test:1",
+            link="https://example.com/1",
+            summary="Test",
+            thumbnail_url="https://example.com/thumb.jpg"
+        )
+        xml = self.builder.build()
+        self.assertIn('<media:thumbnail url="https://example.com/thumb.jpg"/>', xml)
+        ET.fromstring(xml)
 
 
 class TestConvenienceFunctions(unittest.TestCase):


### PR DESCRIPTION
﻿## Summary
- Fix Atom thumbnail XML so `media:thumbnail` closes the `url` attribute before `/>`.
- Add a regression that builds an Atom feed with `thumbnail_url` and parses it as XML.

Fixes #4869

## Validation
- `python -m pytest tests\test_bottube_feed.py -q`
- `python -m py_compile node\bottube_feed.py tests\test_bottube_feed.py`
- `git diff --check -- node\bottube_feed.py tests\test_bottube_feed.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Note: `python -m ruff check node\bottube_feed.py tests\test_bottube_feed.py --select E9,F821,F811 --output-format=concise` was not run because `ruff` is not installed in this environment.
