### PR TITLE
fix: require object JSON for machine passport writes

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -55,6 +55,24 @@ def get_optional_json_object():
     return data, None
 
 
+def get_required_json_object():
+    """Return a required JSON object body or an error response."""
+    data = request.get_json(silent=True)
+    if not data:
+        return None, (jsonify({
+            'ok': False,
+            'error': 'invalid_request',
+            'message': 'JSON body required',
+        }), 400)
+    if not isinstance(data, dict):
+        return None, (jsonify({
+            'ok': False,
+            'error': 'invalid_request',
+            'message': 'JSON object required',
+        }), 400)
+    return data, None
+
+
 # === Public Read Endpoints ===
 
 @machine_passport_bp.route('/<machine_id>', methods=['GET'])
@@ -210,13 +228,9 @@ def create_passport():
             'message': 'Admin key required',
         }), 401
     
-    data = request.get_json()
-    if not data:
-        return jsonify({
-            'ok': False,
-            'error': 'invalid_request',
-            'message': 'JSON body required',
-        }), 400
+    data, error = get_required_json_object()
+    if error:
+        return error
     
     # Validate required fields
     required = ['name', 'owner_miner_id']
@@ -304,13 +318,9 @@ def update_passport(machine_id: str):
             'message': 'Admin key required',
         }), 401
     
-    data = request.get_json()
-    if not data:
-        return jsonify({
-            'ok': False,
-            'error': 'invalid_request',
-            'message': 'JSON body required',
-        }), 400
+    data, error = get_required_json_object()
+    if error:
+        return error
     
     success, msg = ledger.update_passport(machine_id, data)
     
@@ -346,8 +356,10 @@ def add_repair_entry(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json()
-    if not data or 'repair_type' not in data or 'description' not in data:
+    data, error = get_required_json_object()
+    if error:
+        return error
+    if 'repair_type' not in data or 'description' not in data:
         return jsonify({
             'ok': False,
             'error': 'missing_field',
@@ -479,8 +491,10 @@ def add_lineage_note(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json()
-    if not data or 'event_type' not in data:
+    data, error = get_required_json_object()
+    if error:
+        return error
+    if 'event_type' not in data:
         return jsonify({
             'ok': False,
             'error': 'missing_field',
@@ -614,13 +628,9 @@ def compute_machine_id_endpoint():
     
     Request Body: Hardware fingerprint data (same as attestation)
     """
-    data = request.get_json()
-    if not data:
-        return jsonify({
-            'ok': False,
-            'error': 'invalid_request',
-            'message': 'JSON body required',
-        }), 400
+    data, error = get_required_json_object()
+    if error:
+        return error
     
     machine_id = compute_machine_id(data)
     

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -87,3 +87,24 @@ def test_benchmark_route_accepts_object_json(client, ledger):
     assert response.status_code == 200
     assert ledger.benchmark_payload["compute_score"] == 1250.0
     assert ledger.benchmark_payload["memory_bandwidth"] == 3200.5
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    (
+        ("post", "/api/machine-passport", ["name", "owner_miner_id"]),
+        ("put", "/api/machine-passport/machine-1", ["name"]),
+        ("post", "/api/machine-passport/machine-1/repair-log", ["repair_type", "description"]),
+        ("post", "/api/machine-passport/machine-1/lineage", ["event_type"]),
+        ("post", "/api/machine-passport/compute-machine-id", ["not", "object"]),
+    ),
+)
+def test_required_machine_passport_routes_reject_non_object_json(client, method, path, payload):
+    response = getattr(client, method)(path, json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }

--- a/tests/test_wallet_show_regression.py
+++ b/tests/test_wallet_show_regression.py
@@ -46,7 +46,7 @@ class TestWalletBalanceEndpoint:
             balance = resp.get("amount_rtc", resp.get("balance_rtc", resp.get("balance", 0)))
             assert isinstance(balance, (int, float))
 
-    @patch('urllib.request.urlopen')
+    @patch('rustchain_cli.urlopen')
     def test_wallet_show_handles_network_error_gracefully(self, mock_urlopen):
         """Test that wallet show handles network errors without crashing."""
         import urllib.error
@@ -54,14 +54,12 @@ class TestWalletBalanceEndpoint:
         # Simulate network timeout
         mock_urlopen.side_effect = urllib.error.URLError("timeout")
         
-        # Should not raise exception, should handle gracefully
-        # This is the behavior we want to preserve
-        try:
-            # Test the balance fetch logic directly
-            result = fetch_api("/wallet/balance?miner_id=test")
-        except Exception as e:
-            # Expected to fail with network error
-            assert "timeout" in str(e).lower() or "network" in str(e).lower()
+        # The CLI reports a controlled network error and exits instead of
+        # leaking a urllib traceback.
+        with pytest.raises(SystemExit) as exc_info:
+            fetch_api("/wallet/balance?miner_id=test")
+
+        assert exc_info.value.code == 1
 
     def test_balance_endpoint_returns_valid_json(self):
         """Integration test: verify /wallet/balance returns valid JSON."""


### PR DESCRIPTION
﻿﻿﻿## Summary
- require JSON object bodies on the Machine Passport write/compute endpoints that need fields or fingerprint data
- keep the existing optional-object behavior for attestation/benchmark event routes
- add regressions for non-object payloads on create, update, repair-log, lineage, and compute-machine-id
- keep the wallet network-regression test offline by mocking the CLI's imported `urlopen` symbol

## Root cause
Some Machine Passport routes called `request.get_json()` and then either used `.get()` or passed the payload into `compute_machine_id()` without checking that the JSON value was an object. A non-empty JSON array could therefore either produce a 500 (`/api/machine-passport` with `['name', 'owner_miner_id']`) or be accepted as fingerprint input (`/compute-machine-id`) even though the API documents object payloads.

The first CI attempt also exposed an unrelated flaky wallet regression test: it patched `urllib.request.urlopen`, but `rustchain_cli` imports `urlopen` directly, so the test could hit the live network and time out in CI. The test now patches `rustchain_cli.urlopen` and asserts the controlled CLI exit path.

## Verification
- `python -m pytest tests\\test_wallet_show_regression.py::TestWalletBalanceEndpoint::test_wallet_show_handles_network_error_gracefully tests\\test_machine_passport_event_json_validation.py node\\tests\\test_machine_passport.py -q` -> 37 passed
- `python -m pytest tests\\test_machine_passport_event_json_validation.py -q` -> 10 passed
- `python -m pytest node\\tests\\test_machine_passport.py tests\\test_machine_passport_event_json_validation.py -q` -> 36 passed
- `python -m py_compile node\\machine_passport_api.py tests\\test_machine_passport_event_json_validation.py tests\\test_wallet_show_regression.py` -> passed
- `python tools\\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check` -> passed

Note: full local `pytest -q` on Windows is not clean in this checkout because many existing temp-file teardown tests hold SQLite/temp files open and optional integrations are missing. The targeted paths above cover this PR and the CI failure reproduced from GitHub.
---

Payout / receipt reference:

Public RTC receive address / miner_id: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7

This is a public receive reference only. No seed phrase, private key, wallet password, keystore material, bank details, email, or payment token is being shared.

wallet: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7