### PR TITLE
fix: repair p2p announce route

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -404,11 +404,15 @@ class HealthChecker:
 
 def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
     """Add P2P endpoints to Flask app"""
+    from flask import jsonify, request
 
     @app.route('/p2p/announce', methods=['POST'])
     def announce_peer():
         """Endpoint for peer nodes to announce themselves"""
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "JSON object required"}), 400
+
         peer_url = data.get('peer_url')
 
         if peer_url:

--- a/node/tests/test_p2p_sync_routes.py
+++ b/node/tests/test_p2p_sync_routes.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 from flask import Flask
 
 from node.rustchain_p2p_sync import add_p2p_endpoints

--- a/node/tests/test_p2p_sync_routes.py
+++ b/node/tests/test_p2p_sync_routes.py
@@ -1,0 +1,52 @@
+from flask import Flask
+
+from node.rustchain_p2p_sync import add_p2p_endpoints
+
+
+class StubPeerManager:
+    db_path = ":memory:"
+
+    def __init__(self):
+        self.peers = []
+
+    def add_peer(self, peer_url):
+        self.peers.append(peer_url)
+        return True
+
+    def get_active_peers(self):
+        return list(self.peers)
+
+
+def build_client():
+    app = Flask(__name__)
+    peer_manager = StubPeerManager()
+    add_p2p_endpoints(app, peer_manager, block_sync=None, tx_gossip=None)
+    return app.test_client(), peer_manager
+
+
+def test_p2p_announce_accepts_valid_peer_url():
+    client, peer_manager = build_client()
+
+    response = client.post("/p2p/announce", json={"peer_url": "http://peer.example:8088"})
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "peers": 1}
+    assert peer_manager.peers == ["http://peer.example:8088"]
+
+
+def test_p2p_announce_rejects_non_object_json():
+    client, _ = build_client()
+
+    response = client.post("/p2p/announce", json=["peer_url", "http://peer.example:8088"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "JSON object required"}
+
+
+def test_p2p_announce_rejects_missing_peer_url():
+    client, _ = build_client()
+
+    response = client.post("/p2p/announce", json={})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "peer_url required"}


### PR DESCRIPTION
﻿﻿﻿## Summary
- import Flask `request`/`jsonify` inside `add_p2p_endpoints()` so the legacy P2P routes can execute
- make `/p2p/announce` reject non-object JSON with a controlled 400 instead of crashing during field access
- add Flask route regressions for valid announce, array payload, and missing `peer_url`

## Root cause
`node/rustchain_p2p_sync.py` registers `/p2p/announce`, `/p2p/peers`, and `/api/blocks` routes that call `request`/`jsonify`, but those Flask symbols were never imported in the module or route factory. As a result, even a valid `POST /p2p/announce` raised `NameError: name 'request' is not defined`. After adding the imports, the endpoint also needed the usual object-body guard so a JSON array cannot reach `data.get(...)` and raise a second 500.

## Verification
- `python -m pytest node\\tests\\test_p2p_sync_routes.py -q` -> 3 passed
- `python -m py_compile node\\rustchain_p2p_sync.py node\\tests\\test_p2p_sync_routes.py` -> passed
- `python tools\\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check` -> passed

Note: `ruff` is not installed in this local environment, so I could not run the optional targeted Ruff check here.
---

Payout / receipt reference:

Public RTC receive address / miner_id: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7

This is a public receive reference only. No seed phrase, private key, wallet password, keystore material, bank details, email, or payment token is being shared.

wallet: RTCda4841be5b2d109da5d995fb864c09676bb5b7c7