### PR TITLE
fix: repair node health test import

### DIFF
--- a/tools/node-health-cli/tests/test_node_health.py
+++ b/tools/node-health-cli/tests/test_node_health.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """
 Tests for RustChain Node Health Monitor CLI
 """
@@ -8,10 +9,10 @@ import unittest
 from io import StringIO
 from unittest.mock import patch, MagicMock
 from urllib.error import URLError, HTTPError
+from pathlib import Path
 
 import sys
-import os
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from node_health import (
     HealthStatus, EpochStatus, ReachabilityStatus, CheckResult,


### PR DESCRIPTION
## Summary
- fix the node-health CLI test import path so the suite works from the repository root
- add the missing SPDX header to the touched test file

## Root cause
`tools/node-health-cli/tests/test_node_health.py` inserted the `tests` directory into `sys.path`, but `node_health.py` lives one directory above it. Running the suite from the repo root therefore failed during collection with `ModuleNotFoundError: No module named 'node_health'`.

## Verification
- `python -m pytest tools\\node-health-cli\\tests\\test_node_health.py -q` -> 24 passed
- `python -m py_compile tools\\node-health-cli\\node_health.py tools\\node-health-cli\\tests\\test_node_health.py` -> passed
- `python tools\\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check -- tools\\node-health-cli\\tests\\test_node_health.py` -> passed