### PR TITLE
fix: require admin auth for glitch controls

### DIFF
--- a/issue2288/glitch_system/src/api.py
+++ b/issue2288/glitch_system/src/api.py
@@ -56,7 +56,10 @@ def require_admin():
         request.headers.get("X-Admin-Key", "")
         or request.headers.get("X-API-Key", "")
     )
-    if not hmac.compare_digest(provided_key, expected_key):
+    if not hmac.compare_digest(
+        provided_key.encode("utf-8"),
+        expected_key.encode("utf-8"),
+    ):
         return jsonify({
             "error": "unauthorized",
             "message": "Invalid admin key"

--- a/issue2288/glitch_system/src/api.py
+++ b/issue2288/glitch_system/src/api.py
@@ -8,7 +8,9 @@ and configuring the glitch engine.
 
 from flask import Blueprint, jsonify, request, Response
 from typing import Dict, Any
+import hmac
 import json
+import os
 import time
 
 try:
@@ -39,6 +41,28 @@ def get_json_object():
     if not isinstance(data, dict):
         return None, (jsonify({"error": "JSON object required"}), 400)
     return data, None
+
+
+def require_admin():
+    """Require admin authentication for destructive/configuration routes."""
+    expected_key = os.environ.get("GLITCH_ADMIN_KEY", "")
+    if not expected_key:
+        return jsonify({
+            "error": "unauthorized",
+            "message": "GLITCH_ADMIN_KEY not configured"
+        }), 401
+
+    provided_key = (
+        request.headers.get("X-Admin-Key", "")
+        or request.headers.get("X-API-Key", "")
+    )
+    if not hmac.compare_digest(provided_key, expected_key):
+        return jsonify({
+            "error": "unauthorized",
+            "message": "Invalid admin key"
+        }), 401
+
+    return None
 
 
 def parse_limit_arg(default: int = 50, max_value: int = 200):
@@ -299,6 +323,10 @@ def clear_history() -> Response:
     
     POST /api/glitch/history/clear
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     
     engine._glitch_history.clear()
@@ -391,6 +419,10 @@ def update_config() -> Response:
         "base_probability": 0.2
     }
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     
     data, error = get_json_object()
@@ -419,6 +451,10 @@ def reset_config() -> Response:
     
     POST /api/glitch/config/reset
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     
     engine.config.enabled = True
@@ -493,6 +529,10 @@ def enable_glitches() -> Response:
     
     POST /api/glitch/enable
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     engine.enable()
     
@@ -506,6 +546,10 @@ def disable_glitches() -> Response:
     
     POST /api/glitch/disable
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     engine.disable()
     
@@ -525,6 +569,10 @@ def trigger_glitch() -> Response:
         "message": "Test message"
     }
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     engine = get_engine()
     
     data, error = get_json_object()

--- a/issue2288/glitch_system/src/api.py
+++ b/issue2288/glitch_system/src/api.py
@@ -419,15 +419,15 @@ def update_config() -> Response:
         "base_probability": 0.2
     }
     """
+    data, error = get_json_object()
+    if error:
+        return error
+
     auth_error = require_admin()
     if auth_error is not None:
         return auth_error
 
     engine = get_engine()
-    
-    data, error = get_json_object()
-    if error:
-        return error
     
     if "enabled" in data:
         if data["enabled"]:
@@ -569,15 +569,15 @@ def trigger_glitch() -> Response:
         "message": "Test message"
     }
     """
+    data, error = get_json_object()
+    if error:
+        return error
+
     auth_error = require_admin()
     if auth_error is not None:
         return auth_error
 
     engine = get_engine()
-    
-    data, error = get_json_object()
-    if error:
-        return error
     agent_id = data.get("agent_id", "test_agent")
     message = data.get("message", "Test message for glitch")
     

--- a/issue2288/glitch_system/tests/test_glitch_system.py
+++ b/issue2288/glitch_system/tests/test_glitch_system.py
@@ -11,6 +11,7 @@ import sys
 import os
 import time
 import json
+from unittest.mock import patch
 
 # Add src to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
@@ -28,6 +29,8 @@ from trigger import (
     TriggerConfig, DEFAULT_TRIGGERS
 )
 from glitch_engine import GlitchEngine, GlitchConfig
+from flask import Flask
+from api import glitch_bp, init_engine
 
 
 # ─── Glitch Event Tests ─────────────────────────────────────────────────────── #
@@ -722,6 +725,59 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertIn("glitch", response)
 
 
+class TestGlitchAPIAdminAuth(unittest.TestCase):
+    """Tests for admin authentication on mutating glitch API routes."""
+
+    def setUp(self):
+        self.app = Flask(__name__)
+        self.app.config["TESTING"] = True
+        self.app.register_blueprint(glitch_bp)
+        init_engine(GlitchConfig(enabled=True, base_probability=1.0, min_glitch_interval=0.0))
+        self.client = self.app.test_client()
+
+    def test_mutating_routes_require_admin_key(self):
+        routes = (
+            ("post", "/api/glitch/history/clear", None),
+            ("put", "/api/glitch/config", {"base_probability": 0.5}),
+            ("post", "/api/glitch/config/reset", None),
+            ("post", "/api/glitch/enable", None),
+            ("post", "/api/glitch/disable", None),
+            ("post", "/api/glitch/trigger", {"agent_id": "api_test", "message": "hello"}),
+        )
+
+        for method, path, payload in routes:
+            with self.subTest(path=path):
+                with patch.dict("os.environ", {"GLITCH_ADMIN_KEY": "test-admin"}, clear=False):
+                    response = getattr(self.client, method)(
+                        path,
+                        json=payload,
+                        headers={"X-Admin-Key": "wrong-admin"},
+                    )
+
+                self.assertEqual(response.status_code, 401)
+                self.assertEqual(response.get_json()["error"], "unauthorized")
+
+    def test_mutating_routes_fail_closed_when_admin_key_unconfigured(self):
+        with patch.dict("os.environ", {}, clear=True):
+            response = self.client.post(
+                "/api/glitch/disable",
+                headers={"X-Admin-Key": "test-admin"},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json()["error"], "unauthorized")
+
+    def test_mutating_routes_allow_valid_admin_key(self):
+        with patch.dict("os.environ", {"GLITCH_ADMIN_KEY": "test-admin"}, clear=False):
+            response = self.client.post(
+                "/api/glitch/disable",
+                headers={"X-Admin-Key": "test-admin"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"success": True, "enabled": False})
+
+
 # ─── Test Runner ────────────────────────────────────────────────────────────── #
 
 
@@ -741,6 +797,7 @@ def run_tests():
         TestGlitchEngine,
         TestGlitchEngineIntegration,
         TestAPIEndpoints,
+        TestGlitchAPIAdminAuth,
     ]
     
     for test_class in test_classes:

--- a/issue2288/glitch_system/tests/test_glitch_system.py
+++ b/issue2288/glitch_system/tests/test_glitch_system.py
@@ -767,6 +767,16 @@ class TestGlitchAPIAdminAuth(unittest.TestCase):
         self.assertEqual(response.status_code, 401)
         self.assertEqual(response.get_json()["error"], "unauthorized")
 
+    def test_non_ascii_admin_key_is_rejected_without_500(self):
+        with patch.dict("os.environ", {"GLITCH_ADMIN_KEY": "test-admin"}, clear=False):
+            response = self.client.post(
+                "/api/glitch/disable",
+                headers={"X-Admin-Key": "\u00e9"},
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.get_json()["error"], "unauthorized")
+
     def test_mutating_routes_allow_valid_admin_key(self):
         with patch.dict("os.environ", {"GLITCH_ADMIN_KEY": "test-admin"}, clear=False):
             response = self.client.post(


### PR DESCRIPTION
## Summary
- add default-deny admin authentication for Glitch API destructive/configuration routes
- require matching `GLITCH_ADMIN_KEY` via `X-Admin-Key` or `X-API-Key`
- protect history clear, config update/reset, enable, disable, and manual trigger endpoints
- add Flask route tests for wrong-key, unconfigured-key, and valid-key behavior

Fixes #4874

/claim #4874

Wallet: `RTC253255d034065a839cd421811ec589ae5b694ffc`

## Validation
- `python -m pytest issue2288\glitch_system\tests\test_glitch_system.py -q` -> 43 passed
- `python -m py_compile issue2288\glitch_system\src\api.py issue2288\glitch_system\tests\test_glitch_system.py` -> passed
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
