### PR TITLE
fix: restrict proof-of-iron legacy cache unpickling

### DIFF
--- a/issue2307_boot_chime/src/proof_of_iron.py
+++ b/issue2307_boot_chime/src/proof_of_iron.py
@@ -6,7 +6,9 @@ verifiable hardware proofs.
 """
 
 import hashlib
+import io
 import json
+import pickle
 import time
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass, asdict
@@ -29,6 +31,24 @@ class AttestationStatus(Enum):
 class ProofOfIronError(Exception):
     """Proof-of-Iron protocol error"""
     pass
+
+
+class _RestrictedFeatureUnpickler(pickle.Unpickler):
+    """Legacy feature-cache unpickler that rejects arbitrary globals."""
+
+    def find_class(self, module: str, name: str) -> Any:
+        raise pickle.UnpicklingError(f"Forbidden pickle global: {module}.{name}")
+
+
+def _loads_legacy_feature_cache(raw: Any) -> Dict[str, Any]:
+    if isinstance(raw, bytes):
+        payload = raw
+    else:
+        payload = raw.encode("latin1")
+    data = _RestrictedFeatureUnpickler(io.BytesIO(payload)).load()
+    if not isinstance(data, dict):
+        raise pickle.UnpicklingError("Legacy feature cache must be a dict")
+    return data
 
 
 @dataclass
@@ -524,11 +544,10 @@ class ProofOfIron:
             pass
     
     def _load_features(self, features_hash: str) -> Optional[FingerprintFeatures]:
-        """Load cached features with backward-compatible dual-read (JSON first, then pickle)."""
+        """Load cached features with backward-compatible dual-read (JSON first, then restricted pickle)."""
         try:
             import sqlite3
             import json
-            import pickle
             conn = sqlite3.connect(self.db_path)
             c = conn.cursor()
             c.execute('SELECT features FROM feature_cache WHERE hash = ?',
@@ -545,8 +564,8 @@ class ProofOfIron:
                     else:
                         data = json.loads(raw)
                 except (json.JSONDecodeError, UnicodeDecodeError):
-                    # Fallback: legacy pickle data — deserialize and migrate to JSON
-                    data = pickle.loads(raw) if isinstance(raw, bytes) else pickle.loads(raw.encode())
+                    # Fallback: legacy pickle data with arbitrary globals disabled.
+                    data = _loads_legacy_feature_cache(raw)
                     # Re-write as JSON to gradually migrate the cache
                     self._save_features(features_hash, FingerprintFeatures(
                         mfcc_mean=np.array(data['mfcc_mean']),

--- a/issue2307_boot_chime/tests/test_proof_of_iron_safe_cache.py
+++ b/issue2307_boot_chime/tests/test_proof_of_iron_safe_cache.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import pickle
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+from contextlib import closing
+
+import numpy as np
+
+
+src_path = str(Path(__file__).parent.parent / "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+try:
+    from acoustic_fingerprint import FingerprintFeatures
+    from proof_of_iron import ProofOfIron
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    from src.acoustic_fingerprint import FingerprintFeatures
+    from src.proof_of_iron import ProofOfIron
+
+
+def _feature_data():
+    return {
+        "mfcc_mean": [1.0, 2.0],
+        "mfcc_std": [0.1, 0.2],
+        "spectral_centroid": 100.0,
+        "spectral_bandwidth": 200.0,
+        "spectral_rolloff": 300.0,
+        "zero_crossing_rate": 0.05,
+        "chroma_mean": [0.3, 0.4],
+        "temporal_envelope": [0.5, 0.6],
+        "peak_frequencies": [440.0, 880.0],
+        "harmonic_structure": {"h1": 1.0},
+    }
+
+
+def _insert_feature_cache(db_path, features_hash, payload):
+    with closing(sqlite3.connect(db_path)) as conn:
+        conn.execute(
+            """
+            CREATE TABLE feature_cache (
+                hash TEXT PRIMARY KEY,
+                features BLOB,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO feature_cache (hash, features, created_at) VALUES (?, ?, 0)",
+            (features_hash, payload),
+        )
+        conn.commit()
+
+
+def _loader(db_path):
+    proof = ProofOfIron.__new__(ProofOfIron)
+    proof.db_path = db_path
+    return proof
+
+
+class _Exploit:
+    def __reduce__(self):
+        return (os.system, ("echo unsafe",))
+
+
+def test_load_features_rejects_pickle_globals_without_execution():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "features.db")
+        _insert_feature_cache(db_path, "evil", pickle.dumps(_Exploit()))
+
+        loaded = _loader(db_path)._load_features("evil")
+
+        assert loaded is None
+
+
+def test_load_features_migrates_legacy_plain_pickle_dict_to_json():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "features.db")
+        _insert_feature_cache(db_path, "legacy", pickle.dumps(_feature_data()))
+
+        loaded = _loader(db_path)._load_features("legacy")
+
+        assert isinstance(loaded, FingerprintFeatures)
+        np.testing.assert_allclose(loaded.mfcc_mean, np.array([1.0, 2.0]))
+
+        with closing(sqlite3.connect(db_path)) as conn:
+            stored = conn.execute(
+                "SELECT features FROM feature_cache WHERE hash = ?",
+                ("legacy",),
+            ).fetchone()[0]
+        assert isinstance(stored, str)
+        assert stored.startswith("{")


### PR DESCRIPTION
## Summary
- fixes #4885 in the live `issue2307_boot_chime/src/proof_of_iron.py` path
- replaces raw legacy `pickle.loads()` cache fallback with a restricted unpickler that rejects all pickle globals
- preserves migration for plain legacy dict feature caches and rewrites them through the existing JSON cache writer
- adds regressions for malicious pickle global rejection and safe legacy dict migration

## Validation
- `python -m pytest issue2307_boot_chime\tests\test_proof_of_iron_safe_cache.py -q` -> 2 passed
- `python -m pytest issue2307_boot_chime\tests\test_boot_chime.py issue2307_boot_chime\tests\test_proof_of_iron_safe_cache.py -q` -> 32 passed
- `python -m py_compile issue2307_boot_chime\src\proof_of_iron.py issue2307_boot_chime\tests\test_proof_of_iron_safe_cache.py` -> passed
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `rg -n "pickle\.loads" issue2307_boot_chime\src\proof_of_iron.py issue2307_boot_chime\tests\test_proof_of_iron_safe_cache.py` -> no matches

Wallet/miner ID for bounty processing: `RTC253255d034065a839cd421811ec589ae5b694ffc`

No production testing or destructive action was performed.
