### PR TITLE
fix: accept native RTC faucet wallets

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -12,6 +12,7 @@ Features:
 import sqlite3
 import time
 import os
+import re
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify, render_template_string
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -23,6 +24,7 @@ DATABASE = 'faucet.db'
 # Rate limiting settings (per 24 hours)
 MAX_DRIP_AMOUNT = 0.5  # RTC
 RATE_LIMIT_HOURS = 24
+RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
 
 
 def init_db():
@@ -49,6 +51,11 @@ def get_client_ip():
     """
     remote = request.remote_addr or '127.0.0.1'
     return remote
+
+
+def is_valid_wallet_address(wallet):
+    """Validate faucet-compatible legacy and native RustChain wallet formats."""
+    return (wallet.startswith('0x') and len(wallet) >= 10) or RTC_WALLET_RE.fullmatch(wallet)
 def get_last_drip_time(identifier, is_wallet=False):
     """Get the last time this IP or wallet requested a drip."""
     conn = sqlite3.connect(DATABASE)
@@ -206,7 +213,7 @@ HTML_TEMPLATE = """
         <p>Get free test RTC tokens for development.</p>
         <form id="faucetForm">
             <label for="wallet">Your RTC Wallet Address:</label>
-            <input type="text" id="wallet" name="wallet" placeholder="0x..." required>
+            <input type="text" id="wallet" name="wallet" placeholder="0x... or RTC..." required>
             <button type="submit" id="submitBtn">Get Test RTC</button>
         </form>
         
@@ -300,7 +307,7 @@ def drip():
     Handle drip requests.
     
     Request body:
-        {"wallet": "0x..."}
+        {"wallet": "0x..."} or {"wallet": "RTC..."}
     
     Response:
         {"ok": true, "amount": 0.5, "next_available": "2026-03-08T12:00:00Z"}
@@ -319,8 +326,7 @@ def drip():
 
     wallet = wallet_value.strip()
     
-    # Basic wallet validation (should start with 0x and be reasonably long)
-    if not wallet.startswith('0x') or len(wallet) < 10:
+    if not is_valid_wallet_address(wallet):
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400
     
     ip = get_client_ip()

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -34,3 +34,19 @@ def test_legacy_faucet_rejects_non_string_wallet(client):
 
     assert response.status_code == 400
     assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+
+def test_legacy_faucet_accepts_native_rtc_wallet(client):
+    wallet = "RTC9d7caca3039130d3b26d41f7343d8f4ef4592360"
+
+    response = client.post("/faucet/drip", json={"wallet": wallet})
+
+    assert response.status_code == 200
+    assert response.get_json()["wallet"] == wallet
+
+
+def test_legacy_faucet_rejects_malformed_rtc_wallet(client):
+    response = client.post("/faucet/drip", json={"wallet": "RTCnot-a-native-wallet"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}


### PR DESCRIPTION
## Summary
- Fixes the live root `faucet.py` wallet validation bug from #4890.
- Keeps legacy `0x...` faucet addresses accepted.
- Adds strict native `RTC` wallet support for `RTC` plus 40 hex characters, matching the issue example and canonical wallet format.
- Updates the form placeholder and route docstring to show both accepted formats.
- Adds regressions for accepting a valid native RTC wallet and rejecting malformed RTC-prefixed input.

## Validation
- `python -m pytest tests\test_legacy_faucet_json_validation.py -q` -> 5 passed
- `python -m pytest tests\test_legacy_faucet_json_validation.py tests\test_faucet.py -q` -> 9 passed
- `python -m py_compile faucet.py tests\test_legacy_faucet_json_validation.py` -> passed
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No live faucet, production wallet, or destructive testing was performed.

Wallet: RTC253255d034065a839cd421811ec589ae5b694ffc

Fixes #4890