### PR TITLE
fix: accept RTC faucet wallet addresses

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -12,6 +12,7 @@ Features:
 import sqlite3
 import time
 import os
+import re
 from datetime import datetime, timedelta
 from flask import Flask, request, jsonify, render_template_string
 from werkzeug.middleware.proxy_fix import ProxyFix
@@ -19,6 +20,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 DATABASE = 'faucet.db'
+RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
 
 # Rate limiting settings (per 24 hours)
 MAX_DRIP_AMOUNT = 0.5  # RTC
@@ -110,6 +112,13 @@ def record_drip(wallet, ip_address, amount):
     ''', (wallet, ip_address, amount))
     conn.commit()
     conn.close()
+
+
+def is_valid_wallet_address(wallet):
+    """Accept legacy Ethereum-style wallets and native RTC wallets."""
+    return (wallet.startswith('0x') and len(wallet) >= 10) or bool(
+        RTC_WALLET_RE.fullmatch(wallet)
+    )
 
 
 # HTML Template
@@ -320,7 +329,7 @@ def drip():
     wallet = wallet_value.strip()
     
     # Basic wallet validation (accept Ethereum-style and native RTC wallets)
-    if not wallet.startswith(('0x', 'RTC')) or len(wallet) < 10:
+    if not is_valid_wallet_address(wallet):
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400
     
     ip = get_client_ip()

--- a/faucet.py
+++ b/faucet.py
@@ -319,8 +319,8 @@ def drip():
 
     wallet = wallet_value.strip()
     
-    # Basic wallet validation (should start with 0x and be reasonably long)
-    if not wallet.startswith('0x') or len(wallet) < 10:
+    # Basic wallet validation (accept Ethereum-style and native RTC wallets)
+    if not wallet.startswith(('0x', 'RTC')) or len(wallet) < 10:
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400
     
     ip = get_client_ip()

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -34,3 +34,24 @@ def test_legacy_faucet_rejects_non_string_wallet(client):
 
     assert response.status_code == 400
     assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+
+def test_legacy_faucet_rejects_unknown_wallet_prefix(client):
+    response = client.post(
+        "/faucet/drip",
+        json={"wallet": "BAD9d7caca3039130d3b26d41f7343d8f4ef4592360"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+
+def test_legacy_faucet_accepts_native_rtc_wallet(client):
+    wallet = "RTC9d7caca3039130d3b26d41f7343d8f4ef4592360"
+
+    response = client.post("/faucet/drip", json={"wallet": wallet})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["wallet"] == wallet

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -46,6 +46,13 @@ def test_legacy_faucet_rejects_unknown_wallet_prefix(client):
     assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
 
 
+def test_legacy_faucet_rejects_malformed_native_rtc_wallet(client):
+    response = client.post("/faucet/drip", json={"wallet": "RTCzzzzzzzzzz"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+
 def test_legacy_faucet_accepts_native_rtc_wallet(client):
     wallet = "RTC9d7caca3039130d3b26d41f7343d8f4ef4592360"
 


### PR DESCRIPTION
## Summary
- fixes #4890 by accepting native `RTC`-prefixed wallet addresses in the live root `faucet.py` endpoint
- keeps invalid wallet prefixes rejected
- adds legacy faucet regressions for native RTC acceptance and invalid-prefix rejection

## Validation
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile faucet.py tests/test_legacy_faucet_json_validation.py`
- `uv run --no-project --with pytest --with flask --with flask-cors --with requests python -m pytest tests/test_legacy_faucet_json_validation.py tests/test_faucet.py -q` -> 9 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID for bounty payout: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`

No live faucet or production wallet mutation was performed.