### PR TITLE
fix: fail closed machine passport admin writes

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -353,6 +353,10 @@ def add_repair_entry(machine_id: str):
         "notes": "Machine now stable at 1.2V"
     }
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -395,6 +399,10 @@ def add_attestation(machine_id: str):
     
     Typically called automatically during mining attestation.
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -441,6 +449,10 @@ def add_benchmark(machine_id: str):
         "entropy_throughput": 500.0
     }
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
@@ -486,6 +498,10 @@ def add_lineage_note(machine_id: str):
         "tx_hash": "0x..."  # Optional blockchain transaction
     }
     """
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
+
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -41,6 +41,31 @@ def get_ledger() -> MachinePassportLedger:
     return _ledger
 
 
+def require_admin():
+    """Require configured admin authentication for mutating passport routes."""
+    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
+    expected_admin_key = os.environ.get('ADMIN_KEY', '')
+
+    if not expected_admin_key:
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'ADMIN_KEY not configured',
+        }), 401
+
+    if not hmac.compare_digest(
+        admin_key.encode('utf-8'),
+        expected_admin_key.encode('utf-8'),
+    ):
+        return jsonify({
+            'ok': False,
+            'error': 'unauthorized',
+            'message': 'Admin key required',
+        }), 401
+
+    return None
+
+
 def get_optional_json_object():
     """Return an optional JSON object body or an error response."""
     data = request.get_json(silent=True)
@@ -200,15 +225,9 @@ def create_passport():
     }
     """
     # Admin authentication
-    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
-    expected_admin_key = os.environ.get('ADMIN_KEY', '')
-    
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
-        return jsonify({
-            'ok': False,
-            'error': 'unauthorized',
-            'message': 'Admin key required',
-        }), 401
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
     
     data = request.get_json()
     if not data:
@@ -286,23 +305,17 @@ def update_passport(machine_id: str):
     """
     Update a machine passport.
 
-    Requires admin authentication when ADMIN_KEY is configured.
+    Requires admin authentication.
     """
-    admin_key = request.headers.get('X-Admin-Key', '') or request.headers.get('X-API-Key', '')
-    expected_admin_key = os.environ.get('ADMIN_KEY', '')
+    auth_error = require_admin()
+    if auth_error is not None:
+        return auth_error
     
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
     
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
-    
-    if expected_admin_key and not hmac.compare_digest(admin_key, expected_admin_key):
-        return jsonify({
-            'ok': False,
-            'error': 'unauthorized',
-            'message': 'Admin key required',
-        }), 401
     
     data = request.get_json()
     if not data:

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -611,6 +611,60 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'unauthorized')
         self.assertEqual(data['message'], 'ADMIN_KEY not configured')
+
+    def test_mutating_subresources_fail_closed_without_admin_key(self):
+        """All passport subresource writes require configured admin auth."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+        self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json={
+                'name': 'Subresource Auth Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'subresource_auth_test',
+            },
+        )
+        os.environ.pop('ADMIN_KEY', None)
+
+        requests = [
+            (
+                '/api/machine-passport/subresource_auth_test/repair-log',
+                {
+                    'repair_type': 'unauthorized_repair',
+                    'description': 'should not be recorded',
+                },
+            ),
+            (
+                '/api/machine-passport/subresource_auth_test/attestations',
+                {'epoch': 1},
+            ),
+            (
+                '/api/machine-passport/subresource_auth_test/benchmarks',
+                {'compute_score': 123.4},
+            ),
+            (
+                '/api/machine-passport/subresource_auth_test/lineage',
+                {'event_type': 'transfer', 'to_owner': 'attacker_owner'},
+            ),
+        ]
+
+        for path, payload in requests:
+            with self.subTest(path=path):
+                resp = self.client.post(path, json=payload)
+                data = json.loads(resp.data)
+                self.assertEqual(resp.status_code, 401)
+                self.assertFalse(data['ok'])
+                self.assertEqual(data['error'], 'unauthorized')
+                self.assertEqual(data['message'], 'ADMIN_KEY not configured')
+
+        full_passport = json.loads(
+            self.client.get('/api/machine-passport/subresource_auth_test').data
+        )['passport']
+        self.assertEqual(full_passport['passport']['owner_miner_id'], 'miner_owner')
+        self.assertEqual(full_passport['repair_log'], [])
+        self.assertEqual(full_passport['attestation_history'], [])
+        self.assertEqual(full_passport['benchmark_signatures'], [])
+        self.assertEqual(full_passport['lineage_notes'], [])
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -500,8 +500,8 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertTrue(data['ok'])
         self.assertEqual(data['count'], 0)
     
-    def test_create_passport(self):
-        """Test creating a passport via API."""
+    def test_create_passport_fails_closed_without_admin_key(self):
+        """Passport creation is disabled when ADMIN_KEY is not configured."""
         passport_data = {
             'name': 'API Test',
             'owner_miner_id': 'miner_api',
@@ -512,26 +512,47 @@ class TestAPIEndpoints(unittest.TestCase):
         resp = self.client.post(
             '/api/machine-passport',
             json=passport_data,
-            # No admin key needed if ADMIN_KEY env var not set
         )
         data = json.loads(resp.data)
 
-        # Should succeed (no admin key required if ADMIN_KEY not set)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        self.assertEqual(data['message'], 'ADMIN_KEY not configured')
+
+    def test_create_passport_accepts_valid_admin_key(self):
+        """Configured admin key authorizes passport creation."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+        passport_data = {
+            'name': 'API Test',
+            'owner_miner_id': 'miner_api',
+            'architecture': 'TestArch',
+            'machine_id': 'api_test_001',  # Required field
+        }
+
+        resp = self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json=passport_data,
+        )
+        data = json.loads(resp.data)
+
         self.assertEqual(resp.status_code, 201)
         self.assertTrue(data['ok'])
         self.assertIn('machine_id', data)
 
     def test_update_passport_rejects_owner_claim_without_admin_key(self):
         """Client-supplied owner_miner_id is not proof of ownership."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
         self.client.post(
             '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
             json={
                 'name': 'Owner Claim Test',
                 'owner_miner_id': 'miner_owner',
                 'machine_id': 'owner_claim_test',
             },
         )
-        os.environ['ADMIN_KEY'] = 'expected-admin-key'
 
         with patch('hmac.compare_digest', return_value=False) as compare_digest:
             resp = self.client.put(
@@ -547,7 +568,7 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 401)
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'unauthorized')
-        compare_digest.assert_called_once_with('wrong-admin-key', 'expected-admin-key')
+        compare_digest.assert_called_once_with(b'wrong-admin-key', b'expected-admin-key')
 
         get_resp = self.client.get('/api/machine-passport/owner_claim_test')
         passport = json.loads(get_resp.data)['passport']['passport']
@@ -555,15 +576,16 @@ class TestAPIEndpoints(unittest.TestCase):
 
     def test_update_passport_accepts_valid_admin_key(self):
         """Configured admin key still authorizes passport updates."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
         self.client.post(
             '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
             json={
                 'name': 'Admin Update Test',
                 'owner_miner_id': 'miner_owner',
                 'machine_id': 'admin_update_test',
             },
         )
-        os.environ['ADMIN_KEY'] = 'expected-admin-key'
 
         with patch('hmac.compare_digest', return_value=True) as compare_digest:
             resp = self.client.put(
@@ -575,7 +597,20 @@ class TestAPIEndpoints(unittest.TestCase):
         data = json.loads(resp.data)
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
-        compare_digest.assert_called_once_with('expected-admin-key', 'expected-admin-key')
+        compare_digest.assert_called_once_with(b'expected-admin-key', b'expected-admin-key')
+
+    def test_update_passport_fails_closed_without_admin_key(self):
+        """Passport updates fail closed before resource lookup when ADMIN_KEY is missing."""
+        resp = self.client.put(
+            '/api/machine-passport/admin_update_test',
+            json={'name': 'Unauthorized Rename'},
+        )
+
+        data = json.loads(resp.data)
+        self.assertEqual(resp.status_code, 401)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'unauthorized')
+        self.assertEqual(data['message'], 'ADMIN_KEY not configured')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""

--- a/tests/test_machine_passport_event_json_validation.py
+++ b/tests/test_machine_passport_event_json_validation.py
@@ -11,6 +11,9 @@ sys.path.insert(0, str(REPO_ROOT / "node"))
 import machine_passport_api
 
 
+ADMIN_HEADERS = {"X-Admin-Key": "expected-admin-key"}
+
+
 class LedgerStub:
     def __init__(self):
         self.attestation_payload = None
@@ -36,7 +39,8 @@ def ledger(monkeypatch):
 
 
 @pytest.fixture
-def client(ledger):
+def client(ledger, monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
     app = Flask(__name__)
     app.register_blueprint(machine_passport_api.machine_passport_bp)
     return app.test_client()
@@ -50,7 +54,7 @@ def client(ledger):
     ),
 )
 def test_event_routes_reject_non_object_json(client, path):
-    response = client.post(path, json=["not", "object"])
+    response = client.post(path, headers=ADMIN_HEADERS, json=["not", "object"])
 
     assert response.status_code == 400
     assert response.get_json() == {
@@ -61,7 +65,10 @@ def test_event_routes_reject_non_object_json(client, path):
 
 
 def test_attestation_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/attestations")
+    response = client.post(
+        "/api/machine-passport/machine-1/attestations",
+        headers=ADMIN_HEADERS,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "attestation added"}
@@ -70,7 +77,10 @@ def test_attestation_route_preserves_empty_body_defaults(client, ledger):
 
 
 def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
-    response = client.post("/api/machine-passport/machine-1/benchmarks")
+    response = client.post(
+        "/api/machine-passport/machine-1/benchmarks",
+        headers=ADMIN_HEADERS,
+    )
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "message": "benchmark added"}
@@ -81,6 +91,7 @@ def test_benchmark_route_preserves_empty_body_defaults(client, ledger):
 def test_benchmark_route_accepts_object_json(client, ledger):
     response = client.post(
         "/api/machine-passport/machine-1/benchmarks",
+        headers=ADMIN_HEADERS,
         json={"compute_score": 1250.0, "memory_bandwidth": 3200.5},
     )
 


### PR DESCRIPTION
## Summary
- fixes #4878 by requiring a configured `ADMIN_KEY` before machine passport create/update routes can mutate state
- moves update auth before passport lookup so unauthenticated callers cannot probe resource existence
- compares UTF-8 encoded header/key bytes with `hmac.compare_digest()`
- updates API regressions for fail-closed create/update behavior and valid-admin success

## Validation
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile node/machine_passport_api.py node/tests/test_machine_passport.py tests/test_machine_passport_event_json_validation.py`
- `uv run --no-project --with pytest --with flask --with qrcode --with reportlab python -m pytest node/tests/test_machine_passport.py tests/test_machine_passport_event_json_validation.py -q` -> 33 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID for bounty payout: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`

No live node or production passport mutation was performed.