### PR TITLE
fix: fail closed webhook admin api

### DIFF
--- a/tests/test_webhook_admin_auth.py
+++ b/tests/test_webhook_admin_auth.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+
+import json
+import sys
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
+from http.server import HTTPServer
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "webhooks"))
+
+import webhook_server
+
+
+@contextmanager
+def webhook_admin_server(tmp_path, admin_key):
+    store = webhook_server.SubscriberStore(str(tmp_path / "webhooks.db"))
+
+    class TestWebhookAdminHandler(webhook_server.WebhookAdminHandler):
+        pass
+
+    TestWebhookAdminHandler.store = store
+    TestWebhookAdminHandler.ADMIN_API_KEY = admin_key
+
+    server = HTTPServer(("127.0.0.1", 0), TestWebhookAdminHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}", store
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+
+def request_json(base_url, method, path, body=None, headers=None):
+    data = None if body is None else json.dumps(body).encode()
+    req = urllib.request.Request(
+        base_url + path,
+        data=data,
+        method=method,
+        headers={
+            "Content-Type": "application/json",
+            **(headers or {}),
+        },
+    )
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        with opener.open(req, timeout=5) as response:
+            payload = json.loads(response.read().decode())
+            return response.status, payload
+    except urllib.error.HTTPError as exc:
+        payload = json.loads(exc.read().decode())
+        return exc.code, payload
+
+
+def test_webhook_admin_fails_closed_when_key_unconfigured(tmp_path):
+    with webhook_admin_server(tmp_path, admin_key="") as (base_url, store):
+        status, payload = request_json(
+            base_url,
+            "POST",
+            "/webhooks/subscribe",
+            {"id": "sub-1", "url": "https://hooks.example/event"},
+        )
+
+        assert status == 503
+        assert payload == {"error": "WEBHOOK_ADMIN_API_KEY not configured"}
+        assert store.list_all() == []
+
+
+def test_webhook_health_remains_public_when_key_unconfigured(tmp_path):
+    with webhook_admin_server(tmp_path, admin_key="") as (base_url, _store):
+        status, payload = request_json(base_url, "GET", "/health")
+
+        assert status == 200
+        assert payload == {"status": "ok"}
+
+
+def test_webhook_admin_requires_configured_key(tmp_path, monkeypatch):
+    monkeypatch.setattr(webhook_server, "validate_webhook_url", lambda _url: None)
+
+    with webhook_admin_server(tmp_path, admin_key="expected-admin") as (base_url, store):
+        status, payload = request_json(
+            base_url,
+            "POST",
+            "/webhooks/subscribe",
+            {"id": "sub-1", "url": "https://hooks.example/event"},
+        )
+        assert status == 401
+        assert payload == {"error": "invalid or missing API key"}
+
+        status, payload = request_json(
+            base_url,
+            "POST",
+            "/webhooks/subscribe",
+            {"id": "sub-1", "url": "https://hooks.example/event"},
+            headers={"X-Admin-API-Key": "expected-admin"},
+        )
+        assert status == 201
+        assert payload["message"] == "subscribed"
+        assert [sub.id for sub in store.list_all()] == ["sub-1"]

--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -522,7 +522,8 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
     # FIX(#2867 M3): Authenticate admin API requests
     def _check_api_key(self) -> bool:
         if not self.ADMIN_API_KEY:
-            return True  # No key configured — allow (development mode)
+            self._send_json(503, {"error": "WEBHOOK_ADMIN_API_KEY not configured"})
+            return False
         provided = self.headers.get("X-Admin-API-Key", "")
         if not hmac.compare_digest(provided, self.ADMIN_API_KEY):
             self._send_json(401, {"error": "invalid or missing API key"})
@@ -530,9 +531,11 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
         return True
 
     def do_GET(self):
-        if not self._check_api_key():
+        if self.path == "/health":
+            self._send_json(200, {"status": "ok"})
+        elif not self._check_api_key():
             return
-        if self.path == "/webhooks":
+        elif self.path == "/webhooks":
             subs = self.store.list_all()
             self._send_json(200, {
                 "subscribers": [
@@ -544,8 +547,6 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
                     for s in subs
                 ],
             })
-        elif self.path == "/health":
-            self._send_json(200, {"status": "ok"})
         else:
             self._send_json(404, {"error": "not found"})
 


### PR DESCRIPTION
## Summary
- fixes #4785 by making webhook admin routes fail closed when `WEBHOOK_ADMIN_API_KEY` is unset
- keeps `/health` public for monitoring
- adds local HTTPServer regression coverage for unconfigured-key rejection, public health, and configured-key enforcement

## Validation
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile tools/webhooks/webhook_server.py tests/test_webhook_admin_auth.py`
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_webhook_admin_auth.py -q` -> 3 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID for bounty payout: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`

Tests use a local 127.0.0.1 HTTPServer and temporary SQLite database only; no external webhook target was contacted.