### PR TITLE
Secure Rent-a-Relic completion route

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -35,16 +35,23 @@ from tools.rent_a_relic.models import (
 )
 from tools.rent_a_relic.provenance import generate_receipt, verify_receipt
 
+ADMIN_KEY = "test-admin-key"
+
 
 @pytest.fixture()
-def app(tmp_path):
+def app(tmp_path, monkeypatch):
     from tools.rent_a_relic import server
     db_file = str(tmp_path / "test_relic.db")
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
     server.app.config["TESTING"] = True
     server.app.config["DB_PATH"]  = db_file
     server.init_db()
     with server.app.test_client() as client:
         yield client
+
+
+def admin_headers(key: str = ADMIN_KEY) -> dict[str, str]:
+    return {"X-Admin-Key": key}
 
 
 @pytest.fixture()
@@ -149,7 +156,8 @@ class TestReservationFlow:
         })
         assert r.status_code == 201
         cr = app.post(f"/relic/complete/{r.json['session_id']}",
-                      json={"output_hash": hashlib.sha256(b"output").hexdigest()})
+                      json={"output_hash": hashlib.sha256(b"output").hexdigest()},
+                      headers=admin_headers())
         assert cr.status_code == 200
         assert cr.json["status"] == "completed"
 
@@ -160,9 +168,67 @@ class TestReservationFlow:
         })
         assert r.status_code == 201
 
-        cr = app.post(f"/relic/complete/{r.json['session_id']}", json=["not", "object"])
+        cr = app.post(f"/relic/complete/{r.json['session_id']}", json=["not", "object"],
+                      headers=admin_headers())
         assert cr.status_code == 400
         assert cr.json["error"] == "JSON object required"
+
+    def test_complete_requires_admin_key_and_preserves_escrow(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_no_admin", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        sid = r.json["session_id"]
+
+        cr = app.post(f"/relic/complete/{sid}")
+        sr = app.get(f"/relic/reservation/{sid}")
+
+        assert cr.status_code == 401
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
+    def test_complete_rejects_wrong_admin_key_and_preserves_escrow(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_bad_admin", "machine_id": "g5-dual",
+            "duration_hours": 1, "rtc_amount": 8.0,
+        })
+        sid = r.json["session_id"]
+
+        cr = app.post(f"/relic/complete/{sid}", headers=admin_headers("wrong-key"))
+        sr = app.get(f"/relic/reservation/{sid}")
+
+        assert cr.status_code == 401
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
+    def test_complete_rejects_non_ascii_admin_key_without_crashing(self, app):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_non_ascii_admin", "machine_id": "alpha-ds20",
+            "duration_hours": 1, "rtc_amount": 7.0,
+        })
+        sid = r.json["session_id"]
+
+        cr = app.post(f"/relic/complete/{sid}", headers=admin_headers("\u00e9"))
+        sr = app.get(f"/relic/reservation/{sid}")
+
+        assert cr.status_code == 401
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
+    def test_complete_fails_closed_when_admin_key_unconfigured(self, app, monkeypatch):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_unconfigured_admin", "machine_id": "sparc-ultra",
+            "duration_hours": 1, "rtc_amount": 6.0,
+        })
+        sid = r.json["session_id"]
+        monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+        cr = app.post(f"/relic/complete/{sid}", headers=admin_headers())
+        sr = app.get(f"/relic/reservation/{sid}")
+
+        assert cr.status_code == 503
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
 
     def test_status_endpoint(self, app):
         r = app.post("/relic/reserve", json={
@@ -218,7 +284,7 @@ class TestEscrow:
             "duration_hours": 1, "rtc_amount": 10.0,
         })
         sid = r.json["session_id"]
-        app.post(f"/relic/complete/{sid}")
+        app.post(f"/relic/complete/{sid}", headers=admin_headers())
         sr = app.get(f"/relic/reservation/{sid}")
         assert sr.json["escrow"]["status"] == "released"
         assert sr.json["escrow"]["release_reason"] == "completed"
@@ -327,7 +393,7 @@ class TestLeaderboard:
                 "duration_hours": 1, "rtc_amount": 5.0,
             })
             if r.status_code == 201:
-                app.post(f"/relic/complete/{r.json['session_id']}")
+                app.post(f"/relic/complete/{r.json['session_id']}", headers=admin_headers())
         ranks = [e["rank"] for e in app.get("/relic/leaderboard").json["leaderboard"]]
         assert ranks == sorted(ranks)
 

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -18,6 +18,8 @@ RTC escrow: locked on reserve, released on completion or timeout.
 from __future__ import annotations
 
 import hashlib
+import hmac
+import os
 import sqlite3
 import time
 import uuid
@@ -53,6 +55,17 @@ def _get_json_object_or_empty() -> dict:
     if not isinstance(data, dict):
         abort(400, description="JSON object required")
     return data
+
+
+def _require_admin_key() -> None:
+    """Require an admin key before privileged reservation state changes."""
+    expected = os.environ.get("RC_ADMIN_KEY", "")
+    if not expected:
+        abort(503, description="RC_ADMIN_KEY not configured")
+
+    provided = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
+    if not hmac.compare_digest(provided.encode("utf-8"), expected.encode("utf-8")):
+        abort(401, description="invalid admin key")
 
 
 @contextmanager
@@ -425,6 +438,7 @@ def get_reservation(session_id: str):
 @app.post("/relic/complete/<session_id>")
 def post_complete(session_id: str):
     """Mark a session as completed and release escrow."""
+    _require_admin_key()
     data        = _get_json_object_or_empty()
     output_hash = data.get("output_hash") or hashlib.sha256(session_id.encode()).hexdigest()
 
@@ -457,9 +471,11 @@ def post_complete(session_id: str):
 
 
 @app.errorhandler(400)
+@app.errorhandler(401)
 @app.errorhandler(404)
 @app.errorhandler(409)
 @app.errorhandler(500)
+@app.errorhandler(503)
 def handle_error(e):
     return jsonify({"error": str(e.description), "code": e.code}), e.code
 


### PR DESCRIPTION
Fixes #4762.\n\n## Summary\n- require RC_ADMIN_KEY before POST /relic/complete parses the request body or mutates reservation/escrow state\n- compare provided admin credentials as UTF-8 bytes with hmac.compare_digest, so malformed/non-ASCII header values return controlled 401 responses instead of 500s\n- fail closed with 503 when RC_ADMIN_KEY is unset and preserve locked escrow on unauthorized attempts\n\n## Validation\n- python -m pytest tests\\test_rent_a_relic.py -q -> 37 passed\n- python -m py_compile tools\\rent_a_relic\\server.py tests\\test_rent_a_relic.py\n- git diff --check\n- python tools\\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK\n\nNo production testing or live-target probing was performed.