### PR TITLE
fix: validate antiquity score inputs

### DIFF
--- a/rips/rustchain-core/tests/test_validator_score_input_validation.py
+++ b/rips/rustchain-core/tests/test_validator_score_input_validation.py
@@ -1,0 +1,71 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_score_module():
+    root = Path(__file__).resolve().parents[1]
+    package = "rustchain_core_under_test"
+
+    for name, path in (
+        (package, root),
+        (f"{package}.config", root / "config"),
+        (f"{package}.validator", root / "validator"),
+    ):
+        module = sys.modules.get(name)
+        if module is None:
+            module = types.ModuleType(name)
+            module.__path__ = [str(path)]
+            sys.modules[name] = module
+
+    module_name = f"{package}.validator.score"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        root / "validator" / "score.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+score = _load_score_module()
+
+
+def test_unknown_hardware_claim_fails_closed():
+    valid, message = score.validate_hardware_claim("QuantumCPU-9000", 1992)
+
+    assert valid is False
+    assert "Unknown hardware" in message
+
+
+def test_impossible_release_year_gets_no_antiquity_score():
+    valid, message = score.validate_hardware_claim("486DX2", 0)
+
+    assert valid is False
+    assert "Invalid release year" in message
+    assert score.calculate_antiquity_score(0, 365) == 0.0
+
+
+def test_negative_uptime_does_not_crash_and_scores_zero():
+    assert score.calculate_antiquity_score(1992, -1) == 0.0
+
+
+def test_known_hardware_still_validates_and_scores():
+    valid, message = score.validate_hardware_claim("IBM 486DX2", 1992)
+
+    assert valid is True
+    assert "Hardware validated" in message
+    assert score.calculate_antiquity_score(1992, 365) > 0
+
+
+def test_validator_rejects_invalid_uptime_without_exception():
+    validator = score.HardwareValidator()
+    hardware = score.HardwareInfo("486DX2", 1992, -1)
+
+    result = validator.validate_miner("RTC-test-wallet", hardware)
+
+    assert result["eligible"] is False
+    assert "below minimum" in result["errors"][0]

--- a/rips/rustchain-core/validator/score.py
+++ b/rips/rustchain-core/validator/score.py
@@ -80,6 +80,8 @@ HARDWARE_DATABASE: Dict[str, Dict[str, Any]] = {
     "Apple M3": {"year": 2023, "family": "arm", "arch": "Apple Silicon"},
 }
 
+MIN_VALID_RELEASE_YEAR = 1970
+
 
 # =============================================================================
 # Hardware Validation
@@ -127,6 +129,17 @@ def validate_hardware_claim(model: str, claimed_year: int) -> Tuple[bool, str]:
     Returns:
         (valid, message) tuple
     """
+    if (
+        not isinstance(claimed_year, int)
+        or isinstance(claimed_year, bool)
+        or claimed_year < MIN_VALID_RELEASE_YEAR
+        or claimed_year > CURRENT_YEAR
+    ):
+        return (
+            False,
+            f"Invalid release year {claimed_year}; expected {MIN_VALID_RELEASE_YEAR}-{CURRENT_YEAR}",
+        )
+
     # Check if model is in database
     for known_model, info in HARDWARE_DATABASE.items():
         if known_model.lower() in model.lower():
@@ -137,8 +150,8 @@ def validate_hardware_claim(model: str, claimed_year: int) -> Tuple[bool, str]:
             else:
                 return False, f"Year mismatch: claimed {claimed_year}, actual {actual_year}"
 
-    # Unknown hardware - allow with warning
-    return True, f"Unknown hardware: {model} - accepting claimed year {claimed_year}"
+    # Unknown hardware cannot earn high antiquity from a self-reported year.
+    return False, f"Unknown hardware: {model} - cannot validate claimed year {claimed_year}"
 
 
 # =============================================================================
@@ -156,6 +169,21 @@ def calculate_antiquity_score(release_year: int, uptime_days: int) -> float:
     - Node reliability (uptime)
     - NOT computational speed
     """
+    if (
+        not isinstance(release_year, int)
+        or isinstance(release_year, bool)
+        or release_year < MIN_VALID_RELEASE_YEAR
+        or release_year > CURRENT_YEAR
+    ):
+        return 0.0
+
+    if (
+        not isinstance(uptime_days, int)
+        or isinstance(uptime_days, bool)
+        or uptime_days < 0
+    ):
+        return 0.0
+
     age = max(0, CURRENT_YEAR - release_year)
     uptime_factor = math.log10(uptime_days + 1)
     return age * uptime_factor


### PR DESCRIPTION
Fixes #4844
Fixes #4845

## Summary

- fail closed for unknown hardware models instead of accepting self-reported release years
- reject impossible release years before they can create inflated Antiquity Scores
- make invalid uptime inputs return a zero score instead of raising `math domain error`
- add focused regression coverage for unknown hardware, impossible release years, negative uptime, and a known valid hardware path

## Why

`calculate_antiquity_score(0, 365)` previously returned an absurdly high score, and `calculate_antiquity_score(1992, -1)` raised `ValueError`. `validate_hardware_claim()` also accepted arbitrary unknown hardware models with attacker-chosen years. Together, those paths could distort validator/governance scoring.

## Validation

- `python -m py_compile rips\rustchain-core\validator\score.py rips\rustchain-core\tests\test_validator_score_input_validation.py`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest rips\rustchain-core\tests\test_validator_score_input_validation.py -q` -> 5 passed
- `git diff --check origin/main...HEAD -- rips/rustchain-core/validator/score.py rips/rustchain-core/tests/test_validator_score_input_validation.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Wallet/miner ID for bounty processing: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`

GitHub handle for tagging: @galpetame
