### PR TITLE
fix: preserve contributor database on init

### DIFF
--- a/init_contributor_db.py
+++ b/init_contributor_db.py
@@ -1,25 +1,40 @@
 # SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
 
 import sqlite3
-import os
 from datetime import datetime
 
 DB_PATH = 'contributors.db'
 
+
+CONTRIBUTOR_COLUMN_MIGRATIONS = {
+    'roles': "TEXT DEFAULT ''",
+    'payment_status': "TEXT DEFAULT 'pending'",
+    'created_at': "TEXT DEFAULT ''",
+    'updated_at': "TEXT DEFAULT ''",
+}
+
+
+def _existing_columns(cursor, table_name):
+    cursor.execute(f'PRAGMA table_info({table_name})')
+    return {row[1] for row in cursor.fetchall()}
+
+
+def _ensure_contributor_columns(cursor):
+    columns = _existing_columns(cursor, 'contributors')
+    for column_name, column_definition in CONTRIBUTOR_COLUMN_MIGRATIONS.items():
+        if column_name not in columns:
+            cursor.execute(f'ALTER TABLE contributors ADD COLUMN {column_name} {column_definition}')
+
+
 def init_contributor_database():
     """Initialize the contributors database with proper schema"""
-    
-    # Remove existing database if it exists
-    if os.path.exists(DB_PATH):
-        os.remove(DB_PATH)
-    
+
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
-        
+
         # Create contributors table
         cursor.execute('''
-        CREATE TABLE contributors (
+        CREATE TABLE IF NOT EXISTS contributors (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             github_username TEXT UNIQUE NOT NULL,
             contributor_type TEXT NOT NULL CHECK (contributor_type IN ('human', 'bot', 'agent')),
@@ -31,15 +46,16 @@ def init_contributor_database():
             updated_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
         ''')
-        
+        _ensure_contributor_columns(cursor)
+
         # Create index for faster lookups
-        cursor.execute('CREATE INDEX idx_github_username ON contributors(github_username)')
-        cursor.execute('CREATE INDEX idx_payment_status ON contributors(payment_status)')
-        cursor.execute('CREATE INDEX idx_registration_date ON contributors(registration_date)')
-        
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_github_username ON contributors(github_username)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_payment_status ON contributors(payment_status)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_registration_date ON contributors(registration_date)')
+
         # Create contributions tracking table
         cursor.execute('''
-        CREATE TABLE contributions (
+        CREATE TABLE IF NOT EXISTS contributions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             contributor_id INTEGER NOT NULL,
             repo_name TEXT NOT NULL,
@@ -52,10 +68,10 @@ def init_contributor_database():
             FOREIGN KEY (contributor_id) REFERENCES contributors (id) ON DELETE CASCADE
         )
         ''')
-        
+
         # Create payment history table
         cursor.execute('''
-        CREATE TABLE payment_history (
+        CREATE TABLE IF NOT EXISTS payment_history (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             contributor_id INTEGER NOT NULL,
             amount REAL NOT NULL,
@@ -66,7 +82,7 @@ def init_contributor_database():
             FOREIGN KEY (contributor_id) REFERENCES contributors (id) ON DELETE CASCADE
         )
         ''')
-        
+
         conn.commit()
         print(f"Database initialized successfully at {DB_PATH}")
 
@@ -74,27 +90,27 @@ def add_contributor(github_username, contributor_type, rtc_wallet, roles=''):
     """Add a new contributor to the database"""
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
-        
+
         registration_date = datetime.now().isoformat()
-        
+
         try:
             cursor.execute('''
             INSERT INTO contributors (github_username, contributor_type, rtc_wallet, roles, registration_date)
             VALUES (?, ?, ?, ?, ?)
             ''', (github_username, contributor_type, rtc_wallet, roles, registration_date))
-            
+
             contributor_id = cursor.lastrowid
-            
+
             # Add initial registration payment record
             cursor.execute('''
             INSERT INTO payment_history (contributor_id, amount, transaction_type)
             VALUES (?, 5.0, 'registration_bonus')
             ''', (contributor_id,))
-            
+
             conn.commit()
             print(f"Added contributor {github_username} with ID {contributor_id}")
             return contributor_id
-            
+
         except sqlite3.IntegrityError:
             print(f"Error: Contributor {github_username} already exists")
             return None
@@ -103,30 +119,30 @@ def get_contributor_stats():
     """Get basic statistics about contributors"""
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
-        
+
         cursor.execute('SELECT COUNT(*) FROM contributors')
         total = cursor.fetchone()[0]
-        
+
         cursor.execute('SELECT COUNT(*) FROM contributors WHERE payment_status = "paid"')
         paid = cursor.fetchone()[0]
-        
+
         cursor.execute('SELECT COUNT(*) FROM contributors WHERE payment_status = "pending"')
         pending = cursor.fetchone()[0]
-        
+
         return {'total': total, 'paid': paid, 'pending': pending}
 
 if __name__ == '__main__':
     init_contributor_database()
-    
+
     # Add some test data
     test_contributors = [
         ('scottcjn', 'human', 'RTC_wallet_example_123', 'maintainer,founder'),
         ('test_bot', 'bot', 'RTC_wallet_bot_456', 'automation'),
         ('ai_agent', 'agent', 'RTC_wallet_agent_789', 'analysis')
     ]
-    
+
     for username, ctype, wallet, roles in test_contributors:
         add_contributor(username, ctype, wallet, roles)
-    
+
     stats = get_contributor_stats()
     print(f"Database stats: {stats}")

--- a/tests/test_init_contributor_db.py
+++ b/tests/test_init_contributor_db.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sqlite3
 
 import init_contributor_db as contributor_db

--- a/tests/test_init_contributor_db.py
+++ b/tests/test_init_contributor_db.py
@@ -1,0 +1,84 @@
+import sqlite3
+
+import init_contributor_db as contributor_db
+
+
+def table_columns(db_path, table_name):
+    with sqlite3.connect(db_path) as conn:
+        return {
+            row[1]
+            for row in conn.execute(f'PRAGMA table_info({table_name})').fetchall()
+        }
+
+
+def test_init_contributor_database_preserves_existing_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / 'contributors.db'
+    monkeypatch.setattr(contributor_db, 'DB_PATH', str(db_path))
+
+    contributor_db.init_contributor_database()
+    contributor_id = contributor_db.add_contributor(
+        'existing-user',
+        'human',
+        'RTC0123456789abcdef0123456789abcdef01234567',
+        'maintainer',
+    )
+
+    contributor_db.init_contributor_database()
+
+    with sqlite3.connect(db_path) as conn:
+        contributor = conn.execute(
+            'SELECT github_username, rtc_wallet FROM contributors WHERE id = ?',
+            (contributor_id,),
+        ).fetchone()
+        payment = conn.execute(
+            'SELECT amount, transaction_type FROM payment_history WHERE contributor_id = ?',
+            (contributor_id,),
+        ).fetchone()
+
+    assert contributor == ('existing-user', 'RTC0123456789abcdef0123456789abcdef01234567')
+    assert payment == (5.0, 'registration_bonus')
+
+
+def test_init_contributor_database_migrates_legacy_contributors_table(tmp_path, monkeypatch):
+    db_path = tmp_path / 'contributors.db'
+    monkeypatch.setattr(contributor_db, 'DB_PATH', str(db_path))
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute('''
+        CREATE TABLE contributors (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            github_username TEXT UNIQUE NOT NULL,
+            contributor_type TEXT NOT NULL,
+            rtc_wallet TEXT NOT NULL,
+            registration_date TEXT NOT NULL
+        )
+        ''')
+        conn.execute(
+            '''
+            INSERT INTO contributors (github_username, contributor_type, rtc_wallet, registration_date)
+            VALUES (?, ?, ?, ?)
+            ''',
+            ('legacy-user', 'agent', 'RTCabcdef0123456789abcdef0123456789abcdef01', '2026-05-12T00:00:00'),
+        )
+        conn.commit()
+
+    contributor_db.init_contributor_database()
+
+    columns = table_columns(db_path, 'contributors')
+    assert {'roles', 'payment_status', 'created_at', 'updated_at'} <= columns
+
+    with sqlite3.connect(db_path) as conn:
+        contributor = conn.execute(
+            'SELECT github_username, payment_status FROM contributors WHERE github_username = ?',
+            ('legacy-user',),
+        ).fetchone()
+        contributions_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='contributions'"
+        ).fetchone()
+        payment_table = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='payment_history'"
+        ).fetchone()
+
+    assert contributor == ('legacy-user', 'pending')
+    assert contributions_table == ('contributions',)
+    assert payment_table == ('payment_history',)


### PR DESCRIPTION
## Summary
- make `init_contributor_database()` idempotent instead of deleting `contributors.db`
- use `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` for existing deployments
- add contributor-column migrations for legacy databases without dropping rows
- add regression tests proving contributor and payment records survive re-initialization

## Tests
- `python3 -m py_compile init_contributor_db.py`
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_init_contributor_db.py -q`
- `uv run --no-project --with ruff ruff check init_contributor_db.py tests/test_init_contributor_db.py`

Fixes #4913

wallet: dicnunz