### PR TITLE
fix: restrict keeper explorer proxy paths

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -24,12 +24,16 @@ import requests
 from flask import Flask, request, jsonify, render_template_string, send_from_directory
 from flask_cors import CORS
 from datetime import datetime
+from urllib.parse import quote
 
 # Configuration
 NODE_API = os.environ.get("RUSTCHAIN_NODE_API", "http://localhost:8000")
 FAUCET_DB = "faucet_service/faucet.db"
 PORT = 8095
 WALLET_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]{3,128}$")
+ALLOWED_PROXY_EXACT_PATHS = {"epoch", "headers/tip"}
+ALLOWED_PROXY_PREFIXES = ("headers/", "balance/")
+SAFE_RESPONSE_HEADERS = {"content-type", "cache-control", "etag", "last-modified"}
 
 app = Flask(__name__)
 CORS(app)
@@ -97,17 +101,35 @@ def home():
 
 @app.route('/api/proxy/<path:path>')
 def proxy_api(path):
-    """Proxy requests to the RustChain node."""
+    """Proxy only read-only explorer requests to the RustChain node."""
+    normalized_path = path.strip("/")
+    if (
+        not normalized_path
+        or "\\" in normalized_path
+        or ".." in normalized_path.split("/")
+        or not (
+            normalized_path in ALLOWED_PROXY_EXACT_PATHS
+            or any(normalized_path.startswith(prefix) for prefix in ALLOWED_PROXY_PREFIXES)
+        )
+    ):
+        return jsonify({"error": "Proxy path not allowed"}), 403
+
     try:
-        url = f"{NODE_API}/{path}"
-        # Keep query parameters
-        if request.query_string:
-            url += f"?{request.query_string.decode('utf-8')}"
-            
-        resp = requests.get(url, timeout=5)
-        return (resp.content, resp.status_code, resp.headers.items())
-    except Exception as e:
-        return jsonify({"error": f"Node Connection Error: {str(e)}"}), 502
+        encoded_path = "/".join(quote(part, safe="") for part in normalized_path.split("/"))
+        url = f"{NODE_API.rstrip('/')}/{encoded_path}"
+        params = request.args.to_dict(flat=False)
+        if params:
+            resp = requests.get(url, params=params, timeout=5)
+        else:
+            resp = requests.get(url, timeout=5)
+        safe_headers = [
+            (name, value)
+            for name, value in resp.headers.items()
+            if name.lower() in SAFE_RESPONSE_HEADERS
+        ]
+        return (resp.content, resp.status_code, safe_headers)
+    except requests.RequestException:
+        return jsonify({"error": "Node connection error"}), 502
 
 @app.route('/api/faucet/drip', methods=['POST'])
 def faucet_drip():
@@ -144,7 +166,7 @@ def faucet_drip():
 
 # --- Fossil-punk UI Template ---
 
-RETRO_HTML = """
+RETRO_HTML = r"""
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/test_keeper_explorer_faucet.py
+++ b/tests/test_keeper_explorer_faucet.py
@@ -3,6 +3,7 @@ import sqlite3
 import sys
 import types
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
@@ -74,3 +75,57 @@ def test_faucet_drip_records_valid_address(tmp_path, monkeypatch):
             "SELECT address, amount FROM faucet_claims"
         ).fetchone()
     assert row == ("rtc-test-wallet", 0.5)
+
+
+def test_proxy_blocks_unlisted_internal_paths(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    get = Mock()
+    monkeypatch.setattr(keeper.requests, "get", get)
+
+    response = keeper.app.test_client().get("/api/proxy/wallet/transfer")
+
+    assert response.status_code == 403
+    assert response.get_json() == {"error": "Proxy path not allowed"}
+    get.assert_not_called()
+
+
+def test_proxy_allows_read_only_paths_and_strips_internal_headers(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    upstream = types.SimpleNamespace(
+        content=b'{"height": 7}',
+        status_code=200,
+        headers={
+            "Content-Type": "application/json",
+            "Server": "internal-node",
+            "X-Powered-By": "Flask",
+        },
+    )
+    get = Mock(return_value=upstream)
+    monkeypatch.setattr(keeper.requests, "get", get)
+
+    response = keeper.app.test_client().get("/api/proxy/headers/tip?limit=1")
+
+    assert response.status_code == 200
+    assert response.data == b'{"height": 7}'
+    assert response.headers["Content-Type"] == "application/json"
+    assert "Server" not in response.headers
+    assert "X-Powered-By" not in response.headers
+    get.assert_called_once_with(
+        "http://localhost:8000/headers/tip",
+        params={"limit": ["1"]},
+        timeout=5,
+    )
+
+
+def test_proxy_returns_generic_error_for_node_failures(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    monkeypatch.setattr(
+        keeper.requests,
+        "get",
+        Mock(side_effect=keeper.requests.RequestException("localhost:8000 refused")),
+    )
+
+    response = keeper.app.test_client().get("/api/proxy/epoch")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Node connection error"}


### PR DESCRIPTION
## Summary
- Restricts `keeper_explorer.py` `/api/proxy/<path>` to a small read-only allowlist (`epoch`, `headers/*`, `balance/*`).
- Encodes path segments and passes query parameters via `requests` params instead of raw query-string concatenation.
- Strips internal upstream headers and returns a generic node error so internal details are not leaked.
- Adds regression coverage for blocked internal paths, safe read-only proxying, header stripping, and generic upstream failures.

## Proof
- `python -m pytest tests/test_keeper_explorer_faucet.py -q` -> `6 passed`
- `python -m py_compile keeper_explorer.py tests/test_keeper_explorer_faucet.py`
- `git diff --check`

Closes #4904

Wallet: `RTCd84b6e2d917d0272ecaae49f2f0dfe2f5474d585`