### PR TITLE
fix(#4901): accept RTC wallets in faucet service

### DIFF
--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -64,7 +64,9 @@ rate_limit:
 
 # Wallet validation
 validation:
-  required_prefix: "0x"
+  required_prefix:
+    - "0x"
+    - "RTC"
   min_length: 10
   max_length: 66
   blocklist: []
@@ -98,7 +100,7 @@ distribution:
 #### Validation
 | Option | Default | Description |
 |--------|---------|-------------|
-| `required_prefix` | `0x` | Required wallet prefix |
+| `required_prefix` | `["0x", "RTC"]` | Required wallet prefix or prefixes |
 | `min_length` | `10` | Minimum wallet length |
 | `max_length` | `66` | Maximum wallet length |
 | `blocklist` | `[]` | Blocked wallet addresses |
@@ -117,7 +119,7 @@ Request test tokens.
 **Request:**
 ```json
 {
-  "wallet": "0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E"
+  "wallet": "RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce"
 }
 ```
 
@@ -126,7 +128,7 @@ Request test tokens.
 {
   "ok": true,
   "amount": 0.5,
-  "wallet": "0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E",
+  "wallet": "RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce",
   "tx_hash": null,
   "next_available": "2026-03-13T14:20:00.000000"
 }

--- a/faucet_service/faucet_config.yaml
+++ b/faucet_service/faucet_config.yaml
@@ -34,8 +34,10 @@ rate_limit:
 
 # Wallet validation settings
 validation:
-  # Require wallet address to start with prefix
-  required_prefix: "0x"
+  # Require wallet address to start with one of these prefixes
+  required_prefix:
+    - "0x"
+    - "RTC"
   
   # Minimum wallet length (including prefix)
   min_length: 10

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -72,7 +72,7 @@ DEFAULT_CONFIG = {
         }
     },
     'validation': {
-        'required_prefix': '0x',
+        'required_prefix': ['0x', 'RTC'],
         'min_length': 10,
         'max_length': 66,
         'require_checksum': False,
@@ -358,9 +358,15 @@ class FaucetValidator:
         wallet = wallet.strip()
         
         # Check prefix
-        required_prefix = self.validation_config.get('required_prefix', '0x')
-        if required_prefix and not wallet.startswith(required_prefix):
-            return False, f"Wallet must start with '{required_prefix}'"
+        required_prefix = self.validation_config.get('required_prefix', ['0x', 'RTC'])
+        if isinstance(required_prefix, str):
+            accepted_prefixes = [required_prefix]
+        else:
+            accepted_prefixes = list(required_prefix or [])
+
+        if accepted_prefixes and not any(wallet.startswith(prefix) for prefix in accepted_prefixes):
+            joined_prefixes = "', '".join(accepted_prefixes)
+            return False, f"Wallet must start with one of '{joined_prefixes}'"
         
         # Check length
         min_len = self.validation_config.get('min_length', 10)
@@ -522,7 +528,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         Handle drip requests.
         
         Request body:
-            {"wallet": "0x..."}
+            {"wallet": "0x..."} or {"wallet": "RTC..."}
         
         Response:
             {"ok": true, "amount": 0.5, "wallet": "...", "next_available": "..."}
@@ -889,7 +895,7 @@ HTML_TEMPLATE = """
                 <div class="form-group">
                     <label for="wallet">Your RTC Wallet Address</label>
                     <input type="text" id="wallet" name="wallet" 
-                           placeholder="0xYourWalletAddress" required>
+                           placeholder="RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce" required>
                 </div>
                 <button type="submit" id="submitBtn">Request Test RTC</button>
             </form>

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -106,6 +106,12 @@ class TestFaucetValidator(unittest.TestCase):
         valid, error = self.validator.validate_wallet('0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E')
         self.assertTrue(valid)
         self.assertIsNone(error)
+
+    def test_valid_native_rtc_wallet(self):
+        """Default config accepts native RTC wallet addresses."""
+        valid, error = self.validator.validate_wallet('RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce')
+        self.assertTrue(valid)
+        self.assertIsNone(error)
     
     def test_empty_wallet(self):
         """Test empty wallet address."""
@@ -127,6 +133,16 @@ class TestFaucetValidator(unittest.TestCase):
         valid, error = validator.validate_wallet('9683744B6b94F2b0966aBDb8C6BdD9805d207c6E')
         self.assertFalse(valid)
         self.assertIn("must start with", error)
+
+    def test_multiple_required_prefixes_rejects_unknown_prefix(self):
+        """List-style required_prefix rejects unsupported wallet prefixes."""
+        self.config['validation']['required_prefix'] = ['0x', 'RTC']
+        validator = FaucetValidator(self.config, self.logger)
+
+        valid, error = validator.validate_wallet('bc1qw5s80n4aqmrt95p6p9psf4q4echqye6279d36u')
+        self.assertFalse(valid)
+        self.assertIn("0x", error)
+        self.assertIn("RTC", error)
     
     def test_too_short(self):
         """Test wallet that is too short."""


### PR DESCRIPTION
Fixes #4901

## Summary

- accept native `RTC...` wallets in `faucet_service` while preserving legacy `0x...` support
- keep backwards compatibility with existing string-valued `required_prefix` configs and add list-style prefix support for multiple accepted wallet families
- update the faucet config, docs, and UI placeholder so native RTC wallets are first-class
- add focused validator coverage for native RTC acceptance and unsupported prefix rejection

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest faucet_service\test_faucet_service.py -q` -> 35 passed
- `python -m py_compile faucet_service\faucet_service.py faucet_service\test_faucet_service.py`
- `git diff --check -- faucet_service\faucet_service.py faucet_service\test_faucet_service.py faucet_service\faucet_config.yaml faucet_service\README.md`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No live faucet, production wallet, or destructive testing was performed.

Wallet/miner ID for bounty processing: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`

GitHub handle for tagging: @galpetame