### PR TITLE
fix: require admin auth for payout ledger routes

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -12,6 +12,7 @@ import sqlite3
 import uuid
 import json
 import logging
+import hmac
 from flask import request, jsonify, render_template_string
 
 logger = logging.getLogger(__name__)
@@ -167,12 +168,31 @@ def ledger_summary():
     return {r[0]: {"count": r[1], "total_rtc": r[2]} for r in rows}
 
 
+def _require_admin():
+    """Require configured admin auth before exposing payout ledger state."""
+    expected_admin_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not expected_admin_key:
+        return jsonify({"error": "RC_ADMIN_KEY not configured"}), 503
+
+    provided_admin_key = request.headers.get("X-Admin-Key", "")
+    if not hmac.compare_digest(
+        provided_admin_key.encode("utf-8"),
+        expected_admin_key.encode("utf-8"),
+    ):
+        return jsonify({"error": "unauthorized"}), 401
+
+    return None
+
+
 # ── Flask route registration ───────────────────────────────────
 def register_ledger_routes(app):
     """Register /ledger/* routes on the given Flask app."""
 
     @app.route("/ledger")
     def ledger_page():
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         status_filter = request.args.get("status")
         records = ledger_list(status=status_filter)
@@ -181,6 +201,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["GET"])
     def api_ledger_list():
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         status = request.args.get("status")
         contributor = request.args.get("contributor")
@@ -189,6 +212,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>", methods=["GET"])
     def api_ledger_get(record_id):
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         record = ledger_get(record_id)
         if not record:
@@ -197,6 +223,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["POST"])
     def api_ledger_create():
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         required = ["bounty_id", "contributor", "amount_rtc"]
@@ -216,6 +245,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
     def api_ledger_update(record_id):
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         new_status = data.get("status")
@@ -233,6 +265,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/summary", methods=["GET"])
     def api_ledger_summary():
+        auth_error = _require_admin()
+        if auth_error is not None:
+            return auth_error
         init_payout_ledger_tables()
         return jsonify(ledger_summary())
 

--- a/tests/test_payout_ledger_admin_auth.py
+++ b/tests/test_payout_ledger_admin_auth.py
@@ -1,0 +1,107 @@
+from flask import Flask
+
+import payout_ledger
+
+
+ADMIN_HEADERS = {"X-Admin-Key": "expected-admin-key"}
+
+
+def make_client(tmp_path, monkeypatch):
+    db_path = tmp_path / "payout-ledger.db"
+    monkeypatch.setattr(payout_ledger, "DB_PATH", str(db_path))
+    app = Flask(__name__)
+    payout_ledger.register_ledger_routes(app)
+    return app.test_client(), db_path
+
+
+def test_ledger_routes_fail_closed_before_table_init_when_admin_key_unset(
+    tmp_path, monkeypatch
+):
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, db_path = make_client(tmp_path, monkeypatch)
+
+    routes = [
+        ("GET", "/ledger", None),
+        ("GET", "/api/ledger", None),
+        ("GET", "/api/ledger/record-1", None),
+        ("GET", "/api/ledger/summary", None),
+        (
+            "POST",
+            "/api/ledger",
+            {"bounty_id": "bounty-1", "contributor": "alice", "amount_rtc": 5},
+        ),
+        ("PATCH", "/api/ledger/record-1/status", {"status": "confirmed"}),
+    ]
+
+    for method, path, payload in routes:
+        response = client.open(path, method=method, json=payload)
+        assert response.status_code == 503
+        assert response.get_json() == {"error": "RC_ADMIN_KEY not configured"}
+
+    assert not db_path.exists()
+
+
+def test_wrong_admin_key_does_not_create_or_update_payout_records(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+    client, db_path = make_client(tmp_path, monkeypatch)
+
+    denied_create = client.post(
+        "/api/ledger",
+        headers={"X-Admin-Key": "wrong-admin-key"},
+        json={"bounty_id": "bounty-1", "contributor": "alice", "amount_rtc": 5},
+    )
+    assert denied_create.status_code == 401
+    assert denied_create.get_json() == {"error": "unauthorized"}
+    assert not db_path.exists()
+
+    created = client.post(
+        "/api/ledger",
+        headers=ADMIN_HEADERS,
+        json={"bounty_id": "bounty-1", "contributor": "alice", "amount_rtc": 5},
+    )
+    assert created.status_code == 201
+    record_id = created.get_json()["id"]
+
+    denied_update = client.patch(
+        f"/api/ledger/{record_id}/status",
+        headers={"X-Admin-Key": "wrong-admin-key"},
+        json={"status": "confirmed", "tx_hash": "0xattacker"},
+    )
+    assert denied_update.status_code == 401
+    assert denied_update.get_json() == {"error": "unauthorized"}
+
+    record = client.get(f"/api/ledger/{record_id}", headers=ADMIN_HEADERS).get_json()
+    assert record["status"] == "queued"
+    assert record["tx_hash"] == ""
+
+
+def test_valid_admin_key_can_read_create_and_update_payout_record(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin-key")
+    client, _db_path = make_client(tmp_path, monkeypatch)
+
+    created = client.post(
+        "/api/ledger",
+        headers=ADMIN_HEADERS,
+        json={"bounty_id": "bounty-1", "contributor": "alice", "amount_rtc": 5},
+    )
+    assert created.status_code == 201
+    record_id = created.get_json()["id"]
+
+    updated = client.patch(
+        f"/api/ledger/{record_id}/status",
+        headers=ADMIN_HEADERS,
+        json={"status": "confirmed", "tx_hash": "0xpaid"},
+    )
+    assert updated.status_code == 200
+
+    record = client.get(f"/api/ledger/{record_id}", headers=ADMIN_HEADERS).get_json()
+    assert record["status"] == "confirmed"
+    assert record["tx_hash"] == "0xpaid"
+
+    summary = client.get("/api/ledger/summary", headers=ADMIN_HEADERS).get_json()
+    assert summary["confirmed"]["count"] == 1
+    assert summary["confirmed"]["total_rtc"] == 5


### PR DESCRIPTION
## Summary
- fixes #4766 by requiring configured `RC_ADMIN_KEY` admin auth for `/ledger` and all `/api/ledger*` payout ledger routes
- uses `hmac.compare_digest()` against `X-Admin-Key`
- fails closed with `503` before table initialization when `RC_ADMIN_KEY` is unset
- rejects missing or wrong admin keys before payout creation, status mutation, reads, or summary access

## Tests
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile payout_ledger.py tests/test_payout_ledger_admin_auth.py tests/test_payout_ledger_migration.py`
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_payout_ledger_admin_auth.py tests/test_payout_ledger_migration.py -q` -> 5 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

No production service or live payout ledger was contacted.
