### PR TITLE
fix: require delegation caller wallet auth

### DIFF
--- a/rips/rustchain-core/governance/proposals.py
+++ b/rips/rustchain-core/governance/proposals.py
@@ -400,12 +400,19 @@ class GovernanceEngine:
         from_wallet: str,
         to_wallet: str,
         weight: float,
-        caller_wallet: str,
+        *,
+        authenticated_wallet: str,
         duration_days: Optional[int] = None,
     ) -> Delegation:
-        """Delegate voting power to another wallet (RIP-0006)."""
-        if caller_wallet != from_wallet:
-            raise ValueError("caller_wallet must match from_wallet")
+        """
+        Delegate voting power to another wallet (RIP-0006).
+
+        ``authenticated_wallet`` must come from a trusted wallet/session/signature
+        verification layer. Do not populate it directly from user-controlled
+        request fields.
+        """
+        if authenticated_wallet != from_wallet:
+            raise ValueError("authenticated_wallet must match from_wallet")
 
         if weight < 0 or weight > 1:
             raise ValueError("Delegation weight must be between 0 and 1")

--- a/rips/rustchain-core/governance/proposals.py
+++ b/rips/rustchain-core/governance/proposals.py
@@ -400,9 +400,13 @@ class GovernanceEngine:
         from_wallet: str,
         to_wallet: str,
         weight: float,
+        caller_wallet: str,
         duration_days: Optional[int] = None,
     ) -> Delegation:
         """Delegate voting power to another wallet (RIP-0006)."""
+        if caller_wallet != from_wallet:
+            raise ValueError("caller_wallet must match from_wallet")
+
         if weight < 0 or weight > 1:
             raise ValueError("Delegation weight must be between 0 and 1")
 

--- a/tests/test_governance_delegation_auth.py
+++ b/tests/test_governance_delegation_auth.py
@@ -1,0 +1,62 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+RUSTCHAIN_CORE = Path(__file__).resolve().parents[1] / "rips" / "rustchain-core"
+PACKAGE_NAME = "rustchain_core_testpkg"
+
+
+def load_governance_module():
+    package = sys.modules.get(PACKAGE_NAME)
+    if package is None:
+        package = types.ModuleType(PACKAGE_NAME)
+        package.__path__ = [str(RUSTCHAIN_CORE)]
+        sys.modules[PACKAGE_NAME] = package
+    return importlib.import_module(f"{PACKAGE_NAME}.governance.proposals")
+
+
+def test_delegate_voting_power_rejects_legacy_unauthenticated_call():
+    proposals = load_governance_module()
+    engine = proposals.GovernanceEngine()
+
+    with pytest.raises(TypeError):
+        engine.delegate_voting_power("RTC1Victim", "RTC1Attacker", 1.0)
+
+    assert engine.delegations == {}
+
+
+def test_delegate_voting_power_rejects_mismatched_caller_wallet():
+    proposals = load_governance_module()
+    engine = proposals.GovernanceEngine()
+
+    with pytest.raises(ValueError, match="caller_wallet must match from_wallet"):
+        engine.delegate_voting_power(
+            "RTC1Victim",
+            "RTC1Attacker",
+            1.0,
+            caller_wallet="RTC1Attacker",
+        )
+
+    assert engine.delegations == {}
+
+
+def test_delegate_voting_power_accepts_owner_caller_wallet():
+    proposals = load_governance_module()
+    engine = proposals.GovernanceEngine()
+
+    delegation = engine.delegate_voting_power(
+        "RTC1Owner",
+        "RTC1Delegate",
+        0.5,
+        caller_wallet="RTC1Owner",
+        duration_days=7,
+    )
+
+    assert delegation.from_wallet == "RTC1Owner"
+    assert delegation.to_wallet == "RTC1Delegate"
+    assert delegation.weight == 0.5
+    assert engine.delegations["RTC1Delegate"] == [delegation]

--- a/tests/test_governance_delegation_auth.py
+++ b/tests/test_governance_delegation_auth.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib
 import sys
 import types

--- a/tests/test_governance_delegation_auth.py
+++ b/tests/test_governance_delegation_auth.py
@@ -31,22 +31,37 @@ def test_delegate_voting_power_rejects_legacy_unauthenticated_call():
     assert engine.delegations == {}
 
 
-def test_delegate_voting_power_rejects_mismatched_caller_wallet():
+def test_delegate_voting_power_rejects_mismatched_authenticated_wallet():
     proposals = load_governance_module()
     engine = proposals.GovernanceEngine()
 
-    with pytest.raises(ValueError, match="caller_wallet must match from_wallet"):
+    with pytest.raises(ValueError, match="authenticated_wallet must match from_wallet"):
         engine.delegate_voting_power(
             "RTC1Victim",
             "RTC1Attacker",
             1.0,
-            caller_wallet="RTC1Attacker",
+            authenticated_wallet="RTC1Attacker",
         )
 
     assert engine.delegations == {}
 
 
-def test_delegate_voting_power_accepts_owner_caller_wallet():
+def test_delegate_voting_power_rejects_self_supplied_caller_wallet_keyword():
+    proposals = load_governance_module()
+    engine = proposals.GovernanceEngine()
+
+    with pytest.raises(TypeError):
+        engine.delegate_voting_power(
+            "RTC1Victim",
+            "RTC1Attacker",
+            1.0,
+            caller_wallet="RTC1Victim",
+        )
+
+    assert engine.delegations == {}
+
+
+def test_delegate_voting_power_accepts_owner_authenticated_wallet():
     proposals = load_governance_module()
     engine = proposals.GovernanceEngine()
 
@@ -54,7 +69,7 @@ def test_delegate_voting_power_accepts_owner_caller_wallet():
         "RTC1Owner",
         "RTC1Delegate",
         0.5,
-        caller_wallet="RTC1Owner",
+        authenticated_wallet="RTC1Owner",
         duration_days=7,
     )
 


### PR DESCRIPTION
## Summary
- fixes #4838 by making `caller_wallet` required for `GovernanceEngine.delegate_voting_power()`
- rejects mismatched callers before any delegation is recorded
- removes the bypass seen in #4841 where omitting optional `caller_wallet=None` preserved the original unauthenticated path
- adds regressions for the legacy 3-argument call, mismatched caller wallet, and valid owner delegation

## Tests
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile rips/rustchain-core/governance/proposals.py tests/test_governance_delegation_auth.py`
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_governance_delegation_auth.py -q` -> 3 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

No live governance service or production wallet was used.
