### PR TITLE
fix: use csprng for deep entropy challenges

### DIFF
--- a/rips/python/rustchain/deep_entropy.py
+++ b/rips/python/rustchain/deep_entropy.py
@@ -14,10 +14,8 @@ Layers:
 5. Architectural Quirk Entropy - Known hardware bugs/quirks
 """
 
-import hashlib
-import math
 import time
-import random
+import secrets
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Any
 from enum import Enum
@@ -30,6 +28,7 @@ from enum import Enum
 ENTROPY_SAMPLES_REQUIRED: int = 1000
 MIN_ENTROPY_BITS: int = 64
 EMULATION_COST_THRESHOLD_USD: float = 100.0  # Cheaper to buy real hardware
+_CSPRNG = secrets.SystemRandom()
 
 
 # =============================================================================
@@ -262,23 +261,27 @@ class DeepEntropyVerifier:
 
     def generate_challenge(self) -> Dict[str, Any]:
         """Generate a challenge for hardware to solve"""
-        nonce = hashlib.sha256(str(time.time()).encode()).digest()
+        nonce = secrets.token_bytes(32)
         # Multiply the 4-op template by 25 to produce 100 total operations.
-        # The randomised values ensure each challenge is unique, preventing
+        # The CSPRNG values ensure each challenge is unique, preventing
         # a cached replay attack where an attacker pre-records a real machine's response.
-        operations = [
-            {"op": "mul", "value": random.randint(1, 1000000)},
-            {"op": "div", "value": random.randint(1, 1000)},
-            {"op": "fadd", "value": random.uniform(0, 1000)},
-            {"op": "memory", "stride": random.choice([1, 4, 16, 64, 256])},
-        ] * 25  # 100 operations
+        operations = []
+        for _ in range(25):
+            operations.extend([
+                {"op": "mul", "value": _CSPRNG.randint(1, 1000000)},
+                {"op": "div", "value": _CSPRNG.randint(1, 1000)},
+                {"op": "fadd", "value": _CSPRNG.uniform(0, 1000)},
+                {"op": "memory", "stride": _CSPRNG.choice([1, 4, 16, 64, 256])},
+            ])
+
+        now = int(time.time())
 
         return {
             "nonce": nonce.hex(),
             "operations": operations,
             "expected_time_range_us": (1000, 100000),  # 1ms to 100ms
-            "timestamp": int(time.time()),
-            "expires_at": int(time.time()) + 300,  # 5 minute expiry
+            "timestamp": now,
+            "expires_at": now + 300,  # 5 minute expiry
         }
 
     def verify(self, proof: EntropyProof, claimed_hardware: str) -> VerificationResult:

--- a/tests/test_deep_entropy_csprng.py
+++ b/tests/test_deep_entropy_csprng.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+DEEP_ENTROPY_PATH = (
+    Path(__file__).resolve().parents[1] / "rips" / "python" / "rustchain" / "deep_entropy.py"
+)
+
+
+def load_deep_entropy_module():
+    spec = importlib.util.spec_from_file_location("deep_entropy_test_module", DEEP_ENTROPY_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeCSPRNG:
+    def __init__(self):
+        self.randint_calls = []
+        self.uniform_calls = []
+        self.choice_calls = []
+
+    def randint(self, low, high):
+        self.randint_calls.append((low, high))
+        return high
+
+    def uniform(self, low, high):
+        self.uniform_calls.append((low, high))
+        return high / 2
+
+    def choice(self, values):
+        self.choice_calls.append(tuple(values))
+        return values[-1]
+
+
+def test_generate_challenge_uses_csprng_nonce_and_operations(monkeypatch):
+    deep_entropy = load_deep_entropy_module()
+    fake_rng = FakeCSPRNG()
+    monkeypatch.setattr(deep_entropy, "_CSPRNG", fake_rng)
+    monkeypatch.setattr(deep_entropy.secrets, "token_bytes", lambda size: b"\xab" * size)
+    monkeypatch.setattr(deep_entropy.time, "time", lambda: 1234567890.9)
+
+    challenge = deep_entropy.DeepEntropyVerifier().generate_challenge()
+
+    assert challenge["nonce"] == (b"\xab" * 32).hex()
+    assert challenge["timestamp"] == 1234567890
+    assert challenge["expires_at"] == 1234568190
+    assert len(challenge["operations"]) == 100
+    assert len(fake_rng.randint_calls) == 50
+    assert len(fake_rng.uniform_calls) == 25
+    assert len(fake_rng.choice_calls) == 25
+    assert ("mul", 1000000) in [
+        (op["op"], op.get("value")) for op in challenge["operations"]
+    ]
+    assert ("memory", 256) in [
+        (op["op"], op.get("stride")) for op in challenge["operations"]
+    ]

--- a/tests/test_deep_entropy_csprng.py
+++ b/tests/test_deep_entropy_csprng.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
- fixes #4640 by replacing time-derived challenge nonces with `secrets.token_bytes(32)`
- replaces Mersenne Twister challenge operation randomness with `secrets.SystemRandom()`
- generates independent CSPRNG-backed parameters for all 100 operations rather than repeating the same four random dictionaries
- keeps challenge timestamp/expiry semantics unchanged apart from computing `now` once

## Tests
- `git diff --check origin/main...HEAD`
- `python3 -m py_compile rips/python/rustchain/deep_entropy.py tests/test_deep_entropy_csprng.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest tests/test_deep_entropy_csprng.py -q` -> 1 passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

No live verifier or production miner was used.
