### PR TITLE
docs: fix RIP-305 claims guide link

### DIFF
--- a/docs/CLAIMS_GUIDE.md
+++ b/docs/CLAIMS_GUIDE.md
@@ -444,7 +444,7 @@ Claims are settled in batches:
 3. **Maximum Batch** - 100 claims
 4. **Transaction** - Multi-output transfer to all claimants
 
-See [RIP-305](/rips/docs/RIP-0305-reward-claim-system.md) for full specification.
+See [RIP-305](../rips/docs/RIP-0305-reward-claim-system.md) for full specification.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix the RIP-305 link in `docs/CLAIMS_GUIDE.md` so it resolves from the `docs/` directory.

## Verification
- Confirmed `../rips/docs/RIP-0305-reward-claim-system.md` exists locally.

Bounty: Scottcjn/rustchain-bounties#2178

No tests run because this is documentation-only.