### PR TITLE
fix: disable public flask debug by default

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -12,6 +12,9 @@ app.config['SECRET_KEY'] = 'bcos-directory-dev-key'
 
 DATABASE = 'bcos_directory.db'
 
+def _flask_debug_enabled():
+    return os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes', 'on'}
+
 def init_db():
     """Initialize the database with projects table"""
     conn = sqlite3.connect(DATABASE)
@@ -482,4 +485,4 @@ def serve_dist(filename):
 if __name__ == '__main__':
     init_db()
     load_projects_from_json()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=_flask_debug_enabled(), host='0.0.0.0', port=5000)

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -38,6 +38,9 @@ SUPPORTED_CHAINS = {CHAIN_SOLANA, CHAIN_BASE}
 # RTC decimal precision
 RTC_DECIMALS = 6
 
+def _flask_debug_enabled():
+    return os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+
 # Minimum lock amounts
 MIN_LOCK_AMOUNT = 1  # 1 RTC
 MAX_LOCK_AMOUNT = 10_000  # 10,000 RTC per transaction
@@ -621,4 +624,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=_flask_debug_enabled())

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -34,6 +34,9 @@ app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
 
+def _flask_debug_enabled():
+    return os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes', 'on'}
+
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute('''
@@ -188,4 +191,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=_flask_debug_enabled(), host='0.0.0.0', port=5000)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,6 +1,7 @@
 from flask import Flask, render_template, jsonify
 import requests
 import json
+import os
 from datetime import datetime
 
 app = Flask(__name__)
@@ -8,6 +9,9 @@ app = Flask(__name__)
 # Configuration
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
+
+def _flask_debug_enabled():
+    return os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes', 'on'}
 
 @app.route('/')
 def dashboard():
@@ -134,4 +138,4 @@ def internal_error(error):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=_flask_debug_enabled())

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -31,6 +31,9 @@ PORT = 8095
 app = Flask(__name__)
 CORS(app)
 
+def _flask_debug_enabled():
+    return os.environ.get("FLASK_DEBUG", "").lower() in {"1", "true", "yes", "on"}
+
 # --- Faucet Logic (Integrated) ---
 
 def init_faucet_db():
@@ -377,4 +380,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=_flask_debug_enabled())

--- a/security_test_payment_widget.py
+++ b/security_test_payment_widget.py
@@ -14,6 +14,9 @@ app.secret_key = 'test_key_for_security_testing_only'
 
 DB_PATH = 'rustchain.db'
 
+def _flask_debug_enabled():
+    return os.environ.get('FLASK_DEBUG', '').lower() in {'1', 'true', 'yes', 'on'}
+
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute('''CREATE TABLE IF NOT EXISTS test_payments (
@@ -272,4 +275,4 @@ def admin_login():
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=_flask_debug_enabled(), host='0.0.0.0', port=5000)

--- a/tests/test_public_flask_debug_defaults.py
+++ b/tests/test_public_flask_debug_defaults.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PUBLIC_FLASK_ENTRYPOINTS = [
+    "bcos_directory.py",
+    "bridge/bridge_api.py",
+    "contributor_registry.py",
+    "explorer/app.py",
+    "keeper_explorer.py",
+    "security_test_payment_widget.py",
+]
+
+
+def _const_keyword(call, name):
+    for keyword in call.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value
+    return None
+
+
+def _is_public_flask_run(call):
+    return (
+        isinstance(call.func, ast.Attribute)
+        and call.func.attr == "run"
+        and _const_keyword(call, "host") == "0.0.0.0"
+    )
+
+
+def test_public_flask_entrypoints_do_not_default_to_debug_true():
+    violations = []
+
+    for relative_path in PUBLIC_FLASK_ENTRYPOINTS:
+        path = REPO_ROOT / relative_path
+        tree = ast.parse(path.read_text(), filename=str(path))
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_public_flask_run(node):
+                if _const_keyword(node, "debug") is True:
+                    violations.append(f"{relative_path}:{node.lineno}")
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- Fixes #4810
- Gates standalone public Flask debug mode behind FLASK_DEBUG so 0.0.0.0 entrypoints do not default to Werkzeug debug mode
- Adds an AST regression test for public app.run calls with debug=True

## Validation
- git diff --check origin/main...HEAD
- python3 -m py_compile bcos_directory.py bridge/bridge_api.py contributor_registry.py explorer/app.py keeper_explorer.py security_test_payment_widget.py tests/test_public_flask_debug_defaults.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest tests/test_public_flask_debug_defaults.py -q
- python3 tools/bcos_spdx_check.py --base-ref origin/main

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC