### PR TITLE
fix: load moltbook agent tokens from env

### DIFF
--- a/scripts/moltbook_solver.py
+++ b/scripts/moltbook_solver.py
@@ -36,12 +36,30 @@ log = logging.getLogger("moltbook_solver")
 # ─── Agent Registry ──────────────────────────────────────────────────────────
 
 AGENTS = {
-    "sophia":          {"key": "moltbook_sk_nuTK8FxFHuUtknLGrXUJKxcgBsTJ0zP7",  "persona": "warm_tech"},
-    "boris":           {"key": "moltbook_sk_mACTltXU55x6s1mYqDuWkeEcuDQ9feMB",  "persona": "soviet_enthusiast"},
-    "janitor":         {"key": "moltbook_sk_yWpLPPIp1MxWAlbgiCEdamHodyClGg08",  "persona": "sysadmin"},
-    "bottube":         {"key": "moltbook_sk_CJgvb5ecA9ZnutcmmaFy2Scm_X4SQgcz",  "persona": "platform_bot"},
-    "msgoogletoggle":  {"key": "moltbook_sk_-zuaZPUGMVoC_tdQJA-YaLVlj-VnUMdw",  "persona": "gracious_socialite"},
-    "oneo":            {"key": "moltbook_sk_BeO3rZoBKuleNwSX3sZeBNQRYhOBK436",  "persona": "minimalist"},
+    "sophia": {
+        "key_env": "MOLTBOOK_AGENT_SOPHIA_KEY",
+        "persona": "warm_tech",
+    },
+    "boris": {
+        "key_env": "MOLTBOOK_AGENT_BORIS_KEY",
+        "persona": "soviet_enthusiast",
+    },
+    "janitor": {
+        "key_env": "MOLTBOOK_AGENT_JANITOR_KEY",
+        "persona": "sysadmin",
+    },
+    "bottube": {
+        "key_env": "MOLTBOOK_AGENT_BOTTUBE_KEY",
+        "persona": "platform_bot",
+    },
+    "msgoogletoggle": {
+        "key_env": "MOLTBOOK_AGENT_MSGOOGLETOGGLE_KEY",
+        "persona": "gracious_socialite",
+    },
+    "oneo": {
+        "key_env": "MOLTBOOK_AGENT_ONEO_KEY",
+        "persona": "minimalist",
+    },
 }
 
 # Gemini for LLM solving
@@ -124,12 +142,18 @@ def get_available_agents() -> List[str]:
     # Preference order: msgoogletoggle first (it's our best solver host),
     # then sophia, boris, janitor, bottube, oneo
     preferred = ["msgoogletoggle", "sophia", "boris", "janitor", "bottube", "oneo"]
-    return [a for a in preferred if a in AGENTS and a not in suspended]
+    return [
+        a for a in preferred
+        if a in AGENTS and a not in suspended and get_agent_key(a)
+    ]
 
 
 def get_agent_key(agent: str) -> Optional[str]:
     """Get API key for an agent."""
-    return AGENTS.get(agent, {}).get("key")
+    key_env = AGENTS.get(agent, {}).get("key_env")
+    if not key_env:
+        return None
+    return os.environ.get(key_env, "").strip() or None
 
 
 # ─── Content Uniqueness ─────────────────────────────────────────────────────

--- a/scripts/tests/test_moltbook_solver.py
+++ b/scripts/tests/test_moltbook_solver.py
@@ -14,6 +14,7 @@ import tempfile
 scripts_dir = Path(__file__).parent.parent
 sys.path.insert(0, str(scripts_dir))
 
+import moltbook_solver
 from moltbook_solver import (
     degarble,
     extract_numbers,
@@ -114,17 +115,35 @@ class TestContentHash:
 class TestAgentFunctions:
     """Tests for agent functions."""
 
-    def test_get_available_agents(self):
-        agents = get_available_agents()
-        assert isinstance(agents, list) and len(agents) > 0
+    def test_get_available_agents_requires_configured_keys(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(moltbook_solver, "STATE_DB", tmp_path / "state.db")
+        for config in AGENTS.values():
+            monkeypatch.delenv(config["key_env"], raising=False)
 
-    def test_get_agent_key(self):
+        assert get_available_agents() == []
+
+        monkeypatch.setenv(AGENTS["sophia"]["key_env"], "test-token-sophia")
+        agents = get_available_agents()
+        assert agents == ["sophia"]
+
+    def test_get_agent_key_reads_environment(self, monkeypatch):
+        monkeypatch.setenv(AGENTS["sophia"]["key_env"], "test-token-sophia")
         key = get_agent_key("sophia")
-        assert key is not None and key.startswith("moltbook_sk_")
+        assert key == "test-token-sophia"
+
+    def test_get_agent_key_missing_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv(AGENTS["sophia"]["key_env"], raising=False)
+        assert get_agent_key("sophia") is None
 
     def test_agents_have_required_fields(self):
         for agent_name, config in AGENTS.items():
-            assert "key" in config and "persona" in config
+            assert "key_env" in config and "persona" in config
+
+    def test_no_committed_moltbook_agent_tokens(self):
+        source = (scripts_dir / "moltbook_solver.py").read_text()
+        secret_prefix = "moltbook_" + "sk_"
+        assert "moltbook" in source
+        assert secret_prefix not in source
 
 
 class TestRecordPost:


### PR DESCRIPTION
## Summary
- Fixes #4609
- Removes committed Moltbook agent bearer-token values from `scripts/moltbook_solver.py`
- Stores only per-agent environment variable names in the agent registry
- Excludes agents from rotation unless their token environment variable is configured
- Updates solver tests so they do not rely on secret-shaped test values

## Validation
- `rg -n "moltbook_sk_[A-Za-z0-9_-]+" scripts node tests tools integrations --glob "!**/get-pip.py" --glob "!**/package-lock.json"` -> no matches
- `python3 -m py_compile scripts/moltbook_solver.py scripts/tests/test_moltbook_solver.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with requests python -m pytest scripts/tests/test_moltbook_solver.py -q` -> 24 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC