### PR TITLE
fix: harden contributor registry registration

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -4,6 +4,7 @@ import os
 import re
 import secrets
 import sqlite3
+from contextlib import contextmanager
 
 from flask import Flask, abort, flash, redirect, request, session, url_for
 
@@ -43,6 +44,16 @@ EVM_WALLET_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
 
 app.config["CONTRIBUTOR_REGISTRATION_TOKEN"] = os.environ.get("CONTRIBUTOR_REGISTRATION_TOKEN", "")
 app.config["CONTRIBUTOR_ADMIN_TOKEN"] = os.environ.get("CONTRIBUTOR_ADMIN_TOKEN", "")
+
+
+@contextmanager
+def db_connection():
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        with conn:
+            yield conn
+    finally:
+        conn.close()
 
 
 def normalize_github_username(username):
@@ -113,7 +124,7 @@ def build_contributor_view(contributor):
 
 
 def init_db():
-    with sqlite3.connect(DB_PATH) as conn:
+    with db_connection() as conn:
         conn.execute('''
             CREATE TABLE IF NOT EXISTS contributors (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -210,7 +221,7 @@ def index():
     </html>
     '''
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with db_connection() as conn:
         rows = conn.execute(
             'SELECT github_username, contributor_type, rtc_wallet, contribution_history, registration_date, status '
             'FROM contributors ORDER BY registration_date DESC'
@@ -235,7 +246,7 @@ def register():
         return redirect(url_for('index'))
 
     try:
-        with sqlite3.connect(DB_PATH) as conn:
+        with db_connection() as conn:
             conn.execute(
                 'INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history) VALUES (?, ?, ?, ?)',
                 (github_username, contributor_type, rtc_wallet, contribution_history)
@@ -249,7 +260,7 @@ def register():
 
 @app.route('/api/contributors')
 def api_contributors():
-    with sqlite3.connect(DB_PATH) as conn:
+    with db_connection() as conn:
         contributors = conn.execute(
             'SELECT github_username, contributor_type, rtc_wallet, registration_date, status FROM contributors ORDER BY registration_date DESC'
         ).fetchall()
@@ -275,7 +286,7 @@ def approve_contributor(username):
     except ValueError:
         abort(400)
 
-    with sqlite3.connect(DB_PATH) as conn:
+    with db_connection() as conn:
         conn.execute(
             'UPDATE contributors SET status = "approved" WHERE github_username = ?',
             (username,)

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -96,7 +96,7 @@ def validate_registration_token(token):
 
 def require_admin_token():
     configured_token = app.config.get("CONTRIBUTOR_ADMIN_TOKEN", "")
-    supplied_token = request.headers.get("X-Admin-Token", "") or request.args.get("admin_token", "")
+    supplied_token = request.headers.get("X-Admin-Token", "")
     if not configured_token or not supplied_token or not secrets.compare_digest(configured_token, supplied_token):
         abort(403)
 

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: MIT
 
-from flask import Flask, request, redirect, url_for, flash
-import sqlite3
 import os
+import re
 import secrets
-from datetime import datetime
+import sqlite3
+
+from flask import Flask, abort, flash, redirect, request, session, url_for
 
 app = Flask(__name__)
 
@@ -20,19 +21,96 @@ if not SECRET_KEY:
         "CONTRIBUTOR_SECRET_KEY not set. "
         "Using a random key — sessions will NOT persist across restarts. "
         "Set the environment variable before deployment.",
-        UserWarning
+        UserWarning,
+        stacklevel=2,
     )
 elif SECRET_KEY == 'rustchain_contributor_secret_2024':
     import warnings
     warnings.warn(
         "CONTRIBUTOR_SECRET_KEY is set to the known placeholder value. "
         "Please set a new, secure secret before deployment.",
-        UserWarning
+        UserWarning,
+        stacklevel=2,
     )
 
 app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
+ALLOWED_CONTRIBUTOR_TYPES = {"human", "bot", "agent"}
+GITHUB_USERNAME_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
+RTC_WALLET_RE = re.compile(r"^RTC[0-9a-fA-F]{40}$")
+EVM_WALLET_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
+
+app.config["CONTRIBUTOR_REGISTRATION_TOKEN"] = os.environ.get("CONTRIBUTOR_REGISTRATION_TOKEN", "")
+app.config["CONTRIBUTOR_ADMIN_TOKEN"] = os.environ.get("CONTRIBUTOR_ADMIN_TOKEN", "")
+
+
+def normalize_github_username(username):
+    username = username.strip().removeprefix("@")
+    if not GITHUB_USERNAME_RE.fullmatch(username) or "--" in username:
+        raise ValueError("Enter a valid GitHub username.")
+    return username
+
+
+def validate_contributor_type(contributor_type):
+    contributor_type = contributor_type.strip().lower()
+    if contributor_type not in ALLOWED_CONTRIBUTOR_TYPES:
+        raise ValueError("Select a valid contributor type.")
+    return contributor_type
+
+
+def validate_wallet(wallet):
+    wallet = wallet.strip()
+    if not (RTC_WALLET_RE.fullmatch(wallet) or EVM_WALLET_RE.fullmatch(wallet)):
+        raise ValueError("Enter a valid RTC or EVM wallet address.")
+    return wallet
+
+
+def redact_wallet(wallet):
+    if len(wallet) <= 12:
+        return "***"
+    return f"{wallet[:6]}...{wallet[-4:]}"
+
+
+def get_csrf_token():
+    token = session.get("csrf_token")
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session["csrf_token"] = token
+    return token
+
+
+def validate_csrf_token(token):
+    stored_token = session.get("csrf_token", "")
+    if not stored_token or not token or not secrets.compare_digest(stored_token, token):
+        abort(400)
+
+
+def validate_registration_token(token):
+    configured_token = app.config.get("CONTRIBUTOR_REGISTRATION_TOKEN", "")
+    if not configured_token:
+        raise ValueError("Contributor registration is closed until a registration token is configured.")
+    if not token or not secrets.compare_digest(configured_token, token):
+        raise ValueError("Invalid contributor registration token.")
+
+
+def require_admin_token():
+    configured_token = app.config.get("CONTRIBUTOR_ADMIN_TOKEN", "")
+    supplied_token = request.headers.get("X-Admin-Token", "") or request.args.get("admin_token", "")
+    if not configured_token or not supplied_token or not secrets.compare_digest(configured_token, supplied_token):
+        abort(403)
+
+
+def build_contributor_view(contributor):
+    return {
+        "github_username": contributor[0],
+        "type": contributor[1],
+        "wallet": redact_wallet(contributor[2]),
+        "history": contributor[3],
+        "registered": contributor[4],
+        "status": contributor[5],
+    }
+
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -73,14 +151,15 @@ def index():
     <body>
         <h1>RustChain Ecosystem Contributor Registry</h1>
         <p><strong>Bounty:</strong> 5 RTC per registration</p>
-        
+
         <h2>Register as Contributor</h2>
         <form method="POST" action="/register">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <div class="form-group">
                 <label for="github_username">GitHub Username:</label>
                 <input type="text" id="github_username" name="github_username" required>
             </div>
-            
+
             <div class="form-group">
                 <label for="contributor_type">Type:</label>
                 <select id="contributor_type" name="contributor_type" required>
@@ -90,34 +169,39 @@ def index():
                     <option value="agent">Agent</option>
                 </select>
             </div>
-            
+
             <div class="form-group">
                 <label for="rtc_wallet">RTC Wallet Address:</label>
                 <input type="text" id="rtc_wallet" name="rtc_wallet" required>
             </div>
-            
+
+            <div class="form-group">
+                <label for="registration_token">Registration Token:</label>
+                <input type="password" id="registration_token" name="registration_token" autocomplete="one-time-code" required>
+            </div>
+
             <div class="form-group">
                 <label for="contribution_history">Contribution History:</label>
-                <textarea id="contribution_history" name="contribution_history" rows="4" 
+                <textarea id="contribution_history" name="contribution_history" rows="4"
                     placeholder="Describe your contributions (starred repos, PRs, issues, tutorials, mining, security research, community support, etc.)"></textarea>
             </div>
-            
+
             <button type="submit">Register</button>
         </form>
-        
+
         <div class="contributors">
             <h2>Registered Contributors</h2>
             {% for message in get_flashed_messages() %}
                 <div style="color: green; margin: 10px 0;">{{ message }}</div>
             {% endfor %}
-            
+
             {% for contributor in contributors %}
-            <div class="contributor status-{{ contributor[6] }}">
-                <strong>@{{ contributor[1] }}</strong> ({{ contributor[2] }})
-                <br><small>Wallet: {{ contributor[3] }}</small>
-                <br><small>Registered: {{ contributor[5] }} | Status: {{ contributor[6] }}</small>
-                {% if contributor[4] %}
-                    <br><em>{{ contributor[4][:200] }}{% if contributor[4]|length > 200 %}...{% endif %}</em>
+            <div class="contributor status-{{ contributor.status }}">
+                <strong>@{{ contributor.github_username }}</strong> ({{ contributor.type }})
+                <br><small>Wallet: {{ contributor.wallet }}</small>
+                <br><small>Registered: {{ contributor.registered }} | Status: {{ contributor.status }}</small>
+                {% if contributor.history %}
+                    <br><em>{{ contributor.history[:200] }}{% if contributor.history|length > 200 %}...{% endif %}</em>
                 {% endif %}
             </div>
             {% endfor %}
@@ -125,22 +209,31 @@ def index():
     </body>
     </html>
     '''
-    
+
     with sqlite3.connect(DB_PATH) as conn:
-        contributors = conn.execute(
-            'SELECT * FROM contributors ORDER BY registration_date DESC'
+        rows = conn.execute(
+            'SELECT github_username, contributor_type, rtc_wallet, contribution_history, registration_date, status '
+            'FROM contributors ORDER BY registration_date DESC'
         ).fetchall()
-    
+    contributors = [build_contributor_view(row) for row in rows]
+
     from flask import render_template_string
-    return render_template_string(html, contributors=contributors)
+    return render_template_string(html, contributors=contributors, csrf_token=get_csrf_token())
 
 @app.route('/register', methods=['POST'])
 def register():
-    github_username = request.form['github_username']
-    contributor_type = request.form['contributor_type']
-    rtc_wallet = request.form['rtc_wallet']
-    contribution_history = request.form.get('contribution_history', '')
-    
+    validate_csrf_token(request.form.get('csrf_token', ''))
+
+    try:
+        validate_registration_token(request.form.get('registration_token', ''))
+        github_username = normalize_github_username(request.form.get('github_username', ''))
+        contributor_type = validate_contributor_type(request.form.get('contributor_type', ''))
+        rtc_wallet = validate_wallet(request.form.get('rtc_wallet', ''))
+        contribution_history = request.form.get('contribution_history', '').strip()[:2000]
+    except ValueError as exc:
+        flash(str(exc))
+        return redirect(url_for('index'))
+
     try:
         with sqlite3.connect(DB_PATH) as conn:
             conn.execute(
@@ -151,7 +244,7 @@ def register():
         flash(f'Successfully registered @{github_username}! Pending approval for 5 RTC bounty.')
     except sqlite3.IntegrityError:
         flash(f'Error: @{github_username} is already registered!')
-    
+
     return redirect(url_for('index'))
 
 @app.route('/api/contributors')
@@ -160,13 +253,13 @@ def api_contributors():
         contributors = conn.execute(
             'SELECT github_username, contributor_type, rtc_wallet, registration_date, status FROM contributors ORDER BY registration_date DESC'
         ).fetchall()
-    
+
     return {
         'contributors': [
             {
                 'github_username': c[0],
                 'type': c[1],
-                'wallet': c[2],
+                'wallet': redact_wallet(c[2]),
                 'registered': c[3],
                 'status': c[4]
             }
@@ -176,6 +269,12 @@ def api_contributors():
 
 @app.route('/approve/<username>')
 def approve_contributor(username):
+    require_admin_token()
+    try:
+        username = normalize_github_username(username)
+    except ValueError:
+        abort(400)
+
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             'UPDATE contributors SET status = "approved" WHERE github_username = ?',

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -1,11 +1,17 @@
-import pytest
-import sqlite3
 import os
+import re
+import sqlite3
 import tempfile
-from unittest.mock import patch, MagicMock
+
+import pytest
 
 # Module under test
 import contributor_registry as cr
+
+VALID_RTC_WALLET = "RTC019e78d600fb3131c29d7ba80aba8fe644be426e"
+VALID_EVM_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+REGISTRATION_TOKEN = "registration-token"
+ADMIN_TOKEN = "admin-token"
 
 
 @pytest.fixture
@@ -14,6 +20,8 @@ def app():
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
     cr.DB_PATH = db_path
     cr.app.config["TESTING"] = True
+    cr.app.config["CONTRIBUTOR_REGISTRATION_TOKEN"] = REGISTRATION_TOKEN
+    cr.app.config["CONTRIBUTOR_ADMIN_TOKEN"] = ADMIN_TOKEN
     cr.init_db()
     yield cr.app
     os.close(db_fd)
@@ -26,6 +34,26 @@ def client(app):
     return app.test_client()
 
 
+def csrf_token(client):
+    response = client.get("/")
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
+    assert match is not None
+    return match.group(1).decode()
+
+
+def registration_payload(client, **overrides):
+    payload = {
+        "csrf_token": csrf_token(client),
+        "registration_token": REGISTRATION_TOKEN,
+        "github_username": "newuser",
+        "contributor_type": "agent",
+        "rtc_wallet": VALID_RTC_WALLET,
+        "contribution_history": "Mining and staking",
+    }
+    payload.update(overrides)
+    return payload
+
+
 @pytest.fixture
 def seed_contributor(app):
     """Insert a test contributor into the database."""
@@ -33,7 +61,7 @@ def seed_contributor(app):
         conn.execute(
             "INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history, status) "
             "VALUES (?, ?, ?, ?, ?)",
-            ("testuser", "human", "RTC019e78d600fb3131c29d7ba80aba8fe644be426e", "PR reviews and bug reports", "approved"),
+            ("testuser", "human", VALID_RTC_WALLET, "PR reviews and bug reports", "approved"),
         )
         conn.commit()
 
@@ -64,18 +92,14 @@ class TestIndexRoute:
         """GET / should list registered contributors."""
         response = client.get("/")
         assert b"testuser" in response.data
-        assert b"RTC019e78d600fb3131c29d7ba80aba8fe644be426e" in response.data
+        assert b"RTC019...426e" in response.data
+        assert VALID_RTC_WALLET.encode() not in response.data
 
 
 class TestRegisterRoute:
     def test_register_new_contributor(self, client):
         """POST /register should add a new contributor."""
-        response = client.post("/register", data={
-            "github_username": "newuser",
-            "contributor_type": "agent",
-            "rtc_wallet": "RTC0abc123",
-            "contribution_history": "Mining and staking",
-        }, follow_redirects=True)
+        response = client.post("/register", data=registration_payload(client), follow_redirects=True)
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
@@ -87,14 +111,87 @@ class TestRegisterRoute:
 
     def test_register_duplicate_username(self, client, seed_contributor):
         """POST /register with existing username should flash error."""
-        response = client.post("/register", data={
-            "github_username": "testuser",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0dup",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        response = client.post(
+            "/register",
+            data=registration_payload(
+                client,
+                github_username="testuser",
+                contributor_type="human",
+                rtc_wallet=VALID_EVM_WALLET,
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
         assert response.status_code == 200
         assert b"already registered" in response.data
+
+    def test_register_rejects_missing_csrf_token(self, client):
+        """POST /register should reject form submissions without CSRF."""
+        payload = registration_payload(client)
+        payload.pop("csrf_token")
+        response = client.post("/register", data=payload)
+        assert response.status_code == 400
+
+    def test_register_rejects_missing_registration_token(self, client):
+        """POST /register should reject requests without the configured token."""
+        response = client.post(
+            "/register",
+            data=registration_payload(client, registration_token=""),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"Invalid contributor registration token" in response.data
+
+    def test_register_rejects_unconfigured_registration_token(self, app, client):
+        """Deployments without a registration token should fail closed."""
+        app.config["CONTRIBUTOR_REGISTRATION_TOKEN"] = ""
+        response = client.post("/register", data=registration_payload(client), follow_redirects=True)
+        assert response.status_code == 200
+        assert b"registration is closed" in response.data
+
+    def test_register_rejects_invalid_github_username(self, client):
+        """POST /register should reject invalid GitHub username syntax."""
+        response = client.post(
+            "/register",
+            data=registration_payload(client, github_username="-not-valid"),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"valid GitHub username" in response.data
+
+    def test_register_rejects_invalid_contributor_type(self, client):
+        """POST /register should reject contributor types outside the allowlist."""
+        response = client.post(
+            "/register",
+            data=registration_payload(client, contributor_type="miner"),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"valid contributor type" in response.data
+
+    def test_register_rejects_invalid_wallet(self, client):
+        """POST /register should reject malformed wallet strings."""
+        response = client.post(
+            "/register",
+            data=registration_payload(client, rtc_wallet="RTC0abc123"),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"valid RTC or EVM wallet address" in response.data
+
+    def test_register_accepts_leading_at_username(self, client):
+        """POST /register should normalize common @username input."""
+        response = client.post(
+            "/register",
+            data=registration_payload(client, github_username="@newuser"),
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT github_username FROM contributors WHERE github_username='newuser'"
+            ).fetchone()
+        assert row is not None
 
 
 class TestApiContributors:
@@ -120,17 +217,53 @@ class TestApiContributors:
         for field in ("github_username", "type", "wallet", "registered", "status"):
             assert field in contrib
 
+    def test_api_redacts_wallets(self, client, seed_contributor):
+        """The public API should not expose full wallet addresses."""
+        response = client.get("/api/contributors")
+        data = response.get_json()
+        contrib = data["contributors"][0]
+        assert contrib["wallet"] == "RTC019...426e"
+        assert contrib["wallet"] != VALID_RTC_WALLET
+
 
 class TestApproveRoute:
-    def test_approve_pending_contributor(self, client):
-        """GET /approve/<username> should set status to approved."""
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+    def test_approve_rejects_missing_admin_token(self, client):
+        """GET /approve/<username> should require an admin token."""
+        client.post(
+            "/register",
+            data=registration_payload(
+                client,
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
         response = client.get("/approve/pendinguser", follow_redirects=True)
+        assert response.status_code == 403
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_pending_contributor(self, client):
+        """GET /approve/<username> with admin token should set status to approved."""
+        client.post(
+            "/register",
+            data=registration_payload(
+                client,
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
+        response = client.get(
+            "/approve/pendinguser",
+            headers={"X-Admin-Token": ADMIN_TOKEN},
+            follow_redirects=True,
+        )
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
@@ -145,24 +278,27 @@ class TestDatabaseConstraints:
         with sqlite3.connect(cr.DB_PATH) as conn:
             conn.execute(
                 "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                ("unique_test", "human", "RTC0unique"),
+                ("unique-test", "human", VALID_RTC_WALLET),
             )
             with pytest.raises(sqlite3.IntegrityError):
                 conn.execute(
                     "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                    ("unique_test", "agent", "RTC0dup2"),
+                    ("unique-test", "agent", VALID_EVM_WALLET),
                 )
 
     def test_default_status_is_pending(self, client):
         """New registrations should have status=pending by default."""
-        client.post("/register", data={
-            "github_username": "defaultstatus",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0default",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=registration_payload(
+                client,
+                github_username="defaultstatus",
+                contributor_type="human",
+            ),
+            follow_redirects=True,
+        )
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"
             ).fetchone()
         assert row[0] == "pending"
-

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -2,6 +2,7 @@ import os
 import re
 import sqlite3
 import tempfile
+from contextlib import closing
 
 import pytest
 
@@ -12,6 +13,10 @@ VALID_RTC_WALLET = "RTC019e78d600fb3131c29d7ba80aba8fe644be426e"
 VALID_EVM_WALLET = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 REGISTRATION_TOKEN = "registration-token"
 ADMIN_TOKEN = "admin-token"
+
+
+def db_connect():
+    return closing(sqlite3.connect(cr.DB_PATH))
 
 
 @pytest.fixture
@@ -25,7 +30,8 @@ def app():
     cr.init_db()
     yield cr.app
     os.close(db_fd)
-    os.unlink(db_path)
+    if os.path.exists(db_path):
+        os.unlink(db_path)
 
 
 @pytest.fixture
@@ -57,7 +63,7 @@ def registration_payload(client, **overrides):
 @pytest.fixture
 def seed_contributor(app):
     """Insert a test contributor into the database."""
-    with sqlite3.connect(cr.DB_PATH) as conn:
+    with db_connect() as conn:
         conn.execute(
             "INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history, status) "
             "VALUES (?, ?, ?, ?, ?)",
@@ -69,7 +75,7 @@ def seed_contributor(app):
 class TestInitDb:
     def test_creates_table(self, app):
         """init_db should create the contributors table."""
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             result = conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table' AND name='contributors'"
             ).fetchone()
@@ -101,7 +107,7 @@ class TestRegisterRoute:
         """POST /register should add a new contributor."""
         response = client.post("/register", data=registration_payload(client), follow_redirects=True)
         assert response.status_code == 200
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT contributor_type, status FROM contributors WHERE github_username='newuser'"
             ).fetchone()
@@ -187,7 +193,7 @@ class TestRegisterRoute:
             follow_redirects=True,
         )
         assert response.status_code == 200
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT github_username FROM contributors WHERE github_username='newuser'"
             ).fetchone()
@@ -241,7 +247,7 @@ class TestApproveRoute:
         )
         response = client.get("/approve/pendinguser", follow_redirects=True)
         assert response.status_code == 403
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='pendinguser'"
             ).fetchone()
@@ -264,7 +270,7 @@ class TestApproveRoute:
             follow_redirects=True,
         )
         assert response.status_code == 403
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='pendinguser'"
             ).fetchone()
@@ -288,17 +294,36 @@ class TestApproveRoute:
             follow_redirects=True,
         )
         assert response.status_code == 200
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='pendinguser'"
             ).fetchone()
         assert row[0] == "approved"
 
+    def test_route_requests_release_temp_database_file(self, app, client):
+        """Route-level database handles should not block temp DB cleanup on Windows."""
+        client.post(
+            "/register",
+            data=registration_payload(client, github_username="cleanupuser"),
+            follow_redirects=True,
+        )
+        response = client.get(
+            "/approve/cleanupuser",
+            headers={"X-Admin-Token": ADMIN_TOKEN},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+
+        cleanup_path = cr.DB_PATH
+        cr.DB_PATH = os.path.join(tempfile.gettempdir(), "unused-contributor-test.db")
+        os.unlink(cleanup_path)
+        assert not os.path.exists(cleanup_path)
+
 
 class TestDatabaseConstraints:
     def test_unique_username_constraint(self, app):
         """Inserting duplicate github_username should raise IntegrityError."""
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             conn.execute(
                 "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
                 ("unique-test", "human", VALID_RTC_WALLET),
@@ -320,7 +345,7 @@ class TestDatabaseConstraints:
             ),
             follow_redirects=True,
         )
-        with sqlite3.connect(cr.DB_PATH) as conn:
+        with db_connect() as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"
             ).fetchone()

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -247,6 +247,29 @@ class TestApproveRoute:
             ).fetchone()
         assert row[0] == "pending"
 
+    def test_approve_rejects_admin_token_in_query_string(self, client):
+        """GET /approve/<username> should not accept admin secrets in URLs."""
+        client.post(
+            "/register",
+            data=registration_payload(
+                client,
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
+        response = client.get(
+            f"/approve/pendinguser?admin_token={ADMIN_TOKEN}",
+            follow_redirects=True,
+        )
+        assert response.status_code == 403
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
     def test_approve_pending_contributor(self, client):
         """GET /approve/<username> with admin token should set status to approved."""
         client.post(


### PR DESCRIPTION
Fixes #4911

Summary:
- Fail closed unless CONTRIBUTOR_REGISTRATION_TOKEN is configured and submitted with registration requests.
- Add a CSRF token to the registration form and reject missing or mismatched tokens.
- Validate GitHub username syntax, contributor type, and RTC/EVM wallet formats before inserting pending records.
- Redact wallet addresses in the HTML listing and public API response.
- Require CONTRIBUTOR_ADMIN_TOKEN for approval actions via X-Admin-Token or admin_token.

Tests:
- uv run --no-project --with pytest --with flask python -m pytest tests/test_contributor_registry.py -q
- uv run --no-project --with ruff ruff check contributor_registry.py tests/test_contributor_registry.py
- python3 -m py_compile contributor_registry.py

wallet: dicnunz