### PR TITLE
fix: require sophia notification bearer token

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -554,15 +554,19 @@ def _scott_notification_queue_url() -> str:
     )
 
 
+def _scott_notification_bearer() -> str:
+    return (
+        os.getenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", "").strip()
+        or os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "").strip()
+    )
+
+
 def _scott_notification_headers() -> dict[str, str]:
     headers = {
         "Content-Type": "application/json",
         "X-Sophia-Inbox": "sophia-governor-inbox",
     }
-    bearer = (
-        os.getenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", "").strip()
-        or os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "elya2025").strip()
-    )
+    bearer = _scott_notification_bearer()
     if bearer:
         headers["Authorization"] = f"Bearer {bearer}"
     return headers
@@ -681,6 +685,12 @@ def _queue_scott_notification_for_entry(
     queue_url = _scott_notification_queue_url()
     if not queue_url:
         return {"status": "not_configured", "phase": phase}
+    if not _scott_notification_bearer():
+        return {
+            "status": "not_configured",
+            "phase": phase,
+            "error": "scott_notification_token_not_configured",
+        }
 
     sent_column = _phase_notify_column(phase)
     if entry.get(sent_column):
@@ -957,7 +967,8 @@ def get_governor_inbox_status(db_path: str | None = None) -> dict[str, Any]:
         "review_relay": _review_relay_status(),
         "scott_notifications": {
             "queue_url": _scott_notification_queue_url(),
-            "configured": bool(_scott_notification_queue_url()),
+            "configured": bool(_scott_notification_queue_url() and _scott_notification_bearer()),
+            "token_configured": bool(_scott_notification_bearer()),
         },
         "totals": {
             "entries": int(total),

--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -30,7 +30,7 @@ DB_PATH = os.getenv("SOPHIA_GOVERNOR_REVIEW_DB", "/tmp/sophia_governor_review.db
 OLLAMA_URL = os.getenv("SOPHIA_GOVERNOR_OLLAMA_URL", "http://192.168.0.160:11434")
 OLLAMA_MODEL = os.getenv("SOPHIA_GOVERNOR_REVIEW_MODEL", "glm-4.7-flash:latest")
 SCOTT_NOTIFICATION_QUEUE_URL = os.getenv("SCOTT_NOTIFICATION_QUEUE_URL", "").strip()
-SCOTT_NOTIFICATION_SERVICE_TOKEN = os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "elya2025").strip()
+SCOTT_NOTIFICATION_SERVICE_TOKEN = os.getenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", "").strip()
 TRUE_VALUES = {"1", "true", "yes", "on"}
 SECTION_PATTERN = re.compile(
     r"(?is)(?:\*\*|\b)(assessment|analysis(?: of the event)?|reasoning|risk|next step|next steps|recommended action|action|decision)\s*:\s*"
@@ -159,6 +159,8 @@ def _relay_scott_notification(payload: dict[str, Any]) -> tuple[int, dict[str, A
         return 503, {"status": "error", "error": "requests_unavailable"}
     if not SCOTT_NOTIFICATION_QUEUE_URL:
         return 503, {"status": "error", "error": "scott_notification_queue_not_configured"}
+    if not SCOTT_NOTIFICATION_SERVICE_TOKEN:
+        return 503, {"status": "error", "error": "scott_notification_token_not_configured"}
     try:
         response = requests.post(
             SCOTT_NOTIFICATION_QUEUE_URL,

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -260,6 +260,7 @@ def test_ingest_can_queue_scott_notification(client, monkeypatch):
         return DummyResponse()
 
     monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", "relay-token")
     monkeypatch.setattr(
         "sophia_governor_inbox.requests",
         type("DummyRequests", (), {"post": staticmethod(fake_post)}),
@@ -276,8 +277,39 @@ def test_ingest_can_queue_scott_notification(client, monkeypatch):
     assert body["scott_notification"]["status"] == "queued"
     assert body["scott_notification"]["notification_id"] == "SN-GOV-INBOX-1"
     assert calls[0]["url"] == "https://example.com/scott-notifications/queue"
+    assert calls[0]["headers"]["Authorization"] == "Bearer relay-token"
     assert calls[0]["json"]["related_type"] == "rustchain_governor_inbox"
     assert calls[0]["json"]["related_id"] == str(body["inbox"]["inbox_id"])
+
+
+def test_ingest_does_not_queue_scott_notification_without_token(client, monkeypatch):
+    calls = []
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        calls.append({"url": url, "json": json, "headers": headers, "timeout": timeout})
+        raise AssertionError("notification queue should not be called without a bearer token")
+
+    monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.setattr(
+        "sophia_governor_inbox.requests",
+        type("DummyRequests", (), {"post": staticmethod(fake_post)}),
+        raising=False,
+    )
+
+    response = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=_sample_envelope(),
+    )
+
+    assert response.status_code == 202
+    body = response.get_json()
+    assert body["scott_notification"] == {
+        "status": "not_configured",
+        "phase": "ingest",
+        "error": "scott_notification_token_not_configured",
+    }
+    assert calls == []
 
 
 def test_manual_forward_endpoint_records_attempt(client, monkeypatch):
@@ -322,6 +354,7 @@ def test_manual_forward_endpoint_records_attempt(client, monkeypatch):
 
     monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_FORWARD_TARGETS", "https://example.com/sophia/review")
     monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_QUEUE_URL", "https://example.com/scott-notifications/queue")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_SCOTT_NOTIFY_BEARER", "relay-token")
     monkeypatch.setattr(
         "sophia_governor_inbox.requests",
         type("DummyRequests", (), {"post": staticmethod(fake_post)}),

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -20,7 +20,7 @@ def client(monkeypatch):
     monkeypatch.delenv("SCOTT_NOTIFICATION_SERVICE_TOKEN", raising=False)
     review_service.DB_PATH = db_path
     review_service.SCOTT_NOTIFICATION_QUEUE_URL = ""
-    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = "elya2025"
+    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = ""
     review_service.app.config["TESTING"] = True
     try:
         yield review_service.app.test_client()
@@ -300,3 +300,28 @@ def test_scott_notification_queue_relay_endpoint(client, monkeypatch):
     assert body["notification"]["notification_id"] == "SN-RELAY0001"
     assert captured["url"] == "http://100.121.203.9:18790/scott-notifications/queue"
     assert captured["headers"]["Authorization"] == "Bearer relay-token"
+
+
+def test_scott_notification_queue_requires_configured_token(client, monkeypatch):
+    calls = []
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise AssertionError("notification relay should not send without a token")
+
+    monkeypatch.setattr(review_service, "requests", SimpleNamespace(post=fake_post))
+    review_service.SCOTT_NOTIFICATION_QUEUE_URL = "http://100.121.203.9:18790/scott-notifications/queue"
+    review_service.SCOTT_NOTIFICATION_SERVICE_TOKEN = ""
+
+    response = client.post(
+        "/api/sophia/governor/scott-notifications/queue",
+        headers={"X-Admin-Key": "test-admin"},
+        json={
+            "title": "RustChain inbox 7 needs review",
+            "summary": "pending_transfer came in at high risk.",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "scott_notification_token_not_configured"
+    assert calls == []


### PR DESCRIPTION
## Summary
- Fixes #4616
- Removes the hardcoded `elya2025` Scott notification bearer-token fallback
- Fails closed before relaying Scott notifications when a queue URL is configured without a token
- Reports Scott notification configuration as complete only when both queue URL and bearer token are present
- Adds regression coverage for the review-service relay and inbox queue paths

## Validation
- `rg -n "elya2025|SCOTT_NOTIFICATION_SERVICE_TOKEN\", \"" node/sophia_governor_review_service.py node/sophia_governor_inbox.py node/tests/test_sophia_governor_review_service.py node/tests/test_sophia_governor_inbox.py`
- `python3 -m py_compile node/sophia_governor_review_service.py node/sophia_governor_inbox.py node/tests/test_sophia_governor_review_service.py node/tests/test_sophia_governor_inbox.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with requests python -m pytest node/tests/test_sophia_governor_review_service.py node/tests/test_sophia_governor_inbox.py -q` -> 27 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC