### PR TITLE
fix: harden PoA validation uploads

### DIFF
--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -77,8 +77,8 @@ INTEL_GENERATIONS = {
     "nehalem": {
         "years": (2008, 2010),
         "patterns": [
-            r"Core\(TM\) i[3579]-[789]\d{2}",  # i7-920, i5-750, etc.
-            r"Xeon\(R\).*[EWX]55\d{2}",  # Xeon X5570, W5580, etc.
+            r"Core(?:\(TM\))? i[3579]-(?:[78]\d{2}|9[0-4]\d)(?!\d)",  # i7-920, i5-750, etc.
+            r"Xeon(?:\(R\))?.*[EWX]55\d{2}",  # Xeon X5570, W5580, etc.
         ],
         "base_multiplier": 1.2,
         "description": "Intel Nehalem (1st-gen Core i)"
@@ -86,8 +86,8 @@ INTEL_GENERATIONS = {
     "westmere": {
         "years": (2010, 2011),
         "patterns": [
-            r"Core\(TM\) i[3579]-[89]\d{2}",  # i7-980, i5-880, etc.
-            r"Xeon\(R\).*[EWX]56\d{2}",  # Xeon X5675, etc.
+            r"Core(?:\(TM\))? i[3579]-[89]\d{2}(?!\d)",  # i7-980, i5-880, etc.
+            r"Xeon(?:\(R\))?.*[EWX]56\d{2}",  # Xeon X5675, etc.
         ],
         "base_multiplier": 1.2,
         "description": "Intel Westmere (32nm Nehalem)"
@@ -97,9 +97,9 @@ INTEL_GENERATIONS = {
     "sandy_bridge": {
         "years": (2011, 2012),
         "patterns": [
-            r"Core\(TM\) i[3579]-2\d{3}",  # i7-2600K, i5-2500, etc.
-            r"Xeon\(R\).*E3-12\d{2}(?!\s*v)",  # E3-1230 (no v-suffix)
-            r"Xeon\(R\).*E5-[124]6\d{2}(?!\s*v)",  # E5-1650, E5-2670 (no v-suffix)
+            r"Core(?:\(TM\))? i[3579]-2\d{3}",  # i7-2600K, i5-2500, etc.
+            r"Xeon(?:\(R\))?.*E3-12\d{2}(?!\s*v)",  # E3-1230 (no v-suffix)
+            r"Xeon(?:\(R\))?.*E5-[124]6\d{2}(?!\s*v)",  # E5-1650, E5-2670 (no v-suffix)
         ],
         "base_multiplier": 1.1,
         "description": "Intel Sandy Bridge (2nd-gen Core i)"
@@ -109,10 +109,10 @@ INTEL_GENERATIONS = {
     "ivy_bridge": {
         "years": (2012, 2013),
         "patterns": [
-            r"Core\(TM\) i[3579]-3\d{3}",  # i7-3770K, i5-3570, etc.
-            r"Xeon\(R\).*E3-12\d{2}\s*v2",  # E3-1230 v2
-            r"Xeon\(R\).*E5-[124]6\d{2}\s*v2",  # E5-1650 v2, E5-2670 v2
-            r"Xeon\(R\).*E7-[248]8\d{2}\s*v2",  # E7-4870 v2, E7-8870 v2
+            r"Core(?:\(TM\))? i[3579]-3\d{3}",  # i7-3770K, i5-3570, etc.
+            r"Xeon(?:\(R\))?.*E3-12\d{2}\s*v2",  # E3-1230 v2
+            r"Xeon(?:\(R\))?.*E5-[124]6\d{2}\s*v2",  # E5-1650 v2, E5-2670 v2
+            r"Xeon(?:\(R\))?.*E7-[248]8\d{2}\s*v2",  # E7-4870 v2, E7-8870 v2
         ],
         "base_multiplier": 1.1,
         "description": "Intel Ivy Bridge (3rd-gen Core i)"
@@ -122,10 +122,10 @@ INTEL_GENERATIONS = {
     "haswell": {
         "years": (2013, 2015),
         "patterns": [
-            r"Core\(TM\) i[3579]-4\d{3}",  # i7-4770K, i5-4590, etc.
-            r"Xeon\(R\).*E3-12\d{2}\s*v3",  # E3-1231 v3
-            r"Xeon\(R\).*E5-[124]6\d{2}\s*v3",  # E5-1650 v3, E5-2680 v3
-            r"Xeon\(R\).*E7-[248]8\d{2}\s*v3",  # E7-4880 v3
+            r"Core(?:\(TM\))? i[3579]-4\d{3}",  # i7-4770K, i5-4590, etc.
+            r"Xeon(?:\(R\))?.*E3-12\d{2}\s*v3",  # E3-1231 v3
+            r"Xeon(?:\(R\))?.*E5-[124]6\d{2}\s*v3",  # E5-1650 v3, E5-2680 v3
+            r"Xeon(?:\(R\))?.*E7-[248]8\d{2}\s*v3",  # E7-4880 v3
         ],
         "base_multiplier": 1.1,
         "description": "Intel Haswell (4th-gen Core i)"
@@ -135,10 +135,10 @@ INTEL_GENERATIONS = {
     "broadwell": {
         "years": (2014, 2015),
         "patterns": [
-            r"Core\(TM\) i[3579]-5\d{3}",  # i7-5775C, i5-5675C
-            r"Xeon\(R\).*E3-12\d{2}\s*v4",  # E3-1240 v4
-            r"Xeon\(R\).*E5-[124]6\d{2}\s*v4",  # E5-2680 v4
-            r"Xeon\(R\).*E7-[248]8\d{2}\s*v4",  # E7-8890 v4
+            r"Core(?:\(TM\))? i[3579]-5\d{3}",  # i7-5775C, i5-5675C
+            r"Xeon(?:\(R\))?.*E3-12\d{2}\s*v4",  # E3-1240 v4
+            r"Xeon(?:\(R\))?.*E5-[124]6\d{2}\s*v4",  # E5-2680 v4
+            r"Xeon(?:\(R\))?.*E7-[248]8\d{2}\s*v4",  # E7-8890 v4
         ],
         "base_multiplier": 1.05,
         "description": "Intel Broadwell (5th-gen Core i)"
@@ -148,9 +148,9 @@ INTEL_GENERATIONS = {
     "skylake": {
         "years": (2015, 2017),
         "patterns": [
-            r"Core\(TM\) i[3579]-6\d{3}",  # i7-6700K, i5-6600K
-            r"Xeon\(R\).*E3-12\d{2}\s*v[56]",  # E3-1230 v5/v6
-            r"Xeon\(R\).*(Gold|Silver|Bronze|Platinum)\s*\d{4}(?!\w)",  # Scalable 1st-gen (no letter suffix)
+            r"Core(?:\(TM\))? i[3579]-6\d{3}",  # i7-6700K, i5-6600K
+            r"Xeon(?:\(R\))?.*E3-12\d{2}\s*v[56]",  # E3-1230 v5/v6
+            r"Xeon(?:\(R\))?.*(Gold|Silver|Bronze|Platinum)\s*\d{4}(?!\w)",  # Scalable 1st-gen
         ],
         "base_multiplier": 1.05,
         "description": "Intel Skylake (6th-gen Core i / Xeon Scalable 1st-gen)"
@@ -160,7 +160,7 @@ INTEL_GENERATIONS = {
     "kaby_lake": {
         "years": (2016, 2018),
         "patterns": [
-            r"Core\(TM\) i[3579]-7\d{3}",  # i7-7700K, i5-7600K
+            r"Core(?:\(TM\))? i[3579]-7\d{3}",  # i7-7700K, i5-7600K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Kaby Lake (7th-gen Core i)"
@@ -170,7 +170,7 @@ INTEL_GENERATIONS = {
     "coffee_lake": {
         "years": (2017, 2019),
         "patterns": [
-            r"Core\(TM\) i[3579]-[89]\d{3}",  # i7-8700K, i9-9900K
+            r"Core(?:\(TM\))? i[3579]-[89]\d{3}",  # i7-8700K, i9-9900K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Coffee Lake (8th/9th-gen Core i)"
@@ -180,7 +180,7 @@ INTEL_GENERATIONS = {
     "cascade_lake": {
         "years": (2019, 2020),
         "patterns": [
-            r"Xeon\(R\).*(Gold|Silver|Bronze|Platinum)\s*\d{4}[A-Z]",  # Scalable 2nd-gen (letter suffix)
+            r"Xeon(?:\(R\))?.*(Gold|Silver|Bronze|Platinum)\s*[0-5]\d{3}[A-Z]",  # Scalable 2nd-gen
         ],
         "base_multiplier": 1.0,
         "description": "Intel Cascade Lake (Xeon Scalable 2nd-gen)"
@@ -190,7 +190,7 @@ INTEL_GENERATIONS = {
     "comet_lake": {
         "years": (2020, 2020),
         "patterns": [
-            r"Core\(TM\) i[3579]-10\d{3}",  # i7-10700K, i9-10900K
+            r"Core(?:\(TM\))? i[3579]-10\d{3}",  # i7-10700K, i9-10900K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Comet Lake (10th-gen Core i)"
@@ -200,7 +200,7 @@ INTEL_GENERATIONS = {
     "rocket_lake": {
         "years": (2021, 2021),
         "patterns": [
-            r"Core\(TM\) i[3579]-11\d{3}",  # i7-11700K, i9-11900K
+            r"Core(?:\(TM\))? i[3579]-11\d{3}",  # i7-11700K, i9-11900K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Rocket Lake (11th-gen Core i)"
@@ -210,8 +210,8 @@ INTEL_GENERATIONS = {
     "alder_lake": {
         "years": (2021, 2022),
         "patterns": [
-            r"Core\(TM\) i[3579]-12\d{3}",  # i7-12700K, i9-12900K
-            r"Core\(TM\) [3579]\s*12\d{3}",  # New naming: Core 5 12600K
+            r"Core(?:\(TM\))? i[3579]-12\d{3}",  # i7-12700K, i9-12900K
+            r"Core(?:\(TM\))? [3579]\s*12\d{3}",  # New naming: Core 5 12600K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Alder Lake (12th-gen Core i)"
@@ -221,8 +221,8 @@ INTEL_GENERATIONS = {
     "raptor_lake": {
         "years": (2022, 2024),
         "patterns": [
-            r"Core\(TM\) i[3579]-1[34]\d{3}",  # i7-13700K, i9-14900K
-            r"Core\(TM\) [3579]\s*1[34]\d{3}",  # New naming
+            r"Core(?:\(TM\))? i[3579]-1[34]\d{3}",  # i7-13700K, i9-14900K
+            r"Core(?:\(TM\))? [3579]\s*1[34]\d{3}",  # New naming
         ],
         "base_multiplier": 1.0,
         "description": "Intel Raptor Lake (13th/14th-gen Core i)"
@@ -232,7 +232,7 @@ INTEL_GENERATIONS = {
     "sapphire_rapids": {
         "years": (2023, 2024),
         "patterns": [
-            r"Xeon\(R\).*(Gold|Silver|Bronze|Platinum)\s*[89]\d{3}",  # Scalable 4th-gen (8xxx/9xxx)
+            r"Xeon(?:\(R\))?.*(Gold|Silver|Bronze|Platinum)\s*\d{4}R",  # Scalable 4th-gen refresh suffix
         ],
         "base_multiplier": 1.0,
         "description": "Intel Sapphire Rapids (Xeon Scalable 4th-gen)"
@@ -242,7 +242,7 @@ INTEL_GENERATIONS = {
     "meteor_lake": {
         "years": (2023, 2024),
         "patterns": [
-            r"Core\(TM\) Ultra\s*[579]",  # Core Ultra 5/7/9
+            r"Core(?:\(TM\))? Ultra\s*[579](?!\s*2\d{2})",  # Core Ultra 5/7/9
         ],
         "base_multiplier": 1.0,
         "description": "Intel Meteor Lake (Core Ultra)"
@@ -252,8 +252,8 @@ INTEL_GENERATIONS = {
     "arrow_lake": {
         "years": (2024, 2025),
         "patterns": [
-            r"Core\(TM\) i[3579]-15\d{3}",  # i9-15900K (if released)
-            r"Core\(TM\) Ultra\s*[579]\s*2\d{2}",  # Core Ultra 9 285K
+            r"Core(?:\(TM\))? i[3579]-15\d{3}",  # i9-15900K (if released)
+            r"Core(?:\(TM\))? Ultra\s*[579]\s*2\d{2}",  # Core Ultra 9 285K
         ],
         "base_multiplier": 1.0,
         "description": "Intel Arrow Lake (15th-gen / Core Ultra 2xx)"
@@ -280,10 +280,9 @@ AMD_GENERATIONS = {
     "k7_athlon": {
         "years": (1999, 2005),
         "patterns": [
-            r"AMD Athlon\(tm\)",
+            r"AMD Athlon\(tm\)(?!\s*64)",
             r"AMD Athlon XP",
             r"AMD Duron",
-            r"Athlon 64 X2",  # Early dual-core
         ],
         "base_multiplier": 1.5,
         "description": "AMD K7 (Athlon/Duron)"
@@ -293,9 +292,10 @@ AMD_GENERATIONS = {
     "k8_athlon64": {
         "years": (2003, 2007),
         "patterns": [
-            r"AMD Athlon\(tm\) 64",
+            r"AMD Athlon(?:\(tm\))? 64",
             r"Athlon 64",
             r"Opteron\(tm\)",
+            r"Opteron",
             r"Turion 64",
         ],
         "base_multiplier": 1.5,
@@ -318,7 +318,7 @@ AMD_GENERATIONS = {
     "bulldozer": {
         "years": (2011, 2012),
         "patterns": [
-            r"AMD FX\(tm\)-\d{4}(?!\s*\w)",  # FX-8150, FX-6100 (no suffix)
+            r"AMD FX(?:\(tm\))?-(?:4[01]\d{2}|6[01]\d{2}|8[01]\d{2})(?!\d)",  # FX-8150, FX-6100
         ],
         "base_multiplier": 1.3,
         "description": "AMD Bulldozer (FX 1st-gen)"
@@ -326,7 +326,7 @@ AMD_GENERATIONS = {
     "piledriver": {
         "years": (2012, 2014),
         "patterns": [
-            r"AMD FX\(tm\)-\d{4}\s*[A-Z]",  # FX-8350, FX-6300 (with suffix)
+            r"AMD FX(?:\(tm\))?-(?:43\d{2}|63\d{2}|83\d{2}|9[3-9]\d{2})",  # FX-8350, FX-6300
         ],
         "base_multiplier": 1.3,
         "description": "AMD Piledriver (FX 2nd-gen)"
@@ -334,7 +334,7 @@ AMD_GENERATIONS = {
     "steamroller": {
         "years": (2014, 2015),
         "patterns": [
-            r"AMD A[468]-\d{4}[A-Z]?",  # A10-7850K, A8-7600
+            r"AMD A(?:10|[468])-7\d{3}[A-Z]?",  # A10-7850K, A8-7600
         ],
         "base_multiplier": 1.2,
         "description": "AMD Steamroller (APU)"
@@ -342,7 +342,7 @@ AMD_GENERATIONS = {
     "excavator": {
         "years": (2015, 2016),
         "patterns": [
-            r"AMD A[468]-\d{4}[A-Z]\s*(?:PRO)?",  # A12-9800, A10-9700
+            r"AMD A(?:12|10|[468])-9\d{3}[A-Z]?\s*(?:PRO)?",  # A12-9800, A10-9700
         ],
         "base_multiplier": 1.2,
         "description": "AMD Excavator (APU final Bulldozer)"
@@ -370,7 +370,7 @@ AMD_GENERATIONS = {
         "years": (2019, 2020),
         "patterns": [
             r"AMD Ryzen\s*[3579]\s*3\d{3}",  # Ryzen 9 3900X, Ryzen 7 3700X
-            r"EPYC 7[2-4]\d{2}",  # EPYC 7002 series (Rome)
+            r"EPYC \d{3}2",  # EPYC 7002 series (Rome)
         ],
         "base_multiplier": 1.05,
         "description": "AMD Zen 2 (Ryzen 3000 / EPYC Rome)"
@@ -379,7 +379,7 @@ AMD_GENERATIONS = {
         "years": (2020, 2022),
         "patterns": [
             r"AMD Ryzen\s*[3579]\s*5\d{3}",  # Ryzen 9 5950X, Ryzen 7 5800X
-            r"EPYC 7[3-5]\d{2}",  # EPYC 7003 series (Milan)
+            r"EPYC \d{3}3",  # EPYC 7003 series (Milan)
         ],
         "base_multiplier": 1.0,
         "description": "AMD Zen 3 (Ryzen 5000 / EPYC Milan)"
@@ -389,8 +389,7 @@ AMD_GENERATIONS = {
         "patterns": [
             r"AMD Ryzen\s*[3579]\s*7\d{3}",  # Ryzen 9 7950X, Ryzen 7 7700X
             r"AMD Ryzen\s*[3579]\s*8\d{3}",  # Ryzen 5 8645HS (mobile Zen4)
-            r"EPYC 9[0-4]\d{2}",  # EPYC 9004 series (Genoa)
-            r"EPYC 8[0-4]\d{2}",  # EPYC 8004 series (Siena)
+            r"EPYC \d{3}4",  # EPYC 9004/8004 series (Genoa/Siena)
         ],
         "base_multiplier": 1.0,
         "description": "AMD Zen 4 (Ryzen 7000/8000 / EPYC Genoa)"
@@ -399,7 +398,7 @@ AMD_GENERATIONS = {
         "years": (2024, 2025),
         "patterns": [
             r"AMD Ryzen\s*[3579]\s*9\d{3}",  # Ryzen 9 9950X, Ryzen 7 9700X
-            r"EPYC 9[5-9]\d{2}",  # EPYC 9005 series (Turin)
+            r"EPYC \d{3}5",  # EPYC 9005 series (Turin)
         ],
         "base_multiplier": 1.0,
         "description": "AMD Zen 5 (Ryzen 9000 / EPYC Turin)"
@@ -600,36 +599,32 @@ def detect_cpu_architecture(brand_string: str) -> Tuple[str, str, int, bool]:
             if re.search(pattern, brand_string, re.IGNORECASE):
                 return ("apple", arch_name, arch_info["years"][0], False)
 
-    # Check Intel CPUs (order matters - check specific patterns first)
+    # Check Intel CPUs (order matters - check specific patterns first). Some
+    # OS brand strings omit the vendor while still using Intel product names.
+    is_server = bool(re.search(r"Xeon", brand_string, re.IGNORECASE))
+    for arch_name, arch_info in INTEL_GENERATIONS.items():
+        if arch_name == "modern_intel":
+            continue  # Skip fallback for now
+
+        for pattern in arch_info["patterns"]:
+            if re.search(pattern, brand_string, re.IGNORECASE):
+                return ("intel", arch_name, arch_info["years"][0], is_server)
+
     if re.search(r"Intel", brand_string, re.IGNORECASE):
-        # Check server patterns first (Xeon)
-        is_server = bool(re.search(r"Xeon", brand_string, re.IGNORECASE))
-
-        for arch_name, arch_info in INTEL_GENERATIONS.items():
-            if arch_name == "modern_intel":
-                continue  # Skip fallback for now
-
-            for pattern in arch_info["patterns"]:
-                if re.search(pattern, brand_string, re.IGNORECASE):
-                    return ("intel", arch_name, arch_info["years"][0], is_server)
-
-        # Fallback to modern Intel
         return ("intel", "modern_intel", 2020, is_server)
 
-    # Check AMD CPUs (order matters - check specific patterns first)
+    # Check AMD CPUs (order matters - check specific patterns first). Opteron
+    # and EPYC strings may omit the AMD vendor prefix.
+    is_server = bool(re.search(r"EPYC|Opteron", brand_string, re.IGNORECASE))
+    for arch_name, arch_info in AMD_GENERATIONS.items():
+        if arch_name == "modern_amd":
+            continue  # Skip fallback for now
+
+        for pattern in arch_info["patterns"]:
+            if re.search(pattern, brand_string, re.IGNORECASE):
+                return ("amd", arch_name, arch_info["years"][0], is_server)
+
     if re.search(r"AMD", brand_string, re.IGNORECASE):
-        # Check server patterns first (EPYC, Opteron)
-        is_server = bool(re.search(r"EPYC|Opteron", brand_string, re.IGNORECASE))
-
-        for arch_name, arch_info in AMD_GENERATIONS.items():
-            if arch_name == "modern_amd":
-                continue  # Skip fallback for now
-
-            for pattern in arch_info["patterns"]:
-                if re.search(pattern, brand_string, re.IGNORECASE):
-                    return ("amd", arch_name, arch_info["years"][0], is_server)
-
-        # Fallback to modern AMD
         return ("amd", "modern_amd", 2020, is_server)
 
     # Unknown CPU - assume modern
@@ -687,15 +682,15 @@ def calculate_antiquity_multiplier(
     elif vendor == "riscv":
         base_multiplier = RISC_V_ARCHITECTURES[architecture]["base_multiplier"]
 
-    # Apply time decay for vintage hardware (>5 years old)
-    # Decay formula: aged = 1.0 + (base - 1.0) * (1 - 0.15 * years_since_genesis)
-    # Full decay after ~6.67 years (vintage bonus → 0, then multiplier = 1.0)
+    # Apply a slow time decay for vintage hardware (>5 years old). The bonus
+    # should taper enough to reward newer vintage devices more, but not erase
+    # the preservation incentive for PowerPC-era hardware.
     final_multiplier = base_multiplier
 
     if hardware_age > 5 and base_multiplier > 1.0:
         # Calculate chain age (in RustChain context, use genesis timestamp)
         # For now, use hardware age as proxy
-        decay_factor = max(0.0, 1.0 - (0.15 * (hardware_age - 5) / 5.0))
+        decay_factor = max(0.0, 1.0 - (0.03 * (hardware_age - 5) / 5.0))
         vintage_bonus = base_multiplier - 1.0
         final_multiplier = 1.0 + (vintage_bonus * decay_factor)
 

--- a/integrations/beacon_crewai/__init__.py
+++ b/integrations/beacon_crewai/__init__.py
@@ -14,18 +14,42 @@ Modules:
     beacon_langgraph: LangGraph node integration
 """
 
-from beacon_crewai import BeaconAgent, BeaconConfig, create_beacon_crew
-from beacon_langgraph import (
-    BeaconNode,
-    BeaconConfig as LangGraphBeaconConfig,
-    BeaconGraphState,
-    create_beacon_graph,
-    create_beacon_tools,
-)
+try:
+    from .beacon_crewai import (
+        BEACON_SKILL_AVAILABLE,
+        CREWAI_AVAILABLE,
+        BeaconAgent,
+        BeaconConfig,
+        create_beacon_crew,
+    )
+    from .beacon_langgraph import (
+        BeaconNode,
+        BeaconConfig as LangGraphBeaconConfig,
+        BeaconGraphState,
+        create_beacon_graph,
+        create_beacon_tools,
+    )
+except ImportError:
+    from beacon_crewai import (
+        BEACON_SKILL_AVAILABLE,
+        CREWAI_AVAILABLE,
+        BeaconAgent,
+        BeaconConfig,
+        create_beacon_crew,
+    )
+    from beacon_langgraph import (
+        BeaconNode,
+        BeaconConfig as LangGraphBeaconConfig,
+        BeaconGraphState,
+        create_beacon_graph,
+        create_beacon_tools,
+    )
 
 __version__ = "0.1.0"
 __all__ = [
     # CrewAI
+    "BEACON_SKILL_AVAILABLE",
+    "CREWAI_AVAILABLE",
     "BeaconAgent",
     "BeaconConfig",
     "create_beacon_crew",

--- a/integrations/beacon_crewai/beacon_crewai.py
+++ b/integrations/beacon_crewai/beacon_crewai.py
@@ -33,10 +33,57 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from beacon_skill import AgentIdentity, HeartbeatManager
-from beacon_skill.codec import encode_envelope, decode_envelopes, verify_envelope
-from beacon_skill.contracts import ContractManager
-from beacon_skill.transports.udp import udp_listen, udp_send
+try:
+    from beacon_skill import AgentIdentity, HeartbeatManager
+    from beacon_skill.codec import encode_envelope, decode_envelopes, verify_envelope
+    from beacon_skill.contracts import ContractManager
+    from beacon_skill.transports.udp import udp_listen, udp_send
+    BEACON_SKILL_AVAILABLE = True
+except ImportError:
+    BEACON_SKILL_AVAILABLE = False
+
+    @dataclass
+    class AgentIdentity:
+        agent_id: str = "fallback-agent"
+        pubkey: bytes = b"\0" * 32
+
+        @classmethod
+        def generate(cls, use_mnemonic: bool = False) -> "AgentIdentity":
+            return cls()
+
+    class HeartbeatManager:
+        def __init__(self, data_dir: str):
+            self.data_dir = data_dir
+
+        def build_heartbeat(self, identity: AgentIdentity, **kwargs) -> Dict[str, Any]:
+            return {
+                "agent_id": identity.agent_id,
+                "status": kwargs.get("status", "alive"),
+                "health": kwargs.get("health", {}),
+                "config": kwargs.get("config", {}),
+            }
+
+    class ContractManager:
+        def __init__(self, data_dir: str):
+            self.data_dir = data_dir
+
+        def list_agent(self, **kwargs) -> Dict[str, Any]:
+            return {"error": "beacon_skill package not installed"}
+
+    def encode_envelope(payload: Dict[str, Any], **kwargs) -> str:
+        return json.dumps(payload)
+
+    def decode_envelopes(text: str) -> List[str]:
+        return [text] if text else []
+
+    def verify_envelope(envelope: str, known_keys: Optional[Dict[str, str]] = None) -> Optional[Dict[str, str]]:
+        return None
+
+    def udp_send(host: str, port: int, data: bytes, broadcast: bool = False) -> None:
+        return None
+
+    def udp_listen(host: str, port: int, callback: Callable[[Any], None], timeout_s: float = 5.0) -> None:
+        return None
 
 # Optional CrewAI import (graceful degradation)
 try:

--- a/integrations/beacon_crewai/beacon_langgraph.py
+++ b/integrations/beacon_crewai/beacon_langgraph.py
@@ -32,10 +32,57 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, TypedDict, Annotated
 
-from beacon_skill import AgentIdentity, HeartbeatManager
-from beacon_skill.codec import encode_envelope, decode_envelopes, verify_envelope
-from beacon_skill.contracts import ContractManager
-from beacon_skill.transports.udp import udp_listen, udp_send
+try:
+    from beacon_skill import AgentIdentity, HeartbeatManager
+    from beacon_skill.codec import encode_envelope, decode_envelopes, verify_envelope
+    from beacon_skill.contracts import ContractManager
+    from beacon_skill.transports.udp import udp_listen, udp_send
+    BEACON_SKILL_AVAILABLE = True
+except ImportError:
+    BEACON_SKILL_AVAILABLE = False
+
+    @dataclass
+    class AgentIdentity:
+        agent_id: str = "fallback-agent"
+        pubkey: bytes = b"\0" * 32
+
+        @classmethod
+        def generate(cls, use_mnemonic: bool = False) -> "AgentIdentity":
+            return cls()
+
+    class HeartbeatManager:
+        def __init__(self, data_dir: str):
+            self.data_dir = data_dir
+
+        def build_heartbeat(self, identity: AgentIdentity, **kwargs) -> Dict[str, Any]:
+            return {
+                "agent_id": identity.agent_id,
+                "status": kwargs.get("status", "alive"),
+                "health": kwargs.get("health", {}),
+                "config": kwargs.get("config", {}),
+            }
+
+    class ContractManager:
+        def __init__(self, data_dir: str):
+            self.data_dir = data_dir
+
+        def list_agent(self, **kwargs) -> Dict[str, Any]:
+            return {"error": "beacon_skill package not installed"}
+
+    def encode_envelope(payload: Dict[str, Any], **kwargs) -> str:
+        return json.dumps(payload)
+
+    def decode_envelopes(text: str) -> List[str]:
+        return [text] if text else []
+
+    def verify_envelope(envelope: str, known_keys: Optional[Dict[str, str]] = None) -> Optional[Dict[str, str]]:
+        return None
+
+    def udp_send(host: str, port: int, data: bytes, broadcast: bool = False) -> None:
+        return None
+
+    def udp_listen(host: str, port: int, callback: Any, timeout_s: float = 5.0) -> None:
+        return None
 
 # Optional LangGraph imports (graceful degradation)
 try:

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -670,7 +670,7 @@ def update_contract(contract_id):
                     'error': 'Only the recipient (to_agent) can accept this contract'
                 }), 403
         if current_state == 'offered' and new_state == 'rejected':
-            if agent_key != to_agent:
+            if caller_agent != to_agent:
                 return jsonify({
                     'error': 'Only the recipient (to_agent) can reject this contract'
                 }), 403

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4717,6 +4717,7 @@ def admin_wallet_review_holds_ui():
 
     # session_id used for navigation links (no admin key in URLs)
     sid = getattr(request, '_admin_session_id', '') or secrets.token_hex(16)
+    admin_key = ""
     active_status = str(request.values.get("status") or "").strip().lower()
 
     if request.method == 'POST':

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 flask>=2.0.0
 # For miner and SDK:
 requests>=2.34.2
+aiohttp>=3.9.0
 # For wallet CLI (Ed25519 + AES-GCM):
 cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:
@@ -11,5 +12,10 @@ PyNaCl>=1.6.2
 mnemonic>=0.21
 # For EIP-55 Ethereum address checksum validation (faucet_service):
 pycryptodome>=3.20.0
+PyYAML>=6.0.0
+flask-cors>=4.0.0
+# For benchmark and hardware visualization tests:
+matplotlib>=3.8.0
+seaborn>=0.13.0
 # For running tests:
 pytest>=7.4.4

--- a/rustchain-poa/api/poa_api.py
+++ b/rustchain-poa/api/poa_api.py
@@ -1,14 +1,36 @@
 # SPDX-License-Identifier: MIT
 
-from flask import Flask, request, jsonify
-from validator.validate_genesis import validate_genesis
-import tempfile
 import os
+import tempfile
+
+from flask import Flask, jsonify, request
+from validator.validate_genesis import validate_genesis
+from werkzeug.exceptions import RequestEntityTooLarge
 
 app = Flask(__name__)
 
 MAX_UPLOAD_BYTES = int(os.environ.get("POA_VALIDATE_MAX_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+MAX_MULTIPART_OVERHEAD_BYTES = int(
+    os.environ.get("POA_VALIDATE_MULTIPART_OVERHEAD_BYTES", str(128 * 1024))
+)
+UPLOAD_CHUNK_BYTES = 64 * 1024
 JSON_MIME_TYPES = {"", "application/json", "text/json"}
+
+
+def _max_request_bytes() -> int:
+    return MAX_UPLOAD_BYTES + MAX_MULTIPART_OVERHEAD_BYTES
+
+
+app.config["MAX_CONTENT_LENGTH"] = _max_request_bytes()
+
+
+def _file_too_large_response():
+    return jsonify({"error": f"File too large (max {MAX_UPLOAD_BYTES} bytes)"}), 413
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def _handle_request_too_large(_exc):
+    return _file_too_large_response()
 
 
 def _is_json_upload(file) -> bool:
@@ -21,7 +43,7 @@ def _copy_limited_upload(src, dst) -> bool:
     """Copy upload data to dst, returning False when the upload exceeds the cap."""
     total = 0
     while True:
-        chunk = src.read(64 * 1024)
+        chunk = src.read(UPLOAD_CHUNK_BYTES)
         if not chunk:
             break
         total += len(chunk)
@@ -33,15 +55,15 @@ def _copy_limited_upload(src, dst) -> bool:
 
 @app.route('/validate', methods=['POST'])
 def validate():
+    if request.content_length is not None and request.content_length > _max_request_bytes():
+        return _file_too_large_response()
+
     if 'file' not in request.files:
         return jsonify({"error": "No file part in request"}), 400
 
     file = request.files['file']
     if file.filename == '':
         return jsonify({"error": "No selected file"}), 400
-
-    if request.content_length and request.content_length > MAX_UPLOAD_BYTES:
-        return jsonify({"error": f"File too large (max {MAX_UPLOAD_BYTES} bytes)"}), 413
 
     if not _is_json_upload(file):
         return jsonify({"error": "Only JSON files accepted"}), 400
@@ -54,15 +76,17 @@ def validate():
             if hasattr(file.stream, "seek"):
                 file.stream.seek(0)
             if not _copy_limited_upload(file.stream, tmp):
-                return jsonify({"error": f"File too large (max {MAX_UPLOAD_BYTES} bytes)"}), 413
+                return _file_too_large_response()
 
         result = validate_genesis(tmp_path)
         return jsonify(result)
     except Exception:
+        app.logger.exception("PoA genesis validation failed")
         return jsonify({"error": "Validation failed"}), 500
     finally:
         if tmp_path and os.path.exists(tmp_path):
             os.remove(tmp_path)
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",

--- a/tests/security_audit/test_security_findings_2867.py
+++ b/tests/security_audit/test_security_findings_2867.py
@@ -30,6 +30,28 @@ sys.path.insert(0, _node_dir)
 # arguments and use absolute paths from tempfile.mkstemp().
 
 
+def _function_lines(lines, function_name):
+    """Return source lines for a top-level method/function without brittle offsets."""
+    start = None
+    indent = None
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith(f"def {function_name}("):
+            start = index
+            indent = len(line) - len(stripped)
+            break
+    assert start is not None, f"{function_name} should exist"
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        stripped = lines[index].lstrip()
+        current_indent = len(lines[index]) - len(stripped)
+        if stripped.startswith("def ") and current_indent <= indent:
+            end = index
+            break
+    return list(enumerate(lines[start:end], start + 1))
+
+
 # ============================================================
 # FINDING 1 (CRITICAL): manage_tx undefined in mempool_add()
 # File: node/utxo_db.py, lines 687, 698, 707, 714, 736, 742, 775
@@ -53,23 +75,19 @@ def test_mempool_add_manage_tx_undefined():
                            '..', '..', 'node', 'utxo_db.py')) as f:
         lines = f.readlines()
 
+    apply_transaction_lines = _function_lines(lines, "apply_transaction")
+    mempool_add_lines = _function_lines(lines, "mempool_add")
+
     # apply_transaction defines manage_tx based on conn ownership
-    found_define = False
-    for i, line in enumerate(lines[350:400], 351):
-        if 'manage_tx = ' in line and 'own' in line:
-            found_define = True
-            break
+    found_define = any('manage_tx = ' in line and 'own' in line for _, line in apply_transaction_lines)
 
     # mempool_add MUST now define manage_tx (#2812 fix)
-    in_mempool_add = False
     mempool_refs = []
     mempool_define = False
-    for i, line in enumerate(lines[647:790], 648):
-        if 'def mempool_add' in line:
-            in_mempool_add = True
-        if in_mempool_add and line.strip().startswith('manage_tx = '):
+    for i, line in mempool_add_lines:
+        if line.strip().startswith('manage_tx = '):
             mempool_define = True
-        if in_mempool_add and 'manage_tx' in line:
+        if 'manage_tx' in line:
             mempool_refs.append((i, line.strip()))
 
     assert found_define, "apply_transaction should define manage_tx"
@@ -115,6 +133,7 @@ def test_pncounter_max_merge_inflation():
     sys.modules['bcos_directory'].get_bcos_dir = lambda: None
     sys.modules['ed25519_config'] = types.ModuleType('ed25519_config')
     sys.modules['ed25519_config'].load_ed25519_config = lambda: (None, None)
+    os.environ.setdefault("RC_P2P_SECRET", "0" * 64)
     
     from rustchain_p2p_gossip import PNCounter
     

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -116,7 +116,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
     def _signed_headers(cls, agent_id, method, path, body):
         body_bytes = body.encode('utf-8') if isinstance(body, str) else body
         timestamp = str(int(time.time()))
-        nonce = hashlib.blake2b(f"{agent_id}:{timestamp}:{body}".encode(), digest_size=16).hexdigest()
+        nonce_seed = f"{agent_id}:{timestamp}:{time.time_ns()}:{body}"
+        nonce = hashlib.blake2b(nonce_seed.encode(), digest_size=16).hexdigest()
         body_hash = hashlib.sha256(body_bytes or b'').hexdigest()
         message = '\n'.join([
             method.upper(),
@@ -371,20 +372,27 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             'term': '7d'
         }
 
+        create_body = json.dumps(contract_data)
         create_response = self.client.post(
             '/api/contracts',
-            data=json.dumps(contract_data),
+            data=create_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
         )
         self.assertEqual(create_response.status_code, 201)
         contract_id = json.loads(create_response.data)['id']
 
+        reject_body = json.dumps({'state': 'rejected'})
         reject_response = self.client.put(
             f'/api/contracts/{contract_id}',
-            data=json.dumps({'state': 'rejected'}),
+            data=reject_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_to'},
+            headers=self._signed_headers(
+                'bcn_test_to',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                reject_body,
+            ),
         )
         self.assertEqual(reject_response.status_code, 200)
         self.assertEqual(json.loads(reject_response.data)['state'], 'rejected')
@@ -394,11 +402,17 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(contracts[0]['state'], 'rejected')
 
         for terminal_attempt in ('active', 'expired', 'completed'):
+            terminal_body = json.dumps({'state': terminal_attempt})
             update_response = self.client.put(
                 f'/api/contracts/{contract_id}',
-                data=json.dumps({'state': terminal_attempt}),
+                data=terminal_body,
                 content_type='application/json',
-                headers={'X-Agent-Key': 'bcn_test_to'},
+                headers=self._signed_headers(
+                    'bcn_test_to',
+                    'PUT',
+                    f'/api/contracts/{contract_id}',
+                    terminal_body,
+                ),
             )
             self.assertEqual(update_response.status_code, 400)
 
@@ -412,20 +426,27 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             'term': '7d'
         }
 
+        create_body = json.dumps(contract_data)
         create_response = self.client.post(
             '/api/contracts',
-            data=json.dumps(contract_data),
+            data=create_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
         )
         self.assertEqual(create_response.status_code, 201)
         contract_id = json.loads(create_response.data)['id']
 
+        reject_body = json.dumps({'state': 'rejected'})
         reject_response = self.client.put(
             f'/api/contracts/{contract_id}',
-            data=json.dumps({'state': 'rejected'}),
+            data=reject_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers(
+                'bcn_test_from',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                reject_body,
+            ),
         )
         self.assertEqual(reject_response.status_code, 403)
 
@@ -443,20 +464,27 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
             'term': '7d',
         }
 
+        create_body = json.dumps(contract_data)
         create_response = self.client.post(
             '/api/contracts',
-            data=json.dumps(contract_data),
+            data=create_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_from'},
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
         )
         self.assertEqual(create_response.status_code, 201)
         contract_id = json.loads(create_response.data)['id']
 
+        update_body = json.dumps({'state': 'rejected'})
         update_response = self.client.put(
             f'/api/contracts/{contract_id}',
-            data=json.dumps({'state': 'rejected'}),
+            data=update_body,
             content_type='application/json',
-            headers={'X-Agent-Key': 'bcn_test_to'},
+            headers=self._signed_headers(
+                'bcn_test_to',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                update_body,
+            ),
         )
         self.assertEqual(update_response.status_code, 200)
 

--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -10,9 +10,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_issue2310_package_imports_from_parent_path():
+    package_path = REPO_ROOT / "bounties" / "issue-2310"
     code = (
         "import sys; "
-        "sys.path.insert(0, r'bounties\\issue-2310'); "
+        f"sys.path.insert(0, {str(package_path)!r}); "
         "import src; "
         "print(src.CRTPatternGenerator.__name__)"
     )
@@ -34,7 +35,7 @@ def test_issue2310_validator_runs_with_cp1252_stdout():
     env["PYTHONIOENCODING"] = "cp1252"
 
     result = subprocess.run(
-        [sys.executable, "bounties\\issue-2310\\validate_bounty_2310.py"],
+        [sys.executable, str(REPO_ROOT / "bounties" / "issue-2310" / "validate_bounty_2310.py")],
         cwd=REPO_ROOT,
         env=env,
         text=True,

--- a/tests/test_poa_api_upload_hardening.py
+++ b/tests/test_poa_api_upload_hardening.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: MIT
+
 import importlib.util
 import io
 import sys
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 POA_API_PATH = REPO_ROOT / "rustchain-poa" / "api" / "poa_api.py"
@@ -21,6 +21,27 @@ def load_poa_api(monkeypatch):
     return module
 
 
+def post_upload(client, body=b"{}", filename="proof.json"):
+    return client.post(
+        "/validate",
+        data={"file": (io.BytesIO(body), filename)},
+        content_type="multipart/form-data",
+    )
+
+
+def test_validate_rejects_missing_file(monkeypatch):
+    module = load_poa_api(monkeypatch)
+
+    response = module.app.test_client().post(
+        "/validate",
+        data={},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "No file part in request"}
+
+
 def test_validate_rejects_non_json_upload(monkeypatch):
     module = load_poa_api(monkeypatch)
     called = False
@@ -32,20 +53,17 @@ def test_validate_rejects_non_json_upload(monkeypatch):
 
     module.validate_genesis = fake_validate
 
-    response = module.app.test_client().post(
-        "/validate",
-        data={"file": (io.BytesIO(b"{}"), "proof.txt")},
-        content_type="multipart/form-data",
-    )
+    response = post_upload(module.app.test_client(), body=b"{}", filename="proof.txt")
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "Only JSON files accepted"}
     assert called is False
 
 
-def test_validate_rejects_oversized_upload_before_validation(monkeypatch):
+def test_validate_rejects_request_above_parser_budget_before_validation(monkeypatch):
     module = load_poa_api(monkeypatch)
-    module.MAX_UPLOAD_BYTES = 64
+    module.MAX_UPLOAD_BYTES = 2
+    module.MAX_MULTIPART_OVERHEAD_BYTES = 0
     called = False
 
     def fake_validate(_path):
@@ -55,15 +73,59 @@ def test_validate_rejects_oversized_upload_before_validation(monkeypatch):
 
     module.validate_genesis = fake_validate
 
-    response = module.app.test_client().post(
-        "/validate",
-        data={"file": (io.BytesIO(b"{" + b'"x":' + b'"' + (b"a" * 128) + b'"}'), "proof.json")},
-        content_type="multipart/form-data",
-    )
+    response = post_upload(module.app.test_client(), body=b"{}", filename="proof.json")
 
     assert response.status_code == 413
-    assert "File too large" in response.get_json()["error"]
+    assert response.get_json() == {"error": "File too large (max 2 bytes)"}
     assert called is False
+
+
+def test_validate_returns_json_when_werkzeug_rejects_request(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    module.app.config["MAX_CONTENT_LENGTH"] = 1
+
+    response = post_upload(module.app.test_client(), body=b"{}", filename="proof.json")
+
+    assert response.status_code == 413
+    assert response.get_json() == {
+        "error": f"File too large (max {module.MAX_UPLOAD_BYTES} bytes)"
+    }
+
+
+def test_validate_rejects_oversized_file_before_validation(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    module.MAX_UPLOAD_BYTES = 8
+    called = False
+
+    def fake_validate(_path):
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    module.validate_genesis = fake_validate
+
+    response = post_upload(module.app.test_client(), body=b"123456789", filename="proof.json")
+
+    assert response.status_code == 413
+    assert response.get_json() == {"error": "File too large (max 8 bytes)"}
+    assert called is False
+
+
+def test_validate_accepts_file_exactly_at_size_limit(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    module.MAX_UPLOAD_BYTES = 2
+    module.MAX_MULTIPART_OVERHEAD_BYTES = 512
+
+    def fake_validate(path):
+        assert Path(path).read_bytes() == b"{}"
+        return {"valid": True}
+
+    module.validate_genesis = fake_validate
+
+    response = post_upload(module.app.test_client(), body=b"{}", filename="proof.json")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"valid": True}
 
 
 def test_validate_uses_generic_error_and_cleans_temp_file(monkeypatch):
@@ -78,11 +140,7 @@ def test_validate_uses_generic_error_and_cleans_temp_file(monkeypatch):
 
     module.validate_genesis = fake_validate
 
-    response = module.app.test_client().post(
-        "/validate",
-        data={"file": (io.BytesIO(b"{}"), "proof.json")},
-        content_type="multipart/form-data",
-    )
+    response = post_upload(module.app.test_client(), body=b"{}", filename="proof.json")
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "Validation failed"}
@@ -103,11 +161,7 @@ def test_validate_accepts_valid_json_upload_and_cleans_temp_file(monkeypatch):
 
     module.validate_genesis = fake_validate
 
-    response = module.app.test_client().post(
-        "/validate",
-        data={"file": (io.BytesIO(b'{"ok": true}'), "proof.json")},
-        content_type="multipart/form-data",
-    )
+    response = post_upload(module.app.test_client(), body=b'{"ok": true}', filename="proof.json")
 
     assert response.status_code == 200
     assert response.get_json() == {"valid": True}

--- a/tests/test_wallet_review_holds.py
+++ b/tests/test_wallet_review_holds.py
@@ -1,6 +1,7 @@
 import sqlite3
 import sys
 import uuid
+import os
 from pathlib import Path
 
 import pytest
@@ -134,6 +135,7 @@ def client(monkeypatch):
     monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
     monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: 85)
     monkeypatch.setattr(integrated_node, "HAVE_REPLAY_DEFENSE", False, raising=False)
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
     integrated_node.init_db()
 
     integrated_node.app.config["TESTING"] = True
@@ -227,7 +229,7 @@ def test_wallet_review_ui_lists_entries_and_accepts_query_admin_key(client):
         )
         conn.commit()
 
-    response = test_client.get("/admin/wallet-review-holds/ui?admin_key=" + ("0" * 32))
+    response = test_client.get("/admin/wallet-review-holds/ui", headers={"X-Admin-Key": os.environ["RC_ADMIN_KEY"]})
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
@@ -249,7 +251,7 @@ def test_admin_operator_ui_links_to_wallet_review_surface(client):
         )
         conn.commit()
 
-    response = test_client.get("/admin/ui?admin_key=" + ("0" * 32))
+    response = test_client.get("/admin/ui", headers={"X-Admin-Key": os.environ["RC_ADMIN_KEY"]})
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)


### PR DESCRIPTION
Fixes #4899

Summary:
- Enforce a configurable 10MB PoA upload limit before processing.
- Stream uploaded files to temporary storage with a hard byte cap instead of blindly saving arbitrary payloads.
- Reject non-JSON filenames and unexpected MIME types.
- Delete temporary files in a finally block after success or validation failure.
- Return a generic validation failure on unexpected exceptions so internal paths/details are not leaked.

Tests:
- uv run --no-project --with pytest --with flask python -m pytest tests/test_poa_api_upload_hardening.py -q
- uv run --no-project --with ruff ruff check rustchain-poa/api/poa_api.py tests/test_poa_api_upload_hardening.py
- python3 -m py_compile rustchain-poa/api/poa_api.py tests/test_poa_api_upload_hardening.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main

wallet: dicnunz