### PR TITLE
fix: use current year for validator age score

### DIFF
--- a/tests/test_validator_core_with_badge.py
+++ b/tests/test_validator_core_with_badge.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+
+from datetime import datetime, timezone
+
+from tools.validator_core_with_badge import simulate_entropy_score
+
+
+def test_simulate_entropy_score_uses_current_utc_year_by_default():
+    cpu_model = "Pentium III"
+    bios_date = "1998-12-01"
+    current_year = datetime.now(timezone.utc).year
+    expected_age_weight = max(0, current_year - 1998)
+    expected_score = round((expected_age_weight * 0.25) + (len(cpu_model) * 0.05), 2)
+
+    assert simulate_entropy_score(cpu_model, bios_date) == expected_score
+
+
+def test_simulate_entropy_score_can_cover_2026_age_weight():
+    score = simulate_entropy_score("Pentium III", "1998-12-01", current_year=2026)
+
+    assert score == 7.55

--- a/tools/validator_core_with_badge.py
+++ b/tools/validator_core_with_badge.py
@@ -1,10 +1,13 @@
+# SPDX-License-Identifier: MIT
+
 import json
 import hashlib
 from datetime import datetime
 
-def simulate_entropy_score(cpu_model, bios_date):
+def simulate_entropy_score(cpu_model, bios_date, current_year=None):
     year = int(bios_date.split("-")[0])
-    age_weight = max(0, 2025 - year)
+    current_year = current_year if current_year is not None else datetime.utcnow().year
+    age_weight = max(0, current_year - year)
     entropy_score = round((age_weight * 0.25) + (len(cpu_model) * 0.05), 2)
     return entropy_score
 


### PR DESCRIPTION
## Summary
- Fixes #4603
- Replaces the hardcoded 2025 entropy age baseline with the current UTC year
- Keeps testable scoring behavior by allowing `simulate_entropy_score(..., current_year=...)` in focused regressions
- Adds coverage for the default current-year path and the 2026 Pentium III age-weight case

## Validation
- `python3 -m py_compile tools/validator_core_with_badge.py tests/test_validator_core_with_badge.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest tests/test_validator_core_with_badge.py -q` -> 2 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC