### PR TITLE
fix: import hmac for multi-arch oracle seeds

### DIFF
--- a/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
+++ b/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
@@ -45,14 +45,15 @@ can generate. Compromising requires controlling ALL architectures.
 "Diversity is security. The chain speaks many silicon dialects."
 """
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple, Set
-from enum import Enum, auto
 import hashlib
-import struct
+import hmac
 import secrets
+import struct
 import time
+from dataclasses import dataclass, field
 from datetime import datetime
+from enum import Enum
+from typing import Dict, List, Optional, Set, Tuple
 
 class CPUArchitecture(Enum):
     """Supported CPU architectures for oracle nodes"""
@@ -289,7 +290,7 @@ class MultiArchOracleRing:
             final_seed,
             b''.join(a.encode() for a in sorted(contributions.keys())),
             hashlib.sha256
-        ).digest() if 'hmac' in dir() else hashlib.sha256(final_seed).digest()
+        ).digest()
 
         seed = MultiArchMutationSeed(
             seed=final_seed,
@@ -478,5 +479,4 @@ def demo_multi_arch_network():
 
 
 if __name__ == "__main__":
-    import hmac  # Import for ring signature
     demo_multi_arch_network()

--- a/tests/test_multi_arch_oracles_hmac.py
+++ b/tests/test_multi_arch_oracles_hmac.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import hmac
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "rips" / "rustchain-core" / "src" / "mutator_oracle" / "multi_arch_oracles.py"
+
+spec = importlib.util.spec_from_file_location("multi_arch_oracles", MODULE_PATH)
+multi_arch_oracles = importlib.util.module_from_spec(spec)
+sys.modules["multi_arch_oracles"] = multi_arch_oracles
+spec.loader.exec_module(multi_arch_oracles)
+
+
+def test_generate_mutation_seed_uses_hmac_ring_signature_without_crashing():
+    ring = multi_arch_oracles.MultiArchOracleRing()
+    ring.register_oracle(
+        multi_arch_oracles.ArchitectureOracle(
+            node_id="g4-node",
+            hostname="g4.local",
+            ip_address="192.0.2.10",
+            architecture=multi_arch_oracles.CPUArchitecture.POWERPC_G4,
+            cpu_model="PowerPC G4",
+            simd_enabled=True,
+        )
+    )
+    ring.register_oracle(
+        multi_arch_oracles.ArchitectureOracle(
+            node_id="x86-node",
+            hostname="x86.local",
+            ip_address="192.0.2.11",
+            architecture=multi_arch_oracles.CPUArchitecture.INTEL_X86_64,
+            cpu_model="x86_64",
+            simd_enabled=True,
+        )
+    )
+
+    with patch.object(ring, "collect_entropy", side_effect=[b"a" * 64, b"b" * 64]):
+        seed = ring.generate_mutation_seed(12345)
+
+    assert seed is not None
+    assert seed.ring_signature == hmac.new(
+        seed.seed,
+        b"ppc_g4x86_64",
+        hashlib.sha256,
+    ).digest()


### PR DESCRIPTION
Fixes #4852

Summary:
- Import hmac at module scope for MultiArchOracleRing.generate_mutation_seed().
- Remove the dead fallback that checked whether hmac existed after hmac.new() was already evaluated.
- Add a regression proving seed generation returns an HMAC-SHA256 ring signature instead of crashing with NameError.

Tests:
- uv run --no-project --with pytest --with flask python -m pytest tests/test_multi_arch_oracles_hmac.py -q
- uv run --no-project --with ruff ruff check --select F821 rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py tests/test_multi_arch_oracles_hmac.py
- python3 -m py_compile rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py tests/test_multi_arch_oracles_hmac.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main

wallet: dicnunz