### PR TITLE
fix: use current year for hall rust age

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 """
 Hall of Rust - Immortal Registry for Dying Hardware
 ====================================================
@@ -6,6 +8,7 @@ This is the emotional core of RustChain.
 """
 
 from flask import Blueprint, jsonify, request
+from datetime import datetime, timezone
 import sqlite3
 import hashlib
 import time
@@ -24,6 +27,11 @@ RUST_WEIGHTS = {
     'capacitor_plague': 100,   # Bonus for 2001-2006 bad cap era
     'first_attestation': 50,   # Bonus for being among first 100 miners
 }
+
+
+def _current_utc_year():
+    return datetime.now(timezone.utc).year
+
 
 # Capacitor plague era models (infamous bad electrolytic caps)
 CAPACITOR_PLAGUE_MODELS = [
@@ -82,13 +90,14 @@ def init_hall_tables(db_path):
     conn.commit()
     conn.close()
 
-def calculate_rust_score(machine):
+def calculate_rust_score(machine, current_year=None):
     """Calculate the Rust Score for a machine - higher = rustier = better."""
     score = 0
+    current_year = current_year if current_year is not None else _current_utc_year()
     
     # Age bonus (estimated from model/arch)
     if machine.get('manufacture_year'):
-        age = 2025 - machine['manufacture_year']
+        age = max(0, current_year - int(machine['manufacture_year']))
         score += age * RUST_WEIGHTS['age_years']
     
     # Attestation loyalty
@@ -689,7 +698,8 @@ def machine_of_the_day():
         machine = dict(row)
         machine['badge'] = get_rust_badge(machine['rust_score'])
         machine['fun_fact'] = random.choice(VINTAGE_FACTS)
-        machine['age_years'] = 2025 - machine.get('manufacture_year', 2020)
+        mfg_year = machine.get('manufacture_year') or 2020
+        machine['age_years'] = max(0, _current_utc_year() - int(mfg_year))
         
         return jsonify(machine)
     except Exception:

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -44,3 +44,41 @@ def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
     assert body["total_machines"] == 0
     assert body["total_attestations"] == 0
     assert body["average_rust_score"] == 0
+
+
+def test_calculate_rust_score_uses_current_year_for_age_weight():
+    score = hall_of_rust.calculate_rust_score(
+        {
+            "manufacture_year": 2001,
+            "device_arch": "modern",
+            "device_model": "Generic",
+            "total_attestations": 0,
+            "id": 999,
+        },
+        current_year=2026,
+    )
+
+    assert score == 250
+
+
+def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO hall_of_rust
+            (fingerprint_hash, miner_id, device_arch, device_model, manufacture_year,
+             first_attestation, total_attestations, rust_score, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            ("fp-1", "miner-1", "modern", "Generic", 2003, 1, 1, 150, 1),
+        )
+        conn.commit()
+    monkeypatch.setattr(hall_of_rust, "_current_utc_year", lambda: 2026)
+    client = _client_for(db_path)
+
+    response = client.get("/hall/machine_of_the_day")
+
+    assert response.status_code == 200
+    assert response.get_json()["age_years"] == 23


### PR DESCRIPTION
## Summary
- Fixes #4594
- Replaces hardcoded 2025 Hall of Rust age calculations with the current UTC year
- Applies the fix to rust score age weighting and machine-of-the-day `age_years` output
- Adds regressions for both paths

## Validation
- `python3 -m py_compile node/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest node/tests/test_hall_of_rust_error_responses.py -q` -> 4 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC