### PR TITLE
fix: use current year for fingerprint age

### DIFF
--- a/node/hardware_fingerprint.py
+++ b/node/hardware_fingerprint.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
 """
 RIP-PoA Hardware Fingerprint Collection
 ========================================
@@ -13,6 +15,7 @@ import statistics
 import struct
 import subprocess
 import time
+from datetime import datetime, timezone
 from typing import Dict, List, Tuple, Optional
 
 # Number of samples for each measurement
@@ -20,6 +23,10 @@ CLOCK_DRIFT_SAMPLES = 1000
 CACHE_TIMING_ITERATIONS = 100
 JITTER_SAMPLES = 500
 THERMAL_SAMPLES = 50
+
+
+def _current_utc_year() -> int:
+    return datetime.now(timezone.utc).year
 
 
 class HardwareFingerprint:
@@ -433,7 +440,7 @@ class HardwareFingerprint:
             release_year = 2023
         
         oracle["estimated_release_year"] = release_year
-        oracle["estimated_age_years"] = 2025 - release_year
+        oracle["estimated_age_years"] = max(0, _current_utc_year() - release_year)
         oracle["valid"] = "cpu_model" in oracle or "processor" in oracle
         
         return oracle

--- a/node/tests/test_hardware_fingerprint_device_age.py
+++ b/node/tests/test_hardware_fingerprint_device_age.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: MIT
+
+import io
+import os
+import sys
+
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import hardware_fingerprint  # noqa: E402
+
+
+def test_collect_device_oracle_uses_current_year_for_estimated_age(monkeypatch):
+    cpuinfo = "model name\t: PowerPC G4 7447A\n"
+
+    def fake_open(path, *args, **kwargs):
+        if path == "/proc/cpuinfo":
+            return io.StringIO(cpuinfo)
+        raise FileNotFoundError(path)
+
+    monkeypatch.setattr(hardware_fingerprint, "_current_utc_year", lambda: 2026)
+    monkeypatch.setattr(hardware_fingerprint.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(hardware_fingerprint.platform, "machine", lambda: "ppc")
+    monkeypatch.setattr(hardware_fingerprint.platform, "processor", lambda: "PowerPC G4")
+    monkeypatch.setattr(hardware_fingerprint.platform, "release", lambda: "test-release")
+    monkeypatch.setattr(hardware_fingerprint.platform, "python_version", lambda: "3.test")
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    oracle = hardware_fingerprint.HardwareFingerprint.collect_device_oracle()
+
+    assert oracle["estimated_release_year"] == 2003
+    assert oracle["estimated_age_years"] == 23


### PR DESCRIPTION
## Summary
- Fixes #4597
- Replaces the hardcoded 2025 device-age oracle baseline with the current UTC year
- Clamps future release-year age at zero
- Adds a PowerPC G4 / 2003 regression covering `estimated_age_years` in 2026

## Validation
- `python3 -m py_compile node/hardware_fingerprint.py node/tests/test_hardware_fingerprint_device_age.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest python -m pytest node/tests/test_hardware_fingerprint_device_age.py -q` -> 1 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC