### PR TITLE
fix: use current year for hardware age calculations

### DIFF
--- a/node/hardware_fingerprint.py
+++ b/node/hardware_fingerprint.py
@@ -22,6 +22,11 @@ JITTER_SAMPLES = 500
 THERMAL_SAMPLES = 50
 
 
+def _current_utc_year() -> int:
+    """Return the current UTC year for hardware-age calculations."""
+    return time.gmtime().tm_year
+
+
 class HardwareFingerprint:
     """Collects comprehensive hardware fingerprints for attestation"""
     
@@ -433,7 +438,7 @@ class HardwareFingerprint:
             release_year = 2023
         
         oracle["estimated_release_year"] = release_year
-        oracle["estimated_age_years"] = 2025 - release_year
+        oracle["estimated_age_years"] = _current_utc_year() - release_year
         oracle["valid"] = "cpu_model" in oracle or "processor" in oracle
         
         return oracle

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2004,11 +2004,16 @@ def record_macs(miner: str, macs: list):
         conn.commit()
 
 
+def _current_utc_year():
+    """Return the current UTC year for age-based scoring."""
+    return time.gmtime().tm_year
+
+
 def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id):
     """Calculate rust score for a machine."""
     score = 0
     if mfg_year:
-        score += (2025 - mfg_year) * 10  # age bonus
+        score += (_current_utc_year() - mfg_year) * 10  # age bonus
     score += attestations * 0.001  # attestation bonus
     if machine_id <= 100:
         score += 50  # early adopter

--- a/tests/test_current_year_age_calculations.py
+++ b/tests/test_current_year_age_calculations.py
@@ -1,6 +1,8 @@
 import importlib.util
 import os
 import sys
+# SPDX-License-Identifier: MIT
+
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import mock_open, patch

--- a/tests/test_current_year_age_calculations.py
+++ b/tests/test_current_year_age_calculations.py
@@ -1,0 +1,54 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import mock_open, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_DIR = ROOT / "node"
+INTEGRATED_MODULE = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+
+def _load_integrated_module(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_integrated_current_year_test",
+        INTEGRATED_MODULE,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_integrated_hall_score_uses_current_utc_year(monkeypatch):
+    integrated = _load_integrated_module(monkeypatch)
+    monkeypatch.setattr(integrated.time, "gmtime", lambda: SimpleNamespace(tm_year=2026))
+
+    score = integrated.calculate_rust_score_inline(
+        mfg_year=2001,
+        arch="modern",
+        attestations=0,
+        machine_id=999,
+    )
+
+    assert score == 250
+
+
+def test_hardware_fingerprint_age_oracle_uses_current_utc_year(monkeypatch):
+    import hardware_fingerprint
+
+    monkeypatch.setattr(hardware_fingerprint.time, "gmtime", lambda: SimpleNamespace(tm_year=2026))
+    monkeypatch.setattr(hardware_fingerprint.platform, "system", lambda: "Linux")
+
+    cpuinfo = "processor\t: 0\nmodel name\t: PowerPC 7447A\n"
+    with patch("builtins.open", mock_open(read_data=cpuinfo)):
+        oracle = hardware_fingerprint.HardwareFingerprint.collect_device_oracle()
+
+    assert oracle["estimated_release_year"] == 2003
+    assert oracle["estimated_age_years"] == 23


### PR DESCRIPTION
## Summary
- Fixes #4599 by using the current UTC year in integrated Hall of Rust age scoring instead of the stale 2025 baseline.
- Fixes #4597 by using the current UTC year in the hardware fingerprint device-age oracle instead of the stale 2025 baseline.
- Adds regression coverage for both paths with the clock pinned to 2026.

## Validation
- `python -m pytest tests/test_current_year_age_calculations.py -q` -> `2 passed`
- `python -m py_compile node/hardware_fingerprint.py node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_current_year_age_calculations.py` -> passed
- `git diff --check -- node/hardware_fingerprint.py node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_current_year_age_calculations.py` -> passed
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> OK

## Bounty
GitHub handle: @galpetame
Native RTC wallet: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`