### PR TITLE
test: cover quantum flux validator helpers

### DIFF
--- a/tests/test_quantum_flux_validator.py
+++ b/tests/test_quantum_flux_validator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
 import json
+from datetime import datetime
 from pathlib import Path
 
 
@@ -8,6 +9,12 @@ MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "quantum_flux_vali
 spec = importlib.util.spec_from_file_location("quantum_flux_validator", MODULE_PATH)
 quantum_flux_validator = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(quantum_flux_validator)
+
+
+class FixedDatetime:
+    @classmethod
+    def utcnow(cls):
+        return datetime(2026, 5, 13, 6, 30, 0)
 
 
 def test_detect_network_flux_sleeps_with_random_delay_and_returns_choice(monkeypatch):
@@ -46,3 +53,27 @@ def test_award_quantum_flux_badge_does_not_write_when_no_flux(tmp_path, monkeypa
 
     assert not (relics_dir / "badge_quantum_flux_validator.json").exists()
     assert "No network anomaly detected" in capsys.readouterr().out
+
+
+def test_detect_network_flux_can_return_false(monkeypatch):
+    monkeypatch.setattr(quantum_flux_validator.random, "randint", lambda start, end: 2)
+    monkeypatch.setattr(quantum_flux_validator.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(quantum_flux_validator.random, "choice", lambda options: options[1])
+
+    assert quantum_flux_validator.detect_network_flux() is False
+
+
+def test_award_quantum_flux_badge_uses_current_utc_timestamp(tmp_path, monkeypatch):
+    relics_dir = tmp_path / "relics"
+    relics_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(quantum_flux_validator, "datetime", FixedDatetime)
+    monkeypatch.setattr(quantum_flux_validator, "detect_network_flux", lambda: True)
+
+    quantum_flux_validator.award_quantum_flux_badge()
+
+    payload = json.loads((relics_dir / "badge_quantum_flux_validator.json").read_text())
+    badge = payload["badges"][0]
+    assert badge["title"] == "Quantum Flux Validator"
+    assert badge["rarity"] == "Mythic"
+    assert badge["emotional_resonance"]["timestamp"] == "2026-05-13T06:30:00Z"


### PR DESCRIPTION
Related bounty: Scottcjn/rustchain-bounties#1589

## What changed
- Added pytest coverage for quantum flux validator helper behavior.
- Covers randomized detection delay/choice handling, no-flux detection, badge JSON output on flux, no-file behavior without flux, and unchanged blank timestamp without flux.

## Tests
- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_quantum_flux_validator.py -q` -> 5 passed
- `/tmp/rustchain-bounty-venv/bin/python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check` -> clean