### PR TITLE
fix: close Atom feed thumbnail URL attribute

### DIFF
--- a/node/bottube_feed.py
+++ b/node/bottube_feed.py
@@ -595,7 +595,7 @@ class AtomFeedBuilder:
         # Thumbnail
         if entry.get("thumbnail_url"):
             lines.append(
-                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}/>'
+                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}"/>'
             )
         
         lines.append("</entry>")

--- a/tests/test_bottube_feed.py
+++ b/tests/test_bottube_feed.py
@@ -11,6 +11,7 @@ Run with:
 import sys
 import time
 import unittest
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -324,6 +325,25 @@ class TestAtomFeedBuilder(unittest.TestCase):
         xml = self.builder.build()
         self.assertIn("media:content", xml)
         self.assertIn("video.mp4", xml)
+
+    def test_thumbnail_feed_is_well_formed_xml(self):
+        """Test Atom feed with thumbnail parses as XML."""
+        self.builder.add_entry(
+            title="Test",
+            entry_id="urn:test:1",
+            link="https://example.com/1",
+            summary="Test",
+            thumbnail_url="https://example.com/thumb.jpg"
+        )
+
+        xml = self.builder.build()
+        root = ET.fromstring(xml)
+        thumbnail = root.find(
+            ".//{http://search.yahoo.com/mrss/}thumbnail"
+        )
+
+        self.assertIsNotNone(thumbnail)
+        self.assertEqual(thumbnail.attrib["url"], "https://example.com/thumb.jpg")
 
 
 class TestConvenienceFunctions(unittest.TestCase):


### PR DESCRIPTION
Fixes #4869

Summary:
- Fix AtomFeedBuilder thumbnail XML so the media:thumbnail url attribute closes before the self-closing tag.
- Add a regression that builds a feed with thumbnail_url, parses it with ElementTree, and verifies the MRSS thumbnail URL.

Tests:
- python3 -m unittest tests.test_bottube_feed.TestAtomFeedBuilder.test_thumbnail_feed_is_well_formed_xml
- python3 -m unittest tests.test_bottube_feed
- python3 -m py_compile node/bottube_feed.py tests/test_bottube_feed.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main

wallet: dicnunz