### PR TITLE
fix: use current year for integrated hall score

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
 """
 RustChain v2 - Integrated Server
 Includes RIP-0005 (Epoch Rewards), RIP-0008 (Withdrawals), RIP-0009 (Finality)
@@ -2004,11 +2006,16 @@ def record_macs(miner: str, macs: list):
         conn.commit()
 
 
-def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id):
+def _current_utc_year():
+    return time.gmtime().tm_year
+
+
+def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id, current_year=None):
     """Calculate rust score for a machine."""
     score = 0
+    current_year = current_year if current_year is not None else _current_utc_year()
     if mfg_year:
-        score += (2025 - mfg_year) * 10  # age bonus
+        score += max(0, current_year - int(mfg_year)) * 10  # age bonus
     score += attestations * 0.001  # attestation bonus
     if machine_id <= 100:
         score += 50  # early adopter

--- a/node/tests/test_integrated_hall_score_year.py
+++ b/node/tests/test_integrated_hall_score_year.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def _load_node_module():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = str(Path(tmpdir) / "import.db")
+        old_env = {
+            name: os.environ.get(name)
+            for name in ("RUSTCHAIN_DB_PATH", "DB_PATH", "RC_ADMIN_KEY")
+        }
+        os.environ["RUSTCHAIN_DB_PATH"] = db_path
+        os.environ["DB_PATH"] = db_path
+        os.environ["RC_ADMIN_KEY"] = "test-admin-key-for-hall-score-32-bytes"
+        sys.path.insert(0, str(NODE_DIR))
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "rustchain_integrated_hall_score_test_module",
+                MODULE_PATH,
+            )
+            module = importlib.util.module_from_spec(spec)
+            sys.modules["rustchain_integrated_hall_score_test_module"] = module
+            spec.loader.exec_module(module)
+            return module
+        finally:
+            for name, value in old_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+            try:
+                sys.path.remove(str(NODE_DIR))
+            except ValueError:
+                pass
+
+
+def test_calculate_rust_score_inline_uses_current_year_for_age_bonus():
+    node = _load_node_module()
+
+    score = node.calculate_rust_score_inline(
+        2001,
+        "modern",
+        0,
+        999,
+        current_year=2026,
+    )
+
+    assert score == 250

--- a/node/tests/test_integrated_hall_score_year.py
+++ b/node/tests/test_integrated_hall_score_year.py
@@ -11,6 +11,26 @@ NODE_DIR = Path(__file__).resolve().parents[1]
 MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
 
 
+class _NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
 def _load_node_module():
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = str(Path(tmpdir) / "import.db")
@@ -23,6 +43,20 @@ def _load_node_module():
         os.environ["RC_ADMIN_KEY"] = "test-admin-key-for-hall-score-32-bytes"
         sys.path.insert(0, str(NODE_DIR))
         try:
+            import prometheus_client
+        except ImportError:
+            prometheus_client = None
+            old_metrics = None
+        else:
+            old_metrics = (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            )
+            prometheus_client.Counter = _NoopMetric
+            prometheus_client.Gauge = _NoopMetric
+            prometheus_client.Histogram = _NoopMetric
+        try:
             spec = importlib.util.spec_from_file_location(
                 "rustchain_integrated_hall_score_test_module",
                 MODULE_PATH,
@@ -32,6 +66,12 @@ def _load_node_module():
             spec.loader.exec_module(module)
             return module
         finally:
+            if prometheus_client is not None:
+                (
+                    prometheus_client.Counter,
+                    prometheus_client.Gauge,
+                    prometheus_client.Histogram,
+                ) = old_metrics
             for name, value in old_env.items():
                 if value is None:
                     os.environ.pop(name, None)


### PR DESCRIPTION
## Summary
- Fixes #4599
- Replaces hardcoded 2025 integrated-node Hall score age weighting with the current UTC year
- Clamps future manufacture-year age at zero
- Adds an integrated-node regression for the 2026 age bonus case

## Validation
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_hall_score_year.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest node/tests/test_integrated_hall_score_year.py -q` -> 1 passed
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty
Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC