### PR TITLE
fix: use secure nonce generation for anti-spoof challenges

### DIFF
--- a/rips/rustchain-core/src/anti_spoof/challenge_response.c
+++ b/rips/rustchain-core/src/anti_spoof/challenge_response.c
@@ -18,9 +18,11 @@
  * - No real thermal sensors
  * - OpenFirmware values don't match hardware
  *
- * Compile: gcc -O0 challenge_response.c -o challenge -framework CoreFoundation -framework IOKit
+ * Compile: gcc -O0 challenge_response.c -o challenge -framework CoreFoundation -framework IOKit -framework Security
  */
 
+#include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,6 +32,11 @@
 #ifdef __APPLE__
 #include <sys/sysctl.h>
 #include <mach/mach_time.h>
+#include <Security/Security.h>
+#endif
+
+#ifdef __linux__
+#include <sys/random.h>
 #endif
 
 #ifdef __ppc__
@@ -81,6 +88,64 @@ typedef struct {
     float confidence_score;
     char failure_reason[256];
 } ValidationResult;
+
+static int fill_random_from_urandom(unsigned char *buf, size_t len) {
+    size_t offset = 0;
+    int fd = open("/dev/urandom", O_RDONLY);
+
+    if (fd < 0) {
+        return -1;
+    }
+
+    while (offset < len) {
+        ssize_t n = read(fd, buf + offset, len - offset);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            close(fd);
+            return -1;
+        }
+        if (n == 0) {
+            close(fd);
+            return -1;
+        }
+        offset += (size_t)n;
+    }
+
+    close(fd);
+    return 0;
+}
+
+static int fill_secure_random(unsigned char *buf, size_t len) {
+#ifdef __linux__
+    size_t offset = 0;
+
+    while (offset < len) {
+        ssize_t n = getrandom(buf + offset, len - offset, 0);
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return fill_random_from_urandom(buf, len);
+        }
+        if (n == 0) {
+            return fill_random_from_urandom(buf, len);
+        }
+        offset += (size_t)n;
+    }
+
+    return 0;
+#elif defined(__APPLE__)
+    if (SecRandomCopyBytes(kSecRandomDefault, len, buf) == errSecSuccess) {
+        return 0;
+    }
+
+    return fill_random_from_urandom(buf, len);
+#else
+    return fill_random_from_urandom(buf, len);
+#endif
+}
 
 /* PowerPC-specific: Read timebase register */
 static inline unsigned long long read_timebase(void) {
@@ -290,14 +355,13 @@ static void compute_response_hash(Response *resp, unsigned char *hash) {
 /* Generate a challenge */
 Challenge generate_challenge(unsigned char type) {
     Challenge c;
-    int i;
 
     c.challenge_type = type;
     c.timestamp = read_timebase();
 
-    /* Generate random nonce */
-    for (i = 0; i < 32; i++) {
-        c.nonce[i] = (unsigned char)(rand() ^ (c.timestamp >> (i % 8)));
+    if (fill_secure_random(c.nonce, sizeof(c.nonce)) != 0) {
+        fprintf(stderr, "failed to generate secure challenge nonce\n");
+        exit(EXIT_FAILURE);
     }
 
     /* Set expected timing based on challenge type */
@@ -515,8 +579,6 @@ int main(int argc, char *argv[]) {
     printf("║   Philosophy: \"It's cheaper to buy a $50 vintage Mac                ║\n");
     printf("║                than to emulate one\"                                  ║\n");
     printf("╚══════════════════════════════════════════════════════════════════════╝\n");
-
-    srand((unsigned int)time(NULL) ^ (unsigned int)read_timebase());
 
     printf("\n  Generating comprehensive challenge...\n");
     c = generate_challenge(0); /* Full challenge */

--- a/rips/rustchain-core/src/anti_spoof/test_challenge_response_secure_nonce.py
+++ b/rips/rustchain-core/src/anti_spoof/test_challenge_response_secure_nonce.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+"""Regression checks for challenge-response nonce generation."""
+
+from pathlib import Path
+import re
+
+
+SOURCE = Path(__file__).with_name("challenge_response.c")
+TEXT = SOURCE.read_text(encoding="utf-8")
+
+
+def test_no_libc_prng_for_challenge_nonce() -> None:
+    assert not re.search(r"\b(?:srand|rand)\s*\(", TEXT)
+
+
+def test_os_csprng_paths_are_available() -> None:
+    assert "getrandom(" in TEXT
+    assert "SecRandomCopyBytes" in TEXT
+    assert '"/dev/urandom"' in TEXT
+
+
+def test_nonce_generation_fails_closed() -> None:
+    assert "fill_secure_random(c.nonce, sizeof(c.nonce))" in TEXT
+    assert "exit(EXIT_FAILURE)" in TEXT
+
+
+if __name__ == "__main__":
+    test_no_libc_prng_for_challenge_nonce()
+    test_os_csprng_paths_are_available()
+    test_nonce_generation_fails_closed()


### PR DESCRIPTION
Fixes #4861

Summary:
- Replace challenge nonce generation based on libc rand() and timestamp mixing with OS CSPRNG bytes.
- Use getrandom() on Linux, SecRandomCopyBytes() on macOS, and a checked /dev/urandom fallback.
- Fail closed if secure nonce generation fails.
- Remove srand() seeding from main because challenge nonces no longer use libc PRNG.
- Add a focused regression script proving rand()/srand() are absent and secure RNG paths are present.

Tests:
- python3 rips/rustchain-core/src/anti_spoof/test_challenge_response_secure_nonce.py
- cc -fsyntax-only rips/rustchain-core/src/anti_spoof/challenge_response.c
- rg -n "\\b(srand|rand)\\s*\\(" rips/rustchain-core/src/anti_spoof/challenge_response.c -> no matches
- python3 -m py_compile rips/rustchain-core/src/anti_spoof/test_challenge_response_secure_nonce.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main

wallet: dicnunz