### PR TITLE
fix: escape realtime explorer dashboard data

### DIFF
--- a/explorer/static/js/dashboard.js
+++ b/explorer/static/js/dashboard.js
@@ -388,10 +388,10 @@ class DashboardApp {
         tbody.innerHTML = sortedMiners.map((miner, index) => `
             <tr class="${miner.isNew ? 'new' : ''}">
                 <td>${index + 1}</td>
-                <td class="mono">${this.shortenAddress(miner.miner_id || 'unknown')}</td>
-                <td><span class="badge badge-${this.getArchitectureTier(miner.device_arch)}">${miner.device_arch || 'Unknown'}</span></td>
-                <td class="text-accent">${miner.score || 0}</td>
-                <td>${(miner.multiplier || 1).toFixed(2)}x</td>
+                <td class="mono">${this.escapeHtml(this.shortenAddress(miner.miner_id || miner.miner || 'unknown'))}</td>
+                <td><span class="badge badge-${this.getArchitectureTier(miner.device_arch)}">${this.escapeHtml(miner.device_arch || 'Unknown')}</span></td>
+                <td class="text-accent">${this.escapeHtml(miner.score || 0)}</td>
+                <td>${this.escapeHtml(this.formatNumber(miner.multiplier || 1, 2))}x</td>
                 <td><span class="badge badge-active">● ACTIVE</span></td>
             </tr>
         `).join('');
@@ -440,12 +440,12 @@ class DashboardApp {
             <div class="activity-item ${block.isNew ? 'new' : ''}">
                 <div class="activity-icon">📦</div>
                 <div class="activity-content">
-                    <div class="activity-title">Block #${block.height || 0}</div>
-                    <div class="activity-subtitle mono">${this.shortenHash(block.hash || '0x')}</div>
+                    <div class="activity-title">Block #${this.escapeHtml(block.height || 0)}</div>
+                    <div class="activity-subtitle mono">${this.escapeHtml(this.shortenHash(block.hash || '0x'))}</div>
                 </div>
                 <div class="activity-meta">
                     <div class="activity-time">${this.formatRelativeTime(block.timestamp)}</div>
-                    <div class="activity-value">${block.miners_count || 0} miners</div>
+                    <div class="activity-value">${this.escapeHtml(block.miners_count || 0)} miners</div>
                 </div>
             </div>
         `).join('');
@@ -473,12 +473,12 @@ class DashboardApp {
             <div class="activity-item ${tx.isNew ? 'new' : ''}">
                 <div class="activity-icon">💸</div>
                 <div class="activity-content">
-                    <div class="activity-title">${(tx.type || 'transfer').toUpperCase()}</div>
-                    <div class="activity-subtitle mono">${this.shortenAddress(tx.from || '0x')} → ${this.shortenAddress(tx.to || '0x')}</div>
+                    <div class="activity-title">${this.escapeHtml(String(tx.type || 'transfer').toUpperCase())}</div>
+                    <div class="activity-subtitle mono">${this.escapeHtml(this.shortenAddress(tx.from || '0x'))} → ${this.escapeHtml(this.shortenAddress(tx.to || '0x'))}</div>
                 </div>
                 <div class="activity-meta">
                     <div class="activity-time">${this.formatRelativeTime(tx.timestamp)}</div>
-                    <div class="activity-value">${this.formatNumber(tx.amount || 0)} RTC</div>
+                    <div class="activity-value">${this.escapeHtml(this.formatNumber(tx.amount || 0))} RTC</div>
                 </div>
             </div>
         `).join('');
@@ -518,10 +518,10 @@ class DashboardApp {
             <div class="hardware-legend-item">
                 <div class="hardware-legend-color" style="background: ${item.color}"></div>
                 <div class="hardware-legend-info">
-                    <div class="hardware-legend-label">${item.label}</div>
-                    <div class="hardware-legend-value">${item.percent}%</div>
+                    <div class="hardware-legend-label">${this.escapeHtml(item.label)}</div>
+                    <div class="hardware-legend-value">${this.escapeHtml(item.percent)}%</div>
                 </div>
-                <div class="hardware-legend-count">${item.value}</div>
+                <div class="hardware-legend-count">${this.escapeHtml(item.value)}</div>
             </div>
         `).join('');
     }
@@ -739,9 +739,19 @@ class DashboardApp {
         return `${days}d ${hours}h ${mins}m`;
     }
 
+    escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        })[char]);
+    }
+
     getArchitectureTier(arch) {
         if (!arch) return 'modern';
-        const archLower = arch.toLowerCase();
+        const archLower = String(arch).toLowerCase();
         if (archLower.includes('g3') || archLower.includes('g4') || archLower.includes('g5') ||
             archLower.includes('powerpc') || archLower.includes('sparc')) return 'vintage';
         if (archLower.includes('pentium') || archLower.includes('core 2') ||

--- a/explorer/templates/dashboard.html
+++ b/explorer/templates/dashboard.html
@@ -319,16 +319,30 @@
             document.getElementById('active-miners').textContent = stats.active_miners;
             document.getElementById('difficulty').textContent = stats.difficulty;
         }
+
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, char => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            })[char]);
+        }
+
+        function classToken(value) {
+            return String(value ?? 'unknown').toLowerCase().replace(/[^a-z0-9_-]/g, '');
+        }
         
         function updateRecentBlocks(blocks) {
             const tbody = document.getElementById('recent-blocks');
             tbody.innerHTML = blocks.map(block => `
                 <tr>
-                    <td><a href="/block/${block.hash}" class="text-decoration-none">${block.height}</a></td>
-                    <td><code class="text-muted">${block.hash.substring(0, 16)}...</code></td>
-                    <td>${block.tx_count}</td>
-                    <td>${block.miner}</td>
-                    <td class="text-muted">${block.timestamp}</td>
+                    <td><a href="/block/${encodeURIComponent(String(block.hash || ''))}" class="text-decoration-none">${escapeHtml(block.height)}</a></td>
+                    <td><code class="text-muted">${escapeHtml(String(block.hash || '').substring(0, 16))}...</code></td>
+                    <td>${escapeHtml(block.tx_count)}</td>
+                    <td>${escapeHtml(block.miner)}</td>
+                    <td class="text-muted">${escapeHtml(block.timestamp)}</td>
                 </tr>
             `).join('');
         }
@@ -336,29 +350,30 @@
         function updateMiners(miners) {
             const tbody = document.getElementById('miners-tbody');
             tbody.innerHTML = miners.map(miner => {
-                const architectureLower = miner.architecture.toLowerCase().replace('-', '');
+                const architecture = String(miner.architecture || 'unknown');
+                const architectureLower = classToken(architecture);
                 const archIcon = miner.architecture === 'x86' ? 'microchip' : 
                                miner.architecture === 'ARM' ? 'mobile-alt' :
                                miner.architecture === 'RISC-V' ? 'cpu' : 'question';
                 
                 return `
-                    <tr class="miner-row" data-miner-id="${miner.address}">
+                    <tr class="miner-row" data-miner-id="${escapeHtml(miner.address)}">
                         <td>
                             <i class="fas fa-circle ${miner.status === 'active' ? 'status-active' : 'status-inactive'}"></i>
-                            <span class="ms-1">${miner.status.charAt(0).toUpperCase() + miner.status.slice(1)}</span>
+                            <span class="ms-1">${escapeHtml(String(miner.status || 'unknown').charAt(0).toUpperCase() + String(miner.status || 'unknown').slice(1))}</span>
                         </td>
                         <td>
-                            <code class="text-primary">${miner.address.substring(0, 16)}...</code>
+                            <code class="text-primary">${escapeHtml(String(miner.address || '').substring(0, 16))}...</code>
                         </td>
                         <td>
                             <span class="badge architecture-badge badge-${architectureLower}">
                                 <i class="fas fa-${archIcon} me-1"></i>
-                                ${miner.architecture}
+                                ${escapeHtml(architecture)}
                             </span>
                         </td>
-                        <td>${miner.hash_rate}</td>
-                        <td>${miner.blocks_mined}</td>
-                        <td class="text-muted">${miner.last_seen}</td>
+                        <td>${escapeHtml(miner.hash_rate)}</td>
+                        <td>${escapeHtml(miner.blocks_mined)}</td>
+                        <td class="text-muted">${escapeHtml(miner.last_seen)}</td>
                     </tr>
                 `;
             }).join('');

--- a/explorer/templates/ws_explorer.html
+++ b/explorer/templates/ws_explorer.html
@@ -103,6 +103,16 @@ let soundEnabled = false;
 let minerHistory = [];
 const socket = io({ reconnection: true, reconnectionDelay: 2000, reconnectionAttempts: Infinity });
 
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[ch]);
+}
+
 // Connection status
 socket.on('connect', () => {
   document.getElementById('conn-dot').className = 'conn-dot connected';
@@ -148,11 +158,11 @@ function updateEpoch(d) {
 function addBlockFeed(block) {
   const feed = document.getElementById('block-feed');
   if (feed.querySelector('.empty')) feed.innerHTML = '';
-  const hash = block.hash ? block.hash.substring(0, 16) + '...' : '—';
+  const hash = block.hash ? escapeHtml(String(block.hash).substring(0, 16)) + '...' : '—';
   const item = document.createElement('div');
   item.className = 'feed-item new';
   item.innerHTML = `<span class="time">${new Date().toLocaleTimeString()}</span> · 
-    Epoch ${block.epoch||'?'} · <span class="hash">${hash}</span>`;
+    Epoch ${escapeHtml(block.epoch || '?')} · <span class="hash">${hash}</span>`;
   feed.insertBefore(item, feed.firstChild);
   if (feed.children.length > 50) feed.removeChild(feed.lastChild);
   setTimeout(() => item.classList.remove('new'), 2000);
@@ -171,9 +181,9 @@ function updateMiners(d) {
     const grid = document.getElementById('miner-grid');
     grid.innerHTML = d.miners.slice(0, 12).map(m => `
       <div class="miner-card">
-        <div class="miner-id">${m.miner_id || m.id || '?'}</div>
-        <div class="miner-hw">${m.hardware || m.architecture || '?'}</div>
-        <div class="miner-multi">${m.multiplier || 1.0}x</div>
+        <div class="miner-id">${escapeHtml(m.miner_id || m.miner || m.id || '?')}</div>
+        <div class="miner-hw">${escapeHtml(m.hardware || m.device_arch || m.architecture || '?')}</div>
+        <div class="miner-multi">${escapeHtml(m.multiplier || 1.0)}x</div>
       </div>
     `).join('');
   }
@@ -186,7 +196,7 @@ function updateAttestations(list) {
     const item = document.createElement('div');
     item.className = 'feed-item new';
     item.innerHTML = `<span class="time">${new Date().toLocaleTimeString()}</span> · 
-      ${a.miner_id} · ${a.hardware} · <span class="miner-multi">${a.multiplier}x</span>`;
+      ${escapeHtml(a.miner_id || a.miner || '?')} · ${escapeHtml(a.hardware || a.device_arch || '?')} · <span class="miner-multi">${escapeHtml(a.multiplier || 1.0)}x</span>`;
     feed.insertBefore(item, feed.firstChild);
     if (feed.children.length > 50) feed.removeChild(feed.lastChild);
     setTimeout(() => item.classList.remove('new'), 2000);


### PR DESCRIPTION
## Summary
- add HTML escaping for realtime explorer block, miner, attestation, transaction, and hardware legend fields
- normalize dynamic CSS class tokens in the Bootstrap dashboard
- preserve existing template rendering while preventing API/websocket data from becoming executable markup

## Security impact
The realtime explorer dashboards render data from `/api/miners`, `/api/dashboard`, websocket snapshots, and polling fallbacks with `innerHTML`. Miner hardware metadata and API-provided block/transaction fields can contain attacker-controlled strings. This patch escapes those fields before insertion and encodes block hash links.

## Tests
- `node --check explorer/static/js/dashboard.js`
- `python3 -m compileall explorer/realtime_server.py explorer/ws_explorer_server.py explorer/explorer_websocket_server.py`
- `git diff --check`

Note: `pytest -q explorer/test_ws_explorer.py explorer/test_explorer_websocket.py -q` could not collect in this environment because Flask is not installed (`ModuleNotFoundError: No module named 'flask'`).