### PR TITLE
fix: preserve contributor database on init

### DIFF
--- a/init_contributor_db.py
+++ b/init_contributor_db.py
@@ -1,25 +1,19 @@
 # SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
 
 import sqlite3
-import os
 from datetime import datetime
 
 DB_PATH = 'contributors.db'
 
 def init_contributor_database():
-    """Initialize the contributors database with proper schema"""
-    
-    # Remove existing database if it exists
-    if os.path.exists(DB_PATH):
-        os.remove(DB_PATH)
-    
+    """Initialize or migrate the contributors database without deleting data."""
+
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         
         # Create contributors table
         cursor.execute('''
-        CREATE TABLE contributors (
+        CREATE TABLE IF NOT EXISTS contributors (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             github_username TEXT UNIQUE NOT NULL,
             contributor_type TEXT NOT NULL CHECK (contributor_type IN ('human', 'bot', 'agent')),
@@ -33,13 +27,13 @@ def init_contributor_database():
         ''')
         
         # Create index for faster lookups
-        cursor.execute('CREATE INDEX idx_github_username ON contributors(github_username)')
-        cursor.execute('CREATE INDEX idx_payment_status ON contributors(payment_status)')
-        cursor.execute('CREATE INDEX idx_registration_date ON contributors(registration_date)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_github_username ON contributors(github_username)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_payment_status ON contributors(payment_status)')
+        cursor.execute('CREATE INDEX IF NOT EXISTS idx_registration_date ON contributors(registration_date)')
         
         # Create contributions tracking table
         cursor.execute('''
-        CREATE TABLE contributions (
+        CREATE TABLE IF NOT EXISTS contributions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             contributor_id INTEGER NOT NULL,
             repo_name TEXT NOT NULL,
@@ -55,7 +49,7 @@ def init_contributor_database():
         
         # Create payment history table
         cursor.execute('''
-        CREATE TABLE payment_history (
+        CREATE TABLE IF NOT EXISTS payment_history (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             contributor_id INTEGER NOT NULL,
             amount REAL NOT NULL,

--- a/tests/test_init_contributor_db_preserves_data.py
+++ b/tests/test_init_contributor_db_preserves_data.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+import init_contributor_db
+
+
+def _count_rows(db_path, table):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+
+def test_init_contributor_database_is_idempotent_and_preserves_rows(tmp_path, monkeypatch):
+    db_path = tmp_path / "contributors.db"
+    monkeypatch.setattr(init_contributor_db, "DB_PATH", str(db_path))
+
+    init_contributor_db.init_contributor_database()
+    contributor_id = init_contributor_db.add_contributor(
+        "galpetame",
+        "agent",
+        "RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce",
+        "reviews,fixes",
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO contributions (
+                contributor_id, repo_name, contribution_type, description,
+                rtc_earned, date_contributed, verified
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                contributor_id,
+                "Scottcjn/Rustchain",
+                "bugfix",
+                "protect contributor initialization from destructive re-runs",
+                0,
+                "2026-05-13",
+                True,
+            ),
+        )
+
+    init_contributor_db.init_contributor_database()
+
+    assert init_contributor_db.get_contributor_stats() == {
+        "total": 1,
+        "paid": 0,
+        "pending": 1,
+    }
+    assert _count_rows(db_path, "contributors") == 1
+    assert _count_rows(db_path, "contributions") == 1
+    assert _count_rows(db_path, "payment_history") == 1


### PR DESCRIPTION
Fixes #4913.

Summary:
- Stops `init_contributor_database()` from deleting `contributors.db` on every run.
- Changes table/index creation to `IF NOT EXISTS` so initialization can be safely rerun as a migration/bootstrap step.
- Adds a regression test proving existing contributor, contribution, and payment history rows survive a second initialization.

Validation:
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_init_contributor_db_preserves_data.py -q` -> 1 passed
- `python -m py_compile init_contributor_db.py tests\test_init_contributor_db_preserves_data.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No production database or live service was touched.

Bounty context if eligible: @galpetame / native RTC wallet `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`.