### PR TITLE
fix: require signed OTC wallet actions

### DIFF
--- a/otc-bridge/README.md
+++ b/otc-bridge/README.md
@@ -84,8 +84,13 @@ curl -X POST http://localhost:5580/api/orders \
 ```bash
 curl -X POST http://localhost:5580/api/orders/otc_abc123/match \
   -H "Content-Type: application/json" \
-  -d '{"wallet":"buyer-wallet","eth_address":"0x..."}'
+  -d '{"wallet":"RTC...","eth_address":"0x...","wallet_auth":{"public_key":"<ed25519-public-key-hex>","signature":"<signature-hex>","timestamp":1760000000}}'
 ```
+
+`match` and `cancel` require `wallet_auth` for the wallet performing the action.
+Sign this canonical JSON payload with the wallet's Ed25519 key:
+`{"action":"match_order","order_id":"otc_abc123","timestamp":1760000000,"wallet":"RTC..."}`
+Use `"cancel_order"` for cancellations. The timestamp must be within 5 minutes.
 
 ## HTLC Contract (Base)
 

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -24,6 +24,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import sqlite3
 import time
@@ -33,6 +34,13 @@ from functools import wraps
 import requests
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
+
+try:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+except ImportError:  # pragma: no cover - only used in stripped-down deployments
+    InvalidSignature = None
+    Ed25519PublicKey = None
 
 # ---------------------------------------------------------------------------
 # Config
@@ -62,6 +70,8 @@ MAX_ORDER_RTC = 100000              # Maximum 100k RTC
 RATE_LIMIT_WINDOW = 60              # 1 minute
 RATE_LIMIT_MAX = 10                 # 10 requests per minute per IP
 RTC_REFERENCE_RATE = 0.10           # $0.10 USD reference
+WALLET_AUTH_MAX_AGE_SECONDS = 300
+RTC_WALLET_RE = re.compile(r"^RTC[0-9a-fA-F]{40}$")
 
 SUPPORTED_PAIRS = {
     "RTC/ETH": {"quote": "ETH", "decimals": 18},
@@ -164,6 +174,60 @@ def generate_trade_id(order_id, taker):
 
 def hash_ip(ip):
     return hashlib.sha256(f"otc_salt_{ip}".encode()).hexdigest()[:16]
+
+
+def address_from_public_key(public_key_hex):
+    """Derive the canonical RTC wallet address from a hex Ed25519 public key."""
+    public_key_bytes = bytes.fromhex(public_key_hex)
+    return f"RTC{hashlib.sha256(public_key_bytes).hexdigest()[:40]}"
+
+
+def canonical_wallet_auth_message(action, order_id, wallet, timestamp):
+    payload = {
+        "action": action,
+        "order_id": order_id,
+        "timestamp": int(timestamp),
+        "wallet": wallet,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def require_wallet_signature(data, action, order_id, wallet):
+    """Verify the caller controls the RTC wallet used for a sensitive order action."""
+    if Ed25519PublicKey is None:
+        return "wallet_signature_verification_unavailable"
+    if not RTC_WALLET_RE.fullmatch(wallet):
+        return "wallet_must_be_native_rtc_address"
+
+    auth = data.get("wallet_auth")
+    if not isinstance(auth, dict):
+        return "wallet_auth_required"
+
+    public_key = str(auth.get("public_key", "")).strip()
+    signature = str(auth.get("signature", "")).strip()
+    timestamp_raw = auth.get("timestamp")
+    if not public_key or not signature or timestamp_raw is None:
+        return "wallet_auth_public_key_signature_timestamp_required"
+
+    try:
+        timestamp = int(timestamp_raw)
+        now = int(time.time())
+        if abs(now - timestamp) > WALLET_AUTH_MAX_AGE_SECONDS:
+            return "wallet_auth_timestamp_expired"
+        if address_from_public_key(public_key).lower() != wallet.lower():
+            return "wallet_auth_public_key_does_not_match_wallet"
+
+        verify_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key))
+        verify_key.verify(
+            bytes.fromhex(signature),
+            canonical_wallet_auth_message(action, order_id, wallet, timestamp),
+        )
+    except (ValueError, TypeError):
+        return "wallet_auth_invalid_encoding"
+    except InvalidSignature:
+        return "wallet_auth_invalid_signature"
+
+    return None
 
 
 def get_client_ip():
@@ -551,6 +615,9 @@ def match_order(order_id):
 
     if not taker_wallet:
         return jsonify({"error": "wallet required"}), 400
+    auth_error = require_wallet_signature(data, "match_order", order_id, taker_wallet)
+    if auth_error:
+        return jsonify({"error": auth_error}), 401
 
     conn = get_db()
     try:
@@ -779,6 +846,9 @@ def cancel_order(order_id):
 
     if not wallet:
         return jsonify({"error": "wallet required"}), 400
+    auth_error = require_wallet_signature(data, "cancel_order", order_id, wallet)
+    if auth_error:
+        return jsonify({"error": auth_error}), 401
 
     conn = get_db()
     try:

--- a/otc-bridge/requirements.txt
+++ b/otc-bridge/requirements.txt
@@ -1,4 +1,5 @@
 flask>=3.0
 flask-cors>=6.0.2
 requests>=2.31
+cryptography>=46.0.7
 gunicorn>=21.2

--- a/tests/test_otc_bridge_wallet_auth.py
+++ b/tests/test_otc_bridge_wallet_auth.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def load_otc_bridge(tmp_path):
+    if "flask_cors" not in sys.modules:
+        flask_cors = types.ModuleType("flask_cors")
+        flask_cors.CORS = lambda app: app
+        sys.modules["flask_cors"] = flask_cors
+
+    db_path = tmp_path / "otc_bridge.db"
+    os.environ["OTC_DB_PATH"] = str(db_path)
+
+    module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
+    spec = importlib.util.spec_from_file_location("otc_bridge_wallet_auth_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.app.testing = True
+    module.init_db()
+    return module
+
+
+def make_wallet(otc_bridge):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_hex = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    return private_key, public_key_hex, otc_bridge.address_from_public_key(public_key_hex)
+
+
+def wallet_auth(otc_bridge, private_key, public_key_hex, action, order_id, wallet):
+    timestamp = int(time.time())
+    message = otc_bridge.canonical_wallet_auth_message(action, order_id, wallet, timestamp)
+    return {
+        "public_key": public_key_hex,
+        "signature": private_key.sign(message).hex(),
+        "timestamp": timestamp,
+    }
+
+
+def create_buy_order(client, wallet):
+    response = client.post(
+        "/api/orders",
+        json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": wallet,
+            "amount_rtc": 10,
+            "price_per_rtc": 0.10,
+        },
+    )
+    assert response.status_code == 201
+    return response.get_json()["order_id"]
+
+
+def get_order_status(client, order_id):
+    response = client.get(f"/api/orders/{order_id}")
+    assert response.status_code == 200
+    return response.get_json()["order"]["status"]
+
+
+def test_cancel_requires_wallet_signature_and_preserves_order(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(f"/api/orders/{order_id}/cancel", json={"wallet": maker_wallet})
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_required"}
+        assert get_order_status(client, order_id) == "open"
+
+
+def test_cancel_rejects_signature_from_different_wallet_key(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
+    attacker_key, attacker_pub, _ = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(
+            f"/api/orders/{order_id}/cancel",
+            json={
+                "wallet": maker_wallet,
+                "wallet_auth": wallet_auth(
+                    otc_bridge, attacker_key, attacker_pub, "cancel_order", order_id, maker_wallet
+                ),
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_public_key_does_not_match_wallet"}
+        assert get_order_status(client, order_id) == "open"
+
+
+def test_signed_cancel_succeeds_for_order_maker(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(
+            f"/api/orders/{order_id}/cancel",
+            json={
+                "wallet": maker_wallet,
+                "wallet_auth": wallet_auth(
+                    otc_bridge, maker_key, maker_pub, "cancel_order", order_id, maker_wallet
+                ),
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "cancelled"
+
+
+def test_match_requires_taker_wallet_signature(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
+    taker_key, taker_pub, taker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        unsigned_response = client.post(f"/api/orders/{order_id}/match", json={"wallet": taker_wallet})
+        assert unsigned_response.status_code == 401
+        assert unsigned_response.get_json() == {"error": "wallet_auth_required"}
+        assert get_order_status(client, order_id) == "open"
+
+        with patch.object(otc_bridge, "rtc_get_balance", return_value=500.0), patch.object(
+            otc_bridge, "rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_auth_match"}
+        ):
+            signed_response = client.post(
+                f"/api/orders/{order_id}/match",
+                json={
+                    "wallet": taker_wallet,
+                    "wallet_auth": wallet_auth(
+                        otc_bridge, taker_key, taker_pub, "match_order", order_id, taker_wallet
+                    ),
+                },
+            )
+
+        assert signed_response.status_code == 200
+        assert signed_response.get_json()["status"] == "matched"


### PR DESCRIPTION
Fixes #4957.

## Summary
- Adds action-scoped Ed25519 wallet authorization for `POST /api/orders/<id>/match` and `/cancel`.
- Derives the native RTC wallet from the submitted public key and rejects mismatched wallet/public-key pairs.
- Binds signatures to `{action, order_id, wallet, timestamp}` with a five-minute replay window.
- Documents the new `wallet_auth` payload and adds the `cryptography` runtime dependency.
- Adds regressions proving unsigned cancellation is rejected without mutating the order, a different wallet key cannot cancel, signed maker cancellation succeeds, and matching requires the taker signature.

## Validation
- `python -m pytest tests\test_otc_bridge_wallet_auth.py -q` -> 4 passed
- `python -m py_compile otc-bridge\otc_bridge.py tests\test_otc_bridge_wallet_auth.py` -> passed
- `python -m ruff check otc-bridge\otc_bridge.py tests\test_otc_bridge_wallet_auth.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No production bridge, live wallet, or live order book was tested.

Bounty wallet: `RTC253255d034065a839cd421811ec589ae5b694ffc`
