### PR TITLE
fix: randomize python governance execution hash

### DIFF
--- a/rips/python/rustchain/governance.py
+++ b/rips/python/rustchain/governance.py
@@ -14,6 +14,7 @@ Features:
 
 import hashlib
 import json
+import secrets
 import time
 from dataclasses import dataclass, field
 from enum import Enum, auto
@@ -458,8 +459,9 @@ class GovernanceEngine:
 
         proposal.status = ProposalStatus.EXECUTED
         proposal.executed_at = int(time.time())
+        execution_nonce = secrets.token_bytes(32)
         proposal.execution_tx_hash = hashlib.sha256(
-            f"{proposal_id}:{proposal.executed_at}".encode()
+            f"{proposal_id}:{proposal.executed_at}".encode() + execution_nonce
         ).hexdigest()
 
         print(f"⚡ Proposal {proposal_id} executed at block height [N]")

--- a/tests/test_python_governance_execution_hash.py
+++ b/tests/test_python_governance_execution_hash.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import sys
+from pathlib import Path
+
+
+PYTHON_RIPS = Path(__file__).resolve().parents[1] / "rips" / "python"
+sys.path.insert(0, str(PYTHON_RIPS))
+
+from rustchain.core_types import WalletAddress  # noqa: E402
+from rustchain.governance import GovernanceEngine, ProposalStatus, ProposalType  # noqa: E402
+
+
+def test_python_governance_execution_hash_uses_nonce(monkeypatch):
+    engine = GovernanceEngine(total_supply=1_000_000)
+    proposal = engine.create_proposal(
+        title="Upgrade treasury policy",
+        description="Execute a deterministic-time governance action",
+        proposal_type=ProposalType.PARAMETER_CHANGE,
+        proposer=WalletAddress("RTC1234567890abcdef1234567890abcdef12345678"),
+    )
+    proposal.status = ProposalStatus.PASSED
+
+    nonce_one = b"a" * 32
+    nonce_two = b"b" * 32
+    monkeypatch.setattr("rustchain.governance.time.time", lambda: 1_768_000_000)
+    nonces = iter([nonce_one, nonce_two])
+    monkeypatch.setattr("rustchain.governance.secrets.token_bytes", lambda size: next(nonces))
+
+    assert engine.execute_proposal(proposal.id) is True
+    first_hash = proposal.execution_tx_hash
+
+    proposal.status = ProposalStatus.PASSED
+    proposal.executed_at = None
+    proposal.execution_tx_hash = None
+
+    assert engine.execute_proposal(proposal.id) is True
+    second_hash = proposal.execution_tx_hash
+
+    assert first_hash == hashlib.sha256(
+        f"{proposal.id}:1768000000".encode() + nonce_one
+    ).hexdigest()
+    assert second_hash == hashlib.sha256(
+        f"{proposal.id}:1768000000".encode() + nonce_two
+    ).hexdigest()
+    assert first_hash != second_hash


### PR DESCRIPTION
Complements #4842 and helps close #4840.

## Summary
- Fixes the remaining deterministic proposal execution hash in `rips/python/rustchain/governance.py`.
- Adds a 32-byte `secrets.token_bytes()` nonce to the Python package governance `execution_tx_hash` input.
- Adds a focused regression that pins the execution timestamp, executes the same proposal twice with different mocked nonces, and proves the hashes are different and match the nonce-bound expected digests.

## Validation
- `python -m pytest tests\test_python_governance_execution_hash.py -q` -> 1 passed
- `python -m py_compile rips\python\rustchain\governance.py tests\test_python_governance_execution_hash.py` -> passed
- `python -m ruff check rips\python\rustchain\governance.py tests\test_python_governance_execution_hash.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No production node, live governance service, wallet, or destructive testing was used.

Bounty wallet: `RTC253255d034065a839cd421811ec589ae5b694ffc`
