### PR TITLE
fix: protect payout ledger endpoints

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -7,6 +7,7 @@ See: node/rustchain_v2_integrated_v2.2.1_rip200.py for DB conventions.
 Statuses: queued → pending → confirmed | voided
 """
 import os
+import hmac
 import time
 import sqlite3
 import uuid
@@ -54,6 +55,29 @@ def _migrate_payout_ledger_schema(conn):
             raise RuntimeError("payout_ledger table is missing required primary key column: id")
         conn.execute(f"ALTER TABLE payout_ledger ADD COLUMN {name} {definition}")
         logger.info("Added payout_ledger.%s column", name)
+
+
+def _configured_admin_key():
+    """Return the admin key used to protect payout-ledger financial data."""
+    return (
+        os.environ.get("PAYOUT_LEDGER_ADMIN_KEY", "").strip()
+        or os.environ.get("PAYOUT_ADMIN_KEY", "").strip()
+        or os.environ.get("RC_ADMIN_KEY", "").strip()
+    )
+
+
+def _require_admin():
+    expected = _configured_admin_key()
+    if not expected:
+        return jsonify({"error": "admin key not configured"}), 503
+    provided = (
+        request.headers.get("X-Admin-Key", "")
+        or request.headers.get("X-API-Key", "")
+    ).strip()
+    if not provided or not hmac.compare_digest(provided, expected):
+        return jsonify({"error": "unauthorized"}), 401
+    return None
+
 
 # ── Schema ──────────────────────────────────────────────────────
 def init_payout_ledger_tables():
@@ -173,6 +197,9 @@ def register_ledger_routes(app):
 
     @app.route("/ledger")
     def ledger_page():
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         status_filter = request.args.get("status")
         records = ledger_list(status=status_filter)
@@ -181,6 +208,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["GET"])
     def api_ledger_list():
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         status = request.args.get("status")
         contributor = request.args.get("contributor")
@@ -189,6 +219,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>", methods=["GET"])
     def api_ledger_get(record_id):
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         record = ledger_get(record_id)
         if not record:
@@ -197,6 +230,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger", methods=["POST"])
     def api_ledger_create():
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         required = ["bounty_id", "contributor", "amount_rtc"]
@@ -216,6 +252,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
     def api_ledger_update(record_id):
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         data = request.get_json(force=True)
         new_status = data.get("status")
@@ -233,6 +272,9 @@ def register_ledger_routes(app):
 
     @app.route("/api/ledger/summary", methods=["GET"])
     def api_ledger_summary():
+        admin_error = _require_admin()
+        if admin_error:
+            return admin_error
         init_payout_ledger_tables()
         return jsonify(ledger_summary())
 

--- a/tests/test_payout_ledger_admin_auth.py
+++ b/tests/test_payout_ledger_admin_auth.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+import gc
+import os
+import tempfile
+import unittest
+
+from flask import Flask
+
+import payout_ledger
+
+
+class TestPayoutLedgerAdminAuth(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        self.original_db_path = payout_ledger.DB_PATH
+        self.original_admin_key = os.environ.get("RC_ADMIN_KEY")
+        self.original_payout_key = os.environ.get("PAYOUT_ADMIN_KEY")
+        self.original_ledger_key = os.environ.get("PAYOUT_LEDGER_ADMIN_KEY")
+        payout_ledger.DB_PATH = self.db_path
+        app = Flask(__name__)
+        payout_ledger.register_ledger_routes(app)
+        self.client = app.test_client()
+
+    def tearDown(self):
+        payout_ledger.DB_PATH = self.original_db_path
+        self._restore_env("RC_ADMIN_KEY", self.original_admin_key)
+        self._restore_env("PAYOUT_ADMIN_KEY", self.original_payout_key)
+        self._restore_env("PAYOUT_LEDGER_ADMIN_KEY", self.original_ledger_key)
+        gc.collect()
+        try:
+            os.unlink(self.db_path)
+        except PermissionError:
+            pass
+
+    @staticmethod
+    def _restore_env(name, value):
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
+
+    def _seed_record(self):
+        payout_ledger.init_payout_ledger_tables()
+        return payout_ledger.ledger_create(
+            "bounty-1",
+            "alice",
+            7.5,
+            wallet_address="RTC-private-wallet",
+        )
+
+    def _auth(self, key="expected-admin"):
+        return {"X-Admin-Key": key}
+
+    def test_routes_fail_closed_when_admin_key_unset(self):
+        os.environ.pop("RC_ADMIN_KEY", None)
+        os.environ.pop("PAYOUT_ADMIN_KEY", None)
+        os.environ.pop("PAYOUT_LEDGER_ADMIN_KEY", None)
+
+        responses = [
+            self.client.get("/ledger"),
+            self.client.get("/api/ledger"),
+            self.client.get("/api/ledger/anything"),
+            self.client.get("/api/ledger/summary"),
+            self.client.post("/api/ledger", json={}),
+            self.client.patch("/api/ledger/anything/status", json={"status": "confirmed"}),
+        ]
+
+        for response in responses:
+            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.get_json()["error"], "admin key not configured")
+
+    def test_unauthorized_requests_cannot_read_or_mutate_ledger(self):
+        os.environ["RC_ADMIN_KEY"] = "expected-admin"
+        record_id = self._seed_record()
+
+        denied = [
+            self.client.get("/ledger"),
+            self.client.get("/api/ledger"),
+            self.client.get(f"/api/ledger/{record_id}"),
+            self.client.get("/api/ledger/summary"),
+            self.client.post(
+                "/api/ledger",
+                json={
+                    "bounty_id": "evil",
+                    "contributor": "mallory",
+                    "amount_rtc": 1000,
+                },
+            ),
+            self.client.patch(
+                f"/api/ledger/{record_id}/status",
+                json={"status": "confirmed", "tx_hash": "fake"},
+            ),
+        ]
+
+        for response in denied:
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.get_json()["error"], "unauthorized")
+
+        row = payout_ledger.ledger_get(record_id)
+        self.assertEqual(row["status"], "queued")
+        self.assertEqual(row["tx_hash"], "")
+
+    def test_authorized_admin_can_read_create_and_update(self):
+        os.environ["RC_ADMIN_KEY"] = "expected-admin"
+
+        create = self.client.post(
+            "/api/ledger",
+            headers=self._auth(),
+            json={
+                "bounty_id": "bounty-2",
+                "contributor": "bob",
+                "amount_rtc": 12.25,
+                "wallet_address": "RTC-private-wallet",
+            },
+        )
+
+        self.assertEqual(create.status_code, 201)
+        record_id = create.get_json()["id"]
+
+        listed = self.client.get("/api/ledger", headers=self._auth())
+        self.assertEqual(listed.status_code, 200)
+        self.assertEqual(listed.get_json()[0]["id"], record_id)
+
+        update = self.client.patch(
+            f"/api/ledger/{record_id}/status",
+            headers={"X-API-Key": "expected-admin"},
+            json={"status": "confirmed", "tx_hash": "tx-ok"},
+        )
+        self.assertEqual(update.status_code, 200)
+
+        row = payout_ledger.ledger_get(record_id)
+        self.assertEqual(row["status"], "confirmed")
+        self.assertEqual(row["tx_hash"], "tx-ok")
+
+    def test_specific_payout_ledger_key_takes_precedence(self):
+        os.environ["RC_ADMIN_KEY"] = "general-admin"
+        os.environ["PAYOUT_LEDGER_ADMIN_KEY"] = "ledger-admin"
+        self._seed_record()
+
+        wrong = self.client.get("/api/ledger", headers=self._auth("general-admin"))
+        right = self.client.get("/api/ledger", headers=self._auth("ledger-admin"))
+
+        self.assertEqual(wrong.status_code, 401)
+        self.assertEqual(right.status_code, 200)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- protects the live root `payout_ledger.py` routes instead of adding another duplicate RIP-path module
- requires an admin key before the payout ledger page, list/get/summary APIs, record creation, or status updates can expose or mutate payout data
- accepts `PAYOUT_LEDGER_ADMIN_KEY`, then `PAYOUT_ADMIN_KEY`, then `RC_ADMIN_KEY`, and fails closed with 503 when none is configured
- uses `hmac.compare_digest()` and supports both `X-Admin-Key` and `X-API-Key`

## Validation
- `python -m pytest tests\test_payout_ledger_admin_auth.py tests\test_payout_ledger_migration.py -q` -> 6 passed
- `python -m py_compile payout_ledger.py tests\test_payout_ledger_admin_auth.py tests\test_payout_ledger_migration.py` -> passed
- `python -m ruff check payout_ledger.py tests\test_payout_ledger_admin_auth.py tests\test_payout_ledger_migration.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No production payout ledger, live wallet, or destructive testing was used.

Fixes #4902.
