### PR TITLE
fix: align miner alerts with live node api

### DIFF
--- a/tests/test_miner_alerts_live_api.py
+++ b/tests/test_miner_alerts_live_api.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def miner_alerts_module(monkeypatch):
+    fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location("miner_alerts_live_api", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200, error=None):
+        self.payload = payload
+        self.status_code = status_code
+        self.error = error
+
+    def raise_for_status(self):
+        if self.error:
+            raise self.error
+
+    def json(self):
+        return self.payload
+
+
+def test_fetch_miners_accepts_live_paginated_shape(miner_alerts_module, monkeypatch):
+    monkeypatch.setattr(miner_alerts_module, "RUSTCHAIN_API", "https://node.example")
+    monkeypatch.setattr(miner_alerts_module, "VERIFY_SSL", True)
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse(
+            {
+                "miners": [{"miner": "miner-a"}, {"miner_id": "miner-b"}],
+                "pagination": {"total": 2},
+            }
+        )
+
+    monkeypatch.setattr(miner_alerts_module.requests, "get", fake_get)
+
+    assert miner_alerts_module.fetch_miners() == [
+        {"miner": "miner-a"},
+        {"miner_id": "miner-b"},
+    ]
+    assert calls == [
+        ("https://node.example/api/miners", {"verify": True, "timeout": 15})
+    ]
+
+
+def test_fetch_miners_keeps_legacy_list_support(miner_alerts_module, monkeypatch):
+    monkeypatch.setattr(
+        miner_alerts_module.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse([{"miner": "legacy"}]),
+    )
+
+    assert miner_alerts_module.fetch_miners() == [{"miner": "legacy"}]
+
+
+def test_fetch_balance_uses_wallet_balance_endpoint(miner_alerts_module, monkeypatch):
+    monkeypatch.setattr(miner_alerts_module, "RUSTCHAIN_API", "https://node.example")
+    monkeypatch.setattr(miner_alerts_module, "VERIFY_SSL", False)
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse({"amount_rtc": "3.5"})
+
+    monkeypatch.setattr(miner_alerts_module.requests, "get", fake_get)
+
+    assert miner_alerts_module.fetch_balance("miner-a") == 3.5
+    assert calls == [
+        (
+            "https://node.example/wallet/balance",
+            {"params": {"miner_id": "miner-a"}, "verify": False, "timeout": 10},
+        )
+    ]
+
+
+def test_fetch_balance_falls_back_to_path_route(miner_alerts_module, monkeypatch):
+    monkeypatch.setattr(miner_alerts_module, "RUSTCHAIN_API", "https://node.example")
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        if url.endswith("/wallet/balance"):
+            return FakeResponse({}, status_code=404)
+        return FakeResponse({"balance_rtc": "7.25"})
+
+    monkeypatch.setattr(miner_alerts_module.requests, "get", fake_get)
+
+    assert miner_alerts_module.fetch_balance("miner-a") == 7.25
+    assert [url for url, _kwargs in calls] == [
+        "https://node.example/wallet/balance",
+        "https://node.example/balance/miner-a",
+    ]

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -482,7 +482,11 @@ def fetch_miners() -> List[dict]:
         )
         resp.raise_for_status()
         data = resp.json()
-        return data if isinstance(data, list) else []
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and isinstance(data.get("miners"), list):
+            return data["miners"]
+        return []
     except Exception as e:
         logger.error(f"Failed to fetch miners: {e}")
         return []
@@ -492,16 +496,23 @@ def fetch_balance(miner_id: str) -> Optional[float]:
     """Fetch balance for a miner."""
     try:
         resp = requests.get(
-            f"{RUSTCHAIN_API}/balance",
+            f"{RUSTCHAIN_API}/wallet/balance",
             params={"miner_id": miner_id},
             verify=VERIFY_SSL,
             timeout=10,
         )
         if resp.status_code == 404:
-            return None
+            resp = requests.get(
+                f"{RUSTCHAIN_API}/balance/{miner_id}",
+                verify=VERIFY_SSL,
+                timeout=10,
+            )
+            if resp.status_code == 404:
+                return None
         resp.raise_for_status()
         data = resp.json()
-        return float(data.get("balance", data.get("balance_rtc", 0)))
+        amount = data.get("amount_rtc", data.get("balance_rtc", data.get("balance", 0)))
+        return float(amount)
     except Exception as e:
         logger.error(f"Failed to fetch balance for {miner_id}: {e}")
         return None


### PR DESCRIPTION
## Summary
- Accept the current live `/api/miners` response shape (`{"miners": [...], "pagination": ...}`) while preserving legacy top-level list support.
- Read balances from the live `/wallet/balance?miner_id=...` endpoint and parse `amount_rtc`, with a fallback to `/balance/<miner_id>` for older node deployments.
- Add focused tests for the paginated miner response, legacy miner response, live wallet-balance endpoint, and fallback route.

## Why
The miner alert daemon currently returns zero miners against both `https://rustchain.org/api/miners` and `https://50.28.86.131/api/miners` because both live endpoints return an object, not a top-level list. The default `https://rustchain.org/balance?miner_id=...` balance URL also returns 404, so reward/large-transfer alerts can silently stop working.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with requests --with pynacl python -m pytest tests/test_miner_alerts_live_api.py -q` -> 4 passed
- `uv run --no-project python -m py_compile tools/miner_alerts/miner_alerts.py tests/test_miner_alerts_live_api.py` -> passed
- `uv run --no-project --with ruff ruff check tools/miner_alerts/miner_alerts.py tests/test_miner_alerts_live_api.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- `git diff --check` -> passed
- `uv run --no-project python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- Live smoke against `https://50.28.86.131`: `fetch_miners()` returned a list with 13 miners and `fetch_balance()` returned `0.0` for the payout target.

No live writes, wallet transfers, or notification sends were performed.

Bounty references: #1589 test coverage; live API bug surfaced while reviewing #4964.

Payout target / wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`
