### PR TITLE
fix: align miner alerts with live wallet API

### DIFF
--- a/tests/test_miner_alerts_live_api.py
+++ b/tests/test_miner_alerts_live_api.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "miner_alerts" / "miner_alerts.py"
+spec = importlib.util.spec_from_file_location("miner_alerts", MODULE_PATH)
+miner_alerts = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(miner_alerts)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_miners_accepts_live_paginated_shape(monkeypatch):
+    seen = {}
+
+    def fake_get(url, **kwargs):
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return FakeResponse({
+            "miners": [
+                {"miner": "alpha", "last_attest": 123},
+                {"miner": "beta", "last_attest": 456},
+            ],
+            "pagination": {"total": 2, "count": 2},
+        })
+
+    monkeypatch.setattr(miner_alerts.requests, "get", fake_get)
+
+    miners = miner_alerts.fetch_miners()
+
+    assert seen["url"].endswith("/api/miners")
+    assert seen["kwargs"]["timeout"] == 15
+    assert [miner["miner"] for miner in miners] == ["alpha", "beta"]
+
+
+def test_fetch_miners_still_accepts_legacy_list_shape(monkeypatch):
+    monkeypatch.setattr(
+        miner_alerts.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse([{"miner": "legacy"}]),
+    )
+
+    assert miner_alerts.fetch_miners() == [{"miner": "legacy"}]
+
+
+def test_fetch_balance_uses_live_wallet_balance_route_and_amount_rtc(monkeypatch):
+    seen = {}
+
+    def fake_get(url, **kwargs):
+        seen["url"] = url
+        seen["kwargs"] = kwargs
+        return FakeResponse({"amount_i64": 521140570, "amount_rtc": 521.14057, "miner_id": "alpha"})
+
+    monkeypatch.setattr(miner_alerts.requests, "get", fake_get)
+
+    assert miner_alerts.fetch_balance("alpha") == 521.14057
+    assert seen["url"].endswith("/wallet/balance")
+    assert seen["kwargs"]["params"] == {"miner_id": "alpha"}
+
+
+def test_fetch_balance_keeps_backward_compatible_balance_fields(monkeypatch):
+    monkeypatch.setattr(
+        miner_alerts.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse({"balance_rtc": "12.5"}),
+    )
+
+    assert miner_alerts.fetch_balance("alpha") == 12.5

--- a/tools/miner_alerts/README.md
+++ b/tools/miner_alerts/README.md
@@ -69,7 +69,7 @@ python miner_alerts.py test-sms +15551234567
                                     +------------------+
   RustChain Node                    |  Alert System    |
   /api/miners  ──────────────────── | monitor loop     |
-  /balance     ──────────────────── | (polls every 2m) |
+  /wallet/balance ───────────────── | (polls every 2m) |
                                     +--------+---------+
                                              |
                                     +--------+---------+
@@ -89,7 +89,7 @@ python miner_alerts.py test-sms +15551234567
 
 ## How It Works
 
-1. **Poll**: Every `POLL_INTERVAL` seconds, fetch `/api/miners` and `/balance` for all subscribed miners
+1. **Poll**: Every `POLL_INTERVAL` seconds, fetch `/api/miners` and `/wallet/balance` for all subscribed miners
 2. **Compare**: Diff current state against stored state in SQLite
 3. **Detect**: Identify offline transitions, balance changes, attestation drops
 4. **Alert**: Send notifications via email/SMS to all subscribers

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -10,7 +10,7 @@ Monitors RustChain network and alerts miners via email (+ optional SMS via Twili
 - Attestation failures (miner disappears from active list)
 
 Architecture:
-- Polling daemon that checks /api/miners and /balance endpoints periodically
+- Polling daemon that checks /api/miners and /wallet/balance endpoints periodically
 - SQLite database for tracking miner state, alert history, and subscriptions
 - SMTP email delivery (works with Gmail, SendGrid, any SMTP provider)
 - Optional Twilio SMS integration
@@ -33,7 +33,12 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import requests
-from dotenv import load_dotenv
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    def load_dotenv():
+        return False
 
 # Load .env
 load_dotenv()
@@ -482,7 +487,11 @@ def fetch_miners() -> List[dict]:
         )
         resp.raise_for_status()
         data = resp.json()
-        return data if isinstance(data, list) else []
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and isinstance(data.get("miners"), list):
+            return data["miners"]
+        return []
     except Exception as e:
         logger.error(f"Failed to fetch miners: {e}")
         return []
@@ -492,7 +501,7 @@ def fetch_balance(miner_id: str) -> Optional[float]:
     """Fetch balance for a miner."""
     try:
         resp = requests.get(
-            f"{RUSTCHAIN_API}/balance",
+            f"{RUSTCHAIN_API}/wallet/balance",
             params={"miner_id": miner_id},
             verify=VERIFY_SSL,
             timeout=10,
@@ -501,7 +510,7 @@ def fetch_balance(miner_id: str) -> Optional[float]:
             return None
         resp.raise_for_status()
         data = resp.json()
-        return float(data.get("balance", data.get("balance_rtc", 0)))
+        return float(data.get("amount_rtc", data.get("balance", data.get("balance_rtc", 0))))
     except Exception as e:
         logger.error(f"Failed to fetch balance for {miner_id}: {e}")
         return None


### PR DESCRIPTION
## Summary

Fixes #4968.

- Parse the current live `/api/miners` response shape (`{ miners, pagination }`) while preserving legacy top-level list support.
- Query the documented live `/wallet/balance?miner_id=...` route instead of the stale `/balance` route.
- Read `amount_rtc` from live wallet-balance responses while keeping backward compatibility with `balance` / `balance_rtc`.
- Make `python-dotenv` optional so the alert helper can still import in minimal/test environments.
- Update miner-alert docs to reference `/wallet/balance`.
- Add regression coverage for the live API shapes and backward-compatible legacy shapes.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_miner_alerts_live_api.py -q` -> `4 passed`
- `python -m py_compile tools\miner_alerts\miner_alerts.py tests\test_miner_alerts_live_api.py` -> passed
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`
- Read-only live smoke on `https://rustchain.org/api/miners` -> object with `miners[13]` and `pagination`
- Read-only live smoke on `https://rustchain.org/wallet/balance?miner_id=modern-sophia-Pow-9862e3be` -> `amount_rtc=521.14057`
- Read-only live smoke on old `/balance?miner_id=...` -> HTTP 404

No production write, wallet action, or destructive testing was used.
