### PR TITLE
fix: validate BoTTube embed forwarded host

### DIFF
--- a/node/bottube_embed.py
+++ b/node/bottube_embed.py
@@ -24,7 +24,7 @@ import json
 import time
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
-from flask import Blueprint, request, Response, jsonify, render_template_string
+from flask import Blueprint, request, Response, jsonify, render_template_string, current_app
 
 
 # Create blueprint for embed routes
@@ -789,10 +789,12 @@ def _get_related_videos(video_id: str, limit: int = 5) -> List[Dict[str, Any]]:
 
 
 def _get_base_url() -> str:
-    """Get the base URL from request."""
+    """Get the base URL from request, trusting only configured proxy hosts."""
     base_url = request.host_url.rstrip("/")
-    if request.headers.get("X-Forwarded-Host"):
-        base_url = f"https://{request.headers['X-Forwarded-Host']}"
+    forwarded_host = request.headers.get("X-Forwarded-Host", "").strip()
+    trusted_hosts = current_app.config.get("TRUSTED_FORWARD_HOSTS") or []
+    if forwarded_host and forwarded_host in trusted_hosts:
+        base_url = f"https://{forwarded_host}"
     return base_url
 
 

--- a/tests/test_bottube_embed.py
+++ b/tests/test_bottube_embed.py
@@ -217,6 +217,34 @@ class TestOEmbedEndpoint(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("html", data)
 
+    def test_oembed_ignores_untrusted_forwarded_host(self):
+        """Untrusted forwarded hosts must not poison generated embed URLs."""
+        response = self.client.get(
+            "/oembed?url=https://bottube.ai/watch/demo-001",
+            headers={"X-Forwarded-Host": "evil.example"},
+            base_url="https://bottube.ai",
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("https://bottube.ai/embed/demo-001", data["html"])
+        self.assertNotIn("evil.example", data["html"])
+        self.assertNotIn("evil.example", data["thumbnail_url"])
+
+    def test_oembed_allows_trusted_forwarded_host(self):
+        """Trusted forwarded hosts remain supported for proxy deployments."""
+        self.app.config["TRUSTED_FORWARD_HOSTS"] = ["embed.bottube.ai"]
+
+        response = self.client.get(
+            "/oembed?url=https://bottube.ai/watch/demo-001",
+            headers={"X-Forwarded-Host": "embed.bottube.ai"},
+            base_url="https://internal.example",
+        )
+        data = response.get_json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("https://embed.bottube.ai/embed/demo-001", data["html"])
+
 
 class TestWatchPage(unittest.TestCase):
     """Test suite for watch page with Share > Embed UI."""


### PR DESCRIPTION
## Summary
- patches the live `node/bottube_embed.py` module instead of adding a duplicate RIP-path copy
- validates `X-Forwarded-Host` against `current_app.config["TRUSTED_FORWARD_HOSTS"]` before using it to generate embed/oEmbed URLs
- falls back to `request.host_url` for untrusted forwarded hosts
- adds regressions for untrusted and trusted forwarded-host behavior in the existing BoTTube embed test suite

## Validation
- `python -m pytest tests\test_bottube_embed.py -q` -> 45 passed
- `python -m py_compile node\bottube_embed.py tests\test_bottube_embed.py` -> passed
- `python -m ruff check node\bottube_embed.py tests\test_bottube_embed.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No production BoTTube service, live wallet, or destructive testing was used.

Fixes #4966.
