### PR TITLE
fix: remove relic market hardcoded signing seeds

### DIFF
--- a/bounties/issue-2312/src/relic_market_api.py
+++ b/bounties/issue-2312/src/relic_market_api.py
@@ -369,6 +369,7 @@ class ReceiptSigner:
     """Signs provenance receipts with machine Ed25519 keys"""
 
     MACHINE_IDS = ("vm-001", "vm-002", "vm-003", "vm-004", "vm-005")
+    REQUIRE_STABLE_KEYS_ENV = "RELIC_REQUIRE_STABLE_MACHINE_KEYS"
     
     def __init__(self):
         self.machine_keys: Dict[str, nacl.signing.SigningKey] = {}
@@ -379,6 +380,16 @@ class ReceiptSigner:
         """Return the environment variable name for a machine signing key."""
         safe_id = machine_id.upper().replace("-", "_")
         return f"RELIC_MACHINE_KEY_{safe_id}"
+
+    @classmethod
+    def _requires_stable_keys(cls) -> bool:
+        """Return whether production mode requires configured machine keys."""
+        return os.getenv(cls.REQUIRE_STABLE_KEYS_ENV, "").strip().lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
 
     @classmethod
     def _load_signing_key_from_env(cls, machine_id: str) -> Optional[nacl.signing.SigningKey]:
@@ -415,14 +426,22 @@ class ReceiptSigner:
     
     def _initialize_machine_keys(self):
         """Initialize Ed25519 keys without embedding reusable private seeds."""
+        require_stable_keys = self._requires_stable_keys()
         for machine_id in self.MACHINE_IDS:
             signing_key = self._load_signing_key_from_env(machine_id)
             if signing_key is None:
+                env_name = self._key_env_name(machine_id)
+                if require_stable_keys:
+                    raise ValueError(
+                        f"{self.REQUIRE_STABLE_KEYS_ENV}=1 requires {env_name} "
+                        "for stable production receipt verification"
+                    )
+
                 signing_key = nacl.signing.SigningKey.generate()
                 logger.warning(
-                    "Generated ephemeral signing key for %s; set %s for stable production receipts",
+                    "Generated demo-only ephemeral signing key for %s; set %s for stable production receipts",
                     machine_id,
-                    self._key_env_name(machine_id),
+                    env_name,
                 )
             self.machine_keys[machine_id] = signing_key
     

--- a/bounties/issue-2312/src/relic_market_api.py
+++ b/bounties/issue-2312/src/relic_market_api.py
@@ -367,26 +367,64 @@ class EscrowManager:
 
 class ReceiptSigner:
     """Signs provenance receipts with machine Ed25519 keys"""
+
+    MACHINE_IDS = ("vm-001", "vm-002", "vm-003", "vm-004", "vm-005")
     
     def __init__(self):
         self.machine_keys: Dict[str, nacl.signing.SigningKey] = {}
         self._initialize_machine_keys()
+
+    @staticmethod
+    def _key_env_name(machine_id: str) -> str:
+        """Return the environment variable name for a machine signing key."""
+        safe_id = machine_id.upper().replace("-", "_")
+        return f"RELIC_MACHINE_KEY_{safe_id}"
+
+    @classmethod
+    def _load_signing_key_from_env(cls, machine_id: str) -> Optional[nacl.signing.SigningKey]:
+        """Load a 32-byte Ed25519 seed from hex/base64 environment config."""
+        env_name = cls._key_env_name(machine_id)
+        encoded = os.getenv(env_name, "").strip()
+        if not encoded:
+            return None
+
+        if encoded.startswith("hex:"):
+            encoded = encoded[4:]
+        elif encoded.startswith("base64:"):
+            encoded = encoded[7:]
+            try:
+                seed = base64.b64decode(encoded, validate=True)
+            except Exception as exc:
+                raise ValueError(f"{env_name} must be a 32-byte hex or base64 Ed25519 seed") from exc
+            if len(seed) != 32:
+                raise ValueError(f"{env_name} must decode to 32 bytes")
+            return nacl.signing.SigningKey(seed)
+
+        try:
+            seed = bytes.fromhex(encoded)
+        except ValueError:
+            try:
+                seed = base64.b64decode(encoded, validate=True)
+            except Exception as exc:
+                raise ValueError(f"{env_name} must be a 32-byte hex or base64 Ed25519 seed") from exc
+
+        if len(seed) != 32:
+            raise ValueError(f"{env_name} must decode to 32 bytes")
+
+        return nacl.signing.SigningKey(seed)
     
     def _initialize_machine_keys(self):
-        """Initialize Ed25519 keys for machines"""
-        # In production, these would be securely stored per machine
-        # For demo, we generate deterministic keys from machine IDs
-        sample_keys = [
-            ("vm-001", "power8-beast-key-seed-001"),
-            ("vm-002", "g5-tower-key-seed-002"),
-            ("vm-003", "p3-workstation-key-seed-003"),
-            ("vm-004", "sparcstation-20-key-seed-004"),
-            ("vm-005", "alphaserver-800-key-seed-005"),
-        ]
-        
-        for machine_id, seed in sample_keys:
-            seed_hash = hashlib.sha256(seed.encode()).digest()[:32]
-            self.machine_keys[machine_id] = nacl.signing.SigningKey(seed_hash)
+        """Initialize Ed25519 keys without embedding reusable private seeds."""
+        for machine_id in self.MACHINE_IDS:
+            signing_key = self._load_signing_key_from_env(machine_id)
+            if signing_key is None:
+                signing_key = nacl.signing.SigningKey.generate()
+                logger.warning(
+                    "Generated ephemeral signing key for %s; set %s for stable production receipts",
+                    machine_id,
+                    self._key_env_name(machine_id),
+                )
+            self.machine_keys[machine_id] = signing_key
     
     def get_public_key(self, machine_id: str) -> Optional[str]:
         """Get machine's public key as hex string"""

--- a/tests/test_relic_market_signing_keys.py
+++ b/tests/test_relic_market_signing_keys.py
@@ -20,6 +20,7 @@ def load_relic_market_api():
 
 
 def clear_relic_key_env(monkeypatch, module):
+    monkeypatch.delenv(module.ReceiptSigner.REQUIRE_STABLE_KEYS_ENV, raising=False)
     for machine_id in module.ReceiptSigner.MACHINE_IDS:
         monkeypatch.delenv(module.ReceiptSigner._key_env_name(machine_id), raising=False)
 
@@ -57,6 +58,33 @@ def test_receipt_signer_rejects_invalid_environment_seed(monkeypatch):
 
     with pytest.raises(ValueError, match="RELIC_MACHINE_KEY_VM_001"):
         module.ReceiptSigner()
+
+
+def test_receipt_signer_requires_stable_keys_in_production_mode(monkeypatch):
+    module = load_relic_market_api()
+    clear_relic_key_env(monkeypatch, module)
+    monkeypatch.setenv(module.ReceiptSigner.REQUIRE_STABLE_KEYS_ENV, "1")
+
+    with pytest.raises(ValueError, match="RELIC_MACHINE_KEY_VM_001"):
+        module.ReceiptSigner()
+
+
+def test_receipt_signer_stable_keys_verify_across_restart(monkeypatch):
+    module = load_relic_market_api()
+    clear_relic_key_env(monkeypatch, module)
+    monkeypatch.setenv(module.ReceiptSigner.REQUIRE_STABLE_KEYS_ENV, "1")
+    for index, machine_id in enumerate(module.ReceiptSigner.MACHINE_IDS, start=1):
+        seed = bytes([index]) * 32
+        monkeypatch.setenv(module.ReceiptSigner._key_env_name(machine_id), seed.hex())
+
+    first = module.ReceiptSigner()
+    receipt_data = {"receipt_id": "receipt-1", "session_id": "session-1"}
+    signature = first.sign_receipt(receipt_data, "vm-001")
+
+    second = module.ReceiptSigner()
+
+    assert second.get_public_key("vm-001") == first.get_public_key("vm-001")
+    assert second.verify_signature(receipt_data, signature, "vm-001")
 
 
 def test_public_seed_literals_removed_from_source():

--- a/tests/test_relic_market_signing_keys.py
+++ b/tests/test_relic_market_signing_keys.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+import nacl.signing
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "bounties" / "issue-2312" / "src" / "relic_market_api.py"
+
+
+def load_relic_market_api():
+    spec = importlib.util.spec_from_file_location("relic_market_api_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def clear_relic_key_env(monkeypatch, module):
+    for machine_id in module.ReceiptSigner.MACHINE_IDS:
+        monkeypatch.delenv(module.ReceiptSigner._key_env_name(machine_id), raising=False)
+
+
+def test_receipt_signer_does_not_generate_deterministic_fallback_keys(monkeypatch):
+    module = load_relic_market_api()
+    clear_relic_key_env(monkeypatch, module)
+
+    first = module.ReceiptSigner()
+    second = module.ReceiptSigner()
+
+    assert first.machine_keys["vm-001"].encode() != second.machine_keys["vm-001"].encode()
+
+
+def test_receipt_signer_loads_hex_seed_from_environment(monkeypatch):
+    module = load_relic_market_api()
+    clear_relic_key_env(monkeypatch, module)
+    expected_key = nacl.signing.SigningKey.generate()
+
+    monkeypatch.setenv(
+        module.ReceiptSigner._key_env_name("vm-001"),
+        expected_key.encode().hex(),
+    )
+
+    signer = module.ReceiptSigner()
+
+    assert signer.machine_keys["vm-001"].encode() == expected_key.encode()
+    assert signer.get_public_key("vm-001") == expected_key.verify_key.encode().hex()
+
+
+def test_receipt_signer_rejects_invalid_environment_seed(monkeypatch):
+    module = load_relic_market_api()
+    clear_relic_key_env(monkeypatch, module)
+    monkeypatch.setenv(module.ReceiptSigner._key_env_name("vm-001"), "not-a-valid-seed")
+
+    with pytest.raises(ValueError, match="RELIC_MACHINE_KEY_VM_001"):
+        module.ReceiptSigner()
+
+
+def test_public_seed_literals_removed_from_source():
+    source = MODULE_PATH.read_text(encoding="utf-8")
+
+    assert "power8-beast-key-seed-001" not in source
+    assert "g5-tower-key-seed-002" not in source
+    assert "alphaserver-800-key-seed-005" not in source


### PR DESCRIPTION
## Summary

Fixes #4972 by removing the reusable deterministic Ed25519 private-key seeds from the relic market receipt signer.

Changes:
- `ReceiptSigner` now loads each machine signing seed from `RELIC_MACHINE_KEY_<MACHINE_ID>` when configured.
- Env keys may be 32-byte hex, `hex:<seed>`, raw base64, or `base64:<seed>`.
- Missing env keys now generate ephemeral in-memory keys instead of deriving public private keys from source literals.
- Invalid env keys fail fast with a clear `ValueError`.
- Added regressions proving fallback keys are not deterministic, env keys are honored, invalid env keys are rejected, and the old public seed literals are absent from source.

Operational note: deployments that need stable machine identities should set `RELIC_MACHINE_KEY_VM_001`, etc., and rotate any keys derived from the old public source literals.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_relic_market_signing_keys.py -q` -> 4 passed
- `python -m py_compile bounties\issue-2312\src\relic_market_api.py tests\test_relic_market_signing_keys.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No production service, live wallet, private key, or destructive request was used. The tests generate local throwaway keys only.

Bounty #71 payout wallet if eligible: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`