### PR TITLE
docs: fix Hall of Rust API examples

### DIFF
--- a/audits/hall_of_rust/self_audit_7439.md
+++ b/audits/hall_of_rust/self_audit_7439.md
@@ -148,7 +148,7 @@ def set_eulogy(fingerprint):
 
 **Attack Scenario:**
 ```bash
-curl -X POST https://api.rustchain.io/hall/eulogy/abc123def456... \
+curl -X POST https://rustchain.org/hall/eulogy/abc123def456... \
   -H "Content-Type: application/json" \
   -d '{"nickname": "DESTROYED", "eulogy": "RIP", "is_deceased": true}'
 ```
@@ -572,7 +572,7 @@ limit = request.args.get('limit', 50, type=int)
 
 No maximum limit validation:
 ```bash
-curl "https://api.rustchain.io/hall/leaderboard?limit=999999999"
+curl "https://rustchain.org/hall/leaderboard?limit=999999999"
 ```
 
 **Impact:** Resource exhaustion, database performance degradation.


### PR DESCRIPTION
## Summary
- Replace dead `api.rustchain.io` Hall of Rust audit examples with the live `rustchain.org/hall/...` endpoints.
- Keep the audit finding text and scope unchanged.

## Validation
- `git diff --check`
- `curl https://api.rustchain.io/hall/eulogy/abc123def456` fails DNS resolution (`000`).
- `curl https://api.rustchain.io/hall/leaderboard?limit=10` fails DNS resolution (`000`).
- `curl -X OPTIONS https://rustchain.org/hall/eulogy/abc123def456` returns HTTP 200 without mutating state.
- `curl https://rustchain.org/hall/leaderboard?limit=10` returns HTTP 200 JSON.

Bounty: rustchain-bounties#9018
RTC wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`
