### PR TITLE
docs: fix simulator docs link

### DIFF
--- a/simulator/README.md
+++ b/simulator/README.md
@@ -338,7 +338,7 @@ For questions about this simulator:
 - Reference: Issue #2301
 
 For RustChain mining questions:
-- Documentation: https://rustchain.org/docs
+- Documentation: https://github.com/Scottcjn/Rustchain/tree/main/docs
 - Discord: RustChain Community Server
 
 ---


### PR DESCRIPTION
## Summary
- Replace the simulator README support link to `https://rustchain.org/docs`, which currently returns HTTP 403.
- Point users to the live RustChain docs directory in this repository.

## Validation
- `git diff --check`
- `curl https://rustchain.org/docs` returns HTTP 403.
- `curl https://github.com/Scottcjn/Rustchain/tree/main/docs` returns HTTP 200.

Bounty: rustchain-bounties#9018
RTC wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`