### PR TITLE
docs: fix console mining docs link

### DIFF
--- a/docs/CONSOLE_MINING_SETUP.md
+++ b/docs/CONSOLE_MINING_SETUP.md
@@ -379,7 +379,7 @@ Develop attestation ROMs for additional consoles:
 
 - **GitHub Issues**: https://github.com/Scottcjn/Rustchain/issues
 - **Discord**: https://discord.gg/rustchain
-- **Documentation**: https://rustchain.org/docs
+- **Documentation**: https://github.com/Scottcjn/Rustchain/tree/main/docs
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace the Console Mining setup support link to `https://rustchain.org/docs`, which currently returns HTTP 403.
- Point readers to the live RustChain docs directory in this repository.

## Validation
- `git diff --check`
- `curl https://rustchain.org/docs` returns HTTP 403.
- `curl https://github.com/Scottcjn/Rustchain/tree/main/docs` returns HTTP 200.

Bounty: rustchain-bounties#9018
RTC wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`