### PR TITLE
docs: fix api readme docs link

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -495,4 +495,4 @@ curl -sk https://rustchain.org/health
 ## Support
 
 - GitHub: https://github.com/Scottcjn/rustchain-bounties
-- Documentation: https://rustchain.org/docs
+- Documentation: https://github.com/Scottcjn/Rustchain/tree/main/docs


### PR DESCRIPTION
## Summary
- Replace the API README support link to `https://rustchain.org/docs`, which currently returns HTTP 403.
- Point readers to the live RustChain docs directory in this repository.

## Validation
- `git diff --check`
- `curl https://rustchain.org/docs` returns HTTP 403.
- `curl https://github.com/Scottcjn/Rustchain/tree/main/docs` returns HTTP 200.

Bounty: rustchain-bounties#9018
RTC wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`