### PR TITLE
docs: fix simulator mining guide link

### DIFF
--- a/simulator/index.html
+++ b/simulator/index.html
@@ -865,7 +865,7 @@
                 <a href="https://github.com/scottcjn/rustchain" target="_blank" class="btn btn-success">
                     📥 Download Miner
                 </a>
-                <a href="https://rustchain.org/docs/mining" target="_blank" class="btn btn-primary">
+                <a href="https://github.com/Scottcjn/Rustchain/blob/main/docs/MINING_GUIDE.md" target="_blank" class="btn btn-primary">
                     📚 Mining Guide
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- Replace the simulator Mining Guide button link to `https://rustchain.org/docs/mining`, which currently returns HTTP 404.
- Point the button to the live mining guide in this repository.

## Validation
- `git diff --check`
- `curl https://rustchain.org/docs/mining` returns HTTP 404.
- `curl https://github.com/Scottcjn/Rustchain/blob/main/docs/MINING_GUIDE.md` returns HTTP 200.

Bounty: rustchain-bounties#9018
RTC wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`