### PR TITLE
test: cover JSON input parsing utility

### DIFF
--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,3 +1,8 @@
+"""Unit tests for JSON data processing helpers.
+
+SPDX-License-Identifier: Apache-2.0
+"""
+
 import pytest
 
 from src.utils.data_processing import parse_json_input

--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.utils.data_processing import parse_json_input
+
+
+def test_parse_json_input_returns_object_payload():
+    payload = parse_json_input('{"miner": "rtc-node-1", "score": 42}')
+
+    assert payload == {"miner": "rtc-node-1", "score": 42}
+
+
+def test_parse_json_input_preserves_non_object_json_values():
+    payload = parse_json_input('[{"epoch": 7}, {"epoch": 8}]')
+
+    assert payload == [{"epoch": 7}, {"epoch": 8}]
+
+
+def test_parse_json_input_wraps_decode_errors():
+    with pytest.raises(ValueError, match="Invalid JSON input"):
+        parse_json_input('{"miner": "rtc-node-1",')


### PR DESCRIPTION
## Summary
- Add focused pytest coverage for src/utils/data_processing.py::parse_json_input
- Cover object payload parsing, non-object JSON values, and invalid JSON error wrapping

## Validation
- .venv/bin/python -m pytest tests/test_data_processing.py -q -> 3 passed
- .venv/bin/python -m py_compile src/utils/data_processing.py tests/test_data_processing.py -> passed
- git diff --check -> passed

## Bounty
Targets Scottcjn/rustchain-bounties#1589 (2 RTC per unit test file).

## AI disclosure
Prepared with OpenAI Codex assistance and manually reviewed/tested before submission.