### PR TITLE
fix: derive linux miner identity from detected host

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-RustChain Local x86 Miner - Modern Ryzen
+RustChain Local Miner
 With RIP-PoA Hardware Fingerprint Attestation + Serial Binding v2.0
 """
 import warnings
@@ -51,6 +51,17 @@ def _parse_free_memory_gb(output):
             except ValueError:
                 return None
     return None
+
+
+def _safe_id_part(value):
+    slug = re.sub(r"[^a-zA-Z0-9_.:-]+", "-", str(value or "").strip().lower()).strip("-")
+    return slug or "unknown"
+
+
+def _miner_id_from_hw(hw_info):
+    arch = _safe_id_part(hw_info.get("arch") or hw_info.get("machine") or "linux")
+    hostname = _safe_id_part(hw_info.get("hostname") or socket.gethostname())
+    return f"{arch}-{hostname}"
 
 
 def _request_with_network_retry(method, url, action, retries=NETWORK_RETRY_ATTEMPTS,
@@ -133,7 +144,7 @@ class LocalMiner:
 
         self.serial = get_linux_serial()
         print("="*70)
-        print("RustChain Local Miner - HP Victus Ryzen 5 8645HS")
+        print("RustChain Local Linux Miner")
         print("RIP-PoA Hardware Fingerprint + Serial Binding v2.0")
         if self.warthog:
             print("+ Warthog Dual-Mining Sidecar ACTIVE")
@@ -192,8 +203,11 @@ class LocalMiner:
             self.fingerprint_data = {"error": str(e), "all_passed": False}
 
     def _gen_wallet(self):
-        data = f"ryzen5-{uuid.uuid4().hex}-{time.time()}"
+        data = f"linux-miner-{platform.machine()}-{uuid.uuid4().hex}-{time.time()}"
         return hashlib.sha256(data.encode()).hexdigest()[:38] + "RTC"
+
+    def _miner_id(self):
+        return _miner_id_from_hw(self.hw_info)
 
     def _run_cmd(self, args):
         try:
@@ -375,7 +389,7 @@ class LocalMiner:
         # Submit attestation with fingerprint data
         attestation = {
             "miner": self.wallet,
-            "miner_id": f"ryzen5-{self.hw_info['hostname']}",
+            "miner_id": self._miner_id(),
             "nonce": nonce,
             "report": {
                 "nonce": nonce,
@@ -467,7 +481,7 @@ class LocalMiner:
 
         payload = {
             "miner_pubkey": self.wallet,
-            "miner_id": f"ryzen5-{self.hw_info['hostname']}",
+            "miner_id": self._miner_id(),
             "device": {
                 "family": self.hw_info["family"],
                 "arch": self.hw_info["arch"]

--- a/tests/test_linux_miner_identity.py
+++ b/tests/test_linux_miner_identity.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MINER_PATH = REPO_ROOT / "miners" / "linux" / "rustchain_linux_miner.py"
+
+
+def load_miner_module():
+    spec = importlib.util.spec_from_file_location("linux_miner_under_test", MINER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_miner_id_uses_detected_arch_and_hostname():
+    miner = load_miner_module()
+
+    miner_id = miner._miner_id_from_hw(
+        {
+            "arch": "aarch64",
+            "hostname": "Lab ARM Box",
+        }
+    )
+
+    assert miner_id == "aarch64-lab-arm-box"
+    assert "ryzen" not in miner_id
+
+
+def test_linux_miner_source_does_not_hardcode_victus_identity():
+    source = MINER_PATH.read_text(encoding="utf-8")
+
+    assert "HP Victus" not in source
+    assert "ryzen5-" not in source
+    assert "RustChain Local Linux Miner" in source


### PR DESCRIPTION
﻿Fixes #4974

## Summary
- Replaces the hardcoded HP Victus/Ryzen Linux miner banner with a generic Linux miner banner.
- Removes the `ryzen5-` wallet entropy and miner-id prefixes.
- Derives submitted miner IDs from detected architecture and hostname, with stable slug normalization for safe identifiers.
- Adds regression coverage so the hardcoded Ryzen/Victus identity cannot return.

## Verification
- `python -m pytest tests\test_linux_miner_identity.py -q` -> 2 passed
- `python -m py_compile miners\linux\rustchain_linux_miner.py tests\test_linux_miner_identity.py`
- `git diff --check`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

No live miner, wallet, or production node state was modified.

Wallet/miner ID: `RTCd84b6e2d917d0272ecaae49f2f0dfe2f5474d585`
