### PR TITLE
fix: default-deny missing webhook secret

### DIFF
--- a/integrations/rustchain-bounties/auth.py
+++ b/integrations/rustchain-bounties/auth.py
@@ -20,8 +20,8 @@ def verify_webhook_signature(payload_bytes: bytes, signature_header: Optional[st
     """
     secret = os.environ.get("WEBHOOK_SECRET", "")
     if not secret:
-        # No secret configured — skip verification (development/local mode)
-        return True
+        # No secret configured means verification cannot succeed.
+        return False
 
     if not signature_header:
         return False

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -277,11 +277,11 @@ class TestWebhookVerification:
         with patch.dict(os.environ, {"WEBHOOK_SECRET": "mysecret"}):
             assert verify_webhook_signature(payload, None) is False
 
-    def test_no_secret_configured_allows_all(self):
+    def test_no_secret_configured_rejects_unsigned_payload(self):
         payload = b'{"action": "created"}'
         with patch.dict(os.environ, {}, clear=True):
-            # When WEBHOOK_SECRET is not set, verification is skipped
-            assert verify_webhook_signature(payload, None) is True
+            # Without WEBHOOK_SECRET the signature cannot be verified.
+            assert verify_webhook_signature(payload, None) is False
 
     def test_tampered_payload_rejected(self):
         original = b'{"action": "created"}'


### PR DESCRIPTION
## Summary
- Fixes the runtime `integrations/rustchain-bounties/auth.py` webhook verifier so missing `WEBHOOK_SECRET` rejects instead of allowing unsigned payloads.
- Updates the existing tip-bot regression test to assert default-deny behavior.
- Avoids adding duplicate unused integration files.

Fixes #4995.

## Validation
- `PYTHONPATH=integrations/rustchain-bounties PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with pyyaml --with requests python -m pytest integrations/rustchain-bounties/test_tip_bot.py -q` -> 60 passed
- `python3 -m py_compile integrations/rustchain-bounties/auth.py integrations/rustchain-bounties/test_tip_bot.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `uv run --no-project python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- `uv run --no-project --with ruff ruff check integrations/rustchain-bounties/auth.py integrations/rustchain-bounties/test_tip_bot.py --select E9,F821,F811,F841 --output-format=concise` -> passed
- Direct check with no `WEBHOOK_SECRET` and no signature -> `False`

Wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`
