### PR TITLE
fix: close Atom feed thumbnail URL attribute

### DIFF
--- a/node/bottube_feed.py
+++ b/node/bottube_feed.py
@@ -595,7 +595,7 @@ class AtomFeedBuilder:
         # Thumbnail
         if entry.get("thumbnail_url"):
             lines.append(
-                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}/>'
+                f'  <media:thumbnail url="{xml_escape(entry["thumbnail_url"])}"/>'
             )
         
         lines.append("</entry>")

--- a/tests/test_bottube_feed.py
+++ b/tests/test_bottube_feed.py
@@ -11,6 +11,7 @@ Run with:
 import sys
 import time
 import unittest
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -324,6 +325,20 @@ class TestAtomFeedBuilder(unittest.TestCase):
         xml = self.builder.build()
         self.assertIn("media:content", xml)
         self.assertIn("video.mp4", xml)
+
+    def test_thumbnail_xml_is_well_formed(self):
+        """Test Atom thumbnail XML keeps the URL attribute closed."""
+        self.builder.add_entry(
+            title="Test",
+            entry_id="urn:test:1",
+            link="https://example.com/1",
+            summary="Test",
+            thumbnail_url="https://example.com/thumb.jpg"
+        )
+        xml = self.builder.build()
+
+        self.assertIn('<media:thumbnail url="https://example.com/thumb.jpg"/>', xml)
+        ET.fromstring(xml)
 
 
 class TestConvenienceFunctions(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Fix malformed Atom media thumbnail XML by closing the url attribute before />.
- Add a regression test that builds an Atom entry with 	humbnail_url, checks the expected tag, and parses the generated XML with xml.etree.ElementTree.

Fixes #4869.

## Validation
- C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_bottube_feed.py -q -> 33 passed
- python tests\test_bottube_feed.py -> Ran 33 tests ... OK
- python -m py_compile node\bottube_feed.py tests\test_bottube_feed.py -> passed
- git diff --check origin/main...HEAD -> passed
- python tools\bcos_spdx_check.py --base-ref origin/main -> BCOS SPDX check: OK

No production feed, live node, wallet, or destructive request was used.

Bounty #71 payout wallet if eligible: RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce

@galpetame