### PR TITLE
Add Proof-of-Antiquity sea shanty

### DIFF
--- a/docs/community/shanties/rayycave-proof-of-antiquity.md
+++ b/docs/community/shanties/rayycave-proof-of-antiquity.md
@@ -1,0 +1,41 @@
+# The Antiquity Miner Shanty
+
+*An original RustChain sea shanty by @SimplyRayYZL.*
+
+## Verse 1
+Oh the young rigs chase the lightning fast,
+With fans like storms and shadows cast,
+But RustChain calls to the older crew,
+Where faithful iron still pulls through.
+
+## Chorus
+Heave ho, let the old chips sing,
+Proof-of-Antiquity crowns the king,
+G4, POWER, SPARC at sea,
+Mining slow but mining free.
+
+## Verse 2
+A Power Mac hums by the midnight tide,
+Its silver case and scars with pride,
+The ledger hears each vintage beat,
+And pays respect to ancient heat.
+
+## Chorus
+Heave ho, let the old chips sing,
+Proof-of-Antiquity crowns the king,
+G4, POWER, SPARC at sea,
+Mining slow but mining free.
+
+## Verse 3
+Not hash alone shall rule the chain,
+Nor newest silicon take the gain,
+For every relic, rack, and board,
+Can earn its place in RustChain's hoard.
+
+## Chorus
+Heave ho, let the old chips sing,
+Proof-of-Antiquity crowns the king,
+G4, POWER, SPARC at sea,
+Mining slow but mining free.
+
+Wallet for bounty payout: `RTC58795037f647767be4ce9a1fb2bde866594d4bcf`


### PR DESCRIPTION
Claiming Scottcjn/rustchain-bounties#2842.

Adds an original RustChain Proof-of-Antiquity sea shanty under `docs/community/shanties/` with 3 verses and a repeated chorus.

RTC wallet for payout: RTC58795037f647767be4ce9a1fb2bde866594d4bcf