### PR TITLE
Document placeholder validation tradeoff

### DIFF
--- a/i18n/validate_i18n.py
+++ b/i18n/validate_i18n.py
@@ -148,7 +148,9 @@ def check_placeholders(data: Dict[str, Any], filename: str) -> List[str]:
     def check_value(value: str, path: str):
         if not isinstance(value, str):
             return
-        # 检查是否有未闭合的占位符
+        # Keep this validation intentionally lightweight: translation files may
+        # contain many languages and locale-specific punctuation, so this only
+        # catches broken brace pairs without trying to parse Python format specs.
         if '{' in value and '}' not in value:
             issues.append(f"{filename}: {path} - 未闭合的占位符")
         if '}' in value and '{' not in value:


### PR DESCRIPTION
Claiming Scottcjn/rustchain-bounties#1608.

Adds a focused explanatory comment in `i18n/validate_i18n.py` explaining why placeholder validation intentionally checks brace-pair integrity instead of parsing full Python format specs across many locales.

Validation run locally:
- `python3 i18n/validate_i18n.py`
- `python3 -m py_compile i18n/validate_i18n.py`

RTC wallet for payout: RTC58795037f647767be4ce9a1fb2bde866594d4bcf