### PR TITLE
Security: Fix unauthenticated endpoints in registry and payout ledger

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -8,6 +8,21 @@ from datetime import datetime
 
 app = Flask(__name__)
 
+ADMIN_KEY = os.environ.get("ADMIN_KEY")
+
+def admin_required(f):
+    from functools import wraps
+    from flask import abort
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not ADMIN_KEY:
+            abort(403, description="Admin key not configured")
+        req_key = request.headers.get("X-Admin-Key") or request.args.get("admin_key")
+        if req_key != ADMIN_KEY:
+            abort(401)
+        return f(*args, **kwargs)
+    return decorated_function
+
 # Security fix: load secret_key from environment variable.
 # If unset, fall back to a cryptographically random key (warns on first start).
 # If set to the known placeholder, refuse to run (prevents accidental deployment
@@ -138,8 +153,12 @@ def index():
 def register():
     github_username = request.form['github_username']
     contributor_type = request.form['contributor_type']
-    rtc_wallet = request.form['rtc_wallet']
+    rtc_wallet = request.form['rtc_wallet'].strip()
     contribution_history = request.form.get('contribution_history', '')
+    
+    if not (rtc_wallet.startswith('0x') or rtc_wallet.startswith('RTC')) or len(rtc_wallet) < 10:
+        flash("Error: Invalid wallet format. Must start with 0x or RTC.")
+        return redirect(url_for('index'))
     
     try:
         with sqlite3.connect(DB_PATH) as conn:
@@ -166,7 +185,7 @@ def api_contributors():
             {
                 'github_username': c[0],
                 'type': c[1],
-                'wallet': c[2],
+                'wallet': c[2][:6] + '...' + c[2][-4:] if len(c[2]) > 10 else '***',
                 'registered': c[3],
                 'status': c[4]
             }
@@ -175,6 +194,7 @@ def api_contributors():
     }
 
 @app.route('/approve/<username>')
+@admin_required
 def approve_contributor(username):
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(

--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -12,9 +12,23 @@ import sqlite3
 import uuid
 import json
 import logging
-from flask import request, jsonify, render_template_string
+from flask import request, jsonify, render_template_string, abort
+from functools import wraps
 
 logger = logging.getLogger(__name__)
+
+ADMIN_KEY = os.environ.get("ADMIN_KEY")
+
+def admin_required(f):
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        if not ADMIN_KEY:
+            abort(403, description="Admin key not configured")
+        req_key = request.headers.get("X-Admin-Key") or request.args.get("admin_key")
+        if req_key != ADMIN_KEY:
+            abort(401)
+        return f(*args, **kwargs)
+    return decorated_function
 
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "rustchain.db")
 
@@ -196,6 +210,7 @@ def register_ledger_routes(app):
         return jsonify(record)
 
     @app.route("/api/ledger", methods=["POST"])
+    @admin_required
     def api_ledger_create():
         init_payout_ledger_tables()
         data = request.get_json(force=True)
@@ -215,6 +230,7 @@ def register_ledger_routes(app):
         return jsonify({"id": record_id, "status": "queued"}), 201
 
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
+    @admin_required
     def api_ledger_update(record_id):
         init_payout_ledger_tables()
         data = request.get_json(force=True)


### PR DESCRIPTION
## Description\n\nCloses #4911\nCloses #4902\n\nThis PR fixes two critical security vulnerabilities related to unauthenticated API endpoints:\n\n1. **Payout Ledger API (#4902)**: Added an `@admin_required` decorator using the `ADMIN_KEY` environment variable to secure the `POST /api/ledger` (create payout) and `PATCH /api/ledger/<id>/status` (update status) endpoints. This prevents anyone from creating fake payout records or marking them as paid.\n\n2. **Contributor Registry (#4911)**:\n   - Secured the `/approve/<username>` route with the `@admin_required` decorator to prevent anyone from approving pending contributors.\n   - Added format validation for the `rtc_wallet` field during registration (must start with `0x` or `RTC`, length > 10).\n   - Masked wallet addresses in the `/api/contributors` public JSON response to prevent scraping and data leaks.