### PR TITLE
fix: require admin auth for relationship mutations

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1033,8 +1033,32 @@ class RelationshipEngine:
 def create_relationship_blueprint(engine: RelationshipEngine):
     """Create a Flask blueprint for relationship API endpoints."""
     from flask import Blueprint, jsonify, request
+    import hmac
     
     bp = Blueprint("relationships", __name__)
+
+    def _required_mutation_admin_key() -> str:
+        """Return the configured admin key for relationship mutation routes."""
+        return (
+            os.environ.get("RELATIONSHIPS_ADMIN_KEY")
+            or os.environ.get("RC_ADMIN_KEY")
+            or ""
+        ).strip()
+
+    def _require_mutation_admin():
+        required_key = _required_mutation_admin_key()
+        if not required_key:
+            return jsonify({"error": "Relationship mutation admin key is not configured"}), 401
+
+        provided_key = (
+            request.headers.get("X-Admin-Key")
+            or request.headers.get("X-API-Key")
+            or ""
+        ).strip()
+        if not provided_key or not hmac.compare_digest(provided_key, required_key):
+            return jsonify({"error": "Unauthorized relationship mutation"}), 401
+
+        return None
     
     @bp.route("/api/relationships", methods=["GET"])
     def list_relationships():
@@ -1059,7 +1083,11 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/disagree", methods=["POST"])
     def disagree(agent_a: str, agent_b: str):
-        data = request.json or {}
+        auth_error = _require_mutation_admin()
+        if auth_error:
+            return auth_error
+
+        data = request.get_json(silent=True) or {}
         try:
             result = engine.record_disagreement(
                 agent_a, agent_b,
@@ -1072,7 +1100,11 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/collaborate", methods=["POST"])
     def collaborate(agent_a: str, agent_b: str):
-        data = request.json or {}
+        auth_error = _require_mutation_admin()
+        if auth_error:
+            return auth_error
+
+        data = request.get_json(silent=True) or {}
         try:
             result = engine.record_collaboration(
                 agent_a, agent_b,
@@ -1085,7 +1117,11 @@ def create_relationship_blueprint(engine: RelationshipEngine):
     
     @bp.route("/api/relationships/<agent_a>/<agent_b>/reconcile", methods=["POST"])
     def reconcile(agent_a: str, agent_b: str):
-        data = request.json or {}
+        auth_error = _require_mutation_admin()
+        if auth_error:
+            return auth_error
+
+        data = request.get_json(silent=True) or {}
         try:
             result = engine.record_reconciliation(
                 agent_a, agent_b,

--- a/tests/test_agent_relationship_mutation_auth.py
+++ b/tests/test_agent_relationship_mutation_auth.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+
+from flask import Flask
+
+from agent_relationships import RelationshipEngine, create_relationship_blueprint
+
+
+MUTATING_ENDPOINTS = (
+    ("/api/relationships/alice/bob/disagree", {"topic": "model routing"}),
+    ("/api/relationships/alice/bob/collaborate", {"description": "shared runbook"}),
+    ("/api/relationships/alice/bob/reconcile", {"description": "postmortem"}),
+)
+
+
+def _build_client(tmp_path):
+    engine = RelationshipEngine(db_path=str(tmp_path / "relationships.db"))
+    app = Flask(__name__)
+    app.register_blueprint(create_relationship_blueprint(engine))
+    return app.test_client(), engine
+
+
+def test_relationship_mutations_fail_closed_without_admin_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+
+    for path, payload in MUTATING_ENDPOINTS:
+        response = client.post(path, json=payload)
+
+        assert response.status_code == 401
+        assert engine.get_relationship("alice", "bob") is None
+
+
+def test_relationship_mutations_reject_missing_or_wrong_admin_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELATIONSHIPS_ADMIN_KEY", "relationship-admin-secret")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+
+    for path, payload in MUTATING_ENDPOINTS:
+        missing = client.post(path, json=payload)
+        wrong = client.post(path, json=payload, headers={"X-Admin-Key": "wrong"})
+
+        assert missing.status_code == 401
+        assert wrong.status_code == 401
+        assert engine.get_relationship("alice", "bob") is None
+
+
+def test_relationship_mutations_accept_configured_admin_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELATIONSHIPS_ADMIN_KEY", "relationship-admin-secret")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+    engine.initialize_relationship("alice", "bob")
+
+    response = client.post(
+        "/api/relationships/alice/bob/disagree",
+        json={"topic": "model routing"},
+        headers={"X-Admin-Key": "relationship-admin-secret"},
+    )
+
+    assert response.status_code == 200
+    relationship = engine.get_relationship("alice", "bob")
+    assert relationship is not None
+    assert relationship["disagreement_count"] == 1
+
+
+def test_relationship_mutations_accept_legacy_api_key_header(monkeypatch, tmp_path):
+    monkeypatch.setenv("RC_ADMIN_KEY", "legacy-admin-secret")
+    monkeypatch.delenv("RELATIONSHIPS_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+
+    response = client.post(
+        "/api/relationships/alice/bob/collaborate",
+        json={"description": "shared runbook"},
+        headers={"X-API-Key": "legacy-admin-secret"},
+    )
+
+    assert response.status_code == 200
+    relationship = engine.get_relationship("alice", "bob")
+    assert relationship is not None
+    assert relationship["collaboration_count"] == 1


### PR DESCRIPTION
Fixes #5009.

## Summary

- Require an admin key before the live root `agent_relationships.py` Flask blueprint can mutate relationships through `/disagree`, `/collaborate`, or `/reconcile`.
- Fail closed when no mutation admin key is configured.
- Accept `X-Admin-Key` and legacy `X-API-Key`, compared with `hmac.compare_digest`.
- Use `request.get_json(silent=True)` after auth succeeds so malformed JSON cannot be parsed before the security boundary.
- Add focused Flask client regressions proving unauthenticated/mis-keyed mutation requests return 401 without creating relationship state, while configured admin keys still allow intended mutations.

## Scope / duplicate check

- #4752 covers `/intervene` for #4751; this patch covers the separate #5009 endpoints `/disagree`, `/collaborate`, and `/reconcile`.
- #5010 attempts #5009 but modifies a RIP-path copy instead of the live root module and has request-changes feedback for syntax/scope blockers.
- This PR patches the live root `agent_relationships.py` used by existing imports/tests.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_agent_relationship_mutation_auth.py -q` -> `4 passed`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest test_agent_relationships.py tests\test_agent_relationship_mutation_auth.py -q` -> `44 passed`
- `python -m py_compile agent_relationships.py tests\test_agent_relationship_mutation_auth.py` -> passed
- `git diff --check origin/main...HEAD -- agent_relationships.py tests/test_agent_relationship_mutation_auth.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No production service, live wallet, private key, or destructive request was used.

Wallet/miner ID for bounty processing: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`

GitHub handle for tagging: @galpetame
