### PR TITLE
fix: harden PoA validation uploads

### DIFF
--- a/rustchain-poa/api/poa_api.py
+++ b/rustchain-poa/api/poa_api.py
@@ -1,10 +1,35 @@
+# SPDX-License-Identifier: MIT
+
 from flask import Flask, request, jsonify
 from validator.validate_genesis import validate_genesis
 import tempfile
 import os
-import json
 
 app = Flask(__name__)
+
+MAX_UPLOAD_BYTES = int(os.environ.get("POA_VALIDATE_MAX_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+JSON_MIME_TYPES = {"", "application/json", "text/json"}
+
+
+def _is_json_upload(file) -> bool:
+    filename = (file.filename or "").lower()
+    mimetype = (file.mimetype or "").split(";", 1)[0].lower()
+    return filename.endswith(".json") and mimetype in JSON_MIME_TYPES
+
+
+def _copy_limited_upload(src, dst) -> bool:
+    """Copy upload data to dst, returning False when the upload exceeds the cap."""
+    total = 0
+    while True:
+        chunk = src.read(64 * 1024)
+        if not chunk:
+            break
+        total += len(chunk)
+        if total > MAX_UPLOAD_BYTES:
+            return False
+        dst.write(chunk)
+    return True
+
 
 @app.route('/validate', methods=['POST'])
 def validate():
@@ -15,17 +40,29 @@ def validate():
     if file.filename == '':
         return jsonify({"error": "No selected file"}), 400
 
-    # Save the file temporarily
-    with tempfile.NamedTemporaryFile(delete=False, suffix='.json') as tmp:
-        file.save(tmp.name)
-        tmp_path = tmp.name
+    if request.content_length and request.content_length > MAX_UPLOAD_BYTES:
+        return jsonify({"error": f"File too large (max {MAX_UPLOAD_BYTES} bytes)"}), 413
+
+    if not _is_json_upload(file):
+        return jsonify({"error": "Only JSON files accepted"}), 400
+
+    tmp_path = None
 
     try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.json') as tmp:
+            tmp_path = tmp.name
+            if hasattr(file.stream, "seek"):
+                file.stream.seek(0)
+            if not _copy_limited_upload(file.stream, tmp):
+                return jsonify({"error": f"File too large (max {MAX_UPLOAD_BYTES} bytes)"}), 413
+
         result = validate_genesis(tmp_path)
-        os.remove(tmp_path)
         return jsonify(result)
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return jsonify({"error": "Validation failed"}), 500
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/tests/test_poa_api_upload_hardening.py
+++ b/tests/test_poa_api_upload_hardening.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import io
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+POA_API_PATH = REPO_ROOT / "rustchain-poa" / "api" / "poa_api.py"
+
+
+def load_poa_api(monkeypatch):
+    monkeypatch.syspath_prepend(str(REPO_ROOT / "rustchain-poa"))
+    module_name = "poa_api_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, POA_API_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    module.app.config["TESTING"] = True
+    return module
+
+
+def test_validate_rejects_non_json_upload(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    called = False
+
+    def fake_validate(_path):
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    module.validate_genesis = fake_validate
+
+    response = module.app.test_client().post(
+        "/validate",
+        data={"file": (io.BytesIO(b"{}"), "proof.txt")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Only JSON files accepted"}
+    assert called is False
+
+
+def test_validate_rejects_oversized_upload_before_validation(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    module.MAX_UPLOAD_BYTES = 64
+    called = False
+
+    def fake_validate(_path):
+        nonlocal called
+        called = True
+        return {"ok": True}
+
+    module.validate_genesis = fake_validate
+
+    response = module.app.test_client().post(
+        "/validate",
+        data={"file": (io.BytesIO(b"{" + b'"x":' + b'"' + (b"a" * 128) + b'"}'), "proof.json")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 413
+    assert "File too large" in response.get_json()["error"]
+    assert called is False
+
+
+def test_validate_uses_generic_error_and_cleans_temp_file(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    seen_path = {}
+
+    def fake_validate(path):
+        temp_path = Path(path)
+        assert temp_path.exists()
+        seen_path["path"] = temp_path
+        raise RuntimeError("internal path C:/secret/schema.db leaked")
+
+    module.validate_genesis = fake_validate
+
+    response = module.app.test_client().post(
+        "/validate",
+        data={"file": (io.BytesIO(b"{}"), "proof.json")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Validation failed"}
+    assert "secret" not in response.get_data(as_text=True)
+    assert seen_path["path"].exists() is False
+
+
+def test_validate_accepts_valid_json_upload_and_cleans_temp_file(monkeypatch):
+    module = load_poa_api(monkeypatch)
+    seen_path = {}
+
+    def fake_validate(path):
+        temp_path = Path(path)
+        assert temp_path.exists()
+        seen_path["path"] = temp_path
+        assert temp_path.read_text(encoding="utf-8") == '{"ok": true}'
+        return {"valid": True}
+
+    module.validate_genesis = fake_validate
+
+    response = module.app.test_client().post(
+        "/validate",
+        data={"file": (io.BytesIO(b'{"ok": true}'), "proof.json")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"valid": True}
+    assert seen_path["path"].exists() is False


### PR DESCRIPTION
## Summary

Fixes #4899 by hardening `rustchain-poa/api/poa_api.py` upload handling:

- rejects validation uploads whose request body exceeds `POA_VALIDATE_MAX_UPLOAD_BYTES` (default 10 MiB)
- accepts only `.json` uploads with JSON-compatible MIME types
- copies upload streams through a bounded writer instead of blindly saving the file
- removes temp files in a `finally` block even when validation fails
- returns a generic validation failure instead of leaking raw internal exception text
- removes the unused `json` import and adds SPDX coverage

## Validation

```text
C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_poa_api_upload_hardening.py -q
# 4 passed

C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_poa_api_json_validation.py -q
# 10 passed

python -m py_compile rustchain-poa\api\poa_api.py tests\test_poa_api_upload_hardening.py
# passed

git diff --check origin/main...HEAD -- rustchain-poa\api\poa_api.py tests\test_poa_api_upload_hardening.py
# passed

python tools\bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```

No production service, live wallet, private key, or destructive request was used.

## Bounty

@galpetame

Native RTC payout wallet if eligible: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
