### PR TITLE
Add wallet tracker helper tests

### DIFF
--- a/test_wallet_tracker_helpers.py
+++ b/test_wallet_tracker_helpers.py
@@ -1,0 +1,55 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).parent / "wallet-tracker" / "test_tracker.py"
+
+
+def load_tracker_module():
+    spec = importlib.util.spec_from_file_location("wallet_tracker_test_script", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_format_number_uses_plain_comma_and_million_suffixes():
+    tracker = load_tracker_module()
+
+    assert tracker.format_number(999) == "999"
+    assert tracker.format_number(1_000) == "1,000"
+    assert tracker.format_number(1_234_567) == "1.23M"
+
+
+def test_calculate_gini_handles_empty_zero_and_equal_distributions():
+    tracker = load_tracker_module()
+
+    assert tracker.calculate_gini([]) == 0
+    assert tracker.calculate_gini([0, 0, 0]) == 0
+    assert tracker.calculate_gini([10, 10, 10]) == pytest.approx(0)
+
+
+def test_calculate_gini_is_order_independent_for_unequal_balances():
+    tracker = load_tracker_module()
+
+    forward = tracker.calculate_gini([0, 10, 30, 60])
+    reversed_order = tracker.calculate_gini([60, 30, 10, 0])
+
+    assert forward == pytest.approx(reversed_order)
+    assert forward > 0
+
+
+def test_get_balance_returns_zero_balance_payload_on_request_failure(monkeypatch):
+    tracker = load_tracker_module()
+
+    def raise_request_error(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(tracker.requests, "get", raise_request_error)
+
+    assert tracker.get_balance("miner-123") == {
+        "miner_id": "miner-123",
+        "balance_rtc": 0,
+        "balance_i64": 0,
+    }

--- a/test_wallet_tracker_helpers.py
+++ b/test_wallet_tracker_helpers.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 from pathlib import Path
 


### PR DESCRIPTION
Adds focused pytest coverage for the wallet distribution tracker helper script.

Covered edge cases:
- `format_number` plain, comma, and million suffix formatting
- `calculate_gini` empty input, zero-sum input, equal distributions, and order-independent unequal distributions
- `get_balance` network failure fallback payload

Verification:
- `python -m pytest test_wallet_tracker_helpers.py -q` -> 4 passed
- `python -m py_compile wallet-tracker/test_tracker.py test_wallet_tracker_helpers.py`
- `git diff --check`

Bounty context: Scottcjn/rustchain-bounties#1589