### PR TITLE
fix: make faucet service drips atomic

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -306,6 +306,26 @@ class RateLimiter:
             self._record_redis(identifier)
         else:
             self._record_sqlite(ip_address, wallet, amount)
+
+    def record_request_if_allowed(
+        self,
+        identifier: str,
+        ip_address: str,
+        wallet: str,
+        amount: float,
+    ) -> Tuple[bool, Optional[str]]:
+        """Atomically check the active rate limit and record the drip."""
+        if not self.config.get('rate_limit', {}).get('enabled', True):
+            self.record_request(identifier, ip_address, wallet, amount)
+            return True, None
+
+        if self.redis_client and REDIS_AVAILABLE:
+            allowed, next_available = self._check_redis(identifier)
+            if allowed:
+                self._record_redis(identifier)
+            return allowed, next_available
+
+        return self._record_sqlite_if_allowed(ip_address, wallet, amount)
     
     def _record_redis(self, identifier: str) -> None:
         """Record request in Redis."""
@@ -329,6 +349,53 @@ class RateLimiter:
         ''', (wallet, ip_address, amount, datetime.now().isoformat()))
         conn.commit()
         conn.close()
+
+    def _record_sqlite_if_allowed(
+        self,
+        ip_address: str,
+        wallet: str,
+        amount: float,
+    ) -> Tuple[bool, Optional[str]]:
+        """Check and insert under one SQLite write transaction."""
+        conn = sqlite3.connect(self.config['database']['path'], timeout=30)
+        try:
+            conn.isolation_level = None
+            c = conn.cursor()
+            c.execute('PRAGMA busy_timeout = 30000')
+            c.execute('BEGIN IMMEDIATE')
+
+            window_seconds = self.config['rate_limit']['window_seconds']
+            cutoff = datetime.now() - timedelta(seconds=window_seconds)
+            c.execute('''
+                SELECT COUNT(*), MAX(timestamp) FROM drip_requests
+                WHERE (ip_address = ? OR wallet = ?)
+                AND timestamp > ?
+            ''', (ip_address, wallet, cutoff.isoformat()))
+
+            count, last_request = c.fetchone()
+            max_requests = self.config['rate_limit'].get('max_requests', 1)
+            if count >= max_requests:
+                c.execute('ROLLBACK')
+                if last_request:
+                    last_time = datetime.fromisoformat(last_request)
+                    next_available = last_time + timedelta(seconds=window_seconds)
+                    return False, next_available.isoformat()
+                return False, None
+
+            c.execute('''
+                INSERT INTO drip_requests (wallet, ip_address, amount, timestamp)
+                VALUES (?, ?, ?, ?)
+            ''', (wallet, ip_address, amount, datetime.now().isoformat()))
+            c.execute('COMMIT')
+            return True, None
+        except Exception:
+            try:
+                conn.execute('ROLLBACK')
+            except sqlite3.OperationalError:
+                pass
+            raise
+        finally:
+            conn.close()
 
 
 # =============================================================================
@@ -546,8 +613,17 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             logger.warning(f"Invalid wallet {wallet}: {error}")
             return jsonify({'ok': False, 'error': error}), 400
         
-        # Check rate limit
-        allowed, next_available = rate_limiter.check_rate_limit(ip, wallet)
+        # Process drip
+        amount = config.get('distribution', {}).get('amount', 0.5)
+
+        # Check and record under one operation so concurrent SQLite requests
+        # cannot pass the rate-limit check before either insert is visible.
+        allowed, next_available = rate_limiter.record_request_if_allowed(
+            f"{ip}:{wallet}",
+            ip,
+            wallet,
+            amount,
+        )
         if not allowed:
             logger.info(f"Rate limit exceeded for {ip}/{wallet}")
             return jsonify({
@@ -555,9 +631,6 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
                 'error': 'Rate limit exceeded',
                 'next_available': next_available
             }), 429
-        
-        # Process drip
-        amount = config.get('distribution', {}).get('amount', 0.5)
         
         # In mock mode, just record the request
         if config.get('distribution', {}).get('mock_mode', True):
@@ -567,9 +640,6 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             # TODO: Implement actual token transfer
             tx_hash = None
             logger.info(f"Real drip: {amount} RTC to {wallet}")
-        
-        # Record the request
-        rate_limiter.record_request(f"{ip}:{wallet}", ip, wallet, amount)
         
         # Calculate next available time
         window_seconds = config.get('rate_limit', {}).get('window_seconds', 86400)

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -320,12 +320,57 @@ class RateLimiter:
             return True, None
 
         if self.redis_client and REDIS_AVAILABLE:
-            allowed, next_available = self._check_redis(identifier)
-            if allowed:
-                self._record_redis(identifier)
-            return allowed, next_available
+            return self._record_redis_if_allowed(identifier)
 
         return self._record_sqlite_if_allowed(ip_address, wallet, amount)
+
+    def _record_redis_if_allowed(self, identifier: str) -> Tuple[bool, Optional[str]]:
+        """Check and record the Redis rate limit in one atomic script."""
+        key = self._get_key(identifier, 'rl')
+        count_key = self._get_key(identifier, 'count')
+        max_requests = self.config['rate_limit'].get('max_requests', 1)
+        window_seconds = self.config['rate_limit']['window_seconds']
+        now_iso = datetime.now().isoformat()
+
+        result = self.redis_client.eval(
+            """
+            local count_key = KEYS[1]
+            local marker_key = KEYS[2]
+            local max_requests = tonumber(ARGV[1])
+            local window_seconds = tonumber(ARGV[2])
+            local now_iso = ARGV[3]
+
+            local current = tonumber(redis.call('GET', count_key) or '0')
+            if current >= max_requests then
+                local ttl = redis.call('TTL', marker_key)
+                if ttl < 0 then
+                    ttl = redis.call('TTL', count_key)
+                end
+                return {0, ttl}
+            end
+
+            local new_count = redis.call('INCR', count_key)
+            if new_count == 1 or redis.call('TTL', count_key) < 0 then
+                redis.call('EXPIRE', count_key, window_seconds)
+            end
+            redis.call('SET', marker_key, now_iso, 'EX', window_seconds)
+            return {1, redis.call('TTL', marker_key)}
+            """,
+            2,
+            count_key,
+            key,
+            max_requests,
+            window_seconds,
+            now_iso,
+        )
+
+        allowed = int(result[0]) == 1
+        if allowed:
+            return True, None
+
+        ttl = int(result[1]) if len(result) > 1 and result[1] is not None else 0
+        next_available = datetime.now() + timedelta(seconds=max(0, ttl))
+        return False, next_available.isoformat()
     
     def _record_redis(self, identifier: str) -> None:
         """Record request in Redis."""

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -20,6 +20,7 @@ import json
 import time
 import sqlite3
 import tempfile
+import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
@@ -38,6 +39,30 @@ from faucet_service import (
     get_client_ip,
     DEFAULT_CONFIG
 )
+
+
+class FakeAtomicRedis:
+    """Small Redis stand-in that serializes eval like Redis does."""
+
+    def __init__(self):
+        self.values = {}
+        self.ttls = {}
+        self.lock = threading.Lock()
+
+    def eval(self, _script, _numkeys, count_key, marker_key, max_requests, window_seconds, now_iso):
+        with self.lock:
+            max_requests = int(max_requests)
+            window_seconds = int(window_seconds)
+            current = int(self.values.get(count_key, 0))
+
+            if current >= max_requests:
+                return [0, self.ttls.get(marker_key, self.ttls.get(count_key, window_seconds))]
+
+            self.values[count_key] = current + 1
+            self.values[marker_key] = now_iso
+            self.ttls[count_key] = window_seconds
+            self.ttls[marker_key] = window_seconds
+            return [1, window_seconds]
 
 
 class TestConfiguration(unittest.TestCase):
@@ -288,6 +313,34 @@ class TestRateLimiter(unittest.TestCase):
             self.assertEqual(c.fetchone()[0], 1)
         finally:
             conn.close()
+
+    def test_redis_record_request_if_allowed_is_atomic(self):
+        """Test Redis drip attempts use one atomic check-and-record operation."""
+        self.config['rate_limit']['window_seconds'] = 60
+        self.config['rate_limit']['max_requests'] = 1
+        self.config['rate_limit']['redis']['enabled'] = True
+        self.rate_limiter.redis_client = FakeAtomicRedis()
+
+        def attempt_drip(_):
+            return self.rate_limiter.record_request_if_allowed(
+                '192.168.1.10:0xwallet-redis-race',
+                '192.168.1.10',
+                '0xwallet-redis-race',
+                0.5,
+            )[0]
+
+        with patch('faucet_service.REDIS_AVAILABLE', True):
+            with ThreadPoolExecutor(max_workers=8) as executor:
+                results = list(executor.map(attempt_drip, range(8)))
+
+        self.assertEqual(results.count(True), 1)
+        self.assertEqual(results.count(False), 7)
+        count_keys = [
+            key for key in self.rate_limiter.redis_client.values
+            if key.startswith('rustchain_faucet:count:192.168.1.10:0xwallet-redis-race:')
+        ]
+        self.assertEqual(len(count_keys), 1)
+        self.assertEqual(self.rate_limiter.redis_client.values[count_keys[0]], 1)
 
 
 class TestDatabase(unittest.TestCase):

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -21,6 +21,7 @@ import time
 import sqlite3
 import tempfile
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -257,6 +258,36 @@ class TestRateLimiter(unittest.TestCase):
         # Should be allowed again
         allowed, next_available = self.rate_limiter.check_rate_limit('192.168.1.1', '0xwallet1')
         self.assertTrue(allowed)
+
+    def test_sqlite_record_request_if_allowed_is_atomic(self):
+        """Test concurrent SQLite drip attempts only record once."""
+        self.config['rate_limit']['window_seconds'] = 60
+        self.config['rate_limit']['max_requests'] = 1
+
+        def attempt_drip(_):
+            return self.rate_limiter.record_request_if_allowed(
+                '192.168.1.9:0xwallet-race',
+                '192.168.1.9',
+                '0xwallet-race',
+                0.5,
+            )[0]
+
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            results = list(executor.map(attempt_drip, range(8)))
+
+        self.assertEqual(results.count(True), 1)
+        self.assertEqual(results.count(False), 7)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            c = conn.cursor()
+            c.execute('''
+                SELECT COUNT(*) FROM drip_requests
+                WHERE ip_address = ? OR wallet = ?
+            ''', ('192.168.1.9', '0xwallet-race'))
+            self.assertEqual(c.fetchone()[0], 1)
+        finally:
+            conn.close()
 
 
 class TestDatabase(unittest.TestCase):


### PR DESCRIPTION
Fixes #5018.

## Summary

- Adds `RateLimiter.record_request_if_allowed()` for the faucet service path.
- Uses one SQLite `BEGIN IMMEDIATE` transaction to check the active rate-limit window and insert the drip record.
- Updates `/faucet/drip` so SQLite-backed requests no longer do check and insert as separate operations.
- Adds a concurrent regression proving eight same-wallet attempts produce exactly one recorded drip.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest faucet_service\test_faucet_service.py -q` -> `34 passed`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_faucet.py tests\test_legacy_faucet_json_validation.py -q` -> `7 passed`
- `python -m py_compile faucet_service\faucet_service.py faucet_service\test_faucet_service.py` -> passed
- `git diff --check origin/main...HEAD -- faucet_service\faucet_service.py faucet_service\test_faucet_service.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No production faucet, live wallet, private key, or token transfer was used.
