### PR TITLE
Add data processing parser tests

### DIFF
--- a/test_data_processing.py
+++ b/test_data_processing.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parent / "src" / "utils" / "data_processing.py"
+SPEC = importlib.util.spec_from_file_location("data_processing", MODULE_PATH)
+data_processing = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(data_processing)
+
+
+def test_parse_json_input_returns_nested_objects():
+    payload = '{"miner": "RTC123", "stats": {"blocks": 4, "active": true}}'
+
+    assert data_processing.parse_json_input(payload) == {
+        "miner": "RTC123",
+        "stats": {"blocks": 4, "active": True},
+    }
+
+
+def test_parse_json_input_preserves_json_arrays():
+    assert data_processing.parse_json_input('["g4", "g5", "power8"]') == [
+        "g4",
+        "g5",
+        "power8",
+    ]
+
+
+def test_parse_json_input_wraps_decode_errors():
+    with pytest.raises(ValueError) as exc_info:
+        data_processing.parse_json_input('{"miner": "RTC123",}')
+
+    message = str(exc_info.value)
+    assert message.startswith("Invalid JSON input: ")
+    assert "line 1 column" in message


### PR DESCRIPTION
## Summary
- Adds focused unit coverage for the JSON parsing helper in src/utils/data_processing.py.
- Covers nested object parsing, array preservation, and decode-error wrapping.
- Uses direct module loading so the pure helper test does not require the broader Flask-heavy test harness.

## Validation
- python -m pytest test_data_processing.py -q
- python -m py_compile src/utils/data_processing.py test_data_processing.py
- git diff --check

Bounty context: Scottcjn/rustchain-bounties#1589