### PR TITLE
fix: bind claims to registered miner wallet

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -487,6 +487,11 @@ def submit_claim(
     if not eligibility["eligible"]:
         result["error"] = f"ineligible: {eligibility['reason']}"
         return result
+
+    registered_wallet = eligibility.get("wallet_address")
+    if not registered_wallet or wallet_address.lower() != registered_wallet.lower():
+        result["error"] = "wallet_address_mismatch"
+        return result
     
     # Verify signature (unless skipped for testing)
     if not skip_signature_verify:

--- a/tests/test_claims_integration.py
+++ b/tests/test_claims_integration.py
@@ -40,9 +40,9 @@ from claims_settlement import (
 
 
 @pytest.fixture
-def integration_db():
+def integration_db(tmp_path):
     """Create file-based test database with full schema"""
-    db = "test_claims_integration.db"
+    db = str(tmp_path / "test_claims_integration.db")
     
     # Remove existing test database
     if os.path.exists(db):
@@ -124,9 +124,9 @@ def integration_db():
     
     yield db
     
-    # Cleanup
-    if os.path.exists(db):
-        os.remove(db)
+    # Let pytest clean its per-test temp directory. On Windows, SQLite handles
+    # can remain briefly locked after settlement tests and make explicit unlink
+    # flaky even though all query contexts have exited.
 
 
 @pytest.fixture
@@ -597,6 +597,76 @@ class TestEdgeCases:
         
         assert result2["success"] is False
         assert "pending_claim_exists" in result2["error"] or "already exists" in result2["error"] or "Duplicate" in result2["error"]
+
+    def test_claim_rejects_unregistered_payout_wallet(self, integration_db, current_ts, current_slot):
+        """Test claims cannot redirect payout to a wallet not registered to the miner."""
+
+        test_epoch = max(0, current_slot // 144 - 3)
+
+        miner_id = "wallet-mismatch-claimer"
+        registered_wallet = "RTC1RegisteredWallet123456"
+        attacker_wallet = "RTC1AttackerWallet9876543"
+        setup_test_miner(
+            integration_db,
+            miner_id,
+            "g4",
+            registered_wallet,
+            current_ts,
+            epoch=test_epoch,
+        )
+
+        result = submit_claim(
+            db_path=integration_db,
+            miner_id=miner_id,
+            epoch=test_epoch,
+            wallet_address=attacker_wallet,
+            signature="mock_signature",
+            public_key="mock_public_key",
+            current_slot=current_slot,
+            current_ts=current_ts,
+            skip_signature_verify=True
+        )
+
+        assert result["success"] is False
+        assert result["error"] == "wallet_address_mismatch"
+
+        with sqlite3.connect(integration_db) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM claims WHERE miner_id = ?",
+                (miner_id,),
+            ).fetchone()[0]
+
+        assert count == 0
+
+    def test_claim_wallet_match_is_case_insensitive(self, integration_db, current_ts, current_slot):
+        """Test registered wallet comparison preserves existing case-insensitive behavior."""
+
+        test_epoch = max(0, current_slot // 144 - 3)
+
+        miner_id = "wallet-case-claimer"
+        registered_wallet = "RTC1CaseWallet1234567890"
+        setup_test_miner(
+            integration_db,
+            miner_id,
+            "g4",
+            registered_wallet,
+            current_ts,
+            epoch=test_epoch,
+        )
+
+        result = submit_claim(
+            db_path=integration_db,
+            miner_id=miner_id,
+            epoch=test_epoch,
+            wallet_address=registered_wallet.lower(),
+            signature="mock_signature",
+            public_key="mock_public_key",
+            current_slot=current_slot,
+            current_ts=current_ts,
+            skip_signature_verify=True
+        )
+
+        assert result["success"] is True
     
     def test_wallet_address_change(self, integration_db, current_ts, current_slot):
         """Test that wallet address can be updated between claims"""


### PR DESCRIPTION
Fixes #4592.

## Summary

- Reject claim submissions whose request-supplied payout wallet differs from the wallet returned by `check_claim_eligibility()`.
- Compare wallets case-insensitively to preserve the current RTC address validator semantics.
- Add regression coverage proving an attacker wallet cannot create a claim row for an eligible miner.
- Keep legitimate case-insensitive matches working.
- Move the integration test database into pytest's per-test temp directory to avoid Windows SQLite unlink flakes during the claims integration suite.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_claims_integration.py -q` -> `13 passed`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m py_compile node\claims_submission.py tests\test_claims_integration.py` -> passed
- `git diff --check origin/main...HEAD -- node\claims_submission.py tests\test_claims_integration.py` -> passed
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No live wallet, private key, signing action, settlement transaction, or destructive request was used.

@galpetame RTC wallet: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
