### PR TITLE
Allow genesis validation test files through gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@
 *.key
 *.pem
 
+# Keep genesis material ignored, but allow tests/tooling that validate
+# genesis file handling.
+!tools/validate_genesis.py
+!test_*genesis*.py
+!tests/**/test_*genesis*.py
+
 # Python
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary
- keep sensitive genesis artifacts ignored
- allow narrowly scoped genesis validation tooling and test files to be tracked

Fixes #5037.

## Verification
- `git check-ignore --no-index --verbose --non-matching test_validate_genesis.py tests/unit/test_validate_genesis.py sample-genesis.json tools/validate_genesis.py`
- `git diff --check`