### PR TITLE
Fix asciinema recording links in installation walkthrough

### DIFF
--- a/docs/INSTALLATION_WALKTHROUGH.md
+++ b/docs/INSTALLATION_WALKTHROUGH.md
@@ -8,7 +8,7 @@ Visual guides for installing RustChain and completing your first attestation.
 
 Watch the complete installation process from cloning to running:
 
-![Miner Installation](asciinema/miner_install.cast)
+[Watch the miner installation recording](asciinema/miner_install.cast)
 
 **What you'll see:**
 1. Cloning the RustChain repository
@@ -21,7 +21,7 @@ Watch the complete installation process from cloning to running:
 
 See how to complete your first hardware attestation and start mining:
 
-![First Attestation](asciinema/first_attestation.cast)
+[Watch the first attestation recording](asciinema/first_attestation.cast)
 
 **What you'll see:**
 1. Starting the RustChain miner


### PR DESCRIPTION
## Summary
- replace image syntax for `.cast` asciinema recordings with normal Markdown links
- keep the existing local recording paths unchanged

## Why
GitHub Markdown does not render `.cast` terminal recordings as images, so the previous `![...](asciinema/*.cast)` syntax created broken-looking media placeholders instead of usable links.

## Verification
- `git diff --check`
- verified the local `asciinema/*.cast` links resolve from `docs/INSTALLATION_WALKTHROUGH.md`