### PR TITLE
fix: store payout ledger amounts as micro RTC

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -12,11 +12,13 @@ import sqlite3
 import uuid
 import json
 import logging
+from decimal import Decimal, InvalidOperation
 from flask import request, jsonify, render_template_string
 
 logger = logging.getLogger(__name__)
 
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "rustchain.db")
+MICRO_RTC_PER_RTC = Decimal("1000000")
 
 PAYOUT_LEDGER_COLUMNS = [
     ("id", "TEXT"),
@@ -24,7 +26,7 @@ PAYOUT_LEDGER_COLUMNS = [
     ("bounty_title", "TEXT"),
     ("contributor", "TEXT NOT NULL DEFAULT ''"),
     ("wallet_address", "TEXT"),
-    ("amount_rtc", "REAL NOT NULL DEFAULT 0"),
+    ("amount_micro_rtc", "INTEGER NOT NULL DEFAULT 0"),
     ("status", "TEXT NOT NULL DEFAULT 'queued'"),
     ("pr_url", "TEXT"),
     ("tx_hash", "TEXT"),
@@ -42,6 +44,30 @@ def _select_columns_sql():
     return ", ".join(_get_columns())
 
 
+def _rtc_to_micro(amount_rtc) -> int:
+    """Convert RTC input to integer micro-RTC without float arithmetic."""
+    try:
+        value = Decimal(str(amount_rtc))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError("amount_rtc must be a decimal value") from exc
+
+    if not value.is_finite() or value < 0:
+        raise ValueError("amount_rtc must be a non-negative finite decimal value")
+
+    micro = value * MICRO_RTC_PER_RTC
+    if micro != micro.to_integral_value():
+        raise ValueError("amount_rtc supports up to 6 decimal places")
+
+    return int(micro)
+
+
+def _micro_to_rtc_text(amount_micro_rtc) -> str:
+    """Format integer micro-RTC as exact user-facing RTC text."""
+    value = Decimal(int(amount_micro_rtc)) / MICRO_RTC_PER_RTC
+    text = format(value.quantize(Decimal("0.000001")), "f").rstrip("0").rstrip(".")
+    return text or "0"
+
+
 def _migrate_payout_ledger_schema(conn):
     """Add missing columns for nodes with older payout_ledger tables."""
     existing = {
@@ -55,6 +81,21 @@ def _migrate_payout_ledger_schema(conn):
         conn.execute(f"ALTER TABLE payout_ledger ADD COLUMN {name} {definition}")
         logger.info("Added payout_ledger.%s column", name)
 
+    refreshed = {
+        row[1] for row in conn.execute("PRAGMA table_info(payout_ledger)").fetchall()
+    }
+    if "amount_rtc" in refreshed and "amount_micro_rtc" in refreshed:
+        rows = conn.execute("""
+            SELECT id, amount_rtc
+            FROM payout_ledger
+            WHERE amount_micro_rtc = 0 AND COALESCE(amount_rtc, 0) != 0
+        """).fetchall()
+        for record_id, amount_rtc in rows:
+            conn.execute(
+                "UPDATE payout_ledger SET amount_micro_rtc = ? WHERE id = ?",
+                (_rtc_to_micro(amount_rtc), record_id),
+            )
+
 # ── Schema ──────────────────────────────────────────────────────
 def init_payout_ledger_tables():
     """Create the payout_ledger table if it does not exist."""
@@ -66,7 +107,7 @@ def init_payout_ledger_tables():
                 bounty_title    TEXT,
                 contributor     TEXT NOT NULL,
                 wallet_address  TEXT,
-                amount_rtc      REAL NOT NULL DEFAULT 0,
+                amount_micro_rtc INTEGER NOT NULL DEFAULT 0,
                 status          TEXT NOT NULL DEFAULT 'queued',
                 pr_url          TEXT,
                 tx_hash         TEXT,
@@ -91,7 +132,9 @@ def init_payout_ledger_tables():
 # ── Database helpers ────────────────────────────────────────────
 def _row_to_dict(row, columns):
     """Convert a sqlite3 row tuple to a dict."""
-    return dict(zip(columns, row))
+    record = dict(zip(columns, row))
+    record["amount_rtc"] = _micro_to_rtc_text(record.get("amount_micro_rtc", 0))
+    return record
 
 
 def ledger_list(status=None, contributor=None, limit=100):
@@ -128,17 +171,18 @@ def ledger_create(bounty_id, contributor, amount_rtc,
     """Create a new payout record (status = queued)."""
     record_id = str(uuid.uuid4())
     now = int(time.time())
+    amount_micro_rtc = _rtc_to_micro(amount_rtc)
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             "INSERT INTO payout_ledger"
             " (id, bounty_id, bounty_title, contributor, wallet_address,"
-            "  amount_rtc, status, pr_url, tx_hash, notes, created_at, updated_at)"
+            "  amount_micro_rtc, status, pr_url, tx_hash, notes, created_at, updated_at)"
             " VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
             (record_id, bounty_id, bounty_title, contributor, wallet_address,
-             amount_rtc, "queued", pr_url, "", notes, now, now),
+             amount_micro_rtc, "queued", pr_url, "", notes, now, now),
         )
         conn.commit()
-    logger.info("Ledger record created: %s  bounty=%s  rtc=%.2f", record_id, bounty_id, amount_rtc)
+    logger.info("Ledger record created: %s  bounty=%s  rtc=%s", record_id, bounty_id, _micro_to_rtc_text(amount_micro_rtc))
     return record_id
 
 
@@ -161,10 +205,17 @@ def ledger_summary():
     """Aggregate stats by status."""
     with sqlite3.connect(DB_PATH) as conn:
         rows = conn.execute(
-            "SELECT status, COUNT(*), COALESCE(SUM(amount_rtc),0)"
+            "SELECT status, COUNT(*), COALESCE(SUM(amount_micro_rtc),0)"
             " FROM payout_ledger GROUP BY status"
         ).fetchall()
-    return {r[0]: {"count": r[1], "total_rtc": r[2]} for r in rows}
+    return {
+        r[0]: {
+            "count": r[1],
+            "total_micro_rtc": int(r[2]),
+            "total_rtc": _micro_to_rtc_text(r[2]),
+        }
+        for r in rows
+    }
 
 
 # ── Flask route registration ───────────────────────────────────
@@ -203,15 +254,18 @@ def register_ledger_routes(app):
         for field in required:
             if field not in data:
                 return jsonify({"error": f"missing {field}"}), 400
-        record_id = ledger_create(
-            bounty_id=data["bounty_id"],
-            contributor=data["contributor"],
-            amount_rtc=float(data["amount_rtc"]),
-            bounty_title=data.get("bounty_title", ""),
-            wallet_address=data.get("wallet_address", ""),
-            pr_url=data.get("pr_url", ""),
-            notes=data.get("notes", ""),
-        )
+        try:
+            record_id = ledger_create(
+                bounty_id=data["bounty_id"],
+                contributor=data["contributor"],
+                amount_rtc=data["amount_rtc"],
+                bounty_title=data.get("bounty_title", ""),
+                wallet_address=data.get("wallet_address", ""),
+                pr_url=data.get("pr_url", ""),
+                notes=data.get("notes", ""),
+            )
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         return jsonify({"id": record_id, "status": "queued"}), 201
 
     @app.route("/api/ledger/<record_id>/status", methods=["PATCH"])
@@ -269,7 +323,7 @@ LEDGER_HTML = """<!DOCTYPE html>
   {% for st, info in summary.items() %}
   <div class="summary-card">
     <h3>{{ st }}</h3>
-    <div class="val">{{ info.count }} &middot; {{ "%.1f"|format(info.total_rtc) }} RTC</div>
+    <div class="val">{{ info.count }} &middot; {{ info.total_rtc }} RTC</div>
   </div>
   {% endfor %}
 </div>
@@ -286,7 +340,7 @@ LEDGER_HTML = """<!DOCTYPE html>
 <tr>
   <td>{{ r.bounty_id|e }} {{ r.bounty_title|e }}</td>
   <td>{{ r.contributor|e }}</td>
-  <td>{{ "%.1f"|format(r.amount_rtc) }}</td>
+  <td>{{ r.amount_rtc }}</td>
   <td class="status-{{ r.status|e }}">{{ r.status|e }}</td>
   <td>{% if r.pr_url %}<a href="{{ r.pr_url|e }}" target="_blank">PR</a>{% endif %}</td>
   <td>{{ r.tx_hash[:12]|e if r.tx_hash else '' }}</td>

--- a/tests/test_payout_ledger_migration.py
+++ b/tests/test_payout_ledger_migration.py
@@ -54,12 +54,13 @@ class TestPayoutLedgerMigration(unittest.TestCase):
                 row[1] for row in conn.execute("PRAGMA table_info(payout_ledger)")
             }
 
-        self.assertEqual(columns, set(payout_ledger._get_columns()))
+        self.assertTrue(set(payout_ledger._get_columns()).issubset(columns))
         row = payout_ledger.ledger_get("old-1")
         self.assertEqual(row["id"], "old-1")
         self.assertEqual(row["bounty_id"], "bounty-1")
         self.assertEqual(row["contributor"], "alice")
-        self.assertEqual(row["amount_rtc"], 3.5)
+        self.assertEqual(row["amount_micro_rtc"], 3500000)
+        self.assertEqual(row["amount_rtc"], "3.5")
         self.assertEqual(row["status"], "pending")
         self.assertEqual(row["created_at"], 100)
         self.assertEqual(row["updated_at"], 200)
@@ -85,9 +86,40 @@ class TestPayoutLedgerMigration(unittest.TestCase):
         self.assertEqual(row["bounty_id"], "bounty-2")
         self.assertEqual(row["bounty_title"], "Schema fix")
         self.assertEqual(row["contributor"], "bob")
+        self.assertEqual(row["amount_micro_rtc"], 4250000)
+        self.assertEqual(row["amount_rtc"], "4.25")
         self.assertEqual(row["wallet_address"], "RTC-private")
         self.assertEqual(row["pr_url"], "https://example.test/pr/1")
         self.assertEqual(row["notes"], "created after migration")
+
+    def test_new_writes_store_integer_micro_rtc_and_sum_exactly(self):
+        payout_ledger.init_payout_ledger_tables()
+        first = payout_ledger.ledger_create("bounty-1", "alice", "0.1")
+        second = payout_ledger.ledger_create("bounty-2", "bob", "0.2")
+
+        with sqlite3.connect(self.db_path) as conn:
+            columns = {
+                row[1]: row[2] for row in conn.execute("PRAGMA table_info(payout_ledger)")
+            }
+            self.assertEqual(columns["amount_micro_rtc"].upper(), "INTEGER")
+            self.assertNotIn("amount_rtc", columns)
+            total_micro = conn.execute(
+                "SELECT SUM(amount_micro_rtc) FROM payout_ledger"
+            ).fetchone()[0]
+
+        self.assertEqual(total_micro, 300000)
+        self.assertEqual(payout_ledger.ledger_get(first)["amount_rtc"], "0.1")
+        self.assertEqual(payout_ledger.ledger_get(second)["amount_rtc"], "0.2")
+        self.assertEqual(
+            payout_ledger.ledger_summary()["queued"],
+            {"count": 2, "total_micro_rtc": 300000, "total_rtc": "0.3"},
+        )
+
+    def test_amount_rtc_rejects_more_than_micro_precision(self):
+        payout_ledger.init_payout_ledger_tables()
+
+        with self.assertRaises(ValueError):
+            payout_ledger.ledger_create("bounty-1", "alice", "0.0000001")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #5033.

## Summary

- Replaces canonical payout-ledger amount storage with `amount_micro_rtc INTEGER`.
- Keeps legacy `amount_rtc REAL` rows migration-safe by backfilling `amount_micro_rtc` from existing rows.
- Uses `Decimal(str(...))` for input conversion, so new writes avoid Python float arithmetic.
- Returns exact user-facing decimal text from `ledger_get()`, `ledger_list()`, summary, and the HTML page.
- Makes summary totals exact by summing integer micro-RTC, e.g. `0.1 + 0.2` becomes exactly `0.3`.
- Returns `400` from the API if an amount has more than 6 decimal places or is invalid.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_payout_ledger_migration.py -q` -> `4 passed`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m py_compile payout_ledger.py tests\test_payout_ledger_migration.py` -> passed
- `git diff --check origin/main...HEAD -- payout_ledger.py tests\test_payout_ledger_migration.py` -> passed
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No live payout, wallet signing, private key, token transfer, or destructive request was used.

@galpetame RTC wallet: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
