### PR TITLE
fix: harden keeper explorer faucet claims

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -16,7 +16,8 @@ import os
 import sys
 import json
 import time
-import hashlib
+import re
+import secrets
 import sqlite3
 import requests
 from flask import Flask, request, jsonify, render_template_string, send_from_directory
@@ -59,6 +60,48 @@ def check_rate_limit(address, ip):
     conn.close()
     return count == 0
 
+def validate_faucet_address(address):
+    """Accept RTC or EVM-style faucet addresses."""
+    if not isinstance(address, str):
+        return False
+    return bool(
+        re.fullmatch(r"RTC[a-zA-Z0-9]{20,40}", address, re.IGNORECASE)
+        or re.fullmatch(r"0x[a-fA-F0-9]{40}", address)
+    )
+
+def record_faucet_claim_if_allowed(address, ip, amount):
+    """Atomically check the 24h faucet limit and record one claim."""
+    conn = sqlite3.connect(FAUCET_DB, timeout=30)
+    try:
+        conn.isolation_level = None
+        c = conn.cursor()
+        c.execute("PRAGMA busy_timeout = 30000")
+        c.execute("BEGIN IMMEDIATE")
+
+        one_day_ago = int(time.time()) - 86400
+        c.execute(
+            "SELECT COUNT(*) FROM faucet_claims WHERE (address = ? OR ip_address = ?) AND timestamp > ?",
+            (address, ip, one_day_ago),
+        )
+        if c.fetchone()[0] > 0:
+            c.execute("ROLLBACK")
+            return False
+
+        c.execute(
+            "INSERT INTO faucet_claims (address, ip_address, timestamp, amount) VALUES (?, ?, ?, ?)",
+            (address, ip, int(time.time()), amount),
+        )
+        c.execute("COMMIT")
+        return True
+    except Exception:
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.OperationalError:
+            pass
+        raise
+    finally:
+        conn.close()
+
 # --- Routes ---
 
 @app.route('/')
@@ -96,26 +139,20 @@ def faucet_drip():
     
     if not address:
         return jsonify({"success": False, "error": "Wallet address required"}), 400
+
+    if not validate_faucet_address(address):
+        return jsonify({"success": False, "error": "Invalid wallet address"}), 400
         
-    if not check_rate_limit(address, ip):
+    amount = 0.5 # 0.5 test RTC
+    if not record_faucet_claim_if_allowed(address, ip, amount):
         return jsonify({"success": False, "error": "Rate limit exceeded (1 drip per 24h)"}), 429
         
     # In a real scenario, this would call the node's transfer API
     # For the bounty/demo, we log the success
-    timestamp = int(time.time())
-    amount = 0.5 # 0.5 test RTC
-    
-    conn = sqlite3.connect(FAUCET_DB)
-    c = conn.cursor()
-    c.execute("INSERT INTO faucet_claims (address, ip_address, timestamp, amount) VALUES (?, ?, ?, ?)",
-              (address, ip, timestamp, amount))
-    conn.commit()
-    conn.close()
-    
     return jsonify({
         "success": True, 
         "message": f"Drip successful! {amount} RTC sent to {address}",
-        "tx_hash": hashlib.sha256(str(time.time()).encode()).hexdigest() # Mock hash
+        "tx_hash": secrets.token_hex(32) # Mock hash
     })
 
 # --- Fossil-punk UI Template ---
@@ -375,6 +412,5 @@ RETRO_HTML = """
 """
 
 if __name__ == '__main__':
-    import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
     app.run(host='0.0.0.0', port=PORT, debug=True)

--- a/tests/test_keeper_explorer_faucet.py
+++ b/tests/test_keeper_explorer_faucet.py
@@ -2,6 +2,7 @@ import importlib.util
 import sqlite3
 import sys
 import types
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -57,20 +58,59 @@ def test_faucet_drip_rejects_non_string_address(tmp_path, monkeypatch):
 
 def test_faucet_drip_records_valid_address(tmp_path, monkeypatch):
     keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    monkeypatch.setattr(keeper.secrets, "token_hex", lambda n: "a" * (n * 2))
 
     response = keeper.app.test_client().post(
         "/api/faucet/drip",
-        json={"address": "  rtc-test-wallet  "},
+        json={"address": "  RTC1TestWalletAddress1234567890  "},
     )
 
     assert response.status_code == 200
     body = response.get_json()
     assert body["success"] is True
-    assert body["message"] == "Drip successful! 0.5 RTC sent to rtc-test-wallet"
-    assert len(body["tx_hash"]) == 64
+    assert body["message"] == "Drip successful! 0.5 RTC sent to RTC1TestWalletAddress1234567890"
+    assert body["tx_hash"] == "a" * 64
 
     with sqlite3.connect(tmp_path / "faucet_service" / "faucet.db") as conn:
         row = conn.execute(
             "SELECT address, amount FROM faucet_claims"
         ).fetchone()
-    assert row == ("rtc-test-wallet", 0.5)
+    assert row == ("RTC1TestWalletAddress1234567890", 0.5)
+
+
+def test_faucet_drip_rejects_invalid_wallet_string(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+
+    response = keeper.app.test_client().post(
+        "/api/faucet/drip",
+        json={"address": "not-a-wallet"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "success": False,
+        "error": "Invalid wallet address",
+    }
+
+
+def test_faucet_claim_record_is_atomic(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    address = "RTC1RaceWalletAddress123456789"
+    ip = "198.51.100.10"
+
+    def attempt_claim(_):
+        return keeper.record_faucet_claim_if_allowed(address, ip, 0.5)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(attempt_claim, range(8)))
+
+    assert results.count(True) == 1
+    assert results.count(False) == 7
+
+    with sqlite3.connect(tmp_path / "faucet_service" / "faucet.db") as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM faucet_claims WHERE address = ? OR ip_address = ?",
+            (address, ip),
+        ).fetchone()[0]
+
+    assert count == 1


### PR DESCRIPTION
Fixes #5035.

## Summary

- Adds RTC/EVM faucet wallet validation before recording a keeper-explorer drip.
- Replaces the separate rate-limit check + insert with one SQLite `BEGIN IMMEDIATE` transaction.
- Uses `secrets.token_hex(32)` for the mock transaction hash instead of a timestamp-derived SHA-256 value.
- Adds regression coverage for invalid wallet rejection, predictable-hash avoidance, and concurrent same-wallet/IP attempts.

## Validation

- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m pytest tests\test_keeper_explorer_faucet.py -q` -> `5 passed`
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe -m py_compile keeper_explorer.py tests\test_keeper_explorer_faucet.py` -> passed; existing ASCII-art template warning only
- `git diff --check origin/main...HEAD -- keeper_explorer.py tests\test_keeper_explorer_faucet.py` -> passed
- `C:\Users\prian\.openclaw\workspace\crypto-revenue\.venv-rustchain-tests\Scripts\python.exe tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No live faucet, wallet signing, private key, token transfer, or destructive request was used.

@galpetame RTC wallet: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
