### PR TITLE
Allow genesis validation tests through gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *founder*
 *premine*
 *genesis*
+!tools/validate_genesis.py
+!test_*genesis*.py
+!tests/**/test_*genesis*.py
 *private*key*
 *secret*
 *.env


### PR DESCRIPTION
## Summary
- Keep broad `*genesis*` artifact protection in `.gitignore`
- Add narrow negation rules for `tools/validate_genesis.py` and `test_*genesis*.py` test files

## Verification
- `git check-ignore -v sample-genesis.json` still matches `*genesis*`
- Temporary `test_validate_genesis.py` and `tests/unit/test_validate_genesis.py` files appear in `git status --short --untracked-files=all`

Fixes #5037
First PR