### PR TITLE
fix: allow genesis validation test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *founder*
 *premine*
 *genesis*
+!tests/**/*genesis*.py
+!test_*genesis*.py
 *private*key*
 *secret*
 *.env


### PR DESCRIPTION
## Summary
- Keeps the broad `*genesis*` ignore rule for sensitive genesis artifacts.
- Adds explicit exceptions for legitimate Python genesis validation tests.

Fixes #5037.

## Validation
- `git check-ignore -q test_genesis_validation.py` => not ignored
- `git check-ignore -q tests/test_genesis_validation.py` => not ignored
- `git check-ignore -q secrets/genesis.json` => still ignored