### PR TITLE
fix: fail closed when webhook secret is missing

### DIFF
--- a/integrations/rustchain-bounties/auth.py
+++ b/integrations/rustchain-bounties/auth.py
@@ -20,8 +20,7 @@ def verify_webhook_signature(payload_bytes: bytes, signature_header: Optional[st
     """
     secret = os.environ.get("WEBHOOK_SECRET", "")
     if not secret:
-        # No secret configured — skip verification (development/local mode)
-        return True
+        return False
 
     if not signature_header:
         return False

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -277,11 +277,10 @@ class TestWebhookVerification:
         with patch.dict(os.environ, {"WEBHOOK_SECRET": "mysecret"}):
             assert verify_webhook_signature(payload, None) is False
 
-    def test_no_secret_configured_allows_all(self):
+    def test_no_secret_configured_rejects_unsigned_payload(self):
         payload = b'{"action": "created"}'
         with patch.dict(os.environ, {}, clear=True):
-            # When WEBHOOK_SECRET is not set, verification is skipped
-            assert verify_webhook_signature(payload, None) is True
+            assert verify_webhook_signature(payload, None) is False
 
     def test_tampered_payload_rejected(self):
         original = b'{"action": "created"}'

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -30,6 +30,7 @@ from tip_bot import (
     build_failure_comment,
     build_success_comment,
     build_unauthorized_comment,
+    main,
     parse_tip_command,
     process_event,
     validate_tip,
@@ -289,6 +290,59 @@ class TestWebhookVerification:
         sig = self._sign(original, secret)
         with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
             assert verify_webhook_signature(tampered, sig) is False
+
+
+# ---------------------------------------------------------------------------
+# Main entrypoint webhook gate tests
+# ---------------------------------------------------------------------------
+
+class TestMainWebhookGate:
+
+    def _write_event(self, tmp_path) -> str:
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(make_event("Just a normal comment.")))
+        return str(event_path)
+
+    def _base_env(self, event_path: str) -> dict[str, str]:
+        return {
+            "GITHUB_EVENT_PATH": event_path,
+            "GITHUB_TOKEN": "token",
+            "GITHUB_REPOSITORY": "org/repo",
+        }
+
+    def test_external_webhook_without_secret_or_signature_aborts(self, tmp_path):
+        env = self._base_env(self._write_event(tmp_path))
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tip_bot.process_event") as mock_process:
+            with pytest.raises(SystemExit) as exc:
+                main()
+
+        assert exc.value.code == 1
+        mock_process.assert_not_called()
+
+    def test_external_webhook_with_secret_but_missing_signature_aborts(self, tmp_path):
+        env = self._base_env(self._write_event(tmp_path))
+        env["WEBHOOK_SECRET"] = "mysecret"
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tip_bot.process_event") as mock_process:
+            with pytest.raises(SystemExit) as exc:
+                main()
+
+        assert exc.value.code == 1
+        mock_process.assert_not_called()
+
+    def test_github_actions_payload_without_signature_is_allowed(self, tmp_path, config):
+        event_path = self._write_event(tmp_path)
+        env = self._base_env(event_path)
+        env["GITHUB_ACTIONS"] = "true"
+        with patch.dict(os.environ, env, clear=True), \
+             patch("tip_bot.load_config", return_value=config), \
+             patch("tip_bot.TipState") as mock_state, \
+             patch("tip_bot.process_event", return_value="no_command") as mock_process:
+            main()
+
+        mock_state.assert_called_once_with(config["state_file"])
+        mock_process.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -371,17 +371,24 @@ def main() -> None:
         print("No event payload found. Running in test mode — exiting.")
         sys.exit(0)
 
-    with open(event_path) as f:
-        event = json.load(f)
+    with open(event_path, "rb") as f:
+        raw_payload = f.read()
+    event = json.loads(raw_payload.decode("utf-8"))
 
-    # Verify webhook signature if secret is configured AND a signature header
-    # is present. In GitHub Actions, the payload comes from GitHub's own
-    # infrastructure (GITHUB_EVENT_PATH) — no HTTP signature header exists.
-    # WEBHOOK_SECRET is only useful for external webhook deployments.
+    # GitHub Actions supplies GITHUB_EVENT_PATH from GitHub infrastructure and
+    # does not include an HTTP signature header. Any non-Actions deployment is
+    # treated as an external webhook and must fail closed unless both the shared
+    # secret and signature header are present and valid.
     webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
     sig = os.environ.get("HTTP_X_HUB_SIGNATURE_256", "")
-    if webhook_secret and sig:
-        raw_payload = open(event_path, "rb").read()
+    running_in_actions = os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
+    if not running_in_actions or webhook_secret or sig:
+        if not webhook_secret:
+            print("WEBHOOK_SECRET must be set for external webhook payloads. Aborting.")
+            sys.exit(1)
+        if not sig:
+            print("Webhook signature header missing. Aborting.")
+            sys.exit(1)
         if not verify_webhook_signature(raw_payload, sig):
             print("Webhook signature verification failed. Aborting.")
             sys.exit(1)


### PR DESCRIPTION
## Summary
- Makes webhook signature verification fail closed when `WEBHOOK_SECRET` is not configured instead of accepting unsigned payloads.
- Updates the regression test to assert unsigned payloads are rejected without a configured secret.

Fixes #4995.

## Validation
- `python3 -m py_compile auth.py tip_bot.py test_tip_bot.py`
- `python3 -m pytest test_tip_bot.py -q`