### PR TITLE
fix: store OTC bridge money values as scaled integers

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -28,6 +28,7 @@ import secrets
 import sqlite3
 import time
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from functools import wraps
 
 import requests
@@ -62,6 +63,8 @@ MAX_ORDER_RTC = 100000              # Maximum 100k RTC
 RATE_LIMIT_WINDOW = 60              # 1 minute
 RATE_LIMIT_MAX = 10                 # 10 requests per minute per IP
 RTC_REFERENCE_RATE = 0.10           # $0.10 USD reference
+RTC_UNIT = 1_000_000                # 1 micro-RTC
+QUOTE_PRICE_SCALE = 1_000_000_000   # 9 decimal places for quote units
 
 SUPPORTED_PAIRS = {
     "RTC/ETH": {"quote": "ETH", "decimals": 18},
@@ -74,6 +77,65 @@ logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__, static_folder="static")
 CORS(app)
+
+
+def decimal_units(value, scale, field_name):
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        raise ValueError(f"{field_name} must be a finite decimal number")
+
+    if not amount.is_finite():
+        raise ValueError(f"{field_name} must be a finite decimal number")
+
+    units = (amount * Decimal(scale)).to_integral_value(rounding=ROUND_HALF_UP)
+    return amount, int(units)
+
+
+def units_to_float(units, scale):
+    return float(Decimal(int(units)) / Decimal(scale))
+
+
+def money_view(row):
+    data = dict(row)
+    if "amount_micro_rtc" in data and data.get("amount_micro_rtc") is not None:
+        data["amount_rtc"] = units_to_float(data["amount_micro_rtc"], RTC_UNIT)
+    if "price_per_rtc_nano_quote" in data and data.get("price_per_rtc_nano_quote") is not None:
+        data["price_per_rtc"] = units_to_float(
+            data["price_per_rtc_nano_quote"], QUOTE_PRICE_SCALE
+        )
+    if "total_quote_nano" in data and data.get("total_quote_nano") is not None:
+        data["total_quote"] = units_to_float(data["total_quote_nano"], QUOTE_PRICE_SCALE)
+    return data
+
+
+def migrate_precision_columns(cursor, table_name):
+    columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
+    if "amount_micro_rtc" not in columns:
+        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN amount_micro_rtc INTEGER")
+    if "price_per_rtc_nano_quote" not in columns:
+        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN price_per_rtc_nano_quote INTEGER")
+    if "total_quote_nano" not in columns:
+        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN total_quote_nano INTEGER")
+
+    refreshed = {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
+    if {"amount_rtc", "price_per_rtc", "total_quote"}.issubset(refreshed):
+        cursor.execute(f"""
+            UPDATE {table_name}
+            SET amount_micro_rtc = COALESCE(amount_micro_rtc, CAST(ROUND(amount_rtc * ?) AS INTEGER)),
+                price_per_rtc_nano_quote = COALESCE(price_per_rtc_nano_quote, CAST(ROUND(price_per_rtc * ?) AS INTEGER)),
+                total_quote_nano = COALESCE(total_quote_nano, CAST(ROUND(total_quote * ?) AS INTEGER))
+        """, (RTC_UNIT, QUOTE_PRICE_SCALE, QUOTE_PRICE_SCALE))
+
+
+def table_columns(cursor, table_name):
+    return {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
+
+
+def include_legacy_money_columns_if_present(columns, insert_columns, values, amount_rtc, price_per_rtc, total_quote):
+    if {"amount_rtc", "price_per_rtc", "total_quote"}.issubset(columns):
+        insert_columns.extend(["amount_rtc", "price_per_rtc", "total_quote"])
+        values.extend([amount_rtc, price_per_rtc, total_quote])
 
 
 # ---------------------------------------------------------------------------
@@ -90,9 +152,9 @@ def init_db():
                 side TEXT NOT NULL CHECK(side IN ('buy', 'sell')),
                 pair TEXT NOT NULL,
                 maker_wallet TEXT NOT NULL,
-                amount_rtc REAL NOT NULL,
-                price_per_rtc REAL NOT NULL,
-                total_quote REAL NOT NULL,
+                amount_micro_rtc INTEGER NOT NULL,
+                price_per_rtc_nano_quote INTEGER NOT NULL,
+                total_quote_nano INTEGER NOT NULL,
                 status TEXT DEFAULT 'open',
                 escrow_job_id TEXT,
                 htlc_hash TEXT,
@@ -117,9 +179,9 @@ def init_db():
                 side TEXT NOT NULL,
                 maker_wallet TEXT NOT NULL,
                 taker_wallet TEXT NOT NULL,
-                amount_rtc REAL NOT NULL,
-                price_per_rtc REAL NOT NULL,
-                total_quote REAL NOT NULL,
+                amount_micro_rtc INTEGER NOT NULL,
+                price_per_rtc_nano_quote INTEGER NOT NULL,
+                total_quote_nano INTEGER NOT NULL,
                 rtc_tx TEXT,
                 quote_tx TEXT,
                 completed_at INTEGER NOT NULL
@@ -132,6 +194,9 @@ def init_db():
                 timestamp INTEGER NOT NULL
             )
         """)
+
+        migrate_precision_columns(c, "orders")
+        migrate_precision_columns(c, "trades")
 
         c.execute("CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status, pair)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_orders_side ON orders(side, status)")
@@ -356,10 +421,15 @@ def create_order():
         return jsonify({"error": "wallet required (RTC wallet ID)"}), 400
 
     try:
-        amount_rtc = float(amount_rtc)
-        price_per_rtc = float(price_per_rtc)
-    except (TypeError, ValueError):
-        return jsonify({"error": "amount_rtc and price_per_rtc must be numbers"}), 400
+        amount_dec, amount_micro_rtc = decimal_units(amount_rtc, RTC_UNIT, "amount_rtc")
+        price_dec, price_per_rtc_nano_quote = decimal_units(
+            price_per_rtc, QUOTE_PRICE_SCALE, "price_per_rtc"
+        )
+    except (TypeError, ValueError) as e:
+        return jsonify({"error": str(e)}), 400
+
+    amount_rtc = units_to_float(amount_micro_rtc, RTC_UNIT)
+    price_per_rtc = units_to_float(price_per_rtc_nano_quote, QUOTE_PRICE_SCALE)
 
     if amount_rtc < MIN_ORDER_RTC:
         return jsonify({"error": f"Minimum order: {MIN_ORDER_RTC} RTC"}), 400
@@ -371,7 +441,12 @@ def create_order():
         return jsonify({"error": "price_per_rtc too high (max $1000)"}), 400
 
     ttl = min(max(ttl, 3600), ORDER_TTL_MAX)
-    total_quote = round(amount_rtc * price_per_rtc, 8)
+    total_quote_nano = int(
+        (amount_dec * price_dec * Decimal(QUOTE_PRICE_SCALE)).to_integral_value(
+            rounding=ROUND_HALF_UP
+        )
+    )
+    total_quote = units_to_float(total_quote_nano, QUOTE_PRICE_SCALE)
     now = int(time.time())
     order_id = generate_order_id(maker_wallet, side)
 
@@ -407,15 +482,26 @@ def create_order():
     conn = get_db()
     try:
         c = conn.cursor()
-        c.execute("""
-            INSERT INTO orders
-            (order_id, side, pair, maker_wallet, amount_rtc, price_per_rtc,
-             total_quote, status, escrow_job_id, htlc_hash, htlc_secret,
-             maker_eth_address, created_at, expires_at, ip_hash)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
-        """, (order_id, side, pair, maker_wallet, amount_rtc, price_per_rtc,
-              total_quote, escrow_job_id, htlc_hash, htlc_secret,
-              maker_eth_address, now, now + ttl, hash_ip(get_client_ip())))
+        insert_columns = [
+            "order_id", "side", "pair", "maker_wallet", "amount_micro_rtc",
+            "price_per_rtc_nano_quote", "total_quote_nano", "status",
+            "escrow_job_id", "htlc_hash", "htlc_secret", "maker_eth_address",
+            "created_at", "expires_at", "ip_hash",
+        ]
+        values = [
+            order_id, side, pair, maker_wallet, amount_micro_rtc,
+            price_per_rtc_nano_quote, total_quote_nano, "open",
+            escrow_job_id, htlc_hash, htlc_secret, maker_eth_address,
+            now, now + ttl, hash_ip(get_client_ip()),
+        ]
+        include_legacy_money_columns_if_present(
+            table_columns(c, "orders"), insert_columns, values, amount_rtc, price_per_rtc, total_quote
+        )
+        placeholders = ", ".join("?" for _ in values)
+        c.execute(
+            f"INSERT INTO orders ({', '.join(insert_columns)}) VALUES ({placeholders})",
+            values,
+        )
         conn.commit()
 
         response = {
@@ -424,8 +510,11 @@ def create_order():
             "side": side,
             "pair": pair,
             "amount_rtc": amount_rtc,
+            "amount_micro_rtc": amount_micro_rtc,
             "price_per_rtc": price_per_rtc,
+            "price_per_rtc_nano_quote": price_per_rtc_nano_quote,
             "total_quote": total_quote,
+            "total_quote_nano": total_quote_nano,
             "quote_currency": pair.split("/")[1],
             "status": "open",
             "expires_at": now + ttl,
@@ -493,19 +582,19 @@ def list_orders():
             params.append(side)
 
         query = f"""
-            SELECT order_id, side, pair, maker_wallet, amount_rtc,
-                   price_per_rtc, total_quote, status, htlc_hash,
+            SELECT order_id, side, pair, maker_wallet, amount_micro_rtc,
+                   price_per_rtc_nano_quote, total_quote_nano, status, htlc_hash,
                    created_at, expires_at, escrow_job_id
             FROM orders
             WHERE {' AND '.join(where)}
             ORDER BY
-                CASE side WHEN 'sell' THEN price_per_rtc END ASC,
-                CASE side WHEN 'buy' THEN price_per_rtc END DESC,
+                CASE side WHEN 'sell' THEN price_per_rtc_nano_quote END ASC,
+                CASE side WHEN 'buy' THEN price_per_rtc_nano_quote END DESC,
                 created_at ASC
             LIMIT ? OFFSET ?
         """
         params.extend([limit, offset])
-        orders = [dict(r) for r in c.execute(query, params).fetchall()]
+        orders = [money_view(r) for r in c.execute(query, params).fetchall()]
 
         total = c.execute(
             f"SELECT COUNT(*) FROM orders WHERE {' AND '.join(where)}",
@@ -531,7 +620,7 @@ def get_order(order_id):
         if not row:
             return jsonify({"error": "Order not found"}), 404
 
-        order = dict(row)
+        order = money_view(row)
         # Don't expose HTLC secret unless order is confirmed
         if order["status"] not in ("confirmed", "completed"):
             order.pop("htlc_secret", None)
@@ -559,7 +648,7 @@ def match_order(order_id):
         if not row:
             return jsonify({"error": "Order not found"}), 404
 
-        order = dict(row)
+        order = money_view(row)
 
         if order["status"] != "open":
             return jsonify({"error": f"Order is not open (status: {order['status']})"}), 409
@@ -671,7 +760,7 @@ def confirm_order(order_id):
         if not row:
             return jsonify({"error": "Order not found"}), 404
 
-        order = dict(row)
+        order = money_view(row)
 
         if order["status"] != "matched":
             return jsonify({"error": f"Order must be matched to confirm (current: {order['status']})"}), 409
@@ -733,15 +822,30 @@ def confirm_order(order_id):
 
         # Record trade
         trade_id = generate_trade_id(order_id, order["taker_wallet"])
-        c.execute("""
-            INSERT INTO trades
-            (trade_id, order_id, pair, side, maker_wallet, taker_wallet,
-             amount_rtc, price_per_rtc, total_quote, quote_tx, completed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (trade_id, order_id, order["pair"], order["side"],
-              order["maker_wallet"], order["taker_wallet"],
-              order["amount_rtc"], order["price_per_rtc"],
-              order["total_quote"], quote_tx, now))
+        insert_columns = [
+            "trade_id", "order_id", "pair", "side", "maker_wallet", "taker_wallet",
+            "amount_micro_rtc", "price_per_rtc_nano_quote", "total_quote_nano",
+            "quote_tx", "completed_at",
+        ]
+        values = [
+            trade_id, order_id, order["pair"], order["side"],
+            order["maker_wallet"], order["taker_wallet"],
+            order["amount_micro_rtc"], order["price_per_rtc_nano_quote"],
+            order["total_quote_nano"], quote_tx, now,
+        ]
+        include_legacy_money_columns_if_present(
+            table_columns(c, "trades"),
+            insert_columns,
+            values,
+            order["amount_rtc"],
+            order["price_per_rtc"],
+            order["total_quote"],
+        )
+        placeholders = ", ".join("?" for _ in values)
+        c.execute(
+            f"INSERT INTO trades ({', '.join(insert_columns)}) VALUES ({placeholders})",
+            values,
+        )
 
         # Update order
         c.execute("""
@@ -787,7 +891,7 @@ def cancel_order(order_id):
         if not row:
             return jsonify({"error": "Order not found"}), 404
 
-        order = dict(row)
+        order = money_view(row)
 
         if order["maker_wallet"] != wallet:
             return jsonify({"error": "Only the order creator can cancel"}), 403
@@ -837,7 +941,7 @@ def list_trades():
 
         return jsonify({
             "ok": True,
-            "trades": [dict(t) for t in trades]
+            "trades": [money_view(t) for t in trades]
         })
     finally:
         conn.close()
@@ -856,49 +960,69 @@ def orderbook():
 
         # Asks (sell orders) -- sorted by price ascending (cheapest first)
         asks = c.execute("""
-            SELECT price_per_rtc as price, SUM(amount_rtc) as total_rtc,
+            SELECT price_per_rtc_nano_quote as price_nano,
+                   SUM(amount_micro_rtc) as total_micro_rtc,
                    COUNT(*) as order_count
             FROM orders
             WHERE pair = ? AND side = 'sell' AND status = 'open'
-            GROUP BY ROUND(price_per_rtc, 4)
-            ORDER BY price ASC
+            GROUP BY price_per_rtc_nano_quote
+            ORDER BY price_nano ASC
             LIMIT 20
         """, (pair,)).fetchall()
 
         # Bids (buy orders) -- sorted by price descending (highest first)
         bids = c.execute("""
-            SELECT price_per_rtc as price, SUM(amount_rtc) as total_rtc,
+            SELECT price_per_rtc_nano_quote as price_nano,
+                   SUM(amount_micro_rtc) as total_micro_rtc,
                    COUNT(*) as order_count
             FROM orders
             WHERE pair = ? AND side = 'buy' AND status = 'open'
-            GROUP BY ROUND(price_per_rtc, 4)
-            ORDER BY price DESC
+            GROUP BY price_per_rtc_nano_quote
+            ORDER BY price_nano DESC
             LIMIT 20
         """, (pair,)).fetchall()
 
         # Last trade price
         last_trade = c.execute(
-            "SELECT price_per_rtc FROM trades WHERE pair = ? ORDER BY completed_at DESC LIMIT 1",
+            "SELECT price_per_rtc_nano_quote FROM trades WHERE pair = ? ORDER BY completed_at DESC LIMIT 1",
             (pair,)
         ).fetchone()
 
         # 24h volume
         day_ago = int(time.time()) - 86400
         vol = c.execute(
-            "SELECT COALESCE(SUM(amount_rtc), 0), COUNT(*) FROM trades WHERE pair = ? AND completed_at >= ?",
+            "SELECT COALESCE(SUM(amount_micro_rtc), 0), COUNT(*) FROM trades WHERE pair = ? AND completed_at >= ?",
             (pair, day_ago)
         ).fetchone()
+
+        ask_levels = [
+            {
+                "price": units_to_float(a["price_nano"], QUOTE_PRICE_SCALE),
+                "total_rtc": units_to_float(a["total_micro_rtc"], RTC_UNIT),
+                "order_count": a["order_count"],
+            }
+            for a in asks
+        ]
+        bid_levels = [
+            {
+                "price": units_to_float(b["price_nano"], QUOTE_PRICE_SCALE),
+                "total_rtc": units_to_float(b["total_micro_rtc"], RTC_UNIT),
+                "order_count": b["order_count"],
+            }
+            for b in bids
+        ]
 
         return jsonify({
             "ok": True,
             "pair": pair,
-            "asks": [dict(a) for a in asks],
-            "bids": [dict(b) for b in bids],
-            "last_price": last_trade[0] if last_trade else None,
-            "volume_24h_rtc": vol[0],
+            "asks": ask_levels,
+            "bids": bid_levels,
+            "last_price": units_to_float(last_trade[0], QUOTE_PRICE_SCALE) if last_trade else None,
+            "volume_24h_rtc": units_to_float(vol[0], RTC_UNIT),
             "trades_24h": vol[1],
             "reference_rate": RTC_REFERENCE_RATE,
-            "spread": round(asks[0]["price"] - bids[0]["price"], 6) if asks and bids else None
+            "spread": round(ask_levels[0]["price"] - bid_levels[0]["price"], 6)
+            if ask_levels and bid_levels else None
         })
     finally:
         conn.close()
@@ -915,41 +1039,47 @@ def market_stats():
         week_ago = now - 7 * 86400
 
         total_trades = c.execute("SELECT COUNT(*) FROM trades").fetchone()[0]
-        total_volume = c.execute("SELECT COALESCE(SUM(amount_rtc), 0) FROM trades").fetchone()[0]
+        total_volume = c.execute("SELECT COALESCE(SUM(amount_micro_rtc), 0) FROM trades").fetchone()[0]
         vol_24h = c.execute(
-            "SELECT COALESCE(SUM(amount_rtc), 0) FROM trades WHERE completed_at >= ?",
+            "SELECT COALESCE(SUM(amount_micro_rtc), 0) FROM trades WHERE completed_at >= ?",
             (day_ago,)
         ).fetchone()[0]
         vol_7d = c.execute(
-            "SELECT COALESCE(SUM(amount_rtc), 0) FROM trades WHERE completed_at >= ?",
+            "SELECT COALESCE(SUM(amount_micro_rtc), 0) FROM trades WHERE completed_at >= ?",
             (week_ago,)
         ).fetchone()[0]
         open_orders = c.execute(
             "SELECT COUNT(*) FROM orders WHERE status = 'open'"
         ).fetchone()[0]
         open_sell = c.execute(
-            "SELECT COUNT(*), COALESCE(SUM(amount_rtc), 0) FROM orders WHERE status = 'open' AND side = 'sell'"
+            "SELECT COUNT(*), COALESCE(SUM(amount_micro_rtc), 0) FROM orders WHERE status = 'open' AND side = 'sell'"
         ).fetchone()
         open_buy = c.execute(
-            "SELECT COUNT(*), COALESCE(SUM(amount_rtc), 0) FROM orders WHERE status = 'open' AND side = 'buy'"
+            "SELECT COUNT(*), COALESCE(SUM(amount_micro_rtc), 0) FROM orders WHERE status = 'open' AND side = 'buy'"
         ).fetchone()
 
         # Price stats from recent trades
         prices = c.execute(
-            "SELECT price_per_rtc FROM trades ORDER BY completed_at DESC LIMIT 100"
+            "SELECT price_per_rtc_nano_quote FROM trades ORDER BY completed_at DESC LIMIT 100"
         ).fetchall()
-        price_list = [p[0] for p in prices]
+        price_list = [units_to_float(p[0], QUOTE_PRICE_SCALE) for p in prices]
 
         return jsonify({
             "ok": True,
             "stats": {
                 "total_trades": total_trades,
-                "total_volume_rtc": round(total_volume, 2),
-                "volume_24h_rtc": round(vol_24h, 2),
-                "volume_7d_rtc": round(vol_7d, 2),
+                "total_volume_rtc": round(units_to_float(total_volume, RTC_UNIT), 2),
+                "volume_24h_rtc": round(units_to_float(vol_24h, RTC_UNIT), 2),
+                "volume_7d_rtc": round(units_to_float(vol_7d, RTC_UNIT), 2),
                 "open_orders": open_orders,
-                "open_sells": {"count": open_sell[0], "total_rtc": round(open_sell[1], 2)},
-                "open_buys": {"count": open_buy[0], "total_rtc": round(open_buy[1], 2)},
+                "open_sells": {
+                    "count": open_sell[0],
+                    "total_rtc": round(units_to_float(open_sell[1], RTC_UNIT), 2),
+                },
+                "open_buys": {
+                    "count": open_buy[0],
+                    "total_rtc": round(units_to_float(open_buy[1], RTC_UNIT), 2),
+                },
                 "last_price": price_list[0] if price_list else RTC_REFERENCE_RATE,
                 "high_24h": max(price_list) if price_list else None,
                 "low_24h": min(price_list) if price_list else None,

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -3,28 +3,87 @@ Tests for RustChain OTC Bridge
 """
 import json
 import os
+import sqlite3
 import tempfile
 import time
 import unittest
 from unittest.mock import patch, MagicMock
 
-# Set test DB before importing
+# Set an initial test DB before importing, then replace it per test.
 _fd, TEST_DB = tempfile.mkstemp(suffix=".db")
 os.close(_fd)
 os.environ["OTC_DB_PATH"] = TEST_DB
 
+import otc_bridge
 from otc_bridge import app, init_db
 
 
 class OTCBridgeTestCase(unittest.TestCase):
     def setUp(self):
+        global TEST_DB
+        _fd, TEST_DB = tempfile.mkstemp(suffix=".db")
+        os.close(_fd)
+        otc_bridge.DB_PATH = TEST_DB
         self.app = app.test_client()
         self.app.testing = True
         init_db()
 
     def tearDown(self):
+        self.app = None
         if os.path.exists(TEST_DB):
-            os.remove(TEST_DB)
+            try:
+                os.remove(TEST_DB)
+            except PermissionError:
+                pass
+
+    def create_legacy_money_schema(self):
+        """Create the pre-migration schema with REAL NOT NULL money columns."""
+        with sqlite3.connect(TEST_DB) as conn:
+            c = conn.cursor()
+            c.execute("DROP TABLE IF EXISTS orders")
+            c.execute("DROP TABLE IF EXISTS trades")
+            c.execute("DROP TABLE IF EXISTS rate_limits")
+            c.execute("""
+                CREATE TABLE orders (
+                    order_id TEXT PRIMARY KEY,
+                    side TEXT NOT NULL CHECK(side IN ('buy', 'sell')),
+                    pair TEXT NOT NULL,
+                    maker_wallet TEXT NOT NULL,
+                    amount_rtc REAL NOT NULL,
+                    price_per_rtc REAL NOT NULL,
+                    total_quote REAL NOT NULL,
+                    status TEXT DEFAULT 'open',
+                    escrow_job_id TEXT,
+                    htlc_hash TEXT,
+                    htlc_secret TEXT,
+                    taker_wallet TEXT,
+                    taker_eth_address TEXT,
+                    maker_eth_address TEXT,
+                    settlement_tx TEXT,
+                    created_at INTEGER NOT NULL,
+                    matched_at INTEGER,
+                    confirmed_at INTEGER,
+                    expires_at INTEGER NOT NULL,
+                    ip_hash TEXT
+                )
+            """)
+            c.execute("""
+                CREATE TABLE trades (
+                    trade_id TEXT PRIMARY KEY,
+                    order_id TEXT NOT NULL,
+                    pair TEXT NOT NULL,
+                    side TEXT NOT NULL,
+                    maker_wallet TEXT NOT NULL,
+                    taker_wallet TEXT NOT NULL,
+                    amount_rtc REAL NOT NULL,
+                    price_per_rtc REAL NOT NULL,
+                    total_quote REAL NOT NULL,
+                    rtc_tx TEXT,
+                    quote_tx TEXT,
+                    completed_at INTEGER NOT NULL
+                )
+            """)
+            conn.commit()
 
     # ---------------------------------------------------------------
     # Order Creation
@@ -47,6 +106,103 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertAlmostEqual(data["total_quote"], 10.0)
         self.assertEqual(data["status"], "open")
         self.assertIn("otc_", data["order_id"])
+
+    def test_create_order_stores_scaled_integer_money_fields(self):
+        """OTC money values are stored as integer scaled units, not SQLite REAL."""
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "precision-buyer",
+            "amount_rtc": "0.3",
+            "price_per_rtc": "0.1",
+        })
+        data = r.get_json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["amount_micro_rtc"], 300000)
+        self.assertEqual(data["price_per_rtc_nano_quote"], 100000000)
+        self.assertEqual(data["total_quote_nano"], 30000000)
+
+        with sqlite3.connect(TEST_DB) as conn:
+            conn.row_factory = sqlite3.Row
+            columns = {row["name"]: row["type"] for row in conn.execute("PRAGMA table_info(orders)")}
+            self.assertNotIn("amount_rtc", columns)
+            self.assertNotIn("price_per_rtc", columns)
+            self.assertNotIn("total_quote", columns)
+
+            row = conn.execute(
+                "SELECT amount_micro_rtc, price_per_rtc_nano_quote, total_quote_nano FROM orders WHERE order_id = ?",
+                (data["order_id"],),
+            ).fetchone()
+            self.assertEqual(row["amount_micro_rtc"], 300000)
+            self.assertEqual(row["price_per_rtc_nano_quote"], 100000000)
+            self.assertEqual(row["total_quote_nano"], 30000000)
+
+    @patch("requests.post")
+    @patch("otc_bridge.rtc_get_balance", return_value=500.0)
+    @patch("otc_bridge.rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_legacy"})
+    def test_legacy_money_schema_accepts_new_orders_and_trades(self, mock_escrow, mock_balance, mock_post):
+        """Migrated legacy tables still accept inserts despite old REAL NOT NULL columns."""
+        self.create_legacy_money_schema()
+        init_db()
+        mock_post.return_value = MagicMock(ok=True, text='{"ok":true}')
+
+        r1 = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "legacy-buyer",
+            "amount_rtc": "0.3",
+            "price_per_rtc": "0.1",
+        })
+        data = r1.get_json()
+        self.assertEqual(r1.status_code, 201)
+        self.assertTrue(data["ok"])
+        order_id = data["order_id"]
+
+        r2 = self.app.post(f"/api/orders/{order_id}/match", json={
+            "wallet": "legacy-seller",
+        })
+        self.assertEqual(r2.status_code, 200)
+        self.assertTrue(r2.get_json()["ok"])
+
+        with sqlite3.connect(TEST_DB) as conn:
+            secret = conn.execute(
+                "SELECT htlc_secret FROM orders WHERE order_id = ?",
+                (order_id,),
+            ).fetchone()[0]
+
+        r3 = self.app.post(f"/api/orders/{order_id}/confirm", json={
+            "wallet": "legacy-buyer",
+            "quote_tx": "0xlegacy",
+            "secret": secret,
+        })
+        self.assertEqual(r3.status_code, 200)
+        self.assertTrue(r3.get_json()["ok"])
+
+        with sqlite3.connect(TEST_DB) as conn:
+            conn.row_factory = sqlite3.Row
+            order = conn.execute(
+                "SELECT amount_rtc, price_per_rtc, total_quote, amount_micro_rtc, "
+                "price_per_rtc_nano_quote, total_quote_nano FROM orders WHERE order_id = ?",
+                (order_id,),
+            ).fetchone()
+            self.assertEqual(order["amount_rtc"], 0.3)
+            self.assertEqual(order["price_per_rtc"], 0.1)
+            self.assertEqual(order["total_quote"], 0.03)
+            self.assertEqual(order["amount_micro_rtc"], 300000)
+            self.assertEqual(order["price_per_rtc_nano_quote"], 100000000)
+            self.assertEqual(order["total_quote_nano"], 30000000)
+
+            trade = conn.execute(
+                "SELECT amount_rtc, price_per_rtc, total_quote, amount_micro_rtc, "
+                "price_per_rtc_nano_quote, total_quote_nano FROM trades WHERE order_id = ?",
+                (order_id,),
+            ).fetchone()
+            self.assertEqual(trade["amount_rtc"], 0.3)
+            self.assertEqual(trade["price_per_rtc"], 0.1)
+            self.assertEqual(trade["total_quote"], 0.03)
+            self.assertEqual(trade["amount_micro_rtc"], 300000)
+            self.assertEqual(trade["price_per_rtc_nano_quote"], 100000000)
+            self.assertEqual(trade["total_quote_nano"], 30000000)
 
     @patch("otc_bridge.rtc_get_balance", return_value=500.0)
     @patch("otc_bridge.rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_test123"})
@@ -179,6 +335,24 @@ class OTCBridgeTestCase(unittest.TestCase):
         # Bids sorted by price descending
         self.assertGreaterEqual(data["bids"][0]["price"], data["bids"][1]["price"])
 
+    def test_orderbook_keeps_distinct_scaled_prices(self):
+        """Prices that rounded together at 4 decimals stay distinct internally."""
+        self.app.post("/api/orders", json={
+            "side": "buy", "pair": "RTC/USDC",
+            "wallet": "buyer-precision-1", "amount_rtc": 1, "price_per_rtc": "0.100001",
+        })
+        self.app.post("/api/orders", json={
+            "side": "buy", "pair": "RTC/USDC",
+            "wallet": "buyer-precision-2", "amount_rtc": 1, "price_per_rtc": "0.100002",
+        })
+
+        r = self.app.get("/api/orderbook?pair=RTC/USDC")
+        data = r.get_json()
+        self.assertTrue(data["ok"])
+        self.assertEqual(len(data["bids"]), 2)
+        self.assertEqual(data["bids"][0]["price"], 0.100002)
+        self.assertEqual(data["bids"][1]["price"], 0.100001)
+
     # ---------------------------------------------------------------
     # Order Matching
     # ---------------------------------------------------------------
@@ -288,9 +462,15 @@ class OTCBridgeTestCase(unittest.TestCase):
         # Confirm settlement
         with patch("requests.post") as mock_post:
             mock_post.return_value = MagicMock(ok=True, text='{"ok":true}')
+            with sqlite3.connect(TEST_DB) as conn:
+                secret = conn.execute(
+                    "SELECT htlc_secret FROM orders WHERE order_id = ?",
+                    (order_id,),
+                ).fetchone()[0]
             r3 = self.app.post(f"/api/orders/{order_id}/confirm", json={
                 "wallet": "buyer1",
                 "quote_tx": "0xabc123def456",
+                "secret": secret,
             })
             data = r3.get_json()
             self.assertTrue(data["ok"])


### PR DESCRIPTION
Fixes #5034.

## Summary
- Replaces OTC bridge canonical SQLite money storage with scaled integer columns:
  - `amount_micro_rtc`
  - `price_per_rtc_nano_quote`
  - `total_quote_nano`
- Keeps existing public API compatibility by rendering `amount_rtc`, `price_per_rtc`, and `total_quote` from the scaled integer fields.
- Adds migration/backfill support for existing DBs that still have the old REAL columns.
- Updates order listing, matching, trade history, order book aggregation, and stats to use integer-backed values.
- Adds regression tests proving fresh schemas do not create the old REAL money columns and that near-equal prices no longer collapse through `ROUND(price_per_rtc, 4)`.

## Validation
- `python -m pytest .\tests\test_otc_bridge_query_validation.py .\otc-bridge\test_otc_bridge.py -q` -> `30 passed`
- `python -m py_compile .\otc-bridge\otc_bridge.py .\otc-bridge\test_otc_bridge.py`
- `git diff --check`
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`
