### PR TITLE
fix: restrict OTC bridge CORS origins

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -40,6 +40,22 @@ from flask_cors import CORS
 
 RUSTCHAIN_NODE = os.environ.get("RUSTCHAIN_NODE", "https://50.28.86.131")
 DB_PATH = os.environ.get("OTC_DB_PATH", "otc_bridge.db")
+DEFAULT_OTC_CORS_ORIGINS = ("https://bottube.ai", "https://rustchain.org")
+
+
+def _parse_cors_origins(raw_origins):
+    if raw_origins is None:
+        return list(DEFAULT_OTC_CORS_ORIGINS)
+
+    origins = [
+        origin.strip()
+        for origin in raw_origins.split(",")
+        if origin.strip() and origin.strip() != "*"
+    ]
+    return origins or list(DEFAULT_OTC_CORS_ORIGINS)
+
+
+OTC_CORS_ORIGINS = _parse_cors_origins(os.environ.get("OTC_CORS_ORIGINS"))
 
 # TLS verification: defaults to True (secure).
 # Set RUSTCHAIN_TLS_VERIFY=false only for local development with self-signed certs.
@@ -73,7 +89,7 @@ log = logging.getLogger("otc_bridge")
 logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__, static_folder="static")
-CORS(app)
+CORS(app, origins=OTC_CORS_ORIGINS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -5,14 +5,17 @@ import types
 from pathlib import Path
 
 
-def load_otc_bridge(tmp_path):
-    if "flask_cors" not in sys.modules:
-        flask_cors = types.ModuleType("flask_cors")
-        flask_cors.CORS = lambda app: app
-        sys.modules["flask_cors"] = flask_cors
+def load_otc_bridge(tmp_path, cors_origins=None):
+    flask_cors = sys.modules.get("flask_cors") or types.ModuleType("flask_cors")
+    flask_cors.CORS = lambda app, **kwargs: app
+    sys.modules["flask_cors"] = flask_cors
 
     db_path = tmp_path / "otc_bridge.db"
     os.environ["OTC_DB_PATH"] = str(db_path)
+    if cors_origins is None:
+        os.environ.pop("OTC_CORS_ORIGINS", None)
+    else:
+        os.environ["OTC_CORS_ORIGINS"] = cors_origins
 
     module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
     spec = importlib.util.spec_from_file_location("otc_bridge_under_test", module_path)
@@ -21,6 +24,25 @@ def load_otc_bridge(tmp_path):
     module.app.testing = True
     module.init_db()
     return module
+
+
+def test_cors_defaults_to_restricted_public_origins(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    assert otc_bridge.OTC_CORS_ORIGINS == ["https://bottube.ai", "https://rustchain.org"]
+    assert "*" not in otc_bridge.OTC_CORS_ORIGINS
+
+
+def test_cors_env_ignores_wildcard_origin(tmp_path):
+    otc_bridge = load_otc_bridge(
+        tmp_path,
+        cors_origins="*, https://trusted.example, http://localhost:3000",
+    )
+
+    assert otc_bridge.OTC_CORS_ORIGINS == [
+        "https://trusted.example",
+        "http://localhost:3000",
+    ]
 
 
 def test_orders_rejects_malformed_pagination(tmp_path):


### PR DESCRIPTION
﻿## Summary

Fixes #5054 by removing wildcard CORS from the OTC bridge.

## What changed

- Added restricted default OTC bridge CORS origins: `https://bottube.ai` and `https://rustchain.org`.
- Added `OTC_CORS_ORIGINS` as a comma-separated allowlist for deployments that need additional trusted origins.
- Ignored wildcard `*` entries and fell back to restricted defaults if the env value is empty or wildcard-only.
- Added regression coverage proving the default is not wildcard and wildcard env entries are not accepted.

## Why

`CORS(app)` allowed any website origin to read OTC bridge API responses. The bridge exposes order/trade APIs, so keeping cross-origin access to trusted frontends only reduces CSRF-style and data-exposure risk for browser users.

## Validation

- `python -m pytest .\tests\test_otc_bridge_query_validation.py -q` -> 7 passed
- `python -m pytest .\tests\test_otc_bridge_query_validation.py -q -k cors` -> 2 passed, 5 deselected
- `python -m py_compile .\otc-bridge\otc_bridge.py .\tests\test_otc_bridge_query_validation.py` -> passed
- `git diff --check` -> passed
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- Direct Flask-CORS header check in a temporary venv with `otc-bridge/requirements.txt`: allowed origin got `Access-Control-Allow-Origin`; unlisted origin got no CORS allow header.

Note: the older `otc-bridge/test_otc_bridge.py` suite still has a Windows tempfile/SQLite teardown issue in this environment (`PermissionError` deleting the shared temp DB), which then causes cascading rate-limit failures. That appears independent of this CORS change.

No production OTC bridge, live wallet, private key, token transfer, or destructive request was used.

Bounty #71 payout wallet if eligible: `RTCda4841be5b2d109da5d995fb864c09676bb5b7c7`