### PR TITLE
[UTXO-BUG] Reject non-int64 UTXO numeric fields

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -241,6 +241,14 @@ class TestUtxoDB(unittest.TestCase):
         """Oversized timestamps must reject cleanly before SQLite persistence."""
         self._apply_coinbase('alice', 100 * UNIT)
         alice_boxes = self.db.get_unspent_for_address('alice')
+        opened = []
+        original_conn = self.db._conn
+
+        def tracking_conn():
+            opened.append(True)
+            return original_conn()
+
+        self.db._conn = tracking_conn
 
         ok = self.db.apply_transaction({
             'tx_type': 'transfer',
@@ -252,6 +260,7 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
 
         self.assertFalse(ok)
+        self.assertFalse(opened)
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
 
@@ -259,6 +268,14 @@ class TestUtxoDB(unittest.TestCase):
         """Invalid block heights must not reach box-id serialization."""
         self._apply_coinbase('alice', 100 * UNIT)
         alice_boxes = self.db.get_unspent_for_address('alice')
+        opened = []
+        original_conn = self.db._conn
+
+        def tracking_conn():
+            opened.append(True)
+            return original_conn()
+
+        self.db._conn = tracking_conn
 
         ok = self.db.apply_transaction({
             'tx_type': 'transfer',
@@ -269,6 +286,7 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=-1)
 
         self.assertFalse(ok)
+        self.assertFalse(opened)
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
 

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -15,7 +15,7 @@ import unittest
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
-    MAX_OUTPUTS,
+    MAX_OUTPUTS, MAX_SQLITE_INT64,
 )
 
 
@@ -234,6 +234,41 @@ class TestUtxoDB(unittest.TestCase):
 
         self.assertFalse(ok)
         # Balances unchanged
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_timestamp_above_sqlite_int64_rejected(self):
+        """Oversized timestamps must reject cleanly before SQLite persistence."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        alice_boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': MAX_SQLITE_INT64 + 1,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_negative_block_height_rejected(self):
+        """Invalid block heights must not reach box-id serialization."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        alice_boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=-1)
+
+        self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
 

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -688,6 +688,36 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
 
+    def test_mempool_rejects_oversized_timestamp_without_locking_input(self):
+        """Mempool metadata validation must mirror apply_transaction."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        tx = {
+            'tx_id': 'tsov' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': MAX_SQLITE_INT64 + 1,
+        }
+
+        ok = self.db.mempool_add(tx)
+
+        self.assertFalse(ok)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM utxo_mempool_inputs WHERE box_id = ?",
+                (box['box_id'],),
+            ).fetchone()
+            self.assertEqual(row['n'], 0)
+        finally:
+            conn.close()
+
     # -- fix(#9273): mempool output validation ------------------------------
 
     def test_mempool_rejects_too_many_outputs(self):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -482,6 +482,8 @@ class UtxoDB:
 
         Returns True on success, False on validation failure.
         """
+        own = conn is None
+
         ts = tx.get('timestamp', int(time.time()))
         if not _is_nonnegative_int64(ts):
             return False

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -43,9 +43,24 @@ MAX_POOL_SIZE = 10_000
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
 MAX_OUTPUTS = 100
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
+MAX_SQLITE_INT64 = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
 SUPPORTED_TX_TYPES = {'transfer', 'mining_reward'}
 MINTING_TX_TYPES = {'mining_reward'}
+
+
+# ---------------------------------------------------------------------------
+# Numeric validation
+# ---------------------------------------------------------------------------
+
+def _is_nonnegative_int64(value: Any) -> bool:
+    """Return True only for real ints that SQLite can persist as INTEGER."""
+    return type(value) is int and 0 <= value <= MAX_SQLITE_INT64
+
+
+def _is_positive_int64(value: Any) -> bool:
+    """Return True only for positive int64 amounts."""
+    return type(value) is int and 0 < value <= MAX_SQLITE_INT64
 
 
 # ---------------------------------------------------------------------------
@@ -399,11 +414,7 @@ class UtxoDB:
                 return None
 
             val = out.get('value_nrtc')
-            if (
-                isinstance(val, bool)
-                or not isinstance(val, int)
-                or val < DUST_THRESHOLD
-            ):
+            if not _is_positive_int64(val) or val < DUST_THRESHOLD:
                 return None
 
             tokens_json = out.get('tokens_json', '[]')
@@ -472,6 +483,11 @@ class UtxoDB:
         Returns True on success, False on validation failure.
         """
         ts = tx.get('timestamp', int(time.time()))
+        if not _is_nonnegative_int64(ts):
+            return False
+        if not _is_nonnegative_int64(block_height):
+            return False
+
         # NOTE(issue #2085): spending_proof is present on each input dict but
         # is intentionally ignored by this layer.  It is stored for
         # on-chain auditability, but cryptographic verification is the sole
@@ -573,13 +589,7 @@ class UtxoDB:
             if tx_type in MINTING_TX_TYPES and output_total > MAX_COINBASE_OUTPUT_NRTC:
                 return abort()
 
-            if type(fee) is not int:
-                return abort()
-            if fee < 0:
-                return abort()
-            if type(ts) is not int:
-                return abort()
-            if ts < 0 or ts > 2**63 - 1:
+            if not _is_nonnegative_int64(fee):
                 return abort()
             if inputs and (output_total + fee) > input_total:
                 return abort()
@@ -876,11 +886,7 @@ class UtxoDB:
             # Prevent mempool admission of transactions that would fail
             # apply_transaction(), locking UTXOs until expiry (DoS vector).
             fee = tx.get('fee_nrtc', 0)
-            if type(fee) is not int:
-                if manage_tx:
-                        conn.execute("ROLLBACK")
-                return False
-            if fee < 0:
+            if not _is_nonnegative_int64(fee):
                 if manage_tx:
                         conn.execute("ROLLBACK")
                 return False

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -836,6 +836,9 @@ class UtxoDB:
                 return False
             data_inputs = tx.get('data_inputs', [])
             now = int(time.time())
+            timestamp = tx.get('timestamp', now)
+            if not _is_nonnegative_int64(timestamp):
+                return False
 
             # Public mempool admission must never accept minting transactions.
             # Coinbase/mining rewards are internally constructed during block


### PR DESCRIPTION
## Summary
- add explicit SQLite int64 bounds checks for UTXO timestamps, block heights, fees, and output values
- reject invalid numeric fields before box-id serialization or SQLite INTEGER persistence
- add regression tests for oversized timestamps and invalid block heights so these paths fail closed instead of raising

## Bounty
- Targets Scottcjn/rustchain-bounties#2819 (UTXO red-team review)

## Tests
- python3 -m unittest test_utxo_db.TestUtxoDB.test_timestamp_above_sqlite_int64_rejected test_utxo_db.TestUtxoDB.test_negative_block_height_rejected
- python3 -m unittest test_utxo_db
- python3 -m py_compile node/utxo_db.py node/test_utxo_db.py
- git diff --check

## Payout
- RTC Wallet: `RTC4e9b755109fc7b898eaebbd20ad665d9855449eb`
- Readable alias: `zhoueu-star-mac` (not an RTC address)