### PR TITLE
Fix explorer transaction DOM XSS

### DIFF
--- a/explorer/enhanced-explorer.html
+++ b/explorer/enhanced-explorer.html
@@ -623,9 +623,9 @@
             if (transactions.transactions && transactions.transactions.length > 0) {
                 table.innerHTML = transactions.transactions.slice(0, 20).map(tx => `
                     <tr>
-                        <td><code>${tx.hash || tx.tx_hash || 'N/A'}</code></td>
-                        <td><code>${tx.from || 'N/A'}</code></td>
-                        <td><code>${tx.to || 'N/A'}</code></td>
+                        <td><code>${esc(tx.hash || tx.tx_hash || 'N/A')}</code></td>
+                        <td><code>${esc(tx.from || 'N/A')}</code></td>
+                        <td><code>${esc(tx.to || 'N/A')}</code></td>
                         <td>${(tx.amount / 1000000 || 0).toFixed(2)} RTC</td>
                         <td>${(tx.fee / 1000000 || 0).toFixed(4)} RTC</td>
                         <td>${formatTime(tx.timestamp)}</td>

--- a/explorer/test_enhanced_explorer_xss.py
+++ b/explorer/test_enhanced_explorer_xss.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 class TestEnhancedExplorerXss(unittest.TestCase):
     def setUp(self):
-        self.html = Path("enhanced-explorer.html").read_text()
+        self.html = Path(__file__).with_name("enhanced-explorer.html").read_text()
 
     def test_transaction_identity_fields_are_escaped(self):
         self.assertIn("${esc(tx.hash || tx.tx_hash || 'N/A')}", self.html)

--- a/explorer/test_enhanced_explorer_xss.py
+++ b/explorer/test_enhanced_explorer_xss.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+
+
+class TestEnhancedExplorerXss(unittest.TestCase):
+    def setUp(self):
+        self.html = Path("enhanced-explorer.html").read_text()
+
+    def test_transaction_identity_fields_are_escaped(self):
+        self.assertIn("${esc(tx.hash || tx.tx_hash || 'N/A')}", self.html)
+        self.assertIn("${esc(tx.from || 'N/A')}", self.html)
+        self.assertIn("${esc(tx.to || 'N/A')}", self.html)
+
+        self.assertNotIn("${tx.hash || tx.tx_hash || 'N/A'}</code>", self.html)
+        self.assertNotIn("${tx.from || 'N/A'}</code>", self.html)
+        self.assertNotIn("${tx.to || 'N/A'}</code>", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/explorer/test_enhanced_explorer_xss.py
+++ b/explorer/test_enhanced_explorer_xss.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 class TestEnhancedExplorerXss(unittest.TestCase):
     def setUp(self):
-        self.html = Path(__file__).with_name("enhanced-explorer.html").read_text()
+        self.html = Path(__file__).with_name("enhanced-explorer.html").read_text(
+            encoding="utf-8"
+        )
 
     def test_transaction_identity_fields_are_escaped(self):
         self.assertIn("${esc(tx.hash || tx.tx_hash || 'N/A')}", self.html)

--- a/explorer/test_enhanced_explorer_xss.py
+++ b/explorer/test_enhanced_explorer_xss.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import unittest
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- escape transaction hash/from/to before rendering them through enhanced-explorer.html innerHTML
- add a regression test that checks transaction identity fields are passed through esc()

## Bounty
- Targets Scottcjn/rustchain-bounties#68 (Block Explorer & Dashboard hardening)
- Finding class: API response injection / DOM XSS in transaction table rendering

## Tests
- python3 -m unittest test_enhanced_explorer_xss.py
- python3 -m py_compile explorer/test_enhanced_explorer_xss.py
- git diff --check

## Payout
- RTC Wallet / miner_id: `zhoueu-star-mac`