### PR TITLE
fix: require admin auth for boot chime mutations

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -7,6 +7,7 @@ Integrates with RustChain node for miner attestation.
 
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
+import hmac
 import json
 import os
 import time
@@ -63,6 +64,37 @@ def get_json_object() -> Dict[str, Any]:
     return data
 
 
+def get_admin_key() -> str:
+    """Return the configured boot chime admin key."""
+    return os.getenv('BOOT_CHIME_ADMIN_KEY') or os.getenv('RC_ADMIN_KEY') or ''
+
+
+def get_request_admin_key() -> str:
+    """Return the admin key supplied with the current request."""
+    key = request.headers.get('X-Admin-Key', '')
+    if key:
+        return key
+
+    authorization = request.headers.get('Authorization', '')
+    if authorization.startswith('Bearer '):
+        return authorization.removeprefix('Bearer ').strip()
+
+    return ''
+
+
+def require_admin_key():
+    """Fail closed unless a configured admin key is supplied."""
+    expected_key = get_admin_key()
+    if not expected_key:
+        return jsonify({'error': 'BOOT_CHIME_ADMIN_KEY or RC_ADMIN_KEY not configured'}), 503
+
+    provided_key = get_request_admin_key()
+    if not hmac.compare_digest(provided_key, expected_key):
+        return jsonify({'error': 'unauthorized'}), 401
+
+    return None
+
+
 # ============= Health & Info =============
 
 @app.route('/health', methods=['GET'])
@@ -113,6 +145,10 @@ def issue_challenge():
             "expires_at": 1234567890
         }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     try:
         data = get_json_object()
         miner_id = data.get('miner_id')
@@ -158,6 +194,10 @@ def submit_proof():
             "ttl_seconds": 86400
         }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     try:
         miner_id = request.form.get('miner_id')
         challenge_id = request.form.get('challenge_id')
@@ -242,6 +282,10 @@ def enroll_miner():
             "confidence": 0.92
         }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     try:
         miner_id = request.form.get('miner_id')
         
@@ -277,6 +321,10 @@ def capture_audio():
     
     Response: WAV file
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     try:
         duration = request.args.get('duration', default=5.0, type=float)
         trigger = request.args.get('trigger', default='false').lower() == 'true'
@@ -313,6 +361,10 @@ def revoke_attestation():
     Response:
         { "success": true, "message": "..." }
     """
+    auth_error = require_admin_key()
+    if auth_error:
+        return auth_error
+
     try:
         data = get_json_object()
         miner_id = data.get('miner_id')

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -7,6 +7,7 @@ import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_KEY = "test-admin-key"
 
 
 class ChallengeStub:
@@ -65,6 +66,8 @@ def install_dependency_stubs(monkeypatch):
 
 @pytest.fixture
 def api_module(monkeypatch):
+    monkeypatch.setenv("BOOT_CHIME_ADMIN_KEY", ADMIN_KEY)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
     install_dependency_stubs(monkeypatch)
     module_path = REPO_ROOT / "issue2307_boot_chime" / "boot_chime_api.py"
     spec = importlib.util.spec_from_file_location("boot_chime_api_under_test", module_path)
@@ -79,16 +82,66 @@ def client(api_module):
     return api_module.app.test_client()
 
 
+def admin_headers():
+    return {"X-Admin-Key": ADMIN_KEY}
+
+
+@pytest.mark.parametrize(
+    "path, kwargs",
+    (
+        ("/api/v1/challenge", {"json": {"miner_id": "miner-1"}}),
+        ("/api/v1/submit", {"data": {"miner_id": "miner-1", "challenge_id": "c1", "timestamp": "100"}}),
+        ("/api/v1/enroll", {"data": {"miner_id": "miner-1"}}),
+        ("/api/v1/capture", {}),
+        ("/api/v1/revoke", {"json": {"miner_id": "miner-1"}}),
+    ),
+)
+def test_mutating_endpoints_require_admin_key(client, path, kwargs):
+    response = client.post(path, **kwargs)
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "unauthorized"}
+
+
+def test_mutating_endpoints_fail_closed_without_configured_admin_key(client, monkeypatch):
+    monkeypatch.delenv("BOOT_CHIME_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    response = client.post(
+        "/api/v1/revoke",
+        headers=admin_headers(),
+        json={"miner_id": "miner-1"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "BOOT_CHIME_ADMIN_KEY or RC_ADMIN_KEY not configured"}
+
+
+def test_authorization_bearer_admin_key_is_accepted(client, api_module):
+    response = client.post(
+        "/api/v1/challenge",
+        headers={"Authorization": f"Bearer {ADMIN_KEY}"},
+        json={"miner_id": "miner-1"},
+    )
+
+    assert response.status_code == 200
+    assert api_module.poi_system.issued_for == "miner-1"
+
+
 @pytest.mark.parametrize("path", ("/api/v1/challenge", "/api/v1/revoke"))
 def test_json_endpoints_reject_non_object_bodies(client, path):
-    response = client.post(path, json=["not", "object"])
+    response = client.post(path, headers=admin_headers(), json=["not", "object"])
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "JSON object required"}
 
 
 def test_challenge_accepts_valid_json_body(client, api_module):
-    response = client.post("/api/v1/challenge", json={"miner_id": "miner-1"})
+    response = client.post(
+        "/api/v1/challenge",
+        headers=admin_headers(),
+        json={"miner_id": "miner-1"},
+    )
 
     assert response.status_code == 200
     assert api_module.poi_system.issued_for == "miner-1"
@@ -98,6 +151,7 @@ def test_challenge_accepts_valid_json_body(client, api_module):
 def test_revoke_accepts_valid_json_body(client, api_module):
     response = client.post(
         "/api/v1/revoke",
+        headers=admin_headers(),
         json={"miner_id": "miner-1", "reason": "retired"},
     )
 


### PR DESCRIPTION
Fixes #5068.

Summary:
- Adds fail-closed admin key authentication for all five boot chime POST endpoints: `/api/v1/challenge`, `/api/v1/submit`, `/api/v1/enroll`, `/api/v1/capture`, and `/api/v1/revoke`.
- Accepts `X-Admin-Key` or `Authorization: Bearer <key>`.
- Uses `BOOT_CHIME_ADMIN_KEY` with `RC_ADMIN_KEY` fallback.
- Uses `hmac.compare_digest()` and returns 503 when no admin key is configured.
- Keeps read-only health/info/status/identity/metrics endpoints unchanged.

Validation:
- `python -m pytest .\tests\test_boot_chime_api_json_validation.py -q` -> 11 passed
- `python -m py_compile .\issue2307_boot_chime\boot_chime_api.py .\tests\test_boot_chime_api_json_validation.py`
- `git diff --check`
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Note:
- I also attempted `python -m pytest .\tests\test_boot_chime_api_json_validation.py .\test_pickle_to_json_migration.py -q`; collection of the second, unrelated test file requires local `numpy`, so I did not count it as validation for this boot chime API change.