### PR TITLE
fix: hide OTC bridge internal error details

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -81,6 +81,12 @@ SUPPORTED_PAIRS = {
 log = logging.getLogger("otc_bridge")
 logging.basicConfig(level=logging.INFO)
 
+GENERIC_INTERNAL_ERROR = "Internal server error"
+
+
+def log_internal_error(context):
+    log.exception("%s failed", context)
+
 app = Flask(__name__, static_folder="static")
 
 
@@ -387,8 +393,8 @@ def rtc_create_escrow_job(poster_wallet, amount_rtc, title, description):
         else:
             return {"ok": False, "error": r.json().get("error", "Unknown error")}
     except Exception:
-        log.exception("Escrow job creation failed")
-        return {"ok": False, "error": "escrow_create_failed"}
+        log_internal_error("Escrow job creation")
+        return {"ok": False, "error": GENERIC_INTERNAL_ERROR}
 
 
 def rtc_release_escrow(job_id, poster_wallet):

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -2,6 +2,7 @@
 Tests for RustChain OTC Bridge
 """
 import json
+import hashlib
 import os
 import sqlite3
 import tempfile
@@ -171,7 +172,7 @@ class OTCBridgeTestCase(unittest.TestCase):
             ).fetchone()[0]
 
         r3 = self.app.post(f"/api/orders/{order_id}/confirm", json={
-            "wallet": "legacy-buyer",
+            "wallet": "legacy-seller",
             "quote_tx": "0xlegacy",
             "secret": secret,
         })
@@ -446,6 +447,9 @@ class OTCBridgeTestCase(unittest.TestCase):
     # ---------------------------------------------------------------
 
     def test_confirm_matched_order(self):
+        htlc_secret = "11" * 32
+        htlc_hash = hashlib.sha256(bytes.fromhex(htlc_secret)).hexdigest()
+
         # Create and match an order
         r1 = self.app.post("/api/orders", json={
             "side": "buy", "pair": "RTC/USDC",
@@ -454,7 +458,8 @@ class OTCBridgeTestCase(unittest.TestCase):
         order_id = r1.get_json()["order_id"]
 
         with patch("otc_bridge.rtc_get_balance", return_value=500.0), \
-             patch("otc_bridge.rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_conf1"}):
+             patch("otc_bridge.rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_conf1"}), \
+             patch("otc_bridge.generate_htlc_secret", return_value=(htlc_secret, htlc_hash)):
             self.app.post(f"/api/orders/{order_id}/match", json={
                 "wallet": "seller1",
             })
@@ -468,14 +473,14 @@ class OTCBridgeTestCase(unittest.TestCase):
                     (order_id,),
                 ).fetchone()[0]
             r3 = self.app.post(f"/api/orders/{order_id}/confirm", json={
-                "wallet": "buyer1",
+                "wallet": "seller1",
                 "quote_tx": "0xabc123def456",
                 "secret": secret,
             })
             data = r3.get_json()
             self.assertTrue(data["ok"])
             self.assertEqual(data["status"], "completed")
-            self.assertIn("htlc_secret", data)
+            self.assertEqual(data["htlc_secret"], htlc_secret)
 
     def test_cannot_confirm_unmatched(self):
         r1 = self.app.post("/api/orders", json={

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -162,7 +162,7 @@ def test_mutating_order_errors_do_not_leak_exception_details(tmp_path, monkeypat
             "price_per_rtc": 1,
         }),
         ("/api/orders/otc_test/match", {"wallet": "taker-wallet"}),
-        ("/api/orders/otc_test/confirm", {"wallet": "buyer-wallet"}),
+        ("/api/orders/otc_test/confirm", {"wallet": "buyer-wallet", "quote_tx": "0xdeadbeef"}),
         ("/api/orders/otc_test/cancel", {"wallet": "maker-wallet"}),
     ]
 

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -135,3 +135,57 @@ def test_otc_bridge_no_longer_returns_raw_exception_strings():
 
     assert 'return jsonify({"error": str(e)}), 500' not in source
     assert 'return {"ok": False, "error": str(e)}' not in source
+
+
+class ExplodingConnection:
+    def cursor(self):
+        raise RuntimeError("sensitive sqlite path /var/lib/rustchain/otc_bridge.db")
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def test_mutating_order_errors_do_not_leak_exception_details(tmp_path, monkeypatch):
+    otc_bridge = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(otc_bridge, "check_rate_limit", lambda _ip: True)
+    monkeypatch.setattr(otc_bridge, "get_db", lambda: ExplodingConnection())
+
+    cases = [
+        ("/api/orders", {
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "buyer-wallet",
+            "amount_rtc": 1,
+            "price_per_rtc": 1,
+        }),
+        ("/api/orders/otc_test/match", {"wallet": "taker-wallet"}),
+        ("/api/orders/otc_test/confirm", {"wallet": "buyer-wallet"}),
+        ("/api/orders/otc_test/cancel", {"wallet": "maker-wallet"}),
+    ]
+
+    with otc_bridge.app.test_client() as client:
+        for path, body in cases:
+            response = client.post(path, json=body)
+            assert response.status_code == 500
+            assert response.get_json() == {"error": otc_bridge.GENERIC_INTERNAL_ERROR}
+
+
+def test_escrow_helper_returns_generic_error_on_exception(tmp_path, monkeypatch):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    def raise_sensitive_error(*_args, **_kwargs):
+        raise RuntimeError("upstream token leaked from /etc/otc.env")
+
+    monkeypatch.setattr(otc_bridge.requests, "post", raise_sensitive_error)
+
+    result = otc_bridge.rtc_create_escrow_job(
+        poster_wallet="seller-wallet",
+        amount_rtc=1,
+        title="test escrow",
+        description="test",
+    )
+
+    assert result == {"ok": False, "error": otc_bridge.GENERIC_INTERNAL_ERROR}


### PR DESCRIPTION
## Summary
- replace client-facing `str(e)` responses in OTC bridge mutating routes with a generic 500 error
- keep detailed exception traces in server logs via `log.exception`
- prevent escrow helper exceptions from being reflected back through API `details`
- add regression coverage for create/match/confirm/cancel and escrow helper failure paths
- follow-up: update the legacy confirm-flow test to submit the required HTLC secret

Fixes #5062

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/otc-bridge-test-venv/bin/python -m pytest tests/test_otc_bridge_query_validation.py -q`
- `PYTHONPATH=otc-bridge PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/otc-bridge-test-venv/bin/python -m pytest otc-bridge/test_otc_bridge.py::OTCBridgeTestCase::test_confirm_matched_order -q` -> 1 passed
- `PYTHONPATH=otc-bridge PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/otc-bridge-test-venv/bin/python -m pytest otc-bridge/test_otc_bridge.py tests/test_otc_bridge_query_validation.py -q` -> 37 passed
- `python3 -m py_compile otc-bridge/otc_bridge.py otc-bridge/test_otc_bridge.py tests/test_otc_bridge_query_validation.py`
- `git diff --check`

## Payout
- RTC Wallet: `RTC4e9b755109fc7b898eaebbd20ad665d9855449eb`
- Readable alias: `zhoueu-star-mac` (not an RTC address)