### PR TITLE
fix: hide OTC bridge internal errors

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -212,6 +212,12 @@ def non_negative_int_arg(name, default):
     return value, None
 
 
+def internal_error_response(operation):
+    """Log internal exception details without exposing them to clients."""
+    log.exception("%s failed", operation)
+    return jsonify({"error": "Internal server error"}), 500
+
+
 # ---------------------------------------------------------------------------
 # Rate Limiting
 # ---------------------------------------------------------------------------
@@ -293,8 +299,9 @@ def rtc_create_escrow_job(poster_wallet, amount_rtc, title, description):
             return {"ok": True, "job_id": data.get("job_id")}
         else:
             return {"ok": False, "error": r.json().get("error", "Unknown error")}
-    except Exception as e:
-        return {"ok": False, "error": str(e)}
+    except Exception:
+        log.exception("Escrow job creation failed")
+        return {"ok": False, "error": "escrow_create_failed"}
 
 
 def rtc_release_escrow(job_id, poster_wallet):
@@ -442,12 +449,12 @@ def create_order():
 
         return jsonify(response), 201
 
-    except Exception as e:
+    except Exception:
         conn.rollback()
         # If we created an escrow job but DB insert failed, cancel it
         if escrow_job_id:
             rtc_cancel_escrow(escrow_job_id, maker_wallet)
-        return jsonify({"error": str(e)}), 500
+        return internal_error_response("Order creation")
     finally:
         conn.close()
 
@@ -645,9 +652,9 @@ def match_order(order_id):
 
         return jsonify(response)
 
-    except Exception as e:
+    except Exception:
         conn.rollback()
-        return jsonify({"error": str(e)}), 500
+        return internal_error_response("Order match")
     finally:
         conn.close()
 
@@ -762,10 +769,9 @@ def confirm_order(order_id):
             "message": f"Trade completed. {order['amount_rtc']} RTC released to {rtc_recipient}. HTLC secret verified and revealed."
         })
 
-    except Exception as e:
+    except Exception:
         conn.rollback()
-        log.error(f"Confirm error: {e}")
-        return jsonify({"error": str(e)}), 500
+        return internal_error_response("Order confirmation")
     finally:
         conn.close()
 
@@ -807,9 +813,9 @@ def cancel_order(order_id):
             "status": "cancelled",
             "message": "Order cancelled. Escrow refunded."
         })
-    except Exception as e:
+    except Exception:
         conn.rollback()
-        return jsonify({"error": str(e)}), 500
+        return internal_error_response("Order cancellation")
     finally:
         conn.close()
 

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -5,6 +5,9 @@ import types
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 def load_otc_bridge(tmp_path):
     if "flask_cors" not in sys.modules:
         flask_cors = types.ModuleType("flask_cors")
@@ -80,3 +83,35 @@ def test_trades_accepts_capped_limit(tmp_path):
 
     assert response.status_code == 200
     assert response.get_json() == {"ok": True, "trades": []}
+
+
+def test_unexpected_order_errors_are_generic(tmp_path, monkeypatch):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    def fail_hash(_ip):
+        raise RuntimeError("sensitive sqlite path: C:/private/otc_bridge.db")
+
+    monkeypatch.setattr(otc_bridge, "check_rate_limit", lambda _ip: True)
+    monkeypatch.setattr(otc_bridge, "hash_ip", fail_hash)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": 1,
+                "price_per_rtc": 0.10,
+            },
+        )
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Internal server error"}
+
+
+def test_otc_bridge_no_longer_returns_raw_exception_strings():
+    source = (REPO_ROOT / "otc-bridge" / "otc_bridge.py").read_text(encoding="utf-8")
+
+    assert 'return jsonify({"error": str(e)}), 500' not in source
+    assert 'return {"ok": False, "error": str(e)}' not in source


### PR DESCRIPTION
Fixes #5062.

Summary:
- Replaces route-level raw `str(e)` 500 responses with a generic `Internal server error` response.
- Logs the detailed exception server-side via `log.exception()` so operators keep diagnostic detail without exposing it to clients.
- Replaces the OTC escrow helper's exception text with a stable `escrow_create_failed` code so upstream/network internals do not leak through `details`.
- Keeps existing explicit 4xx validation errors unchanged.

Validation:
- `python -m pytest .\tests\test_otc_bridge_query_validation.py -q` -> 7 passed
- `python -m pytest .\otc-bridge\test_otc_bridge.py::OTCBridgeTestCase::test_create_buy_order -q` -> 1 passed
- Source scan: no `return jsonify({error: str(e)}), 500` or `return {ok: False, error: str(e)}` remains in `otc-bridge/otc_bridge.py`
- `python -m py_compile .\otc-bridge\otc_bridge.py .\tests\test_otc_bridge_query_validation.py`
- `git diff --check`
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Note:
- The full legacy `otc-bridge/test_otc_bridge.py` suite is flaky on this Windows workspace because its shared temp SQLite DB remains locked during teardown; I therefore validated the touched query-validation suite plus a legacy order-creation smoke test instead of claiming the full legacy suite.