### PR TITLE
feat: add batch block query endpoint

### DIFF
--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -664,6 +664,13 @@ def _normalize_block_identifier(raw):
     return None
 
 
+def _blocks_table_missing(exc: sqlite3.Error) -> bool:
+    return (
+        isinstance(exc, sqlite3.OperationalError)
+        and "no such table: blocks" in str(exc).lower()
+    )
+
+
 def create_block_api_routes(app, producer: BlockProducer, validator: BlockValidator):
     """Create Flask routes for block API"""
     from flask import request, jsonify
@@ -754,8 +761,12 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
                         height_misses,
                     ).fetchall()
                 except sqlite3.Error as exc:
-                    logger.debug("Block batch height lookup failed: %s", exc)
-                    rows = []
+                    if _blocks_table_missing(exc):
+                        logger.debug("Block batch height lookup skipped: %s", exc)
+                        rows = []
+                    else:
+                        logger.exception("Block batch height lookup failed")
+                        return jsonify({"ok": False, "error": "Block database unavailable"}), 500
                 for row in rows:
                     block = _row_to_block(row)
                     found_by_key[("height", block["height"])] = block
@@ -770,8 +781,12 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
                         hash_misses,
                     ).fetchall()
                 except sqlite3.Error as exc:
-                    logger.debug("Block batch hash lookup failed: %s", exc)
-                    rows = []
+                    if _blocks_table_missing(exc):
+                        logger.debug("Block batch hash lookup skipped: %s", exc)
+                        rows = []
+                    else:
+                        logger.exception("Block batch hash lookup failed")
+                        return jsonify({"ok": False, "error": "Block database unavailable"}), 500
                 for row in rows:
                     block = _row_to_block(row)
                     found_by_key[("height", block["height"])] = block

--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -17,8 +17,15 @@ import time
 import threading
 import logging
 import json
+import os
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - Redis is optional for local nodes/tests.
+    redis = None
 
 from rustchain_crypto import (
     CanonicalBlockHeader,
@@ -45,6 +52,8 @@ GENESIS_TIMESTAMP = 1764706927  # Production chain launch (Dec 2, 2025)
 BLOCK_TIME = 600  # 10 minutes (600 seconds)
 MAX_TXS_PER_BLOCK = 1000
 ATTESTATION_TTL = 600  # 10 minutes
+MAX_BATCH_BLOCKS = 100
+BLOCK_BATCH_CACHE_TTL_SECONDS = 30
 
 
 # =============================================================================
@@ -567,6 +576,94 @@ class BlockValidator:
 # API ROUTES
 # =============================================================================
 
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _block_cache_client(app):
+    client = app.config.get("BLOCK_BATCH_REDIS")
+    if client is not None:
+        return client
+    if redis is None:
+        return None
+
+    redis_url = (
+        app.config.get("BLOCK_BATCH_REDIS_URL")
+        or os.getenv("RUSTCHAIN_BLOCK_BATCH_REDIS_URL")
+        or os.getenv("REDIS_URL")
+    )
+    if not redis_url:
+        return None
+
+    try:
+        client = redis.Redis.from_url(redis_url, decode_responses=True)
+    except Exception as exc:
+        logger.warning("Block batch Redis cache unavailable: %s", exc)
+        return None
+    app.config["BLOCK_BATCH_REDIS"] = client
+    return client
+
+
+def _cache_key(identifier_type: str, identifier) -> str:
+    return f"rustchain:block:{identifier_type}:{identifier}"
+
+
+def _cache_get_block(cache, identifier_type: str, identifier) -> Optional[Dict]:
+    if cache is None:
+        return None
+    try:
+        cached = cache.get(_cache_key(identifier_type, identifier))
+        if not cached:
+            return None
+        parsed = json.loads(cached)
+        return parsed if isinstance(parsed, dict) else None
+    except Exception as exc:
+        logger.debug("Block batch cache read failed: %s", exc)
+        return None
+
+
+def _cache_set_block(cache, block: Dict):
+    if cache is None:
+        return
+    encoded = json.dumps(block, sort_keys=True)
+    for identifier_type, identifier in (
+        ("height", block.get("height")),
+        ("hash", block.get("block_hash")),
+    ):
+        if identifier is None:
+            continue
+        try:
+            cache.setex(
+                _cache_key(identifier_type, identifier),
+                BLOCK_BATCH_CACHE_TTL_SECONDS,
+                encoded,
+            )
+        except Exception as exc:
+            logger.debug("Block batch cache write failed: %s", exc)
+
+
+def _row_to_block(row: sqlite3.Row) -> Dict:
+    block = dict(row)
+    if block.get("body_json"):
+        try:
+            block["body"] = json.loads(block["body_json"])
+        except (TypeError, ValueError):
+            pass
+    return block
+
+
+def _normalize_block_identifier(raw):
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return ("height", raw) if raw >= 0 else None
+    if isinstance(raw, str):
+        identifier = raw.strip()
+        if identifier:
+            return ("hash", identifier)
+    return None
+
+
 def create_block_api_routes(app, producer: BlockProducer, validator: BlockValidator):
     """Create Flask routes for block API"""
     from flask import request, jsonify
@@ -604,6 +701,99 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
             if row:
                 return jsonify(dict(row))
             return jsonify({"error": "Block not found"}), 404
+
+    @app.route('/v1/blocks/batch', methods=['POST'])
+    @app.route('/api/blocks/batch', methods=['POST'])
+    def get_blocks_batch():
+        """Get multiple blocks by height or hash in one request."""
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return jsonify({"ok": False, "error": "JSON object body required"}), 400
+
+        requested = payload.get("blocks")
+        if not isinstance(requested, list):
+            return jsonify({"ok": False, "error": "blocks must be an array"}), 400
+        if len(requested) > MAX_BATCH_BLOCKS:
+            return jsonify({
+                "ok": False,
+                "error": f"blocks cannot contain more than {MAX_BATCH_BLOCKS} entries",
+            }), 400
+
+        normalized = [_normalize_block_identifier(item) for item in requested]
+        if any(item is None for item in normalized):
+            return jsonify({
+                "ok": False,
+                "error": "blocks entries must be non-negative integer heights or non-empty hash strings",
+            }), 400
+        if not normalized:
+            return jsonify({"ok": True, "blocks": [], "count": 0, "missing": [], "timestamp": _utc_timestamp()})
+
+        cache = _block_cache_client(app)
+        found_by_key = {}
+        height_misses = []
+        hash_misses = []
+
+        for identifier_type, identifier in normalized:
+            cached = _cache_get_block(cache, identifier_type, identifier)
+            if cached is not None:
+                found_by_key[(identifier_type, identifier)] = cached
+            elif identifier_type == "height":
+                height_misses.append(identifier)
+            else:
+                hash_misses.append(identifier)
+
+        with sqlite3.connect(producer.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            cursor = conn.cursor()
+
+            if height_misses:
+                placeholders = ", ".join("?" for _ in height_misses)
+                try:
+                    rows = cursor.execute(
+                        f"SELECT * FROM blocks WHERE height IN ({placeholders})",
+                        height_misses,
+                    ).fetchall()
+                except sqlite3.Error as exc:
+                    logger.debug("Block batch height lookup failed: %s", exc)
+                    rows = []
+                for row in rows:
+                    block = _row_to_block(row)
+                    found_by_key[("height", block["height"])] = block
+                    found_by_key[("hash", block["block_hash"])] = block
+                    _cache_set_block(cache, block)
+
+            if hash_misses:
+                placeholders = ", ".join("?" for _ in hash_misses)
+                try:
+                    rows = cursor.execute(
+                        f"SELECT * FROM blocks WHERE block_hash IN ({placeholders})",
+                        hash_misses,
+                    ).fetchall()
+                except sqlite3.Error as exc:
+                    logger.debug("Block batch hash lookup failed: %s", exc)
+                    rows = []
+                for row in rows:
+                    block = _row_to_block(row)
+                    found_by_key[("height", block["height"])] = block
+                    found_by_key[("hash", block["block_hash"])] = block
+                    _cache_set_block(cache, block)
+
+        blocks = []
+        missing = []
+        for identifier_type, identifier in normalized:
+            block = found_by_key.get((identifier_type, identifier))
+            if block is None:
+                missing.append(identifier)
+                continue
+            blocks.append(block)
+
+        return jsonify({
+            "ok": True,
+            "blocks": blocks,
+            "count": len(blocks),
+            "missing": missing,
+            "timestamp": _utc_timestamp(),
+        })
 
     @app.route('/block/slot', methods=['GET'])
     def get_current_slot():

--- a/tests/test_block_batch_api.py
+++ b/tests/test_block_batch_api.py
@@ -162,6 +162,36 @@ def test_batch_blocks_treats_missing_table_as_missing_blocks(tmp_path):
     assert body["missing"] == [1, "hash1"]
 
 
+def test_batch_blocks_surfaces_non_missing_table_database_errors(tmp_path, monkeypatch):
+    class LockedCursor:
+        def execute(self, *args, **kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+    class LockedConnection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def cursor(self):
+            return LockedCursor()
+
+    monkeypatch.setattr(
+        block_producer.sqlite3,
+        "connect",
+        lambda db_path: LockedConnection(),
+    )
+    client, _ = _client(tmp_path)
+
+    response = client.post("/v1/blocks/batch", json={"blocks": [1]})
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["ok"] is False
+    assert body["error"] == "Block database unavailable"
+
+
 def test_batch_blocks_reads_from_configured_cache(tmp_path):
     cache = DummyCache()
     client, db_path = _client(tmp_path, cache)

--- a/tests/test_block_batch_api.py
+++ b/tests/test_block_batch_api.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+import types
+
+from flask import Flask
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "node"))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_block_producer.py")
+
+
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+crypto_mod = sys.modules.get("rustchain_crypto")
+if crypto_mod is None:
+    crypto_mod = types.SimpleNamespace()
+    sys.modules["rustchain_crypto"] = crypto_mod
+for name, value in {
+    "CanonicalBlockHeader": object,
+    "MerkleTree": object,
+    "SignedTransaction": object,
+    "Ed25519Signer": object,
+    "blake2b256_hex": lambda data: "0" * 64,
+    "canonical_json": lambda data: json.dumps(data, sort_keys=True).encode(),
+    "address_from_public_key": lambda public_key: "addr",
+}.items():
+    if not hasattr(crypto_mod, name):
+        setattr(crypto_mod, name, value)
+
+spec = importlib.util.spec_from_file_location("rustchain_block_producer_batch_test", MODULE_PATH)
+block_producer = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = block_producer
+spec.loader.exec_module(block_producer)
+
+
+class DummyProducer:
+    def __init__(self, db_path):
+        self.db_path = db_path
+
+
+class DummyCache:
+    def __init__(self):
+        self.values = {}
+
+    def get(self, key):
+        return self.values.get(key)
+
+    def setex(self, key, ttl, value):
+        self.values[key] = value
+
+
+def _client(tmp_path, cache=None):
+    db_path = tmp_path / "blocks.db"
+    app = Flask(__name__)
+    if cache is not None:
+        app.config["BLOCK_BATCH_REDIS"] = cache
+    block_producer.create_block_api_routes(app, DummyProducer(str(db_path)), object())
+    return app.test_client(), db_path
+
+
+def _seed_blocks(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                prev_hash TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                merkle_root TEXT NOT NULL,
+                state_root TEXT NOT NULL,
+                attestations_hash TEXT NOT NULL,
+                producer TEXT NOT NULL,
+                producer_sig TEXT NOT NULL,
+                tx_count INTEGER NOT NULL,
+                attestation_count INTEGER NOT NULL,
+                body_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        for height in (1, 2):
+            conn.execute(
+                """
+                INSERT INTO blocks
+                (height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                 attestations_hash, producer, producer_sig, tx_count, attestation_count,
+                 body_json, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    height,
+                    f"hash{height}",
+                    f"prev{height - 1}",
+                    100 + height,
+                    f"merkle{height}",
+                    f"state{height}",
+                    f"attest{height}",
+                    f"miner{height}",
+                    f"sig{height}",
+                    height,
+                    0,
+                    json.dumps({"height": height, "tx_count": height}),
+                    200 + height,
+                ),
+            )
+
+
+def test_batch_blocks_returns_ordered_partial_results(tmp_path):
+    client, db_path = _client(tmp_path)
+    _seed_blocks(db_path)
+
+    response = client.post("/v1/blocks/batch", json={"blocks": [2, "hash1", 999, "missing"]})
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["count"] == 2
+    assert [block["height"] for block in body["blocks"]] == [2, 1]
+    assert body["blocks"][0]["body"] == {"height": 2, "tx_count": 2}
+    assert body["missing"] == [999, "missing"]
+    assert "timestamp" in body
+
+
+def test_batch_blocks_rejects_oversized_batches(tmp_path):
+    client, _ = _client(tmp_path)
+
+    response = client.post(
+        "/v1/blocks/batch",
+        json={"blocks": list(range(block_producer.MAX_BATCH_BLOCKS + 1))},
+    )
+
+    assert response.status_code == 400
+    assert "more than 100" in response.get_json()["error"]
+
+
+def test_batch_blocks_rejects_invalid_entries(tmp_path):
+    client, _ = _client(tmp_path)
+
+    response = client.post("/v1/blocks/batch", json={"blocks": [1, -1]})
+
+    assert response.status_code == 400
+    assert "non-negative integer heights" in response.get_json()["error"]
+
+
+def test_batch_blocks_treats_missing_table_as_missing_blocks(tmp_path):
+    client, _ = _client(tmp_path)
+
+    response = client.post("/v1/blocks/batch", json={"blocks": [1, "hash1"]})
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["blocks"] == []
+    assert body["count"] == 0
+    assert body["missing"] == [1, "hash1"]
+
+
+def test_batch_blocks_reads_from_configured_cache(tmp_path):
+    cache = DummyCache()
+    client, db_path = _client(tmp_path, cache)
+    _seed_blocks(db_path)
+
+    first = client.post("/v1/blocks/batch", json={"blocks": [1]})
+    assert first.status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM blocks")
+
+    second = client.post("/v1/blocks/batch", json={"blocks": [1]})
+
+    assert second.status_code == 200
+    body = second.get_json()
+    assert body["count"] == 1
+    assert body["blocks"][0]["height"] == 1


### PR DESCRIPTION
## Summary
- add POST /v1/blocks/batch and /api/blocks/batch for querying up to 100 block heights or hashes in one request
- return successful blocks in request order while reporting missing identifiers instead of failing the whole batch
- add optional Redis-backed block response caching via BLOCK_BATCH_REDIS, BLOCK_BATCH_REDIS_URL, RUSTCHAIN_BLOCK_BATCH_REDIS_URL, or REDIS_URL
- cover ordered partial results, invalid input, oversized batches, missing block table handling, and cache hits

Fixes #2721

## Tests
- PYTHONPATH=node /tmp/otc-bridge-test-venv/bin/python -m pytest tests/test_block_batch_api.py -q
- python3 -m py_compile node/rustchain_block_producer.py tests/test_block_batch_api.py
- git diff --check

## Notes
- Local tests only; no live node probing.
- Existing node/test_block_producer_state_root.py still fails on origin/main because BlockProducer.__init__ does not accept utxo_db and the fixture has an empty UTXO list; this PR does not touch that path.

## Payout
- RTC Wallet / miner_id: `zhoueu-star-mac`