### PR TITLE
[UTXO-BUG] Drop stale spent-input mempool candidates

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -469,6 +469,36 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(len(candidates), 1)
         self.assertEqual(candidates[0]['tx_id'], 'replacement' * 6)
 
+    def test_mempool_block_candidates_drop_spent_inputs(self):
+        """Block candidates must not include txs whose inputs were confirmed.
+
+        A mempool transaction can be invalidated by a direct UTXO transfer path
+        that confirms the same input first. The stale mempool entry must not keep
+        returning to block producers until expiry.
+        """
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+        tx_id = 'stale_tx' * 8
+
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': tx_id,
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }))
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=2)
+        self.assertTrue(ok)
+
+        candidates = self.db.mempool_get_block_candidates()
+        self.assertEqual(candidates, [])
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
     def test_mempool_nonexistent_input_rejected(self):
         tx = {
             'tx_id': 'cccc' * 16,

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -828,17 +828,59 @@ class UtxoDB:
     def mempool_get_block_candidates(self, max_count: int = 100) -> List[dict]:
         """Get highest-fee transactions from mempool for block inclusion."""
         self.mempool_clear_expired()
+        if max_count <= 0:
+            return []
         conn = self._conn()
         try:
             now = int(time.time())
             rows = conn.execute(
-                """SELECT tx_data_json FROM utxo_mempool
+                """SELECT tx_id, tx_data_json FROM utxo_mempool
                    WHERE expires_at > ?
                    ORDER BY fee_nrtc DESC
-                   LIMIT ?""",
-                (now, max_count),
+                """,
+                (now,),
             ).fetchall()
-            return [json.loads(r['tx_data_json']) for r in rows]
+            candidates = []
+            stale_tx_ids = []
+
+            for row in rows:
+                tx_id = row['tx_id']
+                try:
+                    tx = json.loads(row['tx_data_json'])
+                    input_ids = [inp['box_id'] for inp in tx.get('inputs', [])]
+                except Exception:
+                    stale_tx_ids.append(tx_id)
+                    continue
+
+                if not input_ids:
+                    stale_tx_ids.append(tx_id)
+                    continue
+
+                placeholders = ",".join("?" for _ in input_ids)
+                unspent_count = conn.execute(
+                    f"""SELECT COUNT(*) AS n FROM utxo_boxes
+                        WHERE box_id IN ({placeholders}) AND spent_at IS NULL""",
+                    input_ids,
+                ).fetchone()['n']
+                if unspent_count != len(set(input_ids)):
+                    stale_tx_ids.append(tx_id)
+                    continue
+
+                candidates.append(tx)
+                if len(candidates) >= max_count:
+                    break
+
+            for tx_id in stale_tx_ids:
+                conn.execute(
+                    "DELETE FROM utxo_mempool_inputs WHERE tx_id = ?", (tx_id,)
+                )
+                conn.execute(
+                    "DELETE FROM utxo_mempool WHERE tx_id = ?", (tx_id,)
+                )
+            if stale_tx_ids:
+                conn.commit()
+
+            return candidates
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

Fixes a #2819 UTXO mempool bug where `mempool_get_block_candidates()` could keep returning a transaction whose claimed input was already confirmed through another path.

Attack/bug flow:

1. A transaction enters `utxo_mempool` and claims `box_id` in `utxo_mempool_inputs`.
2. The same UTXO is confirmed first through the direct UTXO apply/transfer path.
3. The mempool entry remains unexpired, so block candidate selection still returns an unmineable transaction until expiry and the stale input claim remains present.

This is a mempool DoS / invalid block-candidate issue under the UTXO red-team bounty.

## Changes

- Filter block candidates to transactions whose input boxes are still unspent.
- Remove stale mempool rows and their input claims when candidate selection detects spent or malformed inputs.
- Preserve `max_count <= 0` empty-result behavior.
- Add regression coverage for the stale-candidate path.

## Bounty

Targets Scottcjn/rustchain-bounties#2819.

Payout wallet: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest python -m pytest node/test_utxo_db.py::TestUtxoDB::test_mempool_block_candidates_drop_spent_inputs -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest python -m pytest node/test_utxo_db.py -q`
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`