### PR TITLE
feat: add RISC-V antiquity detection

### DIFF
--- a/VINTAGE_CPU_QUICK_REFERENCE.md
+++ b/VINTAGE_CPU_QUICK_REFERENCE.md
@@ -118,9 +118,19 @@
 ### 🌐 1.4-1.5x - EXOTIC (RISC-V)
 | CPU | Year | Pattern | Systems |
 |-----|------|---------|---------|
+| **RISC-V RV32I/RV32IM** | 2014+ | `RV32I`, `RV32IM`, `riscv32` | 32-bit embedded RISC-V |
 | **RISC-V (SiFive U74)** | 2020 | `SiFive.*U74`, `sifive,u74` | VisionFive 2, HiFive Unmatched |
+| **RISC-V (Allwinner D1 / C906)** | 2021 | `Allwinner.*D1`, `T-Head.*C906`, `Xuantie C906` | Nezha, MangoPi, Lichee RV |
 | **RISC-V (StarFive JH7110)** | 2022 | `JH7110`, `StarFive.*JH7110` | VisionFive 2 SoC |
+| **RISC-V (T-Head C910)** | 2020 | `T-Head.*C910`, `Xuantie C910` | Alibaba/Xuantie boards |
 | **RISC-V (generic)** | 2014+ | `riscv`, `riscv64`, `riscv32`, `RISC-V` | Open-source ISA |
+| **RISC-V RVV modern marker** | 2021+ | `RVV`, `RV64GCV`, `RISC-V.*vector` | Treat as modern, 1.0x |
+
+Detection notes:
+
+- Captured fingerprints may include `misa=0x...`; decode the low extension bits and use `xlen=32` or `xlen=64` when available.
+- RV32I/RV32IM receives the highest RISC-V score because it is the rarest practical profile.
+- RVV/vector-capable systems are valuable, but the vector extension is a modernity marker rather than an antiquity marker.
 
 ---
 

--- a/WEIGHT_SCORING.md
+++ b/WEIGHT_SCORING.md
@@ -58,6 +58,17 @@ Rewards are based on **rarity + preservation value**, not just age.
 | armv7 | 0.0005x | 32-bit ARM |
 | Raspberry Pi | 0.0005x | $35 computer |
 
+### RISC-V (Exotic - Diversity, Not Age)
+| Architecture / Marker | Multiplier | Notes |
+|-------------|-----------|-------|
+| RV32I / RV32IM | 1.5x | 32-bit embedded RISC-V is uncommon and useful for network diversity |
+| RV64GC / RV64IMAFDC | 1.4x | Common 64-bit Linux-capable RISC-V profile |
+| SiFive U74 / FU740 | 1.4x | HiFive Unmatched / VisionFive-class cores |
+| Allwinner D1 / T-Head C906 | 1.4x | Early low-cost RISC-V SBC profile |
+| StarFive JH7110 | 1.35x | VisionFive 2 SoC |
+| T-Head C910 | 1.25x | Modern high-performance RISC-V |
+| RVV / Vector extension present | 1.0x | Vector extension is treated as a modernity marker |
+
 ### Apple Silicon (Special)
 | Architecture | Multiplier | Notes |
 |-------------|-----------|-------|
@@ -75,3 +86,5 @@ Rewards are based on **rarity + preservation value**, not just age.
 3. **VMs get nothing** - Fingerprint detection catches VMs/emulators. They get 0x multiplier (no rewards).
 
 4. **Preservation incentive** - Running a 386 or 68000 Mac is hard. Rewarding vintage hardware encourages preservation.
+
+5. **RISC-V is diversity-positive but modern** - RISC-V boards improve architecture diversity, but most real hardware is 2020s-era. They receive modest exotic multipliers, and RVV-capable systems are scored as modern.

--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -543,9 +543,9 @@ RISC_V_ARCHITECTURES = {
     "rv32im": {
         "years": (2014, 2024),
         "patterns": [
-            r"\bRV32I\b",
-            r"\bRV32IM\b",
-            r"\bRV32IMA?C?\b",
+            r"\bRV32I(?=$|[^A-Z0-9])",
+            r"\bRV32IM(?=$|[^A-Z0-9])",
+            r"\bRV32IMA?C?(?=$|[^A-Z0-9])",
             r"\briscv32\b",
             r"\brisc-v 32\b",
         ],
@@ -555,8 +555,8 @@ RISC_V_ARCHITECTURES = {
     "rv64gc": {
         "years": (2015, 2024),
         "patterns": [
-            r"\bRV64GC\b",
-            r"\bRV64IMAFDC\b",
+            r"\bRV64GC(?=$|[^A-Z0-9])",
+            r"\bRV64IMAFDC(?=$|[^A-Z0-9])",
             r"\briscv64\b",
             r"\brisc-v 64\b",
         ],
@@ -568,8 +568,8 @@ RISC_V_ARCHITECTURES = {
         "patterns": [
             r"\bRVV\b",
             r"RISC-V.*vector",
-            r"\bRV64GCV\b",
-            r"\bRV32.*V\b",
+            r"\bRV64GCV(?=$|[^A-Z0-9])",
+            r"\bRV32[A-Z]*V(?=$|[^A-Z0-9])",
         ],
         "base_multiplier": 1.0,
         "description": "RISC-V with vector extension (modern RVV)"

--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -16,7 +16,7 @@ Sources:
 """
 
 import re
-from typing import Tuple, Optional, Dict
+from typing import List, Tuple, Optional, Dict
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -489,8 +489,158 @@ APPLE_SILICON = {
 
 
 # =============================================================================
+# RISC-V (open ISA, exotic miner diversity)
+# =============================================================================
+
+RISC_V_EXTENSIONS = {
+    idx: chr(ord("a") + idx)
+    for idx in range(26)
+}
+
+RISC_V_ARCHITECTURES = {
+    "sifive_u74": {
+        "years": (2020, 2023),
+        "patterns": [
+            r"SiFive.*U7[4]",
+            r"Freedom U7[4]0",
+            r"FU7[4]0",
+            r"sifive,u7[4]",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V SiFive U74/FU740"
+    },
+    "starfive_jh7110": {
+        "years": (2022, 2024),
+        "patterns": [
+            r"StarFive.*JH7110",
+            r"JH7110",
+            r"starfive,jh7110",
+        ],
+        "base_multiplier": 1.35,
+        "description": "RISC-V StarFive JH7110"
+    },
+    "allwinner_d1_c906": {
+        "years": (2021, 2023),
+        "patterns": [
+            r"Allwinner.*D1",
+            r"\bD1s?\b.*RISC-V",
+            r"T-?Head.*C906",
+            r"Xuantie C906",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V Allwinner D1 / T-Head C906"
+    },
+    "thead_c910": {
+        "years": (2020, 2024),
+        "patterns": [
+            r"T-?Head.*C910",
+            r"Xuantie C910",
+            r"Alibaba.*C910",
+        ],
+        "base_multiplier": 1.25,
+        "description": "RISC-V T-Head C910"
+    },
+    "rv32im": {
+        "years": (2014, 2024),
+        "patterns": [
+            r"\bRV32I\b",
+            r"\bRV32IM\b",
+            r"\bRV32IMA?C?\b",
+            r"\briscv32\b",
+            r"\brisc-v 32\b",
+        ],
+        "base_multiplier": 1.5,
+        "description": "RISC-V RV32I/RV32IM"
+    },
+    "rv64gc": {
+        "years": (2015, 2024),
+        "patterns": [
+            r"\bRV64GC\b",
+            r"\bRV64IMAFDC\b",
+            r"\briscv64\b",
+            r"\brisc-v 64\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V RV64GC"
+    },
+    "rvv_modern": {
+        "years": (2021, 2025),
+        "patterns": [
+            r"\bRVV\b",
+            r"RISC-V.*vector",
+            r"\bRV64GCV\b",
+            r"\bRV32.*V\b",
+        ],
+        "base_multiplier": 1.0,
+        "description": "RISC-V with vector extension (modern RVV)"
+    },
+    "generic": {
+        "years": (2014, 2025),
+        "patterns": [
+            r"\bRISC-V\b",
+            r"\briscv\b",
+        ],
+        "base_multiplier": 1.3,
+        "description": "Generic RISC-V"
+    },
+}
+
+
+# =============================================================================
 # DETECTION FUNCTIONS
 # =============================================================================
+
+def riscv_extensions_from_misa(misa_value: int, xlen: Optional[int] = None) -> Tuple[Optional[int], List[str]]:
+    """Decode RISC-V misa CSR extension bits from collected fingerprint text."""
+    if misa_value < 0:
+        return (xlen, [])
+
+    if xlen is None:
+        if misa_value >= (1 << 62):
+            xlen = 64
+        elif misa_value >= (1 << 30):
+            xlen = 32
+
+    extensions = [
+        letter
+        for bit, letter in RISC_V_EXTENSIONS.items()
+        if misa_value & (1 << bit)
+    ]
+    return (xlen, extensions)
+
+
+def _riscv_profile_from_extensions(xlen: Optional[int], extensions: List[str]) -> str:
+    ext_set = set(extensions)
+    if "v" in ext_set:
+        return "rvv_modern"
+    if xlen == 32:
+        return "rv32im"
+    if xlen == 64 and {"i", "m", "a", "f", "d", "c"}.issubset(ext_set):
+        return "rv64gc"
+    if xlen == 64:
+        return "rv64gc"
+    return "generic"
+
+
+def detect_riscv_architecture(brand_string: str) -> Optional[Tuple[str, str, int, bool]]:
+    """Detect RISC-V profiles from vendor markers, extension strings, or misa CSR text."""
+    misa_match = re.search(r"\bmisa\s*[:=]\s*(0x[0-9a-fA-F]+|\d+)", brand_string)
+    if misa_match:
+        misa_value = int(misa_match.group(1), 0)
+        xlen_match = re.search(r"\b(?:xlen|rv)\s*[:=\- ]?\s*(32|64)\b", brand_string, re.IGNORECASE)
+        xlen = int(xlen_match.group(1)) if xlen_match else None
+        detected_xlen, extensions = riscv_extensions_from_misa(misa_value, xlen=xlen)
+        arch_name = _riscv_profile_from_extensions(detected_xlen, extensions)
+        arch_info = RISC_V_ARCHITECTURES[arch_name]
+        return ("riscv", arch_name, arch_info["years"][0], False)
+
+    for arch_name, arch_info in RISC_V_ARCHITECTURES.items():
+        for pattern in arch_info["patterns"]:
+            if re.search(pattern, brand_string, re.IGNORECASE):
+                return ("riscv", arch_name, arch_info["years"][0], False)
+
+    return None
+
 
 def detect_cpu_architecture(brand_string: str) -> Tuple[str, str, int, bool]:
     """
@@ -504,8 +654,13 @@ def detect_cpu_architecture(brand_string: str) -> Tuple[str, str, int, bool]:
         "AMD Ryzen 5 8645HS" → ("amd", "zen4", 2022, False)
         "Apple M1" → ("apple", "m1", 2020, False)
         "PowerPC G4" → ("powerpc", "g4", 2001, False)
+        "SiFive U74 RV64GC" → ("riscv", "sifive_u74", 2020, False)
     """
     brand_string = brand_string.strip()
+
+    riscv_result = detect_riscv_architecture(brand_string)
+    if riscv_result is not None:
+        return riscv_result
 
     # Check PowerPC first (most distinctive)
     for arch_name, arch_info in POWERPC_ARCHITECTURES.items():
@@ -603,6 +758,8 @@ def calculate_antiquity_multiplier(
         base_multiplier = INTEL_GENERATIONS[architecture]["base_multiplier"]
     elif vendor == "amd":
         base_multiplier = AMD_GENERATIONS[architecture]["base_multiplier"]
+    elif vendor == "riscv":
+        base_multiplier = RISC_V_ARCHITECTURES[architecture]["base_multiplier"]
 
     # Apply time decay for vintage hardware (>5 years old)
     # Decay formula: aged = 1.0 + (base - 1.0) * (1 - 0.15 * years_since_genesis)
@@ -636,6 +793,8 @@ def calculate_antiquity_multiplier(
         generation_name = INTEL_GENERATIONS[architecture]["description"]
     elif vendor == "amd":
         generation_name = AMD_GENERATIONS[architecture]["description"]
+    elif vendor == "riscv":
+        generation_name = RISC_V_ARCHITECTURES[architecture]["description"]
     else:
         generation_name = "Unknown CPU"
 

--- a/cpu_vintage_architectures.py
+++ b/cpu_vintage_architectures.py
@@ -594,9 +594,9 @@ RISC_WORKSTATIONS = {
     "riscv_rv32im": {
         "years": (2014, 2024),
         "patterns": [
-            r"\bRV32I\b",
-            r"\bRV32IM\b",
-            r"\bRV32IMA?C?\b",
+            r"\bRV32I(?=$|[^A-Z0-9])",
+            r"\bRV32IM(?=$|[^A-Z0-9])",
+            r"\bRV32IMA?C?(?=$|[^A-Z0-9])",
             r"\briscv32\b",
             r"\brisc-v 32\b",
         ],
@@ -606,8 +606,8 @@ RISC_WORKSTATIONS = {
     "riscv_rv64gc": {
         "years": (2015, 2024),
         "patterns": [
-            r"\bRV64GC\b",
-            r"\bRV64IMAFDC\b",
+            r"\bRV64GC(?=$|[^A-Z0-9])",
+            r"\bRV64IMAFDC(?=$|[^A-Z0-9])",
             r"\briscv64\b",
             r"\brisc-v 64\b",
         ],
@@ -619,8 +619,8 @@ RISC_WORKSTATIONS = {
         "patterns": [
             r"\bRVV\b",
             r"RISC-V.*vector",
-            r"\bRV64GCV\b",
-            r"\bRV32.*V\b",
+            r"\bRV64GCV(?=$|[^A-Z0-9])",
+            r"\bRV32[A-Z]*V(?=$|[^A-Z0-9])",
         ],
         "base_multiplier": 1.0,
         "description": "RISC-V with vector extension (modern RVV marker)"

--- a/cpu_vintage_architectures.py
+++ b/cpu_vintage_architectures.py
@@ -16,6 +16,7 @@ Research Sources:
 - DEC Alpha: https://en.wikipedia.org/wiki/DEC_Alpha
 - Sun SPARC: https://en.wikipedia.org/wiki/SPARC
 - MIPS: https://en.wikipedia.org/wiki/MIPS_architecture
+- RISC-V: https://riscv.org/technical/specifications/
 - PA-RISC: https://en.wikipedia.org/wiki/PA-RISC
 - PowerPC Amiga: https://en.wikipedia.org/wiki/AmigaOne
 """
@@ -545,6 +546,93 @@ RISC_WORKSTATIONS = {
         ],
         "base_multiplier": 2.4,
         "description": "MIPS R10000 series (SGI Origin/Octane)"
+    },
+
+    # RISC-V (2010+) - exotic/open ISA, modern but diversity-positive
+    "sifive_u74": {
+        "years": (2020, 2023),
+        "patterns": [
+            r"SiFive.*U7[4]",
+            r"Freedom U7[4]0",
+            r"FU7[4]0",
+            r"sifive,u7[4]",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V SiFive U74/FU740 (HiFive Unmatched, VisionFive-class)"
+    },
+    "starfive_jh7110": {
+        "years": (2022, 2024),
+        "patterns": [
+            r"StarFive.*JH7110",
+            r"JH7110",
+            r"starfive,jh7110",
+        ],
+        "base_multiplier": 1.35,
+        "description": "RISC-V StarFive JH7110 (VisionFive 2)"
+    },
+    "allwinner_d1_c906": {
+        "years": (2021, 2023),
+        "patterns": [
+            r"Allwinner.*D1",
+            r"\bD1s?\b.*RISC-V",
+            r"T-?Head.*C906",
+            r"Xuantie C906",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V Allwinner D1 / T-Head C906"
+    },
+    "thead_c910": {
+        "years": (2020, 2024),
+        "patterns": [
+            r"T-?Head.*C910",
+            r"Xuantie C910",
+            r"Alibaba.*C910",
+        ],
+        "base_multiplier": 1.25,
+        "description": "RISC-V T-Head C910 (modern high-performance RISC-V)"
+    },
+    "riscv_rv32im": {
+        "years": (2014, 2024),
+        "patterns": [
+            r"\bRV32I\b",
+            r"\bRV32IM\b",
+            r"\bRV32IMA?C?\b",
+            r"\briscv32\b",
+            r"\brisc-v 32\b",
+        ],
+        "base_multiplier": 1.5,
+        "description": "RISC-V RV32I/RV32IM (32-bit embedded RISC-V)"
+    },
+    "riscv_rv64gc": {
+        "years": (2015, 2024),
+        "patterns": [
+            r"\bRV64GC\b",
+            r"\bRV64IMAFDC\b",
+            r"\briscv64\b",
+            r"\brisc-v 64\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V RV64GC (64-bit general-purpose RISC-V)"
+    },
+    "riscv_vector": {
+        "years": (2021, 2025),
+        "patterns": [
+            r"\bRVV\b",
+            r"RISC-V.*vector",
+            r"\bRV64GCV\b",
+            r"\bRV32.*V\b",
+        ],
+        "base_multiplier": 1.0,
+        "description": "RISC-V with vector extension (modern RVV marker)"
+    },
+    "riscv_generic": {
+        "years": (2014, 2025),
+        "patterns": [
+            r"\bRISC-V\b",
+            r"\briscv\b",
+        ],
+        "base_multiplier": 1.3,
+        "description": "Generic RISC-V board"
     },
 
     # HP PA-RISC (1986-2008)

--- a/tests/test_cpu_architecture_detection_riscv.py
+++ b/tests/test_cpu_architecture_detection_riscv.py
@@ -62,6 +62,27 @@ def test_vector_extension_is_modern_marker():
     )
 
 
+def test_detects_linux_isa_suffixes():
+    assert cpu_detect.detect_cpu_architecture("isa : rv64imafdc_zicsr_zifencei") == (
+        "riscv",
+        "rv64gc",
+        2015,
+        False,
+    )
+    assert cpu_detect.detect_cpu_architecture("isa : rv64gcv_zicsr_zifencei") == (
+        "riscv",
+        "rvv_modern",
+        2021,
+        False,
+    )
+    assert cpu_detect.detect_cpu_architecture("isa : rv32imac_zicsr_zifencei") == (
+        "riscv",
+        "rv32im",
+        2014,
+        False,
+    )
+
+
 def test_riscv_multiplier_uses_profile_weight():
     info = cpu_detect.calculate_antiquity_multiplier(
         "RV32IMAC embedded board",

--- a/tests/test_cpu_architecture_detection_riscv.py
+++ b/tests/test_cpu_architecture_detection_riscv.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+
+sys.path.insert(0, ".")
+import cpu_architecture_detection as cpu_detect
+
+
+def _misa(*letters):
+    value = 0
+    for letter in letters:
+        value |= 1 << (ord(letter.lower()) - ord("a"))
+    return value
+
+
+def test_detects_sifive_u74_profile():
+    assert cpu_detect.detect_cpu_architecture("SiFive Freedom U740 RV64GC") == (
+        "riscv",
+        "sifive_u74",
+        2020,
+        False,
+    )
+
+
+def test_detects_starfive_jh7110_profile():
+    assert cpu_detect.detect_cpu_architecture("StarFive JH7110 riscv64 board") == (
+        "riscv",
+        "starfive_jh7110",
+        2022,
+        False,
+    )
+
+
+def test_detects_allwinner_d1_c906_profile():
+    assert cpu_detect.detect_cpu_architecture("Allwinner D1 Xuantie C906 RV64IMAFDC") == (
+        "riscv",
+        "allwinner_d1_c906",
+        2021,
+        False,
+    )
+
+
+def test_decodes_misa_extensions_for_rv64gc():
+    misa = _misa("i", "m", "a", "f", "d", "c")
+
+    assert cpu_detect.detect_cpu_architecture(f"RISC-V board xlen=64 misa=0x{misa:x}") == (
+        "riscv",
+        "rv64gc",
+        2015,
+        False,
+    )
+
+
+def test_vector_extension_is_modern_marker():
+    misa = _misa("i", "m", "a", "f", "d", "c", "v")
+
+    assert cpu_detect.detect_cpu_architecture(f"RISC-V board xlen=64 misa=0x{misa:x}") == (
+        "riscv",
+        "rvv_modern",
+        2021,
+        False,
+    )
+
+
+def test_riscv_multiplier_uses_profile_weight():
+    info = cpu_detect.calculate_antiquity_multiplier(
+        "RV32IMAC embedded board",
+        custom_year=2024,
+    )
+
+    assert info.vendor == "riscv"
+    assert info.architecture == "rv32im"
+    assert info.generation == "RISC-V RV32I/RV32IM"
+    assert info.antiquity_multiplier == 1.5

--- a/tests/test_cpu_vintage_architectures.py
+++ b/tests/test_cpu_vintage_architectures.py
@@ -207,6 +207,26 @@ class TestDetectVintageArchitecture:
         result = cpu_arch.detect_vintage_architecture("UltraSPARC T1")
         assert result == ("sparc", "sparc_v9", 1995, 2.3)
 
+    def test_riscv_sifive_u74(self):
+        """RISC-V SiFive U74 board marker"""
+        result = cpu_arch.detect_vintage_architecture("SiFive Freedom U740 RV64GC")
+        assert result == ("sifive", "sifive_u74", 2020, 1.4)
+
+    def test_riscv_starfive_jh7110(self):
+        """RISC-V StarFive JH7110 board marker"""
+        result = cpu_arch.detect_vintage_architecture("StarFive JH7110 riscv64 board")
+        assert result == ("starfive", "starfive_jh7110", 2022, 1.35)
+
+    def test_riscv_rv32_profile(self):
+        """RISC-V RV32IM profile gets the 32-bit exotic weight"""
+        result = cpu_arch.detect_vintage_architecture("RV32IMAC embedded board")
+        assert result == ("riscv", "riscv_rv32im", 2014, 1.5)
+
+    def test_riscv_vector_modern_marker(self):
+        """RISC-V vector extension is recognized as a modernity marker"""
+        result = cpu_arch.detect_vintage_architecture("RISC-V RV64GCV vector board")
+        assert result == ("riscv", "riscv_vector", 2021, 1.0)
+
     # ── Edge cases ────────────────────────────────────────────────────
 
     def test_empty_string_returns_none(self):
@@ -283,6 +303,11 @@ class TestGetVintageDescription:
         """HP PA-RISC description"""
         result = cpu_arch.get_vintage_description("pa_risc_1.0")
         assert "PA-RISC" in result or "PA-RISC" in cpu_arch.get_vintage_description("pa_risc_1.0")
+
+    def test_riscv_description(self):
+        """RISC-V description"""
+        result = cpu_arch.get_vintage_description("sifive_u74")
+        assert "RISC-V" in result
 
     def test_unknown_architecture_returns_fallback(self):
         """Unknown architecture returns a fallback string (not exception)"""

--- a/tests/test_cpu_vintage_architectures.py
+++ b/tests/test_cpu_vintage_architectures.py
@@ -227,6 +227,18 @@ class TestDetectVintageArchitecture:
         result = cpu_arch.detect_vintage_architecture("RISC-V RV64GCV vector board")
         assert result == ("riscv", "riscv_vector", 2021, 1.0)
 
+    def test_riscv_linux_isa_suffixes(self):
+        """Linux isa strings may append extension groups with underscores"""
+        assert cpu_arch.detect_vintage_architecture(
+            "isa : rv64imafdc_zicsr_zifencei"
+        ) == ("riscv", "riscv_rv64gc", 2015, 1.4)
+        assert cpu_arch.detect_vintage_architecture(
+            "isa : rv64gcv_zicsr_zifencei"
+        ) == ("riscv", "riscv_vector", 2021, 1.0)
+        assert cpu_arch.detect_vintage_architecture(
+            "isa : rv32imac_zicsr_zifencei"
+        ) == ("riscv", "riscv_rv32im", 2014, 1.5)
+
     # ── Edge cases ────────────────────────────────────────────────────
 
     def test_empty_string_returns_none(self):


### PR DESCRIPTION
## Summary
- add first-class RISC-V profiles for SiFive U74, StarFive JH7110, Allwinner D1/C906, T-Head C910, RV32IM, RV64GC, RVV modern marker, and generic RISC-V
- parse collected misa CSR fingerprints with optional xlen to derive RV32/RV64/RVV profiles
- wire RISC-V weights into antiquity multiplier calculation and vintage detection
- update RISC-V weight and quick-reference docs
- add regression coverage for board markers, misa decoding, RVV scoring, and vintage detection

Fixes #2720

## Tests
- `PYTHONPATH=. /tmp/otc-bridge-test-venv/bin/python -m pytest tests/test_cpu_vintage_architectures.py tests/test_cpu_architecture_detection_riscv.py -q`
- `python3 -m py_compile cpu_vintage_architectures.py cpu_architecture_detection.py tests/test_cpu_vintage_architectures.py tests/test_cpu_architecture_detection_riscv.py`
- `git diff --check`

## Safety
Local tests only; no live node or hardware probing.

## Payout
- RTC Wallet / miner_id: `zhoueu-star-mac`