### PR TITLE
fix: validate UTXO data inputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -721,6 +721,23 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('attacker'), 0)
 
+    def test_user_supplied_mining_reward_rejected_before_opening_db(self):
+        """Unauthorized mining rewards should not leak an owned DB handle."""
+
+        class NoOpenUtxoDB(UtxoDB):
+            def _conn(self):
+                raise AssertionError("apply_transaction opened the DB")
+
+        db = NoOpenUtxoDB(self.tmp.name)
+        ok = db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'attacker', 'value_nrtc': 1 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }, block_height=10)
+        self.assertFalse(ok)
+
     def test_mempool_empty_inputs_rejected_for_transfer(self):
         """Mempool must also reject non-minting txs with empty inputs."""
         tx = {

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -363,6 +363,24 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
 
+    def test_data_input_cannot_overlap_spend_input(self):
+        """A read-only data input cannot be consumed by the same tx."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'data_inputs': [alice_box['box_id']],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+        self.assertIsNone(self.db.get_box(alice_box['box_id'])['spent_at'])
+
     # -- state root ----------------------------------------------------------
 
     def test_empty_state_root(self):
@@ -563,6 +581,22 @@ class TestUtxoDB(unittest.TestCase):
             'tx_id': 'data' * 16,
             'inputs': [{'box_id': box['box_id']}],
             'data_inputs': ['deadbeef' * 8],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
+    def test_mempool_rejects_data_input_overlap_without_locking_input(self):
+        """Mempool rejects txs that consume their read-only context."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        tx = {
+            'tx_id': 'overlap' * 8,
+            'inputs': [{'box_id': box['box_id']}],
+            'data_inputs': [box['box_id']],
             'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
         }

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -6,6 +6,7 @@ Run:  python3 -m pytest test_utxo_db.py -v
   or: python3 test_utxo_db.py
 """
 
+import json
 import os
 import tempfile
 import time
@@ -288,6 +289,80 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
         self.assertFalse(ok)
 
+    def test_unspent_data_input_is_read_only(self):
+        """A valid data input may be referenced without being consumed."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        self._apply_coinbase('oracle', 5 * UNIT, block_height=2)
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+        oracle_box = self.db.get_unspent_for_address('oracle')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'data_inputs': [oracle_box['box_id']],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertTrue(ok)
+        self.assertEqual(self.db.get_balance('oracle'), 5 * UNIT)
+        self.assertIsNone(self.db.get_box(oracle_box['box_id'])['spent_at'])
+
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                """SELECT data_inputs_json FROM utxo_transactions
+                   WHERE tx_type = 'transfer'"""
+            ).fetchone()
+            self.assertEqual(json.loads(row['data_inputs_json']),
+                             [oracle_box['box_id']])
+        finally:
+            conn.close()
+
+    def test_nonexistent_data_input_rejected(self):
+        """Read-only data inputs must point to real unspent boxes."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'data_inputs': ['deadbeef' * 8],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_spent_data_input_rejected(self):
+        """Spent boxes cannot be used as read-only transaction context."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        self._apply_coinbase('oracle', 5 * UNIT, block_height=2)
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+        oracle_box = self.db.get_unspent_for_address('oracle')[0]
+
+        self.assertTrue(self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': oracle_box['box_id'],
+                        'spending_proof': 'sig'}],
+            'outputs': [{'address': 'sink', 'value_nrtc': 5 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=9))
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'data_inputs': [oracle_box['box_id']],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     # -- state root ----------------------------------------------------------
 
     def test_empty_state_root(self):
@@ -478,6 +553,22 @@ class TestUtxoDB(unittest.TestCase):
         }
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
+
+    def test_mempool_rejects_nonexistent_data_input_without_locking_input(self):
+        """Invalid data inputs must not leave spend inputs pinned in mempool."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        tx = {
+            'tx_id': 'data' * 16,
+            'inputs': [{'box_id': box['box_id']}],
+            'data_inputs': ['deadbeef' * 8],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
 
     # -- proposition encoding ------------------------------------------------
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -391,12 +391,6 @@ class UtxoDB:
 
         Returns True on success, False on validation failure.
         """
-        own = conn is None
-        if own:
-            conn = self._conn()
-
-        manage_tx = own or not conn.in_transaction
-
         ts = tx.get('timestamp', int(time.time()))
         # NOTE(issue #2085): spending_proof is present on each input dict but
         # is intentionally ignored by this layer.  It is stored for
@@ -416,6 +410,12 @@ class UtxoDB:
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
             return False
+
+        own = conn is None
+        if own:
+            conn = self._conn()
+
+        manage_tx = own or not conn.in_transaction
 
         try:
             if manage_tx:

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -333,6 +333,26 @@ class UtxoDB:
         finally:
             conn.close()
 
+    def _data_inputs_are_unspent(self, conn: sqlite3.Connection,
+                                 data_inputs: list) -> bool:
+        """Validate read-only UTXO references before accepting a tx."""
+        if not isinstance(data_inputs, list):
+            return False
+
+        for box_id in data_inputs:
+            if not isinstance(box_id, str) or not box_id.strip():
+                return False
+
+            row = conn.execute(
+                """SELECT spent_at FROM utxo_boxes
+                   WHERE box_id = ? AND spent_at IS NULL""",
+                (box_id,),
+            ).fetchone()
+            if not row:
+                return False
+
+        return True
+
     # -- transaction application ---------------------------------------------
 
     def apply_transaction(self, tx: dict, block_height: int,
@@ -372,6 +392,7 @@ class UtxoDB:
         outputs = tx.get('outputs', [])
         fee = tx.get('fee_nrtc', 0)
         tx_type = tx.get('tx_type', 'transfer')
+        data_inputs = tx.get('data_inputs', [])
 
         # FIX(#2207): Defense-in-depth guard against mining_reward type confusion.
         # The endpoint layer hardcodes tx_type='transfer', but if any code path
@@ -416,6 +437,12 @@ class UtxoDB:
                     return abort()
                 input_total += row['value_nrtc']
 
+            # Read-only data inputs must still reference existing unspent
+            # boxes.  Otherwise nodes can record unverifiable script context
+            # in tx history or admit invalid block candidates.
+            if not self._data_inputs_are_unspent(conn, data_inputs):
+                return abort()
+
             # -- conservation check ------------------------------------------
             # Only authorized minting transaction types may have empty inputs.
             # All other transactions must consume at least one input box.
@@ -459,7 +486,7 @@ class UtxoDB:
             tx_identity = {
                 'tx_type': tx_type,
                 'inputs': sorted(i['box_id'] for i in inputs),
-                'data_inputs': sorted(tx.get('data_inputs', [])),
+                'data_inputs': sorted(data_inputs),
                 'outputs': [
                     {
                         'address': out['address'],
@@ -540,7 +567,7 @@ class UtxoDB:
                                  'value_nrtc': r['value_nrtc'],
                                  'owner': r['owner_address']}
                                 for r in output_records]),
-                    json.dumps(tx.get('data_inputs', [])),
+                    json.dumps(data_inputs),
                     fee,
                     ts,
                     block_height,
@@ -688,6 +715,7 @@ class UtxoDB:
 
             inputs = tx.get('inputs', [])
             tx_type = tx.get('tx_type', 'transfer')
+            data_inputs = tx.get('data_inputs', [])
             now = int(time.time())
 
             # Public mempool admission must never accept minting transactions.
@@ -700,6 +728,9 @@ class UtxoDB:
                 return False
 
             if not inputs:
+                return False
+
+            if not isinstance(data_inputs, list):
                 return False
 
             conn.execute("BEGIN IMMEDIATE")
@@ -725,6 +756,11 @@ class UtxoDB:
                     if manage_tx:
                         conn.execute("ROLLBACK")
                     return False
+
+            if not self._data_inputs_are_unspent(conn, data_inputs):
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
 
             # -- conservation-of-value check ---------------------------------
             # Prevent mempool admission of transactions that would fail

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -333,16 +333,30 @@ class UtxoDB:
         finally:
             conn.close()
 
+    def _normalize_data_inputs(self, data_inputs: list) -> Optional[List[str]]:
+        """Return validated read-only UTXO box IDs, or None on invalid input."""
+        if not isinstance(data_inputs, list):
+            return None
+
+        normalized = []
+        for box_id in data_inputs:
+            if not isinstance(box_id, str) or not box_id.strip():
+                return None
+            normalized.append(box_id)
+
+        if len(normalized) != len(set(normalized)):
+            return None
+
+        return normalized
+
     def _data_inputs_are_unspent(self, conn: sqlite3.Connection,
                                  data_inputs: list) -> bool:
         """Validate read-only UTXO references before accepting a tx."""
-        if not isinstance(data_inputs, list):
+        normalized = self._normalize_data_inputs(data_inputs)
+        if normalized is None:
             return False
 
-        for box_id in data_inputs:
-            if not isinstance(box_id, str) or not box_id.strip():
-                return False
-
+        for box_id in normalized:
             row = conn.execute(
                 """SELECT spent_at FROM utxo_boxes
                    WHERE box_id = ? AND spent_at IS NULL""",
@@ -421,6 +435,11 @@ class UtxoDB:
             # today, but only accidentally.  Defense in depth.
             input_box_ids = [i['box_id'] for i in inputs]
             if len(input_box_ids) != len(set(input_box_ids)):
+                return abort()
+            data_inputs = self._normalize_data_inputs(data_inputs)
+            if data_inputs is None:
+                return abort()
+            if set(input_box_ids) & set(data_inputs):
                 return abort()
 
             # -- validate inputs exist and are unspent -----------------------
@@ -730,7 +749,11 @@ class UtxoDB:
             if not inputs:
                 return False
 
-            if not isinstance(data_inputs, list):
+            data_inputs = self._normalize_data_inputs(data_inputs)
+            if data_inputs is None:
+                return False
+            input_box_ids = [i['box_id'] for i in inputs]
+            if set(input_box_ids) & set(data_inputs):
                 return False
 
             conn.execute("BEGIN IMMEDIATE")


### PR DESCRIPTION
## Summary
- validate UTXO data_inputs as existing, unspent read-only box references before applying a transaction
- mirror the same validation at mempool admission so invalid candidates cannot pin spend inputs until expiry
- preserve valid data-input behavior: referenced boxes remain unspent/read-only and are recorded in tx history
- add regression tests for valid, nonexistent, spent, and mempool-invalid data_inputs

Refs Scottcjn/rustchain-bounties#2819 and the existing CVE-UTXO-004 audit note in audits/utxo_db_security_audit.md.

## Tests
- PYTHONPATH=node /tmp/otc-bridge-test-venv/bin/python -m pytest node/test_utxo_db.py -q
- python3 -m py_compile node/utxo_db.py node/test_utxo_db.py
- git diff --check

## Safety
Local unit tests only; no live node probing.

## Payout
- RTC Wallet / miner_id: `zhoueu-star-mac`