### PR TITLE
fix: load Moltbook agent keys from environment

### DIFF
--- a/scripts/moltbook_solver.py
+++ b/scripts/moltbook_solver.py
@@ -36,12 +36,12 @@ log = logging.getLogger("moltbook_solver")
 # ─── Agent Registry ──────────────────────────────────────────────────────────
 
 AGENTS = {
-    "sophia":          {"key": "moltbook_sk_nuTK8FxFHuUtknLGrXUJKxcgBsTJ0zP7",  "persona": "warm_tech"},
-    "boris":           {"key": "moltbook_sk_mACTltXU55x6s1mYqDuWkeEcuDQ9feMB",  "persona": "soviet_enthusiast"},
-    "janitor":         {"key": "moltbook_sk_yWpLPPIp1MxWAlbgiCEdamHodyClGg08",  "persona": "sysadmin"},
-    "bottube":         {"key": "moltbook_sk_CJgvb5ecA9ZnutcmmaFy2Scm_X4SQgcz",  "persona": "platform_bot"},
-    "msgoogletoggle":  {"key": "moltbook_sk_-zuaZPUGMVoC_tdQJA-YaLVlj-VnUMdw",  "persona": "gracious_socialite"},
-    "oneo":            {"key": "moltbook_sk_BeO3rZoBKuleNwSX3sZeBNQRYhOBK436",  "persona": "minimalist"},
+    "sophia":          {"key_env": "MOLTBOOK_AGENT_KEY_SOPHIA",          "persona": "warm_tech"},
+    "boris":           {"key_env": "MOLTBOOK_AGENT_KEY_BORIS",           "persona": "soviet_enthusiast"},
+    "janitor":         {"key_env": "MOLTBOOK_AGENT_KEY_JANITOR",         "persona": "sysadmin"},
+    "bottube":         {"key_env": "MOLTBOOK_AGENT_KEY_BOTTUBE",         "persona": "platform_bot"},
+    "msgoogletoggle":  {"key_env": "MOLTBOOK_AGENT_KEY_MSGOOGLETOGGLE",  "persona": "gracious_socialite"},
+    "oneo":            {"key_env": "MOLTBOOK_AGENT_KEY_ONEO",            "persona": "minimalist"},
 }
 
 # Gemini for LLM solving
@@ -128,8 +128,11 @@ def get_available_agents() -> List[str]:
 
 
 def get_agent_key(agent: str) -> Optional[str]:
-    """Get API key for an agent."""
-    return AGENTS.get(agent, {}).get("key")
+    """Get API key for an agent from the process environment."""
+    key_env = AGENTS.get(agent, {}).get("key_env")
+    if not key_env:
+        return None
+    return os.environ.get(key_env) or None
 
 
 # ─── Content Uniqueness ─────────────────────────────────────────────────────

--- a/scripts/tests/test_moltbook_solver.py
+++ b/scripts/tests/test_moltbook_solver.py
@@ -118,13 +118,23 @@ class TestAgentFunctions:
         agents = get_available_agents()
         assert isinstance(agents, list) and len(agents) > 0
 
-    def test_get_agent_key(self):
+    def test_get_agent_key(self, monkeypatch):
+        monkeypatch.setenv("MOLTBOOK_AGENT_KEY_SOPHIA", "moltbook_" + "sk_test")
         key = get_agent_key("sophia")
-        assert key is not None and key.startswith("moltbook_sk_")
+        assert key is not None and key.startswith("moltbook_" + "sk_")
+
+    def test_get_agent_key_missing_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("MOLTBOOK_AGENT_KEY_SOPHIA", raising=False)
+        assert get_agent_key("sophia") is None
 
     def test_agents_have_required_fields(self):
         for agent_name, config in AGENTS.items():
-            assert "key" in config and "persona" in config
+            assert "key_env" in config and "persona" in config
+            assert config["key_env"].startswith("MOLTBOOK_AGENT_KEY_")
+
+    def test_no_hardcoded_moltbook_secret_keys_in_registry(self):
+        for config in AGENTS.values():
+            assert "moltbook_" + "sk_" not in repr(config)
 
 
 class TestRecordPost:


### PR DESCRIPTION
## Summary

Fixes #4947 by removing the six hardcoded Moltbook agent secret keys from `scripts/moltbook_solver.py`.

The agent registry now stores environment-variable names only, and `get_agent_key()` resolves the key at runtime from the process environment. This keeps the existing agent/persona rotation model without shipping live credentials in source.

## Notes

The exposed keys should still be rotated on the Moltbook service because they remain in Git history. This PR prevents future runtime/source disclosure by requiring configured environment variables:

- `MOLTBOOK_AGENT_KEY_SOPHIA`
- `MOLTBOOK_AGENT_KEY_BORIS`
- `MOLTBOOK_AGENT_KEY_JANITOR`
- `MOLTBOOK_AGENT_KEY_BOTTUBE`
- `MOLTBOOK_AGENT_KEY_MSGOOGLETOGGLE`
- `MOLTBOOK_AGENT_KEY_ONEO`

## Validation

- `python -m pytest .\scripts\tests\test_moltbook_solver.py -q` -> `24 passed`
- `python -m py_compile .\scripts\moltbook_solver.py .\scripts\tests\test_moltbook_solver.py` -> passed
- `rg -n moltbook_sk_[A-Za-z0-9_-]+ .\scripts\moltbook_solver.py .\scripts\tests\test_moltbook_solver.py -S` -> no matches
- `git diff --check origin/main...HEAD -- .\scripts\moltbook_solver.py .\scripts\tests\test_moltbook_solver.py` -> passed
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`