### PR TITLE
[BOUNTY #2864] Fix RTC auto-bounty retry markers

### DIFF
--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -235,10 +235,20 @@ def post_pr_comment(repo: str, pr_number: str, body: str, token: str) -> bool:
 
 
 def check_already_awarded(comments: list) -> bool:
-    """Check if any existing comment contains the award marker."""
+    """Check if any existing comment contains a successful award marker."""
     for c in comments:
-        if _AWARD_MARKER in (c.get("body") or ""):
-            return True
+        body = c.get("body") or ""
+        if _AWARD_MARKER not in body:
+            continue
+
+        marker_tail = body[body.find(_AWARD_MARKER):].lower()
+        marker_end = marker_tail.find("-->")
+        if marker_end != -1:
+            marker_tail = marker_tail[:marker_end]
+
+        if "(dry-run)" in marker_tail or ":failed" in marker_tail:
+            continue
+        return True
     return False
 
 

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -143,6 +143,18 @@ class TestCheckAlreadyAwarded(unittest.TestCase):
         ]
         self.assertTrue(check_already_awarded(comments))
 
+    def test_dry_run_marker_does_not_block_real_award(self):
+        comments = [{"body": f"<!-- {_AWARD_MARKER} (dry-run) -->"}]
+        self.assertFalse(check_already_awarded(comments))
+
+    def test_failed_marker_does_not_block_retry(self):
+        comments = [{"body": f"<!-- {_AWARD_MARKER}:FAILED -->"}]
+        self.assertFalse(check_already_awarded(comments))
+
+    def test_failed_text_outside_marker_does_not_hide_success_marker(self):
+        comments = [{"body": f"failed before marker\n<!-- {_AWARD_MARKER} tx=xyz -->"}]
+        self.assertTrue(check_already_awarded(comments))
+
 
 # ---------------------------------------------------------------------------
 # Config tests
@@ -284,6 +296,44 @@ class TestMainFlow(unittest.TestCase):
             with patch("award_rtc.fetch_pr_comments", return_value=comments):
                 rc = main()
         self.assertEqual(rc, 0)
+
+    def test_retry_after_dry_run_marker(self):
+        from award_rtc import main
+        comments = [{"body": f"<!-- {_AWARD_MARKER} (dry-run) -->"}]
+        transfer_result = {
+            "ok": True,
+            "pending_id": 102,
+            "tx_hash": "tx_after_dry_run",
+        }
+        with self._env():
+            with patch("award_rtc.fetch_pr_comments", return_value=comments):
+                with patch(
+                    "award_rtc.transfer_rtc",
+                    return_value=(True, transfer_result),
+                ) as mock_tx:
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 0)
+        mock_tx.assert_called_once()
+
+    def test_retry_after_failed_marker(self):
+        from award_rtc import main
+        comments = [{"body": f"<!-- {_AWARD_MARKER}:FAILED -->"}]
+        transfer_result = {
+            "ok": True,
+            "pending_id": 103,
+            "tx_hash": "tx_after_failed",
+        }
+        with self._env():
+            with patch("award_rtc.fetch_pr_comments", return_value=comments):
+                with patch(
+                    "award_rtc.transfer_rtc",
+                    return_value=(True, transfer_result),
+                ) as mock_tx:
+                    with patch("award_rtc.post_pr_comment", return_value=True):
+                        rc = main()
+        self.assertEqual(rc, 0)
+        mock_tx.assert_called_once()
 
     def test_dry_run_mode(self):
         from award_rtc import main


### PR DESCRIPTION
## Summary
- fix duplicate-award detection so only successful RTC auto-bounty comments block future payouts
- allow real runs to proceed after dry-run comments and retry after failed transfer comments
- add unit coverage for dry-run, failed, and successful marker behavior

## Why
The action currently writes `RTC-AutoBounty-Awarded` into dry-run and failed-transfer comments. Because duplicate detection checks only for that marker, a dry-run test or transient transfer failure permanently makes later live runs skip with `already_awarded`, even though no RTC was paid.

Refs Scottcjn/rustchain-bounties#2864

Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC

## Validation
- `python3 .github/actions/rtc-auto-bounty/test_award_rtc.py`
- `python3 -m py_compile .github/actions/rtc-auto-bounty/award_rtc.py .github/actions/rtc-auto-bounty/test_award_rtc.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`