### PR TITLE
fix: require admin auth for contributor approvals

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 from flask import Flask, request, redirect, url_for, flash
+import hmac
 import sqlite3
 import os
 import secrets
@@ -33,6 +34,26 @@ elif SECRET_KEY == 'rustchain_contributor_secret_2024':
 app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
+
+
+def _require_contributor_admin():
+    """Require a configured admin key for contributor approval."""
+    expected_key = os.environ.get("CONTRIBUTOR_ADMIN_KEY", "").strip()
+    if not expected_key:
+        return {
+            "error": "unauthorized",
+            "message": "CONTRIBUTOR_ADMIN_KEY not configured",
+        }, 401
+
+    provided_key = (
+        request.headers.get("X-Admin-Key")
+        or request.headers.get("X-API-Key")
+        or ""
+    ).strip()
+    if not provided_key or not hmac.compare_digest(provided_key, expected_key):
+        return {"error": "unauthorized"}, 401
+
+    return None
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -174,8 +195,12 @@ def api_contributors():
         ]
     }
 
-@app.route('/approve/<username>')
+@app.route('/approve/<username>', methods=['POST'])
 def approve_contributor(username):
+    auth_error = _require_contributor_admin()
+    if auth_error:
+        return auth_error
+
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             'UPDATE contributors SET status = "approved" WHERE github_username = ?',

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -9,9 +9,10 @@ import contributor_registry as cr
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
     """Create a test Flask app with a temporary database."""
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
+    monkeypatch.delenv("CONTRIBUTOR_ADMIN_KEY", raising=False)
     cr.DB_PATH = db_path
     cr.app.config["TESTING"] = True
     cr.init_db()
@@ -122,21 +123,73 @@ class TestApiContributors:
 
 
 class TestApproveRoute:
-    def test_approve_pending_contributor(self, client):
-        """GET /approve/<username> should set status to approved."""
+    def _register_pending(self, client, username="pendinguser"):
         client.post("/register", data={
-            "github_username": "pendinguser",
+            "github_username": username,
             "contributor_type": "bot",
             "rtc_wallet": "RTC0pending",
             "contribution_history": "",
         }, follow_redirects=True)
-        response = client.get("/approve/pendinguser", follow_redirects=True)
-        assert response.status_code == 200
+
+    def _status_for(self, username):
         with sqlite3.connect(cr.DB_PATH) as conn:
-            row = conn.execute(
-                "SELECT status FROM contributors WHERE github_username='pendinguser'"
-            ).fetchone()
-        assert row[0] == "approved"
+            return conn.execute(
+                "SELECT status FROM contributors WHERE github_username=?",
+                (username,),
+            ).fetchone()[0]
+
+    def test_approve_get_is_not_allowed(self, client):
+        """GET /approve/<username> must not mutate contributor state."""
+        self._register_pending(client)
+        response = client.get("/approve/pendinguser")
+        assert response.status_code == 405
+        assert self._status_for("pendinguser") == "pending"
+
+    def test_approve_fails_closed_without_admin_key(self, client):
+        """POST /approve/<username> should fail when no admin key is configured."""
+        self._register_pending(client)
+        response = client.post("/approve/pendinguser")
+        assert response.status_code == 401
+        assert self._status_for("pendinguser") == "pending"
+
+    def test_approve_rejects_missing_or_wrong_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> should reject missing or invalid admin keys."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "contrib-admin-secret")
+        self._register_pending(client)
+
+        missing = client.post("/approve/pendinguser")
+        wrong = client.post(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "wrong"},
+        )
+
+        assert missing.status_code == 401
+        assert wrong.status_code == 401
+        assert self._status_for("pendinguser") == "pending"
+
+    def test_approve_pending_contributor_with_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> should set status to approved with admin auth."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "contrib-admin-secret")
+        self._register_pending(client)
+        response = client.post(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "contrib-admin-secret"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert self._status_for("pendinguser") == "approved"
+
+    def test_approve_accepts_legacy_api_key_header(self, client, monkeypatch):
+        """POST /approve/<username> should accept X-API-Key for compatibility."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "contrib-admin-secret")
+        self._register_pending(client, username="legacyuser")
+        response = client.post(
+            "/approve/legacyuser",
+            headers={"X-API-Key": "contrib-admin-secret"},
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert self._status_for("legacyuser") == "approved"
 
 
 class TestDatabaseConstraints:
@@ -165,4 +218,3 @@ class TestDatabaseConstraints:
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"
             ).fetchone()
         assert row[0] == "pending"
-


### PR DESCRIPTION
## Summary
- fix #4722 by requiring contributor approval requests to be authenticated
- restrict `/approve/<username>` to POST so a link/navigation cannot approve a contributor
- fail closed when `CONTRIBUTOR_ADMIN_KEY` is not configured
- accept admin credentials only via `X-Admin-Key` or legacy `X-API-Key`; no query-string secrets
- add regression coverage for GET, unconfigured, missing/wrong key, and valid header cases

## Validation
- `HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 90 uv run --no-project --with pytest --with flask python -m pytest tests/test_contributor_registry.py -q`
- `python3 -m py_compile contributor_registry.py tests/test_contributor_registry.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`

Wallet: b3a58f80a97bae5e2b438894aa85600cb0c066RTC