### PR TITLE
fix: require contributor registration auth

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 
 from flask import Flask, request, redirect, url_for, flash
+import hmac
 import sqlite3
 import os
+import re
 import secrets
 from datetime import datetime
 
@@ -33,6 +35,36 @@ elif SECRET_KEY == 'rustchain_contributor_secret_2024':
 app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
+CONTRIBUTOR_TYPES = {'human', 'bot', 'agent'}
+GITHUB_USERNAME_RE = re.compile(r'^(?!-)(?!.*--)[A-Za-z0-9-]{1,39}(?<!-)$')
+RTC_WALLET_RE = re.compile(
+    r'^(?:RTC[0-9a-fA-F]{40}|[0-9a-fA-F]{40}RTC|0x[0-9a-fA-F]{40})$'
+)
+
+
+def _registration_key_error():
+    expected_key = os.environ.get('CONTRIBUTOR_REGISTRATION_KEY', '')
+    if not expected_key:
+        return 'Registration is closed until CONTRIBUTOR_REGISTRATION_KEY is configured.'
+
+    supplied_key = request.headers.get('X-Registration-Key', '')
+    if not supplied_key:
+        supplied_key = request.form.get('registration_key', '')
+
+    if not supplied_key or not hmac.compare_digest(supplied_key, expected_key):
+        return 'A valid registration key is required.'
+
+    return None
+
+
+def _validate_registration(github_username, contributor_type, rtc_wallet):
+    if not GITHUB_USERNAME_RE.fullmatch(github_username):
+        return 'Invalid GitHub username.'
+    if contributor_type not in CONTRIBUTOR_TYPES:
+        return 'Invalid contributor type.'
+    if not RTC_WALLET_RE.fullmatch(rtc_wallet):
+        return 'Invalid RTC wallet address.'
+    return None
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -95,6 +127,11 @@ def index():
                 <label for="rtc_wallet">RTC Wallet Address:</label>
                 <input type="text" id="rtc_wallet" name="rtc_wallet" required>
             </div>
+
+            <div class="form-group">
+                <label for="registration_key">Registration Key:</label>
+                <input type="password" id="registration_key" name="registration_key" required>
+            </div>
             
             <div class="form-group">
                 <label for="contribution_history">Contribution History:</label>
@@ -136,10 +173,20 @@ def index():
 
 @app.route('/register', methods=['POST'])
 def register():
-    github_username = request.form['github_username']
-    contributor_type = request.form['contributor_type']
-    rtc_wallet = request.form['rtc_wallet']
+    key_error = _registration_key_error()
+    if key_error:
+        flash(key_error)
+        return key_error, 401
+
+    github_username = request.form.get('github_username', '').strip()
+    contributor_type = request.form.get('contributor_type', '').strip()
+    rtc_wallet = request.form.get('rtc_wallet', '').strip()
     contribution_history = request.form.get('contribution_history', '')
+
+    validation_error = _validate_registration(github_username, contributor_type, rtc_wallet)
+    if validation_error:
+        flash(validation_error)
+        return validation_error, 400
     
     try:
         with sqlite3.connect(DB_PATH) as conn:

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -9,8 +9,9 @@ import contributor_registry as cr
 
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
     """Create a test Flask app with a temporary database."""
+    monkeypatch.setenv("CONTRIBUTOR_REGISTRATION_KEY", "test-registration-key")
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
     cr.DB_PATH = db_path
     cr.app.config["TESTING"] = True
@@ -36,6 +37,18 @@ def seed_contributor(app):
             ("testuser", "human", "RTC019e78d600fb3131c29d7ba80aba8fe644be426e", "PR reviews and bug reports", "approved"),
         )
         conn.commit()
+
+
+def registration_form(**overrides):
+    data = {
+        "github_username": "newuser",
+        "contributor_type": "agent",
+        "rtc_wallet": "RTC0abc123000000000000000000000000000000000",
+        "contribution_history": "Mining and staking",
+        "registration_key": "test-registration-key",
+    }
+    data.update(overrides)
+    return data
 
 
 class TestInitDb:
@@ -70,12 +83,7 @@ class TestIndexRoute:
 class TestRegisterRoute:
     def test_register_new_contributor(self, client):
         """POST /register should add a new contributor."""
-        response = client.post("/register", data={
-            "github_username": "newuser",
-            "contributor_type": "agent",
-            "rtc_wallet": "RTC0abc123",
-            "contribution_history": "Mining and staking",
-        }, follow_redirects=True)
+        response = client.post("/register", data=registration_form(), follow_redirects=True)
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
@@ -85,14 +93,67 @@ class TestRegisterRoute:
         assert row[0] == "agent"
         assert row[1] == "pending"
 
+    def test_register_rejects_missing_registration_key(self, client):
+        """POST /register without the shared key must not create a contributor."""
+        response = client.post(
+            "/register",
+            data=registration_form(registration_key=""),
+            follow_redirects=False,
+        )
+        assert response.status_code == 401
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT id FROM contributors WHERE github_username='newuser'"
+            ).fetchone()
+        assert row is None
+
+    def test_register_rejects_when_registration_key_unconfigured(self, client, monkeypatch):
+        """Registration fails closed if the server key is not configured."""
+        monkeypatch.delenv("CONTRIBUTOR_REGISTRATION_KEY", raising=False)
+        response = client.post("/register", data=registration_form(), follow_redirects=False)
+        assert response.status_code == 401
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT id FROM contributors WHERE github_username='newuser'"
+            ).fetchone()
+        assert row is None
+
+    def test_register_rejects_invalid_github_username(self, client):
+        """POST /register should reject usernames that GitHub cannot own."""
+        response = client.post(
+            "/register",
+            data=registration_form(github_username="-not-valid"),
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT id FROM contributors WHERE github_username='-not-valid'"
+            ).fetchone()
+        assert row is None
+
+    def test_register_rejects_invalid_wallet(self, client):
+        """POST /register should reject arbitrary wallet strings."""
+        response = client.post(
+            "/register",
+            data=registration_form(rtc_wallet="not-a-wallet"),
+            follow_redirects=False,
+        )
+        assert response.status_code == 400
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT id FROM contributors WHERE github_username='newuser'"
+            ).fetchone()
+        assert row is None
+
     def test_register_duplicate_username(self, client, seed_contributor):
         """POST /register with existing username should flash error."""
-        response = client.post("/register", data={
-            "github_username": "testuser",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0dup",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        response = client.post("/register", data=registration_form(
+            github_username="testuser",
+            contributor_type="human",
+            rtc_wallet="RTC0abc123000000000000000000000000000000000",
+            contribution_history="",
+        ), follow_redirects=True)
         assert response.status_code == 200
         assert b"already registered" in response.data
 
@@ -124,12 +185,12 @@ class TestApiContributors:
 class TestApproveRoute:
     def test_approve_pending_contributor(self, client):
         """GET /approve/<username> should set status to approved."""
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        client.post("/register", data=registration_form(
+            github_username="pendinguser",
+            contributor_type="bot",
+            rtc_wallet="RTC0abc123000000000000000000000000000000000",
+            contribution_history="",
+        ), follow_redirects=True)
         response = client.get("/approve/pendinguser", follow_redirects=True)
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
@@ -145,24 +206,23 @@ class TestDatabaseConstraints:
         with sqlite3.connect(cr.DB_PATH) as conn:
             conn.execute(
                 "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                ("unique_test", "human", "RTC0unique"),
+                ("unique_test", "human", "RTC0abc123000000000000000000000000000000000"),
             )
             with pytest.raises(sqlite3.IntegrityError):
                 conn.execute(
                     "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                    ("unique_test", "agent", "RTC0dup2"),
+                    ("unique_test", "agent", "RTC0def456000000000000000000000000000000000"),
                 )
 
     def test_default_status_is_pending(self, client):
         """New registrations should have status=pending by default."""
-        client.post("/register", data={
-            "github_username": "defaultstatus",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0default",
-        }, follow_redirects=True)
+        client.post("/register", data=registration_form(
+            github_username="defaultstatus",
+            contributor_type="human",
+            rtc_wallet="RTC0abc123000000000000000000000000000000000",
+        ), follow_redirects=True)
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"
             ).fetchone()
         assert row[0] == "pending"
-


### PR DESCRIPTION
## Summary
- require a configured `CONTRIBUTOR_REGISTRATION_KEY` before `/register` writes a contributor row
- accept the registration key from `X-Registration-Key` or the form password field, without using query-string secrets
- validate GitHub username, contributor type, and RTC/0x wallet address format before insert
- add regressions for valid registration, missing/unconfigured keys, invalid usernames, and invalid wallets

Fixes #4911

## Validation
- `python3 -m py_compile contributor_registry.py tests/test_contributor_registry.py`
- `HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 uv run --no-project --with pytest --with flask python -m pytest tests/test_contributor_registry.py -q` -> 16 passed, 1 warning
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Bounty wallet: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`