### PR TITLE
fix: import hmac for multi arch oracle seeds

### DIFF
--- a/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
+++ b/rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py
@@ -49,6 +49,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Set
 from enum import Enum, auto
 import hashlib
+import hmac
 import struct
 import secrets
 import time
@@ -289,7 +290,7 @@ class MultiArchOracleRing:
             final_seed,
             b''.join(a.encode() for a in sorted(contributions.keys())),
             hashlib.sha256
-        ).digest() if 'hmac' in dir() else hashlib.sha256(final_seed).digest()
+        ).digest()
 
         seed = MultiArchMutationSeed(
             seed=final_seed,
@@ -478,5 +479,4 @@ def demo_multi_arch_network():
 
 
 if __name__ == "__main__":
-    import hmac  # Import for ring signature
     demo_multi_arch_network()

--- a/tests/test_multi_arch_oracles.py
+++ b/tests/test_multi_arch_oracles.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+def load_multi_arch_oracles():
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "rips"
+        / "rustchain-core"
+        / "src"
+        / "mutator_oracle"
+        / "multi_arch_oracles.py"
+    )
+    spec = importlib.util.spec_from_file_location("multi_arch_oracles_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_generate_mutation_seed_builds_hmac_ring_signature():
+    multi_arch = load_multi_arch_oracles()
+    ring = multi_arch.MultiArchOracleRing()
+    ring.register_oracle(
+        multi_arch.ArchitectureOracle(
+            node_id="g4-node",
+            hostname="g4.local",
+            ip_address="192.0.2.10",
+            architecture=multi_arch.CPUArchitecture.POWERPC_G4,
+            cpu_model="PowerPC G4",
+            simd_enabled=True,
+        )
+    )
+    ring.register_oracle(
+        multi_arch.ArchitectureOracle(
+            node_id="x86-node",
+            hostname="x86.local",
+            ip_address="192.0.2.20",
+            architecture=multi_arch.CPUArchitecture.INTEL_X86_64,
+            cpu_model="Intel x86_64",
+            simd_enabled=True,
+        )
+    )
+
+    seed = ring.generate_mutation_seed(block_height=4852)
+
+    assert seed is not None
+    expected_signature = multi_arch.hmac.new(
+        seed.seed,
+        b"".join(
+            arch_id.encode()
+            for arch_id in sorted(seed.architecture_contributions.keys())
+        ),
+        multi_arch.hashlib.sha256,
+    ).digest()
+    assert seed.ring_signature == expected_signature


### PR DESCRIPTION
## Summary
- import `hmac` at module scope before `generate_mutation_seed()` builds the ring signature
- remove the unreachable `dir()` fallback that would have downgraded the ring signature to plain SHA-256
- add a regression that registers two architecture oracles and verifies the generated seed uses the expected HMAC signature

Fixes #4852

## Validation
- `python3 -m py_compile rips/rustchain-core/src/mutator_oracle/multi_arch_oracles.py tests/test_multi_arch_oracles.py`
- `HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 uv run --no-project --with pytest --with flask python -m pytest tests/test_multi_arch_oracles.py -q` -> 1 passed
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Bounty wallet: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`