### PR TITLE
fix: support current welcome bonus ledger schema

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2075,6 +2075,122 @@ def auto_induct_to_hall(miner: str, device: dict):
     except Exception as e:
         print(f"[HALL] Auto-induct error: {e}")
 
+def _table_columns(conn: sqlite3.Connection, table_name: str) -> set:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def _welcome_bonus_epoch() -> int:
+    try:
+        return slot_to_epoch(current_slot())
+    except Exception:
+        return 0
+
+
+def _welcome_bonus_already_paid(conn: sqlite3.Connection, miner: str, ledger_cols: set) -> bool:
+    if {"to_miner", "memo"}.issubset(ledger_cols):
+        row = conn.execute(
+            "SELECT COUNT(*) FROM ledger WHERE to_miner = ? AND memo LIKE '%welcome%'",
+            (miner,),
+        ).fetchone()
+        return bool(row and row[0])
+
+    if {"miner_id", "delta_i64", "reason"}.issubset(ledger_cols):
+        row = conn.execute(
+            """
+            SELECT COUNT(*)
+            FROM ledger
+            WHERE miner_id = ?
+              AND delta_i64 > 0
+              AND reason LIKE 'welcome_bonus:%'
+            """,
+            (miner,),
+        ).fetchone()
+        return bool(row and row[0])
+
+    raise RuntimeError("unsupported ledger schema for welcome bonus")
+
+
+def _insert_account_balance_if_missing(conn: sqlite3.Connection, miner: str, balance_cols: set):
+    if "balance_rtc" in balance_cols:
+        conn.execute(
+            "INSERT OR IGNORE INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
+            (miner,),
+        )
+    else:
+        conn.execute(
+            "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
+            (miner,),
+        )
+
+
+def _update_account_balance(conn: sqlite3.Connection, miner: str, delta_i64: int, balance_cols: set):
+    if "balance_rtc" in balance_cols:
+        conn.execute(
+            """
+            UPDATE balances
+            SET amount_i64 = amount_i64 + ?,
+                balance_rtc = (amount_i64 + ?) / 1000000.0
+            WHERE miner_id = ?
+            """,
+            (delta_i64, delta_i64, miner),
+        )
+    else:
+        conn.execute(
+            "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
+            (delta_i64, miner),
+        )
+
+
+def _write_welcome_bonus(
+    conn: sqlite3.Connection,
+    miner: str,
+    bonus_i64: int,
+    ledger_cols: set,
+    balance_cols: set,
+):
+    reason = f"welcome_bonus:{WELCOME_BONUS_RTC}_rtc"
+    now = int(time.time())
+
+    if (
+        {"miner_id", "amount_i64"}.issubset(balance_cols)
+        and {"miner_id", "delta_i64", "reason"}.issubset(ledger_cols)
+    ):
+        _insert_account_balance_if_missing(conn, miner, balance_cols)
+        _update_account_balance(conn, WELCOME_BONUS_SOURCE, -bonus_i64, balance_cols)
+        _update_account_balance(conn, miner, bonus_i64, balance_cols)
+        epoch = _welcome_bonus_epoch()
+        conn.execute(
+            "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+            (now, epoch, WELCOME_BONUS_SOURCE, -bonus_i64, reason),
+        )
+        conn.execute(
+            "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+            (now, epoch, miner, bonus_i64, reason),
+        )
+        return
+
+    if {"from_miner", "to_miner", "memo"}.issubset(ledger_cols):
+        conn.execute(
+            "UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
+            (bonus_i64, WELCOME_BONUS_SOURCE),
+        )
+        conn.execute(
+            "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)",
+            (miner,),
+        )
+        conn.execute(
+            "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
+            (bonus_i64, miner),
+        )
+        conn.execute(
+            "INSERT INTO ledger (from_miner, to_miner, amount_i64, memo, ts) VALUES (?, ?, ?, ?, ?)",
+            (WELCOME_BONUS_SOURCE, miner, bonus_i64, reason, now),
+        )
+        return
+
+    raise RuntimeError("unsupported welcome bonus balance/ledger schema")
+
+
 def _check_welcome_bonus(miner: str):
     """Award welcome bonus on first-ever attestation. Funded from founder_community."""
     try:
@@ -2085,29 +2201,14 @@ def _check_welcome_bonus(miner: str):
             ).fetchone()[0]
             
             if history_count <= 1:  # First attestation (just recorded)
+                ledger_cols = _table_columns(conn, "ledger")
+                balance_cols = _table_columns(conn, "balances")
                 # Check if welcome bonus already paid
-                already_paid = conn.execute(
-                    "SELECT COUNT(*) FROM ledger WHERE to_miner = ? AND memo LIKE '%welcome%'", (miner,)
-                ).fetchone()[0]
+                already_paid = _welcome_bonus_already_paid(conn, miner, ledger_cols)
                 
-                if already_paid == 0:
+                if not already_paid:
                     bonus_i64 = int(WELCOME_BONUS_RTC * 1_000_000)
-                    # Transfer from founder_community
-                    conn.execute(
-                        "UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
-                        (bonus_i64, WELCOME_BONUS_SOURCE)
-                    )
-                    conn.execute(
-                        "INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (miner,)
-                    )
-                    conn.execute(
-                        "UPDATE balances SET amount_i64 = amount_i64 + ? WHERE miner_id = ?",
-                        (bonus_i64, miner)
-                    )
-                    conn.execute(
-                        "INSERT INTO ledger (from_miner, to_miner, amount_i64, memo, ts) VALUES (?, ?, ?, ?, ?)",
-                        (WELCOME_BONUS_SOURCE, miner, bonus_i64, f"welcome_bonus:{WELCOME_BONUS_RTC}_rtc", int(time.time()))
-                    )
+                    _write_welcome_bonus(conn, miner, bonus_i64, ledger_cols, balance_cols)
                     conn.commit()
                     print(f"[WELCOME] {miner} received {WELCOME_BONUS_RTC} RTC welcome bonus!")
     except Exception as e:

--- a/tests/test_welcome_bonus_schema.py
+++ b/tests/test_welcome_bonus_schema.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+import integrated_node
+
+
+def _create_history(conn, miner="miner_welcome"):
+    conn.execute("CREATE TABLE miner_attest_history (miner TEXT NOT NULL)")
+    conn.execute("INSERT INTO miner_attest_history (miner) VALUES (?)", (miner,))
+
+
+def test_welcome_bonus_credits_current_account_ledger_schema(tmp_path, monkeypatch):
+    db_path = tmp_path / "account-ledger.db"
+    miner = "miner_welcome"
+    bonus_i64 = int(integrated_node.WELCOME_BONUS_RTC * 1_000_000)
+
+    with sqlite3.connect(db_path) as conn:
+        _create_history(conn, miner)
+        conn.execute(
+            """
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                amount_i64 INTEGER NOT NULL DEFAULT 0,
+                balance_rtc REAL NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE ledger (
+                ts INTEGER NOT NULL,
+                epoch INTEGER NOT NULL,
+                miner_id TEXT NOT NULL,
+                delta_i64 INTEGER NOT NULL,
+                reason TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, ?, ?)",
+            (integrated_node.WELCOME_BONUS_SOURCE, bonus_i64 * 2, integrated_node.WELCOME_BONUS_RTC * 2),
+        )
+        conn.commit()
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 144 * 7)
+    monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: slot // 144)
+
+    integrated_node._check_welcome_bonus(miner)
+
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute("SELECT miner_id, amount_i64 FROM balances").fetchall())
+        assert balances[integrated_node.WELCOME_BONUS_SOURCE] == bonus_i64
+        assert balances[miner] == bonus_i64
+
+        ledger_rows = conn.execute(
+            "SELECT epoch, miner_id, delta_i64, reason FROM ledger ORDER BY delta_i64"
+        ).fetchall()
+        assert ledger_rows == [
+            (7, integrated_node.WELCOME_BONUS_SOURCE, -bonus_i64, f"welcome_bonus:{integrated_node.WELCOME_BONUS_RTC}_rtc"),
+            (7, miner, bonus_i64, f"welcome_bonus:{integrated_node.WELCOME_BONUS_RTC}_rtc"),
+        ]
+
+    integrated_node._check_welcome_bonus(miner)
+
+    with sqlite3.connect(db_path) as conn:
+        assert conn.execute("SELECT COUNT(*) FROM ledger").fetchone()[0] == 2
+        balances = dict(conn.execute("SELECT miner_id, amount_i64 FROM balances").fetchall())
+        assert balances[integrated_node.WELCOME_BONUS_SOURCE] == bonus_i64
+        assert balances[miner] == bonus_i64
+
+
+def test_welcome_bonus_keeps_legacy_transfer_ledger_schema(tmp_path, monkeypatch):
+    db_path = tmp_path / "legacy-ledger.db"
+    miner = "miner_legacy"
+    bonus_i64 = int(integrated_node.WELCOME_BONUS_RTC * 1_000_000)
+
+    with sqlite3.connect(db_path) as conn:
+        _create_history(conn, miner)
+        conn.execute(
+            "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL DEFAULT 0)"
+        )
+        conn.execute(
+            """
+            CREATE TABLE ledger (
+                from_miner TEXT NOT NULL,
+                to_miner TEXT NOT NULL,
+                amount_i64 INTEGER NOT NULL,
+                memo TEXT NOT NULL,
+                ts INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            (integrated_node.WELCOME_BONUS_SOURCE, bonus_i64 * 2),
+        )
+        conn.commit()
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    integrated_node._check_welcome_bonus(miner)
+
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute("SELECT miner_id, amount_i64 FROM balances").fetchall())
+        assert balances[integrated_node.WELCOME_BONUS_SOURCE] == bonus_i64
+        assert balances[miner] == bonus_i64
+
+        row = conn.execute(
+            "SELECT from_miner, to_miner, amount_i64, memo FROM ledger"
+        ).fetchone()
+        assert row == (
+            integrated_node.WELCOME_BONUS_SOURCE,
+            miner,
+            bonus_i64,
+            f"welcome_bonus:{integrated_node.WELCOME_BONUS_RTC}_rtc",
+        )


### PR DESCRIPTION
## Summary
- detect whether welcome bonus is running against the current account-ledger schema or the legacy transfer-ledger schema
- for current deployments, credit `balances.amount_i64` and write founder/miner `ledger.delta_i64` rows with `reason=welcome_bonus:...`
- keep the legacy `from_miner` / `to_miner` / `memo` write path for old deployments
- add regression coverage for both schemas and duplicate-bonus prevention

Fixes #4822

## Validation
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_welcome_bonus_schema.py`
- `HTTPS_PROXY=http://127.0.0.1:7890 HTTP_PROXY=http://127.0.0.1:7890 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 240 uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_welcome_bonus_schema.py -q` -> 2 passed
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Bounty wallet: `b3a58f80a97bae5e2b438894aa85600cb0c066RTC`