### PR TITLE
fix: resolve faucet metrics database path

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -658,6 +658,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         @app.route(metrics_path)
         def metrics():
             """Prometheus metrics endpoint."""
+            db_path = config.get('database', {}).get('path', 'faucet.db')
             conn = sqlite3.connect(db_path)
             c = conn.cursor()
             

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -441,6 +441,26 @@ class TestFlaskApp(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data['status'], 'healthy')
         self.assertIn('timestamp', data)
+
+    def test_metrics_endpoint_uses_configured_database(self):
+        """Test metrics endpoint reads from the configured database path."""
+        self.config['monitoring']['metrics_enabled'] = True
+        app = create_app(self.config)
+        client = app.test_client()
+
+        drip_response = client.post('/faucet/drip',
+                                    json={'wallet': '0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E'},
+                                    content_type='application/json')
+        self.assertEqual(drip_response.status_code, 200)
+
+        response = client.get('/metrics')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, 'text/plain')
+
+        metrics = response.get_data(as_text=True)
+        self.assertIn('faucet_drips_total 1', metrics)
+        self.assertIn('faucet_amount_total 0.5', metrics)
+        self.assertIn('faucet_up 1', metrics)
     
     def test_client_ip_detection(self):
         """Test client IP detection with headers."""


### PR DESCRIPTION
## Summary
- resolve the configured faucet database path inside the Prometheus metrics handler
- add regression coverage with metrics enabled so /metrics reads the configured DB

Fixes #4705

## Validation
- python3 -m py_compile faucet_service/faucet_service.py faucet_service/test_faucet_service.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 uv run --no-project --with pytest --with flask --with pyyaml --with pycryptodome --with flask-cors python -m pytest faucet_service/test_faucet_service.py -q
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main