### PR TITLE
fix: load BCOS badge secret from env

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -28,6 +28,7 @@ from tools.bcos_badge_generator import (
     get_badge_stats,
     record_badge_generation,
     increment_download_count,
+    load_secret_key,
 )
 
 
@@ -52,6 +53,19 @@ class TestBadgeConfig(unittest.TestCase):
         self.assertEqual(BADGE_CONFIG['tiers']['L0']['min_score'], 40)
         self.assertEqual(BADGE_CONFIG['tiers']['L1']['min_score'], 60)
         self.assertEqual(BADGE_CONFIG['tiers']['L2']['min_score'], 80)
+
+    def test_secret_key_loads_from_environment(self):
+        """Test secret key loader prefers configured environment value."""
+        with patch.dict(os.environ, {'BADGE_SECRET_KEY': 'configured-secret'}, clear=False):
+            self.assertEqual(load_secret_key(), 'configured-secret')
+
+    def test_secret_key_fallback_is_not_hardcoded(self):
+        """Test secret key fallback no longer uses the public development key."""
+        with patch.dict(os.environ, {'BADGE_SECRET_KEY': ''}, clear=False):
+            secret = load_secret_key()
+
+        self.assertNotEqual(secret, 'bcos-badge-generator-dev-key')
+        self.assertRegex(secret, r'^[0-9a-f]{64}$')
 
 
 class TestBadgeSVGGeneration(unittest.TestCase):

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -29,6 +29,7 @@ import hashlib
 import json
 import os
 import re
+import secrets
 import sqlite3
 import subprocess
 import sys
@@ -46,9 +47,15 @@ except ImportError:
     print("Flask not installed. Install with: pip install flask", file=sys.stderr)
     sys.exit(1)
 
+def load_secret_key() -> str:
+    """Load Flask secret key from env, or generate an ephemeral fallback."""
+    configured = os.environ.get('BADGE_SECRET_KEY', '').strip()
+    return configured or secrets.token_hex(32)
+
+
 # Initialize Flask app
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'bcos-badge-generator-dev-key'
+app.config['SECRET_KEY'] = load_secret_key()
 app.config['MAX_CONTENT_LENGTH'] = 16 * 1024 * 1024  # 16MB max upload
 
 # Database path


### PR DESCRIPTION
## Summary
- update the existing root `tools/bcos_badge_generator.py` to load Flask `SECRET_KEY` from `BADGE_SECRET_KEY`
- generate an ephemeral random fallback instead of using the public development key
- add tests for configured and fallback secret loading

Fixes #5086

Note: existing PR #5087 creates `rips/rustchain-core/tools/bcos_badge_generator.py`; this PR fixes the root file identified by #5086.

## Validation
- python3 -m py_compile tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 uv run --no-project --with pytest --with flask python -m pytest tests/test_bcos_badge_generator.py -q
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main