### PR TITLE
fix: add main server security headers

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -533,6 +533,16 @@ def get_client_ip():
     """Trusted client IP for rate limits and accounting surfaces."""
     return client_ip_from_request(request)
 
+
+SECURITY_HEADERS = {
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+}
+
+
 @app.after_request
 def _after(resp):
     try:
@@ -551,6 +561,9 @@ def _after(resp):
     except Exception:
         pass
     resp.headers["X-Request-Id"] = getattr(g, "request_id", "-")
+    for header, value in SECURITY_HEADERS.items():
+        if header not in resp.headers:
+            resp.headers[header] = value
     return resp
 
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -535,7 +535,14 @@ def get_client_ip():
 
 
 SECURITY_HEADERS = {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+    "Content-Security-Policy": (
+        "default-src 'self'; "
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "font-src 'self' data: https://fonts.gstatic.com; "
+        "img-src 'self' data: https://img.shields.io; "
+        "connect-src 'self' https://raw.githubusercontent.com"
+    ),
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "X-Content-Type-Options": "nosniff",

--- a/node/tests/test_main_security_headers.py
+++ b/node/tests/test_main_security_headers.py
@@ -52,6 +52,16 @@ class TestMainSecurityHeaders(unittest.TestCase):
         self.assertIn("default-src 'self'", response.headers["Content-Security-Policy"])
         self.assertIn("script-src 'self' 'unsafe-inline'", response.headers["Content-Security-Policy"])
 
+    def test_museum_csp_allows_existing_external_assets(self):
+        response = self.client.get("/museum")
+
+        self.assertEqual(response.status_code, 200)
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("https://fonts.googleapis.com", csp)
+        self.assertIn("https://fonts.gstatic.com", csp)
+        self.assertIn("https://raw.githubusercontent.com", csp)
+        self.assertIn("https://img.shields.io", csp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/node/tests/test_main_security_headers.py
+++ b/node/tests/test_main_security_headers.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+
+
+class TestMainSecurityHeaders(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "headers.db")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_security_headers_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def test_main_server_sets_defense_in_depth_security_headers(self):
+        response = self.client.get("/health")
+
+        self.assertIn(response.status_code, (200, 503))
+        self.assertEqual(response.headers["X-Content-Type-Options"], "nosniff")
+        self.assertEqual(response.headers["X-Frame-Options"], "DENY")
+        self.assertEqual(response.headers["Strict-Transport-Security"], "max-age=31536000; includeSubDomains")
+        self.assertEqual(response.headers["Referrer-Policy"], "strict-origin-when-cross-origin")
+        self.assertIn("default-src 'self'", response.headers["Content-Security-Policy"])
+        self.assertIn("script-src 'self' 'unsafe-inline'", response.headers["Content-Security-Policy"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add defense-in-depth security headers to the main node server `after_request` hook
- preserve existing `X-Request-Id` behavior while setting CSP, HSTS, Referrer-Policy, X-Content-Type-Options, and X-Frame-Options when absent
- add a Flask test-client regression for `/health` responses

Fixes #5046

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest node\tests\test_main_security_headers.py -q` -> 1 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_main_security_headers.py` -> passed
- `git diff --check origin/main...HEAD -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_main_security_headers.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

No live node mutation, wallet action, private key, token transfer, or destructive operation was used.

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`