### PR TITLE
fix: store Sophia Elya balances as micro RTC

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -5,6 +5,7 @@ Production Anti-Spoof System with Fair Distribution
 Issue #2295: Added WebSocket real-time feed for Block Explorer
 """
 import os, time, json, secrets, hashlib, sqlite3
+from decimal import Decimal, ROUND_HALF_UP
 from flask import Flask, request, jsonify
 from datetime import datetime
 
@@ -31,6 +32,48 @@ LAST_EPOCH = None
 
 # Database setup
 DB_PATH = "./rustchain_v2.db"
+RTC_MICRO_UNITS = 1_000_000
+
+def _rtc_to_micro(amount_rtc):
+    """Convert public RTC values to canonical integer micro-RTC units."""
+    return int(
+        (Decimal(str(amount_rtc)) * RTC_MICRO_UNITS).to_integral_value(
+            rounding=ROUND_HALF_UP
+        )
+    )
+
+def _micro_to_rtc(amount_micro):
+    """Convert canonical micro-RTC values back to public RTC units."""
+    return int(amount_micro) / RTC_MICRO_UNITS
+
+def _ensure_balance_micro_schema(conn):
+    """Keep balances canonical in integer micro-RTC units."""
+    columns = conn.execute("PRAGMA table_info(balances)").fetchall()
+    if not columns:
+        conn.execute(
+            "CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc INTEGER DEFAULT 0)"
+        )
+        return
+
+    by_name = {row[1]: row for row in columns}
+    balance_column = by_name.get("balance_rtc")
+    if balance_column and "INT" in (balance_column[2] or "").upper():
+        return
+
+    conn.execute("ALTER TABLE balances RENAME TO balances_legacy_real")
+    conn.execute(
+        "CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc INTEGER DEFAULT 0)"
+    )
+    if "miner_pk" in by_name and balance_column:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO balances(miner_pk, balance_rtc)
+            SELECT miner_pk, CAST(ROUND(COALESCE(balance_rtc, 0) * ?) AS INTEGER)
+            FROM balances_legacy_real
+            """,
+            (RTC_MICRO_UNITS,),
+        )
+    conn.execute("DROP TABLE balances_legacy_real")
 
 def init_db():
     """Initialize database with epoch tables"""
@@ -41,8 +84,10 @@ def init_db():
 
         # New epoch tables
         c.execute("CREATE TABLE IF NOT EXISTS epoch_state (epoch INTEGER PRIMARY KEY, accepted_blocks INTEGER DEFAULT 0, finalized INTEGER DEFAULT 0)")
+        # `weight` is a non-financial pro-rata multiplier; balances are financial
+        # and stay in integer micro-RTC units.
         c.execute("CREATE TABLE IF NOT EXISTS epoch_enroll (epoch INTEGER, miner_pk TEXT, weight REAL, PRIMARY KEY (epoch, miner_pk))")
-        c.execute("CREATE TABLE IF NOT EXISTS balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+        _ensure_balance_micro_schema(c)
 
 # Hardware multipliers
 HARDWARE_WEIGHTS = {
@@ -99,8 +144,9 @@ def finalize_epoch(epoch, per_block_rtc):
             for pk, w in miners:
                 amt = total_reward * (w / sum_w)
                 c.execute("INSERT OR IGNORE INTO balances(miner_pk, balance_rtc) VALUES (?,0)", (pk,))
-                c.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk=?", (amt, pk))
-                payouts.append((pk, amt))
+                amount_micro = _rtc_to_micro(amt)
+                c.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk=?", (amount_micro, pk))
+                payouts.append((pk, _micro_to_rtc(amount_micro)))
 
         c.execute("UPDATE epoch_state SET finalized=1 WHERE epoch=?", (epoch,))
         return {"ok": True, "blocks": blocks, "total_reward": total_reward, "sum_w": sum_w, "payouts": payouts}
@@ -109,7 +155,7 @@ def get_balance(miner_pk):
     """Get miner balance"""
     with sqlite3.connect(DB_PATH) as c:
         row = c.execute("SELECT balance_rtc FROM balances WHERE miner_pk=?", (miner_pk,)).fetchone()
-        return float(row[0]) if row else 0.0
+        return _micro_to_rtc(row[0]) if row else 0.0
 
 def get_hardware_weight(device):
     """Get hardware multiplier from device info"""

--- a/node/tests/test_sophia_elya_service_money_units.py
+++ b/node/tests/test_sophia_elya_service_money_units.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sqlite3
+import tempfile
+from pathlib import Path
+
+
+def load_service(tmp_path):
+    module_path = Path(__file__).resolve().parents[1] / "sophia_elya_service.py"
+    spec = importlib.util.spec_from_file_location("sophia_elya_service_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.DB_PATH = str(tmp_path / "elya.db")
+    return module
+
+
+def test_balances_schema_uses_integer_micro_rtc():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        service = load_service(Path(tmp))
+
+        service.init_db()
+
+        with sqlite3.connect(service.DB_PATH) as conn:
+            columns = {
+                row[1]: row[2].upper()
+                for row in conn.execute("PRAGMA table_info(balances)").fetchall()
+            }
+
+        assert columns["balance_rtc"] == "INTEGER"
+
+
+def test_finalize_epoch_stores_integer_micro_rtc_and_returns_public_rtc():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        service = load_service(Path(tmp))
+        service.init_db()
+
+        with sqlite3.connect(service.DB_PATH) as conn:
+            conn.execute(
+                "INSERT INTO epoch_state(epoch, accepted_blocks, finalized) VALUES (?,?,?)",
+                (7, 1, 0),
+            )
+            conn.execute(
+                "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (?,?,?)",
+                (7, "RTC_miner", 1.0),
+            )
+
+        result = service.finalize_epoch(7, 0.1)
+
+        assert result["ok"] is True
+        assert result["payouts"] == [("RTC_miner", 0.1)]
+        assert service.get_balance("RTC_miner") == 0.1
+
+        with sqlite3.connect(service.DB_PATH) as conn:
+            stored_type, stored_value = conn.execute(
+                "SELECT typeof(balance_rtc), balance_rtc FROM balances WHERE miner_pk=?",
+                ("RTC_miner",),
+            ).fetchone()
+
+        assert stored_type == "integer"
+        assert stored_value == 100_000
+
+
+def test_legacy_real_balances_are_migrated_to_micro_rtc():
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
+        service = load_service(Path(tmp))
+
+        with sqlite3.connect(service.DB_PATH) as conn:
+            conn.execute(
+                "CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)"
+            )
+            conn.execute(
+                "INSERT INTO balances(miner_pk, balance_rtc) VALUES (?, ?)",
+                ("RTC_legacy", 1.234567),
+            )
+
+        service.init_db()
+
+        with sqlite3.connect(service.DB_PATH) as conn:
+            column_type = conn.execute("PRAGMA table_info(balances)").fetchall()[1][2]
+            stored_type, stored_value = conn.execute(
+                "SELECT typeof(balance_rtc), balance_rtc FROM balances WHERE miner_pk=?",
+                ("RTC_legacy",),
+            ).fetchone()
+
+        assert column_type.upper() == "INTEGER"
+        assert stored_type == "integer"
+        assert stored_value == 1_234_567
+        assert service.get_balance("RTC_legacy") == 1.234567


### PR DESCRIPTION
Fixes #5096.

## What changed
- Store `node/sophia_elya_service.py` balances in canonical integer micro-RTC units instead of SQLite `REAL` floats.
- Preserve the public `/balance/<miner_pk>` behavior by converting micro-RTC back to RTC for JSON responses.
- Add a small schema migration path from legacy `REAL` `balances.balance_rtc` rows into integer micro-RTC rows.
- Keep `epoch_enroll.weight` as `REAL` because it is a non-financial pro-rata multiplier, not a wallet amount.
- Add focused regression coverage for new schema, payout storage type, public balance rendering, and legacy REAL migration.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest node\tests\test_sophia_elya_service_money_units.py -q` -> 3 passed
- `python -m py_compile node\sophia_elya_service.py node\tests\test_sophia_elya_service_money_units.py` -> passed
- `git diff --check origin/main...HEAD -- node\sophia_elya_service.py node\tests\test_sophia_elya_service_money_units.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Duplicate / scope check
- `gh search prs` for #5096 / `sophia_elya_service` / `balance_rtc INTEGER` / micro RTC returned no open or closed PR coverage before submission.
- This targets the exact file and financial column named in issue #5096.

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`