### PR TITLE
fix: use CSPRNG for Proof-of-Iron nonces

### DIFF
--- a/issue2307_boot_chime/src/proof_of_iron.py
+++ b/issue2307_boot_chime/src/proof_of_iron.py
@@ -7,6 +7,7 @@ verifiable hardware proofs.
 
 import hashlib
 import json
+import secrets
 import time
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass, asdict
@@ -376,12 +377,12 @@ class ProofOfIron:
     
     def _generate_challenge_id(self, miner_id: str) -> str:
         """Generate unique challenge ID"""
-        data = f"{miner_id}:{time.time()}:{np.random.random()}"
+        data = f"{miner_id}:{time.time()}:{secrets.token_hex(16)}"
         return hashlib.sha256(data.encode()).hexdigest()[:16]
     
     def _generate_nonce(self) -> str:
-        """Generate random nonce"""
-        return hashlib.sha256(str(np.random.random()).encode()).hexdigest()[:16]
+        """Generate cryptographically secure challenge nonce"""
+        return secrets.token_hex(8)
     
     def _generate_device_id(self, miner_id: str, signature: str) -> str:
         """Generate unique device ID"""

--- a/issue2307_boot_chime/tests/test_boot_chime.py
+++ b/issue2307_boot_chime/tests/test_boot_chime.py
@@ -11,6 +11,7 @@ import os
 import time
 from pathlib import Path
 import sys
+from unittest.mock import patch
 
 # Add src to path and handle imports
 src_path = str(Path(__file__).parent.parent / 'src')
@@ -303,6 +304,25 @@ class TestProofOfIron(unittest.TestCase):
         self.assertEqual(challenge.miner_id, "miner_test_001")
         self.assertTrue(challenge.is_valid())
         self.assertEqual(len(challenge.nonce), 16)
+
+    def test_challenge_ids_and_nonces_do_not_use_numpy_prng(self):
+        """Challenge entropy must come from secrets, not Mersenne Twister."""
+        proof_globals = ProofOfIron._generate_nonce.__globals__
+        with patch.object(proof_globals["np"].random, "random", side_effect=AssertionError("np.random.random used")):
+            challenge_id = self.poi._generate_challenge_id("miner_test_001")
+            nonce = self.poi._generate_nonce()
+
+        self.assertEqual(len(challenge_id), 16)
+        self.assertEqual(len(nonce), 16)
+
+    def test_nonce_comes_directly_from_secrets_token_hex(self):
+        """Regression for issue #5040: nonce generation must use CSPRNG output."""
+        proof_globals = ProofOfIron._generate_nonce.__globals__
+        with patch.object(proof_globals["secrets"], "token_hex", return_value="a" * 16) as token_hex:
+            nonce = self.poi._generate_nonce()
+
+        token_hex.assert_called_once_with(8)
+        self.assertEqual(nonce, "a" * 16)
     
     def test_challenge_expiration(self):
         """Test challenge expiration"""


### PR DESCRIPTION
Fixes #5040.

## What changed
- Replaced `np.random.random()` entropy in Proof-of-Iron challenge ID generation with `secrets.token_hex(16)`.
- Replaced nonce generation with `secrets.token_hex(8)` so the existing 16-hex-character nonce contract is preserved while using CSPRNG entropy.
- Added regressions proving challenge IDs/nonces no longer call NumPy's Mersenne Twister path and that nonce generation comes from `secrets.token_hex(8)`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest issue2307_boot_chime\tests\test_boot_chime.py::TestProofOfIron -q` -> 12 passed
- `python -m py_compile issue2307_boot_chime\src\proof_of_iron.py issue2307_boot_chime\tests\test_boot_chime.py` -> passed
- `git diff --check origin/main...HEAD -- issue2307_boot_chime\src\proof_of_iron.py issue2307_boot_chime\tests\test_boot_chime.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Duplicate / scope check
- `gh search prs` for #5040 / `proof_of_iron` / `numpy.random` / `secrets.token_hex` / predictable nonces returned no open or closed PR coverage before submission.
- This targets the exact file and entropy path named in issue #5040.

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`