### PR TITLE
fix: fail closed attest debug admin auth

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6374,7 +6374,9 @@ def attest_debug():
     """Debug endpoint: show miner's enrollment eligibility"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes internal config + MAC hashes
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not ADMIN_KEY:
+        return jsonify({"error": "Admin key not configured"}), 503
+    if not hmac.compare_digest(admin_key, ADMIN_KEY):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     data = request.get_json()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,3 +100,13 @@ def test_pending_list_requires_admin(client):
     """Unauthenticated /pending/list should return 401."""
     response = client.get('/pending/list?limit=abc')
     assert response.status_code == 401
+
+
+def test_attest_debug_fails_closed_when_admin_key_unconfigured(client, monkeypatch):
+    """No configured admin key must not authenticate a missing header."""
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", None)
+
+    response = client.post('/ops/attest/debug', json={"miner": "miner-test"})
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "Admin key not configured"


### PR DESCRIPTION
Fixes #5042.

## What changed
- Made `/ops/attest/debug` fail closed when `RC_ADMIN_KEY` / module `ADMIN_KEY` is not configured.
- Avoided the previous `hmac.compare_digest("", "")` case where a missing header could match a missing admin key.
- Preserved the existing unauthorized response for wrong admin keys when an admin key is configured.
- Added a regression proving a missing configured admin key returns 503 instead of authenticating a missing header.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_api.py::test_attest_debug_fails_closed_when_admin_key_unconfigured tests\test_api.py::test_api_balances_requires_admin tests\test_api.py::test_pending_list_requires_admin -q` -> 3 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_api.py` -> passed
- `git diff --check origin/main...HEAD -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_api.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Duplicate / scope check
- `gh search prs` for #5042 / `attest_debug` / `Admin key not configured` / `RC_ADMIN_KEY` + `/ops/attest/debug` returned no open or closed PR coverage before submission.
- This targets the exact endpoint and fail-open default described in issue #5042.

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
