### PR TITLE
fix: rate limit admin API attempts

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -200,6 +200,7 @@ _ADMIN_RATE_LIMIT_PATHS = {
     "/api/bridge/void",
     "/api/lock/forfeit",
     "/api/lock/release",
+    "/genesis/export",
     "/miner/headerkey",
     "/ops/attest/debug",
     "/rewards/settle",
@@ -212,28 +213,36 @@ _ADMIN_RATE_LIMIT_PATHS = {
 }
 
 
-def _is_admin_rate_limited_path(path: str) -> bool:
+def _admin_rate_limit_bucket_path(path: str) -> Optional[str]:
     if path in _ADMIN_RATE_LIMIT_PATHS:
-        return True
+        return path
     if path.startswith("/api/miner/") and path.endswith("/attestations"):
-        return True
-    if path.startswith("/api/bridge/lock/") and (
-        path.endswith("/confirm") or path.endswith("/release")
-    ):
-        return True
+        return "/api/miner/:miner_id/attestations"
+    if path.startswith("/api/bridge/lock/"):
+        if path.endswith("/confirm"):
+            return "/api/bridge/lock/:lock_id/confirm"
+        if path.endswith("/release"):
+            return "/api/bridge/lock/:lock_id/release"
     if path.startswith("/withdraw/history/"):
-        return True
-    return any(path.startswith(prefix) for prefix in _ADMIN_RATE_LIMIT_PREFIXES)
+        return "/withdraw/history/:miner_pk"
+    for prefix in _ADMIN_RATE_LIMIT_PREFIXES:
+        if path.startswith(prefix):
+            return f"{prefix.rstrip('/')}/*"
+    return None
 
 
-def _check_admin_rate_limit(client_ip: str, path: str, now_ts: Optional[int] = None):
+def _is_admin_rate_limited_path(path: str) -> bool:
+    return _admin_rate_limit_bucket_path(path) is not None
+
+
+def _check_admin_rate_limit(client_ip: str, route_key: str, now_ts: Optional[int] = None):
     """Bound repeated admin endpoint attempts per client IP and route."""
     if ADMIN_RATE_LIMIT_MAX <= 0:
         return True, 0
     now_ts = int(time.time()) if now_ts is None else int(now_ts)
     window = max(1, ADMIN_RATE_LIMIT_WINDOW)
     cutoff = now_ts - window
-    key = (client_ip or "unknown", path)
+    key = (client_ip or "unknown", route_key)
     with _ADMIN_RATE_LIMIT_LOCK:
         attempts = [ts for ts in _ADMIN_RATE_LIMIT_BUCKETS.get(key, []) if ts > cutoff]
         if len(attempts) >= ADMIN_RATE_LIMIT_MAX:
@@ -554,8 +563,9 @@ except Exception as e:
 def _start_timer():
     g._ts = time.time()
     g.request_id = request.headers.get("X-Request-Id") or uuid.uuid4().hex
-    if _is_admin_rate_limited_path(request.path):
-        allowed, retry_after = _check_admin_rate_limit(get_client_ip(), request.path)
+    rate_limit_path = _admin_rate_limit_bucket_path(request.path)
+    if rate_limit_path:
+        allowed, retry_after = _check_admin_rate_limit(get_client_ip(), rate_limit_path)
         if not allowed:
             return _admin_rate_limit_response(retry_after)
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5,6 +5,7 @@ Includes RIP-0005 (Epoch Rewards), RIP-0008 (Withdrawals), RIP-0009 (Finality)
 """
 import os, time, json, secrets, hashlib, hmac, sqlite3, base64, struct, uuid, glob, logging, sys, binascii, math, re, statistics
 import ipaddress
+from threading import Lock
 from urllib.parse import urlparse
 from flask import Flask, request, jsonify, g, send_from_directory, send_file, abort, render_template_string, redirect
 import json
@@ -184,6 +185,77 @@ MUSEUM_DIR = os.path.join(REPO_ROOT, "web", "museum")
 HOF_DIR = os.path.join(REPO_ROOT, "web", "hall-of-fame")
 DASHBOARD_DIR = os.path.join(REPO_ROOT, "tools", "miner_dashboard")
 EXPLORER_DIR = os.path.join(REPO_ROOT, "tools", "explorer")
+
+ADMIN_RATE_LIMIT_MAX = int(os.environ.get("RC_ADMIN_RATE_LIMIT_MAX", "12"))
+ADMIN_RATE_LIMIT_WINDOW = int(os.environ.get("RC_ADMIN_RATE_LIMIT_WINDOW_SECONDS", "60"))
+_ADMIN_RATE_LIMIT_BUCKETS = {}
+_ADMIN_RATE_LIMIT_LOCK = Lock()
+_ADMIN_RATE_LIMIT_PREFIXES = (
+    "/admin/",
+    "/gov/rotate/",
+    "/pending/",
+)
+_ADMIN_RATE_LIMIT_PATHS = {
+    "/api/balances",
+    "/api/bridge/void",
+    "/api/lock/forfeit",
+    "/api/lock/release",
+    "/miner/headerkey",
+    "/ops/attest/debug",
+    "/rewards/settle",
+    "/wallet/balances/all",
+    "/wallet/ledger",
+    "/wallet/link-coinbase",
+    "/wallet/transfer",
+    "/wallet/transfer_OLD_DISABLED",
+    "/withdraw/register",
+}
+
+
+def _is_admin_rate_limited_path(path: str) -> bool:
+    if path in _ADMIN_RATE_LIMIT_PATHS:
+        return True
+    if path.startswith("/api/miner/") and path.endswith("/attestations"):
+        return True
+    if path.startswith("/api/bridge/lock/") and (
+        path.endswith("/confirm") or path.endswith("/release")
+    ):
+        return True
+    if path.startswith("/withdraw/history/"):
+        return True
+    return any(path.startswith(prefix) for prefix in _ADMIN_RATE_LIMIT_PREFIXES)
+
+
+def _check_admin_rate_limit(client_ip: str, path: str, now_ts: Optional[int] = None):
+    """Bound repeated admin endpoint attempts per client IP and route."""
+    if ADMIN_RATE_LIMIT_MAX <= 0:
+        return True, 0
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    window = max(1, ADMIN_RATE_LIMIT_WINDOW)
+    cutoff = now_ts - window
+    key = (client_ip or "unknown", path)
+    with _ADMIN_RATE_LIMIT_LOCK:
+        attempts = [ts for ts in _ADMIN_RATE_LIMIT_BUCKETS.get(key, []) if ts > cutoff]
+        if len(attempts) >= ADMIN_RATE_LIMIT_MAX:
+            _ADMIN_RATE_LIMIT_BUCKETS[key] = attempts
+            retry_after = max(1, window - (now_ts - attempts[0]))
+            return False, retry_after
+        attempts.append(now_ts)
+        _ADMIN_RATE_LIMIT_BUCKETS[key] = attempts
+        return True, 0
+
+
+def _admin_rate_limit_response(retry_after: int):
+    response = jsonify({
+        "ok": False,
+        "error": "rate_limited",
+        "code": "ADMIN_RATE_LIMIT",
+        "limit": ADMIN_RATE_LIMIT_MAX,
+        "window_seconds": ADMIN_RATE_LIMIT_WINDOW,
+    })
+    response.status_code = 429
+    response.headers["Retry-After"] = str(retry_after)
+    return response
 
 
 def _attest_mapping(value):
@@ -482,6 +554,10 @@ except Exception as e:
 def _start_timer():
     g._ts = time.time()
     g.request_id = request.headers.get("X-Request-Id") or uuid.uuid4().hex
+    if _is_admin_rate_limited_path(request.path):
+        allowed, retry_after = _check_admin_rate_limit(get_client_ip(), request.path)
+        if not allowed:
+            return _admin_rate_limit_response(retry_after)
 
 def _normalize_client_ip(raw_value) -> str:
     """Normalize a peer/header IP string down to the first address token."""

--- a/node/tests/test_admin_rate_limit.py
+++ b/node/tests/test_admin_rate_limit.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+MODULE_NAME = "rustchain_integrated_rate_limit_test"
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+
+
+def _load_integrated_module():
+    if "integrated_node" in sys.modules:
+        return sys.modules["integrated_node"]
+    if MODULE_NAME in sys.modules:
+        return sys.modules[MODULE_NAME]
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(MODULE_NAME, None)
+        raise
+    return mod
+
+
+class TestAdminRateLimit(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+        os.environ["RUSTCHAIN_DB_PATH"] = str(Path(cls._tmp.name) / "admin_rate_limit.db")
+        cls.mod = _load_integrated_module()
+        cls.mod.DB_PATH = os.environ["RUSTCHAIN_DB_PATH"]
+        cls.mod.app.config["DB_PATH"] = os.environ["RUSTCHAIN_DB_PATH"]
+        cls.mod.app.config["TESTING"] = True
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.mod.ADMIN_RATE_LIMIT_MAX = 2
+        self.mod.ADMIN_RATE_LIMIT_WINDOW = 60
+        self.mod._ADMIN_RATE_LIMIT_BUCKETS.clear()
+
+    def test_admin_endpoint_rejects_repeated_failed_key_attempts(self):
+        statuses = []
+        with mock.patch.object(self.mod.time, "time", return_value=1000):
+            with self.mod.app.test_client() as client:
+                for _ in range(3):
+                    response = client.get(
+                        "/pending/list",
+                        headers={"X-Admin-Key": "wrong-admin-key"},
+                        environ_base={"REMOTE_ADDR": "198.51.100.42"},
+                    )
+                    statuses.append((response.status_code, response.get_json(), response.headers))
+
+        self.assertEqual(statuses[0][0], 401)
+        self.assertEqual(statuses[1][0], 401)
+        self.assertEqual(statuses[2][0], 429)
+        self.assertEqual(statuses[2][1]["code"], "ADMIN_RATE_LIMIT")
+        self.assertEqual(statuses[2][2]["Retry-After"], "60")
+
+    def test_public_health_endpoint_is_not_admin_rate_limited(self):
+        with mock.patch.object(self.mod.time, "time", return_value=1000):
+            with self.mod.app.test_client() as client:
+                responses = [
+                    client.get("/health", environ_base={"REMOTE_ADDR": "198.51.100.43"})
+                    for _ in range(4)
+                ]
+
+        self.assertTrue(all(response.status_code == 200 for response in responses))
+
+    def test_registered_admin_extension_routes_are_limited(self):
+        self.assertTrue(self.mod._is_admin_rate_limited_path("/wallet/link-coinbase"))
+        self.assertTrue(self.mod._is_admin_rate_limited_path("/api/bridge/void"))
+        self.assertTrue(self.mod._is_admin_rate_limited_path("/api/lock/release"))
+        self.assertTrue(self.mod._is_admin_rate_limited_path("/api/bridge/lock/abc123/confirm"))
+        self.assertFalse(self.mod._is_admin_rate_limited_path("/wallet/swap-info"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_admin_rate_limit.py
+++ b/node/tests/test_admin_rate_limit.py
@@ -90,12 +90,50 @@ class TestAdminRateLimit(unittest.TestCase):
 
         self.assertTrue(all(response.status_code == 200 for response in responses))
 
+    def test_dynamic_admin_route_variants_share_rate_limit_bucket(self):
+        paths = [
+            "/withdraw/history/miner-a",
+            "/withdraw/history/miner-b",
+            "/withdraw/history/miner-c",
+        ]
+        statuses = []
+        with mock.patch.object(self.mod.time, "time", return_value=1000):
+            with self.mod.app.test_client() as client:
+                for path in paths:
+                    response = client.get(
+                        path,
+                        headers={"X-Admin-Key": "wrong-admin-key"},
+                        environ_base={"REMOTE_ADDR": "198.51.100.44"},
+                    )
+                    statuses.append(response.status_code)
+
+        self.assertEqual(statuses, [401, 401, 429])
+
     def test_registered_admin_extension_routes_are_limited(self):
         self.assertTrue(self.mod._is_admin_rate_limited_path("/wallet/link-coinbase"))
         self.assertTrue(self.mod._is_admin_rate_limited_path("/api/bridge/void"))
         self.assertTrue(self.mod._is_admin_rate_limited_path("/api/lock/release"))
         self.assertTrue(self.mod._is_admin_rate_limited_path("/api/bridge/lock/abc123/confirm"))
+        self.assertTrue(self.mod._is_admin_rate_limited_path("/genesis/export"))
         self.assertFalse(self.mod._is_admin_rate_limited_path("/wallet/swap-info"))
+
+    def test_dynamic_admin_route_bucket_keys_are_normalized(self):
+        self.assertEqual(
+            self.mod._admin_rate_limit_bucket_path("/api/miner/alice/attestations"),
+            "/api/miner/:miner_id/attestations",
+        )
+        self.assertEqual(
+            self.mod._admin_rate_limit_bucket_path("/withdraw/history/miner-a"),
+            "/withdraw/history/:miner_pk",
+        )
+        self.assertEqual(
+            self.mod._admin_rate_limit_bucket_path("/api/bridge/lock/abc123/confirm"),
+            "/api/bridge/lock/:lock_id/confirm",
+        )
+        self.assertEqual(
+            self.mod._admin_rate_limit_bucket_path("/api/bridge/lock/def456/release"),
+            "/api/bridge/lock/:lock_id/release",
+        )
 
 
 if __name__ == "__main__":

--- a/node/tests/test_admin_rate_limit.py
+++ b/node/tests/test_admin_rate_limit.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
+import gc
 import os
 import sys
 import tempfile
@@ -30,6 +31,14 @@ def _load_integrated_module():
     return mod
 
 
+def _cleanup_tempdir(tempdir):
+    gc.collect()
+    try:
+        tempdir.cleanup()
+    except OSError:
+        pass
+
+
 class TestAdminRateLimit(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -55,7 +64,7 @@ class TestAdminRateLimit(unittest.TestCase):
             os.environ.pop("RUSTCHAIN_DB_PATH", None)
         else:
             os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
-        cls._tmp.cleanup()
+        _cleanup_tempdir(cls._tmp)
 
     def setUp(self):
         self.mod.ADMIN_RATE_LIMIT_MAX = 2

--- a/node/tests/test_attest_challenge_rate_limit.py
+++ b/node/tests/test_attest_challenge_rate_limit.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
+import gc
 import os
 import sqlite3
 import sys
@@ -30,6 +31,14 @@ def _load_integrated_module():
     return mod
 
 
+def _cleanup_tempdir(tempdir):
+    gc.collect()
+    try:
+        tempdir.cleanup()
+    except OSError:
+        pass
+
+
 class TestAttestChallengeRateLimit(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -53,7 +62,7 @@ class TestAttestChallengeRateLimit(unittest.TestCase):
             os.environ.pop("RUSTCHAIN_DB_PATH", None)
         else:
             os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
-        cls._tmp.cleanup()
+        _cleanup_tempdir(cls._tmp)
 
     def _load_module(self, module_name: str, db_name: str):
         db_path = str(Path(self._tmp.name) / db_name)

--- a/node/tests/test_attest_challenge_rate_limit.py
+++ b/node/tests/test_attest_challenge_rate_limit.py
@@ -11,6 +11,23 @@ from unittest import mock
 
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+MODULE_NAME = "rustchain_integrated_rate_limit_test"
+
+
+def _load_integrated_module():
+    if "integrated_node" in sys.modules:
+        return sys.modules["integrated_node"]
+    if MODULE_NAME in sys.modules:
+        return sys.modules[MODULE_NAME]
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception:
+        sys.modules.pop(MODULE_NAME, None)
+        raise
+    return mod
 
 
 class TestAttestChallengeRateLimit(unittest.TestCase):
@@ -23,6 +40,8 @@ class TestAttestChallengeRateLimit(unittest.TestCase):
 
         if NODE_DIR not in sys.path:
             sys.path.insert(0, NODE_DIR)
+        os.environ["RUSTCHAIN_DB_PATH"] = str(Path(cls._tmp.name) / "challenge_rate_limit.db")
+        cls.mod = _load_integrated_module()
 
     @classmethod
     def tearDownClass(cls):
@@ -39,9 +58,9 @@ class TestAttestChallengeRateLimit(unittest.TestCase):
     def _load_module(self, module_name: str, db_name: str):
         db_path = str(Path(self._tmp.name) / db_name)
         os.environ["RUSTCHAIN_DB_PATH"] = db_path
-        spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
-        mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(mod)
+        mod = self.mod
+        mod.DB_PATH = db_path
+        mod.app.config["DB_PATH"] = db_path
         with sqlite3.connect(db_path) as conn:
             mod.attest_ensure_tables(conn)
         mod.ATTEST_CHALLENGE_IP_LIMIT = 2


### PR DESCRIPTION
Fixes #5091.

Summary:
- Adds a small in-memory rate gate for admin-only API paths before auth checks.
- Returns 429 with Retry-After after repeated attempts from the same client IP/path.
- Covers the main admin, pending, governance rotation, withdrawal, bridge, lock, wallet-link, rewards, and debug admin routes without rate-limiting public health endpoints.
- Adds regression coverage for failed admin-key attempts and registered extension route detection.
- Reuses the shared integrated-node module in the adjacent challenge-rate-limit test so Prometheus metrics are not registered twice in one pytest process.

Validation:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest node/tests/test_admin_rate_limit.py node/tests/test_attest_challenge_rate_limit.py tests/test_api.py -q` -> `12 passed`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_admin_rate_limit.py node/tests/test_attest_challenge_rate_limit.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No production node, wallet action, private key, token transfer, or destructive request was used.