### PR TITLE
fix: use secret network challenge signing key

### DIFF
--- a/rips/rustchain-core/src/anti_spoof/network_challenge.py
+++ b/rips/rustchain-core/src/anti_spoof/network_challenge.py
@@ -25,7 +25,7 @@ import secrets
 import struct
 import time
 from dataclasses import dataclass, asdict
-from typing import Optional, Dict, List, Tuple
+from typing import Optional, Dict, List, Tuple, Union
 from enum import Enum
 
 class ChallengeType(Enum):
@@ -438,12 +438,36 @@ class NetworkChallengeProtocol:
     MAX_FAILURES_BEFORE_SLASH = 3    # 3 failures = slashed
     FAILURE_PENALTY_PERCENT = 10     # 10% reward penalty per failure
 
-    def __init__(self, validator_pubkey: str, hardware_profile: Dict):
+    def __init__(
+        self,
+        validator_pubkey: str,
+        hardware_profile: Dict,
+        validator_signing_key: Optional[Union[bytes, str]] = None,
+    ):
         self.pubkey = validator_pubkey
         self.hardware = hardware_profile
+        self.signing_key = self._load_signing_key(validator_signing_key)
         self.validator = AntiSpoofValidator()
         self.pending_challenges: Dict[str, Challenge] = {}
         self.failure_count = 0
+
+    @staticmethod
+    def _load_signing_key(signing_key: Optional[Union[bytes, str]]) -> bytes:
+        """Load secret challenge-signing material without deriving it from public data."""
+        if signing_key is None:
+            env_key = os.getenv("RC_NETWORK_CHALLENGE_SIGNING_KEY", "").strip()
+            if env_key:
+                signing_key = env_key
+            else:
+                return secrets.token_bytes(32)
+
+        if isinstance(signing_key, str):
+            signing_key = signing_key.encode()
+
+        if not signing_key:
+            raise ValueError("validator_signing_key must not be empty")
+
+        return signing_key
 
     def should_challenge(self, block_height: int, target_pubkey: str) -> bool:
         """Determine if we should challenge another validator this block"""
@@ -458,13 +482,10 @@ class NetworkChallengeProtocol:
 
     def create_challenge(self, target_pubkey: str, target_hardware: Dict) -> Challenge:
         """Create a challenge for another validator"""
-        # Use pubkey as signing key for demo (use real keys in production)
-        privkey = hashlib.sha256(self.pubkey.encode()).digest()
-
         challenge = self.validator.generate_challenge(
             target_pubkey=target_pubkey,
             expected_hardware=target_hardware,
-            challenger_privkey=privkey,
+            challenger_privkey=self.signing_key,
             challenge_type=ChallengeType.FULL
         )
 

--- a/tests/test_network_challenge_signing_key.py
+++ b/tests/test_network_challenge_signing_key.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+"""Regressions for network challenge signing key handling."""
+
+import hashlib
+import hmac
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rips"
+    / "rustchain-core"
+    / "src"
+    / "anti_spoof"
+    / "network_challenge.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("network_challenge", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _hardware_profile():
+    return {
+        "tier": "modern",
+        "openfirmware": {"serial_number": "RC-TEST-001"},
+    }
+
+
+def test_network_challenge_uses_instance_secret_not_pubkey_hash():
+    module = _load_module()
+    signing_key = b"validator-secret-not-public"
+
+    protocol = module.NetworkChallengeProtocol(
+        "public-validator-key",
+        _hardware_profile(),
+        validator_signing_key=signing_key,
+    )
+    challenge = protocol.create_challenge("target-validator", _hardware_profile())
+
+    public_derived_key = hashlib.sha256(protocol.pubkey.encode()).digest()
+    forged_signature = hmac.new(
+        public_derived_key,
+        challenge.to_bytes(),
+        hashlib.sha256,
+    ).digest()
+    expected_signature = hmac.new(
+        signing_key,
+        challenge.to_bytes(),
+        hashlib.sha256,
+    ).digest()
+
+    assert challenge.signature == expected_signature
+    assert challenge.signature != forged_signature
+
+
+def test_network_challenge_generates_random_secret_when_not_configured(monkeypatch):
+    module = _load_module()
+    generated_key = b"\x42" * 32
+
+    monkeypatch.delenv("RC_NETWORK_CHALLENGE_SIGNING_KEY", raising=False)
+    monkeypatch.setattr(module.secrets, "token_bytes", lambda size: generated_key)
+
+    protocol = module.NetworkChallengeProtocol("public-validator-key", _hardware_profile())
+    challenge = protocol.create_challenge("target-validator", _hardware_profile())
+
+    assert protocol.signing_key == generated_key
+    assert challenge.signature == hmac.new(
+        generated_key,
+        challenge.to_bytes(),
+        hashlib.sha256,
+    ).digest()
+
+
+def test_network_challenge_rejects_empty_configured_signing_key():
+    module = _load_module()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        module.NetworkChallengeProtocol(
+            "public-validator-key",
+            _hardware_profile(),
+            validator_signing_key=b"",
+        )


### PR DESCRIPTION
Fixes #4850.

## What changed
- Added explicit per-validator challenge signing key loading instead of deriving an HMAC key from the public validator key.
- Supports a provided `validator_signing_key`, `RC_NETWORK_CHALLENGE_SIGNING_KEY`, or a per-instance random secret when no key is configured.
- Rejects empty configured signing material.
- Added regressions proving a public-key-derived forged signature no longer matches and that the generated/configured secret is used for challenge HMACs.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_network_challenge_signing_key.py -q` -> `3 passed`
- `python -m py_compile rips\rustchain-core\src\anti_spoof\network_challenge.py tests\test_network_challenge_signing_key.py` -> passed
- `git diff --check origin/main...HEAD -- rips\rustchain-core\src\anti_spoof\network_challenge.py tests\test_network_challenge_signing_key.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No live validator, wallet, private key, token transfer, or destructive operation was used.
