### PR TITLE
fix: default unknown CPU release year to current

### DIFF
--- a/rips/rustchain-core/validator/setup_validator.py
+++ b/rips/rustchain-core/validator/setup_validator.py
@@ -200,8 +200,8 @@ def estimate_release_year(cpu_model: str, cpu_vendor: str) -> int:
     if "8086" in model_lower or "8088" in model_lower:
         return 1978
 
-    # Default to somewhat recent
-    return 2020
+    # Unknown CPUs should not receive free antiquity from an old fallback year.
+    return CURRENT_YEAR
 
 
 def determine_tier(release_year: int) -> Tuple[str, float]:

--- a/tests/test_setup_validator_release_year.py
+++ b/tests/test_setup_validator_release_year.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+"""Regressions for validator release-year heuristics."""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rips"
+    / "rustchain-core"
+    / "validator"
+    / "setup_validator.py"
+)
+
+
+def _load_module():
+    chain_params = types.ModuleType("config.chain_params")
+    chain_params.CHAIN_ID = "test-chain"
+    chain_params.NETWORK_NAME = "test-network"
+    chain_params.HARDWARE_TIERS = {
+        "ancient": 3.5,
+        "sacred": 3.0,
+        "vintage": 2.5,
+        "classic": 2.0,
+        "retro": 1.5,
+        "modern": 1.0,
+        "recent": 0.5,
+    }
+    chain_params.ANCIENT_THRESHOLD = 30
+    chain_params.SACRED_THRESHOLD = 25
+    chain_params.VINTAGE_THRESHOLD = 20
+    chain_params.CLASSIC_THRESHOLD = 15
+    chain_params.RETRO_THRESHOLD = 10
+    chain_params.MODERN_THRESHOLD = 5
+
+    entropy = types.ModuleType("validator.entropy")
+    entropy.HardwareEntropyCollector = object
+    entropy.SoftwareEntropyCollector = object
+    entropy.EntropyProfile = object
+    entropy.ValidatorIdentityManager = object
+
+    sys.modules["config"] = types.ModuleType("config")
+    sys.modules["config.chain_params"] = chain_params
+    sys.modules["validator"] = types.ModuleType("validator")
+    sys.modules["validator.entropy"] = entropy
+
+    spec = importlib.util.spec_from_file_location("setup_validator", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["setup_validator"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_unknown_cpu_defaults_to_current_year_not_free_antiquity():
+    module = _load_module()
+
+    assert module.estimate_release_year("FakeCPU-X9999", "UnknownVendor") == module.CURRENT_YEAR
+
+
+def test_known_cpu_release_years_are_preserved():
+    module = _load_module()
+
+    assert module.estimate_release_year("Intel Core i7-14700K", "GenuineIntel") == 2024
+    assert module.estimate_release_year("PowerMac3,6 PowerPC G4", "Apple") == 2003


### PR DESCRIPTION
Fixes #4847.

## What changed
- Unknown CPU models now default to `CURRENT_YEAR` instead of 2020 in `estimate_release_year()`.
- This prevents fake/unknown CPU strings from receiving free antiquity age from an old fallback year.
- Added focused regressions for the unknown fallback and known CPU mappings.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_setup_validator_release_year.py -q` -> `2 passed`
- `python -m py_compile rips\rustchain-core\validator\setup_validator.py tests\test_setup_validator_release_year.py` -> passed
- `git diff --check origin/main...HEAD -- rips\rustchain-core\validator\setup_validator.py tests\test_setup_validator_release_year.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

No live validator, wallet, private key, token transfer, or destructive operation was used.
