### PR TITLE
fix: restrict OTC bridge CORS origins

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -40,6 +40,11 @@ from flask_cors import CORS
 
 RUSTCHAIN_NODE = os.environ.get("RUSTCHAIN_NODE", "https://50.28.86.131")
 DB_PATH = os.environ.get("OTC_DB_PATH", "otc_bridge.db")
+DEFAULT_OTC_CORS_ORIGINS = (
+    "https://bottube.ai",
+    "https://rustchain.org",
+    "http://localhost:3000",
+)
 
 # TLS verification: defaults to True (secure).
 # Set RUSTCHAIN_TLS_VERIFY=false only for local development with self-signed certs.
@@ -73,7 +78,23 @@ log = logging.getLogger("otc_bridge")
 logging.basicConfig(level=logging.INFO)
 
 app = Flask(__name__, static_folder="static")
-CORS(app)
+
+
+def parse_cors_origins(raw_origins=None):
+    raw_origins = os.environ.get("OTC_CORS_ORIGINS") if raw_origins is None else raw_origins
+    if raw_origins is None:
+        return list(DEFAULT_OTC_CORS_ORIGINS)
+
+    origins = [origin.strip() for origin in raw_origins.split(",") if origin.strip()]
+    if not origins:
+        return list(DEFAULT_OTC_CORS_ORIGINS)
+    if "*" in origins:
+        raise ValueError("OTC_CORS_ORIGINS must name trusted origins and must not include '*'")
+    return origins
+
+
+OTC_CORS_ORIGINS = parse_cors_origins()
+CORS(app, origins=OTC_CORS_ORIGINS)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -8,7 +8,7 @@ from pathlib import Path
 def load_otc_bridge(tmp_path):
     if "flask_cors" not in sys.modules:
         flask_cors = types.ModuleType("flask_cors")
-        flask_cors.CORS = lambda app: app
+        flask_cors.CORS = lambda app, *args, **kwargs: app
         sys.modules["flask_cors"] = flask_cors
 
     db_path = tmp_path / "otc_bridge.db"
@@ -34,6 +34,26 @@ def test_orders_rejects_malformed_pagination(tmp_path):
     assert limit_response.get_json() == {"error": "limit_must_be_integer"}
     assert offset_response.status_code == 400
     assert offset_response.get_json() == {"error": "offset_must_be_integer"}
+
+
+def test_otc_bridge_cors_uses_trusted_origin_allowlist(tmp_path, monkeypatch):
+    monkeypatch.delenv("OTC_CORS_ORIGINS", raising=False)
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    assert "*" not in otc_bridge.OTC_CORS_ORIGINS
+    assert "https://bottube.ai" in otc_bridge.OTC_CORS_ORIGINS
+    assert "https://rustchain.org" in otc_bridge.OTC_CORS_ORIGINS
+
+
+def test_otc_bridge_cors_rejects_wildcard_origin(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    try:
+        otc_bridge.parse_cors_origins("https://rustchain.org,*")
+    except ValueError as exc:
+        assert "must not include '*'" in str(exc)
+    else:
+        raise AssertionError("wildcard CORS origin should be rejected")
 
 
 def test_orders_rejects_out_of_range_pagination(tmp_path):


### PR DESCRIPTION
## Summary
- replace OTC bridge wildcard `CORS(app)` with an explicit trusted-origin allowlist
- add `OTC_CORS_ORIGINS` parsing for deploy-specific origins
- fail fast if the configured allowlist includes `*`
- add regression coverage for the default allowlist and wildcard rejection

Fixes #5054.

## Validation
- `python -m pytest tests/test_otc_bridge_query_validation.py -q` -> 7 passed
- `python -m py_compile .\otc-bridge\otc_bridge.py .\tests\test_otc_bridge_query_validation.py` -> passed
- `git diff --check -- .\otc-bridge\otc_bridge.py .\tests\test_otc_bridge_query_validation.py` -> clean
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check OK

Note: the legacy `python .\otc-bridge\test_otc_bridge.py` suite still hits the known Windows temp SQLite lock / shared DB state issue; the focused regression for this CORS change is isolated and green.