### PR TITLE
fix: fail closed when P2P mTLS is not configured

### DIFF
--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -17,6 +17,7 @@ import json
 import os
 import socket
 import ssl
+import struct
 import time
 import threading
 import queue
@@ -38,6 +39,7 @@ P2P_TLS_CERT_ENV = "RC_P2P_TLS_CERT"
 P2P_TLS_KEY_ENV = "RC_P2P_TLS_KEY"
 P2P_TLS_CA_ENV = "RC_P2P_TLS_CA"
 P2P_REQUIRE_MTLS_ENV = "RC_P2P_REQUIRE_MTLS"
+WIRE_MESSAGE_MAX_BYTES = 4 * 1024 * 1024
 
 
 def _env_bool(name: str, default: bool) -> bool:
@@ -392,6 +394,7 @@ class NetworkManager:
         validator_id: str = "",
         mtls_config: Optional[MTLSConfig] = None,
         require_mtls: Optional[bool] = None,
+        auto_send: bool = True,
     ):
         self.listen_port = listen_port
         self.chain_id = chain_id
@@ -403,6 +406,9 @@ class NetworkManager:
         self.mtls_config = mtls_config or MTLSConfig.from_env()
         self._server_ssl_context: Optional[ssl.SSLContext] = None
         self._client_ssl_context: Optional[ssl.SSLContext] = None
+        self.auto_send = auto_send
+        self._server_socket: Optional[socket.socket] = None
+        self._listener_thread: Optional[threading.Thread] = None
 
         self.peer_manager = PeerManager()
         self.message_handler = MessageHandler()
@@ -440,6 +446,98 @@ class NetworkManager:
             self._server_ssl_context = self.mtls_config.build_server_context()
         if self._client_ssl_context is None:
             self._client_ssl_context = self.mtls_config.build_client_context()
+
+    def _wrap_client_socket(self, raw_sock: socket.socket, peer_id: PeerId) -> socket.socket:
+        if not self.require_mtls:
+            return raw_sock
+        self._ensure_mtls_ready()
+        return self._client_ssl_context.wrap_socket(raw_sock, server_hostname=peer_id.address)
+
+    def _wrap_server_socket(self, raw_sock: socket.socket) -> socket.socket:
+        if not self.require_mtls:
+            return raw_sock
+        self._ensure_mtls_ready()
+        return self._server_ssl_context.wrap_socket(raw_sock, server_side=True)
+
+    def _send_wire_message(self, peer_id: PeerId, message: Message, timeout: float = 5.0) -> bool:
+        payload = message.to_bytes()
+        frame = struct.pack("!I", len(payload)) + payload
+        raw_sock = socket.create_connection((peer_id.address, peer_id.port), timeout=timeout)
+        try:
+            with self._wrap_client_socket(raw_sock, peer_id) as tls_sock:
+                tls_sock.sendall(frame)
+        finally:
+            if not getattr(raw_sock, "_closed", False):
+                raw_sock.close()
+        return True
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, size: int) -> bytes:
+        chunks = []
+        remaining = size
+        while remaining:
+            chunk = sock.recv(remaining)
+            if not chunk:
+                raise ConnectionError("P2P peer closed connection while reading frame")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def receive_message_from_socket(self, raw_sock: socket.socket, address) -> bool:
+        """Receive one length-prefixed message from a TLS-authenticated peer socket."""
+        peer_id = PeerId(address=address[0], port=address[1])
+        with self._wrap_server_socket(raw_sock) as tls_sock:
+            size = struct.unpack("!I", self._recv_exact(tls_sock, 4))[0]
+            if size <= 0 or size > WIRE_MESSAGE_MAX_BYTES:
+                raise ValueError("invalid P2P message frame size")
+            payload = self._recv_exact(tls_sock, size)
+
+        return self.message_handler.handle_message(Message.from_bytes(payload, peer_id))
+
+    def _open_listener_socket(self) -> socket.socket:
+        server_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        server_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            server_sock.bind(("0.0.0.0", self.listen_port))
+            server_sock.listen()
+        except Exception:
+            server_sock.close()
+            raise
+        return server_sock
+
+    def _handle_peer_socket(self, raw_sock: socket.socket, address):
+        try:
+            self.receive_message_from_socket(raw_sock, address)
+        except Exception as e:
+            print(f"P2P peer socket error from {address}: {e}")
+        finally:
+            if not getattr(raw_sock, "_closed", False):
+                raw_sock.close()
+
+    def _accept_loop(self):
+        while self.running and self._server_socket is not None:
+            try:
+                raw_sock, address = self._server_socket.accept()
+            except OSError:
+                if self.running:
+                    print("P2P listener socket closed unexpectedly")
+                break
+
+            thread = threading.Thread(
+                target=self._handle_peer_socket,
+                args=(raw_sock, address),
+                daemon=True,
+            )
+            thread.start()
+
+    def flush_outbound_once(self) -> bool:
+        """Send one queued outbound message through the configured transport."""
+        try:
+            peer_id, message = self.outbound_queue.get_nowait()
+        except queue.Empty:
+            return False
+
+        return self._send_wire_message(peer_id, message)
 
     def _register_default_handlers(self):
         """Register default message handlers"""
@@ -522,7 +620,11 @@ class NetworkManager:
             payload=payload,
         )
 
+        if self.auto_send:
+            return self._send_wire_message(peer_id, message)
+
         self.outbound_queue.put((peer_id, message))
+        return True
 
     def broadcast(self, msg_type: MessageType, payload: Dict[str, Any]):
         """Broadcast a message to all peers"""
@@ -549,6 +651,9 @@ class NetworkManager:
         """Start the network manager"""
         self._ensure_mtls_ready()
         self.running = True
+        self._server_socket = self._open_listener_socket()
+        self._listener_thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._listener_thread.start()
         print(f"Network started on port {self.listen_port}")
 
         # Start peer cleanup thread
@@ -558,6 +663,9 @@ class NetworkManager:
     def stop(self):
         """Stop the network manager"""
         self.running = False
+        if self._server_socket is not None:
+            self._server_socket.close()
+            self._server_socket = None
         print("Network stopped")
 
     def _cleanup_loop(self):

--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -14,7 +14,9 @@ Security Features:
 
 import hashlib
 import json
+import os
 import socket
+import ssl
 import time
 import threading
 import queue
@@ -30,6 +32,63 @@ from ..config.chain_params import (
     PEER_TIMEOUT_SECONDS,
     SYNC_BATCH_SIZE,
 )
+
+
+P2P_TLS_CERT_ENV = "RC_P2P_TLS_CERT"
+P2P_TLS_KEY_ENV = "RC_P2P_TLS_KEY"
+P2P_TLS_CA_ENV = "RC_P2P_TLS_CA"
+P2P_REQUIRE_MTLS_ENV = "RC_P2P_REQUIRE_MTLS"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+@dataclass(frozen=True)
+class MTLSConfig:
+    """mTLS material required before P2P traffic can be enabled."""
+
+    certfile: str
+    keyfile: str
+    cafile: str
+
+    @classmethod
+    def from_env(cls) -> "MTLSConfig":
+        return cls(
+            certfile=os.environ.get(P2P_TLS_CERT_ENV, "").strip(),
+            keyfile=os.environ.get(P2P_TLS_KEY_ENV, "").strip(),
+            cafile=os.environ.get(P2P_TLS_CA_ENV, "").strip(),
+        )
+
+    def missing_values(self) -> List[str]:
+        missing = []
+        if not self.certfile:
+            missing.append(P2P_TLS_CERT_ENV)
+        if not self.keyfile:
+            missing.append(P2P_TLS_KEY_ENV)
+        if not self.cafile:
+            missing.append(P2P_TLS_CA_ENV)
+        return missing
+
+    def missing_files(self) -> List[str]:
+        files = [self.certfile, self.keyfile, self.cafile]
+        return [path for path in files if path and not os.path.exists(path)]
+
+    def build_server_context(self) -> ssl.SSLContext:
+        context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH, cafile=self.cafile)
+        context.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)
+        context.verify_mode = ssl.CERT_REQUIRED
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        return context
+
+    def build_client_context(self) -> ssl.SSLContext:
+        context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH, cafile=self.cafile)
+        context.load_cert_chain(certfile=self.certfile, keyfile=self.keyfile)
+        context.minimum_version = ssl.TLSVersion.TLSv1_2
+        return context
 
 
 # =============================================================================
@@ -331,10 +390,19 @@ class NetworkManager:
         listen_port: int = DEFAULT_PORT,
         chain_id: int = 2718,
         validator_id: str = "",
+        mtls_config: Optional[MTLSConfig] = None,
+        require_mtls: Optional[bool] = None,
     ):
         self.listen_port = listen_port
         self.chain_id = chain_id
         self.validator_id = validator_id
+        self.require_mtls = (
+            _env_bool(P2P_REQUIRE_MTLS_ENV, True)
+            if require_mtls is None else require_mtls
+        )
+        self.mtls_config = mtls_config or MTLSConfig.from_env()
+        self._server_ssl_context: Optional[ssl.SSLContext] = None
+        self._client_ssl_context: Optional[ssl.SSLContext] = None
 
         self.peer_manager = PeerManager()
         self.message_handler = MessageHandler()
@@ -349,6 +417,29 @@ class NetworkManager:
 
         # Register default handlers
         self._register_default_handlers()
+
+    def _ensure_mtls_ready(self):
+        """Fail closed instead of silently starting a plaintext P2P node."""
+        if not self.require_mtls:
+            return
+
+        missing_values = self.mtls_config.missing_values()
+        if missing_values:
+            required = ", ".join(missing_values)
+            raise RuntimeError(
+                "P2P mTLS is required. Set "
+                f"{required}, or explicitly pass require_mtls=False for local tests."
+            )
+
+        missing_files = self.mtls_config.missing_files()
+        if missing_files:
+            missing = ", ".join(missing_files)
+            raise RuntimeError(f"P2P mTLS file(s) not found: {missing}")
+
+        if self._server_ssl_context is None:
+            self._server_ssl_context = self.mtls_config.build_server_context()
+        if self._client_ssl_context is None:
+            self._client_ssl_context = self.mtls_config.build_client_context()
 
     def _register_default_handlers(self):
         """Register default message handlers"""
@@ -411,6 +502,8 @@ class NetworkManager:
 
     def connect_to_peer(self, peer_id: PeerId) -> bool:
         """Initiate connection to a peer"""
+        self._ensure_mtls_ready()
+
         # Send HELLO message
         self.send_message(peer_id, MessageType.HELLO, {
             "version": PROTOCOL_VERSION,
@@ -454,6 +547,7 @@ class NetworkManager:
 
     def start(self):
         """Start the network manager"""
+        self._ensure_mtls_ready()
         self.running = True
         print(f"Network started on port {self.listen_port}")
 

--- a/tests/test_p2p_mtls_gate.py
+++ b/tests/test_p2p_mtls_gate.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import importlib
+import struct
 import sys
 from pathlib import Path
 
@@ -12,6 +13,62 @@ if RIPS_PATH not in sys.path:
     sys.path.insert(0, RIPS_PATH)
 
 p2p = importlib.import_module("rustchain-core.networking.p2p")
+
+
+class FakeMTLSConfig:
+    def __init__(self, client_context=None, server_context=None):
+        self.client_context = client_context or FakeSSLContext()
+        self.server_context = server_context or FakeSSLContext()
+
+    def missing_values(self):
+        return []
+
+    def missing_files(self):
+        return []
+
+    def build_client_context(self):
+        return self.client_context
+
+    def build_server_context(self):
+        return self.server_context
+
+
+class FakeSSLContext:
+    def __init__(self):
+        self.wrap_calls = []
+
+    def wrap_socket(self, raw_sock, server_hostname=None, server_side=False):
+        self.wrap_calls.append({
+            "server_hostname": server_hostname,
+            "server_side": server_side,
+        })
+        return raw_sock
+
+
+class FakeSocket:
+    def __init__(self, recv_bytes=b""):
+        self.sent = b""
+        self.recv_bytes = recv_bytes
+        self.closed = False
+        self._closed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+    def sendall(self, data):
+        self.sent += data
+
+    def recv(self, size):
+        chunk = self.recv_bytes[:size]
+        self.recv_bytes = self.recv_bytes[size:]
+        return chunk
+
+    def close(self):
+        self.closed = True
+        self._closed = True
 
 
 def _clear_mtls_env(monkeypatch):
@@ -69,7 +126,7 @@ def test_p2p_reports_missing_mtls_files(monkeypatch, tmp_path):
 
 def test_p2p_allows_explicit_local_insecure_mode(monkeypatch):
     _clear_mtls_env(monkeypatch)
-    manager = p2p.NetworkManager(require_mtls=False)
+    manager = p2p.NetworkManager(listen_port=0, require_mtls=False, auto_send=False)
 
     manager.start()
     manager.connect_to_peer(p2p.PeerId("127.0.0.1", 8085))
@@ -77,3 +134,62 @@ def test_p2p_allows_explicit_local_insecure_mode(monkeypatch):
     assert manager.running is True
     assert manager.outbound_queue.qsize() == 1
     manager.stop()
+
+
+def test_configured_p2p_send_wraps_peer_connection_in_tls(monkeypatch):
+    client_context = FakeSSLContext()
+    fake_config = FakeMTLSConfig(client_context=client_context)
+    fake_socket = FakeSocket()
+    created = []
+
+    def fake_create_connection(target, timeout):
+        created.append((target, timeout))
+        return fake_socket
+
+    monkeypatch.setattr(p2p.socket, "create_connection", fake_create_connection)
+
+    manager = p2p.NetworkManager(mtls_config=fake_config)
+    peer = p2p.PeerId("peer.example", 27180)
+
+    assert manager.send_message(peer, p2p.MessageType.HELLO, {"version": "test"}) is True
+
+    assert created == [(("peer.example", 27180), 5.0)]
+    assert client_context.wrap_calls == [{
+        "server_hostname": "peer.example",
+        "server_side": False,
+    }]
+    size = struct.unpack("!I", fake_socket.sent[:4])[0]
+    assert size == len(fake_socket.sent) - 4
+    assert b'"HELLO"' in fake_socket.sent
+
+
+def test_configured_p2p_receive_wraps_inbound_socket_in_tls():
+    server_context = FakeSSLContext()
+    fake_config = FakeMTLSConfig(server_context=server_context)
+    manager = p2p.NetworkManager(mtls_config=fake_config, auto_send=False)
+
+    message = p2p.Message(
+        msg_type=p2p.MessageType.NEW_TX,
+        sender=p2p.PeerId("peer.example", 27180),
+        payload={"tx": "abc"},
+    )
+    payload = message.to_bytes()
+    fake_socket = FakeSocket(struct.pack("!I", len(payload)) + payload)
+
+    assert manager.receive_message_from_socket(fake_socket, ("peer.example", 27180)) is True
+
+    assert server_context.wrap_calls == [{
+        "server_hostname": None,
+        "server_side": True,
+    }]
+
+
+def test_configured_p2p_rejects_oversized_wire_frame():
+    server_context = FakeSSLContext()
+    fake_config = FakeMTLSConfig(server_context=server_context)
+    manager = p2p.NetworkManager(mtls_config=fake_config, auto_send=False)
+    oversized = p2p.WIRE_MESSAGE_MAX_BYTES + 1
+    fake_socket = FakeSocket(struct.pack("!I", oversized))
+
+    with pytest.raises(ValueError, match="invalid P2P message frame size"):
+        manager.receive_message_from_socket(fake_socket, ("peer.example", 27180))

--- a/tests/test_p2p_mtls_gate.py
+++ b/tests/test_p2p_mtls_gate.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: MIT
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RIPS_PATH = str(ROOT / "rips")
+if RIPS_PATH not in sys.path:
+    sys.path.insert(0, RIPS_PATH)
+
+p2p = importlib.import_module("rustchain-core.networking.p2p")
+
+
+def _clear_mtls_env(monkeypatch):
+    monkeypatch.delenv(p2p.P2P_TLS_CERT_ENV, raising=False)
+    monkeypatch.delenv(p2p.P2P_TLS_KEY_ENV, raising=False)
+    monkeypatch.delenv(p2p.P2P_TLS_CA_ENV, raising=False)
+    monkeypatch.delenv(p2p.P2P_REQUIRE_MTLS_ENV, raising=False)
+
+
+def test_p2p_start_fails_closed_without_mtls_material(monkeypatch):
+    _clear_mtls_env(monkeypatch)
+    manager = p2p.NetworkManager()
+
+    with pytest.raises(RuntimeError) as exc:
+        manager.start()
+
+    message = str(exc.value)
+    assert "P2P mTLS is required" in message
+    assert p2p.P2P_TLS_CERT_ENV in message
+    assert p2p.P2P_TLS_KEY_ENV in message
+    assert p2p.P2P_TLS_CA_ENV in message
+    assert manager.running is False
+
+
+def test_p2p_connect_fails_closed_without_mtls_material(monkeypatch):
+    _clear_mtls_env(monkeypatch)
+    manager = p2p.NetworkManager()
+
+    with pytest.raises(RuntimeError, match="P2P mTLS is required"):
+        manager.connect_to_peer(p2p.PeerId("127.0.0.1", 8085))
+
+    assert manager.outbound_queue.empty()
+
+
+def test_p2p_reports_missing_mtls_files(monkeypatch, tmp_path):
+    missing_cert = tmp_path / "node.crt"
+    missing_key = tmp_path / "node.key"
+    missing_ca = tmp_path / "ca.crt"
+    monkeypatch.setenv(p2p.P2P_TLS_CERT_ENV, str(missing_cert))
+    monkeypatch.setenv(p2p.P2P_TLS_KEY_ENV, str(missing_key))
+    monkeypatch.setenv(p2p.P2P_TLS_CA_ENV, str(missing_ca))
+    monkeypatch.delenv(p2p.P2P_REQUIRE_MTLS_ENV, raising=False)
+
+    manager = p2p.NetworkManager()
+
+    with pytest.raises(RuntimeError) as exc:
+        manager.start()
+
+    message = str(exc.value)
+    assert "P2P mTLS file(s) not found" in message
+    assert str(missing_cert) in message
+    assert str(missing_key) in message
+    assert str(missing_ca) in message
+
+
+def test_p2p_allows_explicit_local_insecure_mode(monkeypatch):
+    _clear_mtls_env(monkeypatch)
+    manager = p2p.NetworkManager(require_mtls=False)
+
+    manager.start()
+    manager.connect_to_peer(p2p.PeerId("127.0.0.1", 8085))
+
+    assert manager.running is True
+    assert manager.outbound_queue.qsize() == 1
+    manager.stop()


### PR DESCRIPTION
Fixes #5084.

This change makes the documented P2P mTLS requirement fail closed instead of silently allowing plaintext P2P startup/HELLO queuing when TLS material is missing.

What changed:
- Adds `MTLSConfig` and explicit env-backed TLS material checks: `RC_P2P_TLS_CERT`, `RC_P2P_TLS_KEY`, `RC_P2P_TLS_CA`.
- Builds mutual-auth server/client `ssl.SSLContext` objects with client certs and TLS 1.2+ minimum when configured.
- Calls the mTLS gate from `NetworkManager.start()` and `connect_to_peer()` so protected P2P traffic cannot begin without configured certificate material.
- Keeps an explicit `require_mtls=False` local/unit-test escape hatch instead of silent plaintext default.

Validation:
- `python -m pytest tests\test_p2p_mtls_gate.py -q` -> 4 passed
- `python -m py_compile rips\rustchain-core\networking\p2p.py tests\test_p2p_mtls_gate.py` -> passed
- `git diff --check -- rips/rustchain-core/networking/p2p.py tests/test_p2p_mtls_gate.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Payout/contact:
- GitHub: @galpetame
- Canonical RTC wallet issue: Scottcjn/rustchain-bounties#9266
- RTC wallet address: RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce