### PR TITLE
fix: validate boot chime audio uploads

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -32,6 +32,10 @@ API_PORT = int(os.getenv('BOOT_CHIME_API_PORT', '8085'))
 DB_PATH = os.getenv('BOOT_CHIME_DB_PATH', 'proof_of_iron.db')
 SIMILARITY_THRESHOLD = float(os.getenv('BOOT_CHIME_THRESHOLD', '0.85'))
 CHALLENGE_TTL = int(os.getenv('BOOT_CHIME_CHALLENGE_TTL', '300'))
+MAX_AUDIO_UPLOAD_BYTES = int(
+    os.getenv('BOOT_CHIME_MAX_AUDIO_BYTES', str(10 * 1024 * 1024))
+)
+ALLOWED_AUDIO_MIME_TYPES = {'audio/wav', 'audio/x-wav', 'audio/wave'}
 
 # Initialize Proof-of-Iron system
 poi_system = ProofOfIron(
@@ -55,12 +59,47 @@ class JsonBodyError(ValueError):
     """Raised when a JSON endpoint receives a non-object body."""
 
 
+class AudioUploadError(ValueError):
+    """Raised when an uploaded boot-chime audio file is not acceptable."""
+
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
 def get_json_object() -> Dict[str, Any]:
     """Return the request JSON body when it is an object."""
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         raise JsonBodyError("JSON object required")
     return data
+
+
+def validate_audio_upload(audio_file, *, required: bool = True):
+    """Validate an uploaded boot-chime WAV before saving it to disk."""
+    if audio_file is None:
+        if required:
+            raise AudioUploadError("audio file required")
+        return None
+
+    mimetype = (audio_file.mimetype or audio_file.content_type or "").lower()
+    if mimetype not in ALLOWED_AUDIO_MIME_TYPES:
+        raise AudioUploadError("only WAV files accepted")
+
+    stream = audio_file.stream
+    stream.seek(0, os.SEEK_END)
+    size = stream.tell()
+    stream.seek(0)
+
+    if size > MAX_AUDIO_UPLOAD_BYTES:
+        raise AudioUploadError("file too large", 413)
+
+    header = stream.read(12)
+    stream.seek(0)
+    if len(header) < 12 or not header.startswith(b"RIFF") or header[8:12] != b"WAVE":
+        raise AudioUploadError("invalid WAV file")
+
+    return audio_file
 
 
 # ============= Health & Info =============
@@ -171,7 +210,7 @@ def submit_proof():
         # Load audio file if provided
         audio_data = None
         if 'audio' in request.files:
-            audio_file = request.files['audio']
+            audio_file = validate_audio_upload(request.files.get('audio'), required=False)
             with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
                 audio_file.save(tmp)
                 tmp_path = tmp.name
@@ -200,6 +239,8 @@ def submit_proof():
         
         return jsonify(result.to_dict()), status_code
         
+    except AudioUploadError as e:
+        return jsonify({'error': str(e)}), e.status_code
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -251,7 +292,7 @@ def enroll_miner():
         # Check if audio file provided
         audio_file = None
         if 'audio' in request.files:
-            audio = request.files['audio']
+            audio = validate_audio_upload(request.files.get('audio'), required=False)
             with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
                 audio.save(tmp)
                 audio_file = tmp.name
@@ -262,6 +303,8 @@ def enroll_miner():
         
         return jsonify(result.to_dict()), status_code
         
+    except AudioUploadError as e:
+        return jsonify({'error': str(e)}), e.status_code
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -425,10 +468,7 @@ def analyze_audio():
         }
     """
     try:
-        if 'audio' not in request.files:
-            return jsonify({'error': 'audio file required'}), 400
-        
-        audio_file = request.files['audio']
+        audio_file = validate_audio_upload(request.files.get('audio'), required=True)
         
         with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
             audio_file.save(tmp)
@@ -462,6 +502,8 @@ def analyze_audio():
         finally:
             os.unlink(tmp_path)
             
+    except AudioUploadError as e:
+        return jsonify({'error': str(e)}), e.status_code
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+import io
 import importlib.util
 import sys
 import types
@@ -28,6 +30,12 @@ class ProofOfIronStub:
     def revoke_attestation(self, miner_id, reason):
         self.revoked = (miner_id, reason)
         return True
+
+    def capture_and_enroll(self, miner_id, audio_file):
+        raise AssertionError("invalid uploads should be rejected before enrollment")
+
+    def submit_proof(self, proof, audio_data):
+        raise AssertionError("invalid uploads should be rejected before proof submission")
 
 
 def install_dependency_stubs(monkeypatch):
@@ -104,3 +112,47 @@ def test_revoke_accepts_valid_json_body(client, api_module):
     assert response.status_code == 200
     assert api_module.poi_system.revoked == ("miner-1", "retired")
     assert response.get_json() == {"success": True, "message": "Attestation revoked"}
+
+
+@pytest.mark.parametrize("path", ("/api/v1/submit", "/api/v1/enroll", "/api/v1/analyze"))
+def test_audio_upload_endpoints_reject_non_wav_mime_type(client, path):
+    data = {"audio": (io.BytesIO(b"not a wav"), "proof.txt", "text/plain")}
+    if path == "/api/v1/submit":
+        data.update(
+            {
+                "miner_id": "miner-1",
+                "challenge_id": "challenge-1",
+                "timestamp": "123",
+            }
+        )
+    elif path == "/api/v1/enroll":
+        data["miner_id"] = "miner-1"
+
+    response = client.post(path, data=data, content_type="multipart/form-data")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "only WAV files accepted"}
+
+
+def test_audio_upload_rejects_invalid_wav_magic(client):
+    response = client.post(
+        "/api/v1/analyze",
+        data={"audio": (io.BytesIO(b"RIFFxxxxNOPE"), "proof.wav", "audio/wav")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid WAV file"}
+
+
+def test_audio_upload_rejects_files_larger_than_configured_limit(client, api_module):
+    api_module.MAX_AUDIO_UPLOAD_BYTES = 8
+
+    response = client.post(
+        "/api/v1/analyze",
+        data={"audio": (io.BytesIO(b"RIFFxxxxWAVE"), "proof.wav", "audio/wav")},
+        content_type="multipart/form-data",
+    )
+
+    assert response.status_code == 413
+    assert response.get_json() == {"error": "file too large"}


### PR DESCRIPTION
Fixes #5108.

This adds fail-fast validation for uploaded boot-chime audio before the API writes a file to disk or hands it to the acoustic parser.

What changed:
- Adds a shared `validate_audio_upload()` guard for boot-chime upload endpoints.
- Restricts uploads to WAV MIME types (`audio/wav`, `audio/x-wav`, `audio/wave`).
- Enforces a configurable max upload size via `BOOT_CHIME_MAX_AUDIO_BYTES`, defaulting to 10 MiB.
- Verifies the RIFF/WAVE header before saving the uploaded file.
- Applies the guard to `/api/v1/submit`, `/api/v1/enroll`, and `/api/v1/analyze`.
- Adds regression coverage for non-WAV MIME, invalid WAV magic, and oversized uploads.

Validation:
- `python -m pytest tests\test_boot_chime_api_json_validation.py -q` -> 9 passed
- `python -m py_compile issue2307_boot_chime\boot_chime_api.py tests\test_boot_chime_api_json_validation.py` -> passed
- `git diff --check -- issue2307_boot_chime/boot_chime_api.py tests/test_boot_chime_api_json_validation.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Duplicate gate before coding:
- Exact open PR search for `#5108` -> none
- Exact closed PR search for `#5108` -> none
- Semantic PR searches for boot-chime upload/file-validation terms did not find a matching PR before coding.

No production probing, live uploads, wallet signing, or destructive testing was performed.

@galpetame
RTC wallet address: RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce
Canonical wallet issue: Scottcjn/rustchain-bounties#9266