### PR TITLE
Fix UTXO dust output set-bloat validation

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -14,6 +14,7 @@ import unittest
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
+    MAX_OUTPUTS_PER_TX,
 )
 
 
@@ -724,6 +725,49 @@ class TestUtxoDB(unittest.TestCase):
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
 
+    def test_mempool_rejects_below_dust_output(self):
+        """Mempool must not lock inputs with outputs below the dust floor."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'dust' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [
+                {'address': 'bob',
+                 'value_nrtc': 100 * UNIT - (DUST_THRESHOLD - 1)},
+                {'address': 'dust', 'value_nrtc': DUST_THRESHOLD - 1},
+            ],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_rejects_excessive_output_count(self):
+        """Mempool must reject transactions that fan out too many UTXOs."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'many' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [
+                {'address': f'dust_{idx}', 'value_nrtc': DUST_THRESHOLD}
+                for idx in range(MAX_OUTPUTS_PER_TX + 1)
+            ],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
     # -- bounty #2819: negative / zero value outputs -------------------------
 
     def test_negative_value_output_rejected(self):
@@ -769,6 +813,48 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
 
         self.assertFalse(ok)
+
+    def test_below_dust_output_rejected(self):
+        """Outputs below DUST_THRESHOLD must not create persistent dust UTXOs."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': 'bob',
+                 'value_nrtc': 100 * UNIT - (DUST_THRESHOLD - 1)},
+                {'address': 'dust', 'value_nrtc': DUST_THRESHOLD - 1},
+            ],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+        self.assertEqual(self.db.get_balance('dust'), 0)
+
+    def test_excessive_output_count_rejected(self):
+        """Transactions cannot create more than MAX_OUTPUTS_PER_TX boxes."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': f'dust_{idx}', 'value_nrtc': DUST_THRESHOLD}
+                for idx in range(MAX_OUTPUTS_PER_TX + 1)
+            ],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.count_unspent(), 1)
 
     def test_float_value_nrtc_rejected(self):
         """value_nrtc must be an integer; floats cause silent truncation."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 UNIT = 100_000_000          # 1 RTC = 100,000,000 nanoRTC (8 decimals)
 DUST_THRESHOLD = 1_000      # nanoRTC below which change is absorbed into fee
+MAX_OUTPUTS_PER_TX = 100    # Bound UTXO fan-out to prevent set-bloat DoS
 MAX_COINBASE_OUTPUT_NRTC = 150 * 144 * UNIT  # Max minting output per block (1.5 RTC)
 MAX_POOL_SIZE = 10_000
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
@@ -430,14 +431,21 @@ class UtxoDB:
             if not outputs and tx_type not in MINTING_TX_TYPES:
                 return abort()
 
-            output_total = sum(o['value_nrtc'] for o in outputs)
+            if len(outputs) > MAX_OUTPUTS_PER_TX:
+                return abort()
 
-            # Every output must carry a strictly positive value.
-            # Without this, a negative-value output lowers output_total,
-            # letting an attacker create more value than the inputs hold.
+            # Every output must be above the dust floor. Without this, a
+            # transaction can split one UTXO into thousands of 1-nanoRTC
+            # boxes and permanently bloat the UTXO set.
             for o in outputs:
-                if not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
+                val = o.get('value_nrtc')
+                if (
+                    not isinstance(val, int)
+                    or val < DUST_THRESHOLD
+                ):
                     return abort()
+
+            output_total = sum(o['value_nrtc'] for o in outputs)
 
             # Cap minting (coinbase) output to prevent unbounded fund creation.
             # Without this, any caller that passes tx_type='mining_reward'
@@ -745,6 +753,10 @@ class UtxoDB:
                 if manage_tx:
                         conn.execute("ROLLBACK")
                 return False
+            if len(outputs) > MAX_OUTPUTS_PER_TX:
+                if manage_tx:
+                        conn.execute("ROLLBACK")
+                return False
 
             input_total = 0
             for inp in inputs:
@@ -757,13 +769,13 @@ class UtxoDB:
 
             outputs = tx.get('outputs', [])
 
-            # FIX(#2179): Mirror apply_transaction() output validation.
-            # Reject outputs with missing, non-int, zero, or negative value_nrtc.
-            # Without this, unmineable transactions enter the mempool and lock
-            # UTXOs until expiry (DoS vector).
+            # Mirror apply_transaction() output validation. Reject outputs with
+            # missing, non-int, or below-dust value_nrtc. Without this,
+            # unmineable transactions enter the mempool and lock UTXOs until
+            # expiry (DoS vector).
             for o in outputs:
                 val = o.get('value_nrtc')
-                if not isinstance(val, int) or val <= 0:
+                if not isinstance(val, int) or val < DUST_THRESHOLD:
                     if manage_tx:
                         conn.execute("ROLLBACK")
                     return False


### PR DESCRIPTION
## Summary
- add `MAX_OUTPUTS_PER_TX = 100` and reject confirmed transactions that exceed it
- reject confirmed outputs below `DUST_THRESHOLD` instead of only zero/negative values
- mirror the same output-count and dust checks in `mempool_add()` so invalid transactions cannot lock inputs until expiry
- add regression tests for confirmed and mempool rejection paths

Addresses Scottcjn/rustchain-bounties#9273.

## Validation
- `PYTHONPATH=node PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 timeout 180 uv run --no-project --with pytest python -m pytest node/test_utxo_db.py -q` -> 59 passed
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py` -> passed
- `git diff --check` -> passed

Payout wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`