### PR TITLE
fix: reject contributor placeholder secret

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -23,11 +23,9 @@ if not SECRET_KEY:
         UserWarning
     )
 elif SECRET_KEY == 'rustchain_contributor_secret_2024':
-    import warnings
-    warnings.warn(
+    raise ValueError(
         "CONTRIBUTOR_SECRET_KEY is set to the known placeholder value. "
-        "Please set a new, secure secret before deployment.",
-        UserWarning
+        "Please set a new, secure secret before deployment."
     )
 
 app.secret_key = SECRET_KEY

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -1,6 +1,7 @@
 import pytest
 import sqlite3
 import os
+import importlib
 import tempfile
 from unittest.mock import patch, MagicMock
 
@@ -166,3 +167,19 @@ class TestDatabaseConstraints:
             ).fetchone()
         assert row[0] == "pending"
 
+
+class TestSecretKeyConfiguration:
+    def test_known_placeholder_secret_fails_closed(self, monkeypatch):
+        """The known compromised placeholder must not be accepted as a Flask secret."""
+        original_secret = os.environ.get("CONTRIBUTOR_SECRET_KEY")
+
+        try:
+            monkeypatch.setenv("CONTRIBUTOR_SECRET_KEY", "rustchain_contributor_secret_2024")
+            with pytest.raises(ValueError, match="known placeholder"):
+                importlib.reload(cr)
+        finally:
+            if original_secret is None:
+                monkeypatch.delenv("CONTRIBUTOR_SECRET_KEY", raising=False)
+            else:
+                monkeypatch.setenv("CONTRIBUTOR_SECRET_KEY", original_secret)
+            importlib.reload(cr)


### PR DESCRIPTION
## Summary
- Fail closed when `CONTRIBUTOR_SECRET_KEY` is set to the known compromised placeholder `rustchain_contributor_secret_2024`.
- Preserve the existing unset-env random fallback behavior.
- Add a regression proving the placeholder is rejected at import time.

## Scope / duplicate gate
- This targets only the additional placeholder-secret finding on #5059, not the public Flask debug-mode lane.
- Checked open PRs for `rustchain_contributor_secret_2024`, `known placeholder`, and `CONTRIBUTOR_SECRET_KEY` immediately before push; no open PR covers this hard-fail behavior.
- Existing debug-mode PRs (#4843/#4859/#5060) cover a different lane, so this PR intentionally does not touch debug settings.
- Historical PR #2773 merged env-secret loading but only warned on the placeholder; PR #4064 was closed for branch contamination and did not change this placeholder branch.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest tests/test_contributor_registry.py -q` -> 13 passed
- `python3 -m py_compile contributor_registry.py tests/test_contributor_registry.py` -> passed
- `uv run --no-project --with ruff ruff check --select E9,F821,F811,F841 contributor_registry.py tests/test_contributor_registry.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref upstream/main` -> OK
- `git diff --check` -> passed

## Bounty
Bounty rail: Scottcjn/rustchain-bounties#71
Issue: #5059 additional placeholder-secret finding
Wallet/miner ID: `dicnunz`
Canonical payout target: Scottcjn/rustchain-bounties#9194

No production service, live wallet, private key, token transfer, or destructive request was used.