### PR TITLE
fix: reject bridge direction-chain mismatches

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -142,6 +142,16 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
         return ValidationResult(ok=False, error=f"Invalid dest_chain: {dest_chain}")
     if source_chain == dest_chain:
         return ValidationResult(ok=False, error="Source and destination chains must be different")
+    if direction == "deposit":
+        if source_chain != "rustchain":
+            return ValidationResult(ok=False, error="Deposit source_chain must be rustchain")
+        if dest_chain == "rustchain":
+            return ValidationResult(ok=False, error="Deposit dest_chain must be external")
+    if direction == "withdraw":
+        if source_chain == "rustchain":
+            return ValidationResult(ok=False, error="Withdraw source_chain must be external")
+        if dest_chain != "rustchain":
+            return ValidationResult(ok=False, error="Withdraw dest_chain must be rustchain")
     
     # Validate addresses
     source_address = data.get("source_address", "")

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -258,6 +258,36 @@ class TestBridgeValidation:
         result = bridge_api.validate_bridge_request(data)
         assert result.ok is False
         assert "must be different" in result.error
+
+    def test_deposit_must_start_from_rustchain(self, setup_test_db):
+        """Deposits must be RustChain-to-external so balance locking applies."""
+        bridge_api = setup_test_db['bridge_api']
+        data = {
+            "direction": "deposit",
+            "source_chain": "solana",
+            "dest_chain": "rustchain",
+            "source_address": "4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            "dest_address": "RTC_test123",
+            "amount_rtc": 10.0
+        }
+        result = bridge_api.validate_bridge_request(data)
+        assert result.ok is False
+        assert "Deposit source_chain must be rustchain" in result.error
+
+    def test_withdraw_must_end_on_rustchain(self, setup_test_db):
+        """Withdrawals must be external-to-RustChain, not disguised deposits."""
+        bridge_api = setup_test_db['bridge_api']
+        data = {
+            "direction": "withdraw",
+            "source_chain": "rustchain",
+            "dest_chain": "solana",
+            "source_address": "RTC_test123",
+            "dest_address": "4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            "amount_rtc": 10.0
+        }
+        result = bridge_api.validate_bridge_request(data)
+        assert result.ok is False
+        assert "Withdraw source_chain must be external" in result.error
     
     def test_amount_below_minimum(self, setup_test_db):
         """Test amount below minimum fails validation."""


### PR DESCRIPTION
## Summary
- reject bridge payloads whose direction does not match the RustChain side of the transfer
- keep deposits constrained to RustChain -> external chains so they cannot bypass the balance/lock path
- keep withdrawals constrained to external chains -> RustChain
- add regression coverage for both swapped direction/chain pairs

## Security impact
Before this patch, the validator accepted any non-equal source/destination chain pair. Because route-level deposit handling is where RustChain balance locking is enforced, a RustChain-to-external bridge request could be labeled as a withdraw and pass validation without going through the deposit lock semantics. The patch makes the documented direction semantics explicit at validation time.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest tests/test_bridge_lock_ledger.py -q` -> 37 passed
- `python3 -m py_compile node/bridge_api.py tests/test_bridge_lock_ledger.py`
- `git diff --check -- node/bridge_api.py tests/test_bridge_lock_ledger.py`

Wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`