### PR TITLE
fix: confine server proxy to API paths

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -7,16 +7,27 @@ Allows G4 to connect via different port
 from flask import Flask, request, jsonify
 import requests
 import json
+from urllib.parse import quote
 
 app = Flask(__name__)
 
 # Local server on same machine
 LOCAL_SERVER = "http://localhost:8088"
 
+def _build_local_api_url(path):
+    """Return a local /api URL without allowing dot-segment escapes."""
+    parts = path.split("/")
+    if any(part in ("", ".", "..") for part in parts):
+        return None
+    safe_path = "/".join(quote(part, safe="") for part in parts)
+    return f"{LOCAL_SERVER}/api/{safe_path}"
+
 @app.route('/api/<path:path>', methods=['GET', 'POST'])
 def proxy(path):
     """Forward all API requests to local server"""
-    url = f"{LOCAL_SERVER}/api/{path}"
+    url = _build_local_api_url(path)
+    if not url:
+        return jsonify({'error': 'Invalid API path'}), 400
 
     try:
         if request.method == 'POST':

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -1,0 +1,68 @@
+import importlib.util
+from pathlib import Path
+
+
+def load_server_proxy():
+    module_path = Path(__file__).resolve().parents[1] / "node" / "server_proxy.py"
+    spec = importlib.util.spec_from_file_location("server_proxy_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_api_url_rejects_dot_segments():
+    proxy = load_server_proxy()
+
+    assert proxy._build_local_api_url("../health") is None
+    assert proxy._build_local_api_url("foo/../../health") is None
+    assert proxy._build_local_api_url("./stats") is None
+
+
+def test_local_api_url_quotes_path_segments():
+    proxy = load_server_proxy()
+
+    assert (
+        proxy._build_local_api_url("wallet balance/miner 1")
+        == "http://localhost:8088/api/wallet%20balance/miner%201"
+    )
+
+
+def test_proxy_rejects_encoded_parent_segment(monkeypatch):
+    proxy = load_server_proxy()
+    called = False
+
+    def fake_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("requests.get should not be called")
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/%2e%2e/health")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid API path"
+    assert called is False
+
+
+def test_proxy_keeps_safe_requests_under_api(monkeypatch):
+    proxy = load_server_proxy()
+    captured = {}
+
+    class FakeResponse:
+        status_code = 200
+        text = "ok"
+        headers = {"Content-Type": "text/plain"}
+
+    def fake_get(url, timeout):
+        captured["url"] = url
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/stats")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "ok"
+    assert captured == {"url": "http://localhost:8088/api/stats", "timeout": 10}


### PR DESCRIPTION
## Summary
- validate legacy server proxy paths before forwarding to the local node
- reject empty, dot, and parent directory path segments
- quote safe path segments before building the local `/api/...` URL
- add regression coverage for encoded parent segment rejection and safe forwarding

## Security impact
`node/server_proxy.py` forwards `/api/<path>` to `http://localhost:8088/api/{path}`. A literal parent segment such as `../health` is normalized by `requests` to `http://localhost:8088/health`, escaping the intended `/api` prefix. Encoded dot segments can reach the same dangerous path value through Flask routing. The patch rejects dot segments before forwarding, preventing the vintage proxy from reaching arbitrary local node routes outside `/api`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_server_proxy_path.py -q` -> 4 passed
- `python3 -m py_compile node/server_proxy.py tests/test_server_proxy_path.py`
- `git diff --check -- node/server_proxy.py tests/test_server_proxy_path.py`

Wallet: `6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2`