### PR TITLE
[codex] fix: disable Flask debug mode in keeper explorer services

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -188,4 +188,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=False, host='0.0.0.0', port=5000)

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -377,4 +377,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=False)


### PR DESCRIPTION
## Summary`n- Disable debug mode for the two Flask entrypoints that were exposing debug=True (contributor_registry.py and keeper_explorer.py).`n- This closes debug mode and avoids runtime debug reloader/dev-only behavior in non-local environments.`n- Issue reference: https://github.com/Scottcjn/rustchain/issues/5059`n`n### Files changed`n- contributor_registry.py`n- keeper_explorer.py`n`nNo payment or wallet details included as requested.