### PR TITLE
fix: fail closed tip bot webhook signatures

### DIFF
--- a/integrations/rustchain-bounties/README.md
+++ b/integrations/rustchain-bounties/README.md
@@ -90,7 +90,7 @@ Go to **Settings → Secrets and variables → Actions** and add:
 
 | Secret | Required | Description |
 |--------|----------|-------------|
-| `TIP_BOT_WEBHOOK_SECRET` | Optional | HMAC secret for webhook signature verification (external webhook deployments only — **not needed for GitHub Actions**). Generate with: `openssl rand -hex 32` |
+| `TIP_BOT_WEBHOOK_SECRET` | Optional | HMAC secret for webhook signature verification (external webhook deployments only — **do not configure for GitHub Actions**). Generate with: `openssl rand -hex 32` |
 | `RUSTCHAIN_NODE_URL` | Optional | Override the default RustChain node URL |
 | `WALLET_ADDRESS` | v2 only | Your RustChain wallet address (for auto-payout) |
 | `WALLET_PRIVATE_KEY` | v2 only | Wallet private key — **never commit this** |
@@ -172,15 +172,17 @@ For auto-payout (v2), you will need:
 
 ### Webhook Signature Verification
 
-When `TIP_BOT_WEBHOOK_SECRET` is set **and** an `HTTP_X_HUB_SIGNATURE_256` header
-is present, the bot verifies the HMAC-SHA256 signature before processing. This
-prevents forged webhooks from triggering tip commands.
+When `TIP_BOT_WEBHOOK_SECRET` is set, the bot requires a valid
+`HTTP_X_HUB_SIGNATURE_256` header and verifies the HMAC-SHA256 signature before
+processing. Missing or invalid signatures abort the run. This prevents forged
+webhooks from triggering tip commands.
 
 **Important:** This is only relevant for **external webhook deployments** (e.g.,
 running the bot as a standalone server). When using **GitHub Actions**, the payload
 comes from GitHub's own infrastructure via `GITHUB_EVENT_PATH` — there is no HTTP
 signature header. **Do not set `TIP_BOT_WEBHOOK_SECRET` for GitHub Actions** as
-it is unnecessary and has no effect.
+it is unnecessary and will make action runs fail closed without a webhook
+signature header.
 
 For external webhook deployments, configure the same secret in both:
 - Environment variable: `WEBHOOK_SECRET`

--- a/integrations/rustchain-bounties/auth.py
+++ b/integrations/rustchain-bounties/auth.py
@@ -20,8 +20,7 @@ def verify_webhook_signature(payload_bytes: bytes, signature_header: Optional[st
     """
     secret = os.environ.get("WEBHOOK_SECRET", "")
     if not secret:
-        # No secret configured — skip verification (development/local mode)
-        return True
+        return False
 
     if not signature_header:
         return False

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -30,6 +30,7 @@ from tip_bot import (
     build_failure_comment,
     build_success_comment,
     build_unauthorized_comment,
+    main,
     parse_tip_command,
     process_event,
     validate_tip,
@@ -277,11 +278,10 @@ class TestWebhookVerification:
         with patch.dict(os.environ, {"WEBHOOK_SECRET": "mysecret"}):
             assert verify_webhook_signature(payload, None) is False
 
-    def test_no_secret_configured_allows_all(self):
+    def test_no_secret_configured_fails_closed(self):
         payload = b'{"action": "created"}'
         with patch.dict(os.environ, {}, clear=True):
-            # When WEBHOOK_SECRET is not set, verification is skipped
-            assert verify_webhook_signature(payload, None) is True
+            assert verify_webhook_signature(payload, None) is False
 
     def test_tampered_payload_rejected(self):
         original = b'{"action": "created"}'
@@ -290,6 +290,24 @@ class TestWebhookVerification:
         sig = self._sign(original, secret)
         with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
             assert verify_webhook_signature(tampered, sig) is False
+
+    def test_main_requires_signature_when_secret_configured(self, tmp_path, capsys):
+        event_path = tmp_path / "event.json"
+        event_path.write_text('{"action": "created"}')
+
+        with patch.dict(
+            os.environ,
+            {
+                "GITHUB_EVENT_PATH": str(event_path),
+                "WEBHOOK_SECRET": "mysecret",
+            },
+            clear=True,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                main()
+
+        assert exc.value.code == 1
+        assert "Webhook signature verification failed" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -13,7 +13,7 @@ Required environment variables:
     GITHUB_TOKEN       — Auto-provided by GitHub Actions
     GITHUB_EVENT_PATH  — Auto-provided by GitHub Actions
     GITHUB_REPOSITORY  — Auto-provided by GitHub Actions
-    WEBHOOK_SECRET     — GitHub webhook HMAC secret (optional but recommended)
+    WEBHOOK_SECRET     — GitHub webhook HMAC secret for external webhooks
     RUSTCHAIN_NODE_URL — Override for the RustChain node URL (optional)
 
 Optional secrets (documented in README):
@@ -374,13 +374,12 @@ def main() -> None:
     with open(event_path) as f:
         event = json.load(f)
 
-    # Verify webhook signature if secret is configured AND a signature header
-    # is present. In GitHub Actions, the payload comes from GitHub's own
-    # infrastructure (GITHUB_EVENT_PATH) — no HTTP signature header exists.
-    # WEBHOOK_SECRET is only useful for external webhook deployments.
+    # Verify webhook signatures for external webhook deployments. GitHub Actions
+    # payloads arrive through GITHUB_EVENT_PATH and have no HTTP signature
+    # header, so do not configure WEBHOOK_SECRET for Actions runs.
     webhook_secret = os.environ.get("WEBHOOK_SECRET", "")
     sig = os.environ.get("HTTP_X_HUB_SIGNATURE_256", "")
-    if webhook_secret and sig:
+    if webhook_secret:
         raw_payload = open(event_path, "rb").read()
         if not verify_webhook_signature(raw_payload, sig):
             print("Webhook signature verification failed. Aborting.")


### PR DESCRIPTION
## Summary
- fail closed in `verify_webhook_signature()` when `WEBHOOK_SECRET` is not configured
- require a valid `HTTP_X_HUB_SIGNATURE_256` header whenever `WEBHOOK_SECRET` is configured
- document that GitHub Actions runs should not configure the external webhook secret
- add a regression proving `main()` aborts when a secret is set but the signature header is missing

Fixes #5122.

## Security impact
External webhook deployments could previously skip HMAC verification by omitting `HTTP_X_HUB_SIGNATURE_256`, because `tip_bot.py` only verified when both the secret and signature header were present.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with pyyaml --with requests python -m pytest integrations/rustchain-bounties/test_tip_bot.py -q` -> 61 passed
- `python3 -m py_compile integrations/rustchain-bounties/auth.py integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check -- integrations/rustchain-bounties/auth.py integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py integrations/rustchain-bounties/README.md` -> passed

Responsible testing note: local/static reproduction only. No production webhook probing, live tip processing, fund movement, or private data access.