### PR TITLE
fix: bound boot chime capture duration

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -7,7 +7,9 @@ Integrates with RustChain node for miner attestation.
 
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
+import io
 import json
+import math
 import os
 import time
 import tempfile
@@ -32,6 +34,8 @@ API_PORT = int(os.getenv('BOOT_CHIME_API_PORT', '8085'))
 DB_PATH = os.getenv('BOOT_CHIME_DB_PATH', 'proof_of_iron.db')
 SIMILARITY_THRESHOLD = float(os.getenv('BOOT_CHIME_THRESHOLD', '0.85'))
 CHALLENGE_TTL = int(os.getenv('BOOT_CHIME_CHALLENGE_TTL', '300'))
+MIN_CAPTURE_DURATION_SECONDS = float(os.getenv('BOOT_CHIME_MIN_CAPTURE_DURATION', '0.1'))
+MAX_CAPTURE_DURATION_SECONDS = float(os.getenv('BOOT_CHIME_MAX_CAPTURE_DURATION', '30.0'))
 
 # Initialize Proof-of-Iron system
 poi_system = ProofOfIron(
@@ -55,12 +59,36 @@ class JsonBodyError(ValueError):
     """Raised when a JSON endpoint receives a non-object body."""
 
 
+class CaptureDurationError(ValueError):
+    """Raised when a capture request duration is missing or unsafe."""
+
+
 def get_json_object() -> Dict[str, Any]:
     """Return the request JSON body when it is an object."""
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         raise JsonBodyError("JSON object required")
     return data
+
+
+def get_capture_duration() -> float:
+    """Return a finite capture duration within configured safety bounds."""
+    raw_duration = request.args.get('duration', '5.0')
+    try:
+        duration = float(raw_duration)
+    except (TypeError, ValueError):
+        raise CaptureDurationError("duration must be a number")
+
+    if not math.isfinite(duration):
+        raise CaptureDurationError("duration must be finite")
+
+    if not MIN_CAPTURE_DURATION_SECONDS <= duration <= MAX_CAPTURE_DURATION_SECONDS:
+        raise CaptureDurationError(
+            "duration must be between "
+            f"{MIN_CAPTURE_DURATION_SECONDS:g} and {MAX_CAPTURE_DURATION_SECONDS:g} seconds"
+        )
+
+    return duration
 
 
 # ============= Health & Info =============
@@ -278,23 +306,30 @@ def capture_audio():
     Response: WAV file
     """
     try:
-        duration = request.args.get('duration', default=5.0, type=float)
+        duration = get_capture_duration()
         trigger = request.args.get('trigger', default='false').lower() == 'true'
         
         captured = audio_capture.capture(duration=duration, trigger=trigger)
         
-        # Save to temp file and return
+        tmp_path = None
         with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
-            audio_capture.save_audio(captured, tmp.name)
             tmp_path = tmp.name
+        try:
+            audio_capture.save_audio(captured, tmp_path)
+            audio_bytes = Path(tmp_path).read_bytes()
+        finally:
+            if tmp_path:
+                Path(tmp_path).unlink(missing_ok=True)
         
         return send_file(
-            tmp_path,
+            io.BytesIO(audio_bytes),
             mimetype='audio/wav',
             as_attachment=True,
             download_name=f'boot_chime_{int(time.time())}.wav'
         )
         
+    except CaptureDurationError as e:
+        return jsonify({'error': str(e)}), 400
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -30,6 +30,20 @@ class ProofOfIronStub:
         return True
 
 
+class CaptureRecorder:
+    def __init__(self):
+        self.calls = []
+        self.saved_path = None
+
+    def capture(self, duration, trigger=False):
+        self.calls.append((duration, trigger))
+        return object()
+
+    def save_audio(self, captured, path):
+        self.saved_path = Path(path)
+        self.saved_path.write_bytes(b"RIFF\x24\x00\x00\x00WAVEfmt ")
+
+
 def install_dependency_stubs(monkeypatch):
     flask_cors = types.ModuleType("flask_cors")
     flask_cors.CORS = lambda app: app
@@ -104,3 +118,38 @@ def test_revoke_accepts_valid_json_body(client, api_module):
     assert response.status_code == 200
     assert api_module.poi_system.revoked == ("miner-1", "retired")
     assert response.get_json() == {"success": True, "message": "Attestation revoked"}
+
+
+def test_capture_rejects_excessive_duration_before_recording(client, api_module):
+    recorder = CaptureRecorder()
+    api_module.audio_capture = recorder
+
+    response = client.post("/api/v1/capture?duration=999999")
+
+    assert response.status_code == 400
+    assert "duration must be between" in response.get_json()["error"]
+    assert recorder.calls == []
+
+
+@pytest.mark.parametrize("duration", ("nan", "inf", "-1", "0", "not-a-number"))
+def test_capture_rejects_non_finite_or_invalid_duration(client, api_module, duration):
+    recorder = CaptureRecorder()
+    api_module.audio_capture = recorder
+
+    response = client.post(f"/api/v1/capture?duration={duration}")
+
+    assert response.status_code == 400
+    assert recorder.calls == []
+
+
+def test_capture_accepts_bounded_duration_and_removes_temp_file(client, api_module):
+    recorder = CaptureRecorder()
+    api_module.audio_capture = recorder
+
+    response = client.post("/api/v1/capture?duration=3.5&trigger=true")
+
+    assert response.status_code == 200
+    assert response.mimetype == "audio/wav"
+    assert recorder.calls == [(3.5, True)]
+    assert recorder.saved_path is not None
+    assert not recorder.saved_path.exists()


### PR DESCRIPTION
Fixes #5107.

This bounds `/api/v1/capture` duration before recording so requests like `duration=999999`, `nan`, or `inf` are rejected before audio capture starts. It also reads the generated WAV into memory and removes the temporary file before returning the response, so successful captures do not leave server-side temp files behind.

Bounty identity:
- GitHub: @galpetame
- RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
- Canonical wallet note: Scottcjn/rustchain-bounties#9266

Validation:
- `python -m pytest .\tests\test_boot_chime_api_json_validation.py -q` -> `11 passed`
- `python -m py_compile .\issue2307_boot_chime\boot_chime_api.py .\tests\test_boot_chime_api_json_validation.py` -> passed
- `git diff --check origin/main -- .\issue2307_boot_chime\boot_chime_api.py .\tests\test_boot_chime_api_json_validation.py` -> passed
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`