### PR TITLE
docs: align modern PC reward multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Epoch: 10 minutes  |  Pool: 1.5 RTC/epoch  |  Split by antiquity weight
 
 G4 Mac (2.5x):     0.30 RTC  ████████████████████
 G5 Mac (2.0x):     0.24 RTC  ████████████████
-Modern PC (1.0x):  0.12 RTC  ████████
+Modern PC (0.8x):  0.10 RTC  ██████
 ```
 
 ### Anti-VM Enforcement


### PR DESCRIPTION
## Summary
- align the README Epoch Rewards example with the existing Modern x86_64 hardware table value of 0.8x
- update the example RTC amount/bar from the old 1.0x presentation to a 0.8x presentation

Fixes #2685.

## Validation
- `git diff --check -- README.md`
- confirmed README now shows Modern x86_64 at 0.8x in both referenced sections