### PR TITLE
feat: add RISC-V CPU detection

### DIFF
--- a/VINTAGE_CPU_QUICK_REFERENCE.md
+++ b/VINTAGE_CPU_QUICK_REFERENCE.md
@@ -120,6 +120,7 @@
 |-----|------|---------|---------|
 | **RISC-V (SiFive U74)** | 2020 | `SiFive.*U74`, `sifive,u74` | VisionFive 2, HiFive Unmatched |
 | **RISC-V (StarFive JH7110)** | 2022 | `JH7110`, `StarFive.*JH7110` | VisionFive 2 SoC |
+| **RISC-V (Allwinner D1 / C906)** | 2021 | `Allwinner.*D1`, `sun20i-d1`, `T-Head.*C906` | Nezha, MangoPi, early RISC-V SBCs |
 | **RISC-V (generic)** | 2014+ | `riscv`, `riscv64`, `riscv32`, `RISC-V` | Open-source ISA |
 
 ---

--- a/WEIGHT_SCORING.md
+++ b/WEIGHT_SCORING.md
@@ -66,6 +66,18 @@ Rewards are based on **rarity + preservation value**, not just age.
 | M3 | 1.1x | Third gen |
 | M4 | 1.05x | Latest |
 
+### RISC-V (Exotic / Open ISA)
+| Architecture | Multiplier | Notes |
+|-------------|-----------|-------|
+| SiFive U74 | 1.5x | Early Linux-capable RISC-V board class |
+| StarFive JH7110 | 1.4x | VisionFive 2 SoC, practical SBC mining target |
+| Allwinner D1 / T-Head C906 | 1.4x | Early single-core RISC-V SBC class |
+| RV32IM / RV32IMAC | 1.4x | Minimal extension set, older embedded profile |
+| RV64GC / riscv64 | 1.4x | Generic 64-bit RISC-V baseline |
+| RV64GCV / RVV-present | 1.2x | Vector extension present; treat as a modernity marker |
+
+RISC-V vector extension (`V`/RVV) should be treated as a modernity marker in future attestation scoring rather than a spoofable vendor string by itself.
+
 ## Rationale
 
 1. **Rarity matters more than age** - POWER8 (2014) gets 1.5x because enterprise servers are rare. Ivy Bridge (2012) gets 1.1x because old Intel laptops are everywhere.

--- a/cpu_architecture_detection.py
+++ b/cpu_architecture_detection.py
@@ -13,6 +13,7 @@ Sources:
 - AMD CPU Timeline: https://en.wikipedia.org/wiki/List_of_AMD_CPU_microarchitectures
 - Intel Xeon Generations: https://en.wikipedia.org/wiki/List_of_Intel_Xeon_processors
 - AMD EPYC History: https://en.wikipedia.org/wiki/Epyc
+- RISC-V ISA: https://en.wikipedia.org/wiki/RISC-V
 """
 
 import re
@@ -27,7 +28,7 @@ CURRENT_YEAR = datetime.now().year
 class CPUInfo:
     """Detected CPU information"""
     brand_string: str
-    vendor: str  # "intel" or "amd"
+    vendor: str  # "intel", "amd", "riscv", "apple", or "powerpc"
     architecture: str  # e.g., "sandy_bridge", "zen2", "pentium4"
     microarch_year: int  # Year the microarchitecture was released
     model_year: int  # Estimated year this specific model was released
@@ -489,6 +490,79 @@ APPLE_SILICON = {
 
 
 # =============================================================================
+# RISC-V ARCHITECTURES
+# =============================================================================
+
+RISC_V_ARCHITECTURES = {
+    "riscv_sifive_u74": {
+        "years": (2020, 2022),
+        "patterns": [
+            r"SiFive.*U74",
+            r"sifive,u74",
+            r"HiFive Unmatched",
+        ],
+        "base_multiplier": 1.5,
+        "description": "RISC-V SiFive U74"
+    },
+    "riscv_starfive_jh7110": {
+        "years": (2022, 2024),
+        "patterns": [
+            r"StarFive.*JH7110",
+            r"JH7110",
+            r"VisionFive\s*2",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V StarFive JH7110"
+    },
+    "riscv_allwinner_d1": {
+        "years": (2021, 2022),
+        "patterns": [
+            r"Allwinner.*D1",
+            r"sun20i[-_ ]?d1",
+            r"T-Head.*C906",
+            r"\bC906\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V Allwinner D1 / T-Head C906"
+    },
+    "rv32im": {
+        "years": (2014, 2020),
+        "patterns": [
+            r"\bmisa\s*:\s*rv32im",
+            r"\brv32im\b",
+            r"\brv32ima\b",
+            r"\brv32imac\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V RV32IM/IMA/IMAC"
+    },
+    "rv64gcv": {
+        "years": (2021, 2025),
+        "patterns": [
+            r"\brv64gcv\b",
+            r"\brv64[imafdc]*v[imafdcv]*\b",
+            r"\bmisa\s*:\s*rv64[imafdc]*v[imafdcv]*\b",
+        ],
+        "base_multiplier": 1.2,
+        "description": "RISC-V RV64 with vector extension"
+    },
+    "rv64gc": {
+        "years": (2015, 2025),
+        "patterns": [
+            r"\bmisa\s*:\s*rv64gc",
+            r"\brv64gc\b",
+            r"\brv64imafdc\b",
+            r"\briscv64\b",
+            r"\bRISC-V\b",
+            r"\brvtest\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V RV64GC / generic 64-bit"
+    },
+}
+
+
+# =============================================================================
 # DETECTION FUNCTIONS
 # =============================================================================
 
@@ -506,6 +580,13 @@ def detect_cpu_architecture(brand_string: str) -> Tuple[str, str, int, bool]:
         "PowerPC G4" → ("powerpc", "g4", 2001, False)
     """
     brand_string = brand_string.strip()
+
+    # Check RISC-V before generic vendor fallbacks. RISC-V often appears as ISA
+    # strings from /proc/cpuinfo (rv64gc/rv32imac) rather than CPU brand names.
+    for arch_name, arch_info in RISC_V_ARCHITECTURES.items():
+        for pattern in arch_info["patterns"]:
+            if re.search(pattern, brand_string, re.IGNORECASE):
+                return ("riscv", arch_name, arch_info["years"][0], False)
 
     # Check PowerPC first (most distinctive)
     for arch_name, arch_info in POWERPC_ARCHITECTURES.items():
@@ -603,6 +684,8 @@ def calculate_antiquity_multiplier(
         base_multiplier = INTEL_GENERATIONS[architecture]["base_multiplier"]
     elif vendor == "amd":
         base_multiplier = AMD_GENERATIONS[architecture]["base_multiplier"]
+    elif vendor == "riscv":
+        base_multiplier = RISC_V_ARCHITECTURES[architecture]["base_multiplier"]
 
     # Apply time decay for vintage hardware (>5 years old)
     # Decay formula: aged = 1.0 + (base - 1.0) * (1 - 0.15 * years_since_genesis)
@@ -636,6 +719,8 @@ def calculate_antiquity_multiplier(
         generation_name = INTEL_GENERATIONS[architecture]["description"]
     elif vendor == "amd":
         generation_name = AMD_GENERATIONS[architecture]["description"]
+    elif vendor == "riscv":
+        generation_name = RISC_V_ARCHITECTURES[architecture]["description"]
     else:
         generation_name = "Unknown CPU"
 

--- a/cpu_vintage_architectures.py
+++ b/cpu_vintage_architectures.py
@@ -18,6 +18,7 @@ Research Sources:
 - MIPS: https://en.wikipedia.org/wiki/MIPS_architecture
 - PA-RISC: https://en.wikipedia.org/wiki/PA-RISC
 - PowerPC Amiga: https://en.wikipedia.org/wiki/AmigaOne
+- RISC-V: https://en.wikipedia.org/wiki/RISC-V
 """
 
 import re
@@ -406,6 +407,53 @@ POWERPC_AMIGA = {
 # =============================================================================
 
 RISC_WORKSTATIONS = {
+    # RISC-V (2014+) - open ISA boards now common in SBC mining experiments
+    "riscv_sifive_u74": {
+        "years": (2020, 2022),
+        "patterns": [
+            r"SiFive.*U74",
+            r"sifive,u74",
+            r"HiFive Unmatched",
+        ],
+        "base_multiplier": 1.5,
+        "description": "RISC-V SiFive U74 (HiFive Unmatched / VisionFive class)"
+    },
+    "riscv_starfive_jh7110": {
+        "years": (2022, 2024),
+        "patterns": [
+            r"StarFive.*JH7110",
+            r"JH7110",
+            r"VisionFive\s*2",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V StarFive JH7110 (VisionFive 2 SoC)"
+    },
+    "riscv_allwinner_d1": {
+        "years": (2021, 2022),
+        "patterns": [
+            r"Allwinner.*D1",
+            r"sun20i[-_ ]?d1",
+            r"T-Head.*C906",
+            r"\bC906\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "RISC-V Allwinner D1 / T-Head C906"
+    },
+    "riscv_generic": {
+        "years": (2014, 2025),
+        "patterns": [
+            r"\bRISC-V\b",
+            r"\briscv32\b",
+            r"\briscv64\b",
+            r"\bmisa\s*:\s*.*rv(?:32|64)",
+            r"\brvtest\b",
+            r"\brv32[imafdc]*\b",
+            r"\brv64[imafdcgv]*\b",
+        ],
+        "base_multiplier": 1.4,
+        "description": "Generic RISC-V ISA"
+    },
+
     # DEC Alpha (1992-2004) - Fastest CPU of the 1990s
     "alpha_21064": {
         "years": (1992, 1995),

--- a/tests/test_riscv_cpu_detection.py
+++ b/tests/test_riscv_cpu_detection.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for first-class RISC-V CPU detection."""
+
+import sys
+
+sys.path.insert(0, ".")
+
+import cpu_architecture_detection as modern_cpu
+import cpu_vintage_architectures as vintage_cpu
+
+
+def test_vintage_detection_sifive_u74():
+    assert vintage_cpu.detect_vintage_architecture("SiFive U74 RISC-V rv64gc") == (
+        "riscv",
+        "riscv_sifive_u74",
+        2020,
+        1.5,
+    )
+
+
+def test_vintage_detection_starfive_jh7110():
+    assert vintage_cpu.detect_vintage_architecture("StarFive JH7110 VisionFive 2") == (
+        "riscv",
+        "riscv_starfive_jh7110",
+        2022,
+        1.4,
+    )
+
+
+def test_vintage_detection_allwinner_d1_c906():
+    assert vintage_cpu.detect_vintage_architecture("Allwinner D1 T-Head C906") == (
+        "riscv",
+        "riscv_allwinner_d1",
+        2021,
+        1.4,
+    )
+
+
+def test_vintage_detection_generic_rv64gc():
+    assert vintage_cpu.detect_vintage_architecture("isa : rv64imafdc") == (
+        "riscv",
+        "riscv_generic",
+        2014,
+        1.4,
+    )
+
+
+def test_modern_detection_sifive_u74():
+    assert modern_cpu.detect_cpu_architecture("SiFive U74 RISC-V rv64gc") == (
+        "riscv",
+        "riscv_sifive_u74",
+        2020,
+        False,
+    )
+
+
+def test_modern_detection_generic_riscv64():
+    assert modern_cpu.detect_cpu_architecture("riscv64 rv64gc") == (
+        "riscv",
+        "rv64gc",
+        2015,
+        False,
+    )
+
+
+def test_modern_detection_misa_vector_extension_marker():
+    assert modern_cpu.detect_cpu_architecture("misa: rv64gcv") == (
+        "riscv",
+        "rv64gcv",
+        2021,
+        False,
+    )
+
+
+def test_modern_detection_rvtest_signature():
+    assert modern_cpu.detect_cpu_architecture("rvtest signature: riscv64") == (
+        "riscv",
+        "rv64gc",
+        2015,
+        False,
+    )
+
+
+def test_riscv_description_and_multiplier():
+    info = modern_cpu.calculate_antiquity_multiplier(
+        "StarFive JH7110 RISC-V rv64gc",
+        custom_year=2024,
+    )
+
+    assert info.vendor == "riscv"
+    assert info.architecture == "riscv_starfive_jh7110"
+    assert info.generation == "RISC-V StarFive JH7110"
+    assert info.antiquity_multiplier == 1.4


### PR DESCRIPTION
## Summary
- add first-class RISC-V detection entries for SiFive U74, StarFive JH7110, Allwinner D1 / T-Head C906, RV32IM, RV64GC, and RV64GCV
- parse common RISC-V ISA strings from `/proc/cpuinfo` / `misa`-style text such as `rv64imafdc`, `rv64gcv`, and `rv32imac`
- document RISC-V multiplier weights and add a quick-reference entry for Allwinner D1 / C906
- add focused regression tests for vintage and modern RISC-V detection paths

Fixes #2720.

## Validation
- `python -m pytest .\tests\test_riscv_cpu_detection.py .\tests\test_cpu_vintage_architectures.py -q` -> `61 passed`
- `python -m py_compile .\cpu_vintage_architectures.py .\cpu_architecture_detection.py .\tests\test_riscv_cpu_detection.py`
- `git diff --check -- cpu_vintage_architectures.py cpu_architecture_detection.py tests\test_riscv_cpu_detection.py WEIGHT_SCORING.md VINTAGE_CPU_QUICK_REFERENCE.md`
- `python .\tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`