### PR TITLE
fix: stabilize CRT bounty validation

### DIFF
--- a/bounties/issue-2310/src/__init__.py
+++ b/bounties/issue-2310/src/__init__.py
@@ -4,13 +4,36 @@ CRT Light Attestation - RustChain Security by Cathode Ray
 This package provides practical CRT-based hardware attestation for RustChain.
 """
 
+import importlib
+
 __version__ = '1.0.0'
 __author__ = 'RustChain Bounty Program'
 
-from crt_pattern_generator import CRTPatternGenerator
-from crt_capture import CRTCapture, CaptureConfig, CaptureMethod
-from crt_analyzer import CRTAnalyzer, CRTFingerprint
-from crt_attestation_submitter import CRTAttestationSubmitter, CRTAttestation
+_EXPORT_MODULES = {
+    'CRTPatternGenerator': 'crt_pattern_generator',
+    'CRTCapture': 'crt_capture',
+    'CaptureConfig': 'crt_capture',
+    'CaptureMethod': 'crt_capture',
+    'CRTAnalyzer': 'crt_analyzer',
+    'CRTFingerprint': 'crt_analyzer',
+    'CRTAttestationSubmitter': 'crt_attestation_submitter',
+    'CRTAttestation': 'crt_attestation_submitter',
+}
+
+
+def __getattr__(name):
+    """Lazily load CRT components while supporting package-relative imports."""
+    if name not in _EXPORT_MODULES:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_name = _EXPORT_MODULES[name]
+    if __package__:
+        module = importlib.import_module(f".{module_name}", __name__)
+    else:
+        module = importlib.import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
 
 __all__ = [
     'CRTPatternGenerator',

--- a/bounties/issue-2310/validate_bounty_2310.py
+++ b/bounties/issue-2310/validate_bounty_2310.py
@@ -25,13 +25,13 @@ def print_header(text):
     print(f"{BLUE}{'=' * 60}{RESET}\n")
 
 def print_success(text):
-    print(f"{GREEN}✅ {text}{RESET}")
+    print(f"{GREEN}[OK] {text}{RESET}")
 
 def print_error(text):
-    print(f"{RED}❌ {text}{RESET}")
+    print(f"{RED}[ERROR] {text}{RESET}")
 
 def print_info(text):
-    print(f"{YELLOW}ℹ️  {text}{RESET}")
+    print(f"{YELLOW}[INFO] {text}{RESET}")
 
 def check_file_exists(filepath, description):
     """Check if a file exists"""
@@ -48,7 +48,7 @@ def check_file_content(filepath, patterns, description):
         print_error(f"{description} missing: {filepath}")
         return False
     
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_found = True
@@ -66,7 +66,7 @@ def count_lines(filepath):
     """Count lines in a file"""
     if not os.path.exists(filepath):
         return 0
-    with open(filepath, 'r') as f:
+    with open(filepath, 'r', encoding='utf-8') as f:
         return sum(1 for _ in f)
 
 def get_file_hash(filepath):
@@ -242,7 +242,7 @@ def validate_tests():
         'pytest'
     ]
     
-    with open(test_file, 'r') as f:
+    with open(test_file, 'r', encoding='utf-8') as f:
         content = f.read()
     
     all_valid = True
@@ -271,7 +271,7 @@ def validate_evidence():
         print_error("Evidence file missing: proof.json")
         return False
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     required_fields = [
@@ -306,7 +306,7 @@ def validate_requirements():
     base_dir = Path(__file__).parent / 'evidence'
     proof_file = base_dir / 'proof.json'
     
-    with open(proof_file, 'r') as f:
+    with open(proof_file, 'r', encoding='utf-8') as f:
         proof = json.load(f)
     
     req_verify = proof.get('requirements_verification', {})
@@ -404,10 +404,10 @@ def main():
     print(f"  Total source lines: {total_lines}")
     
     if passed == total:
-        print(f"\n{GREEN}✅ VALIDATION PASSED - Implementation is complete!{RESET}\n")
+        print(f"\n{GREEN}[OK] VALIDATION PASSED - Implementation is complete!{RESET}\n")
         return 0
     else:
-        print(f"\n{RED}❌ VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
+        print(f"\n{RED}[ERROR] VALIDATION FAILED - {total - passed} checks failed{RESET}\n")
         return 1
 
 if __name__ == '__main__':

--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_issue2310_package_imports_from_parent_path():
+    code = (
+        "import sys; "
+        "sys.path.insert(0, r'bounties\\issue-2310'); "
+        "import src; "
+        "print(src.CRTPatternGenerator.__name__)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "CRTPatternGenerator"
+
+
+def test_issue2310_validator_runs_with_cp1252_stdout():
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+
+    result = subprocess.run(
+        [sys.executable, "bounties\\issue-2310\\validate_bounty_2310.py"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Final Results" in result.stdout
+    assert "VALIDATION PASSED" in result.stdout


### PR DESCRIPTION
## Summary
- make the CRT attestation package importable from `bounties/issue-2310` with lazy package-relative exports
- keep direct source-path compatibility for the exported CRT components
- make `validate_bounty_2310.py` safe under Windows-style CP1252 stdout by using ASCII status labels and explicit UTF-8 reads
- add regression coverage for package import and CP1252 validator execution

Fixes #4749.

## Validation
- `python -m pytest tests\test_issue2310_package_validation.py -q` -> 2 passed
- `python -W error::SyntaxWarning -m py_compile bounties\issue-2310\validate_bounty_2310.py bounties\issue-2310\src\__init__.py tests\test_issue2310_package_validation.py` -> passed
- `$env:PYTHONIOENCODING='cp1252'; python bounties\issue-2310\validate_bounty_2310.py` -> passed, 6/6 validation sections
- `python -c "import sys; sys.path.insert(0, r'bounties\issue-2310'); import src; print(src.CRTPatternGenerator.__name__)"` -> `CRTPatternGenerator`
- `git diff --check -- bounties/issue-2310/src/__init__.py bounties/issue-2310/validate_bounty_2310.py tests/test_issue2310_package_validation.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

Note: the broader existing CRT pytest suite requires `scipy`, which is not installed in this local environment, so I did not claim it as passed here.

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
