### PR TITLE
fix: compile entropy enforcement patch helper

### DIFF
--- a/deprecated/patches/rustchain_entropy_enforcement_patch.py
+++ b/deprecated/patches/rustchain_entropy_enforcement_patch.py
@@ -24,7 +24,7 @@ MIN_ENTROPY_SCORE = 0.15  # Phase 1: Start low
 MIN_ENTROPY_WARNING = 0.20  # Warn if below this
 MIN_ENTROPY_STRICT = 0.30  # Phase 2: Future strict enforcement
 
-PATCH_INSTRUCTIONS = """
+PATCH_INSTRUCTIONS = r'''
 ================================================================================
 RUSTCHAIN ENTROPY ENFORCEMENT PATCH
 ================================================================================
@@ -143,7 +143,7 @@ In the final success response of submit_attestation(), add entropy data:
     })
 
 ================================================================================
-"""
+'''
 
 
 def check_prerequisites(node_path="/root/rustchain"):

--- a/tests/test_entropy_enforcement_patch_compile.py
+++ b/tests/test_entropy_enforcement_patch_compile.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: MIT
+
+import py_compile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_entropy_enforcement_patch_helper_byte_compiles():
+    patch_helper = REPO_ROOT / "deprecated" / "patches" / "rustchain_entropy_enforcement_patch.py"
+
+    py_compile.compile(str(patch_helper), doraise=True)


### PR DESCRIPTION
## Summary
- make `PATCH_INSTRUCTIONS` a raw triple-single-quoted string so the embedded triple-double-quoted SQL snippet no longer terminates the string early
- add a byte-compile regression for the deprecated entropy enforcement patch helper

Fixes #4731.

## Validation
- `python -m py_compile deprecated\patches\rustchain_entropy_enforcement_patch.py tests\test_entropy_enforcement_patch_compile.py` -> passed
- `python -m pytest tests\test_entropy_enforcement_patch_compile.py -q` -> 1 passed
- `git diff --check -- deprecated/patches/rustchain_entropy_enforcement_patch.py tests/test_entropy_enforcement_patch_compile.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK

@galpetame
RTC wallet address: `RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce`
