### PR TITLE
test: cover quantum flux validator

### DIFF
--- a/tests/test_quantum_flux_validator.py
+++ b/tests/test_quantum_flux_validator.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import json
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "quantum_flux_validator.py"
+spec = importlib.util.spec_from_file_location("quantum_flux_validator", MODULE_PATH)
+quantum_flux_validator = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(quantum_flux_validator)
+
+
+def test_detect_network_flux_sleeps_with_random_delay_and_returns_choice(monkeypatch):
+    calls = []
+    monkeypatch.setattr(quantum_flux_validator.random, "randint", lambda start, end: 3)
+    monkeypatch.setattr(quantum_flux_validator.time, "sleep", lambda seconds: calls.append(seconds))
+    monkeypatch.setattr(quantum_flux_validator.random, "choice", lambda options: options[0])
+
+    assert quantum_flux_validator.detect_network_flux() is True
+    assert calls == [3]
+
+
+def test_award_quantum_flux_badge_writes_badge_when_flux_detected(tmp_path, monkeypatch, capsys):
+    relics_dir = tmp_path / "relics"
+    relics_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(quantum_flux_validator, "detect_network_flux", lambda: True)
+
+    quantum_flux_validator.award_quantum_flux_badge()
+
+    payload = json.loads((relics_dir / "badge_quantum_flux_validator.json").read_text())
+    badge = payload["badges"][0]
+    assert badge["nft_id"] == "badge_quantum_flux_validator"
+    assert badge["soulbound"] is True
+    assert badge["emotional_resonance"]["timestamp"].endswith("Z")
+    assert "Quantum Flux detected" in capsys.readouterr().out
+
+
+def test_award_quantum_flux_badge_does_not_write_when_no_flux(tmp_path, monkeypatch, capsys):
+    relics_dir = tmp_path / "relics"
+    relics_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(quantum_flux_validator, "detect_network_flux", lambda: False)
+
+    quantum_flux_validator.award_quantum_flux_badge()
+
+    assert not (relics_dir / "badge_quantum_flux_validator.json").exists()
+    assert "No network anomaly detected" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- Add pytest coverage for `tools/quantum_flux_validator.py` without waiting on real sleeps or relying on randomness.
- Cover detection delay/choice behavior, badge JSON creation on detected flux, and no-write behavior when no flux is detected.

## Tests
- `/tmp/rustchain-review-venv/bin/python -m pytest tests/test_quantum_flux_validator.py -q`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check origin/main...HEAD -- tests/test_quantum_flux_validator.py`

Bounty context: unit-test bounty Scottcjn/rustchain-bounties#1589. This adds one new focused test file for an untested helper module.

/claim #1589