### PR TITLE
fix: accept native RTC wallets in faucet

### DIFF
--- a/faucet_service/IMPLEMENTATION_SUMMARY.md
+++ b/faucet_service/IMPLEMENTATION_SUMMARY.md
@@ -156,7 +156,7 @@ rate_limit:
 
 # Validation
 validation:
-  required_prefix: "0x"
+  allowed_prefixes: ["RTC", "0x"]
   min_length: 10
   max_length: 66
   blocklist: []

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -64,7 +64,7 @@ rate_limit:
 
 # Wallet validation
 validation:
-  required_prefix: "0x"
+  allowed_prefixes: ["RTC", "0x"]
   min_length: 10
   max_length: 66
   blocklist: []
@@ -98,7 +98,7 @@ distribution:
 #### Validation
 | Option | Default | Description |
 |--------|---------|-------------|
-| `required_prefix` | `0x` | Required wallet prefix |
+| `allowed_prefixes` | `["RTC", "0x"]` | Accepted wallet prefixes |
 | `min_length` | `10` | Minimum wallet length |
 | `max_length` | `66` | Maximum wallet length |
 | `blocklist` | `[]` | Blocked wallet addresses |

--- a/faucet_service/faucet_config.yaml
+++ b/faucet_service/faucet_config.yaml
@@ -34,8 +34,11 @@ rate_limit:
 
 # Wallet validation settings
 validation:
-  # Require wallet address to start with prefix
-  required_prefix: "0x"
+  # Accepted wallet address prefixes. Native RustChain wallets use RTC...,
+  # while older faucet deployments may still accept EVM-style 0x... addresses.
+  allowed_prefixes:
+    - "RTC"
+    - "0x"
   
   # Minimum wallet length (including prefix)
   min_length: 10

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -72,7 +72,8 @@ DEFAULT_CONFIG = {
         }
     },
     'validation': {
-        'required_prefix': '0x',
+        'allowed_prefixes': ['RTC', '0x'],
+        'required_prefix': None,
         'min_length': 10,
         'max_length': 66,
         'require_checksum': False,
@@ -357,10 +358,16 @@ class FaucetValidator:
         
         wallet = wallet.strip()
         
-        # Check prefix
-        required_prefix = self.validation_config.get('required_prefix', '0x')
-        if required_prefix and not wallet.startswith(required_prefix):
-            return False, f"Wallet must start with '{required_prefix}'"
+        # Check prefix. Native RustChain wallets use RTC..., while older
+        # faucet deployments may still accept EVM-style 0x... addresses.
+        allowed_prefixes = self.validation_config.get('allowed_prefixes')
+        if allowed_prefixes is None:
+            required_prefix = self.validation_config.get('required_prefix')
+            allowed_prefixes = [required_prefix] if required_prefix else []
+
+        if allowed_prefixes and not any(wallet.startswith(prefix) for prefix in allowed_prefixes):
+            prefixes = "', '".join(allowed_prefixes)
+            return False, f"Wallet must start with one of: '{prefixes}'"
         
         # Check length
         min_len = self.validation_config.get('min_length', 10)

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -102,8 +102,14 @@ class TestFaucetValidator(unittest.TestCase):
         self.validator = FaucetValidator(self.config, self.logger)
     
     def test_valid_wallet(self):
-        """Test valid wallet address."""
+        """Test valid legacy EVM-style wallet address."""
         valid, error = self.validator.validate_wallet('0x9683744B6b94F2b0966aBDb8C6BdD9805d207c6E')
+        self.assertTrue(valid)
+        self.assertIsNone(error)
+
+    def test_valid_native_rtc_wallet(self):
+        """Test valid native RTC wallet address."""
+        valid, error = self.validator.validate_wallet('RTCa3f82d9c1e4b07f5a2d6c8e9b0f1d3e2a4c5b7f8')
         self.assertTrue(valid)
         self.assertIsNone(error)
     


### PR DESCRIPTION
## Summary
- accept native RustChain `RTC...` wallet addresses in the faucet validator
- keep backward compatibility for legacy EVM-style `0x...` faucet addresses
- update faucet config/docs and add a regression test for native RTC wallet validation

## Validation
- `python3 -m py_compile faucet_service/faucet_service.py faucet_service/test_faucet_service.py`
- `git diff --check -- faucet_service/faucet_service.py faucet_service/test_faucet_service.py faucet_service/faucet_config.yaml faucet_service/README.md faucet_service/IMPLEMENTATION_SUMMARY.md`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

Note: full `python3 -m pytest faucet_service/test_faucet_service.py -q` could not run in this local environment because the optional faucet test dependency `pycryptodome`/`Crypto` is not installed, but syntax/static/SPDX checks pass.