### PR TITLE
docs: fix incorrect file paths in docs/CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Thanks for helping improve RustChain.
 
 1. Read:
    - `README.md`
-   - `docs/PROTOCOL.md`
-   - `docs/API.md`
+   - `PROTOCOL.md`
+   - `API.md`
 2. Search existing issues and PRs first to avoid duplicate work.
 
 ## 2) Recommended contribution flow


### PR DESCRIPTION
## Summary
Fixes incorrect relative paths in `docs/CONTRIBUTING.md`.

The file is located inside the `docs/` directory, but it was referencing files as `docs/PROTOCOL.md` and `docs/API.md` — which would incorrectly point to `docs/docs/PROTOCOL.md`. Changed to the correct relative paths `PROTOCOL.md` and `API.md`.

## Changes
- `docs/CONTRIBUTING.md` line 9: `docs/PROTOCOL.md` → `PROTOCOL.md`
- `docs/CONTRIBUTING.md` line 10: `docs/API.md` → `API.md`

## Bounty
Claiming bounty #2783 (Star + Fix a Doc Issue - 2 RTC)

I reviewed and fixed the documentation paths in the RustChain repository.
The paths were incorrect — `docs/CONTRIBUTING.md` was referencing files with `docs/` prefix even though it is itself inside `docs/`.

I received RTC compensation for this review.
