### PR TITLE
Add miner checklist tests

### DIFF
--- a/tests/test_miner_checklist.py
+++ b/tests/test_miner_checklist.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: MIT
+"""Unit tests for the miner pre-flight checklist helper."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "miner_checklist.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("miner_checklist_tool", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_prints_pass_and_returns_condition(capsys):
+    module = load_module()
+
+    assert module.check("clawrtc installed", True) is True
+
+    assert "[PASS] clawrtc installed" in capsys.readouterr().out
+
+
+def test_check_prints_fail_and_returns_false(capsys):
+    module = load_module()
+
+    assert module.check("Wallet exists", False) is False
+
+    assert "[FAIL] Wallet exists" in capsys.readouterr().out
+
+
+def test_preflight_reports_ready_when_all_checks_pass(capsys):
+    module = load_module()
+
+    with (
+        patch.object(module.shutil, "which", return_value="/usr/local/bin/clawrtc"),
+        patch.object(module.os.path, "exists", return_value=True),
+        patch.object(module.shutil, "disk_usage", return_value=SimpleNamespace(free=2_000_000_000)),
+        patch.object(module.urllib.request, "urlopen", return_value=object()),
+    ):
+        module.preflight()
+
+    output = capsys.readouterr().out
+    assert "[PASS] clawrtc installed" in output
+    assert "[PASS] Wallet exists" in output
+    assert "[PASS] Disk > 1GB free" in output
+    assert "[PASS] Node reachable" in output
+    assert "Ready to mine!" in output
+
+
+def test_preflight_reports_failures_when_dependencies_are_missing(capsys):
+    module = load_module()
+
+    with (
+        patch.object(module.shutil, "which", return_value=None),
+        patch.object(module.os.path, "exists", return_value=False),
+        patch.object(module.shutil, "disk_usage", return_value=SimpleNamespace(free=500_000_000)),
+        patch.object(module.urllib.request, "urlopen", side_effect=OSError("offline")),
+    ):
+        module.preflight()
+
+    output = capsys.readouterr().out
+    assert "[FAIL] clawrtc installed" in output
+    assert "[FAIL] Wallet exists" in output
+    assert "[FAIL] Disk > 1GB free" in output
+    assert "[FAIL] Node reachable" in output
+    assert "Fix issues above first." in output


### PR DESCRIPTION
## Summary
- Add focused pytest coverage for `tools/miner_checklist.py`.
- Cover PASS/FAIL output from `check()`, successful preflight output, and failure output when miner dependencies, wallet storage, disk space, or node reachability are missing.
- Keep the tests offline by mocking local system checks and the health request.

## Tests
- `/tmp/rustchain-review-venv/bin/python -m pytest tests/test_miner_checklist.py -q`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check origin/main...HEAD -- tests/test_miner_checklist.py`

Bounty context: unit-test bounty Scottcjn/rustchain-bounties#1589. This adds one new focused test file for an untested helper module.

/claim #1589