### PR TITLE
Fix OpenAPI bounties repository link

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -33,7 +33,7 @@ info:
   version: 2.2.1-rip200
   contact:
     name: RustChain Development
-    url: https://github.com/rustchain-bounties/rustchain-bounties
+    url: https://github.com/Scottcjn/rustchain-bounties
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT


### PR DESCRIPTION
## Summary
- Fix the OpenAPI contact URL for the RustChain bounties repository
- Replace the stale `github.com/rustchain-bounties/rustchain-bounties` URL with the live `Scottcjn/rustchain-bounties` repository

## Validation
- Old URL returns HTTP 404
- New URL returns HTTP 200
- `git diff --check` passes

Note: I did not claim full YAML validation because the existing file has an unrelated pre-existing parser error later in the document.
