### PR TITLE
Escape bridge dashboard transaction fields

### DIFF
--- a/static/bridge/dashboard.html
+++ b/static/bridge/dashboard.html
@@ -1067,12 +1067,12 @@
 
             body.innerHTML = filtered.map(tx => `
                 <tr>
-                    <td><span class="tx-id">${tx.lock_id.substring(0, 16)}...</span></td>
-                    <td><span class="tx-type ${tx.type}">${tx.type.toUpperCase()}</span></td>
-                    <td>${tx.sender_wallet}</td>
-                    <td><span class="tx-amount">${formatNumber(tx.amount_rtc)} ${tx.type === 'wrap' ? 'RTC' : 'wRTC'}</span></td>
-                    <td><span class="chain-badge ${tx.target_chain}">${tx.target_chain.toUpperCase()}</span></td>
-                    <td><span class="tx-state ${tx.state}">${tx.state.toUpperCase()}</span></td>
+                    <td><span class="tx-id">${escapeHtml(String(tx.lock_id ?? '').substring(0, 16))}...</span></td>
+                    <td><span class="tx-type ${safeClassToken(tx.type, ['wrap', 'unwrap'], 'wrap')}">${escapeHtml(safeClassToken(tx.type, ['wrap', 'unwrap'], 'wrap').toUpperCase())}</span></td>
+                    <td>${escapeHtml(tx.sender_wallet)}</td>
+                    <td><span class="tx-amount">${escapeHtml(formatNumber(tx.amount_rtc))} ${safeClassToken(tx.type, ['wrap', 'unwrap'], 'wrap') === 'wrap' ? 'RTC' : 'wRTC'}</span></td>
+                    <td><span class="chain-badge ${safeClassToken(tx.target_chain, ['solana', 'base'], 'solana')}">${escapeHtml(safeClassToken(tx.target_chain, ['solana', 'base'], 'solana').toUpperCase())}</span></td>
+                    <td><span class="tx-state ${safeClassToken(tx.state, ['complete', 'pending', 'confirmed', 'requested'], 'pending')}">${escapeHtml(safeClassToken(tx.state, ['complete', 'pending', 'confirmed', 'requested'], 'pending').toUpperCase())}</span></td>
                     <td>${formatTime(tx.created_at || tx.timestamp)}</td>
                 </tr>
             `).join('');
@@ -1087,6 +1087,21 @@
         }
 
         // 鈹€鈹€鈹€ Utility Functions 鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€鈹€
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, char => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            })[char]);
+        }
+
+        function safeClassToken(value, allowed, fallback) {
+            const token = String(value ?? '').toLowerCase();
+            return allowed.includes(token) ? token : fallback;
+        }
+
         function formatNumber(num) {
             return new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 }).format(num || 0);
         }

--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -125,6 +125,26 @@
 </div>
 
 <script>
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        })[char]);
+    }
+
+    function safeClassToken(value, allowed, fallback) {
+        const token = String(value ?? '').toLowerCase();
+        return allowed.includes(token) ? token : fallback;
+    }
+
+    function safeNumber(value, fallback = 0) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
     async function refresh() {
         try {
             const resp = await fetch('bridge_status.json');
@@ -148,12 +168,15 @@
             body.innerHTML = '';
             data.recent_transactions.forEach(tx => {
                 const row = document.createElement('tr');
+                const lockId = escapeHtml(String(tx.lock_id ?? '').substring(0, 12));
+                const targetChain = safeClassToken(tx.target_chain, ['solana', 'base'], 'solana');
+                const state = safeClassToken(tx.state, ['complete', 'pending', 'confirmed', 'requested'], 'pending');
                 row.innerHTML = `
-                    <td style="font-family:monospace; color:#888">${tx.lock_id.substring(0,12)}...</td>
-                    <td>${tx.sender_wallet}</td>
-                    <td style="color:white; font-weight:bold">${tx.amount_rtc}</td>
-                    <td><span style="color:var(--solana)">${tx.target_chain.toUpperCase()}</span></td>
-                    <td><span class="state-tag ${tx.state}">${tx.state.toUpperCase()}</span></td>
+                    <td style="font-family:monospace; color:#888">${lockId}...</td>
+                    <td>${escapeHtml(tx.sender_wallet)}</td>
+                    <td style="color:white; font-weight:bold">${escapeHtml(safeNumber(tx.amount_rtc))}</td>
+                    <td><span style="color:var(--solana)">${escapeHtml(targetChain.toUpperCase())}</span></td>
+                    <td><span class="state-tag ${state}">${escapeHtml(state.toUpperCase())}</span></td>
                 `;
                 body.appendChild(row);
             });

--- a/tests/test_bridge_dashboard_frontend_security.py
+++ b/tests/test_bridge_dashboard_frontend_security.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+
+def test_bridge_monitor_escapes_transaction_fields_before_inner_html():
+    page = Path(__file__).resolve().parents[1] / "static" / "bridge" / "index.html"
+    html = page.read_text(encoding="utf-8")
+
+    assert "function escapeHtml(value)" in html
+    assert "function safeClassToken(value, allowed, fallback)" in html
+    assert "function safeNumber(value, fallback = 0)" in html
+
+    safe_patterns = [
+        "const lockId = escapeHtml(String(tx.lock_id ?? '').substring(0, 12));",
+        "${escapeHtml(tx.sender_wallet)}",
+        "${escapeHtml(safeNumber(tx.amount_rtc))}",
+        "${escapeHtml(targetChain.toUpperCase())}",
+        'class="state-tag ${state}"',
+        "${escapeHtml(state.toUpperCase())}",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in html
+
+    unsafe_patterns = [
+        "${tx.lock_id.substring(0,12)}",
+        "${tx.sender_wallet}",
+        "${tx.amount_rtc}",
+        "${tx.target_chain.toUpperCase()}",
+        'class="state-tag ${tx.state}"',
+        "${tx.state.toUpperCase()}",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in html
+
+
+def test_bridge_dashboard_escapes_transaction_fields_before_inner_html():
+    page = Path(__file__).resolve().parents[1] / "static" / "bridge" / "dashboard.html"
+    html = page.read_text(encoding="utf-8")
+
+    assert "function escapeHtml(value)" in html
+    assert "function safeClassToken(value, allowed, fallback)" in html
+
+    safe_patterns = [
+        "${escapeHtml(String(tx.lock_id ?? '').substring(0, 16))}",
+        'class="tx-type ${safeClassToken(tx.type, [\'wrap\', \'unwrap\'], \'wrap\')}"',
+        "${escapeHtml(safeClassToken(tx.type, ['wrap', 'unwrap'], 'wrap').toUpperCase())}",
+        "${escapeHtml(tx.sender_wallet)}",
+        "${escapeHtml(formatNumber(tx.amount_rtc))}",
+        'class="chain-badge ${safeClassToken(tx.target_chain, [\'solana\', \'base\'], \'solana\')}"',
+        "${escapeHtml(safeClassToken(tx.target_chain, ['solana', 'base'], 'solana').toUpperCase())}",
+        'class="tx-state ${safeClassToken(tx.state, [\'complete\', \'pending\', \'confirmed\', \'requested\'], \'pending\')}"',
+        "${escapeHtml(safeClassToken(tx.state, ['complete', 'pending', 'confirmed', 'requested'], 'pending').toUpperCase())}",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in html
+
+    unsafe_patterns = [
+        "${tx.lock_id.substring(0, 16)}",
+        'class="tx-type ${tx.type}"',
+        "${tx.type.toUpperCase()}",
+        "${tx.sender_wallet}",
+        "${formatNumber(tx.amount_rtc)}",
+        "${tx.type === 'wrap' ? 'RTC' : 'wRTC'}",
+        'class="chain-badge ${tx.target_chain}"',
+        "${tx.target_chain.toUpperCase()}",
+        'class="tx-state ${tx.state}"',
+        "${tx.state.toUpperCase()}",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in html


### PR DESCRIPTION
## Summary
- Escape remote bridge transaction fields before rendering them through template-string innerHTML
- Restrict transaction type, chain, and state CSS class tokens to known values
- Add focused regression coverage for both bridge monitor pages

## Validation
- python -m pytest tests\test_bridge_dashboard_frontend_security.py -q
- git diff --check -- static\bridge\index.html static\bridge\dashboard.html tests\test_bridge_dashboard_frontend_security.py

Closes #4452