### PR TITLE
Escape status dashboard node fields

### DIFF
--- a/static/status/index.html
+++ b/static/status/index.html
@@ -102,6 +102,26 @@
 </div>
 
 <script>
+    function escapeHtml(value) {
+        return String(value ?? '').replace(/[&<>"']/g, char => ({
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;'
+        })[char]);
+    }
+
+    function safeStatus(value) {
+        const status = String(value ?? '').toLowerCase();
+        return status === 'up' ? 'up' : 'down';
+    }
+
+    function safeNumber(value, fallback = '--') {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
     async function updateStatus() {
         try {
             const resp = await fetch('node_status.json');
@@ -114,11 +134,13 @@
             latest.nodes.forEach(node => {
                 const card = document.createElement('div');
                 card.className = 'card';
+                const status = safeStatus(node.status);
+                const statusColor = status === 'up' ? 'var(--green)' : 'var(--red)';
                 
                 // Get node history for uptime bar
                 const nodeHistory = history.map(h => {
                     const found = h.nodes.find(n => n.url === node.url);
-                    return found ? found.status === 'up' : false;
+                    return found ? safeStatus(found.status) === 'up' : false;
                 }).slice(-50); // Show last 50 checks
                 
                 let uptimeHtml = '<div class="uptime-bar">';
@@ -129,30 +151,30 @@
 
                 card.innerHTML = `
                     <div class="node-name">
-                        <span class="status-dot ${node.status === 'up' ? 'up' : 'down'}"></span>
-                        ${node.name}
+                        <span class="status-dot ${status}"></span>
+                        ${escapeHtml(node.name)}
                     </div>
-                    <div class="location">${node.location}</div>
+                    <div class="location">${escapeHtml(node.location)}</div>
                     
                     <div class="stat-row">
                         <span class="stat-label">STATUS</span>
-                        <span style="color: ${node.status === 'up' ? 'var(--green)' : 'var(--red)'}">${node.status.toUpperCase()}</span>
+                        <span style="color: ${statusColor}">${escapeHtml(status.toUpperCase())}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">LATENCY</span>
-                        <span>${node.latency_ms || '--'}ms</span>
+                        <span>${escapeHtml(safeNumber(node.latency_ms))}ms</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">VERSION</span>
-                        <span>${node.version || 'unknown'}</span>
+                        <span>${escapeHtml(node.version || 'unknown')}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">EPOCH</span>
-                        <span>${node.epoch || '--'}</span>
+                        <span>${escapeHtml(safeNumber(node.epoch))}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-label">MINERS</span>
-                        <span>${node.miners || 0}</span>
+                        <span>${escapeHtml(safeNumber(node.miners, 0))}</span>
                     </div>
                     
                     ${uptimeHtml}

--- a/tests/test_status_dashboard_frontend_security.py
+++ b/tests/test_status_dashboard_frontend_security.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+def test_status_dashboard_defines_render_safety_helpers():
+    page = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
+    html = page.read_text(encoding="utf-8")
+
+    assert "function escapeHtml(value)" in html
+    assert "function safeStatus(value)" in html
+    assert "function safeNumber(value, fallback = '--')" in html
+
+
+def test_status_dashboard_escapes_node_status_fields_before_inner_html():
+    page = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
+    html = page.read_text(encoding="utf-8")
+
+    safe_patterns = [
+        "const status = safeStatus(node.status);",
+        "const statusColor = status === 'up' ? 'var(--green)' : 'var(--red)';",
+        "return found ? safeStatus(found.status) === 'up' : false;",
+        'class="status-dot ${status}"',
+        "${escapeHtml(node.name)}",
+        '<div class="location">${escapeHtml(node.location)}</div>',
+        "${escapeHtml(status.toUpperCase())}",
+        "${escapeHtml(safeNumber(node.latency_ms))}ms",
+        "${escapeHtml(node.version || 'unknown')}",
+        "${escapeHtml(safeNumber(node.epoch))}",
+        "${escapeHtml(safeNumber(node.miners, 0))}",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in html
+
+    unsafe_patterns = [
+        "${node.name}",
+        "${node.location}",
+        "${node.status.toUpperCase()}",
+        "${node.latency_ms || '--'}ms",
+        "${node.version || 'unknown'}",
+        "${node.epoch || '--'}",
+        "${node.miners || 0}",
+        "found.status === 'up'",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in html


### PR DESCRIPTION
## Summary
- Escape node status fields from node_status.json before injecting card markup
- Normalize status values before using them in CSS class names and color decisions
- Add focused regression coverage for the status dashboard renderer

## Validation
- python -m pytest tests\test_status_dashboard_frontend_security.py -q
- git diff --check -- static\status\index.html tests\test_status_dashboard_frontend_security.py

Closes #4460