### PR TITLE
Fix broken RustChain documentation links

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "name": "RustChain Agent Framework",
-      "url": "https://rustchain.ai",
+      "url": "https://rustchain.org",
       "github_repo": "https://github.com/Scottcjn/Rustchain",
       "bcos_tier": "L1",
       "latest_sha": "a1b2c3d4e5f6789012345678901234567890abcd",

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -33,7 +33,7 @@ info:
   version: 2.2.1-rip200
   contact:
     name: RustChain Development
-    url: https://github.com/rustchain-bounties/rustchain-bounties
+    url: https://github.com/Scottcjn/rustchain-bounties
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/rips/Cargo.toml
+++ b/rips/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Flamekeeper Scott <scott@rustchain.net>", "Sophia Elya"]
 description = "RustChain Core - Proof of Antiquity blockchain that rewards vintage hardware preservation"
 license = "MIT"
-repository = "https://github.com/rustchain/rustchain-core"
+repository = "https://github.com/Scottcjn/Rustchain"
 keywords = ["blockchain", "vintage", "hardware", "proof-of-antiquity", "crypto"]
 categories = ["cryptography", "hardware-support"]
 

--- a/tools/comment-moderation-bot/pyproject.toml
+++ b/tools/comment-moderation-bot/pyproject.toml
@@ -44,8 +44,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/rustchain/comment-moderation-bot"
-Repository = "https://github.com/rustchain/comment-moderation-bot"
+Homepage = "https://github.com/Scottcjn/Rustchain/tree/main/tools/comment-moderation-bot"
+Repository = "https://github.com/Scottcjn/Rustchain/tree/main/tools/comment-moderation-bot"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/tools/mining-video-pipeline/mining_video_pipeline.py
+++ b/tools/mining-video-pipeline/mining_video_pipeline.py
@@ -329,7 +329,7 @@ def generate_video(miner: MinerData, epoch: dict, output_path: str, duration: fl
             draw.rectangle([0, HEIGHT - 80, WIDTH, HEIGHT], fill=(0, 0, 0))
             draw.rectangle([0, HEIGHT - 82, WIDTH, HEIGHT - 80], fill=style["accent"])
             draw.text((WIDTH // 2 - 200, HEIGHT - 65), "Start mining at", fill=(150, 150, 160), font=small_font)
-            draw.text((WIDTH // 2 - 200, HEIGHT - 40), "github.com/rustchain-hq/miner", fill=style["accent"], font=mono_lg)
+            draw.text((WIDTH // 2 - 200, HEIGHT - 40), "github.com/Scottcjn/Rustchain", fill=style["accent"], font=mono_lg)
 
         # Save frame
         frame_path = f"{FRAMES_DIR}/frame_{frame_num:05d}.png"
@@ -468,7 +468,7 @@ async def upload_all_videos(generated: list[tuple[str, MinerData]], epoch: dict)
             f"Epoch Pot: {epoch['epoch_pot']} RTC\n"
             f"Enrolled Miners: {epoch['enrolled_miners']}\n\n"
             f"RustChain uses Proof of Antiquity — vintage hardware earns more!\n"
-            f"Start mining: github.com/rustchain-hq/miner\n\n"
+            f"Start mining: github.com/Scottcjn/Rustchain\n\n"
             f"#RustChain #Mining #ProofOfAntiquity #Crypto #{miner.hardware_type.replace(' ', '')} #RTC"
         )
         tags = f"rustchain, mining, {miner.hardware_type.lower().replace(' ', '-')}, crypto, blockchain, vintage, proof of antiquity"


### PR DESCRIPTION
## Summary

Fixes several broken or obsolete RustChain documentation/package links:

- replaces the dead `https://rustchain.ai` project URL with `https://rustchain.org`
- updates the OpenAPI contact repository from the non-existent `rustchain-bounties/rustchain-bounties` repo to `Scottcjn/rustchain-bounties`
- updates stale `rustchain/*` and `rustchain-hq/miner` GitHub references to active `Scottcjn/Rustchain` paths

## Verification

Checked the old URLs:

- `https://rustchain.ai` -> DNS resolution failure
- `https://github.com/rustchain-bounties/rustchain-bounties` -> 404
- `https://github.com/rustchain/rustchain-core` -> 404
- `https://github.com/rustchain/comment-moderation-bot` -> 404
- `https://github.com/rustchain-hq/miner` -> 404

Checked the replacement URLs:

- `https://rustchain.org` -> 200
- `https://github.com/Scottcjn/rustchain-bounties` -> 200
- `https://github.com/Scottcjn/Rustchain` -> 200
- `https://github.com/Scottcjn/Rustchain/tree/main/tools/comment-moderation-bot` -> 200

Bounty claim: Scottcjn/rustchain-bounties#2178
Wallet: `RTC937d013bc741f598ae9f2a317d152da19d6eedda`