### PR TITLE
fix(#5000): use timing-safe hmac.compare_digest for bridge admin key

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -166,7 +166,7 @@ def _require_admin(fn):
         key = request.headers.get("X-Admin-Key", "")
         if not BRIDGE_ADMIN_KEY:
             return jsonify({"error": "admin key not configured on server"}), 500
-        if key != BRIDGE_ADMIN_KEY:
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
             return jsonify({"error": "unauthorized"}), 403
         return fn(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Summary

Fixes #5000 — CWE-208 (Observable Timing Discrepancy) in bridge API admin key validation.

## Vulnerability

The `_require_admin` decorator used direct string inequality for admin key comparison:

    if key != BRIDGE_ADMIN_KEY:  # timing-unsafe!

This comparison returns early at the first differing character, enabling an attacker to determine the admin key character-by-character via timing measurements.

## Fix

Replaced with `hmac.compare_digest(key, BRIDGE_ADMIN_KEY)` which runs in constant time regardless of where the first difference occurs.

## Verification

- `hmac` was already imported at line 18 of the same file — no new imports needed.
- Logic unchanged: still returns 403 on mismatch and 500 when key not configured.
- `python3 -m py_compile bridge/bridge_api.py` passes.

## Bounty claim

Claiming bounty for fixing issue #5000.

**Wallet:** GyZXdm8YdZ3ZKCfEUfK7tcuHji5mkv46spYJgU8AvsRg
