### PR TITLE
docs: fix epoch determinism clone URL

### DIFF
--- a/tools/epoch_determinism/README.md
+++ b/tools/epoch_determinism/README.md
@@ -38,7 +38,7 @@ Expected output:
 No extra dependencies beyond Python ≥ 3.8 and the repo itself.
 
 ```bash
-git clone https://github.com/B1tor/Rustchain.git
+git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
 python tools/epoch_determinism/replay.py tools/epoch_determinism/fixtures/normal_epoch.json
 ```
@@ -249,7 +249,7 @@ The replay tool guarantees determinism by:
 ## Reproduction Steps
 
 ```bash
-git clone https://github.com/B1tor/Rustchain.git
+git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
 git checkout scottcjn/epoch-determinism-474
 


### PR DESCRIPTION
## Summary
- Replace two stale `B1tor/Rustchain` clone commands in `tools/epoch_determinism/README.md`
- Point users at the live `Scottcjn/Rustchain` repository instead

## Validation
- old `https://github.com/B1tor/Rustchain.git` final HTTP status -> 404
- new `https://github.com/Scottcjn/Rustchain.git` final HTTP status -> 200
- `rg -n "github.com/(B1tor|Scottcjn)/Rustchain.git" tools/epoch_determinism/README.md` -> only corrected Scottcjn URLs
- `git diff --check -- tools/epoch_determinism/README.md`

Bounty path: rustchain-bounties#2178
Wallet/miner ID: `iamdinhthuan`