### PR TITLE
[UTXO-BUG] Reject oversized UTXO output lists

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -14,6 +14,7 @@ import unittest
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
+    MAX_OUTPUTS_PER_TX,
 )
 
 
@@ -723,6 +724,44 @@ class TestUtxoDB(unittest.TestCase):
         }
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
+
+    def test_apply_transaction_rejects_too_many_outputs(self):
+        """output_index is encoded in two bytes, so larger txs must fail cleanly."""
+        self._apply_coinbase('alice', 100_000)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [
+                {'address': f'user{i}', 'value_nrtc': 1}
+                for i in range(MAX_OUTPUTS_PER_TX + 1)
+            ],
+            'fee_nrtc': 100_000 - (MAX_OUTPUTS_PER_TX + 1),
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100_000)
+
+    def test_mempool_rejects_too_many_outputs(self):
+        """Mempool must not admit txs that apply_transaction cannot encode."""
+        self._apply_coinbase('alice', 100_000)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        tx = {
+            'tx_id': 'outs' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [
+                {'address': f'user{i}', 'value_nrtc': 1}
+                for i in range(MAX_OUTPUTS_PER_TX + 1)
+            ],
+            'fee_nrtc': 100_000 - (MAX_OUTPUTS_PER_TX + 1),
+        }
+
+        self.assertFalse(self.db.mempool_add(tx))
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
 
     # -- bounty #2819: negative / zero value outputs -------------------------
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -39,6 +39,7 @@ DUST_THRESHOLD = 1_000      # nanoRTC below which change is absorbed into fee
 MAX_COINBASE_OUTPUT_NRTC = 150 * 144 * UNIT  # Max minting output per block (1.5 RTC)
 MAX_POOL_SIZE = 10_000
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
+MAX_OUTPUTS_PER_TX = 1 << 16  # output_index is encoded as unsigned 2 bytes
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
 
 
@@ -379,8 +380,6 @@ class UtxoDB:
         # Only the epoch settlement system should create mining_reward transactions.
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
-        if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
-            return False
 
         try:
             if manage_tx:
@@ -390,6 +389,15 @@ class UtxoDB:
                 if manage_tx:
                     conn.execute("ROLLBACK")
                 return False
+
+            if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
+                return abort()
+
+            # output_index is serialized into two bytes in compute_box_id().
+            # Reject oversized transactions before box ID assignment so an
+            # otherwise valid-looking candidate cannot crash block production.
+            if len(outputs) > MAX_OUTPUTS_PER_TX:
+                return abort()
 
             # -- reject duplicate input box_ids --------------------------------
             # Keyed on box_id alone (the PK of the UTXO being consumed).
@@ -741,6 +749,11 @@ class UtxoDB:
 
             # MEDIUM FIX: Reject empty outputs to prevent DoS
             outputs = tx.get('outputs', [])
+            if len(outputs) > MAX_OUTPUTS_PER_TX:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
+
             if not outputs and tx_type not in MINTING_TX_TYPES:
                 if manage_tx:
                         conn.execute("ROLLBACK")


### PR DESCRIPTION
## Summary

Fixes an oversized-output UTXO validation gap covered by Scottcjn/rustchain-bounties#2819.

`compute_box_id()` serializes `output_index` with `output_index.to_bytes(2, 'little')`, so output indexes above `65535` cannot be encoded. Before this patch, a transaction with `65,537` outputs could pass `mempool_add()` and then raise `OverflowError: int too big to convert` inside `apply_transaction()` during block candidate application.

## Impact

A malformed transaction can be admitted to the mempool even though it cannot be applied into a block. That leaves the input claimed in `utxo_mempool_inputs` until expiry and exposes an unmineable candidate to block production.

## Fix

- Add `MAX_OUTPUTS_PER_TX = 1 << 16`, matching the two-byte output index encoding.
- Reject transactions with more than `65,536` outputs in both `apply_transaction()` and `mempool_add()`.
- Move the unauthorized `mining_reward` guard into the transaction cleanup path so rejected calls close/rollback consistently.
- Add regression tests for direct apply and mempool admission.

## Validation

Run locally from a clean worktree based on upstream `main`:

```text
python -m py_compile node\utxo_db.py node\test_utxo_db.py
python node\test_utxo_db.py
# Ran 57 tests in 2.015s - OK
python tools\bcos_spdx_check.py --base-ref main
# BCOS SPDX check: OK
```

Payout details intentionally omitted from the PR; the operator can provide them manually if the bounty maintainer asks on the authorized bounty issue.
