### PR TITLE
Fix issue 765 runbook repository links

### DIFF
--- a/bounties/issue-765/docs/RUNBOOK.md
+++ b/bounties/issue-765/docs/RUNBOOK.md
@@ -445,8 +445,8 @@ curl -G 'http://localhost:9090/api/v1/query' \
 
 ## Contact
 
-- **GitHub Issues**: https://github.com/Scottcjcn/RustChain/issues
-- **Documentation**: https://github.com/Scottcjcn/RustChain/tree/main/bounties/issue-765/docs
+- **GitHub Issues**: https://github.com/Scottcjn/Rustchain/issues
+- **Documentation**: https://github.com/Scottcjn/Rustchain/tree/main/bounties/issue-765/docs
 - **Alert Runbook**: This document
 
 ---


### PR DESCRIPTION
## Summary
- fix the issue 765 runbook contact links that point to the misspelled `Scottcjcn/RustChain` repository
- update them to the canonical `Scottcjn/Rustchain` repository URLs

## Verification
- `https://github.com/Scottcjcn/RustChain/issues` -> 404
- `https://github.com/Scottcjcn/RustChain/tree/main/bounties/issue-765/docs` -> 404
- `https://github.com/Scottcjn/Rustchain/issues` -> 200
- `https://github.com/Scottcjn/Rustchain/tree/main/bounties/issue-765/docs` -> 200
- `git diff --check -- bounties/issue-765/docs/RUNBOOK.md` -> passed

Bounty: Scottcjn/rustchain-bounties#2178