### PR TITLE
fix: enforce strict UTXO conservation + reject bool values (#5181, #5182, #5183)

### DIFF
--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -436,7 +436,9 @@ class UtxoDB:
             # Without this, a negative-value output lowers output_total,
             # letting an attacker create more value than the inputs hold.
             for o in outputs:
-                if not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
+                # Fix #5183: Explicitly reject bool before isinstance(int) check
+                # isinstance(True, int) returns True in Python, allowing bool values
+                if isinstance(o['value_nrtc'], bool) or not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
                     return abort()
 
             # Cap minting (coinbase) output to prevent unbounded fund creation.
@@ -449,7 +451,10 @@ class UtxoDB:
                 return abort()
             if fee < 0:
                 return abort()
-            if inputs and (output_total + fee) > input_total:
+            # Fix #5181: Enforce strict conservation law
+            # Previous check only rejected output+fee > input, but allowed output+fee < input,
+            # permanently destroying the difference. Now require exact equality.
+            if inputs and (output_total + fee) != input_total:
                 return abort()
 
             # -- compute output box IDs and build tx_id ----------------------
@@ -763,13 +768,18 @@ class UtxoDB:
             # UTXOs until expiry (DoS vector).
             for o in outputs:
                 val = o.get('value_nrtc')
-                if not isinstance(val, int) or val <= 0:
+                # Fix #5183: Explicitly reject bool before isinstance(int) check
+                if isinstance(val, bool) or not isinstance(val, int) or val <= 0:
                     if manage_tx:
                         conn.execute("ROLLBACK")
                     return False
 
             output_total = sum(o['value_nrtc'] for o in outputs)
-            if input_total > 0 and (output_total + fee) > input_total:
+            # Fix #5182: Align conservation check gating with apply_transaction()
+            # Previous: if input_total > 0 (skips check for all-zero-value inputs)
+            # Now: if inputs (matches apply_transaction, catches zero-value UTXO lock DoS)
+            # Fix #5181: Enforce strict conservation (use != instead of >)
+            if inputs and (output_total + fee) != input_total:
                 if manage_tx:
                         conn.execute("ROLLBACK")
                 return False


### PR DESCRIPTION
Fixes 3 critical UTXO security bugs reported in issues #5181, #5182, and #5183.

## 1. #5181: Fund Destruction (Medium, 10-15 RTC)

**Bug:** Conservation check was asymmetric — only rejected `output+fee > input`, but allowed `output+fee < input`, permanently destroying the difference.

**Fix:** Changed line 452 from `>` to `!=` to require strict equality.

**Before:**
```python
if inputs and (output_total + fee) > input_total:
    return abort()
```

**After:**
```python
if inputs and (output_total + fee) != input_total:
    return abort()
```

**Impact:** Prevents scenarios where Alice sends 1000 nrtc but Bob only receives 100 nrtc — the 900 nrtc difference is no longer silently destroyed.

---

## 2. #5182: Mempool DoS (Low, 5 RTC)

**Bug:** `apply_transaction()` gates conservation check with `if inputs:` (truthy list), but `mempool_add()` gates with `if input_total > 0`. A transaction with non-empty inputs but all zero values bypasses mempool validation, locking UTXOs for 1 hour until expiry.

**Fix:** Aligned mempool_add() gating to match apply_transaction() + applied strict conservation.

**Line 777:** Changed from `if input_total > 0 and (output_total + fee) > input_total:` to `if inputs and (output_total + fee) != input_total:`

**Impact:** Prevents mempool DoS where zero-value inputs lock UTXOs without proper validation.

---

## 3. #5183: Bool Type Confusion (Low, 5 RTC)

**Bug:** In Python, `isinstance(True, int)` returns `True` because bool is a subclass of int. Since `True > 0` evaluates to `True` (True == 1), a `value_nrtc = True` (JSON bool) passes validation and is accepted as a valid 1 nanoRTC output.

**Fix:** Added explicit bool rejection before isinstance(int) check.

**Lines 439 and 769:** Added `isinstance(o['value_nrtc'], bool)` check.

**Before:**
```python
if not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
    return abort()
```

**After:**
```python
if isinstance(o['value_nrtc'], bool) or not isinstance(o['value_nrtc'], int) or o['value_nrtc'] <= 0:
    return abort()
```

**Impact:** Prevents type contract violation where JSON bool values masquerade as integer amounts.

---

## Files Changed
- `node/utxo_db.py` (4 locations):
  - Line 439: Bool check in apply_transaction output validation
  - Line 452: Strict conservation (> to !=)
  - Line 769: Bool check in mempool_add output validation  
  - Line 777: Align gating + strict conservation

## Total Bounty
20-25 RTC (10-15 + 5 + 5)

## Payment Address
**SOL:** `CU5CCB6zkHkGre7iwWBHpvs6nGKBFkdtMZyQi95sdupJ`

---

Related issues: #5181, #5182, #5183
