### PR TITLE
test: cover health monitor latency coloring

### DIFF
--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -21,7 +21,12 @@ from node_health_monitor import (
     NodeStatus,
     NetworkHealth,
     DEFAULT_NODES,
+    DIM,
+    GREEN,
+    RESET,
     SLOW_THRESHOLD_MS,
+    YELLOW,
+    _color_ms,
 )
 
 
@@ -237,6 +242,21 @@ class TestGetNetworkHealth(unittest.TestCase):
         self.assertEqual(health.total_miners, 0)
         self.assertTrue(health.consensus_ok)  # vacuously true — no epochs to compare
         self.assertTrue(any("ALL NODES OFFLINE" in a for a in health.alerts))
+
+
+class TestColorMs(unittest.TestCase):
+    def test_none_renders_dim_placeholder(self):
+        self.assertEqual(_color_ms(None), f"{DIM}     —{RESET}")
+
+    def test_threshold_boundary_stays_green(self):
+        self.assertEqual(
+            _color_ms(SLOW_THRESHOLD_MS),
+            f"{GREEN}{SLOW_THRESHOLD_MS:>7.1f}ms{RESET}",
+        )
+
+    def test_above_threshold_renders_yellow(self):
+        slow_ms = SLOW_THRESHOLD_MS + 0.1
+        self.assertEqual(_color_ms(slow_ms), f"{YELLOW}{slow_ms:>7.1f}ms{RESET}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add focused unit coverage for `tools/node_health_monitor.py` latency formatting.
- Cover `None` placeholder rendering, the exact slow-threshold boundary, and over-threshold yellow formatting.

## Bounty
- Bounty #1589: unit test for untested function behavior.
- Wallet/miner ID: iamdinhthuan

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_health_monitor.py -q` -> 20 passed
- `python -m py_compile tools/node_health_monitor.py tests/test_health_monitor.py` -> passed
- `git diff --check HEAD~1..HEAD` -> passed