### PR TITLE
docs: fix living compute campaign links

### DIFF
--- a/campaigns/museum_of_living_compute/README.md
+++ b/campaigns/museum_of_living_compute/README.md
@@ -158,6 +158,6 @@ MIT
 ## Links
 
 - [RustChain](https://rustchain.org) -- The blockchain
-- [RIP-200 Spec](https://github.com/Scottcjn/rustchain/blob/main/docs/RIP-200.md) -- Proof of Antiquity consensus
-- [Miner Setup](https://github.com/Scottcjn/rustchain/blob/main/docs/MINER_SETUP.md) -- How to start mining
+- [RIP-200 Spec](https://github.com/Scottcjn/Rustchain/blob/main/docs/PROTOCOL.md) -- Proof of Antiquity consensus
+- [Miner Setup](https://github.com/Scottcjn/Rustchain/blob/main/docs/sprint/miner-setup-guide.md) -- How to start mining
 - [Block Explorer](https://rustchain.org/explorer) -- Live network data


### PR DESCRIPTION
## Summary
- Fix two stale GitHub documentation links in the Museum of Living Compute campaign README.
- Replace dead RIP-200/MINER_SETUP links with existing protocol and miner setup docs.

## Evidence
- old RIP-200 link -> 404
- new protocol link -> 200
- old miner setup link -> 404
- new miner setup guide link -> 200

## Bounty
- Bounty #2178 docs fix
- Wallet/miner ID: iamdinhthuan