### PR TITLE
docs: fix Windows miner validation download URL

### DIFF
--- a/miners/windows/testing/VALIDATION_NOTES.md
+++ b/miners/windows/testing/VALIDATION_NOTES.md
@@ -19,7 +19,7 @@ This document provides step-by-step instructions for reproducing the smoke test 
 
 ```powershell
 # 1. Download the release bundle
-Invoke-WebRequest -Uri "https://github.com/Scottcjn/Rustchain/releases/download/v1.6.0/rustchain_windows_miner_release.zip" -OutFile "$env:TEMP\miner.zip"
+Invoke-WebRequest -Uri "https://github.com/Scottcjn/Rustchain/releases/download/win-miner-2026-02/rustchain_windows_miner_release.zip" -OutFile "$env:TEMP\miner.zip"
 
 # 2. Extract
 Expand-Archive -Path "$env:TEMP\miner.zip" -DestinationPath "$env:TEMP\miner_test"


### PR DESCRIPTION
## Summary
- Fix the Windows miner validation quick-start download URL.
- Replace a stale `v1.6.0` release asset URL that returns 404 with the live `win-miner-2026-02` release asset.

## Evidence
- old URL `https://github.com/Scottcjn/Rustchain/releases/download/v1.6.0/rustchain_windows_miner_release.zip` -> 404
- new URL `https://github.com/Scottcjn/Rustchain/releases/download/win-miner-2026-02/rustchain_windows_miner_release.zip` -> 200

## Verification
- `git diff --check -- miners/windows/testing/VALIDATION_NOTES.md` -> passed

## Bounty
- Bounty #2178 docs fix
- Wallet/miner ID: iamdinhthuan