### PR TITLE
security: remove pickle fallback from _load_features (proof_of_iron)

### DIFF
--- a/issue2307_boot_chime/src/proof_of_iron.py
+++ b/issue2307_boot_chime/src/proof_of_iron.py
@@ -524,55 +524,49 @@ class ProofOfIron:
             pass
     
     def _load_features(self, features_hash: str) -> Optional[FingerprintFeatures]:
-        """Load cached features with backward-compatible dual-read (JSON first, then pickle)."""
+        """Load cached features. JSON only — no pickle fallback.
+
+        pickle fallback removed: poisoned legacy BLOBs in feature_cache were
+        an RCE primitive (vuln-tick 2026-05-14T14:10Z). Any row that does not
+        decode as JSON is treated as a cache miss; callers must rebuild the
+        entry via re-enrollment (capture_and_enroll), which now writes JSON
+        unconditionally. Legacy pickle rows should be removed offline with a
+        one-shot migration tool, not deserialized at runtime.
+        """
         try:
             import sqlite3
-            import json
-            import pickle
             conn = sqlite3.connect(self.db_path)
             c = conn.cursor()
             c.execute('SELECT features FROM feature_cache WHERE hash = ?',
                      (features_hash,))
             row = c.fetchone()
             conn.close()
-            
-            if row:
-                raw = row[0]
-                # Try JSON first (new format)
-                try:
-                    if isinstance(raw, bytes):
-                        data = json.loads(raw.decode('utf-8'))
-                    else:
-                        data = json.loads(raw)
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    # Fallback: legacy pickle data — deserialize and migrate to JSON
-                    data = pickle.loads(raw) if isinstance(raw, bytes) else pickle.loads(raw.encode())
-                    # Re-write as JSON to gradually migrate the cache
-                    self._save_features(features_hash, FingerprintFeatures(
-                        mfcc_mean=np.array(data['mfcc_mean']),
-                        mfcc_std=np.array(data['mfcc_std']),
-                        spectral_centroid=data['spectral_centroid'],
-                        spectral_bandwidth=data['spectral_bandwidth'],
-                        spectral_rolloff=data['spectral_rolloff'],
-                        zero_crossing_rate=data['zero_crossing_rate'],
-                        chroma_mean=np.array(data['chroma_mean']),
-                        temporal_envelope=np.array(data['temporal_envelope']),
-                        peak_frequencies=data['peak_frequencies'],
-                        harmonic_structure=data['harmonic_structure'],
-                    ))
-                
-                return FingerprintFeatures(
-                    mfcc_mean=np.array(data['mfcc_mean']),
-                    mfcc_std=np.array(data['mfcc_std']),
-                    spectral_centroid=data['spectral_centroid'],
-                    spectral_bandwidth=data['spectral_bandwidth'],
-                    spectral_rolloff=data['spectral_rolloff'],
-                    zero_crossing_rate=data['zero_crossing_rate'],
-                    chroma_mean=np.array(data['chroma_mean']),
-                    temporal_envelope=np.array(data['temporal_envelope']),
-                    peak_frequencies=data['peak_frequencies'],
-                    harmonic_structure=data['harmonic_structure'],
-                )
-        except:
-            pass
-        return None
+
+            if not row:
+                return None
+
+            raw = row[0]
+            try:
+                if isinstance(raw, bytes):
+                    data = json.loads(raw.decode('utf-8'))
+                else:
+                    data = json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError, TypeError, ValueError):
+                # Not JSON (likely a legacy pickle BLOB). Treat as cache miss.
+                return None
+
+            return FingerprintFeatures(
+                mfcc_mean=np.array(data['mfcc_mean']),
+                mfcc_std=np.array(data['mfcc_std']),
+                spectral_centroid=data['spectral_centroid'],
+                spectral_bandwidth=data['spectral_bandwidth'],
+                spectral_rolloff=data['spectral_rolloff'],
+                zero_crossing_rate=data['zero_crossing_rate'],
+                chroma_mean=np.array(data['chroma_mean']),
+                temporal_envelope=np.array(data['temporal_envelope']),
+                peak_frequencies=data['peak_frequencies'],
+                harmonic_structure=data['harmonic_structure'],
+            )
+        except (KeyError, TypeError):
+            # Malformed cache row — treat as cache miss.
+            return None

--- a/test_pickle_to_json_migration.py
+++ b/test_pickle_to_json_migration.py
@@ -1,16 +1,33 @@
-"""Test that pickle to JSON migration in proof_of_iron.py works correctly,
-including backward-compatible dual-read for legacy pickle data."""
+"""Test that pickle has been fully removed from proof_of_iron.py.
+
+Updated post vuln-tick 2026-05-14T14:10Z: PR #4530 introduced a dual-read
+that fell back to pickle.loads() on legacy BLOBs. That fallback was an RCE
+primitive — a poisoned legacy cache row could execute arbitrary code during
+_load_features(). These tests now assert:
+
+  1. proof_of_iron.py does not import pickle and does not call pickle.loads/dumps.
+  2. _save_features still serializes with json.dumps.
+  3. _load_features returns None (cache miss) for legacy pickle BLOBs instead
+     of deserializing them.
+  4. JSON rows still round-trip cleanly through _load_features.
+"""
 import os
 import sys
 import json
 import pickle
 import sqlite3
 import tempfile
+import types
 import unittest
+import importlib.util
+
 import numpy as np
 
-# Add the project to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'issue2307_boot_chime', 'src'))
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC_DIR = os.path.join(HERE, 'issue2307_boot_chime', 'src')
+PROOF_OF_IRON_PATH = os.path.join(SRC_DIR, 'proof_of_iron.py')
+
 
 SAMPLE_FEATURES = {
     'mfcc_mean': [0.1, 0.2, 0.3, 0.4, 0.5],
@@ -26,98 +43,141 @@ SAMPLE_FEATURES = {
 }
 
 
-class TestPickleToJsonMigration(unittest.TestCase):
+def _load_proof_of_iron_module():
+    """Load proof_of_iron.py as a top-level module with stub dependencies.
+
+    proof_of_iron.py uses package-relative imports
+    (`from .acoustic_fingerprint import ...`). To exercise it directly from
+    this top-level test file without polluting global packages, we install
+    a fake parent package in sys.modules with the real `src` dir on its
+    __path__, plus stub submodules for the heavy audio dependencies.
+    """
+    pkg_name = '_poi_test_pkg'
+    if pkg_name in sys.modules:
+        return sys.modules[pkg_name].proof_of_iron
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [SRC_DIR]
+    sys.modules[pkg_name] = pkg
+
+    # Real FingerprintFeatures dataclass is needed by _load_features, so
+    # import the real acoustic_fingerprint module under our fake package name.
+    af_spec = importlib.util.spec_from_file_location(
+        f'{pkg_name}.acoustic_fingerprint',
+        os.path.join(SRC_DIR, 'acoustic_fingerprint.py'),
+    )
+    af_mod = importlib.util.module_from_spec(af_spec)
+    sys.modules[f'{pkg_name}.acoustic_fingerprint'] = af_mod
+    af_spec.loader.exec_module(af_mod)
+
+    # Stub boot_chime_capture — only BootChimeCapture and CapturedAudio names
+    # need to exist; we never instantiate them.
+    bcc_stub = types.ModuleType(f'{pkg_name}.boot_chime_capture')
+    bcc_stub.BootChimeCapture = type('BootChimeCapture', (), {'__init__': lambda self, *a, **kw: None})
+    bcc_stub.CapturedAudio = type('CapturedAudio', (), {})
+    sys.modules[f'{pkg_name}.boot_chime_capture'] = bcc_stub
+
+    poi_spec = importlib.util.spec_from_file_location(
+        f'{pkg_name}.proof_of_iron', PROOF_OF_IRON_PATH,
+    )
+    poi_mod = importlib.util.module_from_spec(poi_spec)
+    sys.modules[f'{pkg_name}.proof_of_iron'] = poi_mod
+    poi_spec.loader.exec_module(poi_mod)
+    pkg.proof_of_iron = poi_mod
+    return poi_mod
+
+
+class TestPickleRemoval(unittest.TestCase):
+    def test_no_pickle_in_source(self):
+        """proof_of_iron.py must not import pickle or call pickle.loads/dumps."""
+        with open(PROOF_OF_IRON_PATH, 'r') as f:
+            content = f.read()
+        self.assertNotIn('import pickle', content,
+                         "pickle must not be imported in proof_of_iron.py")
+        self.assertNotIn('pickle.loads', content,
+                         "pickle.loads must not appear (RCE primitive)")
+        self.assertNotIn('pickle.dumps', content,
+                         "pickle.dumps must not appear")
+
+    def test_save_uses_json(self):
+        """_save_features must serialize with json.dumps."""
+        with open(PROOF_OF_IRON_PATH, 'r') as f:
+            content = f.read()
+        self.assertIn('json.dumps', content,
+                      "json.dumps must be used in _save_features")
+
     def test_json_serialization_roundtrip(self):
-        """Test that features can be serialized to JSON and deserialized correctly."""
+        """JSON serialization roundtrip still works."""
         json_data = json.dumps(SAMPLE_FEATURES)
         loaded = json.loads(json_data)
         self.assertEqual(SAMPLE_FEATURES['mfcc_mean'], loaded['mfcc_mean'])
         self.assertEqual(SAMPLE_FEATURES['spectral_centroid'], loaded['spectral_centroid'])
-        print("✓ JSON serialization roundtrip test passed")
 
-    def test_sqlite_json_storage(self):
-        """Test that JSON data can be stored and retrieved from SQLite."""
+    def test_legacy_pickle_blob_returns_none(self):
+        """A legacy pickle BLOB in feature_cache must return None (cache miss),
+        not be deserialized. This is the core anti-RCE invariant."""
+        poi_mod = _load_proof_of_iron_module()
+        ProofOfIron = poi_mod.ProofOfIron
+
         with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
             db_path = f.name
         try:
+            # Set up the schema and insert a malicious-shaped pickle BLOB.
             conn = sqlite3.connect(db_path)
             c = conn.cursor()
             c.execute('''CREATE TABLE feature_cache (
-                hash TEXT PRIMARY KEY, features TEXT, created_at INTEGER)''')
-            conn.commit()
-            c.execute('INSERT INTO feature_cache VALUES (?, ?, ?)',
-                     ('test_hash', json.dumps(SAMPLE_FEATURES), 1234567890))
-            conn.commit()
-            c.execute('SELECT features FROM feature_cache WHERE hash = ?', ('test_hash',))
-            loaded = json.loads(c.fetchone()[0])
-            self.assertEqual(loaded['spectral_centroid'], 1000.0)
-            print("✓ SQLite JSON storage test passed")
-        finally:
-            os.unlink(db_path)
-
-    def test_backward_compat_pickle_fallback(self):
-        """Test that legacy pickle data is deserialized and migrated to JSON."""
-        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
-            db_path = f.name
-        try:
-            conn = sqlite3.connect(db_path)
-            c = conn.cursor()
-            c.execute('''CREATE TABLE feature_cache (
-                hash TEXT PRIMARY KEY, features TEXT, created_at INTEGER)''')
-            conn.commit()
-            # Insert OLD pickle BLOB data
+                hash TEXT PRIMARY KEY, features BLOB, created_at INTEGER)''')
             pickle_blob = pickle.dumps(SAMPLE_FEATURES)
             c.execute('INSERT INTO feature_cache VALUES (?, ?, ?)',
-                     ('old_hash', pickle_blob, 1000000000))
+                     ('legacy_hash', pickle_blob, 1000000000))
             conn.commit()
+            conn.close()
 
-            # Manual dual-read logic test (mimics _load_features behavior)
-            c.execute('SELECT features FROM feature_cache WHERE hash = ?', ('old_hash',))
-            raw = c.fetchone()[0]
-            # Try JSON first — should fail
-            try:
-                json.loads(raw.decode('utf-8') if isinstance(raw, bytes) else raw)
-                self.fail("Expected JSON decode to fail on pickle data")
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                pass  # Expected
-            # Fallback to pickle — should succeed
-            data = pickle.loads(raw) if isinstance(raw, bytes) else pickle.loads(raw.encode())
-            self.assertEqual(data['spectral_centroid'], 1000.0)
+            poi = ProofOfIron(db_path=db_path)
 
-            # Now verify the code path in proof_of_iron.py handles this:
-            # Check that the source has the fallback pattern
-            with open('issue2307_boot_chime/src/proof_of_iron.py', 'r') as f:
-                content = f.read()
-            self.assertIn('JSONDecodeError', content,
-                          "Should catch JSONDecodeError for pickle fallback")
-            self.assertIn('pickle.loads', content,
-                          "Should have pickle.loads as fallback")
-            self.assertIn('json.loads', content,
-                          "Should try json.loads first")
-            print("✓ Backward-compatible pickle fallback test passed")
+            # Contract: legacy pickle BLOBs must NOT be deserialized.
+            result = poi._load_features('legacy_hash')
+            self.assertIsNone(
+                result,
+                "Legacy pickle BLOB must be treated as cache miss, not deserialized",
+            )
+
+            # Missing hash also returns None.
+            missing = poi._load_features('does_not_exist')
+            self.assertIsNone(missing)
         finally:
-            os.unlink(db_path)
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
 
-    def test_no_bare_pickle_in_save(self):
-        """Verify that _save_features uses json.dumps, not pickle.dumps."""
-        with open('issue2307_boot_chime/src/proof_of_iron.py', 'r') as f:
-            content = f.read()
-        self.assertNotIn('pickle.dumps', content,
-                         "pickle.dumps should NOT be used in save")
-        self.assertIn('json.dumps', content,
-                      "json.dumps should be used in save")
-        print("✓ No pickle.dumps in save test passed")
+    def test_json_row_round_trips_through_load(self):
+        """A JSON row written in feature_cache must round-trip through _load_features."""
+        poi_mod = _load_proof_of_iron_module()
+        ProofOfIron = poi_mod.ProofOfIron
 
-    def test_dual_read_in_load(self):
-        """Verify that _load_features has dual-read (json first, pickle fallback)."""
-        with open('issue2307_boot_chime/src/proof_of_iron.py', 'r') as f:
-            content = f.read()
-        self.assertIn('json.loads', content, "json.loads should be used in load")
-        self.assertIn('pickle.loads', content,
-                      "pickle.loads should be present as fallback in load")
-        self.assertIn('JSONDecodeError', content,
-                      "JSONDecodeError should be caught for dual-read")
-        print("✓ Dual-read in load test passed")
+        with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as f:
+            db_path = f.name
+        try:
+            conn = sqlite3.connect(db_path)
+            c = conn.cursor()
+            c.execute('''CREATE TABLE feature_cache (
+                hash TEXT PRIMARY KEY, features TEXT, created_at INTEGER)''')
+            c.execute('INSERT INTO feature_cache VALUES (?, ?, ?)',
+                     ('json_hash', json.dumps(SAMPLE_FEATURES), 1234567890))
+            conn.commit()
+            conn.close()
+
+            poi = ProofOfIron(db_path=db_path)
+            result = poi._load_features('json_hash')
+            self.assertIsNotNone(result, "JSON row must load successfully")
+            self.assertAlmostEqual(result.spectral_centroid, 1000.0)
+            self.assertEqual(list(result.mfcc_mean), SAMPLE_FEATURES['mfcc_mean'])
+        finally:
+            try:
+                os.unlink(db_path)
+            except OSError:
+                pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR #4530 ("backward-compatible pickle→JSON migration") migrated `_save_features` to `json.dumps`, but left a dual-read fallback in `_load_features` that calls `pickle.loads()` on any row that fails to decode as JSON. **That fallback reintroduces the exact RCE primitive the migration was meant to close.** A poisoned legacy `feature_cache.features` BLOB triggers arbitrary code execution during `_load_features()`.

This PR removes the pickle import and the pickle fallback entirely. Non-JSON rows now return `None` (cache miss); the caller rebuilds via `capture_and_enroll`, which always writes JSON. Legacy pickle rows should be cleaned offline with a one-shot migration tool, not deserialized at runtime.

## Vuln-tick evidence

Found by the codex-cli post-merge vuln-audit loop (codex-cli 0.129.0, `goals` feature, session UUID `019e1786-6773-7d62-b8ec-189b55191d83`).

```
# Vuln Audit Tick — 2026-05-14T14:10Z

Commits audited: 30 (range cddf6e5..d1dd31a; backlog remaining: 3 newer commits)

## Findings

### TIER 1 — Critical (manual review NOW)
[Scottcjn/Rustchain] c605584 fix: backward-compatible pickle→JSON migration (#4530)
  Author: BossChaos
  File:line: issue2307_boot_chime/src/proof_of_iron.py:549
  Finding: The compatibility path falls back to `pickle.loads()` on `feature_cache.features` whenever JSON decoding fails, reintroducing unsafe deserialization on DB-backed cache data.
  Why critical: A crafted legacy cache row can trigger arbitrary code execution during `_load_features()`, which restores exactly the class of bug this migration claimed to remove.

### Cross-PR consistency
Follow-up fixes in this window appear to close two earlier post-merge findings: `6e19c54` enforces the mock-signature guard during WSGI startup, and `b2497be` caps `/api/transactions` offset materialization.

## Summary
- Tier 1 findings: 1
- Tier 2 findings: 0
- Tier 3 findings: 0
- Cross-PR concerns: 0
- Recommended actions: Remove the live pickle fallback and migrate legacy `feature_cache` rows with an offline or one-shot tool instead
```

## What changed

- `issue2307_boot_chime/src/proof_of_iron.py` — `_load_features` no longer imports `pickle` and no longer falls back to `pickle.loads`. Non-JSON rows are treated as a cache miss and return `None`. Exception set widened to `(JSONDecodeError, UnicodeDecodeError, TypeError, ValueError)` and a separate `(KeyError, TypeError)` guard wraps the dict-deref, so malformed-but-valid-JSON rows also fall back to `None` instead of raising.
- `test_pickle_to_json_migration.py` — invariants inverted. Now asserts:
  - `import pickle` is **absent** from `proof_of_iron.py`.
  - `pickle.loads` and `pickle.dumps` are **absent** from `proof_of_iron.py`.
  - `_save_features` still uses `json.dumps`.
  - Legacy pickle BLOBs in `feature_cache` return `None` from `_load_features` (the core anti-RCE invariant — not deserialized).
  - JSON rows still round-trip through `_load_features`.

The test uses an isolated module-loader (via `importlib.util.spec_from_file_location` + a fake parent package in `sys.modules`) so it can exercise `_load_features` against a real SQLite db without requiring a top-level `issue2307_boot_chime/__init__.py` or installing the heavy audio dependencies.

## Verification

```
$ python3 -m py_compile issue2307_boot_chime/src/proof_of_iron.py test_pickle_to_json_migration.py
$ python3 -m unittest test_pickle_to_json_migration -v
test_json_row_round_trips_through_load ... ok
test_json_serialization_roundtrip ... ok
test_legacy_pickle_blob_returns_none ... ok
test_no_pickle_in_source ... ok
test_save_uses_json ... ok
----------------------------------------------------------------------
Ran 5 tests in 0.006s

OK
```

```
$ grep -nE 'pickle\.(loads|dumps)|^import pickle|^from pickle' issue2307_boot_chime/src/proof_of_iron.py
# (no matches — pickle fully removed)
```

## Test plan

- [x] `py_compile` clean on `proof_of_iron.py` and `test_pickle_to_json_migration.py`
- [x] All 5 unit tests pass
- [x] No `import pickle`, `pickle.loads`, or `pickle.dumps` in `proof_of_iron.py`
- [x] Legacy pickle BLOB returns `None` (verified end-to-end with real ProofOfIron + sqlite tempfile)
- [x] JSON row still round-trips through `_load_features`
- [ ] Reviewer: confirm no other call site in the tree reads `feature_cache.features` with `pickle.loads`
- [ ] Reviewer: confirm follow-up issue is filed (or this PR is the place) for an offline migration tool to clean legacy pickle rows in production DBs

## Related

- Follow-up to #4530 (BossChaos)
- Vuln-tick: `/home/scott/codex-goals/vuln-agent/ticks/vuln-tick-2026-05-14T14:10Z.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)