### PR TITLE
fix(#4986): add admin key authentication to BCOS badge generator

### DIFF
--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1060,6 +1060,13 @@ def index():
 @app.route('/api/badge/generate', methods=['POST'])
 def generate_badge():
     """Generate a BCOS badge."""
+    # Authentication: require admin key
+    admin_key = os.environ.get("BCOS_ADMIN_KEY", "")
+    if not admin_key:
+        return jsonify({"error": "BCOS admin key not configured"}), 500
+    if request.headers.get("X-Admin-Key", "") != admin_key:
+        return jsonify({"error": "unauthorized"}), 403
+    
     data = request.get_json()
 
     repo_name = data.get('repo_name', '').strip()


### PR DESCRIPTION
## Summary

Fixes #4986 — BCOS badge generator API had no authentication on badge generation.

## Vulnerability

`POST /api/badge/generate` accepted requests from anyone without any auth. Attackers could forge L2 badges or set arbitrary trust scores for any repository, undermining the BCOS trust model.

## Fix

Added mandatory `BCOS_ADMIN_KEY` environment variable check. Requests must include an `X-Admin-Key` header matching the configured value. Returns 500 if key not configured, 403 on mismatch.

## Verification

- `python3 -m py_compile tools/bcos_badge_generator.py` passes

## Bounty claim

Claiming bounty for fixing issue #4986.

**Wallet:** GyZXdm8YdZ3ZKCfEUfK7tcuHji5mkv46spYJgU8AvsRg
