### PR TITLE
Fix Asciinema cast format link

### DIFF
--- a/docs/asciinema/README.md
+++ b/docs/asciinema/README.md
@@ -11,7 +11,7 @@ This directory contains terminal recordings for RustChain documentation.
 
 ## Format
 
-Files use the [asciinema cast v2 format](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) - a JSON-based text format that records:
+Files use the [asciinema cast v2 format](https://docs.asciinema.org/manual/asciicast/v2/) - a JSON-based text format that records:
 - Terminal output
 - Timing information
 - Escape sequences for colors and formatting


### PR DESCRIPTION
## Summary
- replace the dead Asciinema cast v2 GitHub docs link in `docs/asciinema/README.md`
- point readers to the current official Asciinema v2 format documentation

Bounty path: rustchain-bounties#2178
Wallet/miner ID: `iamdinhthuan`

## Verification
- `curl -L -s -o /dev/null -w "%{http_code}\n" https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md` -> 404
- `curl -L -s -o /dev/null -w "%{http_code}\n" https://docs.asciinema.org/manual/asciicast/v2/` -> 200
- `git diff --check -- docs/asciinema/README.md` -> passed

## Duplicate check
- Existing local #2178 claims cover other docs files only.
- Open RustChain PR scan for `asciinema`, `asciicast`, and `cast v2` returned no matches before publishing this PR.