### PR TITLE
[SECURITY] Fix timing side-channel in bridge admin key authentication

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -160,13 +160,17 @@ def _verify_receipt_signature(sender: str, amount_base: int, target_chain: str, 
 
 
 def _require_admin(fn):
-    """Decorator: require X-Admin-Key header."""
+    """Decorator: require X-Admin-Key header.
+
+    Security fix: use hmac.compare_digest() instead of != to prevent
+    timing side-channel attacks that could leak the admin key byte-by-byte.
+    """
     @wraps(fn)
     def wrapper(*args, **kwargs):
         key = request.headers.get("X-Admin-Key", "")
         if not BRIDGE_ADMIN_KEY:
             return jsonify({"error": "admin key not configured on server"}), 500
-        if key != BRIDGE_ADMIN_KEY:
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
             return jsonify({"error": "unauthorized"}), 403
         return fn(*args, **kwargs)
     return wrapper


### PR DESCRIPTION
## Security Fix: Timing Side-Channel Attack in Bridge Admin Authentication

### Vulnerability

The _require_admin() decorator in bridge/bridge_api.py uses Python's != operator to compare the X-Admin-Key header against BRIDGE_ADMIN_KEY. Python's != on strings short-circuits on the first mismatch, allowing timing side-channel attacks to recover the admin key byte-by-byte.

### Impact: HIGH

The decorator guards /bridge/confirm and /bridge/release - endpoints that control wRTC minting on Solana/Base. Key recovery enables unauthorized bridge operations.

### Fix

Replace != with hmac.compare_digest() (constant-time comparison). Note: _verify_receipt_signature() already uses hmac.compare_digest() correctly - this inconsistency is what made the bug exploitable.

### Validation

- py_compile passes
- - hmac already imported
- - No behavioral change
Bounty: #305 (15 RTC - High severity)
Wallet: RTC241359b3438d1222fdc1c3e22fe980657a4bc54e