### PR TITLE
security: fail-closed when RC_ADMIN_KEY unset (cherry-pick from BossChaos #5174)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4867,7 +4867,11 @@ def register_withdrawal_key():
     # SECURITY: prevent unauthenticated key overwrite (withdrawal takeover).
     # First-time registration is allowed. Rotation requires admin key.
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    # Fail-closed: if env is unset/empty, never treat the request as admin
+    # (prevents hmac.compare_digest("", "") returning True from authenticating
+    # an unauthenticated key-rotation request).
+    is_admin = bool(admin_key_env) and bool(admin_key) and hmac.compare_digest(admin_key, admin_key_env)
 
     now = int(time.time())
     with sqlite3.connect(DB_PATH) as c:
@@ -6749,8 +6753,11 @@ def metrics():
 def api_rewards_settle():
     """Settle rewards for a specific epoch (admin/cron callable)"""
     # SECURITY: settling rewards mutates chain state; require admin key.
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"ok": False, "reason": "admin_key_unset", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     body = request.get_json(force=True, silent=True) or {}
@@ -7022,9 +7029,20 @@ def send_sophiacheck_alert(alert_type, message, data):
 @app.route('/wallet/transfer', methods=['POST'])
 def wallet_transfer_v2():
     """Transfer RTC between miner wallets - NOW WITH 2-PHASE COMMIT"""
-    # SECURITY: Require admin key for internal transfers
+    # SECURITY: Require admin key for internal transfers.
+    # FAIL-CLOSED (cherry-pick from #5174): if RC_ADMIN_KEY is unset/empty,
+    # `hmac.compare_digest("", "")` returns True and the endpoint would be
+    # unauthenticated. Reject with 503 before reaching the comparison so
+    # the bug cannot resurface if module-level startup checks are bypassed.
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({
+            "error": "RC_ADMIN_KEY not configured on server",
+            "code": "ADMIN_KEY_UNSET",
+            "hint": "Set the RC_ADMIN_KEY environment variable or use /wallet/transfer/signed"
+        }), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({
             "error": "Unauthorized - admin key required",
             "hint": "Use /wallet/transfer/signed for user transfers"
@@ -7122,8 +7140,11 @@ def wallet_transfer_v2():
 @app.route('/pending/list', methods=['GET'])
 def list_pending():
     """List all pending transfers"""
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"error": "Unauthorized"}), 401
 
     status_filter = request.args.get('status', 'pending')
@@ -7165,8 +7186,11 @@ def list_pending():
 @app.route('/pending/void', methods=['POST'])
 def void_pending():
     """Admin: Void a pending transfer before confirmation"""
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"error": "Unauthorized"}), 401
     
     data = request.get_json()
@@ -7239,8 +7263,11 @@ def void_pending():
 @app.route('/pending/confirm', methods=['POST'])
 def confirm_pending():
     """Worker: Confirm pending transfers that have passed the delay period"""
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"error": "Unauthorized"}), 401
     
     now = int(time.time())
@@ -7329,8 +7356,11 @@ def confirm_pending():
 @app.route('/pending/integrity', methods=['GET'])
 def check_integrity():
     """Check balance integrity: sum of ledger should match balances"""
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"error": "Unauthorized"}), 401
 
     with sqlite3.connect(DB_PATH) as db:
@@ -7384,8 +7414,11 @@ def check_integrity():
 @app.route('/wallet/transfer_OLD_DISABLED', methods=['POST'])
 def wallet_transfer_OLD():
     # SECURITY FIX: Require admin key for internal transfers
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"error": "RC_ADMIN_KEY not configured on server", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"error": "Unauthorized - admin key required", "hint": "Use /wallet/transfer/signed for user transfers"}), 401
     """Transfer RTC between miner wallets"""
     data = request.get_json()
@@ -7440,8 +7473,11 @@ def wallet_transfer_OLD():
 def api_wallet_ledger():
     """Get transaction ledger (optionally filtered by miner)"""
     # SECURITY: ledger entries include transfer reasons + wallet identifiers; require admin key.
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"ok": False, "reason": "admin_key_unset", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     miner_id = request.args.get("miner_id", "").strip()
@@ -7486,8 +7522,11 @@ def api_wallet_ledger():
 def api_wallet_balances_all():
     """Get all miner balances"""
     # SECURITY: exporting all balances is sensitive; require admin key.
+    admin_key_env = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key_env:
+        return jsonify({"ok": False, "reason": "admin_key_unset", "code": "ADMIN_KEY_UNSET"}), 503
     admin_key = request.headers.get("X-Admin-Key", "")
-    if not hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", "")):
+    if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
     with sqlite3.connect(DB_PATH) as db:

--- a/tests/test_wallet_transfer_admin_key_unset.py
+++ b/tests/test_wallet_transfer_admin_key_unset.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression test: fail-closed behavior when RC_ADMIN_KEY is unset.
+
+Cherry-picked finding from BossChaos PR #5174.
+
+The bug: several admin-gated endpoints called
+    hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
+without first checking that the env var was non-empty. If RC_ADMIN_KEY
+became empty at request time (env unset, container misconfig, runtime
+mutation), then `hmac.compare_digest("", "")` returns True and the
+endpoint would be effectively unauthenticated.
+
+Module-level startup already exits if RC_ADMIN_KEY is missing, but this
+test pins the per-request fail-closed behavior so the latent bug cannot
+return via a startup-bypass refactor.
+
+We assert 503 (ADMIN_KEY_UNSET), NOT 401, when the env is empty — the
+distinction matters because 401 implies "you sent the wrong key" and a
+caller could brute-force; 503 makes the operator state explicit.
+"""
+
+import sys
+
+import pytest
+
+# Pre-loaded by conftest.py
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as c:
+        yield c
+
+
+# Endpoints that previously fell through to compare_digest with empty env.
+# Each entry: (method, path, json_body_or_none, expected_503_when_unset)
+ADMIN_GATED_ENDPOINTS = [
+    ("POST", "/wallet/transfer", {"from_miner": "a", "to_miner": "b", "amount_rtc": 1}),
+    ("POST", "/rewards/settle", {"epoch": 1}),
+    ("GET", "/pending/list", None),
+    ("POST", "/pending/void", {"tx_id": "x"}),
+    ("POST", "/pending/confirm", {}),
+    ("GET", "/pending/integrity", None),
+    ("GET", "/wallet/ledger", None),
+    ("GET", "/wallet/balances/all", None),
+]
+
+
+def _request(client, method, path, body):
+    if method == "GET":
+        return client.get(path)
+    return client.post(path, json=body)
+
+
+@pytest.mark.parametrize("method,path,body", ADMIN_GATED_ENDPOINTS)
+def test_admin_endpoint_returns_503_when_admin_key_unset(monkeypatch, client, method, path, body):
+    """When RC_ADMIN_KEY is empty, endpoint must return 503 ADMIN_KEY_UNSET, not 401."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "")
+
+    resp = _request(client, method, path, body)
+
+    assert resp.status_code == 503, (
+        f"{method} {path}: expected 503 when RC_ADMIN_KEY empty, "
+        f"got {resp.status_code} (body={resp.get_data(as_text=True)[:200]})"
+    )
+    payload = resp.get_json() or {}
+    code = payload.get("code") or payload.get("reason") or ""
+    assert "ADMIN_KEY_UNSET" in str(code) or "admin_key_unset" in str(code), (
+        f"{method} {path}: expected ADMIN_KEY_UNSET code, got payload={payload}"
+    )
+
+
+@pytest.mark.parametrize("method,path,body", ADMIN_GATED_ENDPOINTS)
+def test_admin_endpoint_returns_401_with_wrong_key(monkeypatch, client, method, path, body):
+    """When RC_ADMIN_KEY is set but caller sends wrong/no key, return 401 (not 503)."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "a" * 32)
+
+    resp = _request(client, method, path, body)
+
+    # 401 (unauthorized) is the correct response — NOT 503.
+    # We also accept 400 if the body fails validation BEFORE the auth check
+    # is reached, but auth-first endpoints should give 401.
+    assert resp.status_code == 401, (
+        f"{method} {path}: expected 401 with wrong admin key, got {resp.status_code} "
+        f"(body={resp.get_data(as_text=True)[:200]})"
+    )
+
+
+def test_wallet_transfer_does_not_authenticate_empty_to_empty(monkeypatch, client):
+    """
+    Direct regression: the original bug was that with RC_ADMIN_KEY unset
+    AND no X-Admin-Key header, hmac.compare_digest("", "") returned True.
+    Assert this cannot happen — no admin-gated wallet transfer goes through
+    without a configured key, regardless of header content.
+    """
+    monkeypatch.setenv("RC_ADMIN_KEY", "")
+
+    # No header at all
+    resp1 = client.post("/wallet/transfer", json={"from_miner": "a", "to_miner": "b", "amount_rtc": 1})
+    assert resp1.status_code == 503
+
+    # Empty header
+    resp2 = client.post(
+        "/wallet/transfer",
+        json={"from_miner": "a", "to_miner": "b", "amount_rtc": 1},
+        headers={"X-Admin-Key": ""},
+    )
+    assert resp2.status_code == 503
+
+    # Any attacker-supplied header
+    resp3 = client.post(
+        "/wallet/transfer",
+        json={"from_miner": "a", "to_miner": "b", "amount_rtc": 1},
+        headers={"X-Admin-Key": "anything"},
+    )
+    assert resp3.status_code == 503


### PR DESCRIPTION
## Summary

Cherry-pick of the wallet-transfer security hunk from #5174, applied across all sibling admin-gated endpoints with a focused regression test.

### The bug

Several admin-gated endpoints called:

```python
hmac.compare_digest(admin_key, os.environ.get("RC_ADMIN_KEY", ""))
```

without first checking that the env var was non-empty. If `RC_ADMIN_KEY` is empty at request time (env unset, container misconfig, runtime mutation), then `hmac.compare_digest("", "")` returns **True** and the endpoint is **effectively unauthenticated** — anyone could drain wallets via `/wallet/transfer`, settle rewards, or read sensitive ledger data.

The module-level startup at line 5162ff already exits if `RC_ADMIN_KEY` is missing, but that single gate is the only thing standing between a misconfig and an unauthenticated drain path. This PR adds **per-request fail-closed behavior** so the latent bug cannot return via a startup-bypass refactor.

### Endpoints hardened

All now return **`503 ADMIN_KEY_UNSET`** when env is empty, **`401`** when env is set with a wrong/missing key:

- `POST /wallet/transfer`
- `POST /rewards/settle`
- `GET  /pending/list`
- `POST /pending/void`
- `POST /pending/confirm`
- `GET  /pending/integrity`
- `GET  /wallet/ledger`
- `GET  /wallet/balances/all`
- `POST /wallet/transfer_OLD_DISABLED` (defense in depth on the legacy route)

Also hardened the `is_admin` flag on the wallet pubkey-rotation path — was a bare `compare_digest` assignment that would have authenticated an empty header against an empty env.

### Test

`tests/test_wallet_transfer_admin_key_unset.py` — **17 cases, all passing**:
- 8 endpoints x 503-when-unset
- 8 endpoints x 401-when-wrong-key
- 1 direct regression on `/wallet/transfer` covering no-header / empty-header / attacker-header

### Regression run

`pytest tests/test_api.py tests/test_airdrop_bridge_admin_auth.py tests/test_payout_ledger_admin_auth.py tests/test_signed_transfer_replay.py tests/test_utxo_transfer_nonce_required.py tests/test_wallet_*.py tests/test_webhook_admin_auth.py` → **62 passed**.

## Why cherry-pick instead of merging #5174

That PR bundled this real fix with:
- Unrelated workflow YAML edits
- A broken `lock_ledger.py` rewrite that would have broken admin early-release

Credit to **@BossChaos** for surfacing the empty-env vulnerability — this patch extracts only the wallet hunk and applies the same pattern across sibling endpoints. The BossChaos cluster has already been paid 201 RTC across the recent triage.

Refs: #5174

## Test plan

- [x] New test: 17 cases pass
- [x] Regression: 62 related wallet/admin tests pass
- [x] Manual: confirm `503 ADMIN_KEY_UNSET` distinguishable from `401 unauthorized`

🤖 Generated with [Claude Code](https://claude.com/claude-code)