### PR TITLE
[SECURITY] Fix timing side-channel in GPU escrow secret verification

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -2,6 +2,7 @@
 # Author: @createkr (RayBot AI)
 # BCOS-Tier: L1
 import hashlib
+import hmac
 import math
 import secrets
 import sqlite3
@@ -154,7 +155,9 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 return jsonify({"error": "actor_wallet must be escrow participant"}), 403
             if actor_wallet != job["from_wallet"]:
                 return jsonify({"error": "only payer can release escrow"}), 403
-            if _hash_job_secret(escrow_secret) != (job["escrow_secret_hash"] or ""):
+            # Security fix: use hmac.compare_digest() to prevent timing
+            # side-channel attacks that could leak the escrow secret hash.
+            if not hmac.compare_digest(_hash_job_secret(escrow_secret), job["escrow_secret_hash"] or ""):
                 return jsonify({"error": "invalid escrow_secret"}), 403
 
             # Atomic state transition first to prevent races/double-processing.
@@ -198,7 +201,9 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 return jsonify({"error": "actor_wallet must be escrow participant"}), 403
             if actor_wallet != job["to_wallet"]:
                 return jsonify({"error": "only provider can request refund"}), 403
-            if _hash_job_secret(escrow_secret) != (job["escrow_secret_hash"] or ""):
+            # Security fix: use hmac.compare_digest() to prevent timing
+            # side-channel attacks that could leak the escrow secret hash.
+            if not hmac.compare_digest(_hash_job_secret(escrow_secret), job["escrow_secret_hash"] or ""):
                 return jsonify({"error": "invalid escrow_secret"}), 403
 
             # Atomic state transition first to prevent races/double-processing.


### PR DESCRIPTION
## Security Fix: Timing Side-Channel in GPU Escrow Authentication

### Vulnerability

`gpu_render_endpoints.py` uses `!=` to compare SHA-256 hashes of escrow secrets in both `/api/gpu/release` (line 157) and `/api/gpu/refund` (line 201):

```python
if _hash_job_secret(escrow_secret) != (job["escrow_secret_hash"] or ""):
```

Python `!=` short-circuits on first byte mismatch, leaking hash bytes via timing analysis. An attacker could recover the SHA-256 hash, then brute-force the pre-image to steal escrowed RTC.

### Impact: MEDIUM

Escrow secrets authenticate fund release/refund. Hash recovery enables unauthorized escrow operations (fund theft or griefing refunds).

### Fix

- Replace `!=` with `hmac.compare_digest()` in both endpoints
- - Add `import hmac` (was missing)
### Bounty

Bug report for #305 (10 RTC - Medium severity)
Wallet: RTC241359b3438d1222fdc1c3e22fe980657a4bc54e