### PR TITLE
docs: fix sprint epoch endpoint

### DIFF
--- a/docs/sprint/faq-troubleshooting.md
+++ b/docs/sprint/faq-troubleshooting.md
@@ -126,7 +126,7 @@ rtc-miner status
 
 **Fix:** Wait for at least one full epoch to complete. Check epoch status:
 ```bash
-curl -sk https://rustchain.org/api/epoch | jq .
+curl -sk https://rustchain.org/epoch | jq .
 ```
 
 ---
@@ -189,7 +189,7 @@ curl -sSL https://rustchain.org/install.sh | bash
 curl -sk "https://rustchain.org/api/miner-info?id=YOUR_WALLET" | jq .multiplier
 
 # Check total network weight this epoch:
-curl -sk https://rustchain.org/api/epoch | jq .total_weight
+curl -sk https://rustchain.org/epoch | jq .total_weight
 ```
 Your share = `(your_multiplier / total_weight) × 1.5`
 


### PR DESCRIPTION
## Summary
- Update sprint FAQ epoch examples from the stale /api/epoch path to the live /epoch endpoint
- Keep both epoch-status and total-weight examples aligned with the current public API

## Verification
- https://rustchain.org/api/epoch -> 404
- https://rustchain.org/epoch -> 200
- git diff --check HEAD~1..HEAD -- docs/sprint/faq-troubleshooting.md -> passed

Bounty: #2178