### PR TITLE
Fix N64 mining repository link

### DIFF
--- a/docs/N64_MINING_GUIDE.md
+++ b/docs/N64_MINING_GUIDE.md
@@ -360,6 +360,6 @@ The achievement bridge runs alongside the mining relay. Both use the same Pico s
 - [Hardware Fingerprinting](hardware-fingerprinting.md) -- deep dive into the 6+1 fingerprint checks
 - [Vintage Mining Explained](VINTAGE_MINING_EXPLAINED.md) -- why we mine on old hardware
 - [Boudreaux Computing Principles](Boudreaux_COMPUTING_PRINCIPLES.md) -- the philosophy behind Proof of Antiquity
-- [Legend of Elya N64 Repository](https://github.com/Scottcjn/legend-of-elya-n64/mining/)
+- [Legend of Elya N64 Repository](https://github.com/Scottcjn/legend-of-elya-n64/tree/main/mining)
 - [RustChain Arcade Achievement Bridge](https://github.com/Scottcjn/rustchain-arcade)
 - [RustChain Explorer](https://rustchain.org/explorer) -- see your miner live on the network


### PR DESCRIPTION
## Summary
- replace a broken Legend of Elya N64 mining directory link in `docs/N64_MINING_GUIDE.md`
- point readers to the current GitHub tree URL for the `mining` directory

Bounty path: rustchain-bounties#2178
Wallet/miner ID: `iamdinhthuan`

## Verification
- `curl -sS -L -o /dev/null -w "%{http_code} %{url_effective}\n" https://github.com/Scottcjn/legend-of-elya-n64/mining/` -> `404 https://github.com/Scottcjn/legend-of-elya-n64/mining/`
- `curl -sS -L -o /dev/null -w "%{http_code} %{url_effective}\n" https://github.com/Scottcjn/legend-of-elya-n64/tree/main/mining` -> `200 https://github.com/Scottcjn/legend-of-elya-n64/tree/main/mining`
- `git diff --check -- docs/N64_MINING_GUIDE.md` -> passed

## Duplicate check
- Existing local #2178 claims cover other docs files only.
- Open RustChain PR scan for `n64`, `legend-of-elya`, and `mining guide` returned no matches before publishing this PR.