### PR TITLE
docs: fix Altermenta Nucleus links

### DIFF
--- a/docs/bcos/compare.html
+++ b/docs/bcos/compare.html
@@ -632,7 +632,7 @@
                   <div><strong>BCOS:</strong> Completely free under MIT license. No subscription fees, no hidden costs.</div>
                   <div><strong>Nucleus:</strong> Tiered pricing: Basic $20/mo, Pro $35/mo, Enterprise $50/mo.</div>
                   <a href="https://github.com/Scottcjn/rustchain-bounties/blob/main/LICENSE" class="evidence-link" target="_blank">📄 Evidence: BCOS MIT License</a>
-                  <a href="https://altermenta.com/nucleus/pricing" class="evidence-link" target="_blank">📄 Evidence: Nucleus Pricing Page</a>
+                  <a href="https://altermenta.com/#pricing" class="evidence-link" target="_blank">📄 Evidence: Nucleus Pricing Page</a>
                 </div>
               </td>
             </tr>
@@ -844,7 +844,7 @@
         <h4>📎 Evidence & Sources</h4>
         <ol>
           <li><strong>BCOS MIT License:</strong> Full license terms at <a href="https://github.com/Scottcjn/rustchain-bounties/blob/main/LICENSE" target="_blank">github.com/rustchain-bounties/LICENSE</a></li>
-          <li><strong>Nucleus Pricing:</strong> Current pricing at <a href="https://altermenta.com/nucleus/pricing" target="_blank">altermenta.com/nucleus/pricing</a></li>
+          <li><strong>Nucleus Pricing:</strong> Current pricing at <a href="https://altermenta.com/#pricing" target="_blank">altermenta.com/#pricing</a></li>
           <li><strong>BCOS Repository:</strong> Source code at <a href="https://github.com/Scottcjn/rustchain-bounties" target="_blank">github.com/Scottcjn/rustchain-bounties</a></li>
           <li><strong>BCOS Methodology:</strong> Technical specification in <a href="../BCOS.md">docs/BCOS.md</a></li>
           <li><strong>clawrtc CLI:</strong> Package at <a href="https://pypi.org/project/clawrtc/" target="_blank">pypi.org/project/clawrtc</a></li>
@@ -1014,7 +1014,7 @@ clawrtc bcos report --format html --output report.html</code></pre>
 
       <h3>Comparison Resources</h3>
       <ul>
-        <li><a href="https://altermenta.com/nucleus" target="_blank">Altermenta Nucleus (official)</a></li>
+        <li><a href="https://altermenta.com/" target="_blank">Altermenta Nucleus (official)</a></li>
         <li><a href="../RUSTCHAIN_VS_ETHEREUM_POS_COMPARISON.md" target="_blank">RustChain vs Ethereum PoS (comparison template)</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Fix two dead Altermenta Nucleus pricing links in `docs/bcos/compare.html`
- Fix the dead official Nucleus product link to the current Altermenta homepage

## Verification
- `https://altermenta.com/nucleus/pricing` -> 404
- `https://altermenta.com/nucleus` -> 404
- `https://altermenta.com/#pricing` -> 200 and contains `<section id="pricing">`
- `https://altermenta.com/` -> 200
- `git diff --check`