### PR TITLE
fix: macOS miner v2.5 with correct SHA256 verification

### DIFF
--- a/install-miner.sh
+++ b/install-miner.sh
@@ -89,14 +89,14 @@ run_cmd mkdir -p "$INSTALL_DIR"
 verify_sum() {
     [ "$SKIP_CHECKSUM" = true ] && return 0
     local file=$1; local expected=$2
-    local actual=$(sha256sum "$file" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$file" 2>/dev/null | cut -d' ' -f1)
+    local actual=$( (sha256sum "$file" 2>/dev/null || shasum -a 256 "$file" 2>/dev/null) | cut -d' ' -f1)
     if [ "$actual" = "$expected" ]; then return 0; else echo -e "${RED}[!] Checksum fail: $file${NC}"; return 1; fi
 }
 
 download_miner() {
     cd "$INSTALL_DIR"
     case "$PLATFORM" in
-        macos) FILE="macos/rustchain_mac_miner_v2.4.py" ;;
+        macos) FILE="macos/rustchain_mac_miner_v2.5.py" ;;
         rpi|linux) FILE="linux/rustchain_linux_miner.py" ;;
         *) FILE="linux/rustchain_linux_miner.py" ;;
     esac


### PR DESCRIPTION
## Summary

Fix macOS miner installation script to v2.5 with correct SHA256 checksum verification.

### Changes

1. **Fix macOS verify_sum() fallback logic** — The `||` operator was incorrectly placed after the pipe, so on macOS (no sha256sum), `cut` would read empty input and exit 0, causing the `shasum` fallback to never trigger.

   Before (broken):
   ```bash
   local actual=$(sha256sum "$file" 2>/dev/null | cut -d' ' -f1 || shasum -a 256 "$file" 2>/dev/null | cut -d' ' -f1)
   ```

   After (correct):
   ```bash
   local actual=$( (sha256sum "$file" 2>/dev/null || shasum -a 256 "$file" 2>/dev/null) | cut -d' ' -f1)
   ```

2. **Bump macOS miner from v2.4 to v2.5**

### Bounty

- Bounty #1589 (RTC compensation received for this work)
- Wallet: `RTC0185366b31bef08729a93115dacb1fd540bb4350`

### Testing

- ✅ macOS: shasum fallback now correctly triggers when sha256sum is absent
- ✅ Linux: sha256sum continues to work normally
- ✅ Checksum verification prevents tampered binary installation

**Disclosure:** I received RTC compensation for this work.
