### PR TITLE
security(vuln-audit): tighten faucet RTC validation + finish machine_passport array guard

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -22,6 +22,7 @@ API Endpoints:
 """
 
 import os
+import re
 import sys
 import json
 import sqlite3
@@ -447,9 +448,12 @@ class RateLimiter:
 # Validator
 # =============================================================================
 
+RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
+
+
 class FaucetValidator:
     """Request validation with blocklist/allowlist support."""
-    
+
     def __init__(self, config: Dict[str, Any], logger: logging.Logger):
         self.config = config
         self.logger = logger
@@ -489,7 +493,13 @@ class FaucetValidator:
         
         if len(wallet) > max_len:
             return False, f"Wallet address too long (max {max_len} characters)"
-        
+
+        # Tightened format validation for native RTC wallets: RTC + 40 hex chars.
+        # Mirrors the legacy faucet fix in commit 541c784 so malformed values like
+        # "RTCzzzzzzzzzz" or "RTC1234567890" cannot pass as distinct wallet identities.
+        if wallet.startswith('RTC') and not RTC_WALLET_RE.fullmatch(wallet):
+            return False, "Invalid RTC wallet format (expected 'RTC' + 40 hex chars)"
+
         # Check blocklist
         if wallet.lower() in self.blocklist:
             return False, "Wallet address is blocklisted"

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -359,18 +359,21 @@ def add_repair_entry(machine_id: str):
 
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
-    
+
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
-    
-    data = request.get_json()
-    if not data or 'repair_type' not in data or 'description' not in data:
+
+    data, error = get_optional_json_object()
+    if error:
+        return error
+
+    if 'repair_type' not in data or 'description' not in data:
         return jsonify({
             'ok': False,
             'error': 'missing_field',
             'message': "Fields 'repair_type' and 'description' are required",
         }), 400
-    
+
     success, msg = ledger.add_repair_entry(
         machine_id=machine_id,
         repair_date=data.get('repair_date', int(time.time())),
@@ -504,18 +507,21 @@ def add_lineage_note(machine_id: str):
 
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
-    
+
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
-    
-    data = request.get_json()
-    if not data or 'event_type' not in data:
+
+    data, error = get_optional_json_object()
+    if error:
+        return error
+
+    if 'event_type' not in data:
         return jsonify({
             'ok': False,
             'error': 'missing_field',
             'message': "Field 'event_type' is required",
         }), 400
-    
+
     success, msg = ledger.add_lineage_note(
         machine_id=machine_id,
         lineage_ts=data.get('lineage_ts', int(time.time())),

--- a/tests/test_faucet_service_wallet_validation.py
+++ b/tests/test_faucet_service_wallet_validation.py
@@ -1,0 +1,84 @@
+"""Regression tests for ``faucet_service.FaucetValidator.validate_wallet``.
+
+Mirrors the legacy faucet tightening in commit ``541c784`` so malformed
+RTC-prefixed values like ``RTCzzzzzzzzzz`` and ``RTC1234567890`` are rejected
+by the faucet_service path as well. Cited by vuln-audit tick
+``vuln-tick-2026-05-14T1500Z`` (Tier 2 — High).
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "faucet_service"))
+
+import faucet_service  # noqa: E402
+
+
+@pytest.fixture()
+def validator():
+    return faucet_service.FaucetValidator(
+        config={"validation": {}},
+        logger=logging.getLogger("test"),
+    )
+
+
+# --- Malformed RTC wallets now rejected ---------------------------------------
+
+def test_validator_rejects_short_rtc_wallet(validator):
+    """``RTC1234567890`` is 13 chars: passes legacy length>=10 but is malformed."""
+    valid, err = validator.validate_wallet("RTC1234567890")
+    assert valid is False
+    assert err is not None
+    assert "RTC wallet format" in err
+
+
+def test_validator_rejects_non_hex_rtc_wallet(validator):
+    """``RTCzzzzzzzzzz`` has the right prefix and length>=10 but is not hex."""
+    valid, err = validator.validate_wallet("RTCzzzzzzzzzz")
+    assert valid is False
+    assert err is not None
+    assert "RTC wallet format" in err
+
+
+def test_validator_rejects_rtc_with_wrong_hex_length(validator):
+    """RTC + 39 hex chars (one short) is rejected."""
+    valid, err = validator.validate_wallet("RTC" + "a" * 39)
+    assert valid is False
+    assert err is not None
+    assert "RTC wallet format" in err
+
+
+def test_validator_rejects_rtc_with_extra_hex_chars(validator):
+    """RTC + 41 hex chars (one over) is rejected."""
+    valid, err = validator.validate_wallet("RTC" + "a" * 41)
+    assert valid is False
+    assert err is not None
+    assert "RTC wallet format" in err
+
+
+# --- Well-formed wallets still accepted ---------------------------------------
+
+def test_validator_accepts_canonical_rtc_wallet(validator):
+    wallet = "RTC" + "9d7caca3039130d3b26d41f7343d8f4ef4592360"
+    valid, err = validator.validate_wallet(wallet)
+    assert valid is True
+    assert err is None
+
+
+def test_validator_accepts_uppercase_hex_rtc_wallet(validator):
+    wallet = "RTC" + "9D7CACA3039130D3B26D41F7343D8F4EF4592360"
+    valid, err = validator.validate_wallet(wallet)
+    assert valid is True
+    assert err is None
+
+
+def test_validator_still_accepts_ethereum_style_wallet(validator):
+    """Tightening must NOT regress 0x-prefixed wallets."""
+    valid, err = validator.validate_wallet("0x9d7caca3039130d3b26d41f7343d8f4ef4592360")
+    assert valid is True
+    assert err is None

--- a/tests/test_machine_passport_array_payload.py
+++ b/tests/test_machine_passport_array_payload.py
@@ -1,0 +1,174 @@
+"""Regression tests for machine_passport `/repair-log` and `/lineage` routes.
+
+Before this patch, those endpoints called ``request.get_json()`` and then
+``data.get(...)`` directly, so an authenticated array payload would crash
+the handler with ``AttributeError`` and return HTTP 500. They now share the
+``get_optional_json_object()`` validation helper used by ``/attestations``
+and ``/benchmarks`` and reject non-object JSON with HTTP 400.
+
+Cited by vuln-audit tick ``vuln-tick-2026-05-14T1500Z`` (Tier 2 — High).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "node"))
+
+import machine_passport_api  # noqa: E402
+
+
+ADMIN_HEADERS = {"X-Admin-Key": "expected-admin-key"}
+
+
+class LedgerStub:
+    def __init__(self):
+        self.repair_payload = None
+        self.lineage_payload = None
+        self.passport_updates = []
+
+    def get_passport(self, machine_id):
+        return True
+
+    def add_repair_entry(self, **kwargs):
+        self.repair_payload = kwargs
+        return True, "repair added"
+
+    def add_lineage_note(self, **kwargs):
+        self.lineage_payload = kwargs
+        return True, "lineage added"
+
+    def update_passport(self, machine_id, fields):
+        self.passport_updates.append((machine_id, fields))
+        return True
+
+
+@pytest.fixture
+def ledger(monkeypatch):
+    stub = LedgerStub()
+    monkeypatch.setattr(machine_passport_api, "_ledger", stub)
+    return stub
+
+
+@pytest.fixture
+def client(ledger, monkeypatch):
+    monkeypatch.setenv("ADMIN_KEY", "expected-admin-key")
+    app = Flask(__name__)
+    app.register_blueprint(machine_passport_api.machine_passport_bp)
+    return app.test_client()
+
+
+# --- /repair-log array-payload regressions ------------------------------------
+
+def test_repair_log_rejects_empty_array_payload(client):
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        headers=ADMIN_HEADERS,
+        json=[],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }
+
+
+def test_repair_log_rejects_non_object_array_payload(client):
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        headers=ADMIN_HEADERS,
+        json=["repair_type", "description"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_request"
+
+
+def test_repair_log_still_requires_fields_for_empty_object(client):
+    """Empty body still gets the existing missing_field error (not 500)."""
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        headers=ADMIN_HEADERS,
+        json={},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "missing_field"
+
+
+def test_repair_log_accepts_valid_object_payload(client, ledger):
+    response = client.post(
+        "/api/machine-passport/machine-1/repair-log",
+        headers=ADMIN_HEADERS,
+        json={
+            "repair_type": "capacitor_replacement",
+            "description": "Replaced C12-C15",
+        },
+    )
+
+    assert response.status_code == 200
+    assert ledger.repair_payload["repair_type"] == "capacitor_replacement"
+    assert ledger.repair_payload["description"] == "Replaced C12-C15"
+
+
+# --- /lineage array-payload regressions ---------------------------------------
+
+def test_lineage_rejects_empty_array_payload(client):
+    response = client.post(
+        "/api/machine-passport/machine-1/lineage",
+        headers=ADMIN_HEADERS,
+        json=[],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }
+
+
+def test_lineage_rejects_non_object_array_payload(client):
+    response = client.post(
+        "/api/machine-passport/machine-1/lineage",
+        headers=ADMIN_HEADERS,
+        json=["acquisition"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_request"
+
+
+def test_lineage_still_requires_event_type_for_empty_object(client):
+    response = client.post(
+        "/api/machine-passport/machine-1/lineage",
+        headers=ADMIN_HEADERS,
+        json={},
+    )
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["error"] == "missing_field"
+
+
+def test_lineage_accepts_valid_object_payload(client, ledger):
+    response = client.post(
+        "/api/machine-passport/machine-1/lineage",
+        headers=ADMIN_HEADERS,
+        json={"event_type": "acquisition", "to_owner": "miner-42"},
+    )
+
+    assert response.status_code == 200
+    assert ledger.lineage_payload["event_type"] == "acquisition"
+    # to_owner should still propagate to the passport update path
+    assert any(
+        update[1].get("owner_miner_id") == "miner-42"
+        for update in ledger.passport_updates
+    )


### PR DESCRIPTION
## Summary

Closes two **Tier-2 High** vulnerabilities flagged by the vuln-audit tick
[`codex-goals/vuln-agent/ticks/vuln-tick-2026-05-14T1500Z.md`](https://github.com/Scottcjn/Rustchain/blob/main/codex-goals/vuln-agent/ticks/vuln-tick-2026-05-14T1500Z.md). Both are regressions from PRs merged earlier on 2026-05-14 — the underlying hardening commits were correct in shape but left adjacent gaps.

### Finding 1 — `faucet_service` RTC wallet validation too loose
- **File**: `faucet_service/faucet_service.py:473`
- **Issue**: `FaucetValidator.validate_wallet()` accepted any `RTC`-prefixed string meeting generic 10..66 length bounds. Malformed values like `RTCzzzzzzzzzz` and `RTC1234567890` passed as distinct wallet identities on a funds-dispensing path.
- **Fix**: Mirror the legacy-faucet fix in commit [`541c784`](https://github.com/Scottcjn/Rustchain/commit/541c784) — require native RTC wallets to match `^RTC[0-9a-fA-F]{40}$`.

### Finding 2 — `machine_passport_api` array-payload AttributeError
- **File**: `node/machine_passport_api.py` (`/repair-log` line 376, `/lineage` line 521)
- **Issue**: Commit [`2ed75ee`](https://github.com/Scottcjn/Rustchain/commit/2ed75ee) added admin-auth to all four subresource writers, but only ported `/attestations` and `/benchmarks` onto `get_optional_json_object()`. Authenticated array payloads to `/repair-log` and `/lineage` still hit `.get()` on a list and crashed with `AttributeError` → HTTP 500.
- **Fix**: Both routes now share `get_optional_json_object()` and reject non-object JSON with HTTP 400. Existing required-field checks (`repair_type`/`description`, `event_type`) are preserved.

## Files Changed

| File | Change |
|------|--------|
| `faucet_service/faucet_service.py` | Add `RTC_WALLET_RE` + format check inside `validate_wallet()` |
| `node/machine_passport_api.py` | Port `/repair-log` and `/lineage` onto `get_optional_json_object()` |
| `tests/test_faucet_service_wallet_validation.py` | **NEW** — 7 regressions |
| `tests/test_machine_passport_array_payload.py` | **NEW** — 8 regressions |

## Test plan

- [x] `pytest tests/test_faucet_service_wallet_validation.py` — 7 passed (rejects `RTCzzzzzzzzzz`, `RTC1234567890`, wrong-length hex; preserves canonical RTC + 0x acceptance)
- [x] `pytest tests/test_machine_passport_array_payload.py` — 8 passed (both routes return 400 for arrays; missing_field path preserved for empty objects; valid object payloads still accepted)
- [x] `pytest tests/test_legacy_faucet_json_validation.py tests/test_machine_passport_event_json_validation.py` — 11 passed (no regression in earlier vuln-audit work)
- [x] `pytest node/tests/test_machine_passport.py` — 29 passed (no regression in node-level passport coverage)

**Total: 55 tests pass, 15 new.**

## Audit Trail

Credit: vuln-audit tick [`vuln-tick-2026-05-14T1500Z.md`](https://github.com/Scottcjn/Rustchain/blob/main/codex-goals/vuln-agent/ticks/vuln-tick-2026-05-14T1500Z.md) (Tier 2 findings — both High).

🤖 Generated with [Claude Code](https://claude.com/claude-code)