### PR TITLE
chore: add SPDX header to test_validator_score_input_validation

### DIFF
--- a/rips/rustchain-core/tests/test_validator_score_input_validation.py
+++ b/rips/rustchain-core/tests/test_validator_score_input_validation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import importlib.util
 import sys
 import types


### PR DESCRIPTION
Vuln-audit Tier-3 finding (vuln-tick-2026-05-14T1500Z.md): `rips/rustchain-core/tests/test_validator_score_input_validation.py` was added without SPDX header. Repo is actively backfilling SPDX coverage.

Trivial one-line fix to keep license metadata clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)