### PR TITLE
docs: fix postman balance endpoint

### DIFF
--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -140,7 +140,7 @@ Expected response:
 ### Test Miner Balance
 
 ```bash
-curl -sk "https://rustchain.org/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
+curl -sk "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
 ```
 
 Expected response:


### PR DESCRIPTION
## Summary
- Update docs/postman/README.md balance check command from stale /balance to live /wallet/balance
- Keep the existing miner_id example unchanged

## Verification
- https://rustchain.org/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC -> 404 text/html
- https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC -> 200 application/json
- git diff --check HEAD~1..HEAD -- docs/postman/README.md -> passed

Bounty: #2178