### PR TITLE
docs: fix rust miner repo links

### DIFF
--- a/miners/rust/Cargo.toml
+++ b/miners/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["RustChain Contributors"]
 description = "Native Rust miner for the RustChain Proof-of-Antiquity network"
 license = "MIT"
-repository = "https://github.com/B1tor/Rustchain"
+repository = "https://github.com/Scottcjn/Rustchain"
 
 [[bin]]
 name = "rustchain-miner"

--- a/miners/rust/README.md
+++ b/miners/rust/README.md
@@ -42,7 +42,7 @@ source $HOME/.cargo/env
 
 ```bash
 # Clone the repo (if you haven't already)
-git clone https://github.com/B1tor/Rustchain.git
+git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain/miners/rust
 
 # Debug build (faster compile, slower binary)
@@ -158,7 +158,7 @@ cargo clippy
 
 ## Contributing
 
-See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) and the open bounty issue [#1601](https://github.com/B1tor/Rustchain/issues/1601) for context on this implementation.
+See the main [CONTRIBUTING.md](../../CONTRIBUTING.md) and the open bounty issue [#1601](https://github.com/Scottcjn/Rustchain/issues/1601) for context on this implementation.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Replace stale B1tor/Rustchain links in the native Rust miner README
- Update the Rust miner Cargo.toml repository metadata to the live Scottcjn/Rustchain repo

## Verification
- https://github.com/B1tor/Rustchain.git -> 404
- https://github.com/B1tor/Rustchain/issues/1601 -> 404
- https://github.com/Scottcjn/Rustchain.git -> 200
- https://github.com/Scottcjn/Rustchain/issues/1601 -> 200
- git diff --check HEAD~1..HEAD -- miners/rust/README.md miners/rust/Cargo.toml -> passed

Bounty: #2178