### PR TITLE
test: cover digest uptime formatting

### DIFF
--- a/bottube_digest_bot/tests/test_bottube_digest_bot.py
+++ b/bottube_digest_bot/tests/test_bottube_digest_bot.py
@@ -316,6 +316,18 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(generator.config, self.config)
         self.assertIsNotNone(generator.rustchain_client)
         self.assertIsNotNone(generator.bottube_client)
+        asyncio.run(generator.close())
+
+    def test_format_uptime_edges(self):
+        """Test uptime formatting boundaries."""
+        generator = DigestGenerator(self.config)
+
+        self.assertEqual(generator._format_uptime(0), "N/A")
+        self.assertEqual(generator._format_uptime(3599), "59m")
+        self.assertEqual(generator._format_uptime(3600), "1h 0m")
+        self.assertEqual(generator._format_uptime(90061), "1d 1h 1m")
+
+        asyncio.run(generator.close())
 
     def test_formatter_chain(self):
         """Test formatting chain for all channels."""


### PR DESCRIPTION
## Summary
- Add focused coverage for DigestGenerator._format_uptime boundaries
- Cover zero, minutes-only, hours, and days formatting branches
- Close the digest generator client in the initialization test to avoid leaving async clients open

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest -p no:cacheprovider bottube_digest_bot/tests/test_bottube_digest_bot.py -q -> 27 passed
- python3 -m py_compile bottube_digest_bot/bottube_digest_bot.py bottube_digest_bot/tests/test_bottube_digest_bot.py -> passed
- git diff --check HEAD~1..HEAD -- bottube_digest_bot/tests/test_bottube_digest_bot.py -> passed

Bounty: #1589