### PR TITLE
docs: fix developer fingerprint module link

### DIFF
--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -270,7 +270,7 @@ Create `~/.rustchain/config.json`:
 #### Step 6: Download Fingerprint Module
 
 ```bash
-curl -sSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/fingerprint_checks.py" \
+curl -sSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py" \
   -o fingerprint_checks.py
 ```
 


### PR DESCRIPTION
## Summary
- Fix a dead raw GitHub link for `fingerprint_checks.py` in the developer tutorial
- Point the download command at the live `miners/linux/fingerprint_checks.py` path

## Verification
- `https://raw.githubusercontent.com/Scottcjn/Rustchain/main/fingerprint_checks.py` -> 404
- `https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py` -> 200
- `git diff --check -- docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md` -> passed