### PR TITLE
test: cover faucet identity limits

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -18,6 +18,20 @@ def app(tmp_path, monkeypatch):
     return app
 
 
+@pytest.mark.parametrize(
+    ("github_username", "account_age_days", "expected_limit"),
+    [
+        (None, None, 0.5),
+        ("", None, 0.5),
+        ("alice", None, 1.0),
+        ("alice", 364, 1.0),
+        ("alice", 365, 2.0),
+    ],
+)
+def test_limit_for_identity_tiers(github_username, account_age_days, expected_limit):
+    assert faucet._limit_for_identity(github_username, account_age_days) == expected_limit
+
+
 def test_faucet_page(app):
     c = app.test_client()
     r = c.get("/faucet")


### PR DESCRIPTION
## Summary
- add direct unit coverage for tools/testnet_faucet.py::_limit_for_identity
- cover anonymous, empty GitHub, unknown-age GitHub, young account, and 365-day boundary tiers

## Verification
- PYTHONDONTWRITEBYTECODE=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /tmp/rustchain-faucet-venv/bin/python -m pytest -p no:cacheprovider tests/test_faucet.py -q -> 9 passed
- PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-faucet-venv/bin/python -m py_compile tools/testnet_faucet.py tests/test_faucet.py -> passed
- git diff --check -- tests/test_faucet.py -> passed

Note: the default system Python in this environment was missing Flask, so I used a temporary venv at /tmp/rustchain-faucet-venv installed from requirements.txt for verification.