### PR TITLE
docs: fix developer tutorial fingerprint URL

### DIFF
--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -270,7 +270,7 @@ Create `~/.rustchain/config.json`:
 #### Step 6: Download Fingerprint Module
 
 ```bash
-curl -sSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/fingerprint_checks.py" \
+curl -sSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py" \
   -o fingerprint_checks.py
 ```
 


### PR DESCRIPTION
## Summary
- fix the manual-install fingerprint module download URL in docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
- point it at the existing miners/linux/fingerprint_checks.py raw path used by START_HERE.md and install-miner.sh

## Verification
- old URL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/fingerprint_checks.py -> 404 text/plain
- new URL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/fingerprint_checks.py -> 200 text/plain
- test -f miners/linux/fingerprint_checks.py -> exists
- git diff --check -- docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md -> passed