### PR TITLE
docs: fix OpenAPI contact URL

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -33,7 +33,7 @@ info:
   version: 2.2.1-rip200
   contact:
     name: RustChain Development
-    url: https://github.com/rustchain-bounties/rustchain-bounties
+    url: https://github.com/Scottcjn/rustchain-bounties
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT


### PR DESCRIPTION
## Summary
- fix the OpenAPI contact URL from the nonexistent rustchain-bounties/rustchain-bounties repo
- point API consumers to the canonical Scottcjn/rustchain-bounties repository

## Verification
- old URL https://github.com/rustchain-bounties/rustchain-bounties -> 404
- new URL https://github.com/Scottcjn/rustchain-bounties -> 200
- git diff --check -- docs/api/openapi.yaml -> passed