### PR TITLE
fix(#5236): TOCTOU race condition in bridge deposits

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -310,14 +310,17 @@ def create_bridge_transfer(
         unlock_at = now + (6 * 600)  # 6 slots = 1 hour
     
     try:
-        # For deposits, check balance and create lock
+        # FIX(#5236): Acquire IMMEDIATE transaction before balance check to
+        # prevent TOCTOU race between check_miner_balance() and the INSERT.
         if request.direction == "deposit" and not admin_initiated:
+            cursor.execute("BEGIN IMMEDIATE")
             has_balance, available, pending = check_miner_balance(
                 db_conn, 
                 request.source_address, 
                 amount_i64
             )
             if not has_balance:
+                db_conn.rollback()
                 return False, {
                     "error": "Insufficient available balance",
                     "available_rtc": available / BRIDGE_UNIT,


### PR DESCRIPTION
## Summary

Fixes TOCTOU (Time-of-Check-Time-of-Use) race condition in bridge deposit flow (`#5236`).

Also notes that `#5235` (NameError: `own` used before assignment in `apply_transaction`) was already fixed in commit `c6a1a8d`.

## Bug #5236 - TOCTOU in Bridge Deposits

**File:** `node/bridge_api.py` - `create_bridge_transfer()`

**Problem:** `check_miner_balance()` reads the available balance without holding a write lock. Between the balance check and the subsequent `INSERT` into `bridge_transfers` + `lock_ledger`, a concurrent deposit request could pass the same check and double-spend.

**Fix:** Acquire `BEGIN IMMEDIATE` transaction before the balance check for deposit requests, ensuring the check-and-insert is atomic. On insufficient balance, explicit `db_conn.rollback()` is called before returning the error.

## Bug #5235 - Already Fixed

The `own` variable ordering in `node/utxo_db.py:apply_transaction()` was corrected in commit `c6a1a8d` (`#4233`). The line `own = conn is None` now appears before its first use.

Fixes #5235
Fixes #5236