### PR TITLE
docs: fix wRTC bridge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ VMs are detected and receive **1 billionth** of normal rewards. Real hardware on
 |--|------|
 | **Swap** | [Raydium DEX](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
 | **Chart** | [DexScreener](https://dexscreener.com/solana/8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb) |
-| **Bridge** | [Bridge](https://bottube.ai/bridge) |
+| **Bridge** | [Bridge](https://bottube.ai/bridge/wrtc) |
 | **Guide** | [wRTC Quickstart](docs/wrtc.md) |
 
 ---


### PR DESCRIPTION
## Summary
- update the README wRTC Bridge link from the broken /bridge route to the live /bridge/wrtc route
- match the bridge URL already used by the wRTC onboarding docs

## Validation
- curl -I -L --max-time 10 https://bottube.ai/bridge -> HTTP 500
- curl -I -L --max-time 10 https://bottube.ai/bridge/wrtc -> HTTP 200
- git diff --check -- README.md

Bounty: Scottcjn/rustchain-bounties#444
Contact: chaoqiang.tian@gmail.com