### PR TITLE
docs: fix mining installer download command

### DIFF
--- a/docs/mining.html
+++ b/docs/mining.html
@@ -211,9 +211,9 @@
 curl -fsSL https://rustchain.org/install.sh | bash
 
 # Or download manually
-wget https://github.com/Scottcjn/Rustchain/releases/latest/install.sh
-chmod +x install.sh
-./install.sh</pre>
+wget -O install-miner.sh https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh
+chmod +x install-miner.sh
+./install-miner.sh</pre>
       
       <h3>Windows Installation</h3>
       <pre># Download the Windows installer


### PR DESCRIPTION
## Summary
- replace the dead release installer URL in `docs/mining.html`
- keep the manual commands aligned with the downloaded `install-miner.sh` filename

## Verification
- `https://github.com/Scottcjn/Rustchain/releases/latest/install.sh` -> 404
- `https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh` -> 200
- `git diff --check -- docs/mining.html`