### PR TITLE
docs: fix dynamic category badge example

### DIFF
--- a/docs/DYNAMIC_BADGES_V2.md
+++ b/docs/DYNAMIC_BADGES_V2.md
@@ -30,9 +30,7 @@ Add any of these to your `README.md`:
 ## Category Badges
 
 ```markdown
-![Docs Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_docs.json)
-![Bug Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_bugs.json)
-![Outreach](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_outreach.json)
+![Feature Bounties](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/.github/badges/category_feature.json)
 ```
 
 ## Per-Hunter Badge


### PR DESCRIPTION
## Summary
- replace three dead category badge examples with the live category feature badge
- align `docs/DYNAMIC_BADGES_V2.md` with the published `.github/badges/manifest.json`

## Verification
- `category_docs.json` -> 404
- `category_bugs.json` -> 404
- `category_outreach.json` -> 404
- `category_feature.json` -> 200
- `git diff --check -- docs/DYNAMIC_BADGES_V2.md`