### PR TITLE
ci: add pycryptodome for EIP-55 Keccak-256 in faucet_service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,7 @@ cryptography>=46.0.7
 PyNaCl>=1.6.2
 # For wallet CLI (BIP39 seed phrases):
 mnemonic>=0.21
+# For EIP-55 Ethereum address checksum validation (faucet_service):
+pycryptodome>=3.20.0
 # For running tests:
 pytest>=7.4.4


### PR DESCRIPTION
**Critical CI fix.** Currently ALL test runs fail at collection.

`faucet_service/faucet_service.py:36` imports `from Crypto.Hash import keccak` for EIP-55 Ethereum address checksum validation (line 528). `pycryptodome` is not in requirements, so pytest crashes during collection on every PR that imports faucet_service.

## Evidence
```
tests/test_faucet_service_wallet_validation.py:19: in <module>
    import faucet_service
faucet_service/faucet_service.py:36: in <module>
    from Crypto.Hash import keccak
E   ModuleNotFoundError: No module named 'Crypto'
```

Break introduced by commit `ccfe256` (galpetame RTC wallet validation PR).

## Impact
Unblocks 4 Vinayak1337 test-coverage PRs (#4946 #4940 #4933 #4909) currently MERGEABLE+UNSTABLE, plus all downstream PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)