### PR TITLE
fix(cli): use live wallet balance endpoint

### DIFF
--- a/tests/test_wallet_show_regression.py
+++ b/tests/test_wallet_show_regression.py
@@ -11,7 +11,7 @@ import os
 
 # Add tools to path for importing cli module
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools', 'cli'))
-from rustchain_cli import fetch_api, get_node_url
+from rustchain_cli import fetch_api, get_node_url, wallet_balance_endpoint
 
 
 class TestWalletBalanceEndpoint:
@@ -31,6 +31,16 @@ class TestWalletBalanceEndpoint:
         assert "/wallet/balance" in expected_url
         assert "miner_id=" in expected_url
         assert test_address in expected_url
+
+    def test_cli_balance_command_endpoint(self):
+        """Verify the top-level balance command uses the live wallet endpoint."""
+        test_miner_id = "miner id/with spaces"
+
+        endpoint = wallet_balance_endpoint(test_miner_id)
+
+        assert endpoint == "/wallet/balance?miner_id=miner%20id%2Fwith%20spaces"
+        assert not endpoint.startswith("/balance/")
+        assert not endpoint.startswith("/api/balance")
 
     def test_balance_response_parsing(self):
         """Test that balance response is correctly parsed."""

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -223,7 +223,7 @@ echo "✓ All Agent Economy CLI commands working (write commands in --dry-run mo
 - `/health` - Node health check
 - `/epoch` - Current epoch information
 - `/api/miners` - List of active miners
-- `/balance/<miner_id>` - Wallet balance
+- `/wallet/balance?miner_id=<miner_id>` - Wallet balance
 - `/api/hall_of_fame` - Hall of Fame leaderboard
 - `/api/fee_pool` - Fee pool statistics
 

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -35,6 +35,7 @@ import os
 import sys
 import hashlib
 from datetime import datetime, timedelta
+from urllib.parse import quote
 from urllib.request import urlopen, Request
 from urllib.error import URLError, HTTPError
 
@@ -46,6 +47,12 @@ __version__ = "0.2.0"
 def get_node_url():
     """Get node URL from env var or default."""
     return os.environ.get("RUSTCHAIN_NODE", DEFAULT_NODE)
+
+
+def wallet_balance_endpoint(miner_id):
+    """Return the live wallet balance endpoint for a miner ID."""
+    return f"/wallet/balance?miner_id={quote(miner_id, safe='')}"
+
 
 def fetch_api(endpoint):
     """Fetch data from RustChain API."""
@@ -157,14 +164,14 @@ def cmd_balance(args):
             print("Error: Please provide a miner ID or use --all", file=sys.stderr)
             sys.exit(1)
         
-        data = fetch_api(f"/balance/{args.miner_id}")
+        data = fetch_api(wallet_balance_endpoint(args.miner_id))
         
         if args.json:
             print(json.dumps(data, indent=2))
             return
         
         print(f"Balance for {args.miner_id}")
-        print(f"RTC: {data.get('balance_rtc', data.get('balance', 'N/A'))}")
+        print(f"RTC: {data.get('amount_rtc', data.get('balance_rtc', data.get('balance', 'N/A')))}")
 
 def cmd_epoch(args):
     """Show epoch information."""
@@ -302,7 +309,7 @@ def cmd_wallet(args):
                 print("Error: Please provide a wallet address or set RUSTCHAIN_WALLET", file=sys.stderr)
                 sys.exit(1)
         
-        data = fetch_api(f"/wallet/balance?miner_id={args.address}")
+        data = fetch_api(wallet_balance_endpoint(args.address))
         
         if use_json:
             print(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- Fix `tools/cli/rustchain_cli.py balance <miner_id>` to call the live `/wallet/balance?miner_id=...` endpoint instead of the removed `/balance/<miner_id>` path.
- Share the same wallet balance endpoint helper with the `wallet balance` subcommand and URL-encode miner IDs.
- Update the CLI README endpoint list and add regression coverage for the direct balance command endpoint.

## Live verification
- `https://rustchain.org/balance/iamdinhthuan` returns HTTP 404.
- `https://rustchain.org/wallet/balance?miner_id=iamdinhthuan` returns HTTP 200 with `{"amount_i64":0,"amount_rtc":0.0,"miner_id":"iamdinhthuan"}`.
- Before this patch, `python3 tools/cli/rustchain_cli.py balance iamdinhthuan` exited with `Error: API returned 404`.
- After this patch, it prints `RTC: 0.0`.

## Tests
- `python3 -m pytest tests/test_wallet_show_regression.py -q`
- `git diff --check`
- `python3 -m py_compile tools/cli/rustchain_cli.py`
- `python3 tools/cli/rustchain_cli.py balance iamdinhthuan`