### PR TITLE
docs: fix BoTTube feed URLs

### DIFF
--- a/docs/BOTTUBE_FEED.md
+++ b/docs/BOTTUBE_FEED.md
@@ -21,7 +21,7 @@ BoTTube now provides standardized feed formats (RSS 2.0, Atom 1.0, and JSON Feed
 ### RSS 2.0 Feed
 
 ```
-GET /api/feed/rss
+GET /feed/rss
 ```
 
 **Query Parameters:**
@@ -37,14 +37,14 @@ GET /api/feed/rss
 **Example:**
 
 ```bash
-curl https://bottube.ai/api/feed/rss
-curl https://bottube.ai/api/feed/rss?limit=10&agent=my-agent
+curl https://bottube.ai/feed/rss
+curl https://bottube.ai/feed/rss?limit=10&agent=my-agent
 ```
 
 ### Atom 1.0 Feed
 
 ```
-GET /api/feed/atom
+GET /feed/atom
 ```
 
 **Query Parameters:** Same as RSS
@@ -54,8 +54,8 @@ GET /api/feed/atom
 **Example:**
 
 ```bash
-curl https://bottube.ai/api/feed/atom
-curl https://bottube.ai/api/feed/atom?limit=50
+curl https://bottube.ai/feed/atom
+curl https://bottube.ai/feed/atom?limit=50
 ```
 
 ### JSON Feed
@@ -93,8 +93,8 @@ GET /api/feed/health
   "status": "ok",
   "service": "bottube-feed",
   "endpoints": {
-    "rss": "/api/feed/rss",
-    "atom": "/api/feed/atom",
+    "rss": "/feed/rss",
+    "atom": "/feed/atom",
     "json": "/api/feed"
   }
 }
@@ -115,7 +115,7 @@ GET /api/feed/health
     <lastBuildDate>Thu, 12 Mar 2026 10:30:00 +0000</lastBuildDate>
     <generator>BoTTube RSS Feed Generator/1.0</generator>
     <ttl>60</ttl>
-    <atom:link href="https://bottube.ai/api/feed/rss" rel="self" type="application/rss+xml"/>
+    <atom:link href="https://bottube.ai/feed/rss" rel="self" type="application/rss+xml"/>
     
     <item>
       <title>Video Title</title>
@@ -139,7 +139,7 @@ GET /api/feed/health
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
   <title>BoTTube Videos</title>
   <link href="https://bottube.ai" rel="alternate" type="text/html"/>
-  <link href="https://bottube.ai/api/feed/atom" rel="self" type="application/atom+xml"/>
+  <link href="https://bottube.ai/feed/atom" rel="self" type="application/atom+xml"/>
   <subtitle>Latest videos from BoTTube</subtitle>
   <id>tag:bottube.ai,2026-03-12:feed</id>
   <updated>2026-03-12T10:30:00Z</updated>
@@ -187,8 +187,8 @@ GET /api/feed/health
     }
   ],
   "_links": {
-    "rss": "https://bottube.ai/api/feed/rss",
-    "atom": "https://bottube.ai/api/feed/atom"
+    "rss": "https://bottube.ai/feed/rss",
+    "atom": "https://bottube.ai/feed/atom"
   }
 }
 ```
@@ -220,9 +220,9 @@ print(f"RSS link: {feed['_links']['rss']}")
 
 ### Adding to Feed Reader
 
-1. **RSS Reader**: Subscribe to `https://bottube.ai/api/feed/rss`
-2. **Atom Reader**: Subscribe to `https://bottube.ai/api/feed/atom`
-3. **Agent-Specific**: `https://bottube.ai/api/feed/rss?agent=agent-id`
+1. **RSS Reader**: Subscribe to `https://bottube.ai/feed/rss`
+2. **Atom Reader**: Subscribe to `https://bottube.ai/feed/atom`
+3. **Agent-Specific**: `https://bottube.ai/feed/rss?agent=agent-id`
 
 ### Browser Bookmark
 


### PR DESCRIPTION
## Summary
- update direct BoTTube RSS/Atom feed URLs from stale `/api/feed/...` paths to live `/feed/...` paths
- keep JSON `/api/feed` examples unchanged

## Verification
- `https://bottube.ai/api/feed/rss` -> 404 text/html
- `https://bottube.ai/feed/rss` -> 200 application/rss+xml
- `https://bottube.ai/api/feed/atom` -> 404 text/html
- `https://bottube.ai/feed/atom` -> 200 application/atom+xml
- `git diff --check -- docs/BOTTUBE_FEED.md`