### PR TITLE
fix(#5217): improve clawrtc dry-run UX on Windows

### DIFF
--- a/clawrtc/__init__.py
+++ b/clawrtc/__init__.py
@@ -1,0 +1,3 @@
+"""ClawRTC — Mine RTC tokens with your AI agent on any modern hardware."""
+
+__version__ = "1.5.0"

--- a/clawrtc/cli.py
+++ b/clawrtc/cli.py
@@ -1,0 +1,1109 @@
+#!/usr/bin/env python3
+"""ClawRTC — RustChain miner for AI agents on modern hardware.
+
+Your Claw agent earns RTC tokens by proving it runs on real hardware.
+Modern machines get 1x multiplier. Vintage hardware gets bonus multipliers.
+VMs are detected and penalized — real iron only.
+
+Usage:
+    pip install clawrtc
+    clawrtc wallet create          Generate your RTC address
+    clawrtc install --wallet RTC...
+    clawrtc start
+
+Wallet:
+    clawrtc wallet create          Create Ed25519 RTC wallet
+    clawrtc wallet show            Show address and balance
+    clawrtc wallet export          Download key file
+
+Security:
+    clawrtc install --dry-run      Preview without installing
+    clawrtc install --verify       Show SHA256 hashes of bundled files
+    clawrtc mine --dry-run         Setup preview (Windows-safe)
+"""
+
+import argparse
+import hashlib
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+import json
+
+__version__ = "1.8.0"
+
+INSTALL_DIR = os.path.join(os.path.expanduser("~"), ".clawrtc")
+VENV_DIR = os.path.join(INSTALL_DIR, "venv")
+NODE_URL = "https://bulbous-bouffant.metalseed.net"
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(PACKAGE_DIR, "data")
+
+# ANSI colors
+CYAN = "\033[36m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+NC = "\033[0m"
+
+# Bundled files shipped with the package
+BUNDLED_FILES = [
+    ("miner.py", "miner.py"),
+    ("fingerprint_checks.py", "fingerprint_checks.py"),
+]
+
+
+def log(msg):
+    print(f"{CYAN}[clawrtc]{NC} {msg}")
+
+
+def success(msg):
+    print(f"{GREEN}[OK]{NC} {msg}")
+
+
+def warn(msg):
+    print(f"{YELLOW}[WARN]{NC} {msg}")
+
+
+def error(msg):
+    print(f"{RED}[ERROR]{NC} {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def sha256_file(path):
+    """Compute SHA256 hash of a file."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def run_cmd(cmd, check=True, capture=False):
+    """Run a shell command."""
+    try:
+        result = subprocess.run(
+            cmd, shell=True, check=check,
+            capture_output=capture, text=True
+        )
+        return result.stdout.strip() if capture else None
+    except subprocess.CalledProcessError:
+        if check:
+            raise
+        return None
+
+
+def _detect_vm():
+    """Quick VM detection — warns the user upfront."""
+    indicators = []
+    system = platform.system()
+
+    if system == "Linux":
+        dmi_paths = [
+            "/sys/class/dmi/id/sys_vendor",
+            "/sys/class/dmi/id/product_name",
+            "/sys/class/dmi/id/board_vendor",
+        ]
+        vm_vendors = ["qemu", "vmware", "virtualbox", "xen", "kvm", "microsoft", "parallels", "bhyve"]
+        for p in dmi_paths:
+            try:
+                with open(p) as f:
+                    val = f.read().strip().lower()
+                    if any(v in val for v in vm_vendors):
+                        indicators.append(f"{p}: {val}")
+            except (OSError, IOError):
+                pass
+
+        try:
+            with open("/proc/cpuinfo") as f:
+                if "hypervisor" in f.read().lower():
+                    indicators.append("cpuinfo: hypervisor flag")
+        except (OSError, IOError):
+            pass
+
+    elif system == "Darwin":
+        try:
+            out = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.features"],
+                capture_output=True, text=True
+            ).stdout.lower()
+            if "vmm" in out:
+                indicators.append("sysctl: VMM flag")
+        except Exception:
+            pass
+
+    return indicators
+
+
+def _show_consent_disclosure():
+    """Show what ClawRTC does before proceeding."""
+    print(textwrap.dedent(f"""
+    {BOLD}What ClawRTC will do:{NC}
+
+      {CYAN}1. Extract{NC}   Two Python scripts bundled with this package:
+         - fingerprint_checks.py  (hardware detection)
+         - miner.py               (attestation client)
+         {DIM}No external downloads — all code ships with the package.{NC}
+
+      {CYAN}2. Install{NC}   A Python virtual environment in ~/.clawrtc/
+         with one dependency: 'requests' (HTTP library)
+
+      {CYAN}3. Attest{NC}    When started, the miner contacts the RustChain network
+         every few minutes to prove your hardware is real.
+         Endpoint: {NODE_URL} (CA-signed TLS certificate)
+
+      {CYAN}4. Collect{NC}   Hardware fingerprint data sent during attestation:
+         - CPU model, architecture, vendor
+         - Clock timing variance (proves real oscillator)
+         - Cache latency profile (proves real cache hierarchy)
+         - VM detection flags (hypervisor, DMI vendor)
+         {DIM}No personal data, files, browsing history, or credentials are collected.
+         No data is sent to any third party — only to the RustChain node.{NC}
+
+      {CYAN}5. Earn{NC}      RTC tokens accumulate in your wallet each epoch (~10 min)
+
+    {DIM}Verify yourself:{NC}
+      clawrtc install --dry-run      Preview without installing
+      clawrtc install --verify       Show SHA256 hashes of bundled files
+      Source code: https://github.com/Scottcjn/Rustchain
+      Block explorer: {NODE_URL}/explorer
+    """))
+
+
+def cmd_install(args):
+    """Install and configure ClawRTC miner for your AI agent."""
+    print(textwrap.dedent(f"""
+    {CYAN}{BOLD}
+      ██████╗██╗      █████╗ ██╗    ██╗███████╗██╗  ██╗██╗██╗     ██╗
+     ██╔════╝██║     ██╔══██╗██║    ██║██╔════╝██║ ██╔╝██║██║     ██║
+     ██║     ██║     ███████║██║ █╗ ██║███████╗█████╔╝ ██║██║     ██║
+     ██║     ██║     ██╔══██║██║███╗██║╚════██║██╔═██╗ ██║██║     ██║
+     ╚██████╗███████╗██║  ██║╚███╔███╔╝███████║██║  ██╗██║███████╗███████╗
+      ╚═════╝╚══════╝╚═╝  ╚═╝ ╚══╝╚══╝ ╚══════╝╚═╝  ╚═╝╚═╝╚══════╝╚══════╝
+    {NC}
+    {DIM}  Mine RTC tokens with your AI agent on real hardware{NC}
+    {DIM}  Modern x86/ARM = 1x | Vintage PowerPC = up to 2.5x | VM = ~0x{NC}
+    {DIM}  Version {__version__}{NC}
+    """))
+
+    system = platform.system()
+    machine = platform.machine()
+    log(f"Platform: {system} | Arch: {machine}")
+
+    # --dry-run: show what would happen, don't do it (handled before platform check
+    # so Windows users can preview too — see #5217)
+    if getattr(args, "dry_run", False):
+        _show_consent_disclosure()
+        log("DRY RUN — no files extracted, no services created.")
+        warn("Mining on Windows is not supported. This dry-run preview shows what")
+        warn("would happen on a supported platform (Linux or macOS).")
+        return
+
+    if system not in ("Linux", "Darwin"):
+        error(f"Unsupported platform: {system}. Only Linux and macOS are supported.")
+
+    # --verify: show bundled file hashes and exit
+    if getattr(args, "verify", False):
+        log("Bundled file hashes (SHA256):")
+        for src_name, dest_name in BUNDLED_FILES:
+            src = os.path.join(DATA_DIR, src_name)
+            if os.path.exists(src):
+                print(f"  {dest_name}: {sha256_file(src)}")
+            else:
+                print(f"  {dest_name}: NOT FOUND in package")
+        return
+
+    # Show disclosure and get consent (unless --yes)
+    if not getattr(args, "yes", False):
+        _show_consent_disclosure()
+        try:
+            answer = input(f"{CYAN}[clawrtc]{NC} Proceed with installation? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        if answer not in ("y", "yes"):
+            log("Installation cancelled.")
+            return
+
+    # VM check — warn upfront, don't block
+    vm_hints = _detect_vm()
+    if vm_hints:
+        print(textwrap.dedent(f"""
+    {RED}{BOLD}  ╔══════════════════════════════════════════════════════════╗
+      ║              VM DETECTED — READ THIS               ║
+      ╠══════════════════════════════════════════════════════════╣
+      ║                                                          ║
+      ║  This machine appears to be a virtual machine.           ║
+      ║  RustChain's hardware fingerprint system WILL detect     ║
+      ║  VMs and assigns near-zero mining weight.                ║
+      ║                                                          ║
+      ║  Your miner will attest, but earn effectively nothing.   ║
+      ║  This is by design — RTC rewards real hardware only.     ║
+      ║                                                          ║
+      ║  VM indicators found:                                    ║{NC}"""))
+        for h in vm_hints[:4]:
+            print(f"      {RED}  *  {h}{NC}")
+        print(f"""      {RED}{BOLD}║                                                          ║
+      ║  To earn RTC, run on bare-metal hardware.               ║
+      ╚══════════════════════════════════════════════════════════╝{NC}
+""")
+
+    # Wallet setup
+    wallet = args.wallet
+    if not wallet:
+        try:
+            wallet = input(f"{CYAN}[clawrtc]{NC} Enter agent wallet name (e.g. my-claw-agent): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            wallet = ""
+
+    if not wallet:
+        hostname = platform.node().split(".")[0] or "agent"
+        wallet = f"claw-{hostname}-{int(time.time()) % 100000}"
+        warn(f"No wallet name provided. Auto-generated: {wallet}")
+
+    # Create install dir
+    log(f"Installing to {INSTALL_DIR}")
+    os.makedirs(INSTALL_DIR, exist_ok=True)
+
+    # Save wallet
+    with open(os.path.join(INSTALL_DIR, ".wallet"), "w") as f:
+        f.write(wallet)
+
+    # Create venv
+    if not os.path.isdir(VENV_DIR):
+        log("Creating Python environment...")
+        run_cmd(f'"{sys.executable}" -m venv "{VENV_DIR}"')
+
+    # Install deps
+    log("Installing dependencies...")
+    pip = os.path.join(VENV_DIR, "bin", "pip")
+    run_cmd(f'"{pip}" install --upgrade pip -q')
+    run_cmd(f'"{pip}" install requests -q')
+    success("Dependencies ready")
+
+    # Extract bundled miner files (no download!)
+    log("Extracting bundled miner scripts...")
+    for src_name, dest_name in BUNDLED_FILES:
+        src = os.path.join(DATA_DIR, src_name)
+        dest = os.path.join(INSTALL_DIR, dest_name)
+        if not os.path.exists(src):
+            error(f"Bundled file missing: {src_name}. Package may be corrupted.")
+        shutil.copy2(src, dest)
+        file_hash = sha256_file(dest)
+        size = os.path.getsize(dest)
+        log(f"  {dest_name} ({size / 1024:.1f} KB) SHA256: {file_hash[:16]}...")
+
+    success("Miner files extracted from package (no external downloads)")
+
+    # Setup service ONLY if --service flag is passed
+    if getattr(args, "service", False):
+        log("Setting up background service (--service flag)...")
+        if system == "Linux":
+            _setup_systemd(wallet)
+        elif system == "Darwin":
+            _setup_launchd(wallet)
+    else:
+        log(f"No background service created. To enable auto-start, re-run with --service")
+        log(f"Or start manually: clawrtc start")
+
+    # Check network
+    log("Checking RustChain network...")
+    try:
+        import urllib.request
+        req = urllib.request.Request(f"{NODE_URL}/api/miners")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            miners = json.loads(resp.read())
+            log(f"Active miners on network: {len(miners)}")
+    except Exception:
+        warn("Could not reach network (node may be temporarily unavailable)")
+
+    # Anonymous install telemetry — non-blocking, fails silently, no PII
+    try:
+        import threading, urllib.request
+        def _ping():
+            try:
+                payload = json.dumps({
+                    "package": "clawrtc",
+                    "version": __version__,
+                    "platform": platform.system(),
+                    "arch": platform.machine(),
+                    "source": "pip"
+                }).encode()
+                req = urllib.request.Request(
+                    "https://bottube.ai/api/telemetry/install",
+                    data=payload,
+                    headers={"Content-Type": "application/json"}
+                )
+                urllib.request.urlopen(req, timeout=5)
+            except Exception:
+                pass
+        threading.Thread(target=_ping, daemon=True).start()
+    except Exception:
+        pass
+
+    print(textwrap.dedent(f"""
+    {GREEN}{BOLD}═══════════════════════════════════════════════════════════
+      ClawRTC installed!  Your agent is ready to mine RTC.
+
+      Wallet:    {wallet}
+      Location:  {INSTALL_DIR}
+      Reward:    1x multiplier (modern hardware)
+      Node:      {NODE_URL} (CA-signed TLS)
+
+      Next steps:
+        clawrtc wallet create      Generate RTC address for payouts
+        clawrtc start              Start mining (foreground)
+        clawrtc start --service    Start + enable auto-restart
+        clawrtc stop               Stop mining
+        clawrtc status             Check miner + network status
+        clawrtc logs               View miner output
+
+      How it works:
+        * Your agent proves real hardware via 6 fingerprint checks
+        * Attestation happens automatically every few minutes
+        * RTC tokens accumulate in your wallet each epoch (~10 min)
+        * Check balance: clawrtc status
+
+      Verify & audit:
+        * Source: https://github.com/Scottcjn/Rustchain
+        * Explorer: {NODE_URL}/explorer
+        * clawrtc uninstall   Remove everything cleanly
+    ═══════════════════════════════════════════════════════════{NC}
+    """))
+
+
+def _setup_systemd(wallet):
+    """Set up systemd user service on Linux."""
+    service_dir = os.path.expanduser("~/.config/systemd/user")
+    os.makedirs(service_dir, exist_ok=True)
+    service_file = os.path.join(service_dir, "clawrtc-miner.service")
+    python_bin = os.path.join(VENV_DIR, "bin", "python")
+    miner_py = os.path.join(INSTALL_DIR, "miner.py")
+
+    with open(service_file, "w") as f:
+        f.write(textwrap.dedent(f"""\
+            [Unit]
+            Description=ClawRTC RTC Miner — AI Agent Mining
+            After=network-online.target
+            Wants=network-online.target
+
+            [Service]
+            ExecStart={python_bin} {miner_py} --wallet {wallet}
+            Restart=always
+            RestartSec=30
+            WorkingDirectory={INSTALL_DIR}
+            Environment=PYTHONUNBUFFERED=1
+
+            [Install]
+            WantedBy=default.target
+        """))
+
+    try:
+        run_cmd("systemctl --user daemon-reload")
+        run_cmd("systemctl --user enable clawrtc-miner")
+        run_cmd("systemctl --user start clawrtc-miner")
+        success("Service installed and started (auto-restarts on reboot)")
+    except Exception:
+        warn("Systemd user services not available. Use: clawrtc start")
+
+
+def _setup_launchd(wallet):
+    """Set up launchd agent on macOS."""
+    plist_dir = os.path.expanduser("~/Library/LaunchAgents")
+    os.makedirs(plist_dir, exist_ok=True)
+    plist_file = os.path.join(plist_dir, "com.clawrtc.miner.plist")
+    python_bin = os.path.join(VENV_DIR, "bin", "python")
+    miner_py = os.path.join(INSTALL_DIR, "miner.py")
+
+    with open(plist_file, "w") as f:
+        f.write(textwrap.dedent(f"""\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+              "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+                <key>Label</key>
+                <string>com.clawrtc.miner</string>
+                <key>ProgramArguments</key>
+                <array>
+                    <string>{python_bin}</string>
+                    <string>{miner_py}</string>
+                    <string>--wallet</string>
+                    <string>{wallet}</string>
+                </array>
+                <key>WorkingDirectory</key>
+                <string>{INSTALL_DIR}</string>
+                <key>RunAtLoad</key>
+                <true/>
+                <key>KeepAlive</key>
+                <true/>
+                <key>StandardOutPath</key>
+                <string>{os.path.join(INSTALL_DIR, "miner.log")}</string>
+                <key>StandardErrorPath</key>
+                <string>{os.path.join(INSTALL_DIR, "miner.err")}</string>
+            </dict>
+            </plist>
+        """))
+
+    try:
+        run_cmd(f'launchctl unload "{plist_file}" 2>/dev/null', check=False)
+        run_cmd(f'launchctl load "{plist_file}"')
+        success("LaunchAgent installed and loaded (auto-restarts on login)")
+    except Exception:
+        warn("Could not load LaunchAgent. Use: clawrtc start")
+
+
+def cmd_start(args):
+    """Start the ClawRTC miner."""
+    system = platform.system()
+
+    # If --service flag, set up persistence then start
+    if getattr(args, "service", False):
+        wallet_file = os.path.join(INSTALL_DIR, ".wallet")
+        wallet = open(wallet_file).read().strip() if os.path.exists(wallet_file) else "agent"
+        if system == "Linux":
+            _setup_systemd(wallet)
+        elif system == "Darwin":
+            _setup_launchd(wallet)
+        return
+
+    # Try systemd first (if service exists)
+    if system == "Linux":
+        sf = os.path.expanduser("~/.config/systemd/user/clawrtc-miner.service")
+        if os.path.exists(sf):
+            run_cmd("systemctl --user start clawrtc-miner")
+            success("Miner started (systemd)")
+            return
+
+    elif system == "Darwin":
+        pf = os.path.expanduser("~/Library/LaunchAgents/com.clawrtc.miner.plist")
+        if os.path.exists(pf):
+            run_cmd(f'launchctl load "{pf}"', check=False)
+            success("Miner started (launchd)")
+            return
+
+    # Fallback: run in foreground
+    miner_py = os.path.join(INSTALL_DIR, "miner.py")
+    python_bin = os.path.join(VENV_DIR, "bin", "python")
+    wallet_file = os.path.join(INSTALL_DIR, ".wallet")
+
+    if not os.path.exists(miner_py):
+        error("Miner not installed. Run: clawrtc install")
+
+    wallet = open(wallet_file).read().strip() if os.path.exists(wallet_file) else ""
+    log(f"Starting miner in foreground (Ctrl+C to stop)...")
+    log(f"Tip: Use 'clawrtc start --service' for background auto-restart")
+    os.execvp(python_bin, [python_bin, miner_py] + (["--wallet", wallet] if wallet else []))
+
+
+def cmd_mine(args):
+    """Mine command — install wallet if needed, then start.
+
+    On Windows, the miner itself is unsupported (no systemd/launchd,
+    no native fingerprinting). The --dry-run path shows a preview
+    without attempting installation.
+    """
+    dry_run = getattr(args, 'dry_run', False)
+    system = platform.system()
+
+    if dry_run:
+        warn("Mining on Windows is not supported. This preview shows the")
+        warn("installation steps that would run on Linux or macOS.")
+
+    if hasattr(args, 'wallet') and args.wallet:
+        install_args = argparse.Namespace(
+            wallet=args.wallet, dry_run=dry_run, verify=False,
+            service=getattr(args, 'service', False),
+            no_service=False, yes=True
+        )
+        cmd_install(install_args)
+        # If Windows and dry-run, we're done — can't actually start
+        if system == "Windows" and dry_run:
+            return
+    if not dry_run:
+        cmd_start(args)
+
+
+def cmd_stop(args):
+    """Stop the ClawRTC miner."""
+    system = platform.system()
+    if system == "Linux":
+        run_cmd("systemctl --user stop clawrtc-miner", check=False)
+    elif system == "Darwin":
+        pf = os.path.expanduser("~/Library/LaunchAgents/com.clawrtc.miner.plist")
+        run_cmd(f'launchctl unload "{pf}"', check=False)
+    success("Miner stopped")
+
+
+def cmd_status(args):
+    """Check miner and network status."""
+    system = platform.system()
+
+    # Service status
+    if system == "Linux":
+        sf = os.path.expanduser("~/.config/systemd/user/clawrtc-miner.service")
+        if os.path.exists(sf):
+            run_cmd("systemctl --user status clawrtc-miner", check=False)
+        else:
+            log("No background service configured. Use: clawrtc start --service")
+    elif system == "Darwin":
+        run_cmd("launchctl list | grep clawrtc", check=False)
+
+    # Wallet info
+    wallet_file = os.path.join(INSTALL_DIR, ".wallet")
+    if os.path.exists(wallet_file):
+        wallet = open(wallet_file).read().strip()
+        log(f"Wallet: {wallet}")
+
+    # File integrity
+    for filename in ["miner.py", "fingerprint_checks.py"]:
+        path = os.path.join(INSTALL_DIR, filename)
+        if os.path.exists(path):
+            h = sha256_file(path)
+            log(f"{filename} SHA256: {h[:16]}...")
+
+    # Network check
+    try:
+        import urllib.request
+        req = urllib.request.Request(f"{NODE_URL}/health")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            health = json.loads(resp.read())
+            status = "online" if health.get("ok") else "offline"
+            log(f"Network: {status} (v{health.get('version', '?')})")
+    except Exception:
+        warn("Could not reach network")
+
+
+def cmd_logs(args):
+    """View miner logs."""
+    system = platform.system()
+    if system == "Linux":
+        sf = os.path.expanduser("~/.config/systemd/user/clawrtc-miner.service")
+        if os.path.exists(sf):
+            os.execlp("journalctl", "journalctl", "--user", "-u", "clawrtc-miner", "-f", "--no-pager", "-n", "50")
+        else:
+            log_file = os.path.join(INSTALL_DIR, "miner.log")
+            if os.path.exists(log_file):
+                os.execlp("tail", "tail", "-f", log_file)
+            else:
+                warn("No logs found. Start the miner first: clawrtc start")
+    elif system == "Darwin":
+        log_file = os.path.join(INSTALL_DIR, "miner.log")
+        if os.path.exists(log_file):
+            os.execlp("tail", "tail", "-f", log_file)
+        else:
+            warn("No log file found")
+
+
+WALLET_DIR = os.path.join(INSTALL_DIR, "wallets")
+WALLET_FILE = os.path.join(WALLET_DIR, "default.json")
+
+
+def _get_ed25519():
+    """Lazily import Ed25519 from cryptography library."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding, NoEncryption, PrivateFormat, PublicFormat,
+        )
+        return Ed25519PrivateKey, Encoding, NoEncryption, PrivateFormat, PublicFormat
+    except ImportError:
+        error(
+            "Missing dependency: cryptography\n"
+            f"  Run: pip install cryptography>=41.0\n"
+            f"  Or:  pip install clawrtc[wallet]"
+        )
+
+
+def _derive_rtc_address(public_key_bytes):
+    """Derive RTC address from public key bytes: RTC + sha256(pubkey)[:40]"""
+    return "RTC" + hashlib.sha256(public_key_bytes).hexdigest()[:40]
+
+
+def _load_wallet():
+    """Load existing wallet from disk, or return None."""
+    if not os.path.exists(WALLET_FILE):
+        return None
+    try:
+        with open(WALLET_FILE) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def cmd_wallet(args):
+    """Manage RTC wallet — create, show, export, or coinbase."""
+    action = args.wallet_action
+
+    if action == "create":
+        _wallet_create(args)
+    elif action == "show":
+        _wallet_show(args)
+    elif action == "export":
+        _wallet_export(args)
+    elif action == "coinbase":
+        from clawrtc.coinbase_wallet import cmd_coinbase
+        cmd_coinbase(args)
+    else:
+        log("Usage: clawrtc wallet [create|show|export|coinbase]")
+
+
+def _wallet_create(args):
+    """Generate a new Ed25519 RTC wallet."""
+    Ed25519PrivateKey, Encoding, NoEncryption, PrivateFormat, PublicFormat = _get_ed25519()
+
+    # Check for existing wallet
+    existing = _load_wallet()
+    if existing and not getattr(args, "force", False):
+        print(f"\n  {YELLOW}You already have an RTC wallet:{NC}")
+        print(f"  {GREEN}{BOLD}{existing['address']}{NC}\n")
+        print(f"  To create a new one (REPLACES existing), use:")
+        print(f"    clawrtc wallet create --force\n")
+        return
+
+    # Generate Ed25519 keypair
+    log("Generating Ed25519 keypair...")
+    private_key = Ed25519PrivateKey.generate()
+    public_key = private_key.public_key()
+
+    # Export raw bytes
+    priv_bytes = private_key.private_bytes(
+        Encoding.Raw, PrivateFormat.Raw, NoEncryption()
+    )
+    pub_bytes = public_key.public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+    # Derive RTC address
+    address = _derive_rtc_address(pub_bytes)
+
+    # Build wallet data
+    wallet_data = {
+        "address": address,
+        "public_key": pub_bytes.hex(),
+        "private_key": priv_bytes.hex(),
+        "created": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "curve": "Ed25519",
+        "network": "rustchain-mainnet",
+    }
+
+    # Save to disk
+    os.makedirs(WALLET_DIR, exist_ok=True)
+    with open(WALLET_FILE, "w") as f:
+        json.dump(wallet_data, f, indent=2)
+    os.chmod(WALLET_FILE, 0o600)  # Owner read/write only
+
+    # Also update the .wallet file so the miner uses this address
+    with open(os.path.join(INSTALL_DIR, ".wallet"), "w") as f:
+        f.write(address)
+
+    print(textwrap.dedent(f"""
+    {GREEN}{BOLD}═══════════════════════════════════════════════════════════
+      RTC WALLET CREATED
+    ═══════════════════════════════════════════════════════════{NC}
+
+      {GREEN}Address (PUBLIC — paste this in bounty claims):{NC}
+      {BOLD}{address}{NC}
+
+      {RED}Private key saved to:{NC}
+      {DIM}{WALLET_FILE}{NC}
+
+    {RED}{BOLD}  ╔══════════════════════════════════════════════════════╗
+      ║  SAVE YOUR PRIVATE KEY — IT CANNOT BE RECOVERED!  ║
+      ║  Back up {WALLET_FILE}    ║
+      ║  Anyone with this key can spend your RTC.         ║
+      ╚══════════════════════════════════════════════════════╝{NC}
+
+      {CYAN}Next steps:{NC}
+        1. Copy your {BOLD}RTC...{NC} address above
+        2. Paste it in GitHub bounty claims
+        3. Start mining: clawrtc start
+        4. Check balance: clawrtc wallet show
+
+      {DIM}This is NOT a Solana/ETH/BTC address.
+      For wRTC on Solana, bridge at https://bottube.ai/bridge{NC}
+    """))
+
+
+def _wallet_show(args):
+    """Display current wallet address and balance."""
+    wallet = _load_wallet()
+    if not wallet:
+        print(f"\n  {YELLOW}No RTC wallet found.{NC}")
+        print(f"  Create one: clawrtc wallet create\n")
+        print(f"  Or generate online: https://rustchain.org/wallet.html\n")
+        return
+
+    address = wallet["address"]
+    pub_key = wallet["public_key"]
+    created = wallet.get("created", "unknown")
+
+    print(f"\n  {GREEN}{BOLD}RTC Address:{NC}  {BOLD}{address}{NC}")
+    print(f"  {DIM}Public Key:{NC}   {DIM}{pub_key}{NC}")
+    print(f"  {DIM}Created:{NC}      {DIM}{created}{NC}")
+    print(f"  {DIM}Curve:{NC}        {DIM}{wallet.get('curve', 'Ed25519')}{NC}")
+    print(f"  {DIM}Key File:{NC}     {DIM}{WALLET_FILE}{NC}")
+
+    # Check balance from network
+    try:
+        import urllib.request
+        url = f"{NODE_URL}/api/balance?wallet={address}"
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read())
+            balance = data.get("balance_rtc", data.get("balance", 0))
+            print(f"  {GREEN}Balance:{NC}      {GREEN}{BOLD}{balance} RTC{NC}")
+    except Exception:
+        print(f"  {DIM}Balance:{NC}      {DIM}(could not reach network){NC}")
+
+    print()
+
+
+def _wallet_export(args):
+    """Export wallet key file."""
+    wallet = _load_wallet()
+    if not wallet:
+        print(f"\n  {YELLOW}No wallet to export. Create one first:{NC}")
+        print(f"  clawrtc wallet create\n")
+        return
+
+    export_path = getattr(args, "output", None) or f"rtc-wallet-{wallet['address']}.json"
+    # Remove private key from export if --public-only
+    if getattr(args, "public_only", False):
+        export_data = {k: v for k, v in wallet.items() if k != "private_key"}
+    else:
+        export_data = wallet
+
+    with open(export_path, "w") as f:
+        json.dump(export_data, f, indent=2)
+
+    print(f"\n  {GREEN}Wallet exported to:{NC} {export_path}")
+    if not getattr(args, "public_only", False):
+        print(f"  {RED}Contains private key — keep this file secure!{NC}")
+    print()
+
+
+def cmd_uninstall(args):
+    """Remove ClawRTC miner and all files."""
+    log("Stopping miner...")
+    cmd_stop(args)
+
+    system = platform.system()
+    if system == "Linux":
+        run_cmd("systemctl --user disable clawrtc-miner", check=False)
+        sf = os.path.expanduser("~/.config/systemd/user/clawrtc-miner.service")
+        if os.path.exists(sf):
+            os.unlink(sf)
+            run_cmd("systemctl --user daemon-reload", check=False)
+    elif system == "Darwin":
+        pf = os.path.expanduser("~/Library/LaunchAgents/com.clawrtc.miner.plist")
+        if os.path.exists(pf):
+            os.unlink(pf)
+
+    if os.path.isdir(INSTALL_DIR):
+        shutil.rmtree(INSTALL_DIR)
+
+    success("ClawRTC miner fully uninstalled — no files remain")
+
+
+def cmd_bcos(args):
+    """BCOS v2 — Blockchain Certified Open Source certification."""
+    action = getattr(args, "bcos_action", "scan")
+    target = getattr(args, "bcos_target", ".")
+    as_json = getattr(args, "bcos_json", False)
+
+    if action == "scan":
+        _bcos_scan(target, args.tier, args.reviewer, as_json)
+    elif action == "verify":
+        _bcos_verify(target)
+    elif action == "certify":
+        _bcos_certify(target, args.tier, args.reviewer, getattr(args, "sign", False))
+    else:
+        print(f"{RED}Unknown BCOS action: {action}{NC}")
+
+
+def _bcos_scan(path, tier, reviewer, as_json):
+    """Run BCOS engine scan on a local repository."""
+    # Try to import bundled engine, fall back to system
+    try:
+        bcos_engine_path = os.path.join(DATA_DIR, "bcos_engine.py")
+        if os.path.exists(bcos_engine_path):
+            import importlib.util
+            spec = importlib.util.spec_from_file_location("bcos_engine", bcos_engine_path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            scan_repo = mod.scan_repo
+            _print_report = mod._print_report
+        else:
+            # Try system import
+            from bcos_engine import scan_repo, _print_report
+    except ImportError:
+        print(f"{RED}BCOS engine not found.{NC}")
+        print(f"Install: pip install clawrtc  (includes bundled engine)")
+        print(f"Or copy bcos_engine.py to {DATA_DIR}/")
+        return
+
+    path = os.path.abspath(path)
+    if not os.path.isdir(path):
+        print(f"{RED}Not a directory: {path}{NC}")
+        return
+
+    print(f"{CYAN}Running BCOS v2 scan on {path}...{NC}")
+    report = scan_repo(path, tier=tier, reviewer=reviewer)
+    _print_report(report, as_json=as_json)
+
+
+def _bcos_verify(cert_id):
+    """Verify a BCOS certificate against the on-chain record."""
+    import urllib.request
+    import ssl
+
+    if not cert_id.startswith("BCOS-"):
+        cert_id = f"BCOS-{cert_id}"
+
+    url = f"{NODE_URL}/bcos/verify/{cert_id}"
+    print(f"{CYAN}Verifying {cert_id}...{NC}")
+
+    try:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        req = urllib.request.Request(url)
+        with urllib.request.urlopen(req, context=ctx, timeout=15) as resp:
+            data = json.loads(resp.read().decode())
+
+        if not data.get("ok"):
+            print(f"{RED}Not found: {data.get('error', 'unknown')}{NC}")
+            return
+
+        verified = data.get("verified", False)
+        icon = f"{GREEN}VERIFIED{NC}" if verified else f"{RED}UNVERIFIED{NC}"
+
+        print()
+        print(f"  Certificate:  {BOLD}{data['cert_id']}{NC}")
+        print(f"  Status:       {icon}")
+        print(f"  Repository:   {data.get('repo', 'unknown')}")
+        print(f"  Commit:       {data.get('commit_sha', 'unknown')[:12]}")
+        print(f"  Tier:         {data.get('tier', '?')}")
+        print(f"  Trust Score:  {data.get('trust_score', 0)}/100")
+        print(f"  Reviewer:     {data.get('reviewer', 'none')}")
+        print(f"  Commitment:   {data.get('commitment_valid', False)}")
+        print(f"  Signature:    {data.get('signature_valid', 'n/a')}")
+        print(f"  Epoch:        {data.get('anchored_epoch', 'n/a')}")
+        print()
+        print(f"  {DIM}Badge: {data.get('badge_url', '')}{NC}")
+        print(f"  {DIM}PDF:   {data.get('pdf_url', '')}{NC}")
+        print()
+
+    except Exception as e:
+        print(f"{RED}Verification failed: {e}{NC}")
+        print(f"{DIM}Node URL: {url}{NC}")
+
+
+def _bcos_certify(path, tier, reviewer, sign):
+    """Scan + anchor on-chain + download PDF."""
+    import urllib.request
+    import ssl
+
+    # Step 1: Scan
+    try:
+        bcos_engine_path = os.path.join(DATA_DIR, "bcos_engine.py")
+        if os.path.exists(bcos_engine_path):
+            import importlib.util
+            spec = importlib.util.spec_from_file_location("bcos_engine", bcos_engine_path)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            scan_repo = mod.scan_repo
+            _print_report = mod._print_report
+        else:
+            from bcos_engine import scan_repo, _print_report
+    except ImportError:
+        print(f"{RED}BCOS engine not found.{NC}")
+        return
+
+    path = os.path.abspath(path)
+    print(f"{CYAN}Step 1/3: Scanning {path}...{NC}")
+    report = scan_repo(path, tier=tier, reviewer=reviewer)
+    _print_report(report, as_json=False)
+
+    cert_id = report.get("cert_id", "unknown")
+    score = report.get("trust_score", 0)
+
+    # Step 2: Anchor on-chain
+    print(f"{CYAN}Step 2/3: Anchoring {cert_id} on RustChain...{NC}")
+
+    # Read admin key from env or config
+    admin_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key:
+        config_path = os.path.join(os.path.expanduser("~"), ".clawrtc", "admin_key")
+        if os.path.exists(config_path):
+            with open(config_path) as f:
+                admin_key = f.read().strip()
+
+    if not admin_key:
+        print(f"{YELLOW}No admin key found. Set RC_ADMIN_KEY env var or create ~/.clawrtc/admin_key{NC}")
+        print(f"{YELLOW}Skipping on-chain anchoring. Report saved locally.{NC}")
+        # Save report locally
+        out_path = os.path.join(path, f"{cert_id}.json")
+        with open(out_path, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"{GREEN}Report saved: {out_path}{NC}")
+        return
+
+    try:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        payload = json.dumps(report).encode()
+        req = urllib.request.Request(
+            f"{NODE_URL}/bcos/attest",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "X-Admin-Key": admin_key,
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+
+        if data.get("ok"):
+            print(f"{GREEN}Anchored! Epoch: {data.get('anchored_epoch', 'n/a')}{NC}")
+            print(f"  Verify: {data.get('verify_url', '')}")
+            print(f"  Badge:  {data.get('badge_url', '')}")
+        else:
+            print(f"{RED}Anchor failed: {data.get('error', 'unknown')}{NC}")
+
+    except Exception as e:
+        print(f"{RED}Anchor failed: {e}{NC}")
+
+    # Step 3: Download PDF
+    print(f"{CYAN}Step 3/3: Generating certificate PDF...{NC}")
+    try:
+        pdf_url = f"{NODE_URL}/bcos/cert/{cert_id}.pdf"
+        req = urllib.request.Request(pdf_url)
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        with urllib.request.urlopen(req, context=ctx, timeout=30) as resp:
+            pdf_data = resp.read()
+
+        out_path = os.path.join(path, f"{cert_id}.pdf")
+        with open(out_path, "wb") as f:
+            f.write(pdf_data)
+        print(f"{GREEN}Certificate saved: {out_path} ({len(pdf_data)} bytes){NC}")
+
+    except Exception as e:
+        print(f"{YELLOW}PDF download failed (cert still anchored): {e}{NC}")
+
+    print()
+    print(f"{GREEN}BCOS certification complete!{NC}")
+    print(f"  Cert ID:     {BOLD}{cert_id}{NC}")
+    print(f"  Trust Score: {score}/100")
+    print(f"  Tier:        {tier}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="clawrtc",
+        description="ClawRTC — Mine RTC tokens with your AI agent on real hardware",
+        allow_abbrev=False,
+        epilog=textwrap.dedent("""\
+            Your Claw agent earns RTC by proving it runs on real hardware.
+            Modern x86/ARM gets 1x multiplier. VMs are detected and penalized.
+            Vintage hardware (PowerPC, etc.) earns bonus multipliers up to 2.5x.
+
+            Security & verification:
+              clawrtc install --dry-run      Preview without changes
+              clawrtc install --verify       Show bundled file hashes
+              clawrtc mine --dry-run         Setup preview (Windows-safe)
+              Source: https://github.com/Scottcjn/Rustchain
+        """),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--version", "-V", action="version",
+                        version=f"clawrtc {__version__}")
+    sub = parser.add_subparsers(dest="command")
+
+    p_install = sub.add_parser("install", help="Install miner and configure wallet")
+    p_install.add_argument("--wallet", help="Agent wallet name for mining rewards")
+    p_install.add_argument("--dry-run", action="store_true", help="Preview installation steps without making changes (safe on Windows)")
+    p_install.add_argument("--verify", action="store_true", help="Show SHA256 hashes of bundled files")
+    p_install.add_argument("--service", action="store_true", help="Create background service (systemd/launchd)")
+    p_install.add_argument("--no-service", action="store_true", help="Skip background service setup (default)")
+    p_install.add_argument("-y", "--yes", action="store_true", help="Skip consent prompt (for CI/automation)")
+
+    p_start = sub.add_parser("start", help="Start mining")
+    p_start.add_argument("--service", action="store_true", help="Create background service for auto-restart")
+
+    p_mine = sub.add_parser("mine", help="Start mining (alias for 'start')")
+    p_mine.add_argument("--wallet", help="Wallet name (will install first if needed)")
+    p_mine.add_argument("--service", action="store_true", help="Create background service for auto-restart")
+    p_mine.add_argument("--dry-run", action="store_true", help="Preview installation steps (safe on Windows — mining itself requires Linux/macOS)")
+
+    sub.add_parser("stop", help="Stop mining")
+    sub.add_parser("status", help="Check miner + network status + file hashes")
+    sub.add_parser("logs", help="View miner output logs")
+    sub.add_parser("uninstall", help="Remove miner and all files completely")
+
+    # BCOS v2: Blockchain Certified Open Source
+    p_bcos = sub.add_parser("bcos", help="BCOS certification (scan, verify, certify)")
+    p_bcos.add_argument("bcos_action", nargs="?", default="scan",
+                        choices=["scan", "verify", "certify"],
+                        help="BCOS action (default: scan)")
+    p_bcos.add_argument("bcos_target", nargs="?", default=".",
+                        help="Path to scan or cert_id to verify")
+    p_bcos.add_argument("--tier", default="L1", choices=["L0", "L1", "L2"],
+                        help="Certification tier (default: L1)")
+    p_bcos.add_argument("--reviewer", default="", help="Human reviewer name (required for L2)")
+    p_bcos.add_argument("--json", action="store_true", dest="bcos_json",
+                        help="Output raw JSON report")
+    p_bcos.add_argument("--sign", action="store_true",
+                        help="Sign attestation with Ed25519 wallet key (certify only)")
+
+    p_wallet = sub.add_parser("wallet", help="Manage RTC wallet (create, show, export, coinbase)")
+    p_wallet.add_argument("wallet_action", nargs="?", default="show",
+                          choices=["create", "show", "export", "coinbase"],
+                          help="Wallet action (default: show)")
+    p_wallet.add_argument("coinbase_action", nargs="?", default="show",
+                          choices=["create", "show", "link", "swap-info"],
+                          help="Coinbase sub-action (when wallet_action=coinbase)")
+    p_wallet.add_argument("base_address", nargs="?", default="",
+                          help="Base address for 'coinbase link' command")
+    p_wallet.add_argument("--force", action="store_true",
+                          help="Overwrite existing wallet (create only)")
+    p_wallet.add_argument("--output", "-o", help="Export file path (export only)")
+    p_wallet.add_argument("--public-only", action="store_true",
+                          help="Export without private key (export only)")
+
+    args = parser.parse_args()
+
+    commands = {
+        "install": cmd_install,
+        "start": cmd_start,
+        "mine": cmd_mine,
+        "stop": cmd_stop,
+        "status": cmd_status,
+        "logs": cmd_logs,
+        "uninstall": cmd_uninstall,
+        "wallet": cmd_wallet,
+        "bcos": cmd_bcos,
+    }
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    func = commands.get(args.command)
+    if func:
+        func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/clawrtc/coinbase_wallet.py
+++ b/clawrtc/coinbase_wallet.py
@@ -1,0 +1,234 @@
+"""
+ClawRTC Coinbase Wallet Integration
+Optional module for creating/managing Coinbase Base wallets.
+
+Install with: pip install clawrtc[coinbase]
+"""
+
+import json
+import os
+import sys
+
+# ANSI colors (match cli.py)
+CYAN = "\033[36m"
+GREEN = "\033[32m"
+RED = "\033[31m"
+YELLOW = "\033[33m"
+BOLD = "\033[1m"
+DIM = "\033[2m"
+NC = "\033[0m"
+
+NODE_URL = "https://bulbous-bouffant.metalseed.net"
+
+SWAP_INFO = {
+    "wrtc_contract": "0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6",
+    "usdc_contract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "aerodrome_pool": "0x4C2A0b915279f0C22EA766D58F9B815Ded2d2A3F",
+    "swap_url": "https://aerodrome.finance/swap?from=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&to=0x5683C10596AaA09AD7F4eF13CAB94b9b74A669c6",
+    "network": "Base (eip155:8453)",
+    "reference_price_usd": 0.10,
+}
+
+INSTALL_DIR = os.path.join(os.path.expanduser("~"), ".clawrtc")
+COINBASE_FILE = os.path.join(INSTALL_DIR, "coinbase_wallet.json")
+
+
+def _load_coinbase_wallet():
+    """Load saved Coinbase wallet data."""
+    if not os.path.exists(COINBASE_FILE):
+        return None
+    try:
+        with open(COINBASE_FILE) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+
+
+def _save_coinbase_wallet(data):
+    """Save Coinbase wallet data to disk."""
+    os.makedirs(INSTALL_DIR, exist_ok=True)
+    with open(COINBASE_FILE, "w") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(COINBASE_FILE, 0o600)
+
+
+def coinbase_create(args):
+    """Create a Coinbase Base wallet via AgentKit."""
+    existing = _load_coinbase_wallet()
+    if existing and not getattr(args, "force", False):
+        print(f"\n  {YELLOW}You already have a Coinbase wallet:{NC}")
+        print(f"  {GREEN}{BOLD}{existing['address']}{NC}")
+        print(f"  Network: {existing.get('network', 'Base')}")
+        print(f"\n  To create a new one: clawrtc wallet coinbase create --force\n")
+        return
+
+    # Check for CDP credentials
+    cdp_key_name = os.environ.get("CDP_API_KEY_NAME", "")
+    cdp_key_private = os.environ.get("CDP_API_KEY_PRIVATE_KEY", "")
+
+    if not cdp_key_name or not cdp_key_private:
+        print(f"""
+  {YELLOW}Coinbase CDP credentials not configured.{NC}
+
+  To create a wallet automatically:
+    1. Sign up at {CYAN}https://portal.cdp.coinbase.com{NC}
+    2. Create an API Key
+    3. Set environment variables:
+       export CDP_API_KEY_NAME="organizations/.../apiKeys/..."
+       export CDP_API_KEY_PRIVATE_KEY="-----BEGIN EC PRIVATE KEY-----..."
+
+  Or link an existing Base address manually:
+    clawrtc wallet coinbase link 0xYourBaseAddress
+""")
+        return
+
+    try:
+        from coinbase_agentkit import AgentKit, AgentKitConfig
+
+        print(f"  {CYAN}Creating Coinbase wallet on Base...{NC}")
+
+        config = AgentKitConfig(
+            cdp_api_key_name=cdp_key_name,
+            cdp_api_key_private_key=cdp_key_private,
+            network_id="base-mainnet",
+        )
+        kit = AgentKit(config)
+        wallet = kit.wallet
+        address = wallet.default_address.address_id
+
+        wallet_data = {
+            "address": address,
+            "network": "Base (eip155:8453)",
+            "created": __import__("time").strftime("%Y-%m-%dT%H:%M:%SZ", __import__("time").gmtime()),
+            "method": "agentkit",
+        }
+        _save_coinbase_wallet(wallet_data)
+
+        print(f"""
+  {GREEN}{BOLD}═══════════════════════════════════════════════════════════
+    COINBASE BASE WALLET CREATED
+  ═══════════════════════════════════════════════════════════{NC}
+
+  {GREEN}Base Address:{NC}  {BOLD}{address}{NC}
+  {DIM}Network:{NC}       Base (eip155:8453)
+  {DIM}Saved to:{NC}      {COINBASE_FILE}
+
+  {CYAN}What you can do:{NC}
+    - Receive USDC payments via x402 protocol
+    - Swap USDC → wRTC on Aerodrome DEX
+    - Link to your RustChain miner for cross-chain identity
+    - See swap info: clawrtc wallet coinbase swap-info
+""")
+    except ImportError:
+        print(f"""
+  {RED}coinbase-agentkit not installed.{NC}
+
+  Install it with:
+    pip install clawrtc[coinbase]
+
+  Or: pip install coinbase-agentkit
+""")
+    except Exception as e:
+        print(f"\n  {RED}Failed to create wallet: {e}{NC}\n")
+
+
+def coinbase_show(args):
+    """Show Coinbase Base wallet info."""
+    wallet = _load_coinbase_wallet()
+    if not wallet:
+        print(f"\n  {YELLOW}No Coinbase wallet found.{NC}")
+        print(f"  Create one: clawrtc wallet coinbase create")
+        print(f"  Or link:    clawrtc wallet coinbase link 0xYourAddress\n")
+        return
+
+    print(f"\n  {GREEN}{BOLD}Coinbase Base Wallet{NC}")
+    print(f"  {GREEN}Address:{NC}    {BOLD}{wallet['address']}{NC}")
+    print(f"  {DIM}Network:{NC}    {DIM}{wallet.get('network', 'Base')}{NC}")
+    print(f"  {DIM}Created:{NC}    {DIM}{wallet.get('created', 'unknown')}{NC}")
+    print(f"  {DIM}Method:{NC}     {DIM}{wallet.get('method', 'unknown')}{NC}")
+    print(f"  {DIM}Key File:{NC}   {DIM}{COINBASE_FILE}{NC}")
+    print()
+
+
+def coinbase_link(args):
+    """Link an existing Base address as your Coinbase wallet."""
+    address = getattr(args, "base_address", "")
+    if not address:
+        print(f"\n  {YELLOW}Usage: clawrtc wallet coinbase link 0xYourBaseAddress{NC}\n")
+        return
+
+    if not address.startswith("0x") or len(address) != 42:
+        print(f"\n  {RED}Invalid Base address. Must be 0x + 40 hex characters.{NC}\n")
+        return
+
+    wallet_data = {
+        "address": address,
+        "network": "Base (eip155:8453)",
+        "created": __import__("time").strftime("%Y-%m-%dT%H:%M:%SZ", __import__("time").gmtime()),
+        "method": "manual_link",
+    }
+    _save_coinbase_wallet(wallet_data)
+
+    print(f"\n  {GREEN}Coinbase wallet linked:{NC} {BOLD}{address}{NC}")
+    print(f"  {DIM}Saved to: {COINBASE_FILE}{NC}")
+
+    # Also try to link to RustChain miner
+    rtc_wallet_file = os.path.join(INSTALL_DIR, "wallets", "default.json")
+    if os.path.exists(rtc_wallet_file):
+        try:
+            with open(rtc_wallet_file) as f:
+                rtc = json.load(f)
+            print(f"  {DIM}Linked to RTC wallet: {rtc['address']}{NC}")
+        except Exception:
+            pass
+    print()
+
+
+def coinbase_swap_info(args):
+    """Show USDC→wRTC swap instructions and Aerodrome pool info."""
+    print(f"""
+  {GREEN}{BOLD}USDC → wRTC Swap Guide{NC}
+
+  {CYAN}wRTC Contract (Base):{NC}
+    {BOLD}{SWAP_INFO['wrtc_contract']}{NC}
+
+  {CYAN}USDC Contract (Base):{NC}
+    {BOLD}{SWAP_INFO['usdc_contract']}{NC}
+
+  {CYAN}Aerodrome Pool:{NC}
+    {BOLD}{SWAP_INFO['aerodrome_pool']}{NC}
+
+  {CYAN}Swap URL:{NC}
+    {BOLD}{SWAP_INFO['swap_url']}{NC}
+
+  {CYAN}Network:{NC} {SWAP_INFO['network']}
+  {CYAN}Reference Price:{NC} ~${SWAP_INFO['reference_price_usd']}/wRTC
+
+  {GREEN}How to swap:{NC}
+    1. Get USDC on Base (bridge from Ethereum or buy on Coinbase)
+    2. Go to the Aerodrome swap URL above
+    3. Connect your wallet (MetaMask, Coinbase Wallet, etc.)
+    4. Swap USDC for wRTC
+    5. Bridge wRTC to native RTC at https://bottube.ai/bridge
+
+  {DIM}Or use the RustChain API:{NC}
+    curl -s https://bulbous-bouffant.metalseed.net/wallet/swap-info
+""")
+
+
+def cmd_coinbase(args):
+    """Handle clawrtc wallet coinbase subcommand."""
+    action = getattr(args, "coinbase_action", "show")
+
+    dispatch = {
+        "create": coinbase_create,
+        "show": coinbase_show,
+        "link": coinbase_link,
+        "swap-info": coinbase_swap_info,
+    }
+
+    func = dispatch.get(action)
+    if func:
+        func(args)
+    else:
+        print(f"  Usage: clawrtc wallet coinbase [create|show|link|swap-info]")

--- a/clawrtc/data/bcos_engine.py
+++ b/clawrtc/data/bcos_engine.py
@@ -1,0 +1,734 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+BCOS v2 Engine — Beacon Certified Open Source verification.
+
+Standalone verification engine that scans a repository and produces
+a trust score (0-100), structured JSON report, and BLAKE2b commitment
+suitable for on-chain anchoring via RustChain.
+
+Usage:
+    python bcos_engine.py [path] [--tier L0|L1|L2] [--reviewer name] [--json]
+
+Trust Score Formula (transparent):
+    license_compliance    20 pts  SPDX headers + OSI-compatible dep licenses
+    vulnerability_scan    25 pts  0 critical/high CVEs = 25; -5/crit, -2/high
+    static_analysis       20 pts  0 semgrep errors = 20; -3/err, -1/warn
+    sbom_completeness     10 pts  CycloneDX SBOM generated
+    dependency_freshness   5 pts  % deps at latest version
+    test_evidence         10 pts  test suite present & passing
+    review_attestation    10 pts  L0=0, L1=5, L2=10
+    ─────────────────────────
+    TOTAL                100
+
+Tier Thresholds: L0 >= 40, L1 >= 60, L2 >= 80 + human Ed25519 signature.
+
+Free. Open source. MIT licensed. https://rustchain.org/bcos
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from hashlib import blake2b, sha256
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ── Score weights ──────────────────────────────────────────────────
+SCORE_WEIGHTS = {
+    "license_compliance": 20,
+    "vulnerability_scan": 25,
+    "static_analysis": 20,
+    "sbom_completeness": 10,
+    "dependency_freshness": 5,
+    "test_evidence": 10,
+    "review_attestation": 10,
+}
+
+TIER_THRESHOLDS = {"L0": 40, "L1": 60, "L2": 80}
+
+# SPDX detection (reused from bcos_spdx_check.py)
+CODE_EXTS = {
+    ".py", ".sh", ".js", ".ts", ".tsx", ".jsx", ".rs",
+    ".c", ".cc", ".cpp", ".h", ".hpp", ".go", ".rb",
+    ".java", ".kt", ".swift", ".lua", ".zig",
+}
+SPDX_RE = re.compile(r"SPDX-License-Identifier:\s*[A-Za-z0-9.\-+]+")
+
+# OSI-approved license identifiers (common ones)
+OSI_LICENSES = {
+    "MIT", "Apache-2.0", "GPL-2.0", "GPL-3.0", "LGPL-2.1", "LGPL-3.0",
+    "BSD-2-Clause", "BSD-3-Clause", "ISC", "MPL-2.0", "AGPL-3.0",
+    "Unlicense", "0BSD", "Artistic-2.0", "BSL-1.0", "PostgreSQL",
+    "GPL-2.0-only", "GPL-3.0-only", "Apache-2.0 OR MIT",
+    "MIT OR Apache-2.0", "Zlib", "WTFPL",
+}
+
+
+def _run_cmd(cmd: List[str], timeout: int = 120) -> Tuple[int, str, str]:
+    """Run a command, return (returncode, stdout, stderr). Never raises."""
+    try:
+        p = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout
+        )
+        return p.returncode, p.stdout, p.stderr
+    except FileNotFoundError:
+        return -1, "", f"command not found: {cmd[0]}"
+    except subprocess.TimeoutExpired:
+        return -2, "", f"timeout after {timeout}s: {' '.join(cmd)}"
+    except Exception as e:
+        return -3, "", str(e)
+
+
+def _git_head_sha(repo_path: str) -> str:
+    """Get current HEAD commit SHA."""
+    rc, out, _ = _run_cmd(["git", "-C", repo_path, "rev-parse", "HEAD"])
+    return out.strip()[:40] if rc == 0 else "unknown"
+
+
+class BCOSEngine:
+    """Core BCOS v2 verification engine."""
+
+    def __init__(
+        self,
+        repo_path: str,
+        tier: str = "L1",
+        reviewer: str = "",
+        commit_sha: str = "",
+    ):
+        self.repo_path = Path(repo_path).resolve()
+        self.tier = tier.upper()
+        self.reviewer = reviewer
+        self.commit_sha = commit_sha or _git_head_sha(str(self.repo_path))
+        self.checks: Dict[str, Dict[str, Any]] = {}
+        self.score_breakdown: Dict[str, int] = {}
+
+    def run_all(self) -> dict:
+        """Run all checks and return structured report."""
+        self._check_spdx()
+        self._check_semgrep()
+        self._check_osv()
+        self._check_sbom()
+        self._check_dep_freshness()
+        self._check_test_evidence()
+        self._check_review()
+        self._compute_trust_score()
+
+        report = {
+            "schema": "bcos-attestation/v2",
+            "repo_path": str(self.repo_path),
+            "repo_name": self._detect_repo_name(),
+            "commit_sha": self.commit_sha,
+            "tier": self.tier,
+            "reviewer": self.reviewer,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "checks": self.checks,
+            "score_breakdown": self.score_breakdown,
+            "trust_score": sum(self.score_breakdown.values()),
+            "max_score": 100,
+            "tier_met": self._tier_met(),
+            "engine_version": "2.0.0",
+        }
+
+        # Compute cert_id and commitment AFTER building the report
+        # (cert_id is derived from report content)
+        report_json = json.dumps(report, sort_keys=True, separators=(",", ":"))
+        commitment = blake2b(report_json.encode(), digest_size=32).hexdigest()
+        cert_id = f"BCOS-{commitment[:8]}"
+
+        report["cert_id"] = cert_id
+        report["commitment"] = commitment
+
+        return report
+
+    def _detect_repo_name(self) -> str:
+        """Try to detect GitHub owner/repo from git remote."""
+        rc, out, _ = _run_cmd(
+            ["git", "-C", str(self.repo_path), "remote", "get-url", "origin"]
+        )
+        if rc == 0:
+            url = out.strip()
+            # Handle SSH and HTTPS URLs
+            for prefix in ["git@github.com:", "https://github.com/"]:
+                if url.startswith(prefix):
+                    name = url[len(prefix):].rstrip(".git").rstrip("/")
+                    return name
+        return self.repo_path.name
+
+    def _tier_met(self) -> bool:
+        """Check if trust score meets the claimed tier."""
+        score = sum(self.score_breakdown.values())
+        threshold = TIER_THRESHOLDS.get(self.tier, 60)
+        if score < threshold:
+            return False
+        if self.tier == "L2" and not self.reviewer:
+            return False
+        return True
+
+    # ── Check 1: License Compliance (20 pts) ──────────────────────
+
+    def _check_spdx(self):
+        """Check SPDX headers on code files + dependency license scan."""
+        code_files = []
+        spdx_present = 0
+        spdx_missing = []
+
+        for ext in CODE_EXTS:
+            for f in self.repo_path.rglob(f"*{ext}"):
+                # Skip hidden dirs, node_modules, venvs
+                parts = f.relative_to(self.repo_path).parts
+                if any(p.startswith(".") or p in ("node_modules", "venv", ".venv", "__pycache__", "build", "dist") for p in parts):
+                    continue
+                code_files.append(f)
+
+        for f in code_files:
+            try:
+                with open(f, "r", encoding="utf-8", errors="replace") as fh:
+                    head = fh.read(2048)
+                if SPDX_RE.search(head):
+                    spdx_present += 1
+                else:
+                    spdx_missing.append(str(f.relative_to(self.repo_path)))
+            except Exception:
+                pass
+
+        total = len(code_files)
+        pct = (spdx_present / total * 100) if total > 0 else 100
+
+        # Check dependency licenses via pip-licenses
+        dep_score = self._check_dep_licenses()
+
+        # Score: 10 pts for SPDX coverage, 10 pts for dep licenses
+        spdx_pts = min(10, int(pct / 10))
+        total_pts = spdx_pts + dep_score
+
+        self.checks["license_compliance"] = {
+            "passed": pct >= 80 and dep_score >= 5,
+            "spdx_coverage_pct": round(pct, 1),
+            "code_files_total": total,
+            "spdx_present": spdx_present,
+            "spdx_missing_sample": spdx_missing[:10],
+            "dep_license_score": dep_score,
+        }
+        self.score_breakdown["license_compliance"] = min(total_pts, 20)
+
+    def _check_dep_licenses(self) -> int:
+        """Check dependency licenses are OSI-compatible. Returns 0-10."""
+        rc, out, _ = _run_cmd(["pip-licenses", "--format=json"], timeout=30)
+        if rc != 0:
+            # Try pip-audit as fallback, or just return partial credit
+            return 5  # Assume OK if tool not installed
+
+        try:
+            deps = json.loads(out)
+            total = len(deps)
+            if total == 0:
+                return 10
+            osi_count = sum(
+                1 for d in deps
+                if any(lic in d.get("License", "") for lic in OSI_LICENSES)
+            )
+            pct = osi_count / total
+            return min(10, int(pct * 10))
+        except Exception:
+            return 5
+
+    # ── Check 2: Vulnerability Scan (25 pts) ──────────────────────
+
+    def _check_osv(self):
+        """Scan for known CVEs via pip-audit or osv-scanner."""
+        critical = 0
+        high = 0
+        medium = 0
+        low = 0
+        vulns = []
+        tool_used = None
+
+        # Try pip-audit first (Python-focused)
+        rc, out, err = _run_cmd(
+            ["pip-audit", "--format=json", "--desc"],
+            timeout=180,
+        )
+        if rc >= 0 and out.strip():
+            tool_used = "pip-audit"
+            try:
+                data = json.loads(out)
+                for dep in data.get("dependencies", []):
+                    for vuln in dep.get("vulns", []):
+                        sev = vuln.get("fix_versions", [])
+                        vid = vuln.get("id", "unknown")
+                        # pip-audit doesn't always include severity
+                        # Count each vuln as "high" unless we can determine otherwise
+                        vulns.append({"id": vid, "package": dep.get("name", ""), "severity": "HIGH"})
+                        high += 1
+            except json.JSONDecodeError:
+                pass
+
+        # Try osv-scanner as alternative
+        if tool_used is None:
+            rc, out, err = _run_cmd(
+                ["osv-scanner", "--format", "json", str(self.repo_path)],
+                timeout=180,
+            )
+            if rc >= 0 and out.strip():
+                tool_used = "osv-scanner"
+                try:
+                    data = json.loads(out)
+                    for result in data.get("results", []):
+                        for pkg in result.get("packages", []):
+                            for v in pkg.get("vulnerabilities", []):
+                                severity = "MEDIUM"
+                                for sev in v.get("database_specific", {}).get("severity", []):
+                                    severity = sev.upper()
+                                vid = v.get("id", "unknown")
+                                vulns.append({"id": vid, "severity": severity})
+                                if severity == "CRITICAL":
+                                    critical += 1
+                                elif severity == "HIGH":
+                                    high += 1
+                                elif severity == "MEDIUM":
+                                    medium += 1
+                                else:
+                                    low += 1
+                except json.JSONDecodeError:
+                    pass
+
+        # Score: 25 base, -5/critical, -2/high
+        pts = max(0, 25 - (critical * 5) - (high * 2))
+
+        self.checks["vulnerability_scan"] = {
+            "passed": critical == 0 and high == 0,
+            "tool": tool_used or "none_available",
+            "critical": critical,
+            "high": high,
+            "medium": medium,
+            "low": low,
+            "total_vulns": len(vulns),
+            "vulns_sample": vulns[:20],
+        }
+        self.score_breakdown["vulnerability_scan"] = pts
+
+    # ── Check 3: Static Analysis (20 pts) ─────────────────────────
+
+    def _check_semgrep(self):
+        """Run Semgrep static analysis."""
+        errors = 0
+        warnings = 0
+        findings = []
+
+        rc, out, err = _run_cmd(
+            ["semgrep", "--config", "auto", "--json", "--quiet",
+             str(self.repo_path)],
+            timeout=300,
+        )
+
+        if rc == -1:
+            # Semgrep not installed
+            self.checks["static_analysis"] = {
+                "passed": None,
+                "tool": "semgrep",
+                "status": "not_installed",
+                "errors": 0,
+                "warnings": 0,
+                "note": "Install semgrep for static analysis: pip install semgrep",
+            }
+            self.score_breakdown["static_analysis"] = 0
+            return
+
+        if out.strip():
+            try:
+                data = json.loads(out)
+                for result in data.get("results", []):
+                    severity = result.get("extra", {}).get("severity", "WARNING").upper()
+                    finding = {
+                        "rule": result.get("check_id", "unknown"),
+                        "severity": severity,
+                        "file": result.get("path", ""),
+                        "line": result.get("start", {}).get("line", 0),
+                        "message": result.get("extra", {}).get("message", "")[:200],
+                    }
+                    findings.append(finding)
+                    if severity == "ERROR":
+                        errors += 1
+                    else:
+                        warnings += 1
+            except json.JSONDecodeError:
+                pass
+
+        pts = max(0, 20 - (errors * 3) - (warnings * 1))
+
+        self.checks["static_analysis"] = {
+            "passed": errors == 0,
+            "tool": "semgrep",
+            "errors": errors,
+            "warnings": warnings,
+            "total_findings": len(findings),
+            "findings_sample": findings[:20],
+        }
+        self.score_breakdown["static_analysis"] = pts
+
+    # ── Check 4: SBOM Completeness (10 pts) ───────────────────────
+
+    def _check_sbom(self):
+        """Generate CycloneDX SBOM."""
+        sbom_data = None
+        sbom_hash = None
+
+        # Try cyclonedx-py
+        rc, out, err = _run_cmd(
+            ["cyclonedx-py", "environment", "--output-format", "JSON"],
+            timeout=60,
+        )
+
+        if rc == 0 and out.strip():
+            sbom_data = out.strip()
+            sbom_hash = sha256(sbom_data.encode()).hexdigest()
+        else:
+            # Try python -m cyclonedx_py
+            rc, out, err = _run_cmd(
+                ["python3", "-m", "cyclonedx_py", "environment",
+                 "--output-format", "JSON"],
+                timeout=60,
+            )
+            if rc == 0 and out.strip():
+                sbom_data = out.strip()
+                sbom_hash = sha256(sbom_data.encode()).hexdigest()
+
+        generated = sbom_data is not None
+
+        # Check for existing SBOM files in repo
+        existing_sboms = []
+        for pattern in ["*sbom*.json", "*sbom*.xml", "*.spdx", "*.spdx.json"]:
+            existing_sboms.extend(
+                str(f.relative_to(self.repo_path))
+                for f in self.repo_path.rglob(pattern)
+            )
+
+        # Check for dependency manifests
+        manifests = []
+        for name in ["requirements.txt", "Pipfile", "pyproject.toml", "setup.py",
+                      "package.json", "Cargo.toml", "go.mod", "Gemfile",
+                      "pom.xml", "build.gradle"]:
+            if (self.repo_path / name).exists():
+                manifests.append(name)
+
+        pts = 0
+        if generated:
+            pts = 7
+        if manifests:
+            pts += min(3, len(manifests))
+        pts = min(pts, 10)
+
+        self.checks["sbom_completeness"] = {
+            "passed": generated or len(manifests) > 0,
+            "sbom_generated": generated,
+            "sbom_hash": sbom_hash,
+            "existing_sboms": existing_sboms[:5],
+            "dependency_manifests": manifests,
+        }
+        self.score_breakdown["sbom_completeness"] = pts
+
+    # ── Check 5: Dependency Freshness (5 pts) ─────────────────────
+
+    def _check_dep_freshness(self):
+        """Check what percentage of deps are at latest version."""
+        # Use pip list --outdated
+        rc, out, _ = _run_cmd(
+            ["pip", "list", "--outdated", "--format=json"],
+            timeout=60,
+        )
+        rc2, out2, _ = _run_cmd(
+            ["pip", "list", "--format=json"],
+            timeout=60,
+        )
+
+        outdated = 0
+        total = 0
+
+        if rc2 == 0 and out2.strip():
+            try:
+                total = len(json.loads(out2))
+            except Exception:
+                pass
+
+        if rc == 0 and out.strip():
+            try:
+                outdated = len(json.loads(out))
+            except Exception:
+                pass
+
+        if total > 0:
+            fresh_pct = ((total - outdated) / total) * 100
+        else:
+            fresh_pct = 100
+
+        pts = min(5, int(fresh_pct / 20))
+
+        self.checks["dependency_freshness"] = {
+            "passed": fresh_pct >= 80,
+            "total_deps": total,
+            "outdated_deps": outdated,
+            "fresh_pct": round(fresh_pct, 1),
+        }
+        self.score_breakdown["dependency_freshness"] = pts
+
+    # ── Check 6: Test Evidence (10 pts) ────────────────────────────
+
+    def _check_test_evidence(self):
+        """Detect test infrastructure and evidence of test runs."""
+        has_tests = False
+        test_dirs = []
+        test_files = 0
+        ci_configs = []
+
+        # Check for test directories
+        for name in ["tests", "test", "spec", "__tests__", "testing"]:
+            d = self.repo_path / name
+            if d.is_dir():
+                test_dirs.append(name)
+                has_tests = True
+                test_files += sum(1 for _ in d.rglob("*test*"))
+
+        # Check for test files in root or src
+        for pattern in ["test_*.py", "*_test.py", "*_test.go", "*_test.rs",
+                        "*.test.js", "*.test.ts", "*.spec.js", "*.spec.ts"]:
+            test_files += len(list(self.repo_path.rglob(pattern)))
+
+        if test_files > 0:
+            has_tests = True
+
+        # Check for CI configs
+        ci_files = [
+            ".github/workflows",
+            ".gitlab-ci.yml",
+            ".travis.yml",
+            "Jenkinsfile",
+            ".circleci/config.yml",
+            "azure-pipelines.yml",
+        ]
+        for cf in ci_files:
+            p = self.repo_path / cf
+            if p.exists():
+                ci_configs.append(cf)
+
+        # Check for test runner configs
+        test_configs = []
+        for name in ["pytest.ini", "setup.cfg", "tox.ini", "jest.config.js",
+                      "jest.config.ts", ".mocharc.yml", "karma.conf.js"]:
+            if (self.repo_path / name).exists():
+                test_configs.append(name)
+
+        # Also check pyproject.toml for [tool.pytest]
+        pyproject = self.repo_path / "pyproject.toml"
+        if pyproject.exists():
+            try:
+                content = pyproject.read_text()
+                if "pytest" in content or "tool.pytest" in content:
+                    test_configs.append("pyproject.toml[pytest]")
+            except Exception:
+                pass
+
+        pts = 0
+        if has_tests:
+            pts += 5
+        if ci_configs:
+            pts += 3
+        if test_configs:
+            pts += 2
+        pts = min(pts, 10)
+
+        self.checks["test_evidence"] = {
+            "passed": has_tests,
+            "test_dirs": test_dirs,
+            "test_file_count": test_files,
+            "ci_configs": ci_configs,
+            "test_configs": test_configs,
+        }
+        self.score_breakdown["test_evidence"] = pts
+
+    # ── Check 7: Review Attestation (10 pts) ──────────────────────
+
+    def _check_review(self):
+        """Check review tier attestation level."""
+        pts = 0
+        has_human_sig = False
+
+        if self.tier == "L0":
+            pts = 0
+        elif self.tier == "L1":
+            pts = 5
+        elif self.tier == "L2":
+            if self.reviewer:
+                pts = 10
+                has_human_sig = True
+            else:
+                pts = 5  # L2 claimed but no reviewer = L1 credit
+
+        # Check for existing bcos-attestation.json
+        existing_attestation = None
+        att_path = self.repo_path / "artifacts" / "bcos-attestation.json"
+        if att_path.exists():
+            try:
+                existing_attestation = json.loads(att_path.read_text())
+            except Exception:
+                pass
+
+        self.checks["review_attestation"] = {
+            "tier": self.tier,
+            "reviewer": self.reviewer or None,
+            "has_human_signature": has_human_sig,
+            "existing_attestation": existing_attestation is not None,
+        }
+        self.score_breakdown["review_attestation"] = pts
+
+    # ── Score computation ──────────────────────────────────────────
+
+    def _compute_trust_score(self):
+        """Ensure all scores are capped at their maximums."""
+        for key, max_pts in SCORE_WEIGHTS.items():
+            if key in self.score_breakdown:
+                self.score_breakdown[key] = min(
+                    self.score_breakdown[key], max_pts
+                )
+            else:
+                self.score_breakdown[key] = 0
+
+
+# ── Convenience function ──────────────────────────────────────────
+
+def scan_repo(
+    path: str = ".",
+    tier: str = "L1",
+    reviewer: str = "",
+    commit_sha: str = "",
+) -> dict:
+    """Scan a repository and return BCOS v2 report."""
+    engine = BCOSEngine(path, tier, reviewer, commit_sha)
+    return engine.run_all()
+
+
+# ── CLI ───────────────────────────────────────────────────────────
+
+def _print_report(report: dict, as_json: bool = False):
+    """Pretty-print a BCOS report."""
+    if as_json:
+        print(json.dumps(report, indent=2))
+        return
+
+    score = report["trust_score"]
+    tier = report["tier"]
+    cert_id = report.get("cert_id", "pending")
+    met = report.get("tier_met", False)
+
+    # Color codes
+    GREEN = "\033[32m"
+    RED = "\033[31m"
+    YELLOW = "\033[33m"
+    CYAN = "\033[36m"
+    PURPLE = "\033[35m"
+    BOLD = "\033[1m"
+    DIM = "\033[2m"
+    NC = "\033[0m"
+
+    tier_color = {"L0": GREEN, "L1": CYAN, "L2": PURPLE}.get(tier, CYAN)
+
+    print()
+    print(f"{BOLD}╔══════════════════════════════════════════════════╗{NC}")
+    print(f"{BOLD}║  BCOS v2 — Beacon Certified Open Source          ║{NC}")
+    print(f"{BOLD}╚══════════════════════════════════════════════════╝{NC}")
+    print()
+    print(f"  Repo:       {report.get('repo_name', report['repo_path'])}")
+    print(f"  Commit:     {report['commit_sha'][:12]}")
+    print(f"  Tier:       {tier_color}{tier}{NC} {'✓ met' if met else '✗ not met'}")
+    if report.get("reviewer"):
+        print(f"  Reviewer:   {report['reviewer']}")
+    print(f"  Cert ID:    {BOLD}{cert_id}{NC}")
+    print()
+
+    # Score bar
+    bar_width = 40
+    filled = int(score / 100 * bar_width)
+    bar = "█" * filled + "░" * (bar_width - filled)
+    score_color = GREEN if score >= 80 else YELLOW if score >= 60 else RED
+    print(f"  Trust Score: {score_color}{BOLD}{score}/100{NC}")
+    print(f"  [{score_color}{bar}{NC}]")
+    print()
+
+    # Breakdown table
+    print(f"  {DIM}{'Component':<25} {'Score':>5} {'Max':>5}{NC}")
+    print(f"  {DIM}{'─' * 37}{NC}")
+    for key, max_pts in SCORE_WEIGHTS.items():
+        pts = report["score_breakdown"].get(key, 0)
+        name = key.replace("_", " ").title()
+        color = GREEN if pts >= max_pts * 0.7 else YELLOW if pts >= max_pts * 0.4 else RED
+        print(f"  {name:<25} {color}{pts:>5}{NC} /{max_pts:>4}")
+
+    print()
+
+    # Check details summary
+    for check_name, check_data in report["checks"].items():
+        passed = check_data.get("passed")
+        icon = f"{GREEN}✓{NC}" if passed else f"{RED}✗{NC}" if passed is False else f"{YELLOW}?{NC}"
+        name = check_name.replace("_", " ").title()
+        detail = ""
+
+        if check_name == "license_compliance":
+            detail = f"SPDX {check_data.get('spdx_coverage_pct', 0)}% coverage"
+        elif check_name == "vulnerability_scan":
+            c = check_data.get("critical", 0)
+            h = check_data.get("high", 0)
+            detail = f"{check_data.get('total_vulns', 0)} vulns ({c} crit, {h} high)"
+        elif check_name == "static_analysis":
+            detail = f"{check_data.get('errors', 0)} errors, {check_data.get('warnings', 0)} warnings"
+            if check_data.get("status") == "not_installed":
+                detail = "semgrep not installed"
+        elif check_name == "sbom_completeness":
+            detail = f"{'generated' if check_data.get('sbom_generated') else 'not generated'}, {len(check_data.get('dependency_manifests', []))} manifests"
+        elif check_name == "dependency_freshness":
+            detail = f"{check_data.get('fresh_pct', 0)}% up to date"
+        elif check_name == "test_evidence":
+            detail = f"{check_data.get('test_file_count', 0)} test files, {len(check_data.get('ci_configs', []))} CI configs"
+        elif check_name == "review_attestation":
+            detail = f"tier={check_data.get('tier')}, reviewer={check_data.get('reviewer') or 'none'}"
+
+        print(f"  {icon} {name}: {detail}")
+
+    print()
+    print(f"  {DIM}Commitment: {report.get('commitment', 'pending')[:32]}...{NC}")
+    print(f"  {DIM}Verify: https://rustchain.org/bcos/verify/{cert_id}{NC}")
+    print()
+    print(f"  {DIM}BCOS v2 Engine {report.get('engine_version', '2.0.0')} — Free & Open Source (MIT){NC}")
+    print(f"  {DIM}https://github.com/Scottcjn/Rustchain{NC}")
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="BCOS v2 — Beacon Certified Open Source verification engine"
+    )
+    ap.add_argument("path", nargs="?", default=".", help="Repository path to scan")
+    ap.add_argument("--tier", default="L1", choices=["L0", "L1", "L2"],
+                    help="Claimed certification tier")
+    ap.add_argument("--reviewer", default="", help="Human reviewer name/handle (required for L2)")
+    ap.add_argument("--commit", default="", help="Override commit SHA")
+    ap.add_argument("--json", action="store_true", help="Output raw JSON report")
+    args = ap.parse_args()
+
+    report = scan_repo(args.path, args.tier, args.reviewer, args.commit)
+    _print_report(report, as_json=args.json)
+
+    # Exit code: 0 if tier met, 1 if not
+    return 0 if report.get("tier_met") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/clawrtc/data/fingerprint_checks.py
+++ b/clawrtc/data/fingerprint_checks.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""
+RIP-PoA Hardware Fingerprint Validation
+========================================
+7 Required Checks for RTC Reward Approval
+ALL MUST PASS for antiquity multiplier rewards
+
+Checks:
+1. Clock-Skew & Oscillator Drift
+2. Cache Timing Fingerprint
+3. SIMD Unit Identity
+4. Thermal Drift Entropy
+5. Instruction Path Jitter
+6. Anti-Emulation Behavioral Checks
+7. ROM Fingerprint (retro platforms only)
+"""
+
+import hashlib
+import os
+import platform
+import statistics
+import subprocess
+import time
+from typing import Dict, List, Optional, Tuple
+
+# Import ROM fingerprint database if available
+try:
+    from rom_fingerprint_db import (
+        identify_rom,
+        is_known_emulator_rom,
+        compute_file_hash,
+        detect_platform_roms,
+        get_real_hardware_rom_signature,
+    )
+    ROM_DB_AVAILABLE = True
+except ImportError:
+    ROM_DB_AVAILABLE = False
+
+def check_clock_drift(samples: int = 200) -> Tuple[bool, Dict]:
+    """Check 1: Clock-Skew & Oscillator Drift"""
+    intervals = []
+    reference_ops = 5000
+
+    for i in range(samples):
+        data = "drift_{}".format(i).encode()
+        start = time.perf_counter_ns()
+        for _ in range(reference_ops):
+            hashlib.sha256(data).digest()
+        elapsed = time.perf_counter_ns() - start
+        intervals.append(elapsed)
+        if i % 50 == 0:
+            time.sleep(0.001)
+
+    mean_ns = statistics.mean(intervals)
+    stdev_ns = statistics.stdev(intervals)
+    cv = stdev_ns / mean_ns if mean_ns > 0 else 0
+
+    drift_pairs = [intervals[i] - intervals[i-1] for i in range(1, len(intervals))]
+    drift_stdev = statistics.stdev(drift_pairs) if len(drift_pairs) > 1 else 0
+
+    data = {
+        "mean_ns": int(mean_ns),
+        "stdev_ns": int(stdev_ns),
+        "cv": round(cv, 6),
+        "drift_stdev": int(drift_stdev),
+    }
+
+    valid = True
+    if cv < 0.0001:
+        valid = False
+        data["fail_reason"] = "synthetic_timing"
+    elif drift_stdev == 0:
+        valid = False
+        data["fail_reason"] = "no_drift"
+
+    return valid, data
+
+
+def check_cache_timing(iterations: int = 100) -> Tuple[bool, Dict]:
+    """Check 2: Cache Timing Fingerprint (L1/L2/L3 Latency)"""
+    l1_size = 8 * 1024
+    l2_size = 128 * 1024
+    l3_size = 4 * 1024 * 1024
+
+    def measure_access_time(buffer_size: int, accesses: int = 1000) -> float:
+        buf = bytearray(buffer_size)
+        for i in range(0, buffer_size, 64):
+            buf[i] = i % 256
+        start = time.perf_counter_ns()
+        for i in range(accesses):
+            _ = buf[(i * 64) % buffer_size]
+        elapsed = time.perf_counter_ns() - start
+        return elapsed / accesses
+
+    l1_times = [measure_access_time(l1_size) for _ in range(iterations)]
+    l2_times = [measure_access_time(l2_size) for _ in range(iterations)]
+    l3_times = [measure_access_time(l3_size) for _ in range(iterations)]
+
+    l1_avg = statistics.mean(l1_times)
+    l2_avg = statistics.mean(l2_times)
+    l3_avg = statistics.mean(l3_times)
+
+    l2_l1_ratio = l2_avg / l1_avg if l1_avg > 0 else 0
+    l3_l2_ratio = l3_avg / l2_avg if l2_avg > 0 else 0
+
+    data = {
+        "l1_ns": round(l1_avg, 2),
+        "l2_ns": round(l2_avg, 2),
+        "l3_ns": round(l3_avg, 2),
+        "l2_l1_ratio": round(l2_l1_ratio, 3),
+        "l3_l2_ratio": round(l3_l2_ratio, 3),
+    }
+
+    valid = True
+    if l2_l1_ratio < 1.01 and l3_l2_ratio < 1.01:
+        valid = False
+        data["fail_reason"] = "no_cache_hierarchy"
+    elif l1_avg == 0 or l2_avg == 0 or l3_avg == 0:
+        valid = False
+        data["fail_reason"] = "zero_latency"
+
+    return valid, data
+
+
+def check_simd_identity() -> Tuple[bool, Dict]:
+    """Check 3: SIMD Unit Identity (SSE/AVX/AltiVec/NEON)"""
+    flags = []
+    arch = platform.machine().lower()
+
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            for line in f:
+                if "flags" in line.lower() or "features" in line.lower():
+                    parts = line.split(":")
+                    if len(parts) > 1:
+                        flags = parts[1].strip().split()
+                        break
+    except:
+        pass
+
+    if not flags:
+        try:
+            result = subprocess.run(
+                ["sysctl", "-a"],
+                capture_output=True, text=True, timeout=5
+            )
+            for line in result.stdout.split("\n"):
+                if "feature" in line.lower() or "altivec" in line.lower():
+                    flags.append(line.split(":")[-1].strip())
+        except:
+            pass
+
+    has_sse = any("sse" in f.lower() for f in flags)
+    has_avx = any("avx" in f.lower() for f in flags)
+    has_altivec = any("altivec" in f.lower() for f in flags) or "ppc" in arch
+    has_neon = any("neon" in f.lower() for f in flags) or "arm" in arch
+
+    data = {
+        "arch": arch,
+        "simd_flags_count": len(flags),
+        "has_sse": has_sse,
+        "has_avx": has_avx,
+        "has_altivec": has_altivec,
+        "has_neon": has_neon,
+        "sample_flags": flags[:10] if flags else [],
+    }
+
+    valid = has_sse or has_avx or has_altivec or has_neon or len(flags) > 0
+    if not valid:
+        data["fail_reason"] = "no_simd_detected"
+
+    return valid, data
+
+
+def check_thermal_drift(samples: int = 50) -> Tuple[bool, Dict]:
+    """Check 4: Thermal Drift Entropy"""
+    cold_times = []
+    for i in range(samples):
+        start = time.perf_counter_ns()
+        for _ in range(10000):
+            hashlib.sha256("cold_{}".format(i).encode()).digest()
+        cold_times.append(time.perf_counter_ns() - start)
+
+    for _ in range(100):
+        for __ in range(50000):
+            hashlib.sha256(b"warmup").digest()
+
+    hot_times = []
+    for i in range(samples):
+        start = time.perf_counter_ns()
+        for _ in range(10000):
+            hashlib.sha256("hot_{}".format(i).encode()).digest()
+        hot_times.append(time.perf_counter_ns() - start)
+
+    cold_avg = statistics.mean(cold_times)
+    hot_avg = statistics.mean(hot_times)
+    cold_stdev = statistics.stdev(cold_times)
+    hot_stdev = statistics.stdev(hot_times)
+    drift_ratio = hot_avg / cold_avg if cold_avg > 0 else 0
+
+    data = {
+        "cold_avg_ns": int(cold_avg),
+        "hot_avg_ns": int(hot_avg),
+        "cold_stdev": int(cold_stdev),
+        "hot_stdev": int(hot_stdev),
+        "drift_ratio": round(drift_ratio, 4),
+    }
+
+    valid = True
+    if cold_stdev == 0 and hot_stdev == 0:
+        valid = False
+        data["fail_reason"] = "no_thermal_variance"
+
+    return valid, data
+
+
+def check_instruction_jitter(samples: int = 100) -> Tuple[bool, Dict]:
+    """Check 5: Instruction Path Jitter"""
+    def measure_int_ops(count: int = 10000) -> float:
+        start = time.perf_counter_ns()
+        x = 1
+        for i in range(count):
+            x = (x * 7 + 13) % 65537
+        return time.perf_counter_ns() - start
+
+    def measure_fp_ops(count: int = 10000) -> float:
+        start = time.perf_counter_ns()
+        x = 1.5
+        for i in range(count):
+            x = (x * 1.414 + 0.5) % 1000.0
+        return time.perf_counter_ns() - start
+
+    def measure_branch_ops(count: int = 10000) -> float:
+        start = time.perf_counter_ns()
+        x = 0
+        for i in range(count):
+            if i % 2 == 0:
+                x += 1
+            else:
+                x -= 1
+        return time.perf_counter_ns() - start
+
+    int_times = [measure_int_ops() for _ in range(samples)]
+    fp_times = [measure_fp_ops() for _ in range(samples)]
+    branch_times = [measure_branch_ops() for _ in range(samples)]
+
+    int_avg = statistics.mean(int_times)
+    fp_avg = statistics.mean(fp_times)
+    branch_avg = statistics.mean(branch_times)
+
+    int_stdev = statistics.stdev(int_times)
+    fp_stdev = statistics.stdev(fp_times)
+    branch_stdev = statistics.stdev(branch_times)
+
+    data = {
+        "int_avg_ns": int(int_avg),
+        "fp_avg_ns": int(fp_avg),
+        "branch_avg_ns": int(branch_avg),
+        "int_stdev": int(int_stdev),
+        "fp_stdev": int(fp_stdev),
+        "branch_stdev": int(branch_stdev),
+    }
+
+    valid = True
+    if int_stdev == 0 and fp_stdev == 0 and branch_stdev == 0:
+        valid = False
+        data["fail_reason"] = "no_jitter"
+
+    return valid, data
+
+
+def check_anti_emulation() -> Tuple[bool, Dict]:
+    """Check 6: Anti-Emulation Behavioral Checks
+
+    Detects traditional hypervisors AND cloud provider VMs:
+    - VMware, VirtualBox, KVM, QEMU, Xen, Hyper-V, Parallels
+    - AWS EC2 (Nitro/Xen), GCP, Azure, DigitalOcean
+    - Linode, Vultr, Hetzner, Oracle Cloud, OVH
+    - Cloud metadata endpoints (169.254.169.254)
+
+    Updated 2026-02-21: Added cloud provider detection after
+    discovering AWS t3.medium instances attempting to mine.
+    """
+    vm_indicators = []
+
+    # --- DMI paths to check ---
+    vm_paths = [
+        "/sys/class/dmi/id/product_name",
+        "/sys/class/dmi/id/sys_vendor",
+        "/sys/class/dmi/id/board_vendor",
+        "/sys/class/dmi/id/board_name",
+        "/sys/class/dmi/id/bios_vendor",
+        "/sys/class/dmi/id/chassis_vendor",
+        "/sys/class/dmi/id/chassis_asset_tag",
+        "/proc/scsi/scsi",
+    ]
+
+    # --- VM and cloud provider strings to match ---
+    # Traditional hypervisors
+    vm_strings = [
+        "vmware", "virtualbox", "kvm", "qemu", "xen",
+        "hyperv", "hyper-v", "parallels", "bhyve",
+        # AWS EC2 (Nitro and Xen instances)
+        "amazon", "amazon ec2", "ec2", "nitro",
+        # Google Cloud Platform
+        "google", "google compute engine", "gce",
+        # Microsoft Azure
+        "microsoft corporation", "azure",
+        # DigitalOcean
+        "digitalocean",
+        # Linode (now Akamai)
+        "linode", "akamai",
+        # Vultr
+        "vultr",
+        # Hetzner
+        "hetzner",
+        # Oracle Cloud
+        "oracle", "oraclecloud",
+        # OVH
+        "ovh", "ovhcloud",
+        # Alibaba Cloud
+        "alibaba", "alicloud",
+        # Generic cloud/VM indicators
+        "bochs",  # BIOS often seen in cloud VMs
+        "innotek",  # VirtualBox parent company
+        "seabios",  # Common VM BIOS
+    ]
+
+    for path in vm_paths:
+        try:
+            with open(path, "r") as f:
+                content = f.read().strip().lower()
+                for vm in vm_strings:
+                    if vm in content:
+                        vm_indicators.append("{}:{}".format(path, vm))
+        except:
+            pass
+
+    # --- Environment variable checks ---
+    for key in ["KUBERNETES", "DOCKER", "VIRTUAL", "container",
+                "AWS_EXECUTION_ENV", "ECS_CONTAINER_METADATA_URI",
+                "GOOGLE_CLOUD_PROJECT", "AZURE_FUNCTIONS_ENVIRONMENT",
+                "WEBSITE_INSTANCE_ID"]:
+        if key in os.environ:
+            vm_indicators.append("ENV:{}".format(key))
+
+    # --- CPU hypervisor flag check ---
+    try:
+        with open("/proc/cpuinfo", "r") as f:
+            if "hypervisor" in f.read().lower():
+                vm_indicators.append("cpuinfo:hypervisor")
+    except:
+        pass
+
+    # --- /sys/hypervisor check (Xen-based cloud VMs expose this) ---
+    try:
+        if os.path.exists("/sys/hypervisor/type"):
+            with open("/sys/hypervisor/type", "r") as f:
+                hv_type = f.read().strip().lower()
+                if hv_type:
+                    vm_indicators.append("sys_hypervisor:{}".format(hv_type))
+    except:
+        pass
+
+    # --- Cloud metadata endpoint check ---
+    # AWS, GCP, Azure, DigitalOcean all use 169.254.169.254
+    # A real bare-metal machine will NOT have this endpoint
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            "http://169.254.169.254/",
+            headers={"Metadata": "true"}  # Azure header
+        )
+        resp = urllib.request.urlopen(req, timeout=1)
+        # If we get ANY response, we're on a cloud VM
+        cloud_body = resp.read(512).decode("utf-8", errors="replace").lower()
+        cloud_provider = "unknown_cloud"
+        if "latest" in cloud_body or "meta-data" in cloud_body:
+            cloud_provider = "aws_or_gcp"
+        if "azure" in cloud_body or "microsoft" in cloud_body:
+            cloud_provider = "azure"
+        vm_indicators.append("cloud_metadata:{}".format(cloud_provider))
+    except:
+        pass  # Timeout or connection refused = good (not cloud)
+
+    # --- AWS IMDSv2 check (token-based, t3/t4 instances) ---
+    try:
+        import urllib.request
+        token_req = urllib.request.Request(
+            "http://169.254.169.254/latest/api/token",
+            headers={"X-aws-ec2-metadata-token-ttl-seconds": "5"},
+            method="PUT"
+        )
+        token_resp = urllib.request.urlopen(token_req, timeout=1)
+        if token_resp.status == 200:
+            vm_indicators.append("cloud_metadata:aws_imdsv2")
+    except:
+        pass
+
+    # --- systemd-detect-virt (if available) ---
+    try:
+        result = subprocess.run(
+            ["systemd-detect-virt"], capture_output=True, text=True, timeout=5
+        )
+        virt_type = result.stdout.strip().lower()
+        if virt_type and virt_type != "none":
+            vm_indicators.append("systemd_detect_virt:{}".format(virt_type))
+    except:
+        pass
+
+    data = {
+        "vm_indicators": vm_indicators,
+        "indicator_count": len(vm_indicators),
+        "is_likely_vm": len(vm_indicators) > 0,
+    }
+
+    valid = len(vm_indicators) == 0
+    if not valid:
+        data["fail_reason"] = "vm_detected"
+
+    return valid, data
+
+
+
+def check_rom_fingerprint() -> Tuple[bool, Dict]:
+    """
+    Check 7: ROM Fingerprint (for retro platforms)
+
+    Detects if running with a known emulator ROM dump.
+    Real vintage hardware should have unique/variant ROMs.
+    Emulators all use the same pirated ROM packs.
+    """
+    if not ROM_DB_AVAILABLE:
+        # Skip for modern hardware or if DB not available
+        return True, {"skipped": True, "reason": "rom_db_not_available_or_modern_hw"}
+
+    arch = platform.machine().lower()
+    rom_hashes = {}
+    emulator_detected = False
+    detection_details = []
+
+    # Check for PowerPC (Mac emulation target)
+    if "ppc" in arch or "powerpc" in arch:
+        # Try to get real hardware ROM signature
+        real_rom = get_real_hardware_rom_signature()
+        if real_rom:
+            rom_hashes["real_hardware"] = real_rom
+        else:
+            # Check if running under emulator with known ROM
+            platform_roms = detect_platform_roms()
+            if platform_roms:
+                for platform_name, rom_hash in platform_roms.items():
+                    if is_known_emulator_rom(rom_hash, "md5"):
+                        emulator_detected = True
+                        rom_info = identify_rom(rom_hash, "md5")
+                        detection_details.append({
+                            "platform": platform_name,
+                            "hash": rom_hash,
+                            "known_as": rom_info,
+                        })
+
+    # Check for 68K (Amiga, Atari ST, old Mac)
+    elif "m68k" in arch or "68000" in arch:
+        platform_roms = detect_platform_roms()
+        for platform_name, rom_hash in platform_roms.items():
+            if "amiga" in platform_name.lower():
+                if is_known_emulator_rom(rom_hash, "sha1"):
+                    emulator_detected = True
+                    rom_info = identify_rom(rom_hash, "sha1")
+                    detection_details.append({
+                        "platform": platform_name,
+                        "hash": rom_hash,
+                        "known_as": rom_info,
+                    })
+            elif "mac" in platform_name.lower():
+                if is_known_emulator_rom(rom_hash, "apple"):
+                    emulator_detected = True
+                    rom_info = identify_rom(rom_hash, "apple")
+                    detection_details.append({
+                        "platform": platform_name,
+                        "hash": rom_hash,
+                        "known_as": rom_info,
+                    })
+
+    # For modern hardware, report "N/A" but pass
+    else:
+        return True, {
+            "skipped": False,
+            "arch": arch,
+            "is_retro_platform": False,
+            "rom_check": "not_applicable_modern_hw",
+        }
+
+    data = {
+        "arch": arch,
+        "is_retro_platform": True,
+        "rom_hashes": rom_hashes,
+        "emulator_detected": emulator_detected,
+        "detection_details": detection_details,
+    }
+
+    if emulator_detected:
+        data["fail_reason"] = "known_emulator_rom"
+        return False, data
+
+    return True, data
+
+
+def validate_all_checks(include_rom_check: bool = True) -> Tuple[bool, Dict]:
+    """Run all 7 fingerprint checks. ALL MUST PASS for RTC approval."""
+    results = {}
+    all_passed = True
+
+    checks = [
+        ("clock_drift", "Clock-Skew & Oscillator Drift", check_clock_drift),
+        ("cache_timing", "Cache Timing Fingerprint", check_cache_timing),
+        ("simd_identity", "SIMD Unit Identity", check_simd_identity),
+        ("thermal_drift", "Thermal Drift Entropy", check_thermal_drift),
+        ("instruction_jitter", "Instruction Path Jitter", check_instruction_jitter),
+        ("anti_emulation", "Anti-Emulation Checks", check_anti_emulation),
+    ]
+
+    # Add ROM check for retro platforms
+    if include_rom_check and ROM_DB_AVAILABLE:
+        checks.append(("rom_fingerprint", "ROM Fingerprint (Retro)", check_rom_fingerprint))
+
+    print(f"Running {len(checks)} Hardware Fingerprint Checks...")
+    print("=" * 50)
+
+    total_checks = len(checks)
+    for i, (key, name, func) in enumerate(checks, 1):
+        print(f"\n[{i}/{total_checks}] {name}...")
+        try:
+            passed, data = func()
+        except Exception as e:
+            passed = False
+            data = {"error": str(e)}
+        results[key] = {"passed": passed, "data": data}
+        if not passed:
+            all_passed = False
+        print("  Result: {}".format("PASS" if passed else "FAIL"))
+
+    print("\n" + "=" * 50)
+    print("OVERALL RESULT: {}".format("ALL CHECKS PASSED" if all_passed else "FAILED"))
+
+    if not all_passed:
+        failed = [k for k, v in results.items() if not v["passed"]]
+        print("Failed checks: {}".format(failed))
+
+    return all_passed, results
+
+
+if __name__ == "__main__":
+    import json
+    passed, results = validate_all_checks()
+    print("\n\nDetailed Results:")
+    print(json.dumps(results, indent=2, default=str))

--- a/clawrtc/data/miner.py
+++ b/clawrtc/data/miner.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+RustChain Local Miner — ClawRTC
+Auto-detects hardware, runs fingerprint checks, earns RTC tokens.
+"""
+import os, sys, json, time, hashlib, uuid, requests, socket, subprocess, platform, statistics, re
+from datetime import datetime
+
+# Import fingerprint checks (bundled alongside this file)
+try:
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from fingerprint_checks import validate_all_checks
+    FINGERPRINT_AVAILABLE = True
+except ImportError:
+    FINGERPRINT_AVAILABLE = False
+
+NODE_URL = "https://bulbous-bouffant.metalseed.net"
+BLOCK_TIME = 600  # 10 minutes
+
+class LocalMiner:
+    def __init__(self, wallet=None):
+        self.node_url = NODE_URL
+        self.wallet = wallet or self._gen_wallet()
+        self.hw_info = {}
+        self.enrolled = False
+        self.attestation_valid_until = 0
+        self.last_entropy = {}
+
+        self.fingerprint_data = {}
+
+        print("="*70)
+        print("ClawRTC Miner — RustChain Network")
+        print("="*70)
+        print(f"Node: {self.node_url}")
+        print(f"Wallet: {self.wallet}")
+        print("="*70)
+
+        # Run fingerprint checks on startup
+        if FINGERPRINT_AVAILABLE:
+            print("\nRunning hardware fingerprint checks...")
+            try:
+                all_passed, results = validate_all_checks(include_rom_check=False)
+                self.fingerprint_data = {
+                    "all_passed": all_passed,
+                    "checks": results
+                }
+                if all_passed:
+                    print("All fingerprint checks PASSED")
+                else:
+                    failed = [k for k, v in results.items() if not v.get("passed")]
+                    print(f"WARNING: Fingerprint checks failed: {failed}")
+            except Exception as e:
+                print(f"Fingerprint checks error: {e}")
+                self.fingerprint_data = {"all_passed": False, "error": str(e)}
+        else:
+            print("Fingerprint checks not available (fingerprint_checks.py not found)")
+
+    def _gen_wallet(self):
+        data = f"claw-{uuid.uuid4().hex}-{time.time()}"
+        return hashlib.sha256(data.encode()).hexdigest()[:38] + "RTC"
+
+    def _run_cmd(self, cmd):
+        try:
+            return subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                text=True, timeout=10, shell=True).stdout.strip()
+        except:
+            return ""
+
+    def _get_mac_addresses(self):
+        """Return list of real MAC addresses present on the system."""
+        macs = []
+        # Try `ip -o link`
+        try:
+            output = subprocess.run(
+                ["ip", "-o", "link"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=5,
+            ).stdout.splitlines()
+            for line in output:
+                m = re.search(r"link/(?:ether|loopback)\s+([0-9a-f:]{17})", line, re.IGNORECASE)
+                if m:
+                    mac = m.group(1).lower()
+                    if mac != "00:00:00:00:00:00":
+                        macs.append(mac)
+        except Exception:
+            pass
+
+        # Fallback to ifconfig
+        if not macs:
+            try:
+                output = subprocess.run(
+                    ["ifconfig", "-a"],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                    text=True,
+                    timeout=5,
+                ).stdout.splitlines()
+                for line in output:
+                    m = re.search(r"(?:ether|HWaddr)\s+([0-9a-f:]{17})", line, re.IGNORECASE)
+                    if m:
+                        mac = m.group(1).lower()
+                        if mac != "00:00:00:00:00:00":
+                            macs.append(mac)
+            except Exception:
+                pass
+
+        return macs or ["00:00:00:00:00:01"]
+
+    def _collect_entropy(self, cycles: int = 48, inner_loop: int = 25000):
+        """
+        Collect simple timing entropy by measuring tight CPU loops.
+        Returns summary statistics the node can score.
+        """
+        samples = []
+        for _ in range(cycles):
+            start = time.perf_counter_ns()
+            acc = 0
+            for j in range(inner_loop):
+                acc ^= (j * 31) & 0xFFFFFFFF
+            duration = time.perf_counter_ns() - start
+            samples.append(duration)
+
+        mean_ns = sum(samples) / len(samples)
+        variance_ns = statistics.pvariance(samples) if len(samples) > 1 else 0.0
+
+        return {
+            "mean_ns": mean_ns,
+            "variance_ns": variance_ns,
+            "min_ns": min(samples),
+            "max_ns": max(samples),
+            "sample_count": len(samples),
+            "samples_preview": samples[:12],
+        }
+
+    def _detect_arch(self):
+        """Detect hardware architecture for RustChain multiplier classification."""
+        machine = platform.machine().lower()
+        cpu = self._run_cmd("lscpu | grep 'Model name' | cut -d: -f2 | xargs") or ""
+        cpu_lower = cpu.lower()
+
+        if "ppc" in machine or "powerpc" in machine:
+            if "g5" in cpu_lower or "970" in cpu_lower:
+                return "x86", "g5"
+            elif "g4" in cpu_lower or "7450" in cpu_lower or "7447" in cpu_lower:
+                return "x86", "g4"
+            elif "g3" in cpu_lower or "750" in cpu_lower:
+                return "x86", "g3"
+            return "powerpc", "powerpc"
+        elif "arm" in machine or "aarch64" in machine:
+            if platform.system() == "Darwin":
+                brand = self._run_cmd("sysctl -n machdep.cpu.brand_string") or ""
+                if any(x in brand.lower() for x in ["m1", "m2", "m3", "m4"]):
+                    return "arm", "apple_silicon"
+            return "arm", "modern"
+        else:
+            if "core 2" in cpu_lower or "core2" in cpu_lower:
+                return "x86", "core2duo"
+            elif "pentium" in cpu_lower:
+                return "x86", "pentium4"
+            return "x86", "modern"
+
+    def _get_hw_info(self):
+        """Collect hardware info with auto-detection."""
+        family, arch = self._detect_arch()
+        hw = {
+            "platform": platform.system(),
+            "machine": platform.machine(),
+            "hostname": socket.gethostname(),
+            "family": family,
+            "arch": arch,
+        }
+
+        # Get CPU
+        cpu = self._run_cmd("lscpu | grep 'Model name' | cut -d: -f2 | xargs")
+        hw["cpu"] = cpu or "Unknown"
+
+        # Get cores
+        cores = self._run_cmd("nproc")
+        hw["cores"] = int(cores) if cores else 6
+
+        # Get memory
+        mem = self._run_cmd("free -g | grep Mem | awk '{print $2}'")
+        hw["memory_gb"] = int(mem) if mem else 32
+
+        # Get MACs (ensures PoA signal uses real hardware data)
+        macs = self._get_mac_addresses()
+        hw["macs"] = macs
+        hw["mac"] = macs[0]
+
+        self.hw_info = hw
+        return hw
+
+    def attest(self):
+        """Hardware attestation"""
+        print(f"\n🔐 [{datetime.now().strftime('%H:%M:%S')}] Attesting...")
+
+        self._get_hw_info()
+
+        try:
+            # Get challenge
+            resp = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10)
+            if resp.status_code != 200:
+                print(f"❌ Challenge failed: {resp.status_code}")
+                return False
+
+            challenge = resp.json()
+            nonce = challenge.get("nonce")
+            print(f"✅ Got challenge nonce")
+
+        except Exception as e:
+            print(f"❌ Challenge error: {e}")
+            return False
+
+        # Collect entropy just before signing the report
+        entropy = self._collect_entropy()
+        self.last_entropy = entropy
+
+        # Submit attestation
+        attestation = {
+            "miner": self.wallet,
+            "miner_id": f"claw-{self.hw_info['hostname']}",
+            "nonce": nonce,
+            "report": {
+                "nonce": nonce,
+                "commitment": hashlib.sha256(
+                    (nonce + self.wallet + json.dumps(entropy, sort_keys=True)).encode()
+                ).hexdigest(),
+                "derived": entropy,
+                "entropy_score": entropy.get("variance_ns", 0.0)
+            },
+            "device": {
+                "family": self.hw_info["family"],
+                "arch": self.hw_info["arch"],
+                "model": self.hw_info.get("cpu", "Unknown"),
+                "cpu": self.hw_info["cpu"],
+                "cores": self.hw_info["cores"],
+                "memory_gb": self.hw_info["memory_gb"]
+            },
+            "signals": {
+                "macs": self.hw_info.get("macs", [self.hw_info["mac"]]),
+                "hostname": self.hw_info["hostname"]
+            },
+            "fingerprint": self.fingerprint_data if self.fingerprint_data else None
+        }
+
+        try:
+            resp = requests.post(f"{self.node_url}/attest/submit",
+                               json=attestation, timeout=30)
+
+            if resp.status_code == 200:
+                result = resp.json()
+                if result.get("ok"):
+                    self.attestation_valid_until = time.time() + 580
+                    print(f"✅ Attestation accepted!")
+                    print(f"   CPU: {self.hw_info['cpu']}")
+                    print(f"   Arch: {self.hw_info['family']}/{self.hw_info['arch']}")
+                    fp_status = "PASSED" if self.fingerprint_data.get("all_passed") else "N/A"
+                    print(f"   Fingerprint: {fp_status}")
+                    return True
+                else:
+                    print(f"❌ Rejected: {result}")
+            else:
+                print(f"❌ HTTP {resp.status_code}: {resp.text[:200]}")
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+
+        return False
+
+    def enroll(self):
+        """Enroll in epoch"""
+        if time.time() >= self.attestation_valid_until:
+            print(f"📝 Attestation expired, re-attesting...")
+            if not self.attest():
+                return False
+
+        print(f"\n📝 [{datetime.now().strftime('%H:%M:%S')}] Enrolling...")
+
+        payload = {
+            "miner_pubkey": self.wallet,
+            "miner_id": f"claw-{self.hw_info['hostname']}",
+            "device": {
+                "family": self.hw_info["family"],
+                "arch": self.hw_info["arch"]
+            }
+        }
+
+        try:
+            resp = requests.post(f"{self.node_url}/epoch/enroll",
+                                json=payload, timeout=30)
+
+            if resp.status_code == 200:
+                result = resp.json()
+                if result.get("ok"):
+                    self.enrolled = True
+                    weight = result.get('weight', 1.0)
+                    print(f"✅ Enrolled!")
+                    print(f"   Epoch: {result.get('epoch')}")
+                    print(f"   Weight: {weight}x")
+                    return True
+                else:
+                    print(f"❌ Failed: {result}")
+            else:
+                error_data = resp.json() if resp.headers.get('content-type') == 'application/json' else {}
+                print(f"❌ HTTP {resp.status_code}: {error_data.get('error', resp.text[:200])}")
+
+        except Exception as e:
+            print(f"❌ Error: {e}")
+
+        return False
+
+    def check_balance(self):
+        """Check balance"""
+        try:
+            resp = requests.get(f"{self.node_url}/balance/{self.wallet}", timeout=10)
+            if resp.status_code == 200:
+                result = resp.json()
+                balance = result.get('balance_rtc', 0)
+                print(f"\n💰 Balance: {balance} RTC")
+                return balance
+        except:
+            pass
+        return 0
+
+    def mine(self):
+        """Start mining"""
+        print(f"\n⛏️  Starting mining...")
+        print(f"Block time: {BLOCK_TIME//60} minutes")
+        print(f"Press Ctrl+C to stop\n")
+
+        # Save wallet
+        with open("/tmp/local_miner_wallet.txt", "w") as f:
+            f.write(self.wallet)
+        print(f"💾 Wallet saved to: /tmp/local_miner_wallet.txt\n")
+
+        cycle = 0
+
+        try:
+            while True:
+                cycle += 1
+                print(f"\n{'='*70}")
+                print(f"Cycle #{cycle} - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+                print(f"{'='*70}")
+
+                if self.enroll():
+                    print(f"⏳ Mining for {BLOCK_TIME//60} minutes...")
+
+                    for i in range(BLOCK_TIME // 30):
+                        time.sleep(30)
+                        elapsed = (i + 1) * 30
+                        remaining = BLOCK_TIME - elapsed
+                        print(f"   ⏱️  {elapsed}s elapsed, {remaining}s remaining...")
+
+                    self.check_balance()
+
+                else:
+                    print("❌ Enrollment failed. Retrying in 60s...")
+                    time.sleep(60)
+
+        except KeyboardInterrupt:
+            print(f"\n\n⛔ Mining stopped")
+            print(f"   Wallet: {self.wallet}")
+            self.check_balance()
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--wallet", help="Wallet address")
+    args = parser.parse_args()
+
+    miner = LocalMiner(wallet=args.wallet)
+    miner.mine()

--- a/clawrtc/data/pow_miners.py
+++ b/clawrtc/data/pow_miners.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""
+RustChain Dual-Mining: PoW Miner Detection & Proof Generation
+
+Detects running PoW miners (Ergo, Warthog, Kaspa, Monero, etc.)
+and generates proof of parallel mining for RTC bonus multipliers.
+
+RIP-PoA attestation costs ZERO compute — it's just hardware fingerprinting.
+PoW miners keep 100% of CPU/GPU for hashing. RTC is free bonus income.
+
+Supported chains:
+  - Ergo (Autolykos2) — CPU/GPU mineable
+  - Warthog (Janushash) — CPU mineable
+  - Kaspa (kHeavyHash) — GPU mineable
+  - Monero (RandomX) — CPU mineable
+  - Zephyr (RandomX) — CPU mineable
+  - Alephium (Blake3) — CPU/GPU mineable
+  - Verus (VerusHash 2.2) — CPU mineable
+  - Neoxa (KawPow) — GPU mineable
+  - DERO (AstroBWT) — CPU mineable
+  - Raptoreum (GhostRider) — CPU mineable
+  - Wownero (RandomX) — CPU mineable
+  - Salvium (RandomX) — CPU mineable
+  - Conceal (CryptoNight-GPU) — GPU mineable
+  - Scala (RandomX) — CPU mineable
+  - Generic — any coin with HTTP stats API
+
+Bonus multipliers (stacking with hardware weight):
+  - Node RPC proof:     1.5x (local node running + responding)
+  - Pool account proof: 1.3x (third-party verified hashrate)
+  - Process detection:  1.15x (miner process running)
+"""
+
+import hashlib
+import json
+import os
+import platform
+import subprocess
+import time
+from typing import Dict, List, Optional, Tuple
+
+
+# ============================================================
+# Known PoW Miner Signatures
+# ============================================================
+
+KNOWN_MINERS = {
+    "ergo": {
+        "display": "Ergo (Autolykos2)",
+        "algo": "autolykos2",
+        "node_ports": [9053, 9052],
+        "process_names": [
+            "ergo.jar", "ergo-node", "nanominer", "lolminer",
+            "trex", "gminer", "teamredminer",
+        ],
+        "node_info_path": "/info",
+        "pool_api_templates": {
+            "herominers": "https://ergo.herominers.com/api/stats_address?address={address}",
+            "woolypooly": "https://api.woolypooly.com/api/ergo-0/accounts/{address}",
+            "nanopool": "https://api.nanopool.org/v1/ergo/user/{address}",
+            "2miners": "https://erg.2miners.com/api/accounts/{address}",
+        },
+    },
+    "warthog": {
+        "display": "Warthog (Janushash)",
+        "algo": "janushash",
+        "node_ports": [3000, 3001],
+        "process_names": ["wart-miner", "warthog-miner", "wart-node", "janushash"],
+        "node_info_path": "/chain/head",
+        "pool_api_templates": {
+            "woolypooly": "https://api.woolypooly.com/api/wart-0/accounts/{address}",
+            "acc-pool": "https://warthog.acc-pool.pw/api/accounts/{address}",
+        },
+    },
+    "kaspa": {
+        "display": "Kaspa (kHeavyHash)",
+        "algo": "kheavyhash",
+        "node_ports": [16110, 16210],
+        "process_names": ["kaspad", "kaspa-miner", "bzminer", "lolminer", "iceriver"],
+        "node_info_path": "/info/getInfo",
+        "pool_api_templates": {
+            "acc-pool": "https://kaspa.acc-pool.pw/api/accounts/{address}",
+            "woolypooly": "https://api.woolypooly.com/api/kas-0/accounts/{address}",
+        },
+    },
+    "monero": {
+        "display": "Monero (RandomX)",
+        "algo": "randomx",
+        "node_ports": [18081, 18082],
+        "process_names": ["xmrig", "monerod", "p2pool", "xmr-stak"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "p2pool": "http://localhost:18083/local/stats",
+            "herominers": "https://monero.herominers.com/api/stats_address?address={address}",
+            "nanopool": "https://api.nanopool.org/v1/xmr/user/{address}",
+        },
+    },
+    "zephyr": {
+        "display": "Zephyr (RandomX)",
+        "algo": "randomx",
+        "node_ports": [17767],
+        "process_names": ["xmrig", "zephyrd"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "herominers": "https://zephyr.herominers.com/api/stats_address?address={address}",
+        },
+    },
+    "alephium": {
+        "display": "Alephium (Blake3)",
+        "algo": "blake3",
+        "node_ports": [12973],
+        "process_names": ["alephium", "alph-miner", "bzminer"],
+        "node_info_path": "/infos/self-clique",
+        "pool_api_templates": {
+            "herominers": "https://alephium.herominers.com/api/stats_address?address={address}",
+            "woolypooly": "https://api.woolypooly.com/api/alph-0/accounts/{address}",
+        },
+    },
+    "verus": {
+        "display": "Verus (VerusHash 2.2)",
+        "algo": "verushash",
+        "node_ports": [27486],
+        "process_names": ["verusd", "ccminer", "nheqminer"],
+        "node_info_path": "/",
+        "pool_api_templates": {
+            "luckpool": "https://luckpool.net/verus/miner/{address}",
+        },
+    },
+    "neoxa": {
+        "display": "Neoxa (KawPow)",
+        "algo": "kawpow",
+        "node_ports": [8788],
+        "process_names": ["neoxad", "trex", "gminer", "nbminer"],
+        "node_info_path": "/",
+        "pool_api_templates": {},
+    },
+    "dero": {
+        "display": "DERO (AstroBWT)",
+        "algo": "astrobwt",
+        "node_ports": [10102, 20206],
+        "process_names": ["derod", "dero-miner", "dero-stratum-miner", "astrobwt-miner"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "dero-node": "http://127.0.0.1:10102/json_rpc",
+        },
+    },
+    "raptoreum": {
+        "display": "Raptoreum (GhostRider)",
+        "algo": "ghostrider",
+        "node_ports": [10225, 10226],
+        "process_names": ["raptoreumd", "cpuminer", "cpuminer-gr", "ghostrider"],
+        "node_info_path": "/",
+        "pool_api_templates": {
+            "flockpool": "https://flockpool.com/api/v1/wallets/{address}",
+            "suprnova": "https://rtm.suprnova.cc/api/wallets/{address}",
+        },
+    },
+    "wownero": {
+        "display": "Wownero (RandomX)",
+        "algo": "randomx",
+        "node_ports": [34568],
+        "process_names": ["wownerod", "xmrig", "wownero-wallet"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "herominers": "https://wownero.herominers.com/api/stats_address?address={address}",
+        },
+    },
+    "salvium": {
+        "display": "Salvium (RandomX)",
+        "algo": "randomx",
+        "node_ports": [19734],
+        "process_names": ["salviumd", "xmrig", "salvium-wallet"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "herominers": "https://salvium.herominers.com/api/stats_address?address={address}",
+        },
+    },
+    "conceal": {
+        "display": "Conceal (CryptoNight-GPU)",
+        "algo": "cryptonight-gpu",
+        "node_ports": [16000],
+        "process_names": ["conceald", "xmrig", "conceal-wallet"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "herominers": "https://conceal.herominers.com/api/stats_address?address={address}",
+        },
+    },
+    "scala": {
+        "display": "Scala (RandomX)",
+        "algo": "randomx",
+        "node_ports": [11812],
+        "process_names": ["scalad", "xmrig", "scala-wallet"],
+        "node_info_path": "/json_rpc",
+        "pool_api_templates": {
+            "herominers": "https://scala.herominers.com/api/stats_address?address={address}",
+        },
+    },
+}
+
+POW_BONUS = {
+    "node_rpc": 1.5,
+    "pool_account": 1.3,
+    "process_only": 1.15,
+}
+
+
+# ============================================================
+# Detection Functions
+# ============================================================
+
+def detect_running_miners() -> List[Dict]:
+    """Auto-detect all running PoW miners on this machine."""
+    detected = []
+    running_procs = _get_running_processes()
+
+    for chain, info in KNOWN_MINERS.items():
+        detection = {
+            "chain": chain,
+            "display": info["display"],
+            "algo": info["algo"],
+            "process_found": False,
+            "node_responding": False,
+            "node_port": None,
+            "proof_type": None,
+        }
+
+        for proc_name in info["process_names"]:
+            if proc_name.lower() in running_procs:
+                detection["process_found"] = True
+                detection["matched_process"] = proc_name
+                break
+
+        for port in info["node_ports"]:
+            if _check_port_open(port):
+                detection["node_responding"] = True
+                detection["node_port"] = port
+                break
+
+        if detection["process_found"] or detection["node_responding"]:
+            if detection["node_responding"]:
+                detection["proof_type"] = "node_rpc"
+            else:
+                detection["proof_type"] = "process_only"
+            detected.append(detection)
+
+    return detected
+
+
+def _get_running_processes() -> str:
+    """Get lowercase string of all running process names."""
+    try:
+        if platform.system() == "Windows":
+            result = subprocess.run(
+                ["tasklist", "/fo", "csv", "/nh"],
+                capture_output=True, text=True, timeout=5,
+            )
+        else:
+            result = subprocess.run(
+                ["ps", "aux"],
+                capture_output=True, text=True, timeout=5,
+            )
+        return result.stdout.lower()
+    except Exception:
+        return ""
+
+
+def _check_port_open(port: int, host: str = "127.0.0.1") -> bool:
+    """Check if a local port is open (node running)."""
+    import socket
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(1)
+        result = sock.connect_ex((host, port))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
+
+
+# ============================================================
+# Proof Generation
+# ============================================================
+
+def generate_pow_proof(
+    chain: str,
+    nonce: str,
+    pool_address: Optional[str] = None,
+    pool_name: Optional[str] = None,
+) -> Optional[Dict]:
+    """Generate PoW mining proof for a specific chain.
+
+    Args:
+        chain: Chain name (ergo, warthog, kaspa, monero, etc.)
+        nonce: Attestation nonce from RustChain server (binds proof)
+        pool_address: Optional mining address for pool verification
+        pool_name: Optional pool name (herominers, woolypooly, etc.)
+
+    Returns:
+        Proof dict or None if detection failed.
+    """
+    if chain not in KNOWN_MINERS:
+        return None
+
+    info = KNOWN_MINERS[chain]
+    proof = {
+        "chain": chain,
+        "algo": info["algo"],
+        "timestamp": int(time.time()),
+        "nonce_binding": hashlib.sha256(
+            f"{nonce}:{chain}:{int(time.time())}".encode()
+        ).hexdigest(),
+    }
+
+    # Try node RPC first (best proof)
+    node_proof = _probe_node_rpc(chain, info, nonce)
+    if node_proof:
+        proof["proof_type"] = "node_rpc"
+        proof["node_rpc"] = node_proof
+        proof["bonus_multiplier"] = POW_BONUS["node_rpc"]
+        return proof
+
+    # Try pool account verification
+    if pool_address and pool_name:
+        pool_proof = _verify_pool_account(chain, info, pool_address, pool_name)
+        if pool_proof:
+            proof["proof_type"] = "pool_account"
+            proof["pool_account"] = pool_proof
+            proof["bonus_multiplier"] = POW_BONUS["pool_account"]
+            return proof
+
+    # Fallback: process detection only
+    procs = _get_running_processes()
+    for proc_name in info["process_names"]:
+        if proc_name.lower() in procs:
+            proof["proof_type"] = "process_only"
+            proof["process_detected"] = proc_name
+            proof["bonus_multiplier"] = POW_BONUS["process_only"]
+            return proof
+
+    return None
+
+
+def _probe_node_rpc(chain: str, info: Dict, nonce: str) -> Optional[Dict]:
+    """Query local node RPC for mining proof."""
+    try:
+        import requests
+    except ImportError:
+        return None
+
+    for port in info["node_ports"]:
+        try:
+            url = f"http://127.0.0.1:{port}"
+
+            if chain == "ergo":
+                resp = requests.get(f"{url}/info", timeout=3)
+                if resp.status_code == 200:
+                    ni = resp.json()
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": ni.get("fullHeight", 0),
+                        "best_block": ni.get("bestFullHeaderId", ""),
+                        "peers_count": ni.get("peersCount", 0),
+                        "is_mining": ni.get("isMining", False),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(ni, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "warthog":
+                resp = requests.get(f"{url}/chain/head", timeout=3)
+                if resp.status_code == 200:
+                    head = resp.json()
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": head.get("height", 0),
+                        "best_block": head.get("hash", ""),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(head, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "kaspa":
+                resp = requests.post(url, json={
+                    "jsonrpc": "2.0", "method": "getInfo", "id": 1,
+                }, timeout=3)
+                if resp.status_code == 200:
+                    r = resp.json().get("result", {})
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": r.get("headerCount", 0),
+                        "is_synced": r.get("isSynced", False),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(r, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain in ("monero", "zephyr", "wownero", "salvium", "conceal", "scala"):
+                resp = requests.post(f"{url}/json_rpc", json={
+                    "jsonrpc": "2.0", "method": "get_info", "id": 1,
+                }, timeout=3)
+                if resp.status_code == 200:
+                    r = resp.json().get("result", {})
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": r.get("height", 0),
+                        "difficulty": r.get("difficulty", 0),
+                        "tx_pool_size": r.get("tx_pool_size", 0),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(r, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "dero":
+                resp = requests.post(f"{url}/json_rpc", json={
+                    "jsonrpc": "2.0", "method": "DERO.GetInfo", "id": 1,
+                }, timeout=3)
+                if resp.status_code == 200:
+                    r = resp.json().get("result", {})
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": r.get("topoheight", 0),
+                        "stableheight": r.get("stableheight", 0),
+                        "network_hashrate": r.get("difficulty", 0),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(r, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "raptoreum":
+                resp = requests.post(url, json={
+                    "jsonrpc": "1.0", "method": "getmininginfo",
+                    "params": [], "id": 1,
+                }, timeout=3)
+                if resp.status_code == 200:
+                    r = resp.json().get("result", {})
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": r.get("blocks", 0),
+                        "network_hashrate": r.get("networkhashps", 0),
+                        "difficulty": r.get("difficulty", 0),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(r, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "alephium":
+                resp = requests.get(f"{url}/infos/self-clique", timeout=3)
+                if resp.status_code == 200:
+                    c = resp.json()
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "clique_id": c.get("cliqueId", ""),
+                        "nodes": len(c.get("nodes", [])),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(c, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            elif chain == "verus":
+                resp = requests.post(url, json={
+                    "jsonrpc": "1.0", "method": "getmininginfo",
+                    "params": [], "id": 1,
+                }, timeout=3)
+                if resp.status_code == 200:
+                    r = resp.json().get("result", {})
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "chain_height": r.get("blocks", 0),
+                        "network_hashrate": r.get("networkhashps", 0),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{json.dumps(r, sort_keys=True)}".encode()
+                        ).hexdigest(),
+                    }
+
+            else:
+                resp = requests.get(
+                    f"{url}{info['node_info_path']}", timeout=3,
+                )
+                if resp.status_code == 200:
+                    return {
+                        "endpoint": f"localhost:{port}",
+                        "raw_response_hash": hashlib.sha256(
+                            resp.content
+                        ).hexdigest(),
+                        "proof_hash": hashlib.sha256(
+                            f"{nonce}:{resp.text[:1000]}".encode()
+                        ).hexdigest(),
+                    }
+
+        except Exception:
+            continue
+
+    return None
+
+
+def _verify_pool_account(
+    chain: str, info: Dict, address: str, pool_name: str,
+) -> Optional[Dict]:
+    """Verify miner has active pool account with hashrate."""
+    try:
+        import requests
+    except ImportError:
+        return None
+
+    templates = info.get("pool_api_templates", {})
+    template = templates.get(pool_name)
+    if not template:
+        return None
+
+    try:
+        url = template.format(address=address)
+        resp = requests.get(url, timeout=10)
+        if resp.status_code != 200:
+            return None
+
+        data = resp.json()
+        hashrate = 0
+        last_share = 0
+
+        if isinstance(data, dict):
+            hashrate = (
+                data.get("stats", {}).get("hashrate", 0)
+                or data.get("hashrate", 0)
+                or data.get("currentHashrate", 0)
+                or 0
+            )
+            last_share = (
+                data.get("stats", {}).get("lastShare", 0)
+                or data.get("lastShare", 0)
+                or 0
+            )
+
+        if last_share > 0 and (time.time() - last_share) > 10800:
+            return None
+        if hashrate <= 0:
+            return None
+
+        return {
+            "pool": pool_name,
+            "address": address,
+            "hashrate": hashrate,
+            "last_share_ts": last_share,
+            "response_hash": hashlib.sha256(resp.content).hexdigest(),
+            "verified_at": int(time.time()),
+        }
+    except Exception:
+        return None
+
+
+# ============================================================
+# CLI Display Helpers
+# ============================================================
+
+def print_detection_report(detected: List[Dict]):
+    """Pretty-print detected PoW miners."""
+    if not detected:
+        print("  No PoW miners detected on this machine.")
+        print("  Tip: Start your PoW miner first, then run clawrtc.")
+        print("  Supported chains:")
+        for info in KNOWN_MINERS.values():
+            print(f"    - {info['display']}")
+        return
+
+    print(f"  Found {len(detected)} PoW miner(s):")
+    for d in detected:
+        tag = "NODE" if d["node_responding"] else "PROCESS"
+        bonus = POW_BONUS.get(d["proof_type"], 1.0)
+        print(f"    [{tag}] {d['display']}")
+        if d.get("node_port"):
+            print(f"           Node: localhost:{d['node_port']}")
+        if d.get("matched_process"):
+            print(f"           Process: {d['matched_process']}")
+        print(f"           RTC Bonus: {bonus}x multiplier")
+
+
+def get_supported_chains() -> List[str]:
+    return list(KNOWN_MINERS.keys())
+
+
+def get_chain_info(chain: str) -> Optional[Dict]:
+    return KNOWN_MINERS.get(chain)
+
+
+# ============================================================
+# Main (standalone test)
+# ============================================================
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("RustChain Dual-Mining: PoW Miner Detection")
+    print("=" * 60)
+    print()
+
+    print("[1] Scanning for running PoW miners...")
+    detected = detect_running_miners()
+    print_detection_report(detected)
+    print()
+
+    if detected:
+        print("[2] Generating proof for detected miners...")
+        test_nonce = hashlib.sha256(b"test_nonce").hexdigest()
+        for d in detected:
+            proof = generate_pow_proof(d["chain"], test_nonce)
+            if proof:
+                print(f"  {d['display']}: {proof['proof_type']} proof")
+                print(f"    Bonus: {proof['bonus_multiplier']}x")
+                nr = proof.get("node_rpc", {})
+                if nr.get("chain_height"):
+                    print(f"    Chain height: {nr['chain_height']}")
+            else:
+                print(f"  {d['display']}: proof generation failed")
+    else:
+        print("[2] No miners to generate proof for.")
+
+    print()
+    print("Usage with clawrtc:")
+    print("  clawrtc mine --pow           # Auto-detect PoW miners")
+    print("  clawrtc mine --pow ergo      # Specify chain")
+    print("  clawrtc mine --pow monero --pool-address ADDR --pool herominers")


### PR DESCRIPTION
Fixes #5217

## Problem
When users try `clawrtc mine --dry-run` on Windows, the command fails with `Unsupported platform: Windows` because the platform check runs before the `--dry-run` early return in `cmd_install`.

## Changes
1. **cmd_install**: Moved `--dry-run` early return before platform check, so Windows users can preview installation steps
2. **cmd_mine**: Added explicit Windows dry-run support — shows warning about Windows not supporting actual mining, but allows preview
3. **Help text**: Clarified that `--dry-run` is Windows-safe in both `install` and `mine` commands