### PR TITLE
[UTXO-BUG] Reject invalid output metadata before mempool admission

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -940,6 +940,85 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_mempool_rejects_non_string_output_metadata(self):
+        """Mempool must reject metadata that cannot persist to SQLite text.
+
+        A dict-valued tokens_json is JSON-serializable, so the old mempool
+        admission path accepted it and locked the input. Block production then
+        failed when apply_transaction tried to bind the dict into SQLite.
+        """
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'meta' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{
+                'address': 'bob',
+                'value_nrtc': 50 * UNIT,
+                'tokens_json': {'TOKEN': 1},
+            }],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+
+    def test_mempool_rejects_malformed_output_metadata_json(self):
+        """Mempool must reject malformed or wrong-shaped metadata JSON."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        bad_outputs = [
+            {'address': 'bob', 'value_nrtc': 50 * UNIT,
+             'tokens_json': 'not-json'},
+            {'address': 'bob', 'value_nrtc': 50 * UNIT,
+             'tokens_json': '{}'},
+            {'address': 'bob', 'value_nrtc': 50 * UNIT,
+             'registers_json': '[]'},
+        ]
+
+        for idx, output in enumerate(bad_outputs):
+            tx = {
+                'tx_id': f'bad{idx}' * 16,
+                'tx_type': 'transfer',
+                'inputs': [{'box_id': boxes[0]['box_id']}],
+                'outputs': [output],
+                'fee_nrtc': 0,
+            }
+            ok = self.db.mempool_add(tx)
+            self.assertFalse(ok, output)
+
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+
+    def test_apply_transaction_rejects_invalid_output_metadata(self):
+        """Direct application must fail closed on invalid output metadata."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{
+                'address': 'bob',
+                'value_nrtc': 50 * UNIT,
+                'registers_json': {'R4': 1},
+            }],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     # -- bounty #2819: negative / zero value outputs -------------------------
 
     def test_negative_value_output_rejected(self):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -385,6 +385,30 @@ class UtxoDB:
 
         return True
 
+    def _output_metadata_is_valid(self, output: Any) -> bool:
+        """Validate optional JSON text fields before DB persistence."""
+        if not isinstance(output, dict):
+            return False
+
+        metadata_shapes = (
+            ('tokens_json', list),
+            ('registers_json', dict),
+        )
+        for field, expected_type in metadata_shapes:
+            if field not in output:
+                continue
+            raw = output[field]
+            if not isinstance(raw, str):
+                return False
+            try:
+                parsed = json.loads(raw)
+            except (TypeError, json.JSONDecodeError):
+                return False
+            if not isinstance(parsed, expected_type):
+                return False
+
+        return True
+
     # -- transaction application ---------------------------------------------
 
     def apply_transaction(self, tx: dict, block_height: int,
@@ -501,6 +525,8 @@ class UtxoDB:
             # transaction can split one UTXO into thousands of 1-nanoRTC
             # boxes and permanently bloat the UTXO set.
             for o in outputs:
+                if not self._output_metadata_is_valid(o):
+                    return abort()
                 val = o.get('value_nrtc')
                 if (
                     isinstance(val, bool)
@@ -851,6 +877,10 @@ class UtxoDB:
             # unmineable transactions enter the mempool and lock UTXOs until
             # expiry (DoS vector).
             for o in outputs:
+                if not self._output_metadata_is_valid(o):
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
+                    return False
                 val = o.get('value_nrtc')
                 if isinstance(val, bool) or not isinstance(val, int) or val < DUST_THRESHOLD:
                     if manage_tx:


### PR DESCRIPTION
## BCOS Checklist

- [x] Add a tier label: `BCOS-L1`
- [x] No new code files were added; existing SPDX headers unchanged
- [x] Test evidence is included below

## What Changed

- Added UTXO output metadata validation for optional `tokens_json` and `registers_json` fields before transaction application or mempool admission.
- Rejects non-string metadata, malformed JSON, and wrong-shaped JSON (`tokens_json` must decode to a list; `registers_json` must decode to a dict).
- Added regressions proving malformed metadata cannot lock inputs in `utxo_mempool_inputs`, cannot remain as block candidates, and cannot mutate balances through direct `apply_transaction()`.

## Root Cause / Impact

`mempool_add()` validated UTXO input existence, fees, output counts, and `value_nrtc`, but did not validate optional output metadata before storing the transaction. A JSON-serializable but SQLite-invalid payload like `tokens_json: {"TOKEN": 1}` could be admitted to the mempool and claim the input box. When block production later tried to apply that candidate, `apply_transaction()` raised `sqlite3.ProgrammingError` while binding the dict into the `utxo_boxes.tokens_json` TEXT column. The candidate remained in the mempool and kept being returned by `mempool_get_block_candidates()` until expiry.

This is a #2819 UTXO Red Team mempool DoS / invalid block-candidate manipulation finding. Requested severity: Medium (50 RTC).

## Local Pre-Fix Reproduction

Before this patch, a local temp-db repro showed:

- `mempool_add(...) -> True` for an output with `tokens_json` as a dict
- `mempool_get_block_candidates()` returned the malformed transaction
- `apply_transaction(candidate, ...)` raised `ProgrammingError: Error binding parameter 8: type 'dict' is not supported`
- the same candidate remained present after the failed apply attempt

## Testing / Evidence

- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py::TestUtxoDB::test_mempool_rejects_non_string_output_metadata node/test_utxo_db.py::TestUtxoDB::test_mempool_rejects_malformed_output_metadata_json node/test_utxo_db.py::TestUtxoDB::test_apply_transaction_rejects_invalid_output_metadata -q` -> 3 passed
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py -q` -> 70 passed
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m py_compile node/utxo_db.py node/test_utxo_db.py` -> passed
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Bounty / Payout

Bounty: Scottcjn/rustchain-bounties#2819
Wallet/miner ID: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`


