### PR TITLE
fix: harden BCOS directory server defaults

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -6,9 +6,40 @@ import sqlite3
 import json
 import os
 import hashlib
+import secrets
 
 app = Flask(__name__)
-app.config['SECRET_KEY'] = 'bcos-directory-dev-key'
+
+
+def load_secret_key() -> str:
+    """Load the Flask secret key without falling back to a public constant."""
+    configured = os.environ.get('BCOS_DIRECTORY_SECRET_KEY', '').strip()
+    if configured:
+        return configured
+    return secrets.token_hex(32)
+
+
+def debug_enabled() -> bool:
+    """Enable Flask debug mode only by explicit local operator opt-in."""
+    return os.environ.get('BCOS_DIRECTORY_DEBUG', '').strip().lower() in {
+        '1', 'true', 'yes', 'on'
+    }
+
+
+def server_host() -> str:
+    """Default to loopback so the dev server is not exposed accidentally."""
+    return os.environ.get('BCOS_DIRECTORY_HOST', '127.0.0.1').strip() or '127.0.0.1'
+
+
+def server_port() -> int:
+    raw = os.environ.get('BCOS_DIRECTORY_PORT', '5000').strip()
+    try:
+        return int(raw)
+    except ValueError:
+        return 5000
+
+
+app.config['SECRET_KEY'] = load_secret_key()
 
 DATABASE = 'bcos_directory.db'
 
@@ -482,4 +513,4 @@ def serve_dist(filename):
 if __name__ == '__main__':
     init_db()
     load_projects_from_json()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=debug_enabled(), host=server_host(), port=server_port())

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+
+import re
+
+import bcos_directory
+
+
+def test_bcos_directory_secret_key_uses_environment(monkeypatch):
+    monkeypatch.setenv('BCOS_DIRECTORY_SECRET_KEY', 'configured-secret')
+
+    assert bcos_directory.load_secret_key() == 'configured-secret'
+
+
+def test_bcos_directory_secret_key_fallback_is_not_public_constant(monkeypatch):
+    monkeypatch.delenv('BCOS_DIRECTORY_SECRET_KEY', raising=False)
+
+    secret = bcos_directory.load_secret_key()
+
+    assert secret != 'bcos-directory-dev-key'
+    assert re.fullmatch(r'[0-9a-f]{64}', secret)
+
+
+def test_bcos_directory_debug_requires_explicit_opt_in(monkeypatch):
+    monkeypatch.delenv('BCOS_DIRECTORY_DEBUG', raising=False)
+    assert bcos_directory.debug_enabled() is False
+
+    monkeypatch.setenv('BCOS_DIRECTORY_DEBUG', 'true')
+    assert bcos_directory.debug_enabled() is True
+
+
+def test_bcos_directory_host_defaults_to_loopback(monkeypatch):
+    monkeypatch.delenv('BCOS_DIRECTORY_HOST', raising=False)
+
+    assert bcos_directory.server_host() == '127.0.0.1'


### PR DESCRIPTION
## BCOS Checklist

- [x] Add a tier label: `BCOS-L1`
- [x] New test file includes SPDX header
- [x] Test evidence is included below

## What Changed

- Replaced the public hardcoded BCOS directory Flask `SECRET_KEY` with `BCOS_DIRECTORY_SECRET_KEY`, falling back to a per-process random secret.
- Disabled Flask debug mode by default; it now requires `BCOS_DIRECTORY_DEBUG=true`.
- Changed the default development host from `0.0.0.0` to `127.0.0.1`, with `BCOS_DIRECTORY_HOST` and `BCOS_DIRECTORY_PORT` overrides for operators.
- Added regression tests covering secret loading, random fallback, debug opt-in, and loopback default.

## Root Cause / Impact

Fixes #5272.

The BCOS directory executable entrypoint used `app.run(debug=True, host='0.0.0.0', port=5000)` and a shared public `bcos-directory-dev-key`. Running the service as-is could expose the Werkzeug debugger beyond localhost and reuse a known Flask session signing secret across every checkout.

## Testing / Evidence

- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_bcos_directory_security.py -q` -> 4 passed
- `/tmp/rustchain-bounty-venv/bin/python -m py_compile bcos_directory.py tests/test_bcos_directory_security.py` -> passed
- `git diff --check -- bcos_directory.py tests/test_bcos_directory_security.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Bounty / Payout

Bug bounty: #305
Wallet/miner ID: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
Requested severity: Medium/High security bug. Conservative expected minimum: 10 RTC.

