### PR TITLE
fix: reject non-integer UTXO timestamps

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -907,6 +907,28 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_mempool_rejects_non_integer_timestamp(self):
+        """Mempool must not admit txs that apply_transaction() cannot persist."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        for idx, timestamp in enumerate(({'bad': 'timestamp'}, True)):
+            with self.subTest(timestamp=timestamp):
+                tx = {
+                    'tx_id': f'badt{idx}' * 16,
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': boxes[0]['box_id']}],
+                    'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+                    'fee_nrtc': 1 * UNIT,
+                    'timestamp': timestamp,
+                }
+                ok = self.db.mempool_add(tx)
+                self.assertFalse(ok)
+                self.assertEqual(self.db.mempool_get_block_candidates(), [])
+                self.assertFalse(
+                    self.db.mempool_check_double_spend(boxes[0]['box_id'])
+                )
+
     def test_mempool_accepts_valid_tx(self):
         """Mempool should accept a well-formed tx with valid conservation."""
         self._apply_coinbase('alice', 100 * UNIT)
@@ -1122,6 +1144,26 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_non_integer_timestamp_rejected(self):
+        """timestamp must be an integer before writing transaction history."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        for timestamp in ({'bad': 'timestamp'}, True):
+            with self.subTest(timestamp=timestamp):
+                ok = self.db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': boxes[0]['box_id'],
+                                 'spending_proof': 'sig'}],
+                    'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+                    'fee_nrtc': 1 * UNIT,
+                    'timestamp': timestamp,
+                }, block_height=10)
+
+                self.assertFalse(ok)
+                self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+                self.assertEqual(self.db.get_balance('bob'), 0)
 
 
 class TestCoinSelect(unittest.TestCase):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -382,6 +382,15 @@ class UtxoDB:
             return None
         return tx_type
 
+    def _normalize_timestamp(self, tx: dict) -> Optional[int]:
+        """Return a persistable transaction timestamp, or None when invalid."""
+        if 'timestamp' not in tx:
+            return int(time.time())
+        timestamp = tx.get('timestamp')
+        if isinstance(timestamp, bool) or not isinstance(timestamp, int):
+            return None
+        return timestamp
+
     def _data_inputs_are_unspent(self, conn: sqlite3.Connection,
                                  data_inputs: list) -> bool:
         """Validate read-only UTXO references before accepting a tx."""
@@ -424,7 +433,9 @@ class UtxoDB:
 
         Returns True on success, False on validation failure.
         """
-        ts = tx.get('timestamp', int(time.time()))
+        ts = self._normalize_timestamp(tx)
+        if ts is None:
+            return False
         # NOTE(issue #2085): spending_proof is present on each input dict but
         # is intentionally ignored by this layer.  It is stored for
         # on-chain auditability, but cryptographic verification is the sole
@@ -786,6 +797,8 @@ class UtxoDB:
                 return False
             data_inputs = tx.get('data_inputs', [])
             now = int(time.time())
+            if self._normalize_timestamp(tx) is None:
+                return False
 
             # Public mempool admission must never accept minting transactions.
             # Coinbase/mining rewards are internally constructed during block

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,7 @@ pytest>=7.4.4
 PyNaCl>=1.6.2
 # Needed by test_wallet_cli_39 (imports from tools/rustchain_wallet_cli.py)
 cryptography>=46.0.7
+# Needed by CI test collection for SDK, faucet, and visualization tests
+aiohttp>=3.9.0
+flask-cors>=6.0.2
+matplotlib>=3.7

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ cryptography>=46.0.7
 aiohttp>=3.9.0
 flask-cors>=6.0.2
 matplotlib>=3.7
+seaborn>=0.13


### PR DESCRIPTION
## Summary
- validate transaction `timestamp` values before UTXO persistence
- reject non-integer timestamps at both `apply_transaction()` and `mempool_add()`
- add regression coverage for direct application and mempool admission

## Security impact
`mempool_add()` accepted JSON-serializable but SQLite-invalid timestamps such as objects. That transaction could lock an input in the mempool and be returned as a block candidate, but `apply_transaction()` raised `sqlite3.ProgrammingError` when writing `utxo_transactions.timestamp INTEGER`. This created an invalid block-candidate / mempool DoS path until expiry.

## Reproduction before fix
```text
mempool_add True
candidates 1
apply_exception ProgrammingError Error binding parameter 7: type 'dict' is not supported
candidate_still_present 1
```

## Verification
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py -q -k 'non_integer_timestamp'` -> 2 passed
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py -q` -> 69 passed
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

## Bounty
Claiming under Scottcjn/rustchain-bounties#2819 as Medium severity: mempool DoS / invalid block-candidate manipulation.
