### PR TITLE
fix: reject invalid UTXO transaction types

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -845,6 +845,25 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_mempool_rejects_invalid_tx_type(self):
+        """Mempool must not admit txs with non-persistable tx_type values."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'badt' * 16,
+            'tx_type': None,
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+            'fee_nrtc': 1 * UNIT,
+        }
+        ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
     def test_mempool_accepts_valid_tx(self):
         """Mempool should accept a well-formed tx with valid conservation."""
         self._apply_coinbase('alice', 100 * UNIT)
@@ -1043,6 +1062,23 @@ class TestUtxoDB(unittest.TestCase):
             'fee_nrtc': 0,
         }, block_height=10)
         self.assertFalse(ok)
+
+    def test_invalid_tx_type_rejected(self):
+        """tx_type must be a non-empty string before transaction history write."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': None,
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+            'fee_nrtc': 1 * UNIT,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
 
 
 class TestCoinSelect(unittest.TestCase):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -367,6 +367,18 @@ class UtxoDB:
 
         return normalized
 
+    def _normalize_tx_type(self, tx: dict) -> Optional[str]:
+        """Return a valid transaction type, defaulting only when absent."""
+        if 'tx_type' not in tx:
+            return 'transfer'
+        tx_type = tx.get('tx_type')
+        if not isinstance(tx_type, str):
+            return None
+        tx_type = tx_type.strip()
+        if not tx_type:
+            return None
+        return tx_type
+
     def _data_inputs_are_unspent(self, conn: sqlite3.Connection,
                                  data_inputs: list) -> bool:
         """Validate read-only UTXO references before accepting a tx."""
@@ -417,7 +429,9 @@ class UtxoDB:
         inputs = tx.get('inputs', [])
         outputs = tx.get('outputs', [])
         fee = tx.get('fee_nrtc', 0)
-        tx_type = tx.get('tx_type', 'transfer')
+        tx_type = self._normalize_tx_type(tx)
+        if tx_type is None:
+            return False
         data_inputs = tx.get('data_inputs', [])
 
         # FIX(#2207): Defense-in-depth guard against mining_reward type confusion.
@@ -759,7 +773,9 @@ class UtxoDB:
                 return False
 
             inputs = tx.get('inputs', [])
-            tx_type = tx.get('tx_type', 'transfer')
+            tx_type = self._normalize_tx_type(tx)
+            if tx_type is None:
+                return False
             data_inputs = tx.get('data_inputs', [])
             now = int(time.time())
 


### PR DESCRIPTION
## Summary
- validate `tx_type` before UTXO transaction application
- reject explicit non-string or empty transaction types in `apply_transaction()` and `mempool_add()`
- preserve the existing default of `transfer` when `tx_type` is omitted

## Security impact
`mempool_add()` accepted a transaction with `tx_type: null`. That transaction could lock an input in `utxo_mempool_inputs` and be returned to block producers as a candidate, but `apply_transaction()` failed later with `sqlite3.IntegrityError` when writing `utxo_transactions.tx_type TEXT NOT NULL`. This created an invalid block-candidate / mempool DoS path until expiry.

This is distinct from a generic unknown-string whitelist concern: the regression covers a non-persistable `tx_type` value that currently causes a concrete persistence failure after mempool admission.

## Reproduction before fix
```text
mempool_add True
candidates 1
apply_exception IntegrityError NOT NULL constraint failed: utxo_transactions.tx_type
candidate_still_present 1
```

## Verification
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py -q -k 'invalid_tx_type'` -> 2 passed after fix; failed before fix
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m pytest node/test_utxo_db.py -q` -> 69 passed
- `PYTHONPATH=node /tmp/rustchain-bounty-venv/bin/python -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

## Bounty
Claiming under Scottcjn/rustchain-bounties#2819 as Medium severity: mempool DoS / invalid block-candidate manipulation.
