### PR TITLE
Fix payout preflight tests and validation

### DIFF
--- a/API_WALKTHROUGH.md
+++ b/API_WALKTHROUGH.md
@@ -130,7 +130,7 @@ print(response.json())
 
 ## Reference
 
-- **Node:** `https://50.28.86.131`
+- **Node API:** `https://50.28.86.131/health`
 - **Explorer:** `https://50.28.86.131/explorer`
 - **Health:** `https://50.28.86.131/health`
 

--- a/API_WALKTHROUGH.md
+++ b/API_WALKTHROUGH.md
@@ -130,7 +130,7 @@ print(response.json())
 
 ## Reference
 
-- **Node API:** `https://50.28.86.131/health`
+- **Node base URL:** `https://50.28.86.131`
 - **Explorer:** `https://50.28.86.131/explorer`
 - **Health:** `https://50.28.86.131/health`
 

--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation, ROUND_DOWN
 from typing import Any, Dict, Optional, Tuple
@@ -86,7 +87,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=err, details={})
 
     required = ["from_address", "to_address", "amount_rtc", "nonce", "signature"]
-    missing = [k for k in required if not data.get(k)]
+    missing = [k for k in required if k not in data or data.get(k) in (None, "")]
     if missing:
         return PreflightResult(ok=False, error="missing_required_fields", details={"missing": missing})
 
@@ -121,6 +122,10 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
     if nonce_int <= 0:
         return PreflightResult(ok=False, error="nonce_must_be_gt_zero", details={})
 
+    chain_id = str(data.get("chain_id", "")).strip()
+    if chain_id and not re.fullmatch(r"[A-Za-z0-9._-]{1,64}", chain_id):
+        return PreflightResult(ok=False, error="invalid_chain_id_format", details={})
+
     return PreflightResult(
         ok=True,
         error="",
@@ -130,5 +135,6 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
             "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
             "nonce": nonce_int,
+            "chain_id": chain_id or None,
         },
     )

--- a/payout_preflight.py
+++ b/payout_preflight.py
@@ -83,7 +83,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=err, details={})
 
     required = ["from_address", "to_address", "amount_rtc", "nonce", "signature", "public_key"]
-    missing = [k for k in required if not data.get(k)]
+    missing = [k for k in required if k not in data or data.get(k) in (None, "")]
     if missing:
         return PreflightResult(ok=False, error="missing_required_fields", details={"missing": missing})
 

--- a/tests/test_payout_preflight.py
+++ b/tests/test_payout_preflight.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from payout_preflight import (
     _as_dict,
@@ -233,7 +233,7 @@ class TestValidateWalletTransferSigned:
                 result = validate_wallet_transfer_signed({
                               "from_address": self._make_address("a"),
                 })
-                       assert result.ok is False
+                assert result.ok is False
                 assert result.error == "missing_required_fields"
 
       def test_invalid_from_address_format(self):
@@ -262,7 +262,7 @@ class TestValidateWalletTransferSigned:
                 assert result.error == "nonce_must_be_gt_zero"
 
       def test_zero_nonce_rejected(self):
-                payload = self._valid_nonce_rejected(nonce=0)
+                payload = self._valid_payload(nonce=0)
                 result = validate_wallet_transfer_signed(payload)
                 assert result.ok is False
                 assert result.error == "nonce_must_be_gt_zero"


### PR DESCRIPTION
## Summary\n- Fix payout preflight test import path so it targets the repo-root compatibility shim when intended\n- Fix malformed test indentation and invalid nonce fixture call\n- Treat numeric zero values as present before value-specific validation, and mirror signed transfer chain_id validation in node preflight\n\n## Verification\n- python3 -m ruff check payout_preflight.py node/payout_preflight.py tests --select E9,F63,F7,F82\n- python3 -m pytest -q tests/test_payout_preflight.py\n