### PR TITLE
deps: add cargo and npm dependabot configs (bounty #1613)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,3 +46,45 @@ updates:
     labels:
       - "ci/cd"
       - "github-actions"
+
+  - package-ecosystem: "cargo"
+    directories:
+      - "/rustchain-wallet"
+      - "/rips"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "Scottcjn"
+    assignees:
+      - "Scottcjn"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "rust"
+
+  - package-ecosystem: "npm"
+    directories:
+      - "/solana"
+      - "/onboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "Scottcjn"
+    assignees:
+      - "Scottcjn"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "javascript"


### PR DESCRIPTION
## Summary

Extended dependabot.yml to cover two missing ecosystems:

- **cargo**: monitors Rust crates in /rustchain-wallet and /rips
- **npm**: monitors JS packages in /solana and /onboard

Existing pip and github-actions entries are untouched. Both new entries run 
on the same weekly Monday 06:00 UTC schedule, matching the established pattern.

## Test

- Validated YAML syntax against dependabot v2 schema
- Confirmed Cargo.toml exists at /rustchain-wallet and /rips
- Confirmed package.json exists at /solana and /onboard

## Bounty

- **Issue:** #1613
- **Severity:** LOW
- **Payout wallet:** RTC06ad4d5e2738790b4d7154974e97ca664236f576