### PR TITLE
docs: fix dead link — genesi-usa.com/pegasos → Wikipedia (bounty #444)

### DIFF
--- a/VINTAGE_CPU_RESEARCH_SUMMARY.md
+++ b/VINTAGE_CPU_RESEARCH_SUMMARY.md
@@ -405,7 +405,7 @@ def validate_attestation(data):
 
 ### Community Resources
 - [AmigaOne History](https://en.wikipedia.org/wiki/AmigaOne)
-- [Pegasos](https://www.genesi-usa.com/pegasos)
+- [Pegasos](https://en.wikipedia.org/wiki/Pegasos)
 - [AmigaOS 4](https://www.amigaos.net/)
 - [Vintage Computer Federation](https://vcfed.org/)
 


### PR DESCRIPTION
## Summary

Fixed a dead link in `VINTAGE_CPU_RESEARCH_SUMMARY.md`:

- `https://www.genesi-usa.com/pegasos` → `https://en.wikipedia.org/wiki/Pegasos`

The original domain no longer resolves (connection refused). Replaced with the
stable Wikipedia article on Pegasos hardware.

## Test

- `curl -I https://www.genesi-usa.com/pegasos` → connection refused
- `curl -I https://en.wikipedia.org/wiki/Pegasos` → HTTP 200

## Bounty

- **Issue:** #444
- **Severity:** LOW
- **Payout wallet:** RTC06ad4d5e2738790b4d7154974e97ca664236f576