### PR TITLE
chore: add SPDX headers to dashboard frontend-security tests

### DIFF
--- a/tests/test_bridge_dashboard_frontend_security.py
+++ b/tests/test_bridge_dashboard_frontend_security.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 
 

--- a/tests/test_status_dashboard_frontend_security.py
+++ b/tests/test_status_dashboard_frontend_security.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 
 


### PR DESCRIPTION
Vuln-audit Tier-3 finding (vuln-tick-2026-05-15T1506Z.md): 2 test files landed via sming7262-creator's XSS hardening merges (#5161, #5162) without SPDX headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)