### PR TITLE
docs: deduplicate README external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The attestation server doesn't trust self-reported data. It:
 ### AI Agent Economy
 
 RustChain powers an ecosystem where AI agents and humans collaborate:
-- **[BoTTube](https://bottube.ai)** — AI-native video platform where bots create, curate, and engage
+- **BoTTube** — AI-native video platform where bots create, curate, and engage
 - **[Beacon](https://github.com/Scottcjn/beacon-skill)** — Agent discovery protocol
 - **[TrashClaw](https://github.com/Scottcjn/trashclaw)** — Zero-dep local LLM agent
 - **Bounty system** — 25,875+ RTC paid to 260+ contributors, many AI-assisted
@@ -181,10 +181,10 @@ This isn't a roadmap. This is deployed and running:
 | Layer | What | Status |
 |-------|------|--------|
 | **Identity** | Hardware fingerprinting — agents prove they run on real machines, not spoofed VMs | Live, 26+ miners |
-| **Currency** | RTC (native) + wRTC (Solana bridge) — agent-native money with micropayment support | Live, [tradeable on Raydium](https://raydium.io/swap/?inputMint=sol&outputMint=12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X) |
+| **Currency** | RTC (native) + wRTC (Solana bridge) — agent-native money with micropayment support | Live, Raydium swap link below |
 | **Discovery** | [Beacon protocol](https://github.com/Scottcjn/beacon-skill) — agents find and negotiate with other agents | Live, 126 stars |
 | **Execution** | [TrashClaw](https://github.com/Scottcjn/trashclaw) — zero-dep local LLM agent that runs on anything | Live |
-| **Social** | [BoTTube](https://bottube.ai) — AI-native platform where agents create, trade, and engage | Live, 1,000+ videos |
+| **Social** | BoTTube — AI-native platform where agents create, trade, and engage | Live, 1,000+ videos |
 | **Bounties** | Agent-assisted contributions — AI helps humans earn RTC for real code | Live, 25,875+ RTC paid |
 | **Certification** | [BCOS](https://rustchain.org/bcos/) — blockchain-certified open source verification | Live, 44 certs issued |
 


### PR DESCRIPTION
## Summary
- Removes duplicate BoTTube links from earlier README sections while keeping the ecosystem link.
- Replaces the earlier Raydium inline link with a pointer to the dedicated wRTC swap table below.
- Keeps all existing context while avoiding repeated external URLs called out in the issue.

Fixes #2267

## Validation
- Verified README now has a single Raydium swap URL.
- Verified the repeated BoTTube homepage URL is no longer duplicated in the earlier AI Agent Economy / Agent Stack sections.