### PR TITLE
docs: fix RustChain project homepage URL

### DIFF
--- a/data/projects.json
+++ b/data/projects.json
@@ -2,7 +2,7 @@
   "projects": [
     {
       "name": "RustChain Agent Framework",
-      "url": "https://rustchain.ai",
+      "url": "https://rustchain.org",
       "github_repo": "https://github.com/Scottcjn/Rustchain",
       "bcos_tier": "L1",
       "latest_sha": "a1b2c3d4e5f6789012345678901234567890abcd",


### PR DESCRIPTION
## Summary
- Updates the RustChain project homepage in `data/projects.json` from the dead `https://rustchain.ai` domain to the live `https://rustchain.org` domain.
- Keeps the GitHub repository and project metadata unchanged.

## Validation
- `curl https://rustchain.ai` fails DNS resolution.
- `curl https://rustchain.org` returns HTTP 200.
- `node -e 'JSON.parse(require("fs").readFileSync("rustchain-projects-fix/projects.json","utf8"))'` passed locally before upload.

Related to Scottcjn/rustchain-bounties#444.