### PR TITLE
Fix: Payout orphan recovery & Airdrop TOCTOU race (Findings #2, #3, #7)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -833,15 +833,19 @@ class AirdropV2:
                 ),
             )
 
-            # Update allocation
+            # Update allocation atomically to prevent TOCTOU race
             cursor.execute(
                 """
                 UPDATE airdrop_allocation
                 SET claimed_uwrtc = claimed_uwrtc + ?, updated_at = ?
-                WHERE chain = ?
+                WHERE chain = ? AND (total_uwrtc - claimed_uwrtc) >= ?
                 """,
-                (claim.amount_uwrtc, claim.timestamp, chain_lower),
+                (claim.amount_uwrtc, claim.timestamp, chain_lower, claim.amount_uwrtc),
             )
+
+            if cursor.rowcount == 0:
+                conn.rollback()
+                return False, "Airdrop allocation exhausted or concurrent claim conflict", None
 
             conn.commit()
             logger.info(

--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -174,6 +174,42 @@ class PayoutWorker:
             self.stats['failed'] += 1
             return False
 
+    def recover_orphans(self):
+        """Recover withdrawals stuck in processing state (e.g. from a crash during execute_withdrawal)."""
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                rows = conn.execute("""
+                    SELECT withdrawal_id, miner_pk, amount, fee
+                    FROM withdrawals
+                    WHERE status = 'processing'
+                """).fetchall()
+
+                for row in rows:
+                    withdrawal_id, miner_pk, amount, fee = row
+                    total_refund = amount + (fee or 0)
+
+                    logger.warning(f"Recovering orphaned withdrawal {withdrawal_id} (refunding {total_refund} to {miner_pk})")
+
+                    # Refund the balance
+                    conn.execute(
+                        "UPDATE accounts SET balance = balance + ? WHERE public_key = ?",
+                        (total_refund, miner_pk)
+                    )
+
+                    # Mark as failed
+                    conn.execute(
+                        "UPDATE withdrawals SET status = 'failed', error_msg = 'Orphaned processing state recovered' WHERE withdrawal_id = ?",
+                        (withdrawal_id,)
+                    )
+                conn.execute("COMMIT")
+                
+                if rows:
+                    logger.info(f"Recovered {len(rows)} orphaned withdrawals.")
+                    
+        except Exception as e:
+            logger.error(f"Failed to recover orphans: {e}")
+
     def process_batch(self) -> int:
         """Process a batch of withdrawals"""
         withdrawals = self.get_pending_withdrawals()
@@ -203,6 +239,9 @@ class PayoutWorker:
 
         while True:
             try:
+                # Recover orphans before processing new batches to prevent stranded funds
+                self.recover_orphans()
+
                 # Process batch
                 processed = self.process_batch()
 


### PR DESCRIPTION
This PR implements the fix-forward recommendations for the following security audit findings:

- **Finding #2 & #3 (payout_worker)**: Non-atomic deduct/refund and orphan processing recovery. Added `recover_orphans()` to safely handle `processing` states after a crash to prevent permanently stranded funds.
- **Finding #7 (airdrop_v2)**: Airdrop allocation TOCTOU race. Modifies the allocation deduction logic to be atomic using a single SQL UPDATE with a WHERE constraint checking the remaining reward balance.

Wallet for any rewards: `RTC241359b3438d1222fdc1c3e22fe980657a4bc54e`