### PR TITLE
fix: collect macOS miner hardware with sysctl

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -53,6 +53,20 @@ def _parse_free_memory_gb(output):
     return None
 
 
+def _parse_int_output(output):
+    try:
+        return int(str(output).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_memory_bytes_to_gb(output):
+    memory_bytes = _parse_int_output(output)
+    if memory_bytes is None or memory_bytes <= 0:
+        return None
+    return max(1, round(memory_bytes / (1024 ** 3)))
+
+
 def _safe_id_part(value):
     slug = re.sub(r"[^a-zA-Z0-9_.:-]+", "-", str(value or "").strip().lower()).strip("-")
     return slug or "unknown"
@@ -286,9 +300,10 @@ class LocalMiner:
 
     def _get_hw_info(self):
         """Collect hardware info"""
+        system = platform.system()
         machine = platform.machine().lower()
         hw = {
-            "platform": platform.system(),
+            "platform": system,
             "machine": platform.machine(),
             "hostname": socket.gethostname(),
             "family": "x86",
@@ -330,15 +345,24 @@ class LocalMiner:
             hw["arch"] = machine
 
         # Get CPU
-        cpu = _parse_lscpu_model(self._run_cmd(["lscpu"]))
+        if system == "Darwin":
+            cpu = self._run_cmd(["sysctl", "-n", "machdep.cpu.brand_string"]).strip()
+        else:
+            cpu = _parse_lscpu_model(self._run_cmd(["lscpu"]))
         hw["cpu"] = cpu or "Unknown"
 
         # Get cores
-        cores = self._run_cmd(["nproc"])
-        hw["cores"] = int(cores) if cores else 6
+        if system == "Darwin":
+            cores = _parse_int_output(self._run_cmd(["sysctl", "-n", "hw.ncpu"]))
+        else:
+            cores = _parse_int_output(self._run_cmd(["nproc"]))
+        hw["cores"] = cores or os.cpu_count() or 1
 
         # Get memory
-        mem = _parse_free_memory_gb(self._run_cmd(["free", "-g"]))
+        if system == "Darwin":
+            mem = _parse_memory_bytes_to_gb(self._run_cmd(["sysctl", "-n", "hw.memsize"]))
+        else:
+            mem = _parse_free_memory_gb(self._run_cmd(["free", "-g"]))
         hw["memory_gb"] = mem if mem is not None else 32
 
         # Get MACs (ensures PoA signal uses real hardware data)

--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -346,7 +346,7 @@ class LocalMiner:
 
         # Get CPU
         if system == "Darwin":
-            cpu = self._run_cmd(["sysctl", "-n", "machdep.cpu.brand_string"]).strip()
+            cpu = (self._run_cmd(["sysctl", "-n", "machdep.cpu.brand_string"]) or "").strip()
         else:
             cpu = _parse_lscpu_model(self._run_cmd(["lscpu"]))
         hw["cpu"] = cpu or "Unknown"

--- a/tests/test_miner_hardware_probes.py
+++ b/tests/test_miner_hardware_probes.py
@@ -72,6 +72,30 @@ def test_linux_miner_collects_darwin_hardware_with_sysctl(monkeypatch):
     assert hw["memory_gb"] == 16
 
 
+def test_linux_miner_darwin_hardware_falls_back_when_sysctl_missing(monkeypatch):
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_darwin_fallback_hw")
+    instance = object.__new__(miner.LocalMiner)
+    command_output = {
+        ("sysctl", "-n", "machdep.cpu.brand_string"): None,
+        ("sysctl", "-n", "hw.ncpu"): "",
+        ("sysctl", "-n", "hw.memsize"): "",
+    }
+
+    monkeypatch.setattr(miner.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(miner.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(miner.socket, "gethostname", lambda: "macbook.local")
+    monkeypatch.setattr(miner.os, "cpu_count", lambda: 8)
+    monkeypatch.setattr(miner, "get_linux_serial", lambda: None)
+    monkeypatch.setattr(miner.LocalMiner, "_get_mac_addresses", lambda self: ["aa:bb:cc:dd:ee:ff"])
+    monkeypatch.setattr(miner.LocalMiner, "_run_cmd", lambda self, args: command_output.get(tuple(args), ""))
+
+    hw = instance._get_hw_info()
+
+    assert hw["cpu"] == "Unknown"
+    assert hw["cores"] == 8
+    assert hw["memory_gb"] == 32
+
+
 def test_power8_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
     miner = load_module(Path("miners/power8/rustchain_power8_miner.py"), "rustchain_power8_miner_run_cmd")
     instance = object.__new__(miner.LocalMiner)

--- a/tests/test_miner_hardware_probes.py
+++ b/tests/test_miner_hardware_probes.py
@@ -16,6 +16,8 @@ def test_linux_miner_parses_lscpu_and_free_output():
 
     assert miner._parse_lscpu_model("Architecture: x86_64\nModel name: AMD Ryzen 5 8645HS\n") == "AMD Ryzen 5 8645HS"
     assert miner._parse_free_memory_gb("       total used free\nMem:      31    1   30\nSwap:      0    0    0\n") == 31
+    assert miner._parse_int_output("10\n") == 10
+    assert miner._parse_memory_bytes_to_gb("17179869184\n") == 16
 
 
 def test_power8_miner_parses_lscpu_proc_cpuinfo_and_free_output():
@@ -42,6 +44,32 @@ def test_linux_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):
 
     assert instance._run_cmd(["nproc"]) == "ok"
     assert calls == [(["nproc"], {"stdout": miner.subprocess.PIPE, "stderr": miner.subprocess.PIPE, "text": True, "timeout": 10})]
+
+
+def test_linux_miner_collects_darwin_hardware_with_sysctl(monkeypatch):
+    miner = load_module(Path("miners/linux/rustchain_linux_miner.py"), "rustchain_linux_miner_darwin_hw")
+    instance = object.__new__(miner.LocalMiner)
+    command_output = {
+        ("sysctl", "-n", "machdep.cpu.brand_string"): "Apple M5\n",
+        ("sysctl", "-n", "hw.ncpu"): "10\n",
+        ("sysctl", "-n", "hw.memsize"): "17179869184\n",
+    }
+
+    monkeypatch.setattr(miner.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(miner.platform, "machine", lambda: "arm64")
+    monkeypatch.setattr(miner.socket, "gethostname", lambda: "macbook.local")
+    monkeypatch.setattr(miner, "get_linux_serial", lambda: None)
+    monkeypatch.setattr(miner.LocalMiner, "_get_mac_addresses", lambda self: ["aa:bb:cc:dd:ee:ff"])
+    monkeypatch.setattr(miner.LocalMiner, "_run_cmd", lambda self, args: command_output.get(tuple(args), ""))
+
+    hw = instance._get_hw_info()
+
+    assert hw["platform"] == "Darwin"
+    assert hw["family"] == "ARM"
+    assert hw["arch"] == "aarch64"
+    assert hw["cpu"] == "Apple M5"
+    assert hw["cores"] == 10
+    assert hw["memory_gb"] == 16
 
 
 def test_power8_miner_run_cmd_uses_argument_list_without_shell(monkeypatch):


### PR DESCRIPTION
Summary:
- use macOS sysctl probes for CPU model, core count, and memory when the miner runs on Darwin
- keep the existing Linux lscpu/nproc/free probes unchanged
- add regression coverage for Darwin arm64 hardware collection and byte-to-GB parsing

Why:
While running the miner dry-run bounty on Apple Silicon, the Linux miner completed successfully but reported fallback values: CPU Unknown, 6 cores, and 32 GB. The actual host is Apple M5, arm64, 10 cores, 16 GB.

Verification:
- /tmp/rustchain-miner.vohJZo/.venv/bin/python -m pytest tests/test_miner_hardware_probes.py
- /tmp/rustchain-miner.vohJZo/.venv/bin/python miners/linux/rustchain_linux_miner.py --dry-run --show-payload --wallet boopy253

Bounty note:
Found while running rustchain-bounties#2271. If accepted for the dry-run bug bonus, please use wallet/miner ID `boopy253`.