### PR TITLE
Fix SDK wallet balance endpoint

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -185,10 +185,11 @@ balance = client.balance("wallet_address")
 - `miner_id`: Miner wallet address
 
 **Returns:**
-- `miner_pk` (str): Wallet address
-- `balance` (float): Current balance in RTC
-- `epoch_rewards` (float): Rewards in current epoch
-- `total_earned` (float): Total RTC earned
+- `miner_id` (str): Miner wallet address
+- `amount_i64` (int): Current balance in micro-RTC
+- `amount_rtc` (float): Current balance in RTC
+- `balance` (float): Compatibility alias for `amount_rtc`
+- `miner_pk` (str): Compatibility alias for `miner_id`
 
 ##### transfer(from_addr, to_addr, amount, signature=None, fee=0.01)
 

--- a/sdk/rustchain/async_client.py
+++ b/sdk/rustchain/async_client.py
@@ -181,7 +181,7 @@ class AsyncRustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return await self._request("GET", "/balance", params={"miner_id": miner_id})
+        return await self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
 
     async def transfer(
         self,

--- a/sdk/rustchain/async_client.py
+++ b/sdk/rustchain/async_client.py
@@ -18,6 +18,18 @@ from rustchain.exceptions import (
 )
 
 
+def _normalize_wallet_balance(result: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        return result
+
+    normalized = dict(result)
+    if "balance" not in normalized and "amount_rtc" in normalized:
+        normalized["balance"] = normalized["amount_rtc"]
+    if "miner_pk" not in normalized and "miner_id" in normalized:
+        normalized["miner_pk"] = normalized["miner_id"]
+    return normalized
+
+
 class AsyncRustChainClient:
     """
     Async client for interacting with RustChain node API.
@@ -170,10 +182,11 @@ class AsyncRustChainClient:
 
         Returns:
             Dict with balance information:
-                - miner_pk (str): Wallet address
-                - balance (float): Current balance in RTC
-                - epoch_rewards (float): Rewards in current epoch
-                - total_earned (float): Total RTC earned
+                - miner_id (str): Miner wallet address
+                - amount_i64 (int): Current balance in micro-RTC
+                - amount_rtc (float): Current balance in RTC
+                - balance (float): Compatibility alias for amount_rtc
+                - miner_pk (str): Compatibility alias for miner_id
 
         Raises:
             ValidationError: If miner_id is invalid
@@ -181,7 +194,8 @@ class AsyncRustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return await self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
+        result = await self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
+        return _normalize_wallet_balance(result)
 
     async def transfer(
         self,

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -17,6 +17,18 @@ from rustchain.exceptions import (
 )
 
 
+def _normalize_wallet_balance(result: Dict[str, Any]) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        return result
+
+    normalized = dict(result)
+    if "balance" not in normalized and "amount_rtc" in normalized:
+        normalized["balance"] = normalized["amount_rtc"]
+    if "miner_pk" not in normalized and "miner_id" in normalized:
+        normalized["miner_pk"] = normalized["miner_id"]
+    return normalized
+
+
 class RustChainClient:
     """
     Client for interacting with RustChain node API.
@@ -181,10 +193,11 @@ class RustChainClient:
 
         Returns:
             Dict with balance information:
-                - miner_pk (str): Wallet address
-                - balance (float): Current balance in RTC
-                - epoch_rewards (float): Rewards in current epoch
-                - total_earned (float): Total RTC earned
+                - miner_id (str): Miner wallet address
+                - amount_i64 (int): Current balance in micro-RTC
+                - amount_rtc (float): Current balance in RTC
+                - balance (float): Compatibility alias for amount_rtc
+                - miner_pk (str): Compatibility alias for miner_id
 
         Raises:
             ConnectionError: If connection fails
@@ -199,7 +212,8 @@ class RustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
+        result = self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
+        return _normalize_wallet_balance(result)
 
     def transfer(
         self,

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -199,7 +199,7 @@ class RustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return self._request("GET", "/balance", params={"miner_id": miner_id})
+        return self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
 
     def transfer(
         self,

--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -233,7 +233,7 @@ class TestAsyncMinersEndpoint:
 
 
 class TestAsyncBalanceEndpoint:
-    """Test /balance endpoint"""
+    """Test /wallet/balance endpoint"""
 
     @pytest.mark.asyncio
     async def test_balance_success(self):
@@ -266,6 +266,9 @@ class TestAsyncBalanceEndpoint:
             assert balance["balance"] == 123.456
             assert balance["epoch_rewards"] == 10.0
             assert balance["total_earned"] == 1000.0
+            _, kwargs = mock_request.call_args
+            assert kwargs["url"] == "https://rustchain.org/wallet/balance"
+            assert kwargs["params"] == {"miner_id": "test_wallet_address"}
 
     @pytest.mark.asyncio
     async def test_balance_empty_miner_id(self):

--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -237,7 +237,7 @@ class TestAsyncBalanceEndpoint:
 
     @pytest.mark.asyncio
     async def test_balance_success(self):
-        """Test successful balance query"""
+        """Test successful balance query with the legacy SDK shape"""
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value={
@@ -269,6 +269,39 @@ class TestAsyncBalanceEndpoint:
             _, kwargs = mock_request.call_args
             assert kwargs["url"] == "https://rustchain.org/wallet/balance"
             assert kwargs["params"] == {"miner_id": "test_wallet_address"}
+
+    @pytest.mark.asyncio
+    async def test_balance_live_response_shape_adds_sdk_aliases(self):
+        """Test live /wallet/balance shape keeps SDK balance aliases"""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "miner_id": "test_wallet_address",
+            "amount_i64": 123456000,
+            "amount_rtc": 123.456,
+        })
+        mock_response.reason = "OK"
+
+        mock_cm = AsyncContextManager(mock_response)
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_request = Mock(return_value=mock_cm)
+            mock_session = Mock()
+            mock_session.request = mock_request
+            mock_session.closed = False
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_session.close = AsyncMock()
+            mock_session_class.return_value = mock_session
+
+            async with AsyncRustChainClient("https://rustchain.org") as client:
+                balance = await client.balance("test_wallet_address")
+
+            assert balance["miner_id"] == "test_wallet_address"
+            assert balance["amount_i64"] == 123456000
+            assert balance["amount_rtc"] == 123.456
+            assert balance["balance"] == 123.456
+            assert balance["miner_pk"] == "test_wallet_address"
 
     @pytest.mark.asyncio
     async def test_balance_empty_miner_id(self):

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -165,7 +165,7 @@ class TestMinersEndpoint:
 
 
 class TestBalanceEndpoint:
-    """Test /balance endpoint"""
+    """Test /wallet/balance endpoint"""
 
     @patch("requests.Session.request")
     def test_balance_success(self, mock_request):
@@ -186,6 +186,9 @@ class TestBalanceEndpoint:
         assert balance["balance"] == 123.456
         assert balance["epoch_rewards"] == 10.0
         assert balance["total_earned"] == 1000.0
+        _, kwargs = mock_request.call_args
+        assert kwargs["url"] == "https://rustchain.org/wallet/balance"
+        assert kwargs["params"] == {"miner_id": "test_wallet_address"}
 
     def test_balance_empty_miner_id(self):
         """Test balance with empty miner_id raises ValidationError"""

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -169,7 +169,7 @@ class TestBalanceEndpoint:
 
     @patch("requests.Session.request")
     def test_balance_success(self, mock_request):
-        """Test successful balance query"""
+        """Test successful balance query with the legacy SDK shape"""
         mock_response = Mock()
         mock_response.json.return_value = {
             "miner_pk": "test_wallet_address",
@@ -189,6 +189,27 @@ class TestBalanceEndpoint:
         _, kwargs = mock_request.call_args
         assert kwargs["url"] == "https://rustchain.org/wallet/balance"
         assert kwargs["params"] == {"miner_id": "test_wallet_address"}
+
+    @patch("requests.Session.request")
+    def test_balance_live_response_shape_adds_sdk_aliases(self, mock_request):
+        """Test live /wallet/balance shape keeps SDK balance aliases"""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "miner_id": "test_wallet_address",
+            "amount_i64": 123456000,
+            "amount_rtc": 123.456,
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        with RustChainClient("https://rustchain.org") as client:
+            balance = client.balance("test_wallet_address")
+
+        assert balance["miner_id"] == "test_wallet_address"
+        assert balance["amount_i64"] == 123456000
+        assert balance["amount_rtc"] == 123.456
+        assert balance["balance"] == 123.456
+        assert balance["miner_pk"] == "test_wallet_address"
 
     def test_balance_empty_miner_id(self):
         """Test balance with empty miner_id raises ValidationError"""


### PR DESCRIPTION
## Summary

Fixes #5348.

The top-level Python SDK balance helpers were still calling `GET /balance`, but the live RustChain node and other in-repo clients use `GET /wallet/balance`.

Changes:
- update `RustChainClient.balance()` to call `/wallet/balance`
- update `AsyncRustChainClient.balance()` to call `/wallet/balance`
- add sync and async request-path assertions so this cannot silently regress back to `/balance`

## Live proof

`GET https://rustchain.org/balance?miner_id=SimoneMariaRomeo` returns 404.

`GET https://rustchain.org/wallet/balance?miner_id=SimoneMariaRomeo` returns 200 with `amount_rtc: 44.0`.

## Validation

- `python -m pytest sdk\tests\test_client_unit.py -q` -> 24 passed
- direct async balance endpoint smoke -> passed
- live sync SDK balance smoke -> passed
- live async SDK balance smoke -> passed
- `python -m py_compile sdk\rustchain\client.py sdk\rustchain\async_client.py sdk\tests\test_client_unit.py sdk\tests\test_async_client.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref upstream/main` -> BCOS SPDX check OK
- `git diff --check upstream/main...HEAD` -> passed

Note: the full async pytest file needs `pytest-asyncio`; this local environment only has `anyio`, so pytest refuses to run `@pytest.mark.asyncio` tests before code execution. I verified the changed async method with a direct `asyncio.run()` smoke and a live node call instead.