### PR TITLE
Add missing CI test dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,13 +8,14 @@ cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:
 PyNaCl>=1.6.2
 # For async SDK and agent economy client tests:
-aiohttp>=3.9.0
+aiohttp>=3.10.11
 # For Flask apps imported by the test suite:
-flask-cors>=6.0.2
+Flask-Cors>=6.0.2
 # For faucet service YAML config loading:
 PyYAML>=6.0.3
 # For benchmark and visualizer tests:
-matplotlib>=3.7
+matplotlib>=3.9.2
+# Needed when tests import benchmarks/pse/analyze_results.py.
 seaborn>=0.12
 # For wallet CLI (BIP39 seed phrases):
 mnemonic>=0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,15 @@ requests>=2.34.2
 cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:
 PyNaCl>=1.6.2
+# For async SDK and agent economy client tests:
+aiohttp>=3.9.0
+# For Flask apps imported by the test suite:
+flask-cors>=6.0.2
+# For faucet service YAML config loading:
+PyYAML>=6.0.3
+# For benchmark and visualizer tests:
+matplotlib>=3.7
+seaborn>=0.12
 # For wallet CLI (BIP39 seed phrases):
 mnemonic>=0.21
 # For EIP-55 Ethereum address checksum validation (faucet_service):


### PR DESCRIPTION
## Summary

Fixes #5335.

The main CI workflow installs the root `requirements.txt`, but the current full test collection imports modules that need dependencies only listed in nested component requirement files. This adds the missing root development/test dependencies for:

- `agent_economy_sdk.py` / async clients: `aiohttp`
- `faucet_service/faucet_service.py`: `flask-cors`, `PyYAML`
- PSE benchmark analyzer and hardware visualizer tests: `matplotlib`, `seaborn`

## Validation

- `python -c "import aiohttp, flask_cors, matplotlib"`
- `python -m pytest --collect-only -q tests/test_agent_economy_sdk.py tests/test_faucet_service_wallet_validation.py tests/test_hardware_visualizer.py tests/test_pse_analyze_results.py` -> 14 tests collected
- `python -m pytest -q tests/test_agent_economy_sdk.py tests/test_faucet_service_wallet_validation.py tests/test_hardware_visualizer.py tests/test_pse_analyze_results.py` -> 14 passed
- `git diff --check`

RTC wallet for any merged-PR award: `RTC7f251390e4a9c382224e1cbb682810c99cedd898`
