### PR TITLE
Clarify Windows clawrtc dry-run support

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -69,7 +69,9 @@ bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```powershell
 # 使用 Python 安装
 pip install clawrtc
-clawrtc mine --dry-run
+# Windows note: current clawrtc releases do not support miner dry-run.
+# Use Linux/macOS or WSL for `clawrtc mine --dry-run`.
+clawrtc --help
 ```
 
 ### 安装程序会做什么？

--- a/docs/UPGRADE_MIGRATION_GUIDE.md
+++ b/docs/UPGRADE_MIGRATION_GUIDE.md
@@ -336,6 +336,7 @@ launchctl start com.rustchain.miner     # macOS
 clawrtc --version
 
 # 运行干跑测试
+# Linux/macOS/WSL only: current Windows clawrtc releases do not support miner dry-run.
 clawrtc mine --dry-run
 
 # 预期：所有 6 项硬件指纹检查执行成功
@@ -415,7 +416,7 @@ open https://rustchain.org/explorer
 - [ ] 已停止当前矿工
 - [ ] 已下载/安装新版本
 - [ ] 已验证安装（`clawrtc --version`）
-- [ ] 已运行干跑测试（`clawrtc mine --dry-run`）
+- [ ] 已运行干跑测试（Linux/macOS/WSL: `clawrtc mine --dry-run`）
 - [ ] 已启动新矿工
 - [ ] 已验证挖矿状态
 - [ ] 已检查钱包余额（1-2 epoch 后）


### PR DESCRIPTION
Fixes #5217

## What changed
- Replaced the Windows FAQ command that told users to run `clawrtc mine --dry-run`.
- Marked the migration dry-run checklist as Linux/macOS/WSL-only so Windows users see the limitation before trying the command.

## Why
The prior #5268 attempt was closed as too broad. This PR keeps the fix to two documentation lines around the failing Windows dry-run path and does not add or rewrite a `clawrtc` package.

## Validation
- `git diff --check HEAD~1 HEAD`

RTC wallet: `RTC7f251390e4a9c382224e1cbb682810c99cedd898`