### PR TITLE
Fix SDK balance helper endpoint

### DIFF
--- a/sdk/rustchain/async_client.py
+++ b/sdk/rustchain/async_client.py
@@ -181,7 +181,7 @@ class AsyncRustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return await self._request("GET", "/balance", params={"miner_id": miner_id})
+        return await self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
 
     async def transfer(
         self,

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -199,7 +199,7 @@ class RustChainClient:
         if not miner_id or not isinstance(miner_id, str):
             raise ValidationError("miner_id must be a non-empty string")
 
-        return self._request("GET", "/balance", params={"miner_id": miner_id})
+        return self._request("GET", "/wallet/balance", params={"miner_id": miner_id})
 
     def transfer(
         self,

--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -233,7 +233,7 @@ class TestAsyncMinersEndpoint:
 
 
 class TestAsyncBalanceEndpoint:
-    """Test /balance endpoint"""
+    """Test /wallet/balance endpoint"""
 
     @pytest.mark.asyncio
     async def test_balance_success(self):
@@ -266,6 +266,9 @@ class TestAsyncBalanceEndpoint:
             assert balance["balance"] == 123.456
             assert balance["epoch_rewards"] == 10.0
             assert balance["total_earned"] == 1000.0
+            mock_request.assert_called_once()
+            assert mock_request.call_args.kwargs["url"] == "https://rustchain.org/wallet/balance"
+            assert mock_request.call_args.kwargs["params"] == {"miner_id": "test_wallet_address"}
 
     @pytest.mark.asyncio
     async def test_balance_empty_miner_id(self):

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -165,7 +165,7 @@ class TestMinersEndpoint:
 
 
 class TestBalanceEndpoint:
-    """Test /balance endpoint"""
+    """Test /wallet/balance endpoint"""
 
     @patch("requests.Session.request")
     def test_balance_success(self, mock_request):
@@ -186,6 +186,9 @@ class TestBalanceEndpoint:
         assert balance["balance"] == 123.456
         assert balance["epoch_rewards"] == 10.0
         assert balance["total_earned"] == 1000.0
+        mock_request.assert_called_once()
+        assert mock_request.call_args.kwargs["url"] == "https://rustchain.org/wallet/balance"
+        assert mock_request.call_args.kwargs["params"] == {"miner_id": "test_wallet_address"}
 
     def test_balance_empty_miner_id(self):
         """Test balance with empty miner_id raises ValidationError"""


### PR DESCRIPTION
## Summary
- Update sync and async SDK balance helpers to call `/wallet/balance` instead of stale `/balance`.
- Add assertions to unit tests to verify the requested URL and query params.

## Validation
- `pytest -q sdk/tests/test_client_unit.py sdk/tests/test_async_client.py`
- `git diff --check`

Fixes #5348
