### PR TITLE
fix: handle macOS miner termination signals

### DIFF
--- a/miners/macos/intel/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/intel/rustchain_mac_miner_v2.4.py
@@ -16,6 +16,7 @@ import subprocess
 import requests
 import statistics
 import re
+import signal
 from datetime import datetime
 
 # Import fingerprint checks
@@ -237,12 +238,19 @@ class MacMiner:
         self.shares_submitted = 0
         self.shares_accepted = 0
         self.last_entropy = {}
+        self.shutdown_requested = False
 
         self._print_banner()
 
         # Run initial fingerprint check
         if FINGERPRINT_AVAILABLE:
             self._run_fingerprint_checks()
+
+    def request_shutdown(self, signum=None, frame=None):
+        """Request a graceful miner shutdown from SIGTERM/SIGINT."""
+        if not self.shutdown_requested:
+            print("\n\nShutting down miner...")
+        self.shutdown_requested = True
 
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA"""
@@ -443,13 +451,16 @@ class MacMiner:
         print(f"\n[{datetime.now().strftime('%H:%M:%S')}] Starting miner...")
 
         # Initial attestation
-        while not self.attest():
+        while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
             time.sleep(30)
+        if self.shutdown_requested:
+            print("Miner stopped gracefully.")
+            return
 
         last_slot = 0
 
-        while True:
+        while not self.shutdown_requested:
             try:
                 # Re-attest if needed
                 if time.time() > self.attestation_valid_until:
@@ -484,11 +495,12 @@ class MacMiner:
                 time.sleep(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
-                print("\n\nShutting down miner...")
+                self.request_shutdown()
                 break
             except Exception as e:
                 print(f"[{datetime.now().strftime('%H:%M:%S')}] Error: {e}")
                 time.sleep(30)
+        print(f"Miner stopped gracefully. Submitted: {self.shares_submitted} | Accepted: {self.shares_accepted}")
 
 
 if __name__ == "__main__":
@@ -504,4 +516,6 @@ if __name__ == "__main__":
         NODE_URL = args.node
 
     miner = MacMiner(miner_id=args.miner_id, wallet=args.wallet)
+    signal.signal(signal.SIGTERM, miner.request_shutdown)
+    signal.signal(signal.SIGINT, miner.request_shutdown)
     miner.run()

--- a/miners/macos/intel/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/intel/rustchain_mac_miner_v2.4.py
@@ -252,6 +252,15 @@ class MacMiner:
             print("\n\nShutting down miner...")
         self.shutdown_requested = True
 
+    def sleep_until_shutdown(self, seconds, interval=1.0):
+        """Sleep in short checkpoints so signal-driven shutdown returns promptly."""
+        deadline = time.monotonic() + seconds
+        while not self.shutdown_requested:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(interval, remaining))
+
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA"""
         print("\n[FINGERPRINT] Running hardware fingerprint checks...")
@@ -453,7 +462,7 @@ class MacMiner:
         # Initial attestation
         while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
-            time.sleep(30)
+            self.sleep_until_shutdown(30)
         if self.shutdown_requested:
             print("Miner stopped gracefully.")
             return
@@ -492,14 +501,14 @@ class MacMiner:
                           f"Submitted: {self.shares_submitted} | "
                           f"Accepted: {self.shares_accepted}")
 
-                time.sleep(LOTTERY_CHECK_INTERVAL)
+                self.sleep_until_shutdown(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
                 self.request_shutdown()
                 break
             except Exception as e:
                 print(f"[{datetime.now().strftime('%H:%M:%S')}] Error: {e}")
-                time.sleep(30)
+                self.sleep_until_shutdown(30)
         print(f"Miner stopped gracefully. Submitted: {self.shares_submitted} | Accepted: {self.shares_accepted}")
 
 

--- a/miners/macos/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/rustchain_mac_miner_v2.4.py
@@ -293,6 +293,15 @@ class MacMiner:
             print("\n\nShutting down miner...")
         self.shutdown_requested = True
 
+    def sleep_until_shutdown(self, seconds, interval=1.0):
+        """Sleep in short checkpoints so signal-driven shutdown returns promptly."""
+        deadline = time.monotonic() + seconds
+        while not self.shutdown_requested:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(interval, remaining))
+
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA"""
         print(info("\n[FINGERPRINT] Running hardware fingerprint checks..."))
@@ -494,7 +503,7 @@ class MacMiner:
         # Initial attestation
         while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
-            time.sleep(30)
+            self.sleep_until_shutdown(30)
         if self.shutdown_requested:
             print("Miner stopped gracefully.")
             return
@@ -533,14 +542,14 @@ class MacMiner:
                           f"Submitted: {self.shares_submitted} | "
                           f"Accepted: {self.shares_accepted}")
 
-                time.sleep(LOTTERY_CHECK_INTERVAL)
+                self.sleep_until_shutdown(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
                 self.request_shutdown()
                 break
             except Exception as e:
                 print(f"[{datetime.now().strftime('%H:%M:%S')}] Error: {e}")
-                time.sleep(30)
+                self.sleep_until_shutdown(30)
         print(f"Miner stopped gracefully. Submitted: {self.shares_submitted} | Accepted: {self.shares_accepted}")
 
 

--- a/miners/macos/rustchain_mac_miner_v2.4.py
+++ b/miners/macos/rustchain_mac_miner_v2.4.py
@@ -16,6 +16,7 @@ import subprocess
 import requests
 import statistics
 import re
+import signal
 from datetime import datetime
 
 try:
@@ -278,12 +279,19 @@ class MacMiner:
         self.shares_submitted = 0
         self.shares_accepted = 0
         self.last_entropy = {}
+        self.shutdown_requested = False
 
         self._print_banner()
 
         # Run initial fingerprint check
         if FINGERPRINT_AVAILABLE:
             self._run_fingerprint_checks()
+
+    def request_shutdown(self, signum=None, frame=None):
+        """Request a graceful miner shutdown from SIGTERM/SIGINT."""
+        if not self.shutdown_requested:
+            print("\n\nShutting down miner...")
+        self.shutdown_requested = True
 
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA"""
@@ -484,13 +492,16 @@ class MacMiner:
         print(f"\n[{datetime.now().strftime('%H:%M:%S')}] Starting miner...")
 
         # Initial attestation
-        while not self.attest():
+        while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
             time.sleep(30)
+        if self.shutdown_requested:
+            print("Miner stopped gracefully.")
+            return
 
         last_slot = 0
 
-        while True:
+        while not self.shutdown_requested:
             try:
                 # Re-attest if needed
                 if time.time() > self.attestation_valid_until:
@@ -525,11 +536,12 @@ class MacMiner:
                 time.sleep(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
-                print("\n\nShutting down miner...")
+                self.request_shutdown()
                 break
             except Exception as e:
                 print(f"[{datetime.now().strftime('%H:%M:%S')}] Error: {e}")
                 time.sleep(30)
+        print(f"Miner stopped gracefully. Submitted: {self.shares_submitted} | Accepted: {self.shares_accepted}")
 
 
 if __name__ == "__main__":
@@ -546,4 +558,6 @@ if __name__ == "__main__":
         NODE_URL = args.node
 
     miner = MacMiner(miner_id=args.miner_id, wallet=args.wallet)
+    signal.signal(signal.SIGTERM, miner.request_shutdown)
+    signal.signal(signal.SIGINT, miner.request_shutdown)
     miner.run()

--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -22,6 +22,7 @@ import subprocess
 import statistics
 import re
 import socket
+import signal
 from datetime import datetime
 
 # Color helper stubs (no-op if terminal doesn't support ANSI)
@@ -377,6 +378,7 @@ class MacMiner:
         self.shares_submitted = 0
         self.shares_accepted = 0
         self.last_entropy = {}
+        self.shutdown_requested = False
         self._last_system_time = time.monotonic()
 
         self._print_banner()
@@ -384,6 +386,12 @@ class MacMiner:
         # Run initial fingerprint check
         if FINGERPRINT_AVAILABLE:
             self._run_fingerprint_checks()
+
+    def request_shutdown(self, signum=None, frame=None):
+        """Request a graceful miner shutdown from SIGTERM/SIGINT."""
+        if not self.shutdown_requested:
+            print("\n\nShutting down miner...")
+        self.shutdown_requested = True
 
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA."""
@@ -596,14 +604,17 @@ class MacMiner:
         print("\n[{}] Starting miner...".format(ts))
 
         # Initial attestation
-        while not self.attest():
+        while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
             time.sleep(30)
+        if self.shutdown_requested:
+            print("Miner stopped gracefully.")
+            return
 
         last_slot = 0
         status_counter = 0
 
-        while True:
+        while not self.shutdown_requested:
             try:
                 # Detect sleep/wake — force re-attest
                 if self._detect_sleep_wake():
@@ -649,12 +660,15 @@ class MacMiner:
                 time.sleep(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
-                print("\n\nShutting down miner...")
+                self.request_shutdown()
                 break
             except Exception as e:
                 ts = datetime.now().strftime('%H:%M:%S')
                 print("[{}] Error: {}".format(ts, e))
                 time.sleep(30)
+        print("Miner stopped gracefully. Submitted: {} | Accepted: {}".format(
+            self.shares_submitted, self.shares_accepted
+        ))
 
 
 if __name__ == "__main__":
@@ -681,4 +695,6 @@ if __name__ == "__main__":
         node_url=node,
         proxy_url=proxy,
     )
+    signal.signal(signal.SIGTERM, miner.request_shutdown)
+    signal.signal(signal.SIGINT, miner.request_shutdown)
     miner.run()

--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -393,6 +393,15 @@ class MacMiner:
             print("\n\nShutting down miner...")
         self.shutdown_requested = True
 
+    def sleep_until_shutdown(self, seconds, interval=1.0):
+        """Sleep in short checkpoints so signal-driven shutdown returns promptly."""
+        deadline = time.monotonic() + seconds
+        while not self.shutdown_requested:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(interval, remaining))
+
     def _run_fingerprint_checks(self):
         """Run hardware fingerprint checks for RIP-PoA."""
         print(info("\n[FINGERPRINT] Running hardware fingerprint checks..."))
@@ -606,7 +615,7 @@ class MacMiner:
         # Initial attestation
         while not self.shutdown_requested and not self.attest():
             print("  Retrying attestation in 30 seconds...")
-            time.sleep(30)
+            self.sleep_until_shutdown(30)
         if self.shutdown_requested:
             print("Miner stopped gracefully.")
             return
@@ -657,7 +666,7 @@ class MacMiner:
                     ))
                     status_counter = 0
 
-                time.sleep(LOTTERY_CHECK_INTERVAL)
+                self.sleep_until_shutdown(LOTTERY_CHECK_INTERVAL)
 
             except KeyboardInterrupt:
                 self.request_shutdown()
@@ -665,7 +674,7 @@ class MacMiner:
             except Exception as e:
                 ts = datetime.now().strftime('%H:%M:%S')
                 print("[{}] Error: {}".format(ts, e))
-                time.sleep(30)
+                self.sleep_until_shutdown(30)
         print("Miner stopped gracefully. Submitted: {} | Accepted: {}".format(
             self.shares_submitted, self.shares_accepted
         ))

--- a/tests/test_macos_miner_signal_shutdown.py
+++ b/tests/test_macos_miner_signal_shutdown.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import importlib.util
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -7,6 +8,14 @@ MAC_MINERS = [
     ROOT / "miners" / "macos" / "rustchain_mac_miner_v2.4.py",
     ROOT / "miners" / "macos" / "intel" / "rustchain_mac_miner_v2.4.py",
 ]
+
+
+def load_miner_module(miner_path):
+    module_name = "mac_miner_{}".format(abs(hash(miner_path)))
+    spec = importlib.util.spec_from_file_location(module_name, miner_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def test_macos_miners_register_sigterm_shutdown_handler():
@@ -19,3 +28,26 @@ def test_macos_miners_register_sigterm_shutdown_handler():
         assert "while not self.shutdown_requested:" in source
         assert "signal.signal(signal.SIGTERM, miner.request_shutdown)" in source
         assert "signal.signal(signal.SIGINT, miner.request_shutdown)" in source
+        assert "def sleep_until_shutdown(self, seconds, interval=1.0):" in source
+        assert "self.sleep_until_shutdown(30)" in source
+        assert "self.sleep_until_shutdown(LOTTERY_CHECK_INTERVAL)" in source
+
+
+def test_shutdown_sleep_helper_returns_after_shutdown_request(monkeypatch):
+    for miner_path in MAC_MINERS:
+        module = load_miner_module(miner_path)
+        miner = module.MacMiner.__new__(module.MacMiner)
+        miner.shutdown_requested = False
+        sleeps = []
+
+        def fake_sleep(seconds):
+            sleeps.append(seconds)
+            miner.shutdown_requested = True
+
+        monkeypatch.setattr(module.time, "sleep", fake_sleep)
+
+        miner.sleep_until_shutdown(30)
+
+        assert sleeps, "expected {} to sleep in short checkpoints".format(miner_path)
+        assert max(sleeps) <= 1.0
+        assert miner.shutdown_requested

--- a/tests/test_macos_miner_signal_shutdown.py
+++ b/tests/test_macos_miner_signal_shutdown.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MAC_MINERS = [
+    ROOT / "miners" / "macos" / "rustchain_mac_miner_v2.5.py",
+    ROOT / "miners" / "macos" / "rustchain_mac_miner_v2.4.py",
+    ROOT / "miners" / "macos" / "intel" / "rustchain_mac_miner_v2.4.py",
+]
+
+
+def test_macos_miners_register_sigterm_shutdown_handler():
+    for miner_path in MAC_MINERS:
+        source = miner_path.read_text(encoding="utf-8")
+
+        assert "import signal" in source
+        assert "self.shutdown_requested = False" in source
+        assert "def request_shutdown(self, signum=None, frame=None):" in source
+        assert "while not self.shutdown_requested:" in source
+        assert "signal.signal(signal.SIGTERM, miner.request_shutdown)" in source
+        assert "signal.signal(signal.SIGINT, miner.request_shutdown)" in source


### PR DESCRIPTION
Fixes #2745

## Summary
- Registers SIGTERM and SIGINT handlers for the macOS miner entrypoints.
- Adds a shutdown flag so the initial attestation retry loop and mining loop can exit cleanly.
- Preserves the existing KeyboardInterrupt path by routing it through the same graceful shutdown request.
- Adds a regression guard covering the universal v2.5 miner, v2.4 miner, and Intel v2.4 miner scripts.

## Root cause
The macOS miner only handled `KeyboardInterrupt`; SIGTERM used the process default action, so launchd/terminal termination could stop the process without running the miner's shutdown path or printing final state.

## Validation
- `python -m pytest tests\test_macos_miner_signal_shutdown.py -q`
- `python -m py_compile miners\macos\rustchain_mac_miner_v2.5.py miners\macos\rustchain_mac_miner_v2.4.py miners\macos\intel\rustchain_mac_miner_v2.4.py`