### PR TITLE
fix: retry transient RTC award transfers

### DIFF
--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -35,6 +35,7 @@ import json
 import os
 import re
 import sys
+import time
 import textwrap
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -264,6 +265,8 @@ def transfer_rtc(
     to_wallet: str,
     amount: float,
     memo: str,
+    max_attempts: int = 3,
+    retry_delay: float = 2.0,
 ) -> Tuple[bool, Dict[str, Any]]:
     """
     Call the RustChain ``POST /wallet/transfer`` admin endpoint.
@@ -286,19 +289,31 @@ def transfer_rtc(
         },
         method="POST",
     )
-    try:
-        resp = urlopen(req, timeout=30)
-        result = json.loads(resp.read().decode())
-        return result.get("ok", False), result
-    except HTTPError as e:
-        body = e.read().decode(errors="replace")
+    attempts = max(1, int(max_attempts))
+    for attempt in range(1, attempts + 1):
         try:
-            result = json.loads(body)
-        except (json.JSONDecodeError, ValueError):
-            result = {"error": body}
-        return False, result
-    except URLError as e:
-        return False, {"error": f"Connection failed: {e.reason}"}
+            resp = urlopen(req, timeout=30)
+            result = json.loads(resp.read().decode())
+            return result.get("ok", False), result
+        except HTTPError as e:
+            body = e.read().decode(errors="replace")
+            try:
+                result = json.loads(body)
+            except (json.JSONDecodeError, ValueError):
+                result = {"error": body}
+            return False, result
+        except URLError as e:
+            if attempt >= attempts:
+                return False, {
+                    "error": f"Connection failed after {attempts} attempts: {e.reason}"
+                }
+            log_warning(
+                f"Transfer connection attempt {attempt}/{attempts} failed: {e.reason}; retrying."
+            )
+            if retry_delay > 0:
+                time.sleep(retry_delay)
+
+    return False, {"error": "Connection failed"}
 
 
 # ---------------------------------------------------------------------------

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -26,6 +26,7 @@ from award_rtc import (
     resolve_wallet_from_pr_body,
     resolve_wallet_from_file,
     check_already_awarded,
+    transfer_rtc,
     set_output,
     _AWARD_MARKER,
 )
@@ -248,6 +249,45 @@ class TestSetOutput(unittest.TestCase):
             self.assertIn("amount=50.0", content)
         finally:
             os.unlink(output_file)
+
+
+# ---------------------------------------------------------------------------
+# Transfer API tests
+# ---------------------------------------------------------------------------
+
+
+class TestTransferRtc(unittest.TestCase):
+    """Test RTC transfer API behavior."""
+
+    def test_retries_transient_connection_failure_before_success(self):
+        attempts = []
+
+        class FakeResponse:
+            def read(self):
+                return b'{"ok": true, "tx_hash": "tx_retry"}'
+
+        def fake_urlopen(req, timeout):
+            attempts.append((req.full_url, timeout))
+            if len(attempts) == 1:
+                from urllib.error import URLError
+                raise URLError(ConnectionRefusedError(111, "Connection refused"))
+            return FakeResponse()
+
+        with patch("award_rtc.urlopen", side_effect=fake_urlopen):
+            ok, result = transfer_rtc(
+                "1.2.3.4",
+                "admin-key",
+                "founder",
+                "recipient",
+                5,
+                "retry memo",
+                max_attempts=2,
+                retry_delay=0,
+            )
+
+        self.assertTrue(ok)
+        self.assertEqual(result["tx_hash"], "tx_retry")
+        self.assertEqual(len(attempts), 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Retry transient RTC award transfer connection failures before marking the auto-bounty run as failed.
- Keep HTTP transfer rejections non-retried so real server-side failures still surface immediately.
- Add a regression test proving a first `Connection refused` can recover on a second transfer attempt.

## Why
Refs #5333. The failed award run evidence shows the transfer endpoint returned `Connection refused`. The action previously made only one request, so a short service restart or temporary listener gap permanently failed that award run and required manual handling.

This does not attempt to backfill historical failed awards by itself; it makes the merge-award path more resilient so future transient endpoint outages are retried inside the action.

## Validation
```bash
python -m pytest .github\actions\rtc-auto-bounty\test_award_rtc.py -q
python -m py_compile .github\actions\rtc-auto-bounty\award_rtc.py .github\actions\rtc-auto-bounty\test_award_rtc.py
git diff --check
```

All passed locally.