### PR TITLE
fix: avoid refund after withdrawal broadcast hash

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -59,6 +59,34 @@ class PayoutWorker:
 
             return withdrawals
 
+    def _record_broadcast_reconciliation_needed(
+        self,
+        withdrawal_id: str,
+        tx_hash: str,
+        error: str,
+    ) -> None:
+        """Keep broadcast withdrawals out of the refund path after DB failures."""
+        message = (
+            "Broadcast returned transaction hash but completion update failed; "
+            f"manual reconciliation required: {error}"
+        )
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                conn.execute("""
+                    UPDATE withdrawals
+                    SET status = 'processing',
+                        tx_hash = ?,
+                        error_msg = ?
+                    WHERE withdrawal_id = ?
+                """, (tx_hash, message, withdrawal_id))
+        except Exception as record_error:
+            logger.error(
+                "Failed to record reconciliation state for %s (%s): %s",
+                withdrawal_id,
+                tx_hash,
+                record_error,
+            )
+
     def execute_withdrawal(self, withdrawal: Dict) -> Optional[str]:
         """Execute withdrawal transaction"""
         if MOCK_MODE:
@@ -90,6 +118,7 @@ class PayoutWorker:
     def process_withdrawal(self, withdrawal: Dict) -> bool:
         """Process a single withdrawal with balance deduction before execution."""
         withdrawal_id = withdrawal['withdrawal_id']
+        tx_hash = None
 
         try:
             logger.info(f"Processing withdrawal {withdrawal_id}")
@@ -176,6 +205,15 @@ class PayoutWorker:
 
         except Exception as e:
             logger.error(f"✗ Withdrawal {withdrawal_id} failed: {e}")
+
+            if tx_hash:
+                self._record_broadcast_reconciliation_needed(
+                    withdrawal_id,
+                    tx_hash,
+                    str(e),
+                )
+                self.stats['failed'] += 1
+                return False
 
             # Refund balance on broadcast failure and mark as failed
             with sqlite3.connect(self.db_path) as conn:

--- a/tests/test_payout_worker_production_noop.py
+++ b/tests/test_payout_worker_production_noop.py
@@ -71,3 +71,51 @@ def test_process_withdrawal_leaves_pending_when_production_broadcast_is_not_conf
     assert status == "pending"
     assert "not configured" in error_msg
     assert tx_hash is None
+
+
+def test_process_withdrawal_does_not_refund_after_broadcast_tx_hash(
+    tmp_path, monkeypatch
+):
+    class BroadcastThenCompletionUpdateFailsWorker(payout_worker.PayoutWorker):
+        def execute_withdrawal(self, withdrawal):
+            return "tx-broadcasted"
+
+    monkeypatch.setattr(payout_worker, "MOCK_MODE", True)
+    db_path = str(tmp_path / "payout_worker.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE accounts (public_key TEXT PRIMARY KEY, balance INTEGER)")
+        conn.execute(
+            "CREATE TABLE withdrawals ("
+            "withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT, amount INTEGER, fee INTEGER, "
+            "destination TEXT, status TEXT, error_msg TEXT, tx_hash TEXT, created_at INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO accounts (public_key, balance) VALUES (?, ?)",
+            ("miner-pubkey", 100),
+        )
+        conn.execute(
+            "INSERT INTO withdrawals "
+            "(withdrawal_id, miner_pk, amount, fee, destination, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("wd-1", "miner-pubkey", 10, 1, "RTCdest", "pending", 1234567890),
+        )
+
+    worker = BroadcastThenCompletionUpdateFailsWorker()
+    worker.db_path = db_path
+
+    assert worker.process_withdrawal(withdrawal()) is False
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT balance FROM accounts WHERE public_key = ?",
+            ("miner-pubkey",),
+        ).fetchone()[0]
+        status, error_msg, tx_hash = conn.execute(
+            "SELECT status, error_msg, tx_hash FROM withdrawals WHERE withdrawal_id = ?",
+            ("wd-1",),
+        ).fetchone()
+
+    assert balance == 89
+    assert status == "processing"
+    assert tx_hash == "tx-broadcasted"
+    assert "manual reconciliation required" in error_msg


### PR DESCRIPTION
## Summary

Fixes a withdrawal recovery safety gap related to #5346. If `execute_withdrawal()` returns a transaction hash and the later database completion update fails, the worker must not refund the balance because the payout may already have been broadcast.

## Changes

- Track whether a broadcast `tx_hash` has been returned inside `process_withdrawal()`.
- If an error occurs after a `tx_hash` exists, keep the withdrawal in `processing`, record the `tx_hash` and reconciliation error, and do not credit funds back to the account.
- Preserve the existing refund path for failures before any transaction hash exists.
- Add a regression test that simulates a completion-update failure after broadcast and verifies the balance stays debited.

## Validation

- `py -3.14 -B -m py_compile node/payout_worker.py tests/test_payout_worker_production_noop.py`
- `py -3.14 -m pytest tests/test_payout_worker_production_noop.py -q` -> 3 passed
- `git diff --check`

Wallet: RTC3cb17c1f0b2b97c9c120e306f9a4c0d2da6b0877

Fixes #5346