### PR TITLE
fix: reject non-finite bridge lock amounts

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -1,662 +1,886 @@
 """
-RIP-305 Track C: Bridge API
-Cross-chain bridge endpoints for wRTC (Wrapped RTC) on Solana + Base L2
+Unit tests for RIP-305 Track C Bridge API - Issue #727 Proof Validation
 
-Endpoints:
-  POST /bridge/lock      - Lock RTC, get lock_id for cross-chain mint
-  POST /bridge/release   - Admin: release wRTC on target chain
-  GET  /bridge/ledger    - Query lock ledger (transparent)
-  GET  /bridge/status/<lock_id> - Check lock status
+Tests for verifiable proof / signed receipt requirements on /bridge/lock
 
-Admin-controlled Phase 1 (upgrade to trustless lock in Phase 2)
+Run: python -m pytest test_bridge_api.py -v
 """
 
-import os
 import json
-import sqlite3
-import hashlib
-import hmac
+import os
+import sys
 import time
-import threading
-import uuid
-from functools import wraps
-from flask import Flask, Blueprint, request, jsonify
+import hmac
+import hashlib
+import pytest
 
-# ─── Config ──────────────────────────────────────────────────────────────────
-BRIDGE_DB_PATH = os.environ.get("BRIDGE_DB_PATH", "bridge_ledger.db")
-BRIDGE_ADMIN_KEY = os.environ.get("BRIDGE_ADMIN_KEY", "")  # set in production
-BRIDGE_RECEIPT_SECRET = os.environ.get("BRIDGE_RECEIPT_SECRET", "")
+# Use a temp DB for testing
+os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+os.environ["BRIDGE_ADMIN_KEY"] = "test-admin-key-12345"
+os.environ["BRIDGE_RECEIPT_SECRET"] = "test-bridge-receipt-secret-727"
+os.environ["BRIDGE_REQUIRE_PROOF"] = "true"  # Issue #727: require proof
 
-# Security: require proof for all bridge locks (Issue #727)
-BRIDGE_REQUIRE_PROOF = os.environ.get("BRIDGE_REQUIRE_PROOF", "true").lower() == "true"
+# Remove any stale test DB
+if os.path.exists("/tmp/bridge_test_727.db"):
+    os.remove("/tmp/bridge_test_727.db")
 
-# Target chain identifiers
-CHAIN_SOLANA = "solana"
-CHAIN_BASE = "base"
-SUPPORTED_CHAINS = {CHAIN_SOLANA, CHAIN_BASE}
-
-# RTC decimal precision
-RTC_DECIMALS = 6
-
-# Minimum lock amounts
-MIN_LOCK_AMOUNT = 1  # 1 RTC
-MAX_LOCK_AMOUNT = 10_000  # 10,000 RTC per transaction
-
-# Lock states
-STATE_REQUESTED = "requested"  # User submitted request, awaiting proof review
-STATE_PENDING   = "pending"    # Lock received, awaiting processing
-STATE_CONFIRMED = "confirmed"  # Lock confirmed on-chain
-STATE_RELEASING = "releasing"  # Admin is minting wRTC
-STATE_COMPLETE  = "complete"   # wRTC minted on target chain
-STATE_FAILED    = "failed"     # Lock failed / expired
-STATE_REFUNDED  = "refunded"   # RTC refunded to sender
-
-# Lock expiry (24h in seconds)
-LOCK_EXPIRY_SECONDS = 86_400
-
-# ─── Database ─────────────────────────────────────────────────────────────────
-_db_lock = threading.Lock()
+# Import after env setup
+sys.path.insert(0, os.path.dirname(__file__))
+import bridge_api
+from bridge_api import Flask, register_bridge_routes, STATE_REQUESTED, STATE_CONFIRMED
 
 
-def get_db():
-    conn = sqlite3.connect(BRIDGE_DB_PATH)
-    conn.row_factory = sqlite3.Row
-    return conn
-
-
-def init_bridge_db():
-    """Initialize the bridge ledger database."""
-    with get_db() as conn:
-        conn.executescript("""
-        CREATE TABLE IF NOT EXISTS bridge_locks (
-            lock_id       TEXT PRIMARY KEY,
-            sender_wallet TEXT NOT NULL,
-            amount_rtc    INTEGER NOT NULL,       -- in base units (millionths)
-            target_chain  TEXT NOT NULL,
-            target_wallet TEXT NOT NULL,
-            state         TEXT NOT NULL DEFAULT 'pending',
-            tx_hash       TEXT,                  -- RustChain tx that locked RTC
-            proof_type    TEXT DEFAULT '',
-            proof_ref     TEXT DEFAULT '',
-            release_tx    TEXT,                  -- Target chain tx that minted wRTC
-            confirmed_at  INTEGER DEFAULT 0,
-            confirmed_by  TEXT DEFAULT '',
-            created_at    INTEGER NOT NULL,
-            updated_at    INTEGER NOT NULL,
-            expires_at    INTEGER NOT NULL,
-            notes         TEXT
-        );
-
-        CREATE INDEX IF NOT EXISTS idx_locks_sender ON bridge_locks(sender_wallet);
-        CREATE INDEX IF NOT EXISTS idx_locks_state  ON bridge_locks(state);
-        CREATE INDEX IF NOT EXISTS idx_locks_chain  ON bridge_locks(target_chain);
-
-        CREATE TABLE IF NOT EXISTS bridge_events (
-            id            INTEGER PRIMARY KEY AUTOINCREMENT,
-            lock_id       TEXT NOT NULL,
-            event_type    TEXT NOT NULL,
-            actor         TEXT,
-            details       TEXT,
-            ts            INTEGER NOT NULL
-        );
-        """)
-        cols = {row[1] for row in conn.execute("PRAGMA table_info(bridge_locks)").fetchall()}
-        migrations = {
-            "proof_type": "ALTER TABLE bridge_locks ADD COLUMN proof_type TEXT DEFAULT ''",
-            "proof_ref": "ALTER TABLE bridge_locks ADD COLUMN proof_ref TEXT DEFAULT ''",
-            "confirmed_at": "ALTER TABLE bridge_locks ADD COLUMN confirmed_at INTEGER DEFAULT 0",
-            "confirmed_by": "ALTER TABLE bridge_locks ADD COLUMN confirmed_by TEXT DEFAULT ''",
-        }
-        for col, sql in migrations.items():
-            if col not in cols:
-                conn.execute(sql)
-        conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_locks_tx_hash ON bridge_locks(tx_hash) WHERE tx_hash IS NOT NULL AND tx_hash != ''")
-    print("[bridge] DB initialized:", BRIDGE_DB_PATH)
-
-
-def log_event(conn, lock_id: str, event_type: str, actor: str = None, details: dict = None):
-    conn.execute(
-        "INSERT INTO bridge_events (lock_id, event_type, actor, details, ts) VALUES (?,?,?,?,?)",
-        (lock_id, event_type, actor, json.dumps(details or {}), int(time.time()))
-    )
-
-
-# ─── Helpers ──────────────────────────────────────────────────────────────────
-def _amount_to_base(amount_float: float) -> int:
-    """Convert human-readable RTC to base units (6 decimal places)."""
-    return int(round(amount_float * (10 ** RTC_DECIMALS)))
-
-
-def _amount_from_base(amount_int: int) -> float:
-    """Convert base units to human-readable RTC."""
-    return amount_int / (10 ** RTC_DECIMALS)
-
-
-def _generate_lock_id(sender: str, amount: int, target_chain: str, ts: int) -> str:
-    """Deterministic lock ID from key fields."""
-    raw = f"{sender}:{amount}:{target_chain}:{ts}:{uuid.uuid4()}"
-    return "lock_" + hashlib.sha256(raw.encode()).hexdigest()[:24]
-
-
-def _canonical_lock_receipt(sender: str, amount_base: int, target_chain: str, target_wallet: str, tx_hash: str) -> bytes:
-    """Canonical payload for signed lock receipts."""
+def _receipt_signature(sender_wallet, amount, target_chain, target_wallet, tx_hash):
+    """Generate valid HMAC-SHA256 receipt signature for testing."""
     payload = {
-        "sender_wallet": sender,
-        "amount_base": amount_base,
+        "sender_wallet": sender_wallet,
+        "amount_base": int(round(amount * 1_000_000)),
         "target_chain": target_chain,
         "target_wallet": target_wallet,
         "tx_hash": tx_hash,
     }
-    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    message = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(
+        os.environ["BRIDGE_RECEIPT_SECRET"].encode("utf-8"),
+        message,
+        hashlib.sha256,
+    ).hexdigest()
 
 
-def _verify_receipt_signature(sender: str, amount_base: int, target_chain: str, target_wallet: str, tx_hash: str, receipt_signature: str) -> bool:
-    """Verify HMAC-SHA256 bridge receipt signature when a receipt secret is configured."""
-    if not BRIDGE_RECEIPT_SECRET:
-        return False
-    message = _canonical_lock_receipt(sender, amount_base, target_chain, target_wallet, tx_hash)
-    expected = hmac.new(BRIDGE_RECEIPT_SECRET.encode("utf-8"), message, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, receipt_signature.lower())
-
-
-def _require_admin(fn):
-    """Decorator: require X-Admin-Key header."""
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        key = request.headers.get("X-Admin-Key", "")
-        if not BRIDGE_ADMIN_KEY:
-            return jsonify({"error": "admin key not configured on server"}), 500
-        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
-            return jsonify({"error": "unauthorized"}), 403
-        return fn(*args, **kwargs)
-    return wrapper
-
-
-def _json_object_body():
-    """Return the parsed JSON body only when it is an object."""
-    data = request.get_json(force=True, silent=True)
-    if not isinstance(data, dict):
-        return None, (jsonify({"error": "JSON object body is required"}), 400)
-    return data, None
-
-
-def _clean_string_field(data, field_name, *, optional=False, lower=False):
-    value = data.get(field_name)
-    if value is None:
-        return None if optional else ""
-    if not isinstance(value, str):
-        raise ValueError(f"{field_name} must be a string")
-    value = value.strip()
-    if lower:
-        value = value.lower()
-    if optional and not value:
-        return None
-    return value
-
-
-# ─── Blueprint ────────────────────────────────────────────────────────────────
-bridge_bp = Blueprint("bridge", __name__, url_prefix="/bridge")
-
-
-@bridge_bp.route("/lock", methods=["POST"])
-def lock_rtc():
-    """
-    Lock RTC for cross-chain bridge.
-
-    Body (JSON):
-      sender_wallet  : str   - RustChain wallet name
-      amount         : float - RTC to lock (e.g. 100.5)
-      target_chain   : str   - "solana" or "base"
-      target_wallet  : str   - Solana address or Base EVM address
-      tx_hash        : str   - RustChain tx confirming the lock request
-      receipt_signature : str - (optional) HMAC-SHA256 signed receipt for direct confirmation
-
-    Returns:
-      lock_id        : str   - Unique identifier for this lock
-      state          : str   - "requested" or "confirmed"
-      expires_at     : int   - Unix timestamp when lock expires
-      amount_rtc     : float - Amount locked
-
-    Security (Issue #727):
-      - Requires verifiable proof (signed receipt) when BRIDGE_REQUIRE_PROOF is enabled
-      - Rejects requests with invalid proof signatures
-      - Validates proof before accepting lock into ledger
-    """
-    data, error_response = _json_object_body()
-    if error_response:
-        return error_response
-
-    # ── Validate inputs ──
-    try:
-        sender = _clean_string_field(data, "sender_wallet")
-        target_chain = _clean_string_field(data, "target_chain", lower=True)
-        target_wallet = _clean_string_field(data, "target_wallet")
-        tx_hash = _clean_string_field(data, "tx_hash", optional=True)
-        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-
-    try:
-        amount_float = float(data.get("amount", 0))
-    except (TypeError, ValueError):
-        return jsonify({"error": "invalid amount"}), 400
-
-    if not sender:
-        return jsonify({"error": "sender_wallet is required"}), 400
-    if target_chain not in SUPPORTED_CHAINS:
-        return jsonify({"error": f"target_chain must be one of: {', '.join(sorted(SUPPORTED_CHAINS))}"}), 400
-    if not target_wallet:
-        return jsonify({"error": "target_wallet is required"}), 400
-    if not tx_hash:
-        return jsonify({"error": "tx_hash is required for bridge lock requests"}), 400
-    if amount_float < MIN_LOCK_AMOUNT:
-        return jsonify({"error": f"minimum lock amount is {MIN_LOCK_AMOUNT} RTC"}), 400
-    if amount_float > MAX_LOCK_AMOUNT:
-        return jsonify({"error": f"maximum lock amount is {MAX_LOCK_AMOUNT} RTC"}), 400
-
-    # Validate target wallet format
-    if target_chain == CHAIN_BASE and not target_wallet.startswith("0x"):
-        return jsonify({"error": "Base wallet must be a 0x EVM address"}), 400
-    if target_chain == CHAIN_SOLANA and len(target_wallet) < 32:
-        return jsonify({"error": "Solana wallet must be a valid base58 address"}), 400
-
-    amount_base = _amount_to_base(amount_float)
-    now = int(time.time())
-    expires_at = now + LOCK_EXPIRY_SECONDS
-    lock_id = _generate_lock_id(sender, amount_base, target_chain, now)
-
-    # ── Issue #727: Strict proof validation ──
-    proof_type = None
-    proof_ref = None
-    state = None
-    confirmed_at = 0
-    confirmed_by = ""
-
-    if receipt_signature:
-        # User provided a signed receipt - verify it
-        if not BRIDGE_RECEIPT_SECRET:
-            return jsonify({
-                "error": "bridge receipt verification is not configured on server"
-            }), 503
-        if not _verify_receipt_signature(
-            sender, amount_base, target_chain, target_wallet, tx_hash, receipt_signature
-        ):
-            return jsonify({
-                "error": "invalid receipt_signature - proof verification failed"
-            }), 403
-        # Valid signed receipt - lock is confirmed immediately
-        proof_type = "signed_receipt"
-        proof_ref = f"receipt:{tx_hash}"
-        state = STATE_CONFIRMED
-        confirmed_at = now
-        confirmed_by = "receipt"
-    elif BRIDGE_REQUIRE_PROOF:
-        # No proof provided but proof is required
-        return jsonify({
-            "error": "proof required: receipt_signature must be provided for bridge lock acceptance"
-        }), 400
-    else:
-        # Proof not required - accept for manual review (legacy mode)
-        proof_type = "tx_hash_review"
-        proof_ref = tx_hash
-        state = STATE_REQUESTED
-
-    with _db_lock:
-        with get_db() as conn:
-            try:
-                conn.execute(
-                    """
-                    INSERT INTO bridge_locks
-                      (lock_id, sender_wallet, amount_rtc, target_chain, target_wallet,
-                       state, tx_hash, proof_type, proof_ref, confirmed_at, confirmed_by,
-                       created_at, updated_at, expires_at)
-                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-                    """,
-                    (
-                        lock_id,
-                        sender,
-                        amount_base,
-                        target_chain,
-                        target_wallet,
-                        state,
-                        tx_hash,
-                        proof_type,
-                        proof_ref,
-                        confirmed_at,
-                        confirmed_by,
-                        now,
-                        now,
-                        expires_at,
-                    )
-                )
-            except sqlite3.IntegrityError:
-                return jsonify({"error": "tx_hash already used for another bridge lock"}), 409
-
-            log_event(conn, lock_id, "lock_created", actor=sender, details={
-                "amount": amount_float,
-                "target_chain": target_chain,
-                "target_wallet": target_wallet,
-                "tx_hash": tx_hash,
-                "proof_type": proof_type,
-                "state": state,
-            })
-            if state == STATE_CONFIRMED:
-                log_event(conn, lock_id, "lock_confirmed", actor=confirmed_by, details={
-                    "proof_type": proof_type,
-                    "proof_ref": proof_ref,
-                })
-            conn.commit()
-
-    return jsonify({
-        "lock_id": lock_id,
-        "state": state,
-        "sender_wallet": sender,
-        "amount_rtc": amount_float,
+def _receipt_signature_with_secret(sender_wallet, amount, target_chain, target_wallet, tx_hash, secret):
+    """Generate receipt signature with custom secret (for testing invalid signatures)."""
+    payload = {
+        "sender_wallet": sender_wallet,
+        "amount_base": int(round(amount * 1_000_000)),
         "target_chain": target_chain,
         "target_wallet": target_wallet,
         "tx_hash": tx_hash,
-        "proof_type": proof_type,
-        "proof_ref": proof_ref,
-        "expires_at": expires_at,
-        "message": (
-            f"Lock {'confirmed' if state == STATE_CONFIRMED else 'requested'}. "
-            f"Admin will only mint {amount_float} wRTC on {target_chain} "
-            f"to {target_wallet[:12]}... after proof confirmation."
-        )
-    }), 201
+    }
+    message = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(
+        secret.encode("utf-8"),
+        message,
+        hashlib.sha256,
+    ).hexdigest()
 
 
-@bridge_bp.route("/confirm", methods=["POST"])
-@_require_admin
-def confirm_lock():
-    """Admin: confirm a requested lock after reviewing proof."""
-    data, error_response = _json_object_body()
-    if error_response:
-        return error_response
-    try:
-        lock_id = _clean_string_field(data, "lock_id")
-        proof_ref = _clean_string_field(data, "proof_ref")
-        notes = _clean_string_field(data, "notes", optional=True)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-
-    if not lock_id:
-        return jsonify({"error": "lock_id is required"}), 400
-    if not proof_ref:
-        return jsonify({"error": "proof_ref is required"}), 400
-
-    now = int(time.time())
-    with _db_lock:
-        with get_db() as conn:
-            row = conn.execute(
-                "SELECT * FROM bridge_locks WHERE lock_id = ?",
-                (lock_id,),
-            ).fetchone()
-            if not row:
-                return jsonify({"error": "lock not found"}), 404
-            if row["state"] == STATE_CONFIRMED:
-                return jsonify({"error": "lock already confirmed"}), 409
-            if row["state"] != STATE_REQUESTED:
-                return jsonify({"error": f"cannot confirm lock in state '{row['state']}'"}), 409
-            if row["expires_at"] < now:
-                return jsonify({"error": "lock has expired"}), 410
-
-            conn.execute(
-                """
-                UPDATE bridge_locks
-                SET state = ?, proof_ref = ?, confirmed_at = ?, confirmed_by = ?, updated_at = ?, notes = ?
-                WHERE lock_id = ?
-                """,
-                (STATE_CONFIRMED, proof_ref, now, "admin", now, notes, lock_id),
-            )
-            log_event(conn, lock_id, "lock_confirmed", actor="admin", details={
-                "proof_ref": proof_ref,
-                "notes": notes,
-            })
-            conn.commit()
-
-    return jsonify({
-        "lock_id": lock_id,
-        "state": STATE_CONFIRMED,
-        "proof_ref": proof_ref,
-        "message": "Lock confirmed and eligible for release",
-    })
-
-
-@bridge_bp.route("/release", methods=["POST"])
-@_require_admin
-def release_wrtc():
-    """
-    Admin: mark a lock as released (wRTC minted on target chain).
-
-    Body (JSON):
-      lock_id      : str - Lock to release
-      release_tx   : str - Target chain tx hash (Solana or Base)
-      notes        : str - (optional) admin notes
-
-    Returns success/error.
-    """
-    data, error_response = _json_object_body()
-    if error_response:
-        return error_response
-    try:
-        lock_id = _clean_string_field(data, "lock_id")
-        release_tx = _clean_string_field(data, "release_tx")
-        notes = _clean_string_field(data, "notes", optional=True)
-    except ValueError as exc:
-        return jsonify({"error": str(exc)}), 400
-
-    if not lock_id:
-        return jsonify({"error": "lock_id is required"}), 400
-    if not release_tx:
-        return jsonify({"error": "release_tx is required (target chain tx hash)"}), 400
-
-    now = int(time.time())
-    with _db_lock:
-        with get_db() as conn:
-            row = conn.execute(
-                "SELECT * FROM bridge_locks WHERE lock_id = ?", (lock_id,)
-            ).fetchone()
-
-            if not row:
-                return jsonify({"error": "lock not found"}), 404
-            if row["state"] not in (STATE_CONFIRMED, STATE_RELEASING):
-                return jsonify({
-                    "error": f"cannot release lock in state '{row['state']}'"
-                }), 409
-            if row["expires_at"] < now:
-                return jsonify({"error": "lock has expired"}), 410
-
-            conn.execute(
-                "UPDATE bridge_locks SET state=?, release_tx=?, updated_at=?, notes=? WHERE lock_id=?",
-                (STATE_COMPLETE, release_tx, now, notes, lock_id)
-            )
-            log_event(conn, lock_id, "released", actor="admin", details={
-                "release_tx": release_tx,
-                "notes": notes,
-            })
-            conn.commit()
-
-    return jsonify({
-        "lock_id": lock_id,
-        "state": STATE_COMPLETE,
-        "release_tx": release_tx,
-        "message": "wRTC successfully minted on target chain",
-    })
-
-
-@bridge_bp.route("/ledger", methods=["GET"])
-def get_ledger():
-    """
-    Query the lock ledger (transparent).
-
-    Query params:
-      state       : filter by state (pending/confirmed/complete/failed)
-      chain       : filter by target_chain (solana/base)
-      sender      : filter by sender_wallet
-      limit       : max results (default 50, max 200)
-      offset      : pagination offset
-
-    Returns list of locks.
-    """
-    state_filter  = request.args.get("state", "").strip() or None
-    chain_filter  = request.args.get("chain", "").strip() or None
-    sender_filter = request.args.get("sender", "").strip() or None
-    try:
-        limit  = int(request.args.get("limit", 50))
-        offset = int(request.args.get("offset", 0))
-    except (TypeError, ValueError):
-        return jsonify({"error": "limit and offset must be integers"}), 400
-    limit = max(1, min(limit, 200))
-    offset = max(offset, 0)
-
-    where_clauses, params = [], []
-    if state_filter:
-        where_clauses.append("state = ?"); params.append(state_filter)
-    if chain_filter:
-        where_clauses.append("target_chain = ?"); params.append(chain_filter)
-    if sender_filter:
-        where_clauses.append("sender_wallet = ?"); params.append(sender_filter)
-
-    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
-    params += [limit, offset]
-
-    with get_db() as conn:
-        rows = conn.execute(
-            f"""
-            SELECT lock_id, sender_wallet, amount_rtc, target_chain, target_wallet,
-                   state, tx_hash, proof_type, proof_ref, release_tx, confirmed_at, confirmed_by,
-                   created_at, updated_at, expires_at
-            FROM bridge_locks
-            {where_sql}
-            ORDER BY created_at DESC
-            LIMIT ? OFFSET ?
-            """,
-            params
-        ).fetchall()
-
-        total = conn.execute(
-            f"SELECT COUNT(*) FROM bridge_locks {where_sql}",
-            params[:-2]
-        ).fetchone()[0]
-
-    locks = [
-        {
-            "lock_id":       r["lock_id"],
-            "sender_wallet": r["sender_wallet"],
-            "amount_rtc":    _amount_from_base(r["amount_rtc"]),
-            "target_chain":  r["target_chain"],
-            "target_wallet": r["target_wallet"],
-            "state":         r["state"],
-            "tx_hash":       r["tx_hash"],
-            "proof_type":    r["proof_type"],
-            "proof_ref":     r["proof_ref"],
-            "release_tx":    r["release_tx"],
-            "confirmed_at":  r["confirmed_at"],
-            "confirmed_by":  r["confirmed_by"],
-            "created_at":    r["created_at"],
-            "updated_at":    r["updated_at"],
-            "expires_at":    r["expires_at"],
-        }
-        for r in rows
-    ]
-
-    return jsonify({
-        "locks": locks,
-        "total": total,
-        "limit": limit,
-        "offset": offset,
-    })
-
-
-@bridge_bp.route("/status/<lock_id>", methods=["GET"])
-def lock_status(lock_id: str):
-    """Get status of a specific lock."""
-    with get_db() as conn:
-        row = conn.execute(
-            "SELECT * FROM bridge_locks WHERE lock_id = ?", (lock_id,)
-        ).fetchone()
-
-    if not row:
-        return jsonify({"error": "lock not found"}), 404
-
-    events = []
-    with get_db() as conn:
-        evs = conn.execute(
-            "SELECT * FROM bridge_events WHERE lock_id = ? ORDER BY ts ASC",
-            (lock_id,)
-        ).fetchall()
-        events = [{"type": e["event_type"], "actor": e["actor"],
-                   "ts": e["ts"], "details": json.loads(e["details"] or "{}")}
-                  for e in evs]
-
-    return jsonify({
-        "lock_id":       row["lock_id"],
-        "sender_wallet": row["sender_wallet"],
-        "amount_rtc":    _amount_from_base(row["amount_rtc"]),
-        "target_chain":  row["target_chain"],
-        "target_wallet": row["target_wallet"],
-        "state":         row["state"],
-        "tx_hash":       row["tx_hash"],
-        "proof_type":    row["proof_type"],
-        "proof_ref":     row["proof_ref"],
-        "release_tx":    row["release_tx"],
-        "confirmed_at":  row["confirmed_at"],
-        "confirmed_by":  row["confirmed_by"],
-        "created_at":    row["created_at"],
-        "updated_at":    row["updated_at"],
-        "expires_at":    row["expires_at"],
-        "events":        events,
-    })
-
-
-@bridge_bp.route("/stats", methods=["GET"])
-def bridge_stats():
-    """Bridge statistics overview."""
-    with get_db() as conn:
-        stats = {}
-        for state in [STATE_REQUESTED, STATE_PENDING, STATE_CONFIRMED, STATE_RELEASING,
-                      STATE_COMPLETE, STATE_FAILED, STATE_REFUNDED]:
-            row = conn.execute(
-                "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks WHERE state = ?",
-                (state,)
-            ).fetchone()
-            stats[state] = {"count": row[0], "total_rtc": _amount_from_base(row[1])}
-
-        total_row = conn.execute(
-            "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks"
-        ).fetchone()
-
-        by_chain = {}
-        for chain in SUPPORTED_CHAINS:
-            row = conn.execute(
-                "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks "
-                "WHERE target_chain = ? AND state = ?",
-                (chain, STATE_COMPLETE)
-            ).fetchone()
-            by_chain[chain] = {"bridged_count": row[0], "total_wrtc_minted": _amount_from_base(row[1])}
-
-    return jsonify({
-        "by_state": stats,
-        "by_chain": by_chain,
-        "all_time": {
-            "total_locks": total_row[0],
-            "total_rtc_locked": _amount_from_base(total_row[1]),
-        }
-    })
-
-
-# ─── Integration shim ─────────────────────────────────────────────────────────
-def register_bridge_routes(app: Flask):
-    """Register bridge blueprint with an existing Flask app."""
-    init_bridge_db()
-    app.register_blueprint(bridge_bp)
-    print("[bridge] RIP-305 bridge endpoints registered at /bridge/*")
-
-
-# ─── Standalone dev server ─────────────────────────────────────────────────────
-if __name__ == "__main__":
+@pytest.fixture(scope="module")
+def client():
     app = Flask(__name__)
     register_bridge_routes(app)
-    print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+
+# =============================================================================
+# Issue #727: Proof Validation Tests
+# =============================================================================
+
+class TestProofValidation_ValidProof:
+    """Tests for valid proof scenarios - should be accepted and confirmed."""
+
+    def test_lock_with_valid_signed_receipt_solana(self, client):
+        """Valid signed receipt for Solana target - should confirm immediately."""
+        tx_hash = "rtc-lock-valid-proof-sol-001"
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "valid-proof-wallet-sol",
+            "amount": 100.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "valid-proof-wallet-sol",
+                100.0,
+                "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                tx_hash,
+            ),
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["state"] == "confirmed"
+        assert data["proof_type"] == "signed_receipt"
+        assert data["proof_ref"] == f"receipt:{tx_hash}"
+        assert data["lock_id"].startswith("lock_")
+        assert data["amount_rtc"] == 100.0
+
+    def test_lock_with_valid_signed_receipt_base(self, client):
+        """Valid signed receipt for Base target - should confirm immediately."""
+        tx_hash = "rtc-lock-valid-proof-base-001"
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "valid-proof-wallet-base",
+            "amount": 50.5,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "valid-proof-wallet-base",
+                50.5,
+                "base",
+                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+                tx_hash,
+            ),
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["state"] == "confirmed"
+        assert data["proof_type"] == "signed_receipt"
+
+    def test_lock_with_valid_receipt_has_confirmed_at_timestamp(self, client):
+        """Valid receipt should set confirmed_at timestamp."""
+        tx_hash = "rtc-lock-valid-proof-ts-001"
+        before = int(time.time())
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "valid-proof-wallet-ts",
+            "amount": 25.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "valid-proof-wallet-ts",
+                25.0,
+                "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                tx_hash,
+            ),
+        })
+        after = int(time.time())
+        assert resp.status_code == 201
+        data = resp.get_json()
+        # Verify via status endpoint
+        status_resp = client.get(f"/bridge/status/{data['lock_id']}")
+        status_data = status_resp.get_json()
+        assert status_data["confirmed_at"] >= before
+        assert status_data["confirmed_at"] <= after
+        assert status_data["confirmed_by"] == "receipt"
+
+
+class TestProofValidation_InvalidProof:
+    """Tests for invalid proof scenarios - should be rejected with 403."""
+
+    def test_lock_with_invalid_signature_rejected(self, client):
+        """Invalid signature (wrong secret) should be rejected."""
+        tx_hash = "rtc-lock-invalid-proof-badsig-001"
+        bad_signature = _receipt_signature_with_secret(
+            "invalid-proof-wallet",
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+            "wrong-secret-attacker",  # Wrong secret
+        )
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "invalid-proof-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": bad_signature,
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+        assert "proof verification failed" in data["error"]
+
+    def test_lock_with_tampered_signature_rejected(self, client):
+        """Tampered signature (modified hex) should be rejected."""
+        tx_hash = "rtc-lock-invalid-proof-tampered-001"
+        valid_sig = _receipt_signature(
+            "tamper-proof-wallet",
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+        )
+        # Tamper with signature
+        tampered_sig = valid_sig[:-4] + "dead"
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "tamper-proof-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": tampered_sig,
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+
+    def test_lock_with_empty_signature_rejected(self, client):
+        """Empty signature should be treated as missing proof."""
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "empty-sig-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-empty-sig-001",
+            "receipt_signature": "",
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "proof required" in data["error"]
+
+    def test_lock_with_malformed_signature_rejected(self, client):
+        """Malformed signature (non-hex) should be rejected."""
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "malformed-sig-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-malformed-sig-001",
+            "receipt_signature": "not-a-valid-hex-signature!!",
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+
+    def test_lock_with_signature_for_different_tx_rejected(self, client):
+        """Signature for different tx_hash should be rejected."""
+        tx_hash = "rtc-lock-different-tx-001"
+        wrong_tx_signature = _receipt_signature(
+            "diff-tx-wallet",
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "rtc-lock-different-tx-999",  # Different tx_hash
+        )
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "diff-tx-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": wrong_tx_signature,
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+
+    def test_lock_with_signature_for_different_amount_rejected(self, client):
+        """Signature for different amount should be rejected."""
+        tx_hash = "rtc-lock-diff-amount-001"
+        wrong_amount_signature = _receipt_signature(
+            "diff-amount-wallet",
+            999.0,  # Different amount
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+        )
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "diff-amount-wallet",
+            "amount": 10.0,  # Actual amount is different
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": wrong_amount_signature,
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+
+    def test_lock_with_signature_for_different_wallet_rejected(self, client):
+        """Signature for different wallet should be rejected."""
+        tx_hash = "rtc-lock-diff-wallet-001"
+        wrong_wallet_signature = _receipt_signature(
+            "different-wallet-attacker",  # Different wallet
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+        )
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "legit-wallet-victim",  # Actual wallet is different
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": wrong_wallet_signature,
+        })
+        assert resp.status_code == 403
+        data = resp.get_json()
+        assert "invalid receipt_signature" in data["error"]
+
+
+class TestProofValidation_MissingProof:
+    """Tests for missing proof scenarios - should be rejected with 400."""
+
+    def test_lock_without_proof_rejected_when_required(self, client):
+        """No proof provided when BRIDGE_REQUIRE_PROOF=true should be rejected."""
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "no-proof-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-no-proof-001",
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "proof required" in data["error"]
+        assert "receipt_signature" in data["error"]
+
+    def test_lock_with_null_proof_rejected(self, client):
+        """Null proof should be treated as missing."""
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "null-proof-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-null-proof-001",
+            "receipt_signature": None,
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert "proof required" in data["error"]
+
+
+# =============================================================================
+# Legacy Mode Tests (BRIDGE_REQUIRE_PROOF=false)
+# =============================================================================
+
+class TestLegacyMode_ProofNotRequired:
+    """Tests for legacy mode when proof is not required."""
+
+    def test_legacy_mode_lock_without_proof_accepted(self):
+        """When BRIDGE_REQUIRE_PROOF=false, locks without proof go to requested state."""
+        # Create a new app with legacy mode - must reimport to pick up new env
+        os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
+        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_legacy_727.db"
+        if os.path.exists("/tmp/bridge_test_legacy_727.db"):
+            os.remove("/tmp/bridge_test_legacy_727.db")
+        
+        # Force reimport to pick up new env vars
+        import importlib
+        import bridge_api
+        importlib.reload(bridge_api)
+        
+        legacy_app = Flask(__name__)
+        bridge_api.register_bridge_routes(legacy_app)
+        legacy_app.config["TESTING"] = True
+        
+        with legacy_app.test_client() as c:
+            resp = c.post("/bridge/lock", json={
+                "sender_wallet": "legacy-wallet",
+                "amount": 10.0,
+                "target_chain": "solana",
+                "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                "tx_hash": "rtc-lock-legacy-001",
+            })
+            assert resp.status_code == 201
+            data = resp.get_json()
+            assert data["state"] == "requested"
+            assert data["proof_type"] == "tx_hash_review"
+        
+        # Restore test env and reload
+        os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
+        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+        importlib.reload(bridge_api)
+
+
+# =============================================================================
+# Admin Authentication Tests
+# =============================================================================
+
+class TestAdminAuthentication:
+    """Tests for bridge admin endpoint authentication."""
+
+    def test_admin_key_uses_constant_time_compare(self, monkeypatch):
+        """Admin-gated endpoints compare configured keys with hmac.compare_digest."""
+        import bridge_api
+
+        app = Flask(__name__)
+        bridge_api.register_bridge_routes(app)
+        app.config["TESTING"] = True
+        calls = []
+
+        def fake_compare(provided, expected):
+            calls.append((provided, expected))
+            return False
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
+
+        with app.test_client() as c:
+            resp = c.post(
+                "/bridge/release",
+                json={"lock_id": "missing-lock", "release_tx": "release-tx"},
+                headers={"X-Admin-Key": "wrong-admin-key"},
+            )
+
+        assert resp.status_code == 403
+        assert calls == [("wrong-admin-key", "test-admin-key-12345")]
+
+
+# =============================================================================
+# Integration Tests - Full Flow with Valid Proof
+# =============================================================================
+
+class TestIntegration_ValidProofFullFlow:
+    """Integration tests for full bridge flow with valid proof."""
+
+    def test_lock_with_valid_proof_then_release(self, client):
+        """Full flow: valid proof lock -> release (no confirm needed)."""
+        tx_hash = "rtc-lock-integration-valid-001"
+        signature = _receipt_signature(
+            "integration-wallet",
+            75.0,
+            "base",
+            "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            tx_hash,
+        )
+        
+        # 1. Create lock with valid proof
+        r1 = client.post("/bridge/lock", json={
+            "sender_wallet": "integration-wallet",
+            "amount": 75.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": tx_hash,
+            "receipt_signature": signature,
+        })
+        assert r1.status_code == 201
+        lock_id = r1.get_json()["lock_id"]
+        assert r1.get_json()["state"] == "confirmed"
+        
+        # 2. Release (should work since lock is confirmed)
+        r2 = client.post(
+            "/bridge/release",
+            json={"lock_id": lock_id, "release_tx": "0xbase-mint-tx-123"},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+        assert r2.status_code == 200
+        assert r2.get_json()["state"] == "complete"
+        
+        # 3. Verify final status
+        r3 = client.get(f"/bridge/status/{lock_id}")
+        assert r3.status_code == 200
+        data = r3.get_json()
+        assert data["state"] == "complete"
+        assert data["proof_type"] == "signed_receipt"
+        assert data["release_tx"] == "0xbase-mint-tx-123"
+
+
+# =============================================================================
+# Security Edge Cases
+# =============================================================================
+
+class TestSecurity_EdgeCases:
+    """Security-focused edge case tests."""
+
+    def test_signature_case_insensitive(self, client):
+        """Signature should work regardless of case."""
+        tx_hash = "rtc-lock-case-insensitive-001"
+        valid_sig = _receipt_signature(
+            "case-wallet",
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+        )
+        # Test uppercase
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "case-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": valid_sig.upper(),
+        })
+        assert resp.status_code == 201
+        assert resp.get_json()["state"] == "confirmed"
+
+    def test_replay_attack_prevented_by_unique_tx_hash(self, client):
+        """Same tx_hash cannot be reused for different lock (unique constraint)."""
+        tx_hash = "rtc-lock-replay-test-001"
+        signature = _receipt_signature(
+            "replay-wallet",
+            10.0,
+            "solana",
+            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            tx_hash,
+        )
+        
+        # First use should succeed
+        r1 = client.post("/bridge/lock", json={
+            "sender_wallet": "replay-wallet",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": signature,
+        })
+        assert r1.status_code == 201
+        
+        # Replay with same tx_hash and same signature should fail (unique constraint)
+        # Note: signature must match or it fails at 403 first
+        r2 = client.post("/bridge/lock", json={
+            "sender_wallet": "replay-wallet",  # Same wallet for valid signature
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,  # Same tx_hash - this triggers unique constraint
+            "receipt_signature": signature,
+        })
+        assert r2.status_code == 409
+        assert "already used" in r2.get_json()["error"]
+
+
+# =============================================================================
+# Existing Tests (Updated for Issue #727)
+# =============================================================================
+
+class TestLockEndpoint:
+    def test_lock_invalid_chain(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "ethereum",
+            "target_wallet": "0x1234",
+            "tx_hash": "rtc-lock-invalid-chain",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 10.0, "ethereum", "0x1234", "rtc-lock-invalid-chain"
+            ),
+        })
+        assert resp.status_code == 400
+        assert "target_chain" in resp.get_json()["error"]
+
+    def test_lock_below_minimum(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 0.5,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-too-small",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 0.5, "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                "rtc-lock-too-small"
+            ),
+        })
+        assert resp.status_code == 400
+
+    def test_lock_above_maximum(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 99999.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": "rtc-lock-too-large",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 99999.0, "base",
+                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+                "rtc-lock-too-large"
+            ),
+        })
+        assert resp.status_code == 400
+
+    def test_lock_missing_sender(self, client):
+        resp = client.post("/bridge/lock", json={
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "0x1234abcd",
+            "tx_hash": "rtc-lock-missing-sender",
+            "receipt_signature": _receipt_signature(
+                "", 10.0, "base", "0x1234abcd", "rtc-lock-missing-sender"
+            ),
+        })
+        assert resp.status_code == 400
+
+    def test_lock_bad_base_wallet(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "not-a-hex-address",
+            "tx_hash": "rtc-lock-bad-base-wallet",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 10.0, "base", "not-a-hex-address", "rtc-lock-bad-base-wallet"
+            ),
+        })
+        assert resp.status_code == 400
+
+    def test_lock_requires_tx_hash(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 10.0, "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                ""
+            ),
+        })
+        assert resp.status_code == 400
+        assert "tx_hash is required" in resp.get_json()["error"]
+
+
+class TestBridgeRequestValidation:
+    def test_lock_rejects_non_object_json(self, client):
+        resp = client.post("/bridge/lock", json=["sender_wallet"])
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object body is required"
+
+    def test_lock_rejects_non_string_fields(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": ["test-miner"],
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": "rtc-lock-bad-sender-type",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "sender_wallet must be a string"
+
+    def test_lock_rejects_non_string_receipt_signature(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": "rtc-lock-bad-sig-type",
+            "receipt_signature": {"sig": "bad"},
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "receipt_signature must be a string"
+
+    def test_lock_rejects_nan_amount(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": "NaN",
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-nan-amount",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid amount"
+
+    def test_confirm_rejects_non_object_json(self, client):
+        resp = client.post(
+            "/bridge/confirm",
+            json=["lock_id"],
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "JSON object body is required"
+
+    def test_confirm_rejects_non_string_notes(self, client):
+        resp = client.post(
+            "/bridge/confirm",
+            json={"lock_id": "lock_fake", "proof_ref": "manual:proof", "notes": {"admin": "note"}},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "notes must be a string"
+
+    def test_release_rejects_non_string_fields(self, client):
+        resp = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": ["0xabc"]},
+            headers={"X-Admin-Key": "test-admin-key-12345"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "release_tx must be a string"
+
+
+class TestReleaseEndpoint:
+    def test_release_requires_admin_key(self, client):
+        resp = client.post("/bridge/release", json={
+            "lock_id": "lock_fake",
+            "release_tx": "0xabc",
+        })
+        assert resp.status_code == 403
+
+    def test_release_uses_constant_time_admin_key_compare(self, client, monkeypatch):
+        calls = []
+
+        def fake_compare(provided, expected):
+            calls.append((provided, expected))
+            return False
+
+        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
+
+        resp = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_fake", "release_tx": "0xabc"},
+            headers={"X-Admin-Key": "wrong-key"},
+        )
+
+        assert resp.status_code == 403
+        assert calls == [("wrong-key", "test-admin-key-12345")]
+
+    def test_release_requires_confirmed_lock(self, client):
+        # Create lock without proof (legacy mode test)
+        os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
+        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_temp_727.db"
+        if os.path.exists("/tmp/bridge_test_temp_727.db"):
+            os.remove("/tmp/bridge_test_temp_727.db")
+        
+        import importlib
+        import bridge_api
+        importlib.reload(bridge_api)
+        
+        temp_app = Flask(__name__)
+        bridge_api.register_bridge_routes(temp_app)
+        temp_app.config["TESTING"] = True
+        
+        with temp_app.test_client() as c:
+            r1 = c.post("/bridge/lock", json={
+                "sender_wallet": "unconfirmed-wallet",
+                "amount": 10.0,
+                "target_chain": "base",
+                "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+                "tx_hash": "rtc-lock-unconfirmed-temp",
+            })
+            assert r1.status_code == 201
+            lock_id = r1.get_json()["lock_id"]
+            
+            r2 = c.post(
+                "/bridge/release",
+                json={"lock_id": lock_id, "release_tx": "0xneedsconfirm"},
+                headers={"X-Admin-Key": "test-admin-key-12345"},
+            )
+            assert r2.status_code == 409
+            assert "cannot release lock in state 'requested'" in r2.get_json()["error"]
+        
+        # Restore
+        os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
+        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+        importlib.reload(bridge_api)
+
+    def test_full_lock_confirm_release_cycle(self, client):
+        # Create lock with valid proof (auto-confirmed)
+        tx_hash = "rtc-lock-cycle-proof-001"
+        r1 = client.post("/bridge/lock", json={
+            "sender_wallet": "cycle-test-wallet-proof",
+            "amount": 25.0,
+            "target_chain": "base",
+            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "cycle-test-wallet-proof",
+                25.0,
+                "base",
+                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
+                tx_hash,
+            ),
+        })
+        assert r1.status_code == 201
+        lock_id = r1.get_json()["lock_id"]
+        assert r1.get_json()["state"] == "confirmed"
+
+        # Release directly (no confirm needed since already confirmed by proof)
+        r2 = client.post(
+            "/bridge/release",
+            json={"lock_id": lock_id, "release_tx": "0xabcdef123456"},
+            headers={"X-Admin-Key": "test-admin-key-12345"}
+        )
+        assert r2.status_code == 200
+        assert r2.get_json()["state"] == "complete"
+
+        # Status should be complete
+        r3 = client.get(f"/bridge/status/{lock_id}")
+        assert r3.status_code == 200
+        data = r3.get_json()
+        assert data["state"] == "complete"
+        assert data["release_tx"] == "0xabcdef123456"
+        assert data["proof_type"] == "signed_receipt"
+        assert len(data["events"]) >= 2  # lock_created + lock_confirmed
+
+    def test_release_nonexistent_lock(self, client):
+        resp = client.post(
+            "/bridge/release",
+            json={"lock_id": "lock_doesnotexist", "release_tx": "0xabc"},
+            headers={"X-Admin-Key": "test-admin-key-12345"}
+        )
+        assert resp.status_code == 404
+
+
+class TestConfirmEndpoint:
+    def test_confirm_requires_admin_key(self, client):
+        resp = client.post("/bridge/confirm", json={
+            "lock_id": "lock_fake",
+            "proof_ref": "manual"
+        })
+        assert resp.status_code == 403
+
+
+class TestLedgerEndpoint:
+    def test_ledger_returns_list(self, client):
+        resp = client.get("/bridge/ledger")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "locks" in data
+        assert "total" in data
+        assert isinstance(data["locks"], list)
+
+    def test_ledger_filter_by_chain(self, client):
+        resp = client.get("/bridge/ledger?chain=solana")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for lock in data["locks"]:
+            assert lock["target_chain"] == "solana"
+
+    def test_ledger_filter_by_state(self, client):
+        resp = client.get("/bridge/ledger?state=confirmed")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        for lock in data["locks"]:
+            assert lock["state"] == "confirmed"
+
+    def test_ledger_rejects_malformed_pagination(self, client):
+        resp = client.get("/bridge/ledger?limit=abc")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit and offset must be integers"
+
+        resp = client.get("/bridge/ledger?offset=abc")
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "limit and offset must be integers"
+
+    def test_ledger_clamps_negative_limit_and_offset(self, client):
+        tx_hash = f"rtc-lock-ledger-limit-{int(time.time())}"
+        payload = {
+            "sender_wallet": "ledger-limit-wallet",
+            "amount": 100.0,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                "ledger-limit-wallet",
+                100.0,
+                "solana",
+                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+                tx_hash,
+            ),
+        }
+        resp_create = client.post("/bridge/lock", json=payload)
+        assert resp_create.status_code == 201
+
+        resp = client.get("/bridge/ledger?limit=-1&offset=-10")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["limit"] == 1
+        assert data["offset"] == 0
+        assert len(data["locks"]) <= 1
+
+
+class TestStatsEndpoint:
+    def test_stats_structure(self, client):
+        resp = client.get("/bridge/stats")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "by_state" in data
+        assert "by_chain" in data
+        assert "all_time" in data
+        assert "solana" in data["by_chain"]
+        assert "base" in data["by_chain"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -1,886 +1,665 @@
 """
-Unit tests for RIP-305 Track C Bridge API - Issue #727 Proof Validation
+RIP-305 Track C: Bridge API
+Cross-chain bridge endpoints for wRTC (Wrapped RTC) on Solana + Base L2
 
-Tests for verifiable proof / signed receipt requirements on /bridge/lock
+Endpoints:
+  POST /bridge/lock      - Lock RTC, get lock_id for cross-chain mint
+  POST /bridge/release   - Admin: release wRTC on target chain
+  GET  /bridge/ledger    - Query lock ledger (transparent)
+  GET  /bridge/status/<lock_id> - Check lock status
 
-Run: python -m pytest test_bridge_api.py -v
+Admin-controlled Phase 1 (upgrade to trustless lock in Phase 2)
 """
 
-import json
 import os
-import sys
-import time
-import hmac
+import json
+import sqlite3
 import hashlib
-import pytest
+import hmac
+import math
+import time
+import threading
+import uuid
+from functools import wraps
+from flask import Flask, Blueprint, request, jsonify
 
-# Use a temp DB for testing
-os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
-os.environ["BRIDGE_ADMIN_KEY"] = "test-admin-key-12345"
-os.environ["BRIDGE_RECEIPT_SECRET"] = "test-bridge-receipt-secret-727"
-os.environ["BRIDGE_REQUIRE_PROOF"] = "true"  # Issue #727: require proof
+# ─── Config ──────────────────────────────────────────────────────────────────
+BRIDGE_DB_PATH = os.environ.get("BRIDGE_DB_PATH", "bridge_ledger.db")
+BRIDGE_ADMIN_KEY = os.environ.get("BRIDGE_ADMIN_KEY", "")  # set in production
+BRIDGE_RECEIPT_SECRET = os.environ.get("BRIDGE_RECEIPT_SECRET", "")
 
-# Remove any stale test DB
-if os.path.exists("/tmp/bridge_test_727.db"):
-    os.remove("/tmp/bridge_test_727.db")
+# Security: require proof for all bridge locks (Issue #727)
+BRIDGE_REQUIRE_PROOF = os.environ.get("BRIDGE_REQUIRE_PROOF", "true").lower() == "true"
 
-# Import after env setup
-sys.path.insert(0, os.path.dirname(__file__))
-import bridge_api
-from bridge_api import Flask, register_bridge_routes, STATE_REQUESTED, STATE_CONFIRMED
+# Target chain identifiers
+CHAIN_SOLANA = "solana"
+CHAIN_BASE = "base"
+SUPPORTED_CHAINS = {CHAIN_SOLANA, CHAIN_BASE}
+
+# RTC decimal precision
+RTC_DECIMALS = 6
+
+# Minimum lock amounts
+MIN_LOCK_AMOUNT = 1  # 1 RTC
+MAX_LOCK_AMOUNT = 10_000  # 10,000 RTC per transaction
+
+# Lock states
+STATE_REQUESTED = "requested"  # User submitted request, awaiting proof review
+STATE_PENDING   = "pending"    # Lock received, awaiting processing
+STATE_CONFIRMED = "confirmed"  # Lock confirmed on-chain
+STATE_RELEASING = "releasing"  # Admin is minting wRTC
+STATE_COMPLETE  = "complete"   # wRTC minted on target chain
+STATE_FAILED    = "failed"     # Lock failed / expired
+STATE_REFUNDED  = "refunded"   # RTC refunded to sender
+
+# Lock expiry (24h in seconds)
+LOCK_EXPIRY_SECONDS = 86_400
+
+# ─── Database ─────────────────────────────────────────────────────────────────
+_db_lock = threading.Lock()
 
 
-def _receipt_signature(sender_wallet, amount, target_chain, target_wallet, tx_hash):
-    """Generate valid HMAC-SHA256 receipt signature for testing."""
+def get_db():
+    conn = sqlite3.connect(BRIDGE_DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_bridge_db():
+    """Initialize the bridge ledger database."""
+    with get_db() as conn:
+        conn.executescript("""
+        CREATE TABLE IF NOT EXISTS bridge_locks (
+            lock_id       TEXT PRIMARY KEY,
+            sender_wallet TEXT NOT NULL,
+            amount_rtc    INTEGER NOT NULL,       -- in base units (millionths)
+            target_chain  TEXT NOT NULL,
+            target_wallet TEXT NOT NULL,
+            state         TEXT NOT NULL DEFAULT 'pending',
+            tx_hash       TEXT,                  -- RustChain tx that locked RTC
+            proof_type    TEXT DEFAULT '',
+            proof_ref     TEXT DEFAULT '',
+            release_tx    TEXT,                  -- Target chain tx that minted wRTC
+            confirmed_at  INTEGER DEFAULT 0,
+            confirmed_by  TEXT DEFAULT '',
+            created_at    INTEGER NOT NULL,
+            updated_at    INTEGER NOT NULL,
+            expires_at    INTEGER NOT NULL,
+            notes         TEXT
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_locks_sender ON bridge_locks(sender_wallet);
+        CREATE INDEX IF NOT EXISTS idx_locks_state  ON bridge_locks(state);
+        CREATE INDEX IF NOT EXISTS idx_locks_chain  ON bridge_locks(target_chain);
+
+        CREATE TABLE IF NOT EXISTS bridge_events (
+            id            INTEGER PRIMARY KEY AUTOINCREMENT,
+            lock_id       TEXT NOT NULL,
+            event_type    TEXT NOT NULL,
+            actor         TEXT,
+            details       TEXT,
+            ts            INTEGER NOT NULL
+        );
+        """)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(bridge_locks)").fetchall()}
+        migrations = {
+            "proof_type": "ALTER TABLE bridge_locks ADD COLUMN proof_type TEXT DEFAULT ''",
+            "proof_ref": "ALTER TABLE bridge_locks ADD COLUMN proof_ref TEXT DEFAULT ''",
+            "confirmed_at": "ALTER TABLE bridge_locks ADD COLUMN confirmed_at INTEGER DEFAULT 0",
+            "confirmed_by": "ALTER TABLE bridge_locks ADD COLUMN confirmed_by TEXT DEFAULT ''",
+        }
+        for col, sql in migrations.items():
+            if col not in cols:
+                conn.execute(sql)
+        conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_locks_tx_hash ON bridge_locks(tx_hash) WHERE tx_hash IS NOT NULL AND tx_hash != ''")
+    print("[bridge] DB initialized:", BRIDGE_DB_PATH)
+
+
+def log_event(conn, lock_id: str, event_type: str, actor: str = None, details: dict = None):
+    conn.execute(
+        "INSERT INTO bridge_events (lock_id, event_type, actor, details, ts) VALUES (?,?,?,?,?)",
+        (lock_id, event_type, actor, json.dumps(details or {}), int(time.time()))
+    )
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+def _amount_to_base(amount_float: float) -> int:
+    """Convert human-readable RTC to base units (6 decimal places)."""
+    return int(round(amount_float * (10 ** RTC_DECIMALS)))
+
+
+def _amount_from_base(amount_int: int) -> float:
+    """Convert base units to human-readable RTC."""
+    return amount_int / (10 ** RTC_DECIMALS)
+
+
+def _generate_lock_id(sender: str, amount: int, target_chain: str, ts: int) -> str:
+    """Deterministic lock ID from key fields."""
+    raw = f"{sender}:{amount}:{target_chain}:{ts}:{uuid.uuid4()}"
+    return "lock_" + hashlib.sha256(raw.encode()).hexdigest()[:24]
+
+
+def _canonical_lock_receipt(sender: str, amount_base: int, target_chain: str, target_wallet: str, tx_hash: str) -> bytes:
+    """Canonical payload for signed lock receipts."""
     payload = {
-        "sender_wallet": sender_wallet,
-        "amount_base": int(round(amount * 1_000_000)),
+        "sender_wallet": sender,
+        "amount_base": amount_base,
         "target_chain": target_chain,
         "target_wallet": target_wallet,
         "tx_hash": tx_hash,
     }
-    message = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hmac.new(
-        os.environ["BRIDGE_RECEIPT_SECRET"].encode("utf-8"),
-        message,
-        hashlib.sha256,
-    ).hexdigest()
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 
-def _receipt_signature_with_secret(sender_wallet, amount, target_chain, target_wallet, tx_hash, secret):
-    """Generate receipt signature with custom secret (for testing invalid signatures)."""
-    payload = {
-        "sender_wallet": sender_wallet,
-        "amount_base": int(round(amount * 1_000_000)),
+def _verify_receipt_signature(sender: str, amount_base: int, target_chain: str, target_wallet: str, tx_hash: str, receipt_signature: str) -> bool:
+    """Verify HMAC-SHA256 bridge receipt signature when a receipt secret is configured."""
+    if not BRIDGE_RECEIPT_SECRET:
+        return False
+    message = _canonical_lock_receipt(sender, amount_base, target_chain, target_wallet, tx_hash)
+    expected = hmac.new(BRIDGE_RECEIPT_SECRET.encode("utf-8"), message, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, receipt_signature.lower())
+
+
+def _require_admin(fn):
+    """Decorator: require X-Admin-Key header."""
+    @wraps(fn)
+    def wrapper(*args, **kwargs):
+        key = request.headers.get("X-Admin-Key", "")
+        if not BRIDGE_ADMIN_KEY:
+            return jsonify({"error": "admin key not configured on server"}), 500
+        if not hmac.compare_digest(key, BRIDGE_ADMIN_KEY):
+            return jsonify({"error": "unauthorized"}), 403
+        return fn(*args, **kwargs)
+    return wrapper
+
+
+def _json_object_body():
+    """Return the parsed JSON body only when it is an object."""
+    data = request.get_json(force=True, silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object body is required"}), 400)
+    return data, None
+
+
+def _clean_string_field(data, field_name, *, optional=False, lower=False):
+    value = data.get(field_name)
+    if value is None:
+        return None if optional else ""
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    value = value.strip()
+    if lower:
+        value = value.lower()
+    if optional and not value:
+        return None
+    return value
+
+
+# ─── Blueprint ────────────────────────────────────────────────────────────────
+bridge_bp = Blueprint("bridge", __name__, url_prefix="/bridge")
+
+
+@bridge_bp.route("/lock", methods=["POST"])
+def lock_rtc():
+    """
+    Lock RTC for cross-chain bridge.
+
+    Body (JSON):
+      sender_wallet  : str   - RustChain wallet name
+      amount         : float - RTC to lock (e.g. 100.5)
+      target_chain   : str   - "solana" or "base"
+      target_wallet  : str   - Solana address or Base EVM address
+      tx_hash        : str   - RustChain tx confirming the lock request
+      receipt_signature : str - (optional) HMAC-SHA256 signed receipt for direct confirmation
+
+    Returns:
+      lock_id        : str   - Unique identifier for this lock
+      state          : str   - "requested" or "confirmed"
+      expires_at     : int   - Unix timestamp when lock expires
+      amount_rtc     : float - Amount locked
+
+    Security (Issue #727):
+      - Requires verifiable proof (signed receipt) when BRIDGE_REQUIRE_PROOF is enabled
+      - Rejects requests with invalid proof signatures
+      - Validates proof before accepting lock into ledger
+    """
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+
+    # ── Validate inputs ──
+    try:
+        sender = _clean_string_field(data, "sender_wallet")
+        target_chain = _clean_string_field(data, "target_chain", lower=True)
+        target_wallet = _clean_string_field(data, "target_wallet")
+        tx_hash = _clean_string_field(data, "tx_hash", optional=True)
+        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    try:
+        amount_float = float(data.get("amount", 0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "invalid amount"}), 400
+    if not math.isfinite(amount_float):
+        return jsonify({"error": "invalid amount"}), 400
+
+    if not sender:
+        return jsonify({"error": "sender_wallet is required"}), 400
+    if target_chain not in SUPPORTED_CHAINS:
+        return jsonify({"error": f"target_chain must be one of: {', '.join(sorted(SUPPORTED_CHAINS))}"}), 400
+    if not target_wallet:
+        return jsonify({"error": "target_wallet is required"}), 400
+    if not tx_hash:
+        return jsonify({"error": "tx_hash is required for bridge lock requests"}), 400
+    if amount_float < MIN_LOCK_AMOUNT:
+        return jsonify({"error": f"minimum lock amount is {MIN_LOCK_AMOUNT} RTC"}), 400
+    if amount_float > MAX_LOCK_AMOUNT:
+        return jsonify({"error": f"maximum lock amount is {MAX_LOCK_AMOUNT} RTC"}), 400
+
+    # Validate target wallet format
+    if target_chain == CHAIN_BASE and not target_wallet.startswith("0x"):
+        return jsonify({"error": "Base wallet must be a 0x EVM address"}), 400
+    if target_chain == CHAIN_SOLANA and len(target_wallet) < 32:
+        return jsonify({"error": "Solana wallet must be a valid base58 address"}), 400
+
+    amount_base = _amount_to_base(amount_float)
+    now = int(time.time())
+    expires_at = now + LOCK_EXPIRY_SECONDS
+    lock_id = _generate_lock_id(sender, amount_base, target_chain, now)
+
+    # ── Issue #727: Strict proof validation ──
+    proof_type = None
+    proof_ref = None
+    state = None
+    confirmed_at = 0
+    confirmed_by = ""
+
+    if receipt_signature:
+        # User provided a signed receipt - verify it
+        if not BRIDGE_RECEIPT_SECRET:
+            return jsonify({
+                "error": "bridge receipt verification is not configured on server"
+            }), 503
+        if not _verify_receipt_signature(
+            sender, amount_base, target_chain, target_wallet, tx_hash, receipt_signature
+        ):
+            return jsonify({
+                "error": "invalid receipt_signature - proof verification failed"
+            }), 403
+        # Valid signed receipt - lock is confirmed immediately
+        proof_type = "signed_receipt"
+        proof_ref = f"receipt:{tx_hash}"
+        state = STATE_CONFIRMED
+        confirmed_at = now
+        confirmed_by = "receipt"
+    elif BRIDGE_REQUIRE_PROOF:
+        # No proof provided but proof is required
+        return jsonify({
+            "error": "proof required: receipt_signature must be provided for bridge lock acceptance"
+        }), 400
+    else:
+        # Proof not required - accept for manual review (legacy mode)
+        proof_type = "tx_hash_review"
+        proof_ref = tx_hash
+        state = STATE_REQUESTED
+
+    with _db_lock:
+        with get_db() as conn:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO bridge_locks
+                      (lock_id, sender_wallet, amount_rtc, target_chain, target_wallet,
+                       state, tx_hash, proof_type, proof_ref, confirmed_at, confirmed_by,
+                       created_at, updated_at, expires_at)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+                    """,
+                    (
+                        lock_id,
+                        sender,
+                        amount_base,
+                        target_chain,
+                        target_wallet,
+                        state,
+                        tx_hash,
+                        proof_type,
+                        proof_ref,
+                        confirmed_at,
+                        confirmed_by,
+                        now,
+                        now,
+                        expires_at,
+                    )
+                )
+            except sqlite3.IntegrityError:
+                return jsonify({"error": "tx_hash already used for another bridge lock"}), 409
+
+            log_event(conn, lock_id, "lock_created", actor=sender, details={
+                "amount": amount_float,
+                "target_chain": target_chain,
+                "target_wallet": target_wallet,
+                "tx_hash": tx_hash,
+                "proof_type": proof_type,
+                "state": state,
+            })
+            if state == STATE_CONFIRMED:
+                log_event(conn, lock_id, "lock_confirmed", actor=confirmed_by, details={
+                    "proof_type": proof_type,
+                    "proof_ref": proof_ref,
+                })
+            conn.commit()
+
+    return jsonify({
+        "lock_id": lock_id,
+        "state": state,
+        "sender_wallet": sender,
+        "amount_rtc": amount_float,
         "target_chain": target_chain,
         "target_wallet": target_wallet,
         "tx_hash": tx_hash,
-    }
-    message = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hmac.new(
-        secret.encode("utf-8"),
-        message,
-        hashlib.sha256,
-    ).hexdigest()
+        "proof_type": proof_type,
+        "proof_ref": proof_ref,
+        "expires_at": expires_at,
+        "message": (
+            f"Lock {'confirmed' if state == STATE_CONFIRMED else 'requested'}. "
+            f"Admin will only mint {amount_float} wRTC on {target_chain} "
+            f"to {target_wallet[:12]}... after proof confirmation."
+        )
+    }), 201
 
 
-@pytest.fixture(scope="module")
-def client():
+@bridge_bp.route("/confirm", methods=["POST"])
+@_require_admin
+def confirm_lock():
+    """Admin: confirm a requested lock after reviewing proof."""
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    try:
+        lock_id = _clean_string_field(data, "lock_id")
+        proof_ref = _clean_string_field(data, "proof_ref")
+        notes = _clean_string_field(data, "notes", optional=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if not lock_id:
+        return jsonify({"error": "lock_id is required"}), 400
+    if not proof_ref:
+        return jsonify({"error": "proof_ref is required"}), 400
+
+    now = int(time.time())
+    with _db_lock:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT * FROM bridge_locks WHERE lock_id = ?",
+                (lock_id,),
+            ).fetchone()
+            if not row:
+                return jsonify({"error": "lock not found"}), 404
+            if row["state"] == STATE_CONFIRMED:
+                return jsonify({"error": "lock already confirmed"}), 409
+            if row["state"] != STATE_REQUESTED:
+                return jsonify({"error": f"cannot confirm lock in state '{row['state']}'"}), 409
+            if row["expires_at"] < now:
+                return jsonify({"error": "lock has expired"}), 410
+
+            conn.execute(
+                """
+                UPDATE bridge_locks
+                SET state = ?, proof_ref = ?, confirmed_at = ?, confirmed_by = ?, updated_at = ?, notes = ?
+                WHERE lock_id = ?
+                """,
+                (STATE_CONFIRMED, proof_ref, now, "admin", now, notes, lock_id),
+            )
+            log_event(conn, lock_id, "lock_confirmed", actor="admin", details={
+                "proof_ref": proof_ref,
+                "notes": notes,
+            })
+            conn.commit()
+
+    return jsonify({
+        "lock_id": lock_id,
+        "state": STATE_CONFIRMED,
+        "proof_ref": proof_ref,
+        "message": "Lock confirmed and eligible for release",
+    })
+
+
+@bridge_bp.route("/release", methods=["POST"])
+@_require_admin
+def release_wrtc():
+    """
+    Admin: mark a lock as released (wRTC minted on target chain).
+
+    Body (JSON):
+      lock_id      : str - Lock to release
+      release_tx   : str - Target chain tx hash (Solana or Base)
+      notes        : str - (optional) admin notes
+
+    Returns success/error.
+    """
+    data, error_response = _json_object_body()
+    if error_response:
+        return error_response
+    try:
+        lock_id = _clean_string_field(data, "lock_id")
+        release_tx = _clean_string_field(data, "release_tx")
+        notes = _clean_string_field(data, "notes", optional=True)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    if not lock_id:
+        return jsonify({"error": "lock_id is required"}), 400
+    if not release_tx:
+        return jsonify({"error": "release_tx is required (target chain tx hash)"}), 400
+
+    now = int(time.time())
+    with _db_lock:
+        with get_db() as conn:
+            row = conn.execute(
+                "SELECT * FROM bridge_locks WHERE lock_id = ?", (lock_id,)
+            ).fetchone()
+
+            if not row:
+                return jsonify({"error": "lock not found"}), 404
+            if row["state"] not in (STATE_CONFIRMED, STATE_RELEASING):
+                return jsonify({
+                    "error": f"cannot release lock in state '{row['state']}'"
+                }), 409
+            if row["expires_at"] < now:
+                return jsonify({"error": "lock has expired"}), 410
+
+            conn.execute(
+                "UPDATE bridge_locks SET state=?, release_tx=?, updated_at=?, notes=? WHERE lock_id=?",
+                (STATE_COMPLETE, release_tx, now, notes, lock_id)
+            )
+            log_event(conn, lock_id, "released", actor="admin", details={
+                "release_tx": release_tx,
+                "notes": notes,
+            })
+            conn.commit()
+
+    return jsonify({
+        "lock_id": lock_id,
+        "state": STATE_COMPLETE,
+        "release_tx": release_tx,
+        "message": "wRTC successfully minted on target chain",
+    })
+
+
+@bridge_bp.route("/ledger", methods=["GET"])
+def get_ledger():
+    """
+    Query the lock ledger (transparent).
+
+    Query params:
+      state       : filter by state (pending/confirmed/complete/failed)
+      chain       : filter by target_chain (solana/base)
+      sender      : filter by sender_wallet
+      limit       : max results (default 50, max 200)
+      offset      : pagination offset
+
+    Returns list of locks.
+    """
+    state_filter  = request.args.get("state", "").strip() or None
+    chain_filter  = request.args.get("chain", "").strip() or None
+    sender_filter = request.args.get("sender", "").strip() or None
+    try:
+        limit  = int(request.args.get("limit", 50))
+        offset = int(request.args.get("offset", 0))
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit and offset must be integers"}), 400
+    limit = max(1, min(limit, 200))
+    offset = max(offset, 0)
+
+    where_clauses, params = [], []
+    if state_filter:
+        where_clauses.append("state = ?"); params.append(state_filter)
+    if chain_filter:
+        where_clauses.append("target_chain = ?"); params.append(chain_filter)
+    if sender_filter:
+        where_clauses.append("sender_wallet = ?"); params.append(sender_filter)
+
+    where_sql = ("WHERE " + " AND ".join(where_clauses)) if where_clauses else ""
+    params += [limit, offset]
+
+    with get_db() as conn:
+        rows = conn.execute(
+            f"""
+            SELECT lock_id, sender_wallet, amount_rtc, target_chain, target_wallet,
+                   state, tx_hash, proof_type, proof_ref, release_tx, confirmed_at, confirmed_by,
+                   created_at, updated_at, expires_at
+            FROM bridge_locks
+            {where_sql}
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            """,
+            params
+        ).fetchall()
+
+        total = conn.execute(
+            f"SELECT COUNT(*) FROM bridge_locks {where_sql}",
+            params[:-2]
+        ).fetchone()[0]
+
+    locks = [
+        {
+            "lock_id":       r["lock_id"],
+            "sender_wallet": r["sender_wallet"],
+            "amount_rtc":    _amount_from_base(r["amount_rtc"]),
+            "target_chain":  r["target_chain"],
+            "target_wallet": r["target_wallet"],
+            "state":         r["state"],
+            "tx_hash":       r["tx_hash"],
+            "proof_type":    r["proof_type"],
+            "proof_ref":     r["proof_ref"],
+            "release_tx":    r["release_tx"],
+            "confirmed_at":  r["confirmed_at"],
+            "confirmed_by":  r["confirmed_by"],
+            "created_at":    r["created_at"],
+            "updated_at":    r["updated_at"],
+            "expires_at":    r["expires_at"],
+        }
+        for r in rows
+    ]
+
+    return jsonify({
+        "locks": locks,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    })
+
+
+@bridge_bp.route("/status/<lock_id>", methods=["GET"])
+def lock_status(lock_id: str):
+    """Get status of a specific lock."""
+    with get_db() as conn:
+        row = conn.execute(
+            "SELECT * FROM bridge_locks WHERE lock_id = ?", (lock_id,)
+        ).fetchone()
+
+    if not row:
+        return jsonify({"error": "lock not found"}), 404
+
+    events = []
+    with get_db() as conn:
+        evs = conn.execute(
+            "SELECT * FROM bridge_events WHERE lock_id = ? ORDER BY ts ASC",
+            (lock_id,)
+        ).fetchall()
+        events = [{"type": e["event_type"], "actor": e["actor"],
+                   "ts": e["ts"], "details": json.loads(e["details"] or "{}")}
+                  for e in evs]
+
+    return jsonify({
+        "lock_id":       row["lock_id"],
+        "sender_wallet": row["sender_wallet"],
+        "amount_rtc":    _amount_from_base(row["amount_rtc"]),
+        "target_chain":  row["target_chain"],
+        "target_wallet": row["target_wallet"],
+        "state":         row["state"],
+        "tx_hash":       row["tx_hash"],
+        "proof_type":    row["proof_type"],
+        "proof_ref":     row["proof_ref"],
+        "release_tx":    row["release_tx"],
+        "confirmed_at":  row["confirmed_at"],
+        "confirmed_by":  row["confirmed_by"],
+        "created_at":    row["created_at"],
+        "updated_at":    row["updated_at"],
+        "expires_at":    row["expires_at"],
+        "events":        events,
+    })
+
+
+@bridge_bp.route("/stats", methods=["GET"])
+def bridge_stats():
+    """Bridge statistics overview."""
+    with get_db() as conn:
+        stats = {}
+        for state in [STATE_REQUESTED, STATE_PENDING, STATE_CONFIRMED, STATE_RELEASING,
+                      STATE_COMPLETE, STATE_FAILED, STATE_REFUNDED]:
+            row = conn.execute(
+                "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks WHERE state = ?",
+                (state,)
+            ).fetchone()
+            stats[state] = {"count": row[0], "total_rtc": _amount_from_base(row[1])}
+
+        total_row = conn.execute(
+            "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks"
+        ).fetchone()
+
+        by_chain = {}
+        for chain in SUPPORTED_CHAINS:
+            row = conn.execute(
+                "SELECT COUNT(*), COALESCE(SUM(amount_rtc),0) FROM bridge_locks "
+                "WHERE target_chain = ? AND state = ?",
+                (chain, STATE_COMPLETE)
+            ).fetchone()
+            by_chain[chain] = {"bridged_count": row[0], "total_wrtc_minted": _amount_from_base(row[1])}
+
+    return jsonify({
+        "by_state": stats,
+        "by_chain": by_chain,
+        "all_time": {
+            "total_locks": total_row[0],
+            "total_rtc_locked": _amount_from_base(total_row[1]),
+        }
+    })
+
+
+# ─── Integration shim ─────────────────────────────────────────────────────────
+def register_bridge_routes(app: Flask):
+    """Register bridge blueprint with an existing Flask app."""
+    init_bridge_db()
+    app.register_blueprint(bridge_bp)
+    print("[bridge] RIP-305 bridge endpoints registered at /bridge/*")
+
+
+# ─── Standalone dev server ─────────────────────────────────────────────────────
+if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
-    app.config["TESTING"] = True
-    with app.test_client() as c:
-        yield c
-
-
-# =============================================================================
-# Issue #727: Proof Validation Tests
-# =============================================================================
-
-class TestProofValidation_ValidProof:
-    """Tests for valid proof scenarios - should be accepted and confirmed."""
-
-    def test_lock_with_valid_signed_receipt_solana(self, client):
-        """Valid signed receipt for Solana target - should confirm immediately."""
-        tx_hash = "rtc-lock-valid-proof-sol-001"
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "valid-proof-wallet-sol",
-            "amount": 100.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": _receipt_signature(
-                "valid-proof-wallet-sol",
-                100.0,
-                "solana",
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                tx_hash,
-            ),
-        })
-        assert resp.status_code == 201
-        data = resp.get_json()
-        assert data["state"] == "confirmed"
-        assert data["proof_type"] == "signed_receipt"
-        assert data["proof_ref"] == f"receipt:{tx_hash}"
-        assert data["lock_id"].startswith("lock_")
-        assert data["amount_rtc"] == 100.0
-
-    def test_lock_with_valid_signed_receipt_base(self, client):
-        """Valid signed receipt for Base target - should confirm immediately."""
-        tx_hash = "rtc-lock-valid-proof-base-001"
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "valid-proof-wallet-base",
-            "amount": 50.5,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": tx_hash,
-            "receipt_signature": _receipt_signature(
-                "valid-proof-wallet-base",
-                50.5,
-                "base",
-                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-                tx_hash,
-            ),
-        })
-        assert resp.status_code == 201
-        data = resp.get_json()
-        assert data["state"] == "confirmed"
-        assert data["proof_type"] == "signed_receipt"
-
-    def test_lock_with_valid_receipt_has_confirmed_at_timestamp(self, client):
-        """Valid receipt should set confirmed_at timestamp."""
-        tx_hash = "rtc-lock-valid-proof-ts-001"
-        before = int(time.time())
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "valid-proof-wallet-ts",
-            "amount": 25.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": _receipt_signature(
-                "valid-proof-wallet-ts",
-                25.0,
-                "solana",
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                tx_hash,
-            ),
-        })
-        after = int(time.time())
-        assert resp.status_code == 201
-        data = resp.get_json()
-        # Verify via status endpoint
-        status_resp = client.get(f"/bridge/status/{data['lock_id']}")
-        status_data = status_resp.get_json()
-        assert status_data["confirmed_at"] >= before
-        assert status_data["confirmed_at"] <= after
-        assert status_data["confirmed_by"] == "receipt"
-
-
-class TestProofValidation_InvalidProof:
-    """Tests for invalid proof scenarios - should be rejected with 403."""
-
-    def test_lock_with_invalid_signature_rejected(self, client):
-        """Invalid signature (wrong secret) should be rejected."""
-        tx_hash = "rtc-lock-invalid-proof-badsig-001"
-        bad_signature = _receipt_signature_with_secret(
-            "invalid-proof-wallet",
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-            "wrong-secret-attacker",  # Wrong secret
-        )
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "invalid-proof-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": bad_signature,
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-        assert "proof verification failed" in data["error"]
-
-    def test_lock_with_tampered_signature_rejected(self, client):
-        """Tampered signature (modified hex) should be rejected."""
-        tx_hash = "rtc-lock-invalid-proof-tampered-001"
-        valid_sig = _receipt_signature(
-            "tamper-proof-wallet",
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-        )
-        # Tamper with signature
-        tampered_sig = valid_sig[:-4] + "dead"
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "tamper-proof-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": tampered_sig,
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-
-    def test_lock_with_empty_signature_rejected(self, client):
-        """Empty signature should be treated as missing proof."""
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "empty-sig-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-empty-sig-001",
-            "receipt_signature": "",
-        })
-        assert resp.status_code == 400
-        data = resp.get_json()
-        assert "proof required" in data["error"]
-
-    def test_lock_with_malformed_signature_rejected(self, client):
-        """Malformed signature (non-hex) should be rejected."""
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "malformed-sig-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-malformed-sig-001",
-            "receipt_signature": "not-a-valid-hex-signature!!",
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-
-    def test_lock_with_signature_for_different_tx_rejected(self, client):
-        """Signature for different tx_hash should be rejected."""
-        tx_hash = "rtc-lock-different-tx-001"
-        wrong_tx_signature = _receipt_signature(
-            "diff-tx-wallet",
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "rtc-lock-different-tx-999",  # Different tx_hash
-        )
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "diff-tx-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": wrong_tx_signature,
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-
-    def test_lock_with_signature_for_different_amount_rejected(self, client):
-        """Signature for different amount should be rejected."""
-        tx_hash = "rtc-lock-diff-amount-001"
-        wrong_amount_signature = _receipt_signature(
-            "diff-amount-wallet",
-            999.0,  # Different amount
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-        )
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "diff-amount-wallet",
-            "amount": 10.0,  # Actual amount is different
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": wrong_amount_signature,
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-
-    def test_lock_with_signature_for_different_wallet_rejected(self, client):
-        """Signature for different wallet should be rejected."""
-        tx_hash = "rtc-lock-diff-wallet-001"
-        wrong_wallet_signature = _receipt_signature(
-            "different-wallet-attacker",  # Different wallet
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-        )
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "legit-wallet-victim",  # Actual wallet is different
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": wrong_wallet_signature,
-        })
-        assert resp.status_code == 403
-        data = resp.get_json()
-        assert "invalid receipt_signature" in data["error"]
-
-
-class TestProofValidation_MissingProof:
-    """Tests for missing proof scenarios - should be rejected with 400."""
-
-    def test_lock_without_proof_rejected_when_required(self, client):
-        """No proof provided when BRIDGE_REQUIRE_PROOF=true should be rejected."""
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "no-proof-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-no-proof-001",
-        })
-        assert resp.status_code == 400
-        data = resp.get_json()
-        assert "proof required" in data["error"]
-        assert "receipt_signature" in data["error"]
-
-    def test_lock_with_null_proof_rejected(self, client):
-        """Null proof should be treated as missing."""
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "null-proof-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-null-proof-001",
-            "receipt_signature": None,
-        })
-        assert resp.status_code == 400
-        data = resp.get_json()
-        assert "proof required" in data["error"]
-
-
-# =============================================================================
-# Legacy Mode Tests (BRIDGE_REQUIRE_PROOF=false)
-# =============================================================================
-
-class TestLegacyMode_ProofNotRequired:
-    """Tests for legacy mode when proof is not required."""
-
-    def test_legacy_mode_lock_without_proof_accepted(self):
-        """When BRIDGE_REQUIRE_PROOF=false, locks without proof go to requested state."""
-        # Create a new app with legacy mode - must reimport to pick up new env
-        os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_legacy_727.db"
-        if os.path.exists("/tmp/bridge_test_legacy_727.db"):
-            os.remove("/tmp/bridge_test_legacy_727.db")
-        
-        # Force reimport to pick up new env vars
-        import importlib
-        import bridge_api
-        importlib.reload(bridge_api)
-        
-        legacy_app = Flask(__name__)
-        bridge_api.register_bridge_routes(legacy_app)
-        legacy_app.config["TESTING"] = True
-        
-        with legacy_app.test_client() as c:
-            resp = c.post("/bridge/lock", json={
-                "sender_wallet": "legacy-wallet",
-                "amount": 10.0,
-                "target_chain": "solana",
-                "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                "tx_hash": "rtc-lock-legacy-001",
-            })
-            assert resp.status_code == 201
-            data = resp.get_json()
-            assert data["state"] == "requested"
-            assert data["proof_type"] == "tx_hash_review"
-        
-        # Restore test env and reload
-        os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
-        importlib.reload(bridge_api)
-
-
-# =============================================================================
-# Admin Authentication Tests
-# =============================================================================
-
-class TestAdminAuthentication:
-    """Tests for bridge admin endpoint authentication."""
-
-    def test_admin_key_uses_constant_time_compare(self, monkeypatch):
-        """Admin-gated endpoints compare configured keys with hmac.compare_digest."""
-        import bridge_api
-
-        app = Flask(__name__)
-        bridge_api.register_bridge_routes(app)
-        app.config["TESTING"] = True
-        calls = []
-
-        def fake_compare(provided, expected):
-            calls.append((provided, expected))
-            return False
-
-        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
-
-        with app.test_client() as c:
-            resp = c.post(
-                "/bridge/release",
-                json={"lock_id": "missing-lock", "release_tx": "release-tx"},
-                headers={"X-Admin-Key": "wrong-admin-key"},
-            )
-
-        assert resp.status_code == 403
-        assert calls == [("wrong-admin-key", "test-admin-key-12345")]
-
-
-# =============================================================================
-# Integration Tests - Full Flow with Valid Proof
-# =============================================================================
-
-class TestIntegration_ValidProofFullFlow:
-    """Integration tests for full bridge flow with valid proof."""
-
-    def test_lock_with_valid_proof_then_release(self, client):
-        """Full flow: valid proof lock -> release (no confirm needed)."""
-        tx_hash = "rtc-lock-integration-valid-001"
-        signature = _receipt_signature(
-            "integration-wallet",
-            75.0,
-            "base",
-            "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            tx_hash,
-        )
-        
-        # 1. Create lock with valid proof
-        r1 = client.post("/bridge/lock", json={
-            "sender_wallet": "integration-wallet",
-            "amount": 75.0,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": tx_hash,
-            "receipt_signature": signature,
-        })
-        assert r1.status_code == 201
-        lock_id = r1.get_json()["lock_id"]
-        assert r1.get_json()["state"] == "confirmed"
-        
-        # 2. Release (should work since lock is confirmed)
-        r2 = client.post(
-            "/bridge/release",
-            json={"lock_id": lock_id, "release_tx": "0xbase-mint-tx-123"},
-            headers={"X-Admin-Key": "test-admin-key-12345"},
-        )
-        assert r2.status_code == 200
-        assert r2.get_json()["state"] == "complete"
-        
-        # 3. Verify final status
-        r3 = client.get(f"/bridge/status/{lock_id}")
-        assert r3.status_code == 200
-        data = r3.get_json()
-        assert data["state"] == "complete"
-        assert data["proof_type"] == "signed_receipt"
-        assert data["release_tx"] == "0xbase-mint-tx-123"
-
-
-# =============================================================================
-# Security Edge Cases
-# =============================================================================
-
-class TestSecurity_EdgeCases:
-    """Security-focused edge case tests."""
-
-    def test_signature_case_insensitive(self, client):
-        """Signature should work regardless of case."""
-        tx_hash = "rtc-lock-case-insensitive-001"
-        valid_sig = _receipt_signature(
-            "case-wallet",
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-        )
-        # Test uppercase
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "case-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": valid_sig.upper(),
-        })
-        assert resp.status_code == 201
-        assert resp.get_json()["state"] == "confirmed"
-
-    def test_replay_attack_prevented_by_unique_tx_hash(self, client):
-        """Same tx_hash cannot be reused for different lock (unique constraint)."""
-        tx_hash = "rtc-lock-replay-test-001"
-        signature = _receipt_signature(
-            "replay-wallet",
-            10.0,
-            "solana",
-            "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            tx_hash,
-        )
-        
-        # First use should succeed
-        r1 = client.post("/bridge/lock", json={
-            "sender_wallet": "replay-wallet",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": signature,
-        })
-        assert r1.status_code == 201
-        
-        # Replay with same tx_hash and same signature should fail (unique constraint)
-        # Note: signature must match or it fails at 403 first
-        r2 = client.post("/bridge/lock", json={
-            "sender_wallet": "replay-wallet",  # Same wallet for valid signature
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,  # Same tx_hash - this triggers unique constraint
-            "receipt_signature": signature,
-        })
-        assert r2.status_code == 409
-        assert "already used" in r2.get_json()["error"]
-
-
-# =============================================================================
-# Existing Tests (Updated for Issue #727)
-# =============================================================================
-
-class TestLockEndpoint:
-    def test_lock_invalid_chain(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 10.0,
-            "target_chain": "ethereum",
-            "target_wallet": "0x1234",
-            "tx_hash": "rtc-lock-invalid-chain",
-            "receipt_signature": _receipt_signature(
-                "test-miner", 10.0, "ethereum", "0x1234", "rtc-lock-invalid-chain"
-            ),
-        })
-        assert resp.status_code == 400
-        assert "target_chain" in resp.get_json()["error"]
-
-    def test_lock_below_minimum(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 0.5,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-too-small",
-            "receipt_signature": _receipt_signature(
-                "test-miner", 0.5, "solana",
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                "rtc-lock-too-small"
-            ),
-        })
-        assert resp.status_code == 400
-
-    def test_lock_above_maximum(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 99999.0,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": "rtc-lock-too-large",
-            "receipt_signature": _receipt_signature(
-                "test-miner", 99999.0, "base",
-                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-                "rtc-lock-too-large"
-            ),
-        })
-        assert resp.status_code == 400
-
-    def test_lock_missing_sender(self, client):
-        resp = client.post("/bridge/lock", json={
-            "amount": 10.0,
-            "target_chain": "base",
-            "target_wallet": "0x1234abcd",
-            "tx_hash": "rtc-lock-missing-sender",
-            "receipt_signature": _receipt_signature(
-                "", 10.0, "base", "0x1234abcd", "rtc-lock-missing-sender"
-            ),
-        })
-        assert resp.status_code == 400
-
-    def test_lock_bad_base_wallet(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 10.0,
-            "target_chain": "base",
-            "target_wallet": "not-a-hex-address",
-            "tx_hash": "rtc-lock-bad-base-wallet",
-            "receipt_signature": _receipt_signature(
-                "test-miner", 10.0, "base", "not-a-hex-address", "rtc-lock-bad-base-wallet"
-            ),
-        })
-        assert resp.status_code == 400
-
-    def test_lock_requires_tx_hash(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 10.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "receipt_signature": _receipt_signature(
-                "test-miner", 10.0, "solana",
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                ""
-            ),
-        })
-        assert resp.status_code == 400
-        assert "tx_hash is required" in resp.get_json()["error"]
-
-
-class TestBridgeRequestValidation:
-    def test_lock_rejects_non_object_json(self, client):
-        resp = client.post("/bridge/lock", json=["sender_wallet"])
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "JSON object body is required"
-
-    def test_lock_rejects_non_string_fields(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": ["test-miner"],
-            "amount": 10.0,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": "rtc-lock-bad-sender-type",
-        })
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "sender_wallet must be a string"
-
-    def test_lock_rejects_non_string_receipt_signature(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": 10.0,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": "rtc-lock-bad-sig-type",
-            "receipt_signature": {"sig": "bad"},
-        })
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "receipt_signature must be a string"
-
-    def test_lock_rejects_nan_amount(self, client):
-        resp = client.post("/bridge/lock", json={
-            "sender_wallet": "test-miner",
-            "amount": "NaN",
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-nan-amount",
-        })
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "invalid amount"
-
-    def test_confirm_rejects_non_object_json(self, client):
-        resp = client.post(
-            "/bridge/confirm",
-            json=["lock_id"],
-            headers={"X-Admin-Key": "test-admin-key-12345"},
-        )
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "JSON object body is required"
-
-    def test_confirm_rejects_non_string_notes(self, client):
-        resp = client.post(
-            "/bridge/confirm",
-            json={"lock_id": "lock_fake", "proof_ref": "manual:proof", "notes": {"admin": "note"}},
-            headers={"X-Admin-Key": "test-admin-key-12345"},
-        )
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "notes must be a string"
-
-    def test_release_rejects_non_string_fields(self, client):
-        resp = client.post(
-            "/bridge/release",
-            json={"lock_id": "lock_fake", "release_tx": ["0xabc"]},
-            headers={"X-Admin-Key": "test-admin-key-12345"},
-        )
-
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "release_tx must be a string"
-
-
-class TestReleaseEndpoint:
-    def test_release_requires_admin_key(self, client):
-        resp = client.post("/bridge/release", json={
-            "lock_id": "lock_fake",
-            "release_tx": "0xabc",
-        })
-        assert resp.status_code == 403
-
-    def test_release_uses_constant_time_admin_key_compare(self, client, monkeypatch):
-        calls = []
-
-        def fake_compare(provided, expected):
-            calls.append((provided, expected))
-            return False
-
-        monkeypatch.setattr(bridge_api.hmac, "compare_digest", fake_compare)
-
-        resp = client.post(
-            "/bridge/release",
-            json={"lock_id": "lock_fake", "release_tx": "0xabc"},
-            headers={"X-Admin-Key": "wrong-key"},
-        )
-
-        assert resp.status_code == 403
-        assert calls == [("wrong-key", "test-admin-key-12345")]
-
-    def test_release_requires_confirmed_lock(self, client):
-        # Create lock without proof (legacy mode test)
-        os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_temp_727.db"
-        if os.path.exists("/tmp/bridge_test_temp_727.db"):
-            os.remove("/tmp/bridge_test_temp_727.db")
-        
-        import importlib
-        import bridge_api
-        importlib.reload(bridge_api)
-        
-        temp_app = Flask(__name__)
-        bridge_api.register_bridge_routes(temp_app)
-        temp_app.config["TESTING"] = True
-        
-        with temp_app.test_client() as c:
-            r1 = c.post("/bridge/lock", json={
-                "sender_wallet": "unconfirmed-wallet",
-                "amount": 10.0,
-                "target_chain": "base",
-                "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-                "tx_hash": "rtc-lock-unconfirmed-temp",
-            })
-            assert r1.status_code == 201
-            lock_id = r1.get_json()["lock_id"]
-            
-            r2 = c.post(
-                "/bridge/release",
-                json={"lock_id": lock_id, "release_tx": "0xneedsconfirm"},
-                headers={"X-Admin-Key": "test-admin-key-12345"},
-            )
-            assert r2.status_code == 409
-            assert "cannot release lock in state 'requested'" in r2.get_json()["error"]
-        
-        # Restore
-        os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
-        importlib.reload(bridge_api)
-
-    def test_full_lock_confirm_release_cycle(self, client):
-        # Create lock with valid proof (auto-confirmed)
-        tx_hash = "rtc-lock-cycle-proof-001"
-        r1 = client.post("/bridge/lock", json={
-            "sender_wallet": "cycle-test-wallet-proof",
-            "amount": 25.0,
-            "target_chain": "base",
-            "target_wallet": "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-            "tx_hash": tx_hash,
-            "receipt_signature": _receipt_signature(
-                "cycle-test-wallet-proof",
-                25.0,
-                "base",
-                "0x4215a73199d56b7e9c71575bec1632cd1d36908f",
-                tx_hash,
-            ),
-        })
-        assert r1.status_code == 201
-        lock_id = r1.get_json()["lock_id"]
-        assert r1.get_json()["state"] == "confirmed"
-
-        # Release directly (no confirm needed since already confirmed by proof)
-        r2 = client.post(
-            "/bridge/release",
-            json={"lock_id": lock_id, "release_tx": "0xabcdef123456"},
-            headers={"X-Admin-Key": "test-admin-key-12345"}
-        )
-        assert r2.status_code == 200
-        assert r2.get_json()["state"] == "complete"
-
-        # Status should be complete
-        r3 = client.get(f"/bridge/status/{lock_id}")
-        assert r3.status_code == 200
-        data = r3.get_json()
-        assert data["state"] == "complete"
-        assert data["release_tx"] == "0xabcdef123456"
-        assert data["proof_type"] == "signed_receipt"
-        assert len(data["events"]) >= 2  # lock_created + lock_confirmed
-
-    def test_release_nonexistent_lock(self, client):
-        resp = client.post(
-            "/bridge/release",
-            json={"lock_id": "lock_doesnotexist", "release_tx": "0xabc"},
-            headers={"X-Admin-Key": "test-admin-key-12345"}
-        )
-        assert resp.status_code == 404
-
-
-class TestConfirmEndpoint:
-    def test_confirm_requires_admin_key(self, client):
-        resp = client.post("/bridge/confirm", json={
-            "lock_id": "lock_fake",
-            "proof_ref": "manual"
-        })
-        assert resp.status_code == 403
-
-
-class TestLedgerEndpoint:
-    def test_ledger_returns_list(self, client):
-        resp = client.get("/bridge/ledger")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert "locks" in data
-        assert "total" in data
-        assert isinstance(data["locks"], list)
-
-    def test_ledger_filter_by_chain(self, client):
-        resp = client.get("/bridge/ledger?chain=solana")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        for lock in data["locks"]:
-            assert lock["target_chain"] == "solana"
-
-    def test_ledger_filter_by_state(self, client):
-        resp = client.get("/bridge/ledger?state=confirmed")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        for lock in data["locks"]:
-            assert lock["state"] == "confirmed"
-
-    def test_ledger_rejects_malformed_pagination(self, client):
-        resp = client.get("/bridge/ledger?limit=abc")
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "limit and offset must be integers"
-
-        resp = client.get("/bridge/ledger?offset=abc")
-        assert resp.status_code == 400
-        assert resp.get_json()["error"] == "limit and offset must be integers"
-
-    def test_ledger_clamps_negative_limit_and_offset(self, client):
-        tx_hash = f"rtc-lock-ledger-limit-{int(time.time())}"
-        payload = {
-            "sender_wallet": "ledger-limit-wallet",
-            "amount": 100.0,
-            "target_chain": "solana",
-            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": tx_hash,
-            "receipt_signature": _receipt_signature(
-                "ledger-limit-wallet",
-                100.0,
-                "solana",
-                "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-                tx_hash,
-            ),
-        }
-        resp_create = client.post("/bridge/lock", json=payload)
-        assert resp_create.status_code == 201
-
-        resp = client.get("/bridge/ledger?limit=-1&offset=-10")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["limit"] == 1
-        assert data["offset"] == 0
-        assert len(data["locks"]) <= 1
-
-
-class TestStatsEndpoint:
-    def test_stats_structure(self, client):
-        resp = client.get("/bridge/stats")
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert "by_state" in data
-        assert "by_chain" in data
-        assert "all_time" in data
-        assert "solana" in data["by_chain"]
-        assert "base" in data["by_chain"]
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+    print("Bridge dev server on http://0.0.0.0:8096")
+    app.run(host="0.0.0.0", port=8096, debug=True)

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -237,8 +237,11 @@ def lock_rtc():
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
+    raw_amount = data.get("amount", 0)
+    if isinstance(raw_amount, bool):
+        return jsonify({"error": "invalid amount"}), 400
     try:
-        amount_float = float(data.get("amount", 0))
+        amount_float = float(raw_amount)
     except (TypeError, ValueError):
         return jsonify({"error": "invalid amount"}), 400
     if not math.isfinite(amount_float):

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -646,13 +646,14 @@ class TestBridgeRequestValidation:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "receipt_signature must be a string"
 
-    def test_lock_rejects_nan_amount(self, client):
+    @pytest.mark.parametrize("amount", ["NaN", "Infinity", "-Infinity"])
+    def test_lock_rejects_non_finite_amount(self, client, amount):
         resp = client.post("/bridge/lock", json={
             "sender_wallet": "test-miner",
-            "amount": "NaN",
+            "amount": amount,
             "target_chain": "solana",
             "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
-            "tx_hash": "rtc-lock-nan-amount",
+            "tx_hash": f"rtc-lock-{amount.lower()}-amount",
         })
 
         assert resp.status_code == 400

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -646,6 +646,18 @@ class TestBridgeRequestValidation:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "receipt_signature must be a string"
 
+    def test_lock_rejects_nan_amount(self, client):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": "NaN",
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": "rtc-lock-nan-amount",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid amount"
+
     def test_confirm_rejects_non_object_json(self, client):
         resp = client.post(
             "/bridge/confirm",

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -659,6 +659,19 @@ class TestBridgeRequestValidation:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "invalid amount"
 
+    @pytest.mark.parametrize("amount", [True, False])
+    def test_lock_rejects_boolean_amount(self, client, amount):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": amount,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": f"rtc-lock-bool-{str(amount).lower()}-amount",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid amount"
+
     def test_confirm_rejects_non_object_json(self, client):
         resp = client.post(
             "/bridge/confirm",


### PR DESCRIPTION
## Summary

Fixes #5361.

`float("NaN")` bypasses the existing bridge lock min/max checks because comparisons with NaN are false. The request then reaches `_amount_to_base()`, where converting NaN to `int` raises instead of returning the same clean `400 invalid amount` response used for malformed amounts.

This patch rejects non-finite parsed amounts with `math.isfinite()` before range checks and adds a regression test for `"amount": "NaN"`.

## Validation

- `PYTHONPATH=/tmp/rustchain-testdeps python3 -m pytest bridge/test_bridge_api.py -q` -> `42 passed`
- `python3 -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py` -> passed

## Bounty note

This is a small reproducible input-validation bug for #305. RTC wallet/miner id is not yet configured; I can provide it when payout is reviewed.
