### PR TITLE
fix: validate Sophia governor route inputs

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -947,17 +947,24 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
 
     @app.route("/sophia/governor/recent", methods=["GET"])
     def sophia_governor_recent():
-        limit = request.args.get("limit", 20)
+        limit_raw = request.args.get("limit", 20)
+        try:
+            limit = int(limit_raw)
+        except (TypeError, ValueError):
+            return jsonify({"error": "limit must be an integer"}), 400
         return jsonify({
             "ok": True,
-            "events": get_recent_governor_events(db_path=db, limit=int(limit)),
+            "events": get_recent_governor_events(db_path=db, limit=limit),
         })
 
     @app.route("/sophia/governor/review", methods=["POST"])
     def sophia_governor_review():
         if not _is_admin(request):
             return jsonify({"error": "Unauthorized -- admin key required"}), 401
-        data = request.get_json(silent=True) or {}
+        data = request.get_json(silent=True)
+        if data is not None and not isinstance(data, dict):
+            return jsonify({"error": "JSON object required"}), 400
+        data = data or {}
         event_type = str(data.get("event_type", "")).strip()
         source = str(data.get("source", "manual")).strip() or "manual"
         payload = data.get("payload") if isinstance(data.get("payload"), dict) else {}

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -186,6 +186,24 @@ def test_governor_endpoints_require_admin_for_manual_review(client):
     assert response.status_code == 401
 
 
+def test_governor_recent_rejects_malformed_limit(client):
+    response = client.get("/sophia/governor/recent?limit=not-an-int")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be an integer"
+
+
+def test_governor_review_rejects_non_object_json(client):
+    response = client.post(
+        "/sophia/governor/review",
+        headers={"X-Admin-Key": "test-admin"},
+        json=[{"event_type": "pending_transfer"}],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "JSON object required"
+
+
 def test_governor_admin_auth_uses_constant_time_compare(client, monkeypatch):
     """Admin-gated governor endpoints compare configured keys with hmac.compare_digest."""
     calls = []


### PR DESCRIPTION
Fixes #4398

## Summary
- Validate `/sophia/governor/recent` query limits before calling the storage helper.
- Reject authenticated `/sophia/governor/review` requests when the parsed JSON body is not an object.
- Add regression coverage for malformed limits and non-object review JSON.

## Root cause
The recent endpoint called `int(limit)` directly on client-controlled query input, so malformed values raised `ValueError`. The review endpoint accepted any parsed JSON value, so a JSON array could reach `data.get(...)` and raise `AttributeError`.

## Validation
- `python -m pytest node\tests\test_sophia_governor.py -q`
- `python -m py_compile node\sophia_governor.py node\tests\test_sophia_governor.py`
- `git diff --check`