### PR TITLE
fix: validate lock ledger write request fields

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -656,6 +656,28 @@ def register_lock_ledger_routes(app):
         except (TypeError, ValueError):
             return None, (jsonify({"error": f"{name} must be an integer"}), 400)
         return max(minimum, min(value, maximum)), None
+
+    def parse_json_object_body():
+        data = request.get_json(silent=True)
+        if data is not None and not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
+
+    def parse_lock_id(data):
+        raw = data.get("lock_id")
+        if raw is None:
+            return None, (jsonify({"error": "lock_id required"}), 400)
+        if isinstance(raw, bool) or not isinstance(raw, int):
+            return None, (jsonify({"error": "lock_id must be an integer"}), 400)
+        return raw, None
+
+    def parse_optional_string(data, name: str, default: Optional[str] = None):
+        raw = data.get(name, default)
+        if raw is None or raw == "":
+            return default, None
+        if not isinstance(raw, str):
+            return None, (jsonify({"error": f"{name} must be a string"}), 400)
+        return raw, None
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):
@@ -762,15 +784,18 @@ def register_lock_ledger_routes(app):
         if not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         
-        data = request.get_json(silent=True)
+        data, error_response = parse_json_object_body()
+        if error_response is not None:
+            return error_response
         if not data:
             return jsonify({"error": "Request body required"}), 400
         
-        lock_id = data.get("lock_id")
-        release_tx_hash = data.get("release_tx_hash")
-        
-        if not lock_id:
-            return jsonify({"error": "lock_id required"}), 400
+        lock_id, error_response = parse_lock_id(data)
+        if error_response is not None:
+            return error_response
+        release_tx_hash, error_response = parse_optional_string(data, "release_tx_hash")
+        if error_response is not None:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:
@@ -796,15 +821,18 @@ def register_lock_ledger_routes(app):
         if not hmac.compare_digest(admin_key, expected_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         
-        data = request.get_json(silent=True)
+        data, error_response = parse_json_object_body()
+        if error_response is not None:
+            return error_response
         if not data:
             return jsonify({"error": "Request body required"}), 400
         
-        lock_id = data.get("lock_id")
-        reason = data.get("reason", "admin_forfeit")
-        
-        if not lock_id:
-            return jsonify({"error": "lock_id required"}), 400
+        lock_id, error_response = parse_lock_id(data)
+        if error_response is not None:
+            return error_response
+        reason, error_response = parse_optional_string(data, "reason", "admin_forfeit")
+        if error_response is not None:
+            return error_response
         
         conn = sqlite3.connect(DB_PATH)
         try:

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -669,15 +669,20 @@ def register_lock_ledger_routes(app):
             return None, (jsonify({"error": "lock_id required"}), 400)
         if isinstance(raw, bool) or not isinstance(raw, int):
             return None, (jsonify({"error": "lock_id must be an integer"}), 400)
+        if raw <= 0:
+            return None, (jsonify({"error": "lock_id must be positive"}), 400)
         return raw, None
 
     def parse_optional_string(data, name: str, default: Optional[str] = None):
         raw = data.get(name, default)
-        if raw is None or raw == "":
+        if raw is None:
             return default, None
         if not isinstance(raw, str):
             return None, (jsonify({"error": f"{name} must be a string"}), 400)
-        return raw, None
+        value = raw.strip()
+        if value == "":
+            return default, None
+        return value, None
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -785,6 +785,16 @@ class TestLockLedgerRoutes:
         lock_ledger.register_lock_ledger_routes(app)
         return app.test_client()
 
+    def _insert_locked_lock(self, db_path, miner_id, lock_id=1):
+        now = int(time.time())
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (id, miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (lock_id, miner_id, 5 * 1000000, "bridge_deposit", now - 3600, now + 3600, "locked", now - 3600),
+            )
+
     def test_miner_locks_rejects_malformed_limit(self, setup_test_db, funded_miner):
         lock_ledger = setup_test_db["lock_ledger"]
         client = self._client(lock_ledger, setup_test_db["db_path"])
@@ -893,17 +903,42 @@ class TestLockLedgerRoutes:
         assert response.status_code == 400
         assert response.get_json() == {"error": "lock_id must be an integer"}
 
+    @pytest.mark.parametrize("path", ["/api/lock/release", "/api/lock/forfeit"])
+    @pytest.mark.parametrize("lock_id", [0, -1])
+    def test_admin_write_routes_reject_non_positive_lock_id(self, setup_test_db, monkeypatch, path, lock_id):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            path,
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": lock_id},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "lock_id must be positive"}
+
+    @pytest.mark.parametrize("path", ["/api/lock/release", "/api/lock/forfeit"])
+    @pytest.mark.parametrize("lock_id", [True, False])
+    def test_admin_write_routes_reject_boolean_lock_id(self, setup_test_db, monkeypatch, path, lock_id):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            path,
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": lock_id},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "lock_id must be an integer"}
+
     def test_release_route_rejects_structured_tx_hash(self, setup_test_db, funded_miner, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
         db_path = setup_test_db["db_path"]
-        now = int(time.time())
-        with sqlite3.connect(db_path) as conn:
-            conn.execute(
-                """INSERT INTO lock_ledger
-                   (id, miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                (1, funded_miner, 5 * 1000000, "bridge_deposit", now - 3600, now - 60, "locked", now - 3600),
-            )
+        self._insert_locked_lock(db_path, funded_miner)
         client = self._client(lock_ledger, db_path)
         monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
 
@@ -916,17 +951,29 @@ class TestLockLedgerRoutes:
         assert response.status_code == 400
         assert response.get_json() == {"error": "release_tx_hash must be a string"}
 
+    def test_release_route_treats_whitespace_tx_hash_as_empty(self, setup_test_db, funded_miner, monkeypatch):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        self._insert_locked_lock(db_path, funded_miner)
+        client = self._client(lock_ledger, db_path)
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            "/api/lock/release",
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": 1, "release_tx_hash": "   "},
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["release_tx_hash"] is None
+        with sqlite3.connect(db_path) as conn:
+            stored = conn.execute("SELECT release_tx_hash FROM lock_ledger WHERE id = 1").fetchone()[0]
+        assert stored is None
+
     def test_forfeit_route_rejects_structured_reason(self, setup_test_db, funded_miner, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
         db_path = setup_test_db["db_path"]
-        now = int(time.time())
-        with sqlite3.connect(db_path) as conn:
-            conn.execute(
-                """INSERT INTO lock_ledger
-                   (id, miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
-                (1, funded_miner, 5 * 1000000, "bridge_deposit", now - 3600, now - 60, "locked", now - 3600),
-            )
+        self._insert_locked_lock(db_path, funded_miner)
         client = self._client(lock_ledger, db_path)
         monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
 
@@ -938,6 +985,22 @@ class TestLockLedgerRoutes:
 
         assert response.status_code == 400
         assert response.get_json() == {"error": "reason must be a string"}
+
+    def test_forfeit_route_treats_whitespace_reason_as_default(self, setup_test_db, funded_miner, monkeypatch):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        self._insert_locked_lock(db_path, funded_miner)
+        client = self._client(lock_ledger, db_path)
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            "/api/lock/forfeit",
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": 1, "reason": "   "},
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["reason"] == "admin_forfeit"
 
 
 # =============================================================================

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -863,6 +863,82 @@ class TestLockLedgerRoutes:
         assert body["count"] == 0
         assert body["locks"] == []
 
+    @pytest.mark.parametrize("path", ["/api/lock/release", "/api/lock/forfeit"])
+    def test_admin_write_routes_reject_non_object_json(self, setup_test_db, monkeypatch, path):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            path,
+            headers={"X-Admin-Key": "expected-admin"},
+            json=[{"lock_id": 1}],
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "JSON object required"}
+
+    @pytest.mark.parametrize("path", ["/api/lock/release", "/api/lock/forfeit"])
+    def test_admin_write_routes_reject_structured_lock_id(self, setup_test_db, monkeypatch, path):
+        lock_ledger = setup_test_db["lock_ledger"]
+        client = self._client(lock_ledger, setup_test_db["db_path"])
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            path,
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": {"id": 1}},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "lock_id must be an integer"}
+
+    def test_release_route_rejects_structured_tx_hash(self, setup_test_db, funded_miner, monkeypatch):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        now = int(time.time())
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (id, miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (1, funded_miner, 5 * 1000000, "bridge_deposit", now - 3600, now - 60, "locked", now - 3600),
+            )
+        client = self._client(lock_ledger, db_path)
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            "/api/lock/release",
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": 1, "release_tx_hash": {"tx": "abc"}},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "release_tx_hash must be a string"}
+
+    def test_forfeit_route_rejects_structured_reason(self, setup_test_db, funded_miner, monkeypatch):
+        lock_ledger = setup_test_db["lock_ledger"]
+        db_path = setup_test_db["db_path"]
+        now = int(time.time())
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (id, miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (1, funded_miner, 5 * 1000000, "bridge_deposit", now - 3600, now - 60, "locked", now - 3600),
+            )
+        client = self._client(lock_ledger, db_path)
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+        response = client.post(
+            "/api/lock/forfeit",
+            headers={"X-Admin-Key": "expected-admin"},
+            json={"lock_id": 1, "reason": ["bad"]},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "reason must be a string"}
+
 
 # =============================================================================
 # Integration Tests


### PR DESCRIPTION
Fixes #4392

## Summary
- Require JSON object bodies for admin lock release/forfeit routes.
- Validate `lock_id` as an integer before passing it to SQLite-backed helpers.
- Validate optional text fields (`release_tx_hash`, `reason`) before database writes or response serialization.
- Add regression coverage for malformed bodies and structured field values.

## Root cause
The write routes parsed request JSON and then assumed the parsed body was a dict with well-typed fields. JSON arrays raised on `.get(...)`, structured `lock_id` values reached SQLite binding, and structured optional text fields could return database errors or be accepted as malformed data.

## Validation
- `python -m pytest tests\test_bridge_lock_ledger.py::TestLockLedgerRoutes -q`
- `python -m py_compile node\lock_ledger.py tests\test_bridge_lock_ledger.py`
- `git diff --check`