### PR TITLE
fix: validate GPU protocol route inputs

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -29,6 +29,7 @@ import os
 import logging
 import hashlib
 import hmac
+import math
 import secrets
 from functools import wraps
 
@@ -452,22 +453,88 @@ class GPURenderProtocol:
 
 def register_routes(app):
     """Register GPU Render Protocol routes with a Flask app."""
+    from flask import jsonify, request
+
     protocol = GPURenderProtocol()
+
+    def _json_object_body():
+        data = request.get_json(force=True, silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
+
+    _MISSING = object()
+
+    def _string_field(data, name: str, default: str = ""):
+        value = data.get(name, _MISSING)
+        if value is _MISSING or value == "":
+            return default, None
+        if not isinstance(value, str):
+            return None, (jsonify({"error": f"{name} must be a string"}), 400)
+        return value, None
+
+    def _finite_number_field(data, name: str, default: float = 0.0):
+        value = data.get(name, default)
+        try:
+            parsed = float(value)
+        except (TypeError, ValueError):
+            return None, (jsonify({"error": f"{name} must be a finite number"}), 400)
+        if not math.isfinite(parsed):
+            return None, (jsonify({"error": f"{name} must be a finite number"}), 400)
+        return parsed, None
+
+    def _sanitize_optional_string(data, name: str):
+        if name not in data:
+            return None
+        value, error_response = _string_field(data, name, default=None)
+        if error_response is not None:
+            return error_response
+        data[name] = value
+        return None
+
+    def _sanitize_optional_number(data, name: str):
+        if name not in data:
+            return None
+        value, error_response = _finite_number_field(data, name)
+        if error_response is not None:
+            return error_response
+        data[name] = value
+        return None
 
     @app.route("/gpu/attest", methods=["POST"])
     def gpu_attest():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
-        miner_id = data.get("miner_id")
+        data, error_response = _json_object_body()
+        if error_response is not None:
+            return error_response
+        data = dict(data)
+        miner_id, error_response = _string_field(data, "miner_id")
+        if error_response is not None:
+            return error_response
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400
+        for field in ("gpu_model", "device_arch", "cuda_version", "rocm_version"):
+            error_response = _sanitize_optional_string(data, field)
+            if error_response is not None:
+                return error_response
+        for field in (
+            "vram_gb",
+            "benchmark_score",
+            "price_render_minute",
+            "price_tts_1k_chars",
+            "price_stt_minute",
+            "price_llm_1k_tokens",
+        ):
+            error_response = _sanitize_optional_number(data, field)
+            if error_response is not None:
+                return error_response
         result = protocol.attest_gpu(miner_id, data)
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
     @app.route("/gpu/nodes", methods=["GET"])
     def gpu_nodes():
-        from flask import request, jsonify
         job_type = request.args.get("job_type")
         device_arch = request.args.get("device_arch")
         nodes = protocol.list_gpu_nodes(job_type, device_arch)
@@ -477,23 +544,38 @@ def register_routes(app):
     @app.route("/voice/escrow", methods=["POST"])
     @app.route("/llm/escrow", methods=["POST"])
     def create_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response is not None:
+            return error_response
         # Infer job_type from path
         path = request.path
         if path.startswith("/voice"):
-            job_type = data.get("job_type", "tts")  # tts or stt
+            job_type, error_response = _string_field(data, "job_type", "tts")  # tts or stt
         elif path.startswith("/llm"):
             job_type = "llm"
         else:
-            job_type = data.get("job_type", "render")
+            job_type, error_response = _string_field(data, "job_type", "render")
+        if error_response is not None:
+            return error_response
+        from_wallet, error_response = _string_field(data, "from_wallet")
+        if error_response is not None:
+            return error_response
+        to_wallet, error_response = _string_field(data, "to_wallet")
+        if error_response is not None:
+            return error_response
+        amount_rtc, error_response = _finite_number_field(data, "amount_rtc")
+        if error_response is not None:
+            return error_response
+        metadata = data.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            return jsonify({"error": "metadata must be an object"}), 400
 
         result = protocol.create_escrow(
             job_type=job_type,
-            from_wallet=data.get("from_wallet", ""),
-            to_wallet=data.get("to_wallet", ""),
-            amount_rtc=data.get("amount_rtc", 0),
-            metadata=data.get("metadata"),
+            from_wallet=from_wallet,
+            to_wallet=to_wallet,
+            amount_rtc=amount_rtc,
+            metadata=metadata,
         )
         status_code = 201 if "error" not in result else 400
         return jsonify(result), status_code
@@ -502,49 +584,74 @@ def register_routes(app):
     @app.route("/voice/release", methods=["POST"])
     @app.route("/llm/release", methods=["POST"])
     def release_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response is not None:
+            return error_response
+        job_id, error_response = _string_field(data, "job_id")
+        if error_response is not None:
+            return error_response
+        actor_wallet, error_response = _string_field(data, "actor_wallet")
+        if error_response is not None:
+            return error_response
+        escrow_secret, error_response = _string_field(data, "escrow_secret")
+        if error_response is not None:
+            return error_response
         result = protocol.release_escrow(
-            data.get("job_id", ""),
-            actor_wallet=data.get("actor_wallet", ""),
-            escrow_secret=data.get("escrow_secret", ""),
+            job_id,
+            actor_wallet=actor_wallet,
+            escrow_secret=escrow_secret,
         )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
     @app.route("/render/refund", methods=["POST"])
     def refund_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response is not None:
+            return error_response
+        job_id, error_response = _string_field(data, "job_id")
+        if error_response is not None:
+            return error_response
+        actor_wallet, error_response = _string_field(data, "actor_wallet")
+        if error_response is not None:
+            return error_response
+        escrow_secret, error_response = _string_field(data, "escrow_secret")
+        if error_response is not None:
+            return error_response
         result = protocol.refund_escrow(
-            data.get("job_id", ""),
-            actor_wallet=data.get("actor_wallet", ""),
-            escrow_secret=data.get("escrow_secret", ""),
+            job_id,
+            actor_wallet=actor_wallet,
+            escrow_secret=escrow_secret,
         )
         status_code = 200 if "error" not in result else 400
         return jsonify(result), status_code
 
     @app.route("/render/escrow/<job_id>", methods=["GET"])
     def get_escrow(job_id):
-        from flask import jsonify
         result = protocol.get_escrow(job_id)
         status_code = 200 if "error" not in result else 404
         return jsonify(result), status_code
 
     @app.route("/render/pricing", methods=["GET"])
     def get_pricing():
-        from flask import request, jsonify
         job_type = request.args.get("job_type")
         result = protocol.get_fair_market_rates(job_type)
         return jsonify(result)
 
     @app.route("/render/pricing/check", methods=["POST"])
     def check_pricing():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error_response = _json_object_body()
+        if error_response is not None:
+            return error_response
+        job_type, error_response = _string_field(data, "job_type", "render")
+        if error_response is not None:
+            return error_response
+        price, error_response = _finite_number_field(data, "price")
+        if error_response is not None:
+            return error_response
         result = protocol.detect_price_manipulation(
-            data.get("job_type", "render"),
-            data.get("price", 0),
+            job_type,
+            price,
         )
         return jsonify(result)
 

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -4,7 +4,11 @@ import sys
 import tempfile
 import unittest
 
+import pytest
+from flask import Flask
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from node import gpu_render_protocol
 from node.gpu_render_protocol import GPURenderProtocol
 
 
@@ -166,6 +170,67 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertEqual(result["status"], "locked")
         status = self.proto.get_escrow(result["job_id"])
         self.assertEqual(status["metadata"]["model"], "llama-70b")
+
+
+def _route_client(tmp_path, monkeypatch):
+    proto = GPURenderProtocol(db_path=str(tmp_path / "gpu_routes.db"))
+    monkeypatch.setattr(gpu_render_protocol, "GPURenderProtocol", lambda: proto)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    gpu_render_protocol.register_routes(app)
+    return app.test_client()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/gpu/attest",
+        "/render/escrow",
+        "/voice/escrow",
+        "/llm/escrow",
+        "/render/release",
+        "/voice/release",
+        "/llm/release",
+        "/render/refund",
+        "/render/pricing/check",
+    ],
+)
+def test_gpu_protocol_routes_reject_non_object_json(tmp_path, monkeypatch, path):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(path, json=[{"unexpected": "array"}])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_gpu_protocol_escrow_rejects_structured_wallet(tmp_path, monkeypatch):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/render/escrow",
+        json={
+            "job_type": "render",
+            "from_wallet": {"wallet": "payer"},
+            "to_wallet": "provider",
+            "amount_rtc": 1,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "from_wallet must be a string"}
+
+
+def test_gpu_protocol_pricing_check_rejects_structured_price(tmp_path, monkeypatch):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/render/pricing/check",
+        json={"job_type": "render", "price": ["not", "numeric"]},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "price must be a finite number"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #4396

## Summary
- Require JSON object bodies for GPU render protocol POST routes.
- Validate route-level string fields before passing them into protocol methods or SQLite bindings.
- Parse finite numeric fields for escrow amounts, attestation pricing/scores, and pricing checks.
- Add Flask route regression coverage for all affected POST routes plus structured wallet/price payloads.

## Root cause
The route layer used `request.get_json(force=True)` and then assumed the parsed body was a dict. JSON arrays could raise on `.get(...)`, while structured string/numeric fields could reach protocol code that expects scalar strings or numbers.

## Validation
- `python -m pytest tests\test_gpu_render_protocol.py -q`
- `python -m py_compile node\gpu_render_protocol.py tests\test_gpu_render_protocol.py`
- `git diff --check`