### PR TITLE
test: use portable bridge temp databases

### DIFF
--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -12,17 +12,28 @@ import sys
 import time
 import hmac
 import hashlib
+import tempfile
 import pytest
 
-# Use a temp DB for testing
-os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+def _test_db_path(name):
+    return os.path.join(tempfile.gettempdir(), f"{name}_{os.getpid()}.db")
+
+
+def _remove_test_db(path):
+    if os.path.exists(path):
+        os.remove(path)
+
+
+# Use a platform-neutral temp DB for testing
+BRIDGE_TEST_DB_PATH = _test_db_path("bridge_test_727")
+
+os.environ["BRIDGE_DB_PATH"] = BRIDGE_TEST_DB_PATH
 os.environ["BRIDGE_ADMIN_KEY"] = "test-admin-key-12345"
 os.environ["BRIDGE_RECEIPT_SECRET"] = "test-bridge-receipt-secret-727"
 os.environ["BRIDGE_REQUIRE_PROOF"] = "true"  # Issue #727: require proof
 
 # Remove any stale test DB
-if os.path.exists("/tmp/bridge_test_727.db"):
-    os.remove("/tmp/bridge_test_727.db")
+_remove_test_db(BRIDGE_TEST_DB_PATH)
 
 # Import after env setup
 sys.path.insert(0, os.path.dirname(__file__))
@@ -344,10 +355,10 @@ class TestLegacyMode_ProofNotRequired:
     def test_legacy_mode_lock_without_proof_accepted(self):
         """When BRIDGE_REQUIRE_PROOF=false, locks without proof go to requested state."""
         # Create a new app with legacy mode - must reimport to pick up new env
+        legacy_db_path = _test_db_path("bridge_test_legacy_727")
         os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_legacy_727.db"
-        if os.path.exists("/tmp/bridge_test_legacy_727.db"):
-            os.remove("/tmp/bridge_test_legacy_727.db")
+        os.environ["BRIDGE_DB_PATH"] = legacy_db_path
+        _remove_test_db(legacy_db_path)
         
         # Force reimport to pick up new env vars
         import importlib
@@ -373,7 +384,7 @@ class TestLegacyMode_ProofNotRequired:
         
         # Restore test env and reload
         os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+        os.environ["BRIDGE_DB_PATH"] = BRIDGE_TEST_DB_PATH
         importlib.reload(bridge_api)
 
 
@@ -705,10 +716,10 @@ class TestReleaseEndpoint:
 
     def test_release_requires_confirmed_lock(self, client):
         # Create lock without proof (legacy mode test)
+        temp_db_path = _test_db_path("bridge_test_temp_727")
         os.environ["BRIDGE_REQUIRE_PROOF"] = "false"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_temp_727.db"
-        if os.path.exists("/tmp/bridge_test_temp_727.db"):
-            os.remove("/tmp/bridge_test_temp_727.db")
+        os.environ["BRIDGE_DB_PATH"] = temp_db_path
+        _remove_test_db(temp_db_path)
         
         import importlib
         import bridge_api
@@ -739,7 +750,7 @@ class TestReleaseEndpoint:
         
         # Restore
         os.environ["BRIDGE_REQUIRE_PROOF"] = "true"
-        os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
+        os.environ["BRIDGE_DB_PATH"] = BRIDGE_TEST_DB_PATH
         importlib.reload(bridge_api)
 
     def test_full_lock_confirm_release_cycle(self, client):


### PR DESCRIPTION
Fixes #5369.

## Summary
- Replace hard-coded `/tmp/...` bridge test database paths with `tempfile.gettempdir()`.
- Add a small helper for per-process bridge test database paths so Windows, macOS, and Linux use valid temp directories.
- Restore the main test DB path after legacy-mode reload tests so later tests do not inherit a Unix-only path.

## Why
`bridge/test_bridge_api.py` hard-coded `/tmp/bridge_test_727.db` and similar paths. On Windows, sqlite cannot open those paths, so the test file failed before endpoint assertions could run.

## Validation
- `python -m pytest bridge\test_bridge_api.py -q` -> 41 passed
- `python -m py_compile bridge\test_bridge_api.py bridge\bridge_api.py` -> passed
- `git diff --check` -> passed
- Confirmed no remaining `/tmp` references in `bridge/test_bridge_api.py`

Bounty context: bug report #5369, claimed under #305.