### PR TITLE
test: make anti double mining fixtures portable

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -24,6 +24,9 @@ import time
 import hashlib
 import json
 import logging
+import os
+import tempfile
+from contextlib import closing
 from typing import Dict, List, Optional, Tuple, Any
 from dataclasses import dataclass
 
@@ -448,7 +451,7 @@ def calculate_anti_double_mining_rewards(
     epoch_start_ts = GENESIS_TIMESTAMP + (epoch_start_slot * BLOCK_TIME)
     epoch_end_ts = GENESIS_TIMESTAMP + (epoch_end_slot * BLOCK_TIME)
 
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn:
         conn.execute("BEGIN")
         
         # Detect duplicate identities
@@ -845,13 +848,11 @@ def setup_test_scenario(db_path: str):
     - Machine B: 1 miner ID (should reward normally)
     - Machine C: 2 miner IDs (should only reward 1)
     """
-    import os
-    
     # Remove existing test DB
     if os.path.exists(db_path):
         os.remove(db_path)
     
-    with sqlite3.connect(db_path) as conn:
+    with closing(sqlite3.connect(db_path)) as conn:
         # Create tables
         conn.execute("""
             CREATE TABLE miner_attest_recent (
@@ -870,6 +871,13 @@ def setup_test_scenario(db_path: str):
                 miner TEXT NOT NULL,
                 ts INTEGER NOT NULL,
                 profile_json TEXT NOT NULL
+            )
+        """)
+
+        conn.execute("""
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL
             )
         """)
         
@@ -995,7 +1003,7 @@ if __name__ == "__main__":
     import sys
     
     # Run tests
-    test_db = "/tmp/test_anti_double_mining.db"
+    test_db = os.path.join(tempfile.gettempdir(), "test_anti_double_mining.db")
     setup_test_scenario(test_db)
     
     print("\n=== Testing Anti-Double-Mining Detection ===\n")

--- a/node/tests/test_anti_double_mining.py
+++ b/node/tests/test_anti_double_mining.py
@@ -16,6 +16,7 @@ import time
 import json
 import os
 import sys
+import tempfile
 import unittest
 from typing import Dict, List
 
@@ -29,8 +30,12 @@ from anti_double_mining import (
     select_representative_miner,
     get_epoch_miner_groups,
     calculate_anti_double_mining_rewards,
-    setup_test_scenario
+    setup_test_scenario,
+    GENESIS_TIMESTAMP
 )
+
+def _test_db_path(name: str) -> str:
+    return os.path.join(tempfile.gettempdir(), f"{name}_{os.getpid()}.db")
 
 
 class TestMachineIdentity(unittest.TestCase):
@@ -120,7 +125,7 @@ class TestDuplicateDetection(unittest.TestCase):
     
     def setUp(self):
         """Create test database."""
-        self.test_db = "/tmp/test_1449_duplicate_detection.db"
+        self.test_db = _test_db_path("test_1449_duplicate_detection")
         if os.path.exists(self.test_db):
             os.remove(self.test_db)
         
@@ -153,10 +158,17 @@ class TestDuplicateDetection(unittest.TestCase):
                 profile_json TEXT NOT NULL
             )
         """)
+
+        self.conn.execute("""
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL
+            )
+        """)
     
     def test_detect_same_machine_multiple_miners(self):
         """Should detect same machine running multiple miner IDs."""
-        epoch_start_ts = 1728000000
+        epoch_start_ts = GENESIS_TIMESTAMP
         current_ts = int(time.time())
         
         # Same fingerprint for 3 miners
@@ -191,7 +203,7 @@ class TestDuplicateDetection(unittest.TestCase):
     
     def test_no_duplicates_distinct_machines(self):
         """Should not report duplicates for distinct machines."""
-        epoch_start_ts = 1728000000
+        epoch_start_ts = GENESIS_TIMESTAMP
         current_ts = int(time.time())
         
         # Different fingerprints for 3 miners
@@ -229,7 +241,7 @@ class TestRepresentativeSelection(unittest.TestCase):
     
     def setUp(self):
         """Create test database."""
-        self.test_db = "/tmp/test_1449_representive.db"
+        self.test_db = _test_db_path("test_1449_representive")
         if os.path.exists(self.test_db):
             os.remove(self.test_db)
         
@@ -313,7 +325,7 @@ class TestAntiDoubleMiningRewards(unittest.TestCase):
     
     def setUp(self):
         """Setup test scenario."""
-        self.test_db = "/tmp/test_1449_rewards.db"
+        self.test_db = _test_db_path("test_1449_rewards")
         setup_test_scenario(self.test_db)
     
     def tearDown(self):
@@ -374,7 +386,7 @@ class TestIdempotency(unittest.TestCase):
     
     def setUp(self):
         """Setup test scenario."""
-        self.test_db = "/tmp/test_1449_idempotent.db"
+        self.test_db = _test_db_path("test_1449_idempotent")
         setup_test_scenario(self.test_db)
     
     def tearDown(self):
@@ -426,7 +438,7 @@ class TestEdgeCases(unittest.TestCase):
     
     def setUp(self):
         """Create test database."""
-        self.test_db = "/tmp/test_1449_edge.db"
+        self.test_db = _test_db_path("test_1449_edge")
         if os.path.exists(self.test_db):
             os.remove(self.test_db)
         
@@ -458,6 +470,13 @@ class TestEdgeCases(unittest.TestCase):
                 miner TEXT NOT NULL,
                 ts INTEGER NOT NULL,
                 profile_json TEXT NOT NULL
+            )
+        """)
+
+        self.conn.execute("""
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL
             )
         """)
         
@@ -498,7 +517,7 @@ class TestEdgeCases(unittest.TestCase):
     
     def test_fingerprint_failure_zero_weight(self):
         """Miners with failed fingerprint should get zero weight."""
-        epoch_start_ts = 1728000000
+        epoch_start_ts = GENESIS_TIMESTAMP
         
         # One miner with fingerprint_passed=0
         self.conn.execute("""
@@ -518,7 +537,7 @@ class TestEdgeCases(unittest.TestCase):
     
     def test_missing_fingerprint_profile(self):
         """Missing fingerprint profile should be handled gracefully."""
-        epoch_start_ts = 1728000000
+        epoch_start_ts = GENESIS_TIMESTAMP
         
         # Miner with no fingerprint history
         self.conn.execute("""


### PR DESCRIPTION
Fixes #5374

## Summary
- Replace Unix-only `/tmp/test_1449_*.db` test fixture paths with platform-neutral temp directory paths.
- Add the current `epoch_enroll` fixture table where tests exercise fallback behavior.
- Use `GENESIS_TIMESTAMP` in anti-double-mining edge-case fixtures so inserted attestations fall inside the epoch window used by the implementation.
- Explicitly close SQLite connections in the reward calculation path and setup utility so Windows can remove temp DB files during teardown.
- Move the module smoke-test DB path off `/tmp` as well.

## Root cause
The anti-double-mining tests assumed a Unix `/tmp` directory and older fixture shape. After switching to a Windows temp path, the tests also exposed Windows file-handle cleanup issues because SQLite connection context managers do not close the connection object.

## Validation
- RED before fix: `python -m pytest node\tests\test_anti_double_mining.py -q` -> 13 failed, 6 passed.
- GREEN after fix: `python -m pytest node\tests\test_anti_double_mining.py -q` -> 19 passed.
- `python -m py_compile node\tests\test_anti_double_mining.py node\anti_double_mining.py` -> passed.
- `git diff --check` -> passed.
- Confirmed no remaining `/tmp/test_1449` or `/tmp/test_anti_double` paths in the touched files.