### PR TITLE
test: make clawrtc config path assertion portable

### DIFF
--- a/miners/clawrtc/test_config.py
+++ b/miners/clawrtc/test_config.py
@@ -41,7 +41,8 @@ def sample_config():
 class TestGetConfigPath:
     def test_default_path(self):
         path = get_config_path()
-        assert str(path).endswith(".clawrtc/config.json")
+        assert path.parent.name == ".clawrtc"
+        assert path.name == "config.json"
 
     def test_custom_path(self):
         path = get_config_path("/tmp/custom.json")


### PR DESCRIPTION
Fixes #5378

## Summary
- Make the clawrtc default config path test assert `Path` components instead of a Unix-only string suffix.
- Leave `get_config_path()` behavior unchanged.

## Root cause
The test compared the string form of a platform-native path against `.clawrtc/config.json`. On Windows, `Path` renders with backslashes, so the assertion failed even though the returned path pointed to the correct `.clawrtc/config.json` location.

## Validation
- RED before fix: `python -m pytest miners\clawrtc\test_config.py -q` -> 1 failed, 24 passed.
- GREEN after fix: `python -m pytest miners\clawrtc\test_config.py -q` -> 25 passed.
- `python -m py_compile miners\clawrtc\test_config.py miners\clawrtc\config.py` -> passed.
- `git diff --check` -> passed.