### PR TITLE
test: authorize UTXO redteam mint fixtures

### DIFF
--- a/node/test_utxo_empty_outputs_bug.py
+++ b/node/test_utxo_empty_outputs_bug.py
@@ -62,6 +62,7 @@ class TestUTXOEmptyOutputsBug(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
         self.assertTrue(ok, "Coinbase should succeed")
 

--- a/node/test_utxo_mempool_bug.py
+++ b/node/test_utxo_mempool_bug.py
@@ -50,6 +50,7 @@ class TestUTXOMempoolEmptyOutputsBug(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
         self.assertTrue(ok, "Coinbase should succeed")
 

--- a/node/test_utxo_mempool_poc_redteam.py
+++ b/node/test_utxo_mempool_poc_redteam.py
@@ -67,6 +67,7 @@ class TestMempoolZeroValueOutputBug(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
 
         boxes = self.db.get_unspent_for_address('alice')
@@ -95,6 +96,7 @@ class TestMempoolZeroValueOutputBug(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
 
         boxes = self.db.get_unspent_for_address('alice')
@@ -143,6 +145,7 @@ class TestMempoolDuplicateTxIdInputClaimBug(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
 
         boxes = self.db.get_unspent_for_address('alice')
@@ -206,6 +209,7 @@ class TestMempoolCallerProvidedTxIdCollision(unittest.TestCase):
             'outputs': [{'address': 'alice', 'value_nrtc': 100 * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
+            '_allow_minting': True,
         }, block_height=1)
 
         boxes = self.db.get_unspent_for_address('alice')


### PR DESCRIPTION
Fixes #5380

## Summary
- Add `_allow_minting=True` to seed mining reward transactions in stale UTXO red-team regression tests.
- Keep the exploit/regression transaction assertions unchanged.
- Leave UTXO production behavior unchanged.

## Root cause
The UTXO layer now correctly requires `_allow_minting=True` for internal `mining_reward` transactions. These older red-team tests still seeded Alice's initial UTXO without that guard, so setup failed before the actual empty-output/mempool regression checks ran.

## Validation
- RED before fix: `python -m pytest node\test_utxo_empty_outputs_bug.py node\test_utxo_mempool_bug.py node\test_utxo_mempool_poc_redteam.py -q` -> 6 failed.
- GREEN after fix: same command -> 6 passed.
- `python -m py_compile node\test_utxo_empty_outputs_bug.py node\test_utxo_mempool_bug.py node\test_utxo_mempool_poc_redteam.py node\utxo_db.py` -> passed.
- `git diff --check` -> passed.