### PR TITLE
fix: reject boolean GPU protocol numerics

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -29,10 +29,23 @@ import os
 import logging
 import hashlib
 import hmac
+import math
 import secrets
 from functools import wraps
 
 logger = logging.getLogger("gpu_render_protocol")
+
+
+def _coerce_finite_number(value, field_name: str):
+    if isinstance(value, bool):
+        return None, {"error": f"{field_name} must be a finite number"}
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None, {"error": f"{field_name} must be a finite number"}
+    if not math.isfinite(number):
+        return None, {"error": f"{field_name} must be a finite number"}
+    return number, None
 
 # ---------------------------------------------------------------------------
 # Database schema
@@ -257,6 +270,9 @@ class GPURenderProtocol:
         valid_types = ("render", "tts", "stt", "llm")
         if job_type not in valid_types:
             return {"error": f"job_type must be one of {valid_types}"}
+        amount_rtc, amount_error = _coerce_finite_number(amount_rtc, "amount_rtc")
+        if amount_error:
+            return amount_error
         if amount_rtc <= 0:
             return {"error": "amount_rtc must be positive"}
         if from_wallet == to_wallet:
@@ -430,6 +446,9 @@ class GPURenderProtocol:
 
     def detect_price_manipulation(self, job_type: str, proposed_price: float) -> dict:
         """Check if a proposed price deviates significantly from market rates."""
+        proposed_price, price_error = _coerce_finite_number(proposed_price, "price")
+        if price_error:
+            return price_error
         rates = self.get_fair_market_rates(job_type)
         if "error" in rates or job_type not in rates.get("rates", {}):
             return {"manipulated": False, "reason": "insufficient data"}
@@ -546,7 +565,8 @@ def register_routes(app):
             data.get("job_type", "render"),
             data.get("price", 0),
         )
-        return jsonify(result)
+        status_code = 200 if "error" not in result else 400
+        return jsonify(result), status_code
 
     logger.info("GPU Render Protocol routes registered")
     return protocol

--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -35,6 +35,8 @@ from functools import wraps
 
 logger = logging.getLogger("gpu_render_protocol")
 
+VALID_JOB_TYPES = ("render", "tts", "stt", "llm")
+
 
 def _coerce_finite_number(value, field_name: str):
     if isinstance(value, bool):
@@ -267,9 +269,8 @@ class GPURenderProtocol:
     def create_escrow(self, job_type: str, from_wallet: str, to_wallet: str,
                       amount_rtc: float, metadata: dict = None) -> dict:
         """Lock RTC in escrow for a compute job."""
-        valid_types = ("render", "tts", "stt", "llm")
-        if job_type not in valid_types:
-            return {"error": f"job_type must be one of {valid_types}"}
+        if job_type not in VALID_JOB_TYPES:
+            return {"error": f"job_type must be one of {VALID_JOB_TYPES}"}
         amount_rtc, amount_error = _coerce_finite_number(amount_rtc, "amount_rtc")
         if amount_error:
             return amount_error
@@ -397,6 +398,9 @@ class GPURenderProtocol:
 
     def get_fair_market_rates(self, job_type=None) -> dict:
         """Calculate fair market rates from active GPU node pricing."""
+        if job_type is not None and job_type not in VALID_JOB_TYPES:
+            return {"error": f"job_type must be one of {VALID_JOB_TYPES}", "rates": {}}
+
         conn = self._get_conn()
         try:
             nodes = conn.execute(
@@ -446,6 +450,8 @@ class GPURenderProtocol:
 
     def detect_price_manipulation(self, job_type: str, proposed_price: float) -> dict:
         """Check if a proposed price deviates significantly from market rates."""
+        if job_type not in VALID_JOB_TYPES:
+            return {"error": f"job_type must be one of {VALID_JOB_TYPES}"}
         proposed_price, price_error = _coerce_finite_number(proposed_price, "price")
         if price_error:
             return price_error
@@ -471,7 +477,15 @@ class GPURenderProtocol:
 
 def register_routes(app):
     """Register GPU Render Protocol routes with a Flask app."""
+    from flask import jsonify, request
+
     protocol = GPURenderProtocol()
+
+    def _json_object_body():
+        data = request.get_json(force=True)
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
 
     @app.route("/gpu/attest", methods=["POST"])
     def gpu_attest():
@@ -496,8 +510,9 @@ def register_routes(app):
     @app.route("/voice/escrow", methods=["POST"])
     @app.route("/llm/escrow", methods=["POST"])
     def create_escrow():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error = _json_object_body()
+        if error:
+            return error
         # Infer job_type from path
         path = request.path
         if path.startswith("/voice"):
@@ -559,8 +574,9 @@ def register_routes(app):
 
     @app.route("/render/pricing/check", methods=["POST"])
     def check_pricing():
-        from flask import request, jsonify
-        data = request.get_json(force=True)
+        data, error = _json_object_body()
+        if error:
+            return error
         result = protocol.detect_price_manipulation(
             data.get("job_type", "render"),
             data.get("price", 0),

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -139,32 +139,73 @@ class TestGPURenderProtocol(unittest.TestCase):
     def test_escrow_route_rejects_boolean_amount(self):
         client = self.route_client()
 
-        response = client.post("/render/escrow", json={
-            "job_type": "render",
-            "from_wallet": "wallet-a",
-            "to_wallet": "wallet-b",
-            "amount_rtc": True,
-        })
+        for amount in (True, False):
+            with self.subTest(amount=amount):
+                response = client.post("/render/escrow", json={
+                    "job_type": "render",
+                    "from_wallet": "wallet-a",
+                    "to_wallet": "wallet-b",
+                    "amount_rtc": amount,
+                })
 
-        self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.get_json(),
-            {"error": "amount_rtc must be a finite number"},
-        )
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json(),
+                    {"error": "amount_rtc must be a finite number"},
+                )
+
+    def test_escrow_route_rejects_non_object_json(self):
+        client = self.route_client()
+
+        for payload in ([{"amount_rtc": True}], "not-an-object"):
+            with self.subTest(payload=payload):
+                response = client.post("/render/escrow", json=payload)
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "JSON object required"})
 
     def test_pricing_check_rejects_boolean_price(self):
         client = self.route_client()
 
+        for price in (True, False):
+            with self.subTest(price=price):
+                response = client.post("/render/pricing/check", json={
+                    "job_type": "render",
+                    "price": price,
+                })
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json(),
+                    {"error": "price must be a finite number"},
+                )
+
+    def test_pricing_check_rejects_non_object_json(self):
+        client = self.route_client()
+
+        for payload in ([{"price": True}], "not-an-object"):
+            with self.subTest(payload=payload):
+                response = client.post("/render/pricing/check", json=payload)
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"error": "JSON object required"})
+
+    def test_pricing_check_rejects_unknown_job_type_with_active_gpu(self):
+        self.proto.attest_gpu("miner-1", {
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "price_render_minute": 0.5,
+        })
+        client = self.route_client()
+
         response = client.post("/render/pricing/check", json={
-            "job_type": "render",
-            "price": True,
+            "job_type": "bad-type",
+            "price": 1.0,
         })
 
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(
-            response.get_json(),
-            {"error": "price must be a finite number"},
-        )
+        self.assertIn("job_type must be one of", response.get_json()["error"])
 
     def test_escrow_same_wallet(self):
         result = self.proto.create_escrow("render", "same", "same", 1.0)

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from node import gpu_render_protocol
 from node.gpu_render_protocol import GPURenderProtocol
 
 
@@ -13,6 +14,19 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.tmp = tempfile.mkdtemp()
         self.db = os.path.join(self.tmp, "test_gpu.db")
         self.proto = GPURenderProtocol(db_path=self.db)
+
+    def route_client(self):
+        from flask import Flask
+
+        original_protocol = gpu_render_protocol.GPURenderProtocol
+        try:
+            gpu_render_protocol.GPURenderProtocol = lambda: self.proto
+            app = Flask(__name__)
+            app.config["TESTING"] = True
+            gpu_render_protocol.register_routes(app)
+            return app.test_client()
+        finally:
+            gpu_render_protocol.GPURenderProtocol = original_protocol
 
     def test_attest_gpu(self):
         result = self.proto.attest_gpu("miner-1", {
@@ -121,6 +135,36 @@ class TestGPURenderProtocol(unittest.TestCase):
     def test_escrow_negative_amount(self):
         result = self.proto.create_escrow("llm", "a", "b", -1.0)
         self.assertIn("error", result)
+
+    def test_escrow_route_rejects_boolean_amount(self):
+        client = self.route_client()
+
+        response = client.post("/render/escrow", json={
+            "job_type": "render",
+            "from_wallet": "wallet-a",
+            "to_wallet": "wallet-b",
+            "amount_rtc": True,
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"error": "amount_rtc must be a finite number"},
+        )
+
+    def test_pricing_check_rejects_boolean_price(self):
+        client = self.route_client()
+
+        response = client.post("/render/pricing/check", json={
+            "job_type": "render",
+            "price": True,
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"error": "price must be a finite number"},
+        )
 
     def test_escrow_same_wallet(self):
         result = self.proto.create_escrow("render", "same", "same", 1.0)


### PR DESCRIPTION
## Summary
- reject JSON booleans before GPU render numeric fields are coerced with `float(...)`
- return a `400` response from `/render/pricing/check` when `price` is not a finite number
- add route-level regression coverage for boolean `amount_rtc` and `price`

## Root cause
Python treats `bool` as a subclass of `int`, so route payloads like `amount_rtc: true` and `price: true` were accepted as `1.0` instead of being rejected as non-numeric API input.

## Validation
- `python -m pytest tests/test_gpu_render_protocol.py -q` -> `16 passed`
- `python -m py_compile node/gpu_render_protocol.py tests/test_gpu_render_protocol.py`
- `git diff --check`

Fixes #5368.

Bounty note: submitting for bug bounty #305. RTC payout/miner id can be provided when reviewed.