### PR TITLE
fix: validate sophia inbox limit

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -251,6 +251,8 @@ def _coerce_int(value: Any) -> int | None:
 def _normalize_limit(value: Any, default: int = 20, maximum: int = 200) -> int:
     if value is None or value == "":
         return default
+    if isinstance(value, bool) or isinstance(value, float):
+        raise ValueError("limit must be an integer")
     try:
         limit = int(value)
     except (TypeError, ValueError):

--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -248,6 +248,16 @@ def _coerce_int(value: Any) -> int | None:
         return None
 
 
+def _normalize_limit(value: Any, default: int = 20, maximum: int = 200) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+    return max(1, min(limit, maximum))
+
+
 def _normalize_envelope(envelope: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(envelope, dict):
         raise ValueError("envelope_must_be_object")
@@ -840,7 +850,7 @@ def list_governor_inbox_entries(
 ) -> list[dict[str, Any]]:
     db = db_path or DB_PATH
     init_sophia_governor_inbox_schema(db)
-    limit = max(1, min(int(limit), 200))
+    limit = _normalize_limit(limit)
 
     clauses = []
     params: list[Any] = []
@@ -1142,7 +1152,7 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
         if not _is_authorized(request):
             return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
 
-        limit = request.args.get("limit", 20, type=int)
+        limit = request.args.get("limit")
         status = request.args.get("status")
         risk_level = request.args.get("risk_level")
         try:

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -169,6 +169,17 @@ def test_ingest_and_list_endpoints(client):
     assert detail_body["entry"]["remote_instance"] == "node-1"
 
 
+@pytest.mark.parametrize("limit", ["abc", "10.5"])
+def test_inbox_list_rejects_malformed_limit(client, limit):
+    response = client.get(
+        f"/api/sophia/governor/inbox?limit={limit}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be an integer"
+
+
 def test_update_status_endpoint(client):
     ingest = client.post(
         "/api/sophia/governor/ingest",

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -88,6 +88,23 @@ def _sample_envelope():
     }
 
 
+def _sample_envelope_with_id(event_id):
+    envelope = _sample_envelope()
+    envelope["event_id"] = event_id
+    envelope["payload"]["amount_rtc"] = event_id
+    return envelope
+
+
+def _ingest_inbox_entries(client, count):
+    for event_id in range(1, count + 1):
+        response = client.post(
+            "/api/sophia/governor/ingest",
+            headers={"X-Admin-Key": "test-admin"},
+            json=_sample_envelope_with_id(event_id),
+        )
+        assert response.status_code == 202
+
+
 def test_ingest_helper_persists_and_deduplicates(tmp_db):
     first = ingest_governor_envelope(_sample_envelope(), db_path=tmp_db)
     second = ingest_governor_envelope(_sample_envelope(), db_path=tmp_db)
@@ -178,6 +195,58 @@ def test_inbox_list_rejects_malformed_limit(client, limit):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "limit must be an integer"
+
+
+@pytest.mark.parametrize("limit", [10.5, True, False])
+def test_inbox_helper_rejects_non_integer_limit_values(tmp_db, limit):
+    ingest_governor_envelope(_sample_envelope(), db_path=tmp_db)
+
+    with pytest.raises(ValueError, match="limit must be an integer"):
+        list_governor_inbox_entries(tmp_db, limit=limit)
+
+
+@pytest.mark.parametrize("query_string", ["", "?limit="])
+def test_inbox_list_uses_default_limit_for_missing_or_empty_limit(client, query_string):
+    _ingest_inbox_entries(client, 25)
+
+    response = client.get(
+        f"/api/sophia/governor/inbox{query_string}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert len(body["entries"]) == 20
+
+
+@pytest.mark.parametrize("limit", ["0", "-5"])
+def test_inbox_list_clamps_zero_and_negative_limits_to_one(client, limit):
+    _ingest_inbox_entries(client, 3)
+
+    response = client.get(
+        f"/api/sophia/governor/inbox?limit={limit}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert len(body["entries"]) == 1
+
+
+def test_inbox_list_clamps_oversized_limits_to_maximum(client):
+    _ingest_inbox_entries(client, 205)
+
+    response = client.get(
+        "/api/sophia/governor/inbox?limit=999",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert len(body["entries"]) == 200
 
 
 def test_update_status_endpoint(client):


### PR DESCRIPTION
﻿Fixes #5387

## Summary
- Reject malformed `limit` query values on `GET /api/sophia/governor/inbox` with `400 Bad Request`.
- Keep valid/default limit behavior centralized through the inbox limit normalizer.
- Add regression coverage for non-integer query values such as `abc` and `10.5`.

## Root cause
The route used Flask's `request.args.get("limit", 20, type=int)`. When conversion failed, the malformed query value was silently replaced with the default, so invalid pagination input returned `200 OK` instead of a clear validation error.

## Validation
- `python -m pytest node/tests/test_sophia_governor_inbox.py -k malformed_limit -q`
- `python -m py_compile node/sophia_governor_inbox.py node/tests/test_sophia_governor_inbox.py`
- `python -m pytest node/tests/test_sophia_governor_inbox.py -q`
- `git diff --check`
