### PR TITLE
fix: validate sophia review limit

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -149,6 +149,16 @@ def _matches_secret(candidate: str, secrets: Iterable[str]) -> bool:
     return matched
 
 
+def _normalize_limit(value: Any, default: int = 10, maximum: int = 100) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+    return max(1, min(limit, maximum))
+
+
 def _is_authorized(req) -> bool:
     required_admin = os.getenv("RC_ADMIN_KEY", "").strip()
     if required_admin:
@@ -457,7 +467,7 @@ def _store_review(
 def _recent_reviews(limit: int = 10, db_path: str | None = None) -> list[dict[str, Any]]:
     db = db_path or DB_PATH
     init_db(db)
-    limit = max(1, min(int(limit), 100))
+    limit = _normalize_limit(limit)
     with sqlite3.connect(db) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
@@ -622,7 +632,10 @@ def health():
 def recent():
     if not _is_authorized(request):
         return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
-    limit = request.args.get("limit", 10, type=int)
+    try:
+        limit = _normalize_limit(request.args.get("limit"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
     return jsonify({"ok": True, "reviews": _recent_reviews(limit=limit)})
 
 

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -123,6 +123,17 @@ def test_review_endpoint_calls_model_and_stores(client, monkeypatch):
     assert recent_body["reviews"][0]["recommended_resolution"]["target_inbox_status"] == "resolved"
 
 
+@pytest.mark.parametrize("limit", ["abc", "10.5"])
+def test_recent_rejects_malformed_limit(client, limit):
+    response = client.get(
+        f"/recent?limit={limit}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be an integer"
+
+
 def test_health_reports_status(client):
     response = client.get("/health")
     assert response.status_code == 200


### PR DESCRIPTION
﻿Fixes #5389

## Summary
- Reject malformed `limit` query values on the Sophia governor review service recent-review endpoints.
- Centralize review-service limit parsing so helper callers and HTTP callers use the same bounds.
- Add regression coverage for non-integer values such as `abc` and `10.5`.

## Root cause
The `/recent` route used Flask's `request.args.get("limit", 10, type=int)`. When conversion failed, Flask returned the default value, so malformed pagination input looked successful and returned `200 OK`.

## Validation
- `python -m pytest node/tests/test_sophia_governor_review_service.py -k malformed_limit -q`
- `python -m py_compile node/sophia_governor_review_service.py node/tests/test_sophia_governor_review_service.py`
- `python -m pytest node/tests/test_sophia_governor_review_service.py -q`
- `git diff --check`
