### PR TITLE
Fix Windows miner bundle startup issues

### DIFF
--- a/miners/windows/build_windows_miner.ps1
+++ b/miners/windows/build_windows_miner.ps1
@@ -1,4 +1,4 @@
-# Build script for Windows: requires Python 3.11+ and PyInstaller.
+﻿# Build script for Windows: requires Python 3.11+ and PyInstaller.
 Set-StrictMode -Version Latest
 $env:PYINSTALLER_HOME = "$PSScriptRoot\dist"
 Write-Host "Ensuring pip is up to date..."
@@ -9,5 +9,12 @@ if (Test-Path $env:PYINSTALLER_HOME) {
     Remove-Item $env:PYINSTALLER_HOME -Recurse -Force
 }
 Write-Host "Building rustchain_windows_miner.exe..."
-pyinstaller --onefile --name rustchain_windows_miner rustchain_windows_miner.py
+pyinstaller `
+    --onefile `
+    --name rustchain_windows_miner `
+    --collect-submodules tkinter `
+    --hidden-import tkinter `
+    --hidden-import tkinter.ttk `
+    --hidden-import tkinter.scrolledtext `
+    rustchain_windows_miner.py
 Write-Host "Build complete. Executable located at dist\rustchain_windows_miner.exe"

--- a/miners/windows/build_windows_miner.ps1
+++ b/miners/windows/build_windows_miner.ps1
@@ -1,4 +1,4 @@
-﻿# Build script for Windows: requires Python 3.11+ and PyInstaller.
+# Build script for Windows: requires Python 3.11+ and PyInstaller.
 Set-StrictMode -Version Latest
 $env:PYINSTALLER_HOME = "$PSScriptRoot\dist"
 Write-Host "Ensuring pip is up to date..."

--- a/miners/windows/build_windows_miner_wine.sh
+++ b/miners/windows/build_windows_miner_wine.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -40,6 +40,14 @@ DIST_DIR="$ROOT_DIR/dist"
 rm -rf "$DIST_DIR"
 
 echo "Building rustchain_windows_miner.exe with PyInstaller..."
-wine "$PYTHON_EXE" -m PyInstaller --noconfirm --onefile --name rustchain_windows_miner "$SCRIPT_WIN" >/tmp/wine_pyinstaller.log
+wine "$PYTHON_EXE" -m PyInstaller \
+  --noconfirm \
+  --onefile \
+  --name rustchain_windows_miner \
+  --collect-submodules tkinter \
+  --hidden-import tkinter \
+  --hidden-import tkinter.ttk \
+  --hidden-import tkinter.scrolledtext \
+  "$SCRIPT_WIN" >/tmp/wine_pyinstaller.log
 
 echo "Build finished; executable located at $DIST_DIR/rustchain_windows_miner.exe"

--- a/miners/windows/build_windows_miner_wine.sh
+++ b/miners/windows/build_windows_miner_wine.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -1,4 +1,4 @@
-@echo off
+﻿@echo off
 setlocal enabledelayedexpansion
 set "SCRIPT_DIR=%~dp0"
 set "REQUIREMENTS=%SCRIPT_DIR%requirements-miner.txt"
@@ -43,7 +43,7 @@ echo Installing miner dependencies...
 python -m pip install -r "%REQUIREMENTS%"
 
 if exist "%MINER_SCRIPT%" (
-    echo Keeping existing miner script (%MINER_SCRIPT%).
+    echo Keeping existing miner script: "%MINER_SCRIPT%"
 ) else (
     echo Downloading the latest miner script...
     powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%MINER_URL%' -OutFile '%MINER_SCRIPT%'"

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 setlocal enabledelayedexpansion
 set "SCRIPT_DIR=%~dp0"
 set "REQUIREMENTS=%SCRIPT_DIR%requirements-miner.txt"


### PR DESCRIPTION
## Summary
- fix `rustchain_miner_setup.bat` so the existing-script message does not include an unescaped `)` inside a parenthesized batch block
- update both Windows and Wine PyInstaller build scripts to explicitly collect/import tkinter modules for the packaged GUI/headless executable

Fixes #5398
Related to #5399

## Validation
- Reproduced the released batch failure from `win-miner-2026-02` before this patch: `. was unexpected at this time.` before `rustchain_windows_miner.py` was downloaded.
- Verified the released exe failure separately: bundled executable exits before argparse with `ModuleNotFoundError: No module named 'tkinter'`.
- The batch change is a direct parser fix: `echo Keeping existing miner script: %MINER_SCRIPT%` avoids the unescaped parenthesis that breaks cmd block parsing.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7