### PR TITLE
fix(#5389): reject malformed limit param in Sophia governor review endpoint (Closes #5389)

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -622,7 +622,10 @@ def health():
 def recent():
     if not _is_authorized(request):
         return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
-    limit = request.args.get("limit", 10, type=int)
+    try:
+        limit = int(request.args.get("limit", 10))
+    except (ValueError, TypeError):
+        return jsonify({"error": "limit must be an integer"}), 400
     return jsonify({"ok": True, "reviews": _recent_reviews(limit=limit)})
 
 


### PR DESCRIPTION
## Fix #5389\n\n**Problem:** GET /recent silently accepts malformed limit values (abc, 10.5) returning 200 OK.\n\n**Fix:** Replace Flask's silent type=int with explicit int() in try/except, returning 400 Bad Request.\n\n**Testing:** cd node && python -m pytest tests/test_sophia_governor_review_service.py -k malformed -v