### PR TITLE
Fix Windows miner setup echo parsing

### DIFF
--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -43,7 +43,7 @@ echo Installing miner dependencies...
 python -m pip install -r "%REQUIREMENTS%"
 
 if exist "%MINER_SCRIPT%" (
-    echo Keeping existing miner script (%MINER_SCRIPT%).
+    echo Keeping existing miner script: %MINER_SCRIPT%
 ) else (
     echo Downloading the latest miner script...
     powershell -Command "Invoke-WebRequest -UseBasicParsing -Uri '%MINER_URL%' -OutFile '%MINER_SCRIPT%'"

--- a/tests/test_windows_miner_setup_checksum.py
+++ b/tests/test_windows_miner_setup_checksum.py
@@ -32,3 +32,10 @@ def test_windows_miner_setup_verifies_miner_before_run_instructions():
     assert 'if /I not "!ACTUAL_MINER_SHA256!"=="%MINER_SHA256%"' in text
     assert 'del /f /q "%MINER_SCRIPT%"' in text
     assert "Miner script SHA-256 mismatch." in text
+
+
+def test_windows_miner_setup_echo_inside_if_block_has_no_unescaped_closing_parenthesis():
+    text = _setup_text()
+
+    assert "Keeping existing miner script:" in text
+    assert "Keeping existing miner script (%MINER_SCRIPT%)." not in text


### PR DESCRIPTION
## Summary
- remove literal parentheses from the miner setup echo inside the parenthesized if exist block
- add a regression assertion so the batch parser footgun does not return

Fixes #5398.

## Validation
- py -3.12 - manual checksum/setup assertions matching 	ests/test_windows_miner_setup_checksum.py
- git diff --check (only existing LF-to-CRLF warning on the batch file)

RTC payout details can be provided privately if this PR is selected/merged.