### PR TITLE
fix(#5387): reject malformed limit param in Sophia governor inbox endpoint (Closes #5387)

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -1142,7 +1142,10 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
         if not _is_authorized(request):
             return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
 
-        limit = request.args.get("limit", 20, type=int)
+        try:
+            limit = int(request.args.get("limit", 20))
+        except (ValueError, TypeError):
+            return jsonify({"error": "limit must be an integer"}), 400
         status = request.args.get("status")
         risk_level = request.args.get("risk_level")
         try:


### PR DESCRIPTION
## Fix #5387\n\n**Problem:** GET /api/sophia/governor/inbox silently accepts malformed limit values returning 200 OK.\n\n**Fix:** Replace Flask's silent type=int with explicit int() in try/except, returning 400 Bad Request.\n\n**Testing:** cd node && python -m pytest tests/test_sophia_governor_inbox.py -k malformed -v