### PR TITLE
fix: cross-platform path assertion in clawrtc test_config

### DIFF
--- a/miners/clawrtc/test_config.py
+++ b/miners/clawrtc/test_config.py
@@ -41,7 +41,7 @@ def sample_config():
 class TestGetConfigPath:
     def test_default_path(self):
         path = get_config_path()
-        assert str(path).endswith(".clawrtc/config.json")
+        assert str(path).endswith(os.path.join(".clawrtc", "config.json"))
 
     def test_custom_path(self):
         path = get_config_path("/tmp/custom.json")


### PR DESCRIPTION
## Summary
`test_default_path` used `.endswith(".clawrtc/config.json")` which fails on Windows where paths use backslashes. Changed to use `os.path.join` for cross-platform compatibility.

## Test
```
miners/clawrtc/test_config.py::TestGetConfigPath::test_default_path PASSED
```

Closes #5378

🤖 Generated with [Claude Code](https://claude.com/claude-code)