### PR TITLE
fix: validate limit parameter in Sophia governor review endpoint

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -622,7 +622,11 @@ def health():
 def recent():
     if not _is_authorized(request):
         return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
-    limit = request.args.get("limit", 10, type=int)
+    limit_raw = request.args.get("limit", "10")
+    try:
+        limit = int(limit_raw)
+    except (ValueError, TypeError):
+        return jsonify({"error": "limit must be a valid integer"}), 400
     return jsonify({"ok": True, "reviews": _recent_reviews(limit=limit)})
 
 


### PR DESCRIPTION
## Summary
`GET /recent` and `GET /api/sophia/governor/recent` silently accepted malformed `limit` values like `"abc"` or `"10.5"`, returning 200 OK with the default page size. Now returns 400 with a clear error message.

## Test
```
node/tests/test_sophia_governor_review_service.py ............... 15 passed
```

Closes #5389

🤖 Generated with [Claude Code](https://claude.com/claude-code)