### PR TITLE
fix: validate limit parameter in Sophia governor inbox endpoint

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -1142,7 +1142,11 @@ def register_sophia_governor_inbox_endpoints(app, db_path: str | None = None) ->
         if not _is_authorized(request):
             return jsonify({"error": "Unauthorized -- admin key or bearer required"}), 401
 
-        limit = request.args.get("limit", 20, type=int)
+        limit_raw = request.args.get("limit", "20")
+        try:
+            limit = int(limit_raw)
+        except (ValueError, TypeError):
+            return jsonify({"error": "limit must be a valid integer"}), 400
         status = request.args.get("status")
         risk_level = request.args.get("risk_level")
         try:


### PR DESCRIPTION
## Summary
`GET /api/sophia/governor/inbox` silently accepted malformed `limit` values like `"abc"` or `"10.5"`, returning 200 OK with the default page size. Now returns 400 with a clear error message.

## Test
```
node/tests/test_sophia_governor_inbox.py ............... 15 passed
```

Closes #5387

🤖 Generated with [Claude Code](https://claude.com/claude-code)