### PR TITLE
Log Windows headless miner attestation and enrollment events

### DIFF
--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -353,6 +353,12 @@ class RustChainMiner:
         """Stop mining"""
         self.mining = False
 
+    def _emit_lifecycle(self, callback, event_type, message, **extra):
+        if callback:
+            event = {"type": event_type, "message": message}
+            event.update(extra)
+            callback(event)
+
     def _mine_loop(self, callback):
         """Main mining loop"""
         while self.mining:
@@ -391,12 +397,24 @@ class RustChainMiner:
                 if callback:
                     callback({"type": "error", "message": "Attestation failed"})
                 return False
+            self._emit_lifecycle(
+                callback,
+                "attest",
+                "Attestation successful",
+                valid_until=int(self.attestation_valid_until),
+            )
 
         if (now - self.last_enroll) > 3600 or not self.enrolled:
             if not self.enroll():
                 if callback:
                     callback({"type": "error", "message": "Epoch enrollment failed"})
                 return False
+            self._emit_lifecycle(
+                callback,
+                "enroll",
+                "Epoch enrollment successful",
+                last_enroll=int(self.last_enroll),
+            )
 
         return True
 

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,7 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
-set "MINER_SHA256=c6182f52a95a310eb25eae8f50ad80f645ee04f7454d15cb20fc544cb16ac041"
+set "MINER_SHA256=ba3c07d5b5b208763416e8e573fb4544f19129a9d629ee3cf5a64722ba7c605a"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,7 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
-set "MINER_SHA256=51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662"
+set "MINER_SHA256=c6182f52a95a310eb25eae8f50ad80f645ee04f7454d15cb20fc544cb16ac041"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -246,6 +246,12 @@ class RustChainMiner:
         """Stop mining"""
         self.mining = False
 
+    def _emit_lifecycle(self, callback, event_type, message, **extra):
+        if callback:
+            event = {"type": event_type, "message": message}
+            event.update(extra)
+            callback(event)
+
     def _mine_loop(self, callback):
         """Main mining loop"""
         while self.mining:
@@ -283,12 +289,24 @@ class RustChainMiner:
                 if callback:
                     callback({"type": "error", "message": "Attestation failed"})
                 return False
+            self._emit_lifecycle(
+                callback,
+                "attest",
+                "Attestation successful",
+                valid_until=int(self.attestation_valid_until),
+            )
 
         if (now - self.last_enroll) > 3600 or not self.enrolled:
             if not self.enroll():
                 if callback:
                     callback({"type": "error", "message": "Epoch enrollment failed"})
                 return False
+            self._emit_lifecycle(
+                callback,
+                "enroll",
+                "Epoch enrollment successful",
+                last_enroll=int(self.last_enroll),
+            )
 
         return True
 
@@ -598,6 +616,8 @@ def run_headless(wallet_address: str, node_url: str) -> int:
             )
         elif t == "error":
             print(f"[error] {evt.get('message')}", file=sys.stderr, flush=True)
+        elif evt.get("message"):
+            print(f"[{t}] {evt.get('message')}", flush=True)
 
     print("RustChain Windows miner: headless mode", flush=True)
     print(f"node={miner.node_url} miner_id={miner.miner_id}", flush=True)

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -617,7 +617,8 @@ def run_headless(wallet_address: str, node_url: str) -> int:
         elif t == "error":
             print(f"[error] {evt.get('message')}", file=sys.stderr, flush=True)
         elif evt.get("message"):
-            print(f"[{t}] {evt.get('message')}", flush=True)
+            event_type = t or "event"
+            print(f"[{event_type}] {evt.get('message')}", flush=True)
 
     print("RustChain Windows miner: headless mode", flush=True)
     print(f"node={miner.node_url} miner_id={miner.miner_id}", flush=True)

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -27,7 +27,7 @@ MINER_ARTIFACTS = {
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",
-        "sha256": "c6182f52a95a310eb25eae8f50ad80f645ee04f7454d15cb20fc544cb16ac041",
+        "sha256": "ba3c07d5b5b208763416e8e573fb4544f19129a9d629ee3cf5a64722ba7c605a",
     },
 }
 

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",
@@ -27,7 +27,7 @@ MINER_ARTIFACTS = {
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",
-        "sha256": "51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662",
+        "sha256": "c6182f52a95a310eb25eae8f50ad80f645ee04f7454d15cb20fc544cb16ac041",
     },
 }
 

--- a/tests/test_windows_headless_lifecycle_logging.py
+++ b/tests/test_windows_headless_lifecycle_logging.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MINER_SCRIPT = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+
+
+def _load_windows_miner():
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_windows_miner_under_test",
+        MINER_SCRIPT,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _miner_without_init(module):
+    miner = object.__new__(module.RustChainMiner)
+    miner.attestation_valid_until = 0
+    miner.last_enroll = 0
+    miner.enrolled = False
+
+    def attest():
+        miner.attestation_valid_until = time.time() + 580
+        return True
+
+    def enroll():
+        miner.enrolled = True
+        miner.last_enroll = time.time()
+        return True
+
+    miner.attest = attest
+    miner.enroll = enroll
+    return miner
+
+
+def test_ready_refresh_emits_headless_audit_events():
+    module = _load_windows_miner()
+    miner = _miner_without_init(module)
+    events = []
+
+    assert miner._ensure_ready(events.append) is True
+
+    assert [event["type"] for event in events] == ["attest", "enroll"]
+    assert events[0]["message"] == "Attestation successful"
+    assert events[0]["valid_until"] > int(time.time())
+    assert events[1]["message"] == "Epoch enrollment successful"
+    assert events[1]["last_enroll"] <= int(time.time())
+
+
+def test_ready_state_does_not_emit_duplicate_lifecycle_events():
+    module = _load_windows_miner()
+    miner = _miner_without_init(module)
+    now = time.time()
+    miner.attestation_valid_until = now + 580
+    miner.last_enroll = now
+    miner.enrolled = True
+
+    def fail_if_called():
+        raise AssertionError("fresh miner should not refresh lifecycle state")
+
+    miner.attest = fail_if_called
+    miner.enroll = fail_if_called
+    events = []
+
+    assert miner._ensure_ready(events.append) is True
+    assert events == []
+
+
+def test_headless_runner_prints_lifecycle_messages(monkeypatch, capsys):
+    module = _load_windows_miner()
+
+    class FakeWallet:
+        def __init__(self):
+            self.wallet_data = {"address": "wallet-from-config"}
+
+        def save_wallet(self, wallet_data=None):
+            if wallet_data:
+                self.wallet_data = wallet_data
+
+    class FakeMiner:
+        def __init__(self, wallet_address):
+            self.wallet_address = wallet_address
+            self.node_url = "http://node-from-init"
+            self.miner_id = "windows_test"
+            self.stopped = False
+
+        def start_mining(self, callback):
+            callback({"type": "attest", "message": "Attestation successful"})
+            callback({"type": "enroll", "message": "Epoch enrollment successful"})
+
+        def stop_mining(self):
+            self.stopped = True
+
+    def stop_loop(_seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "RustChainWallet", FakeWallet)
+    monkeypatch.setattr(module, "RustChainMiner", FakeMiner)
+    monkeypatch.setattr(module.time, "sleep", stop_loop)
+
+    assert module.run_headless("wallet-from-args", "http://node-from-args") == 0
+
+    output = capsys.readouterr()
+    assert "[attest] Attestation successful" in output.out
+    assert "[enroll] Epoch enrollment successful" in output.out

--- a/tests/test_windows_headless_lifecycle_logging.py
+++ b/tests/test_windows_headless_lifecycle_logging.py
@@ -13,6 +13,8 @@ def _load_windows_miner():
         "rustchain_windows_miner_under_test",
         MINER_SCRIPT,
     )
+    assert spec is not None
+    assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -108,3 +110,39 @@ def test_headless_runner_prints_lifecycle_messages(monkeypatch, capsys):
     output = capsys.readouterr()
     assert "[attest] Attestation successful" in output.out
     assert "[enroll] Epoch enrollment successful" in output.out
+
+
+def test_headless_runner_uses_default_event_label(monkeypatch, capsys):
+    module = _load_windows_miner()
+
+    class FakeWallet:
+        wallet_data = {"address": "wallet-from-config"}
+
+        def save_wallet(self, wallet_data=None):
+            if wallet_data:
+                self.wallet_data = wallet_data
+
+    class FakeMiner:
+        node_url = "http://node-from-init"
+        miner_id = "windows_test"
+
+        def __init__(self, wallet_address):
+            self.wallet_address = wallet_address
+
+        def start_mining(self, callback):
+            callback({"message": "Lifecycle message without type"})
+
+        def stop_mining(self):
+            pass
+
+    def stop_loop(_seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(module, "RustChainWallet", FakeWallet)
+    monkeypatch.setattr(module, "RustChainMiner", FakeMiner)
+    monkeypatch.setattr(module.time, "sleep", stop_loop)
+
+    assert module.run_headless("wallet-from-args", "http://node-from-args") == 0
+
+    output = capsys.readouterr()
+    assert "[event] Lifecycle message without type" in output.out


### PR DESCRIPTION
Fixes #5401.

Summary:
- Emit lifecycle callback events when Windows miner attestation/enrollment refreshes succeed.
- Print those lifecycle messages in --headless mode so smoke tests and operators can see successful attest/enroll progress.
- Keep the packaged installer copy in sync and update pinned miner checksums. Also refresh the existing stale Linux setup_miner.py checksum because the repo test asserts all artifact hashes match current files.

Tests:
- uv run --no-project --with pytest --with requests python -m pytest --noconftest tests/test_windows_headless_lifecycle_logging.py tests/test_setup_miner_downloads.py tests/test_windows_miner_setup_checksum.py -q -> 7 passed
- python3 -m py_compile miners/windows/rustchain_windows_miner.py miners/windows/installer/src/rustchain_windows_miner.py tests/test_windows_headless_lifecycle_logging.py setup_miner.py -> passed
- git diff --check -> passed, only Git line-ending warning for existing .bat CRLF normalization