### PR TITLE
Fix bounty verifier URL allowlist redirects

### DIFF
--- a/tests/test_bounty_verifier.py
+++ b/tests/test_bounty_verifier.py
@@ -410,6 +410,48 @@ class TestBountyVerifier:
         
         assert len(urls) == 2
         assert "https://github.com/user" in urls
+
+    def test_verify_url_liveness_rejects_suffix_impersonation(self, sample_config):
+        """Allowlist matching should not accept github.com.evil.example."""
+        sample_config.url_check.enabled = True
+        sample_config.url_check.allowed_domains = ["github.com"]
+        verifier = BountyVerifier(sample_config)
+
+        checks = verifier.verify_url_liveness([
+            "https://github.com.evil.example/proof",
+        ])
+
+        assert len(checks) == 1
+        assert checks[0].status == VerificationStatus.FAILED
+        assert "Domain not in allowlist" in checks[0].message
+
+    def test_verify_url_liveness_rejects_off_allowlist_redirect(self, sample_config):
+        """An allowlisted URL that redirects away should fail verification."""
+        sample_config.url_check.enabled = True
+        sample_config.url_check.allowed_domains = ["github.com"]
+        verifier = BountyVerifier(sample_config)
+
+        class FakeResponse:
+            status = 200
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def geturl(self):
+                return "https://evil.example/proof"
+
+        fake_opener = MagicMock()
+        fake_opener.open.return_value = FakeResponse()
+
+        with patch("tools.bounty_verifier.verifier.build_opener", return_value=fake_opener):
+            checks = verifier.verify_url_liveness(["https://github.com/user/proof"])
+
+        assert len(checks) == 1
+        assert checks[0].status == VerificationStatus.FAILED
+        assert "Redirect target domain not in allowlist" in checks[0].message
     
     def test_parse_claim_comment(self, sample_claim_comment):
         """Test parsing claim comment."""
@@ -666,3 +708,4 @@ class TestIntegration:
         result = verifier.verify_claim(sample_claim_comment)
         
         assert result.overall_status == VerificationStatus.FAILED
+

--- a/tests/test_bounty_verifier.py
+++ b/tests/test_bounty_verifier.py
@@ -708,4 +708,3 @@ class TestIntegration:
         result = verifier.verify_claim(sample_claim_comment)
         
         assert result.overall_status == VerificationStatus.FAILED
-

--- a/tools/bounty_verifier/verifier.py
+++ b/tools/bounty_verifier/verifier.py
@@ -7,7 +7,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.error import URLError
-from urllib.request import Request, urlopen
+from urllib.parse import urlparse
+from urllib.request import HTTPRedirectHandler, Request, build_opener, urlopen
 
 from .config import Config
 from .github_client import GitHubClient, RateLimitExceeded
@@ -120,6 +121,44 @@ class BountyVerifier:
     def _extract_urls(self, text: str) -> List[str]:
         """Extract URLs from text."""
         return re.findall(self.URL_PATTERN, text)
+
+    def _url_host_allowed(self, url: str) -> bool:
+        """Return True when *url* is on an allowed host or subdomain."""
+        allowed_domains = self.config.url_check.allowed_domains
+        if not allowed_domains:
+            return True
+
+        host = (urlparse(url).hostname or "").rstrip(".").lower()
+        if not host:
+            return False
+
+        for domain in allowed_domains:
+            allowed = domain.lower().lstrip(".").rstrip(".")
+            if host == allowed or host.endswith(f".{allowed}"):
+                return True
+        return False
+
+    def _url_host(self, url: str) -> str:
+        """Return the parsed URL host for diagnostics."""
+        return urlparse(url).netloc or url
+
+    def _open_url_with_redirect_allowlist(self, req: Request, timeout: int):
+        """Open a URL while rejecting redirects outside the allowlist."""
+        if not self.config.url_check.allowed_domains:
+            return urlopen(req, timeout=timeout)
+
+        verifier = self
+
+        class AllowlistRedirectHandler(HTTPRedirectHandler):
+            def redirect_request(self, req, fp, code, msg, headers, newurl):
+                if not verifier._url_host_allowed(newurl):
+                    raise UrlLivenessError(
+                        "Redirect target domain not in allowlist: "
+                        f"{verifier._url_host(newurl)}"
+                    )
+                return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+        return build_opener(AllowlistRedirectHandler).open(req, timeout=timeout)
     
     def parse_claim_comment(self, comment: ClaimComment) -> ClaimComment:
         """Parse a claim comment to extract relevant data."""
@@ -311,17 +350,14 @@ class BountyVerifier:
                     ))
                     continue
                 
-                # Check domain allowlist
-                from urllib.parse import urlparse
-                parsed = urlparse(url)
-                if self.config.url_check.allowed_domains:
-                    if not any(d in parsed.netloc for d in self.config.url_check.allowed_domains):
-                        checks.append(VerificationCheck(
-                            name=f"URL: {url[:50]}",
-                            status=VerificationStatus.FAILED,
-                            message=f"Domain not in allowlist: {parsed.netloc}",
-                        ))
-                        continue
+                # Check domain allowlist with exact host/subdomain matching.
+                if self.config.url_check.allowed_domains and not self._url_host_allowed(url):
+                    checks.append(VerificationCheck(
+                        name=f"URL: {url[:50]}",
+                        status=VerificationStatus.FAILED,
+                        message=f"Domain not in allowlist: {self._url_host(url)}",
+                    ))
+                    continue
                 
                 # Check liveness
                 req = Request(
@@ -330,7 +366,22 @@ class BountyVerifier:
                     method="HEAD",
                 )
                 
-                with urlopen(req, timeout=self.config.url_check.timeout) as resp:
+                with self._open_url_with_redirect_allowlist(
+                    req,
+                    timeout=self.config.url_check.timeout,
+                ) as resp:
+                    final_url = resp.geturl()
+                    if not self._url_host_allowed(final_url):
+                        checks.append(VerificationCheck(
+                            name=f"URL: {url[:50]}",
+                            status=VerificationStatus.FAILED,
+                            message=(
+                                "Redirect target domain not in allowlist: "
+                                f"{self._url_host(final_url)}"
+                            ),
+                        ))
+                        continue
+
                     if resp.status < 400:
                         checks.append(VerificationCheck(
                             name=f"URL: {url[:50]}",
@@ -344,6 +395,12 @@ class BountyVerifier:
                             message=f"URL returned status {resp.status}",
                         ))
                         
+            except UrlLivenessError as e:
+                checks.append(VerificationCheck(
+                    name=f"URL: {url[:50]}",
+                    status=VerificationStatus.FAILED,
+                    message=str(e),
+                ))
             except URLError as e:
                 checks.append(VerificationCheck(
                     name=f"URL: {url[:50]}",
@@ -564,3 +621,4 @@ class BountyVerifier:
         if response:
             return response.get("html_url")
         return None
+

--- a/tools/bounty_verifier/verifier.py
+++ b/tools/bounty_verifier/verifier.py
@@ -621,4 +621,3 @@ class BountyVerifier:
         if response:
             return response.get("html_url")
         return None
-


### PR DESCRIPTION
## Summary
- replace substring domain allowlist checks with exact host/subdomain matching
- reject redirects that leave the configured allowlist
- add regression tests for `github.com.evil.example` and off-allowlist redirect targets

## Tests
- `python -m pytest -q tests/test_bounty_verifier.py`

Fixes the URL verification issue noted on rustchain-bounties#747.