### PR TITLE
fix: validate p2p block pagination

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -13,6 +13,29 @@ from typing import List, Dict
 
 from flask import jsonify, request
 
+
+def _parse_int_query_arg(
+    raw_value,
+    name: str,
+    default: int,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int:
+    if raw_value is None or raw_value == "":
+        value = default
+    else:
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            raise ValueError(f"{name} must be an integer")
+
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None and value > maximum:
+        return maximum
+    return value
+
+
 # ============================================================================
 # PEER DISCOVERY & MANAGEMENT
 # ============================================================================
@@ -431,8 +454,11 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
     @app.route('/api/blocks', methods=['GET'])
     def get_blocks():
         """Get blocks for sync (start height, limit)"""
-        start = request.args.get('start', 0, type=int)
-        limit = request.args.get('limit', 100, type=int)
+        try:
+            start = _parse_int_query_arg(request.args.get('start'), "start", 0, minimum=0)
+            limit = _parse_int_query_arg(request.args.get('limit'), "limit", 100, minimum=1, maximum=1000)
+        except ValueError as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 400
 
         # Fetch blocks from database
         with sqlite3.connect(peer_manager.db_path) as conn:

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -4,6 +4,7 @@ import os
 import sqlite3
 import sys
 
+import pytest
 from flask import Flask
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -49,3 +50,77 @@ def test_p2p_sync_flask_routes_use_flask_request_and_jsonify(tmp_path):
     assert blocks.get_json()["blocks"] == [
         {"height": 1, "hash": "block-hash", "data": {"ok": True}}
     ]
+
+
+@pytest.mark.parametrize(
+    ("query", "message"),
+    [
+        ("start=abc", "start must be an integer"),
+        ("start=10.5", "start must be an integer"),
+        ("start=-1", "start must be >= 0"),
+        ("limit=abc", "limit must be an integer"),
+        ("limit=10.5", "limit must be an integer"),
+        ("limit=0", "limit must be >= 1"),
+        ("limit=-1", "limit must be >= 1"),
+    ],
+)
+def test_p2p_blocks_rejects_invalid_pagination(tmp_path, query, message):
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER,
+                hash TEXT,
+                data TEXT
+            )
+            """
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.get(f"/api/blocks?{query}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": message}
+
+
+def test_p2p_blocks_caps_oversized_limit(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER,
+                hash TEXT,
+                data TEXT
+            )
+            """
+        )
+        conn.executemany(
+            "INSERT INTO blocks (height, hash, data) VALUES (?, ?, ?)",
+            [
+                (height, f"block-{height}", '{"ok": true}')
+                for height in range(1, 1003)
+            ],
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.get("/api/blocks?start=1&limit=5000")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["count"] == 1000
+    assert body["blocks"][0]["height"] == 1
+    assert body["blocks"][-1]["height"] == 1000


### PR DESCRIPTION
﻿Fixes #5421

## Summary
- Add centralized integer query parsing for the P2P `/api/blocks` sync endpoint.
- Reject malformed `start`/`limit` values with clear `400 Bad Request` JSON errors.
- Reject negative `start`, zero/negative `limit`, and cap oversized valid limits to a safe maximum of 1000 blocks.
- Add regression coverage for malformed strings, float strings, negative values, zero limits, and oversized limits.

## Root cause
The route used Flask's `request.args.get(..., type=int)`, which silently falls back to defaults when conversion fails. It also accepted negative and oversized values directly into the SQL query.

## Validation
- RED first: `python -m pytest node/tests/test_p2p_sync_flask_imports.py -k "invalid_pagination or oversized_limit" -q` failed across the new edge cases before the fix.
- `python -m pytest node/tests/test_p2p_sync_flask_imports.py -k "invalid_pagination or oversized_limit" -q`
- `python -m py_compile node/rustchain_p2p_sync.py node/tests/test_p2p_sync_flask_imports.py`
- `python -m pytest node/tests/test_p2p_sync_flask_imports.py node/tests/test_p2p_sync_routes.py -q`
- `git diff --check`
