### PR TITLE
fix: validate sophia governor recent limit

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -143,6 +143,19 @@ def _max_recent_rows() -> int:
     return max(1, min(int(os.getenv("SOPHIA_GOVERNOR_MAX_RECENT", "50")), 200))
 
 
+def _parse_recent_limit(value: Any, default: int = 20) -> int:
+    if value is None or value == "":
+        limit = default
+    else:
+        try:
+            limit = int(value)
+        except (TypeError, ValueError):
+            raise ValueError("limit must be an integer")
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    return min(limit, _max_recent_rows())
+
+
 def _parse_csv_env(name: str) -> list[str]:
     raw = os.getenv(name, "")
     if not raw:
@@ -837,7 +850,7 @@ def get_governor_event(event_id: int, db_path: str | None = None) -> dict[str, A
 def get_recent_governor_events(db_path: str | None = None, limit: int = 20) -> list[dict[str, Any]]:
     db = db_path or DB_PATH
     init_sophia_governor_schema(db)
-    limit = max(1, min(int(limit), _max_recent_rows()))
+    limit = _parse_recent_limit(limit)
     with sqlite3.connect(db) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(
@@ -947,10 +960,13 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
 
     @app.route("/sophia/governor/recent", methods=["GET"])
     def sophia_governor_recent():
-        limit = request.args.get("limit", 20)
+        try:
+            limit = _parse_recent_limit(request.args.get("limit"))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         return jsonify({
             "ok": True,
-            "events": get_recent_governor_events(db_path=db, limit=int(limit)),
+            "events": get_recent_governor_events(db_path=db, limit=limit),
         })
 
     @app.route("/sophia/governor/review", methods=["POST"])

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -250,6 +250,36 @@ def test_governor_endpoints_report_status_and_recent(client):
     assert len(recent_body["events"]) >= 1
 
 
+@pytest.mark.parametrize(
+    ("limit", "message"),
+    [
+        ("abc", "limit must be an integer"),
+        ("10.5", "limit must be an integer"),
+        ("0", "limit must be >= 1"),
+        ("-1", "limit must be >= 1"),
+    ],
+)
+def test_governor_recent_rejects_invalid_limit(client, limit, message):
+    response = client.get(f"/sophia/governor/recent?limit={limit}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": message}
+
+
+def test_governor_recent_caps_oversized_limit(tmp_db):
+    for index in range(55):
+        review_rustchain_event(
+            event_type="node_health",
+            source=f"pytest.{index}",
+            payload={"status": "ok"},
+            db_path=tmp_db,
+        )
+
+    recent = get_recent_governor_events(tmp_db, limit=500)
+
+    assert len(recent) == 50
+
+
 def test_governor_status_helpers(tmp_db):
     review_rustchain_event(
         event_type="attestation_verdict",


### PR DESCRIPTION
﻿Fixes #5424

## Summary
- Validate `limit` for the Sophia governor recent-events endpoint before querying.
- Return `400 Bad Request` for non-integer and non-positive limits instead of raising or silently clamping unsafe input.
- Preserve the existing `SOPHIA_GOVERNOR_MAX_RECENT` cap for oversized valid numeric limits.
- Add regression coverage for malformed strings, float strings, zero, negative, and oversized limits.

## Root cause
The route called `int(limit)` directly before passing the value to `get_recent_governor_events`. Malformed values raised `ValueError`, while zero/negative values reached the helper and were silently clamped.

## Validation
- RED first: `python -m pytest node/tests/test_sophia_governor.py -k "invalid_limit or oversized_limit" -q` failed before the fix.
- `python -m pytest node/tests/test_sophia_governor.py -k "invalid_limit or oversized_limit" -q`
- `python -m py_compile node/sophia_governor.py node/tests/test_sophia_governor.py`
- `python -m pytest node/tests/test_sophia_governor.py -q`
- `git diff --check -- node/sophia_governor.py node/tests/test_sophia_governor.py`
