### PR TITLE
fix: fail closed when sync admin key is unset

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -92,7 +92,7 @@ def register_sync_endpoints(app, db_path, admin_key):
         @wraps(f)
         def decorated(*args, **kwargs):
             key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
-            if not key or not hmac.compare_digest(key, admin_key):
+            if not key or not admin_key or not hmac.compare_digest(key, admin_key):
                 return jsonify({"error": "Unauthorized"}), 401
             return f(*args, **kwargs)
 

--- a/node/tests/test_rustchain_sync_endpoints.py
+++ b/node/tests/test_rustchain_sync_endpoints.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 from flask import Flask
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -51,3 +52,32 @@ def test_require_admin_uses_constant_time_compare(monkeypatch, tmp_path):
         ("wrong-secret", "sync-secret"),
         ("sync-secret", "sync-secret"),
     ]
+
+
+@pytest.mark.parametrize("admin_key", [None, ""])
+def test_sync_admin_auth_fails_closed_when_admin_key_unconfigured(
+    monkeypatch, tmp_path, admin_key
+):
+    """Missing sync admin key must reject requests instead of crashing."""
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setattr(rustchain_sync_endpoints.hmac, "compare_digest", spy_compare_digest)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        admin_key,
+    )
+    client = app.test_client()
+
+    response = client.get("/api/sync/status", headers={"X-Admin-Key": "anything"})
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized"}
+    assert calls == []


### PR DESCRIPTION
﻿/claim #5429
/claim #305

## Summary
- Make sync admin endpoints fail closed when the configured admin key is missing or empty.
- Preserve constant-time comparison for configured keys.
- Add regression coverage for both `None` and empty-string admin key configuration.

## Root cause
The sync endpoint auth wrapper only checked whether the request provided an admin key. If a request included any non-empty `X-Admin-Key` or `X-API-Key` while the configured `admin_key` was missing, the wrapper still called `hmac.compare_digest(key, admin_key)`. With a real `None` configured key, that path can raise `TypeError` instead of returning a normal unauthorized response.

## Why this matters
Admin-protected sync endpoints should fail closed cleanly when credentials are not configured. A missing secret is an auth-boundary configuration error, not a reason for the route to crash or expose internal error behavior.

## Validation
- Wrote the regression test first and confirmed it failed because the wrapper still called `compare_digest` with `None` / empty configured keys.
- `python -m pytest node/tests/test_rustchain_sync_endpoints.py -q` -> 3 passed
- `python -m py_compile node\rustchain_sync_endpoints.py node\tests\test_rustchain_sync_endpoints.py` -> passed
- `git diff --check` -> passed
