### PR TITLE
fix: validate x402 wallet address hex

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -113,6 +113,14 @@ def _json_string_field(data, field_name, default=""):
     return value.strip()
 
 
+def _is_base_address(value: str) -> bool:
+    return (
+        value.startswith("0x")
+        and len(value) == 42
+        and all(char in "0123456789abcdefABCDEF" for char in value[2:])
+    )
+
+
 # ---------------------------------------------------------------------------
 # x402 payment check
 # ---------------------------------------------------------------------------
@@ -206,7 +214,7 @@ def init_app(app, get_db_func):
             address = _json_string_field(data, "coinbase_address")
         except ValueError as exc:
             return _cors_json({"error": str(exc)}, 400)
-        if not address or not address.startswith("0x") or len(address) != 42:
+        if not address or not _is_base_address(address):
             return _cors_json({"error": "Invalid Base address"}, 400)
 
         db = get_db_func()

--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -70,6 +70,14 @@ def _json_string_field(data, field_name, default=""):
     return value.strip()
 
 
+def _is_base_address(value: str) -> bool:
+    return (
+        value.startswith("0x")
+        and len(value) == 42
+        and all(char in "0123456789abcdefABCDEF" for char in value[2:])
+    )
+
+
 def init_app(app, db_path):
     """Register x402 routes on the RustChain Flask app."""
 
@@ -104,7 +112,7 @@ def init_app(app, db_path):
 
         if not miner_id:
             return jsonify({"error": "miner_id is required"}), 400
-        if not coinbase_address or not coinbase_address.startswith("0x") or len(coinbase_address) != 42:
+        if not coinbase_address or not _is_base_address(coinbase_address):
             return jsonify({"error": "Invalid Base address (must be 0x + 40 hex chars)"}), 400
 
         conn = sqlite3.connect(db_path)

--- a/tests/test_beacon_x402_wallet.py
+++ b/tests/test_beacon_x402_wallet.py
@@ -54,6 +54,17 @@ def test_set_agent_wallet_rejects_non_string_coinbase_address(client):
     assert response.get_json()["error"] == "coinbase_address must be a string"
 
 
+def test_set_agent_wallet_rejects_non_hex_base_address(client):
+    response = client.post(
+        "/api/agents/agent-1/wallet",
+        json={"coinbase_address": "0xZZ34567890123456789012345678901234567890"},
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid Base address"
+
+
 def test_set_agent_wallet_preserves_valid_address(client):
     response = client.post(
         "/api/agents/agent-1/wallet",

--- a/tests/test_rustchain_x402_wallet.py
+++ b/tests/test_rustchain_x402_wallet.py
@@ -66,6 +66,20 @@ def test_link_coinbase_rejects_non_string_fields(client, field, value):
     assert response.get_json()["error"] == f"{field} must be a string"
 
 
+def test_link_coinbase_rejects_non_hex_base_address(client):
+    response = client.post(
+        "/wallet/link-coinbase",
+        json={
+            "miner_id": "miner-1",
+            "coinbase_address": "0xZZ34567890123456789012345678901234567890",
+        },
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid Base address (must be 0x + 40 hex chars)"
+
+
 def test_link_coinbase_preserves_valid_request(client):
     response = client.post(
         "/wallet/link-coinbase",


### PR DESCRIPTION
/claim #5432
/claim #305

## Summary
- Add strict `0x` + 40-hex-character validation for RustChain x402 wallet linking.
- Add the same validation for Beacon x402 native agent wallet linking.
- Cover both endpoints with regression tests that reject a length-valid but non-hex `0xZZ...` address.

## Root cause
Both x402 wallet endpoints only checked that a submitted Base/Coinbase address started with `0x` and had length 42. That allowed non-hex values to be persisted as wallet addresses and returned in later x402/swap guidance.

## Validation
RED first:
- `python -m pytest tests/test_rustchain_x402_wallet.py::test_link_coinbase_rejects_non_hex_base_address -q` failed with `200 == 400`.
- `python -m pytest tests/test_beacon_x402_wallet.py::test_set_agent_wallet_rejects_non_hex_base_address -q` failed with `200 == 400`.

GREEN after fix:
- `python -m pytest tests/test_rustchain_x402_wallet.py -q` -> 5 passed.
- `python -m pytest tests/test_beacon_x402_wallet.py -q` -> 4 passed.
- `python -m pytest tests/test_rustchain_x402_wallet.py tests/test_beacon_x402_wallet.py -q` -> 9 passed.
- `python -m py_compile node\rustchain_x402.py node\beacon_x402.py tests\test_rustchain_x402_wallet.py tests\test_beacon_x402_wallet.py` -> passed.
- `git diff --check -- node/rustchain_x402.py node/beacon_x402.py tests/test_rustchain_x402_wallet.py tests/test_beacon_x402_wallet.py` -> passed.