### PR TITLE
fix: validate bridge base address hex

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -227,6 +227,8 @@ def validate_chain_address_format(chain: str, address: str) -> Tuple[bool, str]:
             return False, "Base addresses must start with '0x'"
         if len(address) != 42:
             return False, "Invalid Base address length"
+        if not all(char in "0123456789abcdefABCDEF" for char in address[2:]):
+            return False, "Invalid Base address hex"
     
     return True, ""
 

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -355,6 +355,13 @@ class TestAddressValidation:
         valid, msg = bridge_api.validate_chain_address_format("base", "742d35Cc6634C0532925a3b844Bc9e7595f0bEb0")
         assert valid is False
 
+    def test_invalid_base_address_non_hex(self, setup_test_db):
+        """Test Base address with non-hex characters."""
+        bridge_api = setup_test_db["bridge_api"]
+        valid, msg = bridge_api.validate_chain_address_format("base", "0xZZ2d35Cc6634C0532925a3b844Bc9e7595f0bEb0")
+        assert valid is False
+        assert "hex" in msg.lower()
+
 
 # =============================================================================
 # Bridge Transfer Creation Tests


### PR DESCRIPTION
/claim #5434
/claim #305

## Summary
- Reject non-hex Base addresses in `node/bridge_api.py::validate_chain_address_format`.
- Add regression coverage for a length-valid `0xZZ...` Base address.
- Preserve existing valid Base address and existing prefix/length validation behavior.

## Root cause
The Base address validator only checked `address.startswith(0x)` and `len(address) == 42`. That allowed strings that are the right length but not valid hexadecimal addresses.

## Validation
RED first:
- `python -m pytest tests/test_bridge_lock_ledger.py::TestAddressValidation::test_invalid_base_address_non_hex -q` failed with `assert True is False`.

GREEN after fix:
- `python -m pytest tests/test_bridge_lock_ledger.py::TestAddressValidation -q` -> 8 passed.
- `python -m py_compile node\bridge_api.py tests\test_bridge_lock_ledger.py` -> passed.
- `git diff --check -- node/bridge_api.py tests/test_bridge_lock_ledger.py` -> passed.