### PR TITLE
fix: validate bridge lock base wallet hex

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -132,6 +132,14 @@ def _amount_from_base(amount_int: int) -> float:
     return amount_int / (10 ** RTC_DECIMALS)
 
 
+def _is_base_wallet_address(value: str) -> bool:
+    return (
+        value.startswith("0x")
+        and len(value) == 42
+        and all(char in "0123456789abcdefABCDEF" for char in value[2:])
+    )
+
+
 def _generate_lock_id(sender: str, amount: int, target_chain: str, ts: int) -> str:
     """Deterministic lock ID from key fields."""
     raw = f"{sender}:{amount}:{target_chain}:{ts}:{uuid.uuid4()}"
@@ -255,7 +263,7 @@ def lock_rtc():
         return jsonify({"error": f"maximum lock amount is {MAX_LOCK_AMOUNT} RTC"}), 400
 
     # Validate target wallet format
-    if target_chain == CHAIN_BASE and not target_wallet.startswith("0x"):
+    if target_chain == CHAIN_BASE and not _is_base_wallet_address(target_wallet):
         return jsonify({"error": "Base wallet must be a 0x EVM address"}), 400
     if target_chain == CHAIN_SOLANA and len(target_wallet) < 32:
         return jsonify({"error": "Solana wallet must be a valid base58 address"}), 400

--- a/tests/test_bridge_lock_base_wallet_validation.py
+++ b/tests/test_bridge_lock_base_wallet_validation.py
@@ -1,0 +1,73 @@
+import hashlib
+import hmac
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BRIDGE_API_PATH = REPO_ROOT / "bridge" / "bridge_api.py"
+
+
+def _load_bridge_api(tmp_path, monkeypatch):
+    monkeypatch.setenv("BRIDGE_DB_PATH", str(tmp_path / "bridge.db"))
+    monkeypatch.setenv("BRIDGE_ADMIN_KEY", "test-admin-key")
+    monkeypatch.setenv("BRIDGE_RECEIPT_SECRET", "test-bridge-secret")
+    monkeypatch.setenv("BRIDGE_REQUIRE_PROOF", "true")
+
+    module_name = "bridge_api_base_wallet_validation"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, BRIDGE_API_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _receipt_signature(module, sender_wallet, amount, target_chain, target_wallet, tx_hash):
+    payload = {
+        "sender_wallet": sender_wallet,
+        "amount_base": module._amount_to_base(amount),
+        "target_chain": target_chain,
+        "target_wallet": target_wallet,
+        "tx_hash": tx_hash,
+    }
+    message = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hmac.new(
+        module.BRIDGE_RECEIPT_SECRET.encode("utf-8"),
+        message,
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def test_bridge_lock_rejects_length_valid_non_hex_base_wallet(tmp_path, monkeypatch):
+    bridge_api = _load_bridge_api(tmp_path, monkeypatch)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    bridge_api.register_bridge_routes(app)
+
+    target_wallet = "0xZZ15a73199d56b7e9c71575bec1632cd1d36908f"
+    tx_hash = "rtc-lock-non-hex-base-wallet"
+    response = app.test_client().post(
+        "/bridge/lock",
+        json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": target_wallet,
+            "tx_hash": tx_hash,
+            "receipt_signature": _receipt_signature(
+                bridge_api,
+                "test-miner",
+                10.0,
+                "base",
+                target_wallet,
+                tx_hash,
+            ),
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Base wallet must be a 0x EVM address"


### PR DESCRIPTION
/claim #5436
/claim #305

## Summary
- Reject length-valid but non-hex Base target wallets in standalone `/bridge/lock`.
- Add a focused Flask regression test using a Windows-safe temp DB setup instead of the legacy `/tmp` test fixture.
- Preserve the existing `Base wallet must be a 0x EVM address` client error for malformed Base wallets.

## Root cause
`bridge/bridge_api.py` only checked `target_wallet.startswith(0x)` for Base lock requests. With proof validation enabled, a request signed over `0xZZ...` still created a lock because the target wallet passed format validation.

## Validation
RED first:
- `python -m pytest tests/test_bridge_lock_base_wallet_validation.py -q` failed with `201 == 400` before the fix.

GREEN after fix:
- `python -m pytest tests/test_bridge_lock_base_wallet_validation.py -q` -> 1 passed.
- `python -m py_compile bridge\bridge_api.py tests\test_bridge_lock_base_wallet_validation.py` -> passed.
- `git diff --check -- bridge/bridge_api.py tests/test_bridge_lock_base_wallet_validation.py` -> passed.