### PR TITLE
fix: hide keeper proxy connection details

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -14,6 +14,7 @@ Features:
 
 import hashlib
 import json
+import logging
 import os
 import re
 import secrets
@@ -30,6 +31,7 @@ NODE_API = os.environ.get("RUSTCHAIN_NODE_API", "http://localhost:8000")
 FAUCET_DB = "faucet_service/faucet.db"
 PORT = 8095
 WALLET_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]{3,128}$")
+logger = logging.getLogger(__name__)
 
 app = Flask(__name__)
 CORS(app)
@@ -106,8 +108,9 @@ def proxy_api(path):
             
         resp = requests.get(url, timeout=5)
         return (resp.content, resp.status_code, resp.headers.items())
-    except Exception as e:
-        return jsonify({"error": f"Node Connection Error: {str(e)}"}), 502
+    except Exception:
+        logger.exception("Keeper explorer proxy request failed")
+        return jsonify({"error": "Node connection failed"}), 502
 
 @app.route('/api/faucet/drip', methods=['POST'])
 def faucet_drip():

--- a/tests/test_keeper_explorer_faucet.py
+++ b/tests/test_keeper_explorer_faucet.py
@@ -74,3 +74,23 @@ def test_faucet_drip_records_valid_address(tmp_path, monkeypatch):
             "SELECT address, amount FROM faucet_claims"
         ).fetchone()
     assert row == ("rtc-test-wallet", 0.5)
+
+
+def test_proxy_hides_internal_connection_errors(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    internal_error = (
+        "Connection refused for http://10.0.0.5:8000/private/admin "
+        "from /srv/rustchain/node.py"
+    )
+
+    def fail_request(*_args, **_kwargs):
+        raise RuntimeError(internal_error)
+
+    monkeypatch.setattr(keeper.requests, "get", fail_request)
+
+    response = keeper.app.test_client().get("/api/proxy/blocks/latest")
+
+    assert response.status_code == 502
+    body = response.get_json()
+    assert body == {"error": "Node connection failed"}
+    assert internal_error not in response.get_data(as_text=True)


### PR DESCRIPTION
Fixes #5438.

## Summary
- Add a regression test for `keeper_explorer.py` proxy failures that include internal URL/path text in the raised exception.
- Log the full proxy exception server-side with `logger.exception(...)`.
- Return a stable generic `502` JSON error to clients instead of echoing `str(e)`.

## Root cause
`/api/proxy/<path:path>` caught upstream request failures and returned `Node Connection Error: {str(e)}` directly to the caller. If the exception text contains private node URLs, hostnames, IPs, file paths, or deployment details, those details are exposed in the API response.

## Validation
- RED first: `python -m pytest tests/test_keeper_explorer_faucet.py::test_proxy_hides_internal_connection_errors -q` failed because the response leaked `http://10.0.0.5:8000/private/admin` and `/srv/rustchain/node.py`.
- GREEN: `python -m pytest tests/test_keeper_explorer_faucet.py::test_proxy_hides_internal_connection_errors -q` -> `1 passed`.
- Focused suite: `python -m pytest tests/test_keeper_explorer_faucet.py -q` -> `4 passed`.
- Syntax check: `python -m py_compile keeper_explorer.py tests/test_keeper_explorer_faucet.py` -> passed, with the pre-existing `SyntaxWarning` in the ASCII template.
- Whitespace: `git diff --check -- keeper_explorer.py tests/test_keeper_explorer_faucet.py` -> passed.
