### PR TITLE
Fix keeper proxy error redaction

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -14,6 +14,7 @@ Features:
 
 import hashlib
 import json
+import logging
 import os
 import re
 import secrets
@@ -33,6 +34,7 @@ WALLET_ADDRESS_RE = re.compile(r"^[A-Za-z0-9._:-]{3,128}$")
 
 app = Flask(__name__)
 CORS(app)
+logger = logging.getLogger(__name__)
 
 # --- Faucet Logic (Integrated) ---
 
@@ -106,8 +108,9 @@ def proxy_api(path):
             
         resp = requests.get(url, timeout=5)
         return (resp.content, resp.status_code, resp.headers.items())
-    except Exception as e:
-        return jsonify({"error": f"Node Connection Error: {str(e)}"}), 502
+    except Exception:
+        logger.exception("Keeper explorer proxy request failed")
+        return jsonify({"error": "Node connection failed"}), 502
 
 @app.route('/api/faucet/drip', methods=['POST'])
 def faucet_drip():

--- a/tests/test_keeper_explorer_faucet.py
+++ b/tests/test_keeper_explorer_faucet.py
@@ -74,3 +74,19 @@ def test_faucet_drip_records_valid_address(tmp_path, monkeypatch):
             "SELECT address, amount FROM faucet_claims"
         ).fetchone()
     assert row == ("rtc-test-wallet", 0.5)
+
+
+def test_proxy_api_hides_upstream_connection_details(tmp_path, monkeypatch):
+    keeper = load_keeper_explorer(tmp_path, monkeypatch)
+    internal_detail = "http://10.0.0.5:8000/private/admin from /srv/rustchain/node.py"
+
+    def fail_request(*args, **kwargs):
+        raise RuntimeError(internal_detail)
+
+    monkeypatch.setattr(keeper.requests, "get", fail_request)
+
+    response = keeper.app.test_client().get("/api/proxy/blocks/latest")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Node connection failed"}
+    assert internal_detail not in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- Stop returning raw upstream exception text from `keeper_explorer.py` proxy failures.
- Log the full exception server-side with `logger.exception(...)`.
- Add a regression test proving internal URLs/paths from a failed proxy request are not exposed to clients.

Fixes #5438

## Validation
- `python -m pytest .tmp-issue5438\tests\test_keeper_explorer_faucet.py -q --confcutdir=.tmp-issue5438` -> 4 passed
- `python -m py_compile .tmp-issue5438\keeper_explorer.py .tmp-issue5438\tests\test_keeper_explorer_faucet.py` -> passed