### PR TITLE
fix: hide bottube mood exception details

### DIFF
--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -45,11 +45,14 @@ import sqlite3
 import os
 import json
 import random
+import logging
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 from collections import deque
+
+logger = logging.getLogger(__name__)
 
 
 # ─── Mood States ────────────────────────────────────────────────────────────── #
@@ -938,6 +941,11 @@ def _get_json_object(allow_empty: bool = False):
     return data, None
 
 
+def _mood_service_unavailable(operation: str):
+    logger.exception("BoTTube mood route failed during %s", operation)
+    return jsonify({"error": "Mood service unavailable"}), 500
+
+
 @mood_bp.route("/<agent_name>/mood", methods=["GET"])
 def get_agent_mood_endpoint(agent_name: str):
     """
@@ -960,8 +968,8 @@ def get_agent_mood_endpoint(agent_name: str):
 
         return jsonify(mood_info)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("get_agent_mood")
 
 
 @mood_bp.route("/<agent_name>/mood/signal", methods=["POST"])
@@ -992,8 +1000,8 @@ def record_mood_signal(agent_name: str):
         result = engine.record_signal(agent_name, signal_type, value, weight)
         return jsonify(result)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("record_mood_signal")
 
 
 @mood_bp.route("/<agent_name>/mood/title", methods=["POST"])
@@ -1022,8 +1030,8 @@ def generate_mood_title(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("generate_mood_title")
 
 
 @mood_bp.route("/<agent_name>/mood/comment", methods=["POST"])
@@ -1051,8 +1059,8 @@ def generate_mood_comment(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("generate_mood_comment")
 
 
 @mood_bp.route("/<agent_name>/mood/post-probability", methods=["GET"])
@@ -1074,8 +1082,8 @@ def get_post_probability(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("get_post_probability")
 
 
 @mood_bp.route("/<agent_name>/mood/statistics", methods=["GET"])
@@ -1090,8 +1098,8 @@ def get_mood_statistics_endpoint(agent_name: str):
         stats = engine.get_mood_statistics(agent_name)
         return jsonify(stats)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_unavailable("get_mood_statistics")
 
 
 def init_mood_routes(app):

--- a/tests/test_bottube_mood.py
+++ b/tests/test_bottube_mood.py
@@ -634,6 +634,58 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("generated_comment", response.get_json())
 
+    def test_mood_routes_hide_internal_exception_details(self):
+        sensitive_error = (
+            "sqlite3.OperationalError: no such table: agent_mood_history "
+            "at /srv/rustchain/private/mood.db token=super-secret"
+        )
+
+        class FailingMoodEngine:
+            def _fail(self, *args, **kwargs):
+                raise RuntimeError(sensitive_error)
+
+            get_agent_mood = _fail
+            get_mood_statistics = _fail
+            record_signal = _fail
+            generate_title = _fail
+            generate_comment = _fail
+            get_post_probability = _fail
+            should_post_now = _fail
+
+        requests_to_check = [
+            ("get", "/api/v1/agents/test-agent/mood", {}),
+            (
+                "post",
+                "/api/v1/agents/test-agent/mood/signal",
+                {"json": {"signal_type": "video_views", "value": {"views": 1}}},
+            ),
+            (
+                "post",
+                "/api/v1/agents/test-agent/mood/title",
+                {"json": {"topic": "Internal Error Demo"}},
+            ),
+            (
+                "post",
+                "/api/v1/agents/test-agent/mood/comment",
+                {"json": {"base_comment": "hello"}},
+            ),
+            ("get", "/api/v1/agents/test-agent/mood/post-probability", {}),
+            ("get", "/api/v1/agents/test-agent/mood/statistics", {}),
+        ]
+
+        with patch("bottube_mood_engine.get_mood_engine", return_value=FailingMoodEngine()):
+            for method, endpoint, kwargs in requests_to_check:
+                with self.subTest(endpoint=endpoint):
+                    response = getattr(self.client, method)(endpoint, **kwargs)
+
+                    self.assertEqual(response.status_code, 500)
+                    body = response.get_json()
+                    self.assertEqual(body["error"], "Mood service unavailable")
+                    serialized_body = json.dumps(body)
+                    self.assertNotIn("agent_mood_history", serialized_body)
+                    self.assertNotIn("/srv/rustchain/private", serialized_body)
+                    self.assertNotIn("super-secret", serialized_body)
+
 
 def run_demo():
     """Run demonstration of mood system."""


### PR DESCRIPTION
﻿Fixes #5445.

## Summary
- Hide raw BoTTube mood engine exception text from all six mood API route responses.
- Log full exception details server-side with `logger.exception(...)` for debuggability.
- Add a regression test that forces sensitive SQL/path/token-like exception text through every affected GET/POST route and asserts the client only sees a generic error.

## Root cause
The route handlers caught broad exceptions and returned raw `str(e)` to clients. If the mood engine raised a database, filesystem, or integration error, callers received the raw exception text, including table names, paths, or secret-like substrings.

## Behavior after fix
The affected routes now return a generic `Mood service unavailable` HTTP 500 for internal failures, while malformed/non-object/missing client JSON still uses the existing 400 responses.

## Validation
Red before fix:
- `python -m pytest tests/test_bottube_mood.py::TestMoodBlueprintJsonValidation::test_mood_routes_hide_internal_exception_details -q` -> failed on all six subtests because the response leaked `agent_mood_history`, `/srv/rustchain/private`, and `super-secret`.

Green after fix:
- `python -m pytest tests/test_bottube_mood.py::TestMoodBlueprintJsonValidation::test_mood_routes_hide_internal_exception_details -q` -> 1 passed, 6 subtests passed
- `python -m pytest tests/test_bottube_mood.py -q` -> 31 passed, 14 subtests passed
- `python -m py_compile bottube_mood_engine.py tests\test_bottube_mood.py` -> passed
- `git diff --check -- bottube_mood_engine.py tests/test_bottube_mood.py` -> passed
- `rg -n 'return jsonify\(\{"error": str\(e\)\}\), 500' bottube_mood_engine.py` -> no matches
