### PR TITLE
fix: hide webhook processing error details

### DIFF
--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -301,7 +301,7 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=str(e),
+                detail="Internal moderation processing error",
             )
 
     @app.get("/stats")

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -390,6 +390,49 @@ class TestWebhookProcessing:
             assert data["action"] == "delete"
             assert data["risk_score"] > 0.8
 
+    @pytest.mark.asyncio
+    async def test_webhook_processing_errors_hide_internal_details(
+        self, app: TestClient, sample_webhook_payload: dict, mock_config: MagicMock
+    ) -> None:
+        """Test webhook processing errors do not leak internal exception details."""
+        body = json.dumps(sample_webhook_payload).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+        sensitive_error = (
+            "database dsn=postgres://bot:secret@internal-db/moderation "
+            "at /srv/rustchain/private/moderation.py"
+        )
+
+        with (
+            patch.object(
+                app.app.state.moderation_service,
+                "process_comment_event",
+                new_callable=AsyncMock,
+            ) as mock_process,
+            patch.object(app.app.state.audit_logger, "log_error") as mock_log_error,
+        ):
+            mock_process.side_effect = RuntimeError(sensitive_error)
+
+            response = app.post(
+                "/webhook",
+                content=body,
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "processing-error-delivery-id",
+                    "X-Hub-Signature-256": signature,
+                },
+            )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json()["detail"] == "Internal moderation processing error"
+        serialized_response = json.dumps(response.json())
+        assert "postgres://bot:secret@internal-db" not in serialized_response
+        assert "/srv/rustchain/private" not in serialized_response
+        mock_log_error.assert_called_once()
+        audit_kwargs = mock_log_error.call_args.kwargs
+        assert audit_kwargs["error_type"] == "processing_error"
+        assert sensitive_error in audit_kwargs["message"]
+        assert sensitive_error in audit_kwargs["traceback"]
+
     def test_webhook_missing_payload_data(
         self, app: TestClient, mock_config: MagicMock
     ) -> None:


### PR DESCRIPTION
﻿Fixes #5447.

## Summary
- Hide raw moderation processing exception details from `POST /webhook` HTTP 500 responses.
- Keep detailed exception context in the existing audit log path for operators.
- Add a regression test that forces DSN/path-like exception text through `process_comment_event(...)` and verifies it is absent from the HTTP response but still present in audit logging.

## Root cause
The processing error handler logged the failure through `audit_logger.log_error(...)`, then raised `HTTPException(..., detail=str(e))`. That made internal backend exception details visible to webhook callers.

## Behavior after fix
Processing failures now return a generic `Internal moderation processing error` detail while preserving specific logs via `message` and `traceback` fields.

## Validation
Red before fix:
- `python -m pytest -p no:flask tools/comment-moderation-bot/tests/test_webhook.py::TestWebhookProcessing::test_webhook_processing_errors_hide_internal_details -q` -> failed because response detail leaked `postgres://bot:secret@internal-db` and `/srv/rustchain/private`.

Green after fix:
- `python -m pytest -p no:flask tools/comment-moderation-bot/tests/test_webhook.py::TestWebhookProcessing::test_webhook_processing_errors_hide_internal_details -q` -> 1 passed
- `python -m pytest -p no:flask tools/comment-moderation-bot/tests/test_webhook.py -q` -> 22 passed
- `python -m py_compile tools\comment-moderation-bot\src\webhook.py tools\comment-moderation-bot\tests\test_webhook.py` -> passed
- `git diff --check -- tools/comment-moderation-bot/src/webhook.py tools/comment-moderation-bot/tests/test_webhook.py` -> passed

Note: `-p no:flask` is used because the local environment has pytest-flask installed globally and it mistakes this FastAPI suite's `app` fixture for a Flask app before tests run.
