### PR TITLE
fix: hide explorer upstream connection details

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,13 +1,23 @@
 from flask import Flask, render_template, jsonify
 import requests
 import json
+import logging
 from datetime import datetime
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 # Configuration
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
+
+
+def _upstream_node_unavailable(include_miners=False):
+    logger.exception("Explorer upstream node request failed")
+    payload = {"error": "Upstream node unavailable"}
+    if include_miners:
+        payload["miners"] = []
+    return jsonify(payload), 500
 
 @app.route('/')
 def dashboard():
@@ -49,8 +59,8 @@ def get_miners():
             return jsonify(miners_data)
         else:
             return jsonify({'error': 'Failed to fetch miners data', 'miners': []}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}', 'miners': []}), 500
+    except requests.exceptions.RequestException:
+        return _upstream_node_unavailable(include_miners=True)
 
 @app.route('/api/network/stats')
 def get_network_stats():
@@ -80,8 +90,8 @@ def get_network_stats():
             return jsonify(stats)
         else:
             return jsonify({'error': 'Failed to fetch network stats'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        return _upstream_node_unavailable()
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
@@ -122,8 +132,8 @@ def get_miner_detail(miner_id):
                 return jsonify({'error': 'Miner not found'}), 404
         else:
             return jsonify({'error': 'Failed to fetch miner data'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        return _upstream_node_unavailable()
 
 @app.errorhandler(404)
 def not_found(error):

--- a/tests/test_explorer_api_errors.py
+++ b/tests/test_explorer_api_errors.py
@@ -1,0 +1,44 @@
+import json
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from explorer.app import app as explorer_app
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expects_miners_fallback"),
+    [
+        ("/api/miners", True),
+        ("/api/network/stats", False),
+        ("/api/miner/miner-001", False),
+    ],
+)
+def test_explorer_api_hides_upstream_connection_details(
+    endpoint,
+    expects_miners_fallback,
+):
+    sensitive_error = (
+        "HTTPConnectionPool(host='127.0.0.1', port=8000): "
+        "url=/api/miners?token=super-secret "
+        "trace=/srv/rustchain/private/node.py"
+    )
+
+    with (
+        explorer_app.test_client() as client,
+        patch("explorer.app.requests.get") as mock_get,
+    ):
+        mock_get.side_effect = requests.exceptions.ConnectionError(sensitive_error)
+        response = client.get(endpoint)
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["error"] == "Upstream node unavailable"
+    if expects_miners_fallback:
+        assert body["miners"] == []
+
+    serialized_body = json.dumps(body)
+    assert "127.0.0.1" not in serialized_body
+    assert "super-secret" not in serialized_body
+    assert "/srv/rustchain/private" not in serialized_body


### PR DESCRIPTION
﻿Fixes #5449.

## Summary
- Hide raw upstream `requests` connection exception details from the explorer API.
- Add a shared helper that returns `Upstream node unavailable` while logging the full exception server-side.
- Add parameterized regression coverage for `/api/miners`, `/api/network/stats`, and `/api/miner/<miner_id>`.

## Root cause
The explorer caught `requests.exceptions.RequestException` and returned `Connection error: {str(e)}` directly in JSON responses. Upstream connection errors can include internal hostnames, ports, request paths, query strings, and deployment paths.

## Behavior after fix
All three affected routes now return a generic `Upstream node unavailable` HTTP 500 response. `/api/miners` still includes the existing empty `miners` fallback list.

## Validation
Red before fix:
- `python -m pytest tests/test_explorer_api_errors.py -q` -> 3 failed because responses leaked `127.0.0.1`, `super-secret`, and `/srv/rustchain/private`.

Green after fix:
- `python -m pytest tests/test_explorer_api_errors.py -q` -> 3 passed
- `python -m py_compile explorer\app.py tests\test_explorer_api_errors.py` -> passed
- `git diff --check -- explorer/app.py tests/test_explorer_api_errors.py` -> passed
- `rg -n 'Connection error: \{str\(e\)\}|Connection error:|str\(e\)' explorer\app.py` -> no matches
