### PR TITLE
[UTXO-BUG] Reject unpersistable UTXO outputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1002,6 +1002,94 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_mempool_rejects_unpersistable_outputs_without_locking_input(self):
+        """Mempool output validation must mirror block application.
+
+        These payloads are JSON-serializable enough to store in utxo_mempool,
+        but would fail later in apply_transaction() while computing
+        propositions or binding TEXT metadata columns. Rejecting them at
+        admission prevents unmineable candidates from locking inputs until
+        expiry.
+        """
+        cases = [
+            {'value_nrtc': 100 * UNIT - 1000},
+            {'address': None, 'value_nrtc': 100 * UNIT - 1000},
+            {'address': '', 'value_nrtc': 100 * UNIT - 1000},
+            {
+                'address': 'bob',
+                'value_nrtc': 100 * UNIT - 1000,
+                'tokens_json': {'TOKEN': 1},
+            },
+            {
+                'address': 'bob',
+                'value_nrtc': 100 * UNIT - 1000,
+                'registers_json': [],
+            },
+            {
+                'address': 'bob',
+                'value_nrtc': 100 * UNIT - 1000,
+                'tokens_json': '{}',
+            },
+            {
+                'address': 'bob',
+                'value_nrtc': 100 * UNIT - 1000,
+                'registers_json': '[]',
+            },
+        ]
+
+        for idx, output in enumerate(cases):
+            with self.subTest(output=output):
+                db = UtxoDB(self.tmp.name)
+                self.assertTrue(db.apply_transaction({
+                    'tx_type': 'mining_reward',
+                    'inputs': [],
+                    'outputs': [
+                        {'address': f'alice_{idx}', 'value_nrtc': 100 * UNIT}
+                    ],
+                    'fee_nrtc': 0,
+                    'timestamp': int(time.time()) + idx,
+                    '_allow_minting': True,
+                }, block_height=idx + 1))
+                box = db.get_unspent_for_address(f'alice_{idx}')[0]
+
+                ok = db.mempool_add({
+                    'tx_id': f'badout{idx}' * 8,
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id']}],
+                    'outputs': [output],
+                    'fee_nrtc': 1000,
+                })
+
+                self.assertFalse(ok)
+                self.assertEqual(db.mempool_get_block_candidates(), [])
+                self.assertFalse(db.mempool_check_double_spend(box['box_id']))
+
+    def test_apply_transaction_rejects_unpersistable_outputs(self):
+        """Direct apply must fail closed before mutating balances."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        cases = [
+            {'value_nrtc': 100 * UNIT},
+            {'address': None, 'value_nrtc': 100 * UNIT},
+            {'address': 'bob', 'value_nrtc': 100 * UNIT, 'tokens_json': '{}'},
+            {'address': 'bob', 'value_nrtc': 100 * UNIT, 'registers_json': '[]'},
+        ]
+
+        for output in cases:
+            with self.subTest(output=output):
+                ok = self.db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': boxes[0]['box_id'],
+                                 'spending_proof': 'sig'}],
+                    'outputs': [output],
+                    'fee_nrtc': 0,
+                }, block_height=10)
+
+                self.assertFalse(ok)
+                self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+                self.assertEqual(self.db.get_balance('bob'), 0)
+
     # -- bounty #2819: negative / zero value outputs -------------------------
 
     def test_negative_value_output_rejected(self):

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -382,6 +382,51 @@ class UtxoDB:
             return None
         return tx_type
 
+    def _normalize_outputs(self, outputs: Any) -> Optional[List[dict]]:
+        """Return outputs that are safe for both mempool and persistence."""
+        if not isinstance(outputs, list):
+            return None
+
+        normalized = []
+        for out in outputs:
+            if not isinstance(out, dict):
+                return None
+
+            address = out.get('address')
+            if not isinstance(address, str) or not address.strip():
+                return None
+
+            val = out.get('value_nrtc')
+            if (
+                isinstance(val, bool)
+                or not isinstance(val, int)
+                or val < DUST_THRESHOLD
+            ):
+                return None
+
+            tokens_json = out.get('tokens_json', '[]')
+            registers_json = out.get('registers_json', '{}')
+            if not isinstance(tokens_json, str):
+                return None
+            if not isinstance(registers_json, str):
+                return None
+            try:
+                tokens = json.loads(tokens_json)
+                registers = json.loads(registers_json)
+            except (TypeError, json.JSONDecodeError):
+                return None
+            if not isinstance(tokens, list):
+                return None
+            if not isinstance(registers, dict):
+                return None
+
+            record = dict(out)
+            record['tokens_json'] = tokens_json
+            record['registers_json'] = registers_json
+            normalized.append(record)
+
+        return normalized
+
     def _data_inputs_are_unspent(self, conn: sqlite3.Connection,
                                  data_inputs: list) -> bool:
         """Validate read-only UTXO references before accepting a tx."""
@@ -448,6 +493,9 @@ class UtxoDB:
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
             if conn:
                 conn.close()
+            return False
+        outputs = self._normalize_outputs(outputs)
+        if outputs is None:
             return False
         if own:
             conn = self._conn()
@@ -516,21 +564,9 @@ class UtxoDB:
             if len(outputs) > MAX_OUTPUTS:
                 return abort()
 
-            # Every output must be above the dust floor. Without this, a
-            # transaction can split one UTXO into thousands of 1-nanoRTC
-            # boxes and permanently bloat the UTXO set.
-            for o in outputs:
-                val = o.get('value_nrtc')
-                if (
-                    isinstance(val, bool)
-                    or not isinstance(val, int)
-                    or val < DUST_THRESHOLD
-                ):
-                    return abort()
-                # FIX(#9273): Reject dust outputs below DUST_THRESHOLD
-                if o['value_nrtc'] < DUST_THRESHOLD:
-                    return abort()
-
+            # Output shape, dust, and metadata checks are shared with
+            # mempool_add() so block candidates cannot drift from the
+            # transaction application rules.
             output_total = sum(o['value_nrtc'] for o in outputs)
 
             # Cap minting (coinbase) output to prevent unbounded fund creation.
@@ -850,6 +886,11 @@ class UtxoDB:
 
             # MEDIUM FIX: Reject empty outputs to prevent DoS
             outputs = tx.get('outputs', [])
+            outputs = self._normalize_outputs(outputs)
+            if outputs is None:
+                if manage_tx:
+                        conn.execute("ROLLBACK")
+                return False
             if not outputs and tx_type not in MINTING_TX_TYPES:
                 if manage_tx:
                         conn.execute("ROLLBACK")
@@ -868,24 +909,6 @@ class UtxoDB:
                 ).fetchone()
                 if row:
                     input_total += row['value_nrtc']
-
-            outputs = tx.get('outputs', [])
-
-            # FIX(#2179): Mirror apply_transaction() output validation.
-            # Reject outputs with missing, non-int, zero, or negative value_nrtc.
-            # Without this, unmineable transactions enter the mempool and lock
-            # UTXOs until expiry (DoS vector).
-            for o in outputs:
-                val = o.get('value_nrtc')
-                if isinstance(val, bool) or not isinstance(val, int) or val < DUST_THRESHOLD:
-                    if manage_tx:
-                        conn.execute("ROLLBACK")
-                    return False
-                # FIX(#9273): Reject dust outputs below DUST_THRESHOLD.
-                if val < DUST_THRESHOLD:
-                    if manage_tx:
-                        conn.execute("ROLLBACK")
-                    return False
 
             output_total = sum(o['value_nrtc'] for o in outputs)
             if input_total > 0 and (output_total + fee) > input_total:


### PR DESCRIPTION
## Summary
- add shared UTXO output normalization for both `apply_transaction()` and `mempool_add()`
- reject outputs that cannot be safely converted into propositions or SQLite TEXT metadata
- add regressions proving malformed outputs cannot enter the mempool, lock inputs, remain as block candidates, or mutate balances through direct apply

## Security impact
Current `main` accepts several JSON-serializable output payloads into the mempool even though block application cannot persist or apply them. The admitted transaction claims the input in `utxo_mempool_inputs`, appears in `mempool_get_block_candidates()`, then fails during `apply_transaction()` and remains available as an unmineable candidate until expiry.

Confirmed pre-fix cases on current `main`:

```text
missing_address admitted=True candidates=1 locked=True apply_exception=KeyError: 'address' after_candidates=1
none_address admitted=True candidates=1 locked=True apply_exception=AttributeError: 'NoneType' object has no attribute 'encode' after_candidates=1
dict_tokens_json admitted=True candidates=1 locked=True apply_exception=ProgrammingError: Error binding parameter 8: type 'dict' is not supported after_candidates=1
list_registers_json admitted=True candidates=1 locked=True apply_exception=ProgrammingError: Error binding parameter 9: type 'list' is not supported after_candidates=1
```

## Duplicate boundary
This overlaps the same UTXO mempool-hardening area as older reports, but it is not only the missing-`address` case. This patch centralizes output normalization and covers additional unpersistable shapes that still reproduce on `main`: non-string/blank addresses and metadata payloads whose JSON shape cannot be persisted consistently (`tokens_json` must be JSON text decoding to a list; `registers_json` must be JSON text decoding to a dict). The goal is to keep mempool admission and direct application on the same validation rules.

## Verification
- `python -B -m unittest test_utxo_db.TestUtxoDB.test_mempool_rejects_unpersistable_outputs_without_locking_input test_utxo_db.TestUtxoDB.test_apply_transaction_rejects_unpersistable_outputs -v` -> 2 passed
- `python -m py_compile node\utxo_db.py node\test_utxo_db.py` -> passed
- `python -B node\test_utxo_db.py` -> 73 passed
- `git diff --check -- node\utxo_db.py node\test_utxo_db.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Bounty
Claiming under Scottcjn/rustchain-bounties#2819.

Requested severity: Medium, mempool DoS / invalid block-candidate manipulation.

Wallet/miner ID: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
