### PR TITLE
fix: validate UTXO transfer string fields

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -212,6 +212,34 @@ class TestUtxoEndpoints(unittest.TestCase):
             self.assertEqual(r.status_code, 400)
             self.assertEqual(r.get_json()['error'], 'JSON object body required')
 
+    def test_transfer_rejects_non_string_fields(self):
+        """Malformed scalar fields must fail as 400s, not server errors."""
+        base = {
+            'from_address': 'RTC_test_aabbccdd',
+            'to_address': 'bob',
+            'amount_rtc': 1.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': 123,
+        }
+        cases = [
+            ('from_address', {'nested': 'sender'}),
+            ('to_address', ['bob']),
+            ('public_key', {'key': 'aabb'}),
+            ('signature', ['sig']),
+        ]
+
+        for field, value in cases:
+            with self.subTest(field=field):
+                payload = dict(base)
+                payload[field] = value
+                r = self.client.post('/utxo/transfer', json=payload)
+                self.assertEqual(r.status_code, 400)
+                self.assertEqual(
+                    r.get_json()['error'],
+                    'Transfer fields must be strings',
+                )
+
     def test_transfer_zero_amount(self):
         r = self.client.post('/utxo/transfer', json={
             'from_address': 'RTC_test_aabbccdd',

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -151,6 +151,15 @@ def _missing_transfer_nonce(nonce) -> bool:
     )
 
 
+def _optional_stripped_field(data: dict, field: str) -> str | None:
+    value = data.get(field, '')
+    if value is None:
+        return ''
+    if not isinstance(value, str):
+        return None
+    return value.strip()
+
+
 def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
                             verify_sig_fn, addr_from_pk_fn,
                             current_slot_fn, dual_write: bool = False):
@@ -358,10 +367,12 @@ def utxo_transfer():
     if not isinstance(data, dict):
         return jsonify({'error': 'JSON object body required'}), 400
 
-    from_address = (data.get('from_address') or '').strip()
-    to_address = (data.get('to_address') or '').strip()
-    public_key = (data.get('public_key') or '').strip()
-    signature = (data.get('signature') or '').strip()
+    from_address = _optional_stripped_field(data, 'from_address')
+    to_address = _optional_stripped_field(data, 'to_address')
+    public_key = _optional_stripped_field(data, 'public_key')
+    signature = _optional_stripped_field(data, 'signature')
+    if None in (from_address, to_address, public_key, signature):
+        return jsonify({'error': 'Transfer fields must be strings'}), 400
     nonce = data.get('nonce')
     memo = data.get('memo', '')
     if not isinstance(memo, str):


### PR DESCRIPTION
## Summary
- reject non-string `/utxo/transfer` scalar fields before calling `.strip()`
- return a controlled 400 response instead of a Flask 500 for malformed JSON objects/arrays
- add regression coverage for `from_address`, `to_address`, `public_key`, and `signature`

## Security impact
The public `/utxo/transfer` endpoint currently assumes these request fields are strings:

- `from_address`
- `to_address`
- `public_key`
- `signature`

A JSON object or array in any of those fields raises `AttributeError: '<type>' object has no attribute 'strip'` before normal validation runs. In production Flask mode this becomes a 500 Internal Server Error. A low-effort malformed request can therefore turn ordinary validation failures into server errors and noisy logs.

Pre-fix reproduction on current `main`:

```text
from_address 500 AttributeError: 'dict' object has no attribute 'strip'
to_address 500 AttributeError: 'list' object has no attribute 'strip'
public_key 500 AttributeError: 'dict' object has no attribute 'strip'
signature 500 AttributeError: 'list' object has no attribute 'strip'
```

## Fix
Add a small helper that accepts `None` as a missing value, accepts strings after trimming, and rejects all other JSON types before `.strip()` is called.

## Verification
- `python -B -m unittest test_utxo_endpoints.TestUtxoEndpoints.test_transfer_rejects_non_string_fields test_utxo_endpoints.TestUtxoEndpoints.test_transfer_success -v` -> 2 passed
- `python -m py_compile node\utxo_endpoints.py node\test_utxo_endpoints.py` -> passed
- `git diff --check -- node\utxo_endpoints.py node\test_utxo_endpoints.py` -> passed

## Bounty
Claiming under Scottcjn/rustchain-bounties#2819.

Requested severity: Low / code quality input-validation bug.

Wallet/miner ID: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
