### PR TITLE
Fix explorer upstream error disclosure

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,13 +1,22 @@
 from flask import Flask, render_template, jsonify
 import requests
 import json
+import logging
 from datetime import datetime
 
 app = Flask(__name__)
+logger = logging.getLogger(__name__)
 
 # Configuration
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
+
+
+def upstream_unavailable_response(include_miners=False):
+    body = {'error': 'Upstream node unavailable'}
+    if include_miners:
+        body['miners'] = []
+    return jsonify(body), 500
 
 @app.route('/')
 def dashboard():
@@ -49,8 +58,9 @@ def get_miners():
             return jsonify(miners_data)
         else:
             return jsonify({'error': 'Failed to fetch miners data', 'miners': []}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}', 'miners': []}), 500
+    except requests.exceptions.RequestException:
+        logger.exception("Unable to fetch miners from upstream RustChain node")
+        return upstream_unavailable_response(include_miners=True)
 
 @app.route('/api/network/stats')
 def get_network_stats():
@@ -80,8 +90,9 @@ def get_network_stats():
             return jsonify(stats)
         else:
             return jsonify({'error': 'Failed to fetch network stats'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        logger.exception("Unable to fetch network stats from upstream RustChain node")
+        return upstream_unavailable_response()
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
@@ -122,8 +133,9 @@ def get_miner_detail(miner_id):
                 return jsonify({'error': 'Miner not found'}), 404
         else:
             return jsonify({'error': 'Failed to fetch miner data'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        logger.exception("Unable to fetch miner detail from upstream RustChain node")
+        return upstream_unavailable_response()
 
 @app.errorhandler(404)
 def not_found(error):

--- a/tests/test_explorer_app_upstream_errors.py
+++ b/tests/test_explorer_app_upstream_errors.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import requests
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "explorer" / "app.py"
+
+
+@pytest.fixture()
+def explorer_app_module():
+    spec = importlib.util.spec_from_file_location("explorer_app_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.app.config["TESTING"] = True
+    return module
+
+
+@pytest.mark.parametrize(
+    ("route", "expected_extra"),
+    [
+        ("/api/miners", {"miners": []}),
+        ("/api/network/stats", {}),
+        ("/api/miner/alice", {}),
+    ],
+)
+def test_upstream_connection_errors_do_not_leak_internal_details(
+    explorer_app_module, monkeypatch, route, expected_extra
+):
+    sensitive_error = (
+        "HTTPConnectionPool(host='127.0.0.1', port=8000): "
+        "url=/api/miners?token=super-secret trace=/srv/rustchain/private/node.py"
+    )
+
+    def raise_sensitive_error(*args, **kwargs):
+        raise requests.exceptions.ConnectionError(sensitive_error)
+
+    monkeypatch.setattr(explorer_app_module.requests, "get", raise_sensitive_error)
+
+    response = explorer_app_module.app.test_client().get(route)
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body == {"error": "Upstream node unavailable", **expected_extra}
+    assert "127.0.0.1" not in str(body)
+    assert "super-secret" not in str(body)
+    assert "/srv/rustchain/private" not in str(body)


### PR DESCRIPTION
## Summary
- Fixes #5449
- Stop returning raw upstream `requests` exception text from explorer API routes
- Log the full exception server-side while returning a generic `Upstream node unavailable` error to clients
- Preserve the existing `/api/miners` fallback `miners: []` response shape

## Tests
- `.venv/bin/python -m pytest tests/test_explorer_app_upstream_errors.py -q`
- `.venv/bin/python -m pytest tests/test_validate_web_explorer.py tests/test_explorer_app_upstream_errors.py -q`
- `.venv/bin/python -m py_compile explorer/app.py tests/test_explorer_app_upstream_errors.py`
- `git diff --check`
