### PR TITLE
[UTXO-BUG] Reject malformed UTXO spend inputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -740,6 +740,32 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('attacker'), 0)
 
+    def test_malformed_spend_inputs_rejected_without_exception(self):
+        """Bad spend input shapes must fail validation, not raise errors."""
+        self._apply_coinbase('alice', 100 * UNIT)
+
+        malformed_inputs = [
+            None,
+            'not-a-list',
+            [{'spending_proof': 'sig'}],
+            [{'box_id': '', 'spending_proof': 'sig'}],
+            [{'box_id': '   ', 'spending_proof': 'sig'}],
+            ['not-a-dict'],
+        ]
+
+        for inputs in malformed_inputs:
+            with self.subTest(inputs=inputs):
+                ok = self.db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': inputs,
+                    'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                }, block_height=10)
+
+                self.assertFalse(ok)
+                self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+                self.assertEqual(self.db.get_balance('bob'), 0)
+
     def test_self_transfer(self):
         """Self-transfer (from == to) must work correctly."""
         self._apply_coinbase('alice', 100 * UNIT)
@@ -823,6 +849,35 @@ class TestUtxoDB(unittest.TestCase):
         }
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
+
+    def test_mempool_rejects_malformed_spend_inputs_without_locking(self):
+        """Mempool must reject malformed inputs before claiming any UTXO."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        malformed_inputs = [
+            None,
+            'not-a-list',
+            [{'spending_proof': 'sig'}],
+            [{'box_id': '', 'spending_proof': 'sig'}],
+            [{'box_id': '   ', 'spending_proof': 'sig'}],
+            ['not-a-dict'],
+            [{'box_id': box['box_id']}, {'box_id': box['box_id']}],
+        ]
+
+        for index, inputs in enumerate(malformed_inputs):
+            with self.subTest(inputs=inputs):
+                ok = self.db.mempool_add({
+                    'tx_id': f'badinput{index:02d}' * 4,
+                    'tx_type': 'transfer',
+                    'inputs': inputs,
+                    'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                })
+
+                self.assertFalse(ok)
+                self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+                self.assertEqual(self.db.mempool_get_block_candidates(), [])
 
     # -- mempool conservation-of-value (DoS prevention) ----------------------
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -370,6 +370,26 @@ class UtxoDB:
 
         return normalized
 
+    def _normalize_spend_inputs(self, inputs: list) -> Optional[List[dict]]:
+        """Return validated spend inputs, or None on invalid input."""
+        if not isinstance(inputs, list):
+            return None
+
+        normalized = []
+        seen = set()
+        for inp in inputs:
+            if not isinstance(inp, dict):
+                return None
+            box_id = inp.get('box_id')
+            if not isinstance(box_id, str) or not box_id.strip():
+                return None
+            if box_id in seen:
+                return None
+            seen.add(box_id)
+            normalized.append(inp)
+
+        return normalized
+
     def _normalize_tx_type(self, tx: dict) -> Optional[str]:
         """Return a valid transaction type, defaulting only when absent."""
         if 'tx_type' not in tx:
@@ -470,9 +490,10 @@ class UtxoDB:
             # Without this, the same box_id counted twice inflates
             # input_total.  The spend-phase rowcount check catches it
             # today, but only accidentally.  Defense in depth.
-            input_box_ids = [i['box_id'] for i in inputs]
-            if len(input_box_ids) != len(set(input_box_ids)):
+            inputs = self._normalize_spend_inputs(inputs)
+            if inputs is None:
                 return abort()
+            input_box_ids = [i['box_id'] for i in inputs]
             data_inputs = self._normalize_data_inputs(data_inputs)
             if data_inputs is None:
                 return abort()
@@ -796,7 +817,8 @@ class UtxoDB:
             if tx_type in MINTING_TX_TYPES:
                 return False
 
-            if not inputs:
+            inputs = self._normalize_spend_inputs(inputs)
+            if inputs is None or not inputs:
                 return False
 
             data_inputs = self._normalize_data_inputs(data_inputs)


### PR DESCRIPTION
## Summary

Fixes a UTXO spend-input validation gap in `node/utxo_db.py`.

Before this patch, malformed `inputs` payloads could reach raw indexing in both transaction application and mempool admission:

- `inputs=None` or a string could raise instead of returning a validation failure.
- non-dict input entries could raise when indexed.
- missing, blank, or whitespace-only `box_id` values could raise or drift into later validation.
- duplicate `box_id` handling was local to `apply_transaction()` and not shared with `mempool_add()`.

The patch adds a shared `_normalize_spend_inputs()` helper and applies it at both boundaries, so malformed spend inputs fail closed before they can raise, persist, or claim UTXOs in the mempool.

## Bounty

- Bounty issue: Scottcjn/rustchain-bounties#2819
- Requested severity: Low / code-quality validation hardening, with mempool DoS prevention for malformed input shapes.
- RTC wallet/miner ID: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`

## Duplicate Boundary

This overlaps the broad UTXO validation area, but it covers a distinct spend-input shape path on current `main`: malformed `inputs` are normalized before both `apply_transaction()` and `mempool_add()`. Prior nearby fixes covered output metadata, timestamps, tx types, data inputs, or transfer endpoint scalar fields.

## Verification

- `python -B node\test_utxo_db.py` -> 73 passed
- `python -m py_compile node\utxo_db.py node\test_utxo_db.py` -> passed
- `git diff --check` -> passed
- `python -B test_bcos_spdx_check.py` -> passed

This is a public receive address only. No private key, seed phrase, keystore, password, bank, exchange, withdrawal, or transfer action is included.