### PR TITLE
fix(#5445): hide internal exception details in BoTTube mood routes (Closes #5445)

### DIFF
--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -961,7 +961,7 @@ def get_agent_mood_endpoint(agent_name: str):
         return jsonify(mood_info)
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @mood_bp.route("/<agent_name>/mood/signal", methods=["POST"])
@@ -993,7 +993,7 @@ def record_mood_signal(agent_name: str):
         return jsonify(result)
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @mood_bp.route("/<agent_name>/mood/title", methods=["POST"])
@@ -1023,7 +1023,7 @@ def generate_mood_title(agent_name: str):
         })
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @mood_bp.route("/<agent_name>/mood/comment", methods=["POST"])
@@ -1052,7 +1052,7 @@ def generate_mood_comment(agent_name: str):
         })
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @mood_bp.route("/<agent_name>/mood/post-probability", methods=["GET"])
@@ -1075,7 +1075,7 @@ def get_post_probability(agent_name: str):
         })
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 @mood_bp.route("/<agent_name>/mood/statistics", methods=["GET"])
@@ -1091,7 +1091,7 @@ def get_mood_statistics_endpoint(agent_name: str):
         return jsonify(stats)
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Internal server error"}), 500
 
 
 def init_mood_routes(app):


### PR DESCRIPTION
## Fix #5445\n\n**Problem:** 6 BoTTube mood API routes expose raw exception text.\n\n**Fix:** Replace `str(e)` with generic `"Internal server error"` in all 6 error handlers.\n\n**Affected routes:**\n- GET /<agent_name>/mood\n- POST /<agent_name>/mood/signal\n- POST /<agent_name>/mood/title\n- POST /<agent_name>/mood/comment\n- GET /<agent_name>/mood/post-probability\n- GET /<agent_name>/mood/statistics