### PR TITLE
fix(#5447): hide internal exception detail in comment moderation webhook (Closes #5447)

### DIFF
--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -201,7 +201,7 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(e),
+                detail="Internal server error",
             )
 
         # Log webhook receipt
@@ -263,7 +263,7 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(e),
+                detail="Internal server error",
             )
 
         # Process the comment
@@ -301,7 +301,7 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=str(e),
+                detail="Internal server error",
             )
 
     @app.get("/stats")


### PR DESCRIPTION
## Fix #5447\n\n**Problem:** POST /webhook returns `detail=str(e)` when moderation processing fails, leaking internal exception details.\n\n**Fix:** Replace `detail=str(e)` with `"Internal server error"`.\n\n**File:** `tools/comment-moderation-bot/src/webhook.py`