### PR TITLE
fix(#5449): hide upstream connection error details in Explorer API proxy (Closes #5449)

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -59,7 +59,7 @@ def proxy(path):
     except requests.exceptions.Timeout:
         return jsonify({'error': 'Local server timeout'}), 504
     except Exception as e:
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'Upstream node unavailable'}), 502
 
 @app.route('/status')
 def status():


### PR DESCRIPTION
## Fix #5449\n\n**Problem:** Explorer API proxy returns raw `requests.exceptions` detail when local RustChain node is unavailable.\n\n**Fix:** Replace `str(e)` with generic `"Upstream node unavailable"` and change HTTP code from 500 to 502 (Bad Gateway).\n\n**File:** `node/server_proxy.py`