### PR TITLE
Document Linux miner dry-run help

### DIFF
--- a/miners/README.md
+++ b/miners/README.md
@@ -37,6 +37,9 @@ The Linux miner auto-detects your hardware via `platform.machine()` and reports 
 # Linux
 python3 rustchain_linux_miner.py
 
+# Linux dry run: print hardware fingerprint/preflight details without mining
+python3 rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+
 # macOS
 python3 rustchain_mac_miner_v2.4.py
 

--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -668,7 +668,11 @@ if __name__ == "__main__":
     parser.add_argument("--wart-pool", help="Warthog mining pool API URL")
     parser.add_argument("--bzminer-path", help="Path to BzMiner binary")
     parser.add_argument("--manage-bzminer", action="store_true", help="Auto-start/stop BzMiner")
-    parser.add_argument("--dry-run", action="store_true", help="Run preflight checks only; do not start mining")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run preflight checks only; print hardware fingerprint info; do not start mining",
+    )
     parser.add_argument("--verbose", action="store_true", help="Enable verbose output showing API endpoints, headers, and response details")
     parser.add_argument("--show-payload", action="store_true", help="Show request payload in dry-run mode")
     args = parser.parse_args()

--- a/tests/test_linux_miner_cli_help.py
+++ b/tests/test_linux_miner_cli_help.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: MIT
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_linux_miner_help_documents_dry_run():
+    miner = Path(__file__).resolve().parents[1] / "miners" / "linux" / "rustchain_linux_miner.py"
+
+    result = subprocess.run(
+        [sys.executable, str(miner), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    help_text = " ".join(result.stdout.split())
+
+    assert "--dry-run" in help_text
+    assert "print hardware fingerprint info" in help_text
+    assert "do not start mining" in help_text


### PR DESCRIPTION
## Summary
- Clarify the Linux miner `--dry-run` help text so `--help` explains that it prints hardware fingerprint/preflight info without mining.
- Add a direct Linux dry-run example to `miners/README.md` with `--wallet`.
- Add a regression test that checks the Linux miner help output documents `--dry-run`.

Closes #2767

RTC payout/miner id: `sypham98-prog`

## Verification
- `python3 miners/linux/rustchain_linux_miner.py --help`
- inline subprocess assertions for `--dry-run`, hardware fingerprint info, and no mining text
- `python3 -m py_compile miners/linux/rustchain_linux_miner.py tests/test_linux_miner_cli_help.py`
- `git diff --check`

Note: `python3 -m pytest tests/test_linux_miner_cli_help.py -q` could not be run in this WSL image because Python has no `pytest` module installed.