### PR TITLE
docs: fix rust miner documentation link

### DIFF
--- a/rustchain-miner/README.md
+++ b/rustchain-miner/README.md
@@ -272,6 +272,6 @@ See the main [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
 
 ## Support
 
-- Documentation: [RustChain Docs](https://rustchain.org/docs)
+- Documentation: [RustChain Docs](https://github.com/Scottcjn/rustchain-bounties/tree/main/docs)
 - Issues: [GitHub Issues](https://github.com/Scottcjn/Rustchain/issues)
 - Discord: [RustChain Discord](https://discord.gg/rustchain)


### PR DESCRIPTION
## Bounty Submission

**Bounty**: Scottcjn/rustchain-bounties#444

**RTC Wallet**: RTC74b80ab40602e5ae31819912b2fca974484e5dab

## Changes

- Updated the support documentation link in `rustchain-miner/README.md`.
- Replaced `https://rustchain.org/docs` with `https://github.com/Scottcjn/rustchain-bounties/tree/main/docs`.

## Validation

- Old URL: `https://rustchain.org/docs` -> `403 0`
- New URL: `https://github.com/Scottcjn/rustchain-bounties/tree/main/docs` -> `200 0`
- `git diff --check HEAD~1..HEAD` -> passed

## Duplicate Check

- Checked open/all PRs for `rustchain-miner/README.md` and the docs link target.
- Existing docs-link PRs touch different files (`docs/index.html`, `docs/about.html`, `docs/hardware.html`, etc.); this PR only touches `rustchain-miner/README.md`.

## Checklist

- [x] One-file docs-only change
- [x] No secrets or credentials committed
- [x] No wallet registration, transfers, withdrawals, or private-key actions performed