### PR TITLE
docs: fix faucet documentation link

### DIFF
--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -448,6 +448,6 @@ See CONTRIBUTING.md for contribution guidelines.
 
 ## Support
 
-- Documentation: https://rustchain.org/docs/faucet
+- Documentation: https://github.com/Scottcjn/Rustchain/tree/main/faucet_service
 - Issues: https://github.com/Scottcjn/rustchain-bounties/issues
 - Discord: https://discord.gg/rustchain


### PR DESCRIPTION
## Bounty Submission

**Bounty**: Scottcjn/rustchain-bounties#444

**RTC Wallet**: RTC74b80ab40602e5ae31819912b2fca974484e5dab

## Changes

- Updated the support documentation link in `faucet_service/README.md`.
- Replaced the broken `https://rustchain.org/docs/faucet` URL with the live faucet service docs directory in this repo.

## Validation

- Old URL: `https://rustchain.org/docs/faucet` -> `404 0`
- New URL: `https://github.com/Scottcjn/Rustchain/tree/main/faucet_service` -> `200 0`
- `git diff --check HEAD~1..HEAD` -> passed

## Duplicate Check

- Checked PR history for `faucet_service/README.md` and `docs/faucet`.
- The prior URL-standardization PR #2849 is already merged and introduced/left this stale docs target; no open PR currently fixes this support link.

## Checklist

- [x] One-file docs-only change
- [x] No secrets or credentials committed
- [x] No wallet registration, transfers, withdrawals, or private-key actions performed