### PR TITLE
fix: let packaged Windows miner run headless without Tk

### DIFF
--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -16,8 +16,19 @@ import statistics
 import uuid
 import subprocess
 import re
-import tkinter as tk
-from tkinter import ttk, messagebox, scrolledtext
+import argparse
+try:
+    import tkinter as tk
+    from tkinter import ttk, messagebox, scrolledtext
+    TK_AVAILABLE = True
+    _TK_IMPORT_ERROR = ""
+except Exception as e:
+    TK_AVAILABLE = False
+    _TK_IMPORT_ERROR = str(e)
+    tk = None
+    ttk = None
+    messagebox = None
+    scrolledtext = None
 import requests
 # urllib3.disable_warnings no longer needed — TLS verification enabled
 from datetime import datetime
@@ -567,6 +578,8 @@ class RustChainMiner:
 class RustChainGUI:
     """Windows GUI for RustChain"""
     def __init__(self):
+        if not TK_AVAILABLE:
+            raise RuntimeError(f"tkinter is not available: {_TK_IMPORT_ERROR}")
         self.root = tk.Tk()
         self.root.title("RustChain Wallet & Miner for Windows")
         self.root.geometry("800x600")
@@ -667,10 +680,69 @@ class RustChainGUI:
         """Run the GUI"""
         self.root.mainloop()
 
-def main():
+def run_headless(wallet_address: str, node_url: str) -> int:
+    wallet = RustChainWallet()
+    if wallet_address:
+        wallet.wallet_data["address"] = wallet_address
+        wallet.save_wallet(wallet.wallet_data)
+
+    miner = RustChainMiner(wallet.wallet_data["address"])
+    miner.node_url = node_url
+
+    def cb(evt):
+        if evt.get("type") == "share":
+            ok = "OK" if evt.get("success") else "FAIL"
+            print(
+                f"[share] submitted={evt.get('submitted')} "
+                f"accepted={evt.get('accepted')} {ok}",
+                flush=True,
+            )
+        elif evt.get("type") == "error":
+            print(f"[error] {evt.get('message')}", file=sys.stderr, flush=True)
+
+    print("RustChain Windows miner: headless mode", flush=True)
+    print(f"node={miner.node_url} miner_id={miner.miner_id}", flush=True)
+    miner.start_mining(cb)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        miner.stop_mining()
+        print("\nStopping miner.", flush=True)
+        return 0
+
+
+def main(argv=None):
     """Main entry point"""
+    ap = argparse.ArgumentParser(
+        description="RustChain Windows wallet + miner (GUI or headless fallback)."
+    )
+    ap.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run without GUI when Tcl/Tk is unavailable.",
+    )
+    ap.add_argument("--node", default=RUSTCHAIN_API, help="RustChain node base URL.")
+    ap.add_argument("--wallet", default="", help="Wallet address / miner pubkey string.")
+    args = ap.parse_args(argv)
+
+    if args.headless or not TK_AVAILABLE:
+        if not TK_AVAILABLE and not args.headless:
+            print(
+                f"tkinter unavailable ({_TK_IMPORT_ERROR}); falling back to --headless.",
+                file=sys.stderr,
+            )
+        return run_headless(args.wallet, args.node)
+
     app = RustChainGUI()
+    app.miner.node_url = args.node
+    if args.wallet:
+        app.wallet.wallet_data["address"] = args.wallet
+        app.wallet.save_wallet(app.wallet.wallet_data)
+        app.miner.wallet_address = args.wallet
+        app.miner.miner_id = f"windows_{hashlib.md5(args.wallet.encode()).hexdigest()[:8]}"
     app.run()
+    return 0
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_windows_installer_tkinter_fallback.py
+++ b/tests/test_windows_installer_tkinter_fallback.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+import builtins
+import runpy
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGED_MINER = ROOT / "miners" / "windows" / "installer" / "src" / "rustchain_windows_miner.py"
+
+
+def test_packaged_miner_help_works_without_tkinter(monkeypatch, capsys):
+    real_import = builtins.__import__
+
+    def block_tkinter(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "tkinter" or name.startswith("tkinter."):
+            raise ModuleNotFoundError("No module named 'tkinter'")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", block_tkinter)
+    monkeypatch.setattr(sys, "argv", [str(PACKAGED_MINER), "--help"])
+
+    try:
+        runpy.run_path(str(PACKAGED_MINER), run_name="__main__")
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    captured = capsys.readouterr()
+    assert "--headless" in captured.out
+    assert "--wallet" in captured.out


### PR DESCRIPTION
## Summary
- make the packaged Windows miner tolerate missing `tkinter` at startup
- add `--headless`, `--node`, and `--wallet` parsing to the packaged miner entry point
- add a regression test that blocks `tkinter` imports and verifies `--help` still reaches argparse

Fixes #5399.

## Duplicate boundary
PR #5400 addresses the packaging side by asking PyInstaller to include Tk modules. This PR covers the runtime fallback path requested in #5399: even when Tk/Tcl is absent from the packaged environment, the executable can still parse `--help` and run the console/headless path instead of failing before argparse.

## Validation
- `python -m pytest -q tests\test_windows_installer_tkinter_fallback.py` -> 1 passed
- `python -m pytest -q tests\test_windows_installer_tkinter_fallback.py tests\test_windows_miner_setup_checksum.py` -> 3 passed
- `python -m py_compile miners\windows\installer\src\rustchain_windows_miner.py tests\test_windows_installer_tkinter_fallback.py` -> passed
- `python miners\windows\installer\src\rustchain_windows_miner.py --help` -> shows `--headless`, `--node`, and `--wallet`
- `git diff --check` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

RTC wallet: RTC74b80ab40602e5ae31819912b2fca974484e5dab
