### PR TITLE
fix: require auth for sophia inspect

### DIFF
--- a/sophia_api.py
+++ b/sophia_api.py
@@ -10,6 +10,9 @@ Endpoints:
   GET  /sophia/explorer/<miner_id> -- explorer-friendly verdict with emoji
 """
 
+import hmac
+import os
+
 from flask import Flask, request, jsonify
 
 from sophia_core import SophiaCoreInspector, VERDICTS
@@ -21,6 +24,22 @@ from sophia_db import (
 
 app = Flask(__name__)
 inspector = SophiaCoreInspector()
+
+
+def require_sophia_admin():
+    expected_key = os.getenv("SOPHIA_ADMIN_KEY", "").strip()
+    if not expected_key:
+        return jsonify({"error": "SOPHIA_ADMIN_KEY not configured"}), 503
+
+    provided_key = (
+        request.headers.get("X-Admin-Key")
+        or request.headers.get("X-API-Key")
+        or ""
+    ).strip()
+    if not hmac.compare_digest(provided_key, expected_key):
+        return jsonify({"error": "Unauthorized"}), 401
+
+    return None
 
 
 def positive_int_query_arg(name, default, max_value=None):
@@ -53,6 +72,10 @@ def _ensure_db():
 @app.route("/sophia/inspect", methods=["POST"])
 def inspect_fingerprint():
     """Submit a hardware fingerprint for Sophia inspection."""
+    auth_error = require_sophia_admin()
+    if auth_error:
+        return auth_error
+
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return jsonify({"error": "JSON body must be an object"}), 400

--- a/sophia_api.py
+++ b/sophia_api.py
@@ -36,7 +36,15 @@ def require_sophia_admin():
         or request.headers.get("X-API-Key")
         or ""
     ).strip()
-    if not hmac.compare_digest(provided_key, expected_key):
+    try:
+        authorized = hmac.compare_digest(
+            provided_key.encode("utf-8"),
+            expected_key.encode("utf-8"),
+        )
+    except UnicodeError:
+        authorized = False
+
+    if not authorized:
         return jsonify({"error": "Unauthorized"}), 401
 
     return None

--- a/tests/test_sophia_core.py
+++ b/tests/test_sophia_core.py
@@ -513,14 +513,23 @@ class TestSophiaAPI(unittest.TestCase):
         inspector.ollama_endpoints = []  # force rule-based
         app._db_initialized = True
         self.client = app.test_client()
+        self.admin_key = "test-sophia-admin"
 
     def tearDown(self):
         import sophia_db
         sophia_db.DB_PATH = self._orig_db_path
         os.unlink(self.db_path)
 
+    def _post_inspection(self, payload):
+        with patch.dict(os.environ, {"SOPHIA_ADMIN_KEY": self.admin_key}, clear=False):
+            return self.client.post(
+                "/sophia/inspect",
+                json=payload,
+                headers={"X-Admin-Key": self.admin_key},
+            )
+
     def test_inspect_endpoint(self):
-        resp = self.client.post("/sophia/inspect", json={
+        resp = self._post_inspection({
             "miner_id": "test_miner",
             "fingerprint": _good_fingerprint(),
         })
@@ -530,34 +539,76 @@ class TestSophiaAPI(unittest.TestCase):
         self.assertIn("confidence", data)
         self.assertIn("emoji", data)
 
+    def test_inspect_fails_closed_when_admin_key_unconfigured(self):
+        with patch.dict(os.environ, {}, clear=True):
+            resp = self.client.post("/sophia/inspect", json={
+                "miner_id": "unauth_miner",
+                "fingerprint": _good_fingerprint(),
+            })
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.get_json()["error"], "SOPHIA_ADMIN_KEY not configured")
+
+        conn = get_connection()
+        try:
+            self.assertIsNone(get_latest_inspection(conn, "unauth_miner"))
+        finally:
+            conn.close()
+
+    def test_inspect_requires_valid_admin_key_before_storing(self):
+        with patch.dict(os.environ, {"SOPHIA_ADMIN_KEY": self.admin_key}, clear=False):
+            missing = self.client.post("/sophia/inspect", json={
+                "miner_id": "auth_guard_miner",
+                "fingerprint": _good_fingerprint(),
+            })
+            wrong = self.client.post(
+                "/sophia/inspect",
+                json={
+                    "miner_id": "auth_guard_miner",
+                    "fingerprint": _good_fingerprint(),
+                },
+                headers={"X-Admin-Key": "wrong-secret"},
+            )
+
+        self.assertEqual(missing.status_code, 401)
+        self.assertEqual(wrong.status_code, 401)
+
+        conn = get_connection()
+        try:
+            self.assertIsNone(get_latest_inspection(conn, "auth_guard_miner"))
+        finally:
+            conn.close()
+
     def test_inspect_missing_miner_id(self):
-        resp = self.client.post("/sophia/inspect", json={
+        resp = self._post_inspection({
             "fingerprint": _good_fingerprint(),
         })
         self.assertEqual(resp.status_code, 400)
 
     def test_inspect_missing_fingerprint(self):
-        resp = self.client.post("/sophia/inspect", json={
+        resp = self._post_inspection({
             "miner_id": "test",
         })
         self.assertEqual(resp.status_code, 400)
 
     def test_inspect_rejects_non_object_json(self):
-        resp = self.client.post("/sophia/inspect", json=[])
+        resp = self._post_inspection([])
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json()["error"], "JSON body must be an object")
 
-        resp = self.client.post(
-            "/sophia/inspect",
-            data="not-json",
-            content_type="application/json",
-        )
+        with patch.dict(os.environ, {"SOPHIA_ADMIN_KEY": self.admin_key}, clear=False):
+            resp = self.client.post(
+                "/sophia/inspect",
+                data="not-json",
+                content_type="application/json",
+                headers={"X-Admin-Key": self.admin_key},
+            )
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json()["error"], "JSON body must be an object")
 
     def test_status_endpoint(self):
         # First, create an inspection
-        self.client.post("/sophia/inspect", json={
+        self._post_inspection({
             "miner_id": "status_miner",
             "fingerprint": _good_fingerprint(),
         })
@@ -572,7 +623,7 @@ class TestSophiaAPI(unittest.TestCase):
         self.assertEqual(resp.status_code, 404)
 
     def test_history_endpoint(self):
-        self.client.post("/sophia/inspect", json={
+        self._post_inspection({
             "miner_id": "hist_m",
             "fingerprint": _good_fingerprint(),
         })
@@ -602,7 +653,7 @@ class TestSophiaAPI(unittest.TestCase):
 
     def test_history_caps_per_page(self):
         for idx in range(3):
-            self.client.post("/sophia/inspect", json={
+            self._post_inspection({
                 "miner_id": f"hist_cap_{idx}",
                 "fingerprint": _good_fingerprint(),
             })
@@ -614,7 +665,7 @@ class TestSophiaAPI(unittest.TestCase):
         self.assertEqual(data["per_page"], 100)
 
     def test_dashboard_endpoint(self):
-        self.client.post("/sophia/inspect", json={
+        self._post_inspection({
             "miner_id": "dash_m",
             "fingerprint": _suspicious_fingerprint(),
         })
@@ -625,7 +676,7 @@ class TestSophiaAPI(unittest.TestCase):
         self.assertIn("spot_check_queue", data)
 
     def test_explorer_endpoint_with_record(self):
-        self.client.post("/sophia/inspect", json={
+        self._post_inspection({
             "miner_id": "exp_m",
             "fingerprint": _good_fingerprint(),
         })

--- a/tests/test_sophia_core.py
+++ b/tests/test_sophia_core.py
@@ -579,6 +579,26 @@ class TestSophiaAPI(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_inspect_rejects_non_ascii_admin_key_before_storing(self):
+        with patch.dict(os.environ, {"SOPHIA_ADMIN_KEY": self.admin_key}, clear=False):
+            resp = self.client.post(
+                "/sophia/inspect",
+                json={
+                    "miner_id": "unicode_guard_miner",
+                    "fingerprint": _good_fingerprint(),
+                },
+                headers={"X-Admin-Key": "\u00e9"},
+            )
+
+        self.assertEqual(resp.status_code, 401)
+        self.assertEqual(resp.get_json()["error"], "Unauthorized")
+
+        conn = get_connection()
+        try:
+            self.assertIsNone(get_latest_inspection(conn, "unicode_guard_miner"))
+        finally:
+            conn.close()
+
     def test_inspect_missing_miner_id(self):
         resp = self._post_inspection({
             "fingerprint": _good_fingerprint(),


### PR DESCRIPTION
Fixes #5015.

## Summary
- Require `SOPHIA_ADMIN_KEY` authentication before accepting `POST /sophia/inspect` submissions.
- Accept the existing admin header conventions: `X-Admin-Key` and `X-API-Key`.
- Fail closed when the Sophia admin key is not configured, before fingerprint data is inspected or stored.
- Add regression coverage for unconfigured, missing, wrong, and valid admin-key requests.

## Root cause
The Sophia inspection endpoint accepted arbitrary POST bodies without an auth guard. That allowed unauthenticated callers to submit fake hardware fingerprints into the inspection path.

## Validation
- `python -m pytest tests/test_sophia_core.py::TestSophiaAPI -q` -> 15 passed
- `python -m pytest tests/test_sophia_core.py -q` -> 58 passed
- `python -m py_compile sophia_api.py tests/test_sophia_core.py`
- `git diff --check -- sophia_api.py tests/test_sophia_core.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## CI note
The repository-wide `test` workflow is currently failing during test collection because the workflow environment is missing `aiohttp`, `flask_cors`, and `matplotlib`. The failure happens before this patch-specific Sophia test module runs. The focused Sophia API tests pass locally.

BCOS tier: BCOS-L2, security/auth change.

RTC wallet for accepted bounty payout: `RTC877021895fd29d034f35c87e1b37af8534703792`
