### PR TITLE
fix: reject non-finite bridge lock amounts

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -13,6 +13,7 @@ Admin-controlled Phase 1 (upgrade to trustless lock in Phase 2)
 
 import os
 import json
+import math
 import sqlite3
 import hashlib
 import hmac
@@ -239,6 +240,8 @@ def lock_rtc():
     try:
         amount_float = float(data.get("amount", 0))
     except (TypeError, ValueError):
+        return jsonify({"error": "invalid amount"}), 400
+    if not math.isfinite(amount_float):
         return jsonify({"error": "invalid amount"}), 400
 
     if not sender:

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -573,6 +573,19 @@ class TestLockEndpoint:
         })
         assert resp.status_code == 400
 
+    @pytest.mark.parametrize("amount", ["NaN", "Infinity", "-Infinity"])
+    def test_lock_rejects_non_finite_amount(self, client, amount):
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": amount,
+            "target_chain": "solana",
+            "target_wallet": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+            "tx_hash": f"rtc-lock-non-finite-{amount}",
+        })
+
+        assert resp.status_code == 400
+        assert resp.get_json()["error"] == "invalid amount"
+
     def test_lock_missing_sender(self, client):
         resp = client.post("/bridge/lock", json={
             "amount": 10.0,


### PR DESCRIPTION
## What Changed

- Reject non-finite `/bridge/lock` amounts (`NaN`, `Infinity`, `-Infinity`) immediately after parsing.
- Add regression coverage proving those payloads return `400` with the existing `invalid amount` response instead of reaching base-unit conversion or min/max checks.

## Why

`float("NaN")` bypasses normal min/max comparisons and then raises during `int(round(...))`, producing an unhandled error path. Non-finite values should be treated the same as other invalid amounts before any lock state or proof handling runs.

Fixes #5361

## Testing / Evidence

- `python -m pytest bridge/test_bridge_api.py::TestLockEndpoint::test_lock_rejects_non_finite_amount -q` -> 3 passed
- `python -m pytest bridge/test_bridge_api.py -q` -> 44 passed
- `python -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py` -> passed
- `git diff --check -- bridge/bridge_api.py bridge/test_bridge_api.py` -> passed

## BCOS Checklist

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (this bridge validation change should be `BCOS-L2`)
- [x] If adding new code files, include SPDX header near the top (no new code files added)
- [x] Provide test evidence

RTC payout address for any accepted bounty: `RTC877021895fd29d034f35c87e1b37af8534703792`
