### PR TITLE
fix: refresh setup miner linux hash

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Fixes #5466.
- Updates `setup_miner.py` so the Linux `MINER_ARTIFACTS` SHA-256 matches the current committed `miners/linux/rustchain_linux_miner.py` artifact.
- Keeps the change intentionally limited to the stale pinned hash; Darwin and Windows hashes already match their committed artifacts.

## Testing / Evidence

- RED before fix: `python3 -m pytest tests/test_setup_miner_downloads.py::test_setup_miner_pins_current_miner_artifacts -q` failed because the Linux artifact hash was pinned to `9475fe15...` while the current artifact hashes to `91815ecf...`.
- GREEN after fix: `python3 -m pytest tests/test_setup_miner_downloads.py -q` -> `2 passed in 0.06s`.
- `python3 -m py_compile setup_miner.py tests/test_setup_miner_downloads.py` -> passed.
- `git diff --check` -> passed.

Bounty reference: #305
Payout address: `RTC877021895fd29d034f35c87e1b37af8534703792`
