### PR TITLE
fix(#5466): refresh Linux miner SHA-256 hash

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## Fix #5466\n\nThe Linux miner was updated on main but the SHA-256 in setup_miner.py was not refreshed. This causes verification failures for Linux users.\n\n**Fix:** Updated the Linux miner SHA-256 from the old hash to the current one.\n\nOld: `9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c`\nNew: `91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a`\n\n**File:** setup_miner.py