### PR TITLE
fix(#5429 #5424 #5421): validate unsafe None/malformed/invalid parameters

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -431,8 +431,17 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
     @app.route('/api/blocks', methods=['GET'])
     def get_blocks():
         """Get blocks for sync (start height, limit)"""
-        start = request.args.get('start', 0, type=int)
-        limit = request.args.get('limit', 100, type=int)
+        raw_start = request.args.get('start', '0')
+        raw_limit = request.args.get('limit', '100')
+        try:
+            start = int(raw_start)
+            limit = int(raw_limit)
+        except (ValueError, TypeError):
+            return jsonify({"error": "start and limit must be integers"}), 400
+        if start < 0:
+            return jsonify({"error": "start must be non-negative"}), 400
+        if limit < 1 or limit > 1000:
+            return jsonify({"error": "limit must be between 1 and 1000"}), 400
 
         # Fetch blocks from database
         with sqlite3.connect(peer_manager.db_path) as conn:

--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -92,7 +92,7 @@ def register_sync_endpoints(app, db_path, admin_key):
         @wraps(f)
         def decorated(*args, **kwargs):
             key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
-            if not key or not hmac.compare_digest(key, admin_key):
+            if not key or not admin_key or not hmac.compare_digest(key, admin_key):
                 return jsonify({"error": "Unauthorized"}), 401
             return f(*args, **kwargs)
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7793,14 +7793,23 @@ try:
     @require_peer_auth
     def p2p_get_blocks():
         """Get blocks for sync"""
+        raw_start = request.args.get('start', '0')
+        raw_limit = request.args.get('limit', '100')
         try:
-            start_height = int(request.args.get('start', 0))
-            limit = min(int(request.args.get('limit', 100)), 1000)
+            start_height = int(raw_start)
+            limit = int(raw_limit)
+        except (ValueError, TypeError):
+            return jsonify({"ok": False, "error": "start and limit must be integers"}), 400
+        if start_height < 0:
+            return jsonify({"ok": False, "error": "start must be non-negative"}), 400
+        if limit < 1 or limit > 1000:
+            limit = min(max(limit, 1), 1000) if limit > 0 else 100
 
+        try:
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})
-        except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 400
+        except Exception:
+            return jsonify({"ok": False, "error": "failed to retrieve blocks"}), 400
 
     @app.route('/p2p/add_peer', methods=['POST'])
     @require_peer_auth

--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -947,10 +947,16 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
 
     @app.route("/sophia/governor/recent", methods=["GET"])
     def sophia_governor_recent():
-        limit = request.args.get("limit", 20)
+        raw_limit = request.args.get("limit", "20")
+        try:
+            limit = int(raw_limit)
+        except (ValueError, TypeError):
+            return jsonify({"error": "limit must be a positive integer"}), 400
+        if limit < 1:
+            return jsonify({"error": "limit must be a positive integer"}), 400
         return jsonify({
             "ok": True,
-            "events": get_recent_governor_events(db_path=db, limit=int(limit)),
+            "events": get_recent_governor_events(db_path=db, limit=limit),
         })
 
     @app.route("/sophia/governor/review", methods=["POST"])


### PR DESCRIPTION
## Fix #5429 — Sync admin crash\nAdded `not admin_key` guard before `hmac.compare_digest` call to prevent TypeError when admin_key is None.\n\n## Fix #5424 — Sophia governor invalid limits\nAdded try/except int() and positivity check for limit parameter.\n\n## Fix #5421 — P2P block sync unsafe pagination\nAdded validation for start/limit parameters: non-negative start, limit 1-1000. Also fixed error leak in integrated version.\n\n**Files:**\n- node/rustchain_sync_endpoints.py\n- node/sophia_governor.py\n- node/rustchain_p2p_sync.py\n- node/rustchain_v2_integrated_v2.2.1_rip200.py