### PR TITLE
docs: fix broken asciinema recording links

### DIFF
--- a/docs/INSTALLATION_WALKTHROUGH.md
+++ b/docs/INSTALLATION_WALKTHROUGH.md
@@ -6,9 +6,9 @@ Visual guides for installing RustChain and completing your first attestation.
 
 ### Miner Installation (45 seconds)
 
-Watch the complete installation process from cloning to running:
+The recording workflow is documented in the asciinema guide:
 
-[Watch the miner installation recording](asciinema/miner_install.cast)
+[Open the miner installation recording guide](asciinema/README.md)
 
 **What you'll see:**
 1. Cloning the RustChain repository
@@ -19,9 +19,9 @@ Watch the complete installation process from cloning to running:
 
 ### First Attestation (52 seconds)
 
-See how to complete your first hardware attestation and start mining:
+The attestation recording workflow is documented in the asciinema guide:
 
-[Watch the first attestation recording](asciinema/first_attestation.cast)
+[Open the first attestation recording guide](asciinema/README.md)
 
 **What you'll see:**
 1. Starting the RustChain miner


### PR DESCRIPTION
Fixes two broken links in `docs/INSTALLATION_WALKTHROUGH.md`.

The page linked directly to:

- `asciinema/miner_install.cast`
- `asciinema/first_attestation.cast`

Those `.cast` files are not present in `docs/asciinema/`. This PR points both calls to action at the existing `docs/asciinema/README.md` guide instead.

Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/444

RTC wallet: RTCc0d58160b6e1a32c428f9dbd53ff1a3f3ce2a244

