### PR TITLE
test: load withdrawal validation node by path

### DIFF
--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -56,16 +56,21 @@ def load_integrated_node():
     os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(_IMPORT_TMP.name, "import.db")
     os.environ["RC_ADMIN_KEY"] = "0" * 32
 
-    import prometheus_client
-
-    previous_metrics = (
-        prometheus_client.Counter,
-        prometheus_client.Gauge,
-        prometheus_client.Histogram,
-    )
-    prometheus_client.Counter = NoopMetric
-    prometheus_client.Gauge = NoopMetric
-    prometheus_client.Histogram = NoopMetric
+    prometheus_client = None
+    previous_metrics = None
+    try:
+        import prometheus_client
+    except ImportError:
+        pass
+    else:
+        previous_metrics = (
+            prometheus_client.Counter,
+            prometheus_client.Gauge,
+            prometheus_client.Histogram,
+        )
+        prometheus_client.Counter = NoopMetric
+        prometheus_client.Gauge = NoopMetric
+        prometheus_client.Histogram = NoopMetric
     try:
         spec = importlib.util.spec_from_file_location("rustchain_withdrawal_validation_test", MODULE_PATH)
         module = importlib.util.module_from_spec(spec)
@@ -74,11 +79,12 @@ def load_integrated_node():
         _INTEGRATED_NODE = module
         return _INTEGRATED_NODE
     finally:
-        (
-            prometheus_client.Counter,
-            prometheus_client.Gauge,
-            prometheus_client.Histogram,
-        ) = previous_metrics
+        if prometheus_client is not None:
+            (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            ) = previous_metrics
         if previous_db_path is None:
             os.environ.pop("RUSTCHAIN_DB_PATH", None)
         else:

--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -8,12 +8,85 @@ Covers the fix for:
 3. Negative amount bypass - could withdraw negative amounts
 """
 
-import pytest
-import json
-import sys
+import importlib.util
 import os
+import sys
+import tempfile
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import pytest
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+_INTEGRATED_NODE = None
+_IMPORT_TMP = None
+
+
+class NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+def load_integrated_node():
+    global _IMPORT_TMP, _INTEGRATED_NODE
+    if _INTEGRATED_NODE is not None:
+        return _INTEGRATED_NODE
+
+    previous_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+    previous_admin_key = os.environ.get("RC_ADMIN_KEY")
+    _IMPORT_TMP = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(_IMPORT_TMP.name, "import.db")
+    os.environ["RC_ADMIN_KEY"] = "0" * 32
+
+    import prometheus_client
+
+    previous_metrics = (
+        prometheus_client.Counter,
+        prometheus_client.Gauge,
+        prometheus_client.Histogram,
+    )
+    prometheus_client.Counter = NoopMetric
+    prometheus_client.Gauge = NoopMetric
+    prometheus_client.Histogram = NoopMetric
+    try:
+        spec = importlib.util.spec_from_file_location("rustchain_withdrawal_validation_test", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        _INTEGRATED_NODE = module
+        return _INTEGRATED_NODE
+    finally:
+        (
+            prometheus_client.Counter,
+            prometheus_client.Gauge,
+            prometheus_client.Histogram,
+        ) = previous_metrics
+        if previous_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = previous_db_path
+        if previous_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = previous_admin_key
 
 
 class TestWithdrawalRequestValidation:
@@ -22,7 +95,7 @@ class TestWithdrawalRequestValidation:
     @pytest.fixture
     def app(self):
         """Create test app instance"""
-        from rustchain_v2_integrated_v2.2.1_rip200 import app
+        app = load_integrated_node().app
         app.config['TESTING'] = True
         return app
 


### PR DESCRIPTION
## Summary
- load `rustchain_v2_integrated_v2.2.1_rip200.py` by path in the withdrawal validation test
- reuse the same no-op Prometheus metric import pattern used by nearby integrated-node tests
- set a temporary import DB/admin key so the module can be collected and tested in isolation

## Validation
- `python -m py_compile node\tests\test_withdrawal_validation.py`
- `python -m compileall -q node\tests\test_withdrawal_validation.py`
- `python -m pytest node\tests\test_withdrawal_validation.py -q` (7 passed)
- `git diff --check -- node\tests\test_withdrawal_validation.py`

`python -m ruff check node\tests\test_withdrawal_validation.py` was not run because `ruff` is not installed in this environment.

BCOS tier: BCOS-L1

Fixes #5476
Bug bounty reference: #305
