### PR TITLE
fix(#5476): use importlib to import module with dots in filename

### DIFF
--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -22,7 +22,8 @@ class TestWithdrawalRequestValidation:
     @pytest.fixture
     def app(self):
         """Create test app instance"""
-        from rustchain_v2_integrated_v2.2.1_rip200 import app
+        import importlib
+        app = importlib.import_module("rustchain_v2_integrated_v2.2.1_rip200").app
         app.config['TESTING'] = True
         return app
 


### PR DESCRIPTION
## Fix #5476\n\n`test_withdrawal_validation.py` used a normal import statement for a file containing dots (`rustchain_v2_integrated_v2.2.1_rip200`). Python parses `.2.1` as invalid decimal literal syntax.\n\n**Fix:** Use `importlib.import_module()` instead of a normal import statement.