### PR TITLE
test: load withdrawal validation module by path

### DIFF
--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -8,21 +8,99 @@ Covers the fix for:
 3. Negative amount bypass - could withdraw negative amounts
 """
 
-import pytest
-import json
-import sys
+import importlib.util
 import os
+import sys
+import tempfile
+from pathlib import Path
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import pytest
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+
+class NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+@pytest.fixture(scope="module")
+def integrated_node():
+    previous_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+    previous_admin_key = os.environ.get("RC_ADMIN_KEY")
+    import_tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+    os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(import_tmp.name, "withdrawal_validation.db")
+    os.environ["RC_ADMIN_KEY"] = "0" * 32
+
+    prometheus_client = None
+    previous_metrics = None
+    try:
+        import prometheus_client
+
+        previous_metrics = (
+            prometheus_client.Counter,
+            prometheus_client.Gauge,
+            prometheus_client.Histogram,
+        )
+        prometheus_client.Counter = NoopMetric
+        prometheus_client.Gauge = NoopMetric
+        prometheus_client.Histogram = NoopMetric
+    except ModuleNotFoundError:
+        pass
+
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_integrated_withdrawal_validation_test",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        if prometheus_client is not None and previous_metrics is not None:
+            (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            ) = previous_metrics
+        if previous_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = previous_db_path
+        if previous_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = previous_admin_key
+        import_tmp.cleanup()
 
 
 class TestWithdrawalRequestValidation:
     """Tests for /withdraw/request endpoint input validation"""
 
     @pytest.fixture
-    def app(self):
+    def app(self, integrated_node):
         """Create test app instance"""
-        from rustchain_v2_integrated_v2.2.1_rip200 import app
+        app = integrated_node.app
         app.config['TESTING'] = True
         return app
 


### PR DESCRIPTION
## Summary

Fixes #5476 by loading `node/rustchain_v2_integrated_v2.2.1_rip200.py` by file path in `node/tests/test_withdrawal_validation.py` instead of using the invalid dotted import syntax.

This keeps the fix tests-only:
- uses `importlib.util.spec_from_file_location(...)` for the integrated node filename that contains dots;
- imports with a temporary `RUSTCHAIN_DB_PATH` and test admin key so collection does not touch the default node DB;
- patches installed Prometheus metric constructors to no-op metrics during import, while still allowing the module's built-in fallback when `prometheus_client` is absent;
- restores environment variables and Prometheus constructors after the module-scoped fixture completes.

## Difference from existing attempts

There are already overlapping PRs for #5476, but this PR addresses the two practical blockers together:
- #5477 uses path loading, but review evidence shows it still fails in a minimal checkout when `prometheus_client` is unavailable.
- #5478 describes `importlib.import_module()`, which does not solve importing a single file named `rustchain_v2_integrated_v2.2.1_rip200.py` as a normal dotted module path.

This version keeps the working path-based import and the isolated fixture setup in one patch.

## Validation

- `python -m py_compile node\tests\test_withdrawal_validation.py` -> passed
- `python -m pytest node\tests\test_withdrawal_validation.py -q --tb=short` -> 7 passed
- `git diff --check -- node\tests\test_withdrawal_validation.py` -> passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

I also ran `python -m pytest node\tests\test_withdrawal_validation.py node\tests\test_withdraw_amount_validation.py -q --tb=short`; the withdrawal validation tests passed, while `test_withdraw_amount_validation.py` still has pre-existing current-main failures around non-finite amount handling / missing withdrawal tables. I left that production withdrawal logic out of this tests-lane patch.

Wallet for any accepted small tests bounty: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`