### PR TITLE
Fix strict Base address validation

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -34,6 +34,7 @@ BRIDGE_REQUIRE_PROOF = os.environ.get("BRIDGE_REQUIRE_PROOF", "true").lower() ==
 CHAIN_SOLANA = "solana"
 CHAIN_BASE = "base"
 SUPPORTED_CHAINS = {CHAIN_SOLANA, CHAIN_BASE}
+EVM_HEX_CHARS = set("0123456789abcdefABCDEF")
 
 # RTC decimal precision
 RTC_DECIMALS = 6
@@ -194,6 +195,16 @@ def _clean_string_field(data, field_name, *, optional=False, lower=False):
     return value
 
 
+def _is_base_evm_address(value: str) -> bool:
+    """Return True for canonical Base/EVM addresses: 0x plus 40 hex chars."""
+    return (
+        isinstance(value, str)
+        and len(value) == 42
+        and value.startswith("0x")
+        and all(ch in EVM_HEX_CHARS for ch in value[2:])
+    )
+
+
 # ─── Blueprint ────────────────────────────────────────────────────────────────
 bridge_bp = Blueprint("bridge", __name__, url_prefix="/bridge")
 
@@ -255,8 +266,8 @@ def lock_rtc():
         return jsonify({"error": f"maximum lock amount is {MAX_LOCK_AMOUNT} RTC"}), 400
 
     # Validate target wallet format
-    if target_chain == CHAIN_BASE and not target_wallet.startswith("0x"):
-        return jsonify({"error": "Base wallet must be a 0x EVM address"}), 400
+    if target_chain == CHAIN_BASE and not _is_base_evm_address(target_wallet):
+        return jsonify({"error": "Base wallet must be a 0x EVM address with 40 hex chars"}), 400
     if target_chain == CHAIN_SOLANA and len(target_wallet) < 32:
         return jsonify({"error": "Solana wallet must be a valid base58 address"}), 400
 

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -598,6 +598,36 @@ class TestLockEndpoint:
         })
         assert resp.status_code == 400
 
+    def test_lock_rejects_short_base_wallet(self, client):
+        bad_wallet = "0x1234"
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": bad_wallet,
+            "tx_hash": "rtc-lock-short-base-wallet",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 10.0, "base", bad_wallet, "rtc-lock-short-base-wallet"
+            ),
+        })
+        assert resp.status_code == 400
+        assert "40 hex chars" in resp.get_json()["error"]
+
+    def test_lock_rejects_non_hex_base_wallet(self, client):
+        bad_wallet = "0x" + ("g" * 40)
+        resp = client.post("/bridge/lock", json={
+            "sender_wallet": "test-miner",
+            "amount": 10.0,
+            "target_chain": "base",
+            "target_wallet": bad_wallet,
+            "tx_hash": "rtc-lock-non-hex-base-wallet",
+            "receipt_signature": _receipt_signature(
+                "test-miner", 10.0, "base", bad_wallet, "rtc-lock-non-hex-base-wallet"
+            ),
+        })
+        assert resp.status_code == 400
+        assert "40 hex chars" in resp.get_json()["error"]
+
     def test_lock_requires_tx_hash(self, client):
         resp = client.post("/bridge/lock", json={
             "sender_wallet": "test-miner",

--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -58,6 +58,17 @@ CREATE TABLE IF NOT EXISTS beacon_wallets (
 RELAY_MIGRATION_SQL = [
     "ALTER TABLE relay_agents ADD COLUMN coinbase_address TEXT DEFAULT NULL",
 ]
+EVM_HEX_CHARS = set("0123456789abcdefABCDEF")
+
+
+def _is_base_evm_address(value):
+    """Return True for canonical Base/EVM addresses: 0x plus 40 hex chars."""
+    return (
+        isinstance(value, str)
+        and len(value) == 42
+        and value.startswith("0x")
+        and all(ch in EVM_HEX_CHARS for ch in value[2:])
+    )
 
 
 def _run_migrations(db_path):
@@ -206,7 +217,7 @@ def init_app(app, get_db_func):
             address = _json_string_field(data, "coinbase_address")
         except ValueError as exc:
             return _cors_json({"error": str(exc)}, 400)
-        if not address or not address.startswith("0x") or len(address) != 42:
+        if not _is_base_evm_address(address):
             return _cors_json({"error": "Invalid Base address"}, 400)
 
         db = get_db_func()

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -57,6 +57,7 @@ BRIDGE_LOCK_EXPIRY_SECONDS = int(os.environ.get("RC_BRIDGE_LOCK_EXPIRY_SECONDS",
 BRIDGE_MIN_AMOUNT_RTC = float(os.environ.get("RC_BRIDGE_MIN_AMOUNT_RTC", "1.0"))
 BRIDGE_UNIT = 1000000  # Micro-units per RTC
 logger = logging.getLogger(__name__)
+EVM_HEX_CHARS = set("0123456789abcdefABCDEF")
 
 
 # =============================================================================
@@ -222,11 +223,13 @@ def validate_chain_address_format(chain: str, address: str) -> Tuple[bool, str]:
             return False, "Ergo address too short"
     
     elif chain == "base":
-        # Base (Ethereum L2) addresses are 0x-prefixed
+        # Base (Ethereum L2) addresses are 0x-prefixed plus 40 hex chars.
         if not address.startswith("0x"):
             return False, "Base addresses must start with '0x'"
         if len(address) != 42:
             return False, "Invalid Base address length"
+        if not all(ch in EVM_HEX_CHARS for ch in address[2:]):
+            return False, "Invalid Base address format"
     
     return True, ""
 

--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -37,6 +37,17 @@ except ImportError:
 
 
 COINBASE_MIGRATION = "ALTER TABLE balances ADD COLUMN coinbase_address TEXT DEFAULT NULL"
+EVM_HEX_CHARS = set("0123456789abcdefABCDEF")
+
+
+def _is_base_evm_address(value):
+    """Return True for canonical Base/EVM addresses: 0x plus 40 hex chars."""
+    return (
+        isinstance(value, str)
+        and len(value) == 42
+        and value.startswith("0x")
+        and all(ch in EVM_HEX_CHARS for ch in value[2:])
+    )
 
 
 def _run_migration(db_path):
@@ -104,7 +115,7 @@ def init_app(app, db_path):
 
         if not miner_id:
             return jsonify({"error": "miner_id is required"}), 400
-        if not coinbase_address or not coinbase_address.startswith("0x") or len(coinbase_address) != 42:
+        if not _is_base_evm_address(coinbase_address):
             return jsonify({"error": "Invalid Base address (must be 0x + 40 hex chars)"}), 400
 
         conn = sqlite3.connect(db_path)

--- a/node/tests/test_base_evm_address_validation.py
+++ b/node/tests/test_base_evm_address_validation.py
@@ -1,0 +1,72 @@
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+from flask import Flask
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+beacon_x402 = _load_module("beacon_x402_under_test", NODE_DIR / "beacon_x402.py")
+rustchain_x402 = _load_module("rustchain_x402_under_test", NODE_DIR / "rustchain_x402.py")
+
+
+INVALID_BASE_ADDRESSES = [
+    "0x1234",
+    "0x" + ("g" * 40),
+]
+
+
+def test_rustchain_x402_rejects_short_and_non_hex_coinbase_addresses(tmp_path, monkeypatch):
+    db_path = tmp_path / "balances.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, miner_pk TEXT)")
+    conn.execute("INSERT INTO balances (miner_id, miner_pk) VALUES (?, ?)", ("miner-1", "pk-1"))
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    app = Flask(__name__)
+    rustchain_x402.init_app(app, str(db_path))
+    client = app.test_client()
+
+    for address in INVALID_BASE_ADDRESSES:
+        response = client.post(
+            "/wallet/link-coinbase",
+            headers={"X-Admin-Key": "test-admin-key"},
+            json={"miner_id": "miner-1", "coinbase_address": address},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid Base address" in response.get_json()["error"]
+
+
+def test_beacon_x402_rejects_short_and_non_hex_agent_wallets(monkeypatch):
+    monkeypatch.setenv("BEACON_ADMIN_KEY", "test-admin-key")
+    monkeypatch.setattr(beacon_x402, "_run_migrations", lambda db_path: None)
+
+    def get_db():
+        raise AssertionError("invalid wallet requests should not touch the database")
+
+    app = Flask(__name__)
+    beacon_x402.init_app(app, get_db)
+    client = app.test_client()
+
+    for address in INVALID_BASE_ADDRESSES:
+        response = client.post(
+            "/api/agents/beacon-1/wallet",
+            headers={"X-Admin-Key": "test-admin-key"},
+            json={"coinbase_address": address},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid Base address" in response.get_json()["error"]

--- a/node/tests/test_base_evm_address_validation.py
+++ b/node/tests/test_base_evm_address_validation.py
@@ -18,6 +18,7 @@ def _load_module(name, path):
 
 beacon_x402 = _load_module("beacon_x402_under_test", NODE_DIR / "beacon_x402.py")
 rustchain_x402 = _load_module("rustchain_x402_under_test", NODE_DIR / "rustchain_x402.py")
+bridge_api = _load_module("node_bridge_api_under_test", NODE_DIR / "bridge_api.py")
 
 
 INVALID_BASE_ADDRESSES = [
@@ -70,3 +71,16 @@ def test_beacon_x402_rejects_short_and_non_hex_agent_wallets(monkeypatch):
 
         assert response.status_code == 400
         assert "Invalid Base address" in response.get_json()["error"]
+
+def test_node_bridge_api_rejects_non_hex_base_addresses():
+    for address in INVALID_BASE_ADDRESSES:
+        ok, msg = bridge_api.validate_chain_address_format("base", address)
+
+        assert ok is False
+        assert "Base address" in msg
+
+    ok, msg = bridge_api.validate_chain_address_format(
+        "base", "0x1234567890abcdefABCDEF1234567890abcdef12"
+    )
+    assert ok is True
+    assert msg == ""


### PR DESCRIPTION
## Summary
- add a shared-style strict Base/EVM address validator for bridge locks and x402 wallet endpoints
- require `0x` plus exactly 40 hex characters instead of only checking prefix or length
- add regressions for short and non-hex Base addresses across bridge, RustChain x402, and Beacon x402 flows

Fixes #5432
Fixes #5434
Fixes #5436

## Validation
- `python -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py node/rustchain_x402.py node/beacon_x402.py node/tests/test_base_evm_address_validation.py`
- `python -m pytest bridge/test_bridge_api.py node/tests/test_base_evm_address_validation.py -q --tb=short` -> 45 passed
- `git diff --check -- bridge/bridge_api.py bridge/test_bridge_api.py node/rustchain_x402.py node/beacon_x402.py node/tests/test_base_evm_address_validation.py`

RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
