### PR TITLE
Hide explorer upstream exception details

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -1,6 +1,5 @@
 from flask import Flask, render_template, jsonify
 import requests
-import json
 from datetime import datetime
 
 app = Flask(__name__)
@@ -8,6 +7,14 @@ app = Flask(__name__)
 # Configuration
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
+UPSTREAM_UNAVAILABLE_ERROR = "Upstream RustChain API unavailable"
+
+
+def upstream_error_response(include_miners=False):
+    payload = {"error": UPSTREAM_UNAVAILABLE_ERROR}
+    if include_miners:
+        payload["miners"] = []
+    return jsonify(payload), 500
 
 @app.route('/')
 def dashboard():
@@ -49,8 +56,9 @@ def get_miners():
             return jsonify(miners_data)
         else:
             return jsonify({'error': 'Failed to fetch miners data', 'miners': []}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}', 'miners': []}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch miners from upstream RustChain API")
+        return upstream_error_response(include_miners=True)
 
 @app.route('/api/network/stats')
 def get_network_stats():
@@ -80,8 +88,9 @@ def get_network_stats():
             return jsonify(stats)
         else:
             return jsonify({'error': 'Failed to fetch network stats'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch network stats from upstream RustChain API")
+        return upstream_error_response()
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
@@ -122,8 +131,9 @@ def get_miner_detail(miner_id):
                 return jsonify({'error': 'Miner not found'}), 404
         else:
             return jsonify({'error': 'Failed to fetch miner data'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch miner detail from upstream RustChain API")
+        return upstream_error_response()
 
 @app.errorhandler(404)
 def not_found(error):

--- a/tests/test_explorer_app_upstream_errors.py
+++ b/tests/test_explorer_app_upstream_errors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import importlib.util
 from pathlib import Path
 

--- a/tests/test_explorer_app_upstream_errors.py
+++ b/tests/test_explorer_app_upstream_errors.py
@@ -1,0 +1,45 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import requests
+
+
+def load_explorer_app():
+    module_path = Path(__file__).resolve().parents[1] / "explorer" / "app.py"
+    spec = importlib.util.spec_from_file_location("explorer_app_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.app.testing = True
+    return module
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_payload"),
+    [
+        ("/api/miners", {"error": "Upstream RustChain API unavailable", "miners": []}),
+        ("/api/network/stats", {"error": "Upstream RustChain API unavailable"}),
+        ("/api/miner/alice", {"error": "Upstream RustChain API unavailable"}),
+    ],
+)
+def test_explorer_api_hides_upstream_exception_details(monkeypatch, path, expected_payload):
+    explorer_app = load_explorer_app()
+    leaked_error = (
+        "HTTPConnectionPool(host='127.0.0.1', port=8000): "
+        "url=/api/miners?token=super-secret trace=/srv/rustchain/private/node.py"
+    )
+
+    def fail_upstream(*args, **kwargs):
+        raise requests.exceptions.ConnectionError(leaked_error)
+
+    monkeypatch.setattr(explorer_app.requests, "get", fail_upstream)
+
+    with explorer_app.app.test_client() as client:
+        response = client.get(path)
+
+    assert response.status_code == 500
+    assert response.get_json() == expected_payload
+
+    response_text = response.get_data(as_text=True)
+    for secret in ("127.0.0.1", "8000", "super-secret", "/srv/rustchain/private", "node.py"):
+        assert secret not in response_text


### PR DESCRIPTION
Fixes #5449.

## Summary

- stops the explorer API from returning raw upstream `requests` exception strings to clients
- logs full upstream failures server-side with route-specific context
- preserves the existing `/api/miners` fallback shape with `miners: []`
- adds regression coverage for `/api/miners`, `/api/network/stats`, and `/api/miner/<id>` using a host/token/path-bearing upstream exception

## Validation

- `/tmp/rustchain-5449-venv/bin/python -m pytest tests/test_explorer_app_upstream_errors.py -q` -> `3 passed`
- `/tmp/rustchain-5449-venv/bin/python -m py_compile explorer/app.py tests/test_explorer_app_upstream_errors.py`
- `git diff --check`
