### PR TITLE
docs: normalize explorer links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ For package-specific work, use the closest local manifest or test folder:
 | Node Health | `https://rustchain.org/health` |
 | Active Miners | `https://rustchain.org/api/miners` |
 | Current Epoch | `https://rustchain.org/epoch` |
-| Block Explorer | `https://rustchain.org/explorer` |
+| Block Explorer | `https://rustchain.org/explorer/` |
 | wRTC Bridge | `https://bottube.ai/bridge` |
 
 ## RTC Payout Process

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -334,7 +334,7 @@ curl -sk https://rustchain.org/epoch
 curl -sk https://rustchain.org/api/miners
 
 # 区块浏览器
-open https://rustchain.org/explorer
+open https://rustchain.org/explorer/
 ```
 
 ### 节点架构
@@ -410,7 +410,7 @@ curl -sk -X POST https://rustchain.org/governance/vote \
 - **Discord:** [discord.gg/VqVVS2CW9Q](https://discord.gg/VqVVS2CW9Q)
 - **GitHub:** [github.com/Scottcjn/RustChain](https://github.com/Scottcjn/RustChain)
 - **网站:** [rustchain.org](https://rustchain.org)
-- **区块浏览器:** [rustchain.org/explorer](https://rustchain.org/explorer)
+- **区块浏览器:** [rustchain.org/explorer/](https://rustchain.org/explorer/)
 
 ### 相关项目
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -199,7 +199,7 @@ is running.
 
 You can also see the full network, all miners, and your rewards at:
 
-[https://rustchain.org/explorer](https://rustchain.org/explorer)
+[https://rustchain.org/explorer/](https://rustchain.org/explorer/)
 
 ---
 
@@ -280,7 +280,7 @@ Even fixing a single typo in the README earns RTC.
 
 See all miners, blocks, and balances at:
 
-[https://rustchain.org/explorer](https://rustchain.org/explorer)
+[https://rustchain.org/explorer/](https://rustchain.org/explorer/)
 
 ### API Endpoints (for the curious)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@
 ## Live Network
 
 - **Primary Node**: `https://rustchain.org`
-- **Explorer**: `https://rustchain.org/explorer`
+- **Explorer**: `https://rustchain.org/explorer/`
 - **Health Check**: `curl -sk https://rustchain.org/health`
 - **Network Status Page**: `docs/network-status.html` (GitHub Pages-hostable status dashboard)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -473,7 +473,7 @@ R9: Timestamp</pre>
         <div>
           <h3>Live Endpoints</h3>
           <p><a href="https://rustchain.org/health">Health Check</a></p>
-          <p><a href="https://rustchain.org/explorer">Block Explorer</a></p>
+          <p><a href="https://rustchain.org/explorer/">Block Explorer</a></p>
           <p><a href="https://rustchain.org/api/miners">Active Miners API</a></p>
           <p><a href="https://rustchain.org/epoch">Current Epoch</a></p>
         </div>
@@ -560,7 +560,7 @@ sophia-nas           x86_64  1.00x   0.1191 RTC  (7.9%)</pre>
     <div class="card">
       <h2>Quick Links</h2>
       <p>
-        <span class="tag green">Live</span> <a href="https://rustchain.org/explorer">Block Explorer</a><br>
+        <span class="tag green">Live</span> <a href="https://rustchain.org/explorer/">Block Explorer</a><br>
         <span class="tag green">Live</span> <a href="https://bottube.ai">BoTTube.ai</a> &mdash; AI video platform<br>
         <span class="tag green">Live</span> <a href="https://github.com/Scottcjn/rustchain-bounties">Bounty Board</a><br>
         <span class="tag">GitHub</span> <a href="https://github.com/Scottcjn/Rustchain">RustChain repo</a><br>


### PR DESCRIPTION
## Summary
- normalize the main human-facing explorer documentation links to `https://rustchain.org/explorer/`
- keep the change scoped to five entry-point docs/pages so the diff stays reviewable
- leave API subpaths and generated/demo artifacts untouched

## Why
This is a clean re-file for #2623. The earlier PR was closed because line-ending churn hid the intended trailing-slash changes. This branch keeps LF endings and only changes the explorer URL tokens.

## Validation
- `rg --pcre2 -n https://rustchain\.org/explorer(?!/) CONTRIBUTING.md docs/README.md docs/QUICKSTART.md docs/FAQ.md docs/index.html` -> no matches
- `git diff --check -- CONTRIBUTING.md docs/README.md docs/QUICKSTART.md docs/FAQ.md docs/index.html`
- `git ls-files --eol CONTRIBUTING.md docs/README.md docs/QUICKSTART.md docs/FAQ.md docs/index.html` -> all `i/lf w/lf attr/text eol=lf`

Fixes #2623