### PR TITLE
docs: align README modern PC multiplier example

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Epoch: 10 minutes  |  Pool: 1.5 RTC/epoch  |  Split by antiquity weight
 
 G4 Mac (2.5x):     0.30 RTC  ████████████████████
 G5 Mac (2.0x):     0.24 RTC  ████████████████
-Modern PC (0.8x):  0.10 RTC  ██████
+Modern PC (1.0x):  0.12 RTC  ████████
 ```
 
 ### Anti-VM Enforcement


### PR DESCRIPTION
## Summary
- Align the README Epoch Rewards example with the hardware multiplier table for modern x86_64 hardware.
- Update the example payout text from `0.8x` / `0.10 RTC` to `1.0x` / `0.12 RTC` so both README references use the same baseline multiplier.

Fixes #2690.

## Validation
- `git diff --check`

Payout details can be provided privately if this is accepted.
