### PR TITLE
docs: add smart contract developer guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 | [FAQ & Troubleshooting](./FAQ_TROUBLESHOOTING.md) | Common setup/runtime issues and recovery steps |
 | [Wallet User Guide](./WALLET_USER_GUIDE.md) | Wallet basics, balance checks, and safe operations |
 | [Contributing Guide](./CONTRIBUTING.md) | Contribution workflow, PR checklist, and bounty submission notes |
+| [Smart Contract Developer Guide](./SMART_CONTRACT_DEVELOPER_GUIDE.md) | Contract quickstart, lifecycle, deployment, and security checklist |
 | [Reward Analytics Dashboard](./REWARD_ANALYTICS_DASHBOARD.md) | Charts and API for RTC reward transparency |
 | [Cross-Node Sync Validator](./CROSS_NODE_SYNC_VALIDATOR.md) | Multi-node consistency checks and discrepancy reports |
 | [Discord Leaderboard Bot](./DISCORD_LEADERBOARD_BOT.md) | Webhook bot setup and usage |

--- a/docs/SMART_CONTRACT_DEVELOPER_GUIDE.md
+++ b/docs/SMART_CONTRACT_DEVELOPER_GUIDE.md
@@ -1,0 +1,90 @@
+# Smart Contract Developer Guide
+
+This guide gives DApp builders a practical path through the RustChain contract
+workspace. The current on-chain contract surface is the wrapped RTC token stack
+for Base, with bridge-aware mint and burn flows documented under
+`contracts/base` and `contracts/erc20`.
+
+## Quick Start
+
+Use the Hardhat package when you need the full development loop:
+
+```bash
+cd contracts/erc20
+npm install
+npm run compile
+npm test
+```
+
+For a smaller reference implementation, inspect `contracts/base/wRTC.sol`. For
+the production-style Base package with permit, bridge operators, pausing, tests,
+deployment scripts, and interaction tooling, use `contracts/erc20`.
+
+## Contract Lifecycle
+
+1. Develop the contract in `contracts/erc20/contracts/WRTC.sol`.
+2. Add or update tests in `contracts/erc20/test/WRTC.test.js`.
+3. Compile and run the test suite with `npm run compile` and `npm test`.
+4. Deploy to Base Sepolia first with `npm run deploy:base-sepolia`.
+5. Verify the testnet contract before any mainnet deployment.
+6. Configure bridge operators or ownership only after deployment is verified.
+7. Monitor mint, burn, pause, unpause, and operator-change events.
+
+Mainnet deployment should happen only after testnet validation, contract review,
+and bridge-operator confirmation.
+
+## Minimal DApp Interaction Example
+
+Set `WRTC_ADDRESS` to the deployed token contract and use the provided script for
+read-only checks before sending transactions:
+
+```bash
+cd contracts/erc20
+export WRTC_ADDRESS=0xYourDeployedContract
+
+node scripts/interact.js info
+node scripts/interact.js balance 0xYourWallet
+```
+
+For write operations, test the exact call on Base Sepolia first:
+
+```bash
+node scripts/interact.js transfer 0xRecipient 1.5
+node scripts/interact.js approve 0xSpender 10
+```
+
+Bridge-only operations such as `add-operator`, `bridge-mint`, `bridge-burn`,
+`pause`, and `unpause` are administrative actions. They should be run by the
+configured owner or bridge operator, preferably through a multi-signature wallet
+for production deployments.
+
+## Best Practices
+
+- Keep private keys and RPC credentials in `.env`; never commit them.
+- Run `npm test` after every Solidity or script change.
+- Deploy to Base Sepolia before Base mainnet.
+- Use a dedicated deployer wallet with only the gas needed for deployment.
+- Transfer ownership to a multi-signature wallet for production.
+- Treat bridge operator changes as high-risk configuration changes.
+- Prefer read-only `info` and `balance` checks when integrating a frontend.
+- Log deployed addresses, transaction hashes, constructor arguments, and
+  verification status in the PR or deployment record.
+
+## Security Checklist
+
+Before mainnet, confirm:
+
+- The bridge operator is not the same hot wallet used for routine development.
+- The owner address is controlled by the intended production authority.
+- `pause` and `unpause` procedures are documented for incident response.
+- Mint and burn event monitoring is configured.
+- BaseScan verification succeeds and constructor arguments are recorded.
+- No test private keys, RPC URLs with tokens, or mnemonic material are committed.
+
+## Reference Documents
+
+- `contracts/base/README.md` - compact RIP-305 wRTC overview.
+- `contracts/erc20/README.md` - full Base ERC-20 package guide.
+- `contracts/erc20/docs/DEPLOYMENT_GUIDE.md` - deployment workflow.
+- `contracts/erc20/docs/SECURITY_CONSIDERATIONS.md` - production risk notes.
+- `contracts/erc20/docs/BRIDGE_INTEGRATION.md` - bridge integration details.


### PR DESCRIPTION
## Summary
- add `docs/SMART_CONTRACT_DEVELOPER_GUIDE.md` for DApp and contract builders
- cover quickstart, contract lifecycle, minimal interaction commands, best practices, and security checklist
- link the guide from `docs/README.md`

## Validation
- `git diff --check -- docs/SMART_CONTRACT_DEVELOPER_GUIDE.md docs/README.md`
- Verified referenced contract docs exist:
  - `contracts/base/README.md`
  - `contracts/erc20/README.md`
  - `contracts/erc20/docs/DEPLOYMENT_GUIDE.md`
  - `contracts/erc20/docs/SECURITY_CONSIDERATIONS.md`
  - `contracts/erc20/docs/BRIDGE_INTEGRATION.md`

Fixes #2739