### PR TITLE
fix: disable bridge debug server

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -659,4 +659,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=False)

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -13,6 +13,7 @@ import time
 import hmac
 import hashlib
 import pytest
+from pathlib import Path
 
 # Use a temp DB for testing
 os.environ["BRIDGE_DB_PATH"] = "/tmp/bridge_test_727.db"
@@ -28,6 +29,12 @@ if os.path.exists("/tmp/bridge_test_727.db"):
 sys.path.insert(0, os.path.dirname(__file__))
 import bridge_api
 from bridge_api import Flask, register_bridge_routes, STATE_REQUESTED, STATE_CONFIRMED
+
+
+def test_standalone_bridge_server_does_not_enable_debugger():
+    source = Path(bridge_api.__file__).read_text(encoding="utf-8")
+    assert "debug=True" not in source
+    assert 'debug=False' in source
 
 
 def _receipt_signature(sender_wallet, amount, target_chain, target_wallet, tx_hash):


### PR DESCRIPTION
## Summary

- Disable Flask debug mode for the standalone RIP-305 bridge dev server.
- Add a regression test so the bridge entrypoint cannot reintroduce debug=True.

## Notes

This is intentionally scoped to the bridge instance from the #5059 discussion and avoids touching contributor_registry.py / keeper_explorer.py, which are already covered by PR #5118.

## Checks

- /tmp/rustchain-5449-venv/bin/python -m pytest bridge/test_bridge_api.py::test_standalone_bridge_server_does_not_enable_debugger -q
- /tmp/rustchain-5449-venv/bin/python -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py
