### PR TITLE
docs: align license references with Apache 2.0

### DIFF
--- a/docs/BOUNTY_2313_IMPLEMENTATION.md
+++ b/docs/BOUNTY_2313_IMPLEMENTATION.md
@@ -575,7 +575,7 @@ sudo rustchain-witness write --epoch 1 --device /dev/fd0
 
 ## License
 
-MIT License - See LICENSE file in repository root.
+Apache License 2.0 - See LICENSE file in repository root.
 
 ---
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -435,7 +435,7 @@ curl -sk -X POST https://rustchain.org/governance/vote \
 ```
 RustChain - Proof of Antiquity by Scott (Scottcjn)
 https://github.com/Scottcjn/Rustchain
-MIT License
+Apache License 2.0
 ```
 
 ---

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -888,6 +888,6 @@ Response: {"epoch": 62, "slot": 8928, "next_settlement": 1707000000}
 
 ---
 
-*Copyright © 2025-2026 Scott Johnson / Elyan Labs. Released under MIT License.*
+*Copyright © 2025-2026 Scott Johnson / Elyan Labs. Released under Apache License 2.0.*
 
 *RustChain — Making vintage hardware valuable again.*

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: 古董证明区块链
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)
@@ -426,7 +426,7 @@ https://github.com/Scottcjn/Rustchain
 
 ## 📜 许可证
 
-MIT 许可证 - 可自由使用，但请保留版权声明和署名。
+Apache License 2.0 - 可自由使用，但请遵守 Apache License 2.0 条款并保留版权声明和署名。
 
 ---
 

--- a/docs/zh-CN/RustChain_Whitepaper_zh-CN_v1.0.md
+++ b/docs/zh-CN/RustChain_Whitepaper_zh-CN_v1.0.md
@@ -887,6 +887,6 @@ GET /epoch
 
 ---
 
-*版权所有 © 2025-2026 Scott Johnson / Elyan Labs。根据 MIT 许可证发布。*
+*版权所有 © 2025-2026 Scott Johnson / Elyan Labs。根据 Apache License 2.0 许可证发布。*
 
 *RustChain — 让复古硬件再次变得有价值。*


### PR DESCRIPTION
## Summary
- Align remaining RustChain documentation license references with the root Apache License 2.0 license.
- Update FAQ, whitepaper footer, Chinese README badge/footer, Chinese whitepaper footer, and the Floppy Witness Kit implementation note.
- Completes the current-main residue behind #2754 after INSTALL.md had already been corrected.

## Validation
- Root LICENSE begins with Apache License 2.0.
- `rg -n "MIT License|MIT ???|License-MIT" docs\FAQ.md docs\WHITEPAPER.md docs\zh-CN\README.md docs\zh-CN\RustChain_Whitepaper_zh-CN_v1.0.md docs\BOUNTY_2313_IMPLEMENTATION.md` returned no matches.
- `rg -n "Apache License 2\.0|License-Apache_2\.0" docs\FAQ.md docs\WHITEPAPER.md docs\zh-CN\README.md docs\zh-CN\RustChain_Whitepaper_zh-CN_v1.0.md docs\BOUNTY_2313_IMPLEMENTATION.md` shows the corrected references.
- `git diff --check -- docs\FAQ.md docs\WHITEPAPER.md docs\zh-CN\README.md docs\zh-CN\RustChain_Whitepaper_zh-CN_v1.0.md docs\BOUNTY_2313_IMPLEMENTATION.md`

Fixes #2754
