### PR TITLE
Handle corrupt N64 attestation save markers

### DIFF
--- a/mining/n64-miner/host_relay.py
+++ b/mining/n64-miner/host_relay.py
@@ -26,6 +26,9 @@ PKT_TYPE_ATTEST = 0
 PKT_TYPE_HEARTBEAT = 1
 PKT_TYPE_BALANCE = 2
 PKT_TYPE_EPOCH_ACK = 3
+PKT_TYPE_REATTEST = 4
+
+CORRUPTED_SAVE_MAGIC_VALUES = {0xFFFFFFFF, 0x00000000}
 
 FRAME_HEADER = bytes([0x52, 0x54])
 DEVICE_ARCH = "mips_r4300"
@@ -52,6 +55,8 @@ class N64Relay:
         self.serial_conn = None
         self.attestations_sent = 0
         self.attestations_ok = 0
+        self.corrupt_attestations = 0
+        self.health_events = []
         self.total_earned = 0
         self.current_epoch = 0
 
@@ -110,6 +115,39 @@ class N64Relay:
         self.serial_conn.write(header + data + checksum)
         return True
 
+    def emit_health_event(self, event: dict) -> None:
+        """Record a miner health event for node-side observers."""
+        self.health_events.append(event)
+
+    def send_reattest_request(self, epoch: int) -> bool:
+        """Ask the miner to re-attest from the last known checkpoint."""
+        req = struct.pack("<IBBHI",
+                          ATTEST_MAGIC,
+                          1,  # version
+                          PKT_TYPE_REATTEST,
+                          0,  # payload_len
+                          epoch)
+        return self.send_frame(req)
+
+    def _record_corrupt_attestation(self, magic: int) -> None:
+        """Log and surface corrupted cartridge save-data markers."""
+        self.corrupt_attestations += 1
+        event = {
+            "type": "miner_attestation_corrupt",
+            "severity": "warn",
+            "magic": f"0x{magic:08X}",
+            "block_height": self.current_epoch,
+            "epoch": self.current_epoch,
+            "action": "reattest_requested",
+        }
+        print(
+            "[relay][WARN] miner_attestation_corrupt: "
+            f"magic=0x{magic:08X} block_height={self.current_epoch}; "
+            "requesting re-attest"
+        )
+        self.emit_health_event(event)
+        self.send_reattest_request(self.current_epoch)
+
     def _demo_attestation(self) -> bytes:
         """Generate a fake attestation packet for demo mode."""
         import os
@@ -147,6 +185,10 @@ class N64Relay:
             return None
 
         magic = struct.unpack_from("<I", data, 0)[0]
+        if magic in CORRUPTED_SAVE_MAGIC_VALUES:
+            self._record_corrupt_attestation(magic)
+            return None
+
         if magic != ATTEST_MAGIC:
             return None
 

--- a/mining/n64-miner/n64_miner.c
+++ b/mining/n64-miner/n64_miner.c
@@ -133,16 +133,20 @@ int miner_attest(miner_context_t *ctx) {
     
     ctx->attestations_sent++;
     ctx->last_fingerprint = fp;
-    
-    /* Wait for epoch acknowledgment */
+    /* Wait for epoch acknowledgment or re-attestation request */
     epoch_ack_packet_t ack;
     rc = serial_recv(&ack, sizeof(ack), 10000);
-    if (rc > 0 && ack.header.magic == ATTEST_MAGIC && 
-        ack.header.type == PKT_TYPE_EPOCH_ACK) {
-        ctx->current_epoch = ack.epoch;
-        ctx->total_earned += ack.balance_rtc;
-        ctx->session_earned += ack.balance_rtc;
-        ctx->attestations_ok++;
+    if (rc > 0 && ack.header.magic == ATTEST_MAGIC) {
+        if (ack.header.type == PKT_TYPE_EPOCH_ACK) {
+            ctx->current_epoch = ack.epoch;
+            ctx->total_earned += ack.balance_rtc;
+            ctx->session_earned += ack.balance_rtc;
+            ctx->attestations_ok++;
+        } else if (ack.header.type == PKT_TYPE_REATTEST) {
+            ctx->current_epoch = ack.epoch;
+            ctx->state = STATE_ATTEST;
+            return miner_attest(ctx);
+        }
     }
     
     ctx->state = STATE_MINING;

--- a/mining/n64-miner/n64_miner.h
+++ b/mining/n64-miner/n64_miner.h
@@ -46,7 +46,7 @@
 typedef struct {
     uint32_t magic;
     uint8_t  version;
-    uint8_t  type;           /* 0=attest, 1=heartbeat, 2=balance_req */
+    uint8_t  type;           /* 0=attest, 1=heartbeat, 2=balance_req, 4=reattest_req */
     uint16_t payload_len;
 } packet_header_t;
 
@@ -54,6 +54,7 @@ typedef struct {
 #define PKT_TYPE_HEARTBEAT   1
 #define PKT_TYPE_BALANCE     2
 #define PKT_TYPE_EPOCH_ACK   3
+#define PKT_TYPE_REATTEST    4
 
 typedef struct {
     uint32_t count_drift_ns;

--- a/mining/n64-miner/test_host_relay.py
+++ b/mining/n64-miner/test_host_relay.py
@@ -162,6 +162,14 @@ class TestAttestationProtocol(unittest.TestCase):
         self.assertEqual(PKT_TYPE_EPOCH_ACK, 3)
         self.assertEqual(PKT_TYPE_REATTEST, 4)
 
+    def test_n64_firmware_handles_reattest_request(self):
+        source_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "n64_miner.c")
+        with open(source_path, encoding="utf-8") as fh:
+            source = fh.read()
+
+        self.assertIn("ack.header.type == PKT_TYPE_REATTEST", source)
+        self.assertIn("return miner_attest(ctx);", source)
+
     def test_device_constants(self):
         self.assertEqual(DEVICE_ARCH, "mips_r4300")
         self.assertEqual(DEVICE_FAMILY, "N64")

--- a/mining/n64-miner/test_host_relay.py
+++ b/mining/n64-miner/test_host_relay.py
@@ -15,8 +15,23 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from host_relay import (
     N64Relay, crc8, ATTEST_MAGIC, PKT_TYPE_ATTEST, PKT_TYPE_EPOCH_ACK,
-    DEVICE_ARCH, DEVICE_FAMILY
+    PKT_TYPE_REATTEST, DEVICE_ARCH, DEVICE_FAMILY
 )
+
+
+class CapturingRelay(N64Relay):
+    def __init__(self):
+        super().__init__(
+            port=None,
+            node_url="https://rustchain.org",
+            wallet="RTC_TEST_WALLET",
+            demo=False
+        )
+        self.sent_frames = []
+
+    def send_frame(self, data: bytes) -> bool:
+        self.sent_frames.append(data)
+        return True
 
 
 class TestCRC8(unittest.TestCase):
@@ -92,6 +107,32 @@ class TestN64RelayDemo(unittest.TestCase):
         bad_data = struct.pack("<I", 0xDEADBEEF) + b"\x00" * 100
         result = self.relay.parse_attestation(bad_data)
         self.assertIsNone(result)
+        self.assertEqual(self.relay.corrupt_attestations, 0)
+        self.assertEqual(self.relay.health_events, [])
+
+    def test_parse_detects_erased_save_data(self):
+        relay = CapturingRelay()
+        relay.current_epoch = 42
+        result = relay.parse_attestation(struct.pack("<I", 0xFFFFFFFF) + b"\x00" * 100)
+
+        self.assertIsNone(result)
+        self.assertEqual(relay.corrupt_attestations, 1)
+        self.assertEqual(relay.health_events[0]["type"], "miner_attestation_corrupt")
+        self.assertEqual(relay.health_events[0]["magic"], "0xFFFFFFFF")
+        self.assertEqual(relay.health_events[0]["block_height"], 42)
+        self.assertEqual(len(relay.sent_frames), 1)
+        self.assertEqual(struct.unpack_from("<I", relay.sent_frames[0], 0)[0], ATTEST_MAGIC)
+        self.assertEqual(relay.sent_frames[0][5], PKT_TYPE_REATTEST)
+        self.assertEqual(struct.unpack_from("<I", relay.sent_frames[0], 8)[0], 42)
+
+    def test_parse_detects_zeroed_save_data(self):
+        relay = CapturingRelay()
+        result = relay.parse_attestation(b"\x00" * 104)
+
+        self.assertIsNone(result)
+        self.assertEqual(relay.corrupt_attestations, 1)
+        self.assertEqual(relay.health_events[0]["magic"], "0x00000000")
+        self.assertEqual(len(relay.sent_frames), 1)
 
     def test_parse_rejects_short(self):
         result = self.relay.parse_attestation(b"\x00\x01\x02")
@@ -119,6 +160,7 @@ class TestAttestationProtocol(unittest.TestCase):
     def test_packet_types(self):
         self.assertEqual(PKT_TYPE_ATTEST, 0)
         self.assertEqual(PKT_TYPE_EPOCH_ACK, 3)
+        self.assertEqual(PKT_TYPE_REATTEST, 4)
 
     def test_device_constants(self):
         self.assertEqual(DEVICE_ARCH, "mips_r4300")


### PR DESCRIPTION
## Summary
- detect erased/zeroed N64 cartridge save-data magic values instead of dropping them as generic invalid packets
- emit a `miner_attestation_corrupt` health event and log a WARN with last checkpoint/block-height context
- send a re-attest request frame and add the packet type to the N64 protocol header

Fixes #2722.
Also addresses duplicate #2723.

## Validation
- `/tmp/rustchain-5449-venv/bin/python -m pytest mining/n64-miner/test_host_relay.py -q`
- `/tmp/rustchain-5449-venv/bin/python -m py_compile mining/n64-miner/host_relay.py mining/n64-miner/test_host_relay.py`
- `/opt/homebrew/bin/git diff --check -- mining/n64-miner/host_relay.py mining/n64-miner/test_host_relay.py mining/n64-miner/n64_miner.h`
