### PR TITLE
Add JSON-RPC mining stats subscription

### DIFF
--- a/node/tests/test_websocket_feed_json_rpc.py
+++ b/node/tests/test_websocket_feed_json_rpc.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for JSON-RPC mining stats subscriptions."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from websocket_feed import WebSocketFeed
+
+
+def test_eth_subscribe_mining_stats_returns_subscription_and_stats():
+    feed = WebSocketFeed()
+    feed.update_state("miners", [{"hashrate": 12.5}, {"hashrate_hs": 30}])
+    feed.update_state("blocks", [{"height": 1}, {"height": 2}, {"height": 3}])
+    feed.update_state("transactions", [{"id": "a"}, {"id": "b"}])
+    feed.update_state("health", {"peers": 8})
+
+    response = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 1, "method": "eth_subscribe", "params": ["mining_stats", {}]},
+        client_id="client-1",
+    )
+
+    assert response["jsonrpc"] == "2.0"
+    assert response["id"] == 1
+    assert response["result"].startswith("mining_stats:client-1:")
+
+    stats = feed.get_mining_stats()
+    assert stats["hashrate"] == 42.5
+    assert stats["blocks_found"] == 3
+    assert stats["pending_tx"] == 2
+    assert stats["peers"] == 8
+    assert isinstance(stats["uptime_s"], int)
+
+
+def test_mining_stats_notification_matches_eth_subscription_shape():
+    feed = WebSocketFeed()
+    notification = feed.build_mining_stats_notification(
+        "mining_stats:client-1:1",
+        {"hashrate": 42.5, "blocks_found": 3, "pending_tx": 12, "peers": 8, "uptime_s": 86400},
+    )
+
+    assert notification == {
+        "jsonrpc": "2.0",
+        "method": "eth_subscription",
+        "params": {
+            "subscription": "mining_stats:client-1:1",
+            "result": {
+                "hashrate": 42.5,
+                "blocks_found": 3,
+                "pending_tx": 12,
+                "peers": 8,
+                "uptime_s": 86400,
+            },
+        },
+    }
+
+
+def test_json_rpc_rejects_unknown_method():
+    feed = WebSocketFeed()
+    response = feed.handle_json_rpc_message({"jsonrpc": "2.0", "id": 2, "method": "net_version"})
+
+    assert response["id"] == 2
+    assert response["error"]["code"] == -32601
+
+
+def test_json_rpc_rejects_unknown_subscription():
+    feed = WebSocketFeed()
+    response = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 3, "method": "eth_subscribe", "params": ["newHeads", {}]}
+    )
+
+    assert response["id"] == 3
+    assert response["error"]["code"] == -32602

--- a/node/tests/test_websocket_feed_json_rpc.py
+++ b/node/tests/test_websocket_feed_json_rpc.py
@@ -73,3 +73,55 @@ def test_json_rpc_rejects_unknown_subscription():
 
     assert response["id"] == 3
     assert response["error"]["code"] == -32602
+class FakeSocketIO:
+    def __init__(self):
+        self.emitted = []
+
+    def emit(self, event, payload, **kwargs):
+        self.emitted.append((event, payload, kwargs))
+
+
+def test_disconnect_cleanup_removes_stale_subscription_before_broadcast():
+    feed = WebSocketFeed()
+    response = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 4, "method": "eth_subscribe", "params": ["mining_stats", {}]},
+        client_id="client-1",
+    )
+    subscription_id = response["result"]
+
+    assert subscription_id in feed.json_rpc_subscriptions
+    assert feed.remove_json_rpc_subscriptions("client-1") == 1
+    assert subscription_id not in feed.json_rpc_subscriptions
+
+    fake_socketio = FakeSocketIO()
+    feed.socketio = fake_socketio
+    feed.broadcast_mining_stats()
+
+    assert [event for event, _, _ in fake_socketio.emitted] == ["mining_stats"]
+
+
+def test_eth_unsubscribe_removes_only_callers_subscription():
+    feed = WebSocketFeed()
+    own = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 5, "method": "eth_subscribe", "params": ["mining_stats", {}]},
+        client_id="client-1",
+    )["result"]
+    other = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 6, "method": "eth_subscribe", "params": ["mining_stats", {}]},
+        client_id="client-2",
+    )["result"]
+
+    rejected = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 7, "method": "eth_unsubscribe", "params": [other]},
+        client_id="client-1",
+    )
+    removed = feed.handle_json_rpc_message(
+        {"jsonrpc": "2.0", "id": 8, "method": "eth_unsubscribe", "params": [own]},
+        client_id="client-1",
+    )
+
+    assert rejected["result"] is False
+    assert removed["result"] is True
+    assert own not in feed.json_rpc_subscriptions
+    assert other in feed.json_rpc_subscriptions
+

--- a/node/tests/test_websocket_feed_json_rpc.py
+++ b/node/tests/test_websocket_feed_json_rpc.py
@@ -73,6 +73,8 @@ def test_json_rpc_rejects_unknown_subscription():
 
     assert response["id"] == 3
     assert response["error"]["code"] == -32602
+
+
 class FakeSocketIO:
     def __init__(self):
         self.emitted = []
@@ -102,10 +104,13 @@ def test_disconnect_cleanup_removes_stale_subscription_before_broadcast():
 
 def test_eth_unsubscribe_removes_only_callers_subscription():
     feed = WebSocketFeed()
-    own = feed.handle_json_rpc_message(
+    own_response = feed.handle_json_rpc_message(
         {"jsonrpc": "2.0", "id": 5, "method": "eth_subscribe", "params": ["mining_stats", {}]},
         client_id="client-1",
-    )["result"]
+    )
+    own = own_response["result"]
+    assert feed._mining_stats_notification_subscription_id(own_response) == own
+
     other = feed.handle_json_rpc_message(
         {"jsonrpc": "2.0", "id": 6, "method": "eth_subscribe", "params": ["mining_stats", {}]},
         client_id="client-2",
@@ -122,6 +127,6 @@ def test_eth_unsubscribe_removes_only_callers_subscription():
 
     assert rejected["result"] is False
     assert removed["result"] is True
+    assert feed._mining_stats_notification_subscription_id(removed) is None
     assert own not in feed.json_rpc_subscriptions
     assert other in feed.json_rpc_subscriptions
-

--- a/node/websocket_feed.py
+++ b/node/websocket_feed.py
@@ -44,6 +44,8 @@ WS_PORT = int(os.environ.get('WEBSOCKET_PORT', 8765))
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'http://localhost:8088')
 POLL_INTERVAL = float(os.environ.get('WS_POLL_INTERVAL', '3'))
 MAX_EVENTS = int(os.environ.get('WS_MAX_EVENTS', '100'))
+JSON_RPC_VERSION = '2.0'
+MINING_STATS_SUBSCRIPTION = 'mining_stats'
 
 
 @dataclass
@@ -105,6 +107,7 @@ class WebSocketFeed:
         self.block_history: deque = deque(maxlen=MAX_EVENTS)
         self.attestation_history: deque = deque(maxlen=MAX_EVENTS)
         self.settlement_history: deque = deque(maxlen=10)
+        self.started_at = time.time()
         
         # State
         self.state: Dict[str, Any] = {
@@ -124,6 +127,7 @@ class WebSocketFeed:
             'attestations_sent': 0,
             'settlements_sent': 0
         }
+        self.json_rpc_subscriptions: Dict[str, Dict[str, Any]] = {}
         
         # Lock for thread safety
         self._lock = threading.Lock()
@@ -248,6 +252,15 @@ class WebSocketFeed:
             with self._lock:
                 emit('metrics', dict(self.metrics))
 
+        @self.socketio.on('json_rpc')
+        def handle_json_rpc(data):
+            """Handle JSON-RPC requests over the existing WebSocket channel."""
+            client_id = request.sid if request else None
+            response = self.handle_json_rpc_message(data, client_id=client_id)
+            emit('json_rpc', response)
+            if isinstance(response, dict) and response.get('result'):
+                emit('json_rpc', self.build_mining_stats_notification(response['result']))
+
     def set_fetch_callbacks(self, fetch_blocks=None, fetch_miners=None, 
                             fetch_epoch=None, fetch_health=None):
         """Set custom callbacks for data fetching"""
@@ -267,6 +280,7 @@ class WebSocketFeed:
         
         self.socketio.emit('block', block.to_dict(), namespace='/')
         logger.info(f"[WebSocket] Broadcasted block #{block.height}")
+        self.broadcast_mining_stats()
 
     def broadcast_attestation(self, attestation: AttestationEvent):
         """Broadcast new attestation to all connected clients"""
@@ -302,6 +316,7 @@ class WebSocketFeed:
             self.state['last_update'] = time.time()
         
         self.socketio.emit('miner_update', {'miners': miners}, namespace='/')
+        self.broadcast_mining_stats()
 
     def broadcast_epoch_update(self, epoch: Dict):
         """Broadcast epoch update"""
@@ -313,6 +328,7 @@ class WebSocketFeed:
             self.state['last_update'] = time.time()
         
         self.socketio.emit('epoch_update', epoch, namespace='/')
+        self.broadcast_mining_stats()
 
     def broadcast_health_update(self, health: Dict):
         """Broadcast health status update"""
@@ -324,6 +340,7 @@ class WebSocketFeed:
             self.state['last_update'] = time.time()
         
         self.socketio.emit('health', health, namespace='/')
+        self.broadcast_mining_stats()
 
     def update_state(self, key: str, value: Any):
         """Update internal state"""
@@ -340,6 +357,135 @@ class WebSocketFeed:
         """Get current metrics"""
         with self._lock:
             return dict(self.metrics)
+
+    def handle_json_rpc_message(self, message: Dict, client_id: Optional[str] = None) -> Dict:
+        """Handle JSON-RPC subscription requests for mining stats."""
+        if not isinstance(message, dict):
+            return self._json_rpc_error(None, -32600, "Invalid Request")
+
+        request_id = message.get('id')
+        if message.get('method') != 'eth_subscribe':
+            return self._json_rpc_error(request_id, -32601, "Method not found")
+
+        params = message.get('params') or []
+        if not isinstance(params, list) or not params or params[0] != MINING_STATS_SUBSCRIPTION:
+            return self._json_rpc_error(request_id, -32602, "Expected params ['mining_stats', options]")
+
+        subscription_id = self._create_json_rpc_subscription(MINING_STATS_SUBSCRIPTION, client_id)
+        return {
+            'jsonrpc': JSON_RPC_VERSION,
+            'id': request_id,
+            'result': subscription_id
+        }
+
+    def _create_json_rpc_subscription(self, channel: str, client_id: Optional[str]) -> str:
+        with self._lock:
+            subscription_id = f"{channel}:{client_id or 'anonymous'}:{len(self.json_rpc_subscriptions) + 1}"
+            self.json_rpc_subscriptions[subscription_id] = {
+                'channel': channel,
+                'client_id': client_id,
+                'created_at': time.time()
+            }
+        return subscription_id
+
+    def build_mining_stats_notification(self, subscription_id: str, stats: Optional[Dict] = None) -> Dict:
+        """Build an Ethereum-style eth_subscription notification."""
+        return {
+            'jsonrpc': JSON_RPC_VERSION,
+            'method': 'eth_subscription',
+            'params': {
+                'subscription': subscription_id,
+                'result': stats or self.get_mining_stats()
+            }
+        }
+
+    def get_mining_stats(self) -> Dict:
+        """Return the compact stats payload expected by JSON-RPC subscribers."""
+        with self._lock:
+            miners = list(self.state.get('miners') or [])
+            blocks = list(self.state.get('blocks') or [])
+            transactions = list(self.state.get('transactions') or [])
+            health = dict(self.state.get('health') or {})
+            metrics = dict(self.metrics)
+            started_at = self.started_at
+
+        hashrate = self._sum_hashrate(miners)
+        if hashrate == 0:
+            hashrate = self._to_float(health.get('hashrate', health.get('hash_rate', 0)))
+
+        blocks_found = self._to_int(
+            health.get('blocks_found', health.get('block_count', len(blocks) or metrics.get('blocks_sent', 0)))
+        )
+        pending_tx = self._to_int(
+            health.get('pending_tx', health.get('pending_transactions', len(transactions)))
+        )
+
+        return {
+            'hashrate': hashrate,
+            'blocks_found': blocks_found,
+            'pending_tx': pending_tx,
+            'peers': self._peer_count(health),
+            'uptime_s': max(0, int(time.time() - started_at))
+        }
+
+    def broadcast_mining_stats(self) -> Dict:
+        """Broadcast mining stats through plain SocketIO and JSON-RPC streams."""
+        stats = self.get_mining_stats()
+        if not self.socketio:
+            return stats
+
+        self.socketio.emit('mining_stats', stats, namespace='/')
+        with self._lock:
+            subscriptions = list(self.json_rpc_subscriptions.items())
+
+        for subscription_id, subscription in subscriptions:
+            notification = self.build_mining_stats_notification(subscription_id, stats)
+            client_id = subscription.get('client_id')
+            if client_id:
+                self.socketio.emit('json_rpc', notification, to=client_id, namespace='/')
+            else:
+                self.socketio.emit('json_rpc', notification, namespace='/')
+
+        return stats
+
+    def _json_rpc_error(self, request_id: Any, code: int, message: str) -> Dict:
+        return {
+            'jsonrpc': JSON_RPC_VERSION,
+            'id': request_id,
+            'error': {
+                'code': code,
+                'message': message
+            }
+        }
+
+    def _sum_hashrate(self, miners: List[Dict]) -> float:
+        total = 0.0
+        for miner in miners:
+            if not isinstance(miner, dict):
+                continue
+            for key in ('hashrate', 'hash_rate', 'hashrate_hs', 'hashrate_hps'):
+                if key in miner:
+                    total += self._to_float(miner.get(key))
+                    break
+        return total
+
+    def _peer_count(self, health: Dict) -> int:
+        peers = health.get('peers', health.get('peer_count', health.get('connected_peers', 0)))
+        if isinstance(peers, list):
+            return len(peers)
+        return self._to_int(peers)
+
+    def _to_float(self, value: Any) -> float:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def _to_int(self, value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
 
     def run(self, host: str = '0.0.0.0', port: int = None, **kwargs):
         """Run the WebSocket server"""

--- a/node/websocket_feed.py
+++ b/node/websocket_feed.py
@@ -209,6 +209,10 @@ class WebSocketFeed:
                 self.metrics['active_connections'] = max(0, self.metrics['active_connections'] - 1)
             
             client_id = request.sid if request else 'unknown'
+            if client_id != 'unknown':
+                removed = self.remove_json_rpc_subscriptions(client_id)
+                if removed:
+                    logger.info(f"[WebSocket] Removed {removed} JSON-RPC subscription(s) for {client_id}")
             logger.info(f"[WebSocket] Client disconnected: {client_id}")
 
         @self.socketio.on('ping')
@@ -364,10 +368,22 @@ class WebSocketFeed:
             return self._json_rpc_error(None, -32600, "Invalid Request")
 
         request_id = message.get('id')
-        if message.get('method') != 'eth_subscribe':
+        method = message.get('method')
+        params = message.get('params') or []
+
+        if method == 'eth_unsubscribe':
+            if not isinstance(params, list) or not params:
+                return self._json_rpc_error(request_id, -32602, "Expected subscription id")
+            removed = self.remove_json_rpc_subscription(params[0], client_id=client_id)
+            return {
+                'jsonrpc': JSON_RPC_VERSION,
+                'id': request_id,
+                'result': removed
+            }
+
+        if method != 'eth_subscribe':
             return self._json_rpc_error(request_id, -32601, "Method not found")
 
-        params = message.get('params') or []
         if not isinstance(params, list) or not params or params[0] != MINING_STATS_SUBSCRIPTION:
             return self._json_rpc_error(request_id, -32602, "Expected params ['mining_stats', options]")
 
@@ -387,6 +403,29 @@ class WebSocketFeed:
                 'created_at': time.time()
             }
         return subscription_id
+
+    def remove_json_rpc_subscription(self, subscription_id: str, client_id: Optional[str] = None) -> bool:
+        """Remove one JSON-RPC subscription if it belongs to the caller."""
+        with self._lock:
+            subscription = self.json_rpc_subscriptions.get(subscription_id)
+            if not subscription:
+                return False
+            if client_id is not None and subscription.get('client_id') != client_id:
+                return False
+            del self.json_rpc_subscriptions[subscription_id]
+            return True
+
+    def remove_json_rpc_subscriptions(self, client_id: str) -> int:
+        """Remove all JSON-RPC subscriptions owned by a disconnected client."""
+        with self._lock:
+            stale_ids = [
+                subscription_id
+                for subscription_id, subscription in self.json_rpc_subscriptions.items()
+                if subscription.get('client_id') == client_id
+            ]
+            for subscription_id in stale_ids:
+                del self.json_rpc_subscriptions[subscription_id]
+            return len(stale_ids)
 
     def build_mining_stats_notification(self, subscription_id: str, stats: Optional[Dict] = None) -> Dict:
         """Build an Ethereum-style eth_subscription notification."""

--- a/node/websocket_feed.py
+++ b/node/websocket_feed.py
@@ -262,8 +262,9 @@ class WebSocketFeed:
             client_id = request.sid if request else None
             response = self.handle_json_rpc_message(data, client_id=client_id)
             emit('json_rpc', response)
-            if isinstance(response, dict) and response.get('result'):
-                emit('json_rpc', self.build_mining_stats_notification(response['result']))
+            subscription_id = self._mining_stats_notification_subscription_id(response)
+            if subscription_id:
+                emit('json_rpc', self.build_mining_stats_notification(subscription_id))
 
     def set_fetch_callbacks(self, fetch_blocks=None, fetch_miners=None, 
                             fetch_epoch=None, fetch_health=None):
@@ -402,6 +403,18 @@ class WebSocketFeed:
                 'client_id': client_id,
                 'created_at': time.time()
             }
+        return subscription_id
+
+    def _mining_stats_notification_subscription_id(self, response: Dict) -> Optional[str]:
+        if not isinstance(response, dict):
+            return None
+        subscription_id = response.get('result')
+        if not isinstance(subscription_id, str):
+            return None
+        with self._lock:
+            subscription = self.json_rpc_subscriptions.get(subscription_id)
+        if not subscription or subscription.get('channel') != MINING_STATS_SUBSCRIPTION:
+            return None
         return subscription_id
 
     def remove_json_rpc_subscription(self, subscription_id: str, client_id: Optional[str] = None) -> bool:


### PR DESCRIPTION
## Summary
- add an `eth_subscribe` JSON-RPC handler for `mining_stats` over the existing WebSocket feed
- stream Ethereum-style `eth_subscription` notifications with hashrate, blocks found, pending transaction count, peer count, and uptime
- add focused regression coverage for subscription responses, notification shape, and JSON-RPC errors

Fixes #2746.

## Validation
- `/tmp/rustchain-5449-venv/bin/python -m pytest node/tests/test_websocket_feed_json_rpc.py -q`
- `/tmp/rustchain-5449-venv/bin/python -m py_compile node/websocket_feed.py node/tests/test_websocket_feed_json_rpc.py`
- `/opt/homebrew/bin/git diff --cached --check -- node/websocket_feed.py node/tests/test_websocket_feed_json_rpc.py`
