### PR TITLE
Add fork choice visualizer

### DIFF
--- a/node/fork_choice_visualizer.py
+++ b/node/fork_choice_visualizer.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Fork-choice graph helpers and optional Flask endpoints."""
+
+from dataclasses import dataclass, asdict
+from typing import Callable, Dict, Iterable, List, Optional
+
+try:
+    from flask import Blueprint, jsonify, render_template_string
+    FLASK_AVAILABLE = True
+except ImportError:  # pragma: no cover - pure helper tests do not need Flask
+    Blueprint = None
+    jsonify = None
+    render_template_string = None
+    FLASK_AVAILABLE = False
+
+
+@dataclass(frozen=True)
+class ForkChoiceBlock:
+    block_hash: str
+    parent_hash: Optional[str]
+    height: int
+    weight: int = 1
+    timestamp: int = 0
+    miner: str = ""
+
+
+FORK_CHOICE_HTML = """
+<!doctype html>
+<html>
+<head>
+  <title>RustChain Fork Choice</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 24px; color: #111827; }
+    .metrics { display: flex; gap: 12px; margin-bottom: 20px; flex-wrap: wrap; }
+    .metric { border: 1px solid #d1d5db; border-radius: 6px; padding: 10px 12px; }
+    .metric strong { display: block; font-size: 20px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border-bottom: 1px solid #e5e7eb; padding: 8px; text-align: left; }
+    .canonical { color: #047857; font-weight: 700; }
+    .fork { color: #b45309; }
+  </style>
+</head>
+<body>
+  <h1>Fork Choice</h1>
+  <div class="metrics">
+    {% for key, value in graph.metrics.items() %}
+      <div class="metric"><span>{{ key }}</span><strong>{{ value }}</strong></div>
+    {% endfor %}
+  </div>
+  <table>
+    <thead><tr><th>Height</th><th>Hash</th><th>Parent</th><th>Weight</th><th>Status</th></tr></thead>
+    <tbody>
+    {% for node in graph.nodes %}
+      <tr class="{{ 'canonical' if node.is_canonical else 'fork' }}">
+        <td>{{ node.height }}</td>
+        <td>{{ node.id }}</td>
+        <td>{{ node.parent or '' }}</td>
+        <td>{{ node.weight }}</td>
+        <td>{{ 'canonical' if node.is_canonical else ('head' if node.is_head else 'side') }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</body>
+</html>
+"""
+
+
+def normalize_blocks(blocks: Iterable[Dict]) -> List[ForkChoiceBlock]:
+    """Normalize block rows from API/database shapes into visualizer blocks."""
+    normalized = []
+    for raw in blocks:
+        block_hash = raw.get("block_hash") or raw.get("hash") or raw.get("id")
+        if not block_hash:
+            continue
+        parent_hash = raw.get("parent_hash") or raw.get("prev_hash") or raw.get("previous_hash")
+        height = _to_int(raw.get("height", raw.get("block_height", 0)))
+        weight = _to_int(raw.get("weight", raw.get("total_difficulty", raw.get("work", 1))), default=1)
+        timestamp = _to_int(raw.get("timestamp", raw.get("ts", 0)))
+        normalized.append(ForkChoiceBlock(
+            block_hash=str(block_hash),
+            parent_hash=str(parent_hash) if parent_hash else None,
+            height=height,
+            weight=weight,
+            timestamp=timestamp,
+            miner=str(raw.get("miner", raw.get("miner_id", "")) or ""),
+        ))
+    return normalized
+
+
+def build_fork_choice_graph(blocks: Iterable[Dict]) -> Dict:
+    """Build graph, metrics, and canonical path data for fork-choice views."""
+    normalized = normalize_blocks(blocks)
+    by_hash = {block.block_hash: block for block in normalized}
+    children: Dict[str, List[str]] = {block.block_hash: [] for block in normalized}
+
+    for block in normalized:
+        if block.parent_hash in children:
+            children[block.parent_hash].append(block.block_hash)
+
+    heads = [
+        block for block in normalized
+        if not children.get(block.block_hash)
+    ]
+    canonical_head = _select_canonical_head(heads)
+    canonical_path = _canonical_path(canonical_head, by_hash)
+    canonical_hashes = set(canonical_path)
+
+    nodes = []
+    edges = []
+    for block in sorted(normalized, key=lambda item: (item.height, item.block_hash)):
+        child_hashes = sorted(children.get(block.block_hash, []))
+        nodes.append({
+            "id": block.block_hash,
+            "parent": block.parent_hash,
+            "height": block.height,
+            "weight": block.weight,
+            "timestamp": block.timestamp,
+            "miner": block.miner,
+            "children": child_hashes,
+            "is_head": block in heads,
+            "is_canonical": block.block_hash in canonical_hashes,
+        })
+        if block.parent_hash:
+            edges.append({"source": block.parent_hash, "target": block.block_hash})
+
+    fork_points = [block_hash for block_hash, child_hashes in children.items() if len(child_hashes) > 1]
+    canonical_height = canonical_head.height if canonical_head else 0
+
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "heads": [block.block_hash for block in sorted(heads, key=lambda item: item.block_hash)],
+        "canonical_head": canonical_head.block_hash if canonical_head else None,
+        "canonical_path": canonical_path,
+        "fork_points": sorted(fork_points),
+        "history": _fork_history(normalized, fork_points),
+        "metrics": {
+            "blocks": len(normalized),
+            "forks": len(fork_points),
+            "heads": len(heads),
+            "max_depth": max((block.height for block in normalized), default=0),
+            "canonical_height": canonical_height,
+        },
+    }
+
+
+def create_fork_choice_blueprint(block_provider: Callable[[], Iterable[Dict]]):
+    """Create dashboard and JSON endpoints for fork-choice visualization."""
+    if not FLASK_AVAILABLE:
+        raise RuntimeError("Flask is required for fork-choice routes")
+
+    blueprint = Blueprint("fork_choice_visualizer", __name__)
+
+    @blueprint.get("/fork-choice")
+    def fork_choice_dashboard():
+        graph = build_fork_choice_graph(block_provider())
+        return render_template_string(FORK_CHOICE_HTML, graph=_AttrDict(graph))
+
+    @blueprint.get("/api/fork-choice")
+    def fork_choice_api():
+        return jsonify(build_fork_choice_graph(block_provider()))
+
+    return blueprint
+
+
+def _select_canonical_head(heads: List[ForkChoiceBlock]) -> Optional[ForkChoiceBlock]:
+    if not heads:
+        return None
+    return max(heads, key=lambda block: (block.weight, block.height, block.timestamp, block.block_hash))
+
+
+def _canonical_path(head: Optional[ForkChoiceBlock], by_hash: Dict[str, ForkChoiceBlock]) -> List[str]:
+    path = []
+    current = head
+    while current:
+        path.append(current.block_hash)
+        current = by_hash.get(current.parent_hash) if current.parent_hash else None
+    return list(reversed(path))
+
+
+def _fork_history(blocks: List[ForkChoiceBlock], fork_points: List[str]) -> List[Dict]:
+    by_hash = {block.block_hash: block for block in blocks}
+    history = []
+    for block_hash in fork_points:
+        block = by_hash.get(block_hash)
+        if block:
+            history.append(asdict(block))
+    return sorted(history, key=lambda item: (item["height"], item["block_hash"]))
+
+
+def _to_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class _AttrDict(dict):
+    def __getattr__(self, item):
+        value = self[item]
+        if isinstance(value, dict):
+            return _AttrDict(value)
+        return value

--- a/node/fork_choice_visualizer.py
+++ b/node/fork_choice_visualizer.py
@@ -122,7 +122,7 @@ def build_fork_choice_graph(blocks: Iterable[Dict]) -> Dict:
             "is_head": block in heads,
             "is_canonical": block.block_hash in canonical_hashes,
         })
-        if block.parent_hash:
+        if block.parent_hash in by_hash:
             edges.append({"source": block.parent_hash, "target": block.block_hash})
 
     fork_points = [block_hash for block_hash, child_hashes in children.items() if len(child_hashes) > 1]

--- a/node/tests/test_fork_choice_visualizer.py
+++ b/node/tests/test_fork_choice_visualizer.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for fork-choice graph visualization helpers."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from fork_choice_visualizer import build_fork_choice_graph, normalize_blocks
+
+
+def test_build_graph_marks_weighted_canonical_path():
+    graph = build_fork_choice_graph([
+        {"hash": "genesis", "height": 0, "weight": 1},
+        {"hash": "a1", "parent_hash": "genesis", "height": 1, "weight": 10},
+        {"hash": "a2", "parent_hash": "a1", "height": 2, "weight": 20},
+        {"hash": "b1", "parent_hash": "genesis", "height": 1, "weight": 30},
+    ])
+
+    assert graph["canonical_head"] == "b1"
+    assert graph["metrics"] == {
+        "blocks": 4,
+        "forks": 1,
+        "heads": 2,
+        "max_depth": 2,
+        "canonical_height": 1,
+    }
+
+    canonical = {node["id"] for node in graph["nodes"] if node["is_canonical"]}
+    assert canonical == {"genesis", "b1"}
+    assert graph["fork_points"] == ["genesis"]
+
+
+def test_normalize_blocks_accepts_api_aliases():
+    blocks = normalize_blocks([
+        {
+            "block_hash": "h1",
+            "prev_hash": "h0",
+            "block_height": "7",
+            "total_difficulty": "11",
+            "ts": "1234",
+            "miner_id": "miner-a",
+        }
+    ])
+
+    assert blocks[0].block_hash == "h1"
+    assert blocks[0].parent_hash == "h0"
+    assert blocks[0].height == 7
+    assert blocks[0].weight == 11
+    assert blocks[0].timestamp == 1234
+    assert blocks[0].miner == "miner-a"
+
+
+def test_graph_edges_and_heads_are_stable():
+    graph = build_fork_choice_graph([
+        {"hash": "a", "height": 0},
+        {"hash": "c", "parent_hash": "b", "height": 2},
+        {"hash": "b", "parent_hash": "a", "height": 1},
+    ])
+
+    assert graph["heads"] == ["c"]
+    assert graph["edges"] == [
+        {"source": "a", "target": "b"},
+        {"source": "b", "target": "c"},
+    ]
+    assert [node["id"] for node in graph["nodes"]] == ["a", "b", "c"]

--- a/node/tests/test_fork_choice_visualizer.py
+++ b/node/tests/test_fork_choice_visualizer.py
@@ -65,3 +65,14 @@ def test_graph_edges_and_heads_are_stable():
         {"source": "b", "target": "c"},
     ]
     assert [node["id"] for node in graph["nodes"]] == ["a", "b", "c"]
+
+
+def test_graph_suppresses_edges_to_missing_windowed_parents():
+    graph = build_fork_choice_graph([
+        {"hash": "child", "parent_hash": "missing-parent", "height": 10},
+    ])
+
+    assert graph["nodes"][0]["id"] == "child"
+    assert graph["nodes"][0]["parent"] == "missing-parent"
+    assert graph["edges"] == []
+    assert graph["heads"] == ["child"]


### PR DESCRIPTION
## Summary
- add fork-choice graph helpers that derive nodes, edges, heads, fork points, canonical path, metrics, and history from block rows
- add optional Flask dashboard and `/api/fork-choice` endpoints using a caller-provided block source
- add regression tests for weighted canonical-head selection, API field aliases, stable heads, and edge ordering

Fixes #2570.

## Validation
- `/tmp/rustchain-5449-venv/bin/python -m pytest node/tests/test_fork_choice_visualizer.py -q`
- `/tmp/rustchain-5449-venv/bin/python -m py_compile node/fork_choice_visualizer.py node/tests/test_fork_choice_visualizer.py`
- `/opt/homebrew/bin/git diff --cached --check -- node/fork_choice_visualizer.py node/tests/test_fork_choice_visualizer.py`
