### PR TITLE
docs: clarify Windows dry-run guidance

### DIFF
--- a/README_ES.md
+++ b/README_ES.md
@@ -227,6 +227,8 @@ bash install-miner.sh --wallet TU_BILLETERA
 bash install-miner.sh --dry-run --wallet TU_BILLETERA
 ```
 
+Nota para Windows: `install-miner.sh --dry-run` es una ruta de vista previa para Linux/macOS/WSL. En Windows nativo, usa la guía de Windows o ejecuta la prueba dentro de WSL para evitar el error de plataforma no compatible.
+
 ## 💰 Tablero de Bounties
 
 ¡Gana **RTC** contribuyendo al ecosistema RustChain!
@@ -480,6 +482,7 @@ clawrtc mine --dry-run
 ```
 
 Esperado: las 6 verificaciones de huella digital de hardware se ejecutan en ARM64 nativo sin errores de fallback de arquitectura.
+Nota: esta ruta de `clawrtc mine --dry-run` está pensada para Linux/macOS/WSL, no para Windows nativo.
 
 ---
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -229,6 +229,8 @@ bash install-miner.sh --wallet YOUR_WALLET_NAME
 bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```
 
+Windows向け注記: `install-miner.sh --dry-run` は Linux/macOS/WSL 用のプレビュー手順です。ネイティブ Windows では Windows 向けガイドを使うか、WSL 内で実行してください。
+
 ## 💰 バウンティボード
 
 RustChainエコシステムへの貢献で**RTC**を獲得！
@@ -473,3 +475,4 @@ clawrtc mine --dry-run
 ```
 
 期待される動作：6つすべてのハードウェアフィンガープリントチェックが、アーキテクチャフォールバックエラーなしでネイティブARM64で実行されます。
+注: この `clawrtc mine --dry-run` の確認手順は Linux/macOS/WSL 向けであり、ネイティブ Windows 向けではありません。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -209,6 +209,8 @@ bash install-miner.sh --wallet YOUR_WALLET_NAME
 bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```
 
+注意：`install-miner.sh --dry-run` 是 Linux/macOS/WSL 预览路径。原生 Windows 用户应使用 Windows 矿工说明，或在 WSL 中运行该 dry-run，避免遇到不支持平台的报错。
+
 ## 💰 悬赏板
 
 通过为 RustChain 生态系统做贡献来赚取 **RTC**！


### PR DESCRIPTION
Fixes #5217.

## Summary
- clarify the localized README dry-run snippets so Windows users do not follow the Linux/macOS/WSL-only `install-miner.sh --dry-run` path on native Windows
- add the same boundary to the Spanish and Japanese `clawrtc mine --dry-run` quick checks
- keep this scoped to docs only; this complements #5351, which updates FAQ and migration-guide pages but leaves these README entrypoints unchanged

## Duplicate/collision check
- #5268 was closed by maintainers as too broad/destructive for #5217.
- #5351 is open and scoped to `docs/FAQ.md` plus `docs/UPGRADE_MIGRATION_GUIDE.md`.
- This PR touches only `README_ES.md`, `README_JA.md`, and `docs/zh-CN/README.md`, covering separate user-facing paths that still pointed native Windows users at the confusing dry-run commands.

## Validation
- `git diff --check -- README_ES.md README_JA.md docs/zh-CN/README.md`
- `python tools/bcos_spdx_check.py --base-ref origin/main`