### PR TITLE
Add bridge live health aggregation

### DIFF
--- a/bridge/dashboard_api.py
+++ b/bridge/dashboard_api.py
@@ -22,6 +22,7 @@ from bridge.bridge_api import get_db, _amount_from_base, STATE_COMPLETE
 
 # ─── Config ──────────────────────────────────────────────────────────────────
 DASHBOARD_DB_PATH = os.environ.get("DASHBOARD_DB_PATH", "bridge_ledger.db")
+BRIDGE_HEALTH_LOG_PATH = os.environ.get("BRIDGE_HEALTH_LOG_PATH", "data/bridge_health.jsonl")
 SOLANA_RPC_URL = os.environ.get(
     "SOLANA_RPC_URL",
     "https://api.mainnet-beta.solana.com"
@@ -223,6 +224,31 @@ def get_bridge_health():
     })
 
 
+@dashboard_bp.route("/live", methods=["GET"])
+def get_live_bridge_health():
+    """
+    Get live bridge operations data from structured bridge health logs.
+
+    Returns:
+    {
+        "bridge_status": "ACTIVE" | "DEGRADED" | "OFFLINE",
+        "pending_txs": int,
+        "last_finalized_height": int,
+        "solana_slot_diff": int,
+        "alerts": [...],
+        "analytics": {...}
+    }
+    """
+    limit = request.args.get("limit", 500)
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 5000))
+
+    return jsonify(build_live_bridge_health(BRIDGE_HEALTH_LOG_PATH, limit=limit))
+
+
 @dashboard_bp.route("/transactions", methods=["GET"])
 def get_dashboard_transactions():
     """
@@ -324,6 +350,165 @@ def get_dashboard_transactions():
         "unwrap_count": unwrap_count,
         "total_volume_24h": round(total_volume_24h, 2),
     })
+
+
+# ─── Live Bridge Health Aggregation ───────────────────────────────────────────
+
+def build_live_bridge_health(path: str, limit: int = 500, now: int = None) -> dict:
+    """Aggregate bridge health JSONL into dashboard status, alerts, and analytics."""
+    now = int(time.time()) if now is None else int(now)
+    events = _read_bridge_health_events(path, limit=limit)
+    if not events:
+        return {
+            "bridge_status": "OFFLINE",
+            "pending_txs": 0,
+            "last_finalized_height": 0,
+            "solana_slot_diff": 0,
+            "alerts": [{"type": "no_health_events", "severity": "critical"}],
+            "analytics": {
+                "uptime_24h_pct": 0.0,
+                "uptime_7d_pct": 0.0,
+                "avg_settlement_time_s": 0.0,
+                "failed_tx_breakdown": {},
+            },
+            "last_event_ts": None,
+            "sample_count": 0,
+        }
+
+    latest = events[-1]
+    pending_txs = _to_int(latest.get("pending_txs", latest.get("pending_transactions", 0)))
+    last_finalized_height = _to_int(latest.get("last_finalized_height", latest.get("height", 0)))
+    solana_slot_diff = _to_int(latest.get("solana_slot_diff", latest.get("slot_diff", 0)))
+    latest_ts = _event_ts(latest)
+    alerts = _bridge_alerts(events, pending_txs, solana_slot_diff, now)
+    bridge_status = _derive_bridge_status(latest, latest_ts, alerts, now)
+
+    return {
+        "bridge_status": bridge_status,
+        "pending_txs": pending_txs,
+        "last_finalized_height": last_finalized_height,
+        "solana_slot_diff": solana_slot_diff,
+        "alerts": alerts,
+        "analytics": {
+            "uptime_24h_pct": _uptime_pct(events, now - 86400),
+            "uptime_7d_pct": _uptime_pct(events, now - 604800),
+            "avg_settlement_time_s": _avg_settlement_time(events),
+            "failed_tx_breakdown": _failed_tx_breakdown(events),
+        },
+        "last_event_ts": latest_ts,
+        "sample_count": len(events),
+    }
+
+
+def _read_bridge_health_events(path: str, limit: int = 500) -> list:
+    events = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    events.append(event)
+    except FileNotFoundError:
+        return []
+
+    return events[-limit:]
+
+
+def _bridge_alerts(events: list, pending_txs: int, solana_slot_diff: int, now: int) -> list:
+    alerts = []
+    pending_streak_start = None
+    for event in reversed(events):
+        if _to_int(event.get("pending_txs", event.get("pending_transactions", 0))) > 50:
+            pending_streak_start = _event_ts(event)
+        else:
+            break
+
+    if pending_txs > 50 and pending_streak_start and now - pending_streak_start >= 300:
+        alerts.append({
+            "type": "pending_txs_high",
+            "severity": "warning",
+            "value": pending_txs,
+            "threshold": 50,
+            "duration_s": now - pending_streak_start,
+        })
+
+    if solana_slot_diff > 1000:
+        alerts.append({
+            "type": "solana_slot_lag",
+            "severity": "critical",
+            "value": solana_slot_diff,
+            "threshold": 1000,
+        })
+
+    return alerts
+
+
+def _derive_bridge_status(latest: dict, latest_ts: int, alerts: list, now: int) -> str:
+    explicit = str(latest.get("bridge_status", latest.get("status", ""))).upper()
+    if explicit in {"ACTIVE", "DEGRADED", "OFFLINE"}:
+        return explicit
+    if latest_ts is None or now - latest_ts > 300:
+        return "OFFLINE"
+    if alerts:
+        return "DEGRADED"
+    return "ACTIVE"
+
+
+def _uptime_pct(events: list, since_ts: int) -> float:
+    window = [event for event in events if (_event_ts(event) or 0) >= since_ts]
+    if not window:
+        return 0.0
+    active = sum(1 for event in window if str(event.get("bridge_status", event.get("status", "ACTIVE"))).upper() == "ACTIVE")
+    return round(active / len(window) * 100, 2)
+
+
+def _avg_settlement_time(events: list) -> float:
+    values = [
+        _to_float(event.get("settlement_time_s", event.get("settlement_seconds")))
+        for event in events
+        if event.get("settlement_time_s", event.get("settlement_seconds")) is not None
+    ]
+    if not values:
+        return 0.0
+    return round(sum(values) / len(values), 2)
+
+
+def _failed_tx_breakdown(events: list) -> dict:
+    breakdown = {}
+    for event in events:
+        reason = event.get("failed_reason") or event.get("reason_code")
+        if not reason:
+            continue
+        breakdown[str(reason)] = breakdown.get(str(reason), 0) + 1
+    return breakdown
+
+
+def _event_ts(event: dict):
+    ts = event.get("ts", event.get("timestamp", event.get("time")))
+    try:
+        return int(ts)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_float(value, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
 
 
 @dashboard_bp.route("/price", methods=["GET"])

--- a/bridge/dashboard_api.py
+++ b/bridge/dashboard_api.py
@@ -450,11 +450,11 @@ def _bridge_alerts(events: list, pending_txs: int, solana_slot_diff: int, now: i
 
 
 def _derive_bridge_status(latest: dict, latest_ts: int, alerts: list, now: int) -> str:
+    if latest_ts is None or now - latest_ts > 300:
+        return "OFFLINE"
     explicit = str(latest.get("bridge_status", latest.get("status", ""))).upper()
     if explicit in {"ACTIVE", "DEGRADED", "OFFLINE"}:
         return explicit
-    if latest_ts is None or now - latest_ts > 300:
-        return "OFFLINE"
     if alerts:
         return "DEGRADED"
     return "ACTIVE"

--- a/bridge/test_dashboard_api.py
+++ b/bridge/test_dashboard_api.py
@@ -23,7 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from flask import Flask
 from bridge.bridge_api import register_bridge_routes, init_bridge_db, get_db, _amount_to_base, STATE_COMPLETE
-from bridge.dashboard_api import register_dashboard_routes
+from bridge.dashboard_api import build_live_bridge_health, register_dashboard_routes
 
 
 @pytest.fixture
@@ -185,6 +185,43 @@ class TestBridgeHealth:
         
         now = int(time.time())
         assert abs(data['last_checked'] - now) < 5  # Within 5 seconds
+
+
+class TestLiveBridgeHealth:
+    """Test bridge health JSONL aggregation for real-time dashboard data."""
+
+    def test_live_bridge_health_missing_log_is_offline(self, tmp_path):
+        result = build_live_bridge_health(str(tmp_path / "missing.jsonl"), now=1000)
+
+        assert result["bridge_status"] == "OFFLINE"
+        assert result["alerts"][0]["type"] == "no_health_events"
+        assert result["sample_count"] == 0
+
+    def test_live_bridge_health_aggregates_status_alerts_and_analytics(self, tmp_path):
+        health_log = tmp_path / "bridge_health.jsonl"
+        events = [
+            {"ts": 1000, "bridge_status": "ACTIVE", "pending_txs": 10, "solana_slot_diff": 100, "settlement_time_s": 20},
+            {"ts": 1300, "bridge_status": "ACTIVE", "pending_txs": 55, "solana_slot_diff": 120, "settlement_time_s": 40},
+            {"ts": 1700, "bridge_status": "DEGRADED", "pending_txs": 60, "solana_slot_diff": 1200, "failed_reason": "solana_timeout"},
+        ]
+        health_log.write_text("\n".join(json.dumps(event) for event in events), encoding="utf-8")
+
+        result = build_live_bridge_health(str(health_log), now=1800)
+
+        assert result["bridge_status"] == "DEGRADED"
+        assert result["pending_txs"] == 60
+        assert result["solana_slot_diff"] == 1200
+        assert {alert["type"] for alert in result["alerts"]} == {"pending_txs_high", "solana_slot_lag"}
+        assert result["analytics"]["uptime_24h_pct"] == 66.67
+        assert result["analytics"]["avg_settlement_time_s"] == 30.0
+        assert result["analytics"]["failed_tx_breakdown"] == {"solana_timeout": 1}
+
+    def test_live_bridge_endpoint_rejects_bad_limit(self, client):
+        response = client.get('/bridge/dashboard/live?limit=abc')
+
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data["error"] == "limit must be an integer"
 
 
 class TestDashboardTransactions:

--- a/bridge/test_dashboard_api.py
+++ b/bridge/test_dashboard_api.py
@@ -216,6 +216,23 @@ class TestLiveBridgeHealth:
         assert result["analytics"]["avg_settlement_time_s"] == 30.0
         assert result["analytics"]["failed_tx_breakdown"] == {"solana_timeout": 1}
 
+    def test_live_bridge_health_stale_active_sample_is_offline(self, tmp_path):
+        health_log = tmp_path / "bridge_health.jsonl"
+        health_log.write_text(
+            json.dumps({
+                "ts": 1000,
+                "bridge_status": "ACTIVE",
+                "pending_txs": 0,
+                "solana_slot_diff": 0,
+            }) + "\n",
+            encoding="utf-8",
+        )
+
+        result = build_live_bridge_health(str(health_log), now=1400)
+
+        assert result["bridge_status"] == "OFFLINE"
+        assert result["last_event_ts"] == 1000
+
     def test_live_bridge_endpoint_rejects_bad_limit(self, client):
         response = client.get('/bridge/dashboard/live?limit=abc')
 


### PR DESCRIPTION
## Summary
- Add `/bridge/dashboard/live` for live bridge status from `data/bridge_health.jsonl`.
- Aggregate pending transaction count, last finalized height, Solana slot lag, uptime, settlement timing, and failed transaction reasons.
- Add alert rules for pending transaction backlog and Solana slot lag, plus regression tests for missing logs, degraded status, bad query limits, and stale health samples.

## Issue

Refs #2724. This is the backend/API live-health slice; it intentionally does not claim to close the full dashboard WebSocket panel, Telegram degradation notification, or historical analytics integration scope.

## Validation
- `/tmp/rustchain-5449-venv/bin/python -m pytest bridge/test_dashboard_api.py::TestLiveBridgeHealth -q`
- `/tmp/rustchain-5449-venv/bin/python -m py_compile bridge/dashboard_api.py bridge/test_dashboard_api.py`
- `/opt/homebrew/bin/git diff --check -- bridge/dashboard_api.py bridge/test_dashboard_api.py`