### PR TITLE
fix: update Linux miner artifact SHA

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## Summary

- update the pinned Linux miner SHA-256 in `setup_miner.py`
- keep the existing artifact pinning regression as coverage

Fixes #5466.

## Validation

- `python -m pytest tests/test_setup_miner_downloads.py::test_setup_miner_pins_current_miner_artifacts -q`
- `python -m py_compile setup_miner.py tests/test_setup_miner_downloads.py`
- `git diff --check -- setup_miner.py tests/test_setup_miner_downloads.py`

RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
