### PR TITLE
docs: align root README license references

### DIFF
--- a/DOCKER_DEPLOYMENT.md
+++ b/DOCKER_DEPLOYMENT.md
@@ -348,4 +348,4 @@ sudo iptables-save | sudo tee /etc/iptables/rules.v4
 
 ## License
 
-MIT License - See LICENSE file for details
+Apache License 2.0 - See LICENSE file for details

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 **所有硬件都会变老。这只是时间问题。**
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
 [![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
@@ -273,7 +273,7 @@ clawrtc mine --wallet=你的钱包地址
 
 ## 许可证
 
-MIT License - 查看 [LICENSE](LICENSE) 了解详情。
+Apache License 2.0 - 查看 [LICENSE](LICENSE) 了解详情。
 
 ---
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -123,7 +123,7 @@ Belohnungsfaktor = f(Produktionsdatum, Nachweis der Nutzung)
 
 ## 📜 Lizenz
 
-MIT Lizenz – siehe [LICENSE](LICENSE)
+Apache License 2.0 – siehe [LICENSE](LICENSE)
 
 ---
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -2,7 +2,7 @@
 
 # 🧱 RustChain: Proof-of-Antiquity Blockchain
 
-[![Lizenz](https://img.shields.io/badge/Lizenz-MIT-blue.svg)](LICENSE)
+[![Lizenz](https://img.shields.io/badge/Lizenz-Apache_2.0-blue.svg)](LICENSE)
 [![PowerPC](https://img.shields.io/badge/PowerPC-G3%2FG4%2FG5-orange)](https://github.com/Scottcjn/Rustchain)
 [![Blockchain](https://img.shields.io/badge/Konsens-Proof--of--Antiquity-green)](https://github.com/Scottcjn/Rustchain)
 [![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://python.org)

--- a/README_ES.md
+++ b/README_ES.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: Blockchain Proof-of-Antiquity
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)

--- a/README_ES.md
+++ b/README_ES.md
@@ -454,7 +454,7 @@ https://github.com/Scottcjn/Rustchain
 
 ## 📜 Licencia
 
-Licencia MIT - Libre de usar, pero por favor mantén el aviso de copyright y atribución.
+Licencia Apache 2.0 - Libre de usar, pero cumple los términos de Apache 2.0 y conserva el aviso de copyright y atribución.
 
 ---
 

--- a/README_HI.md
+++ b/README_HI.md
@@ -5,7 +5,7 @@
 > **हिंदी अनुवाद संस्करण** | [English Version](README.md)
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)

--- a/README_JA.md
+++ b/README_JA.md
@@ -5,7 +5,7 @@
 > **日本語翻訳版** | [English Version](README.md)
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)

--- a/README_JA.md
+++ b/README_JA.md
@@ -447,7 +447,7 @@ https://github.com/Scottcjn/Rustchain
 
 ## 📜 ライセンス
 
-MITライセンス - 自由に使用できますが、著作権表示と帰属を保持してください。
+Apache License 2.0 - 自由に使用できますが、Apache License 2.0 の条項を遵守し、著作権表示と帰属を保持してください。
 
 ---
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: Блокчейн с консенсусом Proof-of-Antiquity
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 
 **Первый блокчейн, который вознаграждает ретро-железо за возраст, а не за скорость.**

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -2,7 +2,7 @@
 
 # 🧱 RustChain：古董證明區塊鏈
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PowerPC](https://img.shields.io/badge/PowerPC-G3%2FG4%2FG5-orange)](https://github.com/Scottcjn/Rustchain)
 [![Blockchain](https://img.shields.io/badge/Consensus-Proof--of--Antiquity-green)](https://github.com/Scottcjn/Rustchain)
 [![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://python.org)

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -333,7 +333,7 @@ https://github.com/Scottcjn/Rustchain
 
 ## 📜 授權條款
 
-MIT 授權條款 - 可自由使用，但請保留版權聲明與出處。
+Apache License 2.0 - 可自由使用，但請遵守 Apache License 2.0 條款並保留版權聲明與署名。
 
 ---
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,7 +2,7 @@
 
 # 🧱 RustChain：古董证明区块链
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![PowerPC](https://img.shields.io/badge/PowerPC-G3%2FG4%2FG5-orange)](https://github.com/Scottcjn/Rustchain)
 [![Blockchain](https://img.shields.io/badge/Consensus-Proof--of--Antiquity-green)](https://github.com/Scottcjn/Rustchain)
 [![Python](https://img.shields.io/badge/Python-3.x-yellow)](https://python.org)
@@ -387,7 +387,7 @@ https://github.com/Scottcjn/Rustchain
 
 ## 📜 许可证
 
-MIT许可证 - 可免费使用，但请保留版权声明和署名。
+Apache License 2.0 - 可免费使用，但请遵守 Apache License 2.0 条款并保留版权声明和署名。
 
 ---
 


### PR DESCRIPTION
## Summary
- Align remaining root-facing README/deployment license references with the repository root Apache License 2.0 license.
- Update the MIT badges in the top-level translated READMEs to the Apache 2.0 badge.
- Update the top-level Chinese/German/deployment license text that still pointed readers to MIT.

## Scope note
This intentionally avoids SDKs, tools, examples, and bundled subprojects that may have their own MIT licensing. It covers the root README/deployment files called out during review of PR #5492 and does not touch that PR's `docs/**` files.

## Validation
- Root `LICENSE` begins with Apache License Version 2.0.
- `rg -n "MIT License|MIT ???|MIT Lizenz|MIT???|License-MIT|License: MIT" DOCKER_DEPLOYMENT.md README.zh-CN.md README_DE.md README_ES.md README_HI.md README_JA.md README_RU.md README_ZH-TW.md README_ZH.md` returns no matches.
- `rg -n "Apache License 2\.0|License-Apache_2\.0" DOCKER_DEPLOYMENT.md README.zh-CN.md README_DE.md README_ES.md README_HI.md README_JA.md README_RU.md README_ZH-TW.md README_ZH.md` shows the corrected references.
- `git diff --check -- DOCKER_DEPLOYMENT.md README.zh-CN.md README_DE.md README_ES.md README_HI.md README_JA.md README_RU.md README_ZH-TW.md README_ZH.md`

Related to #2754.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7
