### PR TITLE
fix: log Windows headless miner lifecycle

### DIFF
--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,7 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
-set "MINER_SHA256=51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662"
+set "MINER_SHA256=230f6405a03b4e455a3e2a9097d4796acec82237512a1e56e11d9855060cf5da"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -254,6 +254,7 @@ class RustChainMiner:
                     time.sleep(10)
                     continue
 
+                self._emit_ready_status(callback)
                 eligible = self.check_eligibility()
                 if eligible:
                     header = self.generate_header()
@@ -283,14 +284,39 @@ class RustChainMiner:
                 if callback:
                     callback({"type": "error", "message": "Attestation failed"})
                 return False
+            if callback:
+                callback({
+                    "type": "attest",
+                    "message": "Attestation submitted",
+                    "miner_id": self.miner_id,
+                    "attestation_ttl_seconds": max(0, int(self.attestation_valid_until - time.time())),
+                })
 
         if (now - self.last_enroll) > 3600 or not self.enrolled:
             if not self.enroll():
                 if callback:
                     callback({"type": "error", "message": "Epoch enrollment failed"})
                 return False
+            if callback:
+                callback({
+                    "type": "enroll",
+                    "message": "Epoch enrollment succeeded",
+                    "miner_id": self.miner_id,
+                    "last_enroll": int(self.last_enroll),
+                })
 
         return True
+
+    def _emit_ready_status(self, callback):
+        if not callback:
+            return
+        callback({
+            "type": "status",
+            "message": "Miner ready",
+            "miner_id": self.miner_id,
+            "enrolled": self.enrolled,
+            "attestation_ttl_seconds": max(0, int(self.attestation_valid_until - time.time())),
+        })
 
     def _get_mac_addresses(self):
         macs = set()
@@ -579,6 +605,35 @@ class RustChainGUI:
         self.root.mainloop()
 
 
+def _format_headless_event(evt):
+    t = evt.get("type")
+    if t == "share":
+        ok = "OK" if evt.get("success") else "FAIL"
+        return (
+            f"[share] submitted={evt.get('submitted')} "
+            f"accepted={evt.get('accepted')} {ok}"
+        )
+    if t == "attest":
+        return (
+            f"[attest] {evt.get('message')} "
+            f"miner_id={evt.get('miner_id')} "
+            f"ttl={evt.get('attestation_ttl_seconds')}s"
+        )
+    if t == "enroll":
+        return f"[enroll] {evt.get('message')} miner_id={evt.get('miner_id')}"
+    if t == "status":
+        enrolled = "yes" if evt.get("enrolled") else "no"
+        return (
+            f"[status] {evt.get('message')} "
+            f"miner_id={evt.get('miner_id')} "
+            f"enrolled={enrolled} "
+            f"attest_ttl={evt.get('attestation_ttl_seconds')}s"
+        )
+    if t == "error":
+        return f"[error] {evt.get('message')}"
+    return None
+
+
 def run_headless(wallet_address: str, node_url: str) -> int:
     wallet = RustChainWallet()
     if wallet_address:
@@ -588,16 +643,13 @@ def run_headless(wallet_address: str, node_url: str) -> int:
     miner.node_url = node_url
 
     def cb(evt):
-        t = evt.get("type")
-        if t == "share":
-            ok = "OK" if evt.get("success") else "FAIL"
-            print(
-                f"[share] submitted={evt.get('submitted')} "
-                f"accepted={evt.get('accepted')} {ok}",
-                flush=True
-            )
-        elif t == "error":
-            print(f"[error] {evt.get('message')}", file=sys.stderr, flush=True)
+        line = _format_headless_event(evt)
+        if not line:
+            return
+        if evt.get("type") == "error":
+            print(line, file=sys.stderr, flush=True)
+        else:
+            print(line, flush=True)
 
     print("RustChain Windows miner: headless mode", flush=True)
     print(f"node={miner.node_url} miner_id={miner.miner_id}", flush=True)

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -27,7 +27,7 @@ MINER_ARTIFACTS = {
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",
-        "sha256": "51fe431cbee3c5b81218a738c221d45e675dafa5d67f9aff716d4ea11f304662",
+        "sha256": "230f6405a03b4e455a3e2a9097d4796acec82237512a1e56e11d9855060cf5da",
     },
 }
 

--- a/tests/test_windows_headless_lifecycle_logging.py
+++ b/tests/test_windows_headless_lifecycle_logging.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MINER_PATH = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+
+
+def _load_windows_miner():
+    spec = importlib.util.spec_from_file_location("windows_miner_under_test", MINER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ensure_ready_emits_attest_and_enroll_success_events(monkeypatch):
+    module = _load_windows_miner()
+    miner = module.RustChainMiner("RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7")
+    events = []
+
+    def fake_attest():
+        miner.attestation_valid_until = time.time() + 580
+        return True
+
+    def fake_enroll():
+        miner.enrolled = True
+        miner.last_enroll = time.time()
+        return True
+
+    monkeypatch.setattr(miner, "attest", fake_attest)
+    monkeypatch.setattr(miner, "enroll", fake_enroll)
+
+    assert miner._ensure_ready(events.append)
+    assert [event["type"] for event in events] == ["attest", "enroll"]
+    assert events[0]["message"] == "Attestation submitted"
+    assert events[0]["miner_id"] == miner.miner_id
+    assert events[0]["attestation_ttl_seconds"] > 0
+    assert events[1]["message"] == "Epoch enrollment succeeded"
+    assert events[1]["miner_id"] == miner.miner_id
+
+
+def test_ready_status_and_headless_format_include_lifecycle_details():
+    module = _load_windows_miner()
+    miner = module.RustChainMiner("RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7")
+    miner.enrolled = True
+    miner.attestation_valid_until = time.time() + 60
+    events = []
+
+    miner._emit_ready_status(events.append)
+
+    assert events[0]["type"] == "status"
+    assert events[0]["enrolled"] is True
+    assert "Miner ready" in module._format_headless_event(events[0])
+    assert "enrolled=yes" in module._format_headless_event(events[0])
+    assert module._format_headless_event({
+        "type": "attest",
+        "message": "Attestation submitted",
+        "miner_id": "windows_abc123",
+        "attestation_ttl_seconds": 580,
+    }) == "[attest] Attestation submitted miner_id=windows_abc123 ttl=580s"
+    assert module._format_headless_event({
+        "type": "enroll",
+        "message": "Epoch enrollment succeeded",
+        "miner_id": "windows_abc123",
+    }) == "[enroll] Epoch enrollment succeeded miner_id=windows_abc123"


### PR DESCRIPTION
## Summary
- Emit lifecycle callback events when the Windows miner successfully submits attestation, enrolls for the epoch, and reaches ready/heartbeat status.
- Teach headless mode to print those lifecycle events to stdout, while preserving error output on stderr.
- Update the Windows miner SHA-256 pins in `setup_miner.py` and `miners/windows/rustchain_miner_setup.bat`.
- Add regression coverage for the callback events and headless event formatting.

## Validation
- `python -m pytest tests\test_windows_headless_lifecycle_logging.py tests\test_windows_miner_setup_checksum.py -q --tb=short` -> 4 passed
- `python -m py_compile miners\windows\rustchain_windows_miner.py tests\test_windows_headless_lifecycle_logging.py setup_miner.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check -- miners\windows\rustchain_windows_miner.py miners\windows\rustchain_miner_setup.bat setup_miner.py tests\test_windows_headless_lifecycle_logging.py`

Fixes #5401.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7
