### PR TITLE
fix: reject out-of-range UTXO timestamps

### DIFF
--- a/node/test_integer_overflow.py
+++ b/node/test_integer_overflow.py
@@ -16,10 +16,13 @@ import os
 import sys
 import tempfile
 import sqlite3
+import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from node.utxo_db import UtxoDB, compute_box_id, address_to_proposition
+
+SEED_TX_ID = '00' * 32
 
 
 def test_fee_overflow():
@@ -45,7 +48,7 @@ def test_fee_overflow():
         test_box_id = compute_box_id(
             1000_000_000,  # 10 RTC
             address_to_proposition('RTC_TEST'),
-            0, 'test_tx', 0
+            0, SEED_TX_ID, 0
         )
         
         conn.execute(
@@ -55,7 +58,7 @@ def test_fee_overflow():
                 created_at)
                VALUES (?,?,?,?,?,?,?,?)""",
             (test_box_id, 1000_000_000, address_to_proposition('RTC_TEST'),
-             'RTC_TEST', 0, 'test_tx', 0, 1234567890)
+             'RTC_TEST', 0, SEED_TX_ID, 0, 1234567890)
         )
         conn.commit()
         conn.close()
@@ -79,17 +82,17 @@ def test_fee_overflow():
             print(f"Transaction result: {result}")
             
             if result:
-                print("🔴 BUG: Overflow fee accepted!")
+                print("[BUG] Overflow fee accepted!")
                 return False
             else:
-                print("✅ PASS: Transaction rejected safely")
+                print("[PASS] Transaction rejected safely")
                 return True
                 
         except sqlite3.IntegrityError as e:
-            print(f"🔴 BUG: Database error (DoS): {e}")
+            print(f"[BUG] Database error (DoS): {e}")
             return False
         except Exception as e:
-            print(f"🔴 BUG: Unexpected error (DoS): {e}")
+            print(f"[BUG] Unexpected error (DoS): {e}")
             return False
             
     finally:
@@ -114,7 +117,7 @@ def test_timestamp_overflow():
         test_box_id = compute_box_id(
             1000_000_000,
             address_to_proposition('RTC_TEST'),
-            0, 'test_tx', 0
+            0, SEED_TX_ID, 0
         )
         
         conn.execute(
@@ -124,7 +127,7 @@ def test_timestamp_overflow():
                 created_at)
                VALUES (?,?,?,?,?,?,?,?)""",
             (test_box_id, 1000_000_000, address_to_proposition('RTC_TEST'),
-             'RTC_TEST', 0, 'test_tx', 0, 1234567890)
+             'RTC_TEST', 0, SEED_TX_ID, 0, 1234567890)
         )
         conn.commit()
         conn.close()
@@ -147,14 +150,14 @@ def test_timestamp_overflow():
             result = db.apply_transaction(malicious_tx, block_height=1)
             
             if result:
-                print("🔴 BUG: Overflow timestamp accepted!")
+                print("[BUG] Overflow timestamp accepted!")
                 return False
             else:
-                print("✅ PASS: Transaction rejected safely")
+                print("[PASS] Transaction rejected safely")
                 return True
                 
         except Exception as e:
-            print(f"🔴 BUG: Error (DoS): {e}")
+            print(f"[BUG] Error (DoS): {e}")
             return False
             
     finally:
@@ -179,7 +182,7 @@ def test_negative_fee():
         test_box_id = compute_box_id(
             1000_000_000,
             address_to_proposition('RTC_TEST'),
-            0, 'test_tx', 0
+            0, SEED_TX_ID, 0
         )
         
         conn.execute(
@@ -189,7 +192,7 @@ def test_negative_fee():
                 created_at)
                VALUES (?,?,?,?,?,?,?,?)""",
             (test_box_id, 1000_000_000, address_to_proposition('RTC_TEST'),
-             'RTC_TEST', 0, 'test_tx', 0, 1234567890)
+             'RTC_TEST', 0, SEED_TX_ID, 0, 1234567890)
         )
         conn.commit()
         conn.close()
@@ -212,14 +215,14 @@ def test_negative_fee():
             result = db.apply_transaction(malicious_tx, block_height=1)
             
             if result:
-                print("🔴 BUG: Negative fee accepted (fund creation)!")
+                print("[BUG] Negative fee accepted (fund creation)!")
                 return False
             else:
-                print("✅ PASS: Negative fee rejected")
+                print("[PASS] Negative fee rejected")
                 return True
                 
         except Exception as e:
-            print(f"🔴 BUG: Error: {e}")
+            print(f"[BUG] Error: {e}")
             return False
             
     finally:
@@ -228,8 +231,6 @@ def test_negative_fee():
 
 
 if __name__ == '__main__':
-    import time
-    
     print("=" * 60)
     print("Testing Integer Overflow Protection")
     print("=" * 60)
@@ -240,8 +241,8 @@ if __name__ == '__main__':
     
     print("\n" + "=" * 60)
     if result1 and result2 and result3:
-        print("✅ ALL TESTS PASSED")
+        print("[PASS] ALL TESTS PASSED")
         sys.exit(0)
     else:
-        print("🔴 SOME TESTS FAILED")
+        print("[BUG] SOME TESTS FAILED")
         sys.exit(1)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -43,6 +43,7 @@ MAX_POOL_SIZE = 10_000
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
 MAX_OUTPUTS = 100
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
+SQLITE_INT64_MAX = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
 
 
@@ -425,6 +426,8 @@ class UtxoDB:
         Returns True on success, False on validation failure.
         """
         ts = tx.get('timestamp', int(time.time()))
+        if type(ts) is not int or ts < 0 or ts > SQLITE_INT64_MAX:
+            return False
         # NOTE(issue #2085): spending_proof is present on each input dict but
         # is intentionally ignored by this layer.  It is stored for
         # on-chain auditability, but cryptographic verification is the sole

--- a/tests/test_utxo_timestamp_validation.py
+++ b/tests/test_utxo_timestamp_validation.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+import pytest
+
+from node.utxo_db import (
+    SQLITE_INT64_MAX,
+    UtxoDB,
+    address_to_proposition,
+    compute_box_id,
+)
+
+
+SEED_TX_ID = "00" * 32
+OWNER = "RTC_TEST"
+VALUE_NRTC = 1_000_000_000
+
+
+def _seed_box(db: UtxoDB):
+    proposition = address_to_proposition(OWNER)
+    box_id = compute_box_id(VALUE_NRTC, proposition, 0, SEED_TX_ID, 0)
+    conn = db._conn()
+    try:
+        conn.execute(
+            """INSERT INTO utxo_boxes
+               (box_id, value_nrtc, proposition, owner_address,
+                creation_height, transaction_id, output_index,
+                created_at)
+               VALUES (?,?,?,?,?,?,?,?)""",
+            (box_id, VALUE_NRTC, proposition, OWNER, 0, SEED_TX_ID, 0, 1234567890),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return box_id
+
+
+def _transfer_tx(box_id, timestamp):
+    return {
+        "tx_type": "transfer",
+        "inputs": [{"box_id": box_id, "spending_proof": "test"}],
+        "outputs": [{"address": "RTC_DEST", "value_nrtc": VALUE_NRTC}],
+        "fee_nrtc": 0,
+        "timestamp": timestamp,
+    }
+
+
+@pytest.mark.parametrize("bad_timestamp", [10**20, -1, "123", True])
+def test_apply_transaction_rejects_invalid_timestamps_without_sqlite_overflow(
+    tmp_path, bad_timestamp
+):
+    db = UtxoDB(str(tmp_path / "utxo.sqlite3"))
+    db.init_tables()
+    box_id = _seed_box(db)
+
+    assert db.apply_transaction(_transfer_tx(box_id, bad_timestamp), block_height=1) is False
+    assert db.get_box(box_id)["spent_at"] is None
+
+
+def test_apply_transaction_accepts_sqlite_int64_timestamp_boundary(tmp_path):
+    db = UtxoDB(str(tmp_path / "utxo.sqlite3"))
+    db.init_tables()
+    box_id = _seed_box(db)
+
+    assert db.apply_transaction(_transfer_tx(box_id, SQLITE_INT64_MAX), block_height=1)


### PR DESCRIPTION
## Summary
- Reject UTXO transaction timestamps that are non-int, bool, negative, or above SQLite signed-int64 range before opening the write transaction.
- Add regression coverage for oversized, negative, string, and bool timestamps, plus the SQLite int64 upper boundary.
- Repair `node/test_integer_overflow.py` so its seeded transaction id is valid hex and its console output is Windows-safe ASCII.

## Validation
- `python -m pytest tests\test_utxo_timestamp_validation.py -q --tb=short` -> 5 passed
- `python node\test_integer_overflow.py` -> all checks passed
- `python -m py_compile node\utxo_db.py node\test_integer_overflow.py tests\test_utxo_timestamp_validation.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check -- node\utxo_db.py node\test_integer_overflow.py tests\test_utxo_timestamp_validation.py`

Fixes #5382.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7
