### PR TITLE
test: make clawrtc config path assertion portable

### DIFF
--- a/miners/clawrtc/test_config.py
+++ b/miners/clawrtc/test_config.py
@@ -41,7 +41,8 @@ def sample_config():
 class TestGetConfigPath:
     def test_default_path(self):
         path = get_config_path()
-        assert str(path).endswith(".clawrtc/config.json")
+        assert path.name == "config.json"
+        assert path.parent.name == ".clawrtc"
 
     def test_custom_path(self):
         path = get_config_path("/tmp/custom.json")


### PR DESCRIPTION
## Summary
- Make the clawrtc default config path test assert `Path` structure instead of hard-coding `/` separators.
- Keeps the same behavior check while allowing Windows paths such as `.clawrtc\config.json`.

## Validation
- `python -m pytest miners\clawrtc\test_config.py -q` -> 25 passed
- `python -m py_compile miners\clawrtc\test_config.py miners\clawrtc\config.py`
- `git diff --check -- miners\clawrtc\test_config.py`

Fixes #5378.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7
