### PR TITLE
test: use temp paths for fingerprint replay fixtures

### DIFF
--- a/tests/test_fingerprint_replay.py
+++ b/tests/test_fingerprint_replay.py
@@ -36,26 +36,28 @@ fleet = _load_module("fleet", "rips/python/rustchain/fleet_immune_system.py")
 class TestFingerprintReplay:
     """Attack 1: Replay a captured fingerprint from a different machine."""
 
-    def test_capture_produces_valid_fingerprint(self):
-        captured = poc.capture_fingerprint("/tmp/test_fp_capture.json")
+    def test_capture_produces_valid_fingerprint(self, tmp_path):
+        captured = poc.capture_fingerprint(str(tmp_path / "test_fp_capture.json"))
         assert captured["all_passed"] is True
         assert len(captured["checks"]) == 6
 
-    def test_replay_loads_captured_data(self):
-        poc.capture_fingerprint("/tmp/test_fp_replay.json")
+    def test_replay_loads_captured_data(self, tmp_path):
+        capture_path = tmp_path / "test_fp_replay.json"
+        poc.capture_fingerprint(str(capture_path))
         random.seed(999)
-        replayed = poc.replay_fingerprint("/tmp/test_fp_replay.json")
+        replayed = poc.replay_fingerprint(str(capture_path))
         assert replayed["all_passed"] is True
         assert "clock_drift" in replayed["checks"]
 
-    def test_replayed_fingerprint_accepted_by_fleet_system(self):
+    def test_replayed_fingerprint_accepted_by_fleet_system(self, tmp_path):
         """Server accepts replayed fingerprint without question."""
         db = sqlite3.connect(":memory:")
         fleet.ensure_schema(db)
 
-        captured = poc.capture_fingerprint("/tmp/test_fp_fleet.json")
+        capture_path = tmp_path / "test_fp_fleet.json"
+        captured = poc.capture_fingerprint(str(capture_path))
         random.seed(42)
-        replayed = poc.replay_fingerprint("/tmp/test_fp_fleet.json")
+        replayed = poc.replay_fingerprint(str(capture_path))
 
         # Record the replayed fingerprint as if from a different miner
         fleet.record_fleet_signals_from_request(
@@ -70,13 +72,14 @@ class TestFingerprintReplay:
         assert "attacker-vm" in scores or len(scores) == 0
         # The point: NO verification step rejected the replay
 
-    def test_replay_with_jitter_produces_unique_values(self):
+    def test_replay_with_jitter_produces_unique_values(self, tmp_path):
         """Replayed fingerprints can be jittered to avoid exact-match detection."""
-        poc.capture_fingerprint("/tmp/test_fp_jitter.json")
+        capture_path = tmp_path / "test_fp_jitter.json"
+        poc.capture_fingerprint(str(capture_path))
         replays = []
         for seed in range(5):
             random.seed(seed)
-            r = poc.replay_fingerprint("/tmp/test_fp_jitter.json")
+            r = poc.replay_fingerprint(str(capture_path))
             replays.append(r["checks"]["clock_drift"]["data"]["cv"])
 
         # Each replay has slightly different CV due to jitter


### PR DESCRIPTION
## Summary
- Replace `/tmp/test_fp_*.json` fingerprint replay fixtures with pytest-managed `tmp_path` files.
- Keeps the replay/spoofing test behavior unchanged while making the suite portable on Windows, Linux, and macOS.

## Validation
- `python -m pytest tests\test_fingerprint_replay.py -q` -> 21 passed
- `python -m py_compile tests\test_fingerprint_replay.py tools\rip_poa_fingerprint_replay_poc.py rips\python\rustchain\fleet_immune_system.py`
- `git diff --check -- tests\test_fingerprint_replay.py`

Fixes #5376.

RTC wallet: RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7
