### PR TITLE
fix: reject mismatched BCOS attest commitments

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -93,18 +93,21 @@ def _parse_bounded_int_arg(name: str, default: int, maximum: int):
     return min(value, maximum), None, None
 
 
+def _report_commitment(report: dict) -> str:
+    """Compute the canonical BCOS report commitment."""
+    report_copy = {
+        k: v for k, v in report.items()
+        if k not in ("cert_id", "commitment")
+    }
+    canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
+    return blake2b(canonical.encode(), digest_size=32).hexdigest()
+
+
 def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
     """Recompute BLAKE2b commitment and compare."""
     try:
-        # Reparse and re-serialize to canonical form
         report = json.loads(report_json_str)
-        # Remove cert_id and commitment before recomputing
-        # (they were added after the commitment was computed)
-        report_copy = {k: v for k, v in report.items()
-                       if k not in ("cert_id", "commitment")}
-        canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
-        computed = blake2b(canonical.encode(), digest_size=32).hexdigest()
-        return computed == claimed_commitment
+        return hmac.compare_digest(_report_commitment(report), claimed_commitment)
     except Exception:
         return False
 
@@ -256,6 +259,11 @@ def bcos_attest():
 
     # Verify commitment matches report
     report_json_str = json.dumps(report, sort_keys=True, separators=(",", ":"))
+    if not _verify_commitment(report_json_str, commitment):
+        return jsonify({
+            "error": "invalid_commitment",
+            "message": "commitment does not match report payload",
+        }), 400
 
     # Store
     now = int(time.time())
@@ -322,11 +330,8 @@ def bcos_verify(cert_id):
 
         # Recompute commitment from stored report
         report = json.loads(row["report_json"])
-        report_copy = {k: v for k, v in report.items()
-                       if k not in ("cert_id", "commitment")}
-        canonical = json.dumps(report_copy, sort_keys=True, separators=(",", ":"))
-        recomputed = blake2b(canonical.encode(), digest_size=32).hexdigest()
-        commitment_valid = recomputed == row["commitment"]
+        recomputed = _report_commitment(report)
+        commitment_valid = hmac.compare_digest(recomputed, row["commitment"])
 
         # Verify Ed25519 signature if present
         sig_valid = None

--- a/node/tests/test_bcos_routes.py
+++ b/node/tests/test_bcos_routes.py
@@ -1,13 +1,27 @@
 # SPDX-License-Identifier: MIT
 
+import json
 import os
+import sqlite3
 import sys
+from hashlib import blake2b
 
 from flask import Flask
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from bcos_routes import register_bcos_routes
+from bcos_routes import init_bcos_table, register_bcos_routes
+
+
+def _with_commitment(report):
+    report = dict(report)
+    commitment_report = {
+        k: v for k, v in report.items()
+        if k not in ("cert_id", "commitment")
+    }
+    canonical = json.dumps(commitment_report, sort_keys=True, separators=(",", ":"))
+    report["commitment"] = blake2b(canonical.encode(), digest_size=32).hexdigest()
+    return report
 
 
 def test_bcos_attest_rejects_non_object_json(tmp_path, monkeypatch):
@@ -40,3 +54,60 @@ def test_bcos_attest_rejects_non_object_report(tmp_path, monkeypatch):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "report must be an object"
+
+
+def test_bcos_attest_rejects_mismatched_commitment(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    app = Flask(__name__)
+    register_bcos_routes(app, str(tmp_path / "bcos.db"))
+    app.config["TESTING"] = True
+
+    response = app.test_client().post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json={
+            "cert_id": "BCOS-mismatch",
+            "commitment": "0" * 64,
+            "repo": "Scottcjn/Rustchain",
+            "commit_sha": "abcdef1234567890",
+            "tier": "L1",
+            "trust_score": 75,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "invalid_commitment",
+        "message": "commitment does not match report payload",
+    }
+
+
+def test_bcos_attest_stores_matching_commitment(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    db_path = tmp_path / "bcos.db"
+    with sqlite3.connect(db_path) as conn:
+        init_bcos_table(conn)
+    app = Flask(__name__)
+    register_bcos_routes(app, str(db_path))
+    app.config["TESTING"] = True
+
+    report = _with_commitment({
+        "cert_id": "BCOS-valid",
+        "repo": "Scottcjn/Rustchain",
+        "commit_sha": "abcdef1234567890",
+        "tier": "L1",
+        "trust_score": 75,
+        "reviewer": "codex-reviewer",
+    })
+
+    response = app.test_client().post(
+        "/bcos/attest",
+        headers={"X-Admin-Key": "test-admin"},
+        json=report,
+    )
+
+    assert response.status_code == 200
+
+    verify_response = app.test_client().get("/bcos/verify/BCOS-valid")
+    assert verify_response.status_code == 200
+    assert verify_response.get_json()["commitment_valid"] is True

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -1,4 +1,6 @@
+import json
 import sqlite3
+from hashlib import blake2b
 
 import pytest
 from flask import Flask
@@ -6,8 +8,22 @@ from flask import Flask
 from bcos_routes import init_bcos_table, register_bcos_routes
 
 
+def _with_commitment(report):
+    report = dict(report)
+    commitment_report = {
+        k: v for k, v in report.items()
+        if k not in ("cert_id", "commitment")
+    }
+    if "trust_score" in commitment_report and not isinstance(commitment_report["trust_score"], bool):
+        commitment_report["trust_score"] = int(commitment_report["trust_score"])
+    canonical = json.dumps(commitment_report, sort_keys=True, separators=(",", ":"))
+    report["commitment"] = blake2b(canonical.encode(), digest_size=32).hexdigest()
+    return report
+
+
 @pytest.fixture
-def bcos_client(tmp_path):
+def bcos_client(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
     db_path = tmp_path / "bcos.sqlite"
     with sqlite3.connect(db_path) as conn:
         init_bcos_table(conn)
@@ -98,17 +114,18 @@ def test_bcos_attest_rejects_invalid_trust_score(bcos_client, trust_score, messa
 
 
 def test_bcos_attest_stores_numeric_trust_score(bcos_client):
+    report = _with_commitment({
+        "cert_id": "cert-good-score",
+        "repo": "Scottcjn/Rustchain",
+        "commit_sha": "abcdef1234567890",
+        "tier": "L1",
+        "trust_score": "81",
+    })
+
     response = bcos_client.post(
         "/bcos/attest",
         headers={"X-Admin-Key": "0" * 32},
-        json={
-            "cert_id": "cert-good-score",
-            "commitment": "commitment",
-            "repo": "Scottcjn/Rustchain",
-            "commit_sha": "abcdef1234567890",
-            "tier": "L1",
-            "trust_score": "81",
-        },
+        json=report,
     )
 
     assert response.status_code == 200
@@ -136,18 +153,18 @@ def test_bcos_public_urls_default_to_certificate_valid_host(bcos_client):
 def test_bcos_attest_uses_configured_public_url(monkeypatch, bcos_client):
     monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
     monkeypatch.setenv("RUSTCHAIN_BCOS_PUBLIC_BASE_URL", "https://bcos.example/")
+    report = _with_commitment({
+        "cert_id": "cert-custom-host",
+        "repo": "Scottcjn/Rustchain",
+        "commit_sha": "abcdef1234567890",
+        "tier": "L1",
+        "trust_score": 82,
+    })
 
     response = bcos_client.post(
         "/bcos/attest",
         headers={"X-Admin-Key": "test-admin"},
-        json={
-            "cert_id": "cert-custom-host",
-            "commitment": "commitment",
-            "repo": "Scottcjn/Rustchain",
-            "commit_sha": "abcdef1234567890",
-            "tier": "L1",
-            "trust_score": 82,
-        },
+        json=report,
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add a shared canonical BCOS report commitment helper
- reject POST /bcos/attest requests when the claimed commitment does not match the normalized report payload
- reuse the same helper when verifying stored certificates
- update BCOS route tests to use real commitments and cover mismatch rejection

Fixes #4579.

## Validation
- python3 -m py_compile node/bcos_routes.py node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py
- git diff --check -- node/bcos_routes.py node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py
- PYTHONPATH=node .tmp-bcos-venv/bin/python -m pytest node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py -q -> 17 passed