### PR TITLE
fix: validate relationship mutation payloads

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1069,6 +1069,14 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             return jsonify({"error": "Unauthorized relationship mutation"}), 401
 
         return None
+
+    def _relationship_payload():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object expected"}), 400)
+        return data, None
     
     @bp.route("/api/relationships", methods=["GET"])
     def list_relationships():
@@ -1097,7 +1105,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, payload_error = _relationship_payload()
+        if payload_error:
+            return payload_error
         try:
             result = engine.record_disagreement(
                 agent_a, agent_b,
@@ -1114,7 +1124,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, payload_error = _relationship_payload()
+        if payload_error:
+            return payload_error
         try:
             result = engine.record_collaboration(
                 agent_a, agent_b,
@@ -1131,7 +1143,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, payload_error = _relationship_payload()
+        if payload_error:
+            return payload_error
         try:
             result = engine.record_reconciliation(
                 agent_a, agent_b,
@@ -1147,7 +1161,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.json or {}
+        data, payload_error = _relationship_payload()
+        if payload_error:
+            return payload_error
         try:
             result = engine.admin_intervene(
                 agent_a, agent_b,

--- a/tests/test_agent_relationship_mutation_auth.py
+++ b/tests/test_agent_relationship_mutation_auth.py
@@ -11,6 +11,10 @@ MUTATING_ENDPOINTS = (
     ("/api/relationships/alice/bob/reconcile", {"description": "postmortem"}),
 )
 
+ALL_MUTATING_ENDPOINTS = MUTATING_ENDPOINTS + (
+    ("/api/relationships/alice/bob/intervene", {"reason": "moderation reset"}),
+)
+
 
 def _build_client(tmp_path):
     engine = RelationshipEngine(db_path=str(tmp_path / "relationships.db"))
@@ -78,3 +82,20 @@ def test_relationship_mutations_accept_legacy_api_key_header(monkeypatch, tmp_pa
     relationship = engine.get_relationship("alice", "bob")
     assert relationship is not None
     assert relationship["collaboration_count"] == 1
+
+
+def test_relationship_mutations_reject_non_object_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELATIONSHIPS_ADMIN_KEY", "relationship-admin-secret")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+
+    for path, _payload in ALL_MUTATING_ENDPOINTS:
+        response = client.post(
+            path,
+            headers={"X-Admin-Key": "relationship-admin-secret"},
+            json=["not", "an", "object"],
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "JSON object expected"
+        assert engine.get_relationship("alice", "bob") is None


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on relationship mutation routes with HTTP 400
- share the same payload parsing path across disagreement, collaboration, reconciliation, and intervention mutations
- add regression coverage for JSON array payloads so malformed requests do not create or change relationships

Fixes #5508
Bounty reference: #305

## Validation
- `/tmp/rustchain-relationship-venv/bin/python -m pytest tests/test_agent_relationship_mutation_auth.py tests/test_agent_relationships_admin_auth.py -q`
- `python3 -m py_compile agent_relationships.py tests/test_agent_relationship_mutation_auth.py tests/test_agent_relationships_admin_auth.py`
- `git diff --check -- agent_relationships.py tests/test_agent_relationship_mutation_auth.py`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

