### PR TITLE
fix: update Linux miner setup checksum

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## Summary
- update the pinned Linux miner SHA-256 in setup_miner.py
- keep the setup verifier aligned with the current committed miners/linux/rustchain_linux_miner.py

Fixes #5466.

## Validation
- python -m py_compile setup_miner.py tests/test_setup_miner_downloads.py
- git diff --check
- manual artifact hash check for Linux/Darwin/Windows entries

Note: python -m pytest tests/test_setup_miner_downloads.py -q could not start in this local environment because the default interpreter is missing Flask, and repo tests/conftest.py imports the integrated node before collecting this test.