### PR TITLE
fix: redact agent economy internal errors

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -284,6 +284,11 @@ def _parse_ttl_seconds(raw):
     return min(max(ttl_seconds, 3600), JOB_TTL_MAX), None
 
 
+def _internal_error_response(action: str, exc: Exception):
+    log.exception("%s failed with %s", action, type(exc).__name__)
+    return jsonify({"error": "Internal error"}), 500
+
+
 # ---------------------------------------------------------------------------
 # Route Registration
 # ---------------------------------------------------------------------------
@@ -399,8 +404,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            log.error(f"agent_post_job error: {e}")
-            return jsonify({"error": "Internal error", "details": str(e)}), 500
+            return _internal_error_response("agent_post_job", e)
         finally:
             conn.close()
 
@@ -472,8 +476,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            log.error(f"agent_claim_job error: {e}")
-            return jsonify({"error": str(e)}), 500
+            return _internal_error_response("agent_claim_job", e)
         finally:
             conn.close()
 
@@ -532,7 +535,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            return jsonify({"error": str(e)}), 500
+            return _internal_error_response("agent_deliver_job", e)
         finally:
             conn.close()
 
@@ -649,7 +652,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            return jsonify({"error": str(e)}), 500
+            return _internal_error_response("agent_accept_delivery", e)
         finally:
             conn.close()
 
@@ -711,7 +714,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            return jsonify({"error": str(e)}), 500
+            return _internal_error_response("agent_dispute_job", e)
         finally:
             conn.close()
 
@@ -777,7 +780,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
         except Exception as e:
             conn.rollback()
-            return jsonify({"error": str(e)}), 500
+            return _internal_error_response("agent_cancel_job", e)
         finally:
             conn.close()
 

--- a/tests/test_agent_economy_error_redaction.py
+++ b/tests/test_agent_economy_error_redaction.py
@@ -1,0 +1,74 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+import rip302_agent_economy
+
+
+SECRET_ERROR = "no such table: balances at /srv/rustchain/private.db with super-secret"
+
+
+def make_client(tmp_path: Path):
+    app = Flask(__name__)
+    rip302_agent_economy.register_agent_economy(app, str(tmp_path / "agent_jobs.db"))
+    return app.test_client()
+
+
+class FailingConnection:
+    def cursor(self):
+        raise sqlite3.OperationalError(SECRET_ERROR)
+
+    def rollback(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    (
+        (
+            "/agent/jobs",
+            {
+                "poster_wallet": "poster",
+                "title": "Build integration",
+                "description": "Build a complete test integration",
+                "category": "other",
+                "reward_rtc": 1,
+            },
+        ),
+        ("/agent/jobs/job-1/claim", {"worker_wallet": "worker"}),
+        (
+            "/agent/jobs/job-1/deliver",
+            {"worker_wallet": "worker", "result_summary": "done"},
+        ),
+        ("/agent/jobs/job-1/accept", {"poster_wallet": "poster"}),
+        (
+            "/agent/jobs/job-1/dispute",
+            {"poster_wallet": "poster", "reason": "not accepted"},
+        ),
+        ("/agent/jobs/job-1/cancel", {"poster_wallet": "poster"}),
+    ),
+)
+def test_agent_job_write_routes_hide_internal_database_errors(
+    tmp_path, monkeypatch, path, payload
+):
+    client = make_client(tmp_path)
+
+    monkeypatch.setattr(
+        rip302_agent_economy.sqlite3,
+        "connect",
+        lambda *args, **kwargs: FailingConnection(),
+    )
+
+    response = client.post(path, json=payload)
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Internal error"}
+    body = response.get_data(as_text=True)
+    assert "no such table" not in body
+    assert "/srv/rustchain" not in body
+    assert "super-secret" not in body

--- a/tests/test_agent_economy_error_redaction.py
+++ b/tests/test_agent_economy_error_redaction.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import sqlite3
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- replace raw exception responses in RIP-302 Agent Economy write routes with a generic 500 payload
- keep full exception details in server logs via log.exception
- add regression coverage for post, claim, deliver, accept, dispute, and cancel routes

## Bounty / Issue
Bug bounty claim under #305.

This addresses an uncovered Agent Economy slice of #3202: database/internal exception text could be returned to API clients from write-route 500 handlers.

## Verification
- uv run --with pytest --with flask python -m pytest tests/test_agent_economy_error_redaction.py tests/test_agent_jobs_query_validation.py tests/test_agent_dispute_accept_race.py -q -> 23 passed
- python3 -m py_compile rip302_agent_economy.py tests/test_agent_economy_error_redaction.py tests/test_agent_jobs_query_validation.py tests/test_agent_dispute_accept_race.py -> passed
- git diff --check -> passed

RTC wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945