### PR TITLE
fix(#5511 #5508): set RC_P2P_SECRET in test, guard json body type in routes

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1098,6 +1098,8 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             return auth_error
 
         data = request.get_json(silent=True) or {}
+        if not isinstance(data, dict):
+            return jsonify({"error": "expected JSON object, got array"}), 400
         try:
             result = engine.record_disagreement(
                 agent_a, agent_b,
@@ -1115,6 +1117,8 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             return auth_error
 
         data = request.get_json(silent=True) or {}
+        if not isinstance(data, dict):
+            return jsonify({"error": "expected JSON object, got array"}), 400
         try:
             result = engine.record_collaboration(
                 agent_a, agent_b,
@@ -1132,6 +1136,8 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             return auth_error
 
         data = request.get_json(silent=True) or {}
+        if not isinstance(data, dict):
+            return jsonify({"error": "expected JSON object, got array"}), 400
         try:
             result = engine.record_reconciliation(
                 agent_a, agent_b,

--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1097,7 +1097,10 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        raw = request.get_json(silent=True)
+    data = {} if raw is None else raw
+    if not isinstance(data, dict):
+        return jsonify({"error": "expected JSON object"}), 400
         if not isinstance(data, dict):
             return jsonify({"error": "expected JSON object, got array"}), 400
         try:
@@ -1116,7 +1119,10 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        raw = request.get_json(silent=True)
+    data = {} if raw is None else raw
+    if not isinstance(data, dict):
+        return jsonify({"error": "expected JSON object"}), 400
         if not isinstance(data, dict):
             return jsonify({"error": "expected JSON object, got array"}), 400
         try:
@@ -1135,7 +1141,10 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        raw = request.get_json(silent=True)
+    data = {} if raw is None else raw
+    if not isinstance(data, dict):
+        return jsonify({"error": "expected JSON object"}), 400
         if not isinstance(data, dict):
             return jsonify({"error": "expected JSON object, got array"}), 400
         try:

--- a/node/tests/test_epoch_proposal_merkle_validation.py
+++ b/node/tests/test_epoch_proposal_merkle_validation.py
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: MIT
+import os
+# Set test HMAC secret before importing the module under test.
+os.environ.setdefault("RC_P2P_SECRET", "test-secret-for-pytest-collection")
+
 """
 Test: P2P epoch proposal merkle self-validation flaw
 


### PR DESCRIPTION
## Fix #5511\nSet `RC_P2P_SECRET` env var at the top of the test file so pytest collection doesn't crash when the gossip module checks for it.\n\n## Fix #5508\nAdded `isinstance(data, dict)` guards to all mutation routes (disagree, collaborate, reconcile) so sending a JSON array returns 400 instead of 500.\n\n**Files:**\n- node/tests/test_epoch_proposal_merkle_validation.py\n- agent_relationships.py