### PR TITLE
docs: fix agent economy demo delivery url

### DIFF
--- a/agent_economy_sdk.py
+++ b/agent_economy_sdk.py
@@ -165,7 +165,7 @@ async def demo_workflow():
         
         delivered = await client.submit_delivery(
             job_id, "demo-worker",
-            "https://github.com/rustchain/docs/pull/123",
+            "https://github.com/Scottcjn/Rustchain/pull/123",
             "Comprehensive API documentation with examples"
         )
         print(f"Delivery submitted: {delivered['success']}")


### PR DESCRIPTION
## Summary
- update the Agent Economy demo delivery URL to point at the real RustChain repository
- replace the nonexistent github.com/rustchain/docs example link with a resolving Scottcjn/Rustchain PR URL

Bounty reference: Scottcjn/rustchain-bounties#444

## Validation
- curl https://github.com/rustchain/docs/pull/123 -> HTTP 404
- curl https://github.com/Scottcjn/Rustchain/pull/123 -> HTTP 200
- python -m py_compile agent_economy_sdk.py tests/test_agent_economy_sdk.py
- python -m pytest tests/test_agent_economy_sdk.py -q -> 2 passed
- git diff --check -- agent_economy_sdk.py
- duplicate check: no open PR found for agent_economy_sdk.py / github.com/rustchain/docs