### PR TITLE
fix: negotiate P2P handshake parameters

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -115,6 +115,84 @@ MESSAGE_EXPIRY = 300  # 5 minutes
 MAX_INV_BATCH = 1000
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "/root/rustchain/rustchain_v2.db")
 
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed > 0 else default
+
+
+P2P_PROTOCOL_VERSION = _positive_int(os.environ.get("RC_P2P_PROTOCOL_VERSION"), 1)
+P2P_K_BUCKET_SIZE = _positive_int(os.environ.get("RC_P2P_K_BUCKET_SIZE"), 20)
+P2P_PING_INTERVAL = _positive_int(os.environ.get("RC_P2P_PING_INTERVAL"), SYNC_INTERVAL)
+P2P_HANDSHAKE_TIMEOUT = _positive_int(os.environ.get("RC_P2P_HANDSHAKE_TIMEOUT"), 10)
+_HANDSHAKE_FIELDS = (
+    "protocol_version",
+    "k_bucket_size",
+    "ping_interval",
+    "timeout",
+)
+
+
+def local_handshake_params() -> Dict[str, int]:
+    """Return the local P2P compatibility parameters advertised to peers."""
+    return {
+        "protocol_version": P2P_PROTOCOL_VERSION,
+        "k_bucket_size": P2P_K_BUCKET_SIZE,
+        "ping_interval": P2P_PING_INTERVAL,
+        "timeout": P2P_HANDSHAKE_TIMEOUT,
+    }
+
+
+def _normalise_handshake_params(
+    params: Optional[Dict],
+    defaults: Dict[str, int],
+) -> Dict[str, int]:
+    params = params if isinstance(params, dict) else {}
+    return {
+        field: _positive_int(params.get(field), defaults[field])
+        for field in _HANDSHAKE_FIELDS
+    }
+
+
+def negotiate_handshake_params(local: Dict, remote: Optional[Dict]) -> Dict[str, int]:
+    """Choose compatible P2P parameters for a local/remote handshake pair."""
+    local_values = _normalise_handshake_params(local, local_handshake_params())
+    remote_values = _normalise_handshake_params(remote, local_values)
+    return {
+        "protocol_version": min(
+            local_values["protocol_version"],
+            remote_values["protocol_version"],
+        ),
+        "k_bucket_size": min(
+            local_values["k_bucket_size"],
+            remote_values["k_bucket_size"],
+        ),
+        "ping_interval": min(
+            local_values["ping_interval"],
+            remote_values["ping_interval"],
+        ),
+        "timeout": max(local_values["timeout"], remote_values["timeout"]),
+    }
+
+
+def handshake_mismatches(
+    local: Dict,
+    remote: Optional[Dict],
+) -> Dict[str, Dict[str, int]]:
+    """Return advertised handshake fields where local and remote disagree."""
+    if not isinstance(remote, dict):
+        return {}
+    local_values = _normalise_handshake_params(local, local_handshake_params())
+    remote_values = _normalise_handshake_params(remote, local_values)
+    return {
+        field: {"local": local_values[field], "remote": remote_values[field]}
+        for field in _HANDSHAKE_FIELDS
+        if field in remote and local_values[field] != remote_values[field]
+    }
+
 # TLS verification: defaults to True (secure).
 # Set RUSTCHAIN_TLS_VERIFY=false only for local development with self-signed certs.
 # Prefer RUSTCHAIN_CA_BUNDLE to point at a pinned CA/cert file instead of disabling.
@@ -540,6 +618,13 @@ class GossipLayer:
         )
         return msg
 
+    def create_ping(self) -> GossipMessage:
+        """Create a ping that advertises local P2P handshake parameters."""
+        return self.create_message(MessageType.PING, {
+            "node_id": self.node_id,
+            "handshake": local_handshake_params(),
+        })
+
     def verify_message(self, msg: GossipMessage) -> bool:
         """Verify message signature and freshness.
 
@@ -672,11 +757,29 @@ class GossipLayer:
 
     def _handle_ping(self, msg: GossipMessage) -> Dict:
         """Respond to ping with pong"""
-        pong = self.create_message(MessageType.PONG, {
+        local_handshake = local_handshake_params()
+        remote_handshake = msg.payload.get("handshake")
+        agreed_handshake = negotiate_handshake_params(local_handshake, remote_handshake)
+        mismatches = handshake_mismatches(local_handshake, remote_handshake)
+        if mismatches:
+            logger.info(
+                "P2P handshake with %s negotiated %s; mismatches=%s",
+                msg.sender_id,
+                agreed_handshake,
+                mismatches,
+            )
+
+        pong_payload = {
             "node_id": self.node_id,
             "attestation_count": len(self.attestation_crdt.data),
-            "settled_epochs": len(self.epoch_crdt.items)
-        })
+            "settled_epochs": len(self.epoch_crdt.items),
+            "handshake": local_handshake,
+            "agreed_handshake": agreed_handshake,
+        }
+        if mismatches:
+            pong_payload["handshake_mismatches"] = mismatches
+
+        pong = self.create_message(MessageType.PONG, pong_payload)
         return {"status": "ok", "pong": pong.to_dict()}
 
     def _handle_inv_attestation(self, msg: GossipMessage) -> Dict:

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -116,18 +116,54 @@ MAX_INV_BATCH = 1000
 DB_PATH = os.environ.get("RUSTCHAIN_DB", "/root/rustchain/rustchain_v2.db")
 
 
-def _positive_int(value: Any, default: int) -> int:
+MIN_P2P_PROTOCOL_VERSION = 1
+MAX_P2P_PROTOCOL_VERSION = 10
+MIN_P2P_K_BUCKET_SIZE = 1
+MAX_P2P_K_BUCKET_SIZE = 1000
+MIN_P2P_PING_INTERVAL = 5
+MAX_P2P_PING_INTERVAL = 3600
+MIN_P2P_HANDSHAKE_TIMEOUT = 1
+MAX_P2P_HANDSHAKE_TIMEOUT = 120
+_HANDSHAKE_BOUNDS = {
+    "protocol_version": (MIN_P2P_PROTOCOL_VERSION, MAX_P2P_PROTOCOL_VERSION),
+    "k_bucket_size": (MIN_P2P_K_BUCKET_SIZE, MAX_P2P_K_BUCKET_SIZE),
+    "ping_interval": (MIN_P2P_PING_INTERVAL, MAX_P2P_PING_INTERVAL),
+    "timeout": (MIN_P2P_HANDSHAKE_TIMEOUT, MAX_P2P_HANDSHAKE_TIMEOUT),
+}
+
+
+def _bounded_int(value: Any, default: int, min_value: int, max_value: int) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
         return default
-    return parsed if parsed > 0 else default
+    return min(max(parsed, min_value), max_value)
 
 
-P2P_PROTOCOL_VERSION = _positive_int(os.environ.get("RC_P2P_PROTOCOL_VERSION"), 1)
-P2P_K_BUCKET_SIZE = _positive_int(os.environ.get("RC_P2P_K_BUCKET_SIZE"), 20)
-P2P_PING_INTERVAL = _positive_int(os.environ.get("RC_P2P_PING_INTERVAL"), SYNC_INTERVAL)
-P2P_HANDSHAKE_TIMEOUT = _positive_int(os.environ.get("RC_P2P_HANDSHAKE_TIMEOUT"), 10)
+P2P_PROTOCOL_VERSION = _bounded_int(
+    os.environ.get("RC_P2P_PROTOCOL_VERSION"),
+    1,
+    MIN_P2P_PROTOCOL_VERSION,
+    MAX_P2P_PROTOCOL_VERSION,
+)
+P2P_K_BUCKET_SIZE = _bounded_int(
+    os.environ.get("RC_P2P_K_BUCKET_SIZE"),
+    20,
+    MIN_P2P_K_BUCKET_SIZE,
+    MAX_P2P_K_BUCKET_SIZE,
+)
+P2P_PING_INTERVAL = _bounded_int(
+    os.environ.get("RC_P2P_PING_INTERVAL"),
+    SYNC_INTERVAL,
+    MIN_P2P_PING_INTERVAL,
+    MAX_P2P_PING_INTERVAL,
+)
+P2P_HANDSHAKE_TIMEOUT = _bounded_int(
+    os.environ.get("RC_P2P_HANDSHAKE_TIMEOUT"),
+    10,
+    MIN_P2P_HANDSHAKE_TIMEOUT,
+    MAX_P2P_HANDSHAKE_TIMEOUT,
+)
 _HANDSHAKE_FIELDS = (
     "protocol_version",
     "k_bucket_size",
@@ -152,7 +188,11 @@ def _normalise_handshake_params(
 ) -> Dict[str, int]:
     params = params if isinstance(params, dict) else {}
     return {
-        field: _positive_int(params.get(field), defaults[field])
+        field: _bounded_int(
+            params.get(field),
+            defaults[field],
+            *_HANDSHAKE_BOUNDS[field],
+        )
         for field in _HANDSHAKE_FIELDS
     }
 

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -798,7 +798,8 @@ class GossipLayer:
     def _handle_ping(self, msg: GossipMessage) -> Dict:
         """Respond to ping with pong"""
         local_handshake = local_handshake_params()
-        remote_handshake = msg.payload.get("handshake")
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        remote_handshake = payload.get("handshake")
         agreed_handshake = negotiate_handshake_params(local_handshake, remote_handshake)
         mismatches = handshake_mismatches(local_handshake, remote_handshake)
         if mismatches:

--- a/node/tests/test_p2p_handshake_negotiation.py
+++ b/node/tests/test_p2p_handshake_negotiation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 #!/usr/bin/env python3
 """Regression tests for P2P handshake parameter negotiation."""
 

--- a/node/tests/test_p2p_handshake_negotiation.py
+++ b/node/tests/test_p2p_handshake_negotiation.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Regression tests for P2P handshake parameter negotiation."""
+
+import importlib
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+P2P_SECRET = "unit-test-secret-0123456789abcdef"
+os.environ["RC_P2P_SECRET"] = P2P_SECRET
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(NODE_DIR))
+
+if "rustchain_p2p_gossip" in sys.modules:
+    del sys.modules["rustchain_p2p_gossip"]
+gossip = importlib.import_module("rustchain_p2p_gossip")
+
+
+def _init_minimal_p2p_db(path: Path) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS p2p_seen_messages (
+                msg_id TEXT PRIMARY KEY,
+                ts INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS p2p_epoch_votes (
+                epoch INTEGER NOT NULL,
+                proposal_hash TEXT NOT NULL,
+                voter TEXT NOT NULL,
+                vote TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                PRIMARY KEY (epoch, proposal_hash, voter)
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS epoch_state (
+                epoch INTEGER PRIMARY KEY,
+                settled INTEGER
+            )
+            """
+        )
+
+
+def test_negotiate_handshake_params_chooses_compatible_values():
+    local = {
+        "protocol_version": 2,
+        "k_bucket_size": 20,
+        "ping_interval": 30,
+        "timeout": 10,
+    }
+    remote = {
+        "protocol_version": 1,
+        "k_bucket_size": 16,
+        "ping_interval": 60,
+        "timeout": 45,
+    }
+
+    assert gossip.negotiate_handshake_params(local, remote) == {
+        "protocol_version": 1,
+        "k_bucket_size": 16,
+        "ping_interval": 30,
+        "timeout": 45,
+    }
+    assert gossip.handshake_mismatches(local, remote) == {
+        "protocol_version": {"local": 2, "remote": 1},
+        "k_bucket_size": {"local": 20, "remote": 16},
+        "ping_interval": {"local": 30, "remote": 60},
+        "timeout": {"local": 10, "remote": 45},
+    }
+
+
+def test_ping_response_includes_local_and_agreed_handshake(tmp_path):
+    local_db = tmp_path / "local.db"
+    remote_db = tmp_path / "remote.db"
+    _init_minimal_p2p_db(local_db)
+    _init_minimal_p2p_db(remote_db)
+
+    local = gossip.GossipLayer(
+        "local",
+        {"remote": "http://remote.example"},
+        str(local_db),
+    )
+    remote = gossip.GossipLayer(
+        "remote",
+        {"local": "http://local.example"},
+        str(remote_db),
+    )
+
+    ping = remote.create_message(gossip.MessageType.PING, {
+        "node_id": "remote",
+        "handshake": {
+            "protocol_version": 1,
+            "k_bucket_size": 12,
+            "ping_interval": 90,
+            "timeout": 45,
+        },
+    })
+
+    response = local.handle_message(ping)
+
+    assert response["status"] == "ok"
+    pong_payload = response["pong"]["payload"]
+    assert pong_payload["handshake"] == gossip.local_handshake_params()
+    assert pong_payload["agreed_handshake"] == {
+        "protocol_version": 1,
+        "k_bucket_size": 12,
+        "ping_interval": gossip.local_handshake_params()["ping_interval"],
+        "timeout": 45,
+    }
+    assert pong_payload["handshake_mismatches"]["k_bucket_size"] == {
+        "local": gossip.local_handshake_params()["k_bucket_size"],
+        "remote": 12,
+    }

--- a/node/tests/test_p2p_handshake_negotiation.py
+++ b/node/tests/test_p2p_handshake_negotiation.py
@@ -91,6 +91,28 @@ def test_negotiate_handshake_params_chooses_compatible_values():
     }
 
 
+def test_negotiate_handshake_params_clamps_extreme_values():
+    local = {
+        "protocol_version": 50,
+        "k_bucket_size": 1_000_000,
+        "ping_interval": 1,
+        "timeout": 10_000,
+    }
+    remote = {
+        "protocol_version": 50,
+        "k_bucket_size": 1_000_000,
+        "ping_interval": 1,
+        "timeout": 10_000,
+    }
+
+    assert gossip.negotiate_handshake_params(local, remote) == {
+        "protocol_version": gossip.MAX_P2P_PROTOCOL_VERSION,
+        "k_bucket_size": gossip.MAX_P2P_K_BUCKET_SIZE,
+        "ping_interval": gossip.MIN_P2P_PING_INTERVAL,
+        "timeout": gossip.MAX_P2P_HANDSHAKE_TIMEOUT,
+    }
+
+
 def test_ping_response_includes_local_and_agreed_handshake(tmp_path):
     local_db = tmp_path / "local.db"
     remote_db = tmp_path / "remote.db"

--- a/node/tests/test_p2p_handshake_negotiation.py
+++ b/node/tests/test_p2p_handshake_negotiation.py
@@ -155,3 +155,32 @@ def test_ping_response_includes_local_and_agreed_handshake(tmp_path):
         "local": gossip.local_handshake_params()["k_bucket_size"],
         "remote": 12,
     }
+
+
+def test_ping_response_ignores_non_object_payloads(tmp_path):
+    local_db = tmp_path / "local.db"
+    remote_db = tmp_path / "remote.db"
+    _init_minimal_p2p_db(local_db)
+    _init_minimal_p2p_db(remote_db)
+
+    local = gossip.GossipLayer(
+        "local",
+        {"remote": "http://remote.example"},
+        str(local_db),
+    )
+    remote = gossip.GossipLayer(
+        "remote",
+        {"local": "http://local.example"},
+        str(remote_db),
+    )
+
+    for payload in (["legacy"], None, "legacy"):
+        ping = remote.create_message(gossip.MessageType.PING, payload)
+
+        response = local.handle_message(ping)
+
+        assert response["status"] == "ok"
+        pong_payload = response["pong"]["payload"]
+        assert pong_payload["handshake"] == gossip.local_handshake_params()
+        assert pong_payload["agreed_handshake"] == gossip.local_handshake_params()
+        assert "handshake_mismatches" not in pong_payload


### PR DESCRIPTION
## Summary
- advertise local P2P handshake parameters on ping/pong messages
- negotiate compatible protocol version, k-bucket size, ping interval, and timeout when a peer advertises different values
- add regression coverage for negotiation helpers and ping response payloads

Fixes #2687.
Related bounty pool: #305.

## Verification
- .....                                                                    [100%]
5 passed in 0.33s
- 

RTC wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945