### PR TITLE
Add TLS-valid P2P Prometheus metrics

### DIFF
--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -69,6 +69,13 @@ def test_fetch_json_returns_payload_and_handles_errors():
         assert module.fetch_json("/health") is None
 
 
+def test_default_p2p_node_url_uses_certificate_valid_hostname():
+    module = load_module()
+
+    assert module.P2P_NODE_URL == "https://bulbous-bouffant.metalseed.net"
+    assert "50.28.86.131" not in module.P2P_NODE_URL
+
+
 def test_collect_epoch_computes_progress_and_fallback_defaults():
     module = load_module()
 
@@ -147,3 +154,47 @@ def test_collect_hall_of_fame_fee_pool_and_stats_fallbacks():
     assert module.rustchain_highest_rust_score._value.get() == 9.5
     assert module.rustchain_total_fees_collected_rtc._value.get() == 12.25
     assert module.rustchain_fee_events_total._value.get() == 6
+
+
+def test_collect_p2p_exports_health_metrics():
+    module = load_module()
+
+    with (
+        patch.object(module, "fetch_json", return_value={
+            "running": True,
+            "peer_count": "3",
+            "attestation_count": "11",
+            "settled_epochs": "4",
+            "messages_per_second": "2.5",
+            "messages_total": "99",
+        }) as fetch_json,
+        patch.object(module.time, "time", side_effect=[100.0, 100.25]),
+    ):
+        module.collect_p2p()
+
+    fetch_json.assert_called_once_with("/p2p/health", module.P2P_NODE_URL)
+    assert module.rustchain_p2p_up._value.get() == 1
+    assert module.rustchain_p2p_peer_count._value.get() == 3
+    assert module.rustchain_p2p_attestation_count._value.get() == 11
+    assert module.rustchain_p2p_settled_epochs._value.get() == 4
+    assert module.rustchain_p2p_message_rate_per_second._value.get() == 2.5
+    assert module.rustchain_p2p_messages_total._value.get() == 99
+    assert module.rustchain_p2p_health_latency_seconds._value.get() == 0.25
+
+
+def test_collect_p2p_zeros_metrics_when_endpoint_unavailable():
+    module = load_module()
+
+    with (
+        patch.object(module, "fetch_json", return_value=None),
+        patch.object(module.time, "time", side_effect=[100.0, 100.5]),
+    ):
+        module.collect_p2p()
+
+    assert module.rustchain_p2p_up._value.get() == 0
+    assert module.rustchain_p2p_peer_count._value.get() == 0
+    assert module.rustchain_p2p_attestation_count._value.get() == 0
+    assert module.rustchain_p2p_settled_epochs._value.get() == 0
+    assert module.rustchain_p2p_message_rate_per_second._value.get() == 0
+    assert module.rustchain_p2p_messages_total._value.get() == 0
+    assert module.rustchain_p2p_health_latency_seconds._value.get() == 0.5

--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -69,6 +69,22 @@ def test_fetch_json_returns_payload_and_handles_errors():
         assert module.fetch_json("/health") is None
 
 
+def test_fetch_json_redacts_credentials_from_warning_logs(caplog):
+    module = load_module()
+    credential_url = "https://node-user:super-secret-token@p2p.example.invalid/path?token=abc"
+
+    with (
+        patch.object(module.session, "get", side_effect=RuntimeError("offline")),
+        caplog.at_level("WARNING", logger="rustchain_exporter"),
+    ):
+        assert module.fetch_json("/p2p/health", credential_url) is None
+
+    assert "super-secret-token" not in caplog.text
+    assert "node-user:super-secret-token" not in caplog.text
+    assert "token=abc" not in caplog.text
+    assert "https://p2p.example.invalid" in caplog.text
+
+
 def test_default_p2p_node_url_uses_certificate_valid_hostname():
     module = load_module()
 
@@ -180,6 +196,22 @@ def test_collect_p2p_exports_health_metrics():
     assert module.rustchain_p2p_message_rate_per_second._value.get() == 2.5
     assert module.rustchain_p2p_messages_total._value.get() == 99
     assert module.rustchain_p2p_health_latency_seconds._value.get() == 0.25
+
+
+def test_collect_p2p_uses_peer_count_when_peers_is_null():
+    module = load_module()
+
+    with (
+        patch.object(module, "fetch_json", return_value={
+            "running": True,
+            "peer_count": "7",
+            "peers": None,
+        }),
+        patch.object(module.time, "time", side_effect=[100.0, 100.25]),
+    ):
+        module.collect_p2p()
+
+    assert module.rustchain_p2p_peer_count._value.get() == 7
 
 
 def test_collect_p2p_zeros_metrics_when_endpoint_unavailable():

--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -85,6 +85,30 @@ def test_fetch_json_redacts_credentials_from_warning_logs(caplog):
     assert "https://p2p.example.invalid" in caplog.text
 
 
+def test_main_redacts_credentials_from_startup_logs(caplog):
+    module = load_module()
+    module.NODE_URL = "https://node-user:node-secret@example.invalid/path?token=node"
+    module.P2P_NODE_URL = "https://p2p-user:p2p-secret@p2p.example.invalid/path?token=p2p"
+
+    with (
+        patch.object(module, "start_http_server"),
+        patch.object(module, "collect_once"),
+        patch.object(module.time, "sleep", side_effect=KeyboardInterrupt),
+        caplog.at_level("INFO", logger="rustchain_exporter"),
+    ):
+        try:
+            module.main()
+        except KeyboardInterrupt:
+            pass
+
+    assert "node-secret" not in caplog.text
+    assert "p2p-secret" not in caplog.text
+    assert "token=node" not in caplog.text
+    assert "token=p2p" not in caplog.text
+    assert "https://example.invalid" in caplog.text
+    assert "https://p2p.example.invalid" in caplog.text
+
+
 def test_default_p2p_node_url_uses_certificate_valid_hostname():
     module = load_module()
 

--- a/tools/prometheus/README.md
+++ b/tools/prometheus/README.md
@@ -34,6 +34,13 @@ Implemented metrics:
 - `rustchain_highest_rust_score`
 - `rustchain_total_fees_collected_rtc`
 - `rustchain_fee_events_total`
+- `rustchain_p2p_up`
+- `rustchain_p2p_peer_count`
+- `rustchain_p2p_attestation_count`
+- `rustchain_p2p_settled_epochs`
+- `rustchain_p2p_message_rate_per_second`
+- `rustchain_p2p_messages_total`
+- `rustchain_p2p_health_latency_seconds`
 
 ## API Endpoints Scraped (every 60s)
 
@@ -43,12 +50,14 @@ Implemented metrics:
 - `/api/hall_of_fame`
 - `/api/fee_pool`
 - `/api/stats`
+- `/p2p/health` from `P2P_NODE_URL`
 
 ## Configuration
 
 Environment variables:
 
 - `NODE_URL` (default: `https://rustchain.org`)
+- `P2P_NODE_URL` (default: `https://bulbous-bouffant.metalseed.net`, the public node currently exposing `/p2p/health` with a certificate-valid hostname)
 - `EXPORTER_PORT` (default: `9100`)
 - `SCRAPE_INTERVAL` (default: `60`)
 - `REQUEST_TIMEOUT` (default: `15`)

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -10,6 +10,10 @@ import requests
 from prometheus_client import Gauge, start_http_server
 
 NODE_URL = os.getenv("NODE_URL", "https://rustchain.org").rstrip("/")
+P2P_NODE_URL = os.getenv(
+    "P2P_NODE_URL",
+    "https://bulbous-bouffant.metalseed.net",
+).rstrip("/")
 EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9100"))
 SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
 REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
@@ -41,14 +45,19 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
-def fetch_json(endpoint: str) -> Any:
-    url = f"{NODE_URL}{endpoint}"
+def fetch_json(endpoint: str, base_url: str = NODE_URL) -> Any:
+    url = f"{base_url}{endpoint}"
     try:
         response = session.get(url, timeout=REQUEST_TIMEOUT)
         response.raise_for_status()
         return response.json()
     except Exception as exc:  # noqa: BLE001
-        logger.warning("request failed endpoint=%s error=%s", endpoint, exc)
+        logger.warning(
+            "request failed base_url=%s endpoint=%s error=%s",
+            base_url,
+            endpoint,
+            exc,
+        )
         return None
 
 
@@ -112,6 +121,34 @@ rustchain_total_fees_collected_rtc = Gauge(
 rustchain_fee_events_total = Gauge(
     "rustchain_fee_events_total",
     "Total fee events",
+)
+rustchain_p2p_up = Gauge(
+    "rustchain_p2p_up",
+    "RustChain P2P health endpoint status (1=up, 0=down)",
+)
+rustchain_p2p_peer_count = Gauge(
+    "rustchain_p2p_peer_count",
+    "Number of peers reported by the P2P subsystem",
+)
+rustchain_p2p_attestation_count = Gauge(
+    "rustchain_p2p_attestation_count",
+    "Number of attestations reported by the P2P subsystem",
+)
+rustchain_p2p_settled_epochs = Gauge(
+    "rustchain_p2p_settled_epochs",
+    "Number of settled epochs reported by the P2P subsystem",
+)
+rustchain_p2p_message_rate_per_second = Gauge(
+    "rustchain_p2p_message_rate_per_second",
+    "P2P message rate reported by the node, if available",
+)
+rustchain_p2p_messages_total = Gauge(
+    "rustchain_p2p_messages_total",
+    "Total P2P messages reported by the node, if available",
+)
+rustchain_p2p_health_latency_seconds = Gauge(
+    "rustchain_p2p_health_latency_seconds",
+    "Latency of the P2P health scrape in seconds",
 )
 
 
@@ -261,6 +298,47 @@ def collect_stats() -> None:
         rustchain_balance_rtc.labels(miner=miner).set(balance)
 
 
+def collect_p2p() -> None:
+    start = time.time()
+    payload = fetch_json("/p2p/health", P2P_NODE_URL)
+    rustchain_p2p_health_latency_seconds.set(time.time() - start)
+
+    if not isinstance(payload, dict):
+        rustchain_p2p_up.set(0)
+        rustchain_p2p_peer_count.set(0)
+        rustchain_p2p_attestation_count.set(0)
+        rustchain_p2p_settled_epochs.set(0)
+        rustchain_p2p_message_rate_per_second.set(0)
+        rustchain_p2p_messages_total.set(0)
+        return
+
+    rustchain_p2p_up.set(1 if payload.get("running", True) else 0)
+    rustchain_p2p_peer_count.set(
+        _to_float(payload.get("peer_count", len(payload.get("peers", []))))
+    )
+    rustchain_p2p_attestation_count.set(_to_float(payload.get("attestation_count", 0)))
+    rustchain_p2p_settled_epochs.set(_to_float(payload.get("settled_epochs", 0)))
+    rustchain_p2p_message_rate_per_second.set(
+        _to_float(
+            payload.get(
+                "message_rate",
+                payload.get(
+                    "messages_per_second",
+                    payload.get("gossip_messages_per_second", 0),
+                ),
+            )
+        )
+    )
+    rustchain_p2p_messages_total.set(
+        _to_float(
+            payload.get(
+                "message_count",
+                payload.get("messages_total", payload.get("gossip_messages_total", 0)),
+            )
+        )
+    )
+
+
 def collect_once() -> None:
     health_ok = collect_health()
     epoch = collect_epoch()
@@ -268,13 +346,15 @@ def collect_once() -> None:
     collect_hall_of_fame()
     collect_fee_pool()
     collect_stats()
+    collect_p2p()
     logger.info("collection complete health_ok=%s", health_ok)
 
 
 def main() -> None:
     logger.info(
-        "starting exporter node_url=%s port=%s scrape_interval=%ss",
+        "starting exporter node_url=%s p2p_node_url=%s port=%s scrape_interval=%ss",
         NODE_URL,
+        P2P_NODE_URL,
         EXPORTER_PORT,
         SCRAPE_INTERVAL,
     )

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -377,8 +377,8 @@ def collect_once() -> None:
 def main() -> None:
     logger.info(
         "starting exporter node_url=%s p2p_node_url=%s port=%s scrape_interval=%ss",
-        NODE_URL,
-        P2P_NODE_URL,
+        _safe_base_url_for_log(NODE_URL),
+        _safe_base_url_for_log(P2P_NODE_URL),
         EXPORTER_PORT,
         SCRAPE_INTERVAL,
     )

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 from prometheus_client import Gauge, start_http_server
@@ -45,6 +46,24 @@ def _to_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _safe_base_url_for_log(base_url: str) -> str:
+    try:
+        parts = urlsplit(base_url)
+    except ValueError:
+        return "<invalid-url>"
+
+    if not parts.scheme or not parts.hostname:
+        return "<invalid-url>"
+
+    host = parts.hostname
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    if parts.port is not None:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, "", "", ""))
+
+
 def fetch_json(endpoint: str, base_url: str = NODE_URL) -> Any:
     url = f"{base_url}{endpoint}"
     try:
@@ -54,7 +73,7 @@ def fetch_json(endpoint: str, base_url: str = NODE_URL) -> Any:
     except Exception as exc:  # noqa: BLE001
         logger.warning(
             "request failed base_url=%s endpoint=%s error=%s",
-            base_url,
+            _safe_base_url_for_log(base_url),
             endpoint,
             exc,
         )
@@ -298,6 +317,13 @@ def collect_stats() -> None:
         rustchain_balance_rtc.labels(miner=miner).set(balance)
 
 
+def _p2p_peer_count(payload: dict[str, Any]) -> int:
+    if payload.get("peer_count") is not None:
+        return _to_int(payload.get("peer_count"))
+    peers = payload.get("peers")
+    return len(peers) if isinstance(peers, list) else 0
+
+
 def collect_p2p() -> None:
     start = time.time()
     payload = fetch_json("/p2p/health", P2P_NODE_URL)
@@ -313,9 +339,7 @@ def collect_p2p() -> None:
         return
 
     rustchain_p2p_up.set(1 if payload.get("running", True) else 0)
-    rustchain_p2p_peer_count.set(
-        _to_float(payload.get("peer_count", len(payload.get("peers", []))))
-    )
+    rustchain_p2p_peer_count.set(_p2p_peer_count(payload))
     rustchain_p2p_attestation_count.set(_to_float(payload.get("attestation_count", 0)))
     rustchain_p2p_settled_epochs.set(_to_float(payload.get("settled_epochs", 0)))
     rustchain_p2p_message_rate_per_second.set(


### PR DESCRIPTION
## Summary
- Add `/p2p/health` scraping to the Prometheus exporter through configurable `P2P_NODE_URL`.
- Export P2P up status, peer count, attestation count, settled epochs, optional message rate/total, and scrape latency metrics.
- Default `P2P_NODE_URL` to the public P2P node's certificate-valid hostname instead of the raw HTTPS IP, so normal `requests` TLS verification works out of the box.
- Document the new metrics/configuration and add focused regression coverage.

Closes #2758.

This covers the same feature area as #5460, but avoids the reviewed raw-IP TLS failure path where `https://50.28.86.131/p2p/health` works only with insecure clients such as `curl -k`.

## Verification
- `python3 -B -m py_compile tools/prometheus/rustchain_exporter.py tests/test_prometheus_rustchain_exporter.py`
- `uv run --no-project --with pytest --with requests python -B -m pytest -q tests/test_prometheus_rustchain_exporter.py --noconftest`
- `git diff --check`
- `uv run --no-project --with requests python -c "import requests; r = requests.get('https://bulbous-bouffant.metalseed.net/p2p/health', timeout=10); print(r.status_code); print(r.json())"`

RTC wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
