### PR TITLE
fix(#5525): guard JSON body type and validate ttl_seconds in OTC order creation

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -430,7 +430,7 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
-    if not data:
+    if not isinstance(data, dict):
         return jsonify({"error": "JSON body required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
@@ -439,7 +439,10 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    try:
+        ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    except (ValueError, TypeError):
+        return jsonify({"error": "ttl_seconds must be an integer"}), 400
 
     # Validation
     if side not in ("buy", "sell"):


### PR DESCRIPTION
## Fix #5525\n\nAdded isinstance(data, dict) check and ttl_seconds int validation to prevent 500 on malformed input.\n\n**File:** otc-bridge/otc_bridge.py