### PR TITLE
fix(#5525): validate OTC order payloads

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -114,6 +114,25 @@ def decimal_units(value, scale, field_name):
     return amount, int(units)
 
 
+def get_json_object():
+    data = request.get_json(silent=True)
+    if data is None:
+        return None, (jsonify({"error": "JSON body required"}), 400)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
+def parse_order_ttl(raw):
+    if isinstance(raw, bool):
+        return None, "ttl_seconds must be an integer"
+    try:
+        ttl = int(raw)
+    except (TypeError, ValueError):
+        return None, "ttl_seconds must be an integer"
+    return min(max(ttl, 3600), ORDER_TTL_MAX), None
+
+
 def units_to_float(units, scale):
     return float(Decimal(int(units)) / Decimal(scale))
 
@@ -429,9 +448,9 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 @rate_limited
 def create_order():
     """Create a new buy or sell order."""
-    data = request.get_json(silent=True)
-    if not data:
-        return jsonify({"error": "JSON body required"}), 400
+    data, error = get_json_object()
+    if error:
+        return error
 
     side = str(data.get("side", "")).strip().lower()
     pair = str(data.get("pair", "RTC/USDC")).strip().upper()
@@ -439,7 +458,9 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    ttl, error = parse_order_ttl(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    if error:
+        return jsonify({"error": error}), 400
 
     # Validation
     if side not in ("buy", "sell"):
@@ -469,7 +490,6 @@ def create_order():
     if price_per_rtc > 1000:
         return jsonify({"error": "price_per_rtc too high (max $1000)"}), 400
 
-    ttl = min(max(ttl, 3600), ORDER_TTL_MAX)
     total_quote_nano = int(
         (amount_dec * price_dec * Decimal(QUOTE_PRICE_SCALE)).to_integral_value(
             rounding=ROUND_HALF_UP

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -126,9 +126,15 @@ def get_json_object():
 def parse_order_ttl(raw):
     if isinstance(raw, bool):
         return None, "ttl_seconds must be an integer"
-    try:
-        ttl = int(raw)
-    except (TypeError, ValueError):
+    if isinstance(raw, int):
+        ttl = raw
+    elif isinstance(raw, str):
+        value = raw.strip()
+        digits = value[1:] if value.startswith(("+", "-")) else value
+        if not digits.isdecimal():
+            return None, "ttl_seconds must be an integer"
+        ttl = int(value)
+    else:
         return None, "ttl_seconds must be an integer"
     return min(max(ttl, 3600), ORDER_TTL_MAX), None
 

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -107,6 +107,37 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertEqual(data["status"], "open")
         self.assertIn("otc_", data["order_id"])
 
+    def test_create_order_rejects_non_object_json(self):
+        r = self.app.post("/api/orders", json=["not-an-object"])
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json(), {"error": "JSON object required"})
+
+    def test_create_order_rejects_non_integer_ttl(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "test-buyer",
+            "amount_rtc": "1",
+            "price_per_rtc": "0.10",
+            "ttl_seconds": "abc",
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json(), {"error": "ttl_seconds must be an integer"})
+
+    def test_create_buy_order_accepts_valid_ttl(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "ttl-buyer",
+            "amount_rtc": "1",
+            "price_per_rtc": "0.10",
+            "ttl_seconds": "3600",
+        })
+        data = r.get_json()
+        self.assertEqual(r.status_code, 201)
+        self.assertTrue(data["ok"])
+        self.assertEqual(data["side"], "buy")
+
     def test_create_order_stores_scaled_integer_money_fields(self):
         """OTC money values are stored as integer scaled units, not SQLite REAL."""
         r = self.app.post("/api/orders", json={

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -124,6 +124,18 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertEqual(r.status_code, 400)
         self.assertEqual(r.get_json(), {"error": "ttl_seconds must be an integer"})
 
+    def test_create_order_rejects_float_ttl(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "test-buyer",
+            "amount_rtc": "1",
+            "price_per_rtc": "0.10",
+            "ttl_seconds": 3600.5,
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json(), {"error": "ttl_seconds must be an integer"})
+
     def test_create_buy_order_accepts_valid_ttl(self):
         r = self.app.post("/api/orders", json={
             "side": "buy",

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -130,6 +130,56 @@ def test_unexpected_order_errors_are_generic(tmp_path, monkeypatch):
     assert response.get_json() == {"error": "Internal server error"}
 
 
+def test_order_create_rejects_non_object_json(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post("/api/orders", json=["not-an-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_order_create_rejects_non_integer_ttl(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": "1",
+                "price_per_rtc": "0.10",
+                "ttl_seconds": "abc",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def test_order_create_accepts_valid_buy_order_with_ttl(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": "1",
+                "price_per_rtc": "0.10",
+                "ttl_seconds": "3600",
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.get_json()["ok"] is True
+
+
 def test_otc_bridge_no_longer_returns_raw_exception_strings():
     source = (REPO_ROOT / "otc-bridge" / "otc_bridge.py").read_text(encoding="utf-8")
 

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -160,6 +160,26 @@ def test_order_create_rejects_non_integer_ttl(tmp_path):
     assert response.get_json() == {"error": "ttl_seconds must be an integer"}
 
 
+def test_order_create_rejects_float_ttl(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": "1",
+                "price_per_rtc": "0.10",
+                "ttl_seconds": 3600.5,
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
 def test_order_create_accepts_valid_buy_order_with_ttl(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
 


### PR DESCRIPTION
## Summary
- require POST /api/orders JSON bodies to be objects before reading fields
- validate ttl_seconds before clamping it into the supported range
- add regression coverage for non-object JSON, invalid ttl_seconds, and valid buy orders with ttl_seconds

## Tests
- python -m pytest tests/test_otc_bridge_query_validation.py
- python -m pytest otc-bridge/test_otc_bridge.py -k "non_object_json or non_integer_ttl or accepts_valid_ttl or test_create_buy_order"
