### PR TITLE
Fix OTC order create validation 500s

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -430,8 +430,10 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
     pair = str(data.get("pair", "RTC/USDC")).strip().upper()
@@ -439,7 +441,10 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    try:
+        ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    except (TypeError, ValueError):
+        return jsonify({"error": "ttl_seconds must be an integer"}), 400
 
     # Validation
     if side not in ("buy", "sell"):

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -107,6 +107,25 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertEqual(data["status"], "open")
         self.assertIn("otc_", data["order_id"])
 
+    def test_create_order_rejects_non_object_json(self):
+        r = self.app.post("/api/orders", json=["not-an-object"])
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json(), {"error": "JSON object required"})
+
+    def test_create_order_rejects_non_integer_ttl_seconds(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "test-buyer",
+            "amount_rtc": 100,
+            "price_per_rtc": 0.10,
+            "ttl_seconds": "abc",
+        })
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json(), {"error": "ttl_seconds must be an integer"})
+
     def test_create_order_stores_scaled_integer_money_fields(self):
         """OTC money values are stored as integer scaled units, not SQLite REAL."""
         r = self.app.post("/api/orders", json={


### PR DESCRIPTION
Fixes #5525.\n\n## Summary\n- Return JSON 400 when POST /api/orders receives non-object JSON.\n- Return JSON 400 when ttl_seconds cannot be parsed as an integer.\n- Add regression coverage for both malformed-input cases.\n\n## Tests\n- pytest test_otc_bridge.py -q -k 'non_object_json or non_integer_ttl_seconds or test_create_buy_order'\n- Full otc_bridge test file currently has 2 unrelated existing failures in confirm/migration paths (26 passed, 2 failed).