### PR TITLE
fix: disable Flask debug entrypoints

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -659,4 +659,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=False)

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -186,4 +186,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=False, host='0.0.0.0', port=5000)

--- a/faucet_service/IMPLEMENTATION_SUMMARY.md
+++ b/faucet_service/IMPLEMENTATION_SUMMARY.md
@@ -284,7 +284,7 @@ cd faucet_service
 python3 test_faucet_service.py
 
 # Start the service
-python3 faucet_service.py --debug
+python3 faucet_service.py
 
 # Test API
 curl http://localhost:8090/health

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -37,7 +37,7 @@ python faucet_service.py
 python faucet_service.py --config faucet_config.local.yaml
 
 # Run with command-line overrides
-python faucet_service.py --host 0.0.0.0 --port 9000 --debug
+python faucet_service.py --host 0.0.0.0 --port 9000
 ```
 
 The faucet will start at `http://localhost:8090/faucet`
@@ -85,7 +85,7 @@ distribution:
 |--------|---------|-------------|
 | `host` | `0.0.0.0` | Server bind address |
 | `port` | `8090` | Server port |
-| `debug` | `false` | Enable debug mode |
+| `debug` | `false` | Flask debug mode stays disabled |
 | `base_path` | `/faucet` | Base URL path |
 
 #### Rate Limiting
@@ -430,13 +430,9 @@ redis-cli ping
 sqlite3 faucet.db "SELECT * FROM drip_requests LIMIT 5;"
 ```
 
-### Debug Mode
+### Debugging
 
-Enable debug mode for detailed logging:
-
-```bash
-python faucet_service.py --debug
-```
+Use application logs and health endpoints for diagnostics. Flask debug mode stays disabled for service entrypoints.
 
 ## License
 

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -1146,7 +1146,8 @@ def main():
                         help='Path to configuration file')
     parser.add_argument('--host', help='Override host from config')
     parser.add_argument('--port', '-p', type=int, help='Override port from config')
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
+    parser.add_argument('--debug', action='store_true',
+                        help='Deprecated; Flask debug mode remains disabled')
     
     args = parser.parse_args()
     
@@ -1158,8 +1159,7 @@ def main():
         config['server']['host'] = args.host
     if args.port:
         config['server']['port'] = args.port
-    if args.debug:
-        config['server']['debug'] = True
+    config['server']['debug'] = False
     
     # Create and run app
     app = create_app(config)

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -401,4 +401,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=False)

--- a/tests/test_flask_debug_disabled.py
+++ b/tests/test_flask_debug_disabled.py
@@ -1,0 +1,51 @@
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ENTRYPOINTS = [
+    ROOT / "keeper_explorer.py",
+    ROOT / "contributor_registry.py",
+    ROOT / "bridge" / "bridge_api.py",
+    ROOT / "faucet_service" / "faucet_service.py",
+]
+
+
+def _is_debug_subscript(node):
+    if not isinstance(node, ast.Subscript):
+        return False
+
+    slice_node = node.slice
+    if isinstance(slice_node, ast.Constant):
+        return slice_node.value == "debug"
+    return False
+
+
+def _debug_true_locations(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    locations = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for keyword in node.keywords:
+                if keyword.arg == "debug" and isinstance(keyword.value, ast.Constant):
+                    if keyword.value.value is True:
+                        locations.append((node.lineno, "app.run debug=True"))
+
+        if isinstance(node, ast.Assign):
+            assigns_true = isinstance(node.value, ast.Constant) and node.value.value is True
+            if assigns_true and any(_is_debug_subscript(target) for target in node.targets):
+                locations.append((node.lineno, "debug config assignment to True"))
+
+    return locations
+
+
+def test_public_flask_entrypoints_do_not_enable_debug_mode():
+    failures = {
+        str(path.relative_to(ROOT)): _debug_true_locations(path)
+        for path in ENTRYPOINTS
+    }
+    failures = {path: locations for path, locations in failures.items() if locations}
+
+    assert failures == {}


### PR DESCRIPTION
## Summary
- Disable Flask debug mode in the four public service entrypoints listed under #5059.
- Keep the faucet `--debug` flag as a deprecated compatibility no-op and force Flask debug mode off after config loading.
- Update faucet docs so they no longer recommend starting the service with Flask debug mode.
- Add a static regression test that fails if these entrypoints reintroduce `debug=True` or assign debug config to `True`.

## Covered entrypoints
- `keeper_explorer.py`
- `contributor_registry.py`
- `bridge/bridge_api.py`
- `faucet_service/faucet_service.py`

## Tests
- `rg -n "debug\\s*=\\s*True|\\['debug'\\]\\s*=\\s*True" keeper_explorer.py contributor_registry.py bridge/bridge_api.py faucet_service/faucet_service.py` -> no matches
- `git diff --check -- keeper_explorer.py contributor_registry.py bridge/bridge_api.py faucet_service/faucet_service.py faucet_service/README.md faucet_service/IMPLEMENTATION_SUMMARY.md tests/test_flask_debug_disabled.py`
- `python -B -m py_compile keeper_explorer.py contributor_registry.py bridge/bridge_api.py faucet_service/faucet_service.py tests/test_flask_debug_disabled.py`
- `python -B -m pytest -q tests/test_flask_debug_disabled.py --noconftest` -> `1 passed`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

Note: `py_compile` still emits the existing `keeper_explorer.py` invalid escape SyntaxWarning from the unchanged HTML banner; the command exits 0.

Fixes #5059