### PR TITLE
fix: add missing CI test dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,10 @@
 flask>=2.0.0
 # For miner and SDK:
 requests>=2.34.2
+# For async agent-economy SDK calls:
+aiohttp>=3.9.0
+# For faucet service CORS headers:
+flask-cors>=4.0.0
 # For wallet CLI (Ed25519 + AES-GCM):
 cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,6 @@ pytest>=7.4.4
 PyNaCl>=1.6.2
 # Needed by test_wallet_cli_39 (imports from tools/rustchain_wallet_cli.py)
 cryptography>=46.0.7
+# Needed by hardware visualizer and PSE result plotting tests
+matplotlib>=3.8.0
+seaborn>=0.13.0


### PR DESCRIPTION
## Summary
- Add `aiohttp` and `flask-cors` to the root development/runtime dependency set used by CI.
- Add `matplotlib` and `seaborn` to test dependencies for visualizer and PSE result-analysis tests.
- This lets the CI blocking pytest job collect the affected modules reported in #5335.

## Validation
- `python -m pip install --disable-pip-version-check -q -r requirements.txt -r tests/requirements.txt`
- `python -c "import aiohttp, flask_cors, matplotlib, Crypto; print('deps ok')"` -> `deps ok`
- `python -B -m pytest -q tests/test_agent_economy_sdk.py tests/test_faucet_service_wallet_validation.py tests/test_hardware_visualizer.py tests/test_pse_analyze_results.py --collect-only --noconftest` -> `14 tests collected`
- `python -B -m pytest -q tests/test_agent_economy_sdk.py tests/test_faucet_service_wallet_validation.py tests/test_hardware_visualizer.py tests/test_pse_analyze_results.py --noconftest` -> `14 passed`
- `python -B -m pytest tests/ --collect-only -q --ignore=tests/test_epoch_settlement_formal.py --ignore=tests/test_rip201_bucket_spoof.py` -> `2413 tests collected`

Fixes #5335