### PR TITLE
fix: fail closed when sync admin key is unset

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -92,7 +92,7 @@ def register_sync_endpoints(app, db_path, admin_key):
         @wraps(f)
         def decorated(*args, **kwargs):
             key = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
-            if not key or not hmac.compare_digest(key, admin_key):
+            if not key or not admin_key or not hmac.compare_digest(key, admin_key):
                 return jsonify({"error": "Unauthorized"}), 401
             return f(*args, **kwargs)
 

--- a/node/tests/test_rustchain_sync_endpoints.py
+++ b/node/tests/test_rustchain_sync_endpoints.py
@@ -51,3 +51,29 @@ def test_require_admin_uses_constant_time_compare(monkeypatch, tmp_path):
         ("wrong-secret", "sync-secret"),
         ("sync-secret", "sync-secret"),
     ]
+
+
+def test_require_admin_fails_closed_when_admin_key_is_unset(monkeypatch, tmp_path):
+    """Unset sync admin keys reject requests without comparing against None."""
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        raise AssertionError("compare_digest must not receive an unset admin key")
+
+    monkeypatch.setattr(rustchain_sync_endpoints.hmac, "compare_digest", spy_compare_digest)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        None,
+    )
+    client = app.test_client()
+
+    response = client.get("/api/sync/status", headers={"X-Admin-Key": "any-secret"})
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized"}
+    assert calls == []


### PR DESCRIPTION
## Summary
- fail closed before constant-time comparison when sync admin key is unset
- keep configured-key checks on hmac.compare_digest
- add regression coverage for unset admin keys with a provided header

## Tests
- python -B -m py_compile node\\rustchain_sync_endpoints.py node\\tests\\test_rustchain_sync_endpoints.py
- python -B -m pytest -q node\\tests\\test_rustchain_sync_endpoints.py --noconftest
- git diff --check
- python tools\\bcos_spdx_check.py --base-ref origin/main

Closes #5429