### PR TITLE
fix: validate OTC order create JSON

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -516,6 +516,8 @@ def parse_order_ttl(value):
         return ORDER_TTL_DEFAULT
     if isinstance(value, bool):
         raise ValueError("ttl_seconds must be an integer")
+    if isinstance(value, float) and not value.is_integer():
+        raise ValueError("ttl_seconds must be an integer")
     try:
         return int(value)
     except (TypeError, ValueError) as exc:

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -511,6 +511,17 @@ def rtc_cancel_escrow(job_id, poster_wallet):
         return False
 
 
+def parse_order_ttl(value):
+    if value is None:
+        return ORDER_TTL_DEFAULT
+    if isinstance(value, bool):
+        raise ValueError("ttl_seconds must be an integer")
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("ttl_seconds must be an integer") from exc
+
+
 # ---------------------------------------------------------------------------
 # API Routes
 # ---------------------------------------------------------------------------
@@ -520,7 +531,11 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"error": "JSON body required"}), 400
     if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+    if not data:
         return jsonify({"error": "JSON body required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
@@ -530,9 +545,9 @@ def create_order():
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
     try:
-        ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
-    except (ValueError, TypeError):
-        return jsonify({"error": "ttl_seconds must be an integer"}), 400
+        ttl = parse_order_ttl(data.get("ttl_seconds"))
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
 
     # Validation
     if side not in ("buy", "sell"):

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -223,6 +223,27 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertEqual(data["escrow_status"], "locked")
         mock_escrow.assert_called_once()
 
+    def test_create_order_rejects_non_object_json(self):
+        r = self.app.post("/api/orders", json=["not-an-object"])
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(data["error"], "JSON object required")
+
+    def test_create_order_rejects_invalid_ttl_seconds(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "test-buyer",
+            "amount_rtc": 100,
+            "price_per_rtc": 0.10,
+            "ttl_seconds": "abc",
+        })
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(data["error"], "ttl_seconds must be an integer")
+
     @patch("otc_bridge.rtc_get_balance", return_value=10.0)
     def test_sell_order_insufficient_balance(self, mock_balance):
         """Reject sell order if balance too low."""

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -244,6 +244,20 @@ class OTCBridgeTestCase(unittest.TestCase):
         self.assertEqual(r.status_code, 400)
         self.assertEqual(data["error"], "ttl_seconds must be an integer")
 
+    def test_create_order_rejects_fractional_ttl_seconds(self):
+        r = self.app.post("/api/orders", json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": "test-buyer",
+            "amount_rtc": 100,
+            "price_per_rtc": 0.10,
+            "ttl_seconds": 3600.5,
+        })
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(data["error"], "ttl_seconds must be an integer")
+
     @patch("otc_bridge.rtc_get_balance", return_value=10.0)
     def test_sell_order_insufficient_balance(self, mock_balance):
         """Reject sell order if balance too low."""

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -10,6 +10,9 @@ import time
 import unittest
 from unittest.mock import patch, MagicMock
 
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
 # Set an initial test DB before importing, then replace it per test.
 _fd, TEST_DB = tempfile.mkstemp(suffix=".db")
 os.close(_fd)
@@ -36,6 +39,45 @@ class OTCBridgeTestCase(unittest.TestCase):
                 os.remove(TEST_DB)
             except PermissionError:
                 pass
+
+    def signed_create_order_payload(self, payload):
+        private_key = Ed25519PrivateKey.generate()
+        public_key_hex = private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        ).hex()
+        wallet = otc_bridge.rtc_address_from_public_key(public_key_hex)
+        payload = dict(payload, wallet=wallet)
+        _, amount_micro_rtc = otc_bridge.decimal_units(
+            payload["amount_rtc"], otc_bridge.RTC_UNIT, "amount_rtc"
+        )
+        _, price_per_rtc_nano_quote = otc_bridge.decimal_units(
+            payload["price_per_rtc"], otc_bridge.QUOTE_PRICE_SCALE, "price_per_rtc"
+        )
+        ttl = otc_bridge.parse_order_ttl(payload.get("ttl_seconds"))
+        ttl = min(max(ttl, 3600), otc_bridge.ORDER_TTL_MAX)
+        timestamp = int(time.time())
+        auth_fields = otc_bridge.create_order_auth_fields(
+            payload["side"],
+            payload["pair"],
+            amount_micro_rtc,
+            price_per_rtc_nano_quote,
+            ttl,
+            payload.get("eth_address", ""),
+        )
+        message = otc_bridge.wallet_auth_message(
+            "create_order",
+            otc_bridge.CREATE_ORDER_AUTH_ID,
+            wallet,
+            timestamp,
+            auth_fields,
+        )
+        payload["wallet_auth"] = {
+            "public_key": public_key_hex,
+            "signature": private_key.sign(message).hex(),
+            "timestamp": timestamp,
+        }
+        return payload
 
     def create_legacy_money_schema(self):
         """Create the pre-migration schema with REAL NOT NULL money columns."""
@@ -92,13 +134,12 @@ class OTCBridgeTestCase(unittest.TestCase):
 
     def test_create_buy_order(self):
         """Buy orders don't need escrow -- just post to order book."""
-        r = self.app.post("/api/orders", json={
+        r = self.app.post("/api/orders", json=self.signed_create_order_payload({
             "side": "buy",
             "pair": "RTC/USDC",
-            "wallet": "test-buyer",
             "amount_rtc": 100,
             "price_per_rtc": 0.10,
-        })
+        }))
         data = r.get_json()
         self.assertTrue(data["ok"])
         self.assertEqual(data["side"], "buy")


### PR DESCRIPTION
## Summary
- Reject non-object JSON bodies in POST /api/orders with a JSON 400 instead of raising on dot-get.
- Validate ttl_seconds before clamping it so malformed TTL values return a JSON 400.
- Add regression coverage for both crash cases plus the existing valid buy-order path.

Closes #5525

## Validation
- /tmp/rustchain-otc-venv/bin/python -m unittest test_otc_bridge.OTCBridgeTestCase.test_create_buy_order test_otc_bridge.OTCBridgeTestCase.test_create_order_rejects_non_object_json test_otc_bridge.OTCBridgeTestCase.test_create_order_rejects_invalid_ttl_seconds -v
- /tmp/rustchain-otc-venv/bin/python -m py_compile otc_bridge.py test_otc_bridge.py
- git diff --check

Notes:
- Running the full existing otc-bridge/test_otc_bridge.py suite currently still hits an unrelated test_confirm_matched_order KeyError on ok; the focused regression tests for this fix pass.
- The repo-wide CI test job is currently failing outside this patch. The first CI run failed during collection due missing existing test dependencies; after locally adding those deps in a throwaway venv to inspect deeper, the suite exposed unrelated failures in CPU architecture detection, issue2310 path handling, setup miner artifact hash, and wallet review holds.

## Bounty / payout
RTC wallet: RTCacb2dc6d434201337e3954997f08b3fb9569cb02

AI assistance note: this PR was prepared with AI assistance and manually validated before submission.