### PR TITLE
docs: fix wallet guide link

### DIFF
--- a/docs/sprint/wallet-user-guide.md
+++ b/docs/sprint/wallet-user-guide.md
@@ -59,14 +59,14 @@ cargo build --release
 curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | jq .
 ```
 
-### 2. Web Wallet
+### 2. Wallet Documentation
 
-Access your wallet from any browser at **https://rustchain.org/wallet**
+Read the current wallet documentation from any browser at **https://rustchain.org/wallets/**
 
-- No installation required
-- Supports key import via seed phrase or private key
-- View balance, transaction history, and epoch rewards
-- Initiate transfers with a confirmation dialog
+- Native RTC wallet setup with `clawrtc wallet create`
+- Wallet address display with `clawrtc wallet show`
+- Coinbase/Base wallet linking for x402 payment flows
+- Swap and bridge references for wRTC
 
 > ⚠️ Always verify you are on the official domain (`rustchain.org`) before entering keys.
 
@@ -101,13 +101,12 @@ The RustChain browser extension integrates your wallet with dApps and the x402 p
 # 3. Back up your seed phrase (see section below)
 ```
 
-### Step-by-Step (Web)
+### Step-by-Step (Hosted Docs)
 
-1. Go to `https://rustchain.org/wallet`
-2. Click **Create New Wallet**
+1. Go to `https://rustchain.org/wallets/`
+2. Follow the native RTC wallet commands (`pip install clawrtc`, `clawrtc wallet create`, `clawrtc wallet show`)
 3. Write down your 12-word seed phrase — **do not screenshot it**
-4. Confirm two random words from the seed phrase
-5. Your wallet address is now ready
+4. Confirm your public wallet address before using it for mining or bounty claims
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace stale hosted wallet page references in `docs/sprint/wallet-user-guide.md`.
- Point the hosted-docs workflow to the current `https://rustchain.org/wallets/` page.
- Align the guide text with the current `clawrtc` wallet commands instead of the unavailable web-wallet flow.

## Why
The old guide points users to `https://rustchain.org/wallet`. That URL redirects to `https://rustchain.org/wallet/`, which currently returns 404. The current wallet documentation page at `https://rustchain.org/wallets/` returns 200 and documents the native RTC wallet commands.

## Validation
- `curl.exe -k -I -L --max-redirs 3 https://rustchain.org/wallet` -> 301 to `/wallet/`, then 404
- `curl.exe -k -I https://rustchain.org/wallets/` -> 200
- `git diff --check -- docs/sprint/wallet-user-guide.md` -> passed

Bounty reference: Scottcjn/rustchain-bounties#444
Bounty claim: https://github.com/Scottcjn/rustchain-bounties/issues/444#issuecomment-4468998774
RTC wallet: `RTCc68dae2dab2117db937bce7508472c8a7d11ac8b`