### PR TITLE
docs: fix health dashboard demo link

### DIFF
--- a/health-dashboard/README.md
+++ b/health-dashboard/README.md
@@ -15,9 +15,9 @@ A production-ready monitoring dashboard that tracks the health and performance o
 - **Mobile-friendly** responsive design
 - **Deployable** as static site + lightweight backend
 
-## 🌐 Live Demo
+## 🌐 Local Demo
 
-Access the dashboard at: `https://rustchain.org/status`
+Run the dashboard locally at: `http://localhost:5000`
 
 ## ✨ Features
 


### PR DESCRIPTION
## Summary
- Replace the stale `https://rustchain.org/status` live-demo link in `health-dashboard/README.md`.
- Point readers to the local dashboard URL already used by the setup instructions.
- Keep the later nginx `/status` production deployment example intact.

## Validation
- `git diff --check -- health-dashboard/README.md` -> passed
- `curl.exe -k -s -o NUL -w '%{http_code} %{url_effective}' -L --max-redirs 3 https://rustchain.org/status` -> 404
- Confirmed `health-dashboard/README.md` already documents `http://localhost:5000` for local browser access.

Bounty reference: Scottcjn/rustchain-bounties#444