### PR TITLE
fix: redact explorer upstream errors

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -9,6 +9,15 @@ app = Flask(__name__)
 API_BASE_URL = "http://localhost:8000"
 MINERS_ENDPOINT = f"{API_BASE_URL}/api/miners"
 
+UPSTREAM_UNAVAILABLE_ERROR = "Upstream node unavailable"
+
+
+def upstream_unavailable_response(*, include_miners=False):
+    payload = {"error": UPSTREAM_UNAVAILABLE_ERROR}
+    if include_miners:
+        payload["miners"] = []
+    return jsonify(payload), 502
+
 @app.route('/')
 def dashboard():
     return render_template('dashboard.html')
@@ -49,8 +58,9 @@ def get_miners():
             return jsonify(miners_data)
         else:
             return jsonify({'error': 'Failed to fetch miners data', 'miners': []}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}', 'miners': []}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch miners from upstream node")
+        return upstream_unavailable_response(include_miners=True)
 
 @app.route('/api/network/stats')
 def get_network_stats():
@@ -80,8 +90,9 @@ def get_network_stats():
             return jsonify(stats)
         else:
             return jsonify({'error': 'Failed to fetch network stats'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch network stats from upstream node")
+        return upstream_unavailable_response()
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
@@ -122,8 +133,9 @@ def get_miner_detail(miner_id):
                 return jsonify({'error': 'Miner not found'}), 404
         else:
             return jsonify({'error': 'Failed to fetch miner data'}), 500
-    except requests.exceptions.RequestException as e:
-        return jsonify({'error': f'Connection error: {str(e)}'}), 500
+    except requests.exceptions.RequestException:
+        app.logger.exception("Failed to fetch miner detail from upstream node")
+        return upstream_unavailable_response()
 
 @app.errorhandler(404)
 def not_found(error):

--- a/tests/test_explorer_app_error_redaction.py
+++ b/tests/test_explorer_app_error_redaction.py
@@ -1,0 +1,48 @@
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+
+import requests
+
+
+def load_explorer_app():
+    module_path = Path(__file__).resolve().parents[1] / "explorer" / "app.py"
+    spec = importlib.util.spec_from_file_location("explorer_app_error_redaction_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.app.testing = True
+    return module
+
+
+def test_explorer_api_redacts_upstream_request_exceptions(monkeypatch):
+    explorer_app = load_explorer_app()
+    leaked = (
+        "HTTPConnectionPool(host='127.0.0.1', port=8000): "
+        "url=/api/miners?token=super-secret trace=/srv/rustchain/private/node.py"
+    )
+    logger_exception = Mock()
+
+    def fail_request(*args, **kwargs):
+        raise requests.exceptions.ConnectionError(leaked)
+
+    monkeypatch.setattr(explorer_app.requests, "get", fail_request)
+    monkeypatch.setattr(explorer_app.app.logger, "exception", logger_exception)
+
+    with explorer_app.app.test_client() as client:
+        responses = [
+            client.get("/api/miners"),
+            client.get("/api/network/stats"),
+            client.get("/api/miner/alice"),
+        ]
+
+    for response in responses:
+        assert response.status_code == 502
+        body = response.get_json()
+        assert body["error"] == "Upstream node unavailable"
+        rendered = str(body)
+        assert "127.0.0.1" not in rendered
+        assert "super-secret" not in rendered
+        assert "/srv/rustchain/private/node.py" not in rendered
+
+    assert responses[0].get_json()["miners"] == []
+    assert logger_exception.call_count == 3


### PR DESCRIPTION
﻿## Summary
- replace raw upstream `requests` exception text in explorer API responses with a generic `Upstream node unavailable` error
- preserve the `/api/miners` empty-list fallback while returning 502 for upstream connection failures
- add regression coverage for `/api/miners`, `/api/network/stats`, and `/api/miner/<miner_id>` to ensure internal host/token/path details are not client-visible

Closes #5449

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest -q tests\test_explorer_app_error_redaction.py` -> 1 passed
- `py -3 -m py_compile explorer\app.py tests\test_explorer_app_error_redaction.py` -> passed
- `git diff --check -- explorer\app.py tests\test_explorer_app_error_redaction.py` -> passed

## Bounty / payout
RTC wallet: RTCc68dae2dab2117db937bce7508472c8a7d11ac8b
