### PR TITLE
fix: redact moderation webhook errors

### DIFF
--- a/tools/comment-moderation-bot/src/webhook.py
+++ b/tools/comment-moderation-bot/src/webhook.py
@@ -20,6 +20,8 @@ from .moderation_service import ModerationService
 
 logger = logging.getLogger(__name__)
 
+INTERNAL_MODERATION_ERROR = "Internal moderation processing error"
+
 
 def _payload_object(
     payload: dict[str, Any],
@@ -301,7 +303,7 @@ def register_routes(app: FastAPI, config: BotConfig) -> None:
             )
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=str(e),
+                detail=INTERNAL_MODERATION_ERROR,
             )
 
     @app.get("/stats")

--- a/tools/comment-moderation-bot/tests/test_webhook.py
+++ b/tools/comment-moderation-bot/tests/test_webhook.py
@@ -390,6 +390,50 @@ class TestWebhookProcessing:
             assert data["action"] == "delete"
             assert data["risk_score"] > 0.8
 
+    @pytest.mark.asyncio
+    async def test_webhook_processing_error_redacts_internal_details(
+        self, app: TestClient, sample_webhook_payload: dict, mock_config: MagicMock
+    ) -> None:
+        """Test processing failures keep details in audit logs, not responses."""
+        leaked = (
+            "database dsn=postgres://bot:secret@internal-db/moderation "
+            "at /srv/rustchain/private/moderation.py"
+        )
+        body = json.dumps(sample_webhook_payload).encode()
+        signature = generate_signature(body, mock_config.github_app.webhook_secret.get_secret_value())
+
+        with patch.object(
+            app.app.state.moderation_service,
+            "process_comment_event",
+            new_callable=AsyncMock,
+        ) as mock_process, patch.object(
+            app.app.state.audit_logger,
+            "log_error",
+        ) as mock_log_error:
+            mock_process.side_effect = RuntimeError(leaked)
+
+            response = app.post(
+                "/webhook",
+                content=body,
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "test-delivery-id",
+                    "X-Hub-Signature-256": signature,
+                },
+            )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+        assert response.json()["detail"] == "Internal moderation processing error"
+        rendered = response.text
+        assert "postgres://bot:secret@internal-db" not in rendered
+        assert "/srv/rustchain/private/moderation.py" not in rendered
+
+        mock_log_error.assert_called()
+        audit_kwargs = mock_log_error.call_args.kwargs
+        assert audit_kwargs["error_type"] == "processing_error"
+        assert leaked in audit_kwargs["message"]
+        assert leaked in audit_kwargs["traceback"]
+
     def test_webhook_missing_payload_data(
         self, app: TestClient, mock_config: MagicMock
     ) -> None:


### PR DESCRIPTION
﻿## Summary
- return a generic `Internal moderation processing error` for comment moderation webhook processing failures
- keep the original exception details in the existing audit log path
- add a regression test proving DSN/path details stay out of the HTTP 500 response while audit logging still receives the original exception

Closes #5447

## Validation
- `uv run --no-project --with pytest --with pytest-asyncio --with fastapi --with httpx --with pydantic --with pydantic-settings --with pyjwt --with cryptography python -m pytest -q tests\test_webhook.py --override-ini addopts=` -> 22 passed
- `py -3 -m py_compile tools\comment-moderation-bot\src\webhook.py tools\comment-moderation-bot\tests\test_webhook.py` -> passed
- `git diff --check -- tools\comment-moderation-bot\src\webhook.py tools\comment-moderation-bot\tests\test_webhook.py` -> passed

## Bounty / payout
RTC wallet: RTCc68dae2dab2117db937bce7508472c8a7d11ac8b
