### PR TITLE
fix: redact bottube mood errors

### DIFF
--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -912,9 +912,10 @@ class MoodEngine:
 
 
 # ─── Flask Blueprint ─────────────────────────────────────────────────────────── #
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 
 mood_bp = Blueprint("bottube_mood", __name__, url_prefix="/api/v1/agents")
+MOOD_SERVICE_ERROR = "Mood service unavailable"
 
 
 def get_mood_engine() -> MoodEngine:
@@ -936,6 +937,11 @@ def _get_json_object(allow_empty: bool = False):
     if not isinstance(data, dict):
         return None, (jsonify({"error": "JSON object required"}), 400)
     return data, None
+
+
+def _mood_service_error_response():
+    current_app.logger.exception("BoTTube mood service failure")
+    return jsonify({"error": MOOD_SERVICE_ERROR}), 500
 
 
 @mood_bp.route("/<agent_name>/mood", methods=["GET"])
@@ -960,8 +966,8 @@ def get_agent_mood_endpoint(agent_name: str):
 
         return jsonify(mood_info)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 @mood_bp.route("/<agent_name>/mood/signal", methods=["POST"])
@@ -992,8 +998,8 @@ def record_mood_signal(agent_name: str):
         result = engine.record_signal(agent_name, signal_type, value, weight)
         return jsonify(result)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 @mood_bp.route("/<agent_name>/mood/title", methods=["POST"])
@@ -1022,8 +1028,8 @@ def generate_mood_title(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 @mood_bp.route("/<agent_name>/mood/comment", methods=["POST"])
@@ -1051,8 +1057,8 @@ def generate_mood_comment(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 @mood_bp.route("/<agent_name>/mood/post-probability", methods=["GET"])
@@ -1074,8 +1080,8 @@ def get_post_probability(agent_name: str):
             "current_mood": engine.get_agent_mood(agent_name)["current_mood"],
         })
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 @mood_bp.route("/<agent_name>/mood/statistics", methods=["GET"])
@@ -1090,8 +1096,8 @@ def get_mood_statistics_endpoint(agent_name: str):
         stats = engine.get_mood_statistics(agent_name)
         return jsonify(stats)
 
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
+    except Exception:
+        return _mood_service_error_response()
 
 
 def init_mood_routes(app):

--- a/tests/test_bottube_mood.py
+++ b/tests/test_bottube_mood.py
@@ -566,6 +566,7 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
         app.config["TESTING"] = True
         app.config["DB_PATH"] = self.temp_db.name
         app.register_blueprint(mood_bp)
+        self.app = app
         self.client = app.test_client()
 
     def tearDown(self):
@@ -633,6 +634,39 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn("generated_comment", response.get_json())
+
+    def test_mood_routes_redact_internal_engine_errors(self):
+        leaked = (
+            "sqlite3.OperationalError: no such table: agent_mood_history "
+            "at /srv/rustchain/private/mood.db token=super-secret"
+        )
+        routes = [
+            ("GET", "/api/v1/agents/test-agent/mood", None),
+            ("POST", "/api/v1/agents/test-agent/mood/signal", {"signal_type": "video_views"}),
+            ("POST", "/api/v1/agents/test-agent/mood/title", {"topic": "status"}),
+            ("POST", "/api/v1/agents/test-agent/mood/comment", {"base_comment": "hello"}),
+            ("GET", "/api/v1/agents/test-agent/mood/post-probability", None),
+            ("GET", "/api/v1/agents/test-agent/mood/statistics", None),
+        ]
+
+        with patch("bottube_mood_engine.get_mood_engine", side_effect=RuntimeError(leaked)):
+            self.app.logger.exception = MagicMock()
+
+            for method, route, payload in routes:
+                with self.subTest(route=route):
+                    if method == "GET":
+                        response = self.client.get(route)
+                    else:
+                        response = self.client.post(route, json=payload)
+
+                    self.assertEqual(response.status_code, 500)
+                    self.assertEqual(response.get_json()["error"], "Mood service unavailable")
+                    rendered = response.get_data(as_text=True)
+                    self.assertNotIn("agent_mood_history", rendered)
+                    self.assertNotIn("/srv/rustchain/private/mood.db", rendered)
+                    self.assertNotIn("super-secret", rendered)
+
+        self.assertEqual(self.app.logger.exception.call_count, len(routes))
 
 
 def run_demo():


### PR DESCRIPTION
﻿## Summary
- return a generic `Mood service unavailable` response for BoTTube mood engine failures
- log the full exception server-side with Flask's logger instead of reflecting `str(e)` to clients
- add regression coverage across all six mood routes to ensure table names, filesystem paths, and secret-like tokens are not client-visible

Closes #5445

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest -q tests\test_bottube_mood.py` -> 31 passed, 14 subtests passed
- `py -3 -m py_compile bottube_mood_engine.py tests\test_bottube_mood.py` -> passed
- `git diff --check -- bottube_mood_engine.py tests\test_bottube_mood.py` -> passed

## Bounty / payout
RTC wallet: RTCc68dae2dab2117db937bce7508472c8a7d11ac8b
