### PR TITLE
docs: fix wallet source link in claims guide

### DIFF
--- a/docs/CLAIMS_GUIDE.md
+++ b/docs/CLAIMS_GUIDE.md
@@ -44,7 +44,7 @@ Before claiming rewards, ensure you have:
 
 If you don't have a wallet address:
 
-1. Download the [RustChain Wallet](/wallet) (Note: wallet download page not yet live — use `pip install clawrtc` or build from source)
+1. Use `pip install clawrtc` or build from the [RustChain Wallet source](../wallet) (wallet download page not yet live)
 2. Generate a new address
 3. Save your private key securely (never share it!)
 4. Copy the public address (starts with `RTC`)


### PR DESCRIPTION
## Summary
- Fix the wallet setup link in `docs/CLAIMS_GUIDE.md` so it points to the repository's wallet source directory instead of the absolute `/wallet` path.
- Keep the note that the wallet download page is not live, while making the current `clawrtc`/source options clearer.

## Validation
- `Test-Path .\wallet` -> `True`
- `Test-Path .\docs\..\wallet` -> `True`
- `rg -n "\]\(/wallet\)|\]\(\.\./wallet\)|RustChain Wallet source" docs\CLAIMS_GUIDE.md`

First PR.
Wallet ID: pending; I can provide it when requested for RTC payout.
