### PR TITLE
fix: hide server proxy upstream errors

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -58,8 +58,9 @@ def proxy(path):
 
     except requests.exceptions.Timeout:
         return jsonify({'error': 'Local server timeout'}), 504
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        app.logger.exception("RustChain proxy upstream request failed")
+        return jsonify({'error': 'Local server unavailable'}), 502
 
 @app.route('/status')
 def status():

--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -14,6 +14,19 @@ app = Flask(__name__)
 # Local server on same machine
 LOCAL_SERVER = "http://localhost:8088"
 
+
+def _generic_upstream_error(response, reason):
+    """Hide upstream failure details from public proxy clients."""
+    app.logger.warning(
+        "RustChain proxy upstream %s: status=%s content_type=%r body=%r",
+        reason,
+        getattr(response, "status_code", None),
+        getattr(response, "headers", {}).get("Content-Type", ""),
+        getattr(response, "text", "")[:1000],
+    )
+    return jsonify({'error': 'Local server unavailable'}), 502
+
+
 def _build_local_api_url(path):
     """Return a local /api URL without allowing dot-segment escapes."""
     parts = path.split("/")
@@ -44,14 +57,16 @@ def proxy(path):
             response = requests.get(url, timeout=10)
 
         # Return the response from local server
+        if response.status_code >= 500:
+            return _generic_upstream_error(response, "error response")
+
         # Safely handle non-JSON responses from upstream
         content_type = response.headers.get('Content-Type', '')
         if 'application/json' in content_type:
             try:
                 return response.json(), response.status_code
-            except (ValueError, Exception):
-                # JSON parse failed, fall back to text
-                return response.text, response.status_code
+            except ValueError:
+                return _generic_upstream_error(response, "invalid json")
         else:
             # Non-JSON response (e.g., HTML error page), return as-is with text
             return response.text, response.status_code

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -89,3 +89,49 @@ def test_proxy_hides_upstream_exception_details(monkeypatch):
     assert "127.0.0.1" not in response.get_data(as_text=True)
     assert "token=secret" not in response.get_data(as_text=True)
     assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)
+
+
+def test_proxy_hides_upstream_error_response_details(monkeypatch):
+    proxy = load_server_proxy()
+
+    class FakeResponse:
+        status_code = 500
+        text = "trace token=super-secret path=/srv/rustchain/private.db host=127.0.0.1"
+        headers = {"Content-Type": "text/html"}
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/miners")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Local server unavailable"}
+    assert "super-secret" not in response.get_data(as_text=True)
+    assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)
+    assert "127.0.0.1" not in response.get_data(as_text=True)
+
+
+def test_proxy_hides_invalid_json_response_details(monkeypatch):
+    proxy = load_server_proxy()
+
+    class FakeResponse:
+        status_code = 200
+        text = '{"error":"token=super-secret path=/srv/rustchain/private.db"}'
+        headers = {"Content-Type": "application/json"}
+
+        def json(self):
+            raise ValueError("invalid json")
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/miners")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Local server unavailable"}
+    assert "super-secret" not in response.get_data(as_text=True)
+    assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -68,3 +68,24 @@ def test_proxy_keeps_safe_requests_under_api(monkeypatch):
     assert response.status_code == 200
     assert response.get_data(as_text=True) == "ok"
     assert captured == {"url": "http://localhost:8088/api/stats", "timeout": 10}
+
+
+def test_proxy_hides_upstream_exception_details(monkeypatch):
+    proxy = load_server_proxy()
+
+    def fake_get(url, timeout):
+        raise RuntimeError(
+            "connect failed to http://127.0.0.1:8088/api/miners "
+            "token=secret path=/srv/rustchain/private.db"
+        )
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/miners")
+    body = response.get_json()
+
+    assert response.status_code == 502
+    assert body == {"error": "Local server unavailable"}
+    assert "127.0.0.1" not in response.get_data(as_text=True)
+    assert "token=secret" not in response.get_data(as_text=True)
+    assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary

- Return a stable generic 502 response when the vintage-hardware server proxy hits an unexpected upstream request exception.
- Log the original exception server-side with `app.logger.exception(...)` for operators.
- Add regression coverage proving internal details are not reflected to proxy clients.

Fixes #5544
Bounty: #305
Wallet: `RTC4e9b755109fc7b898eaebbd20ad665d9855449eb`
BCOS tier: BCOS-L1

## Validation

- `/tmp/rustchain-bug-venv/bin/python -m pytest tests/test_server_proxy_path.py -q`
  - `5 passed, 1 warning in 0.05s`
- `/tmp/rustchain-bug-venv/bin/python -m py_compile node/server_proxy.py tests/test_server_proxy_path.py`
  - passed
- `git diff --check -- node/server_proxy.py tests/test_server_proxy_path.py`
  - passed
