### PR TITLE
fix: redact tx handler internal errors

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -693,6 +693,10 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
     """
     from flask import request, jsonify
 
+    def internal_error(route_name: str):
+        logger.exception("Internal error in %s", route_name)
+        return jsonify({"error": "internal_error"}), 500
+
     @app.route('/tx/submit', methods=['POST'])
     def submit_transaction():
         """Submit a signed transaction"""
@@ -730,9 +734,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
                     "error": result
                 }), 400
 
-        except Exception as e:
-            logger.error(f"Error submitting transaction: {e}")
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("submit_transaction")
 
     @app.route('/tx/status/<tx_hash>', methods=['GET'])
     def get_tx_status(tx_hash: str):
@@ -740,8 +743,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
         try:
             status = tx_pool.get_transaction_status(tx_hash)
             return jsonify(status)
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("get_tx_status")
 
     @app.route('/tx/pending', methods=['GET'])
     def list_pending():
@@ -766,8 +769,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
                 "count": len(pending),
                 "transactions": [tx.to_dict() for tx in pending]
             })
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("list_pending")
 
     @app.route('/wallet/<address>/balance', methods=['GET'])
     def get_wallet_balance(address: str):
@@ -785,8 +788,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
                 "balance_rtc": balance / 100_000_000,
                 "available_rtc": available / 100_000_000
             })
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("get_wallet_balance")
 
     @app.route('/wallet/<address>/nonce', methods=['GET'])
     def get_wallet_nonce(address: str):
@@ -806,8 +809,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
                 "next_nonce": next_nonce,
                 "pending_nonces": sorted(pending_nonces)
             })
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("get_wallet_nonce")
 
     @app.route('/wallet/<address>/history', methods=['GET'])
     def get_wallet_history(address: str):
@@ -850,8 +853,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
                 "count": len(transactions),
                 "transactions": transactions
             })
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
+        except Exception:
+            return internal_error("get_wallet_history")
 
 
 # =============================================================================

--- a/tests/test_tx_handler_error_redaction.py
+++ b/tests/test_tx_handler_error_redaction.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for transaction API internal error redaction.
+"""
+
+from flask import Flask
+
+from node.rustchain_tx_handler import create_tx_api_routes
+
+
+LEAKY_ERROR = "no such table: pending_transactions at /srv/rustchain/prod.db"
+
+
+class ExplodingPool:
+    db_path = "/srv/rustchain/prod.db"
+
+    def _boom(self):
+        raise RuntimeError(LEAKY_ERROR)
+
+    def get_transaction_status(self, tx_hash):
+        self._boom()
+
+    def get_pending_transactions(self, limit):
+        self._boom()
+
+    def get_balance(self, address):
+        self._boom()
+
+    def get_available_balance(self, address):
+        self._boom()
+
+    def get_pending_amount(self, address):
+        self._boom()
+
+    def get_wallet_nonce(self, address):
+        self._boom()
+
+    def _get_pending_nonces(self, address):
+        self._boom()
+
+
+def _client_for_exploding_pool():
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    create_tx_api_routes(app, ExplodingPool())
+    return app.test_client()
+
+
+def _assert_redacted(response):
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "internal_error"}
+    assert b"pending_transactions" not in response.data
+    assert b"/srv/rustchain/prod.db" not in response.data
+
+
+def test_tx_status_redacts_internal_exception_details():
+    with _client_for_exploding_pool() as client:
+        _assert_redacted(client.get("/tx/status/hash_1"))
+
+
+def test_tx_pending_redacts_internal_exception_details():
+    with _client_for_exploding_pool() as client:
+        _assert_redacted(client.get("/tx/pending"))
+
+
+def test_wallet_balance_redacts_internal_exception_details():
+    with _client_for_exploding_pool() as client:
+        _assert_redacted(client.get("/wallet/alice/balance"))
+
+
+def test_wallet_nonce_redacts_internal_exception_details():
+    with _client_for_exploding_pool() as client:
+        _assert_redacted(client.get("/wallet/alice/nonce"))
+
+
+def test_wallet_history_redacts_internal_exception_details(monkeypatch):
+    from node import rustchain_tx_handler as tx_handler
+
+    def raise_connect_error(*args, **kwargs):
+        raise RuntimeError(LEAKY_ERROR)
+
+    monkeypatch.setattr(tx_handler.sqlite3, "connect", raise_connect_error)
+
+    with _client_for_exploding_pool() as client:
+        _assert_redacted(client.get("/wallet/alice/history"))


### PR DESCRIPTION
## Summary
- Redact raw internal exception text from `node/rustchain_tx_handler.py` 500 responses.
- Keep full exception details in server logs via `logger.exception(...)`.
- Add regression coverage for transaction status, pending list, wallet balance, wallet nonce, and wallet history routes so SQLite/path details do not leak to clients.

## Related
- Follow-up for #3202.
- Bounty context: Scottcjn/rustchain-bounties#71.
- RTC wallet/miner metadata: `RTC4e9b755109fc7b898eaebbd20ad665d9855449eb` / `ZHOUEU-star`.
- BCOS tier: L2 security hardening.

## Validation
- `/tmp/rustchain-bug-venv/bin/python -m pytest tests/test_tx_handler_error_redaction.py tests/test_tx_handler_limits.py tests/test_tx_submit_route.py -q` -> 22 passed, 1 urllib3 LibreSSL warning
- `/tmp/rustchain-bug-venv/bin/python -m py_compile node/rustchain_tx_handler.py tests/test_tx_handler_error_redaction.py tests/test_tx_handler_limits.py tests/test_tx_submit_route.py` -> passed
- `git diff --check` -> passed
