### PR TITLE
fix: harden Beacon x402 wallet/export fallbacks

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -28,7 +28,7 @@ try:
     )
     X402_CONFIG_OK = True
 except ImportError:
-    log.warning("x402_config not found — x402 features disabled")
+    log.warning("x402_config not found ? x402 features disabled")
     X402_CONFIG_OK = False
 
 
@@ -182,7 +182,7 @@ def init_app(app, get_db_func):
         log.error(f"Beacon x402 migration failed: {e}")
 
     # ---------------------------------------------------------------
-    # Wallet Management — Native Agents
+    # Wallet Management ? Native Agents
     # ---------------------------------------------------------------
 
     @app.route("/api/agents/<agent_id>/wallet", methods=["POST", "OPTIONS"])
@@ -191,13 +191,13 @@ def init_app(app, get_db_func):
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
 
-        # Simple admin check — require admin key in header
+        # Simple admin check ? require admin key in header
         admin_key = request.headers.get("X-Admin-Key", "")
         expected = os.environ.get("BEACON_ADMIN_KEY", "")
         if not expected:
             return _cors_json({"error": "Admin key not configured"}, 503)
         if not hmac.compare_digest(admin_key, expected):
-            return _cors_json({"error": "Unauthorized — admin key required"}, 401)
+            return _cors_json({"error": "Unauthorized ? admin key required"}, 401)
 
         data, error_response = _json_object_body()
         if error_response:
@@ -254,7 +254,7 @@ def init_app(app, get_db_func):
                 "SELECT coinbase_address FROM relay_agents WHERE agent_id = ?",
                 (agent_id,),
             ).fetchone()
-            if relay and relay.get("coinbase_address"):
+            if relay and relay["coinbase_address"]:
                 return _cors_json({
                     "agent_id": agent_id,
                     "coinbase_address": relay["coinbase_address"],
@@ -317,9 +317,12 @@ def init_app(app, get_db_func):
             return err_resp
 
         db = get_db_func()
-        rows = db.execute(
-            "SELECT * FROM contracts ORDER BY created_at DESC"
-        ).fetchall()
+        try:
+            rows = db.execute(
+                "SELECT * FROM contracts ORDER BY created_at DESC"
+            ).fetchall()
+        except sqlite3.OperationalError:
+            rows = []
 
         contracts = []
         for r in rows:

--- a/tests/test_beacon_x402_payment_gate.py
+++ b/tests/test_beacon_x402_payment_gate.py
@@ -85,3 +85,14 @@ def test_paid_beacon_reputation_rejects_unverified_payment_header(tmp_path, monk
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM x402_beacon_payments").fetchone()[0]
     assert count == 0
+
+def test_free_contract_export_handles_missing_contracts_table(tmp_path, monkeypatch):
+    client, _db_path = _make_paid_beacon_client(tmp_path, monkeypatch)
+    monkeypatch.setattr(beacon_x402, "PRICE_BEACON_CONTRACT", "0", raising=False)
+
+    response = client.get("/api/premium/contracts/export")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["total"] == 0
+    assert body["contracts"] == []

--- a/tests/test_beacon_x402_wallet.py
+++ b/tests/test_beacon_x402_wallet.py
@@ -16,6 +16,32 @@ def client(tmp_path, monkeypatch):
     db_path = tmp_path / "beacon.db"
     with sqlite3.connect(db_path) as conn:
         conn.executescript(beacon_x402.X402_BEACON_SCHEMA)
+        conn.execute(
+            """
+            CREATE TABLE relay_agents (
+                agent_id TEXT PRIMARY KEY,
+                pubkey_hex TEXT NOT NULL,
+                name TEXT,
+                status TEXT DEFAULT 'active',
+                coinbase_address TEXT DEFAULT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """INSERT INTO relay_agents
+               (agent_id, pubkey_hex, name, coinbase_address, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                "relay-1",
+                "00" * 32,
+                "Relay One",
+                "0x1234567890123456789012345678901234567890",
+                1,
+                1,
+            ),
+        )
 
     monkeypatch.setenv("BEACON_ADMIN_KEY", "test-admin-key")
     monkeypatch.setattr(beacon_x402, "_run_migrations", lambda _db_path: None)
@@ -63,3 +89,11 @@ def test_set_agent_wallet_preserves_valid_address(client):
 
     assert response.status_code == 200
     assert response.get_json()["coinbase_address"] == "0x1234567890123456789012345678901234567890"
+
+def test_get_agent_wallet_returns_relay_wallet(client):
+    response = client.get("/api/agents/relay-1/wallet")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["source"] == "relay"
+    assert body["coinbase_address"] == "0x1234567890123456789012345678901234567890"


### PR DESCRIPTION
﻿## Summary
- fix Beacon x402 relay wallet lookup when `relay_agents.coinbase_address` is present
- make the premium contracts export tolerate an uninitialized `contracts` table the same way reputation export already does
- add regression coverage for the relay wallet fallback and free contracts export path

## Root cause
`sqlite3.Row` does not implement `.get()`, so `GET /api/agents/<relay_id>/wallet` raised an AttributeError whenever a relay row with `coinbase_address` existed. The contracts export also queried `contracts` unguarded, so a free or configured x402 export could 500 before the table had been initialized.

## Impact
Relay agent wallet discovery and the Beacon x402 contracts export can fail with server errors in valid deployment states, which breaks the paid/premium Beacon workflow and makes relay wallet metadata unavailable.

## Validation
- `PYTHONPATH=node:. python -B -m pytest -q tests/test_beacon_x402_wallet.py tests/test_beacon_x402_payment_gate.py --tb=short`
- `python -B -m py_compile node/beacon_x402.py tests/test_beacon_x402_wallet.py tests/test_beacon_x402_payment_gate.py`
- `git diff --check -- node/beacon_x402.py tests/test_beacon_x402_wallet.py tests/test_beacon_x402_payment_gate.py`

## Bounty
Claiming under Scottcjn/rustchain-bounties#71.
RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`
