### PR TITLE
fix: mask upstream exception details in server proxy

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -58,8 +58,9 @@ def proxy(path):
 
     except requests.exceptions.Timeout:
         return jsonify({'error': 'Local server timeout'}), 504
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        app.logger.exception('Unexpected local server proxy failure for path %s', path)
+        return jsonify({'error': 'Local server unavailable'}), 500
 
 @app.route('/status')
 def status():

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -68,3 +68,24 @@ def test_proxy_keeps_safe_requests_under_api(monkeypatch):
     assert response.status_code == 200
     assert response.get_data(as_text=True) == "ok"
     assert captured == {"url": "http://localhost:8088/api/stats", "timeout": 10}
+
+
+def test_proxy_masks_unexpected_upstream_exception_details(monkeypatch):
+    proxy = load_server_proxy()
+
+    def fake_get(url, timeout):
+        raise RuntimeError(
+            "connect failed to http://127.0.0.1:8088/api/miners "
+            "token=secret path=/srv/rustchain/private.db"
+        )
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/miners")
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Local server unavailable"}
+    body = response.get_data(as_text=True)
+    assert "127.0.0.1" not in body
+    assert "token=secret" not in body
+    assert "/srv/rustchain/private.db" not in body


### PR DESCRIPTION
## Summary
- add a regression test for upstream exception leakage in the server proxy
- log upstream exceptions server-side instead of returning raw exception text
- return a generic client-facing error when the local server is unavailable

## Testing
- python3 -m pytest tests/test_server_proxy_path.py::test_proxy_returns_generic_error_on_upstream_exception -q
- python3 -m pytest tests/test_server_proxy_path.py -q

Fixes #5544
