### PR TITLE
fix: validate OTC order JSON body and ttl_seconds

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -430,8 +430,10 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
     pair = str(data.get("pair", "RTC/USDC")).strip().upper()
@@ -439,7 +441,10 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    try:
+        ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    except (TypeError, ValueError):
+        return jsonify({"error": "ttl_seconds must be an integer"}), 400
 
     # Validation
     if side not in ("buy", "sell"):

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -82,6 +82,36 @@ def test_orders_accepts_capped_limit(tmp_path):
     assert response.get_json()["ok"] is True
 
 
+def test_order_creation_rejects_non_object_json(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post("/api/orders", json=["not-an-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_order_creation_rejects_non_integer_ttl_seconds(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": 1,
+                "price_per_rtc": 0.10,
+                "ttl_seconds": "abc",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
 def test_trades_rejects_bad_limits(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
 


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies for `POST /api/orders` with a stable JSON 400 response
- validate `ttl_seconds` before order creation logic runs and return a JSON 400 on bad input
- add regression coverage for both malformed order-create payloads

## Testing
- python3 -m pytest tests/test_otc_bridge_query_validation.py -q

Fixes #5525
