### PR TITLE
fix: redact mining dashboard API errors

### DIFF
--- a/node/rustchain_dashboard.py
+++ b/node/rustchain_dashboard.py
@@ -599,7 +599,7 @@ def api_stats():
             'active_miners': [],
             'recent_blocks': [],
             'system_stats': {},
-            'error': str(e)
+            'error': 'stats_unavailable'
         }), 500
 
 @app.route('/api/wallet/<wallet_address>')
@@ -683,7 +683,7 @@ def api_wallet_lookup(wallet_address):
 
     except Exception as e:
         print(f"Error in wallet lookup: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'wallet_lookup_unavailable'}), 500
 
 def format_uptime(seconds):
     """Format uptime in human-readable format"""

--- a/tests/test_rustchain_dashboard_frontend_security.py
+++ b/tests/test_rustchain_dashboard_frontend_security.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import importlib.util
 from pathlib import Path
 
 
@@ -10,6 +11,18 @@ RUSTCHAIN_DASHBOARD = (
 
 def _source() -> str:
     return RUSTCHAIN_DASHBOARD.read_text(encoding="utf-8")
+
+
+def _load_dashboard_module():
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_dashboard_under_test",
+        RUSTCHAIN_DASHBOARD,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.app.config["TESTING"] = True
+    return module
 
 
 def test_dashboard_escapes_api_fields_before_inner_html_rendering():
@@ -56,3 +69,35 @@ def test_dashboard_escapes_search_result_and_error_text():
     assert "${data.weight}" not in source
     assert "${data.tier}" not in source
     assert '<span class="mono">${wallet}</span>' not in source
+
+
+def test_stats_api_does_not_echo_internal_exception_details(monkeypatch):
+    dashboard = _load_dashboard_module()
+
+    def fail_connect(*args, **kwargs):
+        raise RuntimeError("secret database path: /private/rustchain.db")
+
+    monkeypatch.setattr(dashboard.sqlite3, "connect", fail_connect)
+
+    response = dashboard.app.test_client().get("/api/stats")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["error"] == "stats_unavailable"
+    assert "secret database path" not in response.get_data(as_text=True)
+
+
+def test_wallet_lookup_api_does_not_echo_internal_exception_details(monkeypatch):
+    dashboard = _load_dashboard_module()
+
+    def fail_connect(*args, **kwargs):
+        raise RuntimeError("secret database path: /private/rustchain.db")
+
+    monkeypatch.setattr(dashboard.sqlite3, "connect", fail_connect)
+
+    response = dashboard.app.test_client().get("/api/wallet/RTCabc123")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["error"] == "wallet_lookup_unavailable"
+    assert "secret database path" not in response.get_data(as_text=True)


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (no new code files added)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

Fixes #5552.

- Keeps full exception details in the mining dashboard server logs.
- Replaces public `/api/stats` backend exception text with `stats_unavailable`.
- Replaces public `/api/wallet/<wallet>` backend exception text with `wallet_lookup_unavailable`.
- Adds regression coverage that injects backend failures and confirms the response body does not echo the internal exception text.

## Testing / Evidence

```text
python3 -m py_compile node/rustchain_dashboard.py
# passed

python3 -m pytest tests/test_rustchain_dashboard_frontend_security.py -q
.....                                                                    [100%]
5 passed in 0.08s
```

Bounty: #305
RTC payout address: `RTC877021895fd29d034f35c87e1b37af8534703792`
