### PR TITLE
fix: validate bcos attest report payload

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -213,11 +213,14 @@ def bcos_attest():
     is_admin = admin_key and hmac.compare_digest(admin_key, _get_admin_key() or "")
 
     data = request.get_json(silent=True)
-    if not data:
-        return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     # Extract fields from report or from wrapper
     report = data.get("report", data)
+    if not isinstance(report, dict):
+        return jsonify({"error": "report must be a JSON object"}), 400
+
     cert_id = report.get("cert_id")
     commitment = report.get("commitment")
     repo = report.get("repo_name", report.get("repo", ""))

--- a/tests/test_bcos_routes_query_validation.py
+++ b/tests/test_bcos_routes_query_validation.py
@@ -97,6 +97,22 @@ def test_bcos_attest_rejects_invalid_trust_score(bcos_client, trust_score, messa
     assert body["message"] == message
 
 
+@pytest.mark.parametrize("payload", [[], ["not", "an", "object"], "bad"])
+def test_bcos_attest_rejects_non_object_json_body(bcos_client, payload):
+    response = bcos_client.post("/bcos/attest", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+@pytest.mark.parametrize("report", [[], ["not", "an", "object"], "bad"])
+def test_bcos_attest_rejects_non_object_nested_report(bcos_client, report):
+    response = bcos_client.post("/bcos/attest", json={"report": report})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "report must be a JSON object"}
+
+
 def test_bcos_attest_stores_numeric_trust_score(bcos_client):
     response = bcos_client.post(
         "/bcos/attest",


### PR DESCRIPTION
## Summary

- require `POST /bcos/attest` JSON bodies to be objects
- reject non-object nested `report` values before reading report fields
- add regression coverage for array/string top-level payloads and array/string nested reports

## Root Cause

`bcos_attest` used a truthiness check on `request.get_json()` and then assumed `data.get("report", data)` was always a dict. Payloads such as `{"report": []}` reached `report.get(...)` and raised `AttributeError`, producing an HTTP 500.

## Impact

Malformed public BCOS attestation requests now return stable JSON 400 validation errors instead of HTML 500 responses.

Related bug report: #5557
Bounty pool: #305

## Validation

- `PYTHONPATH=/tmp/rustchain-bcos-report/node /tmp/rustchain-bcos-venv/bin/python -m pytest tests/test_bcos_routes_query_validation.py -q` -> 19 passed
- `PYTHONPATH=/tmp/rustchain-bcos-report/node /tmp/rustchain-bcos-venv/bin/python -m pytest tests/test_bcos_routes_query_validation.py node/tests/test_bcos_routes_pagination.py -q` -> 21 passed
- `/tmp/rustchain-bcos-venv/bin/python -m py_compile node/bcos_routes.py tests/test_bcos_routes_query_validation.py`
- `git diff --check -- node/bcos_routes.py tests/test_bcos_routes_query_validation.py`

RTC payout address if accepted: `RTC02d8536941d636aee4012596afbcd8185e9f8283`
