### PR TITLE
fix: validate OTC order creation payloads

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -299,6 +299,17 @@ def non_negative_int_arg(name, default):
     return value, None
 
 
+def order_ttl_seconds(data):
+    if "ttl_seconds" not in data:
+        return ORDER_TTL_DEFAULT, None
+
+    value = data["ttl_seconds"]
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, "ttl_seconds must be an integer"
+
+    return min(max(value, 3600), ORDER_TTL_MAX), None
+
+
 def internal_error_response(operation):
     """Log internal exception details without exposing them to clients."""
     log.exception("%s failed", operation)
@@ -430,8 +441,10 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
     pair = str(data.get("pair", "RTC/USDC")).strip().upper()
@@ -439,7 +452,9 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    ttl, ttl_error = order_ttl_seconds(data)
+    if ttl_error:
+        return jsonify({"error": ttl_error}), 400
 
     # Validation
     if side not in ("buy", "sell"):
@@ -469,7 +484,6 @@ def create_order():
     if price_per_rtc > 1000:
         return jsonify({"error": "price_per_rtc too high (max $1000)"}), 400
 
-    ttl = min(max(ttl, 3600), ORDER_TTL_MAX)
     total_quote_nano = int(
         (amount_dec * price_dec * Decimal(QUOTE_PRICE_SCALE)).to_integral_value(
             rounding=ROUND_HALF_UP

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -4,6 +4,8 @@ import sys
 import types
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
@@ -80,6 +82,57 @@ def test_orders_accepts_capped_limit(tmp_path):
 
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
+
+
+def valid_order_payload(**overrides):
+    payload = {
+        "side": "buy",
+        "pair": "RTC/USDC",
+        "wallet": "buyer-1",
+        "amount_rtc": 1,
+        "price_per_rtc": "0.10",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_order_creation_rejects_non_object_json(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post("/api/orders", json=["not-an-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+@pytest.mark.parametrize("ttl", ["abc", 1.5, True, None])
+def test_order_creation_rejects_non_integer_ttl_seconds(tmp_path, ttl):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json=valid_order_payload(ttl_seconds=ttl),
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def test_order_creation_accepts_integer_ttl_seconds(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json=valid_order_payload(ttl_seconds=7200),
+        )
+
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["expires_in_hours"] == 2
 
 
 def test_trades_rejects_bad_limits(tmp_path):


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on `POST /api/orders` with a stable JSON 400
- validate `ttl_seconds` as an actual JSON integer before order creation
- keep missing `ttl_seconds` defaulting to the configured OTC order TTL and preserve min/max clamping

Fixes #5525.

## Validation
- `python -B -m pytest -q tests/test_otc_bridge_query_validation.py`
- `python -B -m py_compile otc-bridge/otc_bridge.py tests/test_otc_bridge_query_validation.py`
- `git diff --check -- otc-bridge/otc_bridge.py tests/test_otc_bridge_query_validation.py`

## Bounty
RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`