### PR TITLE
fix: prevent failed-fingerprint attestations from earning rewards

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1047,7 +1047,7 @@ GOVERNANCE_ACTIVE_MINER_WINDOW_SECONDS = 3600
 EPOCH_WEIGHT_SCALE = 1_000_000_000
 MAX_EPOCH_WEIGHT = 10_000
 MAX_EPOCH_WEIGHT_UNITS = MAX_EPOCH_WEIGHT * EPOCH_WEIGHT_SCALE
-MIN_FAILED_FINGERPRINT_WEIGHT_UNITS = 1
+FAILED_FINGERPRINT_WEIGHT_UNITS = 0
 
 
 def epoch_weight_to_units(weight) -> int:
@@ -3791,7 +3791,7 @@ def _submit_attestation_impl():
                 fingerprint if isinstance(fingerprint, dict) else {},
             )
             if not fingerprint_passed:
-                enroll_weight_units = MIN_FAILED_FINGERPRINT_WEIGHT_UNITS
+                enroll_weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS
             else:
                 enroll_weight_units = epoch_weight_to_units(hw_weight * rotation_eval["active_ratio"])
             enroll_weight = epoch_weight_units_to_display(enroll_weight_units)
@@ -4038,8 +4038,7 @@ def enroll_epoch():
     arch = device.get('arch', 'default')
     hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
 
-    # RIP-PoA Phase 2: VM miners get minimal (but non-zero) weight
-    # VMs can technically earn RTC, but it's economically pointless (1e-9 vs 1.0-2.5 for real hardware)
+    # RIP-PoA Phase 2: failed fingerprints are tracked but receive zero rewards.
     fingerprint_failed = check_result.get('fingerprint_failed', False)
 
     with sqlite3.connect(DB_PATH) as c:
@@ -4049,9 +4048,9 @@ def enroll_epoch():
             data.get('fingerprint') if isinstance(data.get('fingerprint'), dict) else {},
         )
         if fingerprint_failed:
-            weight_units = MIN_FAILED_FINGERPRINT_WEIGHT_UNITS
+            weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS
             weight = epoch_weight_units_to_display(weight_units)
-            print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - VM weight: {weight}")
+            print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - weight: {weight}")
         else:
             weight_units = epoch_weight_to_units(hw_weight * rotation_eval['active_ratio'])
             weight = epoch_weight_units_to_display(weight_units)

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4132,10 +4132,11 @@ def vrf_is_selected(miner_pk: str, slot: int) -> bool:
             "SELECT miner_pk, weight FROM epoch_enroll WHERE epoch = ?",
             (epoch,)
         ).fetchall()
-        all_miners = [
-            (pk, normalize_epoch_weight_units(stored_weight))
-            for pk, stored_weight in raw_miners
-        ]
+        all_miners = []
+        for pk, stored_weight in raw_miners:
+            normalized_weight = normalize_epoch_weight_units(stored_weight)
+            if normalized_weight > 0:
+                all_miners.append((pk, normalized_weight))
 
     if not all_miners:
         return False

--- a/node/tests/test_attest_missing_fingerprint_reward_bypass.py
+++ b/node/tests/test_attest_missing_fingerprint_reward_bypass.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 import os
 import sqlite3

--- a/node/tests/test_attest_missing_fingerprint_reward_bypass.py
+++ b/node/tests/test_attest_missing_fingerprint_reward_bypass.py
@@ -1,0 +1,143 @@
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def _load_integrated_node(db_path: Path):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+
+    from tests import mock_crypto
+
+    sys.modules["rustchain_crypto"] = mock_crypto
+    os.environ["DB_PATH"] = str(db_path)
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+
+    spec = importlib.util.spec_from_file_location(
+        "integrated_node_missing_fingerprint_reward_test",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    module.DB_PATH = str(db_path)
+    module.app.config["TESTING"] = True
+    module.UTXO_DUAL_WRITE = False
+    module.HW_BINDING_V2 = False
+    module.HW_PROOF_AVAILABLE = False
+    module.HAVE_REPLAY_DEFENSE = False
+    module.HAVE_WARTHOG = False
+    module.check_ip_rate_limit = lambda client_ip, miner_id: (True, "ok")
+    module._check_hardware_binding = lambda *args, **kwargs: (True, "ok", "")
+    module._check_oui_gate = lambda macs: (True, {"ok": True})
+    module.wallet_review_gate_response = lambda miner: None
+    module.record_macs = lambda *args, **kwargs: None
+    module._check_welcome_bonus = lambda miner: None
+    module.current_slot = lambda: 12345
+    module.slot_to_epoch = lambda slot: 85
+    return module
+
+
+def _prepare_attestation_db(node, db_path: Path, miner: str, epoch: int, nonce: str):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        node.attest_ensure_tables(conn)
+        conn.execute("INSERT INTO nonces (nonce, expires_at) VALUES (?, ?)", (nonce, now + 3600))
+        conn.executescript(
+            """
+            CREATE TABLE tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT);
+            CREATE TABLE epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER);
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL,
+                weight INTEGER NOT NULL,
+                PRIMARY KEY(epoch, miner_pk)
+            );
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                miner_pk TEXT,
+                amount_i64 INTEGER DEFAULT 0,
+                balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT,
+                signing_pubkey TEXT,
+                fingerprint_checks_json TEXT
+            );
+            CREATE TABLE miner_attest_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                miner TEXT NOT NULL,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                fingerprint_checks_json TEXT
+            );
+            """
+        )
+        conn.execute("INSERT INTO epoch_state(epoch, settled) VALUES (?, 0)", (epoch,))
+        conn.execute(
+            "INSERT INTO balances(miner_id, miner_pk, amount_i64, balance_rtc) VALUES (?, ?, 0, 0)",
+            (miner, miner),
+        )
+        conn.commit()
+
+
+def test_missing_fingerprint_attestation_cannot_receive_epoch_reward(tmp_path):
+    db_path = tmp_path / "missing_fingerprint_reward.sqlite3"
+    node = _load_integrated_node(db_path)
+
+    miner = "failed-fp-miner"
+    epoch = 85
+    nonce = "nonce-failed-fp"
+    _prepare_attestation_db(node, db_path, miner, epoch, nonce)
+
+    payload = {
+        "miner": miner,
+        "miner_id": miner,
+        "nonce": nonce,
+        "device": {"model": "Generic CPU", "arch": "x86_64", "family": "x86_64", "cores": 4},
+        "signals": {"hostname": "baremetal-host"},
+        "report": {"nonce": nonce, "commitment": "commitment"},
+    }
+
+    with node.app.test_client() as client:
+        response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json()["fingerprint_passed"] is False
+
+    with sqlite3.connect(db_path) as conn:
+        recent = conn.execute(
+            "SELECT fingerprint_passed, fingerprint_checks_json FROM miner_attest_recent WHERE miner=?",
+            (miner,),
+        ).fetchone()
+        assert recent == (0, "{}")
+
+    node.finalize_epoch(epoch, node.PER_BLOCK_RTC, prev_block_hash=b"")
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT amount_i64, balance_rtc FROM balances WHERE miner_id=?",
+            (miner,),
+        ).fetchone()
+        assert balance == (0, 0.0)

--- a/node/tests/test_epoch_weight_fixedpoint.py
+++ b/node/tests/test_epoch_weight_fixedpoint.py
@@ -112,3 +112,31 @@ def test_legacy_real_weights_migrate_to_fixed_point_units():
     weight_column = next(col for col in columns if col[1] == "weight")
     assert weight_column[2].upper() == "INTEGER"
     assert rows == [("miner_A", 100_000_000), ("miner_B", 2_500_000_000)]
+
+
+def test_vrf_selection_ignores_zero_weight_enrollments(monkeypatch):
+    node = load_node_module()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = str(Path(tmpdir) / "vrf_zero_weight.db")
+        conn = sqlite3.connect(db_path)
+        try:
+            conn.execute(
+                "CREATE TABLE epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER, PRIMARY KEY (epoch, miner_pk))"
+            )
+            conn.execute(
+                "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                (7, "failed-fingerprint", 0),
+            )
+            conn.execute(
+                "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                (7, "good-miner", 1),
+            )
+            conn.commit()
+
+            monkeypatch.setattr(node, "DB_PATH", db_path)
+            monkeypatch.setattr(node, "slot_to_epoch", lambda slot: 7)
+
+            assert node.vrf_is_selected("failed-fingerprint", 144) is False
+            assert node.vrf_is_selected("good-miner", 144) is True
+        finally:
+            conn.close()

--- a/node/tests/test_epoch_weight_fixedpoint.py
+++ b/node/tests/test_epoch_weight_fixedpoint.py
@@ -116,7 +116,7 @@ def test_legacy_real_weights_migrate_to_fixed_point_units():
 
 def test_vrf_selection_ignores_zero_weight_enrollments(monkeypatch):
     node = load_node_module()
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         db_path = str(Path(tmpdir) / "vrf_zero_weight.db")
         conn = sqlite3.connect(db_path)
         try:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,9 @@ pytest>=7.4.4
 PyNaCl>=1.6.2
 # Needed by test_wallet_cli_39 (imports from tools/rustchain_wallet_cli.py)
 cryptography>=46.0.7
+# Needed by CI collection for SDK/client tests.
+aiohttp>=3.9.0
+# Needed by CI collection for faucet and Flask service tests.
+flask-cors>=4.0.0
+# Needed by CI collection for hardware visualizer and PSE analysis tests.
+matplotlib>=3.8.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,5 @@ aiohttp>=3.9.0
 flask-cors>=4.0.0
 # Needed by CI collection for hardware visualizer and PSE analysis tests.
 matplotlib>=3.8.0
+# Needed by benchmarks/pse/analyze_results.py during CI collection.
+seaborn>=0.13.0


### PR DESCRIPTION
## Summary
- set failed-fingerprint epoch enrollment weight to zero instead of a positive sentinel
- cover the missing-fingerprint attestation reward bypass with a regression test
- keep explicit epoch enrollment aligned with the zero-reward failed-fingerprint policy

## Verification
- python3 -m pytest node/tests/test_attest_missing_fingerprint_reward_bypass.py node/tests/test_settlement_integrity.py node/tests/test_attestation_overwrite_reward_loss.py node/tests/test_rip309_fingerprint_rotation.py -q
- python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_attest_missing_fingerprint_reward_bypass.py
- git diff --check

## Safety
- no private keys, tokens, or account secrets are included
- duplicate search found no exact public duplicate; PR #298 is related but covers a different missing-fingerprint validation path
