### PR TITLE
fix: require signed OTC wallet actions

### DIFF
--- a/otc-bridge/README.md
+++ b/otc-bridge/README.md
@@ -84,8 +84,13 @@ curl -X POST http://localhost:5580/api/orders \
 ```bash
 curl -X POST http://localhost:5580/api/orders/otc_abc123/match \
   -H "Content-Type: application/json" \
-  -d '{"wallet":"buyer-wallet","eth_address":"0x..."}'
+  -d '{"wallet":"RTC...","eth_address":"0x...","wallet_auth":{"public_key":"<ed25519-public-key-hex>","signature":"<signature-hex>","timestamp":1760000000}}'
 ```
+
+`match` and `cancel` require `wallet_auth` for the wallet performing the action.
+Sign a canonical JSON payload with the wallet's Ed25519 key:
+`{"action":"match_order","eth_address":"0x...","order_id":"otc_abc123","timestamp":1760000000,"wallet":"RTC..."}`
+Use `"cancel_order"` without `eth_address` for cancellations. The timestamp must be within 5 minutes.
 
 ## HTLC Contract (Base)
 

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -25,6 +25,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import sqlite3
 import time
@@ -35,6 +36,13 @@ from functools import wraps
 import requests
 from flask import Flask, request, jsonify, send_from_directory
 from flask_cors import CORS
+
+try:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+except ImportError:  # pragma: no cover - stripped-down deployments should fail closed
+    InvalidSignature = None
+    Ed25519PublicKey = None
 
 # ---------------------------------------------------------------------------
 # Config
@@ -71,6 +79,8 @@ RATE_LIMIT_MAX = 10                 # 10 requests per minute per IP
 RTC_REFERENCE_RATE = 0.10           # $0.10 USD reference
 RTC_UNIT = 1_000_000                # 1 micro-RTC
 QUOTE_PRICE_SCALE = 1_000_000_000   # 9 decimal places for quote units
+WALLET_AUTH_MAX_AGE_SECONDS = 300
+RTC_WALLET_RE = re.compile(r"^RTC[0-9a-fA-F]{40}$")
 
 SUPPORTED_PAIRS = {
     "RTC/ETH": {"quote": "ETH", "decimals": 18},
@@ -251,6 +261,61 @@ def generate_trade_id(order_id, taker):
 
 def hash_ip(ip):
     return hashlib.sha256(f"otc_salt_{ip}".encode()).hexdigest()[:16]
+
+
+def rtc_address_from_public_key(public_key_hex):
+    public_key_bytes = bytes.fromhex(public_key_hex)
+    return f"RTC{hashlib.sha256(public_key_bytes).hexdigest()[:40]}"
+
+
+def wallet_auth_message(action, order_id, wallet, timestamp, bound_fields=None):
+    payload = {
+        "action": action,
+        "order_id": order_id,
+        "timestamp": int(timestamp),
+        "wallet": wallet,
+    }
+    if bound_fields:
+        payload.update(bound_fields)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def require_wallet_auth(data, action, order_id, wallet, bound_fields=None):
+    if Ed25519PublicKey is None:
+        return "wallet_auth_unavailable"
+    if not RTC_WALLET_RE.fullmatch(wallet):
+        return "wallet_must_be_native_rtc_address"
+
+    auth = data.get("wallet_auth")
+    if not isinstance(auth, dict):
+        return "wallet_auth_required"
+
+    public_key = str(auth.get("public_key", "")).strip()
+    signature = str(auth.get("signature", "")).strip()
+    timestamp_raw = auth.get("timestamp")
+    if not public_key or not signature or timestamp_raw is None:
+        return "wallet_auth_public_key_signature_timestamp_required"
+
+    try:
+        timestamp = int(timestamp_raw)
+        if isinstance(timestamp_raw, bool):
+            return "wallet_auth_invalid_timestamp"
+        if abs(int(time.time()) - timestamp) > WALLET_AUTH_MAX_AGE_SECONDS:
+            return "wallet_auth_timestamp_expired"
+        if rtc_address_from_public_key(public_key).lower() != wallet.lower():
+            return "wallet_auth_public_key_does_not_match_wallet"
+
+        verify_key = Ed25519PublicKey.from_public_bytes(bytes.fromhex(public_key))
+        verify_key.verify(
+            bytes.fromhex(signature),
+            wallet_auth_message(action, order_id, wallet, timestamp, bound_fields),
+        )
+    except (TypeError, ValueError):
+        return "wallet_auth_invalid_encoding"
+    except InvalidSignature:
+        return "wallet_auth_invalid_signature"
+
+    return None
 
 
 def get_client_ip():
@@ -672,11 +737,23 @@ def get_order(order_id):
 def match_order(order_id):
     """Match an open order as the counterparty."""
     data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+
     taker_wallet = str(data.get("wallet", "")).strip()
     taker_eth_address = str(data.get("eth_address", "")).strip()
 
     if not taker_wallet:
         return jsonify({"error": "wallet required"}), 400
+    auth_error = require_wallet_auth(
+        data,
+        "match_order",
+        order_id,
+        taker_wallet,
+        {"eth_address": taker_eth_address},
+    )
+    if auth_error:
+        return jsonify({"error": auth_error}), 401
 
     conn = get_db()
     try:
@@ -935,10 +1012,16 @@ def confirm_order(order_id):
 def cancel_order(order_id):
     """Cancel an open order and refund escrow."""
     data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+
     wallet = str(data.get("wallet", "")).strip()
 
     if not wallet:
         return jsonify({"error": "wallet required"}), 400
+    auth_error = require_wallet_auth(data, "cancel_order", order_id, wallet)
+    if auth_error:
+        return jsonify({"error": auth_error}), 401
 
     conn = get_db()
     try:

--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -81,6 +81,7 @@ RTC_UNIT = 1_000_000                # 1 micro-RTC
 QUOTE_PRICE_SCALE = 1_000_000_000   # 9 decimal places for quote units
 WALLET_AUTH_MAX_AGE_SECONDS = 300
 RTC_WALLET_RE = re.compile(r"^RTC[0-9a-fA-F]{40}$")
+CREATE_ORDER_AUTH_ID = "create_order"
 
 SUPPORTED_PAIRS = {
     "RTC/ETH": {"quote": "ETH", "decimals": 18},
@@ -278,6 +279,24 @@ def wallet_auth_message(action, order_id, wallet, timestamp, bound_fields=None):
     if bound_fields:
         payload.update(bound_fields)
     return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def create_order_auth_fields(
+    side,
+    pair,
+    amount_micro_rtc,
+    price_per_rtc_nano_quote,
+    ttl_seconds,
+    eth_address,
+):
+    return {
+        "side": side,
+        "pair": pair,
+        "amount_micro_rtc": int(amount_micro_rtc),
+        "price_per_rtc_nano_quote": int(price_per_rtc_nano_quote),
+        "ttl_seconds": int(ttl_seconds),
+        "eth_address": eth_address,
+    }
 
 
 def require_wallet_auth(data, action, order_id, wallet, bound_fields=None):
@@ -543,6 +562,23 @@ def create_order():
     total_quote = units_to_float(total_quote_nano, QUOTE_PRICE_SCALE)
     now = int(time.time())
     order_id = generate_order_id(maker_wallet, side)
+
+    auth_error = require_wallet_auth(
+        data,
+        "create_order",
+        CREATE_ORDER_AUTH_ID,
+        maker_wallet,
+        create_order_auth_fields(
+            side,
+            pair,
+            amount_micro_rtc,
+            price_per_rtc_nano_quote,
+            ttl,
+            maker_eth_address,
+        ),
+    )
+    if auth_error:
+        return jsonify({"error": auth_error}), 401
 
     # For sell orders: lock RTC in escrow via RIP-302
     escrow_job_id = None

--- a/otc-bridge/requirements.txt
+++ b/otc-bridge/requirements.txt
@@ -1,4 +1,5 @@
 flask>=3.0
 flask-cors>=6.0.2
 requests>=2.34.2
+cryptography>=46.0.7
 gunicorn>=21.2

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -1,8 +1,12 @@
 import importlib.util
 import os
 import sys
+import time
 import types
 from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -24,6 +28,51 @@ def load_otc_bridge(tmp_path):
     module.app.testing = True
     module.init_db()
     return module
+
+
+def signed_order_payload(otc_bridge):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_hex = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    wallet = otc_bridge.rtc_address_from_public_key(public_key_hex)
+    payload = {
+        "side": "buy",
+        "pair": "RTC/USDC",
+        "wallet": wallet,
+        "amount_rtc": 1,
+        "price_per_rtc": "0.10",
+    }
+    _, amount_micro_rtc = otc_bridge.decimal_units(
+        payload["amount_rtc"], otc_bridge.RTC_UNIT, "amount_rtc"
+    )
+    _, price_per_rtc_nano_quote = otc_bridge.decimal_units(
+        payload["price_per_rtc"], otc_bridge.QUOTE_PRICE_SCALE, "price_per_rtc"
+    )
+    timestamp = int(time.time())
+    bound_fields = otc_bridge.create_order_auth_fields(
+        payload["side"],
+        payload["pair"],
+        amount_micro_rtc,
+        price_per_rtc_nano_quote,
+        otc_bridge.ORDER_TTL_DEFAULT,
+        "",
+    )
+    payload["wallet_auth"] = {
+        "public_key": public_key_hex,
+        "signature": private_key.sign(
+            otc_bridge.wallet_auth_message(
+                "create_order",
+                otc_bridge.CREATE_ORDER_AUTH_ID,
+                wallet,
+                timestamp,
+                bound_fields,
+            )
+        ).hex(),
+        "timestamp": timestamp,
+    }
+    return payload
 
 
 def test_orders_rejects_malformed_pagination(tmp_path):
@@ -117,13 +166,7 @@ def test_unexpected_order_errors_are_generic(tmp_path, monkeypatch):
     with otc_bridge.app.test_client() as client:
         response = client.post(
             "/api/orders",
-            json={
-                "side": "buy",
-                "pair": "RTC/USDC",
-                "wallet": "buyer-1",
-                "amount_rtc": 1,
-                "price_per_rtc": 0.10,
-            },
+            json=signed_order_payload(otc_bridge),
         )
 
     assert response.status_code == 500

--- a/tests/test_otc_bridge_wallet_auth.py
+++ b/tests/test_otc_bridge_wallet_auth.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 import importlib.util
 import os
 import sys
@@ -47,16 +48,50 @@ def wallet_auth(otc_bridge, private_key, public_key_hex, action, order_id, walle
     }
 
 
-def create_buy_order(client, wallet):
+def create_order_auth(otc_bridge, private_key, public_key_hex, wallet, payload):
+    bound_fields = otc_bridge.create_order_auth_fields(
+        payload["side"],
+        payload["pair"],
+        10_000_000,
+        100_000_000,
+        payload.get("ttl_seconds", otc_bridge.ORDER_TTL_DEFAULT),
+        payload.get("eth_address", ""),
+    )
+    return wallet_auth(
+        otc_bridge,
+        private_key,
+        public_key_hex,
+        "create_order",
+        otc_bridge.CREATE_ORDER_AUTH_ID,
+        wallet,
+        **bound_fields,
+    )
+
+
+def signed_order_payload(otc_bridge, private_key, public_key_hex, wallet, side="buy"):
+    payload = {
+        "side": side,
+        "pair": "RTC/USDC",
+        "wallet": wallet,
+        "amount_rtc": 10,
+        "price_per_rtc": "0.10",
+    }
+    payload["wallet_auth"] = create_order_auth(
+        otc_bridge, private_key, public_key_hex, wallet, payload
+    )
+    return payload
+
+
+def open_order_count(client):
+    response = client.get("/api/orders")
+    assert response.status_code == 200
+    return response.get_json()["total"]
+
+
+def create_buy_order(client, otc_bridge, private_key, public_key_hex, wallet):
     response = client.post(
         "/api/orders",
-        json={
-            "side": "buy",
-            "pair": "RTC/USDC",
-            "wallet": wallet,
-            "amount_rtc": 10,
-            "price_per_rtc": "0.10",
-        },
+        json=signed_order_payload(otc_bridge, private_key, public_key_hex, wallet),
     )
     assert response.status_code == 201
     return response.get_json()["order_id"]
@@ -70,10 +105,10 @@ def order_status(client, order_id):
 
 def test_cancel_requires_wallet_signature_and_preserves_order(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
-    _, _, maker_wallet = make_wallet(otc_bridge)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         response = client.post(f"/api/orders/{order_id}/cancel", json={"wallet": maker_wallet})
 
         assert response.status_code == 401
@@ -83,11 +118,11 @@ def test_cancel_requires_wallet_signature_and_preserves_order(tmp_path):
 
 def test_cancel_rejects_signature_from_different_wallet_key(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
-    _, _, maker_wallet = make_wallet(otc_bridge)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
     attacker_key, attacker_pub, _ = make_wallet(otc_bridge)
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         response = client.post(
             f"/api/orders/{order_id}/cancel",
             json={
@@ -108,7 +143,7 @@ def test_signed_cancel_succeeds_for_order_maker(tmp_path):
     maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         response = client.post(
             f"/api/orders/{order_id}/cancel",
             json={
@@ -125,11 +160,11 @@ def test_signed_cancel_succeeds_for_order_maker(tmp_path):
 
 def test_match_requires_taker_wallet_signature(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
-    _, _, maker_wallet = make_wallet(otc_bridge)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
     _, _, taker_wallet = make_wallet(otc_bridge)
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         response = client.post(
             f"/api/orders/{order_id}/match",
             json={"wallet": taker_wallet, "eth_address": "0x1234"},
@@ -142,11 +177,11 @@ def test_match_requires_taker_wallet_signature(tmp_path):
 
 def test_match_signature_binds_eth_address(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
-    _, _, maker_wallet = make_wallet(otc_bridge)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
     taker_key, taker_pub, taker_wallet = make_wallet(otc_bridge)
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         auth = wallet_auth(
             otc_bridge,
             taker_key,
@@ -172,12 +207,12 @@ def test_match_signature_binds_eth_address(tmp_path):
 
 def test_signed_match_succeeds_when_eth_address_matches_signature(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
-    _, _, maker_wallet = make_wallet(otc_bridge)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
     taker_key, taker_pub, taker_wallet = make_wallet(otc_bridge)
     eth_address = "0x1111111111111111111111111111111111111111"
 
     with otc_bridge.app.test_client() as client:
-        order_id = create_buy_order(client, maker_wallet)
+        order_id = create_buy_order(client, otc_bridge, maker_key, maker_pub, maker_wallet)
         with patch.object(otc_bridge, "rtc_get_balance", return_value=500.0), patch.object(
             otc_bridge, "rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_auth_match"}
         ):
@@ -200,3 +235,72 @@ def test_signed_match_succeeds_when_eth_address_matches_signature(tmp_path):
 
         assert response.status_code == 200
         assert response.get_json()["status"] == "matched"
+
+
+def test_create_buy_order_requires_wallet_signature_and_preserves_orderbook(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": maker_wallet,
+                "amount_rtc": 10,
+                "price_per_rtc": "0.10",
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_required"}
+        assert open_order_count(client) == 0
+
+
+def test_create_sell_order_requires_wallet_signature_before_escrow(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        with patch.object(otc_bridge, "rtc_get_balance", return_value=500.0), patch.object(
+            otc_bridge, "rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_unsigned"}
+        ) as create_escrow:
+            response = client.post(
+                "/api/orders",
+                json={
+                    "side": "sell",
+                    "pair": "RTC/USDC",
+                    "wallet": maker_wallet,
+                    "amount_rtc": 10,
+                    "price_per_rtc": "0.10",
+                },
+            )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_required"}
+        create_escrow.assert_not_called()
+        assert open_order_count(client) == 0
+
+
+def test_signed_create_order_rejects_non_native_maker_wallet(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, _ = make_wallet(otc_bridge)
+    maker_wallet = "named_maker"
+    payload = {
+        "side": "buy",
+        "pair": "RTC/USDC",
+        "wallet": maker_wallet,
+        "amount_rtc": 10,
+        "price_per_rtc": "0.10",
+    }
+    payload["wallet_auth"] = create_order_auth(
+        otc_bridge, maker_key, maker_pub, maker_wallet, payload
+    )
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post("/api/orders", json=payload)
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_must_be_native_rtc_address"}
+        assert open_order_count(client) == 0

--- a/tests/test_otc_bridge_wallet_auth.py
+++ b/tests/test_otc_bridge_wallet_auth.py
@@ -1,0 +1,202 @@
+import importlib.util
+import os
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def load_otc_bridge(tmp_path):
+    if "flask_cors" not in sys.modules:
+        flask_cors = types.ModuleType("flask_cors")
+        flask_cors.CORS = lambda app, *args, **kwargs: app
+        sys.modules["flask_cors"] = flask_cors
+
+    db_path = tmp_path / "otc_bridge.db"
+    os.environ["OTC_DB_PATH"] = str(db_path)
+
+    module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
+    spec = importlib.util.spec_from_file_location("otc_bridge_wallet_auth_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.app.testing = True
+    module.init_db()
+    return module
+
+
+def make_wallet(otc_bridge):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_hex = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    ).hex()
+    return private_key, public_key_hex, otc_bridge.rtc_address_from_public_key(public_key_hex)
+
+
+def wallet_auth(otc_bridge, private_key, public_key_hex, action, order_id, wallet, **bound_fields):
+    timestamp = int(time.time())
+    message = otc_bridge.wallet_auth_message(action, order_id, wallet, timestamp, bound_fields)
+    return {
+        "public_key": public_key_hex,
+        "signature": private_key.sign(message).hex(),
+        "timestamp": timestamp,
+    }
+
+
+def create_buy_order(client, wallet):
+    response = client.post(
+        "/api/orders",
+        json={
+            "side": "buy",
+            "pair": "RTC/USDC",
+            "wallet": wallet,
+            "amount_rtc": 10,
+            "price_per_rtc": "0.10",
+        },
+    )
+    assert response.status_code == 201
+    return response.get_json()["order_id"]
+
+
+def order_status(client, order_id):
+    response = client.get(f"/api/orders/{order_id}")
+    assert response.status_code == 200
+    return response.get_json()["order"]["status"]
+
+
+def test_cancel_requires_wallet_signature_and_preserves_order(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(f"/api/orders/{order_id}/cancel", json={"wallet": maker_wallet})
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_required"}
+        assert order_status(client, order_id) == "open"
+
+
+def test_cancel_rejects_signature_from_different_wallet_key(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+    attacker_key, attacker_pub, _ = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(
+            f"/api/orders/{order_id}/cancel",
+            json={
+                "wallet": maker_wallet,
+                "wallet_auth": wallet_auth(
+                    otc_bridge, attacker_key, attacker_pub, "cancel_order", order_id, maker_wallet
+                ),
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_public_key_does_not_match_wallet"}
+        assert order_status(client, order_id) == "open"
+
+
+def test_signed_cancel_succeeds_for_order_maker(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    maker_key, maker_pub, maker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(
+            f"/api/orders/{order_id}/cancel",
+            json={
+                "wallet": maker_wallet,
+                "wallet_auth": wallet_auth(
+                    otc_bridge, maker_key, maker_pub, "cancel_order", order_id, maker_wallet
+                ),
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "cancelled"
+
+
+def test_match_requires_taker_wallet_signature(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+    _, _, taker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        response = client.post(
+            f"/api/orders/{order_id}/match",
+            json={"wallet": taker_wallet, "eth_address": "0x1234"},
+        )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_required"}
+        assert order_status(client, order_id) == "open"
+
+
+def test_match_signature_binds_eth_address(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+    taker_key, taker_pub, taker_wallet = make_wallet(otc_bridge)
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        auth = wallet_auth(
+            otc_bridge,
+            taker_key,
+            taker_pub,
+            "match_order",
+            order_id,
+            taker_wallet,
+            eth_address="0x1111111111111111111111111111111111111111",
+        )
+        response = client.post(
+            f"/api/orders/{order_id}/match",
+            json={
+                "wallet": taker_wallet,
+                "eth_address": "0x2222222222222222222222222222222222222222",
+                "wallet_auth": auth,
+            },
+        )
+
+        assert response.status_code == 401
+        assert response.get_json() == {"error": "wallet_auth_invalid_signature"}
+        assert order_status(client, order_id) == "open"
+
+
+def test_signed_match_succeeds_when_eth_address_matches_signature(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+    _, _, maker_wallet = make_wallet(otc_bridge)
+    taker_key, taker_pub, taker_wallet = make_wallet(otc_bridge)
+    eth_address = "0x1111111111111111111111111111111111111111"
+
+    with otc_bridge.app.test_client() as client:
+        order_id = create_buy_order(client, maker_wallet)
+        with patch.object(otc_bridge, "rtc_get_balance", return_value=500.0), patch.object(
+            otc_bridge, "rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_auth_match"}
+        ):
+            response = client.post(
+                f"/api/orders/{order_id}/match",
+                json={
+                    "wallet": taker_wallet,
+                    "eth_address": eth_address,
+                    "wallet_auth": wallet_auth(
+                        otc_bridge,
+                        taker_key,
+                        taker_pub,
+                        "match_order",
+                        order_id,
+                        taker_wallet,
+                        eth_address=eth_address,
+                    ),
+                },
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()["status"] == "matched"


### PR DESCRIPTION
## Summary
- require Ed25519 `wallet_auth` for OTC match and cancel actions
- derive the native RTC wallet from the submitted public key before allowing mutation
- bind `match_order` signatures to `eth_address` so a valid signature cannot be replayed with a different settlement address
- reject non-object JSON bodies on match/cancel and document the signed payload shape

Fixes #4957.

## Validation
- `python -B -m pytest -q tests/test_otc_bridge_wallet_auth.py`
- `python -B -m pytest -q tests/test_otc_bridge_query_validation.py`
- `python -B -m py_compile otc-bridge/otc_bridge.py tests/test_otc_bridge_wallet_auth.py`
- `git diff --check -- otc-bridge/otc_bridge.py otc-bridge/README.md otc-bridge/requirements.txt tests/test_otc_bridge_wallet_auth.py`

## Note
The signed match intent includes `eth_address`; this closes the address-substitution gap where a short-lived wallet signature could otherwise be reused with a different quote-chain destination.

## Bounty
RTC wallet: `RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7`