### PR TITLE
fix: prevent failed-fingerprint attestations from earning rewards

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1047,7 +1047,7 @@ GOVERNANCE_ACTIVE_MINER_WINDOW_SECONDS = 3600
 EPOCH_WEIGHT_SCALE = 1_000_000_000
 MAX_EPOCH_WEIGHT = 10_000
 MAX_EPOCH_WEIGHT_UNITS = MAX_EPOCH_WEIGHT * EPOCH_WEIGHT_SCALE
-MIN_FAILED_FINGERPRINT_WEIGHT_UNITS = 1
+FAILED_FINGERPRINT_WEIGHT_UNITS = 0
 
 
 def epoch_weight_to_units(weight) -> int:
@@ -3791,7 +3791,7 @@ def _submit_attestation_impl():
                 fingerprint if isinstance(fingerprint, dict) else {},
             )
             if not fingerprint_passed:
-                enroll_weight_units = MIN_FAILED_FINGERPRINT_WEIGHT_UNITS
+                enroll_weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS
             else:
                 enroll_weight_units = epoch_weight_to_units(hw_weight * rotation_eval["active_ratio"])
             enroll_weight = epoch_weight_units_to_display(enroll_weight_units)
@@ -4038,8 +4038,7 @@ def enroll_epoch():
     arch = device.get('arch', 'default')
     hw_weight = HARDWARE_WEIGHTS.get(family, {}).get(arch, 1.0)
 
-    # RIP-PoA Phase 2: VM miners get minimal (but non-zero) weight
-    # VMs can technically earn RTC, but it's economically pointless (1e-9 vs 1.0-2.5 for real hardware)
+    # RIP-PoA Phase 2: failed fingerprints are tracked but receive zero rewards.
     fingerprint_failed = check_result.get('fingerprint_failed', False)
 
     with sqlite3.connect(DB_PATH) as c:
@@ -4049,9 +4048,9 @@ def enroll_epoch():
             data.get('fingerprint') if isinstance(data.get('fingerprint'), dict) else {},
         )
         if fingerprint_failed:
-            weight_units = MIN_FAILED_FINGERPRINT_WEIGHT_UNITS
+            weight_units = FAILED_FINGERPRINT_WEIGHT_UNITS
             weight = epoch_weight_units_to_display(weight_units)
-            print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - VM weight: {weight}")
+            print(f"[ENROLL] Miner {miner_pk[:16]}... fingerprint FAILED - weight: {weight}")
         else:
             weight_units = epoch_weight_to_units(hw_weight * rotation_eval['active_ratio'])
             weight = epoch_weight_units_to_display(weight_units)

--- a/node/tests/test_attest_missing_fingerprint_reward_bypass.py
+++ b/node/tests/test_attest_missing_fingerprint_reward_bypass.py
@@ -1,0 +1,143 @@
+import importlib.util
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_DIR = PROJECT_ROOT / "node"
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def _load_integrated_node(db_path: Path):
+    if str(PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(PROJECT_ROOT))
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+
+    from tests import mock_crypto
+
+    sys.modules["rustchain_crypto"] = mock_crypto
+    os.environ["DB_PATH"] = str(db_path)
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ.setdefault("RC_ADMIN_KEY", "0" * 32)
+
+    spec = importlib.util.spec_from_file_location(
+        "integrated_node_missing_fingerprint_reward_test",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    module.DB_PATH = str(db_path)
+    module.app.config["TESTING"] = True
+    module.UTXO_DUAL_WRITE = False
+    module.HW_BINDING_V2 = False
+    module.HW_PROOF_AVAILABLE = False
+    module.HAVE_REPLAY_DEFENSE = False
+    module.HAVE_WARTHOG = False
+    module.check_ip_rate_limit = lambda client_ip, miner_id: (True, "ok")
+    module._check_hardware_binding = lambda *args, **kwargs: (True, "ok", "")
+    module._check_oui_gate = lambda macs: (True, {"ok": True})
+    module.wallet_review_gate_response = lambda miner: None
+    module.record_macs = lambda *args, **kwargs: None
+    module._check_welcome_bonus = lambda miner: None
+    module.current_slot = lambda: 12345
+    module.slot_to_epoch = lambda slot: 85
+    return module
+
+
+def _prepare_attestation_db(node, db_path: Path, miner: str, epoch: int, nonce: str):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        node.attest_ensure_tables(conn)
+        conn.execute("INSERT INTO nonces (nonce, expires_at) VALUES (?, ?)", (nonce, now + 3600))
+        conn.executescript(
+            """
+            CREATE TABLE tickets (ticket_id TEXT PRIMARY KEY, expires_at INTEGER, commitment TEXT);
+            CREATE TABLE epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER);
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL,
+                weight INTEGER NOT NULL,
+                PRIMARY KEY(epoch, miner_pk)
+            );
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                miner_pk TEXT,
+                amount_i64 INTEGER DEFAULT 0,
+                balance_rtc REAL DEFAULT 0
+            );
+            CREATE TABLE miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT,
+                signing_pubkey TEXT,
+                fingerprint_checks_json TEXT
+            );
+            CREATE TABLE miner_attest_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                miner TEXT NOT NULL,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                fingerprint_checks_json TEXT
+            );
+            """
+        )
+        conn.execute("INSERT INTO epoch_state(epoch, settled) VALUES (?, 0)", (epoch,))
+        conn.execute(
+            "INSERT INTO balances(miner_id, miner_pk, amount_i64, balance_rtc) VALUES (?, ?, 0, 0)",
+            (miner, miner),
+        )
+        conn.commit()
+
+
+def test_missing_fingerprint_attestation_cannot_receive_epoch_reward(tmp_path):
+    db_path = tmp_path / "missing_fingerprint_reward.sqlite3"
+    node = _load_integrated_node(db_path)
+
+    miner = "failed-fp-miner"
+    epoch = 85
+    nonce = "nonce-failed-fp"
+    _prepare_attestation_db(node, db_path, miner, epoch, nonce)
+
+    payload = {
+        "miner": miner,
+        "miner_id": miner,
+        "nonce": nonce,
+        "device": {"model": "Generic CPU", "arch": "x86_64", "family": "x86_64", "cores": 4},
+        "signals": {"hostname": "baremetal-host"},
+        "report": {"nonce": nonce, "commitment": "commitment"},
+    }
+
+    with node.app.test_client() as client:
+        response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 200
+    assert response.get_json()["fingerprint_passed"] is False
+
+    with sqlite3.connect(db_path) as conn:
+        recent = conn.execute(
+            "SELECT fingerprint_passed, fingerprint_checks_json FROM miner_attest_recent WHERE miner=?",
+            (miner,),
+        ).fetchone()
+        assert recent == (0, "{}")
+
+    node.finalize_epoch(epoch, node.PER_BLOCK_RTC, prev_block_hash=b"")
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT amount_i64, balance_rtc FROM balances WHERE miner_id=?",
+            (miner,),
+        ).fetchone()
+        assert balance == (0, 0.0)


### PR DESCRIPTION
## Summary

Fix failed-fingerprint attestations so they are tracked with zero reward weight instead of the old positive sentinel weight.

## Root cause

`/attest/submit` correctly records a missing hardware fingerprint as `fingerprint_passed=False` and stores `fingerprint_checks_json='{}'`, but the auto-enroll path still inserted the miner into `epoch_enroll` with `MIN_FAILED_FINGERPRINT_WEIGHT_UNITS = 1`. During settlement, `finalize_epoch()` evaluates active RIP-309 checks with pass-open defaults for missing keys, so a failed-fingerprint miner with positive enrollment weight can receive epoch rewards.

## Impact

A miner with no hardware fingerprint can receive settlement rewards despite the route logging that failed fingerprints should receive zero rewards. In an otherwise empty epoch, the failed miner receives the full epoch payout.

## Changes

- Replace the positive failed-fingerprint sentinel weight with zero reward weight.
- Apply the same zero-weight policy in `/attest/submit` auto-enroll and explicit `/epoch/enroll`.
- Add a regression covering a missing-fingerprint attestation followed by settlement.

## Validation

- Red check before fix: `python3 -m pytest node/tests/test_attest_missing_fingerprint_reward_bypass.py -q` failed because the miner balance was `(1499999, 1.499999)` instead of `(0, 0.0)`.
- `python3 -m pytest node/tests/test_attest_missing_fingerprint_reward_bypass.py node/tests/test_settlement_integrity.py node/tests/test_attestation_overwrite_reward_loss.py node/tests/test_rip309_fingerprint_rotation.py -q` -> `23 passed`.
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_attest_missing_fingerprint_reward_bypass.py` -> passed.
- `git diff --cached --check` -> clean.
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK.

Bounty route: Scottcjn/rustchain-bounties#71.
