### PR TITLE
fix: reject malformed bridge initiate field types

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -20,6 +20,7 @@ import hmac
 import hashlib
 import logging
 import os
+import math
 from typing import Optional, Tuple, Dict, Any
 from decimal import Decimal
 from dataclasses import dataclass
@@ -120,6 +121,8 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     """Validate bridge transfer request payload."""
     if not data:
         return ValidationResult(ok=False, error="Request body is required")
+    if not isinstance(data, dict):
+        return ValidationResult(ok=False, error="Request body must be a JSON object")
     
     # Required fields
     required = ["direction", "source_chain", "dest_chain", "source_address", "dest_address", "amount_rtc"]
@@ -129,12 +132,20 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     
     # Validate direction
     direction = data.get("direction")
+    if not isinstance(direction, str):
+        return ValidationResult(ok=False, error="direction must be a string")
     if direction not in ["deposit", "withdraw"]:
         return ValidationResult(ok=False, error=f"Invalid direction: {direction}. Must be 'deposit' or 'withdraw'")
     
     # Validate chains
-    source_chain = data.get("source_chain", "").lower()
-    dest_chain = data.get("dest_chain", "").lower()
+    source_chain_raw = data.get("source_chain", "")
+    dest_chain_raw = data.get("dest_chain", "")
+    if not isinstance(source_chain_raw, str):
+        return ValidationResult(ok=False, error="source_chain must be a string")
+    if not isinstance(dest_chain_raw, str):
+        return ValidationResult(ok=False, error="dest_chain must be a string")
+    source_chain = source_chain_raw.lower()
+    dest_chain = dest_chain_raw.lower()
     
     if source_chain not in VALID_CHAINS:
         return ValidationResult(ok=False, error=f"Invalid source_chain: {source_chain}")
@@ -156,6 +167,10 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     # Validate addresses
     source_address = data.get("source_address", "")
     dest_address = data.get("dest_address", "")
+    if not isinstance(source_address, str):
+        return ValidationResult(ok=False, error="source_address must be a string")
+    if not isinstance(dest_address, str):
+        return ValidationResult(ok=False, error="dest_address must be a string")
     
     if not source_address or len(source_address) < 10:
         return ValidationResult(ok=False, error="Invalid source_address (too short)")
@@ -168,6 +183,8 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     except (TypeError, ValueError):
         return ValidationResult(ok=False, error="amount_rtc must be a number")
     
+    if not math.isfinite(amount_rtc):
+        return ValidationResult(ok=False, error="amount_rtc must be finite")
     if amount_rtc <= 0:
         return ValidationResult(ok=False, error="amount_rtc must be positive")
     if amount_rtc < BRIDGE_MIN_AMOUNT_RTC:
@@ -175,11 +192,15 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     
     # Validate bridge type (optional)
     bridge_type = data.get("bridge_type", "bottube")
+    if not isinstance(bridge_type, str):
+        return ValidationResult(ok=False, error="bridge_type must be a string")
     if bridge_type not in VALID_BRIDGE_TYPES:
         return ValidationResult(ok=False, error=f"Invalid bridge_type: {bridge_type}")
     
     # Validate memo (optional)
     memo = data.get("memo")
+    if memo is not None and not isinstance(memo, str):
+        return ValidationResult(ok=False, error="memo must be a string")
     if memo and len(memo) > 256:
         return ValidationResult(ok=False, error="Memo must be <= 256 characters")
     

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -718,11 +718,12 @@ def register_bridge_routes(app):
         validation = validate_bridge_request(data)
         if not validation.ok:
             return jsonify({"error": validation.error}), 400
+        details = validation.details or {}
         
         # Validate address formats
         for chain, addr in [
-            (data["source_chain"], data["source_address"]),
-            (data["dest_chain"], data["dest_address"])
+            (details["source_chain"], details["source_address"]),
+            (details["dest_chain"], details["dest_address"])
         ]:
             valid, msg = validate_chain_address_format(chain, addr)
             if not valid:
@@ -732,7 +733,7 @@ def register_bridge_routes(app):
         admin_key = request.headers.get("X-Admin-Key", "")
         expected_admin_key = os.environ.get("RC_ADMIN_KEY", "")
         admin_initiated = bool(expected_admin_key) and hmac.compare_digest(admin_key, expected_admin_key)
-        if data["direction"] == "deposit":
+        if details["direction"] == "deposit":
             # Deposits create balance locks by source_address; require operator
             # authorization until a wallet-owner signature flow exists.
             if not expected_admin_key:
@@ -742,14 +743,14 @@ def register_bridge_routes(app):
         
         # Create bridge transfer
         req = BridgeTransferRequest(
-            direction=data["direction"],
-            source_chain=data["source_chain"],
-            dest_chain=data["dest_chain"],
-            source_address=data["source_address"],
-            dest_address=data["dest_address"],
-            amount_rtc=data["amount_rtc"],
-            memo=data.get("memo"),
-            bridge_type=data.get("bridge_type", "bottube")
+            direction=details["direction"],
+            source_chain=details["source_chain"],
+            dest_chain=details["dest_chain"],
+            source_address=details["source_address"],
+            dest_address=details["dest_address"],
+            amount_rtc=details["amount_rtc"],
+            memo=details.get("memo"),
+            bridge_type=details["bridge_type"]
         )
         
         conn = sqlite3.connect(DB_PATH)

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -178,8 +178,11 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
         return ValidationResult(ok=False, error="Invalid dest_address (too short)")
     
     # Validate amount
+    amount_raw = data.get("amount_rtc", 0)
+    if isinstance(amount_raw, bool):
+        return ValidationResult(ok=False, error="amount_rtc must be a number")
     try:
-        amount_rtc = float(data.get("amount_rtc", 0))
+        amount_rtc = float(amount_raw)
     except (TypeError, ValueError):
         return ValidationResult(ok=False, error="amount_rtc must be a number")
     

--- a/node/test_bridge_initiate_type_validation.py
+++ b/node/test_bridge_initiate_type_validation.py
@@ -65,6 +65,7 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
             "dest_chain_dict": {"dest_chain": {}},
             "source_address_list": {"source_address": ["x"] * 12},
             "dest_address_dict": {"dest_address": {"wallet": "RTCdestination12345"}},
+            "amount_bool": {"amount_rtc": True},
             "bridge_type_list": {"bridge_type": []},
             "memo_dict": {"memo": {"note": "not a string"}},
         }

--- a/node/test_bridge_initiate_type_validation.py
+++ b/node/test_bridge_initiate_type_validation.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 import os
 import sqlite3
 import tempfile
@@ -14,7 +15,8 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
         self.tmp.close()
         self.db_path = self.tmp.name
         bridge_api.DB_PATH = self.db_path
-        with sqlite3.connect(self.db_path) as conn:
+        conn = sqlite3.connect(self.db_path)
+        try:
             bridge_api.init_bridge_schema(conn.cursor())
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)"
@@ -35,6 +37,8 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
                 """
             )
             conn.commit()
+        finally:
+            conn.close()
 
         app = Flask(__name__)
         bridge_api.register_bridge_routes(app)
@@ -77,6 +81,31 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
                 payload = {**self.valid_payload(), "amount_rtc": amount_rtc}
                 response = self.client.post("/api/bridge/initiate", json=payload)
                 self.assertEqual(response.status_code, 400)
+
+    def test_mixed_case_chain_uses_normalized_value_for_address_validation(self):
+        payload = {
+            **self.valid_payload(),
+            "source_chain": "Base",
+            "source_address": "not-a-base-wallet",
+        }
+
+        response = self.client.post("/api/bridge/initiate", json=payload)
+
+        self.assertEqual(response.status_code, 400)
+
+    def test_successful_mixed_case_chain_response_uses_normalized_values(self):
+        payload = {
+            **self.valid_payload(),
+            "source_chain": "Solana",
+            "dest_chain": "RustChain",
+        }
+
+        response = self.client.post("/api/bridge/initiate", json=payload)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["source_chain"], "solana")
+        self.assertEqual(body["dest_chain"], "rustchain")
 
 
 if __name__ == "__main__":

--- a/node/test_bridge_initiate_type_validation.py
+++ b/node/test_bridge_initiate_type_validation.py
@@ -1,0 +1,83 @@
+import os
+import sqlite3
+import tempfile
+import unittest
+
+from flask import Flask
+
+import bridge_api
+
+
+class TestBridgeInitiateTypeValidation(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        bridge_api.DB_PATH = self.db_path
+        with sqlite3.connect(self.db_path) as conn:
+            bridge_api.init_bridge_schema(conn.cursor())
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)"
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS lock_ledger (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    bridge_transfer_id INTEGER,
+                    miner_id TEXT,
+                    amount_i64 INTEGER,
+                    lock_type TEXT,
+                    locked_at INTEGER,
+                    unlock_at INTEGER,
+                    status TEXT,
+                    created_at INTEGER
+                )
+                """
+            )
+            conn.commit()
+
+        app = Flask(__name__)
+        bridge_api.register_bridge_routes(app)
+        app.config["TESTING"] = False
+        self.client = app.test_client()
+
+    def tearDown(self):
+        self.client = None
+        os.unlink(self.db_path)
+
+    def valid_payload(self):
+        return {
+            "direction": "withdraw",
+            "source_chain": "solana",
+            "dest_chain": "rustchain",
+            "source_address": "S" * 32,
+            "dest_address": "RTCdestination12345",
+            "amount_rtc": 1.0,
+        }
+
+    def test_malformed_json_field_types_return_400_not_500(self):
+        cases = {
+            "source_chain_list": {"source_chain": []},
+            "dest_chain_dict": {"dest_chain": {}},
+            "source_address_list": {"source_address": ["x"] * 12},
+            "dest_address_dict": {"dest_address": {"wallet": "RTCdestination12345"}},
+            "bridge_type_list": {"bridge_type": []},
+            "memo_dict": {"memo": {"note": "not a string"}},
+        }
+
+        for name, override in cases.items():
+            with self.subTest(name=name):
+                payload = {**self.valid_payload(), **override}
+                response = self.client.post("/api/bridge/initiate", json=payload)
+                self.assertEqual(response.status_code, 400)
+
+    def test_non_finite_amounts_return_400_not_500(self):
+        for amount_rtc in ("nan", "inf", "-inf"):
+            with self.subTest(amount_rtc=amount_rtc):
+                payload = {**self.valid_payload(), "amount_rtc": amount_rtc}
+                response = self.client.post("/api/bridge/initiate", json=payload)
+                self.assertEqual(response.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- require `/api/bridge/initiate` JSON payloads and scalar fields to have the expected types before route validation calls `.lower()`, length checks, or membership checks
- reject non-finite `amount_rtc` values such as `nan` and `inf` with a controlled 400 response
- add route-level regression coverage for malformed bridge initiation payloads

## Why
The public bridge initiation route accepted untrusted JSON and assumed fields like `source_chain`, `dest_chain`, `bridge_type`, addresses, and `memo` were already strings. Structured values could raise uncaught exceptions and produce 500 responses instead of client validation errors. Non-finite amount strings could also reach later integer conversion paths and fail as server errors.

## Validation
```bash
PYTHONPATH=node python3 -m pytest -q node/test_bridge_initiate_type_validation.py tests/test_bridge_lock_ledger.py node/test_bridge_precision.py node/tests/test_bridge_api_limit_validation.py
python3 -m py_compile node/bridge_api.py node/test_bridge_initiate_type_validation.py
git diff --check
```

Observed locally: `49 passed, 9 subtests passed`, py_compile passed, and `git diff --check` was clean.

## Duplicate / safety checks
Before opening this PR I searched public issues and PRs for `bridge initiate type validation`, `malformed bridge initiate 500`, `reject malformed bridge initiate field types`, `source_chain list lower bridge_api`, and related bridge-initiate type-confusion terms. I did not find an exact duplicate; the broad `#500` hit was an unrelated closed bounty title/number collision.

No private keys, tokens, credentials, or account-internal data are included.
