### PR TITLE
fix: reject below-dust UTXO endpoint transfers

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -16,7 +16,7 @@ from flask import Flask
 
 import utxo_endpoints
 from utxo_db import (
-    UtxoDB, UNIT, address_to_proposition, compute_box_id,
+    UtxoDB, UNIT, DUST_THRESHOLD, address_to_proposition, compute_box_id,
 )
 from utxo_endpoints import register_utxo_blueprint
 
@@ -281,8 +281,8 @@ class TestUtxoEndpoints(unittest.TestCase):
                          f"Expected 10_000_000 nanoRTC, got {bob_bal} "
                          f"(float truncation bug)")
 
-    def test_transfer_preserves_three_nanortc_amount(self):
-        """Issue #4671: 0.00000003 RTC must transfer exactly 3 nanoRTC."""
+    def test_transfer_rejects_below_dust_amount(self):
+        """Amounts below DUST_THRESHOLD must fail before UTXO commit."""
         sender = 'RTC_test_aabbccdd'
         recipient = 'bob'
         self._seed_coinbase(sender, UNIT)
@@ -297,10 +297,32 @@ class TestUtxoEndpoints(unittest.TestCase):
         })
         data = r.get_json()
 
+        self.assertEqual(r.status_code, 400, data)
+        self.assertIn('below dust threshold', data['error'])
+        self.assertEqual(self.utxo_db.get_balance(recipient), 0)
+        self.assertEqual(self.utxo_db.get_balance(sender), UNIT)
+
+    def test_transfer_preserves_dust_threshold_amount(self):
+        """A transfer exactly at DUST_THRESHOLD remains valid."""
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_coinbase(sender, UNIT)
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': DUST_THRESHOLD / UNIT,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+        data = r.get_json()
+
         self.assertEqual(r.status_code, 200, data)
         self.assertTrue(data['ok'])
-        self.assertEqual(self.utxo_db.get_balance(recipient), 3)
-        self.assertEqual(self.utxo_db.get_balance(sender), UNIT - 3)
+        self.assertEqual(self.utxo_db.get_balance(recipient), DUST_THRESHOLD)
+        self.assertEqual(self.utxo_db.get_balance(sender),
+                         UNIT - DUST_THRESHOLD)
 
     def test_transfer_rejects_decimal_amount_not_preserved_by_signed_float(self):
         """The signed float amount must match the ledger nanoRTC amount.

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -26,7 +26,9 @@ from decimal import Decimal, InvalidOperation
 
 from flask import Blueprint, request, jsonify
 
-from utxo_db import UtxoDB, coin_select, address_to_proposition, UNIT
+from utxo_db import (
+    UtxoDB, coin_select, address_to_proposition, UNIT, DUST_THRESHOLD,
+)
 
 # FIX(#2867 M2): Reject inputs that would overflow int64 (signed) or
 # represent absurd amounts. Total RTC supply is bounded; cap at 2^53 RTC
@@ -395,6 +397,16 @@ def utxo_transfer():
         _ensure_signed_float_preserves_nrtc(fee_rtc, fee_nrtc, 'fee_rtc')
     except ValueError as e:
         return jsonify({'error': f'Invalid amount: {e}'}), 400
+
+    if amount_nrtc < DUST_THRESHOLD:
+        return jsonify({
+            'error': (
+                f'Amount below dust threshold: minimum is '
+                f'{DUST_THRESHOLD / UNIT:.8f} RTC'
+            ),
+            'dust_threshold_nrtc': DUST_THRESHOLD,
+            'dust_threshold_rtc': DUST_THRESHOLD / UNIT,
+        }), 400
 
     # Verify pubkey → address
     expected_addr = _addr_from_pk_fn(public_key)


### PR DESCRIPTION
## Summary

Reject `/utxo/transfer` amounts below `DUST_THRESHOLD` at the endpoint boundary instead of letting the DB layer reject them later as a generic 500.

## Root cause

`UtxoDB.apply_transaction()` enforces `DUST_THRESHOLD`, but the public `/utxo/transfer` route still accepted smaller RTC amounts, built a transaction, reserved a nonce, and only failed when the DB layer rejected the below-dust output. That leaked as `500 UTXO transaction failed (race condition or validation)` instead of a client-facing validation error.

## Changes

- Import `DUST_THRESHOLD` into the UTXO endpoint layer.
- Return HTTP 400 for `amount_nrtc < DUST_THRESHOLD` before the UTXO commit path.
- Update the stale 3-nanoRTC regression to assert the post-#5121 dust policy.
- Add a boundary regression proving exactly `DUST_THRESHOLD` remains transferable.

## Validation

- Red check before fix: `python3 -m pytest node/test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_rejects_below_dust_amount node/test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_preserves_dust_threshold_amount -q` failed because below-dust transfer returned 500 instead of 400.
- `python3 -m pytest node/test_utxo_endpoints.py node/test_utxo_db.py -q` -> `93 passed, 3 subtests passed`.
- `python3 -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py node/test_utxo_db.py` -> passed.
- `git diff --check` -> clean.
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK.

Bounty route: Scottcjn/rustchain-bounties#2819.
