### PR TITLE
fix: align integrated node schema with reward settlement

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2101,6 +2101,22 @@ def _ensure_rewards_settle_schema(conn: sqlite3.Connection):
     """Keep init_db() compatible with the RIP-200 rewards settlement module."""
     conn.execute(
         """
+        CREATE TABLE IF NOT EXISTS miner_attest_recent (
+            miner TEXT PRIMARY KEY,
+            ts_ok INTEGER DEFAULT 0,
+            device_family TEXT,
+            device_arch TEXT,
+            entropy_score REAL DEFAULT 0.0,
+            fingerprint_passed INTEGER DEFAULT 0,
+            source_ip TEXT,
+            warthog_bonus REAL DEFAULT 1.0,
+            signing_pubkey TEXT,
+            fingerprint_checks_json TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
         CREATE TABLE IF NOT EXISTS ledger (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             ts INTEGER,

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1172,6 +1172,7 @@ def init_db():
         c.execute("CREATE TABLE IF NOT EXISTS epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER, PRIMARY KEY (epoch, miner_pk))")
         ensure_epoch_enroll_integer_weights(c)
         c.execute("CREATE TABLE IF NOT EXISTS balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+        _ensure_rewards_settle_schema(c)
         ensure_fingerprint_history_table(c)
         ensure_epoch_fingerprint_rotation_table(c)
 
@@ -2094,6 +2095,41 @@ def auto_induct_to_hall(miner: str, device: dict):
 
 def _table_columns(conn: sqlite3.Connection, table_name: str) -> set:
     return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def _ensure_rewards_settle_schema(conn: sqlite3.Connection):
+    """Keep init_db() compatible with the RIP-200 rewards settlement module."""
+    epoch_cols = _table_columns(conn, "epoch_state")
+    if "settled" not in epoch_cols:
+        conn.execute("ALTER TABLE epoch_state ADD COLUMN settled INTEGER DEFAULT 0")
+    if "settled_ts" not in epoch_cols:
+        conn.execute("ALTER TABLE epoch_state ADD COLUMN settled_ts INTEGER")
+
+    balance_cols = _table_columns(conn, "balances")
+    if "miner_id" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN miner_id TEXT")
+    if "amount_i64" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN amount_i64 INTEGER DEFAULT 0")
+    if "balance_rtc" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN balance_rtc REAL DEFAULT 0")
+
+    balance_cols = _table_columns(conn, "balances")
+    if {"miner_pk", "miner_id"}.issubset(balance_cols):
+        conn.execute(
+            "UPDATE balances SET miner_id = miner_pk WHERE miner_id IS NULL AND miner_pk IS NOT NULL"
+        )
+    if {"balance_rtc", "amount_i64"}.issubset(balance_cols):
+        conn.execute(
+            """
+            UPDATE balances
+            SET amount_i64 = CAST(balance_rtc * 1000000 AS INTEGER)
+            WHERE COALESCE(amount_i64, 0) = 0
+              AND COALESCE(balance_rtc, 0) != 0
+            """
+        )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_balances_miner_id ON balances(miner_id)"
+    )
 
 
 def _welcome_bonus_epoch() -> int:

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2099,6 +2099,29 @@ def _table_columns(conn: sqlite3.Connection, table_name: str) -> set:
 
 def _ensure_rewards_settle_schema(conn: sqlite3.Connection):
     """Keep init_db() compatible with the RIP-200 rewards settlement module."""
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ledger (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts INTEGER,
+            epoch INTEGER,
+            miner_id TEXT,
+            delta_i64 INTEGER,
+            reason TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS epoch_rewards (
+            epoch INTEGER,
+            miner_id TEXT,
+            share_i64 INTEGER,
+            PRIMARY KEY (epoch, miner_id)
+        )
+        """
+    )
+
     epoch_cols = _table_columns(conn, "epoch_state")
     if "settled" not in epoch_cols:
         conn.execute("ALTER TABLE epoch_state ADD COLUMN settled INTEGER DEFAULT 0")

--- a/tests/test_rewards_settle_schema_compat.py
+++ b/tests/test_rewards_settle_schema_compat.py
@@ -15,16 +15,17 @@ def test_init_db_schema_supports_rewards_settle(tmp_path, monkeypatch):
     monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: slot // integrated_node.EPOCH_SLOTS)
     monkeypatch.setattr(rewards, "DB_PATH", str(db_path))
     monkeypatch.setattr(rewards, "ANTI_DOUBLE_MINING_AVAILABLE", False)
-    monkeypatch.setattr(
-        rewards,
-        "calculate_epoch_rewards_time_aged",
-        lambda db_path_arg, epoch, total, current, prev: {"alice": total},
-    )
 
     integrated_node.init_db()
     with sqlite3.connect(db_path) as conn:
-        conn.execute("CREATE TABLE IF NOT EXISTS miner_attest_recent(miner TEXT, device_arch TEXT)")
-        conn.execute("INSERT INTO miner_attest_recent(miner, device_arch) VALUES (?, ?)", ("alice", "x86_64"))
+        conn.execute(
+            "INSERT INTO miner_attest_recent(miner, ts_ok, device_arch, fingerprint_passed) VALUES (?, ?, ?, ?)",
+            ("alice", 0, "x86_64", 1),
+        )
+        conn.execute(
+            "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (?, ?, ?)",
+            (0, "alice", 1),
+        )
         conn.commit()
 
     integrated_node.app.config["TESTING"] = True
@@ -48,8 +49,18 @@ def test_init_db_schema_supports_rewards_settle(tmp_path, monkeypatch):
             "SELECT settled FROM epoch_state WHERE epoch = ?",
             (0,),
         ).fetchone()
+        ledger = conn.execute(
+            "SELECT miner_id, delta_i64, reason FROM ledger WHERE miner_id = ?",
+            ("alice",),
+        ).fetchall()
+        reward = conn.execute(
+            "SELECT miner_id, share_i64 FROM epoch_rewards WHERE epoch = ?",
+            (0,),
+        ).fetchall()
 
     assert {"settled", "settled_ts"}.issubset(epoch_cols)
     assert {"miner_id", "amount_i64"}.issubset(balance_cols)
     assert balance == ("alice", rewards.PER_EPOCH_URTC)
     assert settled == (1,)
+    assert ledger == [("alice", rewards.PER_EPOCH_URTC, "epoch_0_reward")]
+    assert reward == [("alice", rewards.PER_EPOCH_URTC)]

--- a/tests/test_rewards_settle_schema_compat.py
+++ b/tests/test_rewards_settle_schema_compat.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sqlite3
 
 
@@ -22,8 +24,6 @@ def test_init_db_schema_supports_rewards_settle(tmp_path, monkeypatch):
     integrated_node.init_db()
     with sqlite3.connect(db_path) as conn:
         conn.execute("CREATE TABLE IF NOT EXISTS miner_attest_recent(miner TEXT, device_arch TEXT)")
-        conn.execute("CREATE TABLE IF NOT EXISTS epoch_rewards(epoch INTEGER, miner_id TEXT, share_i64 INTEGER)")
-        conn.execute("CREATE TABLE IF NOT EXISTS ledger(ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
         conn.execute("INSERT INTO miner_attest_recent(miner, device_arch) VALUES (?, ?)", ("alice", "x86_64"))
         conn.commit()
 

--- a/tests/test_rewards_settle_schema_compat.py
+++ b/tests/test_rewards_settle_schema_compat.py
@@ -1,0 +1,55 @@
+import sqlite3
+
+
+def test_init_db_schema_supports_rewards_settle(tmp_path, monkeypatch):
+    import integrated_node
+    import rewards_implementation_rip200 as rewards
+
+    db_path = tmp_path / "rewards_settle.sqlite3"
+    admin_key = "c" * 32
+    monkeypatch.setenv("RC_ADMIN_KEY", admin_key)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 1000)
+    monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: slot // integrated_node.EPOCH_SLOTS)
+    monkeypatch.setattr(rewards, "DB_PATH", str(db_path))
+    monkeypatch.setattr(rewards, "ANTI_DOUBLE_MINING_AVAILABLE", False)
+    monkeypatch.setattr(
+        rewards,
+        "calculate_epoch_rewards_time_aged",
+        lambda db_path_arg, epoch, total, current, prev: {"alice": total},
+    )
+
+    integrated_node.init_db()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS miner_attest_recent(miner TEXT, device_arch TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS epoch_rewards(epoch INTEGER, miner_id TEXT, share_i64 INTEGER)")
+        conn.execute("CREATE TABLE IF NOT EXISTS ledger(ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+        conn.execute("INSERT INTO miner_attest_recent(miner, device_arch) VALUES (?, ?)", ("alice", "x86_64"))
+        conn.commit()
+
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        response = client.post(
+            "/rewards/settle",
+            headers={"X-Admin-Key": admin_key},
+            json={"epoch": 0},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    with sqlite3.connect(db_path) as conn:
+        epoch_cols = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)")}
+        balance_cols = {row[1] for row in conn.execute("PRAGMA table_info(balances)")}
+        balance = conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances WHERE miner_id = ?",
+            ("alice",),
+        ).fetchone()
+        settled = conn.execute(
+            "SELECT settled FROM epoch_state WHERE epoch = ?",
+            (0,),
+        ).fetchone()
+
+    assert {"settled", "settled_ts"}.issubset(epoch_cols)
+    assert {"miner_id", "amount_i64"}.issubset(balance_cols)
+    assert balance == ("alice", rewards.PER_EPOCH_URTC)
+    assert settled == (1,)


### PR DESCRIPTION
## Summary

Aligns the integrated node schema with the RIP-200 rewards settlement implementation so a fresh integrated-node DB can use `/rewards/settle` without schema errors.

The integrated `init_db()` path created `epoch_state(finalized)` and `balances(miner_pk, balance_rtc)`, while the settlement code expects `epoch_state(settled, settled_ts)` and `balances(miner_id, amount_i64)`. This patch adds the compatible columns/indexes idempotently and adds a regression test that settles rewards on a fresh integrated-node schema.

## Verification

Focused checks for this PR:

```bash
python3 tools/bcos_spdx_check.py --base-ref origin/main
PYTHONPATH=node python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_rewards_settle_schema_compat.py
PYTHONPATH=node python3 -B -m pytest -q tests/test_rewards_settle_schema_compat.py
PYTHONPATH=node python3 -B -m pytest -q tests/test_rewards_settle_schema_compat.py tests/test_welcome_bonus_schema.py node/tests/test_rewards_settle_race.py --tb=short
git diff --check origin/main...HEAD -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_rewards_settle_schema_compat.py
```

Observed on current head `4c9bc066d7cc352f5994f207394bb5a9c990c07c`:

```text
BCOS SPDX check: OK
py_compile passed
tests/test_rewards_settle_schema_compat.py: 1 passed
focused rewards-settle/schema suite: 7 passed
git diff --check clean
```

A broader Linux confidence run previously passed locally, but it is not part of the required PR verification here because reviewers reported Windows/environment failures outside this patch in unrelated suites. The required evidence for this PR is the focused fresh-schema rewards settlement surface above.

## Bounty route

Prepared for Scottcjn/rustchain-bounties#71 and related security quest #398. No private keys, tokens, credentials, wallet secrets, or account-internal data are included.
