### PR TITLE
fix: align reward settlement schema

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1172,6 +1172,7 @@ def init_db():
         c.execute("CREATE TABLE IF NOT EXISTS epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER, PRIMARY KEY (epoch, miner_pk))")
         ensure_epoch_enroll_integer_weights(c)
         c.execute("CREATE TABLE IF NOT EXISTS balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+        _ensure_rewards_settle_schema(c)
         ensure_fingerprint_history_table(c)
         ensure_epoch_fingerprint_rotation_table(c)
 
@@ -2094,6 +2095,41 @@ def auto_induct_to_hall(miner: str, device: dict):
 
 def _table_columns(conn: sqlite3.Connection, table_name: str) -> set:
     return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+
+
+def _ensure_rewards_settle_schema(conn: sqlite3.Connection):
+    """Keep init_db() compatible with the RIP-200 rewards settlement module."""
+    epoch_cols = _table_columns(conn, "epoch_state")
+    if "settled" not in epoch_cols:
+        conn.execute("ALTER TABLE epoch_state ADD COLUMN settled INTEGER DEFAULT 0")
+    if "settled_ts" not in epoch_cols:
+        conn.execute("ALTER TABLE epoch_state ADD COLUMN settled_ts INTEGER")
+
+    balance_cols = _table_columns(conn, "balances")
+    if "miner_id" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN miner_id TEXT")
+    if "amount_i64" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN amount_i64 INTEGER DEFAULT 0")
+    if "balance_rtc" not in balance_cols:
+        conn.execute("ALTER TABLE balances ADD COLUMN balance_rtc REAL DEFAULT 0")
+
+    balance_cols = _table_columns(conn, "balances")
+    if {"miner_pk", "miner_id"}.issubset(balance_cols):
+        conn.execute(
+            "UPDATE balances SET miner_id = miner_pk WHERE miner_id IS NULL AND miner_pk IS NOT NULL"
+        )
+    if {"balance_rtc", "amount_i64"}.issubset(balance_cols):
+        conn.execute(
+            """
+            UPDATE balances
+            SET amount_i64 = CAST(balance_rtc * 1000000 AS INTEGER)
+            WHERE COALESCE(amount_i64, 0) = 0
+              AND COALESCE(balance_rtc, 0) != 0
+            """
+        )
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_balances_miner_id ON balances(miner_id)"
+    )
 
 
 def _welcome_bonus_epoch() -> int:

--- a/tests/test_rewards_settle_schema_compat.py
+++ b/tests/test_rewards_settle_schema_compat.py
@@ -1,0 +1,55 @@
+import sqlite3
+
+
+def test_init_db_schema_supports_rewards_settle(tmp_path, monkeypatch):
+    import integrated_node
+    import rewards_implementation_rip200 as rewards
+
+    db_path = tmp_path / "rewards_settle.sqlite3"
+    admin_key = "c" * 32
+    monkeypatch.setenv("RC_ADMIN_KEY", admin_key)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 1000)
+    monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: slot // integrated_node.EPOCH_SLOTS)
+    monkeypatch.setattr(rewards, "DB_PATH", str(db_path))
+    monkeypatch.setattr(rewards, "ANTI_DOUBLE_MINING_AVAILABLE", False)
+    monkeypatch.setattr(
+        rewards,
+        "calculate_epoch_rewards_time_aged",
+        lambda db_path_arg, epoch, total, current, prev: {"alice": total},
+    )
+
+    integrated_node.init_db()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE IF NOT EXISTS miner_attest_recent(miner TEXT, device_arch TEXT)")
+        conn.execute("CREATE TABLE IF NOT EXISTS epoch_rewards(epoch INTEGER, miner_id TEXT, share_i64 INTEGER)")
+        conn.execute("CREATE TABLE IF NOT EXISTS ledger(ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+        conn.execute("INSERT INTO miner_attest_recent(miner, device_arch) VALUES (?, ?)", ("alice", "x86_64"))
+        conn.commit()
+
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        response = client.post(
+            "/rewards/settle",
+            headers={"X-Admin-Key": admin_key},
+            json={"epoch": 0},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    with sqlite3.connect(db_path) as conn:
+        epoch_cols = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)")}
+        balance_cols = {row[1] for row in conn.execute("PRAGMA table_info(balances)")}
+        balance = conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances WHERE miner_id = ?",
+            ("alice",),
+        ).fetchone()
+        settled = conn.execute(
+            "SELECT settled FROM epoch_state WHERE epoch = ?",
+            (0,),
+        ).fetchone()
+
+    assert {"settled", "settled_ts"}.issubset(epoch_cols)
+    assert {"miner_id", "amount_i64"}.issubset(balance_cols)
+    assert balance == ("alice", rewards.PER_EPOCH_URTC)
+    assert settled == (1,)


### PR DESCRIPTION
## Summary
- add the reward-settlement columns that RIP-200 expects when integrated-node databases are initialized
- keep legacy balance columns while backfilling miner_id and amount_i64 compatibility fields
- add a regression proving /rewards/settle works on a fresh init_db() database

## Tests
- RED: python3 -m pytest tests/test_rewards_settle_schema_compat.py -q -> failed with sqlite3.OperationalError: no such column: settled before the fix
- PYTHONPATH=node python3 -m pytest -q tests/test_rewards_settle_schema_compat.py tests/test_welcome_bonus_schema.py tests/test_api.py tests/test_wallet_show_regression.py node/tests/test_rewards_settle_endpoint.py node/tests/test_rewards_settle_race.py node/tests/test_integrated_balance_scale.py -> 31 passed
- python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_rewards_settle_schema_compat.py
- git diff --check

Bounty route: Scottcjn/rustchain-bounties#71 / #398
Miner/payout id: iamdinhthuan