### PR TITLE
[UTXO-BUG] Preserve caller-owned UTXO DB connection

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -812,6 +812,32 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
         self.assertFalse(ok)
 
+    def test_user_supplied_mining_reward_preserves_external_conn(self):
+        """Rejected mint attempts must not close a caller-owned connection."""
+        conn = self.db._conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            ok = self.db.apply_transaction({
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': 'attacker', 'value_nrtc': 1 * UNIT}],
+                'fee_nrtc': 0,
+                'timestamp': int(time.time()),
+            }, block_height=10, conn=conn)
+            self.assertFalse(ok)
+
+            try:
+                self.assertEqual(conn.execute("SELECT 1").fetchone()[0], 1)
+            except Exception as exc:
+                self.fail(f"apply_transaction closed caller-owned conn: {exc}")
+        finally:
+            try:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                conn.close()
+            except Exception:
+                pass
+
     def test_mempool_empty_inputs_rejected_for_transfer(self):
         """Mempool must also reject non-minting txs with empty inputs."""
         tx = {

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -446,8 +446,6 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
-            if conn:
-                conn.close()
             return False
         if own:
             conn = self._conn()


### PR DESCRIPTION
## Summary
- stop `UtxoDB.apply_transaction()` from closing caller-supplied SQLite connections on the rejected `mining_reward` guard path
- add a regression proving a caller can still inspect and roll back its external transaction after a rejected mint attempt

## Why
`apply_transaction(..., conn=caller_conn)` accepts a caller-owned connection. On the unauthorized `mining_reward` validation path, the current code closes that external connection before returning `False`. That turns a normal validation failure into `sqlite3.ProgrammingError: Cannot operate on a closed database` for callers that need to inspect or roll back their own transaction.

## Validation
```bash
# RED before production fix
python3 -m pytest node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_preserves_external_conn node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_rejected_before_opening_db -q
```

Observed before fix: `test_user_supplied_mining_reward_preserves_external_conn` failed because the caller-owned connection was closed.

```bash
python3 -m pytest node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_preserves_external_conn node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_rejected_before_opening_db node/test_utxo_db.py -q
python3 -m py_compile node/utxo_db.py node/test_utxo_db.py
git diff --check
```

Observed locally: `72 passed`, py_compile passed, and `git diff --check` was clean.

## Duplicate / safety checks
Before opening this PR I searched public issues and PRs for `caller-owned connection apply_transaction mining_reward`, `external conn close apply_transaction mining_reward`, and `preserve external connection apply_transaction`. I did not find an exact duplicate. Open PR #4638 is about unmineable mempool outputs, not this external-connection ownership path.

Bounty route: Scottcjn/rustchain-bounties#2819.
Miner / payout id: iamdinhthuan.
No private keys, tokens, credentials, or account-internal data are included.
