### PR TITLE
fix: preserve caller-owned UTXO DB connection

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -812,6 +812,32 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
         self.assertFalse(ok)
 
+    def test_user_supplied_mining_reward_preserves_external_conn(self):
+        """Rejected mint attempts must not close a caller-owned connection."""
+        conn = self.db._conn()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            ok = self.db.apply_transaction({
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': 'attacker', 'value_nrtc': 1 * UNIT}],
+                'fee_nrtc': 0,
+                'timestamp': int(time.time()),
+            }, block_height=10, conn=conn)
+            self.assertFalse(ok)
+
+            try:
+                self.assertEqual(conn.execute("SELECT 1").fetchone()[0], 1)
+            except Exception as exc:
+                self.fail(f"apply_transaction closed caller-owned conn: {exc}")
+        finally:
+            try:
+                if conn.in_transaction:
+                    conn.execute("ROLLBACK")
+                conn.close()
+            except Exception:
+                pass
+
     def test_mempool_empty_inputs_rejected_for_transfer(self):
         """Mempool must also reject non-minting txs with empty inputs."""
         tx = {

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -446,8 +446,6 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
-            if conn:
-                conn.close()
             return False
         if own:
             conn = self._conn()


### PR DESCRIPTION
## Summary
- keep `UtxoDB.apply_transaction()` from closing a caller-owned SQLite connection when rejecting an unauthorized `mining_reward` transaction
- add a regression proving callers can continue using their explicit connection after the validation failure
- preserve the existing no-extra-connection behavior for unauthorized mint attempts

## Why
`apply_transaction(..., conn=external_conn)` accepts a caller-owned connection. The unauthorized public `mining_reward` guard returned `False`, but closed `external_conn` first, so callers could not inspect, roll back, or continue their transaction after a normal validation failure.

## Bounty route
- Scottcjn/rustchain-bounties#2819
- Miner / payout id: `iamdinhthuan`

## Tests
- Red before fix: `python3 -m pytest node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_preserves_external_conn -q` failed with `sqlite3.ProgrammingError: Cannot operate on a closed database`
- `python3 -m pytest node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_preserves_external_conn node/test_utxo_db.py::TestUtxoDB::test_user_supplied_mining_reward_rejected_before_opening_db node/test_utxo_db.py -q` -> `72 passed`
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check`

## Duplicate / safety check
- Fresh exact PR/issue searches for `caller-owned connection apply_transaction mining_reward` and `preserve caller owned UTXO connection` returned no exact public duplicate immediately before push.
- No private keys, tokens, account-private data, cookies, or credentials are included.
