### PR TITLE
fix: require manual payout recovery after broadcast uncertainty

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -20,6 +20,7 @@ BATCH_SIZE = 10
 POLL_INTERVAL = 30  # seconds
 MAX_RETRIES = 3
 MOCK_MODE = os.environ.get("RUSTCHAIN_MOCK_MODE", "0") == "1"  # Default: production (False)
+RECOVERY_REQUIRED_STATUS = "recovery_required"
 
 
 class ProductionWithdrawalNotConfigured(RuntimeError):
@@ -90,6 +91,8 @@ class PayoutWorker:
     def process_withdrawal(self, withdrawal: Dict) -> bool:
         """Process a single withdrawal with balance deduction before execution."""
         withdrawal_id = withdrawal['withdrawal_id']
+        marked_processing = False
+        broadcast_tx_hash = None
 
         try:
             logger.info(f"Processing withdrawal {withdrawal_id}")
@@ -149,14 +152,15 @@ class PayoutWorker:
                         (withdrawal_id,)
                     )
                     conn.execute("COMMIT")
+                    marked_processing = True
                 except Exception:
                     conn.execute("ROLLBACK")
                     raise
 
             # Execute withdrawal (broadcast transaction)
-            tx_hash = self.execute_withdrawal(withdrawal)
+            broadcast_tx_hash = self.execute_withdrawal(withdrawal)
 
-            if tx_hash:
+            if broadcast_tx_hash:
                 # Mark as completed
                 with sqlite3.connect(self.db_path) as conn:
                     conn.execute("""
@@ -165,9 +169,9 @@ class PayoutWorker:
                             processed_at = ?,
                             tx_hash = ?
                         WHERE withdrawal_id = ?
-                    """, (int(time.time()), tx_hash, withdrawal_id))
+                    """, (int(time.time()), broadcast_tx_hash, withdrawal_id))
 
-                logger.info(f"[OK] Withdrawal {withdrawal_id} completed: {tx_hash}")
+                logger.info(f"[OK] Withdrawal {withdrawal_id} completed: {broadcast_tx_hash}")
                 self.stats['processed'] += 1
                 self.stats['total_rtc'] += withdrawal['amount']
                 return True
@@ -177,21 +181,32 @@ class PayoutWorker:
         except Exception as e:
             logger.error(f"✗ Withdrawal {withdrawal_id} failed: {e}")
 
-            # Refund balance on broadcast failure and mark as failed
-            with sqlite3.connect(self.db_path) as conn:
-                conn.execute("BEGIN IMMEDIATE")
-                conn.execute(
-                    "UPDATE accounts SET balance = balance + ? WHERE public_key = ?",
-                    (withdrawal['amount'] + withdrawal.get('fee', 0),
-                     withdrawal['miner_pk'])
+            if marked_processing:
+                message = (
+                    "Manual recovery required after processing failure; "
+                    "verify transaction status before retrying or refunding: "
+                    f"{e}"
                 )
+                with sqlite3.connect(self.db_path) as conn:
+                    conn.execute("""
+                        UPDATE withdrawals
+                        SET status = ?,
+                            error_msg = ?,
+                            tx_hash = COALESCE(?, tx_hash)
+                        WHERE withdrawal_id = ?
+                    """, (RECOVERY_REQUIRED_STATUS, message, broadcast_tx_hash, withdrawal_id))
+
+                self.stats['failed'] += 1
+                return False
+
+            # Fail only pre-processing errors; no funds have been deducted yet.
+            with sqlite3.connect(self.db_path) as conn:
                 conn.execute("""
                     UPDATE withdrawals
                     SET status = 'failed',
                         error_msg = ?
                     WHERE withdrawal_id = ?
                 """, (str(e), withdrawal_id))
-                conn.execute("COMMIT")
 
             self.stats['failed'] += 1
             return False
@@ -214,6 +229,24 @@ class PayoutWorker:
             time.sleep(1)
 
         return processed
+
+    def recover_processing_withdrawals(self) -> int:
+        """Move startup-orphaned processing withdrawals to manual recovery."""
+        message = (
+            "Manual recovery required after worker restart; verify transaction "
+            "status before retrying or refunding"
+        )
+        with sqlite3.connect(self.db_path) as conn:
+            cursor = conn.execute("""
+                UPDATE withdrawals
+                SET status = ?,
+                    error_msg = CASE
+                        WHEN error_msg IS NULL OR error_msg = '' THEN ?
+                        ELSE error_msg || '; ' || ?
+                    END
+                WHERE status = 'processing'
+            """, (RECOVERY_REQUIRED_STATUS, message, message))
+            return cursor.rowcount
 
     def run_forever(self):
         """Main worker loop"""
@@ -303,11 +336,17 @@ class PayoutWorker:
                 "SELECT COUNT(*) FROM withdrawals WHERE status = 'failed'"
             ).fetchone()[0]
 
+            recovery_required = conn.execute(
+                "SELECT COUNT(*) FROM withdrawals WHERE status = ?",
+                (RECOVERY_REQUIRED_STATUS,),
+            ).fetchone()[0]
+
         return {
             'pending': pending,
             'processing': processing,
             'completed': completed,
             'failed': failed,
+            'recovery_required': recovery_required,
             'session_processed': self.stats['processed'],
             'session_failed': self.stats['failed'],
             'session_total_rtc': self.stats['total_rtc']
@@ -318,6 +357,12 @@ def main():
     worker = PayoutWorker()
 
     try:
+        recovered = worker.recover_processing_withdrawals()
+        if recovered:
+            logger.warning(
+                "Moved %s processing withdrawals to manual recovery", recovered
+            )
+
         # Print initial stats
         stats = worker.get_stats()
         logger.info(f"Initial queue state: {stats}")

--- a/tests/test_payout_worker_production_noop.py
+++ b/tests/test_payout_worker_production_noop.py
@@ -71,3 +71,96 @@ def test_process_withdrawal_leaves_pending_when_production_broadcast_is_not_conf
     assert status == "pending"
     assert "not configured" in error_msg
     assert tx_hash is None
+
+
+def test_processing_withdrawal_failure_requires_manual_recovery_without_refund(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(payout_worker, "MOCK_MODE", True)
+    db_path = str(tmp_path / "payout_worker.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE accounts (public_key TEXT PRIMARY KEY, balance INTEGER)")
+        conn.execute(
+            "CREATE TABLE withdrawals ("
+            "withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT, amount INTEGER, fee INTEGER, "
+            "destination TEXT, status TEXT, error_msg TEXT, processed_at INTEGER, "
+            "tx_hash TEXT, created_at INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO accounts (public_key, balance) VALUES (?, ?)",
+            ("miner-pubkey", 100),
+        )
+        conn.execute(
+            "INSERT INTO withdrawals "
+            "(withdrawal_id, miner_pk, amount, fee, destination, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("wd-1", "miner-pubkey", 10, 1, "RTCdest", "pending", 1234567890),
+        )
+
+    class AmbiguousBroadcastWorker(payout_worker.PayoutWorker):
+        def execute_withdrawal(self, withdrawal):
+            raise RuntimeError("broadcast status unknown after restart")
+
+    worker = AmbiguousBroadcastWorker()
+    worker.db_path = db_path
+
+    assert worker.process_withdrawal(withdrawal()) is False
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT balance FROM accounts WHERE public_key = ?",
+            ("miner-pubkey",),
+        ).fetchone()[0]
+        status, error_msg = conn.execute(
+            "SELECT status, error_msg FROM withdrawals WHERE withdrawal_id = ?",
+            ("wd-1",),
+        ).fetchone()
+
+    assert balance == 89
+    assert status == "recovery_required"
+    assert "Manual recovery required" in error_msg
+    assert "broadcast status unknown" in error_msg
+    assert worker.get_stats()["recovery_required"] == 1
+
+
+def test_startup_recovery_moves_processing_withdrawals_to_manual_review_without_refund(
+    tmp_path,
+):
+    db_path = str(tmp_path / "payout_worker.db")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE accounts (public_key TEXT PRIMARY KEY, balance INTEGER)")
+        conn.execute(
+            "CREATE TABLE withdrawals ("
+            "withdrawal_id TEXT PRIMARY KEY, miner_pk TEXT, amount INTEGER, fee INTEGER, "
+            "destination TEXT, status TEXT, error_msg TEXT, processed_at INTEGER, "
+            "tx_hash TEXT, created_at INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO accounts (public_key, balance) VALUES (?, ?)",
+            ("miner-pubkey", 89),
+        )
+        conn.execute(
+            "INSERT INTO withdrawals "
+            "(withdrawal_id, miner_pk, amount, fee, destination, status, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            ("wd-1", "miner-pubkey", 10, 1, "RTCdest", "processing", 1234567890),
+        )
+
+    worker = payout_worker.PayoutWorker()
+    worker.db_path = db_path
+
+    assert worker.recover_processing_withdrawals() == 1
+
+    with sqlite3.connect(db_path) as conn:
+        balance = conn.execute(
+            "SELECT balance FROM accounts WHERE public_key = ?",
+            ("miner-pubkey",),
+        ).fetchone()[0]
+        status, error_msg = conn.execute(
+            "SELECT status, error_msg FROM withdrawals WHERE withdrawal_id = ?",
+            ("wd-1",),
+        ).fetchone()
+
+    assert balance == 89
+    assert status == "recovery_required"
+    assert "worker restart" in error_msg


### PR DESCRIPTION
## Summary
- Move startup-orphaned `processing` withdrawals into explicit `recovery_required` state without refunding balances
- Treat post-deduction broadcast/completion failures as manual-recovery cases instead of automatically refunding
- Expose `recovery_required` in payout worker stats

Fixes #5346.

## Verification
- RED: `python3 -m pytest tests/test_payout_worker_production_noop.py::test_processing_withdrawal_failure_requires_manual_recovery_without_refund -q` failed with `assert 100 == 89` before the fix
- RED: `python3 -m pytest tests/test_payout_worker_production_noop.py::test_startup_recovery_moves_processing_withdrawals_to_manual_review_without_refund -q` failed with missing method before the fix
- GREEN: `python3 -m pytest tests/test_payout_worker_production_noop.py -q` -> `4 passed`
- `python3 -m py_compile node/payout_worker.py tests/test_payout_worker_production_noop.py`
- `git diff --check`

## Safety
- No secrets added
- GitHub write gate was `github_write_gate=cleared`
- Duplicate search found no matching PR for #5346 / payout_worker recovery route before posting