### PR TITLE
fix: load withdrawal validation test module by path

### DIFF
--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -22,6 +22,9 @@ if NODE_DIR not in sys.path:
 
 
 def _load_integrated_node():
+    if "integrated_node" in sys.modules:
+        return sys.modules["integrated_node"]
+
     spec = importlib.util.spec_from_file_location(
         "rustchain_integrated_withdrawal_validation_test",
         MODULE_PATH,
@@ -29,6 +32,13 @@ def _load_integrated_node():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def test_loader_reuses_preloaded_integrated_node(monkeypatch):
+    preloaded_module = object()
+    monkeypatch.setitem(sys.modules, "integrated_node", preloaded_module)
+
+    assert _load_integrated_node() is preloaded_module
 
 
 @pytest.fixture(scope="module")

--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -10,21 +10,57 @@ Covers the fix for:
 
 import pytest
 import json
+import importlib.util
 import sys
 import os
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+
+def _load_integrated_node():
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_integrated_withdrawal_validation_test",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def integrated_node(tmp_path_factory):
+    previous_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+    previous_admin_key = os.environ.get("RC_ADMIN_KEY")
+    db_path = tmp_path_factory.mktemp("withdrawal_validation") / "import.db"
+    os.environ["RUSTCHAIN_DB_PATH"] = str(db_path)
+    os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+    module = _load_integrated_node()
+    try:
+        yield module
+    finally:
+        if previous_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = previous_db_path
+        if previous_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = previous_admin_key
 
 
 class TestWithdrawalRequestValidation:
     """Tests for /withdraw/request endpoint input validation"""
 
     @pytest.fixture
-    def app(self):
+    def app(self, integrated_node):
         """Create test app instance"""
-        from rustchain_v2_integrated_v2.2.1_rip200 import app
-        app.config['TESTING'] = True
-        return app
+        integrated_node.app.config['TESTING'] = True
+        return integrated_node.app
 
     @pytest.fixture
     def client(self, app):


### PR DESCRIPTION
## Summary
- load `node/tests/test_withdrawal_validation.py` via `importlib.util.spec_from_file_location` so the dotted filename `rustchain_v2_integrated_v2.2.1_rip200.py` is not parsed as a Python package import
- set temporary `RUSTCHAIN_DB_PATH` and test `RC_ADMIN_KEY` before importing the integrated node, then reuse the loaded module across the test file

Closes #5476.

## Validation
- `python3 -B -m py_compile node/tests/test_withdrawal_validation.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python3 -B -m pytest -q node/tests/test_withdrawal_validation.py --noconftest` -> 7 passed
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Note
- A combined run with `node/tests/test_withdraw_amount_validation.py` still exposes an existing cross-file integrated-node reimport/Prometheus registration problem outside this one-file fix; this PR keeps the #5476 compile repair scoped.