### PR TITLE
fix: use rustchain.org for SDK public defaults

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -55,7 +55,7 @@ except ImportError:
     CPU_DETECTION_AVAILABLE = False
 
 MINER_VERSION = "2.5.0"
-NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://50.28.86.131")
+NODE_URL = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
 PROXY_URL = os.environ.get("RUSTCHAIN_PROXY", "http://192.168.0.160:8089")
 BLOCK_TIME = 600  # 10 minutes
 LOTTERY_CHECK_INTERVAL = 10

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -24,7 +24,7 @@ from rustchain_sdk import RustChainClient, RustChainWallet
 
 async def main():
     # Connect to a RustChain node
-    client = RustChainClient("https://50.28.86.131")
+    client = RustChainClient("https://rustchain.org")
 
     async with client:
         # Check node health

--- a/sdk/python/rustchain_sdk/__init__.py
+++ b/sdk/python/rustchain_sdk/__init__.py
@@ -18,7 +18,7 @@ Quick Start:
   from rustchain_sdk import RustChainClient, RustChainWallet
 
   # Connect to a node
-  client = RustChainClient("https://50.28.86.131")
+  client = RustChainClient("https://rustchain.org")
 
   # Check health
   health = await client.health()

--- a/sdk/python/rustchain_sdk/cli.py
+++ b/sdk/python/rustchain_sdk/cli.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 import click
 
-from .client import RustChainClient
+from .client import DEFAULT_NODE_URL, RustChainClient
 from .wallet import RustChainWallet
 from .exceptions import RustChainError
 
@@ -87,7 +87,7 @@ def wallet_create(words: int, as_json: bool):
 @click.argument("address")
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(
@@ -136,7 +136,7 @@ async def _wallet_balance(address: str, node: str, as_json: bool):
 )
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(
@@ -206,7 +206,7 @@ async def _wallet_send(
 @main.command(name="node")
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(
@@ -244,7 +244,7 @@ async def _node_status(node: str, as_json: bool):
 @main.command(name="epoch")
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(
@@ -286,7 +286,7 @@ def miners_group():
 @miners_group.command(name="list")
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(
@@ -329,7 +329,7 @@ async def _miners_list(node: str, as_json: bool):
 )
 @click.option(
     "--node",
-    default="https://50.28.86.131",
+    default=DEFAULT_NODE_URL,
     help="RustChain node URL.",
 )
 @click.option(

--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -15,13 +15,16 @@ from .exceptions import (
 )
 
 
+DEFAULT_NODE_URL = "https://rustchain.org"
+
+
 class RustChainClient:
     """
     Async HTTP client for the RustChain blockchain network.
 
     Args:
         base_url: Base URL of the RustChain node RPC endpoint.
-                   Defaults to "https://50.28.86.131".
+                   Defaults to "https://rustchain.org".
         timeout: Request timeout in seconds. Defaults to 30.
 
     Example:
@@ -40,7 +43,7 @@ class RustChainClient:
 
     def __init__(
         self,
-        base_url: str = "https://50.28.86.131",
+        base_url: str = DEFAULT_NODE_URL,
         timeout: float = 30.0,
         verify: Optional[bool] = None,
     ):

--- a/sdk/python/rustchain_sdk/tests/test_client.py
+++ b/sdk/python/rustchain_sdk/tests/test_client.py
@@ -3,10 +3,10 @@ Tests for RustChainClient.
 Uses respx for HTTP mocking.
 """
 
+import httpx
 import pytest
 import respx
-import httpx
-from rustchain_sdk.client import RustChainClient
+from rustchain_sdk.client import DEFAULT_NODE_URL, RustChainClient
 from rustchain_sdk.exceptions import ConnectionError, APIError
 
 
@@ -16,7 +16,7 @@ class TestRustChainClientInit:
     def test_default_base_url(self):
         """Default base URL is set correctly."""
         client = RustChainClient()
-        assert client._base_url == "https://50.28.86.131"
+        assert client._base_url == DEFAULT_NODE_URL
 
     def test_custom_base_url(self):
         """Custom base URL is set correctly."""
@@ -61,7 +61,7 @@ class TestRustChainClientHealth:
     @respx.mock
     async def test_health_returns_dict(self):
         """Health returns a dict."""
-        route = respx.get("https://50.28.86.131/health").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/health").mock(
             return_value=httpx.Response(200, json={"status": "ok", "version": "1.0.0"})
         )
         async with RustChainClient() as client:
@@ -73,7 +73,7 @@ class TestRustChainClientHealth:
     @respx.mock
     async def test_health_raises_on_connection_error(self):
         """Connection error raises RustChainError."""
-        route = respx.get("https://50.28.86.131/health").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/health").mock(
             side_effect=httpx.ConnectError("Connection refused")
         )
         async with RustChainClient() as client:
@@ -88,7 +88,7 @@ class TestRustChainClientEpoch:
     @respx.mock
     async def test_get_epoch_returns_dict(self):
         """get_epoch returns epoch info dict."""
-        route = respx.get("https://50.28.86.131/epoch").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/epoch").mock(
             return_value=httpx.Response(200, json={
                 "epoch_number": 42,
                 "start_time": 1700000000,
@@ -108,7 +108,7 @@ class TestRustChainClientMiners:
     @respx.mock
     async def test_get_miners_returns_list(self):
         """get_miners returns a list of miner dicts."""
-        route = respx.get("https://50.28.86.131/miners").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/miners").mock(
             return_value=httpx.Response(200, json=[
                 {"public_key": "pk1", "score": 100},
                 {"public_key": "pk2", "score": 90},
@@ -123,7 +123,7 @@ class TestRustChainClientMiners:
     @respx.mock
     async def test_get_miners_handles_dict_response(self):
         """get_miners handles miners nested in dict response."""
-        route = respx.get("https://50.28.86.131/miners").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/miners").mock(
             return_value=httpx.Response(200, json={
                 "miners": [{"public_key": "pk1", "score": 100}]
             })
@@ -141,7 +141,7 @@ class TestRustChainClientBalance:
     @respx.mock
     async def test_get_balance_returns_dict(self):
         """get_balance returns balance info dict."""
-        route = respx.get("https://50.28.86.131/wallet/balance").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/wallet/balance").mock(
             return_value=httpx.Response(200, json={
                 "address": "RTCabc123",
                 "balance": 1000,
@@ -161,7 +161,7 @@ class TestRustChainClientTransfer:
     @respx.mock
     async def test_transfer_signed_success(self):
         """transfer_signed returns tx result."""
-        route = respx.post("https://50.28.86.131/transfer").mock(
+        route = respx.post(f"{DEFAULT_NODE_URL}/transfer").mock(
             return_value=httpx.Response(200, json={
                 "tx_hash": "0xabc123",
                 "status": "confirmed",
@@ -183,7 +183,7 @@ class TestRustChainClientTransfer:
     @respx.mock
     async def test_transfer_signed_raises_on_api_error(self):
         """API error raises APIError with status code."""
-        route = respx.post("https://50.28.86.131/transfer").mock(
+        route = respx.post(f"{DEFAULT_NODE_URL}/transfer").mock(
             return_value=httpx.Response(400, json={"message": "Invalid signature"})
         )
         async with RustChainClient() as client:
@@ -201,7 +201,7 @@ class TestRustChainClientExplorer:
     @respx.mock
     async def test_explorer_blocks_returns_list(self):
         """explorer_blocks returns list of blocks."""
-        route = respx.get("https://50.28.86.131/explorer/blocks").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/explorer/blocks").mock(
             return_value=httpx.Response(200, json=[
                 {"height": 100, "hash": "0x1"},
                 {"height": 99, "hash": "0x2"},
@@ -217,7 +217,7 @@ class TestRustChainClientExplorer:
     @respx.mock
     async def test_explorer_transactions_filters_by_address(self):
         """explorer_transactions sends address as param."""
-        route = respx.get("https://50.28.86.131/explorer/transactions").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/explorer/transactions").mock(
             return_value=httpx.Response(200, json=[])
         )
         async with RustChainClient() as client:
@@ -233,7 +233,7 @@ class TestRustChainClientGovernance:
     @respx.mock
     async def test_list_governance_proposals(self):
         """list_governance_proposals returns list."""
-        route = respx.get("https://50.28.86.131/governance/proposals").mock(
+        route = respx.get(f"{DEFAULT_NODE_URL}/governance/proposals").mock(
             return_value=httpx.Response(200, json=[
                 {"id": 1, "type": "param_change", "status": "active"},
             ])
@@ -247,7 +247,7 @@ class TestRustChainClientGovernance:
     @respx.mock
     async def test_governance_vote_success(self):
         """governance_vote returns vote result."""
-        route = respx.post("https://50.28.86.131/governance/vote").mock(
+        route = respx.post(f"{DEFAULT_NODE_URL}/governance/vote").mock(
             return_value=httpx.Response(200, json={
                 "proposal_id": 1,
                 "vote": "yes",
@@ -271,7 +271,7 @@ class TestRustChainClientAttestation:
     @respx.mock
     async def test_attest_challenge_returns_challenge(self):
         """attest_challenge returns challenge string."""
-        route = respx.post("https://50.28.86.131/attestation/challenge").mock(
+        route = respx.post(f"{DEFAULT_NODE_URL}/attestation/challenge").mock(
             return_value=httpx.Response(200, json={
                 "challenge": "random-challenge-string",
                 "expires_at": 1700010000,
@@ -285,7 +285,7 @@ class TestRustChainClientAttestation:
     @respx.mock
     async def test_attest_submit_success(self):
         """attest_submit returns submission result."""
-        route = respx.post("https://50.28.86.131/attestation/submit").mock(
+        route = respx.post(f"{DEFAULT_NODE_URL}/attestation/submit").mock(
             return_value=httpx.Response(200, json={
                 "status": "attested",
                 "miner_public_key": "pk-hex",

--- a/sdk/python/test_rustchain_sdk.py
+++ b/sdk/python/test_rustchain_sdk.py
@@ -7,7 +7,7 @@ from rustchain_sdk import RustChainClient, APIError
 
 
 # Test configuration
-TEST_NODE_URL = "https://50.28.86.131"
+TEST_NODE_URL = "https://rustchain.org"
 
 
 class TestRustChainClient:

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -23,7 +23,7 @@ MINER_ARTIFACTS = {
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",
-        "sha256": "e50cea51a24c8c0337e340287a05e6431f6d95883ab913a1a79c19e99bc03dd8",
+        "sha256": "1ea8d6eb68326761cd7fdd96c9bea04d1c06f72b12a8c2c552bc1d227be077f9",
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",

--- a/tests/test_setup_miner_downloads.py
+++ b/tests/test_setup_miner_downloads.py
@@ -19,6 +19,13 @@ def test_setup_miner_pins_current_miner_artifacts():
         assert artifact["sha256"] == hashlib.sha256(expected_files[platform].read_bytes()).hexdigest()
 
 
+def test_setup_miner_pins_current_macos_artifact():
+    expected_file = ROOT / "miners" / "macos" / "rustchain_mac_miner_v2.5.py"
+    artifact = setup_miner.MINER_ARTIFACTS["Darwin"]
+
+    assert artifact["sha256"] == hashlib.sha256(expected_file.read_bytes()).hexdigest()
+
+
 def test_setup_miner_downloads_current_verified_artifact():
     source = Path(setup_miner.__file__).read_text(encoding="utf-8")
 

--- a/tests/test_tls_config.py
+++ b/tests/test_tls_config.py
@@ -18,6 +18,23 @@ def test_verified_tls_clients_default_to_certificate_hostname():
     )
 
 
+def test_public_sdk_and_macos_defaults_avoid_raw_node_ip():
+    legacy_public_node = "https://" + "50.28.86.131"
+    default_surfaces = [
+        "sdk/python/README.md",
+        "sdk/python/rustchain_sdk/__init__.py",
+        "sdk/python/rustchain_sdk/client.py",
+        "sdk/python/rustchain_sdk/cli.py",
+        "sdk/python/test_rustchain_sdk.py",
+        "miners/macos/rustchain_mac_miner_v2.5.py",
+    ]
+
+    for relpath in default_surfaces:
+        text = Path(relpath).read_text(encoding="utf-8")
+        assert legacy_public_node not in text, relpath
+        assert "https://rustchain.org" in text or "DEFAULT_NODE_URL" in text, relpath
+
+
 def test_ssl_context_verifies_by_default(monkeypatch):
     monkeypatch.delenv("RUSTCHAIN_TLS_VERIFY", raising=False)
     monkeypatch.delenv("RUSTCHAIN_CA_BUNDLE", raising=False)


### PR DESCRIPTION
Fixes #2283.

## Summary
- replace the public Python SDK and macOS miner default node URL with `https://rustchain.org`
- keep TLS verification enabled by default while allowing explicit env/CLI overrides
- update affected SDK tests so the public default no longer points at the raw node IP

## Validation
- `PYTHONPATH=node:. python3 -B -m pytest -q tests/test_tls_config.py --noconftest` -> 4 passed
- `PYTHONPATH=sdk/python uv run --no-project --with pytest --with pytest-asyncio --with respx --with httpx --with cryptography --with pynacl python -B -m pytest -q sdk/python/rustchain_sdk/tests/test_client.py --noconftest` -> 20 passed
- `python3 -B -m py_compile sdk/python/rustchain_sdk/client.py sdk/python/rustchain_sdk/cli.py sdk/python/rustchain_sdk/__init__.py miners/macos/rustchain_mac_miner_v2.5.py sdk/python/test_rustchain_sdk.py tests/test_tls_config.py`
- `git diff --check -- miners/macos/rustchain_mac_miner_v2.5.py sdk/python/README.md sdk/python/rustchain_sdk/__init__.py sdk/python/rustchain_sdk/cli.py sdk/python/rustchain_sdk/client.py sdk/python/rustchain_sdk/tests/test_client.py sdk/python/test_rustchain_sdk.py tests/test_tls_config.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `rg -n "https://50\\.28\\.86\\.131" miners/macos/rustchain_mac_miner_v2.5.py sdk/python/README.md sdk/python/rustchain_sdk/__init__.py sdk/python/rustchain_sdk/cli.py sdk/python/rustchain_sdk/client.py sdk/python/rustchain_sdk/tests/test_client.py sdk/python/test_rustchain_sdk.py tests/test_tls_config.py || true` -> no remaining matches in touched files