### PR TITLE
fix: update Linux setup miner hash

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## Summary
- update `setup_miner.py` so the Linux artifact SHA-256 matches the current committed `miners/linux/rustchain_linux_miner.py`
- keep the existing artifact pin regression as coverage for all setup miner platforms

Closes #5466.

## Validation
- red: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python3 -B -m pytest -q tests/test_setup_miner_downloads.py::test_setup_miner_pins_current_miner_artifacts --noconftest` failed with pinned Linux `9475...` vs current `91815...`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python3 -B -m pytest -q tests/test_setup_miner_downloads.py --noconftest` -> 2 passed
- `python3 -B -m py_compile setup_miner.py tests/test_setup_miner_downloads.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
