### PR TITLE
Fix OTC order create JSON validation

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -299,6 +299,25 @@ def non_negative_int_arg(name, default):
     return value, None
 
 
+def parse_ttl_seconds(data):
+    raw_value = data.get("ttl_seconds", ORDER_TTL_DEFAULT)
+
+    if isinstance(raw_value, bool):
+        return None, "ttl_seconds must be an integer"
+
+    if isinstance(raw_value, int):
+        value = raw_value
+    elif isinstance(raw_value, str):
+        stripped_value = raw_value.strip()
+        if not stripped_value.lstrip("+-").isdigit():
+            return None, "ttl_seconds must be an integer"
+        value = int(stripped_value)
+    else:
+        return None, "ttl_seconds must be an integer"
+
+    return min(max(value, 3600), ORDER_TTL_MAX), None
+
+
 def internal_error_response(operation):
     """Log internal exception details without exposing them to clients."""
     log.exception("%s failed", operation)
@@ -430,8 +449,10 @@ def rtc_cancel_escrow(job_id, poster_wallet):
 def create_order():
     """Create a new buy or sell order."""
     data = request.get_json(silent=True)
-    if not data:
+    if data is None:
         return jsonify({"error": "JSON body required"}), 400
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
 
     side = str(data.get("side", "")).strip().lower()
     pair = str(data.get("pair", "RTC/USDC")).strip().upper()
@@ -439,7 +460,9 @@ def create_order():
     amount_rtc = data.get("amount_rtc", 0)
     price_per_rtc = data.get("price_per_rtc", 0)
     maker_eth_address = str(data.get("eth_address", "")).strip()
-    ttl = int(data.get("ttl_seconds", ORDER_TTL_DEFAULT))
+    ttl, ttl_error = parse_ttl_seconds(data)
+    if ttl_error:
+        return jsonify({"error": ttl_error}), 400
 
     # Validation
     if side not in ("buy", "sell"):
@@ -469,7 +492,6 @@ def create_order():
     if price_per_rtc > 1000:
         return jsonify({"error": "price_per_rtc too high (max $1000)"}), 400
 
-    ttl = min(max(ttl, 3600), ORDER_TTL_MAX)
     total_quote_nano = int(
         (amount_dec * price_dec * Decimal(QUOTE_PRICE_SCALE)).to_integral_value(
             rounding=ROUND_HALF_UP

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -82,6 +82,59 @@ def test_orders_accepts_capped_limit(tmp_path):
     assert response.get_json()["ok"] is True
 
 
+def test_create_order_rejects_non_object_json(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post("/api/orders", json=["not-an-object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_create_order_rejects_non_integer_ttl(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        for ttl_seconds in ("abc", "1.5", 1.5, True):
+            response = client.post(
+                "/api/orders",
+                json={
+                    "side": "buy",
+                    "pair": "RTC/USDC",
+                    "wallet": "buyer-1",
+                    "amount_rtc": 1,
+                    "price_per_rtc": "0.10",
+                    "ttl_seconds": ttl_seconds,
+                },
+            )
+
+            assert response.status_code == 400
+            assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def test_create_order_accepts_valid_buy_with_ttl(tmp_path):
+    otc_bridge = load_otc_bridge(tmp_path)
+
+    with otc_bridge.app.test_client() as client:
+        response = client.post(
+            "/api/orders",
+            json={
+                "side": "buy",
+                "pair": "RTC/USDC",
+                "wallet": "buyer-1",
+                "amount_rtc": 1,
+                "price_per_rtc": "0.10",
+                "ttl_seconds": "7200",
+            },
+        )
+
+    body = response.get_json()
+    assert response.status_code == 201
+    assert body["ok"] is True
+    assert body["expires_in_hours"] == 2.0
+
+
 def test_trades_rejects_bad_limits(tmp_path):
     otc_bridge = load_otc_bridge(tmp_path)
 


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies on `POST /api/orders` with a stable JSON 400
- parse `ttl_seconds` through a validation helper so malformed values return JSON 400 instead of Flask HTML 500
- keep valid buy-order creation and TTL clamping behavior intact

Fixes #5525.

## Validation
- `python -m pytest tests/test_otc_bridge_query_validation.py -q` -> 12 passed
- `python -m py_compile otc-bridge\otc_bridge.py tests\test_otc_bridge_query_validation.py`
- `git diff --check`

Additional note: after installing the missing local `flask-cors` test dependency, `python -m pytest otc-bridge/test_otc_bridge.py tests/test_otc_bridge_query_validation.py -q` reached collection and ran, with 36 passed and 2 existing failures in unrelated order confirmation/HTLC tests (`test_confirm_matched_order`, `test_legacy_money_schema_accepts_new_orders_and_trades`).