### PR TITLE
test: set P2P secret before merkle validation import

### DIFF
--- a/node/tests/test_epoch_proposal_merkle_validation.py
+++ b/node/tests/test_epoch_proposal_merkle_validation.py
@@ -34,6 +34,8 @@ from unittest.mock import patch
 NODE_DIR = os.path.join(os.path.dirname(__file__), '..', 'node')
 sys.path.insert(0, NODE_DIR)
 
+os.environ.setdefault("RC_P2P_SECRET", "unit-test-secret-0123456789abcdef")
+
 from rustchain_p2p_gossip import GossipLayer, GossipMessage, MessageType
 
 


### PR DESCRIPTION
Fixes #5511.

## Summary
- set a deterministic unit-test `RC_P2P_SECRET` before `test_epoch_proposal_merkle_validation.py` imports `rustchain_p2p_gossip`
- keep the existing per-test `P2P_SECRET` patching behavior unchanged after import
- match the pattern used by nearby P2P tests that need to import the gossip module safely during collection

## RED
With no external `RC_P2P_SECRET` exported, the target test aborted during collection before this change:

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 env -u RC_P2P_SECRET python3 -B -m pytest -q node/tests/test_epoch_proposal_merkle_validation.py --tb=short --noconftest
SystemExit: [P2P] FATAL: RC_P2P_SECRET environment variable is not set or contains an insecure placeholder value.
no tests ran
```

## GREEN / Validation
```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 env -u RC_P2P_SECRET python3 -B -m pytest -q node/tests/test_epoch_proposal_merkle_validation.py --tb=short --noconftest
8 passed in 0.29s
```

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 env -u RC_P2P_SECRET python3 -B -m pytest -q node/tests/test_epoch_proposal_merkle_validation.py node/tests/test_p2p_endpoint_auth.py node/tests/test_p2p_gossip_routes.py --tb=short --noconftest
13 passed in 0.29s
```

```text
python3 -B -m py_compile node/tests/test_epoch_proposal_merkle_validation.py
git diff --check -- node/tests/test_epoch_proposal_merkle_validation.py
python3 tools/bcos_spdx_check.py --base-ref origin/main
BCOS SPDX check: OK
```

## Note
`node/tests/test_p2p_vote_spoofing.py` is not included in the passing related set because it is an older PoC that currently expects forged votes to be accepted. Current code rejects those forged votes with `voter_identity_mismatch`, so that PoC fails independently of this one-file collection fix.