### PR TITLE
docs: fix Legend of Elya reference link

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -200,7 +200,7 @@ Assuming 10 total miners, 3 in retro_console bucket:
 - [RIP-0683 Specification](docs/CONSOLE_MINING_SETUP.md)
 - [RIP-0304: Original Console Mining Spec](rips/docs/RIP-0304-retro-console-mining.md)
 - [RIP-201: Fleet Immune System](rips/docs/RIP-0201-fleet-immune-system.md)
-- [Legend of Elya](https://github.com/ilya-kh/legend-of-elya) - N64 neural network demo
+- [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - N64 neural network demo
 - [Console Mining Setup Guide](docs/CONSOLE_MINING_SETUP.md)
 
 ## Acknowledgments

--- a/docs/CONSOLE_MINING_SETUP.md
+++ b/docs/CONSOLE_MINING_SETUP.md
@@ -372,7 +372,7 @@ Develop attestation ROMs for additional consoles:
 - [RIP-0683 Implementation Summary](../IMPLEMENTATION_SUMMARY.md)
 - [RIP-0304: Retro Console Mining](../rips/docs/RIP-0304-retro-console-mining.md)
 - [RIP-201: Fleet Immune System](../rips/docs/RIP-0201-fleet-immune-system.md)
-- [Legend of Elya](https://github.com/ilya-kh/legend-of-elya) - N64 neural network demo
+- [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - N64 neural network demo
 - [Pico SDK Documentation](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf)
 
 ## Support


### PR DESCRIPTION
## Summary
- Replace the dead Legend of Elya reference in `docs/CONSOLE_MINING_SETUP.md` with the current `Scottcjn/legend-of-elya-n64` repository URL.
- Keep the docs-only change scoped to the References list.

Bounty context: Scottcjn/rustchain-bounties#444
Wallet/miner ID: `iamdinhthuan`

## Validation
- `curl -sS -L -o /dev/null -w "%{http_code} %{url_effective}\n" https://github.com/ilya-kh/legend-of-elya` -> `404 https://github.com/ilya-kh/legend-of-elya`
- `curl -sS -L -o /dev/null -w "%{http_code} %{url_effective}\n" https://github.com/Scottcjn/legend-of-elya-n64` -> `200 https://github.com/Scottcjn/legend-of-elya-n64`
- `git diff --check -- docs/CONSOLE_MINING_SETUP.md`

## Duplicate check
- Existing #444 comments mention `docs/CONSOLE_MINING_SETUP.md` for other broken links, but I did not find an existing report for the `ilya-kh/legend-of-elya` target.
- Recent RustChain PRs include other link fixes, but not this file/target pair.