### PR TITLE
test: make issue 2310 validation paths portable

### DIFF
--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -7,12 +7,14 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+ISSUE2310_ROOT = REPO_ROOT / "bounties" / "issue-2310"
 
 
 def test_issue2310_package_imports_from_parent_path():
+    issue_path = str(ISSUE2310_ROOT)
     code = (
         "import sys; "
-        "sys.path.insert(0, r'bounties\\issue-2310'); "
+        f"sys.path.insert(0, {issue_path!r}); "
         "import src; "
         "print(src.CRTPatternGenerator.__name__)"
     )
@@ -34,7 +36,7 @@ def test_issue2310_validator_runs_with_cp1252_stdout():
     env["PYTHONIOENCODING"] = "cp1252"
 
     result = subprocess.run(
-        [sys.executable, "bounties\\issue-2310\\validate_bounty_2310.py"],
+        [sys.executable, str(ISSUE2310_ROOT / "validate_bounty_2310.py")],
         cwd=REPO_ROOT,
         env=env,
         text=True,


### PR DESCRIPTION
## Summary
- build issue-2310 validation subprocess paths with pathlib instead of hard-coded Windows separators
- keep the same CRTPatternGenerator import and validator coverage while making the test pass on Linux CI

## Reproduction before fix
```text
python3 -B -m pytest -q tests/test_issue2310_package_validation.py --tb=short
# 2 failed: imported the wrong top-level src package and could not open bounties\issue-2310\validate_bounty_2310.py
```

## Validation
```text
python3 -B -m pytest -q tests/test_issue2310_package_validation.py --tb=short
# 2 passed
python3 -B -m py_compile tests/test_issue2310_package_validation.py
python3 tools/bcos_spdx_check.py --base-ref origin/main
git diff --check origin/main...HEAD -- tests/test_issue2310_package_validation.py
```

No private tokens, wallet secrets, production services, or payout actions were used.