### PR TITLE
Fix rustchain-wallet dependency compatibility

### DIFF
--- a/rustchain-wallet/Cargo.toml
+++ b/rustchain-wallet/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://rustchain.org"
 [dependencies]
 # Cryptography
 ed25519-dalek = { version = "2.1", features = ["rand_core", "serde"] }
-sha2 = "0.11"
+sha2 = "0.10"
 hex = "0.4"
 bs58 = "0.5"
 aes-gcm = "0.10"
@@ -47,12 +47,12 @@ zeroize = { version = "1.7", features = ["derive"] }
 secrecy = "0.10"
 
 # Key derivation
-hmac = "0.13"
+hmac = "0.12"
 pbkdf2 = "0.12"
 
 # Random number generation
 rand = "0.10"
-getrandom = "0.4"
+getrandom = "0.2"
 
 # Filesystem
 dirs = "5.0"

--- a/rustchain-wallet/src/keys.rs
+++ b/rustchain-wallet/src/keys.rs
@@ -72,7 +72,7 @@ impl KeyPair {
         bs58::encode(self.verifying_key.as_bytes()).into_string()
     }
 
-    /// Derive the RTC address: "RTC" + sha256(pubkey_bytes)[:40] (hex)
+    /// Derive the RTC address: "RTC" + the first 40 hex chars of sha256(pubkey_bytes).
     pub fn rtc_address(&self) -> String {
         use sha2::{Digest, Sha256};
         let hash = Sha256::digest(self.verifying_key.as_bytes());

--- a/rustchain-wallet/src/lib.rs
+++ b/rustchain-wallet/src/lib.rs
@@ -106,7 +106,7 @@ impl Wallet {
         Self::new(KeyPair::generate())
     }
 
-    /// Get the wallet's RTC address (RTC + sha256(pubkey)[:40])
+    /// Get the wallet's RTC address (RTC + first 40 hex chars of sha256(pubkey))
     pub fn address(&self) -> String {
         self.keypair.rtc_address()
     }


### PR DESCRIPTION
## Summary
- pin `rustchain-wallet` crypto dependencies back to the digest 0.10-compatible stack used by the current code
- keep `getrandom::getrandom`, `pbkdf2_hmac::<Sha256/Sha512>`, and `HmacSha512::new_from_slice` compiling on fresh CI resolves
- clean up two rustdoc address-slice comments so docs can run with warnings denied

## Why
Fresh CI resolves currently pull `sha2 0.11`, `hmac 0.13`, and `getrandom 0.4`, which breaks `rustchain-wallet` builds before unrelated PRs can get green checks. This is the same failure currently visible on PRs such as #4623.

## Validation
- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `$env:RUSTDOCFLAGS='-D warnings'; cargo doc --no-deps`