### PR TITLE
Install missing CI test dependencies

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,12 @@ pytest>=7.4.4
 PyNaCl>=1.6.2
 # Needed by test_wallet_cli_39 (imports from tools/rustchain_wallet_cli.py)
 cryptography>=46.0.7
+# Needed by test_agent_economy_sdk.py (imports agent_economy_sdk)
+aiohttp>=3.9.0
+# Needed by test_faucet_service_wallet_validation.py (imports faucet_service)
+flask-cors>=6.0.2
+PyYAML>=6.0.3
+# Needed by hardware and PSE visualization tests
+matplotlib>=3.7
+seaborn>=0.12
+numpy>=1.24


### PR DESCRIPTION
## Summary
- add test-only dependencies needed by modules imported during the blocking `pytest tests/` collection phase
- cover `agent_economy_sdk`, faucet service CORS/YAML imports, and hardware/PSE visualization tests

## Why
The blocking CI test job installs `tests/requirements.txt`, but several collected test modules import packages that were missing from that file. That causes unrelated PRs to fail during collection with `ModuleNotFoundError` for `aiohttp`, `flask_cors`, and `matplotlib` before their focused tests can run.

## Validation
- `python -m pip install -r tests\requirements.txt`
- `python -m pytest tests\test_agent_economy_sdk.py tests\test_faucet_service_wallet_validation.py tests\test_hardware_visualizer.py tests\test_pse_analyze_results.py -q` -> 14 passed
- `python -m py_compile agent_economy_sdk.py faucet_service\faucet_service.py src\visualizations\visualizer.py benchmarks\pse\analyze_results.py`
- `git diff --check`