### PR TITLE
docs: fix rustchain tip bot source link

### DIFF
--- a/integrations/rustchain-bounties/README.md
+++ b/integrations/rustchain-bounties/README.md
@@ -53,16 +53,15 @@ Great fix! /tip @alice 25 RTC for the patch.
 
 ## Setup
 
-### 1. Add this repo as a submodule (or copy files into your repo)
+### 1. Copy the tip-bot files into your repo
 
 ```bash
-# Option A: standalone repo
-git clone https://github.com/mtarcure/rustchain-tip-bot
-cp -r rustchain-tip-bot/.github/workflows/tip-bot.yml your-repo/.github/workflows/
-cp rustchain-tip-bot/{tip_bot.py,auth.py,state.py,config.yml,requirements.txt} your-repo/
+# Option A: copy from the RustChain monorepo
+git clone https://github.com/Scottcjn/Rustchain.git
+cp Rustchain/integrations/rustchain-bounties/{tip_bot.py,tip_bot_action.py,auth.py,state.py,config.yml,requirements.txt} your-repo/
 
 # Option B: reference directly via workflow
-# Point the workflow's checkout step to this repo
+# Check out Scottcjn/Rustchain and run from integrations/rustchain-bounties
 ```
 
 ### 2. Initialize the state file
@@ -253,8 +252,8 @@ requirements.txt                Python dependencies
 README.md                       This file
 ```
 
-> **Note:** The Python source files (`tip_bot.py`, `auth.py`, `state.py`, `test_tip_bot.py`,
-> `requirements.txt`) live in the upstream repository
-> [github.com/mtarcure/rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot).
-> This directory contains only `config.yml` and this README. Follow the Setup section
-> to copy the full project into your repo.
+> **Note:** The Python source files (`tip_bot.py`, `auth.py`, `state.py`,
+> `test_tip_bot.py`, `tip_bot_action.py`, and `requirements.txt`) live in this
+> RustChain directory:
+> [integrations/rustchain-bounties](https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties).
+> Follow the Setup section to copy the project into your repo.

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -521,6 +521,19 @@ class TestProcessEvent:
 
 class TestCommentBuilders:
 
+    def test_comment_footers_link_current_source(self):
+        cmd = TipCommand(recipient="alice", amount=50, token="RTC", raw="")
+        bodies = [
+            build_success_comment("Scottcjn", cmd, "https://example.com"),
+            build_failure_comment("Scottcjn", "Minimum tip is 1 RTC."),
+            build_duplicate_comment("Scottcjn", cmd),
+            build_unauthorized_comment("hacker"),
+        ]
+
+        for body in bodies:
+            assert "https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties" in body
+            assert "github.com/mtarcure/rustchain-tip-bot" not in body
+
     def test_success_comment_contains_fields(self):
         cmd = TipCommand(recipient="alice", amount=50, token="RTC", raw="")
         body = build_success_comment("Scottcjn", cmd, "https://example.com")

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -237,7 +237,7 @@ def build_success_comment(sender: str, cmd: TipCommand, context_url: str) -> str
         f"This tip has been logged and is **pending manual payout** by the maintainer. "
         f"@{cmd.recipient} will receive `{cmd.amount} {cmd.token}` once processed.\n\n"
         f"---\n"
-        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot) — "
+        f"*🤖 [rustchain-tip-bot](https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties) — "
         f"maintainer approval required for payout*"
     )
 
@@ -247,7 +247,7 @@ def build_failure_comment(sender: str, error: str) -> str:
         f"**Tip failed** ❌\n\n"
         f"@{sender}: {error}\n\n"
         f"---\n"
-        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+        f"*🤖 [rustchain-tip-bot](https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties)*"
     )
 
 
@@ -257,7 +257,7 @@ def build_duplicate_comment(sender: str, cmd: TipCommand) -> str:
         f"@{sender}: This tip (`{cmd.amount} {cmd.token}` → @{cmd.recipient}) "
         f"was already recorded from this comment. No action taken.\n\n"
         f"---\n"
-        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+        f"*🤖 [rustchain-tip-bot](https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties)*"
     )
 
 
@@ -266,7 +266,7 @@ def build_unauthorized_comment(sender: str) -> str:
         f"**Unauthorized** ❌\n\n"
         f"@{sender}: Only designated maintainers can issue `/tip` commands.\n\n"
         f"---\n"
-        f"*🤖 [rustchain-tip-bot](https://github.com/mtarcure/rustchain-tip-bot)*"
+        f"*🤖 [rustchain-tip-bot](https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties)*"
     )
 
 


### PR DESCRIPTION
## Summary
- replace the dead `https://github.com/mtarcure/rustchain-tip-bot` references with the live RustChain monorepo path
- update the setup copy command to use the files that live under `integrations/rustchain-bounties`
- add a regression assertion so generated bot comments keep linking to the current source

## Validation
- old URL: `https://github.com/mtarcure/rustchain-tip-bot` -> HTTP 404
- new URL: `https://github.com/Scottcjn/Rustchain/tree/main/integrations/rustchain-bounties` -> HTTP 200
- `python3 -B -m py_compile integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/auth.py integrations/rustchain-bounties/state.py integrations/rustchain-bounties/test_tip_bot.py`
- `python3 -m pytest integrations/rustchain-bounties/test_tip_bot.py -q` -> 64 passed
- `git diff --check -- integrations/rustchain-bounties/README.md integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Duplicate check
- searched #444 comments for `mtarcure`, `rustchain-tip-bot`, and `integrations/rustchain-bounties`; no prior report found
- searched open/closed RustChain PRs and RustChain/rustchain-bounties issues for the same terms; no matching fix or claim found
