### PR TITLE
docs: fix Manticore security tool link

### DIFF
--- a/contracts/erc20/docs/SECURITY_CONSIDERATIONS.md
+++ b/contracts/erc20/docs/SECURITY_CONSIDERATIONS.md
@@ -375,7 +375,7 @@ Maintain list of:
 - [Slither](https://github.com/crytic/slither) - Static analysis
 - [Mythril](https://github.com/ConsenSys/mythril) - Security analysis
 - [Echidna](https://github.com/crytic/echidna) - Fuzz testing
-- [Manticore](https://github.com/crytic/manticore) - Symbolic execution
+- [Manticore](https://github.com/trailofbits/manticore) - Symbolic execution
 
 ### Audit Firms
 


### PR DESCRIPTION
## Summary
- update the ERC20 security considerations Manticore link from the retired `crytic/manticore` path to the live `trailofbits/manticore` repository

## Validation
- `curl -L -s -o /dev/null -w "old=%{http_code} %{url_effective}\n" --max-time 12 https://github.com/crytic/manticore` -> `old=404 https://github.com/crytic/manticore`
- `curl -L -s -o /dev/null -w "new=%{http_code} %{url_effective}\n" --max-time 12 https://github.com/trailofbits/manticore` -> `new=200 https://github.com/trailofbits/manticore`
- `git diff --check -- contracts/erc20/docs/SECURITY_CONSIDERATIONS.md`