### PR TITLE
docs: remove dead funding donation link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
 github: [Scottcjn]
 ko_fi: elyanlabs
-custom: ["https://rustchain.elyanlabs.ai/donate"]


### PR DESCRIPTION
## Summary
- Remove the stale custom funding URL `https://rustchain.elyanlabs.ai/donate` from `.github/FUNDING.yml`.
- Keep the existing live `github: [Scottcjn]` and `ko_fi: elyanlabs` funding entries.

## Validation
```text
curl -L --max-time 12 https://rustchain.elyanlabs.ai/donate
# Could not resolve host: rustchain.elyanlabs.ai

curl -L --max-time 12 https://ko-fi.com/elyanlabs
# HTTP 200

curl -L --max-time 12 https://github.com/Scottcjn
# HTTP 200

git diff --check HEAD^..HEAD -- .github/FUNDING.yml
# passed
```

Duplicate checks before opening:
- No existing RustChain PR found for `rustchain.elyanlabs.ai` / funding donation link.
- No existing rustchain-bounties issue found for `rustchain.elyanlabs.ai/donate`, `rustchain.elyanlabs.ai`, or `.github/FUNDING.yml`.

Bounty lane: Scottcjn/rustchain-bounties#444.
Wallet/miner ID: `iamdinhthuan`.

No private keys, tokens, wallet secrets, production services, live wallet actions, withdrawals, or fund movement were used.