### PR TITLE
docs: fix Go SDK reference link

### DIFF
--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,6 +1,6 @@
 # RustChain Agent Economy Go SDK
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/Scottcjn/Rustchain/sdk/go/agenteco.svg)](https://pkg.go.dev/github.com/Scottcjn/Rustchain/sdk/go/agenteco)
+[![Go SDK](https://img.shields.io/badge/Go%20SDK-agenteco-blue.svg)](https://github.com/Scottcjn/Rustchain/tree/main/sdk/go/agenteco)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Scottcjn/Rustchain/sdk/go)](https://goreportcard.com/report/github.com/Scottcjn/Rustchain/sdk/go)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![RIP-302](https://img.shields.io/badge/RIP-302-Agent%20Economy-green)](https://github.com/Scottcjn/Rustchain)
@@ -459,4 +459,4 @@ MIT License - see [LICENSE](LICENSE) for details.
 - [RustChain GitHub](https://github.com/Scottcjn/Rustchain)
 - [RIP-302 Specification](../../rips/docs/)
 - [Agent Economy Documentation](../docs/AGENT_ECONOMY_SDK.md)
-- [Go Reference](https://pkg.go.dev/github.com/Scottcjn/Rustchain/sdk/go/agenteco)
+- [Go SDK source](https://github.com/Scottcjn/Rustchain/tree/main/sdk/go/agenteco)


### PR DESCRIPTION
## Summary
- replace the stale pkg.go.dev Go Reference links in sdk/go/README.md with the live Go SDK source URL
- keep the README reference actionable while the pkg.go.dev module path returns 404

## Validation
- before fix: stale-link check failed because https://pkg.go.dev/github.com/Scottcjn/Rustchain/sdk/go/agenteco was still present
- after fix: stale-link check passed
- curl -L -o /dev/null -w old=%{http_code}: old URL returns 404
- curl -L -o /dev/null -w new=%{http_code}: new source URL returns 200
- git diff --check -- sdk/go/README.md