### PR TITLE
docs: fix Prometheus exposition reference

### DIFF
--- a/bounties/issue-765/src/metrics_exposition.py
+++ b/bounties/issue-765/src/metrics_exposition.py
@@ -7,7 +7,7 @@ from Python data structures. This module can be used standalone or
 as part of the rustchain_exporter.
 
 The Prometheus text exposition format is documented at:
-https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md
+https://prometheus.io/docs/instrumenting/exposition_formats/
 """
 
 import re

--- a/bounties/issue-765/tests/test_exporter.py
+++ b/bounties/issue-765/tests/test_exporter.py
@@ -27,6 +27,7 @@ from requests.exceptions import RequestException, Timeout
 # Add src to path
 sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
 
+import metrics_exposition
 from rustchain_exporter import (
     ExporterConfig,
     MetricsRegistry,
@@ -400,6 +401,17 @@ class TestMetricsCollector:
 
 class TestPrometheusExposition:
     """Tests for PrometheusExposition."""
+
+    def test_module_docstring_links_to_live_prometheus_docs(self):
+        """The format reference should use Prometheus' live docs URL."""
+        assert (
+            "https://prometheus.io/docs/instrumenting/exposition_formats/"
+            in metrics_exposition.__doc__
+        )
+        assert (
+            "https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md"
+            not in metrics_exposition.__doc__
+        )
 
     def test_add_gauge(self):
         """Test adding gauge metrics."""


### PR DESCRIPTION
## Summary
- replace the retired Prometheus GitHub docs URL in the issue-765 metrics exposition module with the live canonical Prometheus documentation URL
- add a regression assertion so the module docstring keeps the live docs reference and does not reintroduce the dead GitHub path

## Validation
- `curl -L -s -o /dev/null -w "old=%{http_code} %{url_effective}\n" --max-time 12 https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md` -> `old=404 https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md`
- `curl -L -s -o /dev/null -w "new=%{http_code} %{url_effective}\n" --max-time 12 https://prometheus.io/docs/instrumenting/exposition_formats/` -> `new=200 https://prometheus.io/docs/instrumenting/exposition_formats/`
- `python3 -m pytest bounties/issue-765/tests/test_exporter.py -q` -> `33 passed`
- `python3 -m py_compile bounties/issue-765/src/metrics_exposition.py bounties/issue-765/tests/test_exporter.py`
- `git diff --check -- bounties/issue-765/src/metrics_exposition.py bounties/issue-765/tests/test_exporter.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`
