### PR TITLE
fix(#5577): require manual payout recovery after broadcast uncertainty

### DIFF
--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -33,7 +33,7 @@ class PayoutWorker:
             'processed': 0,
             'failed': 0,
             'total_rtc': 0.0
-        }
+        }        self._recover_orphaned_processing()
 
     def get_pending_withdrawals(self, limit: int = BATCH_SIZE) -> List[Dict]:
         """Fetch pending withdrawals from database"""

--- a/node/payout_worker.py
+++ b/node/payout_worker.py
@@ -87,6 +87,33 @@ class PayoutWorker:
                 "complete withdrawal without a broadcast transaction hash"
             )
 
+
+    def _recover_orphaned_processing(self):
+        """Move orphaned processing withdrawals to recovery_required on startup."""
+        import sqlite3
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                cur = conn.execute(
+                    "SELECT COUNT(*) FROM withdrawals WHERE status = 'processing'"
+                )
+                count = cur.fetchone()[0]
+                if count:
+                    conn.execute("BEGIN IMMEDIATE")
+                    conn.execute(
+                        "UPDATE withdrawals SET status = 'recovery_required' "
+                        "WHERE status = 'processing'"
+                    )
+                    conn.execute("COMMIT")
+                    import logging
+                    logging.warning(
+                        f"Recovered {count} orphaned processing withdrawal(s) -> recovery_required"
+                    )
+                self.stats['recovered'] = count
+        except Exception:
+            import logging
+            logging.error("Orphan recovery failed", exc_info=True)
+            self.stats['recovered'] = 0
+
     def process_withdrawal(self, withdrawal: Dict) -> bool:
         """Process a single withdrawal with balance deduction before execution."""
         withdrawal_id = withdrawal['withdrawal_id']
@@ -177,17 +204,12 @@ class PayoutWorker:
         except Exception as e:
             logger.error(f"✗ Withdrawal {withdrawal_id} failed: {e}")
 
-            # Refund balance on broadcast failure and mark as failed
+            # Mark as recovery_required without refunding balance
             with sqlite3.connect(self.db_path) as conn:
                 conn.execute("BEGIN IMMEDIATE")
-                conn.execute(
-                    "UPDATE accounts SET balance = balance + ? WHERE public_key = ?",
-                    (withdrawal['amount'] + withdrawal.get('fee', 0),
-                     withdrawal['miner_pk'])
-                )
                 conn.execute("""
                     UPDATE withdrawals
-                    SET status = 'failed',
+                    SET status = 'recovery_required',
                         error_msg = ?
                     WHERE withdrawal_id = ?
                 """, (str(e), withdrawal_id))
@@ -303,11 +325,16 @@ class PayoutWorker:
                 "SELECT COUNT(*) FROM withdrawals WHERE status = 'failed'"
             ).fetchone()[0]
 
+            recovery_required = conn.execute(
+                "SELECT COUNT(*) FROM withdrawals WHERE status = 'recovery_required'"
+            ).fetchone()[0]
+
         return {
             'pending': pending,
             'processing': processing,
             'completed': completed,
             'failed': failed,
+            'recovery_required': recovery_required,
             'session_processed': self.stats['processed'],
             'session_failed': self.stats['failed'],
             'session_total_rtc': self.stats['total_rtc']

--- a/node/tests/test_payout_preflight.py
+++ b/node/tests/test_payout_preflight.py
@@ -171,5 +171,49 @@ class PayoutPreflightTests(unittest.TestCase):
         self.assertEqual(r.details.get("amount_i64"), 1)
 
 
+
+    def test_processing_withdrawal_failure_requires_manual_recovery_without_refund(self):
+        """Broadcast failure should set recovery_required, not auto-refund."""
+        import os, time, sqlite3, shutil
+        from node.payout_worker import PayoutWorker
+
+        tmpdir = '/tmp/test_payout_worker_5577'
+        if os.path.exists(tmpdir):
+            shutil.rmtree(tmpdir)
+        os.makedirs(tmpdir, exist_ok=True)
+
+        db_path = os.path.join(tmpdir, 'test.db')
+        conn = sqlite3.connect(db_path)
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS accounts (
+                public_key TEXT PRIMARY KEY,
+                balance INTEGER NOT NULL DEFAULT 0
+            );
+            CREATE TABLE IF NOT EXISTS withdrawals (
+                withdrawal_id TEXT PRIMARY KEY,
+                miner_pk TEXT,
+                amount INTEGER,
+                fee INTEGER,
+                status TEXT DEFAULT 'pending',
+                error_msg TEXT,
+                created_at REAL
+            );
+        """)
+        conn.execute("INSERT INTO accounts (public_key, balance) VALUES ('test_pk', 1000)")
+        conn.commit()
+        conn.close()
+
+        worker = PayoutWorker()
+        worker.db_path = db_path
+        worker._recover_orphaned_processing()
+
+        stats = worker.get_stats()
+        self.assertIn('recovery_required', stats,
+                       msg="stats should include recovery_required field")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #5577

- Move startup-orphaned processing withdrawals to recovery_required without refund
- On broadcast/completion failure, set recovery_required instead of auto-refunding
- Expose recovery_required in payout worker stats
- Add regression test