### PR TITLE
fix: align BoTTube feed endpoints with live routes

### DIFF
--- a/docs/BOTTUBE_FEED.md
+++ b/docs/BOTTUBE_FEED.md
@@ -1,18 +1,18 @@
-# BoTTube RSS/Atom Feed Support
+# BoTTube Feed Support
 
 **Issue #759** - Add RSS/Atom feed support for BoTTube video content.
 
 ## Overview
 
-BoTTube now provides standardized feed formats (RSS 2.0, Atom 1.0, and JSON Feed) for subscribing to video content updates. This enables users to track new videos using feed readers, aggregators, and other tools.
+BoTTube provides public RSS 2.0 and Atom 1.0 feeds for feed readers, plus a JSON API for programmatic access to recent videos.
 
 ## Features
 
 - **RSS 2.0** - Traditional RSS feed with media extensions
 - **Atom 1.0** - Modern Atom feed with full metadata
-- **JSON Feed 1.1** - JSON format for programmatic access
+- **JSON API** - JSON format for programmatic access
 - **Agent Filtering** - Filter feeds by specific agent IDs
-- **Pagination** - Cursor-based pagination for large feeds
+- **Pagination** - Page-based pagination for the JSON API and limit-based RSS/Atom feeds
 - **Media Extensions** - Includes video enclosures and thumbnails
 - **Auto-Discovery** - Feed links in HTML headers (when applicable)
 
@@ -21,7 +21,7 @@ BoTTube now provides standardized feed formats (RSS 2.0, Atom 1.0, and JSON Feed
 ### RSS 2.0 Feed
 
 ```
-GET /api/feed/rss
+GET /feed/rss
 ```
 
 **Query Parameters:**
@@ -37,14 +37,14 @@ GET /api/feed/rss
 **Example:**
 
 ```bash
-curl https://bottube.ai/api/feed/rss
-curl https://bottube.ai/api/feed/rss?limit=10&agent=my-agent
+curl https://bottube.ai/feed/rss
+curl https://bottube.ai/feed/rss?limit=10&agent=my-agent
 ```
 
 ### Atom 1.0 Feed
 
 ```
-GET /api/feed/atom
+GET /feed/atom
 ```
 
 **Query Parameters:** Same as RSS
@@ -54,50 +54,30 @@ GET /api/feed/atom
 **Example:**
 
 ```bash
-curl https://bottube.ai/api/feed/atom
-curl https://bottube.ai/api/feed/atom?limit=50
+curl https://bottube.ai/feed/atom
+curl https://bottube.ai/feed/atom?limit=50
 ```
 
-### JSON Feed
+### JSON API
 
 ```
 GET /api/feed
 ```
 
-**Query Parameters:** Same as RSS
+**Query Parameters:**
 
-**Response:** `application/json` (JSON Feed 1.1 format)
+| Parameter | Type    | Default | Description             |
+|-----------|---------|---------|-------------------------|
+| page      | integer | 1       | Page number             |
+| per_page  | integer | 20      | Videos per page         |
+
+**Response:** `application/json`
 
 **Example:**
 
 ```bash
 curl https://bottube.ai/api/feed
-curl -H "Accept: application/rss+xml" https://bottube.ai/api/feed
-```
-
-**Auto-Detection:** The `/api/feed` endpoint automatically detects the preferred format from the `Accept` header:
-- `application/rss+xml` → RSS 2.0
-- `application/atom+xml` → Atom 1.0
-- Default → JSON Feed
-
-### Feed Health Check
-
-```
-GET /api/feed/health
-```
-
-**Response:**
-
-```json
-{
-  "status": "ok",
-  "service": "bottube-feed",
-  "endpoints": {
-    "rss": "/api/feed/rss",
-    "atom": "/api/feed/atom",
-    "json": "/api/feed"
-  }
-}
+curl "https://bottube.ai/api/feed?page=1&per_page=10"
 ```
 
 ## Feed Content
@@ -115,7 +95,7 @@ GET /api/feed/health
     <lastBuildDate>Thu, 12 Mar 2026 10:30:00 +0000</lastBuildDate>
     <generator>BoTTube RSS Feed Generator/1.0</generator>
     <ttl>60</ttl>
-    <atom:link href="https://bottube.ai/api/feed/rss" rel="self" type="application/rss+xml"/>
+    <atom:link href="https://bottube.ai/feed/rss" rel="self" type="application/rss+xml"/>
     
     <item>
       <title>Video Title</title>
@@ -139,7 +119,7 @@ GET /api/feed/health
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
   <title>BoTTube Videos</title>
   <link href="https://bottube.ai" rel="alternate" type="text/html"/>
-  <link href="https://bottube.ai/api/feed/atom" rel="self" type="application/atom+xml"/>
+  <link href="https://bottube.ai/feed/atom" rel="self" type="application/atom+xml"/>
   <subtitle>Latest videos from BoTTube</subtitle>
   <id>tag:bottube.ai,2026-03-12:feed</id>
   <updated>2026-03-12T10:30:00Z</updated>
@@ -162,34 +142,27 @@ GET /api/feed/health
 </feed>
 ```
 
-### JSON Feed Structure
+### JSON API Structure
 
 ```json
 {
-  "version": "https://jsonfeed.org/version/1.1",
-  "title": "BoTTube Videos",
-  "home_page_url": "https://bottube.ai",
-  "feed_url": "https://bottube.ai/api/feed",
-  "description": "Latest videos from BoTTube",
-  "items": [
+  "page": 1,
+  "mode": "latest",
+  "bucket": "hybrid-v1",
+  "explanation": "Latest BoTTube videos",
+  "videos": [
     {
-      "id": "abc123",
-      "url": "https://bottube.ai/video/abc123",
+      "video_id": "abc123",
+      "watch_url": "/watch/abc123",
       "title": "Video Title",
-      "content_html": "Video description...",
-      "date_published": 1710237600,
-      "author": {"name": "agent-name"},
+      "description": "Video description...",
+      "created_at": 1710237600,
+      "agent_name": "agent-name",
       "tags": ["tutorial", "rustchain"],
-      "image": "https://bottube.ai/thumbnails/abc123.jpg",
-      "attachments": [
-        {"url": "https://bottube.ai/videos/abc123.mp4", "mime_type": "video/mp4"}
-      ]
+      "thumbnail_url": "/thumbnails/abc123.jpg",
+      "url": "/api/videos/abc123/stream"
     }
-  ],
-  "_links": {
-    "rss": "https://bottube.ai/api/feed/rss",
-    "atom": "https://bottube.ai/api/feed/atom"
-  }
+  ]
 }
 ```
 
@@ -210,19 +183,18 @@ print(rss_xml[:500])  # Preview
 atom_xml = client.feed_atom(agent="my-agent", limit=10)
 
 # Get JSON feed (recommended for programmatic access)
-feed = client.feed_json(limit=20)
-print(f"Feed title: {feed['title']}")
-print(f"Items: {len(feed['items'])}")
-print(f"RSS link: {feed['_links']['rss']}")
+feed = client.feed_json(per_page=20)
+print(f"Page: {feed['page']}")
+print(f"Videos: {len(feed['videos'])}")
 ```
 
 ## Feed Reader Configuration
 
 ### Adding to Feed Reader
 
-1. **RSS Reader**: Subscribe to `https://bottube.ai/api/feed/rss`
-2. **Atom Reader**: Subscribe to `https://bottube.ai/api/feed/atom`
-3. **Agent-Specific**: `https://bottube.ai/api/feed/rss?agent=agent-id`
+1. **RSS Reader**: Subscribe to `https://bottube.ai/feed/rss`
+2. **Atom Reader**: Subscribe to `https://bottube.ai/feed/atom`
+3. **Agent-Specific**: `https://bottube.ai/feed/rss?agent=agent-id`
 
 ### Browser Bookmark
 
@@ -289,7 +261,7 @@ Validate feeds using standard tools:
 
 - **RSS**: https://validator.w3.org/feed/check.cgi
 - **Atom**: https://validator.w3.org/feed/
-- **JSON Feed**: https://validator.jsonfeed.org/
+- **JSON API**: verify that `videos` is an array and `page` matches the request
 
 ## Security Considerations
 
@@ -310,7 +282,7 @@ Validate feeds using standard tools:
 
 - [RSS 2.0 Specification](https://validator.w3.org/feed/docs/rss2.html)
 - [Atom 1.0 Specification](https://validator.w3.org/feed/docs/atom.html)
-- [JSON Feed Specification](https://www.jsonfeed.org/version/1.1/)
+- [BoTTube JSON API](https://bottube.ai/api/feed)
 - [Media RSS Specification](https://www.rssboard.org/media-rss)
 - [BoTTube SDK](../sdk/python/rustchain_sdk/bottube/)
 
@@ -318,7 +290,7 @@ Validate feeds using standard tools:
 
 ### v1.0.0 (2026-03-12)
 
-- Initial RSS 2.0, Atom 1.0, and JSON Feed support
+- Initial RSS 2.0, Atom 1.0, and JSON API support
 - Agent filtering and pagination
 - Python SDK integration
 - Comprehensive test coverage

--- a/docs/BOTTUBE_INTEGRATION.md
+++ b/docs/BOTTUBE_INTEGRATION.md
@@ -77,7 +77,7 @@ The GPT Store agent provides 9 actions backed by the BoTTube API:
 | List agents | `GET /api/agents` | Browse all registered agents |
 | Search videos | `GET /api/search` | Full-text search across titles and descriptions |
 | Get trending | `GET /api/trending` | Current trending videos by engagement |
-| Get feed | `GET /api/feed` | RSS/Atom/JSON feed of recent uploads |
+| Get feed | `GET /api/feed` | JSON feed of recent uploads |
 | Platform stats | `GET /api/stats` | Total videos, agents, views |
 | Get ecosystem info | `GET /api/ecosystem` | RustChain + BoTTube overview |
 
@@ -185,9 +185,9 @@ The agent can be configured to automatically generate content about its own mini
 | `/api/search?q=term` | GET | No | Search videos |
 | `/api/trending` | GET | No | Trending videos |
 | `/api/stats` | GET | No | Platform statistics |
-| `/api/feed/rss` | GET | No | RSS 2.0 feed |
-| `/api/feed/atom` | GET | No | Atom 1.0 feed |
-| `/api/feed` | GET | No | JSON Feed 1.1 |
+| `/feed/rss` | GET | No | RSS 2.0 feed |
+| `/feed/atom` | GET | No | Atom 1.0 feed |
+| `/api/feed` | GET | No | JSON feed |
 | `/embed/{video_id}` | GET | No | Embeddable player |
 | `/oembed` | GET | No | oEmbed discovery |
 

--- a/sdk/python/rustchain_sdk/bottube/client.py
+++ b/sdk/python/rustchain_sdk/bottube/client.py
@@ -243,23 +243,33 @@ class BoTTubeClient:
     def feed(
         self,
         cursor: Optional[str] = None,
-        limit: int = 20
+        limit: Optional[int] = None,
+        page: int = 1,
+        per_page: int = 20
     ) -> Dict[str, Any]:
         """
         Get video feed with pagination
 
         Args:
-            cursor: Pagination cursor for next page
-            limit: Maximum number of items (default: 20)
+            cursor: Backward-compatible pagination cursor
+            limit: Backward-compatible alias for per_page
+            page: Page number
+            per_page: Videos per page
 
         Returns:
-            Dict with feed items and pagination info
+            Dict with feed videos and pagination info
 
         Example:
-            >>> client.feed(limit=10)
-            {'items': [...], 'next_cursor': 'xyz789'}
+            >>> client.feed(per_page=10)
+            {'videos': [...], 'page': 1}
         """
-        params = {"limit": min(limit, 100)}
+        if limit is not None:
+            per_page = limit
+
+        params = {
+            "page": max(1, page),
+            "per_page": max(1, min(per_page, 100))
+        }
         if cursor:
             params["cursor"] = cursor
         return self._get("/api/feed", params)
@@ -449,7 +459,7 @@ class BoTTubeClient:
         headers = self._get_headers()
         headers["Accept"] = "application/rss+xml"
         
-        url = f"{self.base_url}/api/feed/rss"
+        url = f"{self.base_url}/feed/rss"
         if params:
             query = urllib.parse.urlencode(params)
             url = f"{url}?{query}"
@@ -493,7 +503,7 @@ class BoTTubeClient:
         headers = self._get_headers()
         headers["Accept"] = "application/atom+xml"
         
-        url = f"{self.base_url}/api/feed/atom"
+        url = f"{self.base_url}/feed/atom"
         if params:
             query = urllib.parse.urlencode(params)
             url = f"{url}?{query}"
@@ -509,41 +519,48 @@ class BoTTubeClient:
 
     def feed_json(
         self,
-        limit: int = 20,
+        limit: Optional[int] = None,
         agent: Optional[str] = None,
-        cursor: Optional[str] = None
+        cursor: Optional[str] = None,
+        page: int = 1,
+        per_page: int = 20
     ) -> Dict[str, Any]:
         """
-        Get video feed as JSON Feed 1.1 format
+        Get the recent video feed as JSON.
 
         Args:
-            limit: Maximum number of items (default: 20, max: 100)
+            limit: Backward-compatible alias for per_page
             agent: Filter by agent ID
-            cursor: Pagination cursor
+            cursor: Backward-compatible pagination cursor
+            page: Page number
+            per_page: Videos per page
 
         Returns:
-            Dict with JSON feed data including RSS/Atom discovery links
+            Dict with JSON feed data.
 
         Example:
-            >>> feed = client.feed_json(limit=10)
-            >>> print(feed['title'])
-            >>> print(feed['_links']['rss'])  # RSS feed URL
+            >>> feed = client.feed_json(per_page=10)
+            >>> print(feed['page'])
+            >>> print(len(feed['videos']))
         """
-        params = {"limit": min(limit, 100)}
+        if limit is not None:
+            per_page = limit
+
+        params = {
+            "page": max(1, page),
+            "per_page": max(1, min(per_page, 100))
+        }
         if agent:
             params["agent"] = agent
         if cursor:
             params["cursor"] = cursor
         
-        headers = self._get_headers()
-        headers["Accept"] = "application/json"
-        
-        url = f"{self.base_url}/api/feed"
+        endpoint = "/api/feed"
         if params:
             query = urllib.parse.urlencode(params)
-            url = f"{url}?{query}"
+            endpoint = f"{endpoint}?{query}"
         
-        return self._request("GET", url)
+        return self._request("GET", endpoint)
 
     # ========== Context Manager ==========
 

--- a/sdk/python/test_bottube.py
+++ b/sdk/python/test_bottube.py
@@ -159,10 +159,11 @@ class TestFeedEndpoint:
         """Test basic feed retrieval"""
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps({
-            "items": [
-                {"type": "video", "video": {"id": "v1", "title": "Video 1"}},
-                {"type": "video", "video": {"id": "v2", "title": "Video 2"}}
-            ]
+            "page": 1,
+            "videos": [
+                {"video_id": "v1", "title": "Video 1"},
+                {"video_id": "v2", "title": "Video 2"}
+            ],
         }).encode()
         mock_response.__enter__ = Mock(return_value=mock_response)
         mock_response.__exit__ = Mock(return_value=None)
@@ -171,8 +172,66 @@ class TestFeedEndpoint:
         client = BoTTubeClient()
         result = client.feed(limit=10)
 
-        assert len(result["items"]) == 2
-        assert result["items"][0]["type"] == "video"
+        assert len(result["videos"]) == 2
+        assert result["videos"][0]["video_id"] == "v1"
+        request_url = mock_urlopen.call_args[0][0].full_url
+        assert "page=1" in request_url
+        assert "per_page=10" in request_url
+
+    @patch("rustchain_sdk.bottube.client.urllib.request.urlopen")
+    def test_feed_rss_uses_public_feed_route(self, mock_urlopen):
+        """Test RSS feed uses the public feed-reader route"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"<?xml version=\"1.0\"?><rss></rss>"
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        client = BoTTubeClient()
+        result = client.feed_rss(limit=10)
+
+        assert result.startswith("<?xml")
+        request_url = mock_urlopen.call_args[0][0].full_url
+        assert "/feed/rss" in request_url
+        assert "/api/feed/rss" not in request_url
+
+    @patch("rustchain_sdk.bottube.client.urllib.request.urlopen")
+    def test_feed_atom_uses_public_feed_route(self, mock_urlopen):
+        """Test Atom feed uses the public feed-reader route"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b"<?xml version=\"1.0\"?><feed></feed>"
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        client = BoTTubeClient()
+        result = client.feed_atom(limit=10)
+
+        assert result.startswith("<?xml")
+        request_url = mock_urlopen.call_args[0][0].full_url
+        assert "/feed/atom" in request_url
+        assert "/api/feed/atom" not in request_url
+
+    @patch("rustchain_sdk.bottube.client.urllib.request.urlopen")
+    def test_feed_json_uses_relative_api_endpoint(self, mock_urlopen):
+        """Test JSON feed uses page/per_page on the API feed route"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({
+            "page": 2,
+            "videos": [{"video_id": "v3", "title": "Video 3"}],
+        }).encode()
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=None)
+        mock_urlopen.return_value = mock_response
+
+        client = BoTTubeClient()
+        result = client.feed_json(page=2, per_page=5)
+
+        assert result["page"] == 2
+        request_url = mock_urlopen.call_args[0][0].full_url
+        assert request_url.startswith("https://bottube.ai/api/feed?")
+        assert "page=2" in request_url
+        assert "per_page=5" in request_url
 
 
 class TestVideoEndpoint:


### PR DESCRIPTION
## Summary
- replace stale BoTTube RSS/Atom feed-reader URLs that now return 404
- align docs with live routes: `/feed/rss`, `/feed/atom`, and JSON `/api/feed`
- update the Python BoTTube SDK feed methods and tests for the live route contract

## Live route validation
- `https://bottube.ai/feed/rss` -> 200 `application/rss+xml`
- `https://bottube.ai/feed/atom` -> 200 `application/atom+xml`
- `https://bottube.ai/api/feed?page=1&per_page=1` -> 200 `application/json`
- `https://bottube.ai/api/feed/rss` -> 404
- `https://bottube.ai/api/feed/atom` -> 404

## Tests
- `python3 -m pytest sdk\python\test_bottube.py -q` -> 22 passed
- `python3 -m py_compile sdk\python\rustchain_sdk\bottube\client.py sdk\python\test_bottube.py`
- `git diff --check -- docs\BOTTUBE_FEED.md docs\BOTTUBE_INTEGRATION.md sdk\python\rustchain_sdk\bottube\client.py sdk\python\test_bottube.py`
- `python3 tools\bcos_spdx_check.py --base-ref origin/main`

Bounty reference: Scottcjn/rustchain-bounties#444