### PR TITLE
fix: pin Homebrew miner formula to valid archive

### DIFF
--- a/homebrew/INSTALL.md
+++ b/homebrew/INSTALL.md
@@ -146,7 +146,7 @@ brew style rustchain-miner
 brew test rustchain-miner
 
 # Verify checksums (before release)
-curl -sSL https://github.com/Scottcjn/Rustchain/archive/refs/tags/v2.5.0.tar.gz | sha256sum
+curl -sSL https://github.com/Scottcjn/Rustchain/archive/448e835cd76e28fef9bc76f9ddaaf38be0ffc2b8.tar.gz | sha256sum
 ```
 
 ---
@@ -203,12 +203,12 @@ rm -f ~/Library/LaunchAgents/homebrew.mxcl.rustchain-miner.plist
 
 1. **Checksum Verification**: Before deploying, compute and update the SHA256 in the formula:
    ```bash
-   curl -sSL https://github.com/Scottcjn/Rustchain/archive/refs/tags/v2.5.0.tar.gz | sha256sum
+   curl -sSL https://github.com/Scottcjn/Rustchain/archive/448e835cd76e28fef9bc76f9ddaaf38be0ffc2b8.tar.gz | sha256sum
    ```
 
 2. **Version Pinning**: For production, pin to a specific version:
    ```ruby
-   url "https://github.com/Scottcjn/Rustchain/archive/refs/tags/v2.5.0.tar.gz"
+   url "https://github.com/Scottcjn/Rustchain/archive/448e835cd76e28fef9bc76f9ddaaf38be0ffc2b8.tar.gz"
    version "2.5.0"
    ```
 

--- a/homebrew/rustchain-miner.rb
+++ b/homebrew/rustchain-miner.rb
@@ -5,9 +5,9 @@
 class RustchainMiner < Formula
   desc "RustChain Proof-of-Antiquity Miner - rewards vintage hardware"
   homepage "https://github.com/Scottcjn/Rustchain"
-  url "https://github.com/Scottcjn/Rustchain/archive/refs/tags/v2.5.0.tar.gz"
+  url "https://github.com/Scottcjn/Rustchain/archive/448e835cd76e28fef9bc76f9ddaaf38be0ffc2b8.tar.gz"
   version "2.5.0"
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # REPLACE with actual sha256
+  sha256 "eaa09a1586dec2748c205cca2ec76602fa985e0dbd0d1b110bb12dc98aa6837a"
   license "MIT"
 
   depends_on "python@3.11"
@@ -15,7 +15,7 @@ class RustchainMiner < Formula
   def install
     libexec.install "miners/macos/rustchain_mac_miner_v2.5.py" => "rustchain_miner.py"
     libexec.install "miners/macos/color_logs.py"
-    libexec.install "miners/fingerprint_checks.py"
+    libexec.install "miners/macos/fingerprint_checks.py"
 
     venv = virtualenv_create(libexec, "python@3.11")
     virtualenv_install(venv, "miners/macos/requirements-miner.txt")


### PR DESCRIPTION
## Summary
- replace the missing `v2.5.0` tag archive URL in the Homebrew miner formula with a stable commit archive that contains the v2.5 miner sources
- replace the placeholder SHA256 with the computed archive checksum
- fix the formula install path for `fingerprint_checks.py`
- align the Homebrew install guide checksum/pinning examples with the same archive URL

## Validation
- old `https://github.com/Scottcjn/Rustchain/archive/refs/tags/v2.5.0.tar.gz` -> 404
- new `https://github.com/Scottcjn/Rustchain/archive/448e835cd76e28fef9bc76f9ddaaf38be0ffc2b8.tar.gz` -> 200
- computed SHA256: `eaa09a1586dec2748c205cca2ec76602fa985e0dbd0d1b110bb12dc98aa6837a`
- downloaded archive contains:
  - `miners/macos/rustchain_mac_miner_v2.5.py`
  - `miners/macos/fingerprint_checks.py`
  - `miners/macos/color_logs.py`
  - `miners/macos/requirements-miner.txt`
- `git diff --check -- homebrew\rustchain-miner.rb homebrew\INSTALL.md` -> passed
- `python3 tools\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Note: Ruby/Homebrew is not installed in this Windows workspace, so `ruby -c` / `brew audit` could not be run locally.

Bounty reference: Scottcjn/rustchain-bounties#444