### PR TITLE
[UTXO-BUG] Drop stale mempool data-input candidates

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -593,6 +593,34 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(candidates, [])
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
 
+    def test_mempool_block_candidates_drop_spent_data_inputs(self):
+        """Block candidates must not include txs with spent data inputs."""
+        self._apply_coinbase('oracle', 100 * UNIT, block_height=1)
+        self._apply_coinbase('alice', 100 * UNIT, block_height=2)
+        oracle_box = self.db.get_unspent_for_address('oracle')[0]
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+        tx_id = 'data_stale' * 6 + '0000'
+
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': tx_id,
+            'inputs': [{'box_id': alice_box['box_id']}],
+            'data_inputs': [oracle_box['box_id']],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }))
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': oracle_box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [{'address': 'oracle-next', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=3)
+        self.assertTrue(ok)
+
+        candidates = self.db.mempool_get_block_candidates()
+        self.assertEqual(candidates, [])
+        self.assertFalse(self.db.mempool_check_double_spend(alice_box['box_id']))
+
     def test_mempool_nonexistent_input_rejected(self):
         tx = {
             'tx_id': 'cccc' * 16,

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -967,27 +967,35 @@ class UtxoDB:
                 try:
                     tx = json.loads(row['tx_data_json'])
                     input_ids = [inp['box_id'] for inp in tx.get('inputs', [])]
+                    data_inputs = self._normalize_data_inputs(
+                        tx.get('data_inputs', [])
+                    )
                 except Exception:
                     stale_tx_ids.append(tx_id)
                     continue
 
-                if not input_ids:
+                if not input_ids or data_inputs is None:
                     stale_tx_ids.append(tx_id)
                     continue
 
-                placeholders = ",".join("?" for _ in input_ids)
-                unspent_count = conn.execute(
-                    f"""SELECT COUNT(*) AS n FROM utxo_boxes
-                        WHERE box_id IN ({placeholders}) AND spent_at IS NULL""",
-                    input_ids,
-                ).fetchone()['n']
-                if unspent_count != len(set(input_ids)):
-                    stale_tx_ids.append(tx_id)
-                    continue
+                for box_ids in (input_ids, data_inputs):
+                    if not box_ids:
+                        continue
+                    placeholders = ",".join("?" for _ in box_ids)
+                    unspent_count = conn.execute(
+                        f"""SELECT COUNT(*) AS n FROM utxo_boxes
+                            WHERE box_id IN ({placeholders})
+                              AND spent_at IS NULL""",
+                        box_ids,
+                    ).fetchone()['n']
+                    if unspent_count != len(set(box_ids)):
+                        stale_tx_ids.append(tx_id)
+                        break
+                else:
+                    candidates.append(tx)
+                    if len(candidates) >= max_count:
+                        break
 
-                candidates.append(tx)
-                if len(candidates) >= max_count:
-                    break
 
             for tx_id in stale_tx_ids:
                 conn.execute(


### PR DESCRIPTION
Implements a UTXO red-team fix for Scottcjn/rustchain-bounties#2819.

Finding:
- `mempool_get_block_candidates()` filtered stale spend inputs, while read-only `data_inputs` were only checked at mempool admission.
- A mempool transaction could keep returning as a block candidate after one of its `data_inputs` was confirmed spent by another transaction.
- Applying that stale candidate fails, and the stale mempool row plus spend-input claim can remain until expiry.

Fix:
- Normalize stored `data_inputs` while loading mempool candidates.
- Drop and delete candidates whose spend inputs or data inputs are no longer unspent.
- Add regression coverage for a candidate whose data input is spent after mempool admission.

Validation:
- `python -B -m py_compile node\utxo_db.py node\test_utxo_db.py`
- `python -B -m pytest -q node\test_utxo_db.py -k "spent_data_inputs or spent_inputs or data_input" --tb=short` -> `8 passed, 64 deselected`
- `python -B -m pytest -q node\test_utxo_db.py --tb=short` -> `72 passed`
- `git diff --check -- node\utxo_db.py node\test_utxo_db.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

Duplicate search before submission:
- `spent data_input mempool UTXO`
- `data input block candidates UTXO`
- No matching RustChain PR or rustchain-bounties claim found for this exact stale `data_inputs` block-candidate path.

Payout boundary: this is a public bounty PR for maintainer assessment only; no RTC award, payout approval, wallet transfer, wallet credit, or payment receipt is asserted here.
