### PR TITLE
[UTXO-BUG] Bind state root to UTXO box contents

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -409,6 +409,44 @@ class TestUtxoDB(unittest.TestCase):
         root_after = self.db.compute_state_root()
         self.assertNotEqual(root_before, root_after)
 
+    def test_state_root_commits_to_box_contents(self):
+        """State root must change if unspent box contents are corrupted."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+        root_before = self.db.compute_state_root()
+
+        conn = self.db._conn()
+        try:
+            conn.execute(
+                "UPDATE utxo_boxes SET value_nrtc = ? WHERE box_id = ?",
+                (200 * UNIT, box['box_id']),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        root_after_value_change = self.db.compute_state_root()
+        self.assertNotEqual(root_before, root_after_value_change)
+
+        conn = self.db._conn()
+        try:
+            conn.execute(
+                """UPDATE utxo_boxes
+                   SET proposition = ?, owner_address = ?
+                   WHERE box_id = ?""",
+                (
+                    address_to_proposition('mallory'),
+                    'mallory',
+                    box['box_id'],
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        root_after_owner_change = self.db.compute_state_root()
+        self.assertNotEqual(root_after_value_change, root_after_owner_change)
+
     def test_state_root_odd_count_unique(self):
         """Odd-count UTXO sets must produce unique roots.
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -661,7 +661,7 @@ class UtxoDB:
 
     def compute_state_root(self) -> str:
         """
-        Merkle root of all unspent box IDs (hex).
+        Merkle root of all unspent box contents (hex).
 
         Deterministic: sorted by box_id, pairwise SHA256.
         All nodes with the same UTXO set produce the same root.
@@ -678,7 +678,10 @@ class UtxoDB:
         conn = self._conn()
         try:
             rows = conn.execute(
-                """SELECT box_id FROM utxo_boxes
+                """SELECT box_id, value_nrtc, proposition, owner_address,
+                          creation_height, transaction_id, output_index,
+                          tokens_json, registers_json
+                   FROM utxo_boxes
                    WHERE spent_at IS NULL
                    ORDER BY box_id ASC"""
             ).fetchall()
@@ -688,10 +691,23 @@ class UtxoDB:
 
             # Mix element count into leaf hashes to bind tree to cardinality
             count_bytes = len(rows).to_bytes(8, 'little')
-            hashes = [
-                hashlib.sha256(count_bytes + bytes.fromhex(r['box_id'])).digest()
-                for r in rows
-            ]
+            hashes = []
+            for row in rows:
+                leaf = {
+                    'box_id': row['box_id'],
+                    'value_nrtc': row['value_nrtc'],
+                    'proposition': row['proposition'],
+                    'owner_address': row['owner_address'],
+                    'creation_height': row['creation_height'],
+                    'transaction_id': row['transaction_id'],
+                    'output_index': row['output_index'],
+                    'tokens_json': row['tokens_json'],
+                    'registers_json': row['registers_json'],
+                }
+                leaf_bytes = json.dumps(
+                    leaf, sort_keys=True, separators=(',', ':')
+                ).encode()
+                hashes.append(hashlib.sha256(count_bytes + leaf_bytes).digest())
 
             while len(hashes) > 1:
                 if len(hashes) % 2 == 1:


### PR DESCRIPTION
## Summary
- Bind `compute_state_root()` leaf hashes to canonical unspent box contents instead of only `box_id`.
- Include value, proposition, owner, creation metadata, transaction/output identity, tokens, and registers in deterministic leaf encoding.
- Add regression coverage proving direct value and owner/proposition corruption changes the state root.

## Bounty context
Implements an existing UTXO audit finding recorded in `audits/utxo_db_security_audit.md` for `Scottcjn/rustchain-bounties#2819`.

This implements an existing published audit finding rather than claiming first disclosure.

## Validation
- `python -B -m py_compile node\utxo_db.py node\test_utxo_db.py`
- `python -B -m pytest -q node\test_utxo_db.py -k "state_root" --tb=short`
- `python -B -m pytest -q node\test_utxo_db.py --tb=short`
- `git diff --check -- node\utxo_db.py node\test_utxo_db.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Payout boundary: this is a public bounty claim for maintainer assessment only; no RTC award, payout approval, wallet transfer, wallet credit, or payment receipt is asserted here.