### PR TITLE
fix: reject non-object relationship mutation JSON

### DIFF
--- a/agent_relationships.py
+++ b/agent_relationships.py
@@ -1069,6 +1069,14 @@ def create_relationship_blueprint(engine: RelationshipEngine):
             return jsonify({"error": "Unauthorized relationship mutation"}), 401
 
         return None
+
+    def _mutation_json_object():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
     
     @bp.route("/api/relationships", methods=["GET"])
     def list_relationships():
@@ -1097,7 +1105,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, json_error = _mutation_json_object()
+        if json_error:
+            return json_error
         try:
             result = engine.record_disagreement(
                 agent_a, agent_b,
@@ -1114,7 +1124,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, json_error = _mutation_json_object()
+        if json_error:
+            return json_error
         try:
             result = engine.record_collaboration(
                 agent_a, agent_b,
@@ -1131,7 +1143,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.get_json(silent=True) or {}
+        data, json_error = _mutation_json_object()
+        if json_error:
+            return json_error
         try:
             result = engine.record_reconciliation(
                 agent_a, agent_b,
@@ -1147,7 +1161,9 @@ def create_relationship_blueprint(engine: RelationshipEngine):
         if auth_error:
             return auth_error
 
-        data = request.json or {}
+        data, json_error = _mutation_json_object()
+        if json_error:
+            return json_error
         try:
             result = engine.admin_intervene(
                 agent_a, agent_b,

--- a/tests/test_agent_relationship_mutation_auth.py
+++ b/tests/test_agent_relationship_mutation_auth.py
@@ -9,6 +9,7 @@ MUTATING_ENDPOINTS = (
     ("/api/relationships/alice/bob/disagree", {"topic": "model routing"}),
     ("/api/relationships/alice/bob/collaborate", {"description": "shared runbook"}),
     ("/api/relationships/alice/bob/reconcile", {"description": "postmortem"}),
+    ("/api/relationships/alice/bob/intervene", {"reason": "moderation reset"}),
 )
 
 
@@ -78,3 +79,20 @@ def test_relationship_mutations_accept_legacy_api_key_header(monkeypatch, tmp_pa
     relationship = engine.get_relationship("alice", "bob")
     assert relationship is not None
     assert relationship["collaboration_count"] == 1
+
+
+def test_relationship_mutations_reject_non_object_json(monkeypatch, tmp_path):
+    monkeypatch.setenv("RELATIONSHIPS_ADMIN_KEY", "relationship-admin-secret")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client, engine = _build_client(tmp_path)
+
+    for path, _payload in MUTATING_ENDPOINTS:
+        response = client.post(
+            path,
+            json=["not", "an", "object"],
+            headers={"X-Admin-Key": "relationship-admin-secret"},
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "JSON object required"}
+        assert engine.get_relationship("alice", "bob") is None


### PR DESCRIPTION
## Summary
- add a shared relationship mutation JSON parser that only accepts JSON objects
- reject JSON arrays/scalars with HTTP 400 before calling `.get(...)`
- cover disagree/collaborate/reconcile/intervene mutation routes with authenticated non-object payload regression tests

Fixes #5508

## Validation
- `python -m pytest tests/test_agent_relationship_mutation_auth.py tests/test_agent_relationships_admin_auth.py -q`
- `git diff --check`