### PR TITLE
fix: validate testnet faucet field types

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -63,6 +63,22 @@ def test_drip_accepts_form_payload(app):
     assert r.get_json()["ok"] is True
 
 
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"wallet": ["rtc_wallet_1"]}, "wallet_must_be_string"),
+        ({"wallet": 123}, "wallet_must_be_string"),
+        ({"wallet": "rtc_wallet_1", "github_username": ["alice"]}, "github_username_must_be_string"),
+        ({"wallet": "rtc_wallet_1", "github_username": 123}, "github_username_must_be_string"),
+    ],
+)
+def test_drip_rejects_non_string_fields(app, payload, error):
+    c = app.test_client()
+    r = c.post("/faucet/drip", json=payload)
+    assert r.status_code == 400
+    assert r.get_json() == {"ok": False, "error": error}
+
+
 def test_ip_only_limit(app):
     c = app.test_client()
     h = {"X-Forwarded-For": "1.2.3.4"}

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -93,6 +93,16 @@ def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
     return data, None
 
 
+def _strip_string_field(data: dict[str, Any], name: str) -> tuple[str | None, tuple[Any, int] | None]:
+    value = data.get(name)
+    if value is None:
+        return None, None
+    if not isinstance(value, str):
+        return None, (jsonify({"ok": False, "error": f"{name}_must_be_string"}), 400)
+    value = value.strip()
+    return value or None, None
+
+
 def _sum_last_24h(conn: sqlite3.Connection, github_username: str | None, ip: str) -> float:
     since = (_utcnow() - timedelta(hours=24)).isoformat()
     if github_username:
@@ -173,8 +183,12 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         data, error = _request_data()
         if error:
             return error
-        wallet = (data.get("wallet") or "").strip()
-        github_username = (data.get("github_username") or "").strip() or None
+        wallet, error = _strip_string_field(data, "wallet")
+        if error:
+            return error
+        github_username, error = _strip_string_field(data, "github_username")
+        if error:
+            return error
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()
 
         if not wallet:


### PR DESCRIPTION
## Summary
- reject non-string `wallet` and `github_username` values on `/faucet/drip`
- keep empty or missing wallet values on the existing `wallet_required` path
- add focused regression coverage for typed JSON fields

Fixes #5602
Bounty reference: #305

## Validation
- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_faucet.py -q`
- `/tmp/rustchain-bounty-venv/bin/python -m py_compile tools/testnet_faucet.py tests/test_faucet.py`
- `git diff --check -- tools/testnet_faucet.py tests/test_faucet.py`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

