### PR TITLE
fix: validate relic reservation fields

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -243,6 +243,45 @@ class TestReservationFlow:
         assert resp.status_code == 400
         assert resp.json["error"] == "JSON object required"
 
+    def test_reserve_rejects_non_string_agent_id(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": ["agent"],
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": 4.0,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "agent_id must be a string"
+
+    def test_reserve_rejects_non_string_machine_id(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": "agent",
+            "machine_id": ["g3-beige"],
+            "duration_hours": 1,
+            "rtc_amount": 4.0,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "machine_id must be a string"
+
+    def test_reserve_rejects_boolean_duration_and_amount(self, app):
+        duration_resp = app.post("/relic/reserve", json={
+            "agent_id": "agent",
+            "machine_id": "g3-beige",
+            "duration_hours": True,
+            "rtc_amount": 4.0,
+        })
+        assert duration_resp.status_code == 400
+        assert "duration_hours must be one of" in duration_resp.json["error"]
+
+        amount_resp = app.post("/relic/reserve", json={
+            "agent_id": "agent",
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": True,
+        })
+        assert amount_resp.status_code == 400
+        assert amount_resp.json["error"] == "rtc_amount must be a positive number"
+
     def test_unknown_machine_returns_404(self, app):
         resp = app.post("/relic/reserve", json={
             "agent_id": "a", "machine_id": "nonexistent",

--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -282,6 +282,17 @@ class TestReservationFlow:
         assert amount_resp.status_code == 400
         assert amount_resp.json["error"] == "rtc_amount must be a positive number"
 
+    @pytest.mark.parametrize("rtc_amount", [float("nan"), float("inf")])
+    def test_reserve_rejects_non_finite_rtc_amount(self, app, rtc_amount):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": "agent",
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": rtc_amount,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "rtc_amount must be a positive number"
+
     def test_unknown_machine_returns_404(self, app):
         resp = app.post("/relic/reserve", json={
             "agent_id": "a", "machine_id": "nonexistent",

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -57,6 +57,31 @@ def _get_json_object_or_empty() -> dict:
     return data
 
 
+def _string_field(data: dict, name: str) -> str:
+    value = data.get(name, "")
+    if value is None:
+        value = ""
+    if not isinstance(value, str):
+        abort(400, description=f"{name} must be a string")
+    return value.strip()
+
+
+def _duration_field(data: dict) -> int | None:
+    value = data.get("duration_hours")
+    if isinstance(value, bool) or not isinstance(value, int):
+        abort(400, description=f"duration_hours must be one of {sorted(VALID_DURATIONS_HOURS)}")
+    return value
+
+
+def _positive_number_field(data: dict, name: str) -> int | float | None:
+    value = data.get(name)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        abort(400, description=f"{name} must be a positive number")
+    if value <= 0:
+        abort(400, description=f"{name} must be a positive number")
+    return value
+
+
 def _require_admin_key() -> None:
     """Require the shared RustChain admin key for escrow-releasing actions."""
     expected_key = os.environ.get("RC_ADMIN_KEY", "")
@@ -249,10 +274,10 @@ def post_reserve():
     """Reserve a machine and lock RTC in escrow."""
     data = _get_json_object_or_empty()
 
-    agent_id       = data.get("agent_id", "").strip()
-    machine_id     = data.get("machine_id", "").strip()
-    duration_hours = data.get("duration_hours")
-    rtc_amount     = data.get("rtc_amount")
+    agent_id       = _string_field(data, "agent_id")
+    machine_id     = _string_field(data, "machine_id")
+    duration_hours = _duration_field(data)
+    rtc_amount     = _positive_number_field(data, "rtc_amount")
 
     if not agent_id:
         abort(400, description="agent_id is required")
@@ -260,8 +285,6 @@ def post_reserve():
         abort(400, description="machine_id is required")
     if duration_hours not in VALID_DURATIONS_HOURS:
         abort(400, description=f"duration_hours must be one of {sorted(VALID_DURATIONS_HOURS)}")
-    if rtc_amount is None or not isinstance(rtc_amount, (int, float)) or rtc_amount <= 0:
-        abort(400, description="rtc_amount must be a positive number")
 
     machine = MACHINE_REGISTRY.get(machine_id)
     if machine is None:

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import math
 import os
 import sqlite3
 import time
@@ -77,7 +78,7 @@ def _positive_number_field(data: dict, name: str) -> int | float | None:
     value = data.get(name)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         abort(400, description=f"{name} must be a positive number")
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
         abort(400, description=f"{name} must be a positive number")
     return value
 


### PR DESCRIPTION
## Summary
- reject non-string `agent_id` and `machine_id` values before normalization in `/relic/reserve`
- reject boolean reservation durations and RTC amounts before business-rule checks
- add focused Rent-a-Relic regression coverage for malformed reservation fields

Fixes #5604
Bounty reference: #305

## Validation
- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_rent_a_relic.py -q`
- `/tmp/rustchain-bounty-venv/bin/python -m py_compile tools/rent_a_relic/server.py tests/test_rent_a_relic.py`
- `git diff --check -- tools/rent_a_relic/server.py tests/test_rent_a_relic.py`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

