### PR TITLE
fix: validate relic completion output hash

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -237,6 +237,22 @@ class TestReservationFlow:
         assert sr.json["status"] == "active"
         assert sr.json["escrow"]["status"] == "locked"
 
+    @pytest.mark.parametrize("output_hash", ["abc", "g" * 64])
+    def test_complete_rejects_invalid_sha256_output_hash(self, app, output_hash):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_malformed_output_hash", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+
+        cr = complete_session(app, r.json["session_id"], {"output_hash": output_hash})
+
+        assert cr.status_code == 400
+        assert cr.json["error"] == "output_hash must be a 64-character SHA-256 hex digest"
+        sr = app.get(f"/relic/reservation/{r.json['session_id']}")
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
     def test_status_endpoint(self, app):
         r = app.post("/relic/reserve", json={
             "agent_id": "agent_stat", "machine_id": "g4-quicksilver",

--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -221,6 +221,22 @@ class TestReservationFlow:
         assert cr.status_code == 400
         assert cr.json["error"] == "JSON object required"
 
+    @pytest.mark.parametrize("output_hash", [["not-a-string"], {"hash": "abc"}, 123, True])
+    def test_complete_rejects_non_string_output_hash(self, app, output_hash):
+        r = app.post("/relic/reserve", json={
+            "agent_id": "agent_bad_output_hash", "machine_id": "riscv-hifive",
+            "duration_hours": 1, "rtc_amount": 10.0,
+        })
+        assert r.status_code == 201
+
+        cr = complete_session(app, r.json["session_id"], {"output_hash": output_hash})
+
+        assert cr.status_code == 400
+        assert cr.json["error"] == "output_hash must be a string"
+        sr = app.get(f"/relic/reservation/{r.json['session_id']}")
+        assert sr.json["status"] == "active"
+        assert sr.json["escrow"]["status"] == "locked"
+
     def test_status_endpoint(self, app):
         r = app.post("/relic/reserve", json={
             "agent_id": "agent_stat", "machine_id": "g4-quicksilver",

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -57,6 +57,15 @@ def _get_json_object_or_empty() -> dict:
     return data
 
 
+def _optional_string_value(data: dict, key: str) -> str | None:
+    value = data.get(key)
+    if value is None or value == "":
+        return None
+    if not isinstance(value, str):
+        abort(400, description=f"{key} must be a string")
+    return value
+
+
 def _require_admin_key() -> None:
     """Require the shared RustChain admin key for escrow-releasing actions."""
     expected_key = os.environ.get("RC_ADMIN_KEY", "")
@@ -439,8 +448,9 @@ def get_reservation(session_id: str):
 def post_complete(session_id: str):
     """Mark a session as completed and release escrow."""
     _require_admin_key()
-    data        = _get_json_object_or_empty()
-    output_hash = data.get("output_hash") or hashlib.sha256(session_id.encode()).hexdigest()
+    data                = _get_json_object_or_empty()
+    default_output_hash = hashlib.sha256(session_id.encode()).hexdigest()
+    output_hash         = _optional_string_value(data, "output_hash") or default_output_hash
 
     with db_conn() as conn:
         row = conn.execute("SELECT * FROM reservations WHERE session_id=?", (session_id,)).fetchone()

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -41,6 +41,7 @@ from tools.rent_a_relic.provenance import generate_receipt, verify_receipt
 
 app = Flask(__name__)
 DB_PATH = "rent_a_relic.db"
+SHA256_HEX_CHARS = frozenset("0123456789abcdefABCDEF")
 
 
 def get_db_path() -> str:
@@ -63,6 +64,15 @@ def _optional_string_value(data: dict, key: str) -> str | None:
         return None
     if not isinstance(value, str):
         abort(400, description=f"{key} must be a string")
+    return value
+
+
+def _optional_sha256_hex_value(data: dict, key: str) -> str | None:
+    value = _optional_string_value(data, key)
+    if value is None:
+        return None
+    if len(value) != 64 or any(char not in SHA256_HEX_CHARS for char in value):
+        abort(400, description=f"{key} must be a 64-character SHA-256 hex digest")
     return value
 
 
@@ -450,7 +460,7 @@ def post_complete(session_id: str):
     _require_admin_key()
     data                = _get_json_object_or_empty()
     default_output_hash = hashlib.sha256(session_id.encode()).hexdigest()
-    output_hash         = _optional_string_value(data, "output_hash") or default_output_hash
+    output_hash         = _optional_sha256_hex_value(data, "output_hash") or default_output_hash
 
     with db_conn() as conn:
         row = conn.execute("SELECT * FROM reservations WHERE session_id=?", (session_id,)).fetchone()


### PR DESCRIPTION
## Summary
- reject non-string `output_hash` values on `/relic/complete/<session_id>`
- keep the existing default hash behavior when `output_hash` is missing or blank
- add regression coverage for malformed completion payloads leaving escrow locked

Fixes #5606
Bounty reference: #305

## Validation
- `/tmp/rustchain-bounty-venv/bin/python -m pytest tests/test_rent_a_relic.py -q`
- `/tmp/rustchain-bounty-venv/bin/python -m py_compile tools/rent_a_relic/server.py tests/test_rent_a_relic.py`
- `git diff --check -- tools/rent_a_relic/server.py tests/test_rent_a_relic.py`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

