### PR TITLE
Require admin key for contributor approval

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MIT
 
-from flask import Flask, request, redirect, url_for, flash
+from flask import Flask, request, redirect, url_for, flash, jsonify
 import sqlite3
 import os
 import secrets
+import hmac
 from datetime import datetime
 
 app = Flask(__name__)
@@ -172,8 +173,28 @@ def api_contributors():
         ]
     }
 
-@app.route('/approve/<username>')
+def _require_contributor_admin():
+    expected_key = os.environ.get("CONTRIBUTOR_ADMIN_KEY", "").strip()
+    if not expected_key:
+        return jsonify({"error": "CONTRIBUTOR_ADMIN_KEY not configured"}), 503
+
+    provided_key = (
+        request.headers.get("X-Admin-Key")
+        or request.headers.get("X-API-Key")
+        or ""
+    ).strip()
+    if not hmac.compare_digest(provided_key, expected_key):
+        return jsonify({"error": "Unauthorized - admin key required"}), 401
+
+    return None
+
+
+@app.route('/approve/<username>', methods=['POST'])
 def approve_contributor(username):
+    auth_error = _require_contributor_admin()
+    if auth_error:
+        return auth_error
+
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
             'UPDATE contributors SET status = "approved" WHERE github_username = ?',

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -123,15 +123,79 @@ class TestApiContributors:
 
 
 class TestApproveRoute:
-    def test_approve_pending_contributor(self, client):
-        """GET /approve/<username> should set status to approved."""
+    def test_get_approve_is_not_allowed(self, client):
+        """GET /approve/<username> must not mutate contributor status."""
         client.post("/register", data={
             "github_username": "pendinguser",
             "contributor_type": "bot",
             "rtc_wallet": "RTC0pending",
             "contribution_history": "",
         }, follow_redirects=True)
-        response = client.get("/approve/pendinguser", follow_redirects=True)
+        response = client.get("/approve/pendinguser")
+        assert response.status_code == 405
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_fails_closed_without_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> must not approve when the admin key is unset."""
+        monkeypatch.delenv("CONTRIBUTOR_ADMIN_KEY", raising=False)
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+        response = client.post("/approve/pendinguser")
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "CONTRIBUTOR_ADMIN_KEY not configured"
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    def test_approve_rejects_missing_or_wrong_admin_key(self, client, monkeypatch):
+        """POST /approve/<username> must reject absent and incorrect admin keys."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "expected-admin")
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+
+        missing = client.post("/approve/pendinguser")
+        wrong = client.post(
+            "/approve/pendinguser",
+            headers={"X-Admin-Key": "wrong-admin"},
+        )
+
+        assert missing.status_code == 401
+        assert wrong.status_code == 401
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT status FROM contributors WHERE github_username='pendinguser'"
+            ).fetchone()
+        assert row[0] == "pending"
+
+    @pytest.mark.parametrize("header_name", ["X-Admin-Key", "X-API-Key"])
+    def test_approve_pending_contributor_with_admin_key(self, client, monkeypatch, header_name):
+        """POST /approve/<username> should set status to approved with a valid admin key."""
+        monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "expected-admin")
+        client.post("/register", data={
+            "github_username": "pendinguser",
+            "contributor_type": "bot",
+            "rtc_wallet": "RTC0pending",
+            "contribution_history": "",
+        }, follow_redirects=True)
+        response = client.post(
+            "/approve/pendinguser",
+            headers={header_name: "expected-admin"},
+            follow_redirects=True,
+        )
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(


### PR DESCRIPTION
## Summary
- require a configured CONTRIBUTOR_ADMIN_KEY before approving contributor registry entries
- accept the key via X-Admin-Key or X-API-Key with constant-time comparison
- restrict approval to POST so link prefetch/crawlers cannot mutate contributor status
- add regression coverage for unset, missing/wrong, and valid admin-key cases

Fixes #4714

## Validation
- python3 -B -m pytest tests/test_contributor_registry.py -q
- python3 -B -m py_compile contributor_registry.py tests/test_contributor_registry.py
- git diff --check origin/main..HEAD
- python3 tools/bcos_spdx_check.py --base-ref origin/main