### PR TITLE
Fix /faucet/drip 500 on non-string JSON fields

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -56,6 +56,20 @@ def test_drip_rejects_non_object_json(app, body):
     assert r.get_json() == {"ok": False, "error": "json_object_required"}
 
 
+def test_drip_rejects_non_string_wallet_field(app):
+    c = app.test_client()
+    r = c.post("/faucet/drip", json={"wallet": ["rtc_wallet_1"]})
+    assert r.status_code == 400
+    assert r.get_json() == {"ok": False, "error": "wallet_must_be_string"}
+
+
+def test_drip_rejects_non_string_github_username_field(app):
+    c = app.test_client()
+    r = c.post("/faucet/drip", json={"wallet": "rtc_wallet_1", "github_username": ["alice"]})
+    assert r.status_code == 400
+    assert r.get_json() == {"ok": False, "error": "github_username_must_be_string"}
+
+
 def test_drip_accepts_form_payload(app):
     c = app.test_client()
     r = c.post("/faucet/drip", data={"wallet": "form_wallet"})

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -93,6 +93,15 @@ def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
     return data, None
 
 
+def _normalize_text_field(data: dict[str, Any], key: str) -> tuple[str | None, tuple[Any, int] | None]:
+    value = data.get(key)
+    if value is None:
+        return None, None
+    if not isinstance(value, str):
+        return None, (jsonify({"ok": False, "error": f"{key}_must_be_string"}), 400)
+    return value.strip(), None
+
+
 def _sum_last_24h(conn: sqlite3.Connection, github_username: str | None, ip: str) -> float:
     since = (_utcnow() - timedelta(hours=24)).isoformat()
     if github_username:
@@ -173,8 +182,14 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         data, error = _request_data()
         if error:
             return error
-        wallet = (data.get("wallet") or "").strip()
-        github_username = (data.get("github_username") or "").strip() or None
+        wallet, wallet_error = _normalize_text_field(data, "wallet")
+        if wallet_error:
+            return wallet_error
+        github_username, github_error = _normalize_text_field(data, "github_username")
+        if github_error:
+            return github_error
+        wallet = wallet or ""
+        github_username = github_username or None
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()
 
         if not wallet:


### PR DESCRIPTION
Fixes #5602

## Scope
- validate `wallet` and `github_username` are strings before `.strip()`
- return stable 400 errors (`wallet_must_be_string`, `github_username_must_be_string`) for malformed field types
- add regression tests in `tests/test_faucet.py`

## Validation
- Could not run `pytest` in this environment (`python3 -m pytest` unavailable because pytest is not installed).
- Local environment also misses runtime dependency `requests`, so app-level repro script could not run here.
