### PR TITLE
Fix merkle-validation test import failure without RC_P2P_SECRET

### DIFF
--- a/node/tests/test_epoch_proposal_merkle_validation.py
+++ b/node/tests/test_epoch_proposal_merkle_validation.py
@@ -33,6 +33,7 @@ from unittest.mock import patch
 # Add node directory to path
 NODE_DIR = os.path.join(os.path.dirname(__file__), '..', 'node')
 sys.path.insert(0, NODE_DIR)
+os.environ.setdefault("RC_P2P_SECRET", "a" * 64)
 
 from rustchain_p2p_gossip import GossipLayer, GossipMessage, MessageType
 


### PR DESCRIPTION
Fixes #5511

## Scope
- set `RC_P2P_SECRET` in `node/tests/test_epoch_proposal_merkle_validation.py` before importing `rustchain_p2p_gossip`
- aligns this test with existing P2P test pattern to avoid collection-time `SystemExit`

## Validation
- Could not execute local `pytest` because the environment does not have `pytest` installed.
