### PR TITLE
Fix explorer miner response normalization

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -127,6 +127,11 @@ function getRustBadge(score) {
     return 'Fresh Metal';
 }
 
+
+function normalizeMinersResponse(response) {
+    return Array.isArray(response) ? response : (response?.miners || []);
+}
+
 // API Fetcher with Error Handling
 async function fetchAPI(endpoint, options = {}) {
     const url = `${CONFIG.API_BASE}${endpoint}`;
@@ -204,7 +209,7 @@ async function fetchMiners() {
     try {
         state.loading.miners = true;
         state.error.miners = null;
-        state.miners = await fetchAPI('/api/miners') || [];
+        state.miners = normalizeMinersResponse(await fetchAPI('/api/miners'));
     } catch (error) {
         state.error.miners = error.message;
         // Fallback mock data

--- a/tests/test_explorer_miners_normalization.py
+++ b/tests/test_explorer_miners_normalization.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+JS = Path('explorer/static/js/explorer.js').read_text()
+
+
+def test_explorer_normalizes_paginated_miners_response():
+    assert 'function normalizeMinersResponse(response)' in JS
+    assert 'response?.miners || []' in JS
+    assert "state.miners = normalizeMinersResponse(await fetchAPI('/api/miners'));" in JS
+
+
+def test_explorer_keeps_legacy_array_response_compatible():
+    assert 'Array.isArray(response) ? response' in JS


### PR DESCRIPTION
## Summary\n- Normalize /api/miners responses before rendering the explorer miners table\n- Support both legacy array responses and current paginated { miners, pagination } envelopes\n- Add a small regression test that guards the normalization path\n\nFixes #5614\n\n## Test\n- python3 -m pytest -q tests/test_explorer_miners_normalization.py\n\n## Bounty\nClaiming under bug bounty #305.\nPayout/miner id: iamdinhthuan