### PR TITLE
fix: render explorer miners from paginated API response

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -127,6 +127,12 @@ function getRustBadge(score) {
     return 'Fresh Metal';
 }
 
+function normalizeMinersPayload(payload) {
+    if (Array.isArray(payload)) return payload;
+    if (payload && Array.isArray(payload.miners)) return payload.miners;
+    return [];
+}
+
 // API Fetcher with Error Handling
 async function fetchAPI(endpoint, options = {}) {
     const url = `${CONFIG.API_BASE}${endpoint}`;
@@ -204,7 +210,7 @@ async function fetchMiners() {
     try {
         state.loading.miners = true;
         state.error.miners = null;
-        state.miners = await fetchAPI('/api/miners') || [];
+        state.miners = normalizeMinersPayload(await fetchAPI('/api/miners'));
     } catch (error) {
         state.error.miners = error.message;
         // Fallback mock data
@@ -754,5 +760,6 @@ window.RustChainExplorer = {
         fetchTransactions()
     ]),
     search: handleSearch,
-    switchTab
+    switchTab,
+    normalizeMinersPayload
 };

--- a/tests/test_explorer_miners_payload.py
+++ b/tests/test_explorer_miners_payload.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPLORER_JS = REPO_ROOT / "explorer" / "static" / "js" / "explorer.js"
+
+
+def run_node(script):
+    return subprocess.run(
+        ["node", "-e", script],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout
+
+
+def test_explorer_normalizes_paginated_miners_payload():
+    script = textwrap.dedent(
+        f"""
+        const fs = require('fs');
+        const vm = require('vm');
+
+        const sandbox = {{
+          console,
+          setTimeout,
+          clearTimeout,
+          setInterval: () => 0,
+          fetch: async () => {{ throw new Error('fetch should not run'); }},
+          window: {{ EXPLORER_API_BASE: 'https://node.example' }},
+          document: {{
+            addEventListener: () => {{}},
+            querySelectorAll: () => [],
+            getElementById: () => null
+          }}
+        }};
+        sandbox.window.window = sandbox.window;
+        sandbox.window.document = sandbox.document;
+
+        vm.createContext(sandbox);
+        vm.runInContext(fs.readFileSync({json.dumps(str(EXPLORER_JS))}, 'utf8'), sandbox);
+
+        const normalize = sandbox.window.RustChainExplorer.normalizeMinersPayload;
+        const rows = normalize({{
+          miners: [
+            {{ miner_id: 'miner-a', device_arch: 'PowerPC G4' }},
+            {{ miner_id: 'miner-b', device_arch: 'x86_64' }}
+          ],
+          pagination: {{ total: 2, limit: 20, offset: 0 }}
+        }});
+
+        console.log(JSON.stringify({{
+          paginatedCount: rows.length,
+          firstMiner: rows[0].miner_id,
+          arrayCount: normalize([{{ miner_id: 'direct' }}]).length,
+          invalidCount: normalize({{ pagination: {{ total: 0 }} }}).length
+        }}));
+        """
+    )
+
+    result = json.loads(run_node(script))
+
+    assert result == {
+        "paginatedCount": 2,
+        "firstMiner": "miner-a",
+        "arrayCount": 1,
+        "invalidCount": 0,
+    }


### PR DESCRIPTION
## Summary
- normalize the explorer /api/miners payload so both legacy arrays and the current { miners, pagination } envelope render as miner rows
- keep invalid miner payloads as an empty list instead of leaving state.miners as a non-array object
- add a Node VM regression test for the paginated miners response shape

Fixes #5614.
Related bounty claim: #305.
Payout/miner id: iamdinhthuan.

## Validation
- python3 -B -m pytest -q tests/test_explorer_miners_payload.py explorer/test_realtime.py tests/test_tools_explorer_security.py --tb=short
- node --check explorer/static/js/explorer.js
- git diff --check origin/main...HEAD -- explorer/static/js/explorer.js tests/test_explorer_miners_payload.py
- git diff --check -- explorer/static/js/explorer.js tests/test_explorer_miners_payload.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main

## Safety
No private credentials, wallet actions, withdrawals, transfers, production writes, or secret material were used. This PR is a public bug fix only; payout is subject to maintainer triage/merge.