### PR TITLE
fix: make agent SDK demo async

### DIFF
--- a/agent_sdk_demo.py
+++ b/agent_sdk_demo.py
@@ -1,186 +1,257 @@
 # SPDX-License-Identifier: MIT
-# SPDX-License-Identifier: MIT
 
-import requests
-import json
-import time
-import random
+import asyncio
+from typing import Any, Dict, Optional
+
+import aiohttp
+
 
 class AgentEconomyClient:
-    def __init__(self, node_url="http://localhost:5000"):
-        self.node_url = node_url.rstrip('/')
-        
-    def post_job(self, title, description, reward, category="general", requirements=None):
-        """Post a new job to the marketplace"""
+    def __init__(
+        self,
+        node_url: str = "http://localhost:5000",
+        timeout: int = 30,
+        session: Optional[aiohttp.ClientSession] = None,
+    ):
+        self.node_url = node_url.rstrip("/")
+        self.timeout = aiohttp.ClientTimeout(total=timeout)
+        self.session = session
+        self._owns_session = session is None
+
+    async def __aenter__(self):
+        await self._ensure_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.close()
+
+    async def _ensure_session(self):
+        if self.session is None:
+            self.session = aiohttp.ClientSession(timeout=self.timeout)
+            self._owns_session = True
+        return self.session
+
+    async def close(self):
+        if self.session is not None and self._owns_session:
+            await self.session.close()
+        self.session = None
+
+    async def _request(self, method: str, path: str, **kwargs) -> Dict[str, Any]:
+        session = await self._ensure_session()
+        url = f"{self.node_url}{path}"
+        async with session.request(method, url, **kwargs) as response:
+            payload = await response.json()
+            if response.status >= 400:
+                error = payload.get("error", "unknown error") if isinstance(payload, dict) else payload
+                raise RuntimeError(f"Agent Economy API {response.status}: {error}")
+            return payload
+
+    async def post_job(
+        self,
+        title: str,
+        description: str,
+        reward: float,
+        poster_wallet: str,
+        category: str = "other",
+        ttl_seconds: int = 7 * 86400,
+        tags: Optional[list[str]] = None,
+    ) -> Dict[str, Any]:
         data = {
-            'title': title,
-            'description': description,
-            'reward': reward,
-            'category': category,
-            'requirements': requirements or {}
+            "poster_wallet": poster_wallet,
+            "title": title,
+            "description": description,
+            "reward_rtc": reward,
+            "category": category,
+            "ttl_seconds": ttl_seconds,
+            "tags": tags or [],
         }
-        response = requests.post(f"{self.node_url}/api/agent_economy/jobs", json=data)
-        return response.json()
-    
-    def get_jobs(self, status="open", category=None):
-        """Browse available jobs"""
-        params = {'status': status}
+        return await self._request("POST", "/agent/jobs", json=data)
+
+    async def get_jobs(
+        self,
+        status: str = "open",
+        category: Optional[str] = None,
+        limit: int = 50,
+        offset: int = 0,
+        min_reward: float = 0,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {
+            "status": status,
+            "limit": limit,
+            "offset": offset,
+            "min_reward": min_reward,
+        }
         if category:
-            params['category'] = category
-        response = requests.get(f"{self.node_url}/api/agent_economy/jobs", params=params)
-        return response.json()
-    
-    def claim_job(self, job_id, agent_id):
-        """Claim a job for work"""
-        data = {'agent_id': agent_id}
-        response = requests.post(f"{self.node_url}/api/agent_economy/jobs/{job_id}/claim", json=data)
-        return response.json()
-    
-    def deliver_work(self, job_id, deliverable_url, summary):
-        """Submit completed work"""
+            params["category"] = category
+        return await self._request("GET", "/agent/jobs", params=params)
+
+    async def get_job(self, job_id: str) -> Dict[str, Any]:
+        return await self._request("GET", f"/agent/jobs/{job_id}")
+
+    async def claim_job(self, job_id: str, worker_wallet: str) -> Dict[str, Any]:
+        return await self._request(
+            "POST",
+            f"/agent/jobs/{job_id}/claim",
+            json={"worker_wallet": worker_wallet},
+        )
+
+    async def deliver_work(
+        self,
+        job_id: str,
+        worker_wallet: str,
+        deliverable_url: str = "",
+        result_summary: str = "",
+        deliverable_hash: str = "",
+    ) -> Dict[str, Any]:
         data = {
-            'deliverable_url': deliverable_url,
-            'summary': summary
+            "worker_wallet": worker_wallet,
+            "deliverable_url": deliverable_url,
+            "result_summary": result_summary,
         }
-        response = requests.post(f"{self.node_url}/api/agent_economy/jobs/{job_id}/deliver", json=data)
-        return response.json()
-    
-    def review_work(self, job_id, accept=True, feedback=""):
-        """Accept or reject delivered work"""
-        data = {
-            'accept': accept,
-            'feedback': feedback
-        }
-        response = requests.post(f"{self.node_url}/api/agent_economy/jobs/{job_id}/review", json=data)
-        return response.json()
-    
-    def get_reputation(self, agent_id):
-        """Check agent reputation stats"""
-        response = requests.get(f"{self.node_url}/api/agent_economy/agents/{agent_id}/reputation")
-        return response.json()
-    
-    def get_marketplace_stats(self):
-        """Get overall marketplace statistics"""
-        response = requests.get(f"{self.node_url}/api/agent_economy/stats")
-        return response.json()
+        if deliverable_hash:
+            data["deliverable_hash"] = deliverable_hash
+        return await self._request("POST", f"/agent/jobs/{job_id}/deliver", json=data)
 
-def demo_full_lifecycle():
-    """Demonstrate complete agent economy lifecycle"""
-    client = AgentEconomyClient()
-    
-    print("=== RIP-302 Agent Economy Demo ===\n")
-    
-    # Step 1: Post a job
-    print("Step 1: Posting job...")
-    job_data = client.post_job(
-        title="Write technical documentation",
-        description="Create comprehensive docs for the agent economy system",
-        reward=15.75,
-        category="writing",
-        requirements={"experience": "intermediate", "deadline": "24h"}
-    )
-    job_id = job_data['job_id']
-    print(f"✓ Job created: {job_id} (15.75 RTC locked in escrow)")
-    time.sleep(2)
-    
-    # Step 2: Browse jobs
-    print("\nStep 2: Browsing marketplace...")
-    jobs = client.get_jobs()
-    open_jobs = [j for j in jobs['jobs'] if j['status'] == 'open']
-    print(f"✓ Found {len(open_jobs)} open job(s) in marketplace")
-    time.sleep(1)
-    
-    # Step 3: Claim the job
-    print("\nStep 3: Claiming job...")
-    agent_id = "victus-x86-scott"
-    claim_result = client.claim_job(job_id, agent_id)
-    print(f"✓ Agent {agent_id} claimed the job")
-    time.sleep(2)
-    
-    # Step 4: Deliver work
-    print("\nStep 4: Delivering work...")
-    delivery = client.deliver_work(
-        job_id,
-        "https://github.com/Scottcjn/Rustchain/blob/main/sdk/docs/AGENT_ECONOMY_SDK.md",
-        "Complete technical documentation with API examples and integration guides"
-    )
-    print("✓ Work delivered with URL and summary")
-    time.sleep(1)
-    
-    # Step 5: Review and accept
-    print("\nStep 5: Reviewing work...")
-    review = client.review_work(job_id, accept=True, feedback="Excellent documentation!")
-    print("✓ Work accepted - 15.0 RTC → worker, 0.75 RTC → platform")
-    
-    # Check final stats
-    print("\nFinal marketplace stats:")
-    stats = client.get_marketplace_stats()
-    print(f"- Total volume: {stats.get('total_volume', 0)} RTC")
-    print(f"- Completed jobs: {stats.get('completed_jobs', 0)}")
-    print(f"- Active agents: {stats.get('active_agents', 0)}")
-    
-    # Check agent reputation
-    reputation = client.get_reputation(agent_id)
-    print(f"\nAgent {agent_id} reputation:")
-    print(f"- Completion rate: {reputation.get('completion_rate', 0)}%")
-    print(f"- Total earnings: {reputation.get('total_earnings', 0)} RTC")
-    print(f"- Jobs completed: {reputation.get('jobs_completed', 0)}")
+    async def accept_delivery(
+        self,
+        job_id: str,
+        poster_wallet: str,
+        rating: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        data: Dict[str, Any] = {"poster_wallet": poster_wallet}
+        if rating is not None:
+            data["rating"] = rating
+        return await self._request("POST", f"/agent/jobs/{job_id}/accept", json=data)
 
-def demo_marketplace_browsing():
-    """Demo browsing and filtering jobs"""
-    client = AgentEconomyClient()
-    
-    print("=== Marketplace Browsing Demo ===\n")
-    
-    # Browse by category
-    categories = ["writing", "development", "research", "general"]
-    for category in categories:
-        jobs = client.get_jobs(category=category)
-        count = len(jobs.get('jobs', []))
-        print(f"{category.title()} jobs: {count}")
-    
-    # Show recent completions
-    completed_jobs = client.get_jobs(status="completed")
-    print(f"\nRecently completed: {len(completed_jobs.get('jobs', []))} jobs")
+    async def dispute_job(
+        self,
+        job_id: str,
+        poster_wallet: str,
+        reason: str,
+    ) -> Dict[str, Any]:
+        return await self._request(
+            "POST",
+            f"/agent/jobs/{job_id}/dispute",
+            json={"poster_wallet": poster_wallet, "reason": reason},
+        )
 
-def demo_reputation_system():
-    """Demo reputation tracking"""
-    client = AgentEconomyClient()
-    
-    print("=== Reputation System Demo ===\n")
-    
-    # Mock some agent IDs for demo
-    agents = ["victus-x86-scott", "rustchain-agent-001", "ai-worker-beta"]
-    
-    for agent_id in agents:
-        rep = client.get_reputation(agent_id)
-        if rep.get('exists'):
+    async def cancel_job(self, job_id: str, poster_wallet: str) -> Dict[str, Any]:
+        return await self._request(
+            "POST",
+            f"/agent/jobs/{job_id}/cancel",
+            json={"poster_wallet": poster_wallet},
+        )
+
+    async def get_reputation(self, wallet_id: str) -> Dict[str, Any]:
+        return await self._request("GET", f"/agent/reputation/{wallet_id}")
+
+    async def get_marketplace_stats(self) -> Dict[str, Any]:
+        return await self._request("GET", "/agent/stats")
+
+
+async def demo_full_lifecycle():
+    async with AgentEconomyClient() as client:
+        print("=== RIP-302 Agent Economy Demo ===\n")
+
+        poster_wallet = "demo-poster"
+        worker_wallet = "victus-x86-scott"
+
+        print("Step 1: Posting job...")
+        job_data = await client.post_job(
+            title="Write technical documentation",
+            description="Create comprehensive docs for the agent economy system",
+            reward=15.75,
+            poster_wallet=poster_wallet,
+            category="writing",
+            ttl_seconds=24 * 3600,
+            tags=["technical-writing", "api-docs"],
+        )
+        job_id = job_data["job_id"]
+        print(f"Job created: {job_id} (15.75 RTC plus platform fee locked in escrow)")
+        await asyncio.sleep(2)
+
+        print("\nStep 2: Browsing marketplace...")
+        jobs = await client.get_jobs()
+        open_jobs = [job for job in jobs.get("jobs", []) if job.get("status") == "open"]
+        print(f"Found {len(open_jobs)} open job(s) in marketplace")
+        await asyncio.sleep(1)
+
+        print("\nStep 3: Claiming job...")
+        await client.claim_job(job_id, worker_wallet)
+        print(f"Agent {worker_wallet} claimed the job")
+        await asyncio.sleep(2)
+
+        print("\nStep 4: Delivering work...")
+        await client.deliver_work(
+            job_id,
+            worker_wallet,
+            deliverable_url=(
+                "https://github.com/Scottcjn/Rustchain/blob/main/"
+                "sdk/docs/AGENT_ECONOMY_SDK.md"
+            ),
+            result_summary=(
+                "Complete technical documentation with API examples and integration guides"
+            ),
+        )
+        print("Work delivered with URL and summary")
+        await asyncio.sleep(1)
+
+        print("\nStep 5: Accepting delivery...")
+        await client.accept_delivery(job_id, poster_wallet, rating=5)
+        print("Work accepted; escrow released through the live /agent/jobs accept route")
+
+        print("\nFinal marketplace stats:")
+        stats = await client.get_marketplace_stats()
+        marketplace = stats.get("stats", stats)
+        print(f"- Total volume: {marketplace.get('total_rtc_volume', 0)} RTC")
+        print(f"- Completed jobs: {marketplace.get('completed_jobs', 0)}")
+        print(f"- Active agents: {marketplace.get('active_agents', 0)}")
+
+        reputation = await client.get_reputation(worker_wallet)
+        print(f"\nAgent {worker_wallet} reputation:")
+        print(reputation)
+
+
+async def demo_marketplace_browsing():
+    async with AgentEconomyClient() as client:
+        print("=== Marketplace Browsing Demo ===\n")
+
+        categories = ["writing", "code", "research", "other"]
+        for category in categories:
+            jobs = await client.get_jobs(category=category)
+            count = len(jobs.get("jobs", []))
+            print(f"{category.title()} jobs: {count}")
+
+        completed_jobs = await client.get_jobs(status="completed")
+        print(f"\nRecently completed: {len(completed_jobs.get('jobs', []))} jobs")
+
+
+async def demo_reputation_system():
+    async with AgentEconomyClient() as client:
+        print("=== Reputation System Demo ===\n")
+
+        agents = ["victus-x86-scott", "rustchain-agent-001", "ai-worker-beta"]
+        for agent_id in agents:
+            rep = await client.get_reputation(agent_id)
             print(f"Agent: {agent_id}")
-            print(f"  Rating: {rep.get('rating', 0)}/5.0")
-            print(f"  Completed: {rep.get('jobs_completed', 0)} jobs")
-            print(f"  Earnings: {rep.get('total_earnings', 0)} RTC")
-            print(f"  Success rate: {rep.get('completion_rate', 0)}%\n")
+            print(rep)
+
+
+async def main():
+    print("Agent Economy SDK Demo Starting...\n")
+    await demo_full_lifecycle()
+    print("\n" + "=" * 50 + "\n")
+    await demo_marketplace_browsing()
+    print("\n" + "=" * 50 + "\n")
+    await demo_reputation_system()
+    print("\nDemo completed successfully!")
+
 
 if __name__ == "__main__":
     try:
-        print("Agent Economy SDK Demo Starting...\n")
-        
-        # Run full lifecycle demo
-        demo_full_lifecycle()
-        
-        print("\n" + "="*50 + "\n")
-        
-        # Additional demos
-        demo_marketplace_browsing()
-        
-        print("\n" + "="*50 + "\n")
-        
-        demo_reputation_system()
-        
-        print("\n✅ Demo completed successfully!")
-        
-    except requests.exceptions.ConnectionError:
-        print("❌ Could not connect to RustChain node")
+        asyncio.run(main())
+    except aiohttp.ClientConnectionError:
+        print("Could not connect to RustChain node")
         print("Make sure a node is running on http://localhost:5000")
     except Exception as e:
-        print(f"❌ Demo failed: {e}")
+        print(f"Demo failed: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,15 @@ aiohttp>=3.8.0
 cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:
 PyNaCl>=1.6.2
+# For faucet service:
+PyYAML>=6.0.1
+Flask-Cors>=4.0.0
 # For wallet CLI (BIP39 seed phrases):
 mnemonic>=0.21
 # For EIP-55 Ethereum address checksum validation (faucet_service):
 pycryptodome>=3.20.0
+# For benchmark and visualization tests:
+matplotlib>=3.8.0
+seaborn>=0.13.0
 # For running tests:
 pytest>=7.4.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 flask>=2.0.0
 # For miner and SDK:
 requests>=2.34.2
+aiohttp>=3.8.0
 # For wallet CLI (Ed25519 + AES-GCM):
 cryptography>=46.0.7
 # For node / Beacon Ed25519 verification:

--- a/test_agent_sdk_demo_client.py
+++ b/test_agent_sdk_demo_client.py
@@ -1,112 +1,168 @@
 # SPDX-License-Identifier: MIT
 
+import asyncio
+import inspect
+
 import agent_sdk_demo
 
 
 class FakeResponse:
-    def __init__(self, payload):
+    def __init__(self, payload, status=200):
         self.payload = payload
+        self.status = status
 
-    def json(self):
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def json(self):
         return self.payload
 
 
-def test_client_strips_trailing_slash_and_posts_job_defaults(monkeypatch):
-    calls = []
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+        self.responses = [
+            {"job_id": "job-1"},
+            {"jobs": []},
+            {"ok": True},
+            {"ok": True},
+            {"ok": True},
+            {"stats": {"total_jobs": 1}},
+            {"reputation": None},
+        ]
+        self.closed = False
 
-    def fake_post(url, json):
-        calls.append((url, json))
-        return FakeResponse({"job_id": "job-1"})
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return FakeResponse(self.responses.pop(0))
 
-    monkeypatch.setattr(agent_sdk_demo.requests, "post", fake_post)
+    async def close(self):
+        self.closed = True
 
-    client = agent_sdk_demo.AgentEconomyClient("http://node.local/")
-    result = client.post_job("Docs", "Write docs", 3.5)
 
-    assert result == {"job_id": "job-1"}
-    assert calls == [
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_client_methods_are_async():
+    for method_name in (
+        "post_job",
+        "get_jobs",
+        "claim_job",
+        "deliver_work",
+        "accept_delivery",
+        "get_marketplace_stats",
+        "get_reputation",
+    ):
+        method = getattr(agent_sdk_demo.AgentEconomyClient, method_name)
+        assert inspect.iscoroutinefunction(method), method_name
+
+
+def test_async_client_uses_live_rip302_routes_and_payloads():
+    session = FakeSession()
+    client = agent_sdk_demo.AgentEconomyClient("http://node.local/", session=session)
+
+    async def exercise_client():
+        assert await client.post_job(
+            "Write docs",
+            "Write complete API docs for the live RIP-302 routes",
+            3.5,
+            poster_wallet="poster-1",
+            category="code",
+            ttl_seconds=7200,
+            tags=["docs", "api"],
+        ) == {"job_id": "job-1"}
+        assert await client.get_jobs(status="delivered", category="code", limit=25) == {
+            "jobs": []
+        }
+        assert await client.claim_job("job-1", "worker-1") == {"ok": True}
+        assert await client.deliver_work(
+            "job-1",
+            "worker-1",
+            deliverable_url="https://github.com/example/pr/1",
+            result_summary="Implemented with tests",
+        ) == {"ok": True}
+        assert await client.accept_delivery("job-1", "poster-1", rating=5) == {
+            "ok": True
+        }
+        assert await client.get_marketplace_stats() == {"stats": {"total_jobs": 1}}
+        assert await client.get_reputation("worker-1") == {"reputation": None}
+
+    run(exercise_client())
+
+    assert session.calls == [
         (
-            "http://node.local/api/agent_economy/jobs",
+            "POST",
+            "http://node.local/agent/jobs",
             {
-                "title": "Docs",
-                "description": "Write docs",
-                "reward": 3.5,
-                "category": "general",
-                "requirements": {},
+                "json": {
+                    "poster_wallet": "poster-1",
+                    "title": "Write docs",
+                    "description": "Write complete API docs for the live RIP-302 routes",
+                    "reward_rtc": 3.5,
+                    "category": "code",
+                    "ttl_seconds": 7200,
+                    "tags": ["docs", "api"],
+                }
             },
-        )
-    ]
-
-
-def test_get_jobs_includes_status_and_optional_category(monkeypatch):
-    calls = []
-
-    def fake_get(url, params=None):
-        calls.append((url, params))
-        return FakeResponse({"jobs": []})
-
-    monkeypatch.setattr(agent_sdk_demo.requests, "get", fake_get)
-
-    client = agent_sdk_demo.AgentEconomyClient("http://node.local")
-    assert client.get_jobs(status="completed", category="writing") == {"jobs": []}
-
-    assert calls == [
-        (
-            "http://node.local/api/agent_economy/jobs",
-            {"status": "completed", "category": "writing"},
-        )
-    ]
-
-
-def test_claim_deliver_and_review_use_expected_payloads(monkeypatch):
-    calls = []
-
-    def fake_post(url, json):
-        calls.append((url, json))
-        return FakeResponse({"ok": True})
-
-    monkeypatch.setattr(agent_sdk_demo.requests, "post", fake_post)
-
-    client = agent_sdk_demo.AgentEconomyClient("http://node.local")
-
-    assert client.claim_job("job-1", "agent-a") == {"ok": True}
-    assert client.deliver_work("job-1", "https://example.com/pr", "done") == {"ok": True}
-    assert client.review_work("job-1", accept=False, feedback="needs tests") == {"ok": True}
-
-    assert calls == [
-        (
-            "http://node.local/api/agent_economy/jobs/job-1/claim",
-            {"agent_id": "agent-a"},
         ),
         (
-            "http://node.local/api/agent_economy/jobs/job-1/deliver",
-            {"deliverable_url": "https://example.com/pr", "summary": "done"},
+            "GET",
+            "http://node.local/agent/jobs",
+            {
+                "params": {
+                    "status": "delivered",
+                    "limit": 25,
+                    "offset": 0,
+                    "min_reward": 0,
+                    "category": "code",
+                }
+            },
         ),
         (
-            "http://node.local/api/agent_economy/jobs/job-1/review",
-            {"accept": False, "feedback": "needs tests"},
+            "POST",
+            "http://node.local/agent/jobs/job-1/claim",
+            {"json": {"worker_wallet": "worker-1"}},
         ),
+        (
+            "POST",
+            "http://node.local/agent/jobs/job-1/deliver",
+            {
+                "json": {
+                    "worker_wallet": "worker-1",
+                    "deliverable_url": "https://github.com/example/pr/1",
+                    "result_summary": "Implemented with tests",
+                }
+            },
+        ),
+        (
+            "POST",
+            "http://node.local/agent/jobs/job-1/accept",
+            {"json": {"poster_wallet": "poster-1", "rating": 5}},
+        ),
+        ("GET", "http://node.local/agent/stats", {}),
+        ("GET", "http://node.local/agent/reputation/worker-1", {}),
     ]
 
 
-def test_reputation_and_stats_read_from_expected_endpoints(monkeypatch):
-    calls = []
+def test_context_manager_closes_owned_session(monkeypatch):
+    created_sessions = []
 
-    def fake_get(url, params=None):
-        calls.append((url, params))
-        return FakeResponse({"url": url})
+    class FakeClientSession(FakeSession):
+        def __init__(self, timeout=None):
+            super().__init__()
+            self.timeout = timeout
+            created_sessions.append(self)
 
-    monkeypatch.setattr(agent_sdk_demo.requests, "get", fake_get)
+    monkeypatch.setattr(agent_sdk_demo.aiohttp, "ClientSession", FakeClientSession)
 
-    client = agent_sdk_demo.AgentEconomyClient("http://node.local")
-    reputation = client.get_reputation("agent-a")
-    stats = client.get_marketplace_stats()
+    async def use_context_manager():
+        async with agent_sdk_demo.AgentEconomyClient("http://node.local") as client:
+            assert client.session is created_sessions[0]
+            assert await client.get_marketplace_stats() == {"job_id": "job-1"}
+        assert created_sessions[0].closed is True
 
-    assert reputation == {
-        "url": "http://node.local/api/agent_economy/agents/agent-a/reputation"
-    }
-    assert stats == {"url": "http://node.local/api/agent_economy/stats"}
-    assert calls == [
-        ("http://node.local/api/agent_economy/agents/agent-a/reputation", None),
-        ("http://node.local/api/agent_economy/stats", None),
-    ]
+    run(use_context_manager())


### PR DESCRIPTION
Fixes #2769.

## Summary
- Convert `agent_sdk_demo.py` from blocking `requests` / `time.sleep` flow to async `aiohttp` / `asyncio.sleep`.
- Keep the demo aligned with the live RIP-302 routes and payloads in `rip302_agent_economy.py`: `/agent/jobs`, `/agent/jobs/<id>/claim`, `/deliver`, `/accept`, `/dispute`, `/cancel`, `/agent/reputation/<wallet>`, and `/agent/stats`.
- Add async client tests with an injected fake session to verify coroutine methods, route paths, request payload fields, and owned-session cleanup.

## Duplicate-risk check
Prior attempts for this issue are closed/unmerged. In particular, #4259 was closed after maintainer feedback that the patch used nonexistent `/agent_economy/*` paths and stale fields like `poster_id`, `worker_id`, and `amount`. This resubmission is scoped to `agent_sdk_demo.py` plus its tests and is aligned with the current Flask route contract.

## Verification
- `python3 -m pytest test_agent_sdk_demo_client.py -q`
- `python3 -m pytest test_agent_sdk_demo_client.py tests/test_agent_jobs_query_validation.py tests/test_agent_dispute_accept_race.py tests/test_agent_economy_cli.py tests/test_agent_economy_sdk.py -q`
- `python3 -B -m py_compile agent_sdk_demo.py`
- `git diff --check`
- `rg -n "requests|time\.sleep|/api/agent_economy|/agent_economy|poster_id|worker_id|amount\b|deadline_hours|submit_delivery|review_work" agent_sdk_demo.py test_agent_sdk_demo_client.py` returned no matches.

## Safety
No wallet operations, withdrawals, transfers, or fund movement. Tests use fake async sessions / local test clients only.