### PR TITLE
fix: reject malformed attestation clock drift cv

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -339,8 +339,26 @@ def _validate_attestation_payload_shape(data):
                 return _attest_field_error("INVALID_REPORT", f"Field 'report.{field_name}' must be a string")
 
     fingerprint = data.get("fingerprint")
-    if isinstance(fingerprint, dict) and "checks" in fingerprint and not isinstance(fingerprint.get("checks"), dict):
-        return _attest_field_error("INVALID_FINGERPRINT_CHECKS", "Field 'fingerprint.checks' must be a JSON object")
+    if isinstance(fingerprint, dict):
+        checks = fingerprint.get("checks")
+        if "checks" in fingerprint and not isinstance(checks, dict):
+            return _attest_field_error("INVALID_FINGERPRINT_CHECKS", "Field 'fingerprint.checks' must be a JSON object")
+        if isinstance(checks, dict):
+            clock_drift = checks.get("clock_drift")
+            if isinstance(clock_drift, dict):
+                clock_data = clock_drift.get("data")
+                if "data" in clock_drift and clock_data is not None and not isinstance(clock_data, dict):
+                    return _attest_field_error(
+                        "INVALID_FINGERPRINT_CHECKS",
+                        "Field 'fingerprint.checks.clock_drift.data' must be a JSON object",
+                    )
+                if isinstance(clock_data, dict) and "cv" in clock_data:
+                    cv = clock_data.get("cv")
+                    if isinstance(cv, bool) or not isinstance(cv, (int, float)) or not math.isfinite(cv):
+                        return _attest_field_error(
+                            "INVALID_FINGERPRINT_CHECKS",
+                            "Field 'fingerprint.checks.clock_drift.data.cv' must be a finite number",
+                        )
 
     return None
 

--- a/tests/fuzz/attestation_validators.py
+++ b/tests/fuzz/attestation_validators.py
@@ -229,14 +229,28 @@ def _validate_attestation_payload_shape(data: Any):
                 )
 
     fingerprint = data.get("fingerprint")
-    if (
-        isinstance(fingerprint, dict)
-        and "checks" in fingerprint
-        and not isinstance(fingerprint.get("checks"), dict)
-    ):
-        return _attest_field_error(
-            "INVALID_FINGERPRINT_CHECKS",
-            "Field 'fingerprint.checks' must be a JSON object",
-        )
+    if isinstance(fingerprint, dict):
+        checks = fingerprint.get("checks")
+        if "checks" in fingerprint and not isinstance(checks, dict):
+            return _attest_field_error(
+                "INVALID_FINGERPRINT_CHECKS",
+                "Field 'fingerprint.checks' must be a JSON object",
+            )
+        if isinstance(checks, dict):
+            clock_drift = checks.get("clock_drift")
+            if isinstance(clock_drift, dict):
+                clock_data = clock_drift.get("data")
+                if "data" in clock_drift and clock_data is not None and not isinstance(clock_data, dict):
+                    return _attest_field_error(
+                        "INVALID_FINGERPRINT_CHECKS",
+                        "Field 'fingerprint.checks.clock_drift.data' must be a JSON object",
+                    )
+                if isinstance(clock_data, dict) and "cv" in clock_data:
+                    cv = clock_data.get("cv")
+                    if isinstance(cv, bool) or not isinstance(cv, (int, float)) or not math.isfinite(cv):
+                        return _attest_field_error(
+                            "INVALID_FINGERPRINT_CHECKS",
+                            "Field 'fingerprint.checks.clock_drift.data.cv' must be a finite number",
+                        )
 
     return None

--- a/tests/test_attestation_fuzz.py
+++ b/tests/test_attestation_fuzz.py
@@ -254,6 +254,18 @@ def test_attest_submit_rejects_invalid_miner_id_even_when_miner_is_valid(client)
     assert response.get_json()["code"] == "INVALID_MINER"
 
 
+@pytest.mark.parametrize("cv", ["abc", [], {"nested": "bad"}])
+def test_attest_submit_rejects_malformed_clock_drift_cv(client, cv):
+    payload = _attach_live_challenge(client, _base_payload())
+    payload["fingerprint"]["checks"]["clock_drift"]["data"]["cv"] = cv
+
+    response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["ok"] is False
+    assert response.get_json()["code"] == "INVALID_FINGERPRINT_CHECKS"
+
+
 def test_validate_fingerprint_data_rejects_non_dict_input():
     passed, reason = integrated_node.validate_fingerprint_data(["not", "a", "dict"])
 


### PR DESCRIPTION
## Summary
- reject malformed nested `fingerprint.checks.clock_drift.data.cv` values during `/attest/submit` payload-shape validation
- mirror the production validator change in the extracted fuzz validator used by `tests/fuzz/run_fuzz.py`
- add a regression test for string/list/object `cv` values so the route returns structured 400 errors instead of 500s

## Root cause
`_validate_attestation_payload_shape()` only checked that `fingerprint.checks` was an object. A request with a fresh challenge nonce and otherwise valid attestation could send a non-numeric `clock_drift.data.cv`; that value then reached `validate_fingerprint_data()` and raised `TypeError` at `cv < 0.0001`, producing HTTP 500 `INTERNAL_ERROR`.

This follows up the non-duplicate fuzz report on rustchain-bounties #1112: https://github.com/Scottcjn/rustchain-bounties/issues/1112#issuecomment-4472952697

## Validation
```bash
PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_attestation_fuzz.py::test_attest_submit_rejects_malformed_clock_drift_cv -q -p no:cacheprovider
# 3 passed

PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_attestation_fuzz.py -q -p no:cacheprovider
# 38 passed

PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_attestation_regression.py -q -p no:cacheprovider
# 64 passed, 18 skipped

PYTHONDONTWRITEBYTECODE=1 python3 tests/fuzz/run_fuzz.py --corpus-only
# Corpus results: 11 passed, 0 failed

python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_attestation_fuzz.py tests/fuzz/attestation_validators.py
# passed

git diff --check
# passed

python3 tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```
