### PR TITLE
fix: validate attestation clock drift metrics

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -244,6 +244,18 @@ def _attest_is_valid_positive_int(value, max_value=4096):
     return 1 <= coerced <= max_value
 
 
+def _attest_is_finite_number(value):
+    """Accept finite JSON numeric values while rejecting bools and nested shapes."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        try:
+            return math.isfinite(float(value))
+        except (OverflowError, ValueError):
+            return False
+    return False
+
+
 def client_ip_from_request(req) -> str:
     """Return trusted client IP, honoring proxy headers only for allowlisted peers."""
     remote_addr = _normalize_client_ip(getattr(req, "remote_addr", ""))
@@ -341,6 +353,28 @@ def _validate_attestation_payload_shape(data):
     fingerprint = data.get("fingerprint")
     if isinstance(fingerprint, dict) and "checks" in fingerprint and not isinstance(fingerprint.get("checks"), dict):
         return _attest_field_error("INVALID_FINGERPRINT_CHECKS", "Field 'fingerprint.checks' must be a JSON object")
+    if isinstance(fingerprint, dict) and isinstance(fingerprint.get("checks"), dict):
+        clock_check = fingerprint["checks"].get("clock_drift")
+        if isinstance(clock_check, dict):
+            clock_data = clock_check.get("data")
+            if clock_data is not None and not isinstance(clock_data, dict):
+                return _attest_field_error(
+                    "INVALID_FINGERPRINT_CLOCK_DRIFT",
+                    "Field 'fingerprint.checks.clock_drift.data' must be a JSON object",
+                    status=422,
+                )
+            if isinstance(clock_data, dict):
+                for metric_name in ("cv", "samples"):
+                    if (
+                        metric_name in clock_data
+                        and clock_data[metric_name] is not None
+                        and not _attest_is_finite_number(clock_data[metric_name])
+                    ):
+                        return _attest_field_error(
+                            "INVALID_FINGERPRINT_CLOCK_DRIFT",
+                            f"Field 'fingerprint.checks.clock_drift.data.{metric_name}' must be a finite number",
+                            status=422,
+                        )
 
     return None
 
@@ -2686,8 +2720,17 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
         clock_data = clock_check.get("data", {})
         if not isinstance(clock_data, dict):
             clock_data = {}
+        for metric_name in ("cv", "samples"):
+            if (
+                metric_name in clock_data
+                and clock_data[metric_name] is not None
+                and not _attest_is_finite_number(clock_data[metric_name])
+            ):
+                return False, f"clock_drift_invalid_{metric_name}"
         cv = clock_data.get("cv", 0)
         samples = clock_data.get("samples", 0)
+        cv = float(cv or 0)
+        samples = float(samples or 0)
 
         # Require meaningful sample count
         if clock_check.get("passed") == True and samples == 0 and cv == 0:

--- a/tests/fuzz/attestation_validators.py
+++ b/tests/fuzz/attestation_validators.py
@@ -86,6 +86,18 @@ def _attest_is_valid_positive_int(value: Any, max_value: int = 4096) -> bool:
     return 1 <= coerced <= max_value
 
 
+def _attest_is_finite_number(value: Any) -> bool:
+    """Accept finite JSON numeric values while rejecting bools and nested shapes."""
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        try:
+            return math.isfinite(float(value))
+        except (OverflowError, ValueError):
+            return False
+    return False
+
+
 def _attest_positive_int(value: Any, default: int = 1) -> int:
     """Coerce untrusted integer-like values to a safe positive integer."""
     try:
@@ -238,5 +250,27 @@ def _validate_attestation_payload_shape(data: Any):
             "INVALID_FINGERPRINT_CHECKS",
             "Field 'fingerprint.checks' must be a JSON object",
         )
+    if isinstance(fingerprint, dict) and isinstance(fingerprint.get("checks"), dict):
+        clock_check = fingerprint["checks"].get("clock_drift")
+        if isinstance(clock_check, dict):
+            clock_data = clock_check.get("data")
+            if clock_data is not None and not isinstance(clock_data, dict):
+                return _attest_field_error(
+                    "INVALID_FINGERPRINT_CLOCK_DRIFT",
+                    "Field 'fingerprint.checks.clock_drift.data' must be a JSON object",
+                    status=422,
+                )
+            if isinstance(clock_data, dict):
+                for metric_name in ("cv", "samples"):
+                    if (
+                        metric_name in clock_data
+                        and clock_data[metric_name] is not None
+                        and not _attest_is_finite_number(clock_data[metric_name])
+                    ):
+                        return _attest_field_error(
+                            "INVALID_FINGERPRINT_CLOCK_DRIFT",
+                            f"Field 'fingerprint.checks.clock_drift.data.{metric_name}' must be a finite number",
+                            status=422,
+                        )
 
     return None

--- a/tests/fuzz/regression_corpus/crash_12_clock_drift_cv_type.json
+++ b/tests/fuzz/regression_corpus/crash_12_clock_drift_cv_type.json
@@ -1,0 +1,35 @@
+{
+  "_class": "NESTED_CLOCK_DRIFT_TYPE",
+  "_expected_error_code": "INVALID_FINGERPRINT_CLOCK_DRIFT",
+  "miner": "fuzz-miner",
+  "device": {
+    "cores": 8,
+    "device_arch": "power8"
+  },
+  "signals": {
+    "macs": [
+      "AA:BB:CC:DD:EE:10"
+    ]
+  },
+  "report": {
+    "nonce": "nonce-123",
+    "commitment": "commitment-123"
+  },
+  "fingerprint": {
+    "checks": {
+      "anti_emulation": {
+        "passed": true,
+        "data": {
+          "vm_indicators": []
+        }
+      },
+      "clock_drift": {
+        "passed": true,
+        "data": {
+          "cv": "abc",
+          "samples": 32
+        }
+      }
+    }
+  }
+}

--- a/tests/test_attestation_fuzz.py
+++ b/tests/test_attestation_fuzz.py
@@ -254,6 +254,21 @@ def test_attest_submit_rejects_invalid_miner_id_even_when_miner_is_valid(client)
     assert response.get_json()["code"] == "INVALID_MINER"
 
 
+@pytest.mark.parametrize("bad_value", ["abc", [], {"nested": "bad"}, True])
+def test_attest_submit_rejects_non_numeric_clock_drift_cv(client, bad_value):
+    payload = _attach_live_challenge(client, _base_payload())
+    payload["fingerprint"]["checks"]["clock_drift"]["data"] = {
+        "cv": bad_value,
+        "samples": 32,
+    }
+
+    response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 422
+    assert response.get_json()["ok"] is False
+    assert response.get_json()["code"] == "INVALID_FINGERPRINT_CLOCK_DRIFT"
+
+
 def test_validate_fingerprint_data_rejects_non_dict_input():
     passed, reason = integrated_node.validate_fingerprint_data(["not", "a", "dict"])
 
@@ -357,6 +372,23 @@ def test_attest_submit_mutation_regression_no_unhandled_exceptions(client):
         "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
         "simd_identity": {"passed": True, "data": {"x86_features": "not-a-list"}}
     }},
+    # Non-numeric nested clock drift metrics should fail validation, not raise.
+    {"checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "clock_drift": {"passed": True, "data": {"cv": "abc", "samples": 32}},
+    }},
+    {"checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "clock_drift": {"passed": True, "data": {"cv": [], "samples": 32}},
+    }},
+    {"checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "clock_drift": {"passed": True, "data": {"cv": {"nested": "bad"}, "samples": 32}},
+    }},
+    {"checks": {
+        "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+        "clock_drift": {"passed": True, "data": {"cv": 0.092, "samples": "many"}},
+    }},
     # Empty/malformed checks
     {"checks": None},
     {},
@@ -364,6 +396,10 @@ def test_attest_submit_mutation_regression_no_unhandled_exceptions(client):
     "bridge_type_none", "bridge_type_int", "bridge_type_dict",
     "device_arch_none", "device_arch_int",
     "x86_features_not_list",
+    "clock_drift_cv_string",
+    "clock_drift_cv_list",
+    "clock_drift_cv_dict",
+    "clock_drift_samples_string",
     "checks_none", "checks_empty"
 ])
 def test_validate_fingerprint_data_handles_malformed_inputs_no_crash(malformed_fingerprint):


### PR DESCRIPTION
Refs Scottcjn/rustchain-bounties#1112.
Fuzz report comment: https://github.com/Scottcjn/rustchain-bounties/issues/1112#issuecomment-4472952697
Payout/miner id if accepted: `iamdinhthuan`

## Summary

- reject non-numeric `fingerprint.checks.clock_drift.data.cv` and `samples` values during attestation payload shape validation
- keep `validate_fingerprint_data()` defensive so direct callers return a validation failure instead of raising `TypeError`
- mirror the guard in the extracted fuzz validator and add a regression corpus case
- add endpoint and direct-validator regression coverage for the nested clock-drift type-confusion path

## Root Cause

`_validate_attestation_payload_shape()` only checked that `fingerprint.checks` was an object. A request with a valid challenge and `clock_drift.data.cv` set to a string/list/object reached `validate_fingerprint_data()`, where the numeric comparison `cv < 0.0001` raised `TypeError`. The route-level catch converted that into HTTP 500.

## Duplicate and Safety Checks

- Searched open RustChain PRs and Scottcjn issues for `clock_drift.data.cv`, `INVALID_FINGERPRINT_CLOCK_DRIFT`, `clock_drift_invalid_cv`, `validate_fingerprint_data cv`, and `attest TypeError cv`; no existing open fix or claim was found for this exact nested clock-drift crash.
- This PR links the existing #1112 fuzz report rather than opening a separate duplicate bounty claim.
- No production endpoint fuzzing, private tokens, API keys, wallet credentials, authenticated endpoints, transfers, withdrawals, payout movement, profile edits, stars, reactions, or secret material were used.

## Validation

- RED before fix: `python3 -B -m pytest -q tests/test_attestation_fuzz.py::test_attest_submit_rejects_non_numeric_clock_drift_cv tests/test_attestation_fuzz.py::test_validate_fingerprint_data_handles_malformed_inputs_no_crash --tb=short` -> 8 failures showing HTTP 500 / `TypeError` for non-numeric `cv` and accepted string `samples`
- `PYTHONDONTWRITEBYTECODE=1 ATTEST_FUZZ_CASES=150 ATTEST_FUZZ_SEED=20260518 python3 -B -m pytest -q tests/test_attestation_fuzz.py --tb=short` -> `43 passed in 3.02s`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B -m pytest -q tests/test_attestation_regression.py --tb=short` -> `64 passed, 18 skipped in 3.79s`
- `PYTHONDONTWRITEBYTECODE=1 python3 tests/fuzz/run_fuzz.py --corpus-only` -> `Corpus results: 12 passed, 0 failed`
- `python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/fuzz/attestation_validators.py tests/test_attestation_fuzz.py` -> passed
- `git diff --check HEAD~1..HEAD` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`
