### PR TITLE
fix: reject non-object Hall of Rust JSON

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -157,7 +157,9 @@ def estimate_manufacture_year(model, arch):
 @hall_bp.route('/hall/induct', methods=['POST'])
 def induct_machine():
     """Automatically induct a machine into the Hall of Rust on first attestation."""
-    data = request.json or {}
+    data, error_response = _json_object_or_empty()
+    if error_response:
+        return error_response
     
     # Generate fingerprint hash from hardware identifiers
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
@@ -310,7 +312,9 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
-    data = request.json or {}
+    data, error_response = _json_object_or_empty()
+    if error_response:
+        return error_response
     
     try:
         from flask import current_app
@@ -459,6 +463,15 @@ def _parse_limit_arg(default=50, max_value=500):
     if limit < 0:
         return None, ("limit must be non-negative", 400)
     return min(limit, max_value), None
+
+
+def _json_object_or_empty():
+    data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'JSON object required'}), 400)
+    return data, None
 
 
 def _internal_error_response(context):

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -46,6 +46,28 @@ def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
     assert body["average_rust_score"] == 0
 
 
+def test_induct_rejects_non_object_json(tmp_path):
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    client = _client_for(db_path)
+
+    response = client.post("/hall/induct", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_eulogy_rejects_non_object_json(tmp_path):
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    client = _client_for(db_path)
+
+    response = client.post("/hall/eulogy/fingerprint-1", json=["nickname"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
 def test_calculate_rust_score_uses_current_year_for_age_weight():
     score = hall_of_rust.calculate_rust_score(
         {


### PR DESCRIPTION
## Summary
- Fixes #4410 by requiring JSON object bodies for Hall of Rust write routes.
- Keeps empty or malformed bodies on the existing empty-payload path while rejecting JSON arrays/scalars with 400 before DB work.
- Adds Flask-client regressions for /hall/induct and /hall/eulogy/<fingerprint> non-object JSON.

## Validation
- python3 -B -m pytest -q node/tests/test_hall_of_rust_error_responses.py node/tests/test_hall_of_rust_limit_validation.py --tb=short
- python3 -B -m py_compile node/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py
- git diff --check origin/main...HEAD -- node/hall_of_rust.py node/tests/test_hall_of_rust_error_responses.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main

No private tokens, wallet secrets, production services, withdrawals, transfers, fund movement, or payout actions were used.