### PR TITLE
fix: validate UTXO output addresses

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1002,6 +1002,31 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_mempool_rejects_malformed_output_addresses(self):
+        """Mempool must reject missing or blank output addresses."""
+        cases = [
+            ('missing_addr', {'value_nrtc': 100 * UNIT}),
+            ('blank_addr', {'address': '   ', 'value_nrtc': 100 * UNIT}),
+            ('nonstr_addr', {'address': ['bob'], 'value_nrtc': 100 * UNIT}),
+        ]
+
+        for name, output in cases:
+            with self.subTest(name=name):
+                sender = f'alice_{name}'
+                self._apply_coinbase(sender, 100 * UNIT)
+                box = self.db.get_unspent_for_address(sender)[0]
+
+                ok = self.db.mempool_add({
+                    'tx_id': (name.replace('_', '') * 8)[:64],
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id']}],
+                    'outputs': [output],
+                    'fee_nrtc': 0,
+                })
+
+                self.assertFalse(ok)
+                self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
     # -- bounty #2819: negative / zero value outputs -------------------------
 
     def test_negative_value_output_rejected(self):
@@ -1089,6 +1114,61 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.count_unspent(), 1)
+
+    def test_output_missing_address_rejected_without_crash(self):
+        """Malformed outputs must fail validation instead of raising KeyError."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        try:
+            ok = self.db.apply_transaction({
+                'tx_type': 'transfer',
+                'inputs': [{'box_id': boxes[0]['box_id'],
+                             'spending_proof': 'sig'}],
+                'outputs': [{'value_nrtc': 100 * UNIT}],
+                'fee_nrtc': 0,
+            }, block_height=10)
+        except Exception as exc:
+            self.fail(f'apply_transaction raised instead of rejecting: {exc!r}')
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+
+    def test_output_blank_address_rejected(self):
+        """Blank output addresses should not create unspendable UTXOs."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': ' ', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance(' '), 0)
+
+    def test_output_non_string_address_rejected_without_crash(self):
+        """Output addresses must be strings before proposition encoding."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        try:
+            ok = self.db.apply_transaction({
+                'tx_type': 'transfer',
+                'inputs': [{'box_id': boxes[0]['box_id'],
+                             'spending_proof': 'sig'}],
+                'outputs': [{'address': ['bob'], 'value_nrtc': 100 * UNIT}],
+                'fee_nrtc': 0,
+            }, block_height=10)
+        except Exception as exc:
+            self.fail(f'apply_transaction raised instead of rejecting: {exc!r}')
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
 
     def test_float_value_nrtc_rejected(self):
         """value_nrtc must be an integer; floats cause silent truncation."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -520,6 +520,9 @@ class UtxoDB:
             # transaction can split one UTXO into thousands of 1-nanoRTC
             # boxes and permanently bloat the UTXO set.
             for o in outputs:
+                address = o.get('address')
+                if not isinstance(address, str) or not address.strip():
+                    return abort()
                 val = o.get('value_nrtc')
                 if (
                     isinstance(val, bool)
@@ -876,6 +879,11 @@ class UtxoDB:
             # Without this, unmineable transactions enter the mempool and lock
             # UTXOs until expiry (DoS vector).
             for o in outputs:
+                address = o.get('address')
+                if not isinstance(address, str) or not address.strip():
+                    if manage_tx:
+                        conn.execute("ROLLBACK")
+                    return False
                 val = o.get('value_nrtc')
                 if isinstance(val, bool) or not isinstance(val, int) or val < DUST_THRESHOLD:
                     if manage_tx:


### PR DESCRIPTION
## Summary
- reject missing, blank, and non-string UTXO output addresses before transaction identity/proposition encoding
- mirror the same output-address validation in mempool admission so malformed transactions cannot lock inputs until expiry
- add focused regressions for apply_transaction() and mempool_add() malformed output-address handling

## Validation
- python3 -m pytest node/test_utxo_db.py::TestUtxoDB::test_mempool_rejects_malformed_output_addresses node/test_utxo_db.py::TestUtxoDB::test_output_missing_address_rejected_without_crash node/test_utxo_db.py::TestUtxoDB::test_output_blank_address_rejected node/test_utxo_db.py::TestUtxoDB::test_output_non_string_address_rejected_without_crash -q -> 4 passed, 3 subtests passed
- python3 -m pytest node/test_utxo_db.py -q -> 75 passed, 3 subtests passed
- python3 -m py_compile node/utxo_db.py node/test_utxo_db.py
- git diff --check

Bounty route: rustchain-bounties#2819 UTXO red-team hardening.
