### PR TITLE
fix: validate pending void selectors

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7412,6 +7412,11 @@ def void_pending():
     tx_hash = data.get('tx_hash')
     reason = data.get('reason', 'admin_void')
     voided_by = data.get('voided_by', 'admin')
+
+    if pending_id is not None and not isinstance(pending_id, (int, str)):
+        return jsonify({"error": "pending_id must be a scalar"}), 400
+    if tx_hash is not None and not isinstance(tx_hash, str):
+        return jsonify({"error": "tx_hash must be a string"}), 400
     
     if not pending_id and not tx_hash:
         return jsonify({"error": "Provide pending_id or tx_hash"}), 400

--- a/node/tests/test_pending_void_payload_validation.py
+++ b/node/tests/test_pending_void_payload_validation.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+
+
+class TestPendingVoidPayloadValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "pending_void.db")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_pending_void_payload_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.mod.init_db()
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def test_pending_void_rejects_non_scalar_pending_id(self):
+        response = self.client.post(
+            "/pending/void",
+            json={"pending_id": ["1"]},
+            headers={"X-Admin-Key": ADMIN_KEY},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"error": "pending_id must be a scalar"})
+
+    def test_pending_void_rejects_non_string_tx_hash(self):
+        response = self.client.post(
+            "/pending/void",
+            json={"tx_hash": {"value": "tx-1"}},
+            headers={"X-Admin-Key": ADMIN_KEY},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"error": "tx_hash must be a string"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #4416's remaining selector-type cases for /pending/void.
- Rejects non-scalar pending_id values and non-string tx_hash values with 400 before SQLite binding.
- Adds focused Flask-client regression coverage for list pending_id and object tx_hash payloads.

## Validation
- python3 -B -m pytest -q node/tests/test_pending_void_payload_validation.py --tb=short
- python3 -B -m pytest -q tests/test_wallet_transfer_admin_key_unset.py --tb=short
- python3 -B -m pytest -q node/tests/test_limit_validation.py --tb=short
- python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_pending_void_payload_validation.py
- git diff --cached --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main

Note: running these integrated-node suites together in one pytest process currently hits a pre-existing Prometheus CollectorRegistry duplicate-metric import issue because multiple tests load the integrated node under different module names. The commands above were run in fresh processes.

No private tokens, wallet secrets, production services, withdrawals, transfers, fund movement, or payout actions were used.