### PR TITLE
fix: default installer to rustchain.org node

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,7 @@ INSTALL_DIR="$HOME/.rustchain"
 RUSTCHAIN_REF="${RUSTCHAIN_REF:-main}"
 BASE_URL="${RUSTCHAIN_BASE_URL:-https://raw.githubusercontent.com/Scottcjn/Rustchain/${RUSTCHAIN_REF}}"
 CHECKSUM_URL="${BASE_URL}/miners/checksums.sha256"
-NODE_URL="https://50.28.86.131"
+NODE_URL="https://rustchain.org"
 VERSION="1.0.0"
 
 # ─── Parse Arguments ─────────────────────────────────────────────────

--- a/tests/test_scripts_installer_downloads.py
+++ b/tests/test_scripts_installer_downloads.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 INSTALLER = ROOT / "scripts" / "install.sh"
+ROOT_INSTALLER = ROOT / "install.sh"
 
 
 def test_scripts_installer_uses_existing_linux_miner_paths():
@@ -19,3 +20,10 @@ def test_scripts_installer_fails_on_http_download_errors():
     assert 'download_file "${MINER_URL}"' in script
     assert 'download_file "${FINGERPRINT_URL}"' in script
     assert '[ ! -s "${INSTALL_DIR}/fingerprint_checks.py" ]' in script
+
+
+def test_root_installer_defaults_to_tls_domain_node_url():
+    script = ROOT_INSTALLER.read_text(encoding="utf-8")
+
+    assert 'NODE_URL="https://rustchain.org"' in script
+    assert 'NODE_URL="https://50.28.86.131"' not in script


### PR DESCRIPTION
## Summary
- default the root `install.sh` miner node URL to `https://rustchain.org` instead of the hardcoded IP from #2278
- add a regression test so the root installer does not reintroduce `https://50.28.86.131` as its default

Fixes #2278

## Tests
- `python3 -m pytest tests/test_scripts_installer_downloads.py -q`
- `bash -n install.sh`
- `git diff --check`

## Bounty
Claiming under bug bounty #305 if accepted.
Miner id: `iamdinhthuan`