### PR TITLE
fix: harden attestation temporal metrics

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2406,16 +2406,28 @@ def extract_temporal_profile(fingerprint: dict) -> dict:
             return data if isinstance(data, dict) else {}
         return {}
 
+    def _metric_float(*values):
+        for value in values:
+            if value is None or isinstance(value, bool):
+                continue
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if math.isfinite(numeric):
+                return numeric
+        return 0.0
+
     clock = _check_data("clock_drift")
     thermal = _check_data("thermal_entropy") or _check_data("thermal_drift")
     jitter = _check_data("instruction_jitter")
     cache = _check_data("cache_timing")
 
     return {
-        "clock_drift_cv": float(clock.get("cv", 0.0) or 0.0),
-        "thermal_variance": float(thermal.get("variance", 0.0) or 0.0),
-        "jitter_cv": float(jitter.get("cv", 0.0) or jitter.get("stddev_ns", 0.0) or 0.0),
-        "cache_hierarchy_ratio": float(cache.get("hierarchy_ratio", 0.0) or 0.0),
+        "clock_drift_cv": _metric_float(clock.get("cv")),
+        "thermal_variance": _metric_float(thermal.get("variance")),
+        "jitter_cv": _metric_float(jitter.get("cv"), jitter.get("stddev_ns")),
+        "cache_hierarchy_ratio": _metric_float(cache.get("hierarchy_ratio")),
     }
 
 

--- a/tests/test_attestation_fuzz.py
+++ b/tests/test_attestation_fuzz.py
@@ -261,6 +261,38 @@ def test_validate_fingerprint_data_rejects_non_dict_input():
     assert reason == "fingerprint_not_dict"
 
 
+def test_extract_temporal_profile_sanitizes_malformed_optional_metrics():
+    fingerprint = {
+        "checks": {
+            "clock_drift": {
+                "passed": True,
+                "data": {"cv": 0.031},
+            },
+            "thermal_entropy": {
+                "passed": True,
+                "data": {"variance": "not-a-number"},
+            },
+            "instruction_jitter": {
+                "passed": True,
+                "data": {"cv": {"nested": "bad"}, "stddev_ns": 0.17},
+            },
+            "cache_timing": {
+                "passed": True,
+                "data": {"hierarchy_ratio": ["bad"]},
+            },
+        }
+    }
+
+    profile = integrated_node.extract_temporal_profile(fingerprint)
+
+    assert profile == {
+        "clock_drift_cv": 0.031,
+        "thermal_variance": 0.0,
+        "jitter_cv": 0.17,
+        "cache_hierarchy_ratio": 0.0,
+    }
+
+
 def test_attest_submit_strict_fixture_rejects_malformed_fingerprint(strict_client):
     payload = _base_payload()
     payload["fingerprint"]["checks"] = []


### PR DESCRIPTION
## Summary
- Harden `extract_temporal_profile()` so malformed optional temporal metrics cannot raise during fingerprint snapshot persistence.
- Preserve useful `instruction_jitter` signal by falling back to `stddev_ns` when `cv` is present but not numeric.
- Add a regression test covering malformed thermal, jitter, and cache timing metric values.

## Bug
A fingerprint can satisfy the required attestation validation checks and still carry optional malformed temporal metrics. `record_attestation_success()` persists a fingerprint snapshot after validation, and the old `float(...)` conversions in `extract_temporal_profile()` could raise `ValueError` or `TypeError` for values such as `thermal_entropy.data.variance = "not-a-number"`, `instruction_jitter.data.cv = {"nested":"bad"}`, or `cache_timing.data.hierarchy_ratio = ["bad"]`. That turns an otherwise handled attestation submission into an HTTP 500 on the snapshot path.

This is distinct from the recent `clock_drift.data.cv`/`samples` validation work: this patch covers optional temporal-profile snapshot metrics after validation has already passed.

## Validation
```text
PYTHONDONTWRITEBYTECODE=1 python3 -B -m pytest -q tests/test_attestation_fuzz.py::test_extract_temporal_profile_sanitizes_malformed_optional_metrics --tb=short -p no:cacheprovider
# 1 passed

PYTHONDONTWRITEBYTECODE=1 ATTEST_FUZZ_CASES=150 ATTEST_FUZZ_SEED=20260518 python3 -B -m pytest -q tests/test_attestation_fuzz.py --tb=short -p no:cacheprovider
# 36 passed

python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_attestation_fuzz.py

git diff --check

python3 -B tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```

## Bounty
Reference: Scottcjn/rustchain-bounties#1112