### PR TITLE
fix: reject malformed api miners pagination

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6021,11 +6021,15 @@ def api_miners():
     
     # Pagination args
     try:
-        limit = min(max(int(request.args.get("limit", 100)), 1), 1000)
-        offset = max(int(request.args.get("offset", 0)), 0)
+        limit = int(request.args.get("limit", 100))
     except (ValueError, TypeError):
-        limit = 100
-        offset = 0
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+    try:
+        offset = int(request.args.get("offset", 0))
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "offset must be an integer"}), 400
+    limit = min(max(limit, 1), 1000)
+    offset = max(offset, 0)
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row

--- a/node/tests/test_api_miners_rate_limit.py
+++ b/node/tests/test_api_miners_rate_limit.py
@@ -86,6 +86,24 @@ class TestApiMinersRateLimit(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.headers["X-RateLimit-Remaining"], "1")
 
+    def test_api_miners_rejects_malformed_limit(self):
+        resp = self.client.get(
+            "/api/miners?limit=abc",
+            environ_base={"REMOTE_ADDR": "203.0.113.20"},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
+
+    def test_api_miners_rejects_malformed_offset(self):
+        resp = self.client.get(
+            "/api/miners?offset=abc",
+            environ_base={"REMOTE_ADDR": "203.0.113.21"},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "offset must be an integer"})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Return HTTP 400 for non-integer `/api/miners` `limit` values instead of silently defaulting.
- Return HTTP 400 for non-integer `/api/miners` `offset` values instead of silently defaulting.
- Preserve existing defaults and integer clamping for valid requests.

Fixes #5628

## Validation
- RED before fix: `python3 -B -m pytest -q node/tests/test_api_miners_rate_limit.py --tb=short -p no:cacheprovider` failed the new malformed `limit` and `offset` assertions with `200 != 400`.
- `python3 -B -m pytest -q node/tests/test_api_miners_rate_limit.py tests/test_api.py --tb=short -p no:cacheprovider` -> 14 passed.
- `python3 -B -m pytest -q node/tests/test_explorer_api_routes.py --tb=short -p no:cacheprovider` -> 5 passed.
- `python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_api_miners_rate_limit.py tests/test_api.py node/tests/test_explorer_api_routes.py` -> passed.
- `git diff --check` -> passed.
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK.

## Safety
No private credentials, tokens, wallet action, withdrawal, transfer, or fund movement. Public GET-only repro.

## Bounty
Claiming under bug bounty #305. Miner/payout id: `iamdinhthuan`.