### PR TITLE
fix: reject malformed api miners pagination

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6021,11 +6021,15 @@ def api_miners():
     
     # Pagination args
     try:
-        limit = min(max(int(request.args.get("limit", 100)), 1), 1000)
-        offset = max(int(request.args.get("offset", 0)), 0)
+        limit = int(request.args.get("limit", "100") or "100")
     except (ValueError, TypeError):
-        limit = 100
-        offset = 0
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+    try:
+        offset = int(request.args.get("offset", "0") or "0")
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "offset must be an integer"}), 400
+    limit = min(max(limit, 1), 1000)
+    offset = max(offset, 0)
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -87,6 +87,24 @@ def test_api_miners_requires_auth(client):
         assert response.status_code == 200
 
 
+def test_api_miners_rejects_malformed_pagination(client, monkeypatch, tmp_path):
+    """Malformed /api/miners pagination should return a client error."""
+    db_path = tmp_path / "api_miners_pagination.db"
+    _init_api_miners_db(db_path)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    rate_info = {"limit": 100, "remaining": 99, "reset": 0, "retry_after": 0}
+    with patch('integrated_node.check_api_miners_rate_limit', return_value=(True, rate_info)):
+        limit_response = client.get('/api/miners?limit=abc')
+        offset_response = client.get('/api/miners?offset=abc')
+
+    assert limit_response.status_code == 400
+    assert limit_response.get_json() == {"ok": False, "error": "limit must be an integer"}
+
+    assert offset_response.status_code == 400
+    assert offset_response.get_json() == {"ok": False, "error": "offset must be an integer"}
+
+
 def _init_api_miners_db(path):
     with sqlite3.connect(path) as conn:
         conn.execute(


### PR DESCRIPTION
## Summary
- return JSON 400 errors for malformed `/api/miners` `limit` and `offset` query parameters instead of silently falling back to default pagination
- keep existing default, clamp, rate-limit, and successful empty-list behavior intact
- add regression coverage for `limit=abc` and `offset=abc`

Fixes #5628.

## Validation
- Baseline: `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_api.py -q -p no:cacheprovider` -> 10 passed before adding the regression
- RED: same command failed on the new `/api/miners` malformed-pagination regression because `limit=abc` returned 200
- GREEN: `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest tests/test_api.py -q -p no:cacheprovider` -> 11 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest node/tests/test_api_miners_rate_limit.py -q -p no:cacheprovider` -> 2 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest node/tests/test_explorer_api_routes.py -q -p no:cacheprovider` -> 5 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_api.py node/tests/test_api_miners_rate_limit.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_api.py node/tests/test_api_miners_rate_limit.py` -> passed

## Safety
No private tokens, wallet secrets, production endpoint writes, withdrawals, transfers, or fund movement were used.