### PR TITLE
Fix issue 2310 validation test paths

### DIFF
--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -10,9 +10,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_issue2310_package_imports_from_parent_path():
+    package_dir = REPO_ROOT / "bounties" / "issue-2310"
     code = (
         "import sys; "
-        "sys.path.insert(0, r'bounties\\issue-2310'); "
+        f"sys.path.insert(0, {str(package_dir)!r}); "
         "import src; "
         "print(src.CRTPatternGenerator.__name__)"
     )
@@ -32,9 +33,10 @@ def test_issue2310_package_imports_from_parent_path():
 def test_issue2310_validator_runs_with_cp1252_stdout():
     env = os.environ.copy()
     env["PYTHONIOENCODING"] = "cp1252"
+    validator = REPO_ROOT / "bounties" / "issue-2310" / "validate_bounty_2310.py"
 
     result = subprocess.run(
-        [sys.executable, "bounties\\issue-2310\\validate_bounty_2310.py"],
+        [sys.executable, str(validator)],
         cwd=REPO_ROOT,
         env=env,
         text=True,


### PR DESCRIPTION
## Summary
- replace Windows-only `bounties\issue-2310` subprocess paths with `pathlib`-built absolute paths
- keep the existing cp1252 stdout validation and package import coverage intact

## Why
The broad CI `test` job currently reports `tests/test_issue2310_package_validation.py` failures on Linux because the test subprocess uses Windows backslash paths. On Windows this passes, but on Linux it can import the wrong `src` module and cannot open `bounties\issue-2310\validate_bounty_2310.py`.

## Validation
- `python -B -m pytest -q tests/test_issue2310_package_validation.py --tb=short -p no:cacheprovider` -> 2 passed
- `python -B -m py_compile tests/test_issue2310_package_validation.py`
- `git diff --check`

This is one focused follow-up for the repo-wide CI failure currently blocking otherwise approved PRs.