### PR TITLE
fix: validate hold_id type in admin wallet review UI (bounty #305)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4740,7 +4740,12 @@ def admin_wallet_review_holds_ui():
                     )
                     conn.commit()
             elif form_action == "resolve":
-                hold_id = int(request.form.get("hold_id") or "0")
+                try:
+                    hold_id = int(request.form.get("hold_id") or "0")
+                except (ValueError, TypeError):
+                    return jsonify({
+                        "ok": False, "error": "hold_id must be an integer"
+                    }), 400
                 action = str(request.form.get("review_action") or "release").strip().lower()
                 reviewer_note = str(request.form.get("reviewer_note") or "").strip()
                 coach_note = str(request.form.get("coach_note") or "").strip()


### PR DESCRIPTION
## Summary
POST /admin/wallet-review-holds/ui resolve action uses `int(request.form.get("hold_id") or "0")` without validation. A non-integer value such as `abc` raises ValueError and returns a 500 error.

## Fix
Wrap the conversion in try/except (ValueError, TypeError) and return 400 with a clear error message.

## Test
- `hold_id=123` → 303 redirect (unchanged)
- `hold_id=abc` → 400 `{"ok": false, "error": "hold_id must be an integer"}`
- `hold_id=1.5` → 400 (TypeError from int() on float)
- Missing hold_id → defaults to 0 (unchanged, redirect)

## Enviroment
Tested on local Flask develpment server with the admin UI endpoint.

## Bounty
- **Issue:** #305
- **Severity:** LOW
- **Payout wallet:** RTC06ad4d5e2738790b4d7154974e97ca664236f576