### PR TITLE
Fix pinned Linux miner artifact hash

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -19,7 +19,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "9475fe15d149ef7b3824c0009453c55e17fb6d1d411ea37e9f24f58c6313871c",
+        "sha256": "91815ecf25042cfea1c60817c8b6e701c4324b60ceeb433da068243920344c0a",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",


### PR DESCRIPTION
## Summary
- update the pinned Linux miner artifact SHA-256 in `setup_miner.py`
- align the pin with the current `miners/linux/rustchain_linux_miner.py` contents on `main`

## Why
`tests/test_setup_miner_downloads.py` currently fails because `setup_miner.MINER_ARTIFACTS["Linux"]["sha256"]` still points at an older file hash (`9475fe...`), while the checked-in Linux miner hashes to `91815e...`. That mismatch also means Linux setup would reject the current raw GitHub miner artifact during SHA verification.

## Validation
- `python -B -m pytest -q tests/test_setup_miner_downloads.py --tb=short -p no:cacheprovider` -> 2 passed
- `python -B -m py_compile setup_miner.py tests/test_setup_miner_downloads.py`
- `git diff --check`