### PR TITLE
fix: bound beacon envelope pagination limits

### DIFF
--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -261,6 +261,15 @@ def mark_anchored(envelope_ids: list, db_path=DB_PATH):
 
 def get_recent_envelopes(limit=50, offset=0, db_path=DB_PATH) -> list:
     """Return recent envelopes, newest first."""
+    try:
+        limit = max(1, int(limit))
+    except (TypeError, ValueError):
+        limit = 50
+    try:
+        offset = max(0, int(offset))
+    except (TypeError, ValueError):
+        offset = 0
+
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8365,8 +8365,8 @@ def beacon_digest():
 @app.route("/beacon/envelopes", methods=["GET"])
 def beacon_envelopes_list():
     try:
-        limit = min(int(request.args.get("limit", 50)), 50)
-        offset = max(int(request.args.get("offset", 0)), 0)
+        limit = max(1, min(int(request.args.get("limit", 50)), 50))
+        offset = max(0, int(request.args.get("offset", 0)))
     except (ValueError, TypeError):
         limit, offset = 50, 0
     envelopes = get_recent_envelopes(limit=limit, offset=offset, db_path=DB_PATH)

--- a/node/tests/test_beacon_anchor_signature.py
+++ b/node/tests/test_beacon_anchor_signature.py
@@ -316,6 +316,47 @@ class BeaconAnchorSignatureTests(unittest.TestCase):
         finally:
             os.unlink(db_path)
 
+    def test_get_recent_envelopes_clamps_non_positive_pagination(self):
+        db_path = _make_temp_db()
+        try:
+            beacon_anchor.init_beacon_table(db_path)
+            with sqlite3.connect(db_path) as conn:
+                for idx in range(3):
+                    conn.execute(
+                        """
+                        INSERT INTO beacon_envelopes
+                        (agent_id, kind, nonce, sig, pubkey, payload_hash,
+                         payload_hash_version, anchored, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?)
+                        """,
+                        (
+                            f"bcn_test{idx}",
+                            "hello",
+                            f"nonce-{idx}",
+                            "ab" * 64,
+                            "cd" * 32,
+                            f"hash-{idx}",
+                            beacon_anchor.CURRENT_PAYLOAD_HASH_VERSION,
+                            idx,
+                        ),
+                    )
+                conn.commit()
+
+            self.assertEqual(
+                len(beacon_anchor.get_recent_envelopes(limit=2, offset=0, db_path=db_path)),
+                2,
+            )
+            self.assertEqual(
+                len(beacon_anchor.get_recent_envelopes(limit=-1, offset=0, db_path=db_path)),
+                1,
+            )
+            self.assertEqual(
+                len(beacon_anchor.get_recent_envelopes(limit=0, offset=-10, db_path=db_path)),
+                1,
+            )
+        finally:
+            os.unlink(db_path)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
﻿This PR fixes #5636 by enforcing a lower bound on Beacon envelope pagination before `limit` reaches SQLite. The changed surface is intentionally limited to the Beacon envelope list path and its storage helper, because the bug was a negative-limit bypass of the endpoint's page-size cap.

/claim #5636

| Area | Change | Evidence |
| --- | --- | --- |
| `node/rustchain_v2_integrated_v2.2.1_rip200.py` | Clamp `/beacon/envelopes` `limit` to `1..50` and `offset` to `>=0`. | Local parser/proof output below. |
| `node/beacon_anchor.py` | Defensively normalize helper `limit`/`offset` so future callers cannot pass `LIMIT -1`. | Local post-fix probe: `limit=-1` now returns one row, not all rows. |
| `node/tests/test_beacon_anchor_signature.py` | Adds regression coverage for non-positive Beacon pagination values. | `py_compile` and focused proof passed locally. |

Validation run locally:

```text
git diff --check -- node/beacon_anchor.py node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_beacon_anchor_signature.py
# passed

python -m py_compile node/beacon_anchor.py node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_beacon_anchor_signature.py
# passed

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK

post-fix Beacon pagination probe
# helper limit 2 count -> 2
# helper limit -1 count -> 1
# helper limit 0 count -> 1
```

The PR deliberately leaves the existing behavior for non-integer query values unchanged: the route still falls back to the default page instead of changing that API contract in the same patch.
