### PR TITLE
fix: make Windows miner spec path portable

### DIFF
--- a/miners/windows/rustchain_windows_miner.spec
+++ b/miners/windows/rustchain_windows_miner.spec
@@ -2,7 +2,7 @@
 
 
 a = Analysis(
-    ['Z:\\home\\scott\\Rustchain\\miners\\windows\\rustchain_windows_miner.py'],
+    ['rustchain_windows_miner.py'],
     pathex=[],
     binaries=[],
     datas=[],

--- a/tests/test_windows_miner_setup_checksum.py
+++ b/tests/test_windows_miner_setup_checksum.py
@@ -1,16 +1,31 @@
 # SPDX-License-Identifier: MIT
+import ast
 import hashlib
 import re
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SETUP_SCRIPT = ROOT / "miners" / "windows" / "rustchain_miner_setup.bat"
 MINER_SCRIPT = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+SPEC_FILE = ROOT / "miners" / "windows" / "rustchain_windows_miner.spec"
 
 
 def _setup_text():
     return SETUP_SCRIPT.read_text(encoding="utf-8", errors="replace")
+
+
+def _analysis_scripts():
+    tree = ast.parse(SPEC_FILE.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Call):
+            continue
+        if getattr(node.value.func, "id", "") != "Analysis":
+            continue
+        scripts = node.value.args[0]
+        assert isinstance(scripts, ast.List)
+        return [item.value for item in scripts.elts if isinstance(item, ast.Constant)]
+    raise AssertionError("PyInstaller Analysis() call not found")
 
 
 def test_windows_miner_setup_pins_current_miner_hash():
@@ -32,3 +47,12 @@ def test_windows_miner_setup_verifies_miner_before_run_instructions():
     assert 'if /I not "!ACTUAL_MINER_SHA256!"=="%MINER_SHA256%"' in text
     assert 'del /f /q "%MINER_SCRIPT%"' in text
     assert "Miner script SHA-256 mismatch." in text
+
+
+def test_windows_miner_spec_uses_checkout_relative_script():
+    scripts = _analysis_scripts()
+
+    assert scripts == ["rustchain_windows_miner.py"]
+    for script in scripts:
+        assert not Path(script).is_absolute()
+        assert not PureWindowsPath(script).is_absolute()


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (N/A, no new code files)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Change `miners/windows/rustchain_windows_miner.spec` to analyze the checked-in `rustchain_windows_miner.py` instead of an absolute machine-specific path.
- Add regression coverage that parses the PyInstaller spec and rejects absolute script paths.
- Normalize the small spec file to LF so `git diff --check` stays clean after touching it.

Fixes #5639.

RTC payout address if accepted: `RTC877021895fd29d034f35c87e1b37af8534703792`

## Testing / Evidence

- RED before fix: `python3 -m pytest tests/test_windows_miner_setup_checksum.py -q` -> failed because the spec used `Z:\...\rustchain_windows_miner.py`.
- `python3 -m pytest tests/test_windows_miner_setup_checksum.py -q` -> 3 passed.
- `python3 -m py_compile miners/windows/rustchain_windows_miner.py tests/test_windows_miner_setup_checksum.py miners/windows/rustchain_windows_miner.spec` -> passed.
- `python3 -m PyInstaller --noconfirm --log-level WARN rustchain_windows_miner.spec` from `miners/windows` -> passed; warning only that tkinter is unavailable in the Linux test environment.
- `git diff --check` -> passed.
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK.
