### PR TITLE
Fix beacon envelopes negative limit pagination bypass

### DIFF
--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -259,8 +259,23 @@ def mark_anchored(envelope_ids: list, db_path=DB_PATH):
         conn.commit()
 
 
+def normalize_beacon_pagination(limit=50, offset=0, max_limit=50):
+    """Clamp Beacon envelope pagination before values reach SQLite."""
+    try:
+        normalized_limit = int(limit)
+    except (TypeError, ValueError):
+        normalized_limit = max_limit
+    try:
+        normalized_offset = int(offset)
+    except (TypeError, ValueError):
+        normalized_offset = 0
+
+    return max(1, min(normalized_limit, max_limit)), max(0, normalized_offset)
+
+
 def get_recent_envelopes(limit=50, offset=0, db_path=DB_PATH) -> list:
     """Return recent envelopes, newest first."""
+    limit, offset = normalize_beacon_pagination(limit, offset)
     with sqlite3.connect(db_path) as conn:
         conn.row_factory = sqlite3.Row
         rows = conn.execute(

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from flask import Flask, request, jsonify, g, send_from_directory, send_file, abort, render_template_string, redirect, Response
 import json
 from decimal import Decimal, ROUND_HALF_UP
-from beacon_anchor import init_beacon_table, store_envelope, compute_beacon_digest, get_recent_envelopes, VALID_KINDS
+from beacon_anchor import init_beacon_table, store_envelope, compute_beacon_digest, get_recent_envelopes, normalize_beacon_pagination, VALID_KINDS
 try:
     # Deployment compatibility: production may run this file as a single script.
     from payout_preflight import validate_wallet_transfer_admin, validate_wallet_transfer_signed
@@ -8364,11 +8364,10 @@ def beacon_digest():
 
 @app.route("/beacon/envelopes", methods=["GET"])
 def beacon_envelopes_list():
-    try:
-        limit = min(int(request.args.get("limit", 50)), 50)
-        offset = max(int(request.args.get("offset", 0)), 0)
-    except (ValueError, TypeError):
-        limit, offset = 50, 0
+    limit, offset = normalize_beacon_pagination(
+        request.args.get("limit", 50),
+        request.args.get("offset", 0),
+    )
     envelopes = get_recent_envelopes(limit=limit, offset=offset, db_path=DB_PATH)
     return jsonify({"ok": True, "count": len(envelopes), "envelopes": envelopes})
 
@@ -8543,3 +8542,4 @@ def check_hardware_wallet_consistency(hardware_id, miner_wallet, conn):
             return False, f'hardware_bound_to_different_wallet:{bound_wallet[:20]}'
     
     return True, 'ok'
+    

--- a/tests/test_beacon_envelopes_limit.py
+++ b/tests/test_beacon_envelopes_limit.py
@@ -1,0 +1,64 @@
+import sqlite3
+import unittest
+from contextlib import suppress
+from pathlib import Path
+from uuid import uuid4
+
+from node.beacon_anchor import (
+    get_recent_envelopes,
+    init_beacon_table,
+    normalize_beacon_pagination,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def seed_envelopes(db_path, count=3):
+    init_beacon_table(db_path)
+    with sqlite3.connect(db_path) as conn:
+        for idx in range(count):
+            conn.execute(
+                """
+                INSERT INTO beacon_envelopes(
+                    agent_id, kind, nonce, sig, pubkey,
+                    payload_hash, payload_hash_version, anchored, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"bcn_{idx}",
+                    "hello",
+                    f"nonce_{idx}",
+                    "00",
+                    "00",
+                    f"hash_{idx}",
+                    2,
+                    0,
+                    idx,
+                ),
+            )
+        conn.commit()
+
+
+class BeaconEnvelopesLimitTest(unittest.TestCase):
+    def test_normalize_beacon_pagination_clamps_lower_and_upper_bounds(self):
+        self.assertEqual(normalize_beacon_pagination("-1", "-10"), (1, 0))
+        self.assertEqual(normalize_beacon_pagination("0", "5"), (1, 5))
+        self.assertEqual(normalize_beacon_pagination("999", "bad"), (50, 0))
+        self.assertEqual(normalize_beacon_pagination("bad", None), (50, 0))
+
+    def test_get_recent_envelopes_does_not_allow_negative_limit_bypass(self):
+        db_path = REPO_ROOT / f"beacon_limit_test_{uuid4().hex}.db"
+        try:
+            seed_envelopes(db_path)
+
+            rows = get_recent_envelopes(limit=-1, offset=0, db_path=db_path)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["created_at"], 2)
+        finally:
+            with suppress(PermissionError):
+                db_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #5636.

## Summary

This PR fixes the `/beacon/envelopes` pagination path so negative limits can no longer bypass the intended page-size cap.

Previously, the route used:

```python
limit = min(int(request.args.get("limit", 50)), 50)