### PR TITLE
fix: scope p2p attestations to sender

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -719,6 +719,12 @@ class GossipLayer:
                 f"rejecting future-dated ts_ok={ts_ok} (now={now})"
             )
             return {"status": "error", "reason": "future_timestamp"}
+        if miner_id != msg.sender_id:
+            logger.warning(
+                f"Attestation from {msg.sender_id}: rejecting write for "
+                f"foreign miner namespace {miner_id[:16]}"
+            )
+            return {"status": "error", "reason": "sender_namespace_mismatch"}
 
         # Update CRDT
         if self.attestation_crdt.set(miner_id, attestation, int(ts_ok)):
@@ -1045,6 +1051,12 @@ class GossipLayer:
                             logger.warning(
                                 f"State from {sender}: rejecting future-dated "
                                 f"attestation {key[:16]} (ts={ts}, now={now})"
+                            )
+                            continue
+                        if key != sender:
+                            logger.warning(
+                                f"State from {sender}: rejecting attestation "
+                                f"for foreign miner namespace {key[:16]}"
                             )
                             continue
                         filtered.set(key, value, ts)

--- a/node/tests/test_p2p_hardening_phase2.py
+++ b/node/tests/test_p2p_hardening_phase2.py
@@ -180,6 +180,62 @@ def test_epoch_votes_survive_restart_and_reject_retransmit():
     assert restarted._epoch_votes[key] == {"node2": "accept"}
 
 
+# Phase D / #2867 H2 regression
+def test_phase_d_state_attestations_are_scoped_to_sender_namespace():
+    """State sync must not let one sender overwrite another miner's attestation."""
+    target = _mk_layer("node1", {"node2": "http://n2"})
+    sender = _mk_layer("node2", db_path=target.db_path)
+    sender.broadcast = lambda *args, **kwargs: None
+
+    now = int(time.time())
+    msg = sender.create_message(
+        mod.MessageType.STATE,
+        {
+            "state": {
+                "attestations": {
+                    "node2": {
+                        "ts": now,
+                        "value": {"miner": "node2", "device_arch": "modern"},
+                    },
+                    "victim-miner": {
+                        "ts": now,
+                        "value": {"miner": "victim-miner", "device_arch": "modern"},
+                    },
+                }
+            }
+        },
+    )
+
+    assert target.handle_message(msg)["status"] == "ok"
+    assert target.attestation_crdt.get("node2")["miner"] == "node2"
+    assert target.attestation_crdt.get("victim-miner") is None
+
+
+def test_phase_d_direct_attestation_rejects_foreign_miner_namespace():
+    """A signed ATTESTATION message can only update the sender's own key."""
+    target = _mk_layer("node1", {"node2": "http://n2"})
+    sender = _mk_layer("node2", db_path=target.db_path)
+    sender.broadcast = lambda *args, **kwargs: None
+
+    now = int(time.time())
+    foreign = sender.create_message(
+        mod.MessageType.ATTESTATION,
+        {"miner": "victim-miner", "ts_ok": now, "device_arch": "modern"},
+    )
+    result = target.handle_message(foreign)
+
+    assert result["status"] == "error"
+    assert result.get("reason") == "sender_namespace_mismatch"
+    assert target.attestation_crdt.get("victim-miner") is None
+
+    own = sender.create_message(
+        mod.MessageType.ATTESTATION,
+        {"miner": "node2", "ts_ok": now, "device_arch": "modern"},
+    )
+    assert target.handle_message(own)["status"] == "ok"
+    assert target.attestation_crdt.get("node2")["miner"] == "node2"
+
+
 # Phase E regression
 def test_phase_e_future_timestamp_attestation_rejected():
     """Phase E: attestations with ts_ok far in the future are rejected."""


### PR DESCRIPTION
## Summary
- reject signed ATTESTATION messages that try to update a miner namespace different from the authenticated sender
- filter full-state attestation merges the same way, while preserving existing future timestamp validation
- add regression coverage for direct and state-sync overwrite attempts

Addresses H2 from #2744 / the #2867 security audit notes.

## Tests
- uv run --no-project --with pytest --with flask --with requests --with pynacl --with cryptography python -m pytest node/tests/test_p2p_hardening_phase2.py node/tests/test_p2p_endpoint_auth.py -q
- python3 -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_hardening_phase2.py

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

