### PR TITLE
[UTXO-BUG] Reject unknown UTXO transaction types

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -712,6 +712,24 @@ class TestUtxoDB(unittest.TestCase):
         }, block_height=10)
         self.assertFalse(ok)
 
+    def test_unknown_tx_type_rejected_with_valid_inputs(self):
+        """Unsupported tx_type values must not be treated as transfers."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'airdrop',
+            'inputs': [{'box_id': boxes[0]['box_id'],
+                         'spending_proof': 'sig'}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+            'fee_nrtc': 1 * UNIT,
+            'timestamp': int(time.time()),
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
     def test_mining_reward_empty_inputs_allowed(self):
         """Legitimate mining_reward transactions MUST still work with empty inputs."""
         ok = self._apply_coinbase('alice', 100 * UNIT)
@@ -901,6 +919,27 @@ class TestUtxoDB(unittest.TestCase):
             'fee_nrtc': 1 * UNIT,
         }
         ok = self.db.mempool_add(tx)
+        self.assertFalse(ok)
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        self.assertFalse(
+            self.db.mempool_check_double_spend(boxes[0]['box_id'])
+        )
+
+    def test_mempool_rejects_unknown_tx_type(self):
+        """Mempool must not admit unsupported transfer-like tx_type values."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        boxes = self.db.get_unspent_for_address('alice')
+
+        tx = {
+            'tx_id': 'utyp' * 16,
+            'tx_type': 'airdrop',
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 99 * UNIT}],
+            'fee_nrtc': 1 * UNIT,
+        }
+
+        ok = self.db.mempool_add(tx)
+
         self.assertFalse(ok)
         self.assertEqual(self.db.mempool_get_block_candidates(), [])
         self.assertFalse(

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -44,6 +44,8 @@ MAX_POOL_SIZE = 10_000
 MAX_OUTPUTS = 100
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
+SUPPORTED_TX_TYPES = {'transfer', 'mining_reward'}
+MINTING_TX_TYPES = {'mining_reward'}
 
 
 # ---------------------------------------------------------------------------
@@ -371,14 +373,14 @@ class UtxoDB:
         return normalized
 
     def _normalize_tx_type(self, tx: dict) -> Optional[str]:
-        """Return a valid transaction type, defaulting only when absent."""
+        """Return a supported transaction type, defaulting only when absent."""
         if 'tx_type' not in tx:
             return 'transfer'
         tx_type = tx.get('tx_type')
         if not isinstance(tx_type, str):
             return None
         tx_type = tx_type.strip()
-        if not tx_type:
+        if not tx_type or tx_type not in SUPPORTED_TX_TYPES:
             return None
         return tx_type
 
@@ -444,7 +446,6 @@ class UtxoDB:
         # passes user-controlled tx_type, an attacker could mint unlimited coins.
         # Only the epoch settlement system should create mining_reward transactions.
         # Require _allow_minting=True (internal flag) to permit mining_reward.
-        MINTING_TX_TYPES = {'mining_reward'}
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
             if conn:
                 conn.close()
@@ -502,7 +503,6 @@ class UtxoDB:
             # -- conservation check ------------------------------------------
             # Only authorized minting transaction types may have empty inputs.
             # All other transactions must consume at least one input box.
-            MINTING_TX_TYPES = {'mining_reward'}
             if not inputs and tx_type not in MINTING_TX_TYPES:
                 return abort()
 
@@ -792,7 +792,6 @@ class UtxoDB:
             # production and guarded by apply_transaction(_allow_minting=True).
             # Admitting user-supplied mining_reward txs here lets invalid mint
             # candidates occupy mempool slots and reach block candidate selection.
-            MINTING_TX_TYPES = {'mining_reward'}
             if tx_type in MINTING_TX_TYPES:
                 return False
 


### PR DESCRIPTION
## Summary
- constrain UTXO transaction type normalization to the supported consensus types
- keep omitted `tx_type` defaulting to `transfer` and preserve the guarded `mining_reward` path
- add regression coverage for confirmed transaction application and mempool admission

## Bounty
Targets Scottcjn/rustchain-bounties#2819. This is separate from the earlier non-string/empty `tx_type` fix; arbitrary unknown strings were still accepted as transfer-like transactions.

## Tests
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db.TestUtxoDB.test_unknown_tx_type_rejected_with_valid_inputs node.test_utxo_db.TestUtxoDB.test_mempool_rejects_unknown_tx_type`
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db`
- `PYTHONPATH=node python3 -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

