### PR TITLE
fix: validate fleet report epoch parameter

### DIFF
--- a/rips/python/rustchain/fleet_immune_system.py
+++ b/rips/python/rustchain/fleet_immune_system.py
@@ -1004,6 +1004,21 @@ def register_fleet_endpoints(app, DB_PATH):
 
         return min(limit, max_value)
 
+    def parse_positive_epoch() -> Optional[int]:
+        raw_value = request.args.get('epoch')
+        if raw_value is None:
+            return None
+
+        try:
+            epoch = int(raw_value)
+        except ValueError:
+            raise ValueError("epoch must be an integer") from None
+
+        if epoch < 1:
+            raise ValueError("epoch must be positive")
+
+        return epoch
+
     @app.route('/admin/fleet/report', methods=['GET'])
     def fleet_report():
         import os, hmac
@@ -1014,7 +1029,11 @@ def register_fleet_endpoints(app, DB_PATH):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({"error": "Unauthorized"}), 401
 
-        epoch = request.args.get('epoch', type=int)
+        try:
+            epoch = parse_positive_epoch()
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
+
         if epoch is None:
             from rewards_implementation_rip200 import current_slot, slot_to_epoch
             epoch = slot_to_epoch(current_slot()) - 1

--- a/tests/test_fleet_scores_limit_validation.py
+++ b/tests/test_fleet_scores_limit_validation.py
@@ -42,9 +42,9 @@ def client(monkeypatch, fleet_db):
     return app.test_client()
 
 
-def authed_get(client, query):
+def authed_get(client, path):
     return client.get(
-        f"/admin/fleet/scores?{query}",
+        path,
         headers={"X-Admin-Key": "secret"},
     )
 
@@ -58,21 +58,44 @@ def authed_get(client, query):
     ),
 )
 def test_fleet_scores_rejects_invalid_limits(client, query, expected_error):
-    response = authed_get(client, query)
+    response = authed_get(client, f"/admin/fleet/scores?{query}")
 
     assert response.status_code == 400
     assert response.get_json() == {"error": expected_error}
 
 
 def test_fleet_scores_caps_oversized_limit(client):
-    response = authed_get(client, "limit=5000")
+    response = authed_get(client, "/admin/fleet/scores?limit=5000")
 
     assert response.status_code == 200
     assert len(response.get_json()["scores"]) == 3
 
 
 def test_fleet_scores_respects_valid_limit(client):
-    response = authed_get(client, "limit=2")
+    response = authed_get(client, "/admin/fleet/scores?limit=2")
 
     assert response.status_code == 200
     assert [row["miner"] for row in response.get_json()["scores"]] == ["miner-a", "miner-b"]
+
+
+@pytest.mark.parametrize(
+    "query, expected_error",
+    (
+        ("epoch=abc", "epoch must be an integer"),
+        ("epoch=10.5", "epoch must be an integer"),
+        ("epoch=0", "epoch must be positive"),
+        ("epoch=-1", "epoch must be positive"),
+    ),
+)
+def test_fleet_report_rejects_invalid_epochs(client, query, expected_error):
+    response = authed_get(client, f"/admin/fleet/report?{query}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": expected_error}
+
+
+def test_fleet_report_respects_valid_epoch(client):
+    response = authed_get(client, "/admin/fleet/report?epoch=1")
+
+    assert response.status_code == 200
+    assert response.get_json()["epoch"] == 1

--- a/tests/test_fleet_scores_limit_validation.py
+++ b/tests/test_fleet_scores_limit_validation.py
@@ -1,5 +1,6 @@
 import sqlite3
 import sys
+import types
 from pathlib import Path
 
 import pytest
@@ -99,3 +100,21 @@ def test_fleet_report_respects_valid_epoch(client):
 
     assert response.status_code == 200
     assert response.get_json()["epoch"] == 1
+
+
+def test_fleet_report_without_epoch_uses_previous_current_epoch(client, monkeypatch):
+    monkeypatch.setitem(
+        sys.modules,
+        "rewards_implementation_rip200",
+        types.SimpleNamespace(
+            current_slot=lambda: 288,
+            slot_to_epoch=lambda slot: slot // 144,
+        ),
+    )
+
+    response = authed_get(client, "/admin/fleet/report")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["epoch"] == 1
+    assert payload["total_miners"] == 3


### PR DESCRIPTION
## BCOS Checklist

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (not applicable; no new files)
- [x] Provide test evidence below

## What Changed

Fixes #5647.

This adds explicit validation for `/admin/fleet/report?epoch=...` so malformed values like `abc` or `10.5`, and non-positive values like `0` or `-1`, return HTTP 400 instead of silently falling back to the current/default epoch report.

The implementation mirrors the existing `/admin/fleet/scores?limit=...` validation style and keeps the no-epoch fallback behavior unchanged.

## Testing / Evidence

- `PYTHONPATH=rips/python python3 -m pytest tests/test_fleet_scores_limit_validation.py -q`
- `python3 -m py_compile rips/python/rustchain/fleet_immune_system.py tests/test_fleet_scores_limit_validation.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

Bounty: #305

RTC payout ID: `RTC877021895fd29d034f35c87e1b37af8534703792`
