### PR TITLE
fix: honor persisted rustchainnode testnet config

### DIFF
--- a/rustchainnode/rustchainnode/cli.py
+++ b/rustchainnode/rustchainnode/cli.py
@@ -29,6 +29,7 @@ CONFIG_FILE = CONFIG_DIR / "config.json"
 PID_FILE = CONFIG_DIR / "node.pid"
 
 NODE_URL = "https://50.28.86.131"
+TESTNET_NODE_URL = "http://localhost:8099"
 
 
 # ---------------------------------------------------------------------------
@@ -44,6 +45,15 @@ def _load_config() -> dict:
 def _save_config(cfg: dict):
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     CONFIG_FILE.write_text(json.dumps(cfg, indent=2))
+
+
+def _resolve_node_url(cfg: dict, force_testnet: bool = False) -> str:
+    configured_url = cfg.get("node_url")
+    if force_testnet or cfg.get("testnet"):
+        if configured_url and configured_url != NODE_URL:
+            return configured_url
+        return TESTNET_NODE_URL
+    return configured_url or NODE_URL
 
 
 def _check_health(node_url: str = NODE_URL) -> dict:
@@ -83,11 +93,14 @@ def cmd_init(args):
 
     cfg = get_optimal_config(wallet, port)
     cfg["testnet"] = testnet
+    if testnet:
+        cfg["node_url"] = TESTNET_NODE_URL
     _save_config(cfg)
 
     # Test connectivity
-    print(f"\n  Testing connectivity to {NODE_URL}...")
-    health = _check_health()
+    node_url = _resolve_node_url(cfg)
+    print(f"\n  Testing connectivity to {node_url}...")
+    health = _check_health(node_url)
     if health.get("ok"):
         print(f"  ✅ Node reachable: {health}")
     else:
@@ -103,14 +116,14 @@ def cmd_start(args):
     cfg = _load_config()
     wallet = getattr(args, "wallet", None) or cfg.get("wallet")
     port = getattr(args, "port", None) or cfg.get("port", 8099)
-    testnet = getattr(args, "testnet", False)
+    testnet = getattr(args, "testnet", False) or bool(cfg.get("testnet", False))
 
     if not wallet:
         print("❌ No wallet configured. Run: rustchainnode init --wallet <name>")
         sys.exit(1)
 
     hw = detect_cpu_info()
-    node_url = "http://localhost:8099" if testnet else NODE_URL
+    node_url = _resolve_node_url(cfg, testnet)
 
     print(f"🚀 Starting RustChain node...")
     print(f"   Wallet: {wallet}")
@@ -153,7 +166,7 @@ def cmd_stop(args):
 def cmd_status(args):
     """Show node status."""
     cfg = _load_config()
-    node_url = NODE_URL
+    node_url = _resolve_node_url(cfg)
 
     print("🔍 RustChain Node Status")
     print(f"   Config: {CONFIG_FILE}")
@@ -188,7 +201,7 @@ def cmd_config(args):
 def cmd_dashboard(args):
     """Show TUI-style health dashboard."""
     cfg = _load_config()
-    node_url = NODE_URL
+    node_url = _resolve_node_url(cfg)
 
     print("\n" + "=" * 60)
     print("  🦀 RustChain Node Dashboard")

--- a/tests/test_rustchainnode_cli.py
+++ b/tests/test_rustchainnode_cli.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: MIT
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+
+CPU_INFO = {
+    "arch": "arm64",
+    "arch_type": "apple_silicon",
+    "cpu_count": 8,
+    "antiquity_multiplier": 1.0,
+    "optimal_threads": 8,
+}
+
+
+def load_cli_module(monkeypatch, tmp_path):
+    package_root = Path(__file__).resolve().parents[1] / "rustchainnode"
+    monkeypatch.syspath_prepend(str(package_root))
+
+    module = importlib.import_module("rustchainnode.cli")
+    module = importlib.reload(module)
+    monkeypatch.setattr(module, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(module, "CONFIG_FILE", tmp_path / "config.json")
+    monkeypatch.setattr(module, "PID_FILE", tmp_path / "node.pid")
+    monkeypatch.setattr(module, "detect_cpu_info", lambda: CPU_INFO)
+    return module
+
+
+def record_probe_urls(monkeypatch, module):
+    calls = []
+
+    def fake_health(node_url=module.NODE_URL):
+        calls.append(("health", node_url))
+        return {"ok": True, "version": "test"}
+
+    def fake_epoch(node_url=module.NODE_URL):
+        calls.append(("epoch", node_url))
+        return {"epoch": 1, "slot": 2}
+
+    monkeypatch.setattr(module, "_check_health", fake_health)
+    monkeypatch.setattr(module, "_check_epoch", fake_epoch)
+    return calls
+
+
+def test_init_persists_testnet_node_url(monkeypatch, tmp_path, capsys):
+    module = load_cli_module(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        module,
+        "get_optimal_config",
+        lambda wallet, port: {
+            "wallet": wallet,
+            "port": port,
+            "node_url": module.NODE_URL,
+        },
+    )
+    calls = record_probe_urls(monkeypatch, module)
+
+    module.cmd_init(SimpleNamespace(wallet="wallet-1", port=9000, testnet=True))
+    capsys.readouterr()
+
+    cfg = module._load_config()
+    assert cfg["testnet"] is True
+    assert cfg["node_url"] == module.TESTNET_NODE_URL
+    assert calls == [("health", module.TESTNET_NODE_URL)]
+
+
+def test_start_uses_persisted_testnet_config(monkeypatch, tmp_path, capsys):
+    module = load_cli_module(monkeypatch, tmp_path)
+    module._save_config(
+        {
+            "wallet": "wallet-1",
+            "port": 8099,
+            "testnet": True,
+            "node_url": module.NODE_URL,
+        }
+    )
+    calls = record_probe_urls(monkeypatch, module)
+
+    module.cmd_start(SimpleNamespace(wallet=None, port=None, testnet=False))
+    capsys.readouterr()
+
+    assert calls == [
+        ("health", module.TESTNET_NODE_URL),
+        ("epoch", module.TESTNET_NODE_URL),
+    ]
+
+
+def test_status_and_dashboard_use_persisted_testnet_config(monkeypatch, tmp_path, capsys):
+    module = load_cli_module(monkeypatch, tmp_path)
+    module._save_config(
+        {
+            "wallet": "wallet-1",
+            "port": 8099,
+            "testnet": True,
+            "node_url": module.NODE_URL,
+        }
+    )
+
+    status_calls = record_probe_urls(monkeypatch, module)
+    module.cmd_status(SimpleNamespace())
+    capsys.readouterr()
+    assert status_calls == [
+        ("health", module.TESTNET_NODE_URL),
+        ("epoch", module.TESTNET_NODE_URL),
+    ]
+
+    dashboard_calls = record_probe_urls(monkeypatch, module)
+    module.cmd_dashboard(SimpleNamespace())
+    capsys.readouterr()
+    assert dashboard_calls == [
+        ("health", module.TESTNET_NODE_URL),
+        ("epoch", module.TESTNET_NODE_URL),
+    ]
+
+
+def test_status_keeps_custom_production_node_url(monkeypatch, tmp_path, capsys):
+    module = load_cli_module(monkeypatch, tmp_path)
+    module._save_config(
+        {
+            "wallet": "wallet-1",
+            "port": 8099,
+            "testnet": False,
+            "node_url": "https://node.example",
+        }
+    )
+    calls = record_probe_urls(monkeypatch, module)
+
+    module.cmd_status(SimpleNamespace())
+    capsys.readouterr()
+
+    assert calls == [
+        ("health", "https://node.example"),
+        ("epoch", "https://node.example"),
+    ]


### PR DESCRIPTION
## Summary
- add shared node URL resolution for rustchainnode CLI commands
- persist the local testnet URL during `init --testnet`
- make `start`, `status`, and `dashboard` honor persisted testnet config instead of falling back to the production node
- add focused CLI regression tests for testnet and custom production node URLs

## BCOS
BCOS-L1

## Tests
- `.venv/bin/python -m pytest tests/test_rustchainnode_cli.py tests/test_rustchainnode_node.py -q`

Closes #5646