### PR TITLE
fix: remove plaintext p2p demo peers

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Set, Tuple, Any
 from collections import defaultdict, OrderedDict
 import logging
 import requests
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # P2P HMAC secret — MUST be set via the RC_P2P_SECRET environment variable.
@@ -1437,22 +1438,72 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
 
 
 # =============================================================================
+# STANDALONE DEMO PEER CONFIG
+# =============================================================================
+
+DEFAULT_BOOTSTRAP_PEERS = {
+    "node1": "https://rustchain.org",
+}
+
+
+def _parse_peer_config(raw_peers: str) -> Dict[str, str]:
+    """
+    Parse RC_P2P_PEERS as: node2=https://peer.example,node3=http://localhost:8099
+
+    Remote peers must use HTTPS. Plain HTTP is accepted only for loopback
+    development nodes.
+    """
+    peers: Dict[str, str] = {}
+    for item in raw_peers.split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            raise ValueError("expected entries like node_id=https://host:port")
+
+        node_id, peer_url = (part.strip() for part in item.split("=", 1))
+        if not node_id or not peer_url:
+            raise ValueError("peer entries require both node_id and URL")
+
+        parsed = urlparse(peer_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError(f"invalid URL for peer {node_id!r}: {peer_url!r}")
+
+        is_loopback = parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+        if parsed.scheme == "http" and not is_loopback:
+            raise ValueError(
+                f"remote peer {node_id!r} must use HTTPS, got {peer_url!r}"
+            )
+
+        peers[node_id] = peer_url.rstrip("/")
+    return peers
+
+
+def _load_demo_peers(node_id: str, raw_peers: Optional[str] = None) -> Dict[str, str]:
+    """Return configured standalone peers without including this node."""
+    if raw_peers is None:
+        raw_peers = os.environ.get("RC_P2P_PEERS", "")
+
+    peers = (
+        _parse_peer_config(raw_peers)
+        if raw_peers.strip()
+        else dict(DEFAULT_BOOTSTRAP_PEERS)
+    )
+    peers.pop(node_id, None)
+    return peers
+
+
+# =============================================================================
 # MAIN (for testing)
 # =============================================================================
 
 if __name__ == "__main__":
     # Test configuration
     NODE_ID = os.environ.get("RC_NODE_ID", "node1")
-
-    PEERS = {
-        "node1": "https://rustchain.org",
-        "node2": "http://50.28.86.153:8099",
-        "node3": "http://76.8.228.245:8099"
-    }
-
-    # Remove self from peers
-    if NODE_ID in PEERS:
-        del PEERS[NODE_ID]
+    try:
+        PEERS = _load_demo_peers(NODE_ID)
+    except ValueError as exc:
+        raise SystemExit(f"[P2P] invalid RC_P2P_PEERS: {exc}") from exc
 
     # Create and start node
     node = RustChainP2PNode(NODE_ID, DB_PATH, PEERS)

--- a/tests/test_p2p_demo_peer_config.py
+++ b/tests/test_p2p_demo_peer_config.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+NODE_DIR = ROOT / "node"
+if str(NODE_DIR) not in sys.path:
+    sys.path.insert(0, str(NODE_DIR))
+
+os.environ.setdefault("RC_P2P_SECRET", "test-secret-for-p2p-peer-config-0123456789")
+
+p2p = importlib.import_module("rustchain_p2p_gossip")
+
+
+def test_default_demo_peers_use_https_only():
+    peers = p2p._load_demo_peers("node2", raw_peers="")
+
+    assert peers == {"node1": "https://rustchain.org"}
+    assert all(not url.startswith("http://") for url in peers.values())
+
+
+def test_peer_config_rejects_remote_plaintext_http():
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        p2p._parse_peer_config("node2=http://50.28.86.153:8099")
+
+
+def test_peer_config_allows_loopback_http_for_local_dev():
+    peers = p2p._parse_peer_config(
+        "node2=http://localhost:8099,node3=https://peer.example"
+    )
+
+    assert peers == {
+        "node2": "http://localhost:8099",
+        "node3": "https://peer.example",
+    }


### PR DESCRIPTION
## Summary
- remove the hardcoded remote plaintext HTTP peers from the standalone P2P demo startup
- load optional peers from `RC_P2P_PEERS` instead, requiring HTTPS for remote peers while still allowing loopback HTTP for local development
- add regression coverage for the default peer set and plaintext remote rejection

References Security Audit #2744 H4: hardcoded plaintext HTTP peer URLs.

Bounty context: clean fix for verified #2867 H4. Maintainer can request RTC wallet details on acceptance.

## Tests
- `RC_P2P_SECRET=test-secret-for-p2p-peer-config-0123456789 .venv/bin/python -m pytest tests/test_p2p_demo_peer_config.py tests/test_p2p_nonce_security.py -q`

Note: `tests/security_audit/test_security_findings_2867.py::test_mempool_add_manage_tx_undefined` still fails on current main because it searches a fixed line-number window in `utxo_db.py`; this PR does not touch that file.