### PR TITLE
fix: reject boolean GPU numeric route fields

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -477,6 +477,8 @@ def register_routes(app):
 
     def _finite_number_field(data, name: str, default: float = 0.0):
         value = data.get(name, default)
+        if isinstance(value, bool):
+            return None, (jsonify({"error": f"{name} must be a finite number"}), 400)
         try:
             parsed = float(value)
         except (TypeError, ValueError):

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -233,5 +233,34 @@ def test_gpu_protocol_pricing_check_rejects_structured_price(tmp_path, monkeypat
     assert response.get_json() == {"error": "price must be a finite number"}
 
 
+def test_gpu_protocol_escrow_rejects_boolean_amount(tmp_path, monkeypatch):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/render/escrow",
+        json={
+            "job_type": "render",
+            "from_wallet": "payer",
+            "to_wallet": "provider",
+            "amount_rtc": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "amount_rtc must be a finite number"}
+
+
+def test_gpu_protocol_pricing_check_rejects_boolean_price(tmp_path, monkeypatch):
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/render/pricing/check",
+        json={"job_type": "render", "price": True},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "price must be a finite number"}
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- reject JSON booleans before coercing GPU route numeric fields with `float(...)`
- add regression coverage for `amount_rtc: true` on `/render/escrow`
- add regression coverage for `price: true` on `/render/pricing/check`

Fixes #5368.

## Verification
- `python -m pytest -q tests\test_gpu_render_protocol.py`
- Re-ran the issue reproduction and both boolean payloads now return 400 with finite-number validation errors.

## Payout
RTC wallet/miner id: `RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f`