### PR TITLE
fix(scoring): defensive max(0, ...) age guards + testable current_year param

### DIFF
--- a/node/hardware_fingerprint.py
+++ b/node/hardware_fingerprint.py
@@ -438,7 +438,11 @@ class HardwareFingerprint:
             release_year = 2023
         
         oracle["estimated_release_year"] = release_year
-        oracle["estimated_age_years"] = _current_utc_year() - release_year
+        # Clamp to non-negative: a sensor-reported release_year in the
+        # future (misconfigured firmware, NTP drift on the host, bogus
+        # platform claim) must not produce a negative age that would
+        # corrupt downstream scoring.
+        oracle["estimated_age_years"] = max(0, _current_utc_year() - release_year)
         oracle["valid"] = "cpu_model" in oracle or "processor" in oracle
         
         return oracle

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2107,11 +2107,18 @@ def _current_utc_year():
     return time.gmtime().tm_year
 
 
-def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id):
-    """Calculate rust score for a machine."""
+def calculate_rust_score_inline(mfg_year, arch, attestations, machine_id, current_year=None):
+    """Calculate rust score for a machine.
+
+    `current_year` is injectable for deterministic testing. Defaults to the
+    current UTC year via `_current_utc_year()`. The age bonus is clamped to
+    a non-negative value so that a future-dated `mfg_year` (sensor error,
+    misconfigured firmware) cannot reduce the score below the no-age baseline.
+    """
     score = 0
+    current_year = current_year if current_year is not None else _current_utc_year()
     if mfg_year:
-        score += (_current_utc_year() - mfg_year) * 10  # age bonus
+        score += max(0, current_year - int(mfg_year)) * 10  # age bonus
     score += attestations * 0.001  # attestation bonus
     if machine_id <= 100:
         score += 50  # early adopter


### PR DESCRIPTION
## Synthesis of the current-year-age-scoring cluster (2026-05-18)

This PR adds **two defensive guards** that the per-author cluster work for hardcoded `2025` year-bounds didn't fully apply. Most of the cluster has landed via earlier per-author merges today; this commit just completes it.

### What changes
1. `calculate_rust_score_inline` (integrated node) — testable `current_year=None` parameter + `max(0, ...)` clamp on age bonus
2. `collect_device_oracle` (hardware_fingerprint) — `max(0, ...)` clamp on `estimated_age_years` against future-dated `release_year`

### Why
A future-dated `mfg_year` or `release_year` (sensor error, NTP drift, misconfigured firmware, malicious claim) must not produce a negative age that corrupts scoring downstream. ethever's #4942 introduced this defensive pattern; this PR applies it to the two scoring paths that hadn't yet picked it up.

### Cluster credit
- @saim256 (#4595) — first-poster on `node/hall_of_rust.py`
- @slashdevcorpse (#4629) — testable `current_year=None` + 155-line regression suite
- @galpetame (#4938) — `hardware_fingerprint.py` `_current_utc_year()` helper + integrated-node rust-score current-year fix
- @ethever (#4932, #4942) — defensive `max(0, ...)` pattern + testable parameter
- @junn-dev (#5659) — `cpu_architecture_detection.py` Intel-generation pattern anti-collision

Bounty credit splits across the five contributors per first-poster rule on each file's distinct contribution.