### PR TITLE
fix: bound boot chime capture duration cleanly

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -7,7 +7,9 @@ Integrates with RustChain node for miner attestation.
 
 from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
+import io
 import json
+import math
 import os
 import time
 import tempfile
@@ -36,6 +38,8 @@ MAX_AUDIO_UPLOAD_BYTES = int(
     os.getenv('BOOT_CHIME_MAX_AUDIO_BYTES', str(10 * 1024 * 1024))
 )
 ALLOWED_AUDIO_MIME_TYPES = {'audio/wav', 'audio/x-wav', 'audio/wave'}
+MIN_CAPTURE_DURATION = float(os.getenv('BOOT_CHIME_MIN_CAPTURE_DURATION', '0.1'))
+MAX_CAPTURE_DURATION = float(os.getenv('BOOT_CHIME_MAX_CAPTURE_DURATION', '30.0'))
 
 # Initialize Proof-of-Iron system
 poi_system = ProofOfIron(
@@ -100,6 +104,30 @@ def validate_audio_upload(audio_file, *, required: bool = True):
         raise AudioUploadError("invalid WAV file")
 
     return audio_file
+
+
+def get_capture_duration() -> float:
+    """Return a bounded audio capture duration from query parameters."""
+    raw_duration = request.args.get('duration')
+    if raw_duration is None:
+        duration = capture_config.duration
+    else:
+        try:
+            duration = float(raw_duration)
+        except (TypeError, ValueError):
+            raise ValueError("duration must be a number")
+
+    if (
+        not math.isfinite(duration)
+        or duration < MIN_CAPTURE_DURATION
+        or duration > MAX_CAPTURE_DURATION
+    ):
+        raise ValueError(
+            f"duration must be between {MIN_CAPTURE_DURATION:g} "
+            f"and {MAX_CAPTURE_DURATION:g} seconds"
+        )
+
+    return duration
 
 
 # ============= Health & Info =============
@@ -321,7 +349,7 @@ def capture_audio():
     Response: WAV file
     """
     try:
-        duration = request.args.get('duration', default=5.0, type=float)
+        duration = get_capture_duration()
         trigger = request.args.get('trigger', default='false').lower() == 'true'
         
         captured = audio_capture.capture(duration=duration, trigger=trigger)
@@ -330,14 +358,24 @@ def capture_audio():
         with tempfile.NamedTemporaryFile(delete=False, suffix='.wav') as tmp:
             audio_capture.save_audio(captured, tmp.name)
             tmp_path = tmp.name
-        
+
+        try:
+            wav_data = Path(tmp_path).read_bytes()
+        finally:
+            try:
+                os.unlink(tmp_path)
+            except FileNotFoundError:
+                pass
+
         return send_file(
-            tmp_path,
+            io.BytesIO(wav_data),
             mimetype='audio/wav',
             as_attachment=True,
             download_name=f'boot_chime_{int(time.time())}.wav'
         )
-        
+
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 400
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -38,6 +38,20 @@ class ProofOfIronStub:
         raise AssertionError("invalid uploads should be rejected before proof submission")
 
 
+class BootChimeCaptureStub:
+    def __init__(self, *args, **kwargs):
+        self.calls = []
+        self.saved_paths = []
+
+    def capture(self, duration=None, trigger=False):
+        self.calls.append((duration, trigger))
+        return object()
+
+    def save_audio(self, captured, path):
+        self.saved_paths.append(path)
+        Path(path).write_bytes(b"RIFF\x00\x00\x00\x00WAVE")
+
+
 def install_dependency_stubs(monkeypatch):
     flask_cors = types.ModuleType("flask_cors")
     flask_cors.CORS = lambda app: app
@@ -51,12 +65,12 @@ def install_dependency_stubs(monkeypatch):
     boot_chime_capture.AudioCaptureConfig = type(
         "AudioCaptureConfig",
         (),
-        {"__init__": lambda self, **kwargs: None},
+        {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
     )
     boot_chime_capture.BootChimeCapture = type(
         "BootChimeCapture",
-        (),
-        {"__init__": lambda self, *args, **kwargs: None},
+        (BootChimeCaptureStub,),
+        {},
     )
     monkeypatch.setitem(sys.modules, "boot_chime_capture", boot_chime_capture)
 
@@ -156,3 +170,23 @@ def test_audio_upload_rejects_files_larger_than_configured_limit(client, api_mod
 
     assert response.status_code == 413
     assert response.get_json() == {"error": "file too large"}
+
+
+@pytest.mark.parametrize("duration", ("0", "-1", "30.01", "inf", "not-a-number"))
+def test_capture_rejects_out_of_range_duration(client, api_module, duration):
+    response = client.post(f"/api/v1/capture?duration={duration}")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"].startswith("duration must")
+    assert api_module.audio_capture.calls == []
+
+
+def test_capture_accepts_bounded_duration(client, api_module):
+    response = client.post("/api/v1/capture?duration=30&trigger=true")
+
+    assert response.status_code == 200
+    assert response.mimetype == "audio/wav"
+    assert response.get_data() == b"RIFF\x00\x00\x00\x00WAVE"
+    assert api_module.audio_capture.calls == [(30.0, True)]
+    assert api_module.audio_capture.saved_paths
+    assert not Path(api_module.audio_capture.saved_paths[-1]).exists()


### PR DESCRIPTION
Fixes #5107.

Clean replacement for my closed #5109 after the maintainer rejected that branch for unrelated spillover. This branch is deliberately two-file scoped.

## Summary
- Add explicit min/max duration validation for `/api/v1/capture` before invoking audio capture.
- Reject non-finite, non-numeric, too-short, and over-limit durations with HTTP 400.
- Read the generated WAV into memory and unlink the temp file before returning, avoiding the Windows `send_file` open-handle cleanup race.
- Add focused Flask endpoint regressions using dependency stubs, including response bytes and temp-file cleanup.

## Scope proof
`git diff --name-only upstream/main...HEAD`:
- `issue2307_boot_chime/boot_chime_api.py`
- `tests/test_boot_chime_api_json_validation.py`

No node, miner, beacon, admin, wallet, CI, or package-path changes are in this branch.

## Validation
- `python3 -B -m py_compile issue2307_boot_chime/boot_chime_api.py tests/test_boot_chime_api_json_validation.py` -> passed
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -B -m pytest tests/test_boot_chime_api_json_validation.py -q --noconftest` -> 15 passed
- `uv run --no-project --with pytest --with flask --with numpy python -B -m pytest issue2307_boot_chime/tests/test_boot_chime.py -q --noconftest` -> 32 passed
- `uv run --no-project --with ruff ruff check --select E9,F821,F811,F841 issue2307_boot_chime/boot_chime_api.py tests/test_boot_chime_api_json_validation.py` -> all checks passed
- `python3 tools/bcos_spdx_check.py --base-ref upstream/main` -> BCOS SPDX check: OK
- `git diff --check` -> passed

## Bounty note
This is not a competing duplicate claim against my earlier #5109. If the previous wave payment already covers the work, treat this as the clean landing branch for the same issue rather than an additional payout request.

Miner ID: `dicnunz`
Canonical payout target: https://github.com/Scottcjn/rustchain-bounties/issues/9194