### PR TITLE
Harden rustchainnode persisted testnet config

### DIFF
--- a/rustchainnode/rustchainnode/cli.py
+++ b/rustchainnode/rustchainnode/cli.py
@@ -177,6 +177,7 @@ def cmd_status(args):
         print(f"   Network: {'testnet' if cfg.get('testnet') else 'mainnet'}")
         print(f"   Arch: {cfg.get('arch_type', 'unknown')}")
         print(f"   Antiquity: {cfg.get('antiquity_multiplier', 1.0)}x")
+        print(f"   Testnet: {cfg.get('testnet', False)}")
 
     health = _check_health(node_url)
     if health.get("ok"):

--- a/rustchainnode/tests/test_cli_node_url.py
+++ b/rustchainnode/tests/test_cli_node_url.py
@@ -1,0 +1,14 @@
+from rustchainnode import cli
+
+
+def test_resolve_node_url_uses_persisted_testnet_default():
+    assert cli._resolve_node_url({"testnet": True}) == cli.TESTNET_NODE_URL
+
+
+def test_resolve_node_url_keeps_custom_testnet_url():
+    custom = "http://127.0.0.1:9999"
+    assert cli._resolve_node_url({"testnet": True, "node_url": custom}) == custom
+
+
+def test_resolve_node_url_force_testnet_over_default_mainnet():
+    assert cli._resolve_node_url({"node_url": cli.NODE_URL}, force_testnet=True) == cli.TESTNET_NODE_URL


### PR DESCRIPTION
## Summary

Fixes #5646.

Current `main` already includes the core persisted-testnet URL resolution. This PR hardens that fix by:

- showing the persisted `testnet` flag in `rustchainnode status` so users can verify which mode is active, and
- adding regression coverage for `_resolve_node_url()` to ensure persisted testnet config and forced testnet mode resolve to the local testnet URL unless a custom testnet URL is configured.

## Validation

- `python -m py_compile rustchainnode/rustchainnode/cli.py`
- Local regression functions in `rustchainnode/tests/test_cli_node_url.py` passed.

## Bounty / payout

RTC payout wallet / public receive address: `RTC4e8541f1bdda7dcb47dd2a3453ddc0ddb7ae2f9b`
