### PR TITLE
Allow award RTC action to use full transfer URL

### DIFF
--- a/.github/actions/rtc-auto-bounty/action.yml
+++ b/.github/actions/rtc-auto-bounty/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'RustChain VPS host (IP or hostname)'
     required: false
     default: ''
+  rtc-api-url:
+    description: 'Full RustChain transfer API URL, for example https://rustchain.org/wallet/transfer'
+    required: false
+    default: ''
   rtc-admin-key:
     description: 'Admin key for the /wallet/transfer endpoint'
     required: false
@@ -76,6 +80,7 @@ runs:
       shell: bash
       env:
         INPUT_RTC_AMOUNT: ${{ inputs.rtc-amount }}
+        INPUT_RTC_API_URL: ${{ inputs.rtc-api-url }}
         INPUT_RTC_VPS_HOST: ${{ inputs.rtc-vps-host }}
         INPUT_RTC_ADMIN_KEY: ${{ inputs.rtc-admin-key }}
         INPUT_FROM_WALLET: ${{ inputs.from-wallet }}

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -41,6 +41,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -118,6 +119,7 @@ class Config:
 
     def __init__(self) -> None:
         self.rtc_amount: float = _env_float("INPUT_RTC_AMOUNT", 50.0)
+        self.rtc_api_url: str = _env_stripped("INPUT_RTC_API_URL")
         self.vps_host: str = _env_stripped("INPUT_RTC_VPS_HOST")
         self.admin_key: str = _env_stripped("INPUT_RTC_ADMIN_KEY")
         self.from_wallet: str = _env_stripped("INPUT_FROM_WALLET", "founder_community")
@@ -145,8 +147,8 @@ class Config:
             return "GITHUB_REPOSITORY is not set"
         if not self.pr_number:
             return "PR_NUMBER is not set"
-        if not self.dry_run and not self.vps_host:
-            return "INPUT_RTC_VPS_HOST is required (unless dry-run is enabled)"
+        if not self.dry_run and not (self.rtc_api_url or self.vps_host):
+            return "INPUT_RTC_API_URL or INPUT_RTC_VPS_HOST is required (unless dry-run is enabled)"
         if not self.dry_run and not self.admin_key:
             return "INPUT_RTC_ADMIN_KEY is required (unless dry-run is enabled)"
         if not _is_finite_amount(self.rtc_amount):
@@ -299,7 +301,7 @@ def is_endpoint_unreachable_error(error_msg: str) -> bool:
 
 
 def transfer_rtc(
-    vps_host: str,
+    transfer_url: str,
     admin_key: str,
     from_wallet: str,
     to_wallet: str,
@@ -311,12 +313,11 @@ def transfer_rtc(
 
     Returns ``(success, response_body_dict)``.
     """
-    vps_host = vps_host.strip()
+    transfer_url = build_transfer_url(transfer_url)
     admin_key = admin_key.strip()
     from_wallet = from_wallet.strip()
     to_wallet = to_wallet.strip()
 
-    url = f"http://{vps_host}:{VPS_PORT}/wallet/transfer"
     payload = {
         "from_miner": from_wallet,
         "to_miner": to_wallet,
@@ -324,7 +325,7 @@ def transfer_rtc(
         "memo": memo,
     }
     req = Request(
-        url,
+        transfer_url,
         data=json.dumps(payload).encode("utf-8"),
         headers={
             "Content-Type": "application/json",
@@ -345,6 +346,22 @@ def transfer_rtc(
         return False, result
     except URLError as e:
         return False, {"error": f"Connection failed: {e.reason}"}
+
+
+def build_transfer_url(value: str) -> str:
+    """
+    Build the wallet transfer URL.
+
+    Full URLs are used as-is, except a bare origin gets ``/wallet/transfer``
+    appended. Bare hosts keep the legacy ``http://host:8099`` behavior.
+    """
+    value = value.strip().rstrip("/")
+    parsed = urlparse(value)
+    if parsed.scheme and parsed.netloc:
+        if parsed.path and parsed.path != "/":
+            return value
+        return f"{value}/wallet/transfer"
+    return f"http://{value}:{VPS_PORT}/wallet/transfer"
 
 
 # ---------------------------------------------------------------------------
@@ -472,7 +489,7 @@ def main() -> int:
     # --- Execute transfer --------------------------------------------------
     print(f"Initiating transfer: {amount} RTC from {cfg.from_wallet} to {wallet}")
     ok, result = transfer_rtc(
-        cfg.vps_host,
+        cfg.rtc_api_url or cfg.vps_host,
         cfg.admin_key,
         cfg.from_wallet,
         wallet,

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(ACTION_DIR))
 
 from award_rtc import (
     Config,
+    build_transfer_url,
     resolve_wallet,
     resolve_wallet_from_pr_body,
     resolve_wallet_from_file,
@@ -174,6 +175,7 @@ class TestConfig(unittest.TestCase):
         """Create a Config with the given environment variable overrides."""
         env = {
             "INPUT_RTC_AMOUNT": "50",
+            "INPUT_RTC_API_URL": "",
             "INPUT_RTC_VPS_HOST": "1.2.3.4",
             "INPUT_RTC_ADMIN_KEY": "test-key-32-chars-long!!",
             "INPUT_FROM_WALLET": "founder_community",
@@ -204,6 +206,7 @@ class TestConfig(unittest.TestCase):
     def test_trims_scalar_inputs(self):
         cfg = self._cfg(
             INPUT_RTC_AMOUNT=" 50\n",
+            INPUT_RTC_API_URL=" https://rustchain.org/wallet/transfer\n",
             INPUT_RTC_VPS_HOST=" 1.2.3.4\n",
             INPUT_RTC_ADMIN_KEY=" test-key-32-chars-long!!\n",
             INPUT_FROM_WALLET=" founder_community\n",
@@ -221,6 +224,7 @@ class TestConfig(unittest.TestCase):
         )
 
         self.assertEqual(cfg.rtc_amount, 50.0)
+        self.assertEqual(cfg.rtc_api_url, "https://rustchain.org/wallet/transfer")
         self.assertEqual(cfg.vps_host, "1.2.3.4")
         self.assertEqual(cfg.admin_key, "test-key-32-chars-long!!")
         self.assertEqual(cfg.from_wallet, "founder_community")
@@ -251,6 +255,14 @@ class TestConfig(unittest.TestCase):
     def test_validate_missing_vps_host_in_live_mode(self):
         cfg = self._cfg(INPUT_RTC_VPS_HOST="", INPUT_DRY_RUN="false")
         self.assertIsNotNone(cfg.validate())
+
+    def test_validate_allows_api_url_without_legacy_host(self):
+        cfg = self._cfg(
+            INPUT_RTC_API_URL="https://rustchain.org/wallet/transfer",
+            INPUT_RTC_VPS_HOST="",
+            INPUT_DRY_RUN="false",
+        )
+        self.assertIsNone(cfg.validate())
 
     def test_validate_missing_admin_key_in_live_mode(self):
         cfg = self._cfg(INPUT_RTC_ADMIN_KEY="", INPUT_DRY_RUN="false")
@@ -343,13 +355,31 @@ class TestSetOutput(unittest.TestCase):
 class TestTransferRtc(unittest.TestCase):
     """Test RustChain transfer API request construction."""
 
+    def test_build_transfer_url_preserves_full_path(self):
+        self.assertEqual(
+            build_transfer_url("https://rustchain.org/wallet/transfer"),
+            "https://rustchain.org/wallet/transfer",
+        )
+
+    def test_build_transfer_url_appends_transfer_path_to_origin(self):
+        self.assertEqual(
+            build_transfer_url("https://rustchain.org"),
+            "https://rustchain.org/wallet/transfer",
+        )
+
+    def test_build_transfer_url_keeps_legacy_host_mode(self):
+        self.assertEqual(
+            build_transfer_url("1.2.3.4"),
+            "http://1.2.3.4:8099/wallet/transfer",
+        )
+
     def test_strips_scalar_request_values(self):
         mock_resp = MagicMock()
         mock_resp.read.return_value = b'{"ok": true, "tx_hash": "tx_abc"}'
 
         with patch("award_rtc.urlopen", return_value=mock_resp) as mock_urlopen:
             ok, result = transfer_rtc(
-                " 1.2.3.4\n",
+                " https://rustchain.org/wallet/transfer\n",
                 " test-admin-key\n",
                 " founder_community\n",
                 " alice\n",
@@ -361,7 +391,7 @@ class TestTransferRtc(unittest.TestCase):
         self.assertEqual(result["tx_hash"], "tx_abc")
 
         req = mock_urlopen.call_args[0][0]
-        self.assertEqual(req.full_url, "http://1.2.3.4:8099/wallet/transfer")
+        self.assertEqual(req.full_url, "https://rustchain.org/wallet/transfer")
         self.assertEqual(req.get_header("X-admin-key"), "test-admin-key")
 
         payload = json.loads(req.data.decode("utf-8"))
@@ -383,6 +413,7 @@ class TestMainFlow(unittest.TestCase):
         output_file.close()
         env = {
             "INPUT_RTC_AMOUNT": "75",
+            "INPUT_RTC_API_URL": "",
             "INPUT_RTC_VPS_HOST": "1.2.3.4",
             "INPUT_RTC_ADMIN_KEY": "test-admin-key-32chars!!",
             "INPUT_FROM_WALLET": "founder_community",

--- a/.github/workflows/award-rtc.yml
+++ b/.github/workflows/award-rtc.yml
@@ -21,6 +21,7 @@ jobs:
         uses: ./.github/actions/rtc-auto-bounty
         with:
           rtc-amount: '5'
+          rtc-api-url: ${{ secrets.RTC_API_URL }}
           rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}
           rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}
           from-wallet: 'founder_community'

--- a/tests/test_award_rtc_workflow.py
+++ b/tests/test_award_rtc_workflow.py
@@ -25,5 +25,6 @@ def test_award_rtc_workflow_passes_live_transfer_secrets() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
 
     assert "rtc-vps-host: ${{ secrets.RTC_VPS_HOST }}" in workflow
+    assert "rtc-api-url: ${{ secrets.RTC_API_URL }}" in workflow
     assert "rtc-admin-key: ${{ secrets.RTC_ADMIN_KEY }}" in workflow
     assert "github-token: ${{ secrets.GITHUB_TOKEN }}" in workflow


### PR DESCRIPTION
## Summary
- Add an optional `rtc-api-url` input to the RTC auto-bounty action.
- Prefer `RTC_API_URL` from workflow secrets when present, while preserving the legacy `http://host:8099/wallet/transfer` path for existing `RTC_VPS_HOST` setups.
- Add unit coverage for full transfer URLs, origin-only URLs, and legacy host behavior.

## Why
Merged PR awards are currently failing with endpoint connection errors. The public RustChain wallet API is reachable over HTTPS, but the action can only construct `http://<host>:8099/wallet/transfer`. This lets maintainers point the workflow at the actual transfer endpoint without code changes.

Fixes #5664

wallet: RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f