### PR TITLE
Fix Windows miner attestation diagnostics

### DIFF
--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -331,6 +331,7 @@ class RustChainMiner:
         self.enrolled = False
         self.hw_info = self._get_hw_info()
         self.last_entropy = {}
+        self.last_attestation_error = ""
         self.fingerprint_data = None
         self._run_fingerprint_checks()
 
@@ -400,7 +401,10 @@ class RustChainMiner:
         if now >= self.attestation_valid_until - 60:
             if not self.attest():
                 if callback:
-                    callback({"type": "error", "message": "Attestation failed"})
+                    message = "Attestation failed"
+                    if self.last_attestation_error:
+                        message = f"{message}: {self.last_attestation_error}"
+                    callback({"type": "error", "message": message})
                 return False
 
         if (now - self.last_enroll) > 3600 or not self.enrolled:
@@ -474,9 +478,26 @@ class RustChainMiner:
     def attest(self):
         """Perform hardware attestation for PoA."""
         try:
-            challenge = requests.post(f"{self.node_url}/attest/challenge", json={}, timeout=10, verify=TLS_VERIFY).json()
-            nonce = challenge.get("nonce")
-        except Exception:
+            challenge_resp = requests.post(
+                f"{self.node_url}/attest/challenge",
+                json={},
+                timeout=10,
+                verify=TLS_VERIFY,
+            )
+            if challenge_resp.status_code != 200:
+                self.last_attestation_error = (
+                    f"challenge rejected: {self._response_diagnostic(challenge_resp)}"
+                )
+                return False
+            challenge = challenge_resp.json()
+            nonce = challenge.get("nonce") if isinstance(challenge, dict) else None
+            if not nonce:
+                self.last_attestation_error = (
+                    f"challenge rejected: {self._response_diagnostic(challenge_resp)}"
+                )
+                return False
+        except Exception as e:
+            self.last_attestation_error = f"challenge request failed: {e}"
             return False
 
         entropy = self._collect_entropy()
@@ -514,12 +535,32 @@ class RustChainMiner:
                                  timeout=30, verify=TLS_VERIFY)
             if resp.status_code == 200 and resp.json().get("ok"):
                 self.attestation_valid_until = time.time() + 580
+                self.last_attestation_error = ""
                 return True
-            else:
-                print(f"[ATTEST] Server response: {resp.status_code} {resp.text[:200]}")
+            self.last_attestation_error = f"submit rejected: {self._response_diagnostic(resp)}"
         except Exception as e:
-            print(f"[ATTEST] Error: {e}")
+            self.last_attestation_error = f"submit request failed: {e}"
         return False
+
+    def _response_diagnostic(self, resp):
+        """Return a compact HTTP failure description for operator logs."""
+        parts = [f"HTTP {getattr(resp, 'status_code', 'unknown')}"]
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = None
+
+        if isinstance(payload, dict):
+            for key in ("code", "error", "message"):
+                value = payload.get(key)
+                if value:
+                    parts.append(f"{key}={value}")
+        else:
+            text = (getattr(resp, "text", "") or "").strip()
+            if text:
+                parts.append(f"body={text[:240]}")
+
+        return " ".join(parts)
 
     def enroll(self):
         """Enroll the miner into the current epoch after attesting."""
@@ -682,11 +723,8 @@ class RustChainGUI:
 
 def run_headless(wallet_address: str, node_url: str) -> int:
     wallet = RustChainWallet()
-    if wallet_address:
-        wallet.wallet_data["address"] = wallet_address
-        wallet.save_wallet(wallet.wallet_data)
-
-    miner = RustChainMiner(wallet.wallet_data["address"])
+    active_wallet = wallet_address or wallet.wallet_data["address"]
+    miner = RustChainMiner(active_wallet)
     miner.node_url = node_url
 
     def cb(evt):
@@ -737,8 +775,6 @@ def main(argv=None):
     app = RustChainGUI()
     app.miner.node_url = args.node
     if args.wallet:
-        app.wallet.wallet_data["address"] = args.wallet
-        app.wallet.save_wallet(app.wallet.wallet_data)
         app.miner.wallet_address = args.wallet
         app.miner.miner_id = f"windows_{hashlib.md5(args.wallet.encode()).hexdigest()[:8]}"
     app.run()

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -6,7 +6,7 @@ set "PYTHON_URL=https://www.python.org/ftp/python/3.11.5/python-3.11.5-amd64.exe
 set "PYTHON_INSTALLER=%SCRIPT_DIR%python-3.11.5-amd64.exe"
 set "MINER_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py"
 set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
-set "MINER_SHA256=230f6405a03b4e455a3e2a9097d4796acec82237512a1e56e11d9855060cf5da"
+set "MINER_SHA256=5b69ebc210e4e8e32975b711dcb1ca08e07b731ddfe4f9f2f9a7e68c1e246a9d"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -114,6 +114,7 @@ class RustChainMiner:
         self.enrolled = False
         self.hw_info = self._get_hw_info()
         self.last_entropy = {}
+        self.last_attestation_error = ""
 
         # Zephyr dual-mining state — detected once per attest() cycle
         self._pow_proof = None
@@ -282,7 +283,10 @@ class RustChainMiner:
         if now >= self.attestation_valid_until - 60:
             if not self.attest():
                 if callback:
-                    callback({"type": "error", "message": "Attestation failed"})
+                    message = "Attestation failed"
+                    if self.last_attestation_error:
+                        message = f"{message}: {self.last_attestation_error}"
+                    callback({"type": "error", "message": message})
                 return False
             if callback:
                 callback({
@@ -388,11 +392,23 @@ class RustChainMiner:
         apply the PoW bonus multiplier to this miner's RTC rewards.
         """
         try:
-            challenge = requests.post(
+            challenge_resp = requests.post(
                 f"{self.node_url}/attest/challenge", json={}, timeout=10
-            ).json()
-            nonce = challenge.get("nonce")
-        except Exception:
+            )
+            if challenge_resp.status_code != 200:
+                self.last_attestation_error = (
+                    f"challenge rejected: {self._response_diagnostic(challenge_resp)}"
+                )
+                return False
+            challenge = challenge_resp.json()
+            nonce = challenge.get("nonce") if isinstance(challenge, dict) else None
+            if not nonce:
+                self.last_attestation_error = (
+                    f"challenge rejected: {self._response_diagnostic(challenge_resp)}"
+                )
+                return False
+        except Exception as e:
+            self.last_attestation_error = f"challenge request failed: {e}"
             return False
 
         entropy = self._collect_entropy()
@@ -438,10 +454,32 @@ class RustChainMiner:
             )
             if resp.status_code == 200 and resp.json().get("ok"):
                 self.attestation_valid_until = time.time() + 580
+                self.last_attestation_error = ""
                 return True
-        except Exception:
-            pass
+            self.last_attestation_error = f"submit rejected: {self._response_diagnostic(resp)}"
+        except Exception as e:
+            self.last_attestation_error = f"submit request failed: {e}"
         return False
+
+    def _response_diagnostic(self, resp):
+        """Return a compact HTTP failure description for operator logs."""
+        parts = [f"HTTP {getattr(resp, 'status_code', 'unknown')}"]
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = None
+
+        if isinstance(payload, dict):
+            for key in ("code", "error", "message"):
+                value = payload.get(key)
+                if value:
+                    parts.append(f"{key}={value}")
+        else:
+            text = (getattr(resp, "text", "") or "").strip()
+            if text:
+                parts.append(f"body={text[:240]}")
+
+        return " ".join(parts)
 
     def enroll(self):
         """Enroll the miner into the current epoch after attesting."""
@@ -636,10 +674,8 @@ def _format_headless_event(evt):
 
 def run_headless(wallet_address: str, node_url: str) -> int:
     wallet = RustChainWallet()
-    if wallet_address:
-        wallet.wallet_data["address"] = wallet_address
-        wallet.save_wallet(wallet.wallet_data)
-    miner = RustChainMiner(wallet.wallet_data["address"])
+    active_wallet = wallet_address or wallet.wallet_data["address"]
+    miner = RustChainMiner(active_wallet)
     miner.node_url = node_url
 
     def cb(evt):
@@ -686,8 +722,6 @@ def main(argv=None):
     app = RustChainGUI()
     app.miner.node_url = args.node
     if args.wallet:
-        app.wallet.wallet_data["address"] = args.wallet
-        app.wallet.save_wallet(app.wallet.wallet_data)
         app.miner.wallet_address = args.wallet
         app.miner.miner_id = f"windows_{hashlib.md5(args.wallet.encode()).hexdigest()[:8]}"
     app.run()

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -27,7 +27,7 @@ MINER_ARTIFACTS = {
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",
-        "sha256": "230f6405a03b4e455a3e2a9097d4796acec82237512a1e56e11d9855060cf5da",
+        "sha256": "5b69ebc210e4e8e32975b711dcb1ca08e07b731ddfe4f9f2f9a7e68c1e246a9d",
     },
 }
 

--- a/tests/test_windows_headless_lifecycle_logging.py
+++ b/tests/test_windows_headless_lifecycle_logging.py
@@ -65,3 +65,44 @@ def test_ready_status_and_headless_format_include_lifecycle_details():
         "message": "Epoch enrollment succeeded",
         "miner_id": "windows_abc123",
     }) == "[enroll] Epoch enrollment succeeded miner_id=windows_abc123"
+
+
+def test_ensure_ready_surfaces_attestation_diagnostics(monkeypatch):
+    module = _load_windows_miner()
+    miner = module.RustChainMiner("RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7")
+    miner.last_attestation_error = (
+        "submit rejected: HTTP 409 code=DUPLICATE_HARDWARE "
+        "error=hardware_already_bound"
+    )
+    events = []
+
+    monkeypatch.setattr(miner, "attest", lambda: False)
+
+    assert not miner._ensure_ready(events.append)
+    assert events == [{
+        "type": "error",
+        "message": (
+            "Attestation failed: submit rejected: HTTP 409 "
+            "code=DUPLICATE_HARDWARE error=hardware_already_bound"
+        ),
+    }]
+
+
+def test_response_diagnostic_includes_safe_json_fields():
+    module = _load_windows_miner()
+    miner = module.RustChainMiner("RTC02811ff5e2bb4bb4b95eee44c5429cd9525496e7")
+
+    class Response:
+        status_code = 409
+
+        def json(self):
+            return {
+                "code": "DUPLICATE_HARDWARE",
+                "error": "hardware_already_bound",
+                "message": "This hardware is already registered",
+            }
+
+    assert miner._response_diagnostic(Response()) == (
+        "HTTP 409 code=DUPLICATE_HARDWARE error=hardware_already_bound "
+        "message=This hardware is already registered"
+    )


### PR DESCRIPTION
## Summary
- surface compact challenge/submit attestation diagnostics in Windows headless mode
- keep `--wallet` as a runtime override instead of persisting it into the saved wallet
- apply the same behavior to the installer copy and refresh the pinned miner checksum

## Verification
- `py_compile` on both Windows miner sources
- focused diagnostic assertions for duplicate-hardware output and checksum pinning

Fixes #5575

wallet: RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f