### PR TITLE
fix: harden contributor registration

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -5,6 +5,7 @@ import sqlite3
 import os
 import secrets
 import hmac
+import re
 from datetime import datetime
 
 app = Flask(__name__)
@@ -32,6 +33,10 @@ elif SECRET_KEY == 'rustchain_contributor_secret_2024':
 app.secret_key = SECRET_KEY
 
 DB_PATH = 'contributors.db'
+CONTRIBUTOR_TYPES = {'human', 'bot', 'agent'}
+GITHUB_USERNAME_RE = re.compile(r'^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$')
+RTC_WALLET_RE = re.compile(r'^RTC[0-9A-Fa-f]{40}$')
+EVM_WALLET_RE = re.compile(r'^0x[0-9A-Fa-f]{40}$')
 
 
 def debug_enabled() -> bool:
@@ -46,6 +51,45 @@ def _contributor_admin_authorized() -> bool:
         provided_key,
         expected_key,
     )
+
+def _registration_key_status():
+    expected_key = os.environ.get('CONTRIBUTOR_REGISTRATION_KEY', '')
+    if not expected_key:
+        return False, 503
+
+    provided_key = (
+        request.headers.get('X-Registration-Key')
+        or request.form.get('registration_key', '')
+    )
+    if not provided_key:
+        return False, 401
+
+    return hmac.compare_digest(provided_key, expected_key), 401
+
+def _validate_github_username(value: str) -> str:
+    username = value.strip()
+    if not GITHUB_USERNAME_RE.fullmatch(username):
+        abort(400, description='github_username must be a valid GitHub username')
+    if '--' in username:
+        abort(400, description='github_username must not contain consecutive hyphens')
+    return username
+
+def _validate_contributor_type(value: str) -> str:
+    contributor_type = value.strip().lower()
+    if contributor_type not in CONTRIBUTOR_TYPES:
+        abort(400, description='contributor_type must be human, bot, or agent')
+    return contributor_type
+
+def _validate_wallet(value: str) -> str:
+    wallet = value.strip()
+    if not (RTC_WALLET_RE.fullmatch(wallet) or EVM_WALLET_RE.fullmatch(wallet)):
+        abort(400, description='rtc_wallet must be an RTC or 0x wallet address')
+    return wallet
+
+def _redact_wallet(wallet: str) -> str:
+    if len(wallet) <= 12:
+        return 'redacted'
+    return f'{wallet[:6]}...{wallet[-4:]}'
 
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -108,6 +152,11 @@ def index():
                 <label for="rtc_wallet">RTC Wallet Address:</label>
                 <input type="text" id="rtc_wallet" name="rtc_wallet" required>
             </div>
+
+            <div class="form-group">
+                <label for="registration_key">Registration Key:</label>
+                <input type="password" id="registration_key" name="registration_key" required>
+            </div>
             
             <div class="form-group">
                 <label for="contribution_history">Contribution History:</label>
@@ -127,7 +176,7 @@ def index():
             {% for contributor in contributors %}
             <div class="contributor status-{{ contributor[6] }}">
                 <strong>@{{ contributor[1] }}</strong> ({{ contributor[2] }})
-                <br><small>Wallet: {{ contributor[3] }}</small>
+                <br><small>Wallet: {{ redact_wallet(contributor[3]) }}</small>
                 <br><small>Registered: {{ contributor[5] }} | Status: {{ contributor[6] }}</small>
                 {% if contributor[4] %}
                     <br><em>{{ contributor[4][:200] }}{% if contributor[4]|length > 200 %}...{% endif %}</em>
@@ -145,14 +194,18 @@ def index():
         ).fetchall()
     
     from flask import render_template_string
-    return render_template_string(html, contributors=contributors)
+    return render_template_string(html, contributors=contributors, redact_wallet=_redact_wallet)
 
 @app.route('/register', methods=['POST'])
 def register():
-    github_username = request.form['github_username']
-    contributor_type = request.form['contributor_type']
-    rtc_wallet = request.form['rtc_wallet']
-    contribution_history = request.form.get('contribution_history', '')
+    authorized, status_code = _registration_key_status()
+    if not authorized:
+        abort(status_code)
+
+    github_username = _validate_github_username(request.form.get('github_username', ''))
+    contributor_type = _validate_contributor_type(request.form.get('contributor_type', ''))
+    rtc_wallet = _validate_wallet(request.form.get('rtc_wallet', ''))
+    contribution_history = request.form.get('contribution_history', '').strip()
     
     try:
         with sqlite3.connect(DB_PATH) as conn:
@@ -179,7 +232,7 @@ def api_contributors():
             {
                 'github_username': c[0],
                 'type': c[1],
-                'wallet': c[2],
+                'wallet': _redact_wallet(c[2]),
                 'registered': c[3],
                 'status': c[4]
             }

--- a/tests/test_contributor_registry.py
+++ b/tests/test_contributor_registry.py
@@ -9,10 +9,15 @@ from unittest.mock import patch, MagicMock
 # Module under test
 import contributor_registry as cr
 
+REGISTRATION_KEY = "expected-registration-key"
+VALID_RTC_WALLET = "RTC019e78d600fb3131c29d7ba80aba8fe644be426e"
+VALID_0X_WALLET = "0x019e78d600fb3131c29d7ba80aba8fe644be426e"
+
 
 @pytest.fixture
-def app():
+def app(monkeypatch):
     """Create a test Flask app with a temporary database."""
+    monkeypatch.setenv("CONTRIBUTOR_REGISTRATION_KEY", REGISTRATION_KEY)
     db_fd, db_path = tempfile.mkstemp(suffix=".db")
     os.close(db_fd)
     cr.DB_PATH = db_path
@@ -40,9 +45,21 @@ def seed_contributor(app):
         conn.execute(
             "INSERT INTO contributors (github_username, contributor_type, rtc_wallet, contribution_history, status) "
             "VALUES (?, ?, ?, ?, ?)",
-            ("testuser", "human", "RTC019e78d600fb3131c29d7ba80aba8fe644be426e", "PR reviews and bug reports", "approved"),
+            ("testuser", "human", VALID_RTC_WALLET, "PR reviews and bug reports", "approved"),
         )
         conn.commit()
+
+
+def _registration_data(**overrides):
+    data = {
+        "github_username": "newuser",
+        "contributor_type": "agent",
+        "rtc_wallet": VALID_RTC_WALLET,
+        "registration_key": REGISTRATION_KEY,
+        "contribution_history": "Mining and staking",
+    }
+    data.update(overrides)
+    return data
 
 
 class TestInitDb:
@@ -71,18 +88,18 @@ class TestIndexRoute:
         """GET / should list registered contributors."""
         response = client.get("/")
         assert b"testuser" in response.data
-        assert b"RTC019e78d600fb3131c29d7ba80aba8fe644be426e" in response.data
+        assert b"RTC019...426e" in response.data
+        assert VALID_RTC_WALLET.encode() not in response.data
 
 
 class TestRegisterRoute:
     def test_register_new_contributor(self, client):
         """POST /register should add a new contributor."""
-        response = client.post("/register", data={
-            "github_username": "newuser",
-            "contributor_type": "agent",
-            "rtc_wallet": "RTC0abc123",
-            "contribution_history": "Mining and staking",
-        }, follow_redirects=True)
+        response = client.post(
+            "/register",
+            data=_registration_data(),
+            follow_redirects=True,
+        )
         assert response.status_code == 200
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
@@ -94,14 +111,85 @@ class TestRegisterRoute:
 
     def test_register_duplicate_username(self, client, seed_contributor):
         """POST /register with existing username should flash error."""
-        response = client.post("/register", data={
-            "github_username": "testuser",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0dup",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        response = client.post(
+            "/register",
+            data=_registration_data(
+                github_username="testuser",
+                contributor_type="human",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
         assert response.status_code == 200
         assert b"already registered" in response.data
+
+    def test_register_fails_closed_without_configured_key(self, client, monkeypatch):
+        """Unset CONTRIBUTOR_REGISTRATION_KEY must not allow public registration."""
+        monkeypatch.delenv("CONTRIBUTOR_REGISTRATION_KEY", raising=False)
+        response = client.post("/register", data=_registration_data())
+
+        assert response.status_code == 503
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            count = conn.execute(
+                "SELECT COUNT(*) FROM contributors WHERE github_username='newuser'"
+            ).fetchone()[0]
+        assert count == 0
+
+    def test_register_requires_matching_registration_key(self, client):
+        """POST /register should reject missing or wrong registration keys."""
+        missing = client.post(
+            "/register",
+            data=_registration_data(registration_key=""),
+        )
+        wrong = client.post(
+            "/register",
+            data=_registration_data(github_username="wrongkey", registration_key="wrong"),
+        )
+
+        assert missing.status_code == 401
+        assert wrong.status_code == 401
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM contributors").fetchone()[0]
+        assert count == 0
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("github_username", "-not-valid"),
+            ("github_username", "not--valid"),
+            ("contributor_type", "owner"),
+            ("rtc_wallet", "RTC0abc123"),
+            ("rtc_wallet", "0xZZ9e78d600fb3131c29d7ba80aba8fe644be426e"),
+        ],
+    )
+    def test_register_rejects_invalid_identity_fields(self, client, field, value):
+        """Registration fields are validated before insert."""
+        response = client.post(
+            "/register",
+            data=_registration_data(**{field: value}),
+        )
+
+        assert response.status_code == 400
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM contributors").fetchone()[0]
+        assert count == 0
+
+    def test_register_accepts_registration_key_header(self, client):
+        """CLI callers can provide the registration key in a header."""
+        data = _registration_data(registration_key="", rtc_wallet=VALID_0X_WALLET)
+        response = client.post(
+            "/register",
+            data=data,
+            headers={"X-Registration-Key": REGISTRATION_KEY},
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        with sqlite3.connect(cr.DB_PATH) as conn:
+            row = conn.execute(
+                "SELECT rtc_wallet FROM contributors WHERE github_username='newuser'"
+            ).fetchone()
+        assert row == (VALID_0X_WALLET,)
 
 
 class TestApiContributors:
@@ -126,6 +214,7 @@ class TestApiContributors:
         contrib = data["contributors"][0]
         for field in ("github_username", "type", "wallet", "registered", "status"):
             assert field in contrib
+        assert contrib["wallet"] == "RTC019...426e"
 
 
 class TestApproveRoute:
@@ -137,12 +226,15 @@ class TestApproveRoute:
     def test_approve_fails_closed_without_admin_key(self, client, monkeypatch):
         """Unset CONTRIBUTOR_ADMIN_KEY must not allow approval."""
         monkeypatch.delenv("CONTRIBUTOR_ADMIN_KEY", raising=False)
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=_registration_data(
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
 
         response = client.post(
             "/approve/pendinguser",
@@ -160,12 +252,15 @@ class TestApproveRoute:
     def test_approve_rejects_wrong_admin_key(self, client, monkeypatch):
         """Wrong admin credentials must not approve contributors."""
         monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "expected-admin-key")
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=_registration_data(
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
 
         response = client.post(
             "/approve/pendinguser",
@@ -183,12 +278,15 @@ class TestApproveRoute:
     def test_approve_pending_contributor_with_admin_key(self, client, monkeypatch):
         """POST /approve/<username> with admin key should set status to approved."""
         monkeypatch.setenv("CONTRIBUTOR_ADMIN_KEY", "expected-admin-key")
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=_registration_data(
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
 
         response = client.post(
             "/approve/pendinguser",
@@ -213,12 +311,15 @@ class TestApproveRoute:
             return provided == expected
 
         monkeypatch.setattr(cr.hmac, "compare_digest", spy_compare_digest)
-        client.post("/register", data={
-            "github_username": "pendinguser",
-            "contributor_type": "bot",
-            "rtc_wallet": "RTC0pending",
-            "contribution_history": "",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=_registration_data(
+                github_username="pendinguser",
+                contributor_type="bot",
+                contribution_history="",
+            ),
+            follow_redirects=True,
+        )
 
         response = client.post(
             "/approve/pendinguser",
@@ -236,21 +337,24 @@ class TestDatabaseConstraints:
         with sqlite3.connect(cr.DB_PATH) as conn:
             conn.execute(
                 "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                ("unique_test", "human", "RTC0unique"),
+                ("unique_test", "human", VALID_RTC_WALLET),
             )
             with pytest.raises(sqlite3.IntegrityError):
                 conn.execute(
                     "INSERT INTO contributors (github_username, contributor_type, rtc_wallet) VALUES (?, ?, ?)",
-                    ("unique_test", "agent", "RTC0dup2"),
+                    ("unique_test", "agent", VALID_0X_WALLET),
                 )
 
     def test_default_status_is_pending(self, client):
         """New registrations should have status=pending by default."""
-        client.post("/register", data={
-            "github_username": "defaultstatus",
-            "contributor_type": "human",
-            "rtc_wallet": "RTC0default",
-        }, follow_redirects=True)
+        client.post(
+            "/register",
+            data=_registration_data(
+                github_username="defaultstatus",
+                contributor_type="human",
+            ),
+            follow_redirects=True,
+        )
         with sqlite3.connect(cr.DB_PATH) as conn:
             row = conn.execute(
                 "SELECT status FROM contributors WHERE github_username='defaultstatus'"


### PR DESCRIPTION
## Summary
- require a configured contributor registration key before `/register` accepts new identities
- validate GitHub usernames, contributor types, and RTC/Base wallet formats before inserting rows
- redact contributor wallet addresses from the public page and `/api/contributors` response

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_contributor_registry.py -q` -> 25 passed
- `python3 -m py_compile contributor_registry.py tests/test_contributor_registry.py`
- `git diff --check -- contributor_registry.py tests/test_contributor_registry.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Fixes #4911

BCOS: L2 requested for auth/security code; I do not have permission to change the auto-applied label.
Payment: RTC | RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout

wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
