### PR TITLE
fix: reject malformed badge json

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -149,8 +149,12 @@ def escape_markdown_alt(text):
 @app.route('/api/badge/create', methods=['POST'])
 def create_badge():
     init_badge_db()
-    raw_data = request.get_json(silent=True) or {}
-    data = raw_data if isinstance(raw_data, dict) else {}
+    raw_data = request.get_json(silent=True)
+    if raw_data is None:
+        return jsonify({'success': False, 'error': 'Invalid or missing JSON body'}), 400
+    if not isinstance(raw_data, dict):
+        return jsonify({'success': False, 'error': 'JSON body must be an object'}), 400
+    data = raw_data
     
     username = text_field(data, 'username')
     wallet = text_field(data, 'wallet')

--- a/tests/test_profile_badge_generator.py
+++ b/tests/test_profile_badge_generator.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+
+import pytest
+
+import profile_badge_generator as badges
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "badges.db"
+    monkeypatch.setattr(badges, "DB_PATH", str(db_path))
+    badges.app.config["TESTING"] = True
+    badges.init_badge_db()
+    return badges.app.test_client()
+
+
+def _badge_count():
+    with sqlite3.connect(badges.DB_PATH) as conn:
+        return conn.execute("SELECT COUNT(*) FROM profile_badges").fetchone()[0]
+
+
+@pytest.mark.parametrize("payload", ["null", '["not", "an", "object"]', "{"])
+def test_create_badge_rejects_bad_json_bodies(client, payload):
+    response = client.post(
+        "/api/badge/create",
+        data=payload,
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["success"] is False
+    assert _badge_count() == 0
+
+
+def test_create_badge_accepts_valid_json_object(client):
+    response = client.post(
+        "/api/badge/create",
+        json={
+            "username": "jamilahmadzai",
+            "wallet": "RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116",
+            "badge_type": "bounty-hunter",
+            "custom_message": "Bug Hunter",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["success"] is True
+    assert "Bug%20Hunter" in data["shield_url"]
+    assert _badge_count() == 1


### PR DESCRIPTION
## Summary
- return structured 400 responses when `/api/badge/create` receives malformed, missing, or non-object JSON
- keep valid badge creation behavior unchanged
- add focused regression coverage for `null`, array, malformed JSON, and a valid badge body

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_profile_badge_generator.py -q` -> 4 passed
- `python3 -m py_compile profile_badge_generator.py tests/test_profile_badge_generator.py`
- `git diff --check -- profile_badge_generator.py tests/test_profile_badge_generator.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

Fixes #4346

BCOS: L1
Payment: RTC | RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116

## Payout

wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Primary payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
