### PR TITLE
fix: validate Sophia governor recent limit

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -143,6 +143,18 @@ def _max_recent_rows() -> int:
     return max(1, min(int(os.getenv("SOPHIA_GOVERNOR_MAX_RECENT", "50")), 200))
 
 
+def _parse_recent_limit(value: Any, default: int = 20) -> int:
+    if value is None or value == "":
+        return default
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    return min(limit, _max_recent_rows())
+
+
 def _parse_csv_env(name: str) -> list[str]:
     raw = os.getenv(name, "")
     if not raw:
@@ -947,11 +959,10 @@ def register_sophia_governor_endpoints(app, db_path: str | None = None) -> None:
 
     @app.route("/sophia/governor/recent", methods=["GET"])
     def sophia_governor_recent():
-        limit_raw = request.args.get("limit", 20)
         try:
-            limit = int(limit_raw)
-        except (TypeError, ValueError):
-            return jsonify({"error": "limit must be an integer"}), 400
+            limit = _parse_recent_limit(request.args.get("limit"))
+        except ValueError as exc:
+            return jsonify({"error": str(exc)}), 400
         return jsonify({
             "ok": True,
             "events": get_recent_governor_events(db_path=db, limit=limit),

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -193,6 +193,34 @@ def test_governor_recent_rejects_malformed_limit(client):
     assert response.get_json()["error"] == "limit must be an integer"
 
 
+@pytest.mark.parametrize("limit", ["0", "-1"])
+def test_governor_recent_rejects_non_positive_limit(client, limit):
+    response = client.get(f"/sophia/governor/recent?limit={limit}")
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be positive"
+
+
+def test_governor_recent_caps_oversized_limit(client, monkeypatch):
+    monkeypatch.setattr(sophia_governor, "_max_recent_rows", lambda: 1)
+    for amount in (1200, 1500):
+        review = client.post(
+            "/sophia/governor/review",
+            headers={"X-Admin-Key": "test-admin"},
+            json={
+                "event_type": "pending_transfer",
+                "source": "pytest.manual",
+                "payload": {"amount_rtc": amount},
+            },
+        )
+        assert review.status_code == 200
+
+    response = client.get("/sophia/governor/recent?limit=500")
+
+    assert response.status_code == 200
+    assert len(response.get_json()["events"]) == 1
+
+
 def test_governor_review_rejects_non_object_json(client):
     response = client.post(
         "/sophia/governor/review",


### PR DESCRIPTION
## Summary

Fixes #5424.

- Adds route-level parsing for `/sophia/governor/recent?limit=...`.
- Returns `400` for malformed limits and non-positive limits instead of letting lower helpers silently clamp them.
- Preserves the existing max-row cap for oversized positive limits.
- Adds regressions for malformed, zero, negative, and oversized limit behavior.

## Validation

- `python -m pytest node/tests/test_sophia_governor.py -q` -> 13 passed
- `python -m py_compile node\sophia_governor.py node\tests\test_sophia_governor.py`
- `git diff --check`

## Bounty context

Submitting as a focused fix for open issue #5424. Award recipient can use the GitHub contributor identity `godd-ctrl` unless maintainers require an explicit RTC wallet.