### PR TITLE
fix: validate OUI deny admin payloads

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6032,6 +6032,21 @@ def bounty_multiplier():
 # ---------- RIP-0147a: Admin OUI Management ----------
 
 
+def _normalize_oui_payload_value(value):
+    if not isinstance(value, str):
+        return None
+    return value.lower().replace(':', '').replace('-', '')
+
+
+def _parse_oui_enforce(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 @app.route("/api/nodes")
 def api_nodes():
     """Return list of all registered attestation nodes"""
@@ -6756,9 +6771,15 @@ def add_oui_deny():
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()
-    oui = data.get('oui', '').lower().replace(':', '').replace('-', '')
+    oui = _normalize_oui_payload_value(data.get('oui', ''))
+    if oui is None:
+        return jsonify({"error": "OUI must be a string"}), 400
     vendor = data.get('vendor', 'Unknown')
-    enforce = int(data.get('enforce', 0))
+    if not isinstance(vendor, str):
+        return jsonify({"error": "Vendor must be a string"}), 400
+    enforce = _parse_oui_enforce(data.get('enforce', 0))
+    if enforce is None:
+        return jsonify({"error": "enforce must be an integer"}), 400
 
     if len(oui) != 6 or not all(c in '0123456789abcdef' for c in oui):
         return jsonify({"error": "Invalid OUI (must be 6 hex chars)"}), 400
@@ -6783,7 +6804,11 @@ def remove_oui_deny():
 
     # Extract client IP (handle nginx proxy)
     client_ip = get_client_ip()
-    oui = data.get('oui', '').lower().replace(':', '').replace('-', '')
+    oui = _normalize_oui_payload_value(data.get('oui', ''))
+    if oui is None:
+        return jsonify({"error": "OUI must be a string"}), 400
+    if len(oui) != 6 or not all(c in '0123456789abcdef' for c in oui):
+        return jsonify({"error": "Invalid OUI (must be 6 hex chars)"}), 400
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute("DELETE FROM oui_deny WHERE oui = ?", (oui,))

--- a/tests/test_oui_deny_json_validation.py
+++ b/tests/test_oui_deny_json_validation.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for authenticated OUI deny route JSON validation."""
+
+import sys
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+ADMIN_HEADERS = {"X-Admin-Key": "0" * 32}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as c:
+        yield c
+
+
+@pytest.mark.parametrize("path", ["/admin/oui_deny/add", "/admin/oui_deny/remove"])
+def test_oui_deny_rejects_non_object_json(client, path):
+    response = client.post(path, headers=ADMIN_HEADERS, json=["not", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid JSON body"}
+
+
+@pytest.mark.parametrize("path", ["/admin/oui_deny/add", "/admin/oui_deny/remove"])
+def test_oui_deny_rejects_non_string_oui(client, path):
+    response = client.post(path, headers=ADMIN_HEADERS, json={"oui": ["aa", "bb", "cc"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "OUI must be a string"}
+
+
+def test_oui_deny_add_rejects_invalid_enforce(client):
+    response = client.post(
+        "/admin/oui_deny/add",
+        headers=ADMIN_HEADERS,
+        json={"oui": "aa:bb:cc", "enforce": "yes"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "enforce must be an integer"}
+
+
+def test_oui_deny_add_rejects_boolean_enforce(client):
+    response = client.post(
+        "/admin/oui_deny/add",
+        headers=ADMIN_HEADERS,
+        json={"oui": "aa:bb:cc", "enforce": True},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "enforce must be an integer"}
+
+
+def test_oui_deny_add_rejects_non_string_vendor(client):
+    response = client.post(
+        "/admin/oui_deny/add",
+        headers=ADMIN_HEADERS,
+        json={"oui": "aa:bb:cc", "vendor": {"name": "vmware"}},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Vendor must be a string"}


### PR DESCRIPTION
## Summary

Fixes #4414.

- Validates authenticated `/admin/oui_deny/add` and `/admin/oui_deny/remove` JSON fields before normalization.
- Returns deterministic `400` responses for non-object bodies, non-string `oui`, invalid `enforce`, boolean `enforce`, and non-string `vendor` values.
- Keeps existing OUI normalization for valid string payloads while rejecting malformed input before database mutation.

## Validation

- `python -m pytest tests/test_oui_deny_json_validation.py -q` -> 7 passed
- `python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_oui_deny_json_validation.py`
- `git diff --check`

## Bounty context

Submitting as a focused fix for open issue #4414. Award recipient can use the GitHub contributor identity `godd-ctrl` unless maintainers require an explicit RTC wallet.