### PR TITLE
fix(security): OTC bridge — actually transfer escrow proceeds to recipient (refresh of #4181)

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -68,6 +68,10 @@ elif _tls_verify_env in ("false", "0", "no"):
 else:
     TLS_VERIFY = True                 # Default: full CA verification
 
+# Admin key for /wallet/transfer payouts from otc_bridge_worker → real recipient.
+# Required for confirm_order() to complete OTC settlement. Without it, escrow funds
+# stay trapped in otc_bridge_worker.
+RC_ADMIN_KEY = os.environ.get("RC_ADMIN_KEY", "").strip()
 ESCROW_WALLET = "otc_bridge_escrow"
 ORDER_TTL_DEFAULT = 7 * 86400       # 7 days
 ORDER_TTL_MAX = 30 * 86400          # 30 days
@@ -175,6 +179,111 @@ def include_legacy_money_columns_if_present(columns, insert_columns, values, amo
     if {"amount_rtc", "price_per_rtc", "total_quote"}.issubset(columns):
         insert_columns.extend(["amount_rtc", "price_per_rtc", "total_quote"])
         values.extend([amount_rtc, price_per_rtc, total_quote])
+
+
+# ---------------------------------------------------------------------------
+# OTC payout helpers (close fund-trap bug: escrow accept releases to
+# otc_bridge_worker, then we must transfer from there to the real recipient)
+# ---------------------------------------------------------------------------
+
+_MINER_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+
+
+def is_valid_wallet_id(wallet_id):
+    """Validate a wallet/miner identifier before using it as a transfer target."""
+    wallet_id = str(wallet_id or "").strip()
+    return bool(_MINER_ID_RE.fullmatch(wallet_id))
+
+
+def send_bridge_alert(level, message, fields):
+    """Best-effort alert hook for payout failures and manual recovery events."""
+    webhook = os.environ.get("RC_SOPHIACHECK_WEBHOOK", "").strip()
+    if not webhook:
+        return
+
+    colors = {
+        "warning": 16776960,
+        "critical": 16711680,
+        "info": 3447003,
+    }
+    embed = {
+        "title": f"OTC Bridge {level.upper()}",
+        "description": message,
+        "color": colors.get(level, 3447003),
+        "fields": [
+            {"name": str(k), "value": str(v), "inline": True}
+            for k, v in (fields or {}).items()
+        ],
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    try:
+        requests.post(webhook, json={"embeds": [embed]}, timeout=5)
+    except Exception as exc:
+        log.warning(f"Bridge alert delivery failed: {exc}")
+
+
+def rtc_transfer_from_worker(recipient_wallet, amount_rtc, order_id):
+    """Queue admin payout from the bridge worker to the actual OTC recipient.
+
+    Returns ``{"ok": True, "details": {...}}`` on success (transfer queued or
+    accepted into pending pool), or ``{"ok": False, "error": str, "details": {...}}``
+    on terminal failure after retries.
+    """
+    last_error = "unknown payout error"
+    last_payload = {}
+    retry_delays = (0, 1, 2, 4)
+
+    for attempt, delay_seconds in enumerate(retry_delays, start=1):
+        if delay_seconds:
+            time.sleep(delay_seconds)
+
+        try:
+            transfer_r = requests.post(
+                f"{RUSTCHAIN_NODE}/wallet/transfer",
+                headers={"X-Admin-Key": RC_ADMIN_KEY},
+                json={
+                    "from_miner": "otc_bridge_worker",
+                    "to_miner": recipient_wallet,
+                    "amount_rtc": amount_rtc,
+                    "reason": f"otc_payout:{order_id}",
+                },
+                verify=TLS_VERIFY, timeout=15
+            )
+        except Exception as exc:
+            last_error = str(exc)
+            if attempt < len(retry_delays):
+                log.warning(
+                    f"Worker payout attempt {attempt}/{len(retry_delays)} failed for "
+                    f"{order_id}: {last_error}"
+                )
+                continue
+            return {"ok": False, "error": last_error, "details": last_payload}
+
+        try:
+            last_payload = transfer_r.json()
+        except ValueError:
+            last_payload = {}
+
+        if transfer_r.ok:
+            last_payload.setdefault("phase", "pending")
+            return {"ok": True, "details": last_payload}
+
+        last_error = last_payload.get("error") or transfer_r.text.strip() or f"HTTP {transfer_r.status_code}"
+        should_retry = (
+            transfer_r.status_code >= 500
+            or "insufficient available balance" in last_error.lower()
+        )
+        if should_retry and attempt < len(retry_delays):
+            log.warning(
+                f"Worker payout attempt {attempt}/{len(retry_delays)} for {order_id} "
+                f"failed, retrying: {last_error}"
+            )
+            continue
+
+        break
+
+    return {"ok": False, "error": last_error, "details": last_payload}
 
 
 # ---------------------------------------------------------------------------
@@ -959,6 +1068,25 @@ def confirm_order(order_id):
 
         now = int(time.time())
 
+        # Determine RTC recipient + validate BEFORE touching escrow.
+        rtc_recipient = order["taker_wallet"] if order["side"] == "sell" else order["maker_wallet"]
+        if not is_valid_wallet_id(rtc_recipient):
+            return jsonify({
+                "error": "Invalid RTC recipient wallet on matched order",
+                "rtc_recipient": rtc_recipient,
+            }), 400
+
+        # Without an admin key we cannot transfer escrow proceeds from
+        # otc_bridge_worker to the real recipient — refuse to release escrow
+        # rather than trap funds.
+        if not RC_ADMIN_KEY:
+            return jsonify({
+                "error": "Bridge payout unavailable: RC_ADMIN_KEY not configured"
+            }), 500
+
+        payout_status = "not_started"
+        payout_result = {}
+
         # Release RTC escrow
         if order["escrow_job_id"]:
             # Determine who posted the escrow job
@@ -983,21 +1111,50 @@ def confirm_order(order_id):
                     verify=TLS_VERIFY, timeout=15
                 )
 
-                # Accept (releases funds to otc_bridge_worker, then we transfer to actual recipient)
+                # Accept releases funds to otc_bridge_worker. We then transfer
+                # from worker → recipient via admin /wallet/transfer.
                 if deliver_r.ok:
                     accept_r = requests.post(
                         f"{RUSTCHAIN_NODE}/agent/jobs/{order['escrow_job_id']}/accept",
                         json={"poster_wallet": escrow_poster, "rating": 5},
                         verify=TLS_VERIFY, timeout=15
                     )
-                    if not accept_r.ok:
+                    if accept_r.ok:
+                        payout_result = rtc_transfer_from_worker(
+                            rtc_recipient,
+                            order["amount_rtc"],
+                            order_id,
+                        )
+                        if payout_result["ok"]:
+                            payout_status = payout_result["details"].get("phase", "pending")
+                        else:
+                            payout_status = "manual_recovery_required"
+                            log.error(
+                                f"Bridge payout failed after escrow accept for {order_id}: "
+                                f"{payout_result['error']}"
+                            )
+                            send_bridge_alert(
+                                "critical",
+                                "OTC payout failed after escrow accept",
+                                {
+                                    "order_id": order_id,
+                                    "recipient": rtc_recipient,
+                                    "amount_rtc": order["amount_rtc"],
+                                    "error": payout_result["error"],
+                                },
+                            )
+                    else:
+                        payout_status = "escrow_accept_failed"
                         log.error(f"Escrow accept failed: {accept_r.text}")
-
-        # Determine RTC recipient
-        if order["side"] == "sell":
-            rtc_recipient = order["taker_wallet"]
+                else:
+                    payout_status = "escrow_deliver_failed"
+            else:
+                payout_status = "escrow_claim_failed"
         else:
-            rtc_recipient = order["maker_wallet"]
+            payout_status = "missing_escrow_job"
+
+        payout_details = payout_result.get("details", {}) if isinstance(payout_result, dict) else {}
+        payout_tx = payout_details.get("tx_hash") if isinstance(payout_details, dict) else None
 
         # Record trade
         trade_id = generate_trade_id(order_id, order["taker_wallet"])
@@ -1034,6 +1191,27 @@ def confirm_order(order_id):
         """, (now, quote_tx, order_id))
         conn.commit()
 
+        if payout_status == "pending":
+            message = (
+                f"Trade completed. {order['amount_rtc']} RTC payout to {rtc_recipient} "
+                "was queued successfully. HTLC secret verified and revealed."
+            )
+        elif payout_status == "manual_recovery_required":
+            message = (
+                f"Trade completed, but payout to {rtc_recipient} failed after escrow "
+                "accept. Operators were alerted for manual recovery."
+            )
+        elif payout_status == "escrow_accept_failed":
+            message = (
+                "Trade recorded, but escrow accept failed before payout could be queued. "
+                "Manual review required."
+            )
+        else:
+            message = (
+                f"Trade completed with payout status '{payout_status}'. "
+                "HTLC secret verified and revealed."
+            )
+
         return jsonify({
             "ok": True,
             "order_id": order_id,
@@ -1042,7 +1220,10 @@ def confirm_order(order_id):
             "htlc_secret": secret,
             "amount_rtc": order["amount_rtc"],
             "rtc_recipient": rtc_recipient,
-            "message": f"Trade completed. {order['amount_rtc']} RTC released to {rtc_recipient}. HTLC secret verified and revealed."
+            "rtc_transfer_status": payout_status,
+            "rtc_transfer_pending_id": payout_details.get("pending_id") if isinstance(payout_details, dict) else None,
+            "rtc_transfer_tx_hash": payout_tx,
+            "message": message,
         })
 
     except Exception:


### PR DESCRIPTION
## Summary

Refresh of #4181, which was 1,113 commits behind current main and could not be rebased automatically (irreconcilable conflicts on both modified files). Scope narrowed to the **OTC fund-trap fix only** — Bug 2 from the original PR (enrollment preemption) is now substantially mitigated in current main, so that hunk would be redundant.

## What's still broken (Bug 1)

`otc_bridge.py:confirm_order()` does the full RIP-302 escrow flow — `claim → deliver → accept` — but the comment-promised transfer from `otc_bridge_worker` to the actual recipient is missing. Every completed OTC trade since #4181 was filed (~8 days, 1,113 commits ago) traps user RTC in the bridge worker wallet, while the API response falsely claims success.

**Reproducible**: read current `otc_bridge.py:917-1050` on main. The `accept_r` block at ~1097-1103 releases funds to `otc_bridge_worker`, then `rtc_recipient` is computed at 1106-1109, and the response at 1146-1155 returns `"Trade completed. {amount_rtc} RTC released to {rtc_recipient}"`. There is no actual transfer to `rtc_recipient` between those two lines.

## What's no longer needed (Bug 2)

Original #4181 also added a signed-overwrite preemption guard on `/epoch/enroll`. Current main now **rejects unsigned enrollment by default** (`401 SIGNED_ENROLLMENT_REQUIRED`), gated only by an `ENROLL_ALLOW_UNSIGNED_LEGACY=1` escape hatch. The major preemption vector is closed. The remaining edge case (signed-owner overwrites of own enrollment within the same epoch) is a minor improvement, not a critical security risk. Drop from this PR scope; can be a follow-up if you want it closed.

## Fix

`otc-bridge/otc_bridge.py` adds:

- **`RC_ADMIN_KEY`** env-var loaded at module level (refuses to release escrow if unset → no fund trap on unconfigured deploys)
- **`is_valid_wallet_id()`** — fail-fast format check on the recipient before touching escrow (`^[A-Za-z0-9._:-]{1,128}$`)
- **`send_bridge_alert()`** — best-effort webhook to `RC_SOPHIACHECK_WEBHOOK` on payout failures, so manual recovery is loud
- **`rtc_transfer_from_worker()`** — `POST {RUSTCHAIN_NODE}/wallet/transfer` with `X-Admin-Key`, exponential retry (0/1/2/4s) on 5xx and "insufficient available balance"

`confirm_order()` now:

1. Validates `rtc_recipient` format BEFORE touching escrow (was: after escrow released, which would leave funds trapped)
2. Refuses to release escrow if `RC_ADMIN_KEY` is unset (returns 500 with explicit reason — no silent fund trap)
3. After escrow `accept_r.ok`, calls `rtc_transfer_from_worker()` to actually move funds
4. Tracks `payout_status` through the full flow (`pending` / `manual_recovery_required` / `escrow_accept_failed` / `escrow_deliver_failed` / `escrow_claim_failed` / `missing_escrow_job`)
5. Surfaces `rtc_transfer_status`, `rtc_transfer_pending_id`, `rtc_transfer_tx_hash` in the response so clients can verify payout
6. Sends `critical` bridge alert when payout fails after escrow has already been released (the "stuck money" case)

## Behavior change

Before: every OTC `confirm_order` returned `{"ok": true, "message": "Trade completed. X RTC released to RTCabc..."}` regardless of whether funds reached the recipient. Funds trapped in `otc_bridge_worker`.

After: `{"ok": true, "rtc_transfer_status": "pending", "rtc_transfer_pending_id": "...", ...}` when payout queued successfully. `{"ok": true, "rtc_transfer_status": "manual_recovery_required", ...}` when escrow released but worker→recipient transfer failed (loud alert sent).

## Required deploy step

`RC_ADMIN_KEY` must be set in the OTC bridge environment for new trades to settle. Without it, `confirm_order` now returns `500 Bridge payout unavailable` (refuses to trap funds) instead of silently succeeding while losing the user's RTC.

## Recovery for already-trapped funds

Any OTC trade since #4181 was filed (~8 days) needs a one-time manual sweep of `otc_bridge_worker` balance → original recipients (the `trades` table has `taker_wallet`/`maker_wallet` for each historic order). This PR fixes forward; the sweep is a separate operator action.

## Credit

Original audit on issue #4010 by [@ahmadfardan464-cmyk](https://github.com/ahmadfardan464-cmyk) (Bitbot agent bcn_b13fb9df30e4) — paid 225 RTC for the audit work. This PR is the remediation, refreshed against current main.

Supersedes #4181 (which would have caused destructive deletions if rebased blindly across 1,113 intervening commits).

Closes #4010

Co-Authored-By: ahmadfardan464-cmyk <ahmadfardan464-cmyk@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
