### PR TITLE
docs: clarify miner install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 ```
 
+The miner is installed by this script. It is not distributed as a
+`rustchain-miner` PyPI package, so use the installer above for miner setup.
+
 Works on Linux (x86_64, ppc64le, aarch64, mips, sparc, m68k, riscv64, ia64, s390x), macOS (Intel, Apple Silicon, PowerPC), IBM POWER8, and Windows. If it runs Python, it can mine.
 
 ```bash

--- a/docs/mining.html
+++ b/docs/mining.html
@@ -223,16 +223,16 @@ chmod +x install-miner.sh
 # Follow the on-screen prompts</pre>
       
       <h3>Post-Installation Setup</h3>
-      <p>After installation completes, you'll need to configure your miner:</p>
+      <p>After installation completes, the installer prints the wallet name it will use for rewards. Keep that wallet name and use the installed script to start or restart the miner:</p>
       
-      <pre># Generate your wallet address
-rustchain-wallet generate
+      <pre># Start the installed miner manually, if auto-start is not already running
+~/.rustchain/start.sh
 
-# Start the attestation service
-rustchain-attest --start
+# Or run the installed Python miner directly
+~/.rustchain/venv/bin/python ~/.rustchain/rustchain_miner.py --wallet YOUR_WALLET_NAME
 
-# Begin mining
-rustchain-miner --wallet YOUR_WALLET_ADDRESS</pre>
+# Check rewards for the wallet name printed by the installer
+curl -fsS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"</pre>
       
       <p>The attestation service will run hardware fingerprinting tests to verify your system is genuine physical hardware. This process typically takes 2-5 minutes and only needs to run once per hardware configuration.</p>
     </div>

--- a/tests/test_miner_install_docs.py
+++ b/tests/test_miner_install_docs.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 
 

--- a/tests/test_miner_install_docs.py
+++ b/tests/test_miner_install_docs.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "README.md"
+MINING_HTML = ROOT / "docs" / "mining.html"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def test_readme_does_not_advertise_unpublished_miner_pypi_package():
+    readme = read(README)
+
+    assert "pip install rustchain-miner" not in readme
+    assert "install-miner.sh | bash" in readme
+
+
+def test_mining_page_uses_installed_miner_script_commands():
+    html = read(MINING_HTML)
+
+    assert "rustchain-miner --wallet" not in html
+    assert "rustchain-attest --start" not in html
+    assert "~/.rustchain/start.sh" in html
+    assert "~/.rustchain/venv/bin/python ~/.rustchain/rustchain_miner.py --wallet" in html


### PR DESCRIPTION
## Summary
- clarify that miner setup uses the installer, not a rustchain-miner PyPI package
- update the public mining page post-install commands to use the installed start script/direct Python miner
- add a docs regression check for stale miner install commands

## Validation
- python3 -m py_compile tests/test_miner_install_docs.py
- direct invocation of tests/test_miner_install_docs.py checks
- rg "python3 -m pip install rustchain-miner|pip install rustchain-miner|rustchain-attest --start|rustchain-miner --wallet" README.md docs/mining.html -S
- git diff --check

## Payout

wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
RTC wallet: `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

Closes #5656
