### PR TITLE
fix: harden GPU render endpoint errors

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -45,7 +45,18 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return default, None
         if not isinstance(value, str):
             return None, (jsonify({"error": f"{name} must be a string"}), 400)
+        value = value.strip()
+        if value == "":
+            return default, None
         return value, None
+
+    def _database_error(db, route_name):
+        try:
+            db.rollback()
+        except sqlite3.Error:
+            pass
+        app.logger.exception("GPU render database error in %s", route_name)
+        return jsonify({"error": "Database operation failed"}), 500
 
     def _require_admin_key():
         if not admin_key:
@@ -54,9 +65,6 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
         if not hmac.compare_digest(provided, admin_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         return None
-
-    def _database_error_response():
-        return jsonify({"error": "Database operation failed"}), 500
 
     def _ensure_escrow_secret_column(db):
         """Best-effort migration for older DBs."""
@@ -122,8 +130,8 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             )
             db.commit()
             return jsonify({"ok": True, "message": "GPU attestation recorded"})
-        except sqlite3.Error as e:
-            return _database_error_response()
+        except sqlite3.Error:
+            return _database_error(db, "gpu_attest")
         finally:
             db.close()
 
@@ -188,8 +196,8 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             db.commit()
             # escrow_secret is intentionally returned once to allow participant-auth for release/refund.
             return jsonify({"ok": True, "job_id": job_id, "status": "locked", "escrow_secret": escrow_secret})
-        except sqlite3.Error as e:
-            return _database_error_response()
+        except sqlite3.Error:
+            return _database_error(db, "gpu_escrow")
         finally:
             db.close()
 
@@ -255,8 +263,8 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 )
             db.commit()
             return jsonify({"ok": True, "status": "released"})
-        except sqlite3.Error as e:
-            return _database_error_response()
+        except sqlite3.Error:
+            return _database_error(db, "gpu_release")
         finally:
             db.close()
 
@@ -313,8 +321,8 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             db.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?", (job["amount_rtc"], job["from_wallet"]))
             db.commit()
             return jsonify({"ok": True, "status": "refunded"})
-        except sqlite3.Error as e:
-            return _database_error_response()
+        except sqlite3.Error:
+            return _database_error(db, "gpu_refund")
         finally:
             db.close()
 

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -48,7 +48,6 @@ def _init_db(db_path):
         conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("victim", 25.0))
         conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("attacker", 0.0))
 
-
 def _init_gpu_attestation_table(db_path):
     with sqlite3.connect(db_path) as conn:
         conn.execute(
@@ -71,6 +70,20 @@ def _init_gpu_attestation_table(db_path):
             )
             """
         )
+
+
+def _init_balances_only_db(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE balances (
+                miner_pk TEXT PRIMARY KEY,
+                balance_rtc REAL NOT NULL
+            )
+            """
+        )
+        conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("victim", 25.0))
+        conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("attacker", 0.0))
 
 
 def _balance(db_path, wallet):
@@ -356,3 +369,100 @@ def test_gpu_attest_hides_sqlite_schema_errors(tmp_path):
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "Database operation failed"}
+
+
+def test_gpu_attest_rejects_blank_miner_id_before_database_work(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post(
+        "/api/gpu/attest",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json={"miner_id": "   "},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "miner_id required"}
+
+
+def test_gpu_escrow_rejects_blank_required_strings(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    payload = _escrow_payload()
+    payload["job_type"] = "   "
+
+    response = client.post(
+        "/api/gpu/escrow",
+        json=payload,
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Missing required escrow fields"}
+    assert _balance(db_path, "victim") == 25.0
+    assert _balance(db_path, "attacker") == 0.0
+
+
+def test_gpu_release_rejects_blank_secret_before_transition(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    created = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+    assert created.status_code == 200
+
+    response = client.post(
+        "/api/gpu/release",
+        json={"job_id": "job-1", "actor_wallet": "victim", "escrow_secret": "   "},
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "job_id, actor_wallet, escrow_secret are required"}
+    assert _balance(db_path, "victim") == 20.0
+    assert _balance(db_path, "attacker") == 0.0
+
+
+@pytest.mark.parametrize(
+    ("path", "headers", "payload", "init_db"),
+    [
+        ("/api/gpu/attest", {"X-Admin-Key": ADMIN_KEY}, {"miner_id": "gpu-miner"}, lambda db_path: None),
+        ("/api/gpu/escrow", {"X-Admin-Key": ADMIN_KEY}, _escrow_payload(), _init_balances_only_db),
+        (
+            "/api/gpu/release",
+            {"X-Admin-Key": ADMIN_KEY},
+            {"job_id": "job-1", "actor_wallet": "victim", "escrow_secret": "secret"},
+            _init_balances_only_db,
+        ),
+        (
+            "/api/gpu/refund",
+            {"X-Admin-Key": ADMIN_KEY},
+            {"job_id": "job-1", "actor_wallet": "attacker", "escrow_secret": "secret"},
+            _init_balances_only_db,
+        ),
+    ],
+)
+def test_gpu_routes_hide_sqlite_schema_errors(tmp_path, path, headers, payload, init_db):
+    db_path = tmp_path / "gpu.db"
+    init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post(path, headers=headers, json=payload)
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body == {"error": "Database operation failed"}
+    assert "no such table" not in str(body)
+    assert "gpu_attestations" not in str(body)
+    assert "balances" not in str(body)
+    assert "render_escrow" not in str(body)
+
+    if path == "/api/gpu/escrow":
+        assert _balance(db_path, "victim") == 25.0


### PR DESCRIPTION
Fixes #5520

## Summary
- trim string-only GPU render request fields so whitespace-only required values are rejected before database writes or secret hashing
- return a generic database error response for GPU route SQLite failures instead of exposing table names or schema details
- keep database failures logged server-side and roll back partial escrow writes

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_gpu_render_endpoints_security.py -q
- python3 -B -m py_compile node/gpu_render_endpoints.py tests/test_gpu_render_endpoints_security.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref origin/main

RTC wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

## RTC Wallet
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
