### PR TITLE
Clamp beacon envelope pagination limit

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8365,7 +8365,7 @@ def beacon_digest():
 @app.route("/beacon/envelopes", methods=["GET"])
 def beacon_envelopes_list():
     try:
-        limit = min(int(request.args.get("limit", 50)), 50)
+        limit = max(1, min(int(request.args.get("limit", 50)), 50))
         offset = max(int(request.args.get("offset", 0)), 0)
     except (ValueError, TypeError):
         limit, offset = 50, 0

--- a/node/tests/test_limit_validation.py
+++ b/node/tests/test_limit_validation.py
@@ -82,12 +82,12 @@ class TestLimitValidation(unittest.TestCase):
         self.assertEqual(mock_db.execute.call_args.args[1], ("pending", 1))
 
     def test_beacon_envelopes_clamps_negative_limit(self):
-        with patch.object(self.mod, "get_recent_envelopes", return_value=[]):
+        with patch.object(self.mod, "get_recent_envelopes", return_value=[]) as get_recent_envelopes:
             resp = self.client.get("/beacon/envelopes?limit=-1&offset=-5")
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.get_json(), {"ok": True, "count": 0, "envelopes": []})
-        self.mod.get_recent_envelopes.assert_called_once_with(
+        get_recent_envelopes.assert_called_once_with(
             limit=1, offset=0, db_path=self.mod.DB_PATH
         )
 

--- a/node/tests/test_limit_validation.py
+++ b/node/tests/test_limit_validation.py
@@ -81,6 +81,16 @@ class TestLimitValidation(unittest.TestCase):
         self.assertEqual(resp.get_json(), {"ok": True, "count": 0, "pending": []})
         self.assertEqual(mock_db.execute.call_args.args[1], ("pending", 1))
 
+    def test_beacon_envelopes_clamps_negative_limit(self):
+        with patch.object(self.mod, "get_recent_envelopes", return_value=[]):
+            resp = self.client.get("/beacon/envelopes?limit=-1&offset=-5")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json(), {"ok": True, "count": 0, "envelopes": []})
+        self.mod.get_recent_envelopes.assert_called_once_with(
+            limit=1, offset=0, db_path=self.mod.DB_PATH
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Caps beacon envelope pagination limits so oversized requests cannot force excessive result windows.

## Validation
- Focused local checks from branch creation; branch already pushed to fork.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: RustChain node pagination bug: beacon envelope limits could pass invalid/negative values into the data layer.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.