### PR TITLE
Stop disabling TLS in public node docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,9 +98,9 @@ python -m pip install -e ./sdk
 python -m pytest sdk/tests/test_client_unit.py
 
 # Test against live node
-curl -sk https://rustchain.org/health
-curl -sk https://rustchain.org/api/miners
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/health
+curl -sS https://rustchain.org/api/miners
+curl -sS https://rustchain.org/epoch
 ```
 
 For package-specific work, use the closest local manifest or test folder:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -158,8 +158,8 @@ tail -f ~/.rustchain/miner.log
 
 ### Balance Check
 ```bash
-# Note: Using -k flag because node may use self-signed SSL certificate
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+# Public rustchain.org uses normal TLS verification.
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 Example output:
@@ -173,17 +173,17 @@ Example output:
 
 ### Active Miners
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 ### Node Health
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 ### Current Epoch
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 ## Manual Operation
@@ -315,14 +315,14 @@ cat ~/.rustchain/miner.log
 
 **Check:**
 1. Internet connection is working
-2. Node is accessible: `curl -sk https://rustchain.org/health`
+2. Node is accessible: `curl -sS https://rustchain.org/health`
 3. Firewall isn't blocking HTTPS (port 443)
 
 ### Miner not earning rewards
 
 **Check:**
 1. Miner is actually running: `systemctl --user status rustchain-miner` or `launchctl list | grep rustchain`
-2. Wallet balance: `curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"`
+2. Wallet balance: `curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"`
 3. Miner logs for errors: `journalctl --user -u rustchain-miner -f` or `tail -f ~/.rustchain/miner.log`
 4. Hardware attestation passes: Look for "fingerprint validation" messages in logs
 
@@ -359,7 +359,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 3. The miner runs as your user (not root)
 4. Services are user-level (systemd --user, ~/Library/LaunchAgents)
 5. All logs are stored in your home directory
-6. **SSL Certificate:** The RustChain node (rustchain.org) may use a self-signed SSL certificate. The `-k` flag in curl commands bypasses certificate verification. This is a known limitation of the current infrastructure. In production, you should verify the node's identity through other means (community consensus, explorer verification, etc.).
+6. **TLS certificate:** The public RustChain node at `https://rustchain.org` should validate with the system certificate store. Do not bypass TLS verification for the public hostname; if certificate validation fails, check your local clock, proxy, trust store, or network interception first.
 
 To view the certificate SHA-256 fingerprint:
 

--- a/README.md
+++ b/README.md
@@ -227,9 +227,9 @@ What they *can't* capture:
 
 ```bash
 # Verify right now
-curl -sk https://rustchain.org/health          # Node health
-curl -sk https://rustchain.org/api/miners      # Active miners
-curl -sk https://rustchain.org/epoch           # Current epoch
+curl -sS https://rustchain.org/health          # Node health
+curl -sS https://rustchain.org/api/miners      # Active miners
+curl -sS https://rustchain.org/epoch           # Current epoch
 ```
 
 ### Attestation Nodes
@@ -245,7 +245,7 @@ curl -sk https://rustchain.org/epoch           # Current epoch
 | Fact | Proof |
 |------|-------|
 | 5 nodes across 3 continents (NA ×3, Asia ×1, Local ×1) | [Live explorer](https://rustchain.org/explorer/) |
-| 26+ miners attesting | `curl -sk https://rustchain.org/api/miners` |
+| 26+ miners attesting | `curl -sS https://rustchain.org/api/miners` |
 | 44 BCOS certificates issued | [Certified repos](https://rustchain.org/bcos/) |
 | 6 hardware fingerprint checks per machine | [Fingerprint docs](docs/attestation_fuzzing.md) |
 | 25,875+ RTC paid to 260+ contributors | [Public ledger](https://github.com/Scottcjn/rustchain-bounties/issues/104) |
@@ -271,7 +271,7 @@ Works on Linux (x86_64, ppc64le, aarch64, mips, sparc, m68k, riscv64, ia64, s390
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet my-wallet
 
 # Check your balance
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 ### Manage the Miner

--- a/README_JA.md
+++ b/README_JA.md
@@ -184,22 +184,22 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 **ウォレット残高を確認：**
 ```bash
 # 注意：ノードが自己署名SSL証明書を使用している可能性があるため、-skフラグを使用
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 **アクティブなマイナーを一覧表示：**
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 **ノードの健全性を確認：**
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 **現在のエポックを取得：**
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 **マイナーサービスを管理：**
@@ -331,16 +331,16 @@ RustChainエポック → コミットメントハッシュ → Ergoトランザ
 
 ```bash
 # ネットワークの健全性を確認
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # 現在のエポックを取得
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # アクティブなマイナーを一覧表示
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # ウォレット残高を確認
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 
 # ブロックエクスプローラー（Webブラウザ）
 open https://rustchain.org/explorer

--- a/discord_presence_README.md
+++ b/discord_presence_README.md
@@ -83,7 +83,7 @@ When your miner runs, it displays your miner ID (wallet address):
 List all active miners:
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq '.[].miner'
+curl -sS https://rustchain.org/api/miners | jq '.[].miner'
 ```
 
 ### Option 3: From Wallet
@@ -142,14 +142,14 @@ Your miner must be:
 Check your miner status:
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner=="YOUR_MINER_ID")'
+curl -sS https://rustchain.org/api/miners | jq '.[] | select(.miner=="YOUR_MINER_ID")'
 ```
 
 ### Balance shows 0.0 or "Error getting balance"
 
 1. Verify your miner ID is correct
 2. Make sure you're using the full wallet address (including "RTC" suffix if applicable)
-3. Check network connectivity: `curl -sk https://rustchain.org/health`
+3. Check network connectivity: `curl -sS https://rustchain.org/health`
 
 ## Advanced Usage
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,7 +2,7 @@
 
 Base URL: `https://rustchain.org`
 
-All endpoints use HTTPS. Self-signed certificates require `-k` flag with curl.
+All public endpoints use HTTPS with normal certificate verification.
 
 ---
 
@@ -14,7 +14,7 @@ Check node status and version.
 
 **Request:**
 ```bash
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 ```
 
 **Response:**
@@ -48,7 +48,7 @@ Get current epoch details.
 
 **Request:**
 ```bash
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 **Response:**
@@ -82,7 +82,7 @@ List all active/enrolled miners.
 
 **Request:**
 ```bash
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 ```
 
 **Response:**
@@ -132,7 +132,7 @@ as a compatibility alias for older callers.
 
 **Request:**
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
 ```
 
 **Response:**
@@ -161,7 +161,7 @@ as a compatibility alias for older callers.
 
 **Request:**
 ```bash
-curl -sk "https://rustchain.org/wallet/history?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC&limit=10" | jq .
+curl -sS "https://rustchain.org/wallet/history?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC&limit=10" | jq .
 ```
 
 **Parameters:**
@@ -277,7 +277,7 @@ Transfer RTC to another wallet. Requires Ed25519 signature.
 
 **Request:**
 ```bash
-curl -sk -X POST https://rustchain.org/wallet/transfer/signed \
+curl -sS -X POST https://rustchain.org/wallet/transfer/signed \
   -H "Content-Type: application/json" \
   -d '{
     "from_address": "RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -314,7 +314,7 @@ Submit hardware fingerprint for epoch enrollment.
 
 **Request:**
 ```bash
-curl -sk -X POST https://rustchain.org/attest/submit \
+curl -sS -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "your_miner_id",
@@ -387,7 +387,7 @@ All examples use the `requests` library. Install with `pip install requests`.
 ```python
 import requests
 
-resp = requests.get("https://rustchain.org/health", verify=False)
+resp = requests.get("https://rustchain.org/health")
 data = resp.json()
 print(f"Node OK: {data['ok']}, Version: {data['version']}")
 print(f"Uptime: {data['uptime_s']}s, Epoch: {data.get('epoch', 'N/A')}")
@@ -398,7 +398,7 @@ print(f"Uptime: {data['uptime_s']}s, Epoch: {data.get('epoch', 'N/A')}")
 ```python
 import requests
 
-resp = requests.get("https://rustchain.org/epoch", verify=False)
+resp = requests.get("https://rustchain.org/epoch")
 data = resp.json()
 print(f"Epoch {data['epoch']}, Slot {data['slot']}/{data['blocks_per_epoch']}")
 print(f"Pot: {data['epoch_pot']} RTC, Miners: {data['enrolled_miners']}")
@@ -409,7 +409,7 @@ print(f"Pot: {data['epoch_pot']} RTC, Miners: {data['enrolled_miners']}")
 ```python
 import requests
 
-resp = requests.get("https://rustchain.org/api/miners", verify=False)
+resp = requests.get("https://rustchain.org/api/miners")
 miners = resp.json()
 for m in miners:
     print(f"{m['miner'][:20]}... | {m['device_arch']} | "
@@ -425,8 +425,7 @@ import requests
 miner_id = "your_wallet_name"
 resp = requests.get(
     f"https://rustchain.org/wallet/balance",
-    params={"miner_id": miner_id},
-    verify=False
+    params={"miner_id": miner_id}
 )
 data = resp.json()
 print(f"Balance: {data['amount_rtc']} RTC ({data['amount_i64']} micro-RTC)")
@@ -440,8 +439,7 @@ import requests
 miner_id = "your_wallet_name"
 resp = requests.get(
     "https://rustchain.org/wallet/history",
-    params={"miner_id": miner_id, "limit": 10},
-    verify=False
+    params={"miner_id": miner_id, "limit": 10}
 )
 for tx in resp.json().get("transfers", []):
     print(f"{tx['txid'][:12]}... | {tx['direction']} | {tx['amount_rtc']} RTC")
@@ -471,7 +469,6 @@ sig_serialized, _ = priv.ecdsa_recoverable_serialize(sig)
 resp = requests.post(
     "https://rustchain.org/attest/submit",
     json={**payload, "signature": sig_serialized.hex()},
-    verify=False,
     timeout=10,
 )
 print(resp.json())
@@ -484,8 +481,7 @@ import requests
 
 try:
     resp = requests.get("https://rustchain.org/wallet/balance", 
-                       params={"miner_id": "nonexistent"}, 
-                       verify=False,
+                       params={"miner_id": "nonexistent"},
                        timeout=5)
     if resp.status_code == 200:
         print(resp.json())
@@ -497,17 +493,17 @@ except requests.exceptions.ConnectionError:
     print("Connection failed — node may be offline")
 ```
 
-### Self-Signed Certificate Note
+### TLS Certificate Note
 
-The node uses a self-signed certificate. Use `verify=False` with requests, or add the cert to your trust store:
+The public node uses a standard TLS certificate. Keep verification enabled; for private nodes, add the issuing certificate to your trust store:
 
 ```python
 import requests, ssl
 
-# Option 1: Disable verification (less secure)
-requests.get(url, verify=False)
+# Option 1: Use the public node with system trust
+requests.get(url)
 
-# Option 2: Download cert and verify specifically
+# Option 2: For private nodes, verify against a specific CA
 import httpx
 client = httpx.Client(verify="/path/to/rustchain.crt")
 ```

--- a/docs/API_WALKTHROUGH.md
+++ b/docs/API_WALKTHROUGH.md
@@ -8,7 +8,7 @@ This guide walks you through making your first API calls to RustChain.
 https://rustchain.org
 ```
 
-> ⚠️ **Note**: The node uses a self-signed certificate. Use `-k` or `--insecure` with curl.
+> **Note**: The public node uses a standard TLS certificate. Do not use `-k` or `--insecure` for `https://rustchain.org`; fix local certificate-store or proxy issues instead.
 
 ---
 
@@ -17,7 +17,7 @@ https://rustchain.org
 The simplest way to verify the node is running:
 
 ```bash
-curl -k "https://rustchain.org/health"
+curl "https://rustchain.org/health"
 ```
 
 **Response:**
@@ -39,7 +39,7 @@ curl -k "https://rustchain.org/health"
 Query any wallet balance using the `miner_id` parameter:
 
 ```bash
-curl -k "https://rustchain.org/wallet/balance?miner_id=tomisnotcat"
+curl "https://rustchain.org/wallet/balance?miner_id=tomisnotcat"
 ```
 
 **Response:**
@@ -66,7 +66,7 @@ curl -k "https://rustchain.org/wallet/balance?miner_id=tomisnotcat"
 If you're mining, check your eligibility status:
 
 ```bash
-curl -k "https://rustchain.org/lottery/eligibility?miner_id=tomisnotcat"
+curl "https://rustchain.org/lottery/eligibility?miner_id=tomisnotcat"
 ```
 
 **Response (not eligible):**
@@ -96,7 +96,7 @@ curl -k "https://rustchain.org/lottery/eligibility?miner_id=tomisnotcat"
 ## 4. List Active Miners
 
 ```bash
-curl -k "https://rustchain.org/api/miners"
+curl "https://rustchain.org/api/miners"
 ```
 
 **Response (truncated):**
@@ -201,7 +201,7 @@ payload = {
 response = requests.post(
     "https://rustchain.org/wallet/transfer/signed",
     json=payload,
-    verify=False  # For self-signed cert
+    timeout=15
 )
 print(response.json())
 ```

--- a/docs/BOTTUBE_INTEGRATION.md
+++ b/docs/BOTTUBE_INTEGRATION.md
@@ -35,7 +35,7 @@ RTC (RustChain Token) serves as the shared economic layer across the entire Elya
 │              │   performance    │                          │
 ├──────────────┴──────────────────┴──────────────────────────┤
 │              All use the same RTC wallet system             │
-│          curl -sk https://rustchain.org/wallet/balance      │
+│          curl -sS https://rustchain.org/wallet/balance      │
 └────────────────────────────────────────────────────────────┘
 ```
 

--- a/docs/CROSS_NODE_SYNC_VALIDATOR.md
+++ b/docs/CROSS_NODE_SYNC_VALIDATOR.md
@@ -25,6 +25,6 @@ python3 tools/node_sync_validator.py \
 
 ## Notes
 
-- Default mode uses `verify=False` to support self-signed certificates.
-- Use `--verify-ssl` to enforce certificate checks.
+- Default mode keeps certificate verification enabled for public HTTPS nodes.
+- For private nodes, install the issuing CA certificate before enabling them in scheduled checks.
 - Script is cron-friendly and can run periodically for monitoring.

--- a/docs/DEVELOPER_QUICKSTART.md
+++ b/docs/DEVELOPER_QUICKSTART.md
@@ -11,7 +11,7 @@
 NODE_URL="https://rustchain.org"
 ```
 
-> ⚠️ **Self-Signed Certificate**: The node uses a self-signed TLS certificate. Always use `-k` or `--insecure` with curl.
+> **TLS Certificate**: The public node uses a standard TLS certificate. Keep certificate verification enabled with curl.
 
 ---
 
@@ -20,7 +20,7 @@ NODE_URL="https://rustchain.org"
 Verify the node is running:
 
 ```bash
-curl -k "$NODE_URL/health"
+curl -sS "$NODE_URL/health"
 ```
 
 **Response:**
@@ -53,7 +53,7 @@ curl -k "$NODE_URL/health"
 Get current epoch and network stats:
 
 ```bash
-curl -k "$NODE_URL/epoch"
+curl -sS "$NODE_URL/epoch"
 ```
 
 **Response:**
@@ -86,13 +86,13 @@ curl -k "$NODE_URL/epoch"
 Query a wallet balance with its RustChain address:
 
 ```bash
-curl -k "$NODE_URL/wallet/balance?miner_id=YOUR_RTC_ADDRESS"
+curl -sS "$NODE_URL/wallet/balance?miner_id=YOUR_RTC_ADDRESS"
 ```
 
 A placeholder value also returns the response shape, which is useful for onboarding:
 
 ```bash
-curl -k "$NODE_URL/wallet/balance?miner_id=YOUR_WALLET_ID"
+curl -sS "$NODE_URL/wallet/balance?miner_id=YOUR_WALLET_ID"
 ```
 
 **Tested response (2026-03-09):**
@@ -270,7 +270,6 @@ payload = {
 response = requests.post(
     f"{NODE_URL}/wallet/transfer/signed",
     json=payload,
-    verify=False,
     timeout=15,
 )
 
@@ -311,7 +310,7 @@ EOF
 SIGNATURE=$(echo -n "$MESSAGE" | openssl pkeyutl -sign -inkey private_key.pem -rawin | xxd -p -c 128)
 
 # Send transfer
-curl -k -X POST "$NODE_URL/wallet/transfer/signed" \
+curl -sS -X POST "$NODE_URL/wallet/transfer/signed" \
   -H "Content-Type: application/json" \
   -d "{
     \"from_address\": \"${FROM_ADDRESS}\",
@@ -350,7 +349,7 @@ Before submitting your transfer:
 - [ ] Signature is 128 hex characters
 - [ ] Nonce is unique (not reused)
 - [ ] Wallet IDs are RustChain format (not ETH/SOL)
-- [ ] Using `-k` flag for self-signed cert
+- [ ] Using normal TLS certificate verification
 
 ---
 

--- a/docs/DISCORD_LEADERBOARD_BOT.md
+++ b/docs/DISCORD_LEADERBOARD_BOT.md
@@ -49,5 +49,5 @@ python3 tools/discord_leaderboard_bot.py --schedule-seconds 3600
 
 ## Notes
 
-- The node may use a self-signed certificate. The script allows that intentionally for this endpoint.
+- The public node should validate with the system certificate store; private nodes should use a trusted CA.
 - Missing per-miner balance responses are handled without crashing the run.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -118,8 +118,8 @@ G5 Mac (2.0×): 0.24 RTC ████████████████
 ### 如何检查我的钱包余额？
 
 ```bash
-# 注意：使用 -sk 标志因为节点可能使用自签名 SSL 证书
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+# 注意：公共 rustchain.org 节点应通过正常 TLS 验证
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 ### 如何管理矿工服务？
@@ -315,8 +315,8 @@ curl -I https://rustchain.org
 验证直接连接到节点：
 
 ```bash
-curl -sk https://rustchain.org/health
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS https://rustchain.org/health
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 **注意：** 旧版本可能仍引用已退役的 `bulbous-bouffant.metalseed.net` 主机。
@@ -325,13 +325,13 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 
 ```bash
 # 检查节点健康
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # 获取当前 epoch
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # 列出活跃矿工
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # 区块浏览器
 open https://rustchain.org/explorer
@@ -376,7 +376,7 @@ RustChain 使用链上治理系统：
 
 ```bash
 # 创建提案
-curl -sk -X POST https://rustchain.org/governance/propose \
+curl -sS -X POST https://rustchain.org/governance/propose \
  -H 'Content-Type: application/json' \
  -d '{
  "wallet":"RTC...",
@@ -385,13 +385,13 @@ curl -sk -X POST https://rustchain.org/governance/propose \
  }'
 
 # 列出提案
-curl -sk https://rustchain.org/governance/proposals
+curl -sS https://rustchain.org/governance/proposals
 
 # 提案详情
-curl -sk https://rustchain.org/governance/proposal/1
+curl -sS https://rustchain.org/governance/proposal/1
 
 # 提交签名投票
-curl -sk -X POST https://rustchain.org/governance/vote \
+curl -sS -X POST https://rustchain.org/governance/vote \
  -H 'Content-Type: application/json' \
  -d '{
  "proposal_id":1,

--- a/docs/FAQ_TROUBLESHOOTING.md
+++ b/docs/FAQ_TROUBLESHOOTING.md
@@ -14,7 +14,7 @@ This guide covers common setup and runtime issues for miners and node users.
 ### 2) How do I check if the network is online?
 
 ```bash
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 ```
 
 You should see a JSON response. If the command times out repeatedly, check local firewall/VPN and retry.
@@ -22,7 +22,7 @@ You should see a JSON response. If the command times out repeatedly, check local
 ### 3) How do I verify my miner is visible?
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 ```
 
 If your miner is missing, wait a few minutes after startup and re-check logs.
@@ -30,15 +30,15 @@ If your miner is missing, wait a few minutes after startup and re-check logs.
 ### 4) How do I check wallet balance?
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
-### 5) Is self-signed TLS expected on the node API?
+### 5) Is TLS trust expected on the public node API?
 
-Yes. Existing docs use `-k`/`--insecure` for this reason:
+No. The public `https://rustchain.org` hostname should validate with the system certificate store:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 ## Troubleshooting
@@ -68,17 +68,17 @@ Checks:
 
 Commands:
 ```bash
-curl -sk https://rustchain.org/health | jq .
-curl -sk https://rustchain.org/api/miners | jq .
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/api/miners | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
 ### API calls fail with SSL/certificate errors
 
-Use `-k` as shown in official docs:
+Do not bypass TLS verification for the public hostname. First check your local clock, proxy, and CA trust store:
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 ```
 
 ### `clawrtc wallet show` says "could not reach network"
@@ -86,8 +86,8 @@ curl -sk https://rustchain.org/api/miners | jq .
 The public node is healthy if this succeeds:
 
 ```bash
-curl -sk https://rustchain.org/health | jq .
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS https://rustchain.org/health | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
 If those commands work but your local helper still says `could not reach network`, you are likely using an older `clawrtc` wallet helper that still points at the retired `bulbous-bouffant.metalseed.net` host. Current docs use `https://rustchain.org`, and current `clawrtc` releases also do not ship a generic `wallet show` subcommand.

--- a/docs/MASTERING_THE_MINER.md
+++ b/docs/MASTERING_THE_MINER.md
@@ -41,7 +41,7 @@ Pass these flags to the `LocalMiner` class or your CLI wrapper:
 ---
 
 ## 🚀 4. Optimization Tips
-- **Python Warnings:** The miner ignores `Unverified HTTPS` warnings for self-signed node certificates. This is normal but ensure your `NODE_URL` is set to `https://rustchain.org`.
+- **Python Warnings:** Keep TLS verification enabled for the public `https://rustchain.org` node. If a private node raises certificate errors, install its issuing CA instead of disabling verification.
 - **Entropy Management:** The miner tracks `last_entropy` to ensure your PoW isn't being "pre-calculated" on a different machine.
 - **Log Leveling:** Use `color_logs.py` (if available) to visually distinguish between `[FINGERPRINT]` passes and `[PoW]` shares.
 

--- a/docs/MECHANISM_SPEC_AND_FALSIFICATION_MATRIX.md
+++ b/docs/MECHANISM_SPEC_AND_FALSIFICATION_MATRIX.md
@@ -35,9 +35,9 @@ If any "Fail condition" occurs, the corresponding claim is falsified.
 
 | Claim | Mechanism Under Test | How to Test | Pass Condition | Fail Condition |
 |---|---|---|---|---|
-| C1: Node health/status is deterministic and machine-readable | Health endpoint | `curl -sk https://rustchain.org/health \| jq .` | JSON response with `ok=true`, `version`, and runtime fields | Endpoint missing, malformed, or non-deterministic health state |
-| C2: Epoch state is explicit and observable | Epoch endpoint | `curl -sk https://rustchain.org/epoch \| jq .` | Returns epoch/slot/pot fields and advances over time | No epoch data or inconsistent epoch progression |
-| C3: Miner enrollment + multipliers are transparent | Miner list endpoint | `curl -sk https://rustchain.org/api/miners \| jq .` | Active miners listed with hardware fields and `antiquity_multiplier` | Missing/opaque miner state or absent multiplier disclosure |
+| C1: Node health/status is deterministic and machine-readable | Health endpoint | `curl -sS https://rustchain.org/health \| jq .` | JSON response with `ok=true`, `version`, and runtime fields | Endpoint missing, malformed, or non-deterministic health state |
+| C2: Epoch state is explicit and observable | Epoch endpoint | `curl -sS https://rustchain.org/epoch \| jq .` | Returns epoch/slot/pot fields and advances over time | No epoch data or inconsistent epoch progression |
+| C3: Miner enrollment + multipliers are transparent | Miner list endpoint | `curl -sS https://rustchain.org/api/miners \| jq .` | Active miners listed with hardware fields and `antiquity_multiplier` | Missing/opaque miner state or absent multiplier disclosure |
 | C4: Signed transfer replay is blocked | Nonce replay protection | Send the same signed payload (same nonce/signature) to `/wallet/transfer/signed` twice | First request accepted; second request rejected as replay/duplicate | Same signed payload executes twice |
 | C5: Signature checks are enforced | Signature verification | Submit intentionally invalid signature to `/wallet/transfer/signed` | Transfer rejected with validation error | Invalid signature accepted and state mutates |
 | C6: Cross-node reads can be compared for drift | API consistency | Compare `/health`, `/epoch`, `/api/miners` across live nodes (131, 153, 245) | Differences stay within expected propagation window and reconcile | Persistent divergence with no reconciliation |

--- a/docs/MINING_GUIDE.md
+++ b/docs/MINING_GUIDE.md
@@ -108,7 +108,7 @@ venv/                   # Python virtual environment
 Check the network is reachable:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 Expected response:
@@ -182,13 +182,13 @@ Then it begins attesting to the network every few minutes:
 Rewards settle every **10 minutes** (one epoch). After your first epoch:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 Example:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
 ```
 
 Response:
@@ -203,13 +203,13 @@ Response:
 ### View All Active Miners
 
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 ### Check Mining Eligibility
 
 ```bash
-curl -sk "https://rustchain.org/lottery/eligibility?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/lottery/eligibility?miner_id=YOUR_WALLET_NAME"
 ```
 
 ---
@@ -234,13 +234,13 @@ Over 24 hours (144 epochs), a G4 Mac earns roughly **43 RTC** ($4.30) while a mo
 
 1. **Confirm your miner appears in the active list:**
    ```bash
-   curl -sk https://rustchain.org/api/miners
+   curl -sS https://rustchain.org/api/miners
    ```
    Look for your wallet name in the output.
 
 2. **Confirm you are querying the right wallet:**
    ```bash
-   curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
+   curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
    ```
 
 3. **Wait for epoch settlement** — rewards settle every 10 minutes. Wait at least 2-3 epochs (20-30 minutes).
@@ -257,10 +257,10 @@ This is by design. VMs are detected by the anti-emulation fingerprint check and 
 
 ### SSL Certificate Errors
 
-Add `-k` to curl commands to accept the self-signed TLS certificate:
+Use normal TLS verification for the public node:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 The miner script handles this automatically.
@@ -283,7 +283,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 ### Network Security
 
-- The node uses a self-signed TLS certificate (expected behavior)
+- Your local clock, proxy, or CA trust store is breaking certificate validation
 - Miners pin node certificates for additional security
 - Container detection catches Docker, LXC, K8s at attestation
 
@@ -293,16 +293,16 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 ```bash
 # Node health
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # Current epoch
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # Active miners
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # Connected nodes
-curl -sk https://rustchain.org/api/nodes
+curl -sS https://rustchain.org/api/nodes
 
 # Block explorer (web UI)
 open https://rustchain.org/explorer

--- a/docs/MULTISIG_WALLET_GUIDE.md
+++ b/docs/MULTISIG_WALLET_GUIDE.md
@@ -184,7 +184,7 @@ clawrtc multisig create \
 
 ```bash
 # 查询多签钱包详情
-curl -sk "https://rustchain.org/api/multisig/status?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/api/multisig/status?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 ```
 
 **响应示例：**
@@ -295,7 +295,7 @@ clawrtc multisig execute \
 
 ```bash
 # 查询提案详情
-curl -sk "https://rustchain.org/api/multisig/proposal/prop_abc123def456"
+curl -sS "https://rustchain.org/api/multisig/proposal/prop_abc123def456"
 ```
 
 **响应示例：**
@@ -419,13 +419,13 @@ clawrtc multisig cancel \
 
 ```bash
 # 每周检查多签钱包余额
-curl -sk "https://rustchain.org/wallet/balance?miner_id=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/wallet/balance?miner_id=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 
 # 每月检查待处理提案
-curl -sk "https://rustchain.org/api/multisig/pending?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/api/multisig/pending?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 
 # 每季度审查交易历史
-curl -sk "https://rustchain.org/api/multisig/history?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/api/multisig/history?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 ```
 
 #### 告警设置
@@ -474,10 +474,10 @@ curl -sk "https://rustchain.org/api/multisig/history?address=RTCms7X8Y9Z0A1B2C3D
 **解决方案：**
 ```bash
 # 检查提案状态
-curl -sk "https://rustchain.org/api/multisig/proposal/prop_abc123def456"
+curl -sS "https://rustchain.org/api/multisig/proposal/prop_abc123def456"
 
 # 检查多签钱包余额
-curl -sk "https://rustchain.org/wallet/balance?miner_id=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/wallet/balance?miner_id=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 
 # 重新签名（如签名过期）
 clawrtc multisig sign --proposal prop_abc123def456 --signer signer-b --force
@@ -495,10 +495,10 @@ clawrtc multisig sign --proposal prop_abc123def456 --signer signer-b --force
 **解决方案：**
 ```bash
 # 手动查询待签名提案
-curl -sk "https://rustchain.org/api/multisig/pending-signer?address=RTC2B3C4D5E6F7G8H9I0J1K..."
+curl -sS "https://rustchain.org/api/multisig/pending-signer?address=RTC2B3C4D5E6F7G8H9I0J1K..."
 
 # 验证签名者地址是否在多签配置中
-curl -sk "https://rustchain.org/api/multisig/status?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
+curl -sS "https://rustchain.org/api/multisig/status?address=RTCms7X8Y9Z0A1B2C3D4E5F6G..."
 ```
 
 #### 问题 3：交易执行后未确认
@@ -513,10 +513,10 @@ curl -sk "https://rustchain.org/api/multisig/status?address=RTCms7X8Y9Z0A1B2C3D4
 **解决方案：**
 ```bash
 # 查询交易状态
-curl -sk "https://rustchain.org/explorer/tx/tx_9876543210abcdef"
+curl -sS "https://rustchain.org/explorer/tx/tx_9876543210abcdef"
 
 # 检查网络状态
-curl -sk "https://rustchain.org/health"
+curl -sS "https://rustchain.org/health"
 
 # 联系节点运营商（如超过 30 分钟未确认）
 ```
@@ -576,7 +576,7 @@ clawrtc multisig create \
   --name "my-multisig"
 
 # === 查询多签状态 ===
-curl -sk "https://rustchain.org/api/multisig/status?address=RTCms..."
+curl -sS "https://rustchain.org/api/multisig/status?address=RTCms..."
 
 # === 发起提案 ===
 clawrtc multisig propose \
@@ -601,13 +601,13 @@ clawrtc multisig cancel \
   --proposer signer-a
 
 # === 查询提案状态 ===
-curl -sk "https://rustchain.org/api/multisig/proposal/prop_abc123"
+curl -sS "https://rustchain.org/api/multisig/proposal/prop_abc123"
 
 # === 查询待处理提案 ===
-curl -sk "https://rustchain.org/api/multisig/pending?address=RTCms..."
+curl -sS "https://rustchain.org/api/multisig/pending?address=RTCms..."
 
 # === 查询交易历史 ===
-curl -sk "https://rustchain.org/api/multisig/history?address=RTCms..."
+curl -sS "https://rustchain.org/api/multisig/history?address=RTCms..."
 ```
 
 ---

--- a/docs/N64_MINING_GUIDE.md
+++ b/docs/N64_MINING_GUIDE.md
@@ -279,8 +279,8 @@ With 10 miners at avg 1.5x weight:
 Your actual earnings depend on how many miners are attesting and their multipliers. Check the live epoch data:
 
 ```bash
-curl -sk https://rustchain.org/epoch
-curl -sk "https://rustchain.org/wallet/balance?miner_id=my-n64-miner"
+curl -sS https://rustchain.org/epoch
+curl -sS "https://rustchain.org/wallet/balance?miner_id=my-n64-miner"
 ```
 
 ---
@@ -339,7 +339,7 @@ The achievement bridge runs alongside the mining relay. Both use the same Pico s
 
 ### Attestation returns HTTP 500
 - Check that your wallet ID is unique (not already registered to different hardware)
-- Verify node connectivity: `curl -sk https://rustchain.org/health`
+- Verify node connectivity: `curl -sS https://rustchain.org/health`
 - Check the host relay log for error details
 
 ### N64 hash time is suspiciously fast (< 100ms)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -94,7 +94,7 @@ venv/                   # Python virtual environment
 Check that the network is reachable:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 You should see something like:
@@ -174,13 +174,13 @@ Rewards are distributed every **10 minutes** (one "epoch"). After your first epo
 settles, check your balance:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 Replace `YOUR_WALLET_NAME` with the wallet name you chose during install. Example:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
 ```
 
 Response:
@@ -288,20 +288,20 @@ These all work from your terminal:
 
 ```bash
 # Is the network alive?
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # Who is mining right now?
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # What epoch are we in?
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # What is my balance?
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
-The `-sk` flag tells curl to accept the self-signed TLS certificate. This is normal --
-the node uses a self-signed cert, not a commercial one.
+The public node uses a standard TLS certificate, so curl should validate it
+with the system certificate store.
 
 ---
 
@@ -314,7 +314,7 @@ This usually means your machine cannot reach the RustChain node yet.
 1. Check whether the public node is responding:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 2. If that fails, wait 30-60 seconds and retry. The node may be restarting.
@@ -329,7 +329,7 @@ an existing RTC balance for fees.
 1. Confirm you are using the exact wallet name from install:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
 ```
 
 2. Wait at least one full epoch after the miner first starts. Rewards settle about every
@@ -350,7 +350,7 @@ miner between different hardware.
 ### Miner Configuration Checklist
 
 - The wallet name in your command matches the wallet you want paid.
-- `curl -sk https://rustchain.org/health` returns `"ok": true`.
+- `curl -sS https://rustchain.org/health` returns `"ok": true`.
 - Your system clock is correct; TLS and attestation windows can fail when the clock is far off.
 - You are running on real hardware if you expect normal rewards.
 - You waited at least 2-3 epochs before deciding rewards are missing.
@@ -373,7 +373,7 @@ need to install it yourself first:
 If you see errors about certificates when running `curl` commands, add `-k`:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 The miner script handles this automatically.
@@ -383,7 +383,7 @@ The miner script handles this automatically.
 1. Confirm your miner appears in the active miners list:
 
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 Look for your wallet name in the output.
@@ -391,7 +391,7 @@ Look for your wallet name in the output.
 2. Confirm you are querying the right wallet name:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_EXACT_WALLET_NAME"
 ```
 
 3. Rewards settle every 10 minutes. Wait at least 2-3 epochs (20-30 minutes).

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,20 +27,20 @@
 
 - **Primary Node**: `https://rustchain.org`
 - **Explorer**: `https://rustchain.org/explorer`
-- **Health Check**: `curl -sk https://rustchain.org/health`
+- **Health Check**: `curl -sS https://rustchain.org/health`
 - **Network Status Page**: `docs/network-status.html` (GitHub Pages-hostable status dashboard)
 
 ## Current Stats
 
 ```bash
 # Check node health
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 
 # List active miners
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 
 # Current epoch info
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 ## Architecture Overview

--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -100,7 +100,7 @@ curl --version
 # Expected: curl X.Y.Z with SSL support
 
 # Test network connectivity to RustChain node
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 # Expected: {"status": "ok", ...}
 ```
 
@@ -142,10 +142,10 @@ In a new terminal:
 tail -f ~/.rustchain/miner.log
 
 # Verify your miner is visible on the network
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner_id contains "YOUR_WALLET_NAME")'
+curl -sS https://rustchain.org/api/miners | jq '.[] | select(.miner_id contains "YOUR_WALLET_NAME")'
 
 # Check your balance (after a few minutes of mining)
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
 ### Expected Output
@@ -290,7 +290,7 @@ python -c "import requests; print(requests.__version__)"
 python -c "import fingerprint_checks; print('OK')"
 
 # 4. Test network connectivity
-curl -sk https://rustchain.org/health | jq .status
+curl -sS https://rustchain.org/health | jq .status
 # Expected: "ok"
 ```
 
@@ -373,21 +373,21 @@ tail -f ~/.rustchain/miner.log | grep "rewards"
 
 ```bash
 # Check if your miner is registered
-curl -sk https://rustchain.org/api/miners | jq \
+curl -sS https://rustchain.org/api/miners | jq \
   '.[] | select(.miner_id == "my-vintage-miner")'
 
 # View all active miners
-curl -sk https://rustchain.org/api/miners | jq 'length'
+curl -sS https://rustchain.org/api/miners | jq 'length'
 
 # Check current epoch
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 #### Check Your Balance
 
 ```bash
 # Current balance
-curl -sk "https://rustchain.org/wallet/balance?miner_id=my-vintage-miner" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=my-vintage-miner" | jq .
 
 # Expected response:
 # {
@@ -430,7 +430,7 @@ RustChain transactions are simple value transfers between wallets:
 
 ```bash
 # Send 5 RTC to another wallet
-curl -sk -X POST https://rustchain.org/api/transaction \
+curl -sS -X POST https://rustchain.org/api/transaction \
   -H "Content-Type: application/json" \
   -d '{
     "from": "my-vintage-miner",
@@ -443,10 +443,10 @@ curl -sk -X POST https://rustchain.org/api/transaction \
 
 ```bash
 # Check transaction by ID
-curl -sk "https://rustchain.org/api/transaction/TX_ID" | jq .
+curl -sS "https://rustchain.org/api/transaction/TX_ID" | jq .
 
 # List transactions for a wallet
-curl -sk "https://rustchain.org/api/wallet/my-vintage-miner/transactions" | jq .
+curl -sS "https://rustchain.org/api/wallet/my-vintage-miner/transactions" | jq .
 ```
 
 ### Using the CLI Helper
@@ -486,7 +486,7 @@ Run miners on multiple vintage machines, all reporting to one wallet:
 # config.json: {"wallet_name": "vintage-farm", ...}
 
 # All rewards accumulate to "vintage-farm" wallet
-curl -sk "https://rustchain.org/wallet/balance?miner_id=vintage-farm" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=vintage-farm" | jq .
 ```
 
 ### Example 2: Automated Monitoring Script
@@ -501,14 +501,14 @@ NODE="https://rustchain.org"
 
 check_miner() {
     # Check node health
-    HEALTH=$(curl -sk "$NODE/health" | jq -r '.status')
+    HEALTH=$(curl -sS "$NODE/health" | jq -r '.status')
     if [ "$HEALTH" != "ok" ]; then
         echo "❌ Node unhealthy"
         return 1
     fi
     
     # Check miner visibility
-    MINER=$(curl -sk "$NODE/api/miners" | jq -r \
+    MINER=$(curl -sS "$NODE/api/miners" | jq -r \
         ".[] | select(.miner_id == \"$WALLET\") | .miner_id")
     if [ -z "$MINER" ]; then
         echo "❌ Miner not visible on network"
@@ -516,8 +516,8 @@ check_miner() {
     fi
     
     # Check balance
-    BALANCE=$(curl -sk "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.balance')
-    PENDING=$(curl -sk "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.pending_rewards')
+    BALANCE=$(curl -sS "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.balance')
+    PENDING=$(curl -sS "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.pending_rewards')
     
     echo "✅ Miner online | Balance: $BALANCE RTC | Pending: $PENDING RTC"
     return 0
@@ -589,16 +589,13 @@ def clear_screen():
 def get_miner_data():
     try:
         balance_resp = requests.get(
-            f"{NODE}/wallet/balance?miner_id={WALLET}",
-            verify=False, timeout=5
+            f"{NODE}/wallet/balance?miner_id={WALLET}", timeout=5
         )
         miners_resp = requests.get(
-            f"{NODE}/api/miners",
-            verify=False, timeout=5
+            f"{NODE}/api/miners", timeout=5
         )
         epoch_resp = requests.get(
-            f"{NODE}/epoch",
-            verify=False, timeout=5
+            f"{NODE}/epoch", timeout=5
         )
         
         return {
@@ -743,10 +740,10 @@ Error: Unable to connect to node
 **Diagnosis:**
 ```bash
 # Test network connectivity
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # Check if Python can reach the node
-python3 -c "import requests; print(requests.get('https://rustchain.org/health', verify=False).json())"
+python3 -c "import requests; print(requests.get('https://rustchain.org/health').json())"
 ```
 
 **Solutions:**
@@ -787,10 +784,10 @@ Pending rewards: 0.00 RTC (after hours of mining)
 **Diagnosis:**
 ```bash
 # Verify miner is visible on network
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner_id == "YOUR_WALLET")'
+curl -sS https://rustchain.org/api/miners | jq '.[] | select(.miner_id == "YOUR_WALLET")'
 
 # Check epoch settlement status
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 **Solutions:**
@@ -807,11 +804,11 @@ curl: (60) SSL certificate problem: unable to get local issuer certificate
 ```
 
 **Solutions:**
-1. Use `-k` flag (expected for self-signed certs):
+1. Verify the public node with the system certificate store:
    ```bash
-   curl -sk https://rustchain.org/health
+   curl -sS https://rustchain.org/health
    ```
-2. Or update CA certificates:
+2. Update CA certificates if local verification fails:
    ```bash
    # Ubuntu/Debian
    sudo apt-get update && sudo apt-get install --reinstall ca-certificates
@@ -942,8 +939,8 @@ WALLET = "my-vintage-miner"
 
 def get_optimal_interval():
     """Adjust mining interval based on network congestion."""
-    epoch_data = requests.get(f"{NODE}/epoch", verify=False).json()
-    miners_count = len(requests.get(f"{NODE}/api/miners", verify=False).json())
+    epoch_data = requests.get(f"{NODE}/epoch").json()
+    miners_count = len(requests.get(f"{NODE}/api/miners").json())
     
     # More miners = longer intervals to reduce load
     if miners_count > 100:
@@ -979,8 +976,7 @@ def pay():
     
     # Verify sender has sufficient balance
     balance_resp = requests.get(
-        f"{NODE}/wallet/balance?miner_id={from_wallet}",
-        verify=False
+        f"{NODE}/wallet/balance?miner_id={from_wallet}"
     )
     balance = balance_resp.json().get('balance', 0)
     
@@ -990,8 +986,7 @@ def pay():
     # Process transaction
     tx_resp = requests.post(
         f"{NODE}/api/transaction",
-        json={'from': from_wallet, 'to': to_wallet, 'amount': amount},
-        verify=False
+        json={'from': from_wallet, 'to': to_wallet, 'amount': amount}
     )
     
     return jsonify(tx_resp.json())
@@ -1011,7 +1006,7 @@ if __name__ == '__main__':
 4. **Monitor for unusual activity:**
    ```bash
    # Alert on large balance changes
-   curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | \
+   curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | \
      jq 'if .balance < 10 then "⚠️ Low balance alert" else "OK" end'
    ```
 
@@ -1046,19 +1041,19 @@ if __name__ == '__main__':
 
 ```bash
 # Health check
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 
 # List miners
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 
 # Check balance
-curl -sk "https://rustchain.org/wallet/balance?miner_id=WALLET_NAME" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=WALLET_NAME" | jq .
 
 # Current epoch
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 
 # Send transaction
-curl -sk -X POST https://rustchain.org/api/transaction \
+curl -sS -X POST https://rustchain.org/api/transaction \
   -H "Content-Type: application/json" \
   -d '{"from":"SENDER","to":"RECIPIENT","amount":10}' | jq .
 ```

--- a/docs/RUSTCHAIN_PROTOCOL.md
+++ b/docs/RUSTCHAIN_PROTOCOL.md
@@ -233,7 +233,7 @@ Check node health status.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 **Response**:
@@ -252,7 +252,7 @@ List all active miners.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 **Response**:
@@ -277,7 +277,7 @@ Get current epoch information.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 **Response**:
@@ -297,7 +297,7 @@ Check wallet balance.
 
 **Request**:
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
 ```
 
 **Response**:
@@ -314,7 +314,7 @@ Submit hardware fingerprint (miner only).
 
 **Request**:
 ```bash
-curl -sk -X POST https://rustchain.org/attest \
+curl -sS -X POST https://rustchain.org/attest \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "scott-laptop",
@@ -361,7 +361,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 ### Check Balance
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 ### View Explorer

--- a/docs/UPGRADE_MIGRATION_GUIDE.md
+++ b/docs/UPGRADE_MIGRATION_GUIDE.md
@@ -236,10 +236,10 @@ python3.11 -m pip install clawrtc
 **解决方案：**
 ```bash
 # 检查节点健康
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # 检查钱包余额（替换 YOUR_WALLET）
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 
 # 如果使用旧版本，可能引用已退役的主机
 # 升级到最新版本修复
@@ -252,7 +252,7 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 **解决方案：**
 ```bash
 # 使用 -sk 标志跳过证书验证（节点可能使用自签名证书）
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # 或更新系统证书
 # Ubuntu/Debian
@@ -278,7 +278,7 @@ journalctl --user -u rustchain-miner -f  # Linux
 tail -f ~/.rustchain/miner.log           # macOS/通用
 
 # 验证钱包存在
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 ```
 
 ### 6. 硬件指纹验证失败
@@ -357,20 +357,20 @@ tail -f ~/.rustchain/miner.log           # macOS
 
 ```bash
 # 等待 1-2 个 epoch（10-20 分钟）后检查余额
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 ```
 
 ### 4. 网络健康检查
 
 ```bash
 # 节点健康
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 
 # 当前 epoch
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 
 # 活跃矿工列表
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 
 # 区块浏览器
 open https://rustchain.org/explorer

--- a/docs/VINTAGE_MINING_EXPLAINED.md
+++ b/docs/VINTAGE_MINING_EXPLAINED.md
@@ -230,9 +230,9 @@ RustChain's live mining fleet includes:
 Verify it yourself:
 
 ```bash
-curl -sk https://rustchain.org/health
-curl -sk https://rustchain.org/api/miners
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/health
+curl -sS https://rustchain.org/api/miners
+curl -sS https://rustchain.org/epoch
 ```
 
 ---

--- a/docs/WALLET_SETUP.md
+++ b/docs/WALLET_SETUP.md
@@ -31,7 +31,7 @@ These are the main RustChain endpoints used in this guide:
 - Wallet balance: `https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET`
 - Explorer: `https://rustchain.org/explorer/`
 
-Use `curl -sk` because the public node uses a self-signed TLS certificate.
+Use normal TLS verification for the public node.
 
 ## 1. Three ways to get an RTC wallet
 
@@ -149,13 +149,13 @@ What to save immediately:
 This is the most direct balance check:
 
 ```bash
-curl -sk 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
+curl -sS 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
 ```
 
 Example:
 
 ```bash
-curl -sk 'https://rustchain.org/wallet/balance?miner_id=victus-x86-scott'
+curl -sS 'https://rustchain.org/wallet/balance?miner_id=victus-x86-scott'
 ```
 
 Typical response:
@@ -208,9 +208,9 @@ Mining is automatic once your miner is installed and online.
 Useful checks:
 
 ```bash
-curl -sk https://rustchain.org/health
-curl -sk https://rustchain.org/api/miners
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/health
+curl -sS https://rustchain.org/api/miners
+curl -sS https://rustchain.org/epoch
 ```
 
 What to expect:
@@ -333,7 +333,6 @@ payload = {
 resp = requests.post(
     f"{NODE_URL}/wallet/transfer/signed",
     json=payload,
-    verify=False,
     timeout=15,
 )
 
@@ -405,7 +404,7 @@ Try these in order:
 ```bash
 cat /opt/rustchain-miner/config.json
 ls ~/.rustchain/wallets
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 If you still have the secure wallet keystore or seed phrase, you can usually recover the public `RTC...` address.
@@ -424,9 +423,9 @@ Common reasons:
 Quick checks:
 
 ```bash
-curl -sk https://rustchain.org/health
-curl -sk https://rustchain.org/api/miners
-curl -sk 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
+curl -sS https://rustchain.org/health
+curl -sS https://rustchain.org/api/miners
+curl -sS 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
 ```
 
 ### How long until I earn RTC?
@@ -457,14 +456,14 @@ curl -sL https://rustchain.org/install.sh | bash
 3. Check your balance:
 
 ```bash
-curl -sk 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
+curl -sS 'https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET'
 ```
 
 4. Confirm you are live:
 
 ```bash
-curl -sk https://rustchain.org/api/miners
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/api/miners
+curl -sS https://rustchain.org/epoch
 ```
 
 5. If you later want to send RTC yourself, create a secure `RTC...` wallet with the secure GUI or the Python wallet module.

--- a/docs/WALLET_USER_GUIDE.md
+++ b/docs/WALLET_USER_GUIDE.md
@@ -10,7 +10,7 @@ This guide explains wallet basics, balance checks, and safe transfer practices f
 ## 2) Check wallet balance
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
 Expected response shape:
@@ -26,7 +26,7 @@ Expected response shape:
 ## 3) Confirm miner is active
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq .
+curl -sS https://rustchain.org/api/miners | jq .
 ```
 
 If your miner does not appear:
@@ -60,10 +60,10 @@ Only use this when you fully understand signing and key custody.
 
 ### API SSL warning
 
-Current docs use `curl -k` for self-signed TLS:
+The public node should validate with normal TLS:
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 ### Wrong chain/token confusion (RTC vs wRTC)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-RustChain provides a REST API for interacting with the network. All endpoints use HTTPS with a self-signed certificate (use `-k` flag with curl).
+RustChain provides a REST API for interacting with the network. The public endpoint uses HTTPS with standard certificate validation.
 
 **Base URL**: `https://rustchain.org`
 
@@ -25,7 +25,7 @@ Most endpoints are public. Admin endpoints require the `X-Admin-Key` header:
 Check node health status.
 
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 **Response**:
@@ -56,7 +56,7 @@ curl -sk https://rustchain.org/health
 Kubernetes-style readiness probe.
 
 ```bash
-curl -sk https://rustchain.org/ready
+curl -sS https://rustchain.org/ready
 ```
 
 **Response**:
@@ -75,7 +75,7 @@ curl -sk https://rustchain.org/ready
 Get current epoch and slot information.
 
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 **Response**:
@@ -106,7 +106,7 @@ curl -sk https://rustchain.org/epoch
 List all active miners with hardware details.
 
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 **Response**:
@@ -153,7 +153,7 @@ curl -sk https://rustchain.org/api/miners
 List connected attestation nodes.
 
 ```bash
-curl -sk https://rustchain.org/api/nodes
+curl -sS https://rustchain.org/api/nodes
 ```
 
 **Response**:
@@ -185,7 +185,7 @@ curl -sk https://rustchain.org/api/nodes
 Check RTC balance for a miner wallet.
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott"
 ```
 
 **Parameters**:
@@ -222,7 +222,7 @@ the sender or recipient. Returns an empty array for wallets with no history
 (non-existent wallets do not produce an error).
 
 ```bash
-curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10"
+curl -sS "https://rustchain.org/wallet/history?miner_id=scott&limit=10"
 ```
 
 **Parameters**:
@@ -361,7 +361,7 @@ Invalid limit:
 Submit hardware attestation to enroll in current epoch.
 
 ```bash
-curl -sk -X POST https://rustchain.org/attest/submit \
+curl -sS -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "scott",
@@ -417,7 +417,7 @@ curl -sk -X POST https://rustchain.org/attest/submit \
 Check if miner is enrolled in current epoch.
 
 ```bash
-curl -sk "https://rustchain.org/lottery/eligibility?miner_id=scott"
+curl -sS "https://rustchain.org/lottery/eligibility?miner_id=scott"
 ```
 
 **Response**:
@@ -454,7 +454,7 @@ Returns HTML page (not JSON).
 Query historical settlement data for a specific epoch.
 
 ```bash
-curl -sk https://rustchain.org/api/settlement/75
+curl -sS https://rustchain.org/api/settlement/75
 ```
 
 **Response**:
@@ -488,7 +488,7 @@ These endpoints require the `X-Admin-Key` header.
 Transfer RTC between wallets (admin only).
 
 ```bash
-curl -sk -X POST https://rustchain.org/wallet/transfer \
+curl -sS -X POST https://rustchain.org/wallet/transfer \
   -H "X-Admin-Key: YOUR_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -516,7 +516,7 @@ curl -sk -X POST https://rustchain.org/wallet/transfer \
 Manually trigger epoch settlement (admin only).
 
 ```bash
-curl -sk -X POST https://rustchain.org/rewards/settle \
+curl -sS -X POST https://rustchain.org/rewards/settle \
   -H "X-Admin-Key: YOUR_ADMIN_KEY"
 ```
 
@@ -546,15 +546,15 @@ is not mounted on that host or the public prefix changed.
 
 | Surface | Command | Expected when mounted |
 |---------|---------|-----------------------|
-| BoTTube status | `curl -sk https://bottube.ai/api/x402/status` | JSON status or x402 challenge |
-| BoTTube videos | `curl -sk https://bottube.ai/api/premium/videos` | JSON export or x402 challenge |
-| BoTTube analytics | `curl -sk https://bottube.ai/api/premium/analytics/sophia-elya` | JSON analytics or x402 challenge |
-| Beacon status | `curl -sk https://rustchain.org/beacon/api/x402/status` | JSON status or x402 challenge |
-| Beacon reputation | `curl -sk https://rustchain.org/beacon/api/premium/reputation` | JSON export or x402 challenge |
-| Beacon contracts | `curl -sk https://rustchain.org/beacon/api/premium/contracts/export` | JSON export or x402 challenge |
-| RustChain swap info | `curl -sk https://rustchain.org/wallet/swap-info` | JSON swap guidance |
+| BoTTube status | `curl -sS https://bottube.ai/api/x402/status` | JSON status or x402 challenge |
+| BoTTube videos | `curl -sS https://bottube.ai/api/premium/videos` | JSON export or x402 challenge |
+| BoTTube analytics | `curl -sS https://bottube.ai/api/premium/analytics/sophia-elya` | JSON analytics or x402 challenge |
+| Beacon status | `curl -sS https://rustchain.org/beacon/api/x402/status` | JSON status or x402 challenge |
+| Beacon reputation | `curl -sS https://rustchain.org/beacon/api/premium/reputation` | JSON export or x402 challenge |
+| Beacon contracts | `curl -sS https://rustchain.org/beacon/api/premium/contracts/export` | JSON export or x402 challenge |
+| RustChain swap info | `curl -sS https://rustchain.org/wallet/swap-info` | JSON swap guidance |
 
-Keep the raw `curl -skv` output when filing a deployment issue. It shows the
+Keep the raw `curl -sSv` output when filing a deployment issue. It shows the
 HTTP status, server headers, and whether the request reached the x402 handler.
 
 ### GET /api/premium/videos
@@ -562,7 +562,7 @@ HTTP status, server headers, and whether the request reached the x402 handler.
 Bulk video export (BoTTube integration).
 
 ```bash
-curl -sk https://bottube.ai/api/premium/videos
+curl -sS https://bottube.ai/api/premium/videos
 ```
 
 ---
@@ -572,7 +572,7 @@ curl -sk https://bottube.ai/api/premium/videos
 Deep agent analytics.
 
 ```bash
-curl -sk https://bottube.ai/api/premium/analytics/scott
+curl -sS https://bottube.ai/api/premium/analytics/scott
 ```
 
 ---
@@ -582,7 +582,7 @@ curl -sk https://bottube.ai/api/premium/analytics/scott
 USDC/wRTC swap guidance.
 
 ```bash
-curl -sk https://rustchain.org/wallet/swap-info
+curl -sS https://rustchain.org/wallet/swap-info
 ```
 
 **Response**:
@@ -651,13 +651,13 @@ curl -sk https://rustchain.org/wallet/swap-info
 
 ## HTTPS Certificate
 
-The node uses a self-signed certificate. Options:
+The public node uses a standard TLS certificate. Keep verification enabled:
 
 ```bash
-# Option 1: Skip verification (development)
-curl -sk https://rustchain.org/health
+# Public node
+curl -sS https://rustchain.org/health
 
-# Option 2: Download and trust certificate
+# Private nodes: install and trust the issuing certificate
 openssl s_client -connect rustchain.org:443 -showcerts < /dev/null 2>/dev/null | \
   openssl x509 -outform PEM > rustchain.pem
 curl --cacert rustchain.pem https://rustchain.org/health
@@ -677,13 +677,12 @@ BASE_URL = "https://rustchain.org"
 def get_balance(miner_id):
     resp = requests.get(
         f"{BASE_URL}/wallet/balance",
-        params={"miner_id": miner_id},
-        verify=False  # Self-signed cert
+        params={"miner_id": miner_id}  # Self-signed cert
     )
     return resp.json()
 
 def get_epoch():
-    resp = requests.get(f"{BASE_URL}/epoch", verify=False)
+    resp = requests.get(f"{BASE_URL}/epoch")
     return resp.json()
 
 # Usage
@@ -721,12 +720,12 @@ BASE_URL="https://rustchain.org"
 
 # Get balance
 get_balance() {
-  curl -sk "$BASE_URL/wallet/balance?miner_id=$1" | jq
+  curl -sS "$BASE_URL/wallet/balance?miner_id=$1" | jq
 }
 
 # Get epoch
 get_epoch() {
-  curl -sk "$BASE_URL/epoch" | jq
+  curl -sS "$BASE_URL/epoch" | jq
 }
 
 # Usage

--- a/docs/api/EXAMPLES.md
+++ b/docs/api/EXAMPLES.md
@@ -18,7 +18,7 @@ Complete code examples for interacting with the RustChain REST API.
 ### Health Check
 
 ```bash
-curl -sk https://rustchain.org/health | jq
+curl -sS https://rustchain.org/health | jq
 ```
 
 **Expected Output:**
@@ -36,7 +36,7 @@ curl -sk https://rustchain.org/health | jq
 ### Get Epoch Information
 
 ```bash
-curl -sk https://rustchain.org/epoch | jq
+curl -sS https://rustchain.org/epoch | jq
 ```
 
 **Expected Output:**
@@ -53,17 +53,17 @@ curl -sk https://rustchain.org/epoch | jq
 ### List Active Miners
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq
+curl -sS https://rustchain.org/api/miners | jq
 ```
 
 ### Get Wallet Balance
 
 ```bash
 # Using miner_id parameter (canonical)
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott" | jq
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott" | jq
 
 # Using address parameter (backward compatible)
-curl -sk "https://rustchain.org/wallet/balance?address=scott" | jq
+curl -sS "https://rustchain.org/wallet/balance?address=scott" | jq
 ```
 
 **Expected Output:**
@@ -79,43 +79,43 @@ curl -sk "https://rustchain.org/wallet/balance?address=scott" | jq
 ### Get Transaction History
 
 ```bash
-curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10" | jq
+curl -sS "https://rustchain.org/wallet/history?miner_id=scott&limit=10" | jq
 ```
 
 ### Check Epoch Eligibility
 
 ```bash
-curl -sk "https://rustchain.org/lottery/eligibility?miner_id=scott" | jq
+curl -sS "https://rustchain.org/lottery/eligibility?miner_id=scott" | jq
 ```
 
 ### Get Network Statistics
 
 ```bash
-curl -sk https://rustchain.org/api/stats | jq
+curl -sS https://rustchain.org/api/stats | jq
 ```
 
 ### Get Hall of Fame
 
 ```bash
-curl -sk https://rustchain.org/api/hall_of_fame | jq
+curl -sS https://rustchain.org/api/hall_of_fame | jq
 ```
 
 ### Get Fee Pool Statistics
 
 ```bash
-curl -sk https://rustchain.org/api/fee_pool | jq
+curl -sS https://rustchain.org/api/fee_pool | jq
 ```
 
 ### Get Settlement Data
 
 ```bash
-curl -sk https://rustchain.org/api/settlement/75 | jq
+curl -sS https://rustchain.org/api/settlement/75 | jq
 ```
 
 ### Submit Hardware Attestation
 
 ```bash
-curl -sk -X POST https://rustchain.org/attest/submit \
+curl -sS -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "scott",
@@ -139,7 +139,7 @@ curl -sk -X POST https://rustchain.org/attest/submit \
 ### Admin Transfer
 
 ```bash
-curl -sk -X POST https://rustchain.org/wallet/transfer \
+curl -sS -X POST https://rustchain.org/wallet/transfer \
   -H "X-Admin-Key: YOUR_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -166,10 +166,6 @@ import requests
 from typing import Optional, List, Dict, Any
 
 BASE_URL = "https://rustchain.org"
-
-# Disable SSL warnings for self-signed certificate
-requests.packages.urllib3.disable_warnings()
-
 
 class RustChainClient:
     """Simple RustChain API client."""
@@ -907,11 +903,7 @@ struct RustChainClient {
 
 impl RustChainClient {
     fn new() -> Self {
-        // Accept invalid certificates for self-signed cert
-        let client = reqwest::Client::builder()
-            .danger_accept_invalid_certs(true)
-            .build()
-            .unwrap();
+        let client = reqwest::Client::new();
 
         Self {
             client,
@@ -1014,7 +1006,7 @@ async fn main() {
 set -e
 
 BASE_URL="https://rustchain.org"
-CURL="curl -sk"
+CURL="curl -sS"
 
 # Colors for output
 RED='\033[0;31m'

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -92,7 +92,7 @@ No authentication required. Rate limits apply.
 ### Admin Authentication
 Include the `X-Admin-Key` header:
 ```bash
-curl -sk https://rustchain.org/wallet/transfer \
+curl -sS https://rustchain.org/wallet/transfer \
   -H "X-Admin-Key: YOUR_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{"from_miner": "treasury", "to_miner": "scott", "amount_rtc": 10.0}'
@@ -123,13 +123,13 @@ Ed25519 signature in request body (no admin key needed):
 
 ## HTTPS Certificate
 
-The node uses a self-signed certificate. Options:
+The public node uses a standard TLS certificate. Keep verification enabled:
 
 ```bash
-# Option 1: Skip verification (development)
-curl -sk https://rustchain.org/health
+# Public node
+curl -sS https://rustchain.org/health
 
-# Option 2: Trust the certificate
+# Private nodes: trust the issuing certificate
 openssl s_client -connect rustchain.org:443 -showcerts < /dev/null 2>/dev/null | \
   openssl x509 -outform PEM > rustchain.pem
 curl --cacert rustchain.pem https://rustchain.org/health
@@ -183,32 +183,32 @@ VALIDATION RESULTS
 
 #### Health Check
 ```bash
-curl -sk https://rustchain.org/health | jq
+curl -sS https://rustchain.org/health | jq
 ```
 
 #### Get Epoch Info
 ```bash
-curl -sk https://rustchain.org/epoch | jq
+curl -sS https://rustchain.org/epoch | jq
 ```
 
 #### List Miners
 ```bash
-curl -sk https://rustchain.org/api/miners | jq
+curl -sS https://rustchain.org/api/miners | jq
 ```
 
 #### Check Balance
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott" | jq
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott" | jq
 ```
 
 #### Get Transaction History
 ```bash
-curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10" | jq
+curl -sS "https://rustchain.org/wallet/history?miner_id=scott&limit=10" | jq
 ```
 
 #### Check Eligibility
 ```bash
-curl -sk "https://rustchain.org/lottery/eligibility?miner_id=scott" | jq
+curl -sS "https://rustchain.org/lottery/eligibility?miner_id=scott" | jq
 ```
 
 ### Python Examples
@@ -220,25 +220,24 @@ BASE_URL = "https://rustchain.org"
 
 def get_health():
     """Check node health."""
-    resp = requests.get(f"{BASE_URL}/health", verify=False)
+    resp = requests.get(f"{BASE_URL}/health")
     return resp.json()
 
 def get_epoch():
     """Get current epoch info."""
-    resp = requests.get(f"{BASE_URL}/epoch", verify=False)
+    resp = requests.get(f"{BASE_URL}/epoch")
     return resp.json()
 
 def get_miners():
     """List active miners."""
-    resp = requests.get(f"{BASE_URL}/api/miners", verify=False)
+    resp = requests.get(f"{BASE_URL}/api/miners")
     return resp.json()
 
 def get_balance(miner_id):
     """Get wallet balance."""
     resp = requests.get(
         f"{BASE_URL}/wallet/balance",
-        params={"miner_id": miner_id},
-        verify=False
+        params={"miner_id": miner_id}
     )
     return resp.json()
 
@@ -246,8 +245,7 @@ def get_history(miner_id, limit=10):
     """Get transaction history."""
     resp = requests.get(
         f"{BASE_URL}/wallet/history",
-        params={"miner_id": miner_id, "limit": limit},
-        verify=False
+        params={"miner_id": miner_id, "limit": limit}
     )
     return resp.json()
 
@@ -255,8 +253,7 @@ def check_eligibility(miner_id):
     """Check epoch eligibility."""
     resp = requests.get(
         f"{BASE_URL}/lottery/eligibility",
-        params={"miner_id": miner_id},
-        verify=False
+        params={"miner_id": miner_id}
     )
     return resp.json()
 
@@ -309,7 +306,7 @@ getBalance("scott").then(console.log);
 # RustChain API helper script
 
 BASE_URL="https://rustchain.org"
-CURL="curl -sk"
+CURL="curl -sS"
 
 get_health() {
   $CURL "$BASE_URL/health" | jq
@@ -409,7 +406,7 @@ The `swagger.html` file is self-contained and can be:
 curl https://rustchain.org/health
 
 # ✅ Correct - skip verification
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 ## Response Examples

--- a/docs/api/REFERENCE.md
+++ b/docs/api/REFERENCE.md
@@ -2,7 +2,7 @@
 
 **Base URL:** `https://rustchain.org` (Primary Node)  
 **Authentication:** Read-only endpoints are public. Writes require Ed25519 signatures or an Admin Key.  
-**Certificate Note:** The node uses a self-signed TLS certificate. Use the `-k` flag with `curl` or disable certificate verification in your client.
+**Certificate Note:** The public `https://rustchain.org` node should validate with the system certificate store. Do not use `-k`, `--insecure`, or disabled client verification for the public hostname.
 
 ---
 
@@ -67,7 +67,7 @@ List all miners currently participating in the network with their hardware detai
 Query the RTC balance for any valid miner ID.
 
 - **Endpoint:** `GET /wallet/balance?miner_id={NAME}`
-- **Example:** `curl -sk 'https://rustchain.org/wallet/balance?miner_id=scott'`
+- **Example:** `curl -sS 'https://rustchain.org/wallet/balance?miner_id=scott'`
 - **Response:**
   ```json
   {
@@ -136,7 +136,7 @@ Wallets are **simple UTF-8 strings** (1-256 chars).
 - ❌ `4TR...` (Solana addresses must be bridged via BoTTube)
 
 ### Certificate Errors
-If using `curl`, always include `-k` to bypass the self-signed certificate warning.
+If using `curl`, keep normal TLS verification enabled. Certificate failures usually indicate a local clock, proxy, or CA trust-store problem.
 
 ---
 *Last Updated: February 2026*

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -28,8 +28,8 @@ info:
     | Admin endpoints | 10/min |
     
     ## HTTPS Certificate
-    The node uses a self-signed certificate. Use `-k` flag with curl or
-    disable certificate verification in HTTP clients.
+    The public node uses a standard TLS certificate. Keep certificate
+    verification enabled in curl and HTTP clients.
   version: 2.2.1-rip200
   contact:
     name: RustChain Development

--- a/docs/attestation-flow.md
+++ b/docs/attestation-flow.md
@@ -406,7 +406,7 @@ Submit hardware attestation.
 
 **Request**:
 ```bash
-curl -sk -X POST https://rustchain.org/attest/submit \
+curl -sS -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -d @attestation.json
 ```
@@ -437,7 +437,7 @@ Check if miner is enrolled in current epoch.
 
 **Request**:
 ```bash
-curl -sk "https://rustchain.org/lottery/eligibility?miner_id=scott"
+curl -sS "https://rustchain.org/lottery/eligibility?miner_id=scott"
 ```
 
 **Response**:

--- a/docs/epoch-settlement.md
+++ b/docs/epoch-settlement.md
@@ -347,7 +347,7 @@ Get current epoch information.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 **Response**:
@@ -368,7 +368,7 @@ Check wallet balance after settlement.
 
 **Request**:
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=scott"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=scott"
 ```
 
 **Response**:
@@ -390,7 +390,7 @@ Query historical settlement data.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/api/settlement/75
+curl -sS https://rustchain.org/api/settlement/75
 ```
 
 **Response**:
@@ -450,7 +450,7 @@ tail -f /var/log/rustchain/node.log | grep SETTLEMENT
 
 ```bash
 # Check if settlement completed
-curl -sk https://rustchain.org/api/settlement/75 | jq '.ergo_tx_id'
+curl -sS https://rustchain.org/api/settlement/75 | jq '.ergo_tx_id'
 
 # Verify on Ergo explorer
 curl "https://api.ergoplatform.com/api/v1/transactions/abc123..."

--- a/docs/index.html
+++ b/docs/index.html
@@ -420,13 +420,13 @@ VPS (QEMU):
 
       <pre>
 # Check the network is alive
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # See active miners
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # Check your balance after mining
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"</pre>
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"</pre>
 
       <h3>Current Mining Fleet</h3>
       <pre>

--- a/docs/miner-setup-wizard/README.md
+++ b/docs/miner-setup-wizard/README.md
@@ -20,7 +20,7 @@ Single-file browser wizard for miner onboarding.
 
 - Designed to run locally in browser and on GitHub Pages.
 - No backend required; pure client-side HTML/CSS/JS.
-- If cross-origin fetch is blocked by CORS, use terminal command checks (`curl -sk ...`).
+- If cross-origin fetch is blocked by CORS, use terminal command checks (`curl -sS ...`).
 
 ## Run locally
 

--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -219,14 +219,14 @@ function renderPanel(){
         const r = await testNode(url);
         document.getElementById('testOut').innerHTML = r.ok
           ? `<span class='pill ok'>Reachable</span> <pre>${h(r.text)}</pre>`
-          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sk ${h(url.replace(/\/$/,''))}/health</p>`;
+          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sS ${h(url.replace(/\/$/,''))}/health</p>`;
       }
     },0);
     return;
   }
   if(active==='attest'){
     const wallet = state.address || 'RTC_YOUR_WALLET_ADDRESS';
-    const checkCmd = `curl -sk ${state.nodeUrl.replace(/\/$/,'')}/api/miners | jq`;
+    const checkCmd = `curl -sS ${state.nodeUrl.replace(/\/$/,'')}/api/miners | jq`;
     p.innerHTML=`<h3 class='h'>First Attestation</h3>
       <p class='muted'>Run miner, then verify your wallet/miner appears in <code>/api/miners</code>.</p>
       ${commandBlock(`clawrtc start`)}

--- a/docs/mining.html
+++ b/docs/mining.html
@@ -338,16 +338,16 @@ sophia-nas           Xeon        1.0x        0.1191      7.9%</pre>
       <p>RustChain provides several tools to monitor your mining activity:</p>
       
       <pre># Check your balance
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 
 # View active miners
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # Check current epoch
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # Network health check
-curl -sk https://rustchain.org/health</pre>
+curl -sS https://rustchain.org/health</pre>
       
       <h3>Withdrawing Rewards</h3>
       <p>Once you've accumulated sufficient RTC, you can withdraw to external wallets or trade on supported exchanges. The RustChain light client provides an easy-to-use interface for managing your wallet and transactions.</p>

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -104,7 +104,7 @@ RustChain API - Complete Collection
 ### Test Health Endpoint
 
 ```bash
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 ```
 
 Expected response:
@@ -122,7 +122,7 @@ Expected response:
 ### Test Epoch Endpoint
 
 ```bash
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 Expected response:
@@ -140,7 +140,7 @@ Expected response:
 ### Test Miner Balance
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC" | jq .
 ```
 
 Expected response:
@@ -154,7 +154,7 @@ Expected response:
 ### Submit Attestation (Authenticated)
 
 ```bash
-curl -sk -X POST https://rustchain.org/attest/submit \
+curl -sS -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -H "X-Admin-Key: YOUR_ADMIN_KEY" \
   -d '{
@@ -353,10 +353,10 @@ pm.test("Node is healthy", function () {
 
 ### SSL Certificate Warnings
 
-The RustChain node uses self-signed certificates. In Postman:
+The public RustChain node uses standard TLS certificates. In Postman:
 1. Go to Settings → General
-2. Disable "SSL certificate verification"
-3. Or use `curl -sk` for CLI testing
+2. Keep "SSL certificate verification" enabled
+3. Use `curl -sS` for CLI testing
 
 ## Contributing
 

--- a/docs/protocol-overview.md
+++ b/docs/protocol-overview.md
@@ -207,15 +207,15 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 ### Check Balance
 
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 ```
 
 ### View Network Status
 
 ```bash
-curl -sk https://rustchain.org/health
-curl -sk https://rustchain.org/epoch
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/health
+curl -sS https://rustchain.org/epoch
+curl -sS https://rustchain.org/api/miners
 ```
 
 ## Comparison with Other Consensus Mechanisms

--- a/docs/sprint/api-reference.md
+++ b/docs/sprint/api-reference.md
@@ -14,9 +14,9 @@
 Both nodes expose identical public endpoints. Direct attestation submissions to
 the primary node; use either for read-only queries.
 
-> **Note:** The production TLS endpoint `https://rustchain.org` requires the
-> `-k` flag with curl (self-signed cert). The raw IP:port endpoints shown
-> throughout this reference are HTTP and need no `-k`.
+> **Note:** The production TLS endpoint `https://rustchain.org` should validate
+> with the system certificate store. The raw IP:port endpoints shown throughout
+> this reference are HTTP and do not use TLS.
 
 ---
 

--- a/docs/sprint/faq-troubleshooting.md
+++ b/docs/sprint/faq-troubleshooting.md
@@ -112,7 +112,7 @@ Open an issue on GitHub with your `miner_id` and epoch number. False positives a
 **Fix:**
 ```bash
 # Wait 2-3 minutes, then check:
-curl -sk https://rustchain.org/api/miners | jq . | grep YOUR_WALLET_ID
+curl -sS https://rustchain.org/api/miners | jq . | grep YOUR_WALLET_ID
 
 # Confirm miner is running:
 rtc-miner status
@@ -126,7 +126,7 @@ rtc-miner status
 
 **Fix:** Wait for at least one full epoch to complete. Check epoch status:
 ```bash
-curl -sk https://rustchain.org/epoch | jq .
+curl -sS https://rustchain.org/epoch | jq .
 ```
 
 ---
@@ -141,11 +141,11 @@ curl -sk https://rustchain.org/epoch | jq .
 
 ### Problem: `curl: (60) SSL certificate problem`
 
-**Cause:** The RustChain node uses a self-signed TLS certificate.
+**Cause:** The local certificate store or proxy is not validating the public node certificate.
 
-**Fix:** Use `-sk` flags:
+**Fix:** Keep verification enabled and update the local CA store:
 ```bash
-curl -sk https://rustchain.org/health | jq .
+curl -sS https://rustchain.org/health | jq .
 ```
 
 ---
@@ -186,10 +186,10 @@ curl -sSL https://rustchain.org/install.sh | bash
 **Fix:**
 ```bash
 # Check your assigned multiplier:
-curl -sk "https://rustchain.org/api/miner-info?id=YOUR_WALLET" | jq .multiplier
+curl -sS "https://rustchain.org/api/miner-info?id=YOUR_WALLET" | jq .multiplier
 
 # Check total network weight this epoch:
-curl -sk https://rustchain.org/epoch | jq .total_weight
+curl -sS https://rustchain.org/epoch | jq .total_weight
 ```
 Your share = `(your_multiplier / total_weight) × 1.5`
 

--- a/docs/sprint/wallet-user-guide.md
+++ b/docs/sprint/wallet-user-guide.md
@@ -56,7 +56,7 @@ cargo build --release
 ```bash
 ./rtc-wallet balance --address RTCa3f82d9c1e4b07f5a2d6c8e9b0f1d3e2a4c5b7f8
 # Or via API:
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | jq .
 ```
 
 ### 2. Web Wallet
@@ -178,7 +178,7 @@ Simply share your public wallet address. It is safe to share publicly.
 - Check incoming transactions:
 
 ```bash
-curl -sk "https://rustchain.org/wallet/history?address=RTCa3f82..." | jq .
+curl -sS "https://rustchain.org/wallet/history?address=RTCa3f82..." | jq .
 ```
 
 ---
@@ -203,7 +203,7 @@ curl -sk "https://rustchain.org/wallet/history?address=RTCa3f82..." | jq .
 | Balance shows 0 | Epoch not yet settled | Wait ~24h; check `/api/miners` |
 | Wrong address shown | Querying wrong `miner_id` | Match exactly what the miner was started with |
 | RTC vs wRTC confusion | Different tokens | RTC = native; wRTC = Solana bridge token |
-| SSL warning on API | Self-signed TLS | Use `curl -sk` (expected in current release) |
+| SSL warning on API | TLS trust | Keep TLS verification enabled |
 
 ---
 

--- a/docs/wrtc.md
+++ b/docs/wrtc.md
@@ -280,7 +280,7 @@ Monitor the bridge UI for updates.
 
 1. Check your RustChain wallet balance
 ```bash
-curl -sk "https://rustchain.org/wallet/balance?miner_id=my-miner-id"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=my-miner-id"
 ```
 2. Verify on [RustChain Explorer](https://rustchain.org/explorer)
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -164,22 +164,22 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 **检查钱包余额：**
 ```bash
 # 注意：使用 -sk 标志，因为节点可能使用自签名 SSL 证书
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME"
 ```
 
 **列出活跃矿工：**
 ```bash
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 ```
 
 **检查节点健康状态：**
 ```bash
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 ```
 
 **获取当前纪元：**
 ```bash
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 ```
 
 **管理矿工服务：**
@@ -310,16 +310,16 @@ RustChain 纪元 → 承诺哈希 → Ergo 交易（R4 寄存器）
 
 ```bash
 # 检查网络健康状态
-curl -sk https://rustchain.org/health
+curl -sS https://rustchain.org/health
 
 # 获取当前纪元
-curl -sk https://rustchain.org/epoch
+curl -sS https://rustchain.org/epoch
 
 # 列出活跃矿工
-curl -sk https://rustchain.org/api/miners
+curl -sS https://rustchain.org/api/miners
 
 # 检查钱包余额
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET"
 
 # 区块浏览器（网页浏览器）
 open https://rustchain.org/explorer

--- a/miners/windows/install-miner.sh
+++ b/miners/windows/install-miner.sh
@@ -148,10 +148,10 @@ if [ "$DRY_RUN" != true ]; then
     timeout 15 "$VENV_DIR/bin/python" -c "
 import requests
 try:
-    r = requests.get('$NODE_URL/health', verify=False, timeout=5)
+    r = requests.get('$NODE_URL/health', timeout=5)
     if r.status_code == 200:
         print('[+] Node: ONLINE')
-        r2 = requests.post('$NODE_URL/attest/challenge', json={}, verify=False, timeout=5)
+        r2 = requests.post('$NODE_URL/attest/challenge', json={}, timeout=5)
         if r2.status_code == 200: print('[+] Attestation System: READY')
 except Exception as e: print(f'[-] Node Error: {e}')" 2>/dev/null || true
 fi

--- a/miners/windows/installer/README.md
+++ b/miners/windows/installer/README.md
@@ -74,6 +74,6 @@ rustchain-installer/
 ## Technical Notes
 
 - **Network:** Default node is `https://rustchain.org`.
-- **Security:** TLS verification is currently set to `verify=False` to support the node's self-signed certificate.
+- **Security:** Keep TLS verification enabled for the default `https://rustchain.org` node; only use a custom CA or explicit local override for private test nodes.
 - **Builds:** Automated Windows builds are handled via GitHub Actions (see `.github/workflows/windows-build.yml`).
 

--- a/miners/windows/testing/FINDINGS_TEMPLATE.md
+++ b/miners/windows/testing/FINDINGS_TEMPLATE.md
@@ -250,9 +250,9 @@
 
 **Symptom:** `SSL: CERTIFICATE_VERIFY_FAILED`
 
-**Cause:** Self-signed certificate on node server
+**Cause:** Local certificate store, proxy, or private-node trust configuration
 
-**Fix:** Ensure `verify=False` in requests or install CA certificate
+**Fix:** Keep TLS verification enabled and install the private node's CA certificate
 
 ---
 

--- a/miners/windows/testing/SMOKE_TEST_CHECKLIST.md
+++ b/miners/windows/testing/SMOKE_TEST_CHECKLIST.md
@@ -77,7 +77,7 @@
 | 4 | Attest submit works | `POST /attest/submit` accepts valid attestation | | | |
 | 5 | Custom node URL supported | `--node https://custom.node` works | | | |
 | 6 | Offline mode degrades gracefully | Clear error message when node unreachable | | | |
-| 7 | SSL certificate validation | Self-signed cert accepted or `verify=False` used | | | |
+| 7 | TLS certificate validation | Default public node validates normally; private test nodes require an explicit trust decision | | | |
 | 8 | Timeout handling | Request timeouts don't hang indefinitely | | | |
 | 9 | Retry logic present | Transient failures retry with backoff | | | |
 | 10 | Proxy support (if needed) | HTTP_PROXY/HTTPS_PROXY environment variables respected | | | |

--- a/wallet/NETWORK_ERROR_HANDLING.md
+++ b/wallet/NETWORK_ERROR_HANDLING.md
@@ -15,8 +15,8 @@ Use `https://rustchain.org` for public wallet and health queries.
 If you see `Balance: (could not reach network)` from an older `clawrtc` helper build, verify the live node directly:
 
 ```bash
-curl -sk https://rustchain.org/health | jq .
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
+curl -sS https://rustchain.org/health | jq .
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
 ```
 
 Older helper packages may still reference the retired `bulbous-bouffant.metalseed.net` host. Also note that current `clawrtc` releases do not expose a generic `clawrtc wallet show` command; the supported helper is `clawrtc wallet coinbase show`.
@@ -44,7 +44,7 @@ ping 8.8.8.8
 nslookup rustchain.org
 
 # 3. Test connectivity to node
-curl -skI https://rustchain.org/health
+curl -sSI https://rustchain.org/health
 
 # 4. Check firewall settings
 # Ensure outbound HTTPS (port 443) is allowed
@@ -63,7 +63,7 @@ curl -skI https://rustchain.org/health
 **Troubleshooting:**
 ```bash
 # 1. Check node status
-curl -sk https://rustchain.org/health | jq
+curl -sS https://rustchain.org/health | jq
 
 # 2. Wait and retry (node may be busy)
 
@@ -88,10 +88,10 @@ speedtest-cli  # or use your preferred speed test tool
 # Should be 0x + 40 hex characters for Base addresses
 
 # 2. Check if wallet exists
-curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_ADDRESS"
+curl -sS "https://rustchain.org/wallet/balance?miner_id=YOUR_ADDRESS"
 
 # 3. Check node API status
-curl -sk https://rustchain.org/api/stats | jq
+curl -sS https://rustchain.org/api/stats | jq
 ```
 
 ## Retry Strategy


### PR DESCRIPTION
## Summary
- Removes public documentation guidance that disables TLS verification and replaces it with safer certificate handling.

## Validation
- Documentation diff checked locally; branch already pushed to fork.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: Low-severity security/documentation bug: public docs advised disabling TLS verification.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.