### PR TITLE
Validate Rent-a-Relic text fields

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -28,6 +28,19 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return None
         return parsed
 
+    def _parse_text_field(data, field, *, required=True):
+        value = data.get(field)
+        if value is None:
+            if required:
+                return None, f"{field} is required"
+            return None, None
+        if not isinstance(value, str):
+            return None, f"{field} must be a string"
+        value = value.strip()
+        if required and not value:
+            return None, f"{field} is required"
+        return value, None
+
     def _hash_job_secret(secret):
         return hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
 
@@ -53,9 +66,9 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
     @app.route("/api/gpu/attest", methods=["POST"])
     def gpu_attest():
         data = request.get_json(silent=True) or {}
-        miner_id = data.get("miner_id")
-        if not miner_id:
-            return jsonify({"error": "miner_id required"}), 400
+        miner_id, field_error = _parse_text_field(data, "miner_id")
+        if field_error:
+            return jsonify({"error": field_error}), 400
 
         # In a real node, we'd verify the signed hardware fingerprint here.
         # For the bounty, we implement the protocol storage and API.
@@ -101,18 +114,29 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return auth_error
 
         data = request.get_json(silent=True) or {}
-        job_id = data.get("job_id") or f"job_{secrets.token_hex(8)}"
-        job_type = data.get("job_type")  # render, tts, stt, llm
-        from_wallet = data.get("from_wallet")
-        to_wallet = data.get("to_wallet")
+        job_id, field_error = _parse_text_field(data, "job_id", required=False)
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        job_id = job_id or f"job_{secrets.token_hex(8)}"
+
+        job_type, field_error = _parse_text_field(data, "job_type")  # render, tts, stt, llm
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        from_wallet, field_error = _parse_text_field(data, "from_wallet")
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        to_wallet, field_error = _parse_text_field(data, "to_wallet")
+        if field_error:
+            return jsonify({"error": field_error}), 400
         amount = _parse_positive_amount(data.get("amount_rtc"))
 
-        if not all([job_type, from_wallet, to_wallet]):
-            return jsonify({"error": "Missing required escrow fields"}), 400
         if amount is None:
             return jsonify({"error": "amount_rtc must be a finite number > 0"}), 400
 
-        escrow_secret = data.get("escrow_secret") or secrets.token_hex(16)
+        escrow_secret, field_error = _parse_text_field(data, "escrow_secret", required=False)
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        escrow_secret = escrow_secret or secrets.token_hex(16)
 
         db = get_db()
         try:
@@ -152,12 +176,15 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return auth_error
 
         data = request.get_json(silent=True) or {}
-        job_id = data.get("job_id")
-        actor_wallet = data.get("actor_wallet")
-        escrow_secret = data.get("escrow_secret")
-
-        if not all([job_id, actor_wallet, escrow_secret]):
-            return jsonify({"error": "job_id, actor_wallet, escrow_secret are required"}), 400
+        job_id, field_error = _parse_text_field(data, "job_id")
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        actor_wallet, field_error = _parse_text_field(data, "actor_wallet")
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        escrow_secret, field_error = _parse_text_field(data, "escrow_secret")
+        if field_error:
+            return jsonify({"error": field_error}), 400
 
         db = get_db()
         try:
@@ -202,12 +229,15 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return auth_error
 
         data = request.get_json(silent=True) or {}
-        job_id = data.get("job_id")
-        actor_wallet = data.get("actor_wallet")
-        escrow_secret = data.get("escrow_secret")
-
-        if not all([job_id, actor_wallet, escrow_secret]):
-            return jsonify({"error": "job_id, actor_wallet, escrow_secret are required"}), 400
+        job_id, field_error = _parse_text_field(data, "job_id")
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        actor_wallet, field_error = _parse_text_field(data, "actor_wallet")
+        if field_error:
+            return jsonify({"error": field_error}), 400
+        escrow_secret, field_error = _parse_text_field(data, "escrow_secret")
+        if field_error:
+            return jsonify({"error": field_error}), 400
 
         db = get_db()
         try:

--- a/node/tests/test_gpu_render_endpoint_validation.py
+++ b/node/tests/test_gpu_render_endpoint_validation.py
@@ -1,0 +1,79 @@
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from flask import Flask
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(NODE_DIR))
+
+from gpu_render_endpoints import register_gpu_render_endpoints
+
+
+class GpuRenderEndpointValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = os.path.join(self.tmp.name, "gpu.db")
+        with sqlite3.connect(self.db_path) as db:
+            db.execute("CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+            db.execute(
+                """
+                CREATE TABLE render_escrow (
+                    job_id TEXT PRIMARY KEY,
+                    job_type TEXT,
+                    from_wallet TEXT,
+                    to_wallet TEXT,
+                    amount_rtc REAL,
+                    status TEXT,
+                    created_at INTEGER,
+                    released_at INTEGER,
+                    escrow_secret_hash TEXT
+                )
+                """
+            )
+            db.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES ('payer', 10)")
+
+        app = Flask(__name__)
+        register_gpu_render_endpoints(app, self.db_path, "secret")
+        app.config["TESTING"] = True
+        self.client = app.test_client()
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _post(self, path, payload):
+        return self.client.post(path, json=payload, headers={"X-Admin-Key": "secret"})
+
+    def test_escrow_rejects_non_string_wallet_before_sqlite(self):
+        resp = self._post(
+            "/api/gpu/escrow",
+            {
+                "job_type": "render",
+                "from_wallet": {"id": "payer"},
+                "to_wallet": "provider",
+                "amount_rtc": 1,
+            },
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["error"], "from_wallet must be a string")
+
+    def test_release_rejects_non_string_job_id_before_sqlite(self):
+        resp = self._post(
+            "/api/gpu/release",
+            {
+                "job_id": {"id": "job1"},
+                "actor_wallet": "payer",
+                "escrow_secret": "secret",
+            },
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json()["error"], "job_id must be a string")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds request field type validation for Rent-a-Relic GPU escrow inputs so non-string payloads are rejected cleanly.

## Validation
- Focused local validation from branch creation; branch already pushed to fork.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: Input-validation bug: Rent-a-Relic GPU endpoint text fields accepted structured/non-string payloads.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.