### PR TITLE
Disable public Flask debug entrypoints

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -659,4 +659,4 @@ if __name__ == "__main__":
     app = Flask(__name__)
     register_bridge_routes(app)
     print("Bridge dev server on http://0.0.0.0:8096")
-    app.run(host="0.0.0.0", port=8096, debug=True)
+    app.run(host="0.0.0.0", port=8096, debug=False)

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -186,4 +186,4 @@ def approve_contributor(username):
 if __name__ == '__main__':
     if not os.path.exists(DB_PATH):
         init_db()
-    app.run(debug=True, host='0.0.0.0', port=5000)
+    app.run(debug=False, host='0.0.0.0', port=5000)

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -134,4 +134,4 @@ def internal_error(error):
     return render_template('500.html'), 500
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    app.run(host='0.0.0.0', port=5000, debug=False)

--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -401,4 +401,4 @@ RETRO_HTML = """
 if __name__ == '__main__':
     import hashlib # needed for mock hash
     print(f"[*] Starting Fossil-Punk Keeper Explorer on port {PORT}...")
-    app.run(host='0.0.0.0', port=PORT, debug=True)
+    app.run(host='0.0.0.0', port=PORT, debug=False)

--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -246,4 +246,4 @@ def list_badges():
 
 if __name__ == '__main__':
     init_badge_db()
-    app.run(debug=True, port=5003)
+    app.run(debug=False, port=5003)

--- a/tests/test_flask_debug_disabled.py
+++ b/tests/test_flask_debug_disabled.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import unittest
+
+
+FILES_WITH_PUBLIC_FLASK_ENTRYPOINTS = [
+    "bridge/bridge_api.py",
+    "contributor_registry.py",
+    "explorer/app.py",
+    "keeper_explorer.py",
+    "profile_badge_generator.py",
+]
+
+
+class FlaskDebugDisabledTests(unittest.TestCase):
+    def test_public_flask_entrypoints_do_not_enable_debugger(self):
+        repo = Path(__file__).resolve().parents[1]
+        for relative_path in FILES_WITH_PUBLIC_FLASK_ENTRYPOINTS:
+            with self.subTest(path=relative_path):
+                text = (repo / relative_path).read_text(encoding="utf-8")
+                self.assertNotIn("debug=True", text)
+                self.assertNotIn("debug = True", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Disables public Flask debug mode entrypoints to avoid exposing interactive debugger behavior.

## Validation
- py_compile and diff checks passed at branch creation; focused Flask tests blocked locally because Flask is not installed.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: Security hardening bug: public Flask debug entrypoints could expose Werkzeug debugger behavior.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.