### PR TITLE
Validate beacon JSON bodies

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -36,6 +36,20 @@ contract_store = []
 chat_sessions = {}
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, jsonify({'error': 'JSON object body required'}), 400
+    return data, None, None
+
+
+def _required_text_field(data, field_name):
+    value = data.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        return None, jsonify({'error': f'Missing {field_name}'}), 400
+    return value.strip(), None, None
+
+
 def _coinbase_addresses_match(left, right):
     """Compare optional EVM-style payment addresses without case sensitivity."""
     return (left or '').strip().casefold() == (right or '').strip().casefold()
@@ -866,11 +880,12 @@ def claim_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to claim bounties'}), 401
 
-        data = request.get_json()
-        agent_id = data.get('agent_id')
-        
-        if not agent_id:
-            return jsonify({'error': 'Missing agent_id'}), 400
+        data, body_error, status = _json_object_body()
+        if body_error:
+            return body_error, status
+        agent_id, field_error, status = _required_text_field(data, 'agent_id')
+        if field_error:
+            return field_error, status
         
         db = get_db()
         db.execute(
@@ -900,11 +915,12 @@ def complete_bounty(bounty_id):
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to complete bounties'}), 401
 
-        data = request.get_json()
-        agent_id = data.get('agent_id')
-        
-        if not agent_id:
-            return jsonify({'error': 'Missing agent_id'}), 400
+        data, body_error, status = _json_object_body()
+        if body_error:
+            return body_error, status
+        agent_id, field_error, status = _required_text_field(data, 'agent_id')
+        if field_error:
+            return field_error, status
         
         db = get_db()
 
@@ -1001,9 +1017,15 @@ def get_agent_reputation(agent_id):
 def chat():
     """Send message to an agent (mock response for demo)."""
     try:
-        data = request.get_json()
-        agent_id = data.get('agent_id')
-        message = data.get('message')
+        data, body_error, status = _json_object_body()
+        if body_error:
+            return body_error, status
+        agent_id, field_error, status = _required_text_field(data, 'agent_id')
+        if field_error:
+            return field_error, status
+        message, field_error, status = _required_text_field(data, 'message')
+        if field_error:
+            return field_error, status
         
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -268,7 +268,39 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         response2 = self.client.get('/api/bounties')
         bounties2 = json.loads(response2.data)
         # Bounty should no longer appear in open list (state changed to claimed)
-        
+
+    def test_bounty_claim_rejects_non_object_json(self):
+        """Admin bounty claim route rejects malformed JSON shapes."""
+        response = self.client.post(
+            '/api/bounties/gh_test_bounty/claim',
+            data=json.dumps(['bcn_claimer']),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('JSON object body required', response.get_data(as_text=True))
+
+    def test_bounty_complete_rejects_non_string_agent_id(self):
+        """Admin bounty completion route rejects non-string agent IDs."""
+        response = self.client.post(
+            '/api/bounties/gh_test_bounty/complete',
+            data=json.dumps({'agent_id': {'nested': 'bcn_claimer'}}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Missing agent_id', response.get_data(as_text=True))
+
+    def test_chat_rejects_non_string_message(self):
+        """Chat route rejects non-string message bodies before storage."""
+        response = self.client.post(
+            '/api/chat',
+            data=json.dumps({'agent_id': 'bcn_alice_test', 'message': ['hello']}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Missing message', response.get_data(as_text=True))
+
     def test_reputation_tracking_workflow(self):
         """Reputation is tracked and updated correctly."""
         # Insert test reputation


### PR DESCRIPTION
## Summary
- Adds JSON body and string field validation to beacon bounty claim, complete, and chat routes.

## Validation
- py_compile and git diff --check passed; pytest blocked locally because Flask is not installed.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: Input-validation bug: beacon claim/complete/chat routes accepted malformed JSON bodies and field types.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.