### PR TITLE
Validate OTC action request payloads

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -118,6 +118,22 @@ def units_to_float(units, scale):
     return float(Decimal(int(units)) / Decimal(scale))
 
 
+def json_object_body(data):
+    if not isinstance(data, dict):
+        raise ValueError("JSON object body required")
+    return data
+
+
+def text_field(data, field_name, *, required=False):
+    value = data.get(field_name, "")
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
+    value = value.strip()
+    if required and not value:
+        raise ValueError(f"{field_name} required")
+    return value
+
+
 def money_view(row):
     data = dict(row)
     if "amount_micro_rtc" in data and data.get("amount_micro_rtc") is not None:
@@ -671,12 +687,12 @@ def get_order(order_id):
 @rate_limited
 def match_order(order_id):
     """Match an open order as the counterparty."""
-    data = request.get_json(silent=True) or {}
-    taker_wallet = str(data.get("wallet", "")).strip()
-    taker_eth_address = str(data.get("eth_address", "")).strip()
-
-    if not taker_wallet:
-        return jsonify({"error": "wallet required"}), 400
+    try:
+        data = json_object_body(request.get_json(silent=True))
+        taker_wallet = text_field(data, "wallet", required=True)
+        taker_eth_address = text_field(data, "eth_address")
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
 
     conn = get_db()
     try:
@@ -794,15 +810,13 @@ def match_order(order_id):
 @rate_limited
 def confirm_order(order_id):
     """Confirm settlement -- verifies HTLC preimage, releases escrow."""
-    data = request.get_json(silent=True) or {}
-    wallet = str(data.get("wallet", "")).strip()
-    quote_tx = str(data.get("quote_tx", "")).strip()
-    secret = str(data.get("secret", "")).strip()
-
-    if not wallet:
-        return jsonify({"error": "wallet required"}), 400
-    if not quote_tx:
-        return jsonify({"error": "quote_tx required"}), 400
+    try:
+        data = json_object_body(request.get_json(silent=True))
+        wallet = text_field(data, "wallet", required=True)
+        quote_tx = text_field(data, "quote_tx", required=True)
+        secret = text_field(data, "secret")
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
 
     conn = get_db()
     try:
@@ -934,11 +948,11 @@ def confirm_order(order_id):
 @rate_limited
 def cancel_order(order_id):
     """Cancel an open order and refund escrow."""
-    data = request.get_json(silent=True) or {}
-    wallet = str(data.get("wallet", "")).strip()
-
-    if not wallet:
-        return jsonify({"error": "wallet required"}), 400
+    try:
+        data = json_object_body(request.get_json(silent=True))
+        wallet = text_field(data, "wallet", required=True)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
 
     conn = get_db()
     try:

--- a/otc-bridge/test_otc_bridge.py
+++ b/otc-bridge/test_otc_bridge.py
@@ -395,6 +395,31 @@ class OTCBridgeTestCase(unittest.TestCase):
         })
         self.assertEqual(r.status_code, 404)
 
+    def test_match_rejects_non_object_json(self):
+        r = self.app.post("/api/orders/otc_fake123/match", json=["wallet"])
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("JSON object body required", r.get_json()["error"])
+
+    def test_match_rejects_non_string_wallet_and_eth_address(self):
+        r1 = self.app.post("/api/orders", json={
+            "side": "buy", "pair": "RTC/USDC",
+            "wallet": "buyer1", "amount_rtc": 10, "price_per_rtc": 0.10,
+        })
+        order_id = r1.get_json()["order_id"]
+
+        r2 = self.app.post(f"/api/orders/{order_id}/match", json={
+            "wallet": {"nested": "seller"},
+        })
+        self.assertEqual(r2.status_code, 400)
+        self.assertIn("wallet must be a string", r2.get_json()["error"])
+
+        r3 = self.app.post(f"/api/orders/{order_id}/match", json={
+            "wallet": "seller",
+            "eth_address": ["0xabc"],
+        })
+        self.assertEqual(r3.status_code, 400)
+        self.assertIn("eth_address must be a string", r3.get_json()["error"])
+
     # ---------------------------------------------------------------
     # Order Cancellation
     # ---------------------------------------------------------------
@@ -424,6 +449,13 @@ class OTCBridgeTestCase(unittest.TestCase):
             "wallet": "not-owner",
         })
         self.assertEqual(r2.status_code, 403)
+
+    def test_cancel_rejects_non_string_wallet(self):
+        r = self.app.post("/api/orders/otc_fake123/cancel", json={
+            "wallet": {"owner": "nested"},
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("wallet must be a string", r.get_json()["error"])
 
     @patch("otc_bridge.rtc_get_balance", return_value=500.0)
     @patch("otc_bridge.rtc_create_escrow_job", return_value={"ok": True, "job_id": "job_cancel1"})
@@ -489,6 +521,23 @@ class OTCBridgeTestCase(unittest.TestCase):
             "quote_tx": "0x123",
         })
         self.assertEqual(r2.status_code, 409)
+
+    def test_confirm_rejects_non_string_fields(self):
+        r = self.app.post("/api/orders/otc_fake123/confirm", json={
+            "wallet": "seller",
+            "quote_tx": {"tx": "0x123"},
+            "secret": "abc",
+        })
+        self.assertEqual(r.status_code, 400)
+        self.assertIn("quote_tx must be a string", r.get_json()["error"])
+
+        r2 = self.app.post("/api/orders/otc_fake123/confirm", json={
+            "wallet": "seller",
+            "quote_tx": "0x123",
+            "secret": ["abc"],
+        })
+        self.assertEqual(r2.status_code, 400)
+        self.assertIn("secret must be a string", r2.get_json()["error"])
 
     # ---------------------------------------------------------------
     # Stats & Trades


### PR DESCRIPTION
## Summary
- Rejects non-object JSON and non-string wallet, ETH address, quote transaction, and secret fields in OTC match, confirm, and cancel actions.

## Validation
- git diff --check passed; py_compile passed for otc_bridge.py and test_otc_bridge.py.

Bounty reference: Scottcjn/rustchain-bounties#71 (Ongoing Bug Bounty Program)
Bounty fit: Input-validation bug: OTC match/confirm/cancel actions accepted malformed JSON and non-string fields.
RTC payout wallet: `RTC0a1c0ce2204390bc49ecf9780fe894da9dc3d92c`

Implemented with OpenAI Codex assistance.