### PR TITLE
fix: harden realtime explorer feed rendering

### DIFF
--- a/explorer/realtime-explorer.html
+++ b/explorer/realtime-explorer.html
@@ -966,36 +966,66 @@
             renderFeed();
         }
 
+        function textElement(tagName, className, text) {
+            const element = document.createElement(tagName);
+            if (className) element.className = className;
+            element.textContent = text;
+            return element;
+        }
+
         function renderFeed() {
             const feed = document.getElementById('live-feed');
-            feed.innerHTML = feedItems.map(item => `
-                <div class="feed-item new-entry">
-                    <span class="feed-icon">${item.icon}</span>
-                    <div class="feed-content">
-                        <div class="feed-title">${item.title}</div>
-                        <div style="color: var(--text-secondary); font-size: 13px;">${item.subtitle}</div>
-                    </div>
-                    <span class="feed-time">${item.time}</span>
-                </div>
-            `).join('');
+            const items = feedItems.map(item => {
+                const row = document.createElement('div');
+                row.className = 'feed-item new-entry';
+
+                const icon = textElement('span', 'feed-icon', item.icon);
+                const content = document.createElement('div');
+                content.className = 'feed-content';
+
+                const title = textElement('div', 'feed-title', item.title);
+                const subtitle = textElement('div', null, item.subtitle);
+                subtitle.style.color = 'var(--text-secondary)';
+                subtitle.style.fontSize = '13px';
+
+                const time = textElement('span', 'feed-time', item.time);
+                content.append(title, subtitle);
+                row.append(icon, content, time);
+                return row;
+            });
+            feed.replaceChildren(...items);
         }
 
         function showEpochNotification(data) {
             // Create notification element
             const notification = document.createElement('div');
             notification.className = 'epoch-notification';
-            notification.innerHTML = `
-                <div class="notification-title">
-                    <span aria-hidden="true">🎉</span> Epoch Settlement!
-                </div>
-                <div class="notification-content">
-                    <p>Epoch ${data.epoch} → ${data.new_epoch}</p>
-                    <p style="margin-top: 8px;">
-                        <strong>Pot:</strong> ${data.total_rtc || 0} RTC<br>
-                        <strong>Miners:</strong> ${data.miners || 0}
-                    </p>
-                </div>
-            `;
+
+            const title = document.createElement('div');
+            title.className = 'notification-title';
+            const icon = textElement('span', null, '🎉');
+            icon.setAttribute('aria-hidden', 'true');
+            title.append(icon, document.createTextNode(' Epoch Settlement!'));
+
+            const content = document.createElement('div');
+            content.className = 'notification-content';
+            content.append(
+                textElement('p', null, `Epoch ${data.epoch ?? '?'} → ${data.new_epoch ?? '?'}`)
+            );
+
+            const stats = document.createElement('p');
+            stats.style.marginTop = '8px';
+            const potLabel = textElement('strong', null, 'Pot:');
+            const minersLabel = textElement('strong', null, 'Miners:');
+            stats.append(
+                potLabel,
+                document.createTextNode(` ${data.total_rtc || 0} RTC`),
+                document.createElement('br'),
+                minersLabel,
+                document.createTextNode(` ${data.miners || 0}`)
+            );
+            content.append(stats);
+            notification.append(title, content);
 
             document.body.appendChild(notification);
 

--- a/tests/test_realtime_explorer_frontend_security.py
+++ b/tests/test_realtime_explorer_frontend_security.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REALTIME_EXPLORER = ROOT / "explorer" / "realtime-explorer.html"
+
+
+def test_websocket_feed_renders_event_fields_with_text_nodes():
+    html = REALTIME_EXPLORER.read_text()
+
+    assert "feed.innerHTML = feedItems.map" not in html
+    assert "${item.icon}" not in html
+    assert "${item.title}" not in html
+    assert "${item.subtitle}" not in html
+    assert "feed.replaceChildren(...items)" in html
+    assert "textElement('span', 'feed-icon', item.icon)" in html
+    assert "textElement('div', 'feed-title', item.title)" in html
+    assert "textElement('div', null, item.subtitle)" in html
+
+
+def test_epoch_notification_does_not_interpolate_websocket_payload_html():
+    html = REALTIME_EXPLORER.read_text()
+
+    assert "notification.innerHTML = `" not in html
+    assert "<p>Epoch ${data.epoch}" not in html
+    assert "<strong>Pot:</strong> ${data.total_rtc" not in html
+    assert "<strong>Miners:</strong> ${data.miners" not in html
+    assert "document.createTextNode(` ${data.total_rtc || 0} RTC`)" in html
+    assert "document.createTextNode(` ${data.miners || 0}`)" in html


### PR DESCRIPTION
Fixes #4980

## Summary
- Render realtime WebSocket feed rows with DOM nodes and `textContent` instead of template-string `innerHTML`.
- Build epoch settlement notifications with text nodes so event payload fields cannot become markup.
- Add a focused frontend regression test for the realtime explorer XSS path.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_realtime_explorer_frontend_security.py -q`
- `python3 -B -m py_compile tests/test_realtime_explorer_frontend_security.py`
- Inline `explorer/realtime-explorer.html` script parsed with Node's `Function` constructor
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

No production probing was performed.

## Payout

wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
RTC wallet: `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
