### PR TITLE
fix: validate beacon write json bodies

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -37,6 +37,11 @@ contract_store = []
 chat_sessions = {}
 
 
+def _coinbase_addresses_match(left, right):
+    """Compare optional EVM-style payment addresses without case sensitivity."""
+    return (left or '').strip().casefold() == (right or '').strip().casefold()
+
+
 def _json_object_body():
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
@@ -46,9 +51,14 @@ def _json_object_body():
 
 def _required_text_field(data, field_name):
     value = data.get(field_name)
-    if not isinstance(value, str) or not value.strip():
+    if value is None or value == '':
         return None, jsonify({'error': f'Missing {field_name}'}), 400
-    return value.strip(), None, None
+    if not isinstance(value, str):
+        return None, jsonify({'error': f'{field_name} must be a string'}), 400
+    stripped = value.strip()
+    if not stripped:
+        return None, jsonify({'error': f'Missing {field_name}'}), 400
+    return stripped, None, None
 
 
 def _positive_float_field(data, field_name):
@@ -62,9 +72,29 @@ def _positive_float_field(data, field_name):
     return number, None, None
 
 
-def _coinbase_addresses_match(left, right):
-    """Compare optional EVM-style payment addresses without case sensitivity."""
-    return (left or '').strip().casefold() == (right or '').strip().casefold()
+def _validate_string_fields(data, fields, optional=()):
+    for field in fields:
+        if field in data and not isinstance(data[field], str):
+            return jsonify({'error': f'{field} must be a string'}), 400
+    for field in optional:
+        if field in data and data[field] is not None and not isinstance(data[field], str):
+            return jsonify({'error': f'{field} must be a string'}), 400
+    return None
+
+
+def _required_number_field(data, field_name):
+    value = data.get(field_name)
+    if value is None:
+        return None, jsonify({'error': f'Missing field: {field_name}'}), 400
+    if isinstance(value, bool):
+        return None, jsonify({'error': f'{field_name} must be a number'}), 400
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None, jsonify({'error': f'{field_name} must be a number'}), 400
+    if not math.isfinite(number):
+        return None, jsonify({'error': f'{field_name} must be a finite number'}), 400
+    return number, None, None
 
 
 def get_db():
@@ -571,15 +601,22 @@ def create_contract():
     """
     try:
         body_bytes = request.get_data(cache=True)
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
-            return jsonify({'error': 'Invalid or missing JSON body'}), 400
+        data, body_error, status = _json_object_body()
+        if body_error:
+            return body_error, status
         
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
         for field in required:
             if field not in data:
                 return jsonify({'error': f'Missing field: {field}'}), 400
+        type_error = _validate_string_fields(data, ['from', 'to', 'type', 'term'], optional=['currency'])
+        if type_error:
+            return type_error
+        amount, amount_error, status = _required_number_field(data, 'amount')
+        if amount_error:
+            return amount_error, status
+        currency = data.get('currency') or 'RTC'
         
         from_agent = data['from']
         
@@ -611,7 +648,7 @@ def create_contract():
             'to': data['to'],
             'type': data['type'],
             'amount': amount,
-            'currency': data.get('currency', 'RTC'),
+            'currency': currency,
             'term': data['term'],
             'state': 'offered',  # Initial state
             'created_at': int(time.time()),
@@ -644,13 +681,15 @@ def update_contract(contract_id):
     """
     try:
         body_bytes = request.get_data(cache=True)
-        data = request.get_json(silent=True)
-        if not isinstance(data, dict):
-            return jsonify({'error': 'Invalid or missing JSON body'}), 400
+        data, body_error, status = _json_object_body()
+        if body_error:
+            return body_error, status
         new_state = data.get('state')
         
         if not new_state:
             return jsonify({'error': 'Missing state field'}), 400
+        if not isinstance(new_state, str):
+            return jsonify({'error': 'state must be a string'}), 400
         
         valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired', 'rejected'}
         if new_state not in valid_states:
@@ -1042,9 +1081,6 @@ def chat():
         message, field_error, status = _required_text_field(data, 'message')
         if field_error:
             return field_error, status
-        
-        if not agent_id or not message:
-            return jsonify({'error': 'Missing agent_id or message'}), 400
         safe_agent_id = html.escape(str(agent_id), quote=True)
         safe_message = html.escape(str(message), quote=True)
         

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -241,8 +241,8 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertIn('error', data)
 
     def test_contract_creation_rejects_invalid_amounts(self):
-        """Contract creation rejects malformed and non-positive amounts."""
-        for amount in ('not-a-number', 0, -1):
+        """Contract creation rejects non-positive amounts."""
+        for amount in (0, -1):
             contract_data = {
                 'from': 'bcn_alice_test',
                 'to': 'bcn_bob_test',
@@ -269,6 +269,114 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
                 json.loads(response.data)['error'],
                 'amount must be a positive number',
             )
+
+    def test_contract_create_rejects_non_object_json_body(self):
+        """Contract creation returns 400 for non-object JSON bodies."""
+        response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(['not', 'an', 'object']),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('error', json.loads(response.data))
+
+    def test_contract_create_rejects_structured_string_fields(self):
+        """Contract creation rejects object values for string fields."""
+        invalid_data = {
+            'from': {'agent': 'bcn_alice_test'},
+            'to': 'bcn_bob_test',
+            'type': 'rent',
+            'amount': 50,
+            'term': '30d',
+        }
+
+        response = self.client.post(
+            '/api/contracts',
+            data=json.dumps(invalid_data),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data)['error'], 'from must be a string')
+
+    def test_contract_create_rejects_malformed_amount(self):
+        """Contract creation rejects non-numeric amount values with 400."""
+        for malformed_amount in ({}, 'not-a-number'):
+            invalid_data = {
+                'from': 'bcn_test_from',
+                'to': 'bcn_test_to',
+                'type': 'rent',
+                'amount': malformed_amount,
+                'term': '7d',
+            }
+            create_body = json.dumps(invalid_data)
+
+            response = self.client.post(
+                '/api/contracts',
+                data=create_body,
+                content_type='application/json',
+                headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
+            )
+
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(json.loads(response.data)['error'], 'amount must be a number')
+
+    def test_contract_create_defaults_null_currency(self):
+        """Contract creation normalizes null currency to the RTC default."""
+        contract_data = {
+            'from': 'bcn_test_from',
+            'to': 'bcn_test_to',
+            'type': 'rent',
+            'amount': 25,
+            'currency': None,
+            'term': '7d',
+        }
+        create_body = json.dumps(contract_data)
+
+        response = self.client.post(
+            '/api/contracts',
+            data=create_body,
+            content_type='application/json',
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(json.loads(response.data)['currency'], 'RTC')
+
+    def test_contract_update_rejects_structured_state(self):
+        """Contract update returns 400 when state is not a string."""
+        contract_data = {
+            'from': 'bcn_test_from',
+            'to': 'bcn_test_to',
+            'type': 'rent',
+            'amount': 25,
+            'term': '7d',
+        }
+        create_body = json.dumps(contract_data)
+        create_response = self.client.post(
+            '/api/contracts',
+            data=create_body,
+            content_type='application/json',
+            headers=self._signed_headers('bcn_test_from', 'POST', '/api/contracts', create_body),
+        )
+        contract_id = json.loads(create_response.data)['id']
+
+        update_body = json.dumps({'state': {'next': 'active'}})
+        response = self.client.put(
+            f'/api/contracts/{contract_id}',
+            data=update_body,
+            content_type='application/json',
+            headers=self._signed_headers(
+                'bcn_test_to',
+                'PUT',
+                f'/api/contracts/{contract_id}',
+                update_body,
+            ),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data)['error'], 'state must be a string')
 
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
@@ -304,35 +412,84 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
 
     def test_bounty_claim_rejects_non_object_json(self):
         """Admin bounty claim route rejects malformed JSON shapes."""
-        response = self.client.post(
-            '/api/bounties/gh_test_bounty/claim',
-            data=json.dumps(['bcn_claimer']),
-            content_type='application/json',
-            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
-        )
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, ('gh_bad_claim', 'Bad Claim (5 RTC)', 5.0, 'EASY', 'open', int(time.time())))
+            conn.commit()
+
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            response = self.client.post(
+                '/api/bounties/gh_bad_claim/claim',
+                data=json.dumps(['bcn_claimer']),
+                content_type='application/json',
+                headers={'X-Admin-Key': 'test-admin'},
+            )
+
         self.assertEqual(response.status_code, 400)
-        self.assertIn('JSON object body required', response.get_data(as_text=True))
+        self.assertEqual(json.loads(response.data)['error'], 'JSON object body required')
+
+    def test_bounty_claim_rejects_non_string_agent_id(self):
+        """Bounty claim returns 400 when agent_id is not a string."""
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, ('gh_bad_claim_type', 'Bad Claim Type (5 RTC)', 5.0, 'EASY', 'open', int(time.time())))
+            conn.commit()
+
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            response = self.client.post(
+                '/api/bounties/gh_bad_claim_type/claim',
+                data=json.dumps({'agent_id': {'id': 'bcn_claimer'}}),
+                content_type='application/json',
+                headers={'X-Admin-Key': 'test-admin'},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data)['error'], 'agent_id must be a string')
 
     def test_bounty_complete_rejects_non_string_agent_id(self):
-        """Admin bounty completion route rejects non-string agent IDs."""
-        response = self.client.post(
-            '/api/bounties/gh_test_bounty/complete',
-            data=json.dumps({'agent_id': {'nested': 'bcn_claimer'}}),
-            content_type='application/json',
-            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
-        )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Missing agent_id', response.get_data(as_text=True))
+        """Bounty complete returns 400 when agent_id is not a string."""
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, ('gh_bad_complete', 'Bad Complete (5 RTC)', 5.0, 'EASY', 'claimed', int(time.time())))
+            conn.commit()
 
-    def test_chat_rejects_non_string_message(self):
-        """Chat route rejects non-string message bodies before storage."""
-        response = self.client.post(
+        with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):
+            response = self.client.post(
+                '/api/bounties/gh_bad_complete/complete',
+                data=json.dumps({'agent_id': {'id': 'bcn_completer'}}),
+                content_type='application/json',
+                headers={'X-Admin-Key': 'test-admin'},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.data)['error'], 'agent_id must be a string')
+
+    def test_chat_rejects_malformed_json_field_types(self):
+        """Chat returns 400 for non-object bodies and structured string fields."""
+        non_object = self.client.post(
             '/api/chat',
-            data=json.dumps({'agent_id': 'bcn_alice_test', 'message': ['hello']}),
+            data=json.dumps(['bcn_agent', 'hello']),
             content_type='application/json',
         )
-        self.assertEqual(response.status_code, 400)
-        self.assertIn('Missing message', response.get_data(as_text=True))
+        self.assertEqual(non_object.status_code, 400)
+
+        structured_message = self.client.post(
+            '/api/chat',
+            data=json.dumps({'agent_id': 'bcn_agent', 'message': {'text': 'hello'}}),
+            content_type='application/json',
+        )
+
+        self.assertEqual(structured_message.status_code, 400)
+        self.assertEqual(json.loads(structured_message.data)['error'], 'message must be a string')
 
     def test_reputation_tracking_workflow(self):
         """Reputation is tracked and updated correctly."""


### PR DESCRIPTION
Fixes #4380

## Summary
- reject non-object JSON bodies on Beacon Atlas write routes with HTTP 400
- reject structured/non-string string fields before DB writes or state mutations
- preserve existing missing-field, auth, and happy-path behavior

## Changes
- add shared JSON object and required text-field validation helpers
- validate contract create/update fields before lookup/auth-sensitive handling
- validate bounty claim/complete `agent_id` and chat `agent_id`/`message`
- add regression coverage for malformed contract, bounty, and chat payloads

## Verification

```bash
C:\Program Files (x86)\Android\AndroidNDK\android-ndk-r27c\toolchains\llvm\prebuilt\windows-x86_64\python3\python.exe -m py_compile node\beacon_api.py tests\test_beacon_atlas_behavior.py
git diff --check --cached
```

Results:
- py_compile passed
- diff check passed

Note: full unittest/pytest execution was not available in this workspace because the only local Python runtime is the Android NDK Python, which lacks `_sqlite3`, and `pytest` is not installed.

## Payout

RTC wallet: `RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f`