### PR TITLE
fix: validate rent-a-relic reserve JSON fields

### DIFF
--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -270,6 +270,26 @@ class TestReservationFlow:
         })
         assert resp.status_code == 400
 
+    def test_reserve_rejects_non_string_agent_id(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": ["agent"],
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": 4.0,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "agent_id must be a string"
+
+    def test_reserve_rejects_non_string_machine_id(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": "agent-a",
+            "machine_id": {"machine": "g3-beige"},
+            "duration_hours": 1,
+            "rtc_amount": 4.0,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "machine_id must be a string"
+
     def test_reserve_rejects_non_object_json(self, app):
         resp = app.post("/relic/reserve", json=["not", "object"])
         assert resp.status_code == 400
@@ -289,6 +309,26 @@ class TestReservationFlow:
         })
         assert resp.status_code == 400
         assert "RTC" in resp.json["error"]
+
+    def test_reserve_rejects_boolean_duration_hours(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": "bool-duration",
+            "machine_id": "g3-beige",
+            "duration_hours": True,
+            "rtc_amount": 4.0,
+        })
+        assert resp.status_code == 400
+        assert "duration_hours" in resp.json["error"]
+
+    def test_reserve_rejects_boolean_rtc_amount(self, app):
+        resp = app.post("/relic/reserve", json={
+            "agent_id": "bool-rtc",
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": False,
+        })
+        assert resp.status_code == 400
+        assert resp.json["error"] == "rtc_amount must be a positive number"
 
 
 class TestEscrow:

--- a/tests/test_rent_a_relic.py
+++ b/tests/test_rent_a_relic.py
@@ -330,6 +330,17 @@ class TestReservationFlow:
         assert resp.status_code == 400
         assert resp.json["error"] == "rtc_amount must be a positive number"
 
+    def test_reserve_rejects_non_finite_rtc_amount(self, app):
+        for amount in (float("nan"), float("inf"), float("-inf")):
+            resp = app.post("/relic/reserve", json={
+                "agent_id": "finite-rtc",
+                "machine_id": "g3-beige",
+                "duration_hours": 1,
+                "rtc_amount": amount,
+            })
+            assert resp.status_code == 400
+            assert resp.json["error"] == "rtc_amount must be a positive number"
+
 
 class TestEscrow:
     def test_escrow_locked_on_reserve(self, app):

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -60,10 +60,13 @@ def _get_json_object_or_empty() -> dict:
 
 def _optional_string_value(data: dict, key: str) -> str | None:
     value = data.get(key)
-    if value is None or value == "":
+    if value is None:
         return None
     if not isinstance(value, str):
         abort(400, description=f"{key} must be a string")
+    value = value.strip()
+    if value == "":
+        return None
     return value
 
 
@@ -268,8 +271,8 @@ def post_reserve():
     """Reserve a machine and lock RTC in escrow."""
     data = _get_json_object_or_empty()
 
-    agent_id       = data.get("agent_id", "").strip()
-    machine_id     = data.get("machine_id", "").strip()
+    agent_id       = _optional_string_value(data, "agent_id")
+    machine_id     = _optional_string_value(data, "machine_id")
     duration_hours = data.get("duration_hours")
     rtc_amount     = data.get("rtc_amount")
 
@@ -277,9 +280,11 @@ def post_reserve():
         abort(400, description="agent_id is required")
     if not machine_id:
         abort(400, description="machine_id is required")
+    if isinstance(duration_hours, bool):
+        abort(400, description="duration_hours must be one of [1, 4, 24]")
     if duration_hours not in VALID_DURATIONS_HOURS:
         abort(400, description=f"duration_hours must be one of {sorted(VALID_DURATIONS_HOURS)}")
-    if rtc_amount is None or not isinstance(rtc_amount, (int, float)) or rtc_amount <= 0:
+    if rtc_amount is None or isinstance(rtc_amount, bool) or not isinstance(rtc_amount, (int, float)) or rtc_amount <= 0:
         abort(400, description="rtc_amount must be a positive number")
 
     machine = MACHINE_REGISTRY.get(machine_id)

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import math
 import os
 import sqlite3
 import time
@@ -284,7 +285,13 @@ def post_reserve():
         abort(400, description="duration_hours must be one of [1, 4, 24]")
     if duration_hours not in VALID_DURATIONS_HOURS:
         abort(400, description=f"duration_hours must be one of {sorted(VALID_DURATIONS_HOURS)}")
-    if rtc_amount is None or isinstance(rtc_amount, bool) or not isinstance(rtc_amount, (int, float)) or rtc_amount <= 0:
+    if (
+        rtc_amount is None
+        or isinstance(rtc_amount, bool)
+        or not isinstance(rtc_amount, (int, float))
+        or not math.isfinite(rtc_amount)
+        or rtc_amount <= 0
+    ):
         abort(400, description="rtc_amount must be a positive number")
 
     machine = MACHINE_REGISTRY.get(machine_id)


### PR DESCRIPTION
## Summary

Fixes #5604 by validating `/relic/reserve` JSON field types before normalization and rejecting boolean numeric inputs that Python would otherwise coerce.

## Changes

- validate `agent_id` and `machine_id` as trimmed strings before calling `.strip()`
- reject boolean `duration_hours` values instead of treating `true` as `1`
- reject boolean `rtc_amount` values instead of treating them as numeric amounts
- add regression coverage for non-string reservation IDs and boolean numeric fields

## Verification

```bash
python -m pytest tests/test_rent_a_relic.py -q
python -m py_compile tools/rent_a_relic/server.py tests/test_rent_a_relic.py
git diff --check
```

## Payout

RTC payout wallet: `RTC0bc961e7a95d320d2707470643fa35deb1a26d09`
