### PR TITLE
fix(test): make attestation fuzzer console-safe

### DIFF
--- a/tests/fuzz_attestation_runner.py
+++ b/tests/fuzz_attestation_runner.py
@@ -41,6 +41,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+for _stream in (sys.stdout, sys.stderr):
+    _reconfigure = getattr(_stream, "reconfigure", None)
+    if _reconfigure is not None:
+        _reconfigure(errors="replace")
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Fixes #5699.

`tests/fuzz_attestation_runner.py` prints emoji/status glyphs before it sends any fuzz payloads. On Windows consoles using a non-UTF-8 encoding such as GBK/cp936, the first banner print can raise `UnicodeEncodeError`, so the fuzzer exits before exercising `/attest/submit`.

## Changes

- Configure `sys.stdout` and `sys.stderr` with `errors="replace"` when `reconfigure()` is available.
- Keep existing output unchanged on UTF-8 terminals.
- Allow legacy/non-UTF-8 consoles to degrade unencodable glyphs instead of crashing.

## Verification

```bash
python -m py_compile tests/fuzz_attestation_runner.py
```

Simulated a non-UTF-8 Windows console:

```powershell
$env:PYTHONIOENCODING='cp936'
$env:RUSTCHAIN_URL='http://127.0.0.1:9'
python -B tests\fuzz_attestation_runner.py --count 1 --seed 1
```

Result: the runner reached the fuzz summary without `UnicodeEncodeError`; unencodable banner glyphs were replaced by `?`, as intended.

Bounty references: bug report #5699 and bug bounty #305.

Payout route: PayPal `https://paypal.me/Jeremytsangchina`; USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`. If RustChain bug bounties are RTC-only, please tell me the expected wallet/miner-id format.