### PR TITLE
Reject incomplete attestations before consuming nonce

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -424,6 +424,26 @@ def _validate_attestation_payload_shape(data):
     if isinstance(fingerprint, dict) and "checks" in fingerprint and not isinstance(fingerprint.get("checks"), dict):
         return _attest_field_error("INVALID_FINGERPRINT_CHECKS", "Field 'fingerprint.checks' must be a JSON object")
 
+    required_sections = (
+        ("device", "MISSING_DEVICE", "Field 'device' must include hardware metadata"),
+        ("signals", "MISSING_SIGNALS", "Field 'signals' must include hardware signal metadata"),
+    )
+    for field_name, code, message in required_sections:
+        section = data.get(field_name)
+        if not isinstance(section, dict) or not section:
+            return _attest_field_error(code, message, status=422)
+
+    if (
+        not isinstance(fingerprint, dict)
+        or not isinstance(fingerprint.get("checks"), dict)
+        or not fingerprint.get("checks")
+    ):
+        return _attest_field_error(
+            "MISSING_FINGERPRINT",
+            "Field 'fingerprint.checks' must include hardware fingerprint checks",
+            status=422,
+        )
+
     return None
 
 

--- a/node/tests/test_attest_missing_fingerprint_reward_bypass.py
+++ b/node/tests/test_attest_missing_fingerprint_reward_bypass.py
@@ -104,7 +104,7 @@ def _prepare_attestation_db(node, db_path: Path, miner: str, epoch: int, nonce: 
         conn.commit()
 
 
-def test_missing_fingerprint_attestation_cannot_receive_epoch_reward(tmp_path):
+def test_missing_fingerprint_attestation_rejected_before_nonce_consumption(tmp_path):
     db_path = tmp_path / "missing_fingerprint_reward.sqlite3"
     node = _load_integrated_node(db_path)
 
@@ -125,21 +125,10 @@ def test_missing_fingerprint_attestation_cannot_receive_epoch_reward(tmp_path):
     with node.app.test_client() as client:
         response = client.post("/attest/submit", json=payload)
 
-    assert response.status_code == 200
-    assert response.get_json()["fingerprint_passed"] is False
+    assert response.status_code == 422
+    assert response.get_json()["code"] == "MISSING_FINGERPRINT"
 
     with sqlite3.connect(db_path) as conn:
-        recent = conn.execute(
-            "SELECT fingerprint_passed, fingerprint_checks_json FROM miner_attest_recent WHERE miner=?",
-            (miner,),
-        ).fetchone()
-        assert recent == (0, "{}")
-
-    node.finalize_epoch(epoch, node.PER_BLOCK_RTC, prev_block_hash=b"")
-
-    with sqlite3.connect(db_path) as conn:
-        balance = conn.execute(
-            "SELECT amount_i64, balance_rtc FROM balances WHERE miner_id=?",
-            (miner,),
-        ).fetchone()
-        assert balance == (0, 0.0)
+        assert conn.execute("SELECT COUNT(*) FROM nonces WHERE nonce=?", (nonce,)).fetchone()[0] == 1
+        assert conn.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce=?", (nonce,)).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM miner_attest_recent WHERE miner=?", (miner,)).fetchone()[0] == 0

--- a/node/tests/test_attest_submit_challenge_binding.py
+++ b/node/tests/test_attest_submit_challenge_binding.py
@@ -113,6 +113,8 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         self._loaded_modules.append(mod)
+        mod.HAVE_REPLAY_DEFENSE = False
+        mod.HAVE_WARTHOG = False
         for attempt in range(5):
             try:
                 mod.init_db()
@@ -137,6 +139,24 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
         with mod.app.test_request_context("/attest/submit", method="POST", json=payload):
             return self._response_payload(mod._submit_attestation_impl())
 
+    def _fingerprint(self):
+        return {
+            "checks": {
+                "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+                "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+            },
+            "all_passed": True,
+        }
+
+    def _attestation_payload(self, nonce):
+        return {
+            "miner": "RTC_REPLAY_POC_MINER",
+            "report": {"nonce": nonce, "commitment": "deadbeef"},
+            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
+            "signals": {"hostname": "poc-host", "macs": []},
+            "fingerprint": self._fingerprint(),
+        }
+
     def test_same_challenge_nonce_rejected_on_different_node(self):
         mod1, db1_path = self._load_module("rustchain_attest_node1", "node1.db")
         mod2, db2_path = self._load_module("rustchain_attest_node2", "node2.db")
@@ -145,13 +165,7 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
             challenge_resp = mod1.get_challenge()
         challenge = challenge_resp.get_json()
 
-        payload = {
-            "miner": "RTC_REPLAY_POC_MINER",
-            "report": {"nonce": challenge["nonce"], "commitment": "deadbeef"},
-            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
-            "signals": {"hostname": "poc-host", "macs": []},
-            "fingerprint": {},
-        }
+        payload = self._attestation_payload(challenge["nonce"])
 
         status1, body1 = self._submit(mod1, payload)
         status2, body2 = self._submit(mod2, payload)
@@ -173,13 +187,7 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
             challenge_resp = mod.get_challenge()
         challenge = challenge_resp.get_json()
 
-        payload = {
-            "miner": "RTC_REPLAY_POC_MINER",
-            "report": {"nonce": challenge["nonce"], "commitment": "deadbeef"},
-            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
-            "signals": {"hostname": "poc-host", "macs": []},
-            "fingerprint": {},
-        }
+        payload = self._attestation_payload(challenge["nonce"])
 
         status1, body1 = self._submit(mod, payload)
         status2, body2 = self._submit(mod, payload)
@@ -196,17 +204,8 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
     def test_client_timestamp_cannot_bypass_challenge_validation(self):
         mod, db_path = self._load_module("rustchain_attest_node_bypass", "bypass.db")
 
-        payload = {
-            "miner": "RTC_REPLAY_POC_MINER",
-            "report": {
-                "nonce": "b" * 64,
-                "commitment": "deadbeef",
-                "server_time": 1700000000,
-            },
-            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
-            "signals": {"hostname": "poc-host", "macs": []},
-            "fingerprint": {},
-        }
+        payload = self._attestation_payload("b" * 64)
+        payload["report"]["server_time"] = 1700000000
 
         status, body = self._submit(mod, payload)
 
@@ -220,13 +219,7 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
     def test_submit_rejects_arbitrary_nonce_without_server_challenge(self):
         mod, db_path = self._load_module("rustchain_attest_node_plain", "plain.db")
 
-        payload = {
-            "miner": "RTC_REPLAY_POC_MINER",
-            "report": {"nonce": "legacy-local-nonce", "commitment": "deadbeef"},
-            "device": {"family": "x86_64", "arch": "default", "model": "poc-box", "cores": 4},
-            "signals": {"hostname": "poc-host", "macs": []},
-            "fingerprint": {},
-        }
+        payload = self._attestation_payload("legacy-local-nonce")
 
         status, body = self._submit(mod, payload)
 
@@ -236,6 +229,59 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
         with closing(sqlite3.connect(db_path)) as conn:
             self.assertEqual(conn.execute("SELECT COUNT(*) FROM nonces").fetchone()[0], 0)
             self.assertEqual(conn.execute("SELECT COUNT(*) FROM used_nonces").fetchone()[0], 0)
+
+    def test_missing_required_attestation_evidence_does_not_consume_nonce(self):
+        mod, db_path = self._load_module("rustchain_attest_required_evidence", "required_evidence.db")
+
+        cases = [
+            ("device", "MISSING_DEVICE"),
+            ("signals", "MISSING_SIGNALS"),
+            ("fingerprint", "MISSING_FINGERPRINT"),
+        ]
+        for missing_field, expected_code in cases:
+            with self.subTest(missing_field=missing_field):
+                with mod.app.test_request_context("/attest/challenge", method="POST", json={}):
+                    challenge_resp = mod.get_challenge()
+                challenge = challenge_resp.get_json()
+                payload = self._attestation_payload(challenge["nonce"])
+                payload.pop(missing_field)
+
+                status, body = self._submit(mod, payload)
+
+                self.assertEqual(status, 422)
+                self.assertEqual(body["code"], expected_code)
+                with sqlite3.connect(db_path) as conn:
+                    self.assertEqual(
+                        conn.execute("SELECT COUNT(*) FROM nonces WHERE nonce = ?", (challenge["nonce"],)).fetchone()[0],
+                        1,
+                    )
+                    self.assertEqual(
+                        conn.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce = ?", (challenge["nonce"],)).fetchone()[0],
+                        0,
+                    )
+
+    def test_non_string_signature_does_not_consume_nonce(self):
+        mod, db_path = self._load_module("rustchain_attest_signature_type", "signature_type.db")
+
+        with mod.app.test_request_context("/attest/challenge", method="POST", json={}):
+            challenge_resp = mod.get_challenge()
+        challenge = challenge_resp.get_json()
+        payload = self._attestation_payload(challenge["nonce"])
+        payload["signature"] = True
+
+        status, body = self._submit(mod, payload)
+
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_SIGNATURE_TYPE")
+        with sqlite3.connect(db_path) as conn:
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM nonces WHERE nonce = ?", (challenge["nonce"],)).fetchone()[0],
+                1,
+            )
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce = ?", (challenge["nonce"],)).fetchone()[0],
+                0,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require `device`, `signals`, and non-empty `fingerprint.checks` before `/attest/submit` can consume a challenge nonce
- keep malformed signature/public-key type validation ahead of nonce consumption, with regression coverage for non-string `signature`
- update challenge-binding tests to use complete attestation evidence and assert invalid evidence leaves the nonce live and unused

## Root cause
`_validate_attestation_payload_shape()` rejected malformed section types but allowed missing or empty attestation evidence. The route then validated and stored the one-time challenge nonce before normalizing `device`, `signals`, and `fingerprint`, so incomplete payloads could consume live challenges and still reach the success path with zero/failed fingerprint state.

## Validation
- `python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_attest_submit_challenge_binding.py node/tests/test_attest_missing_fingerprint_reward_bypass.py`
- `RC_ADMIN_KEY=0123456789abcdef0123456789abcdef /tmp/bottube-test-venv/bin/python -B -m unittest node.tests.test_attest_submit_challenge_binding -v`
- `RC_ADMIN_KEY=0123456789abcdef0123456789abcdef /tmp/bottube-test-venv/bin/python -B -m pytest -q node/tests/test_attest_missing_fingerprint_reward_bypass.py --tb=short`
- `RC_ADMIN_KEY=0123456789abcdef0123456789abcdef /tmp/bottube-test-venv/bin/python -B -m pytest -q tests/test_attestation_fuzz.py --tb=short`

Fixes #5698. Also covers the nonce-preservation side of #5697 for non-string `signature` inputs.