### PR TITLE
Fix issue2310 validation test stability

### DIFF
--- a/bounties/issue-2310/validate_bounty_2310.py
+++ b/bounties/issue-2310/validate_bounty_2310.py
@@ -35,11 +35,17 @@ def print_info(text):
 
 def check_file_exists(filepath, description):
     """Check if a file exists"""
+    display_path = filepath
+    try:
+        display_path = str(Path(filepath).resolve().relative_to(Path(__file__).parent.resolve()))
+    except ValueError:
+        pass
+
     if os.path.exists(filepath):
-        print_success(f"{description}: {filepath}")
+        print_success(f"{description}: {display_path}")
         return True
     else:
-        print_error(f"{description} missing: {filepath}")
+        print_error(f"{description} missing: {display_path}")
         return False
 
 def check_file_content(filepath, patterns, description):

--- a/tests/test_issue2310_package_validation.py
+++ b/tests/test_issue2310_package_validation.py
@@ -16,7 +16,8 @@ def test_issue2310_package_imports_from_parent_path():
         "import sys; "
         f"sys.path.insert(0, {issue_path!r}); "
         "import src; "
-        "print(src.CRTPatternGenerator.__name__)"
+        "print(src.__file__); "
+        "print(src.__all__[0])"
     )
 
     result = subprocess.run(
@@ -28,7 +29,9 @@ def test_issue2310_package_imports_from_parent_path():
     )
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "CRTPatternGenerator"
+    stdout = result.stdout.strip().splitlines()
+    assert Path(stdout[0]).resolve() == ISSUE2310_ROOT / "src" / "__init__.py"
+    assert stdout[1] == "CRTPatternGenerator"
 
 
 def test_issue2310_validator_runs_with_cp1252_stdout():


### PR DESCRIPTION
## Summary
- keep `tests/test_issue2310_package_validation.py` focused on package path resolution without importing numpy-backed CRT modules
- print issue-2310 validator file paths relative to the validator directory so cp1252 stdout does not crash from non-ASCII checkout paths

## Why
Follow-up for #5632 / stale PR #5631. On current main, the hard-coded Windows paths are gone, but the focused validation test can still fail before checking the path behavior when optional issue-2310 dependencies are not installed, and the cp1252 validator subprocess can crash if the checkout path contains non-ASCII characters.

## Validation
- `.venv/bin/python -B -m pytest -q tests/test_issue2310_package_validation.py --tb=short -p no:cacheprovider` -> 2 passed
- `.venv/bin/python -B -m py_compile tests/test_issue2310_package_validation.py bounties/issue-2310/validate_bounty_2310.py`
- `git diff --check`

Refs #5632

BCOS-L1