### PR TITLE
fix(p2p): reject unregistered ed25519 senders

### DIFF
--- a/node/p2p_identity.py
+++ b/node/p2p_identity.py
@@ -342,6 +342,19 @@ class PeerRegistry:
 # ---------------------------------------------------------------------------
 # Signature bundle: JSON-encoded dual signature (or legacy hex)
 # ---------------------------------------------------------------------------
+_INVALID_SIGNATURE = "__rustchain_invalid_signature__"
+
+
+def _signature_bundle_value(bundle: Dict, key: str) -> Optional[str]:
+    """Return a string bundle value, or a verifier-failing sentinel."""
+    if key not in bundle:
+        return None
+    value = bundle[key]
+    if not isinstance(value, str) or not value:
+        return _INVALID_SIGNATURE
+    return value
+
+
 def pack_signature(hmac_sig: Optional[str], ed25519_sig: Optional[str], key_version: int = 1) -> str:
     """Pack one or two signatures into the wire-format signature field.
 
@@ -364,14 +377,21 @@ def unpack_signature(sig_field: str) -> Tuple[Optional[str], Optional[str], int]
     Returns (hmac_sig, ed25519_sig, key_version). Either sig may be None if not present.
     Treats raw-hex strings as legacy HMAC-only with version 1.
     """
-    if not sig_field:
+    if not isinstance(sig_field, str) or not sig_field:
         return None, None, 1
     stripped = sig_field.strip()
     if stripped.startswith("{"):
         try:
             bundle = json.loads(stripped)
-            return bundle.get("h"), bundle.get("e"), bundle.get("v", 1)
-        except json.JSONDecodeError:
+            if not isinstance(bundle, dict):
+                return None, None, 1
+            hmac_sig = _signature_bundle_value(bundle, "h")
+            ed25519_sig = _signature_bundle_value(bundle, "e")
+            key_version = bundle.get("v", 1)
+            if isinstance(key_version, bool) or not isinstance(key_version, int):
+                key_version = 1
+            return hmac_sig, ed25519_sig, key_version
+        except (json.JSONDecodeError, TypeError):
             return None, None, 1
     # Legacy hex — assume HMAC, version 1
     return stripped, None, 1
@@ -395,5 +415,5 @@ def verify_ed25519(pubkey_hex: str, signature_hex: str, data: bytes) -> bool:
         pub = Ed25519PublicKey.from_public_bytes(bytes.fromhex(pubkey_hex))
         pub.verify(bytes.fromhex(signature_hex), data)
         return True
-    except (InvalidSignature, ValueError):
+    except (InvalidSignature, TypeError, ValueError):
         return False

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -673,9 +673,10 @@ class GossipLayer:
         part of the signed content — any post-sign flip of those fields
         fails verification.
 
-        Phase F: if an Ed25519 signature is present AND the sender is a
-        registered peer, verify it against their pubkey. HMAC path is a
-        fallback per the current signing mode.
+        Phase F: if an Ed25519 signature is present in a migration-mode
+        bundle, require the sender to be registered and the Ed25519 signature
+        to verify. HMAC remains a legacy fallback only for HMAC-only messages
+        outside strict mode.
         """
         if abs(time.time() - msg.timestamp) > MESSAGE_EXPIRY:
             return False
@@ -687,14 +688,16 @@ class GossipLayer:
         from p2p_identity import unpack_signature, verify_ed25519
         hmac_sig, ed25519_sig, _key_version = unpack_signature(msg.signature)
 
-        # 1) Try Ed25519 if available AND peer is registered.
-        if ed25519_sig and self._peer_registry is not None:
-            pubkey = self._peer_registry.get_pubkey(msg.sender_id)
-            if pubkey and verify_ed25519(pubkey, ed25519_sig, message.encode()):
-                return True
-            # In strict mode, Ed25519 must succeed — no fallback.
-            if mode == "strict":
+        # 1) Try Ed25519 if available. A bundled Ed25519 signature must not
+        # silently downgrade to HMAC when the sender is unregistered or the
+        # signature fails.
+        if ed25519_sig and mode in ("dual", "ed25519", "strict"):
+            if self._peer_registry is None:
                 return False
+            pubkey = self._peer_registry.get_pubkey(msg.sender_id)
+            if pubkey is None:
+                return False
+            return verify_ed25519(pubkey, ed25519_sig, message.encode())
 
         # 2) HMAC fallback (unless strict).
         if mode == "strict":

--- a/node/tests/test_p2p_phase_f_ed25519.py
+++ b/node/tests/test_p2p_phase_f_ed25519.py
@@ -70,8 +70,9 @@ def test_pack_legacy_hmac_only():
                                tempfile.mkdtemp() + "/reg.json")
     packed = ident.pack_signature("abc123", None)
     assert packed == "abc123"
-    h, e = ident.unpack_signature(packed)
+    h, e, v = ident.unpack_signature(packed)
     assert h == "abc123" and e is None
+    assert v == 1
 
 
 def test_pack_dual_bundle():
@@ -79,18 +80,20 @@ def test_pack_dual_bundle():
                                tempfile.mkdtemp() + "/reg.json")
     packed = ident.pack_signature("h_hex", "e_hex")
     bundle = json.loads(packed)
-    assert bundle == {"h": "h_hex", "e": "e_hex"}
-    h, e = ident.unpack_signature(packed)
+    assert bundle == {"h": "h_hex", "e": "e_hex", "v": 1}
+    h, e, v = ident.unpack_signature(packed)
     assert h == "h_hex" and e == "e_hex"
+    assert v == 1
 
 
 def test_pack_ed25519_only():
     ident, _ = _reload_modules("hmac", tempfile.mkdtemp() + "/pk.pem",
                                tempfile.mkdtemp() + "/reg.json")
     packed = ident.pack_signature(None, "e_hex")
-    assert packed == '{"e":"e_hex"}'
-    h, e = ident.unpack_signature(packed)
+    assert packed == '{"e":"e_hex","v":1}'
+    h, e, v = ident.unpack_signature(packed)
     assert h is None and e == "e_hex"
+    assert v == 1
 
 
 # -----------------------------------------------------------------------------
@@ -149,7 +152,7 @@ def test_dual_mode_hmac_still_works():
     # Force HMAC-only signing for this message (simulate legacy peer)
     msg = layer.create_message(gossip.MessageType.PING, {"hello": "world"})
     # In dual mode, signature is a JSON bundle with both — strip to HMAC only
-    h, e = ident.unpack_signature(msg.signature)
+    h, e, _ = ident.unpack_signature(msg.signature)
     assert h is not None
     assert e is not None
     # Replace with HMAC-only (simulating pre-Phase-F peer)
@@ -180,7 +183,7 @@ def test_dual_mode_ed25519_verifies_against_registered_peer():
 
     msg = sender.create_message(gossip.MessageType.PING, {"ping": 1})
     # Msg has both HMAC and Ed25519 in a JSON bundle
-    h, e = ident.unpack_signature(msg.signature)
+    h, e, _ = ident.unpack_signature(msg.signature)
     assert e is not None
 
     # Receiver verifies — should succeed via Ed25519 path
@@ -219,7 +222,7 @@ def test_strict_mode_rejects_hmac_only():
 
 
 def test_ed25519_unknown_peer_rejected():
-    """Ed25519 signature from an unregistered peer is not accepted."""
+    """Ed25519 signature from an unregistered peer is not downgraded to HMAC."""
     tmpdir = tempfile.mkdtemp()
     sender_pk = tmpdir + "/sender.pem"
     empty_reg = tmpdir + "/empty.json"
@@ -231,10 +234,8 @@ def test_ed25519_unknown_peer_rejected():
     receiver = _make_layer(ident, gossip, "node-receiver",
                            {"node-unknown": "http://x"})
     msg = sender.create_message(gossip.MessageType.PING, {"ping": 1})
-    # Strip HMAC so Ed25519 is the only path
-    _, e = ident.unpack_signature(msg.signature)
-    msg.signature = ident.pack_signature(None, e)
-    # Unknown-peer Ed25519 → verification must fail (no fallback in strict,
-    # and dual mode requires registered-peer pubkey for Ed25519 path, falling
-    # back to HMAC which we stripped)
+    h, e, _ = ident.unpack_signature(msg.signature)
+    assert h is not None and e is not None
+    # Unknown-peer Ed25519 must fail even though the legacy HMAC in the bundle
+    # is valid; otherwise an unregistered sender can downgrade to HMAC.
     assert receiver.verify_message(msg) is False

--- a/node/tests/test_p2p_phase_f_ed25519.py
+++ b/node/tests/test_p2p_phase_f_ed25519.py
@@ -239,3 +239,34 @@ def test_ed25519_unknown_peer_rejected():
     # Unknown-peer Ed25519 must fail even though the legacy HMAC in the bundle
     # is valid; otherwise an unregistered sender can downgrade to HMAC.
     assert receiver.verify_message(msg) is False
+
+
+def test_malformed_ed25519_bundle_rejected_without_hmac_downgrade():
+    """Malformed bundled Ed25519 values fail closed instead of falling back."""
+    tmpdir = tempfile.mkdtemp()
+    sender_pk_path = tmpdir + "/sender.pem"
+    _, _ = _reload_modules("dual", sender_pk_path, tmpdir + "/reg.json")
+    from p2p_identity import LocalKeypair
+    sender_kp = LocalKeypair(sender_pk_path)
+
+    reg_path = tmpdir + "/reg.json"
+    with open(reg_path, "w") as f:
+        json.dump({"version": 1, "peers": [
+            {"node_id": "node-sender", "pubkey_hex": sender_kp.pubkey_hex}
+        ]}, f)
+
+    ident, gossip = _reload_modules("dual", sender_pk_path, reg_path)
+    sender = _make_layer(ident, gossip, "node-sender", {})
+    receiver = _make_layer(ident, gossip, "node-receiver",
+                           {"node-sender": "http://x"})
+
+    msg = sender.create_message(gossip.MessageType.PING, {"ping": 1})
+    h, e, _ = ident.unpack_signature(msg.signature)
+    assert h is not None and e is not None
+
+    for malformed_e in (True, [], {}):
+        msg.signature = json.dumps(
+            {"h": h, "e": malformed_e, "v": 1},
+            separators=(",", ":"),
+        )
+        assert receiver.verify_message(msg) is False


### PR DESCRIPTION
## Summary
- require bundled Ed25519 gossip signatures to resolve to a registered peer before verification
- reject unregistered or invalid Ed25519 senders instead of silently downgrading to HMAC
- update the Phase F Ed25519 regression tests for the current signature bundle version field

## Security context
Addresses the verified C4 finding from the 2867 security audit: unregistered peer Ed25519 verification could be skipped and accepted through the legacy HMAC fallback. This keeps HMAC-only legacy messages working in `dual` mode, but prevents a dual-signature bundle with an unregistered Ed25519 sender from downgrading to HMAC.

## Validation
- `.venv/bin/python -m pytest node/tests/test_p2p_phase_f_ed25519.py -q`
- `.venv/bin/python -m pytest node/tests/test_p2p_identity_hardening.py -q`
- `.venv/bin/python -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_phase_f_ed25519.py node/tests/test_p2p_identity_hardening.py`
- `git diff --check`

BCOS-L1
