### PR TITLE
fix(p2p): validate gossip message input

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -301,7 +301,61 @@ class GossipMessage:
 
     @classmethod
     def from_dict(cls, data: Dict) -> 'GossipMessage':
-        return cls(**data)
+        """Validate and construct a gossip message from untrusted JSON."""
+        if not isinstance(data, dict):
+            raise ValueError("invalid gossip message: expected object")
+
+        required = {
+            "msg_type",
+            "msg_id",
+            "sender_id",
+            "timestamp",
+            "ttl",
+            "signature",
+            "payload",
+        }
+        if set(data) != required:
+            raise ValueError("invalid gossip message fields")
+
+        msg_type = data["msg_type"]
+        if not isinstance(msg_type, str) or msg_type not in {m.value for m in MessageType}:
+            raise ValueError("invalid gossip message type")
+
+        def require_string(name: str, max_len: int) -> str:
+            value = data[name]
+            if not isinstance(value, str) or not value or len(value) > max_len:
+                raise ValueError(f"invalid gossip message {name}")
+            return value
+
+        msg_id = require_string("msg_id", 128)
+        sender_id = require_string("sender_id", 128)
+        signature = require_string("signature", 4096)
+
+        timestamp = data["timestamp"]
+        if isinstance(timestamp, bool) or not isinstance(timestamp, int) or timestamp < 0:
+            raise ValueError("invalid gossip message timestamp")
+
+        ttl = data["ttl"]
+        if isinstance(ttl, bool) or not isinstance(ttl, int) or ttl < 0 or ttl > GOSSIP_TTL:
+            raise ValueError("invalid gossip message ttl")
+
+        payload = data["payload"]
+        if not isinstance(payload, dict):
+            raise ValueError("invalid gossip message payload")
+        try:
+            json.dumps(payload, sort_keys=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("invalid gossip message payload") from exc
+
+        return cls(
+            msg_type=msg_type,
+            msg_id=msg_id,
+            sender_id=sender_id,
+            timestamp=timestamp,
+            ttl=ttl,
+            signature=signature,
+            payload=payload,
+        )
 
     def compute_hash(self) -> str:
         """Compute hash of message content for deduplication"""

--- a/node/tests/test_p2p_message_validation.py
+++ b/node/tests/test_p2p_message_validation.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for P2P gossip message input validation."""
+
+import importlib
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+os.environ.setdefault("RC_P2P_SECRET", "unit-test-secret-0123456789abcdef")
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(NODE_DIR))
+
+gossip = importlib.import_module("rustchain_p2p_gossip")
+
+
+def _valid_message_dict():
+    return {
+        "msg_type": gossip.MessageType.PING.value,
+        "msg_id": "msg-123",
+        "sender_id": "node-a",
+        "timestamp": int(time.time()),
+        "ttl": gossip.GOSSIP_TTL,
+        "signature": "abc123",
+        "payload": {"hello": "world"},
+    }
+
+
+def test_from_dict_accepts_valid_message():
+    msg = gossip.GossipMessage.from_dict(_valid_message_dict())
+
+    assert msg.msg_type == gossip.MessageType.PING.value
+    assert msg.msg_id == "msg-123"
+    assert msg.payload == {"hello": "world"}
+
+
+@pytest.mark.parametrize("raw", [None, [], "not-json-object"])
+def test_from_dict_rejects_non_object_payloads(raw):
+    with pytest.raises(ValueError, match="expected object"):
+        gossip.GossipMessage.from_dict(raw)
+
+
+def test_from_dict_rejects_missing_or_extra_fields():
+    missing = _valid_message_dict()
+    missing.pop("signature")
+    with pytest.raises(ValueError, match="fields"):
+        gossip.GossipMessage.from_dict(missing)
+
+    extra = _valid_message_dict()
+    extra["unexpected"] = "field"
+    with pytest.raises(ValueError, match="fields"):
+        gossip.GossipMessage.from_dict(extra)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("msg_type", "unknown", "type"),
+        ("msg_id", "", "msg_id"),
+        ("sender_id", ["node-a"], "sender_id"),
+        ("timestamp", "now", "timestamp"),
+        ("timestamp", True, "timestamp"),
+        ("ttl", -1, "ttl"),
+        ("ttl", gossip.GOSSIP_TTL + 1, "ttl"),
+        ("signature", "", "signature"),
+        ("payload", [], "payload"),
+    ],
+)
+def test_from_dict_rejects_malformed_field_types(field, value, message):
+    raw = _valid_message_dict()
+    raw[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        gossip.GossipMessage.from_dict(raw)


### PR DESCRIPTION
## Summary
- validate untrusted gossip message JSON before constructing `GossipMessage`
- reject missing/extra fields, unknown message types, malformed string fields, invalid timestamps/TTL, and non-object payloads
- add focused regression coverage for malformed gossip message inputs

## Security context
Addresses M4 from the 2867 security audit: `GossipMessage.from_dict()` previously used `cls(**data)` with no explicit validation, allowing unexpected shapes and field types to reach the gossip handler.

## Validation
- `.venv/bin/python -m pytest node/tests/test_p2p_message_validation.py -q`
- `PYTHONPATH=node .venv/bin/python -m pytest node/tests/test_p2p_hardening_phase2.py -q`
- `.venv/bin/python -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_message_validation.py`
- `git diff --check`

BCOS-L1
