### PR TITLE
Reject oversized P2P gossip payloads before auth

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -111,6 +111,10 @@ if not _P2P_SECRET_RAW or _P2P_SECRET_RAW.lower() in _INSECURE_DEFAULTS:
 
 P2P_SECRET = _P2P_SECRET_RAW
 GOSSIP_TTL = 3
+MAX_GOSSIP_PAYLOAD_BYTES = 65536
+MAX_GOSSIP_PAYLOAD_KEYS = 256
+MAX_GOSSIP_PAYLOAD_DEPTH = 16
+MAX_GOSSIP_PAYLOAD_STRING_LENGTH = 4096
 SYNC_INTERVAL = 30
 MESSAGE_EXPIRY = 300  # 5 minutes
 MAX_INV_BATCH = 1000
@@ -342,10 +346,7 @@ class GossipMessage:
         payload = data["payload"]
         if not isinstance(payload, dict):
             raise ValueError("invalid gossip message payload")
-        try:
-            json.dumps(payload, sort_keys=True)
-        except (TypeError, ValueError) as exc:
-            raise ValueError("invalid gossip message payload") from exc
+        cls._validate_payload(payload)
 
         return cls(
             msg_type=msg_type,
@@ -356,6 +357,42 @@ class GossipMessage:
             signature=signature,
             payload=payload,
         )
+
+    @staticmethod
+    def _validate_payload(payload: object, depth: int = 0) -> None:
+        if depth > MAX_GOSSIP_PAYLOAD_DEPTH:
+            raise ValueError("gossip payload exceeds maximum nesting depth")
+
+        try:
+            if len(json.dumps(payload, sort_keys=True)) > MAX_GOSSIP_PAYLOAD_BYTES:
+                raise ValueError("gossip payload exceeds maximum serialized size")
+        except (TypeError, ValueError) as exc:
+            if isinstance(exc, ValueError) and str(exc).startswith("gossip payload"):
+                raise
+            raise ValueError("invalid gossip message payload") from exc
+
+        if isinstance(payload, str):
+            if len(payload) > MAX_GOSSIP_PAYLOAD_STRING_LENGTH:
+                raise ValueError("gossip payload string exceeds maximum length")
+            return
+
+        if isinstance(payload, dict):
+            if len(payload) > MAX_GOSSIP_PAYLOAD_KEYS:
+                raise ValueError("gossip payload has too many keys")
+            for key, value in payload.items():
+                GossipMessage._validate_payload(key, depth + 1)
+                GossipMessage._validate_payload(value, depth + 1)
+            return
+
+        if isinstance(payload, list):
+            if len(payload) > MAX_GOSSIP_PAYLOAD_KEYS:
+                raise ValueError("gossip payload list has too many items")
+            for value in payload:
+                GossipMessage._validate_payload(value, depth + 1)
+            return
+
+        if payload is not None and not isinstance(payload, (bool, int, float)):
+            raise ValueError("invalid gossip message payload")
 
     def compute_hash(self) -> str:
         """Compute hash of message content for deduplication"""

--- a/tests/test_p2p_gossip_payload_limits.py
+++ b/tests/test_p2p_gossip_payload_limits.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import os
 import sys
 import time

--- a/tests/test_p2p_gossip_payload_limits.py
+++ b/tests/test_p2p_gossip_payload_limits.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "node"))
+
+import pytest
+
+from rustchain_p2p_gossip import GOSSIP_TTL, GossipMessage, MessageType
+
+
+def _message(payload):
+    return {
+        "msg_type": MessageType.PING.value,
+        "msg_id": "msg-oversized-payload-demo",
+        "sender_id": "node-a",
+        "timestamp": int(time.time()),
+        "ttl": GOSSIP_TTL,
+        "signature": "invalid",
+        "payload": payload,
+    }
+
+
+def test_gossip_from_dict_rejects_oversized_payload_before_signature_work():
+    payload = {f"k{i:05d}": "x" * 1024 for i in range(5000)}
+
+    with pytest.raises(ValueError, match="too many keys|serialized size"):
+        GossipMessage.from_dict(_message(payload))
+
+
+
+def test_gossip_from_dict_rejects_oversized_list_payload():
+    payload = {"items": ["x" * 4096 for _ in range(256)]}
+
+    with pytest.raises(ValueError, match="serialized size"):
+        GossipMessage.from_dict(_message(payload))
+
+def test_gossip_from_dict_accepts_small_payload():
+    msg = GossipMessage.from_dict(_message({"ping": "pong"}))
+
+    assert msg.payload == {"ping": "pong"}


### PR DESCRIPTION
Fixes #5710.\n\n## Summary\n- add explicit size/shape limits for gossip payloads in GossipMessage.from_dict()\n- reject oversized dict/list/string/nested payloads before signature verification work\n- add regression coverage for the oversized payload report\n\n## Test\n- RUSTCHAIN_DB=/tmp/rustchain-test.db RC_P2P_SECRET=0123456789abcdef0123456789abcdef pytest -q tests/test_p2p_gossip_payload_limits.py