### PR TITLE
fix(fuzz): make attestation runner console output encoding-safe

### DIFF
--- a/tests/fuzz_attestation_runner.py
+++ b/tests/fuzz_attestation_runner.py
@@ -41,6 +41,21 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+
+def _configure_console_output(streams=(sys.stdout, sys.stderr)) -> None:
+    """Avoid UnicodeEncodeError on legacy consoles while preserving UTF-8 output."""
+    for stream in streams:
+        reconfigure = getattr(stream, "reconfigure", None)
+        if not callable(reconfigure):
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (OSError, ValueError):
+            continue
+
+
+_configure_console_output()
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------

--- a/tests/test_fuzz_attestation_runner_console.py
+++ b/tests/test_fuzz_attestation_runner_console.py
@@ -1,0 +1,34 @@
+"""Regression tests for console-safe attestation fuzz runner output."""
+
+import importlib.util
+import io
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tests" / "fuzz_attestation_runner.py"
+
+
+def _load_runner_module():
+    spec = importlib.util.spec_from_file_location("fuzz_attestation_runner", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_console_output_replaces_unencodable_glyphs():
+    runner = _load_runner_module()
+    buffer = io.BytesIO()
+    stream = io.TextIOWrapper(buffer, encoding="gbk", errors="strict")
+
+    runner._configure_console_output((stream,))
+    stream.write("🔥 RustChain Attestation Fuzz Runner")
+    stream.flush()
+
+    assert buffer.getvalue().startswith(b"? RustChain")
+
+
+def test_console_output_ignores_streams_without_reconfigure():
+    runner = _load_runner_module()
+
+    runner._configure_console_output((object(),))


### PR DESCRIPTION
## Summary
- configure fuzz runner stdout/stderr with errors=replace when stream.reconfigure() is available
- keep UTF-8 terminals unchanged while preventing UnicodeEncodeError on legacy Windows/GBK consoles
- add a regression test that writes the banner glyph through a GBK stream without crashing

Fixes #5699.

## Bounty / wallet
- RTC wallet: RTC219810c1e939b0f1a8887a5528949da0e5c97b78

## Validation
- python3.12 -B -m py_compile tests/fuzz_attestation_runner.py tests/test_fuzz_attestation_runner_console.py
- python3.12 -B - <<'PY' ... direct GBK TextIOWrapper regression snippet ... PY
- git diff --check