### PR TITLE
docs: refresh miner setup guide

### DIFF
--- a/docs/sprint/miner-setup-guide.md
+++ b/docs/sprint/miner-setup-guide.md
@@ -4,9 +4,12 @@ Set up a RustChain miner on your hardware and start earning RTC through
 **Proof-of-Antiquity** attestation. Older hardware earns higher multipliers —
 a PowerPC G4 earns 2.5× while a modern x86_64 earns 1.0×.
 
-**Attestation nodes:**
-- Primary: `http://rustchain.org:8088`
-- Anchor:  `http://50.28.86.153:8088`
+**Default node:**
+- `https://rustchain.org`
+
+The public node is served over HTTPS. Current miner scripts default to
+`https://rustchain.org`; only override the node URL when you are intentionally
+testing another deployment.
 
 ---
 
@@ -20,6 +23,46 @@ a PowerPC G4 earns 2.5× while a modern x86_64 earns 1.0×.
 | Modern x86_64 (post-2015) | 1.0× |
 | ARM64 Linux (e.g. Pi 4) | 1.3× |
 | POWER8 (IBM) | 1.8× |
+
+---
+
+## Quick Preflight Before Mining
+
+If you are not ready to start the mining loop, run a dry-run first. This is the
+safest compatibility check because it prints hardware detection, fingerprint
+status, and node health without enrolling or mining.
+
+The current dry-run entrypoint is the Linux miner script:
+
+```bash
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/linux
+python3 -m venv .venv
+source .venv/bin/activate
+pip install requests
+python3 rustchain_linux_miner.py --dry-run --show-payload
+```
+
+Expected high-level output:
+
+```text
+[FINGERPRINT] Running 6 hardware fingerprint checks...
+OVERALL RESULT: ALL CHECKS PASSED
+[DRY-RUN] RustChain Linux Miner preflight
+[DRY-RUN] No mining or network state will be modified
+[DRY-RUN] Node URL: https://rustchain.org
+[DRY-RUN] CPU: Apple M3
+[DRY-RUN] Cores: 8
+[DRY-RUN] Memory(GB): 16
+[DRY-RUN] Fingerprint pass status: True
+[DRY-RUN] Health probe: HTTP 200
+[DRY-RUN] Node version: 2.2.1-rip200
+[DRY-RUN] Next real steps would be: attest -> enroll -> mine loop
+```
+
+The CPU, core count, memory, and fingerprint results vary by machine. A failing
+fingerprint check is still useful: include the full dry-run output when opening
+an issue or claiming a hardware-report bounty.
 
 ---
 
@@ -52,39 +95,32 @@ brew install python@3.11
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/macos
 
-# 2. Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
+# 2. Create a local virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
 
-# 3. Install dependencies
-pip install -r node/requirements.txt
-
-# 4. Configure your miner
-cp node/.env.example node/.env
-nano node/.env          # Set MINER_ID and NODE_URL
-```
-
-Edit `node/.env`:
-
-```ini
-MINER_ID=your_wallet_nameRTC
-NODE_URL=http://rustchain.org:8088
-ATTEST_INTERVAL=600
+# 3. Install the runtime dependency used by the miner
+pip install requests
 ```
 
 #### Run
 
 ```bash
-source venv/bin/activate
-python3 node/hardware_fingerprint.py --miner-id your_wallet_nameRTC \
-    --node http://rustchain.org:8088
+source .venv/bin/activate
+python3 rustchain_mac_miner_v2.5.py \
+    --miner-id your_wallet_nameRTC \
+    --node https://rustchain.org
 ```
 
 > **Apple Silicon:** The `arm64` fingerprint profile applies automatically.
 > Your multiplier is 1.2×. No extra steps needed.
+>
+> **Dry-run note:** In the current checkout, the macOS miner entrypoint accepts
+> `--miner-id`, `--wallet`, and `--node`, but not `--dry-run`. Use the Linux
+> dry-run preflight above when you only need a non-mining compatibility report.
 
 ---
 
@@ -112,19 +148,22 @@ python3 --version
 #### Install & Configure
 
 ```bash
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties
-python3 -m venv venv && source venv/bin/activate
-pip install -r node/requirements.txt
-cp node/.env.example node/.env
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/linux
+python3 -m venv .venv && source .venv/bin/activate
+pip install requests
 ```
 
-Edit `node/.env`, then run:
+Run a dry-run first:
 
 ```bash
-python3 node/hardware_fingerprint.py \
-    --miner-id your_wallet_nameRTC \
-    --node http://rustchain.org:8088
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC --dry-run --show-payload
+```
+
+Start the miner only after the dry-run output looks correct:
+
+```bash
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC
 ```
 
 #### Run as a systemd service
@@ -139,9 +178,8 @@ After=network.target
 Type=simple
 User=$USER
 WorkingDirectory=$PWD
-ExecStart=$PWD/venv/bin/python3 node/hardware_fingerprint.py \
-    --miner-id your_wallet_nameRTC \
-    --node http://rustchain.org:8088
+ExecStart=$PWD/.venv/bin/python3 rustchain_linux_miner.py \
+    --wallet your_wallet_nameRTC
 Restart=on-failure
 RestartSec=60
 
@@ -191,15 +229,12 @@ sudo apt update && sudo apt install -y python3 python3-pip python3-venv git
 The steps inside WSL are identical to Linux x86_64:
 
 ```bash
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties
-python3 -m venv venv && source venv/bin/activate
-pip install -r node/requirements.txt
-cp node/.env.example node/.env
-# Edit node/.env with your MINER_ID and NODE_URL
-python3 node/hardware_fingerprint.py \
-    --miner-id your_wallet_nameRTC \
-    --node http://rustchain.org:8088
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/linux
+python3 -m venv .venv && source .venv/bin/activate
+pip install requests
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC --dry-run --show-payload
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC
 ```
 
 > **Note:** WSL hardware fingerprints are classified as `modern_x86` (1.0×
@@ -228,20 +263,17 @@ Verify: `python3 --version` (must be ≥ 3.8)
 #### Install & Configure
 
 ```bash
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties
-python3 -m venv venv && source venv/bin/activate
-pip install -r node/requirements.txt
-cp node/.env.example node/.env
-# Set MINER_ID and NODE_URL
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/linux
+python3 -m venv .venv && source .venv/bin/activate
+pip install requests
 ```
 
 Run:
 
 ```bash
-python3 node/hardware_fingerprint.py \
-    --miner-id your_wallet_nameRTC \
-    --node http://rustchain.org:8088
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC --dry-run --show-payload
+python3 rustchain_linux_miner.py --wallet your_wallet_nameRTC
 ```
 
 At startup you should see:
@@ -275,30 +307,22 @@ python3.9 -m venv venv
 #### Install & Configure
 
 ```bash
-git clone https://github.com/Scottcjn/rustchain-bounties.git
-cd rustchain-bounties
-python3 -m venv venv && source venv/bin/activate
-pip install -r node/requirements.txt
-cp node/.env.example node/.env
-```
-
-Edit `node/.env`:
-
-```ini
-MINER_ID=mypiRTC
-NODE_URL=http://rustchain.org:8088
-ATTEST_INTERVAL=600
+git clone https://github.com/Scottcjn/Rustchain.git
+cd Rustchain/miners/linux
+python3 -m venv .venv && source .venv/bin/activate
+pip install requests
 ```
 
 Run:
 
 ```bash
-python3 node/hardware_fingerprint.py --miner-id mypiRTC \
-    --node http://rustchain.org:8088
+python3 rustchain_linux_miner.py --wallet mypiRTC --dry-run --show-payload
+python3 rustchain_linux_miner.py --wallet mypiRTC
 ```
 
-> **Pi Zero / Pi 2:** These have ARMv6/ARMv7 CPUs. Use `python3.9` or newer
-> and set `--arch armv7`. Multiplier is 1.3× for all Pi models.
+> **Pi Zero / Pi 2:** These have ARMv6/ARMv7 CPUs. Use `python3.9` or newer.
+> The current Linux miner derives the hardware profile from the local system
+> probes, so there is no manual `--arch` flag in the documented CLI.
 
 ---
 
@@ -306,25 +330,34 @@ python3 node/hardware_fingerprint.py --miner-id mypiRTC \
 
 When everything works correctly, you will see output like this:
 
-```
-[2026-03-28 21:00:00] RustChain Miner v2.2.1-rip200
-[2026-03-28 21:00:00] Miner ID    : eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC
-[2026-03-28 21:00:00] Node URL    : http://rustchain.org:8088
-[2026-03-28 21:00:00] Hardware    : PowerPC G4 (Vintage)
-[2026-03-28 21:00:00] Profile     : ppc_g4 (antiquity_multiplier=2.5x)
+```text
+======================================================================
+RustChain Local Linux Miner
+RIP-PoA Hardware Fingerprint + Serial Binding v2.0
+======================================================================
+Node: https://rustchain.org
+Wallet: your_wallet_nameRTC
 
-[2026-03-28 21:00:01] Running hardware checks...
-[2026-03-28 21:00:01]   clock_skew           ✓  (drift_ppm=24.3)
-[2026-03-28 21:00:02]   cache_timing         ✓  (l1=5ns l2=15ns)
-[2026-03-28 21:00:03]   simd_identity        ✓  (AltiVec pipeline_bias=0.76)
-[2026-03-28 21:00:04]   thermal_entropy      ✓  (idle=42.1°C load=71.3°C)
-[2026-03-28 21:00:05]   instruction_jitter   ✓  (mean=3200ns σ=890ns)
-[2026-03-28 21:00:06]   behavioral_heuristics✓  (cpuid clean, no hypervisor)
+[FINGERPRINT] Running 6 hardware fingerprint checks...
+[1/6] Clock-Skew & Oscillator Drift...
+  Result: PASS
+[2/6] Cache Timing Fingerprint...
+  Result: PASS
+[3/6] SIMD Unit Identity...
+  Result: PASS
+[4/6] Thermal Drift Entropy...
+  Result: PASS
+[5/6] Instruction Path Jitter...
+  Result: PASS
+[6/6] Anti-Emulation Checks...
+  Result: PASS
 
-[2026-03-28 21:00:06] Submitting attestation to node...
-[2026-03-28 21:00:07] ✅ ENROLLED  epoch=75  multiplier=2.5x
-[2026-03-28 21:00:07] Next settlement: 2026-03-28 22:24:00 UTC
-[2026-03-28 21:00:07] Sleeping until next attestation window (600s)...
+OVERALL RESULT: ALL CHECKS PASSED
+[FINGERPRINT] All checks PASSED - eligible for full rewards
+[DRY-RUN] RustChain Linux Miner preflight
+[DRY-RUN] No mining or network state will be modified
+[DRY-RUN] Health probe: HTTP 200
+[DRY-RUN] Node version: 2.2.1-rip200
 ```
 
 ---
@@ -352,10 +385,12 @@ ModuleNotFoundError: No module named 'nacl'
 
 **Fix:**
 
+The current Linux and macOS miner entrypoints only require `requests` for the
+basic miner path. If you are running an older attestation script that imports
+`nacl`, install PyNaCl in the same virtual environment:
+
 ```bash
 pip install PyNaCl
-# or re-run full install:
-pip install -r node/requirements.txt
 ```
 
 ---
@@ -371,11 +406,9 @@ ConnectionRefusedError: [Errno 111] Connection refused
 
 ```bash
 # Test connectivity
-curl http://rustchain.org:8088/health
-curl http://50.28.86.153:8088/health   # fallback node
+curl -fsS https://rustchain.org/health
 ```
-
-If primary is down, update `.env` to point to the anchor node.
+If you intentionally test a private node, pass it with `--node`.
 
 ---
 
@@ -416,11 +449,11 @@ pyenv global 3.11.8
 epoch). Monitor the `/epoch` endpoint and ensure you attest early in the epoch.
 
 ```bash
-curl http://rustchain.org:8088/epoch | python3 -m json.tool
+curl -fsS https://rustchain.org/epoch | python3 -m json.tool
 ```
 
 If `slot` > 140, wait for the next epoch before expecting rewards.
 
 ---
 
-*Guide covers RustChain v2.2.1-rip200 · Nodes: http://rustchain.org:8088, http://50.28.86.153:8088*
+*Guide covers RustChain v2.2.1-rip200 · Default node: https://rustchain.org*


### PR DESCRIPTION
## Summary
- Refresh `docs/sprint/miner-setup-guide.md` to use the current `Scottcjn/Rustchain` repository path instead of the old bounty repo path.
- Replace legacy `node/hardware_fingerprint.py` and `http://rustchain.org:8088` examples with current miner entrypoints and `https://rustchain.org`.
- Add a dry-run preflight section with verified `rustchain_linux_miner.py --dry-run --show-payload` output and clarify the current macOS dry-run limitation.

## Validation
- `git diff --check`
- `python3 -m py_compile miners/linux/rustchain_linux_miner.py miners/macos/rustchain_mac_miner_v2.5.py`
- `python3 miners/linux/rustchain_linux_miner.py --help` confirmed `--dry-run` and `--show-payload` are current Linux miner options
- Ran `python3 miners/linux/rustchain_linux_miner.py --dry-run --show-payload`; fingerprint checks passed and node health returned HTTP 200 / version `2.2.1-rip200`

Bounty context: documentation sprint #72, Miner Setup Guide category.
