### PR TITLE
fix: reject non-finite withdrawal amounts

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5127,7 +5127,9 @@ def request_withdrawal():
     try:
         amount = float(raw_amount)
     except (TypeError, ValueError):
-        return jsonify({"error": "amount must be a number", "received": str(type(raw_amount).__name__)}), 400
+        return jsonify({"error": "Amount must be a number", "received": str(type(raw_amount).__name__)}), 400
+    if not math.isfinite(amount):
+        return jsonify({"error": "Amount must be a finite positive number"}), 400
     if amount < 0:
         return jsonify({"error": "amount must be positive"}), 400
 

--- a/node/tests/test_withdraw_amount_validation.py
+++ b/node/tests/test_withdraw_amount_validation.py
@@ -7,6 +7,7 @@ import unittest
 
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+MODULE_NAME = "rustchain_integrated_withdraw_validation_shared"
 
 
 class TestWithdrawAmountValidation(unittest.TestCase):
@@ -21,9 +22,13 @@ class TestWithdrawAmountValidation(unittest.TestCase):
         if NODE_DIR not in sys.path:
             sys.path.insert(0, NODE_DIR)
 
-        spec = importlib.util.spec_from_file_location("rustchain_integrated_withdraw_test", MODULE_PATH)
-        cls.mod = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(cls.mod)
+        if MODULE_NAME in sys.modules:
+            cls.mod = sys.modules[MODULE_NAME]
+        else:
+            spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+            cls.mod = importlib.util.module_from_spec(spec)
+            sys.modules[MODULE_NAME] = cls.mod
+            spec.loader.exec_module(cls.mod)
         cls.client = cls.mod.app.test_client()
 
     @classmethod

--- a/node/tests/test_withdrawal_validation.py
+++ b/node/tests/test_withdrawal_validation.py
@@ -9,23 +9,50 @@ Covers the fix for:
 """
 
 import pytest
+import importlib.util
 import json
 import sys
 import os
+import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+MODULE_NAME = "rustchain_integrated_withdraw_validation_shared"
+
+sys.path.insert(0, NODE_DIR)
 
 
 class TestWithdrawalRequestValidation:
     """Tests for /withdraw/request endpoint input validation"""
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def app(self):
         """Create test app instance"""
-        import importlib
-        app = importlib.import_module("rustchain_v2_integrated_v2.2.1_rip200").app
-        app.config['TESTING'] = True
-        return app
+        tmp = tempfile.TemporaryDirectory()
+        prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(tmp.name, "withdrawal_validation.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+        try:
+            if MODULE_NAME in sys.modules:
+                module = sys.modules[MODULE_NAME]
+            else:
+                spec = importlib.util.spec_from_file_location(MODULE_NAME, MODULE_PATH)
+                module = importlib.util.module_from_spec(spec)
+                sys.modules[MODULE_NAME] = module
+                spec.loader.exec_module(module)
+            module.app.config['TESTING'] = True
+            yield module.app
+        finally:
+            if prev_db_path is None:
+                os.environ.pop("RUSTCHAIN_DB_PATH", None)
+            else:
+                os.environ["RUSTCHAIN_DB_PATH"] = prev_db_path
+            if prev_admin_key is None:
+                os.environ.pop("RC_ADMIN_KEY", None)
+            else:
+                os.environ["RC_ADMIN_KEY"] = prev_admin_key
+            tmp.cleanup()
 
     @pytest.fixture
     def client(self, app):
@@ -66,7 +93,7 @@ class TestWithdrawalRequestValidation:
         )
         assert response.status_code == 400
         data = response.get_json()
-        assert 'amount must be a number' in data.get('error', '')
+        assert 'amount must be a number' in data.get('error', '').lower()
 
     def test_amount_negative_returns_400(self, client):
         """amount=-100 should return 400 (negative amount bypass)"""


### PR DESCRIPTION
## Summary
- reject NaN and infinity withdrawal amounts before nonce/database work
- keep malformed JSON and invalid amount validation covered by Flask client tests
- make the withdrawal validation tests import the dotted integrated-node filename through importlib and share the module to avoid duplicate Prometheus metric registration

Fixes #4420

## Verification
- python3 -B -m pytest -q node/tests/test_withdraw_amount_validation.py node/tests/test_withdrawal_validation.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_withdraw_amount_validation.py node/tests/test_withdrawal_validation.py
- git diff --check