### PR TITLE
fix: upsert profile badges by username

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -27,6 +27,18 @@ def init_badge_db():
                 custom_message TEXT
             )
         ''')
+        cursor.execute('''
+            DELETE FROM profile_badges
+            WHERE id NOT IN (
+                SELECT MAX(id)
+                FROM profile_badges
+                GROUP BY github_username
+            )
+        ''')
+        cursor.execute('''
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_profile_badges_github_username
+            ON profile_badges(github_username)
+        ''')
         conn.commit()
 
 @app.route('/badge/generator')
@@ -189,9 +201,15 @@ def create_badge():
     with sqlite3.connect(DB_PATH) as conn:
         cursor = conn.cursor()
         cursor.execute('''
-            INSERT OR REPLACE INTO profile_badges 
+            INSERT INTO profile_badges
             (github_username, wallet_address, badge_type, custom_message, bounty_earned)
             VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(github_username) DO UPDATE SET
+                wallet_address = excluded.wallet_address,
+                badge_type = excluded.badge_type,
+                custom_message = excluded.custom_message,
+                bounty_earned = excluded.bounty_earned,
+                created_at = CURRENT_TIMESTAMP
         ''', (username, wallet or None, badge_type, custom_message or None, 3.0))
         conn.commit()
     

--- a/tests/test_profile_badge_generator.py
+++ b/tests/test_profile_badge_generator.py
@@ -51,3 +51,36 @@ def test_create_badge_accepts_valid_json_object(client):
     assert data["success"] is True
     assert "Bug%20Hunter" in data["shield_url"]
     assert _badge_count() == 1
+
+
+def test_create_badge_updates_existing_github_username(client):
+    first = client.post(
+        "/api/badge/create",
+        json={
+            "username": "dupuser",
+            "wallet": "RTCfirst",
+            "badge_type": "contributor",
+            "custom_message": "One",
+        },
+    )
+    second = client.post(
+        "/api/badge/create",
+        json={
+            "username": "dupuser",
+            "wallet": "RTCsecond",
+            "badge_type": "developer",
+            "custom_message": "Two",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    stats = client.get("/api/badge/stats").get_json()
+    listing = client.get("/api/badge/list").get_json()["badges"]
+
+    assert stats["total_badges"] == 1
+    assert stats["total_bounties_earned"] == 3.0
+    assert len(listing) == 1
+    assert listing[0]["username"] == "dupuser"
+    assert listing[0]["type"] == "developer"
+    assert listing[0]["custom_message"] == "Two"


### PR DESCRIPTION
## Summary
- add a unique index on `profile_badges.github_username` and dedupe existing duplicate rows before creating it
- replace the no-op `INSERT OR REPLACE` behavior with an explicit `ON CONFLICT(github_username) DO UPDATE` upsert
- add a regression test proving a repeated badge create for the same user updates the row and does not double-count bounty totals

Fixes #5727

## Verification
- python3 -B -m pytest -q tests/test_profile_badge_generator.py test_profile_badge_generator.py tests/test_profile_badge_generator_security.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile profile_badge_generator.py tests/test_profile_badge_generator.py test_profile_badge_generator.py tests/test_profile_badge_generator_security.py
- git diff --check