### PR TITLE
fix: deduplicate BCOS directory project loads

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -61,6 +61,18 @@ def init_db():
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
     ''')
+    c.execute('''
+        DELETE FROM projects
+        WHERE id NOT IN (
+            SELECT MAX(id)
+            FROM projects
+            GROUP BY github_repo
+        )
+    ''')
+    c.execute('''
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_github_repo
+        ON projects(github_repo)
+    ''')
     conn.commit()
     conn.close()
 

--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -64,9 +64,15 @@ def init_db():
     c.execute('''
         DELETE FROM projects
         WHERE id NOT IN (
-            SELECT MAX(id)
-            FROM projects
-            GROUP BY github_repo
+            SELECT keep.id
+            FROM projects AS keep
+            WHERE keep.id = (
+                SELECT candidate.id
+                FROM projects AS candidate
+                WHERE candidate.github_repo = keep.github_repo
+                ORDER BY datetime(candidate.created_at) DESC, candidate.id DESC
+                LIMIT 1
+            )
         )
     ''')
     c.execute('''

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -91,11 +91,11 @@ def test_bcos_directory_init_deduplicates_existing_projects_before_unique_index(
         ''')
         conn.executemany('''
             INSERT INTO projects
-            (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         ''', [
-            ('Old RustChain', 'https://old.example', 'Scottcjn/Rustchain', 'L1', 'old', None, None, 'chain'),
-            ('New RustChain', 'https://new.example', 'Scottcjn/Rustchain', 'L2', 'new', None, None, 'chain'),
+            ('New RustChain', 'https://new.example', 'Scottcjn/Rustchain', 'L2', 'new', None, None, 'chain', '2026-01-02 00:00:00'),
+            ('Old RustChain', 'https://old.example', 'Scottcjn/Rustchain', 'L1', 'old', None, None, 'chain', '2026-01-01 00:00:00'),
         ])
 
     bcos_directory.init_db()

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
+import json
 import re
+import sqlite3
 
 import bcos_directory
 
@@ -32,3 +34,75 @@ def test_bcos_directory_host_defaults_to_loopback(monkeypatch):
     monkeypatch.delenv('BCOS_DIRECTORY_HOST', raising=False)
 
     assert bcos_directory.server_host() == '127.0.0.1'
+
+
+def test_bcos_directory_project_load_is_idempotent(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'projects.json').write_text(json.dumps({
+        'projects': [{
+            'name': 'RustChain',
+            'url': 'https://example.test/rustchain',
+            'github_repo': 'Scottcjn/Rustchain',
+            'bcos_tier': 'L1',
+            'latest_sha': 'abc123',
+            'sbom_hash': 'hash-one',
+            'review_note': 'initial review',
+            'category': 'chain',
+        }]
+    }))
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    monkeypatch.chdir(tmp_path)
+
+    bcos_directory.init_db()
+    bcos_directory.load_projects_from_json()
+    bcos_directory.load_projects_from_json()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha FROM projects'
+        ).fetchall()
+        indexes = conn.execute(
+            "PRAGMA index_list('projects')"
+        ).fetchall()
+
+    assert rows == [('RustChain', 'Scottcjn/Rustchain', 'abc123')]
+    assert any(row[1] == 'idx_projects_github_repo' and row[2] for row in indexes)
+
+
+def test_bcos_directory_init_deduplicates_existing_projects_before_unique_index(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute('''
+            CREATE TABLE projects (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                url TEXT NOT NULL,
+                github_repo TEXT NOT NULL,
+                bcos_tier TEXT NOT NULL,
+                latest_sha TEXT,
+                sbom_hash TEXT,
+                review_note TEXT,
+                category TEXT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        ''')
+        conn.executemany('''
+            INSERT INTO projects
+            (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ''', [
+            ('Old RustChain', 'https://old.example', 'Scottcjn/Rustchain', 'L1', 'old', None, None, 'chain'),
+            ('New RustChain', 'https://new.example', 'Scottcjn/Rustchain', 'L2', 'new', None, None, 'chain'),
+        ])
+
+    bcos_directory.init_db()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha FROM projects'
+        ).fetchall()
+
+    assert rows == [('New RustChain', 'Scottcjn/Rustchain', 'new')]


### PR DESCRIPTION
## Summary

Fixes #5731.

`load_projects_from_json()` used `INSERT OR REPLACE`, but the `projects` table only had an autoincrement `id` primary key. Re-running the JSON loader for the same `github_repo` therefore appended duplicate BCOS directory rows instead of replacing/updating the existing project entry.

This PR:

- deduplicates existing `projects` rows by `github_repo` during `init_db()` before adding the constraint;
- adds a unique index on `projects(github_repo)` so future `INSERT OR REPLACE` calls have a real conflict target;
- adds regression coverage for repeated loads and pre-existing duplicate cleanup.

## Validation

```text
PYTHONPATH=/tmp/rustchain-flask-deps:. python3 -B -m pytest -q tests/test_bcos_directory_security.py --tb=short -p no:cacheprovider
# 6 passed

PYTHONPATH=/tmp/rustchain-flask-deps:. python3 -B -m py_compile bcos_directory.py tests/test_bcos_directory_security.py
# passed
```

Note: local environment needed Flask supplied via a temporary dependency target because the base runner here does not have Flask installed globally.
