### PR TITLE
fix: tolerate legacy console encodings in attestation fuzzer

### DIFF
--- a/tests/fuzz_attestation_runner.py
+++ b/tests/fuzz_attestation_runner.py
@@ -54,6 +54,19 @@ FUZZ_STATS_FILE = Path(__file__).parent / "fuzz_stats.json"
 TIMEOUT = 10
 DEFAULT_ITERATIONS = 1000
 
+
+def configure_stdio_encoding(stdout=None, stderr=None) -> None:
+    """Avoid UnicodeEncodeError on legacy consoles while preserving UTF-8 output."""
+    for stream in (stdout or sys.stdout, stderr or sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (TypeError, ValueError):
+            pass
+
+
 # Known test values for realistic payloads
 KNOWN_WALLETS = [
     "nox-ventures", "test-miner", "alice", "bob",
@@ -884,6 +897,7 @@ def show_stats() -> None:
 # ---------------------------------------------------------------------------
 
 def main():
+    configure_stdio_encoding()
     parser = argparse.ArgumentParser(
         description="RustChain Attestation Fuzz Runner",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/tests/test_fuzz_attestation_runner_console_encoding.py
+++ b/tests/test_fuzz_attestation_runner_console_encoding.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import io
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tests" / "fuzz_attestation_runner.py"
+
+
+def load_runner():
+    spec = importlib.util.spec_from_file_location("fuzz_attestation_runner_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_configure_stdio_encoding_replaces_unencodable_status_glyphs():
+    runner = load_runner()
+    stdout = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+    stderr = io.TextIOWrapper(io.BytesIO(), encoding="cp1252", errors="strict")
+
+    runner.configure_stdio_encoding(stdout=stdout, stderr=stderr)
+
+    print("🔥 RustChain Attestation Fuzz Runner", file=stdout)
+    print("✅ ready", file=stderr)
+    stdout.flush()
+    stderr.flush()
+    assert b"?" in stdout.buffer.getvalue()
+    assert b"?" in stderr.buffer.getvalue()


### PR DESCRIPTION
## Summary
- configure stdout/stderr with `errors="replace"` before the attestation fuzzer prints status glyphs
- keep UTF-8 terminals unchanged while preventing `UnicodeEncodeError` on legacy Windows/GBK-style consoles
- add a focused regression test using strict cp1252 streams and the existing emoji/status glyphs

Fixes #5699

## Verification
- python3 -B -m pytest -q tests/test_fuzz_attestation_runner_console_encoding.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile tests/fuzz_attestation_runner.py tests/test_fuzz_attestation_runner_console_encoding.py
- git diff --check