### PR TITLE
fix: preserve enrolled weights in anti-double-mining settlement

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -412,6 +412,38 @@ def get_epoch_miner_groups(
     return groups
 
 
+def _get_epoch_enrolled_weights(conn: sqlite3.Connection, epoch: int) -> Dict[str, float]:
+    """Return canonical per-epoch weights from epoch_enroll when available.
+
+    Older test/legacy schemas only have (epoch, miner_pk).  In that case this
+    returns an empty map and callers fall back to the historical arch-derived
+    multiplier path.
+    """
+    try:
+        cols = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
+    except sqlite3.Error:
+        return {}
+
+    if not any(col[1] == "weight" for col in cols):
+        return {}
+
+    try:
+        rows = conn.execute(
+            "SELECT miner_pk, weight FROM epoch_enroll WHERE epoch = ?",
+            (epoch,),
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+
+    weights: Dict[str, float] = {}
+    for miner_pk, weight in rows:
+        try:
+            weights[miner_pk] = max(float(weight or 0.0), 0.0)
+        except (TypeError, ValueError):
+            weights[miner_pk] = 0.0
+    return weights
+
+
 # =============================================================================
 # ANTI-DOUBLE-MINING REWARD CALCULATION
 # =============================================================================
@@ -488,6 +520,7 @@ def calculate_anti_double_mining_rewards(
         
         # Get device arch for each representative miner
         cursor = conn.cursor()
+        enrolled_weights = _get_epoch_enrolled_weights(conn, epoch)
         machine_data = []
         
         for identity_hash, miner_id in representative_map.items():
@@ -510,6 +543,12 @@ def calculate_anti_double_mining_rewards(
             if fingerprint_ok == 0:
                 weight = 0.0
                 logger.info(f"[REWARD] {miner_id[:20]}... fingerprint=FAIL -> weight=0")
+            elif miner_id in enrolled_weights:
+                # Preserve the canonical per-epoch weight snapshot used by the
+                # normal settlement path.  Recomputing from device_arch here can
+                # change the payout split for delayed settlements or RIP-309
+                # filtered weights.
+                weight = enrolled_weights[miner_id]
             else:
                 weight = get_time_aged_multiplier(device_arch, chain_age_years)
             
@@ -756,6 +795,7 @@ def _calculate_anti_double_mining_rewards_conn(
             representative_map[identity_hash] = miner_ids[0]
 
     cursor = conn.cursor()
+    enrolled_weights = _get_epoch_enrolled_weights(conn, epoch)
     machine_data = []
 
     for identity_hash, miner_id in representative_map.items():
@@ -776,6 +816,12 @@ def _calculate_anti_double_mining_rewards_conn(
     for miner_id, device_arch, fingerprint_ok, identity_hash in machine_data:
         if fingerprint_ok == 0:
             weight = 0.0
+        elif miner_id in enrolled_weights:
+            # Preserve the canonical per-epoch weight snapshot used by the
+            # normal settlement path.  Recomputing from device_arch here can
+            # change the payout split for delayed settlements or RIP-309
+            # filtered weights.
+            weight = enrolled_weights[miner_id]
         else:
             weight = get_time_aged_multiplier(device_arch, chain_age_years)
 

--- a/node/tests/test_anti_double_mining.py
+++ b/node/tests/test_anti_double_mining.py
@@ -30,6 +30,7 @@ from anti_double_mining import (
     select_representative_miner,
     get_epoch_miner_groups,
     calculate_anti_double_mining_rewards,
+    _calculate_anti_double_mining_rewards_conn,
     setup_test_scenario,
     GENESIS_TIMESTAMP
 )
@@ -379,6 +380,84 @@ class TestAntiDoubleMiningRewards(unittest.TestCase):
         # Machine B is unique, should be rewarded
         self.assertIn("miner-b1", rewards)
         self.assertGreater(rewards["miner-b1"], 0, "Unique machine should receive positive reward")
+
+
+class TestAntiDoubleMiningEnrolledWeights(unittest.TestCase):
+    """Reward weights must match the canonical epoch_enroll snapshot."""
+
+    def setUp(self):
+        self.test_db = _test_db_path("test_1449_enrolled_weights")
+        if os.path.exists(self.test_db):
+            os.remove(self.test_db)
+
+        self.conn = sqlite3.connect(self.test_db)
+        self.conn.executescript("""
+            CREATE TABLE epoch_enroll (
+                epoch INTEGER NOT NULL,
+                miner_pk TEXT NOT NULL,
+                weight REAL NOT NULL,
+                PRIMARY KEY(epoch, miner_pk)
+            );
+            CREATE TABLE miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                device_arch TEXT,
+                ts_ok INTEGER,
+                fingerprint_passed INTEGER DEFAULT 1,
+                entropy_score REAL DEFAULT 0.5,
+                warthog_bonus REAL DEFAULT 1.0
+            );
+            CREATE TABLE miner_fingerprint_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                miner TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                profile_json TEXT NOT NULL
+            );
+        """)
+
+        # Same device_arch but different enrolled weights.  The anti-double-mining
+        # path should preserve the canonical epoch_enroll split, not recompute a
+        # fresh equal arch-based split.
+        epoch_start_ts = GENESIS_TIMESTAMP + (7 * 144 * 600)
+        for miner, weight, serial in [
+            ("miner-heavy", 100.0, "ADM-WEIGHT-A"),
+            ("miner-light", 1.0, "ADM-WEIGHT-B"),
+        ]:
+            self.conn.execute(
+                "INSERT INTO epoch_enroll(epoch, miner_pk, weight) VALUES (7, ?, ?)",
+                (miner, weight),
+            )
+            self.conn.execute("""
+                INSERT INTO miner_attest_recent
+                    (miner, device_arch, ts_ok, fingerprint_passed, entropy_score, warthog_bonus)
+                VALUES (?, 'modern', ?, 1, 0.5, 1.0)
+            """, (miner, epoch_start_ts))
+            profile = json.dumps({
+                "checks": {"cpu_serial": {"data": {"serial": serial}}}
+            })
+            self.conn.execute(
+                "INSERT INTO miner_fingerprint_history(miner, ts, profile_json) VALUES (?, ?, ?)",
+                (miner, epoch_start_ts, profile),
+            )
+        self.conn.commit()
+
+    def tearDown(self):
+        self.conn.close()
+        if os.path.exists(self.test_db):
+            os.remove(self.test_db)
+
+    def test_path_opening_own_connection_uses_enrolled_weights(self):
+        rewards, _ = calculate_anti_double_mining_rewards(
+            self.test_db, epoch=7, total_reward_urtc=10_100, current_slot=7 * 144 + 1
+        )
+
+        self.assertEqual(rewards, {"miner-heavy": 10_000, "miner-light": 100})
+
+    def test_existing_connection_path_uses_enrolled_weights(self):
+        rewards, _ = _calculate_anti_double_mining_rewards_conn(
+            self.conn, epoch=7, total_reward_urtc=10_100, current_slot=7 * 144 + 1
+        )
+
+        self.assertEqual(rewards, {"miner-heavy": 10_000, "miner-light": 100})
 
 
 class TestIdempotency(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #5739.

The anti-double-mining reward path already prefers `epoch_enroll` as the canonical miner set, but it recomputed each representative miner's reward weight from `device_arch`. That can silently change the payout split versus the normal settlement path when `epoch_enroll.weight` contains per-epoch snapshot weights.

This PR:

- reads `epoch_enroll.weight` when the column exists;
- uses the representative miner's snapshot weight for both anti-double-mining reward paths;
- keeps the existing fallback to arch-derived weights for legacy schemas/tests without a `weight` column;
- adds regression coverage for both `calculate_anti_double_mining_rewards()` and `_calculate_anti_double_mining_rewards_conn()`.

## Repro fixed

Before this PR, two distinct machines with identical `device_arch` but weights `100.0` and `1.0` received an equal split:

```py
{'miner-heavy': 5050, 'miner-light': 5050}
```

After this PR, anti-double-mining settlement preserves the canonical enrolled split:

```py
{'miner-heavy': 10000, 'miner-light': 100}
```

## Validation

```bash
PYTHONPATH=node python3 -B -m pytest -q node/tests/test_anti_double_mining.py::TestAntiDoubleMiningEnrolledWeights --tb=short -p no:cacheprovider
# 2 passed

PYTHONPATH=node python3 -B -m pytest -q \
  node/tests/test_anti_double_mining.py \
  node/tests/test_anti_double_mining_epoch_enroll.py \
  node/tests/test_settlement_integrity.py \
  node/tests/test_rip200_warthog_bonus.py \
  --tb=short -p no:cacheprovider
# 32 passed

python3 -B -m py_compile node/anti_double_mining.py node/tests/test_anti_double_mining.py

git diff --check
```
