### PR TITLE
fix: use epoch enroll snapshot for claims participation

### DIFF
--- a/node/claims_eligibility.py
+++ b/node/claims_eligibility.py
@@ -188,8 +188,45 @@ def check_epoch_participation(
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
+
+            # Primary source: epoch_enroll is the canonical per-epoch snapshot.
+            # miner_attest_recent is a rolling/latest table and may no longer
+            # retain an in-window row by the time a delayed claim is checked.
+            try:
+                cursor.execute("""
+                    SELECT miner_pk
+                    FROM epoch_enroll
+                    WHERE epoch = ? AND miner_pk = ?
+                    LIMIT 1
+                """, (epoch, miner_id))
+                enrolled = cursor.fetchone()
+            except sqlite3.OperationalError:
+                enrolled = None
+
+            if enrolled:
+                cursor.execute("""
+                    SELECT
+                        device_arch,
+                        ts_ok,
+                        fingerprint_passed,
+                        entropy_score
+                    FROM miner_attest_recent
+                    WHERE miner = ?
+                    ORDER BY ts_ok DESC
+                    LIMIT 1
+                """, (miner_id,))
+                row = cursor.fetchone()
+
+                return True, {
+                    "epoch": epoch,
+                    "attestation_ts": row["ts_ok"] if row else None,
+                    "device_arch": row["device_arch"] if row else None,
+                    "fingerprint_passed": row["fingerprint_passed"] if row and "fingerprint_passed" in row.keys() else 1,
+                    "entropy_score": row["entropy_score"] if row and "entropy_score" in row.keys() else 0.0,
+                    "source": "epoch_enroll",
+                }
             
-            # Get any attestation during epoch window (with TTL consideration)
+            # Legacy fallback: get any attestation during epoch window (with TTL consideration)
             cursor.execute("""
                 SELECT 
                     miner,
@@ -218,7 +255,8 @@ def check_epoch_participation(
                 "attestation_ts": row["ts_ok"],
                 "device_arch": row["device_arch"],
                 "fingerprint_passed": row["fingerprint_passed"] if "fingerprint_passed" in row.keys() else 1,
-                "entropy_score": row["entropy_score"] if "entropy_score" in row.keys() else 0.0
+                "entropy_score": row["entropy_score"] if "entropy_score" in row.keys() else 0.0,
+                "source": "miner_attest_recent",
             }
     except sqlite3.Error as e:
         print(f"[CLAIMS] Database error checking epoch participation: {e}")

--- a/node/tests/test_claims_eligibility_helpers.py
+++ b/node/tests/test_claims_eligibility_helpers.py
@@ -7,6 +7,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from claims_eligibility import (
+    BLOCK_TIME,
+    GENESIS_TIMESTAMP,
+    check_epoch_participation,
     check_pending_claim,
     get_wallet_address,
     is_epoch_settled,
@@ -64,6 +67,43 @@ def test_check_pending_claim_only_counts_active_statuses(tmp_path):
 
     assert check_pending_claim(str(db), "miner1", 7) is False
     assert check_pending_claim(str(db), "miner1", 8) is True
+
+
+def test_check_epoch_participation_prefers_epoch_enroll_snapshot(tmp_path):
+    db = tmp_path / "node.db"
+    epoch = 7
+    miner = "miner-delayed-claim"
+    later_ts = GENESIS_TIMESTAMP + ((epoch + 3) * 144 * BLOCK_TIME)
+    with sqlite3.connect(db) as conn:
+        conn.execute(
+            "CREATE TABLE epoch_enroll (epoch INTEGER, miner_pk TEXT, weight REAL DEFAULT 1.0)"
+        )
+        conn.execute(
+            """
+            CREATE TABLE miner_attest_recent (
+                miner TEXT,
+                device_arch TEXT,
+                ts_ok INTEGER,
+                fingerprint_passed INTEGER DEFAULT 1,
+                entropy_score REAL
+            )
+            """
+        )
+        conn.execute("INSERT INTO epoch_enroll VALUES (?, ?, ?)", (epoch, miner, 1.0))
+        # miner_attest_recent only contains a later attestation.  The miner was
+        # still enrolled in the claimed epoch, so participation must not depend
+        # on the rolling recent-attestation table retaining an in-window row.
+        conn.execute(
+            "INSERT INTO miner_attest_recent VALUES (?, ?, ?, ?, ?)",
+            (miner, "modern", later_ts, 1, 0.5),
+        )
+
+    participated, epoch_data = check_epoch_participation(str(db), miner, epoch)
+
+    assert participated is True
+    assert epoch_data["epoch"] == epoch
+    assert epoch_data["source"] == "epoch_enroll"
+    assert epoch_data["device_arch"] == "modern"
 
 
 def test_is_epoch_settled_uses_database_state_when_present(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #5741.

`check_epoch_participation()` was still using `miner_attest_recent` as the proof of epoch participation. That table is a rolling/latest-attestation table, so delayed claims or later re-attestation can remove the in-window row even though `epoch_enroll` still proves the miner participated.

This PR:

- prefers `epoch_enroll` as the canonical per-epoch participation snapshot;
- returns participation true when `(epoch, miner_pk)` exists;
- enriches the response with latest `miner_attest_recent` metadata when available;
- preserves the old timestamp-window query as a fallback for legacy schemas without `epoch_enroll`;
- adds a regression test covering a delayed-claim case where only a later attestation remains in `miner_attest_recent`.

## Validation

```bash
PYTHONPATH=node python3 -B -m pytest -q \
  node/tests/test_claims_eligibility_helpers.py::test_check_epoch_participation_prefers_epoch_enroll_snapshot \
  --tb=short -p no:cacheprovider
# 1 passed

PYTHONPATH=/tmp/rustchain-flask-deps:node python3 -B -m pytest -q \
  node/tests/test_claims_eligibility_helpers.py \
  tests/test_claims_integration.py \
  --tb=short -p no:cacheprovider
# 20 passed

python3 -B -m py_compile node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py

git diff --check
```
