### PR TITLE
fix: bind claims to registered miner key

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -99,6 +99,53 @@ def validate_wallet_address_format(wallet_address: str) -> bool:
     return bool(re.match(pattern, wallet_address, re.IGNORECASE))
 
 
+def get_registered_claim_public_key(db_path: str, miner_id: str) -> Optional[str]:
+    """Return the stored claim/signing public key for a miner when present."""
+    candidate_tables = (
+        ("miner_wallets", "miner_id"),
+        ("miner_attest_recent", "miner"),
+    )
+    candidate_columns = ("public_key", "signing_public_key", "claim_public_key")
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            for table, miner_column in candidate_tables:
+                try:
+                    cursor.execute(f"PRAGMA table_info({table})")
+                    columns = {row[1] for row in cursor.fetchall()}
+                except sqlite3.Error:
+                    continue
+
+                if miner_column not in columns:
+                    continue
+
+                key_columns = [column for column in candidate_columns if column in columns]
+                if not key_columns:
+                    continue
+
+                order_column = "created_at" if "created_at" in columns else "ts_ok" if "ts_ok" in columns else None
+                for key_column in key_columns:
+                    query = f"""
+                        SELECT {key_column}
+                        FROM {table}
+                        WHERE {miner_column} = ?
+                        AND {key_column} IS NOT NULL
+                        AND {key_column} != ''
+                    """
+                    if order_column:
+                        query += f" ORDER BY {order_column} DESC"
+                    query += " LIMIT 1"
+                    cursor.execute(query, (miner_id,))
+                    row = cursor.fetchone()
+                    if row and row[0]:
+                        return str(row[0])
+    except sqlite3.Error as e:
+        print(f"[CLAIMS] Database error getting registered public key: {e}")
+
+    return None
+
+
 def create_claim_payload(
     miner_id: str,
     epoch: int,
@@ -491,6 +538,11 @@ def submit_claim(
     registered_wallet = eligibility.get("wallet_address")
     if not registered_wallet or wallet_address.lower() != registered_wallet.lower():
         result["error"] = "wallet_address_mismatch"
+        return result
+
+    registered_public_key = get_registered_claim_public_key(db_path, miner_id)
+    if registered_public_key and public_key.lower() != registered_public_key.lower():
+        result["error"] = "public_key_mismatch"
         return result
     
     # Verify signature (unless skipped for testing)

--- a/node/test_claims_security.py
+++ b/node/test_claims_security.py
@@ -4,7 +4,10 @@ Tests for CRIT-CLAIMS-1 (signature bypass) and MED-CLAIMS-2 (UNIT mismatch).
 """
 
 import os
+import sqlite3
 import sys
+import tempfile
+import time
 import unittest
 from unittest.mock import patch
 
@@ -42,6 +45,73 @@ class TestClaimsSignatureBypass(unittest.TestCase):
             public_key="1" * 64,  # fake key
         )
         self.assertFalse(valid, "Fake signature must be rejected")
+
+
+    def test_claim_submission_rejects_unregistered_signing_key(self):
+        """A valid signature from an attacker key must not claim another miner."""
+        import claims_submission as cs
+        from claims_eligibility import BLOCK_TIME, GENESIS_TIMESTAMP
+
+        if not cs.HAVE_NACL:
+            self.skipTest("PyNaCl not installed, skipping real submit test")
+
+        from nacl.signing import SigningKey
+
+        fd, db_path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            current_ts = int(time.time())
+            current_slot = (current_ts - GENESIS_TIMESTAMP) // BLOCK_TIME
+            epoch = max(0, current_slot // 144 - 3)
+            epoch_ts = GENESIS_TIMESTAMP + ((epoch * 144 + 72) * BLOCK_TIME)
+            miner_id = "victim-miner"
+            wallet = "RTC" + "A" * 24
+            victim_key = SigningKey.generate()
+            attacker_key = SigningKey.generate()
+            victim_public_key = victim_key.verify_key.encode().hex()
+
+            with sqlite3.connect(db_path) as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE miner_attest_recent (
+                        miner TEXT,
+                        device_arch TEXT,
+                        ts_ok INTEGER,
+                        fingerprint_passed INTEGER DEFAULT 1,
+                        entropy_score REAL,
+                        warthog_bonus REAL DEFAULT 1.0,
+                        wallet_address TEXT,
+                        public_key TEXT
+                    )
+                    """
+                )
+                conn.execute("CREATE TABLE epoch_state (epoch INTEGER, settled INTEGER)")
+                conn.executemany(
+                    "INSERT INTO miner_attest_recent VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    [
+                        (miner_id, "modern", current_ts - 3600, 1, 0.5, 1.0, wallet, victim_public_key),
+                        (miner_id, "modern", epoch_ts, 1, 0.5, 1.0, wallet, victim_public_key),
+                    ],
+                )
+                conn.execute("INSERT INTO epoch_state VALUES (?, 1)", (epoch,))
+
+            payload = cs.create_claim_payload(miner_id, epoch, wallet, current_ts)
+            attacker_signature = attacker_key.sign(payload.encode("utf-8")).signature.hex()
+            result = cs.submit_claim(
+                db_path=db_path,
+                miner_id=miner_id,
+                epoch=epoch,
+                wallet_address=wallet,
+                signature=attacker_signature,
+                public_key=attacker_key.verify_key.encode().hex(),
+                current_slot=current_slot,
+                current_ts=current_ts,
+            )
+
+            self.assertFalse(result["success"])
+            self.assertEqual(result["error"], "public_key_mismatch")
+        finally:
+            os.unlink(db_path)
 
 
 class TestClaimsUnitConsistency(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #5743.

`submit_claim()` verified the signature against the submitted public key, but did not check that the submitted key belonged to the miner being claimed. If a miner already has a registered/stored public key, an unrelated keypair could submit a syntactically valid claim for the same miner/epoch and occupy the pending claim slot.

This PR:

- adds `get_registered_claim_public_key()` to read a stored claim/signing key from `miner_wallets` or `miner_attest_recent` when present;
- rejects claim submissions with `public_key_mismatch` when the submitted public key differs from the registered miner key;
- leaves legacy/no-key schemas compatible by only enforcing the binding when a stored key exists;
- adds a regression test proving a valid attacker signature cannot claim another miner's epoch when the victim's key is registered.

## Validation

```bash
PYTHONPATH=node python3 -B -m pytest -q \
  node/test_claims_security.py::TestClaimsSignatureBypass::test_claim_submission_rejects_unregistered_signing_key \
  --tb=short -p no:cacheprovider
# 1 passed

PYTHONPATH=/tmp/rustchain-flask-deps:node python3 -B -m pytest -q \
  node/test_claims_security.py \
  tests/test_claims_integration.py \
  node/tests/test_claims_eligibility_helpers.py \
  --tb=short -p no:cacheprovider
# 24 passed

python3 -B -m py_compile node/claims_submission.py node/test_claims_security.py

git diff --check
```
