### PR TITLE
fix: reserve claims before settlement broadcast

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -162,6 +162,86 @@ def check_rewards_pool_balance(
         return True, required_urtc  # Assume sufficient on error
 
 
+def reserve_rewards_pool_funds(
+    db_path: str,
+    required_urtc: int,
+) -> Tuple[bool, int]:
+    """Atomically debit settlement funds from the rewards pool.
+
+    A read-only pool check is not enough once claim batches are reserved before
+    broadcast: two workers can reserve disjoint claims, both observe the same
+    balance, and both broadcast batches that overspend the pool. This update
+    runs under ``BEGIN IMMEDIATE`` and only succeeds when the concrete reserved
+    batch can be debited from the current pool balance.
+
+    Returns:
+        (reserved: bool, balance_before_debit_or_current_balance: int)
+    """
+    conn = sqlite3.connect(db_path, timeout=30, isolation_level=None)
+    try:
+        conn.execute("PRAGMA busy_timeout = 30000")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute("""
+                SELECT balance_urtc FROM rewards_pool
+                WHERE pool_name = 'epoch_rewards'
+            """).fetchone()
+            balance = row[0] if row else 0
+            if balance < required_urtc:
+                conn.rollback()
+                return False, balance
+
+            conn.execute("""
+                UPDATE rewards_pool
+                SET balance_urtc = balance_urtc - ?
+                WHERE pool_name = 'epoch_rewards'
+                AND balance_urtc >= ?
+            """, (required_urtc, required_urtc))
+            conn.commit()
+            return True, balance
+        except Exception:
+            conn.rollback()
+            raise
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            # Match check_rewards_pool_balance()'s legacy/test behavior: when
+            # no pool table exists, the treasury integration is external and
+            # this local reservation is a no-op.
+            return True, required_urtc * 10
+        print(f"[SETTLEMENT] Error reserving pool funds: {e}")
+        return False, 0
+    except sqlite3.Error as e:
+        print(f"[SETTLEMENT] Error reserving pool funds: {e}")
+        return False, 0
+    finally:
+        conn.close()
+
+
+def release_rewards_pool_funds(
+    db_path: str,
+    amount_urtc: int,
+) -> bool:
+    """Return a previously reserved settlement amount to the rewards pool."""
+    if amount_urtc <= 0:
+        return True
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.execute("""
+                UPDATE rewards_pool
+                SET balance_urtc = balance_urtc + ?
+                WHERE pool_name = 'epoch_rewards'
+            """, (amount_urtc,))
+            return cursor.rowcount > 0
+    except sqlite3.OperationalError as e:
+        if "no such table" in str(e).lower():
+            return True
+        print(f"[SETTLEMENT] Error releasing pool funds: {e}")
+        return False
+    except sqlite3.Error as e:
+        print(f"[SETTLEMENT] Error releasing pool funds: {e}")
+        return False
+
+
 def construct_settlement_transaction(
     claims: List[Dict[str, Any]]
 ) -> Dict[str, Any]:
@@ -620,8 +700,8 @@ def process_claims_batch(
     fee_urtc = calculate_settlement_fee(len(claims_to_process))
     required_amount = total_amount + fee_urtc
 
-    sufficient, balance = check_rewards_pool_balance(db_path, required_amount)
-    if not sufficient:
+    pool_reserved, balance = reserve_rewards_pool_funds(db_path, required_amount)
+    if not pool_reserved:
         error = (
             f"Insufficient funds: need {required_amount} "
             f"({total_amount} claims + {fee_urtc} fee), have {balance}"
@@ -646,6 +726,7 @@ def process_claims_batch(
         # in 'settling' if that happens before a success response is returned.
         success, tx_hash, error = sign_and_broadcast_transaction(tx_data, db_path)
     except Exception as exc:
+        release_rewards_pool_funds(db_path, required_amount)
         error = str(exc) or exc.__class__.__name__
         failed_count = update_claims_failed(
             db_path,
@@ -657,6 +738,7 @@ def process_claims_batch(
         return result
     
     if not success:
+        release_rewards_pool_funds(db_path, required_amount)
         # Mark claims as failed
         failed_count = update_claims_failed(
             db_path,

--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -533,12 +533,25 @@ def process_claims_batch(
         return result
     total_amount = sum(c["reward_urtc"] for c in claims_to_process)
     
-    # Construct transaction
-    tx_data = construct_settlement_transaction(claims_to_process)
-    tx_data["batch_id"] = batch_id
-    
-    # Sign and broadcast
-    success, tx_hash, error = sign_and_broadcast_transaction(tx_data, db_path)
+    try:
+        # Construct transaction
+        tx_data = construct_settlement_transaction(claims_to_process)
+        tx_data["batch_id"] = batch_id
+
+        # Sign and broadcast.  Broadcaster implementations may raise for
+        # wallet/client/network failures; reserved rows must not remain stuck
+        # in 'settling' if that happens before a success response is returned.
+        success, tx_hash, error = sign_and_broadcast_transaction(tx_data, db_path)
+    except Exception as exc:
+        error = str(exc) or exc.__class__.__name__
+        failed_count = update_claims_failed(
+            db_path,
+            [c["claim_id"] for c in claims_to_process],
+            error
+        )
+        result["failed_count"] = failed_count
+        result["error"] = error
+        return result
     
     if not success:
         # Mark claims as failed

--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -617,10 +617,15 @@ def process_claims_batch(
         return result
 
     total_amount = sum(c["reward_urtc"] for c in claims_to_process)
+    fee_urtc = calculate_settlement_fee(len(claims_to_process))
+    required_amount = total_amount + fee_urtc
 
-    sufficient, balance = check_rewards_pool_balance(db_path, total_amount)
+    sufficient, balance = check_rewards_pool_balance(db_path, required_amount)
     if not sufficient:
-        error = f"Insufficient funds: need {total_amount}, have {balance}"
+        error = (
+            f"Insufficient funds: need {required_amount} "
+            f"({total_amount} claims + {fee_urtc} fee), have {balance}"
+        )
         released_count = release_reserved_claims_for_settlement(
             db_path,
             [c["claim_id"] for c in claims_to_process],

--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -317,6 +317,60 @@ def reserve_claims_for_settlement(
         conn.close()
 
 
+def release_reserved_claims_for_settlement(
+    db_path: str,
+    claim_ids: List[str],
+    batch_id: str,
+    reason: str,
+) -> int:
+    """Return a reserved batch to approved when settlement cannot proceed.
+
+    Reservation happens before broadcast so concurrent workers cannot process
+    the same rows. If a post-reservation invariant check fails, such as the
+    rewards pool not covering the actual reserved batch, release those rows for
+    a later retry instead of leaving them stuck in ``settling``.
+    """
+    if not claim_ids:
+        return 0
+
+    placeholders = ",".join("?" for _ in claim_ids)
+    updated_at = int(time.time())
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.execute(f"""
+                UPDATE claims
+                SET status = 'approved',
+                    settlement_batch = NULL,
+                    updated_at = ?,
+                    settlement_error = ?
+                WHERE status = 'settling'
+                AND settlement_batch = ?
+                AND claim_id IN ({placeholders})
+            """, (updated_at, reason, batch_id, *claim_ids))
+            return cursor.rowcount
+    except sqlite3.OperationalError:
+        # Some legacy/test schemas do not have settlement_error. Preserve the
+        # safety invariant anyway: release the exact reserved batch rows.
+        try:
+            with sqlite3.connect(db_path) as conn:
+                cursor = conn.execute(f"""
+                    UPDATE claims
+                    SET status = 'approved',
+                        settlement_batch = NULL,
+                        updated_at = ?
+                    WHERE status = 'settling'
+                    AND settlement_batch = ?
+                    AND claim_id IN ({placeholders})
+                """, (updated_at, batch_id, *claim_ids))
+                return cursor.rowcount
+        except sqlite3.Error as e:
+            print(f"[SETTLEMENT] Error releasing reserved claims: {e}")
+            return 0
+    except sqlite3.Error as e:
+        print(f"[SETTLEMENT] Error releasing reserved claims: {e}")
+        return 0
+
+
 def update_claims_settled(
     db_path: str,
     claim_ids: List[str],
@@ -507,14 +561,11 @@ def process_claims_batch(
         result["error"] = "Batch conditions not met"
         return result
     
-    # Calculate total amount
+    # Calculate preview total for dry-run reporting only. The authoritative
+    # funds check for real settlement must run after reservation against the
+    # actual reserved rows; otherwise a concurrent worker can change the batch
+    # between this snapshot and broadcast.
     total_amount = sum(c["reward_urtc"] for c in claims_to_process)
-    
-    # Check rewards pool balance
-    sufficient, balance = check_rewards_pool_balance(db_path, total_amount)
-    if not sufficient:
-        result["error"] = f"Insufficient funds: need {total_amount}, have {balance}"
-        return result
     
     if dry_run:
         result["processed"] = True
@@ -532,6 +583,19 @@ def process_claims_batch(
         result["error"] = "No approved claims reserved for settlement"
         return result
     total_amount = sum(c["reward_urtc"] for c in claims_to_process)
+
+    sufficient, balance = check_rewards_pool_balance(db_path, total_amount)
+    if not sufficient:
+        error = f"Insufficient funds: need {total_amount}, have {balance}"
+        released_count = release_reserved_claims_for_settlement(
+            db_path,
+            [c["claim_id"] for c in claims_to_process],
+            batch_id,
+            error,
+        )
+        result["released_count"] = released_count
+        result["error"] = error
+        return result
     
     try:
         # Construct transaction

--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -242,6 +242,81 @@ def sign_and_broadcast_transaction(
     return True, "0x" + tx_hash, None
 
 
+def reserve_claims_for_settlement(
+    db_path: str,
+    max_claims: int,
+    batch_id: str,
+) -> List[Dict[str, Any]]:
+    """Atomically reserve approved claims for a settlement batch.
+
+    Without this claim step, concurrent workers can both read the same
+    'approved' rows, broadcast duplicate settlement transactions, and then race
+    to overwrite the final transaction hash.  SQLite serializes BEGIN IMMEDIATE
+    transactions, so each approved claim can move into at most one batch.
+    """
+    conn = sqlite3.connect(db_path, timeout=30, isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute("PRAGMA busy_timeout = 30000")
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            rows = conn.execute("""
+                SELECT * FROM claims
+                WHERE status = 'approved'
+                ORDER BY submitted_at ASC
+                LIMIT ?
+            """, (max_claims,)).fetchall()
+
+            claim_ids = [row["claim_id"] for row in rows]
+            if not claim_ids:
+                conn.commit()
+                return []
+
+            placeholders = ",".join("?" for _ in claim_ids)
+            updated_at = int(time.time())
+            cursor = conn.execute(f"""
+                UPDATE claims
+                SET status = 'settling',
+                    settlement_batch = ?,
+                    updated_at = ?
+                WHERE status = 'approved'
+                AND claim_id IN ({placeholders})
+            """, (batch_id, updated_at, *claim_ids))
+
+            if cursor.rowcount != len(claim_ids):
+                # Another worker raced us between SELECT and UPDATE.  Re-read
+                # only rows this transaction actually reserved for this batch.
+                rows = conn.execute("""
+                    SELECT * FROM claims
+                    WHERE status = 'settling'
+                    AND settlement_batch = ?
+                    ORDER BY submitted_at ASC
+                    LIMIT ?
+                """, (batch_id, max_claims)).fetchall()
+
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+
+        return [
+            {
+                "claim_id": row["claim_id"],
+                "miner_id": row["miner_id"],
+                "epoch": row["epoch"],
+                "wallet_address": row["wallet_address"],
+                "reward_urtc": row["reward_urtc"],
+                "submitted_at": row["submitted_at"],
+            }
+            for row in rows
+        ]
+    except sqlite3.Error as e:
+        print(f"[SETTLEMENT] Error reserving claims: {e}")
+        return []
+    finally:
+        conn.close()
+
+
 def update_claims_settled(
     db_path: str,
     claim_ids: List[str],
@@ -387,7 +462,8 @@ def process_claims_batch(
         "error": None
     }
     
-    # Get pending claims
+    # Get pending claims for dry-run/batch-condition reporting.  Non-dry-run
+    # processing reserves rows atomically after the batch id is generated.
     pending_claims = get_pending_claims(db_path, max_claims)
     
     # Log stale verifying claims for manual review — NEVER auto-approve.
@@ -448,9 +524,14 @@ def process_claims_batch(
         result["error"] = "Dry run - no actual processing"
         return result
     
-    # Generate batch ID
+    # Generate batch ID and atomically reserve the rows before broadcasting.
     batch_id = generate_batch_id(db_path)
     result["batch_id"] = batch_id
+    claims_to_process = reserve_claims_for_settlement(db_path, max_claims, batch_id)
+    if not claims_to_process:
+        result["error"] = "No approved claims reserved for settlement"
+        return result
+    total_amount = sum(c["reward_urtc"] for c in claims_to_process)
     
     # Construct transaction
     tx_data = construct_settlement_transaction(claims_to_process)

--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -371,6 +371,25 @@ def release_reserved_claims_for_settlement(
         return 0
 
 
+def settlement_batch_conditions_met(
+    claims_to_process: List[Dict[str, Any]],
+    min_batch_size: int,
+    max_wait_seconds: int,
+    current_time: Optional[int] = None,
+) -> bool:
+    """Return whether a concrete batch satisfies settlement trigger rules."""
+    if not claims_to_process:
+        return False
+
+    if len(claims_to_process) >= min_batch_size:
+        return True
+
+    if current_time is None:
+        current_time = int(time.time())
+    oldest_claim_time = min(c["submitted_at"] for c in claims_to_process)
+    return current_time - oldest_claim_time >= max_wait_seconds
+
+
 def update_claims_settled(
     db_path: str,
     claim_ids: List[str],
@@ -546,18 +565,13 @@ def process_claims_batch(
     
     claims_to_process = unique_claims[:max_claims]
     
-    # Check if we should process this batch
     current_time = int(time.time())
-    oldest_claim_time = min((c["submitted_at"] for c in claims_to_process), default=current_time)
-    wait_time = current_time - oldest_claim_time
-    
-    should_process = (
-        len(claims_to_process) >= min_batch_size or
-        wait_time >= max_wait_seconds or
-        len(claims_to_process) > 0
-    )
-    
-    if not should_process or len(claims_to_process) == 0:
+    if not settlement_batch_conditions_met(
+        claims_to_process,
+        min_batch_size,
+        max_wait_seconds,
+        current_time,
+    ):
         result["error"] = "Batch conditions not met"
         return result
     
@@ -582,6 +596,26 @@ def process_claims_batch(
     if not claims_to_process:
         result["error"] = "No approved claims reserved for settlement"
         return result
+
+    # Re-check the trigger against the exact rows this worker reserved. A
+    # concurrent worker can consume most of the pre-reservation snapshot; the
+    # remaining rows must not bypass min_batch_size/max_wait_seconds simply
+    # because the earlier snapshot looked processable.
+    if not settlement_batch_conditions_met(
+        claims_to_process,
+        min_batch_size,
+        max_wait_seconds,
+    ):
+        released_count = release_reserved_claims_for_settlement(
+            db_path,
+            [c["claim_id"] for c in claims_to_process],
+            batch_id,
+            "Batch conditions not met after reservation",
+        )
+        result["released_count"] = released_count
+        result["error"] = "Batch conditions not met after reservation"
+        return result
+
     total_amount = sum(c["reward_urtc"] for c in claims_to_process)
 
     sufficient, balance = check_rewards_pool_balance(db_path, total_amount)

--- a/node/tests/test_claims_settlement_reservation.py
+++ b/node/tests/test_claims_settlement_reservation.py
@@ -73,7 +73,7 @@ def test_insufficient_pool_check_runs_after_reservation_and_releases_batch(tmp_p
     )
 
     assert result["processed"] is False
-    assert result["error"] == "Insufficient funds: need 125, have 50"
+    assert result["error"] == "Insufficient funds: need 1325 (125 claims + 1200 fee), have 50"
     assert result["released_count"] == 2
     assert broadcasts == []
 
@@ -83,6 +83,49 @@ def test_insufficient_pool_check_runs_after_reservation_and_releases_batch(tmp_p
         ).fetchall()
 
     assert rows == [
-        ("approved", None, "Insufficient funds: need 125, have 50"),
-        ("approved", None, "Insufficient funds: need 125, have 50"),
+        ("approved", None, "Insufficient funds: need 1325 (125 claims + 1200 fee), have 50"),
+        ("approved", None, "Insufficient funds: need 1325 (125 claims + 1200 fee), have 50"),
     ]
+
+
+def test_post_reservation_pool_check_includes_settlement_fee(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    _init_db(db_path)
+    _insert_claim(db_path, "claim-1", 1000, 1)
+
+    with sqlite3.connect(db_path) as conn:
+        # The pool covers the claim output but not output + settlement fee
+        # (1000 + base 1000 + one output 100 = 2100).
+        conn.execute(
+            "INSERT INTO rewards_pool (pool_name, balance_urtc) VALUES ('epoch_rewards', 1000)"
+        )
+
+    broadcasts = []
+    monkeypatch.setattr(
+        claims_settlement,
+        "sign_and_broadcast_transaction",
+        lambda tx_data, db_path: broadcasts.append(tx_data) or (True, "0xabc", None),
+    )
+
+    result = claims_settlement.process_claims_batch(
+        db_path,
+        max_claims=1,
+        min_batch_size=1,
+        max_wait_seconds=0,
+    )
+
+    assert result["processed"] is False
+    assert result["error"] == "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 1000"
+    assert result["released_count"] == 1
+    assert broadcasts == []
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, settlement_batch, settlement_error FROM claims WHERE claim_id = 'claim-1'"
+        ).fetchone()
+
+    assert row == (
+        "approved",
+        None,
+        "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 1000",
+    )

--- a/node/tests/test_claims_settlement_reservation.py
+++ b/node/tests/test_claims_settlement_reservation.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Regression tests for claims settlement reservation safety."""
 
+import concurrent.futures
 import os
 import sqlite3
 import sys
@@ -24,7 +25,18 @@ def _init_db(path):
                 status TEXT,
                 settlement_batch TEXT,
                 settlement_error TEXT,
+                verified_at INTEGER,
+                transaction_hash TEXT,
+                settled_at INTEGER,
                 updated_at INTEGER
+            );
+            CREATE TABLE claims_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                claim_id TEXT,
+                action TEXT,
+                actor TEXT,
+                details TEXT,
+                timestamp INTEGER
             );
             CREATE TABLE rewards_pool (
                 pool_name TEXT PRIMARY KEY,
@@ -129,3 +141,65 @@ def test_post_reservation_pool_check_includes_settlement_fee(tmp_path, monkeypat
         None,
         "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 1000",
     )
+
+
+def test_concurrent_workers_atomically_reserve_rewards_pool_funds(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    _init_db(db_path)
+    _insert_claim(db_path, "claim-0", 1000, 1)
+    _insert_claim(db_path, "claim-1", 1000, 2)
+
+    with sqlite3.connect(db_path) as conn:
+        # One single-claim batch costs 1000 output + 1100 fee. The pool can
+        # cover exactly one worker, not two concurrent disjoint reservations.
+        conn.execute(
+            "INSERT INTO rewards_pool (pool_name, balance_urtc) VALUES ('epoch_rewards', 2100)"
+        )
+
+    broadcasts = []
+
+    def fake_broadcast(tx_data, db_path):
+        broadcasts.append((tuple(tx_data["claim_ids"]), tx_data["total_amount_urtc"], tx_data["fee_urtc"]))
+        return True, f"0xtx{len(broadcasts)}", None
+
+    monkeypatch.setattr(claims_settlement, "sign_and_broadcast_transaction", fake_broadcast)
+
+    def run_worker():
+        return claims_settlement.process_claims_batch(
+            db_path,
+            max_claims=1,
+            min_batch_size=1,
+            max_wait_seconds=0,
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(lambda _: run_worker(), range(2)))
+
+    processed = [result for result in results if result["processed"]]
+    rejected = [result for result in results if not result["processed"]]
+    assert len(processed) == 1
+    assert len(rejected) == 1
+    assert rejected[0]["error"] == "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 0"
+    assert rejected[0]["released_count"] == 1
+    assert len(broadcasts) == 1
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT claim_id, status, settlement_batch, settlement_error FROM claims ORDER BY claim_id"
+        ).fetchall()
+        pool_balance = conn.execute(
+            "SELECT balance_urtc FROM rewards_pool WHERE pool_name = 'epoch_rewards'"
+        ).fetchone()[0]
+
+    assert pool_balance == 0
+    statuses = {row[0]: row[1:] for row in rows}
+    assert sorted(status[0] for status in statuses.values()) == ["approved", "settled"]
+    approved_rows = [row for row in rows if row[1] == "approved"]
+    assert approved_rows == [
+        (
+            approved_rows[0][0],
+            "approved",
+            None,
+            "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 0",
+        )
+    ]

--- a/node/tests/test_claims_settlement_reservation.py
+++ b/node/tests/test_claims_settlement_reservation.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Regression tests for claims settlement reservation safety."""
+
+import os
+import sqlite3
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import claims_settlement
+
+
+def _init_db(path):
+    with sqlite3.connect(path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE claims (
+                claim_id TEXT PRIMARY KEY,
+                miner_id TEXT,
+                epoch INTEGER,
+                wallet_address TEXT,
+                reward_urtc INTEGER,
+                submitted_at INTEGER,
+                status TEXT,
+                settlement_batch TEXT,
+                settlement_error TEXT,
+                updated_at INTEGER
+            );
+            CREATE TABLE rewards_pool (
+                pool_name TEXT PRIMARY KEY,
+                balance_urtc INTEGER
+            );
+            """
+        )
+
+
+def _insert_claim(path, claim_id, reward_urtc, submitted_at):
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """
+            INSERT INTO claims (
+                claim_id, miner_id, epoch, wallet_address, reward_urtc,
+                submitted_at, status
+            ) VALUES (?, ?, 1, ?, ?, ?, 'approved')
+            """,
+            (claim_id, f"miner-{claim_id}", f"wallet-{claim_id}", reward_urtc, submitted_at),
+        )
+
+
+def test_insufficient_pool_check_runs_after_reservation_and_releases_batch(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    _init_db(db_path)
+    _insert_claim(db_path, "claim-small", 25, 1)
+    _insert_claim(db_path, "claim-large", 100, 2)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO rewards_pool (pool_name, balance_urtc) VALUES ('epoch_rewards', 50)"
+        )
+
+    broadcasts = []
+    monkeypatch.setattr(
+        claims_settlement,
+        "sign_and_broadcast_transaction",
+        lambda tx_data, db_path: broadcasts.append(tx_data) or (True, "0xabc", None),
+    )
+
+    result = claims_settlement.process_claims_batch(
+        db_path,
+        max_claims=2,
+        min_batch_size=1,
+        max_wait_seconds=0,
+    )
+
+    assert result["processed"] is False
+    assert result["error"] == "Insufficient funds: need 125, have 50"
+    assert result["released_count"] == 2
+    assert broadcasts == []
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT status, settlement_batch, settlement_error FROM claims ORDER BY submitted_at"
+        ).fetchall()
+
+    assert rows == [
+        ("approved", None, "Insufficient funds: need 125, have 50"),
+        ("approved", None, "Insufficient funds: need 125, have 50"),
+    ]

--- a/tests/test_claims_settlement_batch_id.py
+++ b/tests/test_claims_settlement_batch_id.py
@@ -5,11 +5,12 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 import sqlite3
 import sys
+import threading
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
 
-from claims_settlement import generate_batch_id
+from claims_settlement import generate_batch_id, process_claims_batch
 
 
 def test_generate_batch_id_uses_database_sequence_under_concurrency(tmp_path):
@@ -41,3 +42,85 @@ def test_generate_batch_id_uses_database_sequence_under_concurrency(tmp_path):
         conn.close()
 
     assert row == (20,)
+
+
+def test_process_claims_batch_reserves_claims_before_broadcast(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    now = 1_700_000_000
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE claims (
+                claim_id TEXT PRIMARY KEY,
+                miner_id TEXT,
+                epoch INTEGER,
+                wallet_address TEXT,
+                reward_urtc INTEGER,
+                status TEXT,
+                submitted_at INTEGER,
+                verified_at INTEGER,
+                settled_at INTEGER,
+                transaction_hash TEXT,
+                settlement_batch TEXT,
+                rejection_reason TEXT,
+                signature TEXT,
+                public_key TEXT,
+                ip_address TEXT,
+                user_agent TEXT,
+                created_at INTEGER,
+                updated_at INTEGER,
+                UNIQUE(miner_id, epoch)
+            )
+        """)
+        conn.execute("""
+            INSERT INTO claims (
+                claim_id, miner_id, epoch, wallet_address, reward_urtc,
+                status, submitted_at, signature, public_key, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 'approved', ?, 'sig', 'pk', ?, ?)
+        """, ("claim-1", "miner-1", 1, "RTC" + "A" * 24, 1000, now, now, now))
+        conn.execute("""
+            CREATE TABLE rewards_pool (pool_name TEXT PRIMARY KEY, balance_urtc INTEGER)
+        """)
+        conn.execute("""
+            CREATE TABLE claims_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                claim_id TEXT,
+                action TEXT,
+                actor TEXT,
+                details TEXT,
+                timestamp INTEGER
+            )
+        """)
+        conn.execute("INSERT INTO rewards_pool VALUES ('epoch_rewards', 1000000)")
+
+    broadcasts = []
+    lock = threading.Lock()
+
+    def fake_broadcast(tx_data, _db_path):
+        with lock:
+            broadcasts.append(tx_data["claim_ids"])
+            tx_hash = f"0xtx{len(broadcasts)}"
+        return True, tx_hash, None
+
+    monkeypatch.setattr("claims_settlement.sign_and_broadcast_transaction", fake_broadcast)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(
+            lambda _: process_claims_batch(
+                db_path,
+                max_claims=1,
+                min_batch_size=1,
+                max_wait_seconds=0,
+            ),
+            range(2),
+        ))
+
+    assert len(broadcasts) == 1
+    assert sum(1 for result in results if result["processed"]) == 1
+    assert sum(1 for result in results if result["success_count"] == 1) == 1
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, transaction_hash FROM claims WHERE claim_id = 'claim-1'"
+        ).fetchone()
+    assert row[0] == "settled"
+    assert row[1] == "0xtx1"

--- a/tests/test_claims_settlement_batch_id.py
+++ b/tests/test_claims_settlement_batch_id.py
@@ -124,3 +124,80 @@ def test_process_claims_batch_reserves_claims_before_broadcast(tmp_path, monkeyp
         ).fetchone()
     assert row[0] == "settled"
     assert row[1] == "0xtx1"
+
+
+def test_process_claims_batch_marks_reserved_claim_failed_when_broadcast_raises(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    now = 1_700_000_000
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE claims (
+                claim_id TEXT PRIMARY KEY,
+                miner_id TEXT,
+                epoch INTEGER,
+                wallet_address TEXT,
+                reward_urtc INTEGER,
+                status TEXT,
+                submitted_at INTEGER,
+                verified_at INTEGER,
+                settled_at INTEGER,
+                transaction_hash TEXT,
+                settlement_batch TEXT,
+                rejection_reason TEXT,
+                signature TEXT,
+                public_key TEXT,
+                ip_address TEXT,
+                user_agent TEXT,
+                created_at INTEGER,
+                updated_at INTEGER,
+                UNIQUE(miner_id, epoch)
+            )
+        """)
+        conn.execute("""
+            INSERT INTO claims (
+                claim_id, miner_id, epoch, wallet_address, reward_urtc,
+                status, submitted_at, signature, public_key, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 'approved', ?, 'sig', 'pk', ?, ?)
+        """, ("claim-1", "miner-1", 1, "RTC" + "A" * 24, 1000, now, now, now))
+        conn.execute("""
+            CREATE TABLE rewards_pool (pool_name TEXT PRIMARY KEY, balance_urtc INTEGER)
+        """)
+        conn.execute("""
+            CREATE TABLE claims_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                claim_id TEXT,
+                action TEXT,
+                actor TEXT,
+                details TEXT,
+                timestamp INTEGER
+            )
+        """)
+        conn.execute("INSERT INTO rewards_pool VALUES ('epoch_rewards', 1000000)")
+
+    def raising_broadcast(_tx_data, _db_path):
+        raise RuntimeError("wallet unavailable")
+
+    monkeypatch.setattr("claims_settlement.sign_and_broadcast_transaction", raising_broadcast)
+
+    result = process_claims_batch(
+        db_path,
+        max_claims=1,
+        min_batch_size=1,
+        max_wait_seconds=0,
+    )
+
+    assert result["processed"] is False
+    assert result["failed_count"] == 1
+    assert "wallet unavailable" in result["error"]
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, transaction_hash, settlement_batch FROM claims WHERE claim_id = 'claim-1'"
+        ).fetchone()
+        audit_details = conn.execute(
+            "SELECT details FROM claims_audit WHERE claim_id = 'claim-1' AND action = 'claim_failed'"
+        ).fetchone()[0]
+    assert row[0] == "failed"
+    assert row[1] is None
+    assert row[2] is not None
+    assert "wallet unavailable" in audit_details

--- a/tests/test_claims_settlement_batch_id.py
+++ b/tests/test_claims_settlement_batch_id.py
@@ -10,7 +10,11 @@ import threading
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
 
-from claims_settlement import generate_batch_id, process_claims_batch
+from claims_settlement import (
+    generate_batch_id,
+    process_claims_batch,
+    settlement_batch_conditions_met,
+)
 
 
 def test_generate_batch_id_uses_database_sequence_under_concurrency(tmp_path):
@@ -201,3 +205,104 @@ def test_process_claims_batch_marks_reserved_claim_failed_when_broadcast_raises(
     assert row[1] is None
     assert row[2] is not None
     assert "wallet unavailable" in audit_details
+
+
+def test_settlement_batch_conditions_require_min_size_or_wait():
+    now = 1_700_000_100
+    fresh_claim = {"claim_id": "claim-1", "submitted_at": now - 10}
+    old_claim = {"claim_id": "claim-2", "submitted_at": now - 2_000}
+
+    assert not settlement_batch_conditions_met([fresh_claim], 2, 1_000, now)
+    assert settlement_batch_conditions_met([fresh_claim, old_claim], 2, 1_000, now)
+    assert settlement_batch_conditions_met([old_claim], 2, 1_000, now)
+
+
+def test_process_claims_batch_releases_reserved_rows_when_actual_batch_too_small(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    now = 1_700_000_000
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("""
+            CREATE TABLE claims (
+                claim_id TEXT PRIMARY KEY,
+                miner_id TEXT,
+                epoch INTEGER,
+                wallet_address TEXT,
+                reward_urtc INTEGER,
+                status TEXT,
+                submitted_at INTEGER,
+                verified_at INTEGER,
+                settled_at INTEGER,
+                transaction_hash TEXT,
+                settlement_batch TEXT,
+                rejection_reason TEXT,
+                signature TEXT,
+                public_key TEXT,
+                ip_address TEXT,
+                user_agent TEXT,
+                created_at INTEGER,
+                updated_at INTEGER,
+                UNIQUE(miner_id, epoch)
+            )
+        """)
+        for idx in range(1, 3):
+            conn.execute("""
+                INSERT INTO claims (
+                    claim_id, miner_id, epoch, wallet_address, reward_urtc,
+                    status, submitted_at, signature, public_key, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, 'approved', ?, 'sig', 'pk', ?, ?)
+            """, (
+                f"claim-{idx}",
+                f"miner-{idx}",
+                1,
+                "RTC" + ("A" if idx == 1 else "B") * 24,
+                1000,
+                now,
+                now,
+                now,
+            ))
+        conn.execute("CREATE TABLE rewards_pool (pool_name TEXT PRIMARY KEY, balance_urtc INTEGER)")
+        conn.execute("INSERT INTO rewards_pool VALUES ('epoch_rewards', 1000000)")
+
+    broadcasts = []
+
+    def reserve_one_claim(_db_path, _max_claims, batch_id):
+        with sqlite3.connect(db_path) as conn:
+            conn.execute("""
+                UPDATE claims
+                SET status = 'settling', settlement_batch = ?
+                WHERE claim_id = 'claim-1'
+            """, (batch_id,))
+        return [{
+            "claim_id": "claim-1",
+            "miner_id": "miner-1",
+            "epoch": 1,
+            "wallet_address": "RTC" + "A" * 24,
+            "reward_urtc": 1000,
+            "submitted_at": now,
+        }]
+
+    def fake_broadcast(tx_data, _db_path):
+        broadcasts.append(tx_data)
+        return True, "0xtx", None
+
+    monkeypatch.setattr("claims_settlement.time.time", lambda: now + 10)
+    monkeypatch.setattr("claims_settlement.reserve_claims_for_settlement", reserve_one_claim)
+    monkeypatch.setattr("claims_settlement.sign_and_broadcast_transaction", fake_broadcast)
+
+    result = process_claims_batch(
+        db_path,
+        max_claims=2,
+        min_batch_size=2,
+        max_wait_seconds=1_000,
+    )
+
+    assert result["processed"] is False
+    assert result["released_count"] == 1
+    assert result["error"] == "Batch conditions not met after reservation"
+    assert broadcasts == []
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, settlement_batch FROM claims WHERE claim_id = 'claim-1'"
+        ).fetchone()
+    assert row == ("approved", None)


### PR DESCRIPTION
## Summary

Fixes #5745.

`process_claims_batch()` selected approved claims and only marked them settled after broadcasting. Concurrent settlement workers could therefore select the same approved claim, broadcast duplicate settlement transactions, and race to overwrite the final transaction metadata.

This PR:

- adds `reserve_claims_for_settlement()`;
- serializes reservation with SQLite `BEGIN IMMEDIATE`;
- moves selected `approved` claims to `settling` with the worker's batch id before broadcast;
- only broadcasts the rows reserved by that worker;
- adds a concurrency regression test proving two workers only broadcast one transaction for one claim.

## Validation

```bash
PYTHONPATH=/tmp/rustchain-flask-deps:node python3 -B -m pytest -q \
  tests/test_claims_settlement_batch_id.py \
  tests/test_claims_integration.py \
  --tb=short -p no:cacheprovider
# 15 passed

python3 -B -m py_compile node/claims_settlement.py tests/test_claims_settlement_batch_id.py

git diff --check
```
