### PR TITLE
fix: enforce unique ROM cluster snapshots

### DIFF
--- a/node/rom_clustering_server.py
+++ b/node/rom_clustering_server.py
@@ -67,11 +67,70 @@ def init_rom_tables(db_path: str):
     """Initialize ROM clustering tables in the database."""
     conn = sqlite3.connect(db_path)
     conn.executescript(ROM_CLUSTERING_SCHEMA)
+    _ensure_rom_cluster_unique_index(conn)
     conn.commit()
     conn.close()
 
 
+def _ensure_rom_cluster_unique_index(conn: sqlite3.Connection):
+    """Deduplicate legacy cluster rows, then enforce one row per ROM hash/type."""
+    cur = conn.cursor()
+    cur.execute("""
+        SELECT rom_hash, hash_type, COUNT(*)
+        FROM rom_clusters
+        GROUP BY rom_hash, hash_type
+        HAVING COUNT(*) > 1
+    """)
+    duplicate_keys = [(row[0], row[1]) for row in cur.fetchall()]
+
+    for rom_hash, hash_type in duplicate_keys:
+        cur.execute("""
+            SELECT cluster_id, miners, cluster_size, is_known_emulator_rom,
+                   known_rom_info, first_detected, last_updated
+            FROM rom_clusters
+            WHERE rom_hash = ? AND hash_type = ?
+            ORDER BY last_updated DESC, cluster_size DESC, cluster_id DESC
+        """, (rom_hash, hash_type))
+        rows = cur.fetchall()
+        keep = rows[0]
+        keep_id = keep[0]
+        duplicate_ids = [row[0] for row in rows if row[0] != keep_id]
+        first_detected = min(row[5] for row in rows)
+        last_updated = max(row[6] for row in rows)
+        max_cluster = max(rows, key=lambda row: (row[2], row[6]))
+
+        cur.execute("""
+            UPDATE rom_clusters
+            SET miners = ?,
+                cluster_size = ?,
+                is_known_emulator_rom = ?,
+                known_rom_info = ?,
+                first_detected = ?,
+                last_updated = ?
+            WHERE cluster_id = ?
+        """, (
+            max_cluster[1], max_cluster[2], max_cluster[3], max_cluster[4],
+            first_detected, last_updated, keep_id,
+        ))
+        if duplicate_ids:
+            placeholders = ",".join("?" for _ in duplicate_ids)
+            cur.execute(f"""
+                UPDATE miner_rom_flags
+                SET cluster_id = ?
+                WHERE cluster_id IN ({placeholders})
+            """, (keep_id, *duplicate_ids))
+        cur.execute("""
+            DELETE FROM rom_clusters
+            WHERE rom_hash = ? AND hash_type = ? AND cluster_id != ?
+        """, (rom_hash, hash_type, keep_id))
+
+    cur.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_rom_clusters_hash_type
+        ON rom_clusters(rom_hash, hash_type)
+    """)
+
 class ROMClusteringServer:
+
     """
     Server-side ROM clustering detection.
 
@@ -156,7 +215,7 @@ class ROMClusteringServer:
                 INSERT INTO rom_clusters
                 (rom_hash, hash_type, miners, cluster_size, first_detected, last_updated)
                 VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT DO UPDATE SET
+                ON CONFLICT(rom_hash, hash_type) DO UPDATE SET
                     miners = excluded.miners,
                     cluster_size = excluded.cluster_size,
                     last_updated = excluded.last_updated
@@ -166,7 +225,11 @@ class ROMClusteringServer:
                 now, now
             ))
 
-            cluster_id = cur.lastrowid
+            cur.execute("""
+                SELECT cluster_id FROM rom_clusters
+                WHERE rom_hash = ? AND hash_type = ?
+            """, (rom_hash_lower, hash_type))
+            cluster_id = cur.fetchone()[0]
 
             # Flag all miners in the cluster
             for m in all_miners:

--- a/node/rom_clustering_server.py
+++ b/node/rom_clustering_server.py
@@ -8,6 +8,7 @@ When multiple "different" miners report identical ROM hashes,
 they're likely VMs using the same ROM pack - flag them.
 """
 
+import json
 import sqlite3
 import time
 from typing import Dict, List, Optional, Tuple
@@ -97,7 +98,21 @@ def _ensure_rom_cluster_unique_index(conn: sqlite3.Connection):
         duplicate_ids = [row[0] for row in rows if row[0] != keep_id]
         first_detected = min(row[5] for row in rows)
         last_updated = max(row[6] for row in rows)
-        max_cluster = max(rows, key=lambda row: (row[2], row[6]))
+        merged_miners = []
+        seen_miners = set()
+        for row in rows:
+            try:
+                miners = json.loads(row[1])
+            except (TypeError, json.JSONDecodeError):
+                miners = []
+            if not isinstance(miners, list):
+                miners = []
+            for miner in miners:
+                if isinstance(miner, str) and miner not in seen_miners:
+                    merged_miners.append(miner)
+                    seen_miners.add(miner)
+        known_row = next((row for row in rows if row[4]), keep)
+        is_known_emulator_rom = max(row[3] or 0 for row in rows)
 
         cur.execute("""
             UPDATE rom_clusters
@@ -109,7 +124,8 @@ def _ensure_rom_cluster_unique_index(conn: sqlite3.Connection):
                 last_updated = ?
             WHERE cluster_id = ?
         """, (
-            max_cluster[1], max_cluster[2], max_cluster[3], max_cluster[4],
+            json.dumps(merged_miners), len(merged_miners),
+            is_known_emulator_rom, known_row[4],
             first_detected, last_updated, keep_id,
         ))
         if duplicate_ids:

--- a/node/tests/test_rom_clustering_server.py
+++ b/node/tests/test_rom_clustering_server.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import json
 import sqlite3
 import sys
 from pathlib import Path
@@ -79,7 +80,7 @@ def test_init_rom_tables_deduplicates_legacy_cluster_rows_before_unique_index(tm
 
     with sqlite3.connect(db_path) as conn:
         rows = conn.execute(
-            "SELECT cluster_id, cluster_size, first_detected, last_updated FROM rom_clusters WHERE rom_hash = ?",
+            "SELECT cluster_id, cluster_size, miners, first_detected, last_updated FROM rom_clusters WHERE rom_hash = ?",
             (rom_hash,),
         ).fetchall()
         index_rows = conn.execute("PRAGMA index_list(rom_clusters)").fetchall()
@@ -88,6 +89,72 @@ def test_init_rom_tables_deduplicates_legacy_cluster_rows_before_unique_index(tm
         ).fetchone()[0]
 
     assert len(rows) == 1
-    assert rows[0][1:] == (3, 10, 30)
+    assert rows[0][1] == 3
+    assert json.loads(rows[0][2]) == ["miner-1", "miner-2", "miner-3"]
+    assert rows[0][3:] == (10, 30)
     assert flag_cluster_id == rows[0][0]
     assert any(row[2] for row in index_rows if row[1] == "idx_rom_clusters_hash_type")
+
+
+def test_init_rom_tables_merges_partial_legacy_duplicate_cluster_miners(tmp_path):
+    db_path = str(tmp_path / "partial-legacy-roms.db")
+    rom_hash = "ef" * 20
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE miner_rom_reports (
+                miner_id TEXT NOT NULL,
+                rom_hash TEXT NOT NULL,
+                hash_type TEXT NOT NULL,
+                platform TEXT,
+                first_seen INTEGER NOT NULL,
+                last_seen INTEGER NOT NULL,
+                report_count INTEGER DEFAULT 1,
+                PRIMARY KEY (miner_id, rom_hash)
+            );
+            CREATE TABLE rom_clusters (
+                cluster_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                rom_hash TEXT NOT NULL,
+                hash_type TEXT NOT NULL,
+                miners TEXT NOT NULL,
+                cluster_size INTEGER NOT NULL,
+                is_known_emulator_rom INTEGER DEFAULT 0,
+                known_rom_info TEXT,
+                first_detected INTEGER NOT NULL,
+                last_updated INTEGER NOT NULL
+            );
+            CREATE TABLE miner_rom_flags (
+                miner_id TEXT PRIMARY KEY,
+                flag_reason TEXT NOT NULL,
+                cluster_id INTEGER,
+                flagged_at INTEGER NOT NULL,
+                resolved INTEGER DEFAULT 0,
+                resolved_at INTEGER
+            );
+        """)
+        conn.execute(
+            "INSERT INTO rom_clusters VALUES (1, ?, 'sha1', '[\"miner-a\", \"miner-b\"]', 2, 0, NULL, 10, 30)",
+            (rom_hash,),
+        )
+        conn.execute(
+            "INSERT INTO rom_clusters VALUES (2, ?, 'sha1', '[\"miner-b\", \"miner-c\"]', 2, 0, NULL, 11, 20)",
+            (rom_hash,),
+        )
+        conn.execute(
+            "INSERT INTO miner_rom_flags VALUES ('miner-c', 'rom_cluster:2_miners', 2, 20, 0, NULL)"
+        )
+
+    init_rom_tables(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT cluster_id, cluster_size, miners, first_detected, last_updated FROM rom_clusters WHERE rom_hash = ?",
+            (rom_hash,),
+        ).fetchone()
+        flag_cluster_id = conn.execute(
+            "SELECT cluster_id FROM miner_rom_flags WHERE miner_id = 'miner-c'"
+        ).fetchone()[0]
+
+    assert row[1] == 3
+    assert json.loads(row[2]) == ["miner-a", "miner-b", "miner-c"]
+    assert row[3:] == (10, 30)
+    assert flag_cluster_id == row[0]

--- a/node/tests/test_rom_clustering_server.py
+++ b/node/tests/test_rom_clustering_server.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rom_clustering_server import ROMClusteringServer, init_rom_tables
+
+
+def test_rom_cluster_upsert_keeps_one_row_per_rom_hash(tmp_path):
+    db_path = str(tmp_path / "roms.db")
+    server = ROMClusteringServer(db_path, cluster_threshold=1)
+    rom_hash = "ab" * 20
+
+    assert server.process_rom_report("miner-1", rom_hash)[1] == "unique_rom"
+    assert server.process_rom_report("miner-2", rom_hash)[1] == "rom_clustering"
+    assert server.process_rom_report("miner-3", rom_hash)[1] == "rom_clustering"
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT cluster_id, cluster_size, miners FROM rom_clusters WHERE rom_hash = ?",
+            (rom_hash,),
+        ).fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][1] == 3
+
+
+def test_init_rom_tables_deduplicates_legacy_cluster_rows_before_unique_index(tmp_path):
+    db_path = str(tmp_path / "legacy-roms.db")
+    rom_hash = "cd" * 20
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript("""
+            CREATE TABLE miner_rom_reports (
+                miner_id TEXT NOT NULL,
+                rom_hash TEXT NOT NULL,
+                hash_type TEXT NOT NULL,
+                platform TEXT,
+                first_seen INTEGER NOT NULL,
+                last_seen INTEGER NOT NULL,
+                report_count INTEGER DEFAULT 1,
+                PRIMARY KEY (miner_id, rom_hash)
+            );
+            CREATE TABLE rom_clusters (
+                cluster_id INTEGER PRIMARY KEY AUTOINCREMENT,
+                rom_hash TEXT NOT NULL,
+                hash_type TEXT NOT NULL,
+                miners TEXT NOT NULL,
+                cluster_size INTEGER NOT NULL,
+                is_known_emulator_rom INTEGER DEFAULT 0,
+                known_rom_info TEXT,
+                first_detected INTEGER NOT NULL,
+                last_updated INTEGER NOT NULL
+            );
+            CREATE TABLE miner_rom_flags (
+                miner_id TEXT PRIMARY KEY,
+                flag_reason TEXT NOT NULL,
+                cluster_id INTEGER,
+                flagged_at INTEGER NOT NULL,
+                resolved INTEGER DEFAULT 0,
+                resolved_at INTEGER
+            );
+        """)
+        conn.execute(
+            "INSERT INTO rom_clusters VALUES (1, ?, 'sha1', '[\"miner-1\", \"miner-2\"]', 2, 0, NULL, 10, 20)",
+            (rom_hash,),
+        )
+        conn.execute(
+            "INSERT INTO rom_clusters VALUES (2, ?, 'sha1', '[\"miner-1\", \"miner-2\", \"miner-3\"]', 3, 0, NULL, 11, 30)",
+            (rom_hash,),
+        )
+        conn.execute(
+            "INSERT INTO miner_rom_flags VALUES ('miner-3', 'rom_cluster:3_miners', 2, 30, 0, NULL)"
+        )
+
+    init_rom_tables(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT cluster_id, cluster_size, first_detected, last_updated FROM rom_clusters WHERE rom_hash = ?",
+            (rom_hash,),
+        ).fetchall()
+        index_rows = conn.execute("PRAGMA index_list(rom_clusters)").fetchall()
+        flag_cluster_id = conn.execute(
+            "SELECT cluster_id FROM miner_rom_flags WHERE miner_id = 'miner-3'"
+        ).fetchone()[0]
+
+    assert len(rows) == 1
+    assert rows[0][1:] == (3, 10, 30)
+    assert flag_cluster_id == rows[0][0]
+    assert any(row[2] for row in index_rows if row[1] == "idx_rom_clusters_hash_type")


### PR DESCRIPTION
## Summary

Fixes #5747.

`rom_clusters` was intended to keep one mutable cluster snapshot per `(rom_hash, hash_type)`, but the table only had an autoincrement `cluster_id` primary key. The existing `ON CONFLICT DO UPDATE` therefore never fired for repeated detections of the same ROM hash, leaving stale duplicate cluster rows.

This PR:

- deduplicates legacy duplicate `rom_clusters` rows per `(rom_hash, hash_type)`;
- preserves earliest `first_detected`, latest `last_updated`, and largest/latest cluster snapshot;
- repoints existing `miner_rom_flags` from duplicate cluster ids to the kept row;
- creates a unique index on `(rom_hash, hash_type)`;
- uses explicit `ON CONFLICT(rom_hash, hash_type) DO UPDATE`;
- adds regression tests for both fresh DB behavior and legacy duplicate migration.

## Validation

```bash
PYTHONPATH=node python3 -B -m pytest -q node/tests/test_rom_clustering_server.py --tb=short -p no:cacheprovider
# 2 passed

python3 -B -m py_compile node/rom_clustering_server.py node/tests/test_rom_clustering_server.py

git diff --check
```
