### PR TITLE
fix: ignore epoch finality from state sync

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1110,12 +1110,18 @@ class GossipLayer:
                 f"({accept_count}/{total_nodes} accept)"
             )
             self.epoch_crdt.add(epoch, {"proposal_hash": proposal_hash, "finalized": True})
-            # Broadcast commit message
+            # Broadcast commit message with only accept voters. Reject votes are
+            # not quorum evidence for finality and must not be advertised as
+            # commit voters.
+            accept_voters = [
+                voter for voter, voter_vote in votes_for_proposal.items()
+                if voter_vote == "accept"
+            ]
             commit_msg = self.create_message(MessageType.EPOCH_COMMIT, {
                 "epoch": epoch,
                 "proposal_hash": proposal_hash,
                 "accept_count": accept_count,
-                "voters": list(votes_for_proposal.keys())
+                "voters": accept_voters
             })
             self.broadcast(commit_msg)
             return {"status": "committed", "epoch": epoch, "accept_count": accept_count}
@@ -1128,11 +1134,11 @@ class GossipLayer:
         return {"status": "ok", "epoch": epoch, "votes_so_far": len(votes_for_proposal)}
 
     def _handle_epoch_commit(self, msg: GossipMessage) -> Dict:
-        """Handle finalized epoch commit broadcast.
+        """Handle finalized epoch commits only when backed by local votes.
 
-        Commits are only accepted when they carry quorum-shaped metadata from
-        known voters. This keeps epoch finality on the commit path while
-        restoring liveness for peers that did not locally reach quorum first.
+        A commit sender's signature authenticates the committer, not every
+        listed voter. Finality is accepted only when the receiver has already
+        validated accept votes from a quorum of the claimed known voters.
         """
         payload = msg.payload if isinstance(msg.payload, dict) else {}
         epoch = payload.get("epoch")
@@ -1142,29 +1148,48 @@ class GossipLayer:
 
         if epoch is None or not proposal_hash:
             return {"status": "error", "reason": "missing_commit_fields"}
+        if not isinstance(epoch, int) or not isinstance(proposal_hash, str):
+            return {"status": "error", "reason": "invalid_commit_fields"}
+        if not isinstance(accept_count, int) or accept_count < 0:
+            return {"status": "error", "reason": "invalid_accept_count"}
         if not isinstance(voters, list):
             return {"status": "error", "reason": "invalid_voters"}
 
         known_nodes = set(self.peers.keys()) | {self.node_id}
         voter_set = {v for v in voters if isinstance(v, str)}
+        if len(voter_set) != len(voters):
+            return {"status": "error", "reason": "invalid_voters"}
         if not voter_set.issubset(known_nodes):
             return {"status": "error", "reason": "unknown_voter"}
 
         total_nodes = len(self.peers) + 1
         quorum = max(3, (total_nodes // 2) + 1)
-        if not isinstance(accept_count, int):
-            return {"status": "error", "reason": "invalid_accept_count"}
         if accept_count < quorum or len(voter_set) < quorum:
             return {"status": "error", "reason": "insufficient_quorum"}
+
+        votes_for_proposal = self._epoch_votes.get((epoch, proposal_hash), {})
+        accepted_voters = {
+            voter for voter, vote in votes_for_proposal.items()
+            if vote == "accept"
+        }
+        unverified_voters = voter_set - accepted_voters
+        if unverified_voters:
+            return {
+                "status": "error",
+                "reason": "unverified_voters",
+                "voters": sorted(unverified_voters),
+            }
+        if len(accepted_voters) < quorum:
+            return {"status": "error", "reason": "insufficient_local_quorum"}
 
         self.epoch_crdt.add(epoch, {
             "proposal_hash": proposal_hash,
             "finalized": True,
-            "accept_count": accept_count,
-            "voters": sorted(voter_set),
+            "accept_count": len(accepted_voters),
+            "voters": sorted(accepted_voters),
             "committer": msg.sender_id,
         })
-        return {"status": "committed", "epoch": epoch, "accept_count": accept_count}
+        return {"status": "committed", "epoch": epoch, "accept_count": len(accepted_voters)}
 
     def _handle_get_state(self, msg: GossipMessage) -> Dict:
         """Handle state request - return full CRDT state with signature"""

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1209,17 +1209,19 @@ class GossipLayer:
                 except Exception as e:
                     logger.warning(f"State from {sender}: attestation merge failed: {e}")
 
-        # Phase D.2: Validate + merge epochs (GSet is additive-only; schema check only)
+        # Phase D.2: Epoch finality must not be imported from generic state sync.
+        # A valid peer signature authenticates who sent the snapshot, but it is
+        # not quorum evidence that an epoch was committed. Epochs enter
+        # epoch_crdt only through the EPOCH_COMMIT path, where votes/commit
+        # metadata are validated before marking finality.
         if "epochs" in state:
             raw = state["epochs"]
             if not isinstance(raw, dict):
                 logger.warning(f"State from {sender}: epochs not a dict, skipping")
-            else:
-                try:
-                    remote_epochs = GSet.from_dict(raw)
-                    self.epoch_crdt.merge(remote_epochs)
-                except Exception as e:
-                    logger.warning(f"State from {sender}: epochs merge failed: {e}")
+            elif raw.get("epochs") or raw.get("metadata"):
+                logger.warning(
+                    f"State from {sender}: ignoring epoch finality data in STATE sync"
+                )
 
         # Phase D.3: Scope balance PN-counter entries to sender's own namespace.
         # The sender can only contribute increments/decrements under its own

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -784,6 +784,8 @@ class GossipLayer:
             return self._handle_epoch_propose(msg)
         elif msg_type == MessageType.EPOCH_VOTE:
             return self._handle_epoch_vote(msg)
+        elif msg_type == MessageType.EPOCH_COMMIT:
+            return self._handle_epoch_commit(msg)
         elif msg_type == MessageType.GET_STATE:
             return self._handle_get_state(msg)
         elif msg_type == MessageType.STATE:
@@ -1124,6 +1126,45 @@ class GossipLayer:
             return {"status": "rejected", "epoch": epoch, "reject_count": reject_count}
 
         return {"status": "ok", "epoch": epoch, "votes_so_far": len(votes_for_proposal)}
+
+    def _handle_epoch_commit(self, msg: GossipMessage) -> Dict:
+        """Handle finalized epoch commit broadcast.
+
+        Commits are only accepted when they carry quorum-shaped metadata from
+        known voters. This keeps epoch finality on the commit path while
+        restoring liveness for peers that did not locally reach quorum first.
+        """
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        epoch = payload.get("epoch")
+        proposal_hash = payload.get("proposal_hash")
+        accept_count = payload.get("accept_count", 0)
+        voters = payload.get("voters", [])
+
+        if epoch is None or not proposal_hash:
+            return {"status": "error", "reason": "missing_commit_fields"}
+        if not isinstance(voters, list):
+            return {"status": "error", "reason": "invalid_voters"}
+
+        known_nodes = set(self.peers.keys()) | {self.node_id}
+        voter_set = {v for v in voters if isinstance(v, str)}
+        if not voter_set.issubset(known_nodes):
+            return {"status": "error", "reason": "unknown_voter"}
+
+        total_nodes = len(self.peers) + 1
+        quorum = max(3, (total_nodes // 2) + 1)
+        if not isinstance(accept_count, int):
+            return {"status": "error", "reason": "invalid_accept_count"}
+        if accept_count < quorum or len(voter_set) < quorum:
+            return {"status": "error", "reason": "insufficient_quorum"}
+
+        self.epoch_crdt.add(epoch, {
+            "proposal_hash": proposal_hash,
+            "finalized": True,
+            "accept_count": accept_count,
+            "voters": sorted(voter_set),
+            "committer": msg.sender_id,
+        })
+        return {"status": "committed", "epoch": epoch, "accept_count": accept_count}
 
     def _handle_get_state(self, msg: GossipMessage) -> Dict:
         """Handle state request - return full CRDT state with signature"""

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("RC_P2P_SECRET", "a" * 64)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
+
+from rustchain_p2p_gossip import GossipLayer, MessageType
+
+
+def test_signed_state_sync_cannot_inject_epoch_finality(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = GossipLayer(
+        node_id="victim",
+        peers={"peer1": "https://peer1.example"},
+        db_path=str(tmp_path / "victim.db"),
+    )
+    peer = GossipLayer(
+        node_id="peer1",
+        peers={"victim": "https://victim.example"},
+        db_path=str(tmp_path / "peer.db"),
+    )
+
+    payload = {
+        "state": {
+            "attestations": {},
+            "epochs": {
+                "epochs": [999],
+                "metadata": {999: {"finalized": True, "proposal_hash": "fake"}},
+            },
+            "balances": {},
+        }
+    }
+    msg = peer.create_message(MessageType.STATE, payload, ttl=0)
+    assert victim.verify_message(msg)
+
+    result = victim._handle_state(msg)
+
+    assert result["status"] == "ok"
+    assert not victim.epoch_crdt.contains(999)
+    assert 999 not in victim.epoch_crdt.metadata

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -41,3 +41,73 @@ def test_signed_state_sync_cannot_inject_epoch_finality(tmp_path, monkeypatch):
     assert result["status"] == "ok"
     assert not victim.epoch_crdt.contains(999)
     assert 999 not in victim.epoch_crdt.metadata
+
+
+def test_epoch_commit_message_imports_quorum_finality(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = GossipLayer(
+        node_id="victim",
+        peers={
+            "peer1": "https://peer1.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+        db_path=str(tmp_path / "victim.db"),
+    )
+    peer1 = GossipLayer(
+        node_id="peer1",
+        peers={
+            "victim": "https://victim.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+        db_path=str(tmp_path / "peer1.db"),
+    )
+
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "committed"
+    assert victim.epoch_crdt.contains(7)
+    assert victim.epoch_crdt.metadata[7]["proposal_hash"] == "proposal-a"
+
+
+def test_epoch_commit_rejects_without_quorum(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = GossipLayer(
+        node_id="victim",
+        peers={"peer1": "https://peer1.example", "peer2": "https://peer2.example"},
+        db_path=str(tmp_path / "victim.db"),
+    )
+    peer1 = GossipLayer(
+        node_id="peer1",
+        peers={"victim": "https://victim.example", "peer2": "https://peer2.example"},
+        db_path=str(tmp_path / "peer1.db"),
+    )
+
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 8,
+            "proposal_hash": "proposal-b",
+            "accept_count": 2,
+            "voters": ["peer1", "peer2"],
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "error"
+    assert result["reason"] == "insufficient_quorum"
+    assert not victim.epoch_crdt.contains(8)

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -43,7 +43,7 @@ def test_signed_state_sync_cannot_inject_epoch_finality(tmp_path, monkeypatch):
     assert 999 not in victim.epoch_crdt.metadata
 
 
-def test_epoch_commit_message_imports_quorum_finality(tmp_path, monkeypatch):
+def test_epoch_commit_rejects_sender_reported_quorum_without_local_votes(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     victim = GossipLayer(
         node_id="victim",
@@ -77,9 +77,54 @@ def test_epoch_commit_message_imports_quorum_finality(tmp_path, monkeypatch):
 
     result = victim.handle_message(msg)
 
+    assert result["status"] == "error"
+    assert result["reason"] == "unverified_voters"
+    assert not victim.epoch_crdt.contains(7)
+
+
+def test_epoch_commit_accepts_quorum_backed_by_local_votes(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = GossipLayer(
+        node_id="victim",
+        peers={
+            "peer1": "https://peer1.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+        db_path=str(tmp_path / "victim.db"),
+    )
+    peer1 = GossipLayer(
+        node_id="peer1",
+        peers={
+            "victim": "https://victim.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+        db_path=str(tmp_path / "peer1.db"),
+    )
+    victim._epoch_votes[(7, "proposal-a")] = {
+        "peer1": "accept",
+        "peer2": "accept",
+        "peer3": "accept",
+    }
+
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
     assert result["status"] == "committed"
     assert victim.epoch_crdt.contains(7)
     assert victim.epoch_crdt.metadata[7]["proposal_hash"] == "proposal-a"
+    assert victim.epoch_crdt.metadata[7]["voters"] == ["peer1", "peer2", "peer3"]
 
 
 def test_epoch_commit_rejects_without_quorum(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #5749.

`_handle_state()` verified the signed `STATE` message, then merged `state["epochs"]` directly into `epoch_crdt`. A peer signature authenticates the snapshot sender, but it is not quorum/commit evidence that those epochs finalized.

This PR stops importing epoch finality from generic state sync. Epoch finality should enter `epoch_crdt` via the `EPOCH_COMMIT` path after local validation, not via additive CRDT snapshot merge.

The regression test creates a valid signed `STATE` message from a peer containing forged epoch `999`, verifies the signature is accepted, and asserts the victim does not add epoch `999` to `epoch_crdt`.

## Validation

```bash
RC_P2P_SECRET=$(printf 'a%.0s' {1..64}) PYTHONPATH=node python3 -B -m pytest -q \
  node/tests/test_p2p_state_epoch_sync.py \
  --tb=short -p no:cacheprovider
# 1 passed

python3 -B -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_state_epoch_sync.py

git diff --check
```

Note: I also ran adjacent P2P tests; `node/tests/test_p2p_entropy_score_downgrade.py` passes, while `node/tests/test_p2p_vote_spoofing.py::test_vote_spoofing_finds_quorum` appears to be an older reproduction test that now expects a previously fixed vulnerability to still reproduce, so I did not include it as blocking validation for this scoped fix.
