### PR TITLE
fix: clarify reputation eligibility denial reason

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -345,11 +345,15 @@ def check_eligibility():
     max_val = rep["max_job_value_rtc"]
     level = rep["level"]
     eligible = job_value <= max_val
+    reason = None
 
     # High-value job gate: jobs above HIGH_VALUE_THRESHOLD require veteran level
     if eligible and job_value > HIGH_VALUE_THRESHOLD:
         if level not in CAN_POST_HIGH_VALUE:
             eligible = False
+            reason = f"{level} level agents cannot claim high-value jobs (>{HIGH_VALUE_THRESHOLD} RTC)"
+    elif not eligible:
+        reason = f"{level} level agents can only claim jobs up to {max_val:g} RTC"
 
     return jsonify({
         "agent_id": agent_id,
@@ -359,7 +363,7 @@ def check_eligibility():
         "level": level,
         "can_post_high_value": level in CAN_POST_HIGH_VALUE,
         "max_job_value_rtc": max_val,
-        "reason": None if eligible else f"{level} level agents cannot claim high-value jobs (>{HIGH_VALUE_THRESHOLD} RTC)",
+        "reason": reason,
     })
 
 

--- a/tests/test_agent_reputation.py
+++ b/tests/test_agent_reputation.py
@@ -30,6 +30,7 @@ class StubReputationEngine:
 def reputation_client(monkeypatch):
     engine = StubReputationEngine(
         {
+            "newcomer-agent": ("newcomer", 10, 5),
             "trusted-agent": ("trusted", 60, math.inf),
             "veteran-agent": ("veteran", 90, math.inf),
         }
@@ -65,6 +66,18 @@ def test_trusted_agent_cannot_claim_jobs_above_high_value_threshold(reputation_c
     assert payload["eligible"] is False
     assert payload["can_post_high_value"] is False
     assert "trusted level agents cannot claim high-value jobs" in payload["reason"]
+
+
+def test_level_cap_denial_uses_level_cap_reason(reputation_client):
+    response = reputation_client.get(
+        "/agent/reputation/check-eligibility",
+        query_string={"agent_id": "newcomer-agent", "job_value": "5.01"},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["eligible"] is False
+    assert payload["reason"] == "newcomer level agents can only claim jobs up to 5 RTC"
 
 
 def test_veteran_agent_can_claim_high_value_jobs(reputation_client):


### PR DESCRIPTION
## Summary
- fixes `/agent/reputation/check-eligibility` so level-cap denials explain the actual max job value instead of always reporting the high-value gate
- keeps the existing high-value >50 RTC veteran-only denial for trusted agents
- adds a focused regression test for newcomer max-value rejection

## Why
A newcomer/known agent rejected for exceeding its level cap could receive a misleading high-value-job message even when the requested job was below the high-value threshold. That makes claim eligibility debugging confusing for agents and job posters.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `python3 -m py_compile agent_reputation.py tests/test_agent_reputation.py`
- `uv run --with flask --with pytest python -m pytest tests/test_agent_reputation.py -q`

AI-assisted contribution by Codex for dicnunz.