### PR TITLE
fix: store refreshed reputation cache results

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -285,17 +285,23 @@ class ReputationEngine:
             else:
                 self._cache.clear()
 
+    def _refresh_stale_cache_entries(self):
+        now = time.time()
+        with self._lock:
+            stale = [
+                w for w, (_, ts) in self._cache.items()
+                if now - ts > CACHE_TTL_S
+            ]
+        for w in stale:
+            refreshed = self.calculate(w)
+            with self._lock:
+                if w in self._cache:
+                    self._cache[w] = (refreshed, time.time())
+
     def _refresh_loop(self):
         while True:
             time.sleep(CACHE_TTL_S)
-            with self._lock:
-                stale = [w for w, (_, ts) in self._cache.items()
-                         if time.time() - ts > CACHE_TTL_S]
-            for w in stale:
-                self.calculate(w)
-                with self._lock:
-                    if w in self._cache:
-                        self._cache[w] = (self._cache[w][0], time.time())
+            self._refresh_stale_cache_entries()
 
     def start_cache_refresh(self):
         t = threading.Thread(target=self._refresh_loop, daemon=True)

--- a/tests/test_agent_reputation.py
+++ b/tests/test_agent_reputation.py
@@ -100,3 +100,20 @@ def test_leaderboard_rejects_non_positive_limits(reputation_client, limit):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "limit must be between 1 and 100"
+
+
+def test_refresh_stale_cache_entries_stores_recalculated_result(monkeypatch):
+    engine = agent_reputation.ReputationEngine(db_path="/tmp/does-not-exist.db")
+    engine._cache["agent-a"] = ({"reputation_score": 1}, 0)
+
+    monkeypatch.setattr(
+        engine,
+        "calculate",
+        lambda wallet: {"agent_id": wallet, "reputation_score": 99},
+    )
+
+    engine._refresh_stale_cache_entries()
+
+    refreshed, timestamp = engine._cache["agent-a"]
+    assert refreshed == {"agent_id": "agent-a", "reputation_score": 99}
+    assert timestamp > 0


### PR DESCRIPTION
## Summary
- fixes the background reputation cache refresh path so stale entries store the recalculated result, not the old cached payload with a fresh timestamp
- extracts the stale-entry refresh into a small method that can be regression-tested directly
- adds a focused test proving refreshed cache data replaces stale data

## Why
Before this change, `_refresh_loop()` called `calculate(w)` for stale wallets but discarded the returned score data. It then refreshed only the timestamp around the old cached value, which could keep stale reputation scores alive indefinitely.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `python3 -m py_compile agent_reputation.py tests/test_agent_reputation.py`
- `uv run --with flask --with pytest python -m pytest tests/test_agent_reputation.py -q`

AI-assisted contribution by Codex for dicnunz.