### PR TITLE
fix: reject payout amounts above i64

### DIFF
--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional, Tuple
 
 
 MICRO_RTC = Decimal("1000000")
+MAX_I64 = 2**63 - 1
 
 
 def _is_rtc_address(value: str) -> bool:
@@ -44,6 +45,15 @@ def _amount_i64(amount_rtc: Decimal) -> int:
     return int((amount_rtc * MICRO_RTC).to_integral_value(rounding=ROUND_DOWN))
 
 
+def _validate_amount_i64(amount_rtc: Decimal) -> Tuple[Optional[int], str]:
+    amount_i64 = _amount_i64(amount_rtc)
+    if amount_i64 <= 0:
+        return None, "amount_too_small_after_quantization"
+    if amount_i64 > MAX_I64:
+        return None, "amount_exceeds_i64"
+    return amount_i64, ""
+
+
 def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
     """Validate POST /wallet/transfer payload shape (admin transfer)."""
     data, err = _as_dict(payload)
@@ -60,13 +70,15 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = _amount_i64(amount_rtc)
-    if amount_i64 <= 0:
+    amount_i64, ierr = _validate_amount_i64(amount_rtc)
+    if ierr == "amount_too_small_after_quantization":
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
             details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
+    if ierr:
+        return PreflightResult(ok=False, error=ierr, details={})
 
     return PreflightResult(
         ok=True,
@@ -98,13 +110,15 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = _amount_i64(amount_rtc)
-    if amount_i64 <= 0:
+    amount_i64, ierr = _validate_amount_i64(amount_rtc)
+    if ierr == "amount_too_small_after_quantization":
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
             details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
+    if ierr:
+        return PreflightResult(ok=False, error=ierr, details={})
     fee_rtc, ferr = _safe_decimal(data.get("fee_rtc", 0))
     if ferr:
         return PreflightResult(ok=False, error=ferr, details={"field": "fee_rtc"})

--- a/payout_preflight.py
+++ b/payout_preflight.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional, Tuple
 
 
 MICRO_RTC = Decimal("1000000")
+MAX_I64 = 2**63 - 1
 
 
 @dataclass(frozen=True)
@@ -40,6 +41,15 @@ def _amount_i64(amount_rtc: Decimal) -> int:
     return int((amount_rtc * MICRO_RTC).to_integral_value(rounding=ROUND_DOWN))
 
 
+def _validate_amount_i64(amount_rtc: Decimal) -> Tuple[Optional[int], str]:
+    amount_i64 = _amount_i64(amount_rtc)
+    if amount_i64 <= 0:
+        return None, "amount_too_small_after_quantization"
+    if amount_i64 > MAX_I64:
+        return None, "amount_exceeds_i64"
+    return amount_i64, ""
+
+
 def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
     """Validate POST /wallet/transfer payload shape (admin transfer)."""
     data, err = _as_dict(payload)
@@ -56,13 +66,15 @@ def validate_wallet_transfer_admin(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = _amount_i64(amount_rtc)
-    if amount_i64 <= 0:
+    amount_i64, ierr = _validate_amount_i64(amount_rtc)
+    if ierr == "amount_too_small_after_quantization":
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
             details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
+    if ierr:
+        return PreflightResult(ok=False, error=ierr, details={})
 
     return PreflightResult(
         ok=True,
@@ -94,13 +106,15 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         return PreflightResult(ok=False, error=aerr, details={})
     if amount_rtc is None or amount_rtc <= 0:
         return PreflightResult(ok=False, error="amount_must_be_positive", details={})
-    amount_i64 = _amount_i64(amount_rtc)
-    if amount_i64 <= 0:
+    amount_i64, ierr = _validate_amount_i64(amount_rtc)
+    if ierr == "amount_too_small_after_quantization":
         return PreflightResult(
             ok=False,
             error="amount_too_small_after_quantization",
             details={"amount_rtc": float(amount_rtc), "min_rtc": 0.000001},
         )
+    if ierr:
+        return PreflightResult(ok=False, error=ierr, details={})
 
     if not (from_address.startswith("RTC") and len(from_address) == 43):
         return PreflightResult(ok=False, error="invalid_from_address_format", details={})

--- a/tests/test_payout_preflight.py
+++ b/tests/test_payout_preflight.py
@@ -205,6 +205,15 @@ class TestValidateWalletTransferAdmin:
                 assert result.ok is True
                 assert result.details["amount_rtc"] == 5.5
 
+      def test_amount_above_i64_rejected(self):
+                result = validate_wallet_transfer_admin({
+                              "from_miner": "miner_alpha",
+                              "to_miner": "miner_beta",
+                              "amount_rtc": "9223372036854.775808",
+                })
+                assert result.ok is False
+                assert result.error == "amount_exceeds_i64"
+
 
 class TestValidateWalletTransferSigned:
       @staticmethod
@@ -301,6 +310,12 @@ class TestValidateWalletTransferSigned:
                 result = validate_wallet_transfer_signed(None)
                 assert result.ok is False
                 assert result.error == "invalid_json_body"
+
+      def test_amount_above_i64_rejected(self):
+                payload = self._valid_payload(amount_rtc="9223372036854.775808")
+                result = validate_wallet_transfer_signed(payload)
+                assert result.ok is False
+                assert result.error == "amount_exceeds_i64"
 
 
 class TestPreflightResult:


### PR DESCRIPTION
## Summary
- rejects wallet transfer amounts whose micro-RTC quantization exceeds signed i64 max
- applies the same guard to the root deployment shim and node runtime preflight module
- adds public-validator regression tests for admin and signed transfers

## Why
The preflight helpers call the scaled amount `amount_i64`, but enormous positive amounts could quantize above signed i64 max and still pass validation. That can push impossible amounts into downstream wallet code.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `python3 -m py_compile payout_preflight.py node/payout_preflight.py tests/test_payout_preflight.py`
- `uv run --with flask --with pytest python -m pytest tests/test_payout_preflight.py -q`

AI-assisted contribution by Codex for dicnunz.