### PR TITLE
fix: use preflight amount units for admin transfers

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7399,6 +7399,7 @@ def wallet_transfer_v2():
     from_miner = pre.details["from_miner"]
     to_miner = pre.details["to_miner"]
     amount_rtc = pre.details["amount_rtc"]
+    amount_i64 = int(pre.details["amount_i64"])
     reason = str((data or {}).get('reason', 'admin_transfer'))
     idempotency_key = ""
     raw_idempotency_key = (data or {}).get("idempotency_key")
@@ -7409,7 +7410,6 @@ def wallet_transfer_v2():
         if not re.fullmatch(r"[A-Za-z0-9._:-]{1,128}", idempotency_key):
             return jsonify({"error": "invalid_idempotency_key"}), 400
     
-    amount_i64 = int(amount_rtc * 1000000)
     now = int(time.time())
     confirms_at = now + CONFIRMATION_DELAY_SECONDS
     current_epoch = current_slot()

--- a/tests/test_wallet_transfer_admin_idempotency.py
+++ b/tests/test_wallet_transfer_admin_idempotency.py
@@ -104,6 +104,35 @@ def test_admin_transfer_idempotency_key_reuses_pending_transfer(admin_transfer_c
     assert pending_total == 1_000_000
 
 
+def test_admin_transfer_uses_preflight_amount_i64_without_float_loss(admin_transfer_client):
+    client, db_path = admin_transfer_client
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("founder_community", 1_000_000),
+        )
+        conn.commit()
+
+    response = client.post(
+        "/wallet/transfer",
+        json={
+            "from_miner": "founder_community",
+            "to_miner": "contributor",
+            "amount_rtc": "0.000249",
+        },
+        headers={"X-Admin-Key": "a" * 32},
+    )
+    assert response.status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        (pending_amount,) = conn.execute(
+            "SELECT amount_i64 FROM pending_ledger"
+        ).fetchone()
+
+    assert pending_amount == 249
+
+
 def test_admin_transfer_idempotency_key_rejects_changed_transfer(admin_transfer_client):
     client, db_path = admin_transfer_client
 


### PR DESCRIPTION
## Summary
- uses the exact `amount_i64` already computed by payout preflight for admin wallet transfers
- avoids recomputing micro-RTC units through float multiplication
- adds a regression showing `0.000249` RTC must persist as 249 micro-RTC, not 248

## Why
`validate_wallet_transfer_admin()` already quantizes the request with Decimal, but `/wallet/transfer` discarded that value and recomputed `int(amount_rtc * 1000000)` after converting to float. Certain valid decimal amounts could lose or gain one micro-unit before being written to `pending_ledger`.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_idempotency.py`
- `uv run --with flask --with pytest python -m pytest tests/test_wallet_transfer_admin_idempotency.py -q`

AI-assisted contribution by Codex for dicnunz.