### PR TITLE
fix: use preflight amount units for signed transfers

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8464,7 +8464,7 @@ def wallet_transfer_signed():
     # SECURITY/HARDENING: signed transfers should follow the same 2-phase commit
     # semantics as admin transfers (pending_ledger + delayed confirmation). This
     # prevents bypassing the 24h pending window via the signed endpoint.
-    amount_i64 = int(amount_rtc * 1000000)
+    amount_i64 = int(pre.details["amount_i64"])
     now = int(time.time())
     confirms_at = now + CONFIRMATION_DELAY_SECONDS
     current_epoch = current_slot()

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -151,6 +151,30 @@ def test_insufficient_balance_does_not_burn_nonce(signed_transfer_client):
     assert pending_count == 1
 
 
+def test_signed_transfer_uses_preflight_amount_i64_without_float_loss(signed_transfer_client):
+    client, db_path = signed_transfer_client
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("RTC" + "a" * 40, 1_000_000),
+        )
+        conn.commit()
+
+    response = client.post(
+        "/wallet/transfer/signed",
+        json=_payload(amount_rtc="0.000249", nonce=1733420011111),
+    )
+    assert response.status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        (pending_amount,) = conn.execute(
+            "SELECT amount_i64 FROM pending_ledger"
+        ).fetchone()
+
+    assert pending_amount == 249
+
+
 def test_signed_transfer_rejects_nonzero_fee_until_fee_settlement(
     signed_transfer_client,
     monkeypatch,


### PR DESCRIPTION
## Summary
- uses the exact `amount_i64` computed by signed-transfer preflight when writing pending signed transfers
- avoids recomputing micro-RTC units through float multiplication in `/wallet/transfer/signed`
- adds a regression showing `0.000249` RTC must persist as 249 micro-RTC, not 248

## Why
`validate_wallet_transfer_signed()` already quantizes the request with Decimal and returns `amount_i64`, but the signed-transfer route discarded that value and recomputed `int(amount_rtc * 1000000)` after converting the amount to float. Certain valid decimal amounts could lose a micro-unit before being written to `pending_ledger`.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_signed_transfer_replay.py`
- `uv run --with flask --with pytest --with cryptography --with httpx python -m pytest tests/test_signed_transfer_replay.py -q`

AI-assisted contribution by Codex for dicnunz.