### PR TITLE
[UTXO-BUG] Bound mempool text fields before persistence

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -17,7 +17,8 @@ import utxo_db as utxo_db_module
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
-    MAX_OUTPUTS, MAX_SQLITE_INT64,
+    MAX_OUTPUTS, MAX_SQLITE_INT64, MAX_UTXO_ADDRESS_BYTES,
+    MAX_UTXO_METADATA_BYTES, MAX_MEMPOOL_TX_ID_BYTES,
 )
 
 
@@ -1441,6 +1442,84 @@ class TestUtxoDB(unittest.TestCase):
                 self.assertFalse(ok)
                 self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
                 self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_mempool_rejects_oversized_tx_id_without_locking_input(self):
+        """Public mempool tx ids must be bounded before persistence."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.mempool_add({
+            'tx_id': 'x' * (MAX_MEMPOOL_TX_ID_BYTES + 1),
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        })
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
+    def test_mempool_rejects_oversized_output_text_without_locking_input(self):
+        """Reject oversized output fields before storing tx_data_json."""
+        cases = [
+            {'address': 'R' * (MAX_UTXO_ADDRESS_BYTES + 1),
+             'value_nrtc': 100 * UNIT},
+            {'address': 'bob',
+             'value_nrtc': 100 * UNIT,
+             'tokens_json': json.dumps(['x' * (MAX_UTXO_METADATA_BYTES + 1)])},
+            {'address': 'bob',
+             'value_nrtc': 100 * UNIT,
+             'registers_json': json.dumps({
+                 'R4': 'x' * (MAX_UTXO_METADATA_BYTES + 1),
+             })},
+        ]
+
+        for idx, output in enumerate(cases):
+            with self.subTest(output=output):
+                db = UtxoDB(self.tmp.name)
+                self.assertTrue(db.apply_transaction({
+                    'tx_type': 'mining_reward',
+                    'inputs': [],
+                    'outputs': [
+                        {'address': f'alice_big_{idx}',
+                         'value_nrtc': 100 * UNIT}
+                    ],
+                    'fee_nrtc': 0,
+                    'timestamp': int(time.time()) + idx,
+                    '_allow_minting': True,
+                }, block_height=idx + 1))
+                box = db.get_unspent_for_address(f'alice_big_{idx}')[0]
+
+                ok = db.mempool_add({
+                    'tx_id': f'oversized{idx}',
+                    'tx_type': 'transfer',
+                    'inputs': [{'box_id': box['box_id']}],
+                    'outputs': [output],
+                    'fee_nrtc': 0,
+                })
+
+                self.assertFalse(ok)
+                self.assertEqual(db.mempool_get_block_candidates(), [])
+                self.assertFalse(db.mempool_check_double_spend(box['box_id']))
+
+    def test_apply_transaction_rejects_oversized_output_text(self):
+        """Direct block application must reject oversized persisted fields."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id'], 'spending_proof': 'sig'}],
+            'outputs': [{
+                'address': 'R' * (MAX_UTXO_ADDRESS_BYTES + 1),
+                'value_nrtc': 100 * UNIT,
+            }],
+            'fee_nrtc': 0,
+        }, block_height=10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
 
     # -- bounty #2819: negative / zero value outputs -------------------------
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -43,6 +43,9 @@ MAX_POOL_SIZE = 10_000
 # Anti-UTXO-bloat: maximum outputs per transaction
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
 MAX_OUTPUTS = 100
+MAX_UTXO_ADDRESS_BYTES = 256
+MAX_UTXO_METADATA_BYTES = 8_192
+MAX_MEMPOOL_TX_ID_BYTES = 128
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
 MAX_SQLITE_INT64 = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
@@ -62,6 +65,14 @@ def _is_nonnegative_int64(value: Any) -> bool:
 def _is_positive_int64(value: Any) -> bool:
     """Return True only for positive int64 amounts."""
     return type(value) is int and 0 < value <= MAX_SQLITE_INT64
+
+
+def _utf8_len(value: str) -> Optional[int]:
+    """Return UTF-8 byte length, or None for unencodable text."""
+    try:
+        return len(value.encode('utf-8'))
+    except UnicodeEncodeError:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -412,6 +423,9 @@ class UtxoDB:
             address = out.get('address')
             if not isinstance(address, str) or not address.strip():
                 return None
+            address_len = _utf8_len(address)
+            if address_len is None or address_len > MAX_UTXO_ADDRESS_BYTES:
+                return None
 
             val = out.get('value_nrtc')
             if not _is_positive_int64(val):
@@ -422,6 +436,12 @@ class UtxoDB:
             if not isinstance(tokens_json, str):
                 return None
             if not isinstance(registers_json, str):
+                return None
+            tokens_len = _utf8_len(tokens_json)
+            registers_len = _utf8_len(registers_json)
+            if tokens_len is None or tokens_len > MAX_UTXO_METADATA_BYTES:
+                return None
+            if registers_len is None or registers_len > MAX_UTXO_METADATA_BYTES:
                 return None
             try:
                 tokens = json.loads(tokens_json)
@@ -848,7 +868,13 @@ class UtxoDB:
             tx_id = tx.get('tx_id', '')
             # FIX(#2179): Reject empty/whitespace-only tx_id to prevent
             # INSERT OR IGNORE collisions that create orphan input claims.
-            if not tx_id or not tx_id.strip():
+            tx_id_len = _utf8_len(tx_id) if isinstance(tx_id, str) else None
+            if (
+                not isinstance(tx_id, str)
+                or not tx_id.strip()
+                or tx_id_len is None
+                or tx_id_len > MAX_MEMPOOL_TX_ID_BYTES
+            ):
                 if manage_tx:
                     conn.execute("ROLLBACK")
                 return False


### PR DESCRIPTION
## Summary
- Add explicit byte caps for UTXO output addresses, output metadata JSON, and public mempool `tx_id` values.
- Reject oversized fields before `mempool_add()` persists attacker-controlled `tx_data_json` or locks an input.
- Mirror the output-field checks in direct `apply_transaction()` so oversized persisted box fields fail closed before state mutation.

## Finding
Current `main` accepts a valid mempool transfer with an oversized output address. In local reproduction, a single valid input plus a 200 KB output address made `mempool_add()` return `True` and stored a 200,270 byte `tx_data_json` row. `MAX_POOL_SIZE` only caps row count, so oversized text fields can bypass the intended mempool resource limit and create avoidable DB/memory pressure.

This patch keeps the limits conservative:
- output address: 256 UTF-8 bytes
- output `tokens_json` / `registers_json`: 8 KiB each
- mempool `tx_id`: 128 UTF-8 bytes

## Bounty route
Scottcjn/rustchain-bounties#2819

Claimant: @akaalholdings
Suggested severity: Low / Medium, depending on maintainer assessment of mempool resource-exhaustion impact.

## Validation
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db.TestUtxoDB.test_mempool_rejects_oversized_tx_id_without_locking_input node.test_utxo_db.TestUtxoDB.test_mempool_rejects_oversized_output_text_without_locking_input node.test_utxo_db.TestUtxoDB.test_apply_transaction_rejects_oversized_output_text node.test_utxo_db.TestUtxoDB.test_mempool_accepts_valid_tx -v` -> OK
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db.TestUtxoDB.test_mempool_rejects_unpersistable_outputs_without_locking_input node.test_utxo_db.TestUtxoDB.test_apply_transaction_rejects_unpersistable_outputs node.test_utxo_db.TestUtxoDB.test_mempool_accepts_valid_tx node.test_utxo_db.TestUtxoDB.test_transfer -v` -> OK
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py` -> OK
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py` -> OK

Full `PYTHONPATH=node python3 node/test_utxo_db.py` currently fails on two pre-existing dust-threshold tests in `main`; those are already covered by open PR #5696 and are not part of this claim.
