### PR TITLE
fix: validate Sophia inspect JSON body

### DIFF
--- a/node/sophia_attestation_inspector.py
+++ b/node/sophia_attestation_inspector.py
@@ -704,6 +704,14 @@ def register_sophia_endpoints(app, db_path: str = None):
         got = req.headers.get("X-Admin-Key", "") or req.headers.get("X-API-Key", "")
         return bool(need and got and hmac.compare_digest(got, need))
 
+    def _json_object_body():
+        data = request.get_json(silent=True)
+        if data is None:
+            return {}, None
+        if not isinstance(data, dict):
+            return None, (jsonify({"error": "JSON object required"}), 400)
+        return data, None
+
     @app.route("/sophia/status/<miner_id>", methods=["GET"])
     def sophia_status_miner(miner_id):
         result = get_latest_verdict(miner_id, db_path=db)
@@ -733,7 +741,9 @@ def register_sophia_endpoints(app, db_path: str = None):
     def sophia_inspect():
         if not _is_admin(request):
             return jsonify({"error": "Unauthorized -- admin key required"}), 401
-        data = request.get_json(force=True, silent=True) or {}
+        data, error = _json_object_body()
+        if error:
+            return error
         miner_id = data.get("miner_id")
         if not miner_id:
             return jsonify({"error": "miner_id required"}), 400

--- a/node/tests/test_sophia_attestation_inspector.py
+++ b/node/tests/test_sophia_attestation_inspector.py
@@ -49,3 +49,28 @@ def test_sophia_inspector_admin_auth_uses_constant_time_compare(monkeypatch):
         ("wrong-admin", "expected-admin"),
         ("expected-admin", "expected-admin"),
     ]
+
+
+def test_sophia_inspect_rejects_non_object_json_before_inspection(monkeypatch):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    sophia_attestation_inspector.register_sophia_endpoints(app, ":memory:")
+
+    inspect_calls = []
+
+    def fake_inspect(*args, **kwargs):
+        inspect_calls.append((args, kwargs))
+        return {"ok": True}
+
+    monkeypatch.setattr(sophia_attestation_inspector, "inspect_miner", fake_inspect)
+
+    response = app.test_client().post(
+        "/sophia/inspect",
+        headers={"X-Admin-Key": "expected-admin"},
+        json=["miner_id"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+    assert inspect_calls == []


### PR DESCRIPTION
## Summary
- Fixes #5762 by rejecting present non-object JSON bodies on `POST /sophia/inspect` before the route calls `.get()` or invokes inspection logic.
- Preserves the existing missing-body behavior: authenticated empty/malformed bodies still fall through to `miner_id required`.
- Adds a focused regression proving an authenticated JSON array returns a stable 400 and does not call `inspect_miner()`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask python -m pytest node/tests/test_sophia_attestation_inspector.py -q` -> 2 passed
- `python3 -m py_compile node/sophia_attestation_inspector.py node/tests/test_sophia_attestation_inspector.py`
- `git diff --check -- node/sophia_attestation_inspector.py node/tests/test_sophia_attestation_inspector.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK

Miner ID / payout target: `dicnunz`

AI assistance disclosure: OpenAI Codex was used to inspect, patch, test, and package this fix.
