### PR TITLE
fix: validate beacon submit json body

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8554,7 +8554,7 @@ BEACON_RATE_LIMIT  = 60
 @app.route("/beacon/submit", methods=["POST"])
 def beacon_submit():
     data = request.get_json(silent=True)
-    if not data:
+    if not isinstance(data, dict) or not data:
         return jsonify({"ok": False, "error": "invalid_json"}), 400
     agent_id = data.get("agent_id", "")
     kind = data.get("kind", "")

--- a/tests/test_beacon_submit_json_validation.py
+++ b/tests/test_beacon_submit_json_validation.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+import sys
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def beacon_submit_client(monkeypatch):
+    monkeypatch.setattr(integrated_node, "store_envelope", lambda *args, **kwargs: pytest.fail("store_envelope should not be called"))
+
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as test_client:
+        yield test_client
+
+
+def test_beacon_submit_rejects_non_object_json_before_storage(beacon_submit_client):
+    response = beacon_submit_client.post("/beacon/submit", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json"}


### PR DESCRIPTION
Fixes #5764.

## Summary
- require `POST /beacon/submit` to receive a JSON object before reading envelope fields
- keep missing/malformed/empty bodies on the existing `invalid_json` 400 path
- add a route-level regression proving a JSON array is rejected before `store_envelope()` can run

## Why
A non-empty top-level JSON array is truthy, so the old guard skipped `invalid_json` and then called `data.get(...)`, producing a server error before Beacon envelope validation.

Related reward route: RustChain bug bounty / report-a-bug program (#305).

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_beacon_submit_json_validation.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_beacon_submit_json_validation.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_beacon_submit_json_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

AI-assisted contribution by Codex for dicnunz.