### PR TITLE
fix: validate header route json bodies

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4294,7 +4294,9 @@ def miner_set_header_key():
     if not admin_key or not hmac.compare_digest(provided_key, admin_key):
         return jsonify({"ok":False,"error":"unauthorized"}), 403
 
-    body = request.get_json(force=True, silent=True) or {}
+    body = request.get_json(force=True, silent=True)
+    if not isinstance(body, dict):
+        return jsonify({"ok":False,"error":"invalid_json_body"}), 400
     miner_id   = str(body.get("miner_id","")).strip()
     pubkey_hex = str(body.get("pubkey_hex","")).strip().lower()
     if not miner_id or len(pubkey_hex) != 64:
@@ -4328,13 +4330,15 @@ def ingest_signed_header():
       5) on success: validate header continuity, persist, update tip, bump metrics
     """
     start = time.time()
-    body = request.get_json(force=True, silent=True) or {}
+    body = request.get_json(force=True, silent=True)
+    if not isinstance(body, dict):
+        return jsonify({"ok":False,"error":"invalid_json_body"}), 400
 
-    miner_id = (body.get("miner_id") or "").strip()
+    miner_id = str(body.get("miner_id") or "").strip()
     header   = body.get("header") or {}
-    msg_hex  = (body.get("message") or "").strip().lower()
-    sig_hex  = (body.get("signature") or "").strip().lower()
-    inline_pk= (body.get("pubkey") or "").strip().lower()
+    msg_hex  = str(body.get("message") or "").strip().lower()
+    sig_hex  = str(body.get("signature") or "").strip().lower()
+    inline_pk= str(body.get("pubkey") or "").strip().lower()
 
     if not miner_id or not sig_hex or (not header and not msg_hex):
         return jsonify({"ok":False,"error":"missing fields"}), 400

--- a/tests/test_header_routes_json_validation.py
+++ b/tests/test_header_routes_json_validation.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+
+import pytest
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as test_client:
+        yield test_client
+
+
+def test_miner_headerkey_rejects_non_object_json(client):
+    response = client.post(
+        "/miner/headerkey",
+        headers={"X-API-Key": "0" * 32},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json_body"}
+
+
+def test_ingest_signed_header_rejects_non_object_json(client):
+    response = client.post("/headers/ingest_signed", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json_body"}


### PR DESCRIPTION
## Summary
- Fixes #5769.
- Reject non-object JSON bodies before `/miner/headerkey` and `/headers/ingest_signed` read fields with `.get(...)`.
- Normalizes signed-header string fields before `.strip()` to avoid type-driven 500s.
- Adds focused regression tests for JSON arrays hitting both routes.

## Local reproduction before fix
- `POST /miner/headerkey` with a valid admin key and JSON array body returned 500: `AttributeError: list object has no attribute get`.
- `POST /headers/ingest_signed` with a JSON array body returned the same 500.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_header_routes_json_validation.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_header_routes_json_validation.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_header_routes_json_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`