### PR TITLE
fix: validate integrated rewards settle json

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7102,8 +7102,16 @@ def api_rewards_settle():
     if not hmac.compare_digest(admin_key, admin_key_env):
         return jsonify({"ok": False, "reason": "admin_required"}), 401
 
-    body = request.get_json(force=True, silent=True) or {}
-    epoch = int(body.get("epoch", -1))
+    body = request.get_json(force=True, silent=True)
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        return jsonify({"ok": False, "error": "JSON object required"}), 400
+
+    epoch_raw = body.get("epoch", -1)
+    if isinstance(epoch_raw, bool) or not isinstance(epoch_raw, int):
+        return jsonify({"ok": False, "error": "epoch must be an integer"}), 400
+    epoch = epoch_raw
     if epoch < 0:
         return jsonify({"ok": False, "error": "epoch required"}), 400
 

--- a/tests/test_integrated_rewards_settle_validation.py
+++ b/tests/test_integrated_rewards_settle_validation.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+
+import pytest
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as test_client:
+        yield test_client
+
+
+def test_integrated_rewards_settle_rejects_non_object_json(client):
+    response = client.post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "0" * 32},
+        json=["not", "an", "object"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "JSON object required"}
+
+
+@pytest.mark.parametrize("epoch", ["bad", True, {"value": 1}])
+def test_integrated_rewards_settle_rejects_non_integer_epoch(client, epoch):
+    response = client.post(
+        "/rewards/settle",
+        headers={"X-Admin-Key": "0" * 32},
+        json={"epoch": epoch},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "epoch must be an integer"}


### PR DESCRIPTION
## Summary
- make integrated `POST /rewards/settle` reject non-object JSON before accessing `.get()`
- reject boolean and non-integer epoch values before reward settlement
- add regression coverage for the malformed JSON and epoch cases

Fixes #5771.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_integrated_rewards_settle_validation.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_integrated_rewards_settle_validation.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_integrated_rewards_settle_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`