### PR TITLE
fix: validate oui enforce json body

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4632,6 +4632,9 @@ def admin_oui_enforce():
         return jsonify({"ok": False, "error": "forbidden"}), 403
     body = request.get_json(force=True, silent=True)
     if body is None:
+        raw_body = request.get_data(cache=True) or b""
+        if raw_body.strip():
+            return jsonify({"error": "Invalid JSON body"}), 400
         body = {}
     if not isinstance(body, dict):
         return jsonify({"error": "Invalid JSON body"}), 400

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4630,7 +4630,11 @@ def admin_oui_enforce():
     """Toggle OUI enforcement (admin only)"""
     if not is_admin(request):
         return jsonify({"ok": False, "error": "forbidden"}), 403
-    body = request.get_json(force=True, silent=True) or {}
+    body = request.get_json(force=True, silent=True)
+    if body is None:
+        body = {}
+    if not isinstance(body, dict):
+        return jsonify({"error": "Invalid JSON body"}), 400
     enforce = 1 if str(body.get("enforce", "0")).strip() in ("1", "true", "True", "yes") else 0
     kv_set("oui_enforce", enforce)
     return jsonify({"ok": True, "enforce": enforce})

--- a/tests/test_oui_deny_json_validation.py
+++ b/tests/test_oui_deny_json_validation.py
@@ -33,6 +33,22 @@ def test_oui_enforce_rejects_non_object_json(client):
     assert response.get_json() == {"error": "Invalid JSON body"}
 
 
+def test_oui_enforce_rejects_malformed_json_without_changing_state(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(tmp_path / "oui.sqlite3"))
+    integrated_node.kv_set("oui_enforce", 1)
+
+    response = client.post(
+        "/admin/oui_deny/enforce",
+        headers=ADMIN_HEADERS,
+        data="{",
+        content_type="application/json",
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid JSON body"}
+    assert integrated_node.kv_get("oui_enforce") == "1"
+
+
 @pytest.mark.parametrize("path", ["/admin/oui_deny/add", "/admin/oui_deny/remove"])
 def test_oui_deny_rejects_non_string_oui(client, path):
     response = client.post(path, headers=ADMIN_HEADERS, json={"oui": ["aa", "bb", "cc"]})

--- a/tests/test_oui_deny_json_validation.py
+++ b/tests/test_oui_deny_json_validation.py
@@ -26,6 +26,13 @@ def test_oui_deny_rejects_non_object_json(client, path):
     assert response.get_json() == {"error": "Invalid JSON body"}
 
 
+def test_oui_enforce_rejects_non_object_json(client):
+    response = client.post("/admin/oui_deny/enforce", headers=ADMIN_HEADERS, json=["not", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid JSON body"}
+
+
 @pytest.mark.parametrize("path", ["/admin/oui_deny/add", "/admin/oui_deny/remove"])
 def test_oui_deny_rejects_non_string_oui(client, path):
     response = client.post(path, headers=ADMIN_HEADERS, json={"oui": ["aa", "bb", "cc"]})

--- a/tests/test_oui_deny_json_validation.py
+++ b/tests/test_oui_deny_json_validation.py
@@ -13,9 +13,11 @@ ADMIN_HEADERS = {"X-Admin-Key": "0" * 32}
 @pytest.fixture
 def client(monkeypatch):
     monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+    integrated_node._ADMIN_RATE_LIMIT_BUCKETS.clear()
     integrated_node.app.config["TESTING"] = True
     with integrated_node.app.test_client() as c:
         yield c
+    integrated_node._ADMIN_RATE_LIMIT_BUCKETS.clear()
 
 
 @pytest.mark.parametrize("path", ["/admin/oui_deny/add", "/admin/oui_deny/remove"])


### PR DESCRIPTION
## Summary
- make `POST /admin/oui_deny/enforce` reject non-object JSON before reading `.get()`
- keep the existing default empty-body behavior
- extend OUI deny JSON validation coverage to the enforce route

Fixes #5773.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_oui_deny_json_validation.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_oui_deny_json_validation.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_oui_deny_json_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`