### PR TITLE
fix: validate wallet review json bodies

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4681,6 +4681,8 @@ def admin_create_wallet_review_hold():
         return jsonify({"ok": False, "error": "forbidden"}), 403
     data = request.get_json(force=True, silent=True)
     if data is None:
+        if request.get_data(cache=True):
+            return jsonify({"ok": False, "error": "invalid_json_body"}), 400
         data = {}
     if not isinstance(data, dict):
         return jsonify({"ok": False, "error": "invalid_json_body"}), 400
@@ -4714,6 +4716,8 @@ def admin_resolve_wallet_review_hold(hold_id: int):
         return jsonify({"ok": False, "error": "forbidden"}), 403
     data = request.get_json(force=True, silent=True)
     if data is None:
+        if request.get_data(cache=True):
+            return jsonify({"ok": False, "error": "invalid_json_body"}), 400
         data = {}
     if not isinstance(data, dict):
         return jsonify({"ok": False, "error": "invalid_json_body"}), 400

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4679,7 +4679,11 @@ def admin_create_wallet_review_hold():
     """Create a wallet review hold instead of hard-blocking by default."""
     if not is_admin(request):
         return jsonify({"ok": False, "error": "forbidden"}), 403
-    data = request.get_json(force=True, silent=True) or {}
+    data = request.get_json(force=True, silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "invalid_json_body"}), 400
     wallet = _attest_valid_miner(data.get("wallet") or data.get("miner") or "")
     reason = str(data.get("reason") or "manual review required").strip()
     coach_note = str(data.get("coach_note") or "").strip()
@@ -4708,7 +4712,11 @@ def admin_resolve_wallet_review_hold(hold_id: int):
     """Resolve a wallet review hold with explicit release/escalation actions."""
     if not is_admin(request):
         return jsonify({"ok": False, "error": "forbidden"}), 403
-    data = request.get_json(force=True, silent=True) or {}
+    data = request.get_json(force=True, silent=True)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        return jsonify({"ok": False, "error": "invalid_json_body"}), 400
     action = str(data.get("action") or "release").strip().lower()
     reviewer_note = str(data.get("reviewer_note") or "").strip()
     coach_note = str(data.get("coach_note") or "").strip()

--- a/tests/test_wallet_review_holds.py
+++ b/tests/test_wallet_review_holds.py
@@ -134,12 +134,14 @@ def client(monkeypatch):
     monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
     monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: 85)
     monkeypatch.setattr(integrated_node, "HAVE_REPLAY_DEFENSE", False, raising=False)
+    integrated_node._ADMIN_RATE_LIMIT_BUCKETS.clear()
     integrated_node.init_db()
 
     integrated_node.app.config["TESTING"] = True
     with integrated_node.app.test_client() as test_client:
         yield test_client, db_path
 
+    integrated_node._ADMIN_RATE_LIMIT_BUCKETS.clear()
     if db_path.exists():
         try:
             db_path.unlink()
@@ -191,6 +193,20 @@ def test_wallet_review_release_restores_attestation_flow(client):
     response = test_client.post("/attest/submit", json=_attach_live_challenge(test_client, _base_payload()))
     assert response.status_code == 200
     assert response.get_json()["ok"] is True
+
+
+@pytest.mark.parametrize("path", ["/admin/wallet-review-holds", "/admin/wallet-review-holds/1/resolve"])
+def test_wallet_review_admin_routes_reject_non_object_json(client, path):
+    test_client, _db_path = client
+
+    response = test_client.post(
+        path,
+        json=["not", "object"],
+        headers={"X-Admin-Key": "0" * 32},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json_body"}
 
 
 def test_wallet_review_escalation_hard_blocks_attestation(client):

--- a/tests/test_wallet_review_holds.py
+++ b/tests/test_wallet_review_holds.py
@@ -209,6 +209,37 @@ def test_wallet_review_admin_routes_reject_non_object_json(client, path):
     assert response.get_json() == {"ok": False, "error": "invalid_json_body"}
 
 
+def test_wallet_review_resolve_rejects_malformed_json_without_releasing(client):
+    test_client, db_path = client
+    with sqlite3.connect(db_path) as conn:
+        integrated_node.ensure_wallet_review_tables(conn)
+        cur = conn.execute(
+            """
+            INSERT INTO wallet_review_holds(wallet, status, reason, coach_note, reviewer_note, created_at, reviewed_at)
+            VALUES (?, 'needs_review', ?, ?, '', 1000, 0)
+            """,
+            ("review-miner", "manual review", "retry after review"),
+        )
+        hold_id = cur.lastrowid
+        conn.commit()
+
+    response = test_client.post(
+        f"/admin/wallet-review-holds/{hold_id}/resolve",
+        data="{",
+        content_type="application/json",
+        headers={"X-Admin-Key": "0" * 32},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json_body"}
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, reviewer_note, reviewed_at FROM wallet_review_holds WHERE id = ?",
+            (hold_id,),
+        ).fetchone()
+    assert row == ("needs_review", "", 0)
+
+
 def test_wallet_review_escalation_hard_blocks_attestation(client):
     test_client, db_path = client
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
## Summary
- make wallet-review admin mutation routes reject non-object JSON before reading `.get()`
- preserve existing empty-body defaults
- add regression coverage for create and resolve routes

Fixes #5775.

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_wallet_review_holds.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_review_holds.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_review_holds.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`