### PR TITLE
Create miner_header_keys table during DB init

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1434,6 +1434,12 @@ def init_db():
             )
         """)
         c.execute("""
+            CREATE TABLE IF NOT EXISTS miner_header_keys(
+                miner_id TEXT PRIMARY KEY,
+                pubkey_hex TEXT NOT NULL
+            )
+        """)
+        c.execute("""
             CREATE TABLE IF NOT EXISTS schema_version(
                 version INTEGER PRIMARY KEY,
                 applied_at INTEGER NOT NULL

--- a/tests/test_miner_header_keys_schema.py
+++ b/tests/test_miner_header_keys_schema.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for miner header-key schema initialization."""
+
+import sqlite3
+import sys
+
+
+integrated_node = sys.modules["integrated_node"]
+ADMIN_KEY = "0" * 32
+ADMIN_HEADERS = {"X-API-Key": ADMIN_KEY}
+
+
+def test_init_db_creates_miner_header_keys_for_headerkey_route(tmp_path, monkeypatch):
+    db_path = tmp_path / "rustchain.db"
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    integrated_node.app.config["TESTING"] = True
+
+    integrated_node.init_db()
+
+    pubkey_hex = "a" * 64
+    with integrated_node.app.test_client() as client:
+        response = client.post(
+            "/miner/headerkey",
+            headers=ADMIN_HEADERS,
+            json={"miner_id": "miner-a", "pubkey_hex": pubkey_hex},
+        )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "ok": True,
+        "miner_id": "miner-a",
+        "pubkey_hex": pubkey_hex,
+    }
+
+    with sqlite3.connect(db_path) as db:
+        stored = db.execute(
+            "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id = ?",
+            ("miner-a",),
+        ).fetchone()
+
+    assert stored == (pubkey_hex,)


### PR DESCRIPTION
## Summary
- create the `miner_header_keys` table in `init_db()` so fresh databases support header-key registration
- add a regression test that initializes a temp DB, calls `/miner/headerkey`, and verifies the key is stored

Fixes #5777

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_miner_header_keys_schema.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_miner_header_keys_schema.py`
- `git diff --check`