### PR TITLE
fix: initialize wallet review ui redirect parts

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4870,6 +4870,7 @@ def admin_wallet_review_holds_ui():
                             (new_status, reviewer_note, coach_note or row["coach_note"], now, hold_id),
                         )
                         conn.commit()
+        parts = []
         query = ""
         if active_status:
             parts.append(f"status={active_status}")

--- a/tests/test_wallet_review_holds.py
+++ b/tests/test_wallet_review_holds.py
@@ -236,6 +236,31 @@ def test_wallet_review_ui_lists_entries_and_accepts_query_admin_key(client):
     assert "retry from the intended box" in html
 
 
+def test_wallet_review_ui_post_redirects_after_create(client):
+    test_client, db_path = client
+
+    response = test_client.post(
+        "/admin/wallet-review-holds/ui?admin_key=" + ("0" * 32),
+        data={
+            "form_action": "create",
+            "wallet": "review-miner",
+            "reason": "manual review",
+            "coach_note": "retry from intended hardware",
+            "review_status": "needs_review",
+        },
+        headers={"X-Admin-Key": "0" * 32},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"].startswith("/admin/wallet-review-holds/ui")
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, reason, coach_note FROM wallet_review_holds WHERE wallet = ?",
+            ("review-miner",),
+        ).fetchone()
+    assert row == ("needs_review", "manual review", "retry from intended hardware")
+
+
 def test_admin_operator_ui_links_to_wallet_review_surface(client):
     test_client, db_path = client
     with sqlite3.connect(db_path) as conn:


### PR DESCRIPTION
Fixes #5779.

## Summary
- initialize the wallet review UI redirect query part list before appending filters/session id
- add regression coverage for an authorized UI POST create returning 303 instead of crashing

## Tests
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_wallet_review_holds.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_review_holds.py`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_review_holds.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`