### PR TITLE
fix: make keeper explorer strict-compile clean

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -153,7 +153,7 @@ def faucet_drip():
 
 # --- Fossil-punk UI Template ---
 
-RETRO_HTML = """
+RETRO_HTML = r"""
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/tests/test_keeper_explorer_py_compile.py
+++ b/tests/test_keeper_explorer_py_compile.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+
+import py_compile
+import warnings
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+KEEPER_EXPLORER_PATH = PROJECT_ROOT / "keeper_explorer.py"
+
+
+def test_keeper_explorer_compiles_with_syntax_warnings_as_errors():
+    """The embedded ASCII template should not trigger invalid escape warnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", SyntaxWarning)
+        py_compile.compile(str(KEEPER_EXPLORER_PATH), doraise=True)


### PR DESCRIPTION
## Summary
- make the embedded `RETRO_HTML` template a raw string so ASCII-art backslashes compile cleanly under `-W error::SyntaxWarning`
- add a focused regression test for strict `py_compile` on `keeper_explorer.py`

## Context
Current `main` still fails `python3 -W error::SyntaxWarning -m py_compile keeper_explorer.py` for #4725. Prior attempts were closed because the branch was stale or stacked with unrelated changes; this branch is rebuilt from current `origin/main` and only touches the keeper explorer strict-compile scope.

Closes #4725.

## Validation
- `python3 -W error::SyntaxWarning -m py_compile keeper_explorer.py tests/test_keeper_explorer_py_compile.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with flask-cors --with requests python -m pytest tests/test_keeper_explorer_py_compile.py -q`
- `git diff --check origin/main..HEAD -- keeper_explorer.py tests/test_keeper_explorer_py_compile.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`