### PR TITLE
Create attestation submit tables during DB init

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1466,6 +1466,16 @@ def init_db():
             )
         """)
         c.execute("""
+            CREATE TABLE IF NOT EXISTS hardware_bindings(
+                hardware_id TEXT PRIMARY KEY,
+                bound_miner TEXT NOT NULL,
+                device_arch TEXT,
+                device_model TEXT,
+                bound_at INTEGER NOT NULL,
+                attestation_count INTEGER DEFAULT 0
+            )
+        """)
+        c.execute("""
             CREATE TABLE IF NOT EXISTS headers(
                 slot INTEGER PRIMARY KEY,
                 header_json TEXT NOT NULL

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1428,6 +1428,44 @@ def init_db():
         c.execute("CREATE INDEX IF NOT EXISTS idx_wallet_review_wallet ON wallet_review_holds(wallet, created_at DESC)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_wallet_review_status ON wallet_review_holds(status, created_at DESC)")
         c.execute("""
+            CREATE TABLE IF NOT EXISTS blocked_wallets(
+                wallet TEXT PRIMARY KEY,
+                reason TEXT
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS ip_rate_limit(
+                client_ip TEXT NOT NULL,
+                miner_id TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                PRIMARY KEY (client_ip, miner_id)
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS miner_attest_recent(
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT,
+                warthog_bonus REAL DEFAULT 1.0,
+                signing_pubkey TEXT,
+                fingerprint_checks_json TEXT DEFAULT '{}'
+            )
+        """)
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS miner_macs(
+                miner TEXT NOT NULL,
+                mac_hash TEXT NOT NULL,
+                first_ts INTEGER NOT NULL,
+                last_ts INTEGER NOT NULL,
+                count INTEGER DEFAULT 1,
+                PRIMARY KEY (miner, mac_hash)
+            )
+        """)
+        c.execute("""
             CREATE TABLE IF NOT EXISTS headers(
                 slot INTEGER PRIMARY KEY,
                 header_json TEXT NOT NULL

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1476,6 +1476,14 @@ def init_db():
             )
         """)
         c.execute("""
+            CREATE TABLE IF NOT EXISTS oui_deny(
+                oui TEXT PRIMARY KEY,
+                vendor TEXT,
+                added_ts INTEGER,
+                enforce INTEGER DEFAULT 0
+            )
+        """)
+        c.execute("""
             CREATE TABLE IF NOT EXISTS headers(
                 slot INTEGER PRIMARY KEY,
                 header_json TEXT NOT NULL

--- a/tests/test_attest_init_schema.py
+++ b/tests/test_attest_init_schema.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import sqlite3
 import sys
 import uuid

--- a/tests/test_attest_init_schema.py
+++ b/tests/test_attest_init_schema.py
@@ -32,6 +32,7 @@ def test_init_db_creates_attestation_submit_tables(tmp_path, monkeypatch):
     assert "ip_rate_limit" in tables
     assert "miner_attest_recent" in tables
     assert "miner_macs" in tables
+    assert "hardware_bindings" in tables
 
 
 def test_fresh_db_attestation_submit_does_not_crash_on_missing_schema(
@@ -45,7 +46,6 @@ def test_fresh_db_attestation_submit_does_not_crash_on_missing_schema(
     monkeypatch.setattr(integrated_node, "HAVE_UTXO", False)
     monkeypatch.setattr(integrated_node, "HW_BINDING_V2", False)
     monkeypatch.setattr(integrated_node, "HW_PROOF_AVAILABLE", False)
-    monkeypatch.setattr(integrated_node, "_check_hardware_binding", lambda *args, **kwargs: (True, "ok", None))
     monkeypatch.setattr(integrated_node, "_check_oui_gate", lambda *args, **kwargs: (True, {}))
     monkeypatch.setattr(integrated_node, "auto_induct_to_hall", lambda *args, **kwargs: None)
 

--- a/tests/test_attest_init_schema.py
+++ b/tests/test_attest_init_schema.py
@@ -33,6 +33,7 @@ def test_init_db_creates_attestation_submit_tables(tmp_path, monkeypatch):
     assert "miner_attest_recent" in tables
     assert "miner_macs" in tables
     assert "hardware_bindings" in tables
+    assert "oui_deny" in tables
 
 
 def test_fresh_db_attestation_submit_does_not_crash_on_missing_schema(
@@ -46,7 +47,6 @@ def test_fresh_db_attestation_submit_does_not_crash_on_missing_schema(
     monkeypatch.setattr(integrated_node, "HAVE_UTXO", False)
     monkeypatch.setattr(integrated_node, "HW_BINDING_V2", False)
     monkeypatch.setattr(integrated_node, "HW_PROOF_AVAILABLE", False)
-    monkeypatch.setattr(integrated_node, "_check_oui_gate", lambda *args, **kwargs: (True, {}))
     monkeypatch.setattr(integrated_node, "auto_induct_to_hall", lambda *args, **kwargs: None)
 
     integrated_node.init_db()

--- a/tests/test_attest_init_schema.py
+++ b/tests/test_attest_init_schema.py
@@ -1,0 +1,97 @@
+import sqlite3
+import sys
+import uuid
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_init_db_creates_attestation_submit_tables(tmp_path, monkeypatch):
+    db_path = tmp_path / "fresh-rustchain.db"
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "HAVE_REPLAY_DEFENSE", False)
+    monkeypatch.setattr(integrated_node, "HAVE_WARTHOG", False)
+    monkeypatch.setattr(integrated_node, "HAVE_BRIDGE", False)
+    monkeypatch.setattr(integrated_node, "HAVE_UTXO", False)
+    monkeypatch.setattr(integrated_node, "HW_BINDING_V2", False)
+    monkeypatch.setattr(integrated_node, "HW_PROOF_AVAILABLE", False)
+    monkeypatch.setattr(integrated_node, "auto_induct_to_hall", lambda *args, **kwargs: None)
+
+    integrated_node.init_db()
+
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+
+    assert "blocked_wallets" in tables
+    assert "ip_rate_limit" in tables
+    assert "miner_attest_recent" in tables
+    assert "miner_macs" in tables
+
+
+def test_fresh_db_attestation_submit_does_not_crash_on_missing_schema(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "fresh-attest-route.db"
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "HAVE_REPLAY_DEFENSE", False)
+    monkeypatch.setattr(integrated_node, "HAVE_WARTHOG", False)
+    monkeypatch.setattr(integrated_node, "HAVE_BRIDGE", False)
+    monkeypatch.setattr(integrated_node, "HAVE_UTXO", False)
+    monkeypatch.setattr(integrated_node, "HW_BINDING_V2", False)
+    monkeypatch.setattr(integrated_node, "HW_PROOF_AVAILABLE", False)
+    monkeypatch.setattr(integrated_node, "_check_hardware_binding", lambda *args, **kwargs: (True, "ok", None))
+    monkeypatch.setattr(integrated_node, "_check_oui_gate", lambda *args, **kwargs: (True, {}))
+    monkeypatch.setattr(integrated_node, "auto_induct_to_hall", lambda *args, **kwargs: None)
+
+    integrated_node.init_db()
+    client = integrated_node.app.test_client()
+    challenge = client.post("/attest/challenge", json={})
+    assert challenge.status_code == 200
+
+    miner = f"schema-fresh-{uuid.uuid4().hex[:8]}"
+    payload = {
+        "miner": miner,
+        "device": {
+            "device_family": "PowerPC",
+            "device_arch": "g4",
+            "cores": 1,
+            "cpu": "PowerPC G4",
+            "machine": "ppc",
+        },
+        "signals": {
+            "hostname": "schema-fresh-host",
+            "macs": ["AA:BB:CC:DD:EE:12"],
+        },
+        "report": {
+            "nonce": challenge.get_json()["nonce"],
+            "commitment": "schema-fresh-commitment",
+        },
+        "fingerprint": {
+            "checks": {
+                "anti_emulation": {
+                    "passed": True,
+                    "data": {
+                        "vm_indicators": [],
+                        "paths_checked": ["/proc/cpuinfo"],
+                    },
+                }
+            },
+            "all_passed": True,
+        },
+    }
+
+    response = client.post("/attest/submit", json=payload)
+    assert response.status_code != 500
+    assert response.get_json()["ok"] is True
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT miner, fingerprint_passed FROM miner_attest_recent WHERE miner = ?",
+            (miner,),
+        ).fetchone()
+
+    assert row == (miner, 0)


### PR DESCRIPTION
## Summary
- create the tables that `/attest/submit` expects on a fresh DB: `blocked_wallets`, `ip_rate_limit`, `miner_attest_recent`, and `miner_macs`
- add regression coverage that initializes a fresh DB, gets a live challenge, submits an attestation, and verifies the route no longer fails with missing-table 500s

Fixes the fresh-DB `/attest/submit` crash path discovered while checking the attestation fuzz/bug bounty surface.

Bug bounty route: Scottcjn/rustchain-bounties#71
Related fuzz route: Scottcjn/rustchain-bounties#1112

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run --no-project --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_attest_init_schema.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_attest_init_schema.py`
- `git diff --check`