### PR TITLE
fix: reject non-object beacon submit JSON

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8554,7 +8554,7 @@ BEACON_RATE_LIMIT  = 60
 @app.route("/beacon/submit", methods=["POST"])
 def beacon_submit():
     data = request.get_json(silent=True)
-    if not data:
+    if not isinstance(data, dict) or not data:
         return jsonify({"ok": False, "error": "invalid_json"}), 400
     agent_id = data.get("agent_id", "")
     kind = data.get("kind", "")

--- a/tests/test_beacon_submit_json_validation.py
+++ b/tests/test_beacon_submit_json_validation.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for /beacon/submit JSON body shape validation."""
+
+import sys
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as c:
+        yield c
+
+
+def test_beacon_submit_rejects_non_object_json(client):
+    response = client.post("/beacon/submit", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid_json"}


### PR DESCRIPTION
## Summary
- require `/beacon/submit` request JSON to be an object before reading envelope fields
- add a regression test for JSON array payloads returning `invalid_json` instead of reaching storage/field validation

Fixes #5764

## Verification
- `uv run --with pytest --with flask --with pynacl python -m pytest tests/test_beacon_submit_json_validation.py -q`
- `uv run --with pytest --with flask --with pynacl python -m pytest tests/test_beacon_submit_json_validation.py tests/test_beacon_envelopes_limit.py node/tests/test_beacon_submit_signature.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py`
- `git diff --check`