### PR TITLE
fix: reject non-object bridge admin JSON

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -855,7 +855,7 @@ def register_bridge_routes(app):
             return jsonify({"error": "unauthorized"}), 401
         
         data = request.get_json(silent=True)
-        if not data:
+        if not isinstance(data, dict) or not data:
             return jsonify({"error": "Request body required"}), 400
         
         tx_hash = data.get("tx_hash")
@@ -886,7 +886,7 @@ def register_bridge_routes(app):
             return jsonify({"error": "Unauthorized"}), 401
         
         data = request.get_json(silent=True)
-        if not data:
+        if not isinstance(data, dict) or not data:
             return jsonify({"error": "Request body required"}), 400
         
         tx_hash = data.get("tx_hash")

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -1151,6 +1151,38 @@ class TestBridgeCallbackAuth:
         assert response.status_code == 400
         assert response.get_json()["error"] == "Request body required"
 
+    def test_void_bridge_rejects_non_object_json(
+        self, setup_test_db, monkeypatch
+    ):
+        bridge_api = setup_test_db["bridge_api"]
+        client = self._client(bridge_api)
+        monkeypatch.setenv("RC_ADMIN_KEY", "expected-key")
+
+        response = client.post(
+            "/api/bridge/void",
+            headers={"X-Admin-Key": "expected-key"},
+            json=["not", "object"],
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Request body required"
+
+    def test_update_external_rejects_non_object_json(
+        self, setup_test_db, monkeypatch
+    ):
+        bridge_api = setup_test_db["bridge_api"]
+        client = self._client(bridge_api)
+        monkeypatch.setenv("RC_BRIDGE_API_KEY", "expected-key")
+
+        response = client.post(
+            "/api/bridge/update-external",
+            headers={"X-API-Key": "expected-key"},
+            json=["not", "object"],
+        )
+
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Request body required"
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- require bridge admin callback JSON bodies to be objects before reading fields
- cover array payloads for `/api/bridge/void` and `/api/bridge/update-external`

Fixes #5766

## Verification
- `uv run --with pytest --with flask python -m pytest tests/test_bridge_lock_ledger.py::TestBridgeCallbackAuth -q`
- `python3 -m py_compile node/bridge_api.py`
- `git diff --check`