### PR TITLE
fix: normalize realtime miner responses

### DIFF
--- a/explorer/static/js/realtime.js
+++ b/explorer/static/js/realtime.js
@@ -263,6 +263,16 @@ class PollingClient {
         };
     }
 
+    normalizeMinersResponse(response) {
+        if (Array.isArray(response)) {
+            return response;
+        }
+        if (Array.isArray(response?.miners)) {
+            return response.miners;
+        }
+        return [];
+    }
+
     /**
      * Start polling
      */
@@ -309,12 +319,13 @@ class PollingClient {
         this.state.lastPoll = Date.now();
 
         try {
-            const [blocks, transactions, miners, epoch] = await Promise.all([
+            const [blocks, transactions, minersResponse, epoch] = await Promise.all([
                 this.fetchJSON('/blocks'),
                 this.fetchJSON('/api/transactions'),
                 this.fetchJSON('/api/miners'),
                 this.fetchJSON('/epoch')
             ]);
+            const miners = this.normalizeMinersResponse(minersResponse);
 
             // Detect changes and emit events
             this.detectChanges(blocks, transactions, miners, epoch);

--- a/tests/test_realtime_miners_normalization.py
+++ b/tests/test_realtime_miners_normalization.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+"""Regression checks for realtime explorer miner response normalization."""
+
+from pathlib import Path
+
+
+REALTIME_JS = (
+    Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "realtime.js"
+)
+
+
+def source():
+    return REALTIME_JS.read_text(encoding="utf-8")
+
+
+def test_polling_client_normalizes_paginated_miners_response():
+    js = source()
+
+    assert "normalizeMinersResponse(response)" in js
+    assert "Array.isArray(response?.miners)" in js
+    assert "return response.miners;" in js
+    assert "const miners = this.normalizeMinersResponse(minersResponse);" in js
+    assert "miners: miners.length" in js
+
+
+def test_polling_client_does_not_use_raw_miners_response_for_metrics():
+    js = source()
+
+    assert "this.fetchJSON('/api/miners')," in js
+    assert "const [blocks, transactions, minersResponse, epoch]" in js
+    assert "const [blocks, transactions, miners, epoch]" not in js


### PR DESCRIPTION
## Summary
- normalize `/api/miners` responses in the realtime fallback polling client before change detection and metrics
- preserve legacy array responses while accepting the current `{ miners, pagination }` envelope
- add a static regression test with an SPDX header and explicit UTF-8 source reads

Follow-up to the same API-shape class fixed for the main explorer in #5615; this touches `explorer/static/js/realtime.js`, which still used the raw `/api/miners` result as an array.

## Verification
- `node --check explorer/static/js/realtime.js`
- `uv run --with pytest --with flask --with pynacl --with requests --with prometheus-client python -m pytest tests/test_realtime_miners_normalization.py -q`
- `uv run --with pytest python -m pytest tests/test_realtime_miners_normalization.py -q --noconftest -o addopts=''`
- `git diff --check`