### PR TITLE
fix: deduplicate BCOS directory project loads

### DIFF
--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -45,24 +45,35 @@ app.config['SECRET_KEY'] = load_secret_key()
 DATABASE = 'bcos_directory.db'
 
 
-def _project_created_at_sort_key(created_at):
-    """Return a stable timestamp key matching SQLite's datetime ordering."""
+def _canonical_project_created_at(created_at):
+    """Return a strict UTC timestamp string for project ordering, or None."""
     if not created_at:
-        return (0, 0.0)
+        return None
     if not isinstance(created_at, str):
         created_at = str(created_at)
 
     normalized = created_at.strip()
+    if not normalized:
+        return None
     if normalized.endswith('Z'):
         normalized = f'{normalized[:-1]}+00:00'
 
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError:
-        return (-1, normalized)
+        return None
 
     if parsed.tzinfo is not None:
         parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return parsed.strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _project_created_at_sort_key(created_at):
+    """Return a stable timestamp key using strict Python-side parsing."""
+    canonical = _canonical_project_created_at(created_at)
+    if canonical is None:
+        return (0, 0.0)
+    parsed = datetime.fromisoformat(canonical)
     return (1, parsed.timestamp())
 
 
@@ -117,19 +128,21 @@ def load_projects_from_json():
             github_repo = project.get('github_repo')
             if not github_repo:
                 continue
-            candidate_key = (_project_created_at_sort_key(project.get('created_at')), index)
+            canonical_created_at = _canonical_project_created_at(project.get('created_at'))
+            project = {**project, 'created_at': canonical_created_at}
+            candidate_key = _project_created_at_sort_key(canonical_created_at)
             current = deduped_projects.get(github_repo)
             if current is None or candidate_key > current[0]:
-                deduped_projects[github_repo] = (candidate_key, project)
+                deduped_projects[github_repo] = (candidate_key, index, project)
 
         conn = sqlite3.connect(DATABASE)
         c = conn.cursor()
         
-        for _, project in deduped_projects.values():
+        for _, _, project in deduped_projects.values():
             c.execute('''
                 INSERT INTO projects
                 (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(github_repo) DO UPDATE SET
                     name = excluded.name,
                     url = excluded.url,
@@ -139,7 +152,8 @@ def load_projects_from_json():
                     review_note = excluded.review_note,
                     category = excluded.category,
                     created_at = excluded.created_at
-                WHERE datetime(excluded.created_at) >= datetime(projects.created_at)
+                WHERE excluded.created_at IS NOT NULL
+                    AND (projects.created_at IS NULL OR excluded.created_at >= projects.created_at)
             ''', (
                 project.get('name'),
                 project.get('url'),

--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -7,6 +7,7 @@ import json
 import os
 import hashlib
 import secrets
+from datetime import datetime, timezone
 
 app = Flask(__name__)
 
@@ -42,6 +43,28 @@ def server_port() -> int:
 app.config['SECRET_KEY'] = load_secret_key()
 
 DATABASE = 'bcos_directory.db'
+
+
+def _project_created_at_sort_key(created_at):
+    """Return a stable timestamp key matching SQLite's datetime ordering."""
+    if not created_at:
+        return (0, 0.0)
+    if not isinstance(created_at, str):
+        created_at = str(created_at)
+
+    normalized = created_at.strip()
+    if normalized.endswith('Z'):
+        normalized = f'{normalized[:-1]}+00:00'
+
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return (-1, normalized)
+
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+    return (1, parsed.timestamp())
+
 
 def init_db():
     """Initialize the database with projects table"""
@@ -94,8 +117,7 @@ def load_projects_from_json():
             github_repo = project.get('github_repo')
             if not github_repo:
                 continue
-            created_at = project.get('created_at') or ''
-            candidate_key = (created_at, index)
+            candidate_key = (_project_created_at_sort_key(project.get('created_at')), index)
             current = deduped_projects.get(github_repo)
             if current is None or candidate_key > current[0]:
                 deduped_projects[github_repo] = (candidate_key, project)

--- a/bcos_directory.py
+++ b/bcos_directory.py
@@ -89,14 +89,35 @@ def load_projects_from_json():
         with open(json_file, 'r') as f:
             projects_data = json.load(f)
         
+        deduped_projects = {}
+        for index, project in enumerate(projects_data.get('projects', [])):
+            github_repo = project.get('github_repo')
+            if not github_repo:
+                continue
+            created_at = project.get('created_at') or ''
+            candidate_key = (created_at, index)
+            current = deduped_projects.get(github_repo)
+            if current is None or candidate_key > current[0]:
+                deduped_projects[github_repo] = (candidate_key, project)
+
         conn = sqlite3.connect(DATABASE)
         c = conn.cursor()
         
-        for project in projects_data.get('projects', []):
+        for _, project in deduped_projects.values():
             c.execute('''
-                INSERT OR REPLACE INTO projects 
-                (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO projects
+                (name, url, github_repo, bcos_tier, latest_sha, sbom_hash, review_note, category, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, CURRENT_TIMESTAMP))
+                ON CONFLICT(github_repo) DO UPDATE SET
+                    name = excluded.name,
+                    url = excluded.url,
+                    bcos_tier = excluded.bcos_tier,
+                    latest_sha = excluded.latest_sha,
+                    sbom_hash = excluded.sbom_hash,
+                    review_note = excluded.review_note,
+                    category = excluded.category,
+                    created_at = excluded.created_at
+                WHERE datetime(excluded.created_at) >= datetime(projects.created_at)
             ''', (
                 project.get('name'),
                 project.get('url'),
@@ -105,7 +126,8 @@ def load_projects_from_json():
                 project.get('latest_sha'),
                 project.get('sbom_hash'),
                 project.get('review_note'),
-                project.get('category')
+                project.get('category'),
+                project.get('created_at')
             ))
         
         conn.commit()

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -157,3 +157,65 @@ def test_bcos_directory_project_load_deduplicates_json_projects_by_timestamp(tmp
         'security',
         '2026-01-02 00:00:00',
     )]
+
+
+def test_bcos_directory_project_load_deduplicates_mixed_timestamp_formats(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'projects.json').write_text(json.dumps({
+        'projects': [
+            {
+                'name': 'New RustChain',
+                'url': 'https://new.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L2',
+                'latest_sha': 'new-sha',
+                'sbom_hash': 'new-hash',
+                'review_note': 'new review',
+                'category': 'security',
+                'created_at': '2026-01-02 00:00:00',
+            },
+            {
+                'name': 'Old RustChain',
+                'url': 'https://old.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L1',
+                'latest_sha': 'old-sha',
+                'sbom_hash': 'old-hash',
+                'review_note': 'old review',
+                'category': 'chain',
+                'created_at': '2026-01-01T00:00:00Z',
+            },
+            {
+                'name': 'Invalid RustChain',
+                'url': 'https://invalid.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L3',
+                'latest_sha': 'invalid-sha',
+                'sbom_hash': 'invalid-hash',
+                'review_note': 'invalid review',
+                'category': 'invalid',
+                'created_at': 'not-a-timestamp-z-would-sort-last',
+            },
+        ]
+    }))
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    monkeypatch.chdir(tmp_path)
+
+    bcos_directory.init_db()
+    bcos_directory.load_projects_from_json()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha, sbom_hash, category, created_at FROM projects'
+        ).fetchall()
+
+    assert rows == [(
+        'New RustChain',
+        'Scottcjn/Rustchain',
+        'new-sha',
+        'new-hash',
+        'security',
+        '2026-01-02 00:00:00',
+    )]

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -219,3 +219,87 @@ def test_bcos_directory_project_load_deduplicates_mixed_timestamp_formats(tmp_pa
         'security',
         '2026-01-02 00:00:00',
     )]
+
+
+def test_bcos_directory_project_load_preserves_first_equal_timestamp(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'projects.json').write_text(json.dumps({
+        'projects': [
+            {
+                'name': 'First RustChain',
+                'url': 'https://first.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L1',
+                'latest_sha': 'first-sha',
+                'created_at': 'not-a-timestamp',
+            },
+            {
+                'name': 'Second RustChain',
+                'url': 'https://second.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L2',
+                'latest_sha': 'second-sha',
+                'created_at': 'also-not-a-timestamp',
+            },
+        ]
+    }))
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    monkeypatch.chdir(tmp_path)
+
+    bcos_directory.init_db()
+    bcos_directory.load_projects_from_json()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha, created_at FROM projects'
+        ).fetchall()
+
+    assert rows == [('First RustChain', 'Scottcjn/Rustchain', 'first-sha', None)]
+
+
+def test_bcos_directory_project_load_rejects_invalid_timestamp_update(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'projects.json').write_text(json.dumps({
+        'projects': [{
+            'name': 'Invalid RustChain',
+            'url': 'https://invalid.example/rustchain',
+            'github_repo': 'Scottcjn/Rustchain',
+            'bcos_tier': 'L3',
+            'latest_sha': 'invalid-sha',
+            'created_at': 'not-a-timestamp-z-would-sort-last',
+        }]
+    }))
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    monkeypatch.chdir(tmp_path)
+    bcos_directory.init_db()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute('''
+            INSERT INTO projects
+            (name, url, github_repo, bcos_tier, latest_sha, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+        ''', (
+            'Existing RustChain',
+            'https://existing.example/rustchain',
+            'Scottcjn/Rustchain',
+            'L1',
+            'existing-sha',
+            '2026-01-02 00:00:00',
+        ))
+
+    bcos_directory.load_projects_from_json()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha, created_at FROM projects'
+        ).fetchall()
+
+    assert rows == [(
+        'Existing RustChain',
+        'Scottcjn/Rustchain',
+        'existing-sha',
+        '2026-01-02 00:00:00',
+    )]

--- a/tests/test_bcos_directory_security.py
+++ b/tests/test_bcos_directory_security.py
@@ -106,3 +106,54 @@ def test_bcos_directory_init_deduplicates_existing_projects_before_unique_index(
         ).fetchall()
 
     assert rows == [('New RustChain', 'Scottcjn/Rustchain', 'new')]
+
+
+def test_bcos_directory_project_load_deduplicates_json_projects_by_timestamp(tmp_path, monkeypatch):
+    db_path = tmp_path / 'bcos_directory.db'
+    data_dir = tmp_path / 'data'
+    data_dir.mkdir()
+    (data_dir / 'projects.json').write_text(json.dumps({
+        'projects': [
+            {
+                'name': 'Old RustChain',
+                'url': 'https://old.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L1',
+                'latest_sha': 'old-sha',
+                'sbom_hash': 'old-hash',
+                'review_note': 'old review',
+                'category': 'chain',
+                'created_at': '2026-01-01 00:00:00',
+            },
+            {
+                'name': 'New RustChain',
+                'url': 'https://new.example/rustchain',
+                'github_repo': 'Scottcjn/Rustchain',
+                'bcos_tier': 'L2',
+                'latest_sha': 'new-sha',
+                'sbom_hash': 'new-hash',
+                'review_note': 'new review',
+                'category': 'security',
+                'created_at': '2026-01-02 00:00:00',
+            },
+        ]
+    }))
+    monkeypatch.setattr(bcos_directory, 'DATABASE', str(db_path))
+    monkeypatch.chdir(tmp_path)
+
+    bcos_directory.init_db()
+    bcos_directory.load_projects_from_json()
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            'SELECT name, github_repo, latest_sha, sbom_hash, category, created_at FROM projects'
+        ).fetchall()
+
+    assert rows == [(
+        'New RustChain',
+        'Scottcjn/Rustchain',
+        'new-sha',
+        'new-hash',
+        'security',
+        '2026-01-02 00:00:00',
+    )]


### PR DESCRIPTION
## Summary
- Deduplicates BCOS directory project loads so repeated/mirrored entries cannot inflate the project list.
- Keeps the newest duplicate entry by timestamp instead of allowing stale data to win.
- Adds regression coverage for duplicate project sources while preserving distinct projects.

## Evidence / test plan
- OBSERVED_FACT: `bcos_directory.py` now tracks project identities and resolves duplicates deterministically.
- OBSERVED_FACT: `tests/test_bcos_directory_security.py` includes regression coverage for duplicate entries and newest-timestamp replacement.
- `git diff --check origin/main...HEAD`
- `PYTHONPATH=/tmp/rustchain-flask-deps:. python3 -B -m py_compile bcos_directory.py tests/test_bcos_directory_security.py`
- `PYTHONPATH=/tmp/rustchain-flask-deps:. python3 -B -m pytest -q tests/test_bcos_directory_security.py --tb=short --noconftest -p no:cacheprovider` -> 6 passed

BCOS tier: `BCOS-L1` (small bounded server-side directory integrity fix). I do not have label permissions, so please apply the label if required.
