### PR TITLE
fix: require explicit rtc award wallet

### DIFF
--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -431,6 +431,16 @@ def main() -> int:
         skip_reason = "recipient_wallet_missing"
         log_error("No recipient wallet found in PR body or .rtc-wallet file; "
                   "skipping automatic RTC transfer.")
+        if cfg.post_comment:
+            missing_wallet_body = (
+                f"**RTC Auto-Bounty Skipped**\n\n"
+                f"No recipient wallet was found, so no RTC transfer was attempted.\n\n"
+                f"To receive this award, add a line such as "
+                f"`wallet: RTC...` to the PR body or add a `.rtc-wallet` file "
+                f"at the repository root, then rerun the award workflow.\n\n"
+                f"<!-- { _AWARD_MARKER }:FAILED recipient_wallet_missing -->"
+            )
+            post_pr_comment(repo, pr_number, missing_wallet_body, cfg.github_token)
         set_output("awarded", "false")
         set_output("skip_reason", skip_reason)
         return 1

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -438,7 +438,7 @@ def main() -> int:
                 f"To receive this award, add a line such as "
                 f"`wallet: RTC...` to the PR body or add a `.rtc-wallet` file "
                 f"at the repository root, then rerun the award workflow.\n\n"
-                f"<!-- { _AWARD_MARKER }:FAILED recipient_wallet_missing -->"
+                f"<!-- {_AWARD_MARKER}:FAILED recipient_wallet_missing -->"
             )
             post_pr_comment(repo, pr_number, missing_wallet_body, cfg.github_token)
         set_output("awarded", "false")
@@ -492,7 +492,7 @@ def main() -> int:
                 f"| From | `{cfg.from_wallet}` |\n"
                 f"| Memo | {memo} |\n\n"
                 f"This is a **dry-run** — no actual transfer was made.\n\n"
-                f"<!-- { _AWARD_MARKER } (dry-run) -->"
+                f"<!-- {_AWARD_MARKER} (dry-run) -->"
             )
             post_pr_comment(repo, pr_number, dry_body, cfg.github_token)
         return 0
@@ -534,7 +534,7 @@ def main() -> int:
                     f"this transfer manually. This marker intentionally blocks automatic "
                     f"retries to avoid duplicate payouts; remove it only if no manual "
                     f"transfer was completed.\n\n"
-                    f"<!-- { _AWARD_MARKER }:MANUAL-REQUIRED -->"
+                    f"<!-- {_AWARD_MARKER}:MANUAL-REQUIRED -->"
                 )
                 if not post_pr_comment(repo, pr_number, manual_body, cfg.github_token):
                     log_error("Manual transfer notice could not be posted.")
@@ -549,7 +549,7 @@ def main() -> int:
                 f"but the transfer was rejected:\n\n"
                 f"```\n{error_msg}\n```\n\n"
                 f"Please process this award manually.\n\n"
-                f"<!-- { _AWARD_MARKER }:FAILED -->"
+                f"<!-- {_AWARD_MARKER}:FAILED -->"
             )
             post_pr_comment(repo, pr_number, fail_body, cfg.github_token)
         return 1
@@ -585,7 +585,7 @@ def main() -> int:
             {confirms_info}
             Transfer recorded on RustChain.
 
-            <!-- { _AWARD_MARKER } tx_hash={tx_hash} pending_id={pending_id} -->
+            <!-- {_AWARD_MARKER} tx_hash={tx_hash} pending_id={pending_id} -->
         """)
         posted = post_pr_comment(repo, pr_number, confirm_body, cfg.github_token)
         if not posted:

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -190,12 +190,11 @@ def resolve_wallet_from_file(repo_path: str) -> Optional[str]:
 
 def resolve_wallet(pr_body: str, repo_path: str) -> Optional[str]:
     """
-    Resolve the recipient wallet.
+    Resolve the explicitly declared recipient wallet.
 
     Priority:
       1. ``wallet:`` directive in the PR body
       2. ``.rtc-wallet`` file at the repository root
-      3. Fallback to the PR author's GitHub username
     """
     wallet = resolve_wallet_from_pr_body(pr_body)
     if wallet:
@@ -429,10 +428,12 @@ def main() -> int:
     # --- Resolve recipient wallet ------------------------------------------
     wallet = resolve_wallet(cfg.pr_body, cfg.repo_path)
     if not wallet:
-        # Fallback: use PR author's GitHub username as the wallet identifier
-        wallet = cfg.pr_author
-        log_info(f"No wallet found in PR body or .rtc-wallet file; "
-                 f"falling back to PR author: {wallet}")
+        skip_reason = "recipient_wallet_missing"
+        log_error("No recipient wallet found in PR body or .rtc-wallet file; "
+                  "skipping automatic RTC transfer.")
+        set_output("awarded", "false")
+        set_output("skip_reason", skip_reason)
+        return 1
 
     print(f"Recipient wallet: {wallet}")
 

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -588,7 +588,7 @@ class TestMainFlow(unittest.TestCase):
         call_args = mock_tx.call_args
         self.assertEqual(call_args[0][4], 200.0)  # amount parameter
 
-    def test_fallback_to_pr_author_when_no_wallet(self):
+    def test_missing_wallet_fails_without_transfer(self):
         from award_rtc import main
         transfer_result = {
             "ok": True,
@@ -602,10 +602,8 @@ class TestMainFlow(unittest.TestCase):
                 with patch("award_rtc.transfer_rtc", return_value=(True, transfer_result)) as mock_tx:
                     with patch("award_rtc.post_pr_comment", return_value=True):
                         rc = main()
-        self.assertEqual(rc, 0)
-        # Should use PR author as wallet
-        call_args = mock_tx.call_args
-        self.assertEqual(call_args[0][3], "bob")  # to_wallet parameter
+        self.assertEqual(rc, 1)
+        mock_tx.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -600,10 +600,15 @@ class TestMainFlow(unittest.TestCase):
         with self._env(PR_BODY="Just a regular PR\n", PR_AUTHOR="bob"):
             with patch("award_rtc.fetch_pr_comments", return_value=[]):
                 with patch("award_rtc.transfer_rtc", return_value=(True, transfer_result)) as mock_tx:
-                    with patch("award_rtc.post_pr_comment", return_value=True):
+                    with patch("award_rtc.post_pr_comment", return_value=True) as mock_post:
                         rc = main()
         self.assertEqual(rc, 1)
         mock_tx.assert_not_called()
+        mock_post.assert_called_once()
+        comment_body = mock_post.call_args[0][2]
+        self.assertIn("RTC Auto-Bounty Skipped", comment_body)
+        self.assertIn("wallet: RTC...", comment_body)
+        self.assertIn("recipient_wallet_missing", comment_body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stop the RTC auto-bounty action from falling back to the PR author's GitHub username when no recipient wallet is declared
- fail closed with `recipient_wallet_missing` before any `/wallet/transfer` call
- update the regression test so the missing-wallet path verifies no transfer is attempted

## Why
If a merged PR has no `wallet:` directive and no `.rtc-wallet` file, the current action uses `PR_AUTHOR` as `to_miner`. That can credit RTC to a username-keyed phantom balance instead of an explicit payout wallet. Automatic payouts should require an explicitly declared recipient.

## Validation
- `python -m py_compile .github/actions/rtc-auto-bounty/award_rtc.py .github/actions/rtc-auto-bounty/test_award_rtc.py`
- `PYTHONUTF8=1 python .github/actions/rtc-auto-bounty/test_award_rtc.py` -> 55 tests passed
- `python -m pytest .github/actions/rtc-auto-bounty/test_award_rtc.py -q` -> 55 passed, 9 subtests passed
- `git diff --check`

## Payout
RTC wallet: `RTC9dc7130503bf246d9ca11e2c5b402d5129077f56`