### PR TITLE
fix: harden explorer numeric formatting

### DIFF
--- a/explorer/enhanced-explorer.html
+++ b/explorer/enhanced-explorer.html
@@ -558,6 +558,13 @@
         }
 
         function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+        function safeNumber(value, fallback = 0) {
+            const number = Number(value);
+            return Number.isFinite(number) ? number : fallback;
+        }
+        function formatNumber(value, decimals) {
+            return safeNumber(value).toFixed(decimals);
+        }
 
         async function loadHealth() {
             const health = await fetchAPI('/health');
@@ -584,7 +591,7 @@
                         <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
-                        <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
+                        <td>${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC</td>
                     </tr>
                 `).join('');
 
@@ -597,7 +604,7 @@
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
                         <td><code>${esc(miner.wallet || miner.wallet_address || 'N/A')}</code></td>
-                        <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
+                        <td>${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC</td>
                     </tr>
                 `).join('');
             }
@@ -626,8 +633,8 @@
                         <td><code>${esc(tx.hash || tx.tx_hash || 'N/A')}</code></td>
                         <td><code>${esc(tx.from || 'N/A')}</code></td>
                         <td><code>${esc(tx.to || 'N/A')}</code></td>
-                        <td>${(tx.amount / 1000000 || 0).toFixed(2)} RTC</td>
-                        <td>${(tx.fee / 1000000 || 0).toFixed(4)} RTC</td>
+                        <td>${formatNumber(safeNumber(tx.amount) / 1000000, 2)} RTC</td>
+                        <td>${formatNumber(safeNumber(tx.fee) / 1000000, 4)} RTC</td>
                         <td>${formatTime(tx.timestamp)}</td>
                         <td><span class="badge badge-success">Confirmed</span></td>
                     </tr>

--- a/explorer/realtime-explorer.html
+++ b/explorer/realtime-explorer.html
@@ -1160,6 +1160,13 @@
         }
 
         function esc(s) { const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; }
+        function safeNumber(value, fallback = 0) {
+            const number = Number(value);
+            return Number.isFinite(number) ? number : fallback;
+        }
+        function formatNumber(value, decimals) {
+            return safeNumber(value).toFixed(decimals);
+        }
 
         async function loadHealth() {
             const health = await fetchAPI('/health');
@@ -1187,7 +1194,7 @@
                         <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
-                        <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
+                        <td>${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC</td>
                     </tr>
                 `).join('');
 
@@ -1200,7 +1207,7 @@
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
                         <td><code>${esc(miner.wallet || miner.wallet_address || 'N/A')}</code></td>
-                        <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
+                        <td>${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC</td>
                     </tr>
                 `).join('');
             }
@@ -1216,7 +1223,7 @@
                 document.getElementById('epoch-slot-num').textContent = epoch.slot || 'N/A';
                 document.getElementById('epoch-height').textContent = epoch.height || 'N/A';
                 document.getElementById('epoch-timestamp').textContent = epoch.timestamp ? new Date(epoch.timestamp).toLocaleString() : 'N/A';
-                document.getElementById('epoch-pot').textContent = (epoch.pot || epoch.pot_rtc || 0).toFixed(2);
+                document.getElementById('epoch-pot').textContent = formatNumber(epoch.pot || epoch.pot_rtc, 2);
             }
         }
 
@@ -1236,7 +1243,7 @@
                         <td><code>${esc((block.hash || '').substring(0, 16))}...</code></td>
                         <td>${esc(formatTime(block.timestamp))}</td>
                         <td>${esc(block.miners_count || 0)}</td>
-                        <td>${esc((block.reward || 0).toFixed(4))} RTC</td>
+                        <td>${esc(formatNumber(block.reward, 4))} RTC</td>
                     </tr>
                 `).join('');
             }

--- a/explorer/test_enhanced_explorer_xss.py
+++ b/explorer/test_enhanced_explorer_xss.py
@@ -19,6 +19,28 @@ class TestEnhancedExplorerXss(unittest.TestCase):
         self.assertNotIn("${tx.from || 'N/A'}</code>", self.html)
         self.assertNotIn("${tx.to || 'N/A'}</code>", self.html)
 
+    def test_api_numeric_fields_are_formatted_safely(self):
+        self.assertIn("function safeNumber(value, fallback = 0)", self.html)
+        self.assertIn("function formatNumber(value, decimals)", self.html)
+        self.assertIn(
+            "${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC",
+            self.html,
+        )
+        self.assertIn(
+            "${formatNumber(safeNumber(tx.amount) / 1000000, 2)} RTC",
+            self.html,
+        )
+        self.assertIn(
+            "${formatNumber(safeNumber(tx.fee) / 1000000, 4)} RTC",
+            self.html,
+        )
+        self.assertNotIn(
+            "(miner.earnings || miner.total_earned || 0).toFixed(2)",
+            self.html,
+        )
+        self.assertNotIn("(tx.amount / 1000000 || 0).toFixed(2)", self.html)
+        self.assertNotIn("(tx.fee / 1000000 || 0).toFixed(4)", self.html)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_realtime_explorer_frontend_security.py
+++ b/tests/test_realtime_explorer_frontend_security.py
@@ -28,3 +28,19 @@ def test_epoch_notification_does_not_interpolate_websocket_payload_html():
     assert "<strong>Miners:</strong> ${data.miners" not in html
     assert "document.createTextNode(` ${data.total_rtc || 0} RTC`)" in html
     assert "document.createTextNode(` ${data.miners || 0}`)" in html
+
+
+def test_api_numeric_fields_are_formatted_safely():
+    html = REALTIME_EXPLORER.read_text()
+
+    assert "function safeNumber(value, fallback = 0)" in html
+    assert "function formatNumber(value, decimals)" in html
+    assert "${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC" in html
+    assert (
+        "document.getElementById('epoch-pot').textContent = "
+        "formatNumber(epoch.pot || epoch.pot_rtc, 2);"
+    ) in html
+    assert "${esc(formatNumber(block.reward, 4))} RTC" in html
+    assert "(miner.earnings || miner.total_earned || 0).toFixed(2)" not in html
+    assert "(epoch.pot || epoch.pot_rtc || 0).toFixed(2)" not in html
+    assert "(block.reward || 0).toFixed(4)" not in html


### PR DESCRIPTION
## Summary
- add safe numeric formatting helpers to standalone enhanced/realtime explorer pages
- avoid direct toFixed calls on API-provided miner, epoch, block, and transaction values
- extend existing frontend regression tests for those render paths

## Verification
- node -e "const fs=require('fs'); for (const file of ['explorer/enhanced-explorer.html','explorer/realtime-explorer.html']) { const html=fs.readFileSync(file,'utf8'); const match=html.match(/<script>([\\s\\S]*?)<\\/script>/); if(!match) throw new Error(file + ': script block missing'); new Function(match[1]); }"
- uv run --with pytest --with flask python -m pytest tests/test_realtime_explorer_frontend_security.py explorer/test_enhanced_explorer_xss.py -q
- uv run --with pytest python -m pytest tests/test_realtime_explorer_frontend_security.py explorer/test_enhanced_explorer_xss.py -q --noconftest -o addopts=''
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check