### PR TITLE
fix: validate machine passport JSON bodies

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -251,7 +251,9 @@ def create_passport():
     if auth_error is not None:
         return auth_error
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -339,7 +341,9 @@ def update_passport(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -671,7 +675,9 @@ def compute_machine_id_endpoint():
     
     Request Body: Hardware fingerprint data (same as attestation)
     """
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -568,6 +568,39 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertTrue(data['ok'])
         self.assertIn('machine_id', data)
 
+    def test_create_passport_rejects_non_json_body(self):
+        """Passport creation returns a JSON 400 for non-JSON bodies."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        resp = self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            data='not-json',
+            content_type='text/plain',
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON body required')
+
+    def test_create_passport_rejects_json_array_body(self):
+        """Passport creation requires a JSON object body."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        resp = self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json=['name', 'owner_miner_id'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
+
     def test_update_passport_rejects_owner_claim_without_admin_key(self):
         """Client-supplied owner_miner_id is not proof of ownership."""
         os.environ['ADMIN_KEY'] = 'expected-admin-key'
@@ -625,6 +658,31 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
         compare_digest.assert_called_once_with(b'expected-admin-key', b'expected-admin-key')
+
+    def test_update_passport_rejects_json_array_body(self):
+        """Passport updates require a JSON object body."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+        self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json={
+                'name': 'Array Body Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'array_body_test',
+            },
+        )
+
+        resp = self.client.put(
+            '/api/machine-passport/array_body_test',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json=['name'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
 
     def test_update_passport_fails_closed_without_admin_key(self):
         """Passport updates fail closed before resource lookup when ADMIN_KEY is missing."""
@@ -692,6 +750,33 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(full_passport['attestation_history'], [])
         self.assertEqual(full_passport['benchmark_signatures'], [])
         self.assertEqual(full_passport['lineage_notes'], [])
+
+    def test_compute_machine_id_rejects_non_json_body(self):
+        """Machine ID computation returns a JSON 400 for non-JSON bodies."""
+        resp = self.client.post(
+            '/api/machine-passport/compute-machine-id',
+            data='not-json',
+            content_type='text/plain',
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON body required')
+
+    def test_compute_machine_id_rejects_json_array_body(self):
+        """Machine ID computation requires a JSON object body."""
+        resp = self.client.post(
+            '/api/machine-passport/compute-machine-id',
+            json=['cpu', 'serial'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
     
     def test_get_nonexistent_passport(self):
         """Test getting a nonexistent passport."""


### PR DESCRIPTION
## Summary

- Reuse the existing Machine Passport JSON object parser in the create, update, and machine-id computation routes.
- Return JSON 400 responses for missing, non-JSON, or non-object request bodies instead of Flask HTML 415/500 responses.
- Add regression coverage for non-JSON bodies and JSON arrays.

## Reproduction

Before this change:

- `POST /api/machine-passport` with `Content-Type: text/plain` returned Flask's default 415 HTML response.
- `POST /api/machine-passport` with a JSON array reached code that expects a dict and raised `AttributeError: 'list' object has no attribute 'get'`.
- `POST /api/machine-passport/compute-machine-id` with `Content-Type: text/plain` returned Flask's default 415 HTML response.

After this change those requests return API-shaped JSON 400 responses.

## Tests

- `.venv/bin/python -m unittest node.tests.test_machine_passport`
- `.venv/bin/python -m py_compile node/machine_passport_api.py node/tests/test_machine_passport.py`

Related to #305.
