### PR TITLE
fix: harden explorer dashboard app rendering

### DIFF
--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -25,7 +25,7 @@ HTML = """
 async function j(u){const r=await fetch(u);return await r.json();}
 function escapeHtml(value){const d=document.createElement('div');d.textContent=String(value ?? '');return d.innerHTML;}
 function displayValue(value){return value === undefined || value === null || value === '' ? '-' : escapeHtml(value);}
-function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
+function fmtTs(v){if(v === undefined || v === null || v === '') return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
 async function load(){
   const d=await j('/api/dashboard');
   document.getElementById('base').textContent=d.base;
@@ -33,8 +33,8 @@ async function load(){
   document.getElementById('miners').textContent=(d.miners||[]).length;
   document.getElementById('epoch').textContent=d.epoch?.epoch ?? '-';
   document.getElementById('txcount').textContent=(d.transactions||[]).length;
-  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${displayValue(m.miner_id||m.wallet)}</td><td>${displayValue(m.score||m.attestation_score)}</td><td>${displayValue(m.multiplier||m.antiquity_multiplier)}</td></tr>`).join('');
-  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${escapeHtml(fmtTs(t.timestamp||t.created_at||t.time))}</td><td>${displayValue(t.from||t.sender)}</td><td>${displayValue(t.to||t.recipient)}</td><td>${displayValue(t.amount||t.value)}</td></tr>`).join('');
+  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${displayValue(m.miner_id??m.wallet)}</td><td>${displayValue(m.score??m.attestation_score)}</td><td>${displayValue(m.multiplier??m.antiquity_multiplier)}</td></tr>`).join('');
+  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${escapeHtml(fmtTs(t.timestamp??t.created_at??t.time))}</td><td>${displayValue(t.from??t.sender)}</td><td>${displayValue(t.to??t.recipient)}</td><td>${displayValue(t.amount??t.value)}</td></tr>`).join('');
 }
 load(); setInterval(load, 30000);
 </script></body></html>

--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -23,6 +23,8 @@ HTML = """
 <h3>Recent Transactions</h3><table><thead><tr><th>Time</th><th>From</th><th>To</th><th>Amount</th></tr></thead><tbody id='txTbl'></tbody></table>
 <script>
 async function j(u){const r=await fetch(u);return await r.json();}
+function escapeHtml(value){const d=document.createElement('div');d.textContent=String(value ?? '');return d.innerHTML;}
+function displayValue(value){return value === undefined || value === null || value === '' ? '-' : escapeHtml(value);}
 function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
 async function load(){
   const d=await j('/api/dashboard');
@@ -31,8 +33,8 @@ async function load(){
   document.getElementById('miners').textContent=(d.miners||[]).length;
   document.getElementById('epoch').textContent=d.epoch?.epoch ?? '-';
   document.getElementById('txcount').textContent=(d.transactions||[]).length;
-  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${m.miner_id||m.wallet||'-'}</td><td>${m.score||m.attestation_score||'-'}</td><td>${m.multiplier||m.antiquity_multiplier||'-'}</td></tr>`).join('');
-  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${fmtTs(t.timestamp||t.created_at||t.time)}</td><td>${t.from||t.sender||'-'}</td><td>${t.to||t.recipient||'-'}</td><td>${t.amount||t.value||'-'}</td></tr>`).join('');
+  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${displayValue(m.miner_id||m.wallet)}</td><td>${displayValue(m.score||m.attestation_score)}</td><td>${displayValue(m.multiplier||m.antiquity_multiplier)}</td></tr>`).join('');
+  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${escapeHtml(fmtTs(t.timestamp||t.created_at||t.time))}</td><td>${displayValue(t.from||t.sender)}</td><td>${displayValue(t.to||t.recipient)}</td><td>${displayValue(t.amount||t.value)}</td></tr>`).join('');
 }
 load(); setInterval(load, 30000);
 </script></body></html>
@@ -46,6 +48,13 @@ def fetch_json(path):
     except Exception:
         return {}
 
+def as_list(payload, key):
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict) and isinstance(payload.get(key), list):
+        return payload[key]
+    return []
+
 @app.get('/')
 def home():
     return render_template_string(HTML)
@@ -55,9 +64,9 @@ def dashboard():
     return jsonify({
       'base': API_BASE,
       'health': fetch_json('/health'),
-      'miners': fetch_json('/api/miners') or [],
+      'miners': as_list(fetch_json('/api/miners'), 'miners'),
       'epoch': fetch_json('/epoch'),
-      'transactions': fetch_json('/api/transactions') or []
+      'transactions': as_list(fetch_json('/api/transactions'), 'transactions')
     })
 
 if __name__ == '__main__':

--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -33,7 +33,7 @@ async function load(){
   document.getElementById('miners').textContent=(d.miners||[]).length;
   document.getElementById('epoch').textContent=d.epoch?.epoch ?? '-';
   document.getElementById('txcount').textContent=(d.transactions||[]).length;
-  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${displayValue(m.miner_id??m.wallet)}</td><td>${displayValue(m.score??m.attestation_score)}</td><td>${displayValue(m.multiplier??m.antiquity_multiplier)}</td></tr>`).join('');
+  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${displayValue(m.miner_id??m.wallet??m.miner)}</td><td>${displayValue(m.score??m.attestation_score??m.entropy_score)}</td><td>${displayValue(m.multiplier??m.antiquity_multiplier)}</td></tr>`).join('');
   document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${escapeHtml(fmtTs(t.timestamp??t.created_at??t.time))}</td><td>${displayValue(t.from??t.sender)}</td><td>${displayValue(t.to??t.recipient)}</td><td>${displayValue(t.amount??t.value)}</td></tr>`).join('');
 }
 load(); setInterval(load, 30000);

--- a/tests/test_explorer_dashboard_app_security.py
+++ b/tests/test_explorer_dashboard_app_security.py
@@ -27,8 +27,8 @@ def test_dashboard_table_rows_escape_api_fields_before_inner_html():
 
     assert "function escapeHtml(value)" in source
     assert "function displayValue(value)" in source
-    assert "${displayValue(m.miner_id??m.wallet)}" in source
-    assert "${displayValue(m.score??m.attestation_score)}" in source
+    assert "${displayValue(m.miner_id??m.wallet??m.miner)}" in source
+    assert "${displayValue(m.score??m.attestation_score??m.entropy_score)}" in source
     assert "${displayValue(m.multiplier??m.antiquity_multiplier)}" in source
     assert "${escapeHtml(fmtTs(t.timestamp??t.created_at??t.time))}" in source
     assert "${displayValue(t.from??t.sender)}" in source
@@ -88,7 +88,10 @@ const dashboardPayload = {{
   base: 'https://node.example',
   health: {{ status: 'ok' }},
   epoch: {{ epoch: 0 }},
-  miners: [{{ miner_id: 'miner-zero', score: 0, attestation_score: 7, multiplier: 0, antiquity_multiplier: 3 }}],
+      miners: [
+        {{ miner_id: 'miner-zero', score: 0, attestation_score: 7, multiplier: 0, antiquity_multiplier: 3 }},
+        {{ miner: 'alice', entropy_score: 0, antiquity_multiplier: 1.2 }},
+      ],
   transactions: [{{ timestamp: 0, created_at: 1779250000, from: 'alice', to: 'bob', amount: 0, value: 9 }}],
 }};
 const context = {{
@@ -117,12 +120,14 @@ context.load().then(() => {{
     result = subprocess.run(
         ["node", "-e", probe],
         text=True,
+        encoding="utf-8",
         capture_output=True,
         check=True,
     )
     rendered = json.loads(result.stdout)
 
     assert "<td>0</td><td>0</td>" in rendered["miners"]
+    assert "<td>alice</td><td>0</td><td>1.2</td>" in rendered["miners"]
     assert "<td>0</td>" in rendered["txs"]
     assert "<td>7</td>" not in rendered["miners"]
     assert "<td>9</td>" not in rendered["txs"]

--- a/tests/test_explorer_dashboard_app_security.py
+++ b/tests/test_explorer_dashboard_app_security.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 import importlib.util
+import json
+import subprocess
 from pathlib import Path
 
 
@@ -25,16 +27,18 @@ def test_dashboard_table_rows_escape_api_fields_before_inner_html():
 
     assert "function escapeHtml(value)" in source
     assert "function displayValue(value)" in source
-    assert "${displayValue(m.miner_id||m.wallet)}" in source
-    assert "${displayValue(m.score||m.attestation_score)}" in source
-    assert "${displayValue(m.multiplier||m.antiquity_multiplier)}" in source
-    assert "${escapeHtml(fmtTs(t.timestamp||t.created_at||t.time))}" in source
-    assert "${displayValue(t.from||t.sender)}" in source
-    assert "${displayValue(t.to||t.recipient)}" in source
-    assert "${displayValue(t.amount||t.value)}" in source
+    assert "${displayValue(m.miner_id??m.wallet)}" in source
+    assert "${displayValue(m.score??m.attestation_score)}" in source
+    assert "${displayValue(m.multiplier??m.antiquity_multiplier)}" in source
+    assert "${escapeHtml(fmtTs(t.timestamp??t.created_at??t.time))}" in source
+    assert "${displayValue(t.from??t.sender)}" in source
+    assert "${displayValue(t.to??t.recipient)}" in source
+    assert "${displayValue(t.amount??t.value)}" in source
 
     assert "${m.miner_id||m.wallet||'-'}" not in source
+    assert "${displayValue(m.score||m.attestation_score)}" not in source
     assert "${t.from||t.sender||'-'}" not in source
+    assert "${displayValue(t.amount||t.value)}" not in source
     assert "${t.to||t.recipient||'-'}" not in source
 
 
@@ -61,3 +65,64 @@ def test_dashboard_api_normalizes_paginated_rows(monkeypatch):
     data = response.get_json()
     assert data["miners"] == [{"miner_id": "miner-1"}]
     assert data["transactions"] == [{"from": "alice", "to": "bob"}]
+
+
+def test_dashboard_frontend_preserves_zero_values():
+    source = _source()
+    script = source.split("<script>", 1)[1].split("</script>", 1)[0]
+
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+const elements = {{}};
+const htmlEscape = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+const element = () => ({{
+  textContent: '',
+  get innerHTML() {{ return this._innerHTML || htmlEscape(this.textContent); }},
+  set innerHTML(value) {{ this._innerHTML = value; }},
+}});
+const dashboardPayload = {{
+  base: 'https://node.example',
+  health: {{ status: 'ok' }},
+  epoch: {{ epoch: 0 }},
+  miners: [{{ miner_id: 'miner-zero', score: 0, attestation_score: 7, multiplier: 0, antiquity_multiplier: 3 }}],
+  transactions: [{{ timestamp: 0, created_at: 1779250000, from: 'alice', to: 'bob', amount: 0, value: 9 }}],
+}};
+const context = {{
+  setInterval() {{}},
+  fetch: async () => ({{ json: async () => dashboardPayload }}),
+  document: {{
+    createElement: element,
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element();
+      return elements[id];
+    }},
+  }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+context.load().then(() => {{
+  console.log(JSON.stringify({{
+    miners: elements.minersTbl.innerHTML,
+    txs: elements.txTbl.innerHTML,
+  }}));
+}}).catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    rendered = json.loads(result.stdout)
+
+    assert "<td>0</td><td>0</td>" in rendered["miners"]
+    assert "<td>0</td>" in rendered["txs"]
+    assert "<td>7</td>" not in rendered["miners"]
+    assert "<td>9</td>" not in rendered["txs"]

--- a/tests/test_explorer_dashboard_app_security.py
+++ b/tests/test_explorer_dashboard_app_security.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+APP_PATH = Path(__file__).resolve().parents[1] / "explorer" / "dashboard" / "app.py"
+
+
+def _source() -> str:
+    return APP_PATH.read_text(encoding="utf-8")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("explorer_dashboard_app_under_test", APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.app.config["TESTING"] = True
+    return module
+
+
+def test_dashboard_table_rows_escape_api_fields_before_inner_html():
+    source = _source()
+
+    assert "function escapeHtml(value)" in source
+    assert "function displayValue(value)" in source
+    assert "${displayValue(m.miner_id||m.wallet)}" in source
+    assert "${displayValue(m.score||m.attestation_score)}" in source
+    assert "${displayValue(m.multiplier||m.antiquity_multiplier)}" in source
+    assert "${escapeHtml(fmtTs(t.timestamp||t.created_at||t.time))}" in source
+    assert "${displayValue(t.from||t.sender)}" in source
+    assert "${displayValue(t.to||t.recipient)}" in source
+    assert "${displayValue(t.amount||t.value)}" in source
+
+    assert "${m.miner_id||m.wallet||'-'}" not in source
+    assert "${t.from||t.sender||'-'}" not in source
+    assert "${t.to||t.recipient||'-'}" not in source
+
+
+def test_dashboard_api_normalizes_paginated_rows(monkeypatch):
+    module = _load_module()
+
+    def fake_fetch(path):
+        responses = {
+            "/health": {"status": "ok"},
+            "/api/miners": {"miners": [{"miner_id": "miner-1"}], "pagination": {"total": 1}},
+            "/epoch": {"epoch": 42},
+            "/api/transactions": {
+                "transactions": [{"from": "alice", "to": "bob"}],
+                "pagination": {"total": 1},
+            },
+        }
+        return responses[path]
+
+    monkeypatch.setattr(module, "fetch_json", fake_fetch)
+
+    response = module.app.test_client().get("/api/dashboard")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["miners"] == [{"miner_id": "miner-1"}]
+    assert data["transactions"] == [{"from": "alice", "to": "bob"}]


### PR DESCRIPTION
## Summary
- escape miner and transaction API fields before rendering dashboard table rows with `innerHTML`
- keep empty/null table values readable with a shared display helper
- normalize paginated `{ miners }` and `{ transactions }` upstream API responses before returning `/api/dashboard`
- add focused regression coverage for frontend escaping and response normalization

## Verification
- `python3 -m py_compile explorer/dashboard/app.py tests/test_explorer_dashboard_app_security.py`
- `uv run --with pytest --with flask --with requests python -m pytest tests/test_explorer_dashboard_app_security.py -q`
- `uv run --with pytest --with flask --with requests python -m pytest tests/test_explorer_dashboard_app_security.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
- localhost smoke check at `http://127.0.0.1:8877/`: page rendered, `/api/dashboard` returned 200, API base populated, and miner rows rendered from the live endpoint
