### PR TITLE
fix: harden miners dashboard rendering

### DIFF
--- a/explorer/dashboard/miners.html
+++ b/explorer/dashboard/miners.html
@@ -488,7 +488,7 @@
                 const response = await fetch('https://explorer.rustchain.org/api/miners');
                 if (!response.ok) throw new Error('API not available');
                 const data = await response.json();
-                miners = data.miners || [];
+                miners = Array.isArray(data) ? data : (data.miners || []);
             } catch (error) {
                 console.log('Using mock data:', error.message);
                 miners = mockMiners;

--- a/explorer/dashboard/miners.html
+++ b/explorer/dashboard/miners.html
@@ -482,13 +482,18 @@
             if (value.includes('g4')) return 'g4';
             return 'modern';
         }
+
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload) ? payload : (Array.isArray(payload?.miners) ? payload.miners : []);
+            return rows.filter(row => row && typeof row === 'object');
+        }
         
         async function fetchMiners() {
             try {
                 const response = await fetch('https://explorer.rustchain.org/api/miners');
                 if (!response.ok) throw new Error('API not available');
                 const data = await response.json();
-                miners = Array.isArray(data) ? data : (data.miners || []);
+                miners = normalizeMinerRows(data);
             } catch (error) {
                 console.log('Using mock data:', error.message);
                 miners = mockMiners;

--- a/explorer/dashboard/miners.html
+++ b/explorer/dashboard/miners.html
@@ -422,8 +422,66 @@
             "Apple Silicon": "🍎",
             "Modern": "💻"
         };
+
+        const archClasses = {
+            "G5": "g5",
+            "G4": "g4",
+            "POWER8": "power8",
+            "Apple Silicon": "apple",
+            "Modern": "modern"
+        };
         
         let miners = [];
+
+        function escapeHtml(value) {
+            const d = document.createElement('div');
+            d.textContent = String(value ?? '');
+            return d.innerHTML;
+        }
+
+        function safeNumber(value, fallback = 0) {
+            const n = Number(value);
+            return Number.isFinite(n) ? n : fallback;
+        }
+
+        function minerId(miner) {
+            return miner.id || miner.miner_id || miner.miner || miner.wallet || '-';
+        }
+
+        function minerArch(miner) {
+            return miner.arch || miner.device_arch || miner.device_family || 'Modern';
+        }
+
+        function minerMultiplier(miner) {
+            return safeNumber(miner.multiplier ?? miner.antiquity_multiplier, 0);
+        }
+
+        function minerWeight(miner) {
+            return safeNumber(miner.weight ?? miner.attestation_score ?? miner.score ?? miner.entropy_score, 0);
+        }
+
+        function minerLastAttestation(miner) {
+            const value = miner.lastAttestation ?? miner.last_attestation ?? miner.last_seen ?? miner.last_attest;
+            if (value === undefined || value === null || value === '') return '-';
+            const numeric = Number(value);
+            if (!Number.isFinite(numeric)) return value;
+            const ms = numeric > 1e12 ? numeric : numeric * 1000;
+            return new Date(ms).toLocaleString();
+        }
+
+        function minerStatus(miner) {
+            return String(miner.status || 'online').toLowerCase() === 'offline' ? 'offline' : 'online';
+        }
+
+        function archClass(arch) {
+            if (archClasses[arch]) return archClasses[arch];
+            const value = String(arch).toLowerCase();
+            if (value.includes('power')) return 'power8';
+            if (value.includes('apple') || value.includes('m1') || value.includes('m2') || value.includes('m3') || value.includes('m4')) return 'apple';
+            if (value.includes('g5')) return 'g5';
+            if (value.includes('g4')) return 'g4';
+            return 'modern';
+        }
         
         async function fetchMiners() {
             try {
@@ -442,9 +500,9 @@
         function updateDashboard() {
             // Update stats
             const total = miners.length;
-            const online = miners.filter(m => m.status === 'online').length;
+            const online = miners.filter(m => minerStatus(m) === 'online').length;
             const offline = total - online;
-            const totalWeight = miners.reduce((sum, m) => sum + m.weight, 0);
+            const totalWeight = miners.reduce((sum, m) => sum + minerWeight(m), 0);
             
             document.getElementById('totalMiners').textContent = total;
             document.getElementById('onlineMiners').textContent = online;
@@ -464,36 +522,44 @@
                 return;
             }
             
-            tbody.innerHTML = data.map(miner => `
+            tbody.innerHTML = data.map(miner => {
+                const id = minerId(miner);
+                const arch = minerArch(miner);
+                const status = minerStatus(miner);
+                const multiplier = minerMultiplier(miner);
+                const lastAttestation = minerLastAttestation(miner);
+                const weight = minerWeight(miner);
+                return `
                 <tr>
                     <td>
                         <div class="miner-name">
-                            <strong>${miner.id}</strong>
+                            <strong>${escapeHtml(id)}</strong>
                         </div>
                     </td>
                     <td>
-                        <span class="arch-badge ${miner.arch.toLowerCase().replace(' ', '-')}">
-                            ${archIcons[miner.arch] || '⚙️'} ${archLabels[miner.arch] || miner.arch}
+                        <span class="arch-badge ${archClass(arch)}">
+                            ${archIcons[arch] || '⚙️'} ${escapeHtml(archLabels[arch] || arch)}
                         </span>
                     </td>
                     <td>
-                        <span class="status-badge ${miner.status}">
-                            ${miner.status === 'online' ? 'Online' : 'Offline'}
+                        <span class="status-badge ${status}">
+                            ${status === 'online' ? 'Online' : 'Offline'}
                         </span>
                     </td>
-                    <td><span class="multiplier">${miner.multiplier}x</span></td>
-                    <td class="timestamp">${miner.lastAttestation}</td>
-                    <td>${miner.weight.toLocaleString()}</td>
+                    <td><span class="multiplier">${escapeHtml(multiplier)}x</span></td>
+                    <td class="timestamp">${escapeHtml(lastAttestation)}</td>
+                    <td>${escapeHtml(weight.toLocaleString())}</td>
                 </tr>
-            `).join('');
+            `;
+            }).join('');
         }
         
         // Search functionality
         document.getElementById('searchInput').addEventListener('input', (e) => {
             const query = e.target.value.toLowerCase();
             const filtered = miners.filter(m => 
-                m.id.toLowerCase().includes(query) ||
-                m.arch.toLowerCase().includes(query)
+                minerId(m).toLowerCase().includes(query) ||
+                minerArch(m).toLowerCase().includes(query)
             );
             renderTable(filtered);
         });

--- a/tests/test_explorer_miners_dashboard_security.py
+++ b/tests/test_explorer_miners_dashboard_security.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+MINERS_HTML = (
+    Path(__file__).resolve().parents[1] / "explorer" / "dashboard" / "miners.html"
+)
+
+
+def _source() -> str:
+    return MINERS_HTML.read_text(encoding="utf-8")
+
+
+def test_miner_rows_escape_api_fields_before_inner_html_rendering():
+    source = _source()
+
+    assert "function escapeHtml(value)" in source
+    assert "${escapeHtml(id)}" in source
+    assert "${escapeHtml(archLabels[arch] || arch)}" in source
+    assert "${escapeHtml(multiplier)}x" in source
+    assert "${escapeHtml(lastAttestation)}" in source
+    assert "${escapeHtml(weight.toLocaleString())}" in source
+
+    assert "<strong>${miner.id}</strong>" not in source
+    assert "${archLabels[miner.arch] || miner.arch}" not in source
+    assert "${miner.multiplier}x" not in source
+    assert "${miner.lastAttestation}" not in source
+
+
+def test_miner_dashboard_uses_safe_class_tokens_and_current_api_fields():
+    source = _source()
+
+    assert "function archClass(arch)" in source
+    assert "function minerStatus(miner)" in source
+    assert 'class="arch-badge ${archClass(arch)}"' in source
+    assert 'class="status-badge ${status}"' in source
+    assert "miner.miner_id || miner.miner || miner.wallet" in source
+    assert "miner.device_arch || miner.device_family" in source
+    assert "miner.multiplier ?? miner.antiquity_multiplier" in source
+    assert "miner.lastAttestation ?? miner.last_attestation ?? miner.last_seen ?? miner.last_attest" in source
+
+    assert "miner.arch.toLowerCase().replace(' ', '-')" not in source
+    assert 'class="status-badge ${miner.status}"' not in source

--- a/tests/test_explorer_miners_dashboard_security.py
+++ b/tests/test_explorer_miners_dashboard_security.py
@@ -39,6 +39,7 @@ def test_miner_dashboard_uses_safe_class_tokens_and_current_api_fields():
     assert "miner.device_arch || miner.device_family" in source
     assert "miner.multiplier ?? miner.antiquity_multiplier" in source
     assert "miner.lastAttestation ?? miner.last_attestation ?? miner.last_seen ?? miner.last_attest" in source
+    assert "miners = Array.isArray(data) ? data : (data.miners || []);" in source
 
     assert "miner.arch.toLowerCase().replace(' ', '-')" not in source
     assert 'class="status-badge ${miner.status}"' not in source

--- a/tests/test_explorer_miners_dashboard_security.py
+++ b/tests/test_explorer_miners_dashboard_security.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
+import json
+import re
+import subprocess
 
 
 MINERS_HTML = (
@@ -39,7 +42,76 @@ def test_miner_dashboard_uses_safe_class_tokens_and_current_api_fields():
     assert "miner.device_arch || miner.device_family" in source
     assert "miner.multiplier ?? miner.antiquity_multiplier" in source
     assert "miner.lastAttestation ?? miner.last_attestation ?? miner.last_seen ?? miner.last_attest" in source
-    assert "miners = Array.isArray(data) ? data : (data.miners || []);" in source
+    assert "function normalizeMinerRows(payload)" in source
+    assert "miners = normalizeMinerRows(data);" in source
 
     assert "miner.arch.toLowerCase().replace(' ', '-')" not in source
     assert 'class="status-badge ${miner.status}"' not in source
+
+
+def test_malformed_miners_payloads_render_empty_state_without_throwing():
+    script = re.search(
+        r"<script>(?P<script>.*?)</script>",
+        _source(),
+        flags=re.DOTALL,
+    ).group("script")
+
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+
+async function run(payload) {{
+  const elements = {{}};
+  const htmlEscape = (value) => String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  const element = () => ({{
+    textContent: '',
+    value: '',
+    addEventListener() {{}},
+    get innerHTML() {{ return this._innerHTML || htmlEscape(this.textContent); }},
+    set innerHTML(value) {{ this._innerHTML = value; }},
+  }});
+  const context = {{
+    console: {{ log() {{}} }},
+    setInterval() {{}},
+    fetch: async () => ({{ ok: true, json: async () => payload }}),
+    document: {{
+      createElement: element,
+      getElementById(id) {{
+        if (!elements[id]) elements[id] = element();
+        return elements[id];
+      }},
+    }},
+  }};
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  await context.fetchMiners();
+  return {{
+    table: elements.minerTable.innerHTML,
+    total: elements.totalMiners.textContent,
+  }};
+}}
+
+(async () => {{
+  const objectPayload = await run({{ miners: {{}} }});
+  const nullRows = await run({{ miners: [null] }});
+  console.log(JSON.stringify({{ objectPayload, nullRows }}));
+}})().catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["objectPayload"]["total"] == 0
+    assert "No miners found" in data["objectPayload"]["table"]
+    assert data["nullRows"]["total"] == 0
+    assert "No miners found" in data["nullRows"]["table"]


### PR DESCRIPTION
## Summary
- escape live miner API fields before rendering table rows with `innerHTML`
- constrain architecture/status CSS class tokens to known-safe values
- normalize current `/api/miners` fields such as `miner`, `device_arch`, `antiquity_multiplier`, and `last_attest`
- keep search, stats, and weight totals working with both mock and live miner response shapes
- add focused regression coverage for frontend escaping, safe class tokens, and current API field names

## Verification
- extracted and parsed the embedded script in `explorer/dashboard/miners.html` with Node `new Function(...)`
- `uv run --with pytest --with flask python -m pytest tests/test_explorer_miners_dashboard_security.py -q`
- `uv run --with pytest python -m pytest tests/test_explorer_miners_dashboard_security.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
- localhost smoke check at `http://127.0.0.1:8878/explorer/dashboard/miners.html`: rendered 13 live miner rows, first row used current API fields, and the table did not contain `undefined`
