### PR TITLE
fix: harden agent economy dashboard rendering

### DIFF
--- a/explorer/dashboard/agent-economy.html
+++ b/explorer/dashboard/agent-economy.html
@@ -330,6 +330,34 @@
         
         let jobs = [];
         let currentCategory = 'all';
+        const allowedCategories = ['code', 'research', 'writing', 'video', 'audio', 'design', 'data', 'testing', 'other'];
+        const statusOrder = ['open', 'claimed', 'delivered', 'completed'];
+
+        function escapeHtml(value) {
+            const d = document.createElement('div');
+            d.textContent = String(value ?? '');
+            return d.innerHTML;
+        }
+
+        function safeNumber(value, fallback = 0) {
+            const n = Number(value);
+            return Number.isFinite(n) ? n : fallback;
+        }
+
+        function safeCategory(value) {
+            const category = String(value || 'other').toLowerCase();
+            return allowedCategories.includes(category) ? category : 'other';
+        }
+
+        function safeStatus(value) {
+            const status = String(value || 'open').toLowerCase();
+            return statusOrder.includes(status) ? status : 'open';
+        }
+
+        function normalizeJobs(payload) {
+            const rows = Array.isArray(payload) ? payload : (Array.isArray(payload?.jobs) ? payload.jobs : []);
+            return rows.filter(job => job && typeof job === 'object');
+        }
         
         async function fetchData() {
             try {
@@ -345,7 +373,7 @@
                 
                 if (jobsRes.status === 'fulfilled') {
                     const jobsData = await jobsRes.value.json();
-                    jobs = jobsData;
+                    jobs = normalizeJobs(jobsData);
                 } else { jobs = mockJobs; }
             } catch (error) {
                 console.log('Using mock data:', error);
@@ -356,19 +384,23 @@
         }
         
         function updateStats(stats) {
-            document.getElementById('totalVolume').textContent = (stats.total_volume_rtc || 0).toFixed(1) + ' RTC';
-            document.getElementById('openJobs').textContent = stats.open_jobs || 0;
-            document.getElementById('completedJobs').textContent = stats.completed_jobs || 0;
-            document.getElementById('activeAgents').textContent = stats.active_agents || 0;
+            document.getElementById('totalVolume').textContent = safeNumber(stats.total_volume_rtc).toFixed(1) + ' RTC';
+            document.getElementById('openJobs').textContent = safeNumber(stats.open_jobs);
+            document.getElementById('completedJobs').textContent = safeNumber(stats.completed_jobs);
+            document.getElementById('activeAgents').textContent = safeNumber(stats.active_agents);
             document.getElementById('lastUpdate').textContent = new Date().toLocaleTimeString();
         }
         
         function renderJobs() {
             const grid = document.getElementById('jobsGrid');
-            let filtered = currentCategory === 'all' ? jobs : jobs.filter(j => j.category === currentCategory);
+            let filtered = currentCategory === 'all' ? jobs : jobs.filter(j => safeCategory(j.category) === currentCategory);
             const searchTerm = document.getElementById('searchInput').value.toLowerCase();
             if (searchTerm) {
-                filtered = filtered.filter(j => j.title.toLowerCase().includes(searchTerm) || j.description.toLowerCase().includes(searchTerm) || j.poster.toLowerCase().includes(searchTerm));
+                filtered = filtered.filter(j =>
+                    String(j.title || '').toLowerCase().includes(searchTerm) ||
+                    String(j.description || '').toLowerCase().includes(searchTerm) ||
+                    String(j.poster || '').toLowerCase().includes(searchTerm)
+                );
             }
             
             if (filtered.length === 0) {
@@ -376,35 +408,39 @@
                 return;
             }
             
-            grid.innerHTML = filtered.map(job => `
+            grid.innerHTML = filtered.map(job => {
+                const id = String(job.id ?? '');
+                const category = safeCategory(job.category);
+                const status = safeStatus(job.status);
+                return `
                 <div class="job-card">
                     <div class="job-header">
                         <div>
-                            <div class="job-title">${job.title}</div>
-                            <div class="job-id">ID: ${job.id}</div>
+                            <div class="job-title">${escapeHtml(job.title)}</div>
+                            <div class="job-id">ID: ${escapeHtml(id)}</div>
                         </div>
-                        <div class="job-reward">${job.reward} RTC</div>
+                        <div class="job-reward">${escapeHtml(safeNumber(job.reward).toFixed(1))} RTC</div>
                     </div>
-                    <p class="job-description">${job.description}</p>
+                    <p class="job-description">${escapeHtml(job.description)}</p>
                     <div class="job-meta">
-                        <span class="category-badge ${job.category}">${job.category}</span>
-                        <span class="job-tag">👤 ${job.poster}</span>
+                        <span class="category-badge ${category}">${escapeHtml(category)}</span>
+                        <span class="job-tag">👤 ${escapeHtml(job.poster)}</span>
                         <span class="job-tag">📅 ${formatDate(job.created_at)}</span>
                     </div>
                     <div class="lifecycle">
-                        <div class="lifecycle-step ${getStatusClass(job.status, 'open')}">📝 Posted</div>
-                        <div class="lifecycle-step ${getStatusClass(job.status, 'claimed')}">✋ Claimed</div>
-                        <div class="lifecycle-step ${getStatusClass(job.status, 'delivered')}">📤 Delivered</div>
-                        <div class="lifecycle-step ${getStatusClass(job.status, 'completed')}">✅ Completed</div>
+                        <div class="lifecycle-step ${getStatusClass(status, 'open')}">📝 Posted</div>
+                        <div class="lifecycle-step ${getStatusClass(status, 'claimed')}">✋ Claimed</div>
+                        <div class="lifecycle-step ${getStatusClass(status, 'delivered')}">📤 Delivered</div>
+                        <div class="lifecycle-step ${getStatusClass(status, 'completed')}">✅ Completed</div>
                     </div>
-                    ${job.status === 'open' ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${job.id}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
+                    ${status === 'open' ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${escapeHtml(id)}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
                 </div>
-            `).join('');
+            `;
+            }).join('');
         }
         
         function getStatusClass(jobStatus, step) {
-            const order = ['open', 'claimed', 'delivered', 'completed'];
-            return order.indexOf(step) <= order.indexOf(jobStatus) ? 'active' : '';
+            return statusOrder.indexOf(step) <= statusOrder.indexOf(safeStatus(jobStatus)) ? 'active' : '';
         }
         
         function formatDate(dateStr) {
@@ -424,7 +460,7 @@
             document.getElementById('repScore').textContent = '--';
             
             try {
-                const response = await fetch(`https://rustchain.org/agent/reputation/${wallet}`);
+                const response = await fetch(`https://rustchain.org/agent/reputation/${encodeURIComponent(wallet)}`);
                 const rep = response.ok ? await response.json() : mockReputation;
                 updateReputation(rep);
             } catch (error) { updateReputation(mockReputation); }

--- a/explorer/dashboard/agent-economy.html
+++ b/explorer/dashboard/agent-economy.html
@@ -350,8 +350,8 @@
         }
 
         function safeStatus(value) {
-            const status = String(value || 'open').toLowerCase();
-            return statusOrder.includes(status) ? status : 'open';
+            const status = String(value || '').toLowerCase();
+            return statusOrder.includes(status) ? status : 'unknown';
         }
 
         function normalizeJobs(payload) {
@@ -409,7 +409,7 @@
             }
             
             grid.innerHTML = filtered.map(job => {
-                const id = String(job.id ?? '');
+                const id = String(job.id ?? '').trim();
                 const category = safeCategory(job.category);
                 const status = safeStatus(job.status);
                 return `
@@ -433,7 +433,7 @@
                         <div class="lifecycle-step ${getStatusClass(status, 'delivered')}">📤 Delivered</div>
                         <div class="lifecycle-step ${getStatusClass(status, 'completed')}">✅ Completed</div>
                     </div>
-                    ${status === 'open' ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${escapeHtml(id)}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
+                    ${status === 'open' && id ? `<div class="curl-cmd">curl -X POST https://rustchain.org/agent/jobs/${escapeHtml(id)}/claim -d '{"worker_wallet": "your-wallet"}'</div>` : ''}
                 </div>
             `;
             }).join('');

--- a/tests/test_agent_economy_dashboard_security.py
+++ b/tests/test_agent_economy_dashboard_security.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import json
+import re
+import subprocess
+
+
+AGENT_ECONOMY_HTML = (
+    Path(__file__).resolve().parents[1] / "explorer" / "dashboard" / "agent-economy.html"
+)
+
+
+def _source() -> str:
+    return AGENT_ECONOMY_HTML.read_text(encoding="utf-8")
+
+
+def test_agent_economy_job_cards_escape_api_fields():
+    source = _source()
+
+    assert "function escapeHtml(value)" in source
+    assert "${escapeHtml(job.title)}" in source
+    assert "ID: ${escapeHtml(id)}" in source
+    assert "${escapeHtml(safeNumber(job.reward).toFixed(1))} RTC" in source
+    assert "${escapeHtml(job.description)}" in source
+    assert "👤 ${escapeHtml(job.poster)}" in source
+    assert "jobs = normalizeJobs(jobsData);" in source
+
+    assert "${job.title}" not in source
+    assert "ID: ${job.id}" not in source
+    assert "${job.description}" not in source
+    assert "👤 ${job.poster}" not in source
+    assert "jobs = jobsData;" not in source
+
+
+def test_agent_economy_uses_safe_category_status_and_wallet_lookup():
+    source = _source()
+
+    assert "function safeCategory(value)" in source
+    assert "function safeStatus(value)" in source
+    assert "function normalizeJobs(payload)" in source
+    assert 'class="category-badge ${category}"' in source
+    assert "getStatusClass(status, 'open')" in source
+    assert "encodeURIComponent(wallet)" in source
+
+    assert 'class="category-badge ${job.category}"' not in source
+    assert "getStatusClass(job.status, 'open')" not in source
+    assert "agent/reputation/${wallet}" not in source
+
+
+def test_agent_economy_render_jobs_escapes_malicious_payload():
+    script = re.search(
+        r"<script>(?P<script>.*?)</script>",
+        _source(),
+        flags=re.DOTALL,
+    ).group("script")
+    malicious_jobs_json = json.dumps(
+        [
+            {
+                "id": "job-<bad>",
+                "title": "<img src=x onerror=alert(1)>",
+                "description": "<script>alert(1)</script>",
+                "category": "evil class",
+                "reward": "7",
+                "status": "badstatus",
+                "poster": "<b>attacker</b>",
+                "created_at": "2026-05-20T00:00:00Z",
+            }
+        ]
+    )
+
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+const maliciousJobs = {malicious_jobs_json};
+const elements = {{}};
+const htmlEscape = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+const element = (id) => ({{
+  id,
+  value: '',
+  dataset: {{}},
+  classList: {{ add() {{}}, remove() {{}} }},
+  addEventListener() {{}},
+  textContent: '',
+  get innerHTML() {{ return this._innerHTML || htmlEscape(this.textContent); }},
+  set innerHTML(value) {{ this._innerHTML = value; }},
+}});
+const queryElements = [element('tab-all')];
+queryElements[0].dataset.category = 'all';
+const context = {{
+  console: {{ log() {{}} }},
+  setInterval() {{}},
+  fetch: async () => ({{ ok: false, json: async () => ({{}}) }}),
+  document: {{
+    createElement: element,
+    querySelectorAll() {{ return queryElements; }},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element(id);
+      return elements[id];
+    }},
+  }},
+  alert() {{}},
+}};
+context.maliciousJobs = maliciousJobs;
+vm.createContext(context);
+vm.runInContext(script, context);
+vm.runInContext('jobs = maliciousJobs; renderJobs();', context);
+console.log(JSON.stringify({{ html: elements.jobsGrid.innerHTML }}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    html = json.loads(result.stdout)["html"]
+
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "&lt;b&gt;attacker&lt;/b&gt;" in html
+    assert 'class="category-badge other"' in html
+    assert '<img src=x onerror=alert(1)>' not in html
+    assert '<script>alert(1)</script>' not in html

--- a/tests/test_agent_economy_dashboard_security.py
+++ b/tests/test_agent_economy_dashboard_security.py
@@ -113,6 +113,7 @@ console.log(JSON.stringify({{ html: elements.jobsGrid.innerHTML }}));
     result = subprocess.run(
         ["node", "-e", probe],
         text=True,
+        encoding="utf-8",
         capture_output=True,
         check=True,
     )
@@ -122,5 +123,89 @@ console.log(JSON.stringify({{ html: elements.jobsGrid.innerHTML }}));
     assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
     assert "&lt;b&gt;attacker&lt;/b&gt;" in html
     assert 'class="category-badge other"' in html
+    assert "curl -X POST" not in html
     assert '<img src=x onerror=alert(1)>' not in html
     assert '<script>alert(1)</script>' not in html
+
+
+def test_agent_economy_malformed_jobs_do_not_render_claim_commands():
+    script = re.search(
+        r"<script>(?P<script>.*?)</script>",
+        _source(),
+        flags=re.DOTALL,
+    ).group("script")
+    malformed_jobs_json = json.dumps(
+        [
+            {"title": "Missing status and id", "category": "code", "reward": 7},
+            {
+                "id": "",
+                "title": "Invalid status",
+                "category": "code",
+                "reward": 7,
+                "status": "badstatus",
+            },
+            {
+                "id": "   ",
+                "title": "Blank id",
+                "category": "code",
+                "reward": 7,
+                "status": "open",
+            },
+        ]
+    )
+
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+const malformedJobs = {malformed_jobs_json};
+const elements = {{}};
+const htmlEscape = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;');
+const element = (id) => ({{
+  id,
+  value: '',
+  dataset: {{}},
+  classList: {{ add() {{}}, remove() {{}} }},
+  addEventListener() {{}},
+  textContent: '',
+  get innerHTML() {{ return this._innerHTML || htmlEscape(this.textContent); }},
+  set innerHTML(value) {{ this._innerHTML = value; }},
+}});
+const queryElements = [element('tab-all')];
+queryElements[0].dataset.category = 'all';
+const context = {{
+  console: {{ log() {{}} }},
+  setInterval() {{}},
+  fetch: async () => ({{ ok: false, json: async () => ({{}}) }}),
+  document: {{
+    createElement: element,
+    querySelectorAll() {{ return queryElements; }},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element(id);
+      return elements[id];
+    }},
+  }},
+  alert() {{}},
+}};
+context.malformedJobs = malformedJobs;
+vm.createContext(context);
+vm.runInContext(script, context);
+vm.runInContext('jobs = malformedJobs; renderJobs();', context);
+console.log(JSON.stringify({{ html: elements.jobsGrid.innerHTML }}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=True,
+    )
+    html = json.loads(result.stdout)["html"]
+
+    assert "Missing status and id" in html
+    assert "Invalid status" in html
+    assert "Blank id" in html
+    assert "curl -X POST" not in html
+    assert "/agent/jobs//claim" not in html


### PR DESCRIPTION
## Summary
- escape agent economy job fields before inserting API data into job cards
- constrain category/status values used in class names and lifecycle rendering
- normalize job API payloads and encode reputation wallet lookups
- add static and executable regression coverage for malicious job payload rendering

## Tests
- node inline script parse for `explorer/dashboard/agent-economy.html`
- `uv run --with pytest --with flask python -m pytest tests/test_agent_economy_dashboard_security.py -q`
- `uv run --with pytest python -m pytest tests/test_agent_economy_dashboard_security.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
