### PR TITLE
fix: normalize miner withdrawal history

### DIFF
--- a/explorer/miner-dashboard.html
+++ b/explorer/miner-dashboard.html
@@ -308,6 +308,11 @@
         return escapeHtml(String(value ?? fallback));
     }
 
+    function normalizeWithdrawals(payload) {
+        const rows = Array.isArray(payload) ? payload : (Array.isArray(payload?.withdrawals) ? payload.withdrawals : []);
+        return rows.filter(w => w && typeof w === 'object');
+    }
+
     async function loadMiner() {
         const input = document.getElementById('miner-id');
         const minerId = input.value.trim();
@@ -411,17 +416,9 @@
 
         // Withdrawal history
         const wBody = document.getElementById('withdrawals-body');
-        if (historyData && Array.isArray(historyData) && historyData.length > 0) {
-            wBody.innerHTML = historyData.slice(0, 10).map(w => `
-                <tr>
-                    <td style="font-size:0.75rem;">${safeText(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
-                    <td>${safeText(w.amount, '?')} RTC</td>
-                    <td><span class="badge ${w.status === 'completed' ? 'badge-green' : w.status === 'pending' ? 'badge-yellow' : 'badge-red'}">${escapeHtml(w.status || 'unknown')}</span></td>
-                    <td>${safeText(timeAgo(w.requested_at || w.created_at || w.timestamp))}</td>
-                </tr>
-            `).join('');
-        } else if (historyData?.withdrawals && historyData.withdrawals.length > 0) {
-            wBody.innerHTML = historyData.withdrawals.slice(0, 10).map(w => `
+        const withdrawals = normalizeWithdrawals(historyData);
+        if (withdrawals.length > 0) {
+            wBody.innerHTML = withdrawals.slice(0, 10).map(w => `
                 <tr>
                     <td style="font-size:0.75rem;">${safeText(String(w.withdrawal_id || w.id || '--').substring(0, 12))}...</td>
                     <td>${safeText(w.amount, '?')} RTC</td>

--- a/tests/test_explorer_miner_dashboard_security.py
+++ b/tests/test_explorer_miner_dashboard_security.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import json
+import re
+import subprocess
 
 
 HTML = Path(__file__).resolve().parents[1] / "explorer" / "miner-dashboard.html"
@@ -40,7 +43,49 @@ def test_empty_reward_and_activity_rows_escape_api_fields():
 def test_withdrawal_rows_escape_amounts_and_timestamps():
     html = source()
 
-    assert html.count("${safeText(w.amount, '?')} RTC") == 2
-    assert html.count("${safeText(timeAgo(w.requested_at || w.created_at || w.timestamp))}") == 2
+    assert html.count("${safeText(w.amount, '?')} RTC") == 1
+    assert html.count("${safeText(timeAgo(w.requested_at || w.created_at || w.timestamp))}") == 1
     assert "${w.amount ?? '?'} RTC" not in html
     assert "${timeAgo(w.requested_at || w.created_at || w.timestamp)}" not in html
+
+
+def test_withdrawal_history_normalizes_array_envelopes():
+    html = source()
+
+    assert "function normalizeWithdrawals(payload)" in html
+    assert "const withdrawals = normalizeWithdrawals(historyData);" in html
+    assert "historyData.withdrawals.slice(0, 10).map" not in html
+
+
+def test_withdrawal_normalization_rejects_malformed_rows():
+    script = re.search(r"<script>(?P<script>.*?)</script>", source(), flags=re.DOTALL).group(
+        "script"
+    )
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+const payload = {json.dumps({"withdrawals": [None, "bad", {"id": "ok"}, {"id": "<bad>"}]})};
+const context = {{
+  console: {{ warn() {{}} }},
+  window: {{ location: {{ origin: 'https://example.test', search: '' }} }},
+  URLSearchParams,
+  setInterval() {{}},
+  document: {{
+    createElement() {{ return {{ textContent: '', get innerHTML() {{ return this.textContent; }} }}; }},
+    getElementById() {{ return {{ value: '', style: {{}}, textContent: '', appendChild() {{}} }}; }},
+  }},
+}};
+context.payload = payload;
+vm.createContext(context);
+vm.runInContext(script, context);
+const rows = vm.runInContext('normalizeWithdrawals(payload)', context);
+console.log(JSON.stringify(rows));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert json.loads(result.stdout) == [{"id": "ok"}, {"id": "<bad>"}]


### PR DESCRIPTION
## Summary
- normalize miner withdrawal history responses before rendering the table
- handle both array responses and `{ withdrawals: [...] }` envelopes through one path
- filter malformed withdrawal rows so malformed envelopes cannot crash table rendering
- extend miner dashboard security tests with a VM regression for malformed withdrawal payloads

## Tests
- node inline script parse for `explorer/miner-dashboard.html`
- `uv run --with pytest --with flask python -m pytest tests/test_explorer_miner_dashboard_security.py -q`
- `uv run --with pytest python -m pytest tests/test_explorer_miner_dashboard_security.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
