### PR TITLE
fix: normalize static explorer miner rows

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -622,10 +622,11 @@ function renderSearchResults() {
         return;
     }
     
-    const matchingMiners = state.miners.filter(m => 
-        (m.miner_id || '').toLowerCase().includes(query) ||
-        (m.device_arch || '').toLowerCase().includes(query)
-    );
+    const matchingMiners = state.miners.filter(m => {
+        const minerId = String(m.miner_id ?? '').toLowerCase();
+        const arch = String(m.device_arch ?? '').toLowerCase();
+        return minerId.includes(query) || arch.includes(query);
+    });
     
     if (matchingMiners.length === 0) {
         container.innerHTML = `

--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -47,7 +47,7 @@ const state = {
 
 // Utility Functions
 function escapeHtml(str) {
-    if (!str) return '';
+    if (str === null || str === undefined) return '';
     return String(str)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -57,20 +57,24 @@ function escapeHtml(str) {
 }
 
 function shortenHash(hash, chars = 8) {
-    if (!hash) return '';
-    if (hash.length <= chars * 2) return hash;
-    return `${hash.slice(0, chars)}...${hash.slice(-chars)}`;
+    const value = String(hash ?? '');
+    if (!value) return '';
+    if (value.length <= chars * 2) return value;
+    return `${value.slice(0, chars)}...${value.slice(-chars)}`;
 }
 
 function shortenAddress(addr, chars = 6) {
-    if (!addr) return '';
-    if (addr.length <= chars * 2) return addr;
-    return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+    const value = String(addr ?? '');
+    if (!value) return '';
+    if (value.length <= chars * 2) return value;
+    return `${value.slice(0, chars)}...${value.slice(-chars)}`;
 }
 
 function formatNumber(num, decimals = 2) {
     if (num === null || num === undefined) return '0';
-    return Number(num).toLocaleString(undefined, {
+    const value = Number(num);
+    if (!Number.isFinite(value)) return '0';
+    return value.toLocaleString(undefined, {
         minimumFractionDigits: decimals,
         maximumFractionDigits: decimals
     });
@@ -100,14 +104,15 @@ function formatRelativeTime(ts) {
 }
 
 function normalizeMinersResponse(payload) {
-    if (Array.isArray(payload)) return payload;
-    if (payload && Array.isArray(payload.miners)) return payload.miners;
-    return [];
+    const rows = Array.isArray(payload) ? payload :
+        (Array.isArray(payload?.miners) ? payload.miners :
+        (Array.isArray(payload?.data) ? payload.data : []));
+    return rows.filter(row => row && typeof row === 'object');
 }
 
 function getArchitectureTier(arch) {
     if (!arch) return 'modern';
-    const archLower = arch.toLowerCase();
+    const archLower = String(arch).toLowerCase();
     if (archLower.includes('g3') || archLower.includes('g4') || archLower.includes('g5') || 
         archLower.includes('powerpc') || archLower.includes('sparc')) return 'vintage';
     if (archLower.includes('pentium') || archLower.includes('core 2') || 
@@ -131,11 +136,6 @@ function getRustBadge(score) {
     if (score >= 50) return 'Corroded Knight';
     if (score >= 30) return 'Tarnished Squire';
     return 'Fresh Metal';
-}
-
-
-function normalizeMinersResponse(response) {
-    return Array.isArray(response) ? response : (response?.miners || []);
 }
 
 // API Fetcher with Error Handling

--- a/tests/test_explorer_miners_normalization.py
+++ b/tests/test_explorer_miners_normalization.py
@@ -1,13 +1,60 @@
 from pathlib import Path
+import json
+import subprocess
 
 JS = Path('explorer/static/js/explorer.js').read_text(encoding='utf-8')
 
 
 def test_explorer_normalizes_paginated_miners_response():
-    assert 'function normalizeMinersResponse(response)' in JS
-    assert 'response?.miners || []' in JS
+    assert JS.count('function normalizeMinersResponse(') == 1
+    assert "Array.isArray(payload?.miners)" in JS
+    assert "Array.isArray(payload?.data)" in JS
+    assert "return rows.filter(row => row && typeof row === 'object');" in JS
     assert "state.miners = normalizeMinersResponse(await fetchAPI('/api/miners'));" in JS
 
 
 def test_explorer_keeps_legacy_array_response_compatible():
-    assert 'Array.isArray(response) ? response' in JS
+    assert 'Array.isArray(payload) ? payload' in JS
+
+
+def test_explorer_helpers_tolerate_malformed_miner_fields():
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(JS)};
+const context = {{
+  window: {{ EXPLORER_API_BASE: 'https://example.test' }},
+  document: {{
+    addEventListener() {{}},
+    getElementById() {{ return null; }},
+    querySelectorAll() {{ return []; }},
+  }},
+  setInterval() {{}},
+  setTimeout() {{ return 1; }},
+  clearTimeout() {{}},
+  AbortController: class {{ constructor() {{ this.signal = {{}}; }} abort() {{}} }},
+  fetch: async () => ({{ ok: true, json: async () => ({{}}) }}),
+  console: {{ error() {{}}, warn() {{}}, log() {{}} }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+const payload = {{ miners: [null, 'bad', {{ miner_id: {{ id: 'm' }}, device_arch: ['G4'], balance: 'NaN' }}] }};
+const result = {{
+  miners: vm.runInContext('normalizeMinersResponse', context)(payload),
+  address: vm.runInContext('shortenAddress', context)({{ id: 'm' }}),
+  tier: vm.runInContext('getArchitectureTier', context)(['G4']),
+  number: vm.runInContext('formatNumber', context)('NaN', 2),
+}};
+console.log(JSON.stringify(result));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["miners"] == [{"miner_id": {"id": "m"}, "device_arch": ["G4"], "balance": "NaN"}]
+    assert data["address"] == "[objec...bject]"
+    assert data["tier"] == "vintage"
+    assert data["number"] == "0"

--- a/tests/test_explorer_miners_normalization.py
+++ b/tests/test_explorer_miners_normalization.py
@@ -21,11 +21,20 @@ def test_explorer_helpers_tolerate_malformed_miner_fields():
     probe = f"""
 const vm = require('vm');
 const script = {json.dumps(JS)};
+const elements = {{}};
+const element = () => ({{
+  innerHTML: '',
+  addEventListener() {{}},
+  dataset: {{}},
+}});
 const context = {{
   window: {{ EXPLORER_API_BASE: 'https://example.test' }},
   document: {{
     addEventListener() {{}},
-    getElementById() {{ return null; }},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element();
+      return elements[id];
+    }},
     querySelectorAll() {{ return []; }},
   }},
   setInterval() {{}},
@@ -38,12 +47,15 @@ const context = {{
 vm.createContext(context);
 vm.runInContext(script, context);
 const payload = {{ miners: [null, 'bad', {{ miner_id: {{ id: 'm' }}, device_arch: ['G4'], balance: 'NaN' }}] }};
+context.payload = payload;
 const result = {{
   miners: vm.runInContext('normalizeMinersResponse', context)(payload),
   address: vm.runInContext('shortenAddress', context)({{ id: 'm' }}),
   tier: vm.runInContext('getArchitectureTier', context)(['G4']),
   number: vm.runInContext('formatNumber', context)('NaN', 2),
 }};
+vm.runInContext('state.miners = normalizeMinersResponse(payload); state.searchQuery = "g4"; renderSearchResults();', context);
+result.searchHtml = elements['search-results'].innerHTML;
 console.log(JSON.stringify(result));
 """
     result = subprocess.run(
@@ -58,3 +70,4 @@ console.log(JSON.stringify(result));
     assert data["address"] == "[objec...bject]"
     assert data["tier"] == "vintage"
     assert data["number"] == "0"
+    assert "Search Results: 1 found" in data["searchHtml"]


### PR DESCRIPTION
## Summary
- remove the duplicate `normalizeMinersResponse` implementation in the static explorer
- accept legacy arrays, `{ miners: [...] }`, and `{ data: [...] }` envelopes while filtering malformed miner rows
- harden shared formatting helpers against non-string IDs, non-string architectures, and non-finite numeric values
- add an executable VM regression for malformed miner payload fields

## Tests
- node inline script parse for `explorer/static/js/explorer.js`
- `uv run --with pytest --with flask python -m pytest tests/test_explorer_miners_normalization.py -q`
- `uv run --with pytest python -m pytest tests/test_explorer_miners_normalization.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
