### PR TITLE
fix: reject non-object JSON bodies in bridge admin routes (Fixes #5766)

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -118,7 +118,7 @@ VALID_BRIDGE_TYPES = {"bottube", "internal", "custom"}
 
 def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     """Validate bridge transfer request payload."""
-    if not data:
+    if not isinstance(data, dict):
         return ValidationResult(ok=False, error="Request body is required")
     
     # Required fields
@@ -774,7 +774,7 @@ def register_bridge_routes(app):
             return jsonify({"error": "unauthorized"}), 401
         
         data = request.get_json(silent=True)
-        if not data:
+        if not isinstance(data, dict):
             return jsonify({"error": "Request body required"}), 400
         
         tx_hash = data.get("tx_hash")
@@ -805,7 +805,7 @@ def register_bridge_routes(app):
             return jsonify({"error": "Unauthorized"}), 401
         
         data = request.get_json(silent=True)
-        if not data:
+        if not isinstance(data, dict):
             return jsonify({"error": "Request body required"}), 400
         
         tx_hash = data.get("tx_hash")

--- a/node/tests/test_bridge_admin_json_body.py
+++ b/node/tests/test_bridge_admin_json_body.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """
 Regression test for issue #5766:
 Bridge admin callbacks crash on non-object JSON bodies.

--- a/node/tests/test_bridge_admin_json_body.py
+++ b/node/tests/test_bridge_admin_json_body.py
@@ -1,0 +1,112 @@
+"""
+Regression test for issue #5766:
+Bridge admin callbacks crash on non-object JSON bodies.
+
+Verifies that POST /api/bridge/void and POST /api/bridge/update-external
+return HTTP 400 when given a JSON array body instead of a JSON object.
+"""
+import json
+import os
+import sys
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal Flask app fixture that registers only the bridge routes.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def app():
+    """Create a minimal Flask app with bridge routes for testing."""
+    from flask import Flask
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+
+    # Set required env vars for the admin routes
+    os.environ.setdefault('RC_ADMIN_KEY', 'test-admin-key')
+    os.environ.setdefault('RC_BRIDGE_API_KEY', 'test-bridge-key')
+
+    from node.bridge_api import register_bridge_routes
+    register_bridge_routes(app)
+
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — JSON array bodies must be rejected with 400.
+# ---------------------------------------------------------------------------
+
+class TestBridgeVoidNonObjectJSON:
+    """POST /api/bridge/void must reject non-object JSON bodies."""
+
+    def test_array_body_returns_400(self, client):
+        """A JSON array like [\"a\", \"b\"] should not pass the body check."""
+        resp = client.post(
+            '/api/bridge/void',
+            data=json.dumps(["not", "an", "object"]),
+            content_type='application/json',
+            headers={'X-Admin-Key': 'test-admin-key'},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert 'error' in body
+
+    def test_null_body_returns_400(self, client):
+        """A null/empty JSON body should be rejected."""
+        resp = client.post(
+            '/api/bridge/void',
+            data='null',
+            content_type='application/json',
+            headers={'X-Admin-Key': 'test-admin-key'},
+        )
+        assert resp.status_code == 400
+
+    def test_string_body_returns_400(self, client):
+        """A plain JSON string should be rejected."""
+        resp = client.post(
+            '/api/bridge/void',
+            data=json.dumps("just a string"),
+            content_type='application/json',
+            headers={'X-Admin-Key': 'test-admin-key'},
+        )
+        assert resp.status_code == 400
+
+    def test_integer_body_returns_400(self, client):
+        """A plain JSON integer should be rejected."""
+        resp = client.post(
+            '/api/bridge/void',
+            data='42',
+            content_type='application/json',
+            headers={'X-Admin-Key': 'test-admin-key'},
+        )
+        assert resp.status_code == 400
+
+
+class TestBridgeUpdateExternalNonObjectJSON:
+    """POST /api/bridge/update-external must reject non-object JSON bodies."""
+
+    def test_array_body_returns_400(self, client):
+        resp = client.post(
+            '/api/bridge/update-external',
+            data=json.dumps(["not", "an", "object"]),
+            content_type='application/json',
+            headers={'X-API-Key': 'test-bridge-key'},
+        )
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert 'error' in body
+
+    def test_null_body_returns_400(self, client):
+        resp = client.post(
+            '/api/bridge/update-external',
+            data='null',
+            content_type='application/json',
+            headers={'X-API-Key': 'test-bridge-key'},
+        )
+        assert resp.status_code == 400


### PR DESCRIPTION
## Summary

Fixes **#5766**: Bridge admin callbacks crash on non-object JSON bodies.

### Problem

Both `POST /api/bridge/void` and `POST /api/bridge/update-external` parse JSON with `request.get_json(silent=True)` and only reject falsey bodies via `if not data:`. A non-empty JSON array like `["not", "an", "object"]` is truthy, so the check passes but `data.get(...)` raises `AttributeError` returning a 500 instead of a deterministic 400.

### Fix

Replace `if not data:` with `if not isinstance(data, dict):` to ensure only JSON objects are accepted.

### Changes

1. **`node/bridge_api.py`** - 3 fixes:
   - `void_bridge()` route: `if not data:` -> `if not isinstance(data, dict):`
   - `update_external()` route: same fix
   - `validate_bridge_request()`: same pattern, same fix

2. **`node/tests/test_bridge_admin_json_body.py`** [NEW] - Regression tests covering JSON arrays, null, strings, and integers are all rejected with 400.

Closes #5766

**Wallet:** `RTC241359b3438d1222fdc1c3e22fe980657a4bc54e`