### PR TITLE
fix: normalize realtime dashboard rows

### DIFF
--- a/explorer/static/js/dashboard.js
+++ b/explorer/static/js/dashboard.js
@@ -149,6 +149,7 @@ class DashboardApp {
     }
 
     onBlock(block) {
+        if (!block || typeof block !== 'object') return;
         this.state.metrics.blocksReceived++;
         this.state.metrics.updatesReceived++;
         
@@ -165,6 +166,7 @@ class DashboardApp {
     }
 
     onTransaction(tx) {
+        if (!tx || typeof tx !== 'object') return;
         this.state.metrics.transactionsReceived++;
         this.state.metrics.updatesReceived++;
         
@@ -182,13 +184,16 @@ class DashboardApp {
     onMinerUpdate(data) {
         this.state.metrics.updatesReceived++;
         
-        const miners = data.miners || data;
-        if (Array.isArray(miners)) {
-            this.state.miners = miners;
-            this.updateMinersDisplay();
-            this.updateHardwareDistribution();
-            this.updateMinersChart();
+        const rawMiners = data?.miners || data;
+        if (!Array.isArray(rawMiners)) {
+            this.updateLastUpdateTime();
+            return;
         }
+        const miners = this.normalizeRows(rawMiners);
+        this.state.miners = miners;
+        this.updateMinersDisplay();
+        this.updateHardwareDistribution();
+        this.updateMinersChart();
         
         this.updateLastUpdateTime();
     }
@@ -211,9 +216,10 @@ class DashboardApp {
     }
 
     updateState(state) {
-        if (state.blocks) this.state.blocks = state.blocks;
-        if (state.transactions) this.state.transactions = state.transactions;
-        if (state.miners) this.state.miners = state.miners;
+        if (!state || typeof state !== 'object') return;
+        if (state.blocks) this.state.blocks = this.normalizeRows(state.blocks);
+        if (state.transactions) this.state.transactions = this.normalizeRows(state.transactions);
+        if (state.miners) this.state.miners = this.normalizeRows(state.miners);
         if (state.epoch) this.state.epoch = state.epoch;
         if (state.health) this.state.health = state.health;
         
@@ -697,20 +703,24 @@ class DashboardApp {
      * Utility functions
      */
     shortenHash(hash, chars = 8) {
-        if (!hash) return '';
-        if (hash.length <= chars * 2) return hash;
-        return `${hash.slice(0, chars)}...${hash.slice(-chars)}`;
+        const value = String(hash ?? '');
+        if (!value) return '';
+        if (value.length <= chars * 2) return value;
+        return `${value.slice(0, chars)}...${value.slice(-chars)}`;
     }
 
     shortenAddress(addr, chars = 6) {
-        if (!addr) return '';
-        if (addr.length <= chars * 2) return addr;
-        return `${addr.slice(0, chars)}...${addr.slice(-chars)}`;
+        const value = String(addr ?? '');
+        if (!value) return '';
+        if (value.length <= chars * 2) return value;
+        return `${value.slice(0, chars)}...${value.slice(-chars)}`;
     }
 
     formatNumber(num, decimals = 2) {
         if (num === null || num === undefined) return '0';
-        return Number(num).toLocaleString(undefined, {
+        const value = Number(num);
+        if (!Number.isFinite(value)) return '0';
+        return value.toLocaleString(undefined, {
             minimumFractionDigits: decimals,
             maximumFractionDigits: decimals
         });
@@ -759,6 +769,10 @@ class DashboardApp {
         if (archLower.includes('m1') || archLower.includes('m2') || archLower.includes('apple silicon')) return 'classic';
         if (archLower.includes('ancient') || archLower.includes('legacy')) return 'ancient';
         return 'modern';
+    }
+
+    normalizeRows(payload) {
+        return Array.isArray(payload) ? payload.filter(row => row && typeof row === 'object') : [];
     }
 }
 

--- a/tests/test_realtime_dashboard_row_normalization.py
+++ b/tests/test_realtime_dashboard_row_normalization.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import json
+import subprocess
+
+
+DASHBOARD_JS = Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "dashboard.js"
+
+
+def source() -> str:
+    return DASHBOARD_JS.read_text(encoding="utf-8")
+
+
+def test_dashboard_filters_malformed_realtime_rows():
+    js = source()
+
+    assert "normalizeRows(payload)" in js
+    assert "this.state.blocks = this.normalizeRows(state.blocks);" in js
+    assert "this.state.transactions = this.normalizeRows(state.transactions);" in js
+    assert "this.state.miners = this.normalizeRows(state.miners);" in js
+    assert "if (!state || typeof state !== 'object') return;" in js
+    assert "if (!block || typeof block !== 'object') return;" in js
+    assert "if (!tx || typeof tx !== 'object') return;" in js
+
+
+def test_dashboard_helpers_coerce_malformed_field_values():
+    js = source()
+
+    assert "const value = String(hash ?? '');" in js
+    assert "const value = String(addr ?? '');" in js
+    assert "if (!Number.isFinite(value)) return '0';" in js
+
+
+def test_dashboard_vm_handles_malformed_realtime_payloads():
+    js = source()
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(js)};
+const context = {{
+  window: {{ location: {{ origin: 'https://example.test', host: 'example.test' }} }},
+  document: {{
+    addEventListener() {{}},
+    getElementById() {{ return null; }},
+    body: {{ classList: {{ toggle() {{}}, contains() {{ return false; }} }} }},
+  }},
+  localStorage: {{ setItem() {{}} }},
+  navigator: {{ onLine: true }},
+  WebSocket: function() {{}},
+  setInterval() {{ return 1; }},
+  clearInterval() {{}},
+  setTimeout(fn) {{ return 1; }},
+  console: {{ log() {{}}, error() {{}} }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+const result = vm.runInContext(`
+  const app = Object.create(DashboardApp.prototype);
+  app.state = {{
+    blocks: [],
+    transactions: [],
+    miners: [],
+    epoch: {{}},
+    health: {{}},
+    metrics: {{ blocksReceived: 0, transactionsReceived: 0, updatesReceived: 0 }},
+    lastUpdate: null,
+  }};
+  app.charts = {{}};
+  app.updateAllDisplays = function() {{}};
+  app.updateBlocksDisplay = function() {{}};
+  app.updateBlocksChart = function() {{}};
+  app.updateTransactionsDisplay = function() {{}};
+  app.updateTransactionsChart = function() {{}};
+  app.updateMinersDisplay = function() {{}};
+  app.updateHardwareDistribution = function() {{}};
+  app.updateMinersChart = function() {{}};
+  app.updateMetricsDisplay = function() {{}};
+  app.updateLastUpdateTime = function() {{ this.state.lastUpdate = 1; }};
+  app.highlightNewBlock = function() {{}};
+
+  app.onBlock(null);
+  app.onTransaction('bad');
+  app.updateState(null);
+  app.updateState({{
+    blocks: [null, 'bad', {{ hash: {{ id: 'h' }}, height: 'nan' }}],
+    transactions: [null, {{ from: {{ id: 'from' }}, to: ['to'], amount: 'NaN' }}],
+    miners: [undefined, {{ miner_id: {{ id: 'm' }}, device_arch: ['G4'], multiplier: 'NaN' }}],
+  }});
+  JSON.stringify({{
+    blocks: app.state.blocks,
+    transactions: app.state.transactions,
+    miners: app.state.miners,
+    hash: app.shortenHash({{ id: 'h' }}),
+    address: app.shortenAddress({{ id: 'm' }}),
+    number: app.formatNumber('NaN', 2),
+    tier: app.getArchitectureTier(['G4']),
+  }});
+`, context);
+console.log(result);
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["blocks"] == [{"hash": {"id": "h"}, "height": "nan"}]
+    assert data["transactions"] == [{"from": {"id": "from"}, "to": ["to"], "amount": "NaN"}]
+    assert data["miners"] == [{"miner_id": {"id": "m"}, "device_arch": ["G4"], "multiplier": "NaN"}]
+    assert data["hash"] == "[object Object]"
+    assert data["address"] == "[objec...bject]"
+    assert data["number"] == "0"
+    assert data["tier"] == "vintage"


### PR DESCRIPTION
## Summary
- ignore malformed single block/transaction websocket payloads before storing them
- normalize dashboard `blocks`, `transactions`, and `miners` arrays to object rows before rendering
- keep non-array miner updates from clearing the visible miner table
- harden shared realtime dashboard helpers against non-string IDs and non-finite numeric values
- add a VM regression for malformed realtime dashboard payloads

## Tests
- node inline script parse for `explorer/static/js/dashboard.js`
- `uv run --with pytest --with flask python -m pytest tests/test_realtime_dashboard_row_normalization.py -q`
- `uv run --with pytest python -m pytest tests/test_realtime_dashboard_row_normalization.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
