### PR TITLE
fix: render websocket notifications safely

### DIFF
--- a/explorer/static/js/websocket-client.js
+++ b/explorer/static/js/websocket-client.js
@@ -269,6 +269,7 @@ const RustChainWebSocket = (function() {
      * Handle new block event
      */
     function handleNewBlock(block) {
+        if (!block || typeof block !== 'object') return;
         if (window.RustChainExplorer && window.RustChainExplorer.state) {
             // Add to blocks array
             const blocks = window.RustChainExplorer.state.blocks || [];
@@ -290,6 +291,7 @@ const RustChainWebSocket = (function() {
      * Handle new attestation event
      */
     function handleNewAttestation(attestation) {
+        if (!attestation || typeof attestation !== 'object') return;
         if (window.RustChainExplorer && window.RustChainExplorer.state) {
             // Update miners if this miner is new or updated
             const miners = window.RustChainExplorer.state.miners || [];
@@ -310,7 +312,7 @@ const RustChainWebSocket = (function() {
             
             // Show notification
             showNotification('attestation', 'New Attestation', 
-                `Miner: ${attestation.miner_id?.slice(0, 16)}... | Arch: ${attestation.device_arch}`);
+                `Miner: ${shortenValue(attestation.miner_id, 16)}... | Arch: ${attestation.device_arch ?? ''}`);
         }
     }
 
@@ -318,8 +320,10 @@ const RustChainWebSocket = (function() {
      * Handle epoch settlement event (bonus feature)
      */
     function handleEpochSettlement(settlement) {
-        showNotification('settlement', `🎉 Epoch #${settlement.epoch} Settled!`, 
-            `Total Reward: ${settlement.total_reward?.toFixed(2)} RTC | Miners: ${settlement.miners_count}`);
+        if (!settlement || typeof settlement !== 'object') return;
+        const reward = Number(settlement.total_reward);
+        showNotification('settlement', `🎉 Epoch #${settlement.epoch ?? 0} Settled!`,
+            `Total Reward: ${Number.isFinite(reward) ? reward.toFixed(2) : '0.00'} RTC | Miners: ${settlement.miners_count ?? 0}`);
         
         // Play sound notification (bonus feature)
         if (window.playNotificationSound) {
@@ -538,16 +542,37 @@ const RustChainWebSocket = (function() {
         const container = document.getElementById('ws-notifications');
         if (!container) return;
 
+        const safeType = getNotificationType(type);
         const notification = document.createElement('div');
-        notification.className = `ws-notification ws-notification-${type}`;
-        notification.innerHTML = `
-            <div class="ws-notification-header">
-                <span class="ws-notification-icon">${getNotificationIcon(type)}</span>
-                <span class="ws-notification-title">${escapeHtml(title)}</span>
-                <button class="ws-notification-close" onclick="this.parentElement.parentElement.remove()">×</button>
-            </div>
-            <div class="ws-notification-body">${escapeHtml(body)}</div>
-        `;
+        notification.className = `ws-notification ws-notification-${safeType}`;
+
+        const header = document.createElement('div');
+        header.className = 'ws-notification-header';
+
+        const icon = document.createElement('span');
+        icon.className = 'ws-notification-icon';
+        icon.textContent = getNotificationIcon(safeType);
+
+        const titleEl = document.createElement('span');
+        titleEl.className = 'ws-notification-title';
+        titleEl.textContent = String(title ?? '');
+
+        const close = document.createElement('button');
+        close.className = 'ws-notification-close';
+        close.type = 'button';
+        close.textContent = '×';
+        close.addEventListener('click', () => notification.remove());
+
+        header.appendChild(icon);
+        header.appendChild(titleEl);
+        header.appendChild(close);
+
+        const bodyEl = document.createElement('div');
+        bodyEl.className = 'ws-notification-body';
+        bodyEl.textContent = String(body ?? '');
+
+        notification.appendChild(header);
+        notification.appendChild(bodyEl);
 
         container.appendChild(notification);
 
@@ -571,6 +596,16 @@ const RustChainWebSocket = (function() {
             default: '🔔'
         };
         return icons[type] || icons.default;
+    }
+
+    function getNotificationType(type) {
+        const value = String(type || 'default').toLowerCase();
+        return ['block', 'attestation', 'settlement'].includes(value) ? value : 'default';
+    }
+
+    function shortenValue(value, chars = 16) {
+        const text = String(value ?? '');
+        return text.length > chars ? text.slice(0, chars) : text;
     }
 
     /**

--- a/tests/test_websocket_client_notification_security.py
+++ b/tests/test_websocket_client_notification_security.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import json
+import subprocess
+
+
+WEBSOCKET_JS = (
+    Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "websocket-client.js"
+)
+
+
+def source() -> str:
+    return WEBSOCKET_JS.read_text(encoding="utf-8")
+
+
+def test_websocket_notifications_are_built_with_text_nodes():
+    js = source()
+
+    assert "notification.innerHTML = `" not in js
+    assert "titleEl.textContent = String(title ?? '');" in js
+    assert "bodyEl.textContent = String(body ?? '');" in js
+    assert "close.addEventListener('click', () => notification.remove());" in js
+    assert "function getNotificationType(type)" in js
+
+
+def test_websocket_handlers_ignore_malformed_single_events():
+    js = source()
+
+    assert "if (!block || typeof block !== 'object') return;" in js
+    assert "if (!attestation || typeof attestation !== 'object') return;" in js
+    assert "if (!settlement || typeof settlement !== 'object') return;" in js
+    assert "shortenValue(attestation.miner_id, 16)" in js
+    assert "Number.isFinite(reward) ? reward.toFixed(2) : '0.00'" in js
+
+
+def test_websocket_notification_event_path_uses_text_content():
+    js = source()
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(js)};
+const handlers = {{}};
+const elements = {{}};
+function element(tag) {{
+  return {{
+    tag,
+    className: '',
+    type: '',
+    textContent: '',
+    children: [],
+    parentElement: null,
+    classList: {{ add() {{}} }},
+    addEventListener() {{}},
+    appendChild(child) {{ child.parentElement = this; this.children.push(child); }},
+    remove() {{ this.removed = true; }},
+    set innerHTML(value) {{ this.usedInnerHTML = value; }},
+    get innerHTML() {{ return this.usedInnerHTML || ''; }},
+  }};
+}}
+const notifications = element('div');
+elements['ws-notifications'] = notifications;
+const context = {{
+  window: {{
+    location: {{ protocol: 'https:', host: 'example.test', origin: 'https://example.test' }},
+    RustChainExplorer: {{ state: {{ blocks: [] }} }},
+  }},
+  document: {{
+    addEventListener() {{}},
+    getElementById(id) {{ return elements[id] || null; }},
+    createElement: element,
+    head: element('head'),
+  }},
+  io() {{ return {{ on(event, cb) {{ handlers[event] = cb; }}, emit() {{}} }}; }},
+  WebSocket: {{ OPEN: 1 }},
+  setTimeout() {{ return 1; }},
+  setInterval() {{ return 1; }},
+  clearInterval() {{}},
+  console: {{ log() {{}}, error() {{}} }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+context.window.RustChainWebSocket.connect();
+handlers.block({{ height: '<img src=x>', miners_count: '<b>9</b>', reward: '<script>x</script>' }});
+const notification = notifications.children[0];
+const header = notification.children[0];
+const body = notification.children[1];
+console.log(JSON.stringify({{
+  className: notification.className,
+  usedInnerHTML: Boolean(notification.usedInnerHTML),
+  title: header.children[1].textContent,
+  body: body.textContent,
+  storedBlocks: context.window.RustChainExplorer.state.blocks.length,
+}}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["className"] == "ws-notification ws-notification-block"
+    assert data["usedInnerHTML"] is False
+    assert data["title"] == "New Block #<img src=x>"
+    assert data["body"] == "Miners: <b>9</b> | Reward: <script>x</script> RTC"
+    assert data["storedBlocks"] == 1


### PR DESCRIPTION
## Summary
- render websocket notifications with DOM nodes and `textContent` instead of `innerHTML`
- constrain notification type class names to known notification types
- remove inline close-button JavaScript in favor of an event listener
- ignore malformed single block, attestation, and settlement websocket events before reading fields
- harden notification text formatting for malformed miner IDs and settlement rewards

## Tests
- node inline script parse for `explorer/static/js/websocket-client.js`
- `uv run --with pytest --with flask python -m pytest tests/test_websocket_client_notification_security.py -q`
- `uv run --with pytest python -m pytest tests/test_websocket_client_notification_security.py -q --noconftest -o addopts=''`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
