### PR TITLE
security: protect Beacon x402 payment history

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -121,6 +121,18 @@ def _is_base_address(value: str) -> bool:
     )
 
 
+def _require_beacon_admin():
+    expected = os.environ.get("BEACON_ADMIN_KEY", "")
+    if not expected:
+        return _cors_json({"error": "Admin key not configured"}, 503)
+
+    admin_key = request.headers.get("X-Admin-Key", "")
+    if not hmac.compare_digest(admin_key, expected):
+        return _cors_json({"error": "Unauthorized - admin key required"}, 401)
+
+    return None
+
+
 # ---------------------------------------------------------------------------
 # x402 payment check
 # ---------------------------------------------------------------------------
@@ -200,12 +212,9 @@ def init_app(app, get_db_func):
             return _cors_json({"ok": True})
 
         # Simple admin check ? require admin key in header
-        admin_key = request.headers.get("X-Admin-Key", "")
-        expected = os.environ.get("BEACON_ADMIN_KEY", "")
-        if not expected:
-            return _cors_json({"error": "Admin key not configured"}, 503)
-        if not hmac.compare_digest(admin_key, expected):
-            return _cors_json({"error": "Unauthorized ? admin key required"}, 401)
+        admin_error = _require_beacon_admin()
+        if admin_error:
+            return admin_error
 
         data, error_response = _json_object_body()
         if error_response:
@@ -360,6 +369,10 @@ def init_app(app, get_db_func):
         """View x402 payment history for beacon."""
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
+
+        admin_error = _require_beacon_admin()
+        if admin_error:
+            return admin_error
 
         db = get_db_func()
         try:

--- a/node/tests/test_beacon_x402_payments_auth.py
+++ b/node/tests/test_beacon_x402_payments_auth.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+from unittest.mock import patch
+
+from flask import Flask
+
+import beacon_x402
+
+
+def _make_app(monkeypatch):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    monkeypatch.setenv("BEACON_ADMIN_KEY", "expected-beacon-admin-key")
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(beacon_x402.X402_BEACON_SCHEMA)
+    conn.execute(
+        """
+        INSERT INTO x402_beacon_payments (
+            payer_address, payer_agent_id, action, amount_usdc,
+            tx_hash, contract_id, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            "0x0000000000000000000000000000000000000001",
+            "agent-1",
+            "reputation_export",
+            "50000",
+            "tx-sensitive",
+            "contract-1",
+            123.0,
+        ),
+    )
+    conn.commit()
+
+    with patch.object(beacon_x402, "_run_migrations"):
+        beacon_x402.init_app(app, lambda: conn)
+
+    return app
+
+
+def test_x402_payment_history_requires_admin_key(monkeypatch):
+    client = _make_app(monkeypatch).test_client()
+
+    response = client.get("/api/x402/payments")
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Unauthorized - admin key required"
+
+
+def test_x402_payment_history_uses_constant_time_admin_compare(monkeypatch):
+    client = _make_app(monkeypatch).test_client()
+
+    with patch("hmac.compare_digest", return_value=False) as compare_digest:
+        response = client.get(
+            "/api/x402/payments",
+            headers={"X-Admin-Key": "wrong-beacon-admin-key"},
+        )
+
+    assert response.status_code == 401
+    compare_digest.assert_called_once_with(
+        "wrong-beacon-admin-key",
+        "expected-beacon-admin-key",
+    )
+
+
+def test_x402_payment_history_returns_rows_for_admin(monkeypatch):
+    client = _make_app(monkeypatch).test_client()
+
+    response = client.get(
+        "/api/x402/payments",
+        headers={"X-Admin-Key": "expected-beacon-admin-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["total"] == 1
+    assert body["payments"][0]["tx_hash"] == "tx-sensitive"


### PR DESCRIPTION
## Summary
- Protect `/api/x402/payments` with the Beacon admin key instead of exposing payment history publicly.
- Reuse a constant-time Beacon admin check for wallet linking and payment-history access.
- Add regressions covering anonymous access, wrong-key access, and authorized payment-history reads.

## Security finding
Beacon x402 payment history currently exposes recent payer addresses, agent IDs, contract IDs, amounts, and transaction hashes to any unauthenticated caller. Because the helper also adds wildcard CORS headers and allows the `X-PAYMENT` header cross-origin, any website can scrape the endpoint from a visitor browser. That leaks payment metadata and reusable receipt material that should remain operator-only.

## Validation
- `PYTHONPATH=node PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q node/tests/test_beacon_x402_payments_auth.py node/tests/test_x402_admin_key_compare.py` -> 5 passed
- `python -m py_compile node/beacon_x402.py node/tests/test_beacon_x402_payments_auth.py node/tests/test_x402_admin_key_compare.py` -> passed
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check origin/main...HEAD` -> passed

Bounty context: Scottcjn/rustchain-bounties#66
Wallet/miner ID: `RTC5800896ed658aa511d029361b6d7388ddb29248b`
Payout boundary: this is a public bounty claim for maintainer assessment only; no RTC award, payout approval, wallet transfer, wallet credit, or payment receipt is asserted here.