### PR TITLE
fix: normalize websocket explorer payloads

### DIFF
--- a/explorer/templates/ws_explorer.html
+++ b/explorer/templates/ws_explorer.html
@@ -114,6 +114,41 @@ function appendText(parent, text) {
   parent.appendChild(document.createTextNode(text));
 }
 
+function asObject(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function asText(value, fallback = '?') {
+  if (value === undefined || value === null || value === '') return fallback;
+  return String(value);
+}
+
+function safeNumber(value, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function firstPresent(...values) {
+  return values.find(value => value !== undefined && value !== null && value !== '');
+}
+
+function normalizeMinersPayload(payload) {
+  const miners = Array.isArray(payload)
+    ? payload
+    : (Array.isArray(payload?.miners) ? payload.miners : []);
+  const source = asObject(payload);
+  return {
+    count: safeNumber(source.count, miners.length),
+    miners: miners.filter(miner => miner && typeof miner === 'object')
+  };
+}
+
+function normalizeAttestationsPayload(payload) {
+  return Array.isArray(payload)
+    ? payload.filter(attestation => attestation && typeof attestation === 'object')
+    : [];
+}
+
 // Connection status
 socket.on('connect', () => {
   document.getElementById('conn-dot').className = 'conn-dot connected';
@@ -131,39 +166,46 @@ socket.on('reconnecting', () => {
 
 // Welcome
 socket.on('welcome', data => {
-  document.getElementById('clients').textContent = data.connected_clients;
+  const payload = asObject(data);
+  document.getElementById('clients').textContent = safeNumber(payload.connected_clients, 0);
 });
 
 // Snapshot (full state on connect)
 socket.on('snapshot', data => {
-  if (data.epoch) updateEpoch(data.epoch);
-  if (data.miners) updateMiners(data.miners);
+  const payload = asObject(data);
+  if (payload.epoch) updateEpoch(payload.epoch);
+  if (payload.miners) updateMiners(payload.miners);
 });
 
 // Live updates
 socket.on('explorer_update', data => {
+  const payload = asObject(data);
   updateCount++;
   document.getElementById('updates').textContent = updateCount;
 
-  if (data.epoch) updateEpoch(data.epoch);
-  if (data.new_block) addBlockFeed(data.new_block);
-  if (data.miners) updateMiners(data.miners);
-  if (data.attestations) updateAttestations(data.attestations);
+  if (payload.epoch) updateEpoch(payload.epoch);
+  if (payload.new_block) addBlockFeed(payload.new_block);
+  if (payload.miners) updateMiners(payload.miners);
+  if (payload.attestations) updateAttestations(payload.attestations);
 });
 
 function updateEpoch(d) {
-  const epoch = d.epoch || d.current_epoch;
-  if (epoch) document.getElementById('epoch').textContent = epoch;
+  const payload = asObject(d);
+  const epoch = firstPresent(payload.epoch, payload.current_epoch, d);
+  if (epoch !== undefined && epoch !== null && epoch !== '') {
+    document.getElementById('epoch').textContent = asText(epoch);
+  }
 }
 
 function addBlockFeed(block) {
+  const payload = asObject(block);
   const feed = document.getElementById('block-feed');
   if (feed.querySelector('.empty')) feed.replaceChildren();
-  const hash = block.hash ? String(block.hash).substring(0, 16) + '...' : '—';
+  const hash = payload.hash ? asText(payload.hash, '').substring(0, 16) + '...' : '—';
   const item = document.createElement('div');
   item.className = 'feed-item new';
   item.appendChild(spanWithText('time', new Date().toLocaleTimeString()));
-  appendText(item, ` · Epoch ${block.epoch || '?'} · `);
+  appendText(item, ` · Epoch ${asText(payload.epoch)} · `);
   item.appendChild(spanWithText('hash', hash));
   feed.insertBefore(item, feed.firstChild);
   if (feed.children.length > 50) feed.removeChild(feed.lastChild);
@@ -172,30 +214,30 @@ function addBlockFeed(block) {
 }
 
 function updateMiners(d) {
-  const count = d.count || (d.miners ? d.miners.length : 0);
+  const { count, miners } = normalizeMinersPayload(d);
   document.getElementById('miners').textContent = count;
   minerHistory.push(count);
   if (minerHistory.length > 30) minerHistory.shift();
   renderSparkline();
 
   // Miner grid
-  if (d.miners && d.miners.length > 0) {
+  if (miners.length > 0) {
     const grid = document.getElementById('miner-grid');
-    const cards = d.miners.slice(0, 12).map(m => {
+    const cards = miners.slice(0, 12).map(m => {
       const card = document.createElement('div');
       card.className = 'miner-card';
 
       const id = document.createElement('div');
       id.className = 'miner-id';
-      id.textContent = m.miner_id || m.miner || m.id || '?';
+      id.textContent = asText(firstPresent(m.miner_id, m.miner, m.id));
 
       const hardware = document.createElement('div');
       hardware.className = 'miner-hw';
-      hardware.textContent = m.hardware || m.device_arch || m.architecture || '?';
+      hardware.textContent = asText(firstPresent(m.hardware, m.device_arch, m.architecture));
 
       const multiplier = document.createElement('div');
       multiplier.className = 'miner-multi';
-      multiplier.textContent = `${m.multiplier || 1.0}x`;
+      multiplier.textContent = `${safeNumber(m.multiplier, 1.0)}x`;
 
       card.append(id, hardware, multiplier);
       return card;
@@ -205,14 +247,15 @@ function updateMiners(d) {
 }
 
 function updateAttestations(list) {
+  const attestations = normalizeAttestationsPayload(list);
   const feed = document.getElementById('attest-feed');
   if (feed.querySelector('.empty')) feed.replaceChildren();
-  for (const a of list.slice(0, 5)) {
+  for (const a of attestations.slice(0, 5)) {
     const item = document.createElement('div');
     item.className = 'feed-item new';
     item.appendChild(spanWithText('time', new Date().toLocaleTimeString()));
-    appendText(item, ` · ${a.miner_id || a.miner || '?'} · ${a.hardware || a.device_arch || '?'} · `);
-    item.appendChild(spanWithText('miner-multi', `${a.multiplier || 1.0}x`));
+    appendText(item, ` · ${asText(firstPresent(a.miner_id, a.miner))} · ${asText(firstPresent(a.hardware, a.device_arch))} · `);
+    item.appendChild(spanWithText('miner-multi', `${safeNumber(a.multiplier, 1.0)}x`));
     feed.insertBefore(item, feed.firstChild);
     if (feed.children.length > 50) feed.removeChild(feed.lastChild);
     setTimeout(() => item.classList.remove('new'), 2000);

--- a/explorer/test_ws_explorer.py
+++ b/explorer/test_ws_explorer.py
@@ -4,7 +4,7 @@
 import json
 import pytest
 from unittest.mock import patch, MagicMock
-from ws_explorer_server import app, socketio, state, fetch_api
+from ws_explorer_server import app, socketio, state, fetch_api, poll_and_broadcast
 
 
 @pytest.fixture
@@ -106,3 +106,44 @@ class TestStateTracking:
     def test_started_at_set(self):
         assert state["started_at"] is not None
         assert "Z" in state["started_at"]
+
+
+class TestPolling:
+    def test_poll_and_broadcast_handles_bare_miner_array(self):
+        emitted = []
+
+        def fake_fetch(path):
+            if path == "/api/miners":
+                return [{"miner_id": "miner-a", "hardware": "gpu", "multiplier": 1.5}]
+            return None
+
+        def fake_emit(event, payload, namespace="/"):
+            emitted.append((event, payload, namespace))
+
+        with (
+            patch("ws_explorer_server.fetch_api", side_effect=fake_fetch),
+            patch("ws_explorer_server.socketio.emit", side_effect=fake_emit),
+            patch("ws_explorer_server.time.sleep", side_effect=KeyboardInterrupt),
+        ):
+            with pytest.raises(KeyboardInterrupt):
+                poll_and_broadcast()
+
+        assert emitted == [
+            (
+                "explorer_update",
+                {
+                    "miners": {
+                        "count": 1,
+                        "miners": [
+                            {
+                                "miner_id": "miner-a",
+                                "hardware": "gpu",
+                                "multiplier": 1.5,
+                            }
+                        ],
+                    },
+                    "server_time": emitted[0][1]["server_time"],
+                },
+                "/",
+            )
+        ]

--- a/explorer/ws_explorer_server.py
+++ b/explorer/ws_explorer_server.py
@@ -51,6 +51,17 @@ def fetch_api(path):
     return None
 
 
+def normalize_miners_data(miners_data):
+    if isinstance(miners_data, list):
+        return miners_data, len(miners_data)
+    if isinstance(miners_data, dict):
+        miners = miners_data.get("miners", [])
+        if isinstance(miners, list):
+            return miners, len(miners)
+        return [], miners_data.get("count", 0)
+    return [], 0
+
+
 def poll_and_broadcast():
     """Poll RustChain API and broadcast changes via WebSocket."""
     while True:
@@ -79,13 +90,12 @@ def poll_and_broadcast():
                     }
 
             if miners_data:
-                miners = miners_data.get("miners", [])
-                miner_count = len(miners) if isinstance(miners, list) else miners_data.get("count", 0)
+                miners, miner_count = normalize_miners_data(miners_data)
                 if miner_count != state["last_miner_count"]:
                     state["last_miner_count"] = miner_count
                     updates["miners"] = {
                         "count": miner_count,
-                        "miners": miners[:20] if isinstance(miners, list) else [],
+                        "miners": miners[:20],
                     }
 
                 # Attestation feed — send latest attestations

--- a/tests/test_ws_explorer_payload_normalization.py
+++ b/tests/test_ws_explorer_payload_normalization.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+WS_EXPLORER = Path(__file__).resolve().parents[1] / "explorer" / "templates" / "ws_explorer.html"
+
+
+def test_ws_explorer_normalizes_miner_payload_shapes():
+    html = WS_EXPLORER.read_text(encoding="utf-8")
+
+    assert "function normalizeMinersPayload(payload)" in html
+    assert "Array.isArray(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "miners.filter(miner => miner && typeof miner === 'object')" in html
+    assert "const { count, miners } = normalizeMinersPayload(d);" in html
+    assert "const cards = miners.slice(0, 12).map(m => {" in html
+    assert "d.miners.slice(0, 12)" not in html
+
+
+def test_ws_explorer_guards_live_event_payloads():
+    html = WS_EXPLORER.read_text(encoding="utf-8")
+
+    safe_patterns = [
+        "function asObject(value)",
+        "function asText(value, fallback = '?')",
+        "function safeNumber(value, fallback = 0)",
+        "function normalizeAttestationsPayload(payload)",
+        "const payload = asObject(data);",
+        "document.getElementById('clients').textContent = safeNumber(payload.connected_clients, 0);",
+        "const attestations = normalizeAttestationsPayload(list);",
+        "for (const a of attestations.slice(0, 5))",
+        "id.textContent = asText(firstPresent(m.miner_id, m.miner, m.id));",
+        "hardware.textContent = asText(firstPresent(m.hardware, m.device_arch, m.architecture));",
+        "multiplier.textContent = `${safeNumber(m.multiplier, 1.0)}x`;",
+        "spanWithText('miner-multi', `${safeNumber(a.multiplier, 1.0)}x`)",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in html
+
+    unsafe_patterns = [
+        "data.connected_clients",
+        "for (const a of list.slice(0, 5))",
+        "m.miner_id || m.miner || m.id || '?'",
+        "m.hardware || m.device_arch || m.architecture || '?'",
+        "`${m.multiplier || 1.0}x`",
+        "`${a.multiplier || 1.0}x`",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in html


### PR DESCRIPTION
## Summary
- normalize websocket explorer miner payloads from either bare arrays or `{ miners: [...] }` envelopes
- guard welcome, snapshot, update, block, miner, and attestation payload reads before rendering live UI state
- add regression coverage for websocket explorer payload normalization and safe field coercion

## Tests
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run --with pytest --with flask python -m pytest tests/test_ws_explorer_payload_normalization.py -q`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
