### PR TITLE
fix: guard dashboard template payloads

### DIFF
--- a/explorer/templates/dashboard.html
+++ b/explorer/templates/dashboard.html
@@ -302,9 +302,10 @@
             fetch('/api/dashboard-data')
                 .then(response => response.json())
                 .then(data => {
-                    updateNetworkStats(data.network_stats);
-                    updateRecentBlocks(data.recent_blocks);
-                    updateMiners(data.miners);
+                    const payload = asObject(data);
+                    updateNetworkStats(payload.network_stats);
+                    updateRecentBlocks(payload.recent_blocks);
+                    updateMiners(payload.miners);
                     document.getElementById('refresh-icon').classList.remove('fa-spin');
                 })
                 .catch(error => {
@@ -314,10 +315,24 @@
         }
         
         function updateNetworkStats(stats) {
-            document.getElementById('block-height').textContent = stats.block_height;
-            document.getElementById('hash-rate').textContent = stats.hash_rate;
-            document.getElementById('active-miners').textContent = stats.active_miners;
-            document.getElementById('difficulty').textContent = stats.difficulty;
+            const safeStats = asObject(stats);
+            document.getElementById('block-height').textContent = displayText(safeStats.block_height);
+            document.getElementById('hash-rate').textContent = displayText(safeStats.hash_rate);
+            document.getElementById('active-miners').textContent = displayText(safeStats.active_miners);
+            document.getElementById('difficulty').textContent = displayText(safeStats.difficulty);
+        }
+
+        function asObject(value) {
+            return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+        }
+
+        function asArray(value) {
+            return Array.isArray(value) ? value.filter(item => item && typeof item === 'object') : [];
+        }
+
+        function displayText(value, fallback = '--') {
+            if (value === undefined || value === null || value === '') return fallback;
+            return String(value);
         }
 
         function escapeHtml(value) {
@@ -335,8 +350,13 @@
         }
         
         function updateRecentBlocks(blocks) {
+            const blockList = asArray(blocks);
             const tbody = document.getElementById('recent-blocks');
-            tbody.innerHTML = blocks.map(block => `
+            if (blockList.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="5" class="text-muted text-center">No recent blocks</td></tr>';
+                return;
+            }
+            tbody.innerHTML = blockList.map(block => `
                 <tr>
                     <td><a href="/block/${encodeURIComponent(String(block.hash || ''))}" class="text-decoration-none">${escapeHtml(block.height)}</a></td>
                     <td><code class="text-muted">${escapeHtml(String(block.hash || '').substring(0, 16))}...</code></td>
@@ -348,8 +368,13 @@
         }
         
         function updateMiners(miners) {
+            const minerList = asArray(miners);
             const tbody = document.getElementById('miners-tbody');
-            tbody.innerHTML = miners.map(miner => {
+            if (minerList.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="6" class="text-muted text-center">No miners found</td></tr>';
+                return;
+            }
+            tbody.innerHTML = minerList.map(miner => {
                 const architecture = String(miner.architecture || 'unknown');
                 const architectureLower = classToken(architecture);
                 const archIcon = miner.architecture === 'x86' ? 'microchip' : 

--- a/tests/test_dashboard_template_payload_guards.py
+++ b/tests/test_dashboard_template_payload_guards.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+DASHBOARD = Path(__file__).resolve().parents[1] / "explorer" / "templates" / "dashboard.html"
+
+
+def test_dashboard_refresh_normalizes_api_payload_before_rendering():
+    html = DASHBOARD.read_text(encoding="utf-8")
+
+    assert "function asObject(value)" in html
+    assert "function asArray(value)" in html
+    assert "function displayText(value, fallback = '--')" in html
+    assert "const payload = asObject(data);" in html
+    assert "updateNetworkStats(payload.network_stats);" in html
+    assert "updateRecentBlocks(payload.recent_blocks);" in html
+    assert "updateMiners(payload.miners);" in html
+    assert "updateNetworkStats(data.network_stats);" not in html
+    assert "updateRecentBlocks(data.recent_blocks);" not in html
+    assert "updateMiners(data.miners);" not in html
+
+
+def test_dashboard_tables_guard_missing_or_malformed_rows():
+    html = DASHBOARD.read_text(encoding="utf-8")
+
+    safe_patterns = [
+        "const safeStats = asObject(stats);",
+        "textContent = displayText(safeStats.block_height);",
+        "const blockList = asArray(blocks);",
+        "if (blockList.length === 0) {",
+        "No recent blocks",
+        "tbody.innerHTML = blockList.map(block => `",
+        "const minerList = asArray(miners);",
+        "if (minerList.length === 0) {",
+        "No miners found",
+        "tbody.innerHTML = minerList.map(miner => {",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in html
+
+    unsafe_patterns = [
+        "textContent = stats.block_height;",
+        "tbody.innerHTML = blocks.map(block => `",
+        "tbody.innerHTML = miners.map(miner => {",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in html


### PR DESCRIPTION
## Summary
- guard dashboard refresh payloads before reading network stats, block rows, or miner rows
- add empty table states for missing/malformed recent block and miner arrays
- add regression coverage for dashboard template payload normalization

## Tests
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run --with pytest --with flask python -m pytest tests/test_dashboard_template_payload_guards.py -q`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
