### PR TITLE
fix: harden explorer rustchain dashboard

### DIFF
--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 """
 RustChain Mining Dashboard - Enhanced
 --------------------------------------
@@ -189,59 +190,100 @@ DASHBOARD_HTML = """
         .sys-stat .value { font-size: 1.8em; font-weight: bold; }
     </style>
     <script>
-        function escapeHtml(s) {
-            return String(s)
-                .replaceAll('&', '&amp;')
-                .replaceAll('<', '&lt;')
-                .replaceAll('>', '&gt;')
-                .replaceAll('\"', '&quot;')
-                .replaceAll(\"'\", '&#39;');
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, ch => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;',
+            }[ch]));
+        }
+
+        function safeToken(value, allowed, fallback = 'unknown') {
+            const token = String(value ?? '').toLowerCase();
+            return allowed.includes(token) ? token : fallback;
+        }
+
+        function safeNumber(value, fallback = 0) {
+            const number = Number(value);
+            return Number.isFinite(number) ? number : fallback;
+        }
+
+        function displayText(value, fallback = '') {
+            if (value === undefined || value === null || value === '') return fallback;
+            return String(value);
+        }
+
+        function asArray(value) {
+            return Array.isArray(value) ? value.filter(item => item && typeof item === 'object') : [];
+        }
+
+        function asObject(value) {
+            return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
         }
 
         function updateDashboard() {
             fetch('/api/stats')
                 .then(r => r.json())
                 .then(data => {
+                    data = asObject(data);
                     // Update mining stats
-                    document.getElementById('enrolled-miners').textContent = data.enrolled_miners;
-                    document.getElementById('current-epoch').textContent = data.current_epoch;
-                    document.getElementById('epoch-pot').textContent = data.epoch_pot.toFixed(2);
-                    document.getElementById('total-balance').textContent = data.total_balance.toFixed(2);
+                    document.getElementById('enrolled-miners').textContent = safeNumber(data.enrolled_miners);
+                    document.getElementById('current-epoch').textContent = safeNumber(data.current_epoch);
+                    document.getElementById('epoch-pot').textContent = safeNumber(data.epoch_pot).toFixed(2);
+                    document.getElementById('total-balance').textContent = safeNumber(data.total_balance).toFixed(2);
 
                     // Update system stats
-                    if (data.system_stats) {
-                        document.getElementById('sys-cpu').textContent = data.system_stats.cpu + '%';
-                        document.getElementById('sys-mem').textContent = data.system_stats.memory + '%';
-                        document.getElementById('sys-disk').textContent = data.system_stats.disk + '%';
-                        document.getElementById('sys-uptime').textContent = data.system_stats.uptime;
-                        document.getElementById('sys-load').textContent = data.system_stats.load_avg;
+                    const systemStats = asObject(data.system_stats);
+                    if (Object.keys(systemStats).length) {
+                        document.getElementById('sys-cpu').textContent = safeNumber(systemStats.cpu) + '%';
+                        document.getElementById('sys-mem').textContent = safeNumber(systemStats.memory) + '%';
+                        document.getElementById('sys-disk').textContent = safeNumber(systemStats.disk) + '%';
+                        document.getElementById('sys-uptime').textContent = displayText(systemStats.uptime);
+                        document.getElementById('sys-load').textContent = displayText(systemStats.load_avg);
                     }
 
                     // Update miners table
                     const minersTable = document.getElementById('miners-tbody');
-                    minersTable.innerHTML = data.active_miners.map(m => `
-                        <tr>
-                            <td class="mono">${escapeHtml(m.wallet_short)}...</td>
-                            <td><span class="badge badge-${m.arch}">${m.arch.toUpperCase()}</span></td>
-                            <td><strong>${m.weight}x</strong></td>
-                            <td class="green">${m.balance.toFixed(6)} RTC</td>
-                            <td class="mono">${escapeHtml(m.last_seen)}</td>
-                            <td class="blue">${escapeHtml(m.age_on_network || 'New')}</td>
-                            <td><span class="badge badge-active pulse">ACTIVE</span></td>
-                        </tr>
-                    `).join('');
+                    const archTokens = ['active', 'classic', 'retro', 'ancient', 'modern'];
+                    const activeMiners = asArray(data.active_miners);
+                    if (activeMiners.length === 0) {
+                        minersTable.innerHTML = '<tr><td colspan="7">No active miners</td></tr>';
+                    } else {
+                        minersTable.innerHTML = activeMiners.map(m => {
+                            const archToken = safeToken(m.arch, archTokens, 'modern');
+                            const balance = safeNumber(m.balance).toFixed(6);
+                            return `
+                                <tr>
+                                    <td class="mono">${escapeHtml(m.wallet_short)}...</td>
+                                    <td><span class="badge badge-${archToken}">${escapeHtml(m.arch || 'unknown').toUpperCase()}</span></td>
+                                    <td><strong>${escapeHtml(m.weight)}x</strong></td>
+                                    <td class="green">${balance} RTC</td>
+                                    <td class="mono">${escapeHtml(m.last_seen)}</td>
+                                    <td class="blue">${escapeHtml(m.age_on_network || 'New')}</td>
+                                    <td><span class="badge badge-active pulse">ACTIVE</span></td>
+                                </tr>
+                            `;
+                        }).join('');
+                    }
 
                     // Update recent blocks
                     const blocksTable = document.getElementById('blocks-tbody');
-                    blocksTable.innerHTML = data.recent_blocks.map(b => `
-                        <tr>
-                            <td><strong>${b.height}</strong></td>
-                            <td class="mono">${escapeHtml(b.hash_short)}...</td>
-                            <td>${escapeHtml(b.timestamp)}</td>
-                            <td><span class="badge">${b.miners_count} miners</span></td>
-                            <td class="green">${b.reward} RTC</td>
-                        </tr>
-                    `).join('');
+                    const recentBlocks = asArray(data.recent_blocks);
+                    if (recentBlocks.length === 0) {
+                        blocksTable.innerHTML = '<tr><td colspan="5">No recent blocks</td></tr>';
+                    } else {
+                        blocksTable.innerHTML = recentBlocks.map(b => `
+                            <tr>
+                                <td><strong>${escapeHtml(b.height)}</strong></td>
+                                <td class="mono">${escapeHtml(b.hash_short)}...</td>
+                                <td>${escapeHtml(b.timestamp)}</td>
+                                <td><span class="badge">${escapeHtml(b.miners_count)} miners</span></td>
+                                <td class="green">${escapeHtml(b.reward)} RTC</td>
+                            </tr>
+                        `).join('');
+                    }
 
                     document.getElementById('last-update').textContent = new Date().toLocaleTimeString();
                 });
@@ -251,16 +293,18 @@ DASHBOARD_HTML = """
             const wallet = document.getElementById('wallet-search').value.trim();
             if (!wallet) return;
 
-            fetch(`/api/wallet/${wallet}`)
+            fetch(`/api/wallet/${encodeURIComponent(wallet)}`)
                 .then(r => r.json())
                 .then(data => {
+                    data = asObject(data);
                     const resultDiv = document.getElementById('search-result');
                     if (data.found) {
+                        const tierToken = safeToken(data.tier, ['classic', 'retro', 'ancient', 'modern'], 'modern');
                         resultDiv.innerHTML = `
                             <h3>✅ Wallet Found</h3>
                             <p><strong>Address:</strong> <span class="mono">${escapeHtml(data.wallet)}</span></p>
                             <p><strong>Balance:</strong> <span class="green">${escapeHtml(data.balance)} RTC</span></p>
-                            <p><strong>Weight:</strong> ${escapeHtml(data.weight)}x (${escapeHtml(data.tier)})</p>
+                            <p><strong>Weight:</strong> ${escapeHtml(data.weight)}x (<span class="badge badge-${tierToken}">${escapeHtml(data.tier)}</span>)</p>
                             <p><strong>Age on Network:</strong> ${escapeHtml(data.age_on_network || 'Unknown')}</p>
                             <p><strong>Status:</strong> ${data.enrolled ? '✅ Enrolled in current epoch' : '⏸️ Not currently enrolled'}</p>
                             <p><strong>Last Seen:</strong> ${escapeHtml(data.last_seen || 'Never')}</p>
@@ -274,7 +318,8 @@ DASHBOARD_HTML = """
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
-                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${escapeHtml(err)}</p>`;
+                    err = escapeHtml(err.message || err);
+                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
                     document.getElementById('search-result').style.display = 'block';
                 });
         }
@@ -740,7 +785,7 @@ def api_stats():
             'active_miners': [],
             'recent_blocks': [],
             'system_stats': {},
-            'error': str(e)
+            'error': 'stats_unavailable'
         }), 500
 
 @app.route('/api/wallet/<wallet_address>')
@@ -824,7 +869,7 @@ def api_wallet_lookup(wallet_address):
 
     except Exception as e:
         print(f"Error in wallet lookup: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': 'wallet_lookup_unavailable'}), 500
 
 
 @app.route('/reward-analytics')

--- a/tests/test_explorer_rustchain_dashboard_security.py
+++ b/tests/test_explorer_rustchain_dashboard_security.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+RUSTCHAIN_DASHBOARD = (
+    Path(__file__).resolve().parents[1] / "explorer" / "rustchain_dashboard.py"
+)
+
+
+def _source() -> str:
+    return RUSTCHAIN_DASHBOARD.read_text(encoding="utf-8")
+
+
+def _load_dashboard_module():
+    spec = importlib.util.spec_from_file_location(
+        "explorer_rustchain_dashboard_under_test",
+        RUSTCHAIN_DASHBOARD,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    module.app.config["TESTING"] = True
+    return module
+
+
+def test_explorer_dashboard_escapes_dynamic_table_fields_and_class_tokens():
+    source = _source()
+
+    assert "function escapeHtml(value)" in source
+    assert "function safeToken(value, allowed" in source
+    assert "const archToken = safeToken(m.arch, archTokens, 'modern');" in source
+    assert "badge-${archToken}" in source
+    assert "${escapeHtml(m.wallet_short)}" in source
+    assert "${escapeHtml(m.arch || 'unknown').toUpperCase()}" in source
+    assert "${escapeHtml(m.weight)}x" in source
+    assert "${escapeHtml(b.height)}" in source
+    assert "${escapeHtml(b.miners_count)} miners" in source
+    assert "badge-${m.arch}" not in source
+    assert "${m.weight}x" not in source
+    assert "${b.height}" not in source
+
+
+def test_explorer_dashboard_normalizes_api_payloads_before_rendering():
+    source = _source()
+
+    safe_patterns = [
+        "function safeNumber(value, fallback = 0)",
+        "function asArray(value)",
+        "function asObject(value)",
+        "data = asObject(data);",
+        "textContent = safeNumber(data.enrolled_miners);",
+        "textContent = safeNumber(data.epoch_pot).toFixed(2);",
+        "const systemStats = asObject(data.system_stats);",
+        "const activeMiners = asArray(data.active_miners);",
+        "No active miners",
+        "const recentBlocks = asArray(data.recent_blocks);",
+        "No recent blocks",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in source
+
+    unsafe_patterns = [
+        "data.epoch_pot.toFixed(2)",
+        "data.total_balance.toFixed(2)",
+        "data.active_miners.map(m => `",
+        "data.recent_blocks.map(b => `",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in source
+
+
+def test_explorer_dashboard_sanitizes_wallet_search_and_errors():
+    source = _source()
+
+    assert "fetch(`/api/wallet/${encodeURIComponent(wallet)}`)" in source
+    assert "fetch(`/api/wallet/${wallet}`)" not in source
+    assert "const tierToken = safeToken(data.tier" in source
+    assert "badge-${tierToken}" in source
+    assert "err = escapeHtml(err.message || err);" in source
+    assert "document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;" in source
+    assert "${escapeHtml(wallet)}" in source
+    assert '<span class="mono">${wallet}</span>' not in source
+
+
+def test_explorer_stats_api_does_not_echo_internal_exception_details(monkeypatch):
+    dashboard = _load_dashboard_module()
+
+    def fail_connect(*args, **kwargs):
+        raise RuntimeError("secret database path: /private/rustchain.db")
+
+    monkeypatch.setattr(dashboard.sqlite3, "connect", fail_connect)
+
+    response = dashboard.app.test_client().get("/api/stats")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["error"] == "stats_unavailable"
+    assert "secret database path" not in response.get_data(as_text=True)
+
+
+def test_explorer_wallet_lookup_api_does_not_echo_internal_exception_details(monkeypatch):
+    dashboard = _load_dashboard_module()
+
+    def fail_connect(*args, **kwargs):
+        raise RuntimeError("secret database path: /private/rustchain.db")
+
+    monkeypatch.setattr(dashboard.sqlite3, "connect", fail_connect)
+
+    response = dashboard.app.test_client().get("/api/wallet/RTCabc123")
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body["error"] == "wallet_lookup_unavailable"
+    assert "secret database path" not in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- harden explorer RustChain dashboard rendering by escaping dynamic table values and constraining badge class tokens
- normalize `/api/stats` payload fields before using arrays or numeric formatting in the browser
- encode wallet lookup requests and redact internal exception details from stats and wallet APIs

## Tests
- `uv run --with pytest --with flask --with requests --with psutil python -m pytest tests/test_explorer_rustchain_dashboard_security.py -q`
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
