### PR TITLE
fix: render explorer dashboard app rows safely

### DIFF
--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
 import os, requests
 from flask import Flask, jsonify, render_template_string, request
 
@@ -23,16 +24,38 @@ HTML = """
 <h3>Recent Transactions</h3><table><thead><tr><th>Time</th><th>From</th><th>To</th><th>Amount</th></tr></thead><tbody id='txTbl'></tbody></table>
 <script>
 async function j(u){const r=await fetch(u);return await r.json();}
+function asObject(v){return v&&typeof v==='object'&&!Array.isArray(v)?v:{};}
+function asArray(v){return Array.isArray(v)?v.filter(x=>x&&typeof x==='object'):[];}
+function text(v,f='-'){return v===undefined||v===null||v===''?f:String(v);}
 function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
+function td(v){const cell=document.createElement('td');cell.textContent=text(v);return cell;}
+function renderRows(tbodyId,rows,limit,mapper,emptyText){
+  const tbody=document.getElementById(tbodyId);
+  const body=asArray(rows).slice(0,limit).map(row=>{
+    const tr=document.createElement('tr');
+    tr.append(...mapper(row).map(td));
+    return tr;
+  });
+  if(body.length===0){
+    const tr=document.createElement('tr');
+    const cell=td(emptyText);
+    cell.colSpan=mapper({}).length;
+    tr.appendChild(cell);
+    body.push(tr);
+  }
+  tbody.replaceChildren(...body);
+}
 async function load(){
-  const d=await j('/api/dashboard');
-  document.getElementById('base').textContent=d.base;
-  document.getElementById('network').textContent=d.health?.status||'unknown';
-  document.getElementById('miners').textContent=(d.miners||[]).length;
-  document.getElementById('epoch').textContent=d.epoch?.epoch ?? '-';
-  document.getElementById('txcount').textContent=(d.transactions||[]).length;
-  document.getElementById('minersTbl').innerHTML=(d.miners||[]).slice(0,20).map(m=>`<tr><td>${m.miner_id||m.wallet||'-'}</td><td>${m.score||m.attestation_score||'-'}</td><td>${m.multiplier||m.antiquity_multiplier||'-'}</td></tr>`).join('');
-  document.getElementById('txTbl').innerHTML=(d.transactions||[]).slice(0,30).map(t=>`<tr><td>${fmtTs(t.timestamp||t.created_at||t.time)}</td><td>${t.from||t.sender||'-'}</td><td>${t.to||t.recipient||'-'}</td><td>${t.amount||t.value||'-'}</td></tr>`).join('');
+  const d=asObject(await j('/api/dashboard'));
+  const miners=asArray(d.miners);
+  const transactions=asArray(d.transactions);
+  document.getElementById('base').textContent=text(d.base);
+  document.getElementById('network').textContent=text(asObject(d.health).status,'unknown');
+  document.getElementById('miners').textContent=miners.length;
+  document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);
+  document.getElementById('txcount').textContent=transactions.length;
+  renderRows('minersTbl',miners,20,m=>[m.miner_id||m.wallet,m.score||m.attestation_score,m.multiplier||m.antiquity_multiplier],'No miners');
+  renderRows('txTbl',transactions,30,t=>[fmtTs(t.timestamp||t.created_at||t.time),t.from||t.sender,t.to||t.recipient,t.amount||t.value],'No transactions');
 }
 load(); setInterval(load, 30000);
 </script></body></html>

--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -25,7 +25,8 @@ HTML = """
 <script>
 async function j(u){const r=await fetch(u);return await r.json();}
 function asObject(v){return v&&typeof v==='object'&&!Array.isArray(v)?v:{};}
-function asArray(v){return Array.isArray(v)?v.filter(x=>x&&typeof x==='object'):[];}
+function asArray(v){return Array.isArray(v)?v.filter(x=>x&&typeof x==='object'&&!Array.isArray(x)):[];}
+function firstPresent(...values){return values.find(v=>v!==undefined&&v!==null&&v!=='');}
 function text(v,f='-'){return v===undefined||v===null||v===''?f:String(v);}
 function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
 function td(v){const cell=document.createElement('td');cell.textContent=text(v);return cell;}
@@ -54,8 +55,8 @@ async function load(){
   document.getElementById('miners').textContent=miners.length;
   document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);
   document.getElementById('txcount').textContent=transactions.length;
-  renderRows('minersTbl',miners,20,m=>[m.miner_id||m.wallet,m.score||m.attestation_score,m.multiplier||m.antiquity_multiplier],'No miners');
-  renderRows('txTbl',transactions,30,t=>[fmtTs(t.timestamp||t.created_at||t.time),t.from||t.sender,t.to||t.recipient,t.amount||t.value],'No transactions');
+  renderRows('minersTbl',miners,20,m=>[firstPresent(m.miner_id,m.wallet),firstPresent(m.score,m.attestation_score),firstPresent(m.multiplier,m.antiquity_multiplier)],'No miners');
+  renderRows('txTbl',transactions,30,t=>[fmtTs(firstPresent(t.timestamp,t.created_at,t.time)),firstPresent(t.from,t.sender),firstPresent(t.to,t.recipient),firstPresent(t.amount,t.value)],'No transactions');
 }
 load(); setInterval(load, 30000);
 </script></body></html>

--- a/explorer/dashboard/app.py
+++ b/explorer/dashboard/app.py
@@ -26,6 +26,7 @@ HTML = """
 async function j(u){const r=await fetch(u);return await r.json();}
 function asObject(v){return v&&typeof v==='object'&&!Array.isArray(v)?v:{};}
 function asArray(v){return Array.isArray(v)?v.filter(x=>x&&typeof x==='object'&&!Array.isArray(x)):[];}
+function asRows(v,key){return Array.isArray(v)?asArray(v):asArray(asObject(v)[key]);}
 function firstPresent(...values){return values.find(v=>v!==undefined&&v!==null&&v!=='');}
 function text(v,f='-'){return v===undefined||v===null||v===''?f:String(v);}
 function fmtTs(v){if(!v) return '-'; const n=Number(v); if(!Number.isFinite(n)) return String(v); const ms=n>1e12?n:n*1000; return new Date(ms).toLocaleString();}
@@ -48,14 +49,14 @@ function renderRows(tbodyId,rows,limit,mapper,emptyText){
 }
 async function load(){
   const d=asObject(await j('/api/dashboard'));
-  const miners=asArray(d.miners);
-  const transactions=asArray(d.transactions);
+  const miners=asRows(d.miners,'miners');
+  const transactions=asRows(d.transactions,'transactions');
   document.getElementById('base').textContent=text(d.base);
   document.getElementById('network').textContent=text(asObject(d.health).status,'unknown');
   document.getElementById('miners').textContent=miners.length;
   document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);
   document.getElementById('txcount').textContent=transactions.length;
-  renderRows('minersTbl',miners,20,m=>[firstPresent(m.miner_id,m.wallet),firstPresent(m.score,m.attestation_score),firstPresent(m.multiplier,m.antiquity_multiplier)],'No miners');
+  renderRows('minersTbl',miners,20,m=>[firstPresent(m.miner_id,m.wallet,m.miner),firstPresent(m.score,m.attestation_score,m.entropy_score),firstPresent(m.multiplier,m.antiquity_multiplier)],'No miners');
   renderRows('txTbl',transactions,30,t=>[fmtTs(firstPresent(t.timestamp,t.created_at,t.time)),firstPresent(t.from,t.sender),firstPresent(t.to,t.recipient),firstPresent(t.amount,t.value)],'No transactions');
 }
 load(); setInterval(load, 30000);

--- a/tests/test_explorer_dashboard_app_frontend_security.py
+++ b/tests/test_explorer_dashboard_app_frontend_security.py
@@ -11,6 +11,8 @@ def test_explorer_dashboard_app_renders_rows_with_dom_text_nodes():
     safe_patterns = [
         "function asObject(v)",
         "function asArray(v)",
+        "!Array.isArray(x)",
+        "function firstPresent(...values)",
         "function text(v,f='-')",
         "function td(v)",
         "cell.textContent=text(v);",
@@ -44,3 +46,16 @@ def test_explorer_dashboard_app_normalizes_dashboard_payloads():
     assert "document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);" in source
     assert "document.getElementById('miners').textContent=miners.length;" in source
     assert "document.getElementById('txcount').textContent=transactions.length;" in source
+    assert "firstPresent(m.score,m.attestation_score)" in source
+    assert "firstPresent(m.multiplier,m.antiquity_multiplier)" in source
+    assert "firstPresent(t.amount,t.value)" in source
+
+
+def test_explorer_dashboard_app_preserves_zero_values_and_rejects_nested_arrays():
+    source = APP.read_text(encoding="utf-8")
+
+    assert "v!==undefined&&v!==null&&v!==''" in source
+    assert "m.score||m.attestation_score" not in source
+    assert "m.multiplier||m.antiquity_multiplier" not in source
+    assert "t.amount||t.value" not in source
+    assert "typeof x==='object'&&!Array.isArray(x)" in source

--- a/tests/test_explorer_dashboard_app_frontend_security.py
+++ b/tests/test_explorer_dashboard_app_frontend_security.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: MIT
+import json
 from pathlib import Path
+import subprocess
 
 
 APP = Path(__file__).resolve().parents[1] / "explorer" / "dashboard" / "app.py"
@@ -11,6 +13,7 @@ def test_explorer_dashboard_app_renders_rows_with_dom_text_nodes():
     safe_patterns = [
         "function asObject(v)",
         "function asArray(v)",
+        "function asRows(v,key)",
         "!Array.isArray(x)",
         "function firstPresent(...values)",
         "function text(v,f='-')",
@@ -40,13 +43,14 @@ def test_explorer_dashboard_app_normalizes_dashboard_payloads():
     source = APP.read_text(encoding="utf-8")
 
     assert "const d=asObject(await j('/api/dashboard'));" in source
-    assert "const miners=asArray(d.miners);" in source
-    assert "const transactions=asArray(d.transactions);" in source
+    assert "const miners=asRows(d.miners,'miners');" in source
+    assert "const transactions=asRows(d.transactions,'transactions');" in source
     assert "document.getElementById('network').textContent=text(asObject(d.health).status,'unknown');" in source
     assert "document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);" in source
     assert "document.getElementById('miners').textContent=miners.length;" in source
     assert "document.getElementById('txcount').textContent=transactions.length;" in source
-    assert "firstPresent(m.score,m.attestation_score)" in source
+    assert "firstPresent(m.miner_id,m.wallet,m.miner)" in source
+    assert "firstPresent(m.score,m.attestation_score,m.entropy_score)" in source
     assert "firstPresent(m.multiplier,m.antiquity_multiplier)" in source
     assert "firstPresent(t.amount,t.value)" in source
 
@@ -59,3 +63,72 @@ def test_explorer_dashboard_app_preserves_zero_values_and_rejects_nested_arrays(
     assert "m.multiplier||m.antiquity_multiplier" not in source
     assert "t.amount||t.value" not in source
     assert "typeof x==='object'&&!Array.isArray(x)" in source
+
+
+def test_explorer_dashboard_app_renders_live_miners_wrapper_payload():
+    source = APP.read_text(encoding="utf-8")
+    script = source.split("<script>", 1)[1].split("</script>", 1)[0]
+
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(script)};
+const elements = {{}};
+const element = () => ({{
+  textContent: '',
+  children: [],
+  colSpan: 0,
+  append(...nodes) {{ this.children.push(...nodes); }},
+  appendChild(node) {{ this.children.push(node); }},
+  replaceChildren(...nodes) {{ this.children = nodes; }},
+}});
+const dashboardPayload = {{
+  base: 'https://node.example',
+  health: {{ status: 'ok' }},
+  epoch: {{ epoch: 0 }},
+  miners: {{
+    miners: [
+      {{ miner: 'power8-s824-sophia', entropy_score: 0, antiquity_multiplier: 2.0 }},
+    ],
+    pagination: {{ total: 1 }},
+  }},
+  transactions: [],
+}};
+const context = {{
+  setInterval() {{}},
+  fetch: async () => ({{ json: async () => dashboardPayload }}),
+  document: {{
+    createElement(tag) {{
+      const node = element();
+      node.tagName = tag;
+      return node;
+    }},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element();
+      return elements[id];
+    }},
+  }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+context.load().then(() => {{
+  const row = elements.minersTbl.children[0];
+  console.log(JSON.stringify({{
+    minersText: String(elements.miners.textContent),
+    firstRow: row.children.map(cell => cell.textContent),
+  }}));
+}}).catch((error) => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+        check=True,
+    )
+    rendered = json.loads(result.stdout)
+
+    assert rendered["minersText"] == "1"
+    assert rendered["firstRow"] == ["power8-s824-sophia", "0", "2"]

--- a/tests/test_explorer_dashboard_app_frontend_security.py
+++ b/tests/test_explorer_dashboard_app_frontend_security.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+APP = Path(__file__).resolve().parents[1] / "explorer" / "dashboard" / "app.py"
+
+
+def test_explorer_dashboard_app_renders_rows_with_dom_text_nodes():
+    source = APP.read_text(encoding="utf-8")
+
+    safe_patterns = [
+        "function asObject(v)",
+        "function asArray(v)",
+        "function text(v,f='-')",
+        "function td(v)",
+        "cell.textContent=text(v);",
+        "function renderRows(tbodyId,rows,limit,mapper,emptyText)",
+        "tbody.replaceChildren(...body);",
+        "renderRows('minersTbl',miners,20",
+        "renderRows('txTbl',transactions,30",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in source
+
+    unsafe_patterns = [
+        "document.getElementById('minersTbl').innerHTML=(d.miners||[])",
+        "document.getElementById('txTbl').innerHTML=(d.transactions||[])",
+        "<td>${m.miner_id||m.wallet||'-'}</td>",
+        "<td>${t.from||t.sender||'-'}</td>",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in source
+
+
+def test_explorer_dashboard_app_normalizes_dashboard_payloads():
+    source = APP.read_text(encoding="utf-8")
+
+    assert "const d=asObject(await j('/api/dashboard'));" in source
+    assert "const miners=asArray(d.miners);" in source
+    assert "const transactions=asArray(d.transactions);" in source
+    assert "document.getElementById('network').textContent=text(asObject(d.health).status,'unknown');" in source
+    assert "document.getElementById('epoch').textContent=text(asObject(d.epoch).epoch);" in source
+    assert "document.getElementById('miners').textContent=miners.length;" in source
+    assert "document.getElementById('txcount').textContent=transactions.length;" in source


### PR DESCRIPTION
## Summary
- render standalone explorer dashboard miner and transaction rows with DOM text nodes instead of interpolated `innerHTML`
- normalize dashboard payload objects and row arrays before rendering counts or tables
- add frontend regression coverage for safe row rendering and payload normalization

## Tests
- `uv run --with pytest --with flask python -m pytest tests/test_explorer_dashboard_app_frontend_security.py -q`
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
