### PR TITLE
fix: normalize chart renderer data

### DIFF
--- a/explorer/static/js/charts.js
+++ b/explorer/static/js/charts.js
@@ -79,8 +79,18 @@ class ChartRenderer {
         return this.asArray(this.data).map(value => this.numericValue(value));
     }
 
+    isSliceObject(item) {
+        return item && typeof item === 'object' && !Array.isArray(item);
+    }
+
     getSliceValue(item) {
-        return Math.max(0, this.numericValue(item && item.value));
+        if (!this.isSliceObject(item)) return 0;
+        return Math.max(0, this.numericValue(item.value));
+    }
+
+    getSliceLabel(item) {
+        if (!this.isSliceObject(item) || item.label == null) return '';
+        return String(item.label);
     }
 
     /**
@@ -92,7 +102,7 @@ class ChartRenderer {
         if (this.options.animation) {
             this.animate();
         } else {
-            this.data = newData;
+            this.data = this.targetData;
             this.render();
         }
     }
@@ -395,7 +405,7 @@ class ChartRenderer {
             this.ctx.font = '12px sans-serif';
             this.ctx.textAlign = 'center';
             this.ctx.textBaseline = 'middle';
-            this.ctx.fillText(item.label || '', labelX, labelY);
+            this.ctx.fillText(this.getSliceLabel(item), labelX, labelY);
 
             startAngle += sliceAngle;
         });
@@ -446,23 +456,30 @@ class ChartRenderer {
         const itemHeight = 20;
         const itemWidth = 100;
 
-        if (!this.data.length || !this.data[0].label) return;
+        const items = this.asArray(this.data);
+        const legendItems = items
+            .map((item, index) => ({
+                label: this.getSliceLabel(item),
+                colorIndex: index
+            }))
+            .filter(item => item.label);
+        if (legendItems.length === 0) return;
 
         this.ctx.font = '12px sans-serif';
         
-        this.data.forEach((item, index) => {
+        legendItems.forEach((item, index) => {
             const x = padding;
             const y = padding + index * (itemHeight + 5);
             
             // Draw color box
-            this.ctx.fillStyle = colors[index % colors.length];
+            this.ctx.fillStyle = colors[item.colorIndex % colors.length];
             this.ctx.fillRect(x, y, 12, 12);
             
             // Draw label
             this.ctx.fillStyle = '#e8eaed';
             this.ctx.textAlign = 'left';
             this.ctx.textBaseline = 'middle';
-            this.ctx.fillText(item.label || '', x + 18, y + 6);
+            this.ctx.fillText(item.label, x + 18, y + 6);
         });
     }
 

--- a/explorer/static/js/charts.js
+++ b/explorer/static/js/charts.js
@@ -66,11 +66,28 @@ class ChartRenderer {
         observer.observe(this.container);
     }
 
+    asArray(data) {
+        return Array.isArray(data) ? data : [];
+    }
+
+    numericValue(value, fallback = 0) {
+        const number = Number(value);
+        return Number.isFinite(number) ? number : fallback;
+    }
+
+    getNumericData() {
+        return this.asArray(this.data).map(value => this.numericValue(value));
+    }
+
+    getSliceValue(item) {
+        return Math.max(0, this.numericValue(item && item.value));
+    }
+
     /**
      * Update chart data
      */
     update(newData) {
-        this.targetData = newData;
+        this.targetData = this.asArray(newData);
         
         if (this.options.animation) {
             this.animate();
@@ -90,7 +107,7 @@ class ChartRenderer {
 
         const duration = 300;
         const startTime = performance.now();
-        const startData = this.data.length > 0 ? this.data : this.targetData;
+        const startData = this.asArray(this.data).length > 0 ? this.asArray(this.data) : this.targetData;
 
         const animateFrame = (currentTime) => {
             const elapsed = currentTime - startTime;
@@ -196,9 +213,10 @@ class ChartRenderer {
 
         // Vertical grid lines
         const gridWidth = width - padding.left - padding.right;
-        if (this.data.length > 1) {
-            for (let i = 0; i < this.data.length; i++) {
-                const x = padding.left + (gridWidth / (this.data.length - 1)) * i;
+        const dataLength = this.asArray(this.data).length;
+        if (dataLength > 1) {
+            for (let i = 0; i < dataLength; i++) {
+                const x = padding.left + (gridWidth / (dataLength - 1)) * i;
                 this.ctx.beginPath();
                 this.ctx.moveTo(x, padding.top);
                 this.ctx.lineTo(x, height - padding.bottom);
@@ -222,10 +240,11 @@ class ChartRenderer {
         const chartWidth = width - padding.left - padding.right;
         const chartHeight = height - padding.top - padding.bottom;
 
-        if (this.data.length < 2) return;
+        const data = this.getNumericData();
+        if (data.length < 2) return;
 
-        const maxValue = Math.max(...this.data.map(d => typeof d === 'number' ? d : 0));
-        const minValue = Math.min(...this.data.map(d => typeof d === 'number' ? d : 0));
+        const maxValue = Math.max(...data);
+        const minValue = Math.min(...data);
         const range = maxValue - minValue || 1;
 
         // Draw line
@@ -234,8 +253,8 @@ class ChartRenderer {
         this.ctx.lineWidth = 2;
         this.ctx.lineJoin = 'round';
 
-        this.data.forEach((value, index) => {
-            const x = padding.left + (chartWidth / (this.data.length - 1)) * index;
+        data.forEach((value, index) => {
+            const x = padding.left + (chartWidth / (data.length - 1)) * index;
             const y = padding.top + chartHeight - ((value - minValue) / range) * chartHeight;
             
             if (index === 0) {
@@ -248,8 +267,8 @@ class ChartRenderer {
         this.ctx.stroke();
 
         // Draw points
-        this.data.forEach((value, index) => {
-            const x = padding.left + (chartWidth / (this.data.length - 1)) * index;
+        data.forEach((value, index) => {
+            const x = padding.left + (chartWidth / (data.length - 1)) * index;
             const y = padding.top + chartHeight - ((value - minValue) / range) * chartHeight;
             
             this.ctx.beginPath();
@@ -272,10 +291,11 @@ class ChartRenderer {
         const chartWidth = width - padding.left - padding.right;
         const chartHeight = height - padding.top - padding.bottom;
 
-        if (this.data.length < 2) return;
+        const data = this.getNumericData();
+        if (data.length < 2) return;
 
-        const maxValue = Math.max(...this.data.map(d => typeof d === 'number' ? d : 0));
-        const minValue = Math.min(...this.data.map(d => typeof d === 'number' ? d : 0));
+        const maxValue = Math.max(...data);
+        const minValue = Math.min(...data);
         const range = maxValue - minValue || 1;
 
         // Draw filled area
@@ -284,8 +304,8 @@ class ChartRenderer {
         gradient.addColorStop(0, colors[0] + '60');
         gradient.addColorStop(1, colors[0] + '10');
 
-        this.data.forEach((value, index) => {
-            const x = padding.left + (chartWidth / (this.data.length - 1)) * index;
+        data.forEach((value, index) => {
+            const x = padding.left + (chartWidth / (data.length - 1)) * index;
             const y = padding.top + chartHeight - ((value - minValue) / range) * chartHeight;
             
             if (index === 0) {
@@ -314,14 +334,15 @@ class ChartRenderer {
         const chartWidth = width - padding.left - padding.right;
         const chartHeight = height - padding.top - padding.bottom;
 
-        if (this.data.length === 0) return;
+        const data = this.getNumericData();
+        if (data.length === 0) return;
 
-        const maxValue = Math.max(...this.data.map(d => typeof d === 'number' ? d : 0));
-        const barWidth = (chartWidth / this.data.length) * 0.8;
-        const barGap = (chartWidth / this.data.length) * 0.2;
+        const maxValue = Math.max(...data);
+        const barWidth = (chartWidth / data.length) * 0.8;
+        const barGap = (chartWidth / data.length) * 0.2;
 
-        this.data.forEach((value, index) => {
-            const x = padding.left + (chartWidth / this.data.length) * index + barGap / 2;
+        data.forEach((value, index) => {
+            const x = padding.left + (chartWidth / data.length) * index + barGap / 2;
             const barHeight = maxValue > 0 ? (value / maxValue) * chartHeight : 0;
             const y = padding.top + chartHeight - barHeight;
 
@@ -347,13 +368,15 @@ class ChartRenderer {
         const centerY = height / 2;
         const radius = Math.min(width, height) / 2 - 40;
 
-        if (this.data.length === 0) return;
+        const slices = this.asArray(this.data);
+        if (slices.length === 0) return;
 
-        const total = this.data.reduce((sum, item) => sum + (item.value || 0), 0);
+        const total = slices.reduce((sum, item) => sum + this.getSliceValue(item), 0);
+        if (total <= 0) return;
         let startAngle = -Math.PI / 2;
 
-        this.data.forEach((item, index) => {
-            const value = item.value || 0;
+        slices.forEach((item, index) => {
+            const value = this.getSliceValue(item);
             const sliceAngle = (value / total) * Math.PI * 2;
 
             this.ctx.beginPath();
@@ -385,13 +408,15 @@ class ChartRenderer {
         const outerRadius = Math.min(width, height) / 2 - 20;
         const innerRadius = outerRadius * 0.6;
 
-        if (this.data.length === 0) return;
+        const slices = this.asArray(this.data);
+        if (slices.length === 0) return;
 
-        const total = this.data.reduce((sum, item) => sum + (item.value || 0), 0);
+        const total = slices.reduce((sum, item) => sum + this.getSliceValue(item), 0);
+        if (total <= 0) return;
         let startAngle = -Math.PI / 2;
 
-        this.data.forEach((item, index) => {
-            const value = item.value || 0;
+        slices.forEach((item, index) => {
+            const value = this.getSliceValue(item);
             const sliceAngle = (value / total) * Math.PI * 2;
 
             // Draw doughnut slice

--- a/tests/test_chart_renderer_data_normalization.py
+++ b/tests/test_chart_renderer_data_normalization.py
@@ -1,8 +1,59 @@
 # SPDX-License-Identifier: MIT
+import json
+import subprocess
+import textwrap
 from pathlib import Path
 
 
 CHARTS = Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "charts.js"
+
+
+def run_chart_probe(body: str) -> None:
+    script = f"""
+    const fs = require('fs');
+    const vm = require('vm');
+    const source = fs.readFileSync({json.dumps(str(CHARTS))}, 'utf8');
+
+    const noop = () => undefined;
+    const ctx = new Proxy({{}}, {{
+        get(target, prop) {{
+            if (prop === 'createLinearGradient') {{
+                return () => ({{ addColorStop: noop }});
+            }}
+            return target[prop] || noop;
+        }},
+        set(target, prop, value) {{
+            target[prop] = value;
+            return true;
+        }}
+    }});
+    const canvas = {{
+        style: {{}},
+        getContext: () => ctx
+    }};
+    global.window = global;
+    global.document = {{
+        getElementById: () => ({{
+            clientWidth: 400,
+            innerHTML: '',
+            appendChild: noop,
+            removeChild: noop
+        }}),
+        createElement: () => canvas
+    }};
+    global.ResizeObserver = undefined;
+    global.performance = {{ now: () => 0 }};
+    global.requestAnimationFrame = (callback) => {{
+        callback(300);
+        return 1;
+    }};
+    global.cancelAnimationFrame = noop;
+
+    vm.runInThisContext(source);
+
+    {body}
+    """
+    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
 
 
 def test_chart_renderer_normalizes_update_payloads_to_arrays():
@@ -11,8 +62,10 @@ def test_chart_renderer_normalizes_update_payloads_to_arrays():
     assert "asArray(data)" in source
     assert "return Array.isArray(data) ? data : [];" in source
     assert "this.targetData = this.asArray(newData);" in source
+    assert "this.data = this.targetData;" in source
     assert "const startData = this.asArray(this.data).length > 0 ? this.asArray(this.data) : this.targetData;" in source
     assert "this.targetData = newData;" not in source
+    assert "this.data = newData;" not in source
 
 
 def test_chart_renderer_coerces_numeric_series_before_drawing():
@@ -45,10 +98,52 @@ def test_chart_renderer_coerces_numeric_series_before_drawing():
 def test_chart_renderer_skips_zero_total_pie_and_doughnut_charts():
     source = CHARTS.read_text(encoding="utf-8")
 
+    assert "isSliceObject(item)" in source
+    assert "return item && typeof item === 'object' && !Array.isArray(item);" in source
     assert "getSliceValue(item)" in source
-    assert "return Math.max(0, this.numericValue(item && item.value));" in source
+    assert "if (!this.isSliceObject(item)) return 0;" in source
+    assert "return Math.max(0, this.numericValue(item.value));" in source
+    assert "getSliceLabel(item)" in source
+    assert "this.ctx.fillText(this.getSliceLabel(item), labelX, labelY);" in source
     assert "const total = slices.reduce((sum, item) => sum + this.getSliceValue(item), 0);" in source
     assert "if (total <= 0) return;" in source
     assert "const value = this.getSliceValue(item);" in source
+    assert "this.ctx.fillText(item.label || '', labelX, labelY);" not in source
     assert "const total = this.data.reduce((sum, item) => sum + (item.value || 0), 0);" not in source
     assert "const value = item.value || 0;" not in source
+
+
+def test_non_animated_update_stores_normalized_array():
+    run_chart_probe(
+        """
+        const chart = new ChartRenderer('chart', {
+            animation: false,
+            showGrid: false,
+            showLegend: false
+        });
+        chart.update({ not: 'array' });
+
+        if (!Array.isArray(chart.targetData) || chart.targetData.length !== 0) {
+            throw new Error('targetData was not normalized');
+        }
+        if (!Array.isArray(chart.data) || chart.data.length !== 0) {
+            throw new Error('data was not normalized for non-animated update');
+        }
+        """
+    )
+
+
+def test_malformed_pie_slices_do_not_throw():
+    run_chart_probe(
+        """
+        const chart = new ChartRenderer('chart', {
+            type: 'pie',
+            animation: false,
+            showGrid: false,
+            showLegend: true
+        });
+
+        chart.update([{ label: 'valid', value: 1 }, null]);
+        chart.update([null, { label: 'valid', value: 1 }]);
+        """
+    )

--- a/tests/test_chart_renderer_data_normalization.py
+++ b/tests/test_chart_renderer_data_normalization.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+CHARTS = Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "charts.js"
+
+
+def test_chart_renderer_normalizes_update_payloads_to_arrays():
+    source = CHARTS.read_text(encoding="utf-8")
+
+    assert "asArray(data)" in source
+    assert "return Array.isArray(data) ? data : [];" in source
+    assert "this.targetData = this.asArray(newData);" in source
+    assert "const startData = this.asArray(this.data).length > 0 ? this.asArray(this.data) : this.targetData;" in source
+    assert "this.targetData = newData;" not in source
+
+
+def test_chart_renderer_coerces_numeric_series_before_drawing():
+    source = CHARTS.read_text(encoding="utf-8")
+
+    safe_patterns = [
+        "numericValue(value, fallback = 0)",
+        "return Number.isFinite(number) ? number : fallback;",
+        "getNumericData()",
+        "const data = this.getNumericData();",
+        "const maxValue = Math.max(...data);",
+        "data.forEach((value, index) => {",
+        "value.toFixed(1)",
+    ]
+
+    for pattern in safe_patterns:
+        assert pattern in source
+
+    unsafe_patterns = [
+        "Math.max(...this.data.map(d => typeof d === 'number' ? d : 0))",
+        "Math.min(...this.data.map(d => typeof d === 'number' ? d : 0))",
+        "this.data.forEach((value, index) => {",
+        "const barWidth = (chartWidth / this.data.length) * 0.8;",
+    ]
+
+    for pattern in unsafe_patterns:
+        assert pattern not in source
+
+
+def test_chart_renderer_skips_zero_total_pie_and_doughnut_charts():
+    source = CHARTS.read_text(encoding="utf-8")
+
+    assert "getSliceValue(item)" in source
+    assert "return Math.max(0, this.numericValue(item && item.value));" in source
+    assert "const total = slices.reduce((sum, item) => sum + this.getSliceValue(item), 0);" in source
+    assert "if (total <= 0) return;" in source
+    assert "const value = this.getSliceValue(item);" in source
+    assert "const total = this.data.reduce((sum, item) => sum + (item.value || 0), 0);" not in source
+    assert "const value = item.value || 0;" not in source


### PR DESCRIPTION
## Summary
- normalize ChartRenderer update payloads to arrays before animation/rendering
- coerce numeric line/area/bar series before calculations and labels
- skip zero-total pie/doughnut renders to avoid NaN canvas operations

## Tests
- `uv run --with pytest --with flask python -m pytest tests/test_chart_renderer_data_normalization.py -q`
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
