### PR TITLE
fix: guard service worker cache handling

### DIFF
--- a/explorer/static/js/sw.js
+++ b/explorer/static/js/sw.js
@@ -6,6 +6,7 @@
 const CACHE_NAME = 'rustchain-explorer-v1';
 const API_CACHE_NAME = 'rustchain-api-v1';
 const CACHE_DURATION = 10 * 1000; // 10 seconds for API
+const CACHE_PREFIX = 'rustchain-';
 
 // Assets to cache on install
 const STATIC_ASSETS = [
@@ -15,6 +16,18 @@ const STATIC_ASSETS = [
     '/static/css/explorer.css',
     '/static/js/explorer.js'
 ];
+
+function isRustChainCache(name) {
+    return typeof name === 'string' && name.startsWith(CACHE_PREFIX);
+}
+
+function isCurrentCache(name) {
+    return name === CACHE_NAME || name === API_CACHE_NAME;
+}
+
+function isCacheableResponse(response) {
+    return response && response.ok && (response.type === 'basic' || response.type === 'cors');
+}
 
 // Install event - cache static assets
 self.addEventListener('install', (event) => {
@@ -44,7 +57,7 @@ self.addEventListener('activate', (event) => {
                 return Promise.all(
                     cacheNames
                         .filter((name) => {
-                            return name !== CACHE_NAME && name !== API_CACHE_NAME;
+                            return isRustChainCache(name) && !isCurrentCache(name);
                         })
                         .map((name) => {
                             console.log('[SW] Deleting old cache:', name);
@@ -78,6 +91,10 @@ self.addEventListener('fetch', (event) => {
         event.respondWith(
             fetch(request)
                 .then((response) => {
+                    if (!isCacheableResponse(response)) {
+                        return response;
+                    }
+
                     // Clone response for caching
                     const responseClone = response.clone();
                     caches.open(API_CACHE_NAME).then((cache) => {
@@ -137,7 +154,7 @@ self.addEventListener('fetch', (event) => {
                     })
                     .catch(() => {
                         // Offline fallback for HTML
-                        if (request.headers.get('accept').includes('text/html')) {
+                        if ((request.headers.get('accept') || '').includes('text/html')) {
                             return caches.match('/explorer/index.html');
                         }
                     });
@@ -157,7 +174,9 @@ self.addEventListener('message', (event) => {
         event.waitUntil(
             caches.keys().then((cacheNames) => {
                 return Promise.all(
-                    cacheNames.map((name) => caches.delete(name))
+                    cacheNames
+                        .filter(isRustChainCache)
+                        .map((name) => caches.delete(name))
                 );
             })
         );

--- a/tests/test_service_worker_cache_guards.py
+++ b/tests/test_service_worker_cache_guards.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+SW = Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "sw.js"
+
+
+def test_service_worker_only_deletes_rustchain_caches():
+    source = SW.read_text(encoding="utf-8")
+
+    assert "const CACHE_PREFIX = 'rustchain-';" in source
+    assert "function isRustChainCache(name)" in source
+    assert "function isCurrentCache(name)" in source
+    assert "return isRustChainCache(name) && !isCurrentCache(name);" in source
+    assert ".filter(isRustChainCache)" in source
+    assert "return name !== CACHE_NAME && name !== API_CACHE_NAME;" not in source
+    assert "cacheNames.map((name) => caches.delete(name))" not in source
+
+
+def test_service_worker_only_caches_successful_api_responses():
+    source = SW.read_text(encoding="utf-8")
+
+    assert "function isCacheableResponse(response)" in source
+    assert "response && response.ok && (response.type === 'basic' || response.type === 'cors')" in source
+    assert "if (!isCacheableResponse(response)) {" in source
+    assert "return response;" in source
+    assert "const responseClone = response.clone();" in source
+
+
+def test_service_worker_handles_missing_accept_header_for_offline_html_fallback():
+    source = SW.read_text(encoding="utf-8")
+
+    assert "(request.headers.get('accept') || '').includes('text/html')" in source
+    assert "request.headers.get('accept').includes('text/html')" not in source


### PR DESCRIPTION
## Summary
- scope service-worker cache deletion to RustChain-owned cache names
- avoid caching non-successful API responses
- guard offline HTML fallback when requests omit the Accept header

## Tests
- `uv run --with pytest --with flask python -m pytest tests/test_service_worker_cache_guards.py -q`
- `node - <<'NODE' ... new Function(script) ... NODE`
- `uv run python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check`
