### PR TITLE
fix: guard static status dashboard payloads

### DIFF
--- a/static/status/index.html
+++ b/static/status/index.html
@@ -130,6 +130,17 @@
         return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
     }
 
+    function isValidNode(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+        return value.name != null || value.url != null;
+    }
+
+    function formatTimestamp(value) {
+        if (!value) return 'unavailable';
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? 'unavailable' : date.toLocaleTimeString();
+    }
+
     function renderEmptyState(grid, message) {
         const card = document.createElement('div');
         card.className = 'card';
@@ -137,7 +148,15 @@
         grid.appendChild(card);
     }
 
+    function renderUnavailable(grid) {
+        grid.innerHTML = '';
+        renderEmptyState(grid, 'No node status data available');
+        document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: unavailable';
+        document.getElementById('sysTime').innerText = new Date().toISOString();
+    }
+
     async function updateStatus() {
+        const grid = document.getElementById('nodeGrid');
         try {
             const resp = await fetch('node_status.json');
             if (!resp.ok) {
@@ -145,15 +164,12 @@
             }
             const history = safeArray(await resp.json()).map(safeObject);
             const latest = history.length > 0 ? history[history.length - 1] : {};
-            const latestNodes = safeArray(latest.nodes).map(safeObject);
+            const latestNodes = safeArray(latest.nodes).filter(isValidNode).map(safeObject);
             
-            const grid = document.getElementById('nodeGrid');
             grid.innerHTML = '';
 
             if (latestNodes.length === 0) {
-                renderEmptyState(grid, 'No node status data available');
-                document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: unavailable';
-                document.getElementById('sysTime').innerText = new Date().toISOString();
+                renderUnavailable(grid);
                 return;
             }
             
@@ -166,7 +182,7 @@
                 
                 // Get node history for uptime bar
                 const nodeHistory = history.map(h => {
-                    const found = nodeUrl ? safeArray(h.nodes).map(safeObject).find(n => n.url === nodeUrl) : null;
+                    const found = nodeUrl ? safeArray(h.nodes).filter(isValidNode).map(safeObject).find(n => n.url === nodeUrl) : null;
                     return found ? safeStatus(found.status) === 'up' : false;
                 }).slice(-50); // Show last 50 checks
                 
@@ -209,12 +225,12 @@
                 grid.appendChild(card);
             });
             
-            const latestTime = latest.time ? new Date(latest.time).toLocaleTimeString() : 'unavailable';
-            document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: ' + latestTime;
+            document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: ' + formatTimestamp(latest.time);
             document.getElementById('sysTime').innerText = new Date().toISOString();
             
         } catch (e) {
             console.error('Failed to fetch status', e);
+            renderUnavailable(grid);
         }
     }
 

--- a/static/status/index.html
+++ b/static/status/index.html
@@ -122,24 +122,51 @@
         return Number.isFinite(number) ? number : fallback;
     }
 
+    function safeArray(value) {
+        return Array.isArray(value) ? value : [];
+    }
+
+    function safeObject(value) {
+        return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+    }
+
+    function renderEmptyState(grid, message) {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.textContent = message;
+        grid.appendChild(card);
+    }
+
     async function updateStatus() {
         try {
             const resp = await fetch('node_status.json');
-            const history = await resp.json();
-            const latest = history[history.length - 1];
+            if (!resp.ok) {
+                throw new Error(`HTTP ${resp.status}`);
+            }
+            const history = safeArray(await resp.json()).map(safeObject);
+            const latest = history.length > 0 ? history[history.length - 1] : {};
+            const latestNodes = safeArray(latest.nodes).map(safeObject);
             
             const grid = document.getElementById('nodeGrid');
             grid.innerHTML = '';
+
+            if (latestNodes.length === 0) {
+                renderEmptyState(grid, 'No node status data available');
+                document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: unavailable';
+                document.getElementById('sysTime').innerText = new Date().toISOString();
+                return;
+            }
             
-            latest.nodes.forEach(node => {
+            latestNodes.forEach(node => {
                 const card = document.createElement('div');
                 card.className = 'card';
                 const status = safeStatus(node.status);
                 const statusColor = status === 'up' ? 'var(--green)' : 'var(--red)';
+                const nodeUrl = node.url == null ? '' : String(node.url);
                 
                 // Get node history for uptime bar
                 const nodeHistory = history.map(h => {
-                    const found = h.nodes.find(n => n.url === node.url);
+                    const found = nodeUrl ? safeArray(h.nodes).map(safeObject).find(n => n.url === nodeUrl) : null;
                     return found ? safeStatus(found.status) === 'up' : false;
                 }).slice(-50); // Show last 50 checks
                 
@@ -182,7 +209,8 @@
                 grid.appendChild(card);
             });
             
-            document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: ' + new Date(latest.time).toLocaleTimeString();
+            const latestTime = latest.time ? new Date(latest.time).toLocaleTimeString() : 'unavailable';
+            document.getElementById('lastUpdate').innerText = 'LAST_UPDATE: ' + latestTime;
             document.getElementById('sysTime').innerText = new Date().toISOString();
             
         } catch (e) {

--- a/tests/test_status_dashboard_frontend_security.py
+++ b/tests/test_status_dashboard_frontend_security.py
@@ -1,19 +1,100 @@
 # SPDX-License-Identifier: MIT
+import json
+import subprocess
+import textwrap
 from pathlib import Path
 
 
+PAGE = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
+
+
+def run_status_dashboard_probe(payload, assertions: str) -> None:
+    script = f"""
+    const fs = require('fs');
+    const vm = require('vm');
+    const html = fs.readFileSync({json.dumps(str(PAGE))}, 'utf8');
+    const source = html.match(/<script>([\\s\\S]*?)<\\/script>/)[1];
+
+    function makeElement(tagName) {{
+        return {{
+            tagName,
+            children: [],
+            className: '',
+            style: {{}},
+            _innerHTML: '',
+            _innerText: '',
+            _textContent: '',
+            appendChild(child) {{
+                this.children.push(child);
+            }},
+            set innerHTML(value) {{
+                this._innerHTML = String(value);
+                this.children = [];
+            }},
+            get innerHTML() {{
+                return this._innerHTML;
+            }},
+            set innerText(value) {{
+                this._innerText = String(value);
+            }},
+            get innerText() {{
+                return this._innerText;
+            }},
+            set textContent(value) {{
+                this._textContent = String(value);
+            }},
+            get textContent() {{
+                return this._textContent;
+            }}
+        }};
+    }}
+
+    const elements = {{
+        nodeGrid: makeElement('div'),
+        lastUpdate: makeElement('div'),
+        sysTime: makeElement('span')
+    }};
+    const context = {{
+        document: {{
+            getElementById: id => elements[id],
+            createElement: makeElement
+        }},
+        fetch: async () => ({{
+            ok: true,
+            status: 200,
+            json: async () => ({json.dumps(payload)})
+        }}),
+        console: {{ error() {{}} }},
+        Date,
+        setInterval: () => 1
+    }};
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    context.updateStatus().then(() => {{
+        const nodeGrid = elements.nodeGrid;
+        const lastUpdate = elements.lastUpdate;
+        {assertions}
+    }}).catch(error => {{
+        console.error(error);
+        process.exit(1);
+    }});
+    """
+    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+
+
 def test_status_dashboard_defines_render_safety_helpers():
-    page = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
-    html = page.read_text(encoding="utf-8")
+    html = PAGE.read_text(encoding="utf-8")
 
     assert "function escapeHtml(value)" in html
     assert "function safeStatus(value)" in html
     assert "function safeNumber(value, fallback = '--')" in html
+    assert "function safeArray(value)" in html
+    assert "function safeObject(value)" in html
 
 
 def test_status_dashboard_escapes_node_status_fields_before_inner_html():
-    page = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
-    html = page.read_text(encoding="utf-8")
+    html = PAGE.read_text(encoding="utf-8")
 
     safe_patterns = [
         "const status = safeStatus(node.status);",
@@ -45,3 +126,50 @@ def test_status_dashboard_escapes_node_status_fields_before_inner_html():
 
     for pattern in unsafe_patterns:
         assert pattern not in html
+
+
+def test_status_dashboard_handles_empty_or_malformed_history_payloads():
+    run_status_dashboard_probe(
+        {"not": "a history array"},
+        """
+        if (nodeGrid.children.length !== 1) {
+            throw new Error('expected one empty-state card');
+        }
+        if (nodeGrid.children[0].textContent !== 'No node status data available') {
+            throw new Error('missing empty-state message');
+        }
+        if (lastUpdate.innerText !== 'LAST_UPDATE: unavailable') {
+            throw new Error('missing unavailable timestamp');
+        }
+        """,
+    )
+
+
+def test_status_dashboard_handles_malformed_history_rows():
+    run_status_dashboard_probe(
+        [
+            {"time": "2026-05-20T00:00:00Z", "nodes": None},
+            {
+                "time": "2026-05-20T00:01:00Z",
+                "nodes": [
+                    {
+                        "name": "<img src=x onerror=alert(1)>",
+                        "url": "https://node.example/health",
+                        "location": "Lab",
+                        "status": "up",
+                    }
+                ],
+            },
+        ],
+        """
+        if (nodeGrid.children.length !== 1) {
+            throw new Error('expected one rendered node card');
+        }
+        if (!nodeGrid.children[0].innerHTML.includes('&lt;img src=x onerror=alert(1)&gt;')) {
+            throw new Error('node name was not escaped');
+        }
+        if (!nodeGrid.children[0].innerHTML.includes('status-dot up')) {
+            throw new Error('safe status class was not rendered');
+        }
+        """,
+    )

--- a/tests/test_status_dashboard_frontend_security.py
+++ b/tests/test_status_dashboard_frontend_security.py
@@ -8,7 +8,7 @@ from pathlib import Path
 PAGE = Path(__file__).resolve().parents[1] / "static" / "status" / "index.html"
 
 
-def run_status_dashboard_probe(payload, assertions: str) -> None:
+def run_status_dashboard_probe(payload, assertions: str, *, ok: bool = True, status: int = 200) -> None:
     script = f"""
     const fs = require('fs');
     const vm = require('vm');
@@ -60,8 +60,8 @@ def run_status_dashboard_probe(payload, assertions: str) -> None:
             createElement: makeElement
         }},
         fetch: async () => ({{
-            ok: true,
-            status: 200,
+            ok: {json.dumps(ok)},
+            status: {status},
             json: async () => ({json.dumps(payload)})
         }}),
         console: {{ error() {{}} }},
@@ -91,6 +91,9 @@ def test_status_dashboard_defines_render_safety_helpers():
     assert "function safeNumber(value, fallback = '--')" in html
     assert "function safeArray(value)" in html
     assert "function safeObject(value)" in html
+    assert "function isValidNode(value)" in html
+    assert "function formatTimestamp(value)" in html
+    assert "function renderUnavailable(grid)" in html
 
 
 def test_status_dashboard_escapes_node_status_fields_before_inner_html():
@@ -150,8 +153,10 @@ def test_status_dashboard_handles_malformed_history_rows():
         [
             {"time": "2026-05-20T00:00:00Z", "nodes": None},
             {
-                "time": "2026-05-20T00:01:00Z",
+                "time": "bad",
                 "nodes": [
+                    None,
+                    ["bad"],
                     {
                         "name": "<img src=x onerror=alert(1)>",
                         "url": "https://node.example/health",
@@ -171,5 +176,27 @@ def test_status_dashboard_handles_malformed_history_rows():
         if (!nodeGrid.children[0].innerHTML.includes('status-dot up')) {
             throw new Error('safe status class was not rendered');
         }
+        if (lastUpdate.innerText !== 'LAST_UPDATE: unavailable') {
+            throw new Error('invalid timestamp should render unavailable');
+        }
         """,
+    )
+
+
+def test_status_dashboard_renders_empty_state_for_fetch_failures():
+    run_status_dashboard_probe(
+        {},
+        """
+        if (nodeGrid.children.length !== 1) {
+            throw new Error('expected one empty-state card');
+        }
+        if (nodeGrid.children[0].textContent !== 'No node status data available') {
+            throw new Error('missing empty-state message');
+        }
+        if (lastUpdate.innerText !== 'LAST_UPDATE: unavailable') {
+            throw new Error('missing unavailable timestamp');
+        }
+        """,
+        ok=False,
+        status=404,
     )


### PR DESCRIPTION
## Summary
- normalize the static status dashboard history payload before reading latest nodes
- render an empty-state card for empty or malformed node_status.json data
- guard per-history node lookups so missing nodes arrays do not break the uptime bar
- add Node-backed regressions for malformed status payloads

## Validation
- node syntax probe for static/status/index.html embedded script
- python3 -m py_compile tests/test_status_dashboard_frontend_security.py
- uv run --with pytest --with flask python -m pytest tests/test_status_dashboard_frontend_security.py -q
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check