### PR TITLE
fix: write static status data beside dashboard

### DIFF
--- a/static/status/monitor.py
+++ b/static/status/monitor.py
@@ -3,6 +3,7 @@ import time
 import json
 import os
 from datetime import datetime
+from pathlib import Path
 
 # Node configuration
 NODES = [
@@ -12,7 +13,7 @@ NODES = [
     {"name": "Node 4", "url": "http://38.76.217.189:8099/health", "location": "Hong Kong"},
 ]
 
-DATA_FILE = "node_status.json"
+DATA_FILE = str(Path(__file__).with_name("node_status.json"))
 
 def check_nodes():
     results = []

--- a/tests/test_static_status_monitor.py
+++ b/tests/test_static_status_monitor.py
@@ -65,6 +65,12 @@ def test_check_nodes_records_success_and_failure_without_network(tmp_path, monke
     assert history[0]["nodes"] == results
 
 
+def test_default_data_file_lives_next_to_static_dashboard():
+    monitor = load_monitor_module()
+
+    assert Path(monitor.DATA_FILE) == MODULE_PATH.with_name("node_status.json")
+
+
 def test_check_nodes_appends_history_and_keeps_recent_entries(tmp_path, monkeypatch):
     monitor = load_monitor_module()
     data_file = tmp_path / "node_status.json"


### PR DESCRIPTION
## Summary
- make the static status monitor write node_status.json next to static/status/index.html
- add a regression test for the default data-file location

## Why
The dashboard fetches node_status.json relative to static/status/index.html. The monitor previously used a bare relative filename, so running it from the repo root or a service working directory could write node_status.json somewhere the dashboard never serves.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_static_status_monitor.py -q
- python -m py_compile static/status/monitor.py tests/test_static_status_monitor.py
- python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check