### PR TITLE
fix: guard static bridge dashboard payloads

### DIFF
--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -149,8 +149,12 @@
         return Array.isArray(value) ? value : [];
     }
 
+    function isPlainObject(value) {
+        return value && typeof value === 'object' && !Array.isArray(value);
+    }
+
     function safeObject(value) {
-        return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+        return isPlainObject(value) ? value : {};
     }
 
     function formatTimestamp(value) {
@@ -181,7 +185,7 @@
             // Update node status
             const statusDiv = document.getElementById('nodeStatus');
             statusDiv.innerHTML = '';
-            safeArray(data.bridge_nodes).map(safeObject).forEach(node => {
+            safeArray(data.bridge_nodes).filter(isPlainObject).forEach(node => {
                 const pill = document.createElement('span');
                 const status = safeClassToken(node.status, ['up', 'down'], 'down');
                 pill.className = `status-pill ${status === 'up' ? 'online' : ''}`;
@@ -192,7 +196,7 @@
             // Update transactions
             const body = document.getElementById('txBody');
             body.innerHTML = '';
-            safeArray(data.recent_transactions).map(safeObject).forEach(tx => {
+            safeArray(data.recent_transactions).filter(isPlainObject).forEach(tx => {
                 const row = document.createElement('tr');
                 const lockId = escapeHtml(String(tx.lock_id ?? '').substring(0, 12));
                 const targetChain = safeClassToken(tx.target_chain, ['solana', 'base'], 'solana');

--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -159,6 +159,14 @@
         return Number.isNaN(date.getTime()) ? 'unavailable' : date.toLocaleTimeString();
     }
 
+    function renderFallback() {
+        document.getElementById('lockedRtc').innerText = '0 RTC';
+        document.getElementById('circulatingWrtc').innerText = '0 wRTC';
+        document.getElementById('nodeStatus').innerHTML = '';
+        document.getElementById('txBody').innerHTML = '';
+        document.getElementById('lastUpdate').innerText = 'LAST_SYNC: unavailable';
+    }
+
     async function refresh() {
         try {
             const resp = await fetch('bridge_status.json');
@@ -202,6 +210,7 @@
             document.getElementById('lastUpdate').innerText = 'LAST_SYNC: ' + formatTimestamp(data.timestamp);
         } catch (e) {
             console.error(e);
+            renderFallback();
         }
     }
 

--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -153,6 +153,12 @@
         return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
     }
 
+    function formatTimestamp(value) {
+        if (!value) return 'unavailable';
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? 'unavailable' : date.toLocaleTimeString();
+    }
+
     async function refresh() {
         try {
             const resp = await fetch('bridge_status.json');
@@ -193,8 +199,7 @@
                 body.appendChild(row);
             });
 
-            const latestTime = data.timestamp ? new Date(data.timestamp).toLocaleTimeString() : 'unavailable';
-            document.getElementById('lastUpdate').innerText = 'LAST_SYNC: ' + latestTime;
+            document.getElementById('lastUpdate').innerText = 'LAST_SYNC: ' + formatTimestamp(data.timestamp);
         } catch (e) {
             console.error(e);
         }

--- a/static/bridge/index.html
+++ b/static/bridge/index.html
@@ -145,28 +145,40 @@
         return Number.isFinite(number) ? number : fallback;
     }
 
+    function safeArray(value) {
+        return Array.isArray(value) ? value : [];
+    }
+
+    function safeObject(value) {
+        return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+    }
+
     async function refresh() {
         try {
             const resp = await fetch('bridge_status.json');
-            const data = await resp.json();
+            if (!resp.ok) {
+                throw new Error(`HTTP ${resp.status}`);
+            }
+            const data = safeObject(await resp.json());
             
-            document.getElementById('lockedRtc').innerText = data.total_locked_rtc.toLocaleString() + ' RTC';
-            document.getElementById('circulatingWrtc').innerText = (data.circulating_wrtc || 0).toLocaleString() + ' wRTC';
+            document.getElementById('lockedRtc').innerText = safeNumber(data.total_locked_rtc).toLocaleString() + ' RTC';
+            document.getElementById('circulatingWrtc').innerText = safeNumber(data.circulating_wrtc).toLocaleString() + ' wRTC';
             
             // Update node status
             const statusDiv = document.getElementById('nodeStatus');
             statusDiv.innerHTML = '';
-            data.bridge_nodes.forEach(node => {
+            safeArray(data.bridge_nodes).map(safeObject).forEach(node => {
                 const pill = document.createElement('span');
-                pill.className = `status-pill ${node.status === 'up' ? 'online' : ''}`;
-                pill.innerText = `${node.name}: ${node.status.toUpperCase()}`;
+                const status = safeClassToken(node.status, ['up', 'down'], 'down');
+                pill.className = `status-pill ${status === 'up' ? 'online' : ''}`;
+                pill.innerText = `${String(node.name ?? 'Unknown')}: ${status.toUpperCase()}`;
                 statusDiv.appendChild(pill);
             });
 
             // Update transactions
             const body = document.getElementById('txBody');
             body.innerHTML = '';
-            data.recent_transactions.forEach(tx => {
+            safeArray(data.recent_transactions).map(safeObject).forEach(tx => {
                 const row = document.createElement('tr');
                 const lockId = escapeHtml(String(tx.lock_id ?? '').substring(0, 12));
                 const targetChain = safeClassToken(tx.target_chain, ['solana', 'base'], 'solana');
@@ -181,7 +193,8 @@
                 body.appendChild(row);
             });
 
-            document.getElementById('lastUpdate').innerText = 'LAST_SYNC: ' + new Date(data.timestamp).toLocaleTimeString();
+            const latestTime = data.timestamp ? new Date(data.timestamp).toLocaleTimeString() : 'unavailable';
+            document.getElementById('lastUpdate').innerText = 'LAST_SYNC: ' + latestTime;
         } catch (e) {
             console.error(e);
         }

--- a/tests/test_static_bridge_dashboard_frontend_security.py
+++ b/tests/test_static_bridge_dashboard_frontend_security.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: MIT
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+PAGE = Path(__file__).resolve().parents[1] / "static" / "bridge" / "index.html"
+
+
+def run_bridge_dashboard_probe(payload, assertions: str) -> None:
+    script = f"""
+    const fs = require('fs');
+    const vm = require('vm');
+    const html = fs.readFileSync({json.dumps(str(PAGE))}, 'utf8');
+    const source = html.match(/<script>([\\s\\S]*?)<\\/script>/)[1];
+
+    function makeElement(tagName) {{
+        return {{
+            tagName,
+            children: [],
+            className: '',
+            style: {{}},
+            _innerHTML: '',
+            _innerText: '',
+            appendChild(child) {{
+                this.children.push(child);
+            }},
+            set innerHTML(value) {{
+                this._innerHTML = String(value);
+                this.children = [];
+            }},
+            get innerHTML() {{
+                return this._innerHTML;
+            }},
+            set innerText(value) {{
+                this._innerText = String(value);
+            }},
+            get innerText() {{
+                return this._innerText;
+            }}
+        }};
+    }}
+
+    const elements = {{
+        lockedRtc: makeElement('div'),
+        circulatingWrtc: makeElement('div'),
+        nodeStatus: makeElement('div'),
+        txBody: makeElement('tbody'),
+        lastUpdate: makeElement('div')
+    }};
+    const context = {{
+        document: {{
+            getElementById: id => elements[id],
+            createElement: makeElement
+        }},
+        fetch: async () => ({{
+            ok: true,
+            status: 200,
+            json: async () => ({json.dumps(payload)})
+        }}),
+        console: {{ error() {{}} }},
+        Date,
+        setInterval: () => 1
+    }};
+
+    vm.createContext(context);
+    vm.runInContext(source, context);
+    context.refresh().then(() => {{
+        const lockedRtc = elements.lockedRtc;
+        const circulatingWrtc = elements.circulatingWrtc;
+        const nodeStatus = elements.nodeStatus;
+        const txBody = elements.txBody;
+        const lastUpdate = elements.lastUpdate;
+        {assertions}
+    }}).catch(error => {{
+        console.error(error);
+        process.exit(1);
+    }});
+    """
+    subprocess.run(["node", "-e", textwrap.dedent(script)], check=True)
+
+
+def test_bridge_dashboard_defines_payload_safety_helpers():
+    html = PAGE.read_text(encoding="utf-8")
+
+    assert "function escapeHtml(value)" in html
+    assert "function safeClassToken(value, allowed, fallback)" in html
+    assert "function safeNumber(value, fallback = 0)" in html
+    assert "function safeArray(value)" in html
+    assert "function safeObject(value)" in html
+
+
+def test_bridge_dashboard_handles_empty_or_malformed_payloads():
+    run_bridge_dashboard_probe(
+        {"not": "bridge status"},
+        """
+        if (lockedRtc.innerText !== '0 RTC') {
+            throw new Error('locked RTC fallback did not render');
+        }
+        if (circulatingWrtc.innerText !== '0 wRTC') {
+            throw new Error('wRTC fallback did not render');
+        }
+        if (nodeStatus.children.length !== 0 || txBody.children.length !== 0) {
+            throw new Error('malformed arrays should render as empty lists');
+        }
+        if (lastUpdate.innerText !== 'LAST_SYNC: unavailable') {
+            throw new Error('missing unavailable timestamp');
+        }
+        """,
+    )
+
+
+def test_bridge_dashboard_safely_renders_malformed_nodes_and_transactions():
+    run_bridge_dashboard_probe(
+        {
+            "total_locked_rtc": "12.5",
+            "circulating_wrtc": "7",
+            "timestamp": "2026-05-20T00:01:00Z",
+            "bridge_nodes": [
+                {"name": "<img src=x onerror=alert(1)>", "status": "up"},
+                None,
+            ],
+            "recent_transactions": [
+                {
+                    "lock_id": "abcdef1234567890",
+                    "sender_wallet": "<script>alert(1)</script>",
+                    "amount_rtc": "5",
+                    "target_chain": "javascript",
+                    "state": "<bad>",
+                },
+                None,
+            ],
+        },
+        """
+        if (nodeStatus.children.length !== 2) {
+            throw new Error('expected two status pills');
+        }
+        if (nodeStatus.children[0].className !== 'status-pill online') {
+            throw new Error('up node status did not use safe online class');
+        }
+        if (!nodeStatus.children[1].innerText.includes('Unknown: DOWN')) {
+            throw new Error('malformed node did not render fallback text');
+        }
+        if (txBody.children.length !== 2) {
+            throw new Error('expected two transaction rows');
+        }
+        if (!txBody.children[0].innerHTML.includes('&lt;script&gt;alert(1)&lt;/script&gt;')) {
+            throw new Error('sender wallet was not escaped');
+        }
+        if (!txBody.children[0].innerHTML.includes('SOLANA')) {
+            throw new Error('target chain did not fall back to safe token');
+        }
+        if (!txBody.children[0].innerHTML.includes('PENDING')) {
+            throw new Error('state did not fall back to safe token');
+        }
+        """,
+    )

--- a/tests/test_static_bridge_dashboard_frontend_security.py
+++ b/tests/test_static_bridge_dashboard_frontend_security.py
@@ -8,7 +8,7 @@ from pathlib import Path
 PAGE = Path(__file__).resolve().parents[1] / "static" / "bridge" / "index.html"
 
 
-def run_bridge_dashboard_probe(payload, assertions: str) -> None:
+def run_bridge_dashboard_probe(payload, assertions: str, *, ok: bool = True, status: int = 200) -> None:
     script = f"""
     const fs = require('fs');
     const vm = require('vm');
@@ -55,8 +55,8 @@ def run_bridge_dashboard_probe(payload, assertions: str) -> None:
             createElement: makeElement
         }},
         fetch: async () => ({{
-            ok: true,
-            status: 200,
+            ok: {json.dumps(ok)},
+            status: {status},
             json: async () => ({json.dumps(payload)})
         }}),
         console: {{ error() {{}} }},
@@ -90,6 +90,7 @@ def test_bridge_dashboard_defines_payload_safety_helpers():
     assert "function safeArray(value)" in html
     assert "function safeObject(value)" in html
     assert "function formatTimestamp(value)" in html
+    assert "function renderFallback()" in html
 
 
 def test_bridge_dashboard_handles_empty_or_malformed_payloads():
@@ -109,6 +110,28 @@ def test_bridge_dashboard_handles_empty_or_malformed_payloads():
             throw new Error('missing unavailable timestamp');
         }
         """,
+    )
+
+
+def test_bridge_dashboard_handles_fetch_failures():
+    run_bridge_dashboard_probe(
+        {},
+        """
+        if (lockedRtc.innerText !== '0 RTC') {
+            throw new Error('locked RTC fallback did not render');
+        }
+        if (circulatingWrtc.innerText !== '0 wRTC') {
+            throw new Error('wRTC fallback did not render');
+        }
+        if (nodeStatus.children.length !== 0 || txBody.children.length !== 0) {
+            throw new Error('failed fetch should render empty node and tx lists');
+        }
+        if (lastUpdate.innerText !== 'LAST_SYNC: unavailable') {
+            throw new Error('missing unavailable timestamp');
+        }
+        """,
+        ok=False,
+        status=404,
     )
 
 

--- a/tests/test_static_bridge_dashboard_frontend_security.py
+++ b/tests/test_static_bridge_dashboard_frontend_security.py
@@ -88,6 +88,7 @@ def test_bridge_dashboard_defines_payload_safety_helpers():
     assert "function safeClassToken(value, allowed, fallback)" in html
     assert "function safeNumber(value, fallback = 0)" in html
     assert "function safeArray(value)" in html
+    assert "function isPlainObject(value)" in html
     assert "function safeObject(value)" in html
     assert "function formatTimestamp(value)" in html
     assert "function renderFallback()" in html
@@ -157,17 +158,14 @@ def test_bridge_dashboard_safely_renders_malformed_nodes_and_transactions():
             ],
         },
         """
-        if (nodeStatus.children.length !== 2) {
-            throw new Error('expected two status pills');
+        if (nodeStatus.children.length !== 1) {
+            throw new Error('expected one valid status pill');
         }
         if (nodeStatus.children[0].className !== 'status-pill online') {
             throw new Error('up node status did not use safe online class');
         }
-        if (!nodeStatus.children[1].innerText.includes('Unknown: DOWN')) {
-            throw new Error('malformed node did not render fallback text');
-        }
-        if (txBody.children.length !== 2) {
-            throw new Error('expected two transaction rows');
+        if (txBody.children.length !== 1) {
+            throw new Error('expected one valid transaction row');
         }
         if (!txBody.children[0].innerHTML.includes('&lt;script&gt;alert(1)&lt;/script&gt;')) {
             throw new Error('sender wallet was not escaped');
@@ -177,6 +175,24 @@ def test_bridge_dashboard_safely_renders_malformed_nodes_and_transactions():
         }
         if (!txBody.children[0].innerHTML.includes('PENDING')) {
             throw new Error('state did not fall back to safe token');
+        }
+        """,
+    )
+
+
+def test_bridge_dashboard_filters_fully_malformed_rows():
+    run_bridge_dashboard_probe(
+        {
+            "timestamp": "2026-05-20T00:01:00Z",
+            "bridge_nodes": [None],
+            "recent_transactions": [None],
+        },
+        """
+        if (nodeStatus.children.length !== 0) {
+            throw new Error('malformed node row should be filtered');
+        }
+        if (txBody.children.length !== 0) {
+            throw new Error('malformed transaction row should be filtered');
         }
         """,
     )

--- a/tests/test_static_bridge_dashboard_frontend_security.py
+++ b/tests/test_static_bridge_dashboard_frontend_security.py
@@ -89,11 +89,12 @@ def test_bridge_dashboard_defines_payload_safety_helpers():
     assert "function safeNumber(value, fallback = 0)" in html
     assert "function safeArray(value)" in html
     assert "function safeObject(value)" in html
+    assert "function formatTimestamp(value)" in html
 
 
 def test_bridge_dashboard_handles_empty_or_malformed_payloads():
     run_bridge_dashboard_probe(
-        {"not": "bridge status"},
+        {"not": "bridge status", "timestamp": "not-a-date"},
         """
         if (lockedRtc.innerText !== '0 RTC') {
             throw new Error('locked RTC fallback did not render');


### PR DESCRIPTION
## Summary
- normalize bridge_status.json before rendering the static bridge monitor
- guard missing bridge_nodes and recent_transactions arrays
- fall back malformed node statuses, transaction state, target chain, and numeric totals to safe display values
- add Node-backed regressions for malformed bridge status payloads

## Validation
- node syntax probe for static/bridge/index.html embedded script
- python3 -m py_compile tests/test_static_bridge_dashboard_frontend_security.py
- uv run --with pytest --with flask python -m pytest tests/test_static_bridge_dashboard_frontend_security.py -q
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check