### PR TITLE
fix: validate JSON body shape in badge generator (#4367)

### DIFF
--- a/tests/test_bcos_badge_json_regression.py
+++ b/tests/test_bcos_badge_json_regression.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for #4367: BCOS badge generator JSON crash.
+
+Verifies that malformed JSON bodies return 400 instead of 500.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from tools.bcos_badge_generator import app, init_db
+
+ADMIN_KEY = 'test-admin-key-4367'
+
+
+class TestBadgeJsonValidation(unittest.TestCase):
+    """Regression tests for badge generator JSON handling (#4367)."""
+
+    def setUp(self):
+        self.db_fd, self.db_path = tempfile.mkstemp(suffix='.db')
+        os.close(self.db_fd)
+        import tools.bcos_badge_generator as bg
+        self.orig_db = bg.DATABASE
+        bg.DATABASE = self.db_path
+        self.env_patch = patch.dict(os.environ, {'BCOS_ADMIN_KEY': ADMIN_KEY})
+        self.env_patch.start()
+        app.config['TESTING'] = True
+        self.client = app.test_client()
+        init_db()
+
+    def tearDown(self):
+        import tools.bcos_badge_generator as bg
+        bg.DATABASE = self.orig_db
+        self.env_patch.stop()
+        os.unlink(self.db_path)
+
+    def post(self, payload, content_type='application/json'):
+        return self.client.post(
+            '/api/badge/generate',
+            data=json.dumps(payload) if payload is not None else None,
+            headers={'X-Admin-Key': ADMIN_KEY},
+            content_type=content_type,
+        )
+
+    # ── JSON array body ──────────────────────────────────────
+    def test_array_body_returns_400(self):
+        """A JSON array body should return 400, not 500."""
+        r = self.post(['repo_name'])
+        self.assertIn(r.status_code, (400, 200))
+        data = json.loads(r.data)
+        self.assertFalse(data.get('success', False))
+
+    # ── Non-string fields ────────────────────────────────────
+    def test_non_string_repo_name(self):
+        """repo_name as list should not crash."""
+        r = self.post({'repo_name': ['owner', 'repo'], 'tier': 'L1', 'trust_score': 75})
+        self.assertIn(r.status_code, (400, 200))
+        data = json.loads(r.data)
+        self.assertFalse(data.get('success', False))
+
+    def test_non_string_tier(self):
+        """tier as dict should not crash."""
+        r = self.post({'repo_name': 'test/repo', 'tier': {'level': 1}, 'trust_score': 75})
+        self.assertIn(r.status_code, (400, 200))
+        data = json.loads(r.data)
+        self.assertFalse(data.get('success', False))
+
+    # ── Non-numeric trust_score ──────────────────────────────
+    def test_dict_trust_score(self):
+        """trust_score as dict should not crash."""
+        r = self.post({'repo_name': 'test/repo', 'tier': 'L1', 'trust_score': {'high': True}})
+        self.assertIn(r.status_code, (400, 200))
+        data = json.loads(r.data)
+        self.assertFalse(data.get('success', False))
+
+    def test_list_trust_score(self):
+        """trust_score as list should not crash."""
+        r = self.post({'repo_name': 'test/repo', 'tier': 'L1', 'trust_score': [75]})
+        self.assertIn(r.status_code, (400, 200))
+        data = json.loads(r.data)
+        self.assertFalse(data.get('success', False))
+
+    # ── Valid request still works ────────────────────────────
+    def test_valid_request_succeeds(self):
+        """Normal request should still succeed."""
+        r = self.post({'repo_name': 'test/repo', 'tier': 'L1', 'trust_score': 75})
+        self.assertEqual(r.status_code, 200)
+        data = json.loads(r.data)
+        self.assertTrue(data['success'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_bcos_badge_json_regression.py
+++ b/tests/test_bcos_badge_json_regression.py
@@ -53,7 +53,7 @@ class TestBadgeJsonValidation(unittest.TestCase):
     def test_array_body_returns_400(self):
         """A JSON array body should return 400, not 500."""
         r = self.post(['repo_name'])
-        self.assertIn(r.status_code, (400, 200))
+        self.assertEqual(r.status_code, 400)
         data = json.loads(r.data)
         self.assertFalse(data.get('success', False))
 
@@ -61,14 +61,14 @@ class TestBadgeJsonValidation(unittest.TestCase):
     def test_non_string_repo_name(self):
         """repo_name as list should not crash."""
         r = self.post({'repo_name': ['owner', 'repo'], 'tier': 'L1', 'trust_score': 75})
-        self.assertIn(r.status_code, (400, 200))
+        self.assertEqual(r.status_code, 400)
         data = json.loads(r.data)
         self.assertFalse(data.get('success', False))
 
     def test_non_string_tier(self):
         """tier as dict should not crash."""
         r = self.post({'repo_name': 'test/repo', 'tier': {'level': 1}, 'trust_score': 75})
-        self.assertIn(r.status_code, (400, 200))
+        self.assertEqual(r.status_code, 400)
         data = json.loads(r.data)
         self.assertFalse(data.get('success', False))
 
@@ -76,14 +76,14 @@ class TestBadgeJsonValidation(unittest.TestCase):
     def test_dict_trust_score(self):
         """trust_score as dict should not crash."""
         r = self.post({'repo_name': 'test/repo', 'tier': 'L1', 'trust_score': {'high': True}})
-        self.assertIn(r.status_code, (400, 200))
+        self.assertEqual(r.status_code, 400)
         data = json.loads(r.data)
         self.assertFalse(data.get('success', False))
 
     def test_list_trust_score(self):
         """trust_score as list should not crash."""
         r = self.post({'repo_name': 'test/repo', 'tier': 'L1', 'trust_score': [75]})
-        self.assertIn(r.status_code, (400, 200))
+        self.assertEqual(r.status_code, 400)
         data = json.loads(r.data)
         self.assertFalse(data.get('success', False))
 

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1124,12 +1124,29 @@ def generate_badge():
     if auth_error:
         return auth_error
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
 
-    repo_name = data.get('repo_name', '').strip()
-    tier = data.get('tier', 'L1').upper()
+    if data is None:
+        return jsonify({'success': False, 'error': 'JSON body required'}), 400
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'error': 'JSON object required (got array or scalar)'}), 400
+
+    # Validate field types before calling .strip()/.upper()
+    raw_repo = data.get('repo_name', '')
+    raw_tier = data.get('tier', 'L1')
+    raw_cert = data.get('cert_id', '')
+
+    if not isinstance(raw_repo, str):
+        return jsonify({'success': False, 'error': 'repo_name must be a string'})
+    if not isinstance(raw_tier, str):
+        return jsonify({'success': False, 'error': 'tier must be a string'})
+    if not isinstance(raw_cert, str):
+        return jsonify({'success': False, 'error': 'Invalid certificate ID. Use BCOS- followed by letters, numbers, underscores, or hyphens.'})
+
+    repo_name = raw_repo.strip()
+    tier = raw_tier.upper()
     raw_trust_score = data.get('trust_score', 75)
-    cert_id = data.get('cert_id', '')
+    cert_id = raw_cert
     include_qr = data.get('include_qr', False)
 
     # Validation

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1137,16 +1137,16 @@ def generate_badge():
     raw_cert = data.get('cert_id', '')
 
     if not isinstance(raw_repo, str):
-        return jsonify({'success': False, 'error': 'repo_name must be a string'})
+        return jsonify({'success': False, 'error': 'repo_name must be a string'}), 400
     if not isinstance(raw_tier, str):
-        return jsonify({'success': False, 'error': 'tier must be a string'})
-    if not isinstance(raw_cert, str):
-        return jsonify({'success': False, 'error': 'Invalid certificate ID. Use BCOS- followed by letters, numbers, underscores, or hyphens.'})
+        return jsonify({'success': False, 'error': 'tier must be a string'}), 400
+    if raw_cert is not None and not isinstance(raw_cert, str):
+        return jsonify({'success': False, 'error': 'cert_id must be a string or null'}), 400
 
     repo_name = raw_repo.strip()
     tier = raw_tier.upper()
     raw_trust_score = data.get('trust_score', 75)
-    cert_id = raw_cert
+    cert_id = raw_cert or ''
     include_qr = data.get('include_qr', False)
 
     # Validation


### PR DESCRIPTION
## Fix: BCOS badge generator crashes on malformed JSON

**Fixes:** #4367
**Wallet:** `RTC241359b3438d1222fdc1c3e22fe980657a4bc54e`

### Problem

`POST /api/badge/generate` calls `.get()` on the parsed JSON body without checking if it is a dict. A JSON array body crashes with `AttributeError`. Non-string `repo_name`/`tier` values crash on `.strip()`/`.upper()`.

### Fix

1. Check `data is None` -> 400
2. Check `isinstance(data, dict)` -> 400
3. Validate `repo_name`, `tier`, `cert_id` are strings before calling string methods
4. Existing numeric validation for `trust_score` already handles dicts/lists

### Tests

`tests/test_bcos_badge_json_regression.py`:
- Array body -> 400
- Non-string repo_name -> 400
- Non-string tier -> 400
- Dict/list trust_score -> 400
- Valid request -> 200
