### PR TITLE
fix: reject malformed badge generation payloads

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -383,6 +383,50 @@ class TestFlaskIntegration(unittest.TestCase):
         self.assertIn('markdown', data)
         self.assertIn('html', data)
 
+    def test_generate_badge_rejects_non_object_json(self):
+        """Badge generation should reject non-object JSON bodies without 500s."""
+        response = self.client.post(
+            '/api/badge/generate',
+            data=json.dumps(['repo_name']),
+            headers={'X-Admin-Key': self.admin_key},
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'JSON object required')
+
+    def test_generate_badge_rejects_non_string_repo_name(self):
+        """repo_name must be a string before the route calls .strip()."""
+        response = self.post_generate_badge(
+            {
+                'repo_name': ['test', 'repo'],
+                'tier': 'L1',
+                'trust_score': 75,
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'repo_name must be a string')
+
+    def test_generate_badge_rejects_non_string_tier(self):
+        """tier must be a string before the route calls .upper()."""
+        response = self.post_generate_badge(
+            {
+                'repo_name': 'test/repo',
+                'tier': {'level': 'L1'},
+                'trust_score': 75,
+            }
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'tier must be a string')
+
     def test_generate_badge_requires_admin_key(self):
         """Badge generation should reject requests without an admin key."""
         response = self.client.post(
@@ -438,6 +482,22 @@ class TestFlaskIntegration(unittest.TestCase):
         data = json.loads(response.data)
         self.assertTrue(data['success'])
         self.assertIn('cert_id', data)
+
+    def test_generate_badge_treats_null_cert_id_as_omitted(self):
+        """The browser sends null for a blank optional cert ID field."""
+        response = self.post_generate_badge(
+            {
+                'repo_name': 'test/repo',
+                'tier': 'L1',
+                'trust_score': 75,
+                'cert_id': None,
+            }
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['success'])
+        self.assertRegex(data['cert_id'], r'^BCOS-[0-9a-f]{8}$')
 
     def test_generate_badge_missing_repo(self):
         """Test badge generation with missing repo name."""
@@ -532,7 +592,7 @@ class TestFlaskIntegration(unittest.TestCase):
                     }
                 )
 
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, 400)
                 data = json.loads(response.data)
                 self.assertFalse(data['success'])
                 self.assertIn('Invalid certificate ID', data['error'])

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1124,13 +1124,34 @@ def generate_badge():
     if auth_error:
         return auth_error
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
 
-    repo_name = data.get('repo_name', '').strip()
-    tier = data.get('tier', 'L1').upper()
+    if data is None:
+        return jsonify({'success': False, 'error': 'JSON body required'}), 400
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'error': 'JSON object required'}), 400
+
+    raw_repo_name = data.get('repo_name', '')
+    raw_tier = data.get('tier', 'L1')
     raw_trust_score = data.get('trust_score', 75)
-    cert_id = data.get('cert_id', '')
+    raw_cert_id = data.get('cert_id')
     include_qr = data.get('include_qr', False)
+
+    if not isinstance(raw_repo_name, str):
+        return jsonify({'success': False, 'error': 'repo_name must be a string'}), 400
+    if not isinstance(raw_tier, str):
+        return jsonify({'success': False, 'error': 'tier must be a string'}), 400
+    if raw_cert_id is None:
+        raw_cert_id = ''
+    elif not isinstance(raw_cert_id, str):
+        return jsonify({
+            'success': False,
+            'error': 'Invalid certificate ID. Use BCOS- followed by letters, numbers, underscores, or hyphens.',
+        }), 400
+
+    repo_name = raw_repo_name.strip()
+    tier = raw_tier.upper()
+    cert_id = raw_cert_id
 
     # Validation
     if not repo_name:


### PR DESCRIPTION
## Summary
- reject missing, scalar, and array JSON bodies before badge field access
- validate repo_name, tier, and cert_id are strings before calling string helpers
- add regressions for non-object JSON and non-string badge fields

## Why
POST /api/badge/generate can currently crash on non-object JSON and wrong field types because the route calls .get(), .strip(), and .upper() before checking payload shape. This also makes rejected malformed cert IDs safer by returning HTTP 400 instead of a successful status.

Fixes #4367.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_bcos_badge_generator.py -q
- python -m py_compile tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py
- python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check