### PR TITLE
fix: write bridge status data beside dashboard

### DIFF
--- a/static/bridge/update_stats.py
+++ b/static/bridge/update_stats.py
@@ -3,6 +3,7 @@ import time
 import json
 import os
 from datetime import datetime
+from pathlib import Path
 
 # Configuration
 # Note: Production bridge APIs might be on different nodes or ports
@@ -17,7 +18,7 @@ BRIDGE_NODES = [
 # wRTC Mint Address on Solana (Hypothetical for now)
 WRTC_MINT = "wRTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-DATA_FILE = "bridge_status.json"
+DATA_FILE = str(Path(__file__).with_name("bridge_status.json"))
 
 def get_bridge_stats():
     results = {

--- a/tests/test_static_bridge_update_stats.py
+++ b/tests/test_static_bridge_update_stats.py
@@ -63,6 +63,12 @@ def test_get_bridge_stats_uses_max_locked_value_and_first_ledger(tmp_path, monke
     assert json.loads(data_file.read_text()) == result
 
 
+def test_default_data_file_lives_next_to_static_bridge_dashboard():
+    stats = load_update_stats_module()
+
+    assert Path(stats.DATA_FILE) == MODULE_PATH.with_name("bridge_status.json")
+
+
 def test_get_bridge_stats_records_down_nodes_and_empty_ledger(tmp_path, monkeypatch):
     stats = load_update_stats_module()
     data_file = tmp_path / "bridge_status.json"


### PR DESCRIPTION
## Summary
- make the static bridge updater write bridge_status.json next to static/bridge/index.html
- add a regression test for the default bridge data-file location

## Why
The static bridge dashboard fetches bridge_status.json relative to static/bridge/index.html. The updater previously used a bare relative filename, so running it from the repo root, cron, or a service working directory could write the data file somewhere the dashboard never serves.

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_static_bridge_update_stats.py -q
- python -m py_compile static/bridge/update_stats.py tests/test_static_bridge_update_stats.py
- python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check