### PR TITLE
fix: guard static status monitor history

### DIFF
--- a/static/status/monitor.py
+++ b/static/status/monitor.py
@@ -62,8 +62,10 @@ def check_nodes():
     if os.path.exists(DATA_FILE):
         try:
             with open(DATA_FILE, 'r') as f:
-                history = json.load(f)
-        except: pass
+                loaded_history = json.load(f)
+                history = loaded_history if isinstance(loaded_history, list) else []
+        except (OSError, json.JSONDecodeError):
+            pass
     
     history.append({"time": datetime.now().isoformat(), "nodes": results})
     # Keep last 1440 entries (24 hours at 1/min)

--- a/tests/test_static_status_monitor.py
+++ b/tests/test_static_status_monitor.py
@@ -89,3 +89,27 @@ def test_check_nodes_appends_history_and_keeps_recent_entries(tmp_path, monkeypa
     assert history[0]["time"] == "old-1"
     assert history[-1]["nodes"][0]["status"] == "down"
     assert history[-1]["nodes"][0]["error"] == "HTTP 503"
+
+
+def test_check_nodes_recovers_from_non_list_history_file(tmp_path, monkeypatch):
+    monitor = load_monitor_module()
+    data_file = tmp_path / "node_status.json"
+    data_file.write_text(json.dumps({"nodes": "not a history list"}))
+
+    monkeypatch.setattr(monitor, "DATA_FILE", str(data_file))
+    monkeypatch.setattr(
+        monitor,
+        "NODES",
+        [{"name": "Node A", "url": "https://node-a/health", "location": "A"}],
+    )
+
+    response = Mock()
+    response.status_code = 503
+    monkeypatch.setattr(monitor.requests, "get", Mock(return_value=response))
+
+    monitor.check_nodes()
+
+    history = json.loads(data_file.read_text())
+    assert isinstance(history, list)
+    assert len(history) == 1
+    assert history[0]["nodes"][0]["status"] == "down"


### PR DESCRIPTION
## Summary
- validate existing node_status.json history before appending new monitor samples
- recover from valid non-list JSON history files instead of crashing on append
- add a regression for a non-list history file being replaced by a fresh history array

## Validation
- python3 -m py_compile static/status/monitor.py tests/test_static_status_monitor.py
- uv run --with pytest --with requests --with flask python -m pytest tests/test_static_status_monitor.py -q
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check

Note: running the focused pytest without Flask first fails because the repo-level tests/conftest.py imports Flask-backed node code. The command above includes Flask and passes.