### PR TITLE
fix: normalize static bridge stats payloads

### DIFF
--- a/static/bridge/update_stats.py
+++ b/static/bridge/update_stats.py
@@ -19,6 +19,19 @@ WRTC_MINT = "wRTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 DATA_FILE = "bridge_status.json"
 
+def safe_dict(value):
+    return value if isinstance(value, dict) else {}
+
+def safe_list(value):
+    return value if isinstance(value, list) else []
+
+def safe_number(value, fallback=0):
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return number if number == number else fallback
+
 def get_bridge_stats():
     results = {
         "timestamp": datetime.now().isoformat(),
@@ -33,12 +46,14 @@ def get_bridge_stats():
         try:
             resp = requests.get(node["url"], timeout=10, verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True)
             if resp.status_code == 200:
-                data = resp.json()
+                data = safe_dict(resp.json())
+                all_time = safe_dict(data.get("all_time"))
+                solana_stats = safe_dict(safe_dict(data.get("by_chain")).get("solana"))
                 node_stats = {
                     "name": node["name"],
                     "status": "up",
-                    "total_locked": data.get("all_time", {}).get("total_rtc_locked", 0),
-                    "completed_count": data.get("by_chain", {}).get("solana", {}).get("bridged_count", 0)
+                    "total_locked": safe_number(all_time.get("total_rtc_locked")),
+                    "completed_count": safe_number(solana_stats.get("bridged_count"))
                 }
                 results["bridge_nodes"].append(node_stats)
                 # Take max locked value from healthy nodes as source of truth
@@ -54,7 +69,7 @@ def get_bridge_stats():
             ledger_url = node["url"].replace("/stats", "/ledger?limit=10")
             resp = requests.get(ledger_url, timeout=10, verify=os.path.expanduser("~/.rustchain/node_cert.pem") if os.path.exists(os.path.expanduser("~/.rustchain/node_cert.pem")) else True)
             if resp.status_code == 200:
-                results["recent_transactions"] = resp.json().get("locks", [])
+                results["recent_transactions"] = safe_list(safe_dict(resp.json()).get("locks"))
                 break
         except: continue
 

--- a/static/bridge/update_stats.py
+++ b/static/bridge/update_stats.py
@@ -2,6 +2,7 @@ import requests
 import time
 import json
 import os
+import math
 from datetime import datetime
 
 # Configuration
@@ -30,7 +31,7 @@ def safe_number(value, fallback=0):
         number = float(value)
     except (TypeError, ValueError):
         return fallback
-    return number if number == number else fallback
+    return number if math.isfinite(number) else fallback
 
 def get_bridge_stats():
     results = {

--- a/tests/test_static_bridge_update_stats.py
+++ b/tests/test_static_bridge_update_stats.py
@@ -119,3 +119,37 @@ def test_get_bridge_stats_normalizes_numeric_and_ledger_payload_shapes(tmp_path,
     assert result["bridge_nodes"] == [
         {"name": "Node 1", "status": "up", "total_locked": 12.5, "completed_count": 4.0}
     ]
+
+
+def test_get_bridge_stats_rejects_non_finite_numeric_strings(tmp_path, monkeypatch):
+    stats = load_update_stats_module()
+    data_file = tmp_path / "bridge_status.json"
+    monkeypatch.setattr(stats, "DATA_FILE", str(data_file))
+    monkeypatch.setattr(
+        stats,
+        "BRIDGE_NODES",
+        [{"name": "Node 1", "url": "https://node-1/bridge/stats"}],
+    )
+    monkeypatch.setattr(stats.os.path, "exists", Mock(return_value=False))
+
+    def fake_get(url, timeout, verify):
+        if url == "https://node-1/bridge/stats":
+            return response(200, {
+                "all_time": {"total_rtc_locked": "Infinity"},
+                "by_chain": {"solana": {"bridged_count": "-Infinity"}},
+            })
+        if url == "https://node-1/bridge/ledger?limit=10":
+            return response(200, {"locks": []})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(stats.requests, "get", Mock(side_effect=fake_get))
+
+    result = stats.get_bridge_stats()
+
+    assert result["total_locked_rtc"] == 0
+    assert result["bridge_nodes"] == [
+        {"name": "Node 1", "status": "up", "total_locked": 0, "completed_count": 0}
+    ]
+    raw_json = data_file.read_text()
+    assert "Infinity" not in raw_json
+    assert json.loads(raw_json) == result

--- a/tests/test_static_bridge_update_stats.py
+++ b/tests/test_static_bridge_update_stats.py
@@ -87,3 +87,35 @@ def test_get_bridge_stats_records_down_nodes_and_empty_ledger(tmp_path, monkeypa
         {"name": "Node 1", "status": "down", "error": "timed out"}
     ]
     assert json.loads(data_file.read_text()) == result
+
+
+def test_get_bridge_stats_normalizes_numeric_and_ledger_payload_shapes(tmp_path, monkeypatch):
+    stats = load_update_stats_module()
+    data_file = tmp_path / "bridge_status.json"
+    monkeypatch.setattr(stats, "DATA_FILE", str(data_file))
+    monkeypatch.setattr(
+        stats,
+        "BRIDGE_NODES",
+        [{"name": "Node 1", "url": "https://node-1/bridge/stats"}],
+    )
+    monkeypatch.setattr(stats.os.path, "exists", Mock(return_value=False))
+
+    def fake_get(url, timeout, verify):
+        if url == "https://node-1/bridge/stats":
+            return response(200, {
+                "all_time": {"total_rtc_locked": "12.5"},
+                "by_chain": {"solana": {"bridged_count": "4"}},
+            })
+        if url == "https://node-1/bridge/ledger?limit=10":
+            return response(200, {"locks": {"not": "a list"}})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(stats.requests, "get", Mock(side_effect=fake_get))
+
+    result = stats.get_bridge_stats()
+
+    assert result["total_locked_rtc"] == 12.5
+    assert result["recent_transactions"] == []
+    assert result["bridge_nodes"] == [
+        {"name": "Node 1", "status": "up", "total_locked": 12.5, "completed_count": 4.0}
+    ]


### PR DESCRIPTION
## Summary
- coerce bridge stats numeric fields before max/comparison and output rendering
- tolerate non-object bridge stats and ledger payloads without raising attribute errors
- require ledger locks to be arrays before writing recent_transactions
- add a regression for string numeric stats and non-list ledger locks

## Validation
- python3 -m py_compile static/bridge/update_stats.py tests/test_static_bridge_update_stats.py
- uv run --with pytest --with requests --with flask python -m pytest tests/test_static_bridge_update_stats.py -q
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check