### PR TITLE
fix: render paginated monitor miners response

### DIFF
--- a/tests/test_rustchain_monitor.py
+++ b/tests/test_rustchain_monitor.py
@@ -114,11 +114,13 @@ def test_print_miners_limits_rows_and_formats_last_attest(
     monkeypatch.setattr(rustchain_monitor_module, "datetime", FixedDatetime)
 
     rustchain_monitor_module.print_miners(miners)
+    rustchain_monitor_module.print_miners({"miners": miners[:2], "pagination": {"total": 12}})
     rustchain_monitor_module.print_miners({"unexpected": True})
     rustchain_monitor_module.print_miners({"error": "bad gateway"})
 
     output = capsys.readouterr().out
     assert "Active miners: 12" in output
+    assert "Active miners: 2" in output
     assert "miner-0" in output
     assert "HW: PowerPC" in output
     assert "Multiplier: 2.5" in output

--- a/tests/test_rustchain_monitor_cli.py
+++ b/tests/test_rustchain_monitor_cli.py
@@ -92,12 +92,20 @@ def test_print_miners_renders_lists_unexpected_and_errors(capsys):
         {"miner": "alice", "hardware_type": "PowerPC", "antiquity_multiplier": 1.5, "last_attest": 0},
         {"miner": "bob", "hardware_type": "x86", "antiquity_multiplier": 1.0, "last_attest": 60},
     ])
+    module.print_miners({
+        "miners": [
+            {"miner": "carol", "hardware_type": "ARM", "antiquity_multiplier": 1.2, "last_attest": 0},
+        ],
+        "pagination": {"total": 1},
+    })
     module.print_miners({"unexpected": True})
     module.print_miners({"error": "down"})
 
     output = capsys.readouterr().out
     assert "Active miners: 2" in output
+    assert "Active miners: 1" in output
     assert "alice" in output
+    assert "carol" in output
     assert "never" in output
     assert "Unexpected response" in output
     assert "Failed to fetch miners: down" in output

--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -58,6 +58,8 @@ def print_miners(data):
     if "error" in data:
         print(f"❌ Failed to fetch miners: {data['error']}")
         return
+    if isinstance(data, dict) and isinstance(data.get("miners"), list):
+        data = data["miners"]
     if not isinstance(data, list):
         print(f"⚠ Unexpected response: {data}")
         return


### PR DESCRIPTION
## Summary

Fixes #5832.

The `rustchain-monitor --miners` command still expected `/api/miners` to return a top-level list. The live API now returns a paginated object with `miners` and `pagination`, so the command printed `Unexpected response` and dumped the raw payload instead of rendering active miners.

This keeps the existing list behavior, but also normalizes the current paginated response before printing miner rows.

## Validation

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py -q` -> 11 passed
- `python tools/rustchain-monitor/rustchain_monitor.py --miners` -> rendered 15 active miners from the live API
- `python -m py_compile tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check`