### PR TITLE
fix: render monitor miners API envelope

### DIFF
--- a/tests/test_rustchain_monitor.py
+++ b/tests/test_rustchain_monitor.py
@@ -128,6 +128,28 @@ def test_print_miners_limits_rows_and_formats_last_attest(
     assert "Failed to fetch miners: bad gateway" in output
 
 
+def test_print_miners_accepts_paginated_envelope(rustchain_monitor_module, capsys):
+    rustchain_monitor_module.print_miners(
+        {
+            "miners": [
+                {
+                    "miner": "alice",
+                    "hardware_type": "ARM",
+                    "antiquity_multiplier": 1.25,
+                    "last_attest": 0,
+                }
+            ],
+            "pagination": {"total": 1, "page": 1},
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "Active miners: 1" in output
+    assert "alice" in output
+    assert "HW: ARM" in output
+    assert "Unexpected response" not in output
+
+
 def test_print_epoch_formats_success_and_error(rustchain_monitor_module, capsys):
     rustchain_monitor_module.print_epoch(
         {

--- a/tests/test_rustchain_monitor_cli.py
+++ b/tests/test_rustchain_monitor_cli.py
@@ -103,6 +103,23 @@ def test_print_miners_renders_lists_unexpected_and_errors(capsys):
     assert "Failed to fetch miners: down" in output
 
 
+def test_print_miners_renders_paginated_api_envelope(capsys):
+    module = load_module()
+
+    module.print_miners({
+        "miners": [
+            {"miner": "carol", "hardware_type": "ARM", "antiquity_multiplier": 1.25, "last_attest": 0},
+        ],
+        "pagination": {"page": 1, "total": 1},
+    })
+
+    output = capsys.readouterr().out
+    assert "Active miners: 1" in output
+    assert "carol" in output
+    assert "HW: ARM" in output
+    assert "Unexpected response" not in output
+
+
 def test_print_epoch_renders_success_and_error(capsys):
     module = load_module()
 

--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -44,6 +44,13 @@ def get_epoch():
     except Exception as e:
         return {"error": str(e)}
 
+def normalize_miners_payload(data):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("miners"), list):
+        return data["miners"]
+    return None
+
 def print_health(data):
     if "error" in data:
         print(f"❌ Health check failed: {data['error']}")
@@ -58,12 +65,15 @@ def print_miners(data):
     if "error" in data:
         print(f"❌ Failed to fetch miners: {data['error']}")
         return
-    if not isinstance(data, list):
+    miners = normalize_miners_payload(data)
+    if miners is None:
         print(f"⚠ Unexpected response: {data}")
         return
-    print(f"📊 Active miners: {len(data)}")
+    print(f"📊 Active miners: {len(miners)}")
     print("   Recent miners:")
-    for entry in data[:10]:
+    for entry in miners[:10]:
+        if not isinstance(entry, dict):
+            entry = {}
         miner = entry.get('miner', 'unknown')
         hw = entry.get('hardware_type', 'unknown')
         mult = entry.get('antiquity_multiplier', 0)
@@ -73,8 +83,8 @@ def print_miners(data):
         else:
             last_str = 'never'
         print(f"   - {miner:<40} HW: {hw:<25} Multiplier: {mult:<5} Last: {last_str}")
-    if len(data) > 10:
-        print(f"   ... and {len(data)-10} more")
+    if len(miners) > 10:
+        print(f"   ... and {len(miners)-10} more")
 
 def print_epoch(data):
     if "error" in data:


### PR DESCRIPTION
## Summary
- normalize rustchain-monitor miner payloads from both the legacy top-level list and the current paginated API envelope
- preserve the existing unexpected-response path for unsupported payloads
- add regression coverage in both monitor test modules

Fixes #5832.

## Tests
- python3 -m py_compile tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py
- uv run --with pytest --with requests --with flask python -m pytest tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py -q
- uv run python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check