### PR TITLE
fix: redact BFT route exception details

### DIFF
--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -1034,6 +1034,9 @@ def create_bft_routes(app, bft: BFTConsensus):
     def _missing_fields(data: Dict, required: Iterable[str]) -> List[str]:
         return [field for field in required if field not in data]
 
+    def _internal_error_response(message: str, status_code: int):
+        return jsonify({'error': message}), status_code
+
     @app.route('/bft/status', methods=['GET'])
     def bft_status():
         """Get BFT consensus status"""
@@ -1058,9 +1061,9 @@ def create_bft_routes(app, bft: BFTConsensus):
 
             bft.receive_message(msg_data)
             return jsonify({'status': 'ok'})
-        except Exception as e:
-            logging.error(f"BFT message error: {e}")
-            return jsonify({'error': str(e)}), 400
+        except Exception:
+            logging.exception("BFT message error")
+            return _internal_error_response('BFT message processing failed', 400)
 
     @app.route('/bft/view_change', methods=['POST'])
     def bft_view_change():
@@ -1081,9 +1084,9 @@ def create_bft_routes(app, bft: BFTConsensus):
             if not ok:
                 return jsonify({'error': error}), status_code
             return jsonify({'status': 'ok'})
-        except Exception as e:
-            logging.error(f"BFT view change error: {e}")
-            return jsonify({'error': str(e)}), 400
+        except Exception:
+            logging.exception("BFT view change error")
+            return _internal_error_response('BFT view change processing failed', 400)
 
     @app.route('/bft/propose', methods=['POST'])
     def bft_propose():
@@ -1108,9 +1111,9 @@ def create_bft_routes(app, bft: BFTConsensus):
                 return jsonify({'status': 'proposed', 'digest': msg.digest})
             else:
                 return jsonify({'error': 'not_leader_or_already_committed'}), 400
-        except Exception as e:
-            logging.error(f"BFT propose error: {e}")
-            return jsonify({'error': str(e)}), 500
+        except Exception:
+            logging.exception("BFT propose error")
+            return _internal_error_response('BFT proposal failed', 500)
 
 
 # ============================================================================

--- a/node/tests/test_bft_route_validation.py
+++ b/node/tests/test_bft_route_validation.py
@@ -47,6 +47,10 @@ def _signed_view_change(bft, *, view=1, epoch=0):
     }
 
 
+def _raise_runtime_error(message):
+    raise RuntimeError(message)
+
+
 @pytest.mark.parametrize("payload", (None, [], "not-object"))
 def test_bft_message_requires_json_object(bft_client, payload):
     response = bft_client.post("/bft/message", json=payload)
@@ -61,6 +65,23 @@ def test_bft_message_rejects_invalid_message_type(bft_client, payload):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "invalid msg_type"}
+
+
+def test_bft_message_hides_internal_exception_details(bft_context, monkeypatch):
+    client, bft = bft_context
+    secret_detail = "sqlite error: no such table: bft_message_log"
+    monkeypatch.setattr(
+        bft,
+        "receive_message",
+        lambda _data: _raise_runtime_error(secret_detail),
+    )
+
+    response = client.post("/bft/message", json={"msg_type": "prepare"})
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body == {"error": "BFT message processing failed"}
+    assert secret_detail not in str(body)
 
 
 @pytest.mark.parametrize("payload", (None, [], "not-object"))
@@ -112,3 +133,40 @@ def test_bft_view_change_accepts_valid_signature(bft_context):
     assert response.status_code == 200
     assert response.get_json() == {"status": "ok"}
     assert bft.view_change_log[payload["view"]]["peer-a"].node_id == "peer-a"
+
+
+def test_bft_view_change_hides_internal_exception_details(bft_context, monkeypatch):
+    client, bft = bft_context
+    secret_detail = "config path leaked: /var/lib/rustchain/bft.db"
+    monkeypatch.setattr(
+        bft,
+        "handle_view_change",
+        lambda _data: _raise_runtime_error(secret_detail),
+    )
+
+    response = client.post("/bft/view_change", json=_signed_view_change(bft))
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body == {"error": "BFT view change processing failed"}
+    assert secret_detail not in str(body)
+
+
+def test_bft_propose_hides_internal_exception_details(bft_context, monkeypatch):
+    client, bft = bft_context
+    secret_detail = "sqlite error: no such table: bft_committed_epochs"
+    monkeypatch.setattr(
+        bft,
+        "propose_epoch_settlement",
+        lambda _epoch, _miners, _distribution: _raise_runtime_error(secret_detail),
+    )
+
+    response = client.post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": [], "distribution": {}},
+    )
+
+    assert response.status_code == 500
+    body = response.get_json()
+    assert body == {"error": "BFT proposal failed"}
+    assert secret_detail not in str(body)


### PR DESCRIPTION
## Summary
- replace raw BFT route exception responses with generic client-facing errors
- keep full exception details in server-side logs via logging.exception
- add route tests that simulate sensitive internal failures and assert the details are not returned

Addresses remaining BFT route coverage for #3202.

## Tests
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python -m pytest node/tests/test_bft_route_validation.py -q
- python -m py_compile node/rustchain_bft_consensus.py node/tests/test_bft_route_validation.py
- python tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check