### PR TITLE
fix: use attested macOS miner identity for lottery

### DIFF
--- a/miners/macos/rustchain_mac_miner_v2.5.py
+++ b/miners/macos/rustchain_mac_miner_v2.5.py
@@ -588,7 +588,7 @@ class MacMiner:
         try:
             resp = self.transport.get(
                 "/lottery/eligibility",
-                params={"miner_id": self.miner_id},
+                params={"miner_id": self.wallet},
                 timeout=10,
             )
             if resp.status_code == 200:
@@ -600,17 +600,18 @@ class MacMiner:
     def submit_header(self, slot):
         """Submit header for slot."""
         try:
-            message = "slot:{}:miner:{}:ts:{}".format(slot, self.miner_id, int(time.time()))
+            chain_miner_id = self.wallet
+            message = "slot:{}:miner:{}:ts:{}".format(slot, chain_miner_id, int(time.time()))
             message_hex = message.encode().hex()
             sig_data = hashlib.sha512(
                 "{}{}".format(message, self.wallet).encode()
             ).hexdigest()
 
             header_payload = {
-                "miner_id": self.miner_id,
+                "miner_id": chain_miner_id,
                 "header": {
                     "slot": slot,
-                    "miner": self.miner_id,
+                    "miner": chain_miner_id,
                     "timestamp": int(time.time())
                 },
                 "message": message_hex,

--- a/tests/test_macos_miner_chain_identity.py
+++ b/tests/test_macos_miner_chain_identity.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import importlib.util
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MINER_PATH = ROOT / "miners" / "macos" / "rustchain_mac_miner_v2.5.py"
+
+
+class FakeResponse:
+    def __init__(self, payload=None, status_code=200):
+        self._payload = payload or {}
+        self.status_code = status_code
+        self.text = str(self._payload)
+
+    def json(self):
+        return self._payload
+
+
+class FakeTransport:
+    def __init__(self):
+        self.posts = []
+        self.gets = []
+
+    def post(self, path, json=None, timeout=None):
+        self.posts.append({"path": path, "json": json, "timeout": timeout})
+        if path == "/attest/challenge":
+            return FakeResponse({"nonce": "nonce-1"})
+        return FakeResponse({"ok": True})
+
+    def get(self, path, params=None, timeout=None):
+        self.gets.append({"path": path, "params": params, "timeout": timeout})
+        return FakeResponse({"eligible": False, "reason": "not_your_turn", "slot": 1})
+
+
+def load_miner_module():
+    spec = importlib.util.spec_from_file_location("mac_miner_v25_identity", MINER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_miner(module):
+    miner = module.MacMiner.__new__(module.MacMiner)
+    miner.miner_id = "m2-host-hardware"
+    miner.wallet = "RTCwallet"
+    miner.transport = FakeTransport()
+    miner.hw_info = {
+        "family": "Apple Silicon",
+        "arch": "M2",
+        "model": "MacBook Pro",
+        "cpu": "Apple M2",
+        "cores": 12,
+        "memory_gb": 32,
+        "serial": "SERIAL",
+        "mac": "00:11:22:33:44:55",
+        "macs": ["00:11:22:33:44:55"],
+        "hostname": "host",
+    }
+    miner.fingerprint_data = {"all_passed": True, "checks": {}}
+    miner.fingerprint_passed = True
+    miner.attestation_valid_until = 0
+    miner.last_entropy = {}
+    miner.shares_submitted = 0
+    miner.shares_accepted = 0
+    return miner
+
+
+def test_macos_miner_uses_attested_wallet_for_eligibility(monkeypatch):
+    module = load_miner_module()
+    monkeypatch.setattr(module, "collect_entropy", lambda: {"variance_ns": 1.0})
+    miner = make_miner(module)
+
+    assert miner.attest() is True
+    miner.check_eligibility()
+
+    attestation = miner.transport.posts[-1]["json"]
+    assert attestation["miner"] == "RTCwallet"
+    assert attestation["miner_id"] == "m2-host-hardware"
+    assert miner.transport.gets[-1]["params"] == {"miner_id": "RTCwallet"}
+
+
+def test_macos_miner_submits_headers_with_attested_wallet_identity(monkeypatch):
+    module = load_miner_module()
+    monkeypatch.setattr(module.time, "time", lambda: 1234)
+    miner = make_miner(module)
+
+    ok, result = miner.submit_header(42)
+
+    assert ok is True
+    assert result == {"ok": True}
+    header = miner.transport.posts[-1]["json"]
+    assert header["miner_id"] == "RTCwallet"
+    assert header["header"]["miner"] == "RTCwallet"
+    assert bytes.fromhex(header["message"]).decode() == "slot:42:miner:RTCwallet:ts:1234"


### PR DESCRIPTION
## Summary

The macOS v2.5 miner attests with `miner = wallet`, but then checks `/lottery/eligibility` and submits headers with the generated hardware `miner_id`. The node records recent attestation under the `miner` field, so a wallet-only install can successfully attest and then immediately see `not_attested` forever when eligibility is checked under the generated hardware id.

This patch keeps the existing attestation payload shape, but uses the attested wallet identity for lottery eligibility and header submission. That makes the miner ID used for round-robin selection match the identity stored in `miner_attest_recent`.

## Live repro / verification

Before applying the identity fix locally, a real macOS miner on Apple Silicon M2 passed attestation but repeatedly saw:

```text
SUCCESS: Attestation accepted!
Fingerprint: PASSED
Not attested - re-attesting...
```

The live server then returned `not_attested` for the generated hardware id.

After running the miner with the same chain identity for attestation and eligibility, the live server returned the expected healthy state:

```json
{"eligible":false,"reason":"not_your_turn","rotation_size":19,"slot":24260,"slot_producer":"power8-s824-sophia","your_turn_at_slot":24268}
```

The miner is also visible in `/api/miners` as:

```json
{"miner":"RTC5800896ed658aa511D029361b6d7388ddb29248B","device_family":"Apple Silicon","device_arch":"M2","antiquity_multiplier":1.2}
```

## Tests

```text
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_macos_miner_chain_identity.py tests/test_macos_miner_signal_shutdown.py -q
# 4 passed

python -m py_compile miners/macos/rustchain_mac_miner_v2.5.py tests/test_macos_miner_chain_identity.py tests/test_macos_miner_signal_shutdown.py
# passed

git diff --check
# passed

python tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```
