### PR TITLE
fix: require admin auth for boot chime mutations

### DIFF
--- a/issue2307_boot_chime/boot_chime_api.py
+++ b/issue2307_boot_chime/boot_chime_api.py
@@ -9,6 +9,7 @@ from flask import Flask, request, jsonify, send_file
 from flask_cors import CORS
 import io
 import json
+import hmac
 import math
 import os
 import time
@@ -77,6 +78,39 @@ def get_json_object() -> Dict[str, Any]:
     if not isinstance(data, dict):
         raise JsonBodyError("JSON object required")
     return data
+
+
+def _configured_admin_key() -> str:
+    return (
+        os.getenv('BOOT_CHIME_ADMIN_KEY', '').strip()
+        or os.getenv('RC_ADMIN_KEY', '').strip()
+    )
+
+
+def _provided_admin_key() -> str:
+    header_key = (request.headers.get('X-Admin-Key') or request.headers.get('X-API-Key') or '').strip()
+    if header_key:
+        return header_key
+
+    auth_header = (request.headers.get('Authorization') or '').strip()
+    if auth_header.lower().startswith('bearer '):
+        return auth_header.split(' ', 1)[1].strip()
+    return ''
+
+
+def require_admin_auth():
+    """Fail closed unless a configured admin key matches the request."""
+    expected = _configured_admin_key()
+    if not expected:
+        return jsonify({'error': 'Admin key not configured'}), 503
+
+    provided = _provided_admin_key()
+    if not provided or not hmac.compare_digest(
+        provided.encode('utf-8'),
+        expected.encode('utf-8'),
+    ):
+        return jsonify({'error': 'Unauthorized - admin key required'}), 401
+    return None
 
 
 def validate_audio_upload(audio_file, *, required: bool = True):
@@ -181,6 +215,10 @@ def issue_challenge():
         }
     """
     try:
+        auth_error = require_admin_auth()
+        if auth_error:
+            return auth_error
+
         data = get_json_object()
         miner_id = data.get('miner_id')
         
@@ -226,6 +264,10 @@ def submit_proof():
         }
     """
     try:
+        auth_error = require_admin_auth()
+        if auth_error:
+            return auth_error
+
         miner_id = request.form.get('miner_id')
         challenge_id = request.form.get('challenge_id')
         timestamp = request.form.get('timestamp', type=int)
@@ -312,6 +354,10 @@ def enroll_miner():
         }
     """
     try:
+        auth_error = require_admin_auth()
+        if auth_error:
+            return auth_error
+
         miner_id = request.form.get('miner_id')
         
         if not miner_id:
@@ -349,6 +395,10 @@ def capture_audio():
     Response: WAV file
     """
     try:
+        auth_error = require_admin_auth()
+        if auth_error:
+            return auth_error
+
         duration = get_capture_duration()
         trigger = request.args.get('trigger', default='false').lower() == 'true'
         
@@ -395,6 +445,10 @@ def revoke_attestation():
         { "success": true, "message": "..." }
     """
     try:
+        auth_error = require_admin_auth()
+        if auth_error:
+            return auth_error
+
         data = get_json_object()
         miner_id = data.get('miner_id')
         reason = data.get('reason', '')

--- a/tests/test_boot_chime_api_json_validation.py
+++ b/tests/test_boot_chime_api_json_validation.py
@@ -96,21 +96,74 @@ def api_module(monkeypatch):
 
 
 @pytest.fixture
-def client(api_module):
+def client(api_module, monkeypatch):
+    monkeypatch.setenv("BOOT_CHIME_ADMIN_KEY", "boot-admin-secret")
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
     api_module.app.config["TESTING"] = True
     return api_module.app.test_client()
 
 
+AUTH_HEADERS = {"X-Admin-Key": "boot-admin-secret"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/api/v1/challenge",
+        "/api/v1/submit",
+        "/api/v1/enroll",
+        "/api/v1/capture",
+        "/api/v1/revoke",
+    ),
+)
+def test_mutating_endpoints_fail_closed_without_admin_key(client, monkeypatch, path):
+    monkeypatch.delenv("BOOT_CHIME_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+
+    response = client.post(path)
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "Admin key not configured"}
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        "/api/v1/challenge",
+        "/api/v1/submit",
+        "/api/v1/enroll",
+        "/api/v1/capture",
+        "/api/v1/revoke",
+    ),
+)
+def test_mutating_endpoints_reject_wrong_admin_key(client, path):
+    response = client.post(path, headers={"X-Admin-Key": "wrong"})
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized - admin key required"}
+
+
+def test_challenge_accepts_authorization_bearer_admin_key(client, api_module):
+    response = client.post(
+        "/api/v1/challenge",
+        json={"miner_id": "miner-bearer"},
+        headers={"Authorization": "Bearer boot-admin-secret"},
+    )
+
+    assert response.status_code == 200
+    assert api_module.poi_system.issued_for == "miner-bearer"
+
+
 @pytest.mark.parametrize("path", ("/api/v1/challenge", "/api/v1/revoke"))
 def test_json_endpoints_reject_non_object_bodies(client, path):
-    response = client.post(path, json=["not", "object"])
+    response = client.post(path, json=["not", "object"], headers=AUTH_HEADERS)
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "JSON object required"}
 
 
 def test_challenge_accepts_valid_json_body(client, api_module):
-    response = client.post("/api/v1/challenge", json={"miner_id": "miner-1"})
+    response = client.post("/api/v1/challenge", json={"miner_id": "miner-1"}, headers=AUTH_HEADERS)
 
     assert response.status_code == 200
     assert api_module.poi_system.issued_for == "miner-1"
@@ -121,6 +174,7 @@ def test_revoke_accepts_valid_json_body(client, api_module):
     response = client.post(
         "/api/v1/revoke",
         json={"miner_id": "miner-1", "reason": "retired"},
+        headers=AUTH_HEADERS,
     )
 
     assert response.status_code == 200
@@ -142,7 +196,7 @@ def test_audio_upload_endpoints_reject_non_wav_mime_type(client, path):
     elif path == "/api/v1/enroll":
         data["miner_id"] = "miner-1"
 
-    response = client.post(path, data=data, content_type="multipart/form-data")
+    response = client.post(path, data=data, content_type="multipart/form-data", headers=AUTH_HEADERS)
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "only WAV files accepted"}
@@ -174,7 +228,7 @@ def test_audio_upload_rejects_files_larger_than_configured_limit(client, api_mod
 
 @pytest.mark.parametrize("duration", ("0", "-1", "30.01", "inf", "not-a-number"))
 def test_capture_rejects_out_of_range_duration(client, api_module, duration):
-    response = client.post(f"/api/v1/capture?duration={duration}")
+    response = client.post(f"/api/v1/capture?duration={duration}", headers=AUTH_HEADERS)
 
     assert response.status_code == 400
     assert response.get_json()["error"].startswith("duration must")
@@ -182,7 +236,7 @@ def test_capture_rejects_out_of_range_duration(client, api_module, duration):
 
 
 def test_capture_accepts_bounded_duration(client, api_module):
-    response = client.post("/api/v1/capture?duration=30&trigger=true")
+    response = client.post("/api/v1/capture?duration=30&trigger=true", headers=AUTH_HEADERS)
 
     assert response.status_code == 200
     assert response.mimetype == "audio/wav"


### PR DESCRIPTION
## Summary
- require a configured BOOT_CHIME_ADMIN_KEY or RC_ADMIN_KEY before boot-chime challenge, submit, enroll, capture, and revoke POST handlers run
- accept X-Admin-Key, X-API-Key, or Authorization: Bearer with constant-time comparison
- add regression coverage for fail-closed, wrong-key, bearer, and valid-key paths

Closes #5068

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_boot_chime_api_json_validation.py -q
- python3 -m py_compile issue2307_boot_chime/boot_chime_api.py tests/test_boot_chime_api_json_validation.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- issue2307_boot_chime/boot_chime_api.py tests/test_boot_chime_api_json_validation.py