### PR TITLE
fix: install macOS miner v2.5 consistently

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -381,7 +381,7 @@ Rustchain/
 │   └── fingerprint_checks.py       # 硬件验证
 ├── miners/
 │   ├── linux/rustchain_linux_miner.py            # Linux 矿工
-│   └── macos/rustchain_mac_miner_v2.4.py         # macOS 矿工
+│   └── macos/rustchain_mac_miner_v2.5.py         # macOS 矿工
 ├── docs/
 │   ├── RustChain_Whitepaper_*.pdf  # 技术白皮书
 │   └── chain_architecture.md       # 架构文档

--- a/install.sh
+++ b/install.sh
@@ -89,7 +89,7 @@ case "$OS" in
         ;;
     Darwin)
         echo "  OS: macOS"
-        MINER_PATH="macos/rustchain_mac_miner_v2.4.py"
+        MINER_PATH="macos/rustchain_mac_miner_v2.5.py"
         FINGERPRINT_PATH="macos/fingerprint_checks.py"
         ;;
     *)      echo -e "${RED}  Unsupported OS: $OS${NC}"; exit 1 ;;

--- a/miners/macos/README.md
+++ b/miners/macos/README.md
@@ -3,7 +3,7 @@
 ## Supported Platforms
 
 ### Apple Silicon (M1/M2/M3)
-- `rustchain_mac_miner_v2.4.py` - Universal miner with fingerprint attestation
+- `rustchain_mac_miner_v2.5.py` - Universal miner with fingerprint attestation and legacy TLS fallback
 - Multiplier: 0.8x (modern)
 
 ### Intel Mac

--- a/miners/windows/install-miner.sh
+++ b/miners/windows/install-miner.sh
@@ -105,7 +105,7 @@ checksum_for() {
 download_miner() {
     cd "$INSTALL_DIR"
     case "$PLATFORM" in
-        macos) FILE="macos/rustchain_mac_miner_v2.4.py" ;;
+        macos) FILE="macos/rustchain_mac_miner_v2.5.py" ;;
         rpi|linux) FILE="linux/rustchain_linux_miner.py" ;;
         *) FILE="linux/rustchain_linux_miner.py" ;;
     esac


### PR DESCRIPTION
## Summary
- update the root install.sh macOS path from rustchain_mac_miner_v2.4.py to rustchain_mac_miner_v2.5.py
- update the sibling miners/windows/install-miner.sh macOS branch to the same v2.5 artifact
- align macOS miner docs and the Chinese repository map with the current v2.5 artifact
- reuse the existing v2.5 checksum already present in miners/checksums.sha256

Follow-up for #2705

## Validation
- bash -n install.sh install-miner.sh miners/windows/install-miner.sh
- shasum -a 256 miners/macos/rustchain_mac_miner_v2.5.py matches miners/checksums.sha256
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- install.sh miners/windows/install-miner.sh miners/macos/README.md docs/zh-CN/README.md