### PR TITLE
fix: compare inbox bearer tokens safely

### DIFF
--- a/node/sophia_governor_inbox.py
+++ b/node/sophia_governor_inbox.py
@@ -215,11 +215,28 @@ def _review_health_targets() -> list[str]:
     return deduped
 
 
-def _bearer_tokens() -> set[str]:
+def _bearer_tokens() -> list[str]:
     raw = os.getenv("SOPHIA_GOVERNOR_INBOX_BEARER", "").strip()
     if not raw:
-        return set()
-    return {token.strip() for token in raw.split(",") if token.strip()}
+        return []
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for part in raw.split(","):
+        token = part.strip()
+        if token and token not in seen:
+            tokens.append(token)
+            seen.add(token)
+    return tokens
+
+
+def _matches_bearer_token(provided_bearer: str, required_bearers: list[str]) -> bool:
+    if not provided_bearer or not required_bearers:
+        return False
+    matched = False
+    for required_bearer in required_bearers:
+        if hmac.compare_digest(provided_bearer, required_bearer):
+            matched = True
+    return matched
 
 
 def _is_authorized(req) -> bool:
@@ -233,7 +250,7 @@ def _is_authorized(req) -> bool:
     auth_header = (req.headers.get("Authorization") or "").strip()
     if auth_header.lower().startswith("bearer "):
         provided_bearer = auth_header.split(" ", 1)[1].strip()
-        if provided_bearer and provided_bearer in required_bearers:
+        if _matches_bearer_token(provided_bearer, required_bearers):
             return True
 
     return False

--- a/node/tests/test_sophia_governor_inbox.py
+++ b/node/tests/test_sophia_governor_inbox.py
@@ -156,6 +156,39 @@ def test_admin_auth_uses_constant_time_compare(client, monkeypatch):
     ]
 
 
+def test_bearer_auth_uses_constant_time_compare(client, monkeypatch):
+    """Bearer-gated inbox endpoints compare configured tokens with hmac.compare_digest."""
+    calls = []
+
+    def spy_compare_digest(provided, expected):
+        calls.append((provided, expected))
+        return provided == expected
+
+    monkeypatch.setenv("SOPHIA_GOVERNOR_INBOX_BEARER", "review-token, other-token")
+    monkeypatch.setattr(sophia_governor_inbox.hmac, "compare_digest", spy_compare_digest)
+
+    denied = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"Authorization": "Bearer wrong-token"},
+        json=_sample_envelope(),
+    )
+    assert denied.status_code == 401
+
+    accepted = client.post(
+        "/api/sophia/governor/ingest",
+        headers={"Authorization": "Bearer review-token"},
+        json=_sample_envelope(),
+    )
+    assert accepted.status_code == 202
+
+    assert calls == [
+        ("wrong-token", "review-token"),
+        ("wrong-token", "other-token"),
+        ("review-token", "review-token"),
+        ("review-token", "other-token"),
+    ]
+
+
 def test_ingest_and_list_endpoints(client):
     response = client.post(
         "/api/sophia/governor/ingest",


### PR DESCRIPTION
## Summary
- parse Sophia governor inbox bearer tokens in stable env order while preserving duplicate removal
- compare bearer credentials with hmac.compare_digest instead of plain set membership
- add regression coverage proving bearer auth uses constant-time comparisons across configured tokens

## Validation
- uv run --no-project --with pytest --with flask python -m pytest node/tests/test_sophia_governor_inbox.py -q
- python3 -m py_compile node/sophia_governor_inbox.py node/tests/test_sophia_governor_inbox.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- node/sophia_governor_inbox.py node/tests/test_sophia_governor_inbox.py

Bounty context: #305