### PR TITLE
Require trusted Ed25519 identity for epoch votes

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -763,6 +763,32 @@ class GossipLayer:
         ).hexdigest()
         return hmac.compare_digest(hmac_sig, expected)
 
+    def _has_trusted_ed25519_identity(self, msg: GossipMessage) -> bool:
+        """Return True only when msg has a valid trusted Ed25519 signature."""
+        from p2p_identity import unpack_signature, verify_ed25519
+
+        _hmac_sig, ed25519_sig, _key_version = unpack_signature(msg.signature)
+        if not ed25519_sig:
+            return False
+
+        pubkey = None
+        if self._peer_registry is not None:
+            pubkey = self._peer_registry.get_pubkey(msg.sender_id)
+        if pubkey is None and msg.sender_id == self.node_id and self._keypair is not None:
+            pubkey = self._keypair.pubkey_hex
+        if pubkey is None:
+            return False
+
+        content = self._signed_content(
+            msg.msg_type,
+            msg.sender_id,
+            msg.msg_id,
+            msg.ttl,
+            msg.payload,
+        )
+        message = f"{content}:{msg.timestamp}"
+        return verify_ed25519(pubkey, ed25519_sig, message.encode())
+
     def broadcast(self, msg: GossipMessage, exclude_peer: str = None):
         """Broadcast message to all peers"""
         for peer_id, peer_url in self.peers.items():
@@ -1080,9 +1106,11 @@ class GossipLayer:
         Requires at least 3 of 4 nodes (or majority of known nodes)
         to agree before finalizing an epoch reward distribution.
 
-        SECURITY (#2256 Phase A + C):
+        SECURITY (#2256 Phase A + C + Ed25519 binding):
         - Voter identity bound to msg.sender_id (not payload["voter"]).
-          sender_id itself is now HMAC-covered (see Phase A changes above).
+          Consensus votes require a registered Ed25519 identity because the
+          shared HMAC only proves cluster-secret possession, not which peer
+          sent the vote.
         - Votes indexed by (epoch, proposal_hash), not just epoch. Mixed
           votes for different proposals cannot aggregate into a false quorum;
           only the specific proposal_hash that reached quorum finalizes.
@@ -1109,6 +1137,17 @@ class GossipLayer:
                 f"authenticated sender {voter}; rejecting vote"
             )
             return {"status": "error", "reason": "voter_identity_mismatch"}
+
+        known_nodes = set(self.peers.keys()) | {self.node_id}
+        if voter not in known_nodes:
+            return {"status": "error", "reason": "unknown_voter"}
+
+        if not self._has_trusted_ed25519_identity(msg):
+            logger.warning(
+                f"Epoch {epoch}: rejecting vote from {voter}; "
+                "trusted Ed25519 identity required for consensus votes"
+            )
+            return {"status": "error", "reason": "epoch_vote_requires_ed25519"}
 
         # Phase C: index by (epoch, proposal_hash) — not just epoch.
         key = (epoch, proposal_hash)

--- a/node/tests/test_p2p_phase_f_ed25519.py
+++ b/node/tests/test_p2p_phase_f_ed25519.py
@@ -194,6 +194,62 @@ def test_dual_mode_ed25519_verifies_against_registered_peer():
     assert receiver.verify_message(msg) is True
 
 
+def test_epoch_vote_quorum_accepts_registered_ed25519_votes():
+    """Consensus votes from registered Ed25519 peers still reach quorum."""
+    tmpdir = tempfile.mkdtemp()
+    reg_path = tmpdir + "/reg.json"
+    ident, gossip = _reload_modules("dual", tmpdir + "/bootstrap.pem", reg_path)
+
+    peer_key_paths = {
+        "peer1": tmpdir + "/peer1.pem",
+        "peer2": tmpdir + "/peer2.pem",
+        "peer3": tmpdir + "/peer3.pem",
+    }
+    registry = {"version": 1, "peers": []}
+    for peer_id, key_path in peer_key_paths.items():
+        registry["peers"].append({
+            "node_id": peer_id,
+            "pubkey_hex": ident.LocalKeypair(key_path).pubkey_hex,
+        })
+    with open(reg_path, "w") as f:
+        json.dump(registry, f)
+
+    os.environ["RC_P2P_PRIVKEY_PATH"] = tmpdir + "/victim.pem"
+    victim = _make_layer(
+        ident,
+        gossip,
+        "victim",
+        {
+            "peer1": "https://peer1.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+    )
+
+    results = []
+    for peer_id, key_path in peer_key_paths.items():
+        os.environ["RC_P2P_PRIVKEY_PATH"] = key_path
+        sender = _make_layer(
+            ident,
+            gossip,
+            peer_id,
+            {"victim": "https://victim.example"},
+        )
+        msg = sender.create_message(gossip.MessageType.EPOCH_VOTE, {
+            "epoch": 11,
+            "proposal_hash": "proposal-ed25519-quorum",
+            "vote": "accept",
+            "voter": peer_id,
+        })
+        _hmac_sig, ed25519_sig, _key_version = ident.unpack_signature(msg.signature)
+        assert ed25519_sig is not None
+        results.append(victim.handle_message(msg))
+
+    assert results[-1]["status"] == "committed"
+    assert victim.epoch_crdt.contains(11)
+    assert victim.epoch_crdt.metadata[11]["proposal_hash"] == "proposal-ed25519-quorum"
+
+
 def test_strict_mode_rejects_hmac_only():
     """Strict mode: an HMAC-only message is rejected even if HMAC is valid."""
     tmpdir = tempfile.mkdtemp()

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -82,6 +82,53 @@ def test_epoch_commit_rejects_sender_reported_quorum_without_local_votes(tmp_pat
     assert not victim.epoch_crdt.contains(7)
 
 
+def test_hmac_epoch_votes_cannot_impersonate_multiple_voters(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = GossipLayer(
+        node_id="victim",
+        peers={
+            "peer1": "https://peer1.example",
+            "peer2": "https://peer2.example",
+            "peer3": "https://peer3.example",
+        },
+        db_path=str(tmp_path / "victim.db"),
+    )
+    proposal_hash = "proposal-hmac-impersonation"
+
+    results = []
+    for peer_id in ("peer1", "peer2", "peer3"):
+        sender = GossipLayer(
+            node_id=peer_id,
+            peers={
+                "victim": "https://victim.example",
+                "peer1": "https://peer1.example",
+                "peer2": "https://peer2.example",
+                "peer3": "https://peer3.example",
+            },
+            db_path=str(tmp_path / f"{peer_id}.db"),
+        )
+        msg = sender.create_message(
+            MessageType.EPOCH_VOTE,
+            {
+                "epoch": 9,
+                "proposal_hash": proposal_hash,
+                "vote": "accept",
+                "voter": peer_id,
+            },
+            ttl=0,
+        )
+        assert victim.verify_message(msg)
+        results.append(victim.handle_message(msg))
+
+    assert [result["reason"] for result in results] == [
+        "epoch_vote_requires_ed25519",
+        "epoch_vote_requires_ed25519",
+        "epoch_vote_requires_ed25519",
+    ]
+    assert not victim.epoch_crdt.contains(9)
+    assert victim._epoch_votes.get((9, proposal_hash), {}) == {}
+
+
 def test_epoch_commit_accepts_quorum_backed_by_local_votes(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     victim = GossipLayer(


### PR DESCRIPTION
## Plan
- Treat `EPOCH_VOTE` as consensus-critical: a shared HMAC proves cluster-secret possession, but not which peer cast the vote.
- Keep legacy HMAC verification available for non-consensus gossip while requiring a trusted Ed25519 identity before a vote can affect quorum.
- Preserve valid Ed25519 quorum behavior with regression coverage.

## Changes
- Adds a trusted Ed25519 identity check for epoch votes before votes are persisted or counted.
- Rejects votes from unknown node IDs before quorum accounting.
- Adds a regression test showing HMAC-only votes from multiple claimed senders cannot finalize an epoch.
- Adds a dual-mode Ed25519 quorum test proving registered peers can still commit.

## Validation
- `PYTHONPATH=node uv run --with pytest --with requests --with cryptography python -B -m pytest -q node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_phase_f_ed25519.py --tb=short -p no:cacheprovider`
- `PYTHONPATH=node uv run --with requests --with cryptography python -B -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_phase_f_ed25519.py`

Related follow-up to the HMAC-only `EPOCH_VOTE` impersonation finding discussed on #5754.

wallet: RTC5c9a1d4b59bdd557f45778ef25899caf1bb6b377