### PR TITLE
fix: validate payout ledger JSON bodies

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -232,6 +232,13 @@ def _require_admin_key():
     return None
 
 
+def _json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
+
 # ── Flask route registration ───────────────────────────────────
 def register_ledger_routes(app):
     """Register /ledger/* routes on the given Flask app."""
@@ -275,7 +282,9 @@ def register_ledger_routes(app):
         if auth_error:
             return auth_error
         init_payout_ledger_tables()
-        data = request.get_json(force=True)
+        data, body_error = _json_object_body()
+        if body_error:
+            return body_error
         required = ["bounty_id", "contributor", "amount_rtc"]
         for field in required:
             if field not in data:
@@ -300,7 +309,9 @@ def register_ledger_routes(app):
         if auth_error:
             return auth_error
         init_payout_ledger_tables()
-        data = request.get_json(force=True)
+        data, body_error = _json_object_body()
+        if body_error:
+            return body_error
         new_status = data.get("status")
         if not new_status:
             return jsonify({"error": "missing status"}), 400

--- a/tests/test_payout_ledger_admin_auth.py
+++ b/tests/test_payout_ledger_admin_auth.py
@@ -98,6 +98,41 @@ def test_ledger_status_update_requires_admin_key_before_mutation(tmp_path, monke
     assert record["tx_hash"] == ""
 
 
+def test_ledger_create_rejects_non_object_json(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/ledger",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json=["bounty_id", "contributor", "amount_rtc"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+    assert _table_exists(db_path)
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM payout_ledger").fetchone()[0]
+    assert count == 0
+
+
+def test_ledger_status_update_rejects_non_object_json_before_mutation(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path, monkeypatch)
+    payout_ledger.init_payout_ledger_tables()
+    record_id = payout_ledger.ledger_create("bug-1", "alice", 25)
+
+    response = client.patch(
+        f"/api/ledger/{record_id}/status",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json=["status"],
+    )
+
+    record = payout_ledger.ledger_get(record_id)
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+    assert record["status"] == "queued"
+    assert record["tx_hash"] == ""
+
+
 def test_admin_key_allows_create_read_summary_and_status_update(tmp_path, monkeypatch):
     client, _db_path = _make_client(tmp_path, monkeypatch)
     headers = {"X-Admin-Key": ADMIN_KEY}


### PR DESCRIPTION
## Summary
- require JSON object bodies for payout ledger create and status update routes
- return controlled 400 responses for array/scalar/malformed bodies before field access
- add regression coverage that create/update reject non-object JSON without mutating ledger rows

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_payout_ledger_admin_auth.py tests/test_payout_ledger_migration.py -q
- python3 -m py_compile payout_ledger.py tests/test_payout_ledger_admin_auth.py tests/test_payout_ledger_migration.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- payout_ledger.py tests/test_payout_ledger_admin_auth.py

Bounty context: #305