### PR TITLE
fix: validate sync pull query bounds

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -98,6 +98,16 @@ def register_sync_endpoints(app, db_path, admin_key):
 
         return decorated
 
+    def _parse_sync_int_arg(name, default, minimum, maximum):
+        raw_value = request.args.get(name)
+        if raw_value is None or raw_value == "":
+            return default, None
+        try:
+            value = int(raw_value)
+        except (TypeError, ValueError):
+            return None, f"{name} must be an integer"
+        return max(minimum, min(value, maximum)), None
+
     @app.route("/api/sync/status", methods=["GET"])
     @require_admin
     def sync_status():
@@ -121,14 +131,12 @@ def register_sync_endpoints(app, db_path, admin_key):
         - offset: row offset (default 0)
         """
         table = request.args.get("table", "").strip()
-        try:
-            limit = int(request.args.get("limit", 200))
-            offset = int(request.args.get("offset", 0))
-        except ValueError:
-            return jsonify({"error": "limit/offset must be integers"}), 400
-
-        limit = max(1, min(limit, 1000))
-        offset = max(0, offset)
+        limit, error = _parse_sync_int_arg("limit", 200, 1, 1000)
+        if error:
+            return jsonify({"error": error}), 400
+        offset, error = _parse_sync_int_arg("offset", 0, 0, 10**12)
+        if error:
+            return jsonify({"error": error}), 400
 
         tables = sync_manager.SYNC_TABLES
         if table:

--- a/node/tests/test_rustchain_sync_endpoints.py
+++ b/node/tests/test_rustchain_sync_endpoints.py
@@ -12,14 +12,19 @@ import rustchain_sync_endpoints
 
 
 class DummySyncManager:
-    SYNC_TABLES = []
+    SYNC_TABLES = ["headers", "balances"]
 
     def __init__(self, db_path, admin_key):
         self.db_path = db_path
         self.admin_key = admin_key
+        self.calls = []
 
     def get_sync_status(self):
         return {"merkle_root": "test-root"}
+
+    def get_table_data(self, table, limit=200, offset=0):
+        self.calls.append((table, limit, offset))
+        return [{"table": table, "limit": limit, "offset": offset}]
 
 
 def test_require_admin_uses_constant_time_compare(monkeypatch, tmp_path):
@@ -81,3 +86,101 @@ def test_sync_admin_auth_fails_closed_when_admin_key_unconfigured(
     assert response.status_code == 401
     assert response.get_json() == {"error": "Unauthorized"}
     assert calls == []
+
+
+def test_sync_pull_validates_and_clamps_query_bounds(monkeypatch, tmp_path):
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    response = client.get(
+        "/api/sync/pull?table=headers&limit=5000&offset=-10",
+        headers={"X-Admin-Key": "sync-secret"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["meta"] == {
+        "limit": 1000,
+        "offset": 0,
+        "tables": ["headers"],
+    }
+    assert body["data"]["headers"] == [{"table": "headers", "limit": 1000, "offset": 0}]
+
+
+def test_sync_pull_uses_defaults_for_empty_query_values(monkeypatch, tmp_path):
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    response = client.get(
+        "/api/sync/pull?limit=&offset=",
+        headers={"X-Admin-Key": "sync-secret"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["meta"] == {
+        "limit": 200,
+        "offset": 0,
+        "tables": ["headers", "balances"],
+    }
+
+
+@pytest.mark.parametrize(
+    ("query", "error"),
+    [
+        ("limit=abc", "limit must be an integer"),
+        ("offset=soon", "offset must be an integer"),
+    ],
+)
+def test_sync_pull_rejects_malformed_query_values(monkeypatch, tmp_path, query, error):
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    response = client.get(
+        f"/api/sync/pull?{query}",
+        headers={"X-Admin-Key": "sync-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": error}
+
+
+def test_sync_pull_rejects_unknown_table(monkeypatch, tmp_path):
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    response = client.get(
+        "/api/sync/pull?table=unknown",
+        headers={"X-Admin-Key": "sync-secret"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid table: unknown"}


### PR DESCRIPTION
## Summary
- parse `/api/sync/pull` `limit` and `offset` through a shared integer helper
- treat empty query values as defaults, clamp bounds consistently, and return field-specific 400s for malformed values
- add regression coverage for clamped, empty, malformed, and unknown-table sync pull requests

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_rustchain_sync_endpoints.py -q`
- `python3 -m py_compile node/rustchain_sync_endpoints.py node/tests/test_rustchain_sync_endpoints.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/rustchain_sync_endpoints.py node/tests/test_rustchain_sync_endpoints.py`

Bounty context: #305