### PR TITLE
fix: default empty bridge ledger pagination

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -522,8 +522,10 @@ def get_ledger():
     chain_filter  = request.args.get("chain", "").strip() or None
     sender_filter = request.args.get("sender", "").strip() or None
     try:
-        limit  = int(request.args.get("limit", 50))
-        offset = int(request.args.get("offset", 0))
+        raw_limit = request.args.get("limit")
+        raw_offset = request.args.get("offset")
+        limit  = int(raw_limit) if raw_limit not in (None, "") else 50
+        offset = int(raw_offset) if raw_offset not in (None, "") else 0
     except (TypeError, ValueError):
         return jsonify({"error": "limit and offset must be integers"}), 400
     limit = max(1, min(limit, 200))

--- a/bridge/test_bridge_api.py
+++ b/bridge/test_bridge_api.py
@@ -888,6 +888,13 @@ class TestLedgerEndpoint:
         assert resp.status_code == 400
         assert resp.get_json()["error"] == "limit and offset must be integers"
 
+    def test_ledger_uses_defaults_for_empty_pagination(self, client):
+        resp = client.get("/bridge/ledger?limit=&offset=")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["limit"] == 50
+        assert data["offset"] == 0
+
     def test_ledger_clamps_negative_limit_and_offset(self, client):
         tx_hash = f"rtc-lock-ledger-limit-{int(time.time())}"
         payload = {


### PR DESCRIPTION
## Summary
- treat blank `/bridge/ledger` `limit` and `offset` query values as absent optional parameters
- preserve integer validation for malformed pagination values
- add a regression test for empty pagination defaults

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest bridge/test_bridge_api.py::TestLedgerEndpoint -q`
- `python3 -m py_compile bridge/bridge_api.py bridge/test_bridge_api.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- bridge/bridge_api.py bridge/test_bridge_api.py`

Note: full `bridge/test_bridge_api.py -q` currently fails one unrelated pre-existing source assertion expecting literal `debug=False`; the ledger endpoint class passes.