### PR TITLE
fix: default empty bottube feed limits

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -46,6 +46,13 @@ def _get_base_url() -> str:
     return request.host_url.rstrip("/")
 
 
+def _parse_feed_limit(default: int = 20, maximum: int = 100) -> int:
+    raw_limit = request.args.get("limit")
+    if raw_limit in (None, ""):
+        return default
+    return max(1, min(int(raw_limit), maximum))
+
+
 def _get_db_connection():
     """Get database connection from Flask app config."""
     db_path = current_app.config.get("DB_PATH")
@@ -226,7 +233,7 @@ def rss_feed():
     """
     try:
         # Parse parameters
-        limit = max(1, min(int(request.args.get("limit", 20)), 100))
+        limit = _parse_feed_limit()
         agent = request.args.get("agent")
         cursor = request.args.get("cursor")
         
@@ -280,7 +287,7 @@ def atom_feed():
     """
     try:
         # Parse parameters
-        limit = max(1, min(int(request.args.get("limit", 20)), 100))
+        limit = _parse_feed_limit()
         agent = request.args.get("agent")
         cursor = request.args.get("cursor")
         
@@ -342,7 +349,7 @@ def feed_index():
     
     # Parse parameters
     try:
-        limit = max(1, min(int(request.args.get("limit", 20)), 100))
+        limit = _parse_feed_limit()
     except ValueError:
         return jsonify({"error": "Invalid limit parameter"}), 400
     

--- a/tests/test_bottube_feed_routes.py
+++ b/tests/test_bottube_feed_routes.py
@@ -98,6 +98,13 @@ class TestFeedRoutes(unittest.TestCase):
         response = self.client.get("/api/feed/rss?limit=5")
         self.assertEqual(response.status_code, 200)
 
+    def test_feed_routes_default_empty_limit_parameter(self):
+        """Test optional blank limits use the default limit."""
+        for path in ("/api/feed/rss", "/api/feed/atom", "/api/feed"):
+            with self.subTest(path=path):
+                response = self.client.get(f"{path}?limit=")
+                self.assertEqual(response.status_code, 200)
+
     def test_rss_feed_invalid_limit(self):
         """Test RSS feed handles invalid limit."""
         response = self.client.get("/api/feed/rss?limit=invalid")


### PR DESCRIPTION
## Summary
- parse BoTTube feed `limit` values through one helper for RSS, Atom, and JSON feed routes
- treat blank optional `limit=` as the documented default instead of a malformed value
- add regression coverage for blank limits on all three feed entrypoints

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_bottube_feed_routes.py -q`
- `python3 -m py_compile node/bottube_feed_routes.py tests/test_bottube_feed_routes.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/bottube_feed_routes.py tests/test_bottube_feed_routes.py`

Bounty context: #305