### PR TITLE
fix: default empty reputation query values

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -341,7 +341,8 @@ def check_eligibility():
         return jsonify({"error": "agent_id required"}), 400
 
     try:
-        job_value = float(request.args.get("job_value", 0))
+        raw_job_value = request.args.get("job_value")
+        job_value = float(raw_job_value) if raw_job_value not in (None, "") else 0
     except (ValueError, TypeError):
         return jsonify({"error": "job_value must be a number"}), 400
     if not math.isfinite(job_value) or job_value < 0:
@@ -380,7 +381,8 @@ def leaderboard():
     Returns top agents by reputation (from cache).
     """
     try:
-        limit = min(int(request.args.get("limit", 20)), 100)
+        raw_limit = request.args.get("limit")
+        limit = min(int(raw_limit), 100) if raw_limit not in (None, "") else 20
     except (ValueError, TypeError):
         return jsonify({"error": "limit must be an integer"}), 400
     if limit < 1:

--- a/tests/test_agent_reputation.py
+++ b/tests/test_agent_reputation.py
@@ -93,6 +93,18 @@ def test_veteran_agent_can_claim_high_value_jobs(reputation_client):
     assert payload["reason"] is None
 
 
+def test_check_eligibility_uses_default_for_empty_job_value(reputation_client):
+    response = reputation_client.get(
+        "/agent/reputation/check-eligibility",
+        query_string={"agent_id": "trusted-agent", "job_value": ""},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["job_value_rtc"] == 0
+    assert payload["eligible"] is True
+
+
 @pytest.mark.parametrize("job_value", ["-1", "nan", "inf", "-inf"])
 def test_check_eligibility_rejects_invalid_job_values(reputation_client, job_value):
     response = reputation_client.get(
@@ -113,6 +125,16 @@ def test_leaderboard_rejects_non_positive_limits(reputation_client, limit):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "limit must be between 1 and 100"
+
+
+def test_leaderboard_uses_default_for_empty_limit(reputation_client):
+    response = reputation_client.get(
+        "/agent/reputation/leaderboard",
+        query_string={"limit": ""},
+    )
+
+    assert response.status_code == 200
+    assert len(response.get_json()["leaderboard"]) == 2
 
 
 def test_refresh_stale_cache_entries_stores_recalculated_result(monkeypatch):


### PR DESCRIPTION
## Summary
- treat blank `job_value=` on eligibility checks as the existing default `0`
- treat blank leaderboard `limit=` as the existing default `20`
- add regression coverage for both empty query defaults

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_agent_reputation.py -q`
- `python3 -m py_compile agent_reputation.py tests/test_agent_reputation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- agent_reputation.py tests/test_agent_reputation.py`

Bounty context: #305