### PR TITLE
fix: default empty dashboard transaction limits

### DIFF
--- a/bridge/dashboard_api.py
+++ b/bridge/dashboard_api.py
@@ -252,7 +252,8 @@ def get_dashboard_transactions():
 
     state_filter = request.args.get("state", "").strip() or None
     try:
-        limit = int(request.args.get("limit", 50))
+        raw_limit = request.args.get("limit")
+        limit = int(raw_limit) if raw_limit not in (None, "") else 50
     except (TypeError, ValueError):
         return jsonify({"error": "limit must be an integer"}), 400
     limit = max(1, min(limit, 200))

--- a/bridge/test_dashboard_api.py
+++ b/bridge/test_dashboard_api.py
@@ -298,6 +298,13 @@ class TestDashboardTransactions:
         # Should cap at 200
         assert len(data['transactions']) <= 200
 
+    def test_transactions_uses_default_for_empty_limit(self, client):
+        """Test transactions limit treats blank optional values as omitted."""
+        response = client.get('/bridge/dashboard/transactions?limit=')
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert 'transactions' in data
+
     def test_transactions_rejects_non_integer_limit(self, client):
         """Test transactions limit rejects malformed values."""
         response = client.get('/bridge/dashboard/transactions?limit=abc')


### PR DESCRIPTION
## Summary
- treat blank `/bridge/dashboard/transactions?limit=` as the documented default limit
- keep malformed limit values rejected with the existing 400 response
- add regression coverage for the empty optional limit case

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest bridge/test_dashboard_api.py -q`
- `python3 -m py_compile bridge/dashboard_api.py bridge/test_dashboard_api.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- bridge/dashboard_api.py bridge/test_dashboard_api.py`

Bounty context: Scottcjn/rustchain-bounties#71