### PR TITLE
fix: default empty explorer pagination values

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6232,7 +6232,9 @@ def api_miners():
 
 def _explorer_int_arg(name, default, minimum, maximum):
     """Parse bounded integer query args for public explorer endpoints."""
-    raw = request.args.get(name, str(default))
+    raw = request.args.get(name)
+    if raw in (None, ""):
+        return default, None, None
     try:
         value = int(raw)
     except (TypeError, ValueError):

--- a/node/tests/test_explorer_api_routes.py
+++ b/node/tests/test_explorer_api_routes.py
@@ -200,6 +200,16 @@ class TestExplorerApiRoutes(unittest.TestCase):
         self.assertEqual(tx_resp.status_code, 200)
         self.assertEqual(tx_resp.get_json(), {"ok": True, "transactions": [], "count": 0, "total": 0})
 
+    def test_explorer_endpoints_default_empty_pagination_values(self):
+        blocks_resp = self.client.get("/api/blocks?limit=&offset=")
+        tx_resp = self.client.get("/api/transactions?limit=&offset=")
+
+        self.assertEqual(blocks_resp.status_code, 200)
+        self.assertEqual(blocks_resp.get_json(), {"ok": True, "blocks": [], "count": 0, "total": 0})
+
+        self.assertEqual(tx_resp.status_code, 200)
+        self.assertEqual(tx_resp.get_json(), {"ok": True, "transactions": [], "count": 0, "total": 0})
+
     def test_explorer_endpoints_reject_invalid_pagination(self):
         blocks_resp = self.client.get("/api/blocks?limit=bad")
         tx_resp = self.client.get("/api/transactions?offset=bad")


### PR DESCRIPTION
## Summary
- treat blank explorer `limit` and `offset` query values as omitted optional pagination
- keep malformed pagination strings rejected through the existing 400 responses
- add regression coverage for empty pagination on `/api/blocks` and `/api/transactions`

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_explorer_api_routes.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_explorer_api_routes.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_explorer_api_routes.py`

Bounty context: #305