### PR TITLE
fix: default empty api miners pagination

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6145,11 +6145,13 @@ def api_miners():
     
     # Pagination args
     try:
-        limit = int(request.args.get("limit", 100))
+        raw_limit = request.args.get("limit")
+        limit = int(raw_limit) if raw_limit not in (None, "") else 100
     except (ValueError, TypeError):
         return jsonify({"ok": False, "error": "limit must be an integer"}), 400
     try:
-        offset = int(request.args.get("offset", 0))
+        raw_offset = request.args.get("offset")
+        offset = int(raw_offset) if raw_offset not in (None, "") else 0
     except (ValueError, TypeError):
         return jsonify({"ok": False, "error": "offset must be an integer"}), 400
     limit = min(max(limit, 1), 1000)

--- a/node/tests/test_api_miners_rate_limit.py
+++ b/node/tests/test_api_miners_rate_limit.py
@@ -104,6 +104,18 @@ class TestApiMinersRateLimit(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "offset must be an integer"})
 
+    def test_api_miners_defaults_empty_pagination_values(self):
+        resp = self.client.get(
+            "/api/miners?limit=&offset=",
+            environ_base={"REMOTE_ADDR": "203.0.113.22"},
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp.get_json()["pagination"],
+            {"total": 0, "limit": 100, "offset": 0, "count": 0},
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- treat blank `/api/miners` `limit` and `offset` query values as omitted optional pagination
- preserve existing malformed pagination 400s and clamp behavior
- add regression coverage for empty pagination defaults with rate-limit headers active

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest node/tests/test_api_miners_rate_limit.py -q`
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_api_miners_rate_limit.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_api_miners_rate_limit.py`

Bounty context: Scottcjn/rustchain-bounties#71