### PR TITLE
fix: normalize discord leaderboard miners payload

### DIFF
--- a/tests/test_discord_leaderboard_bot.py
+++ b/tests/test_discord_leaderboard_bot.py
@@ -62,6 +62,54 @@ def test_rewards_for_epoch_sorts_rewards_and_returns_empty_on_fetch_failure(monk
     assert discord_leaderboard_bot.rewards_for_epoch(object(), "https://node", 7, 1) == []
 
 
+def test_collect_data_normalizes_paginated_miners_payload(monkeypatch):
+    payloads = {
+        "https://node/api/miners": {
+            "miners": [
+                {
+                    "miner": "alice-miner",
+                    "device_arch": "G4",
+                    "antiquity_multiplier": 2.5,
+                },
+                {
+                    "miner_id": "bob-miner",
+                    "device_family": "PowerPC",
+                    "antiquity_multiplier": 1.5,
+                },
+            ],
+            "pagination": {"total": 2, "limit": 100, "offset": 0, "count": 2},
+        },
+        "https://node/epoch": {"epoch": 12},
+        "https://node/health": {"ok": True},
+        "https://node/wallet/balance?miner_id=alice-miner": {"amount_rtc": 3.0},
+        "https://node/wallet/balance?miner_id=bob-miner": {"amount_rtc": 5.0},
+    }
+
+    monkeypatch.setattr(
+        discord_leaderboard_bot,
+        "get_json",
+        lambda session, url, timeout: payloads[url],
+    )
+
+    rows, epoch, health = discord_leaderboard_bot.collect_data(object(), "https://node", 1)
+
+    assert epoch == {"epoch": 12}
+    assert health == {"ok": True}
+    assert rows == [
+        {"miner": "bob-miner", "balance_rtc": 5.0, "arch": "PowerPC", "multiplier": 1.5},
+        {"miner": "alice-miner", "balance_rtc": 3.0, "arch": "G4", "multiplier": 2.5},
+    ]
+
+
+def test_normalize_miners_payload_accepts_common_envelopes():
+    rows = [{"miner": "alice"}]
+
+    assert discord_leaderboard_bot.normalize_miners_payload(rows) == rows
+    assert discord_leaderboard_bot.normalize_miners_payload({"data": rows}) == rows
+    assert discord_leaderboard_bot.normalize_miners_payload({"items": rows}) == rows
+    assert discord_leaderboard_bot.normalize_miners_payload({"pagination": {}}) == []
+
+
 def test_render_payload_includes_top_miners_rewards_and_architecture(monkeypatch):
     monkeypatch.setattr(
         discord_leaderboard_bot,

--- a/tools/discord_leaderboard_bot.py
+++ b/tools/discord_leaderboard_bot.py
@@ -80,8 +80,19 @@ def rewards_for_epoch(session: requests.Session, base: str, epoch: int, timeout:
     return out
 
 
+def normalize_miners_payload(data):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("miners", "data", "items"):
+            miners = data.get(key)
+            if isinstance(miners, list):
+                return miners
+    return []
+
+
 def collect_data(session: requests.Session, base: str, timeout: float):
-    miners = get_json(session, f"{base}/api/miners", timeout)
+    miners = normalize_miners_payload(get_json(session, f"{base}/api/miners", timeout))
     epoch = get_json(session, f"{base}/epoch", timeout)
     health = get_json(session, f"{base}/health", timeout)
 


### PR DESCRIPTION
## Summary
- normalize the Discord leaderboard bot miners payload before rendering
- support legacy top-level miner arrays plus common `/api/miners` envelopes (`miners`, `data`, `items`)
- return an empty row set for unexpected miner payloads instead of iterating dictionary keys
- add regression coverage for paginated miner envelopes, balance lookups, sorting, and architecture fallback

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_discord_leaderboard_bot.py -q`
- `uv run --no-project --with ruff --with requests python -m ruff check tools/discord_leaderboard_bot.py tests/test_discord_leaderboard_bot.py`
- `python3 -m py_compile tools/discord_leaderboard_bot.py tests/test_discord_leaderboard_bot.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/discord_leaderboard_bot.py tests/test_discord_leaderboard_bot.py`

Bounty context: Scottcjn/rustchain-bounties#71