### PR TITLE
fix: render cli miners envelope responses

### DIFF
--- a/tests/test_wallet_show_regression.py
+++ b/tests/test_wallet_show_regression.py
@@ -85,6 +85,46 @@ class TestWalletBalanceEndpoint:
         assert exc_info.value.code == 1
         assert "Error: sentinel-main-error" in capsys.readouterr().err
 
+    def test_miners_count_uses_paginated_response_rows(self, capsys):
+        """Test miners --count counts rows inside current API envelopes."""
+        args = type("Args", (), {"count": True, "json": False})()
+        with patch.object(
+            rustchain_cli,
+            "fetch_api",
+            return_value={
+                "miners": [{"miner": "alice"}, {"miner": "bob"}],
+                "pagination": {"total": 2, "limit": 100, "offset": 0, "count": 2},
+            },
+        ):
+            rustchain_cli.cmd_miners(args)
+
+        assert "Active miners: 2" in capsys.readouterr().out
+
+    def test_miners_table_renders_paginated_response_fields(self, capsys):
+        """Test miners table renders current API envelope and row field names."""
+        args = type("Args", (), {"count": False, "json": False})()
+        with patch.object(
+            rustchain_cli,
+            "fetch_api",
+            return_value={
+                "miners": [
+                    {
+                        "miner": "alice-miner-long-identifier",
+                        "device_arch": "G4",
+                        "ts_ok": 1_700_000_000,
+                    }
+                ],
+                "pagination": {"total": 1, "limit": 100, "offset": 0, "count": 1},
+            },
+        ):
+            rustchain_cli.cmd_miners(args)
+
+        output = capsys.readouterr().out
+        assert "Active Miners (1 total, showing 20)" in output
+        assert "alice-miner-long-id" in output
+        assert "G4" in output
+        assert "2023-11-14" in output
+
     def test_balance_endpoint_returns_valid_json(self):
         """Integration test: verify /wallet/balance returns valid JSON."""
         node_url = get_node_url()

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -103,15 +103,24 @@ def cmd_status(args):
     print(f"Tip Age:     {data.get('tip_age_slots', 0)} slots")
     print(f"Backup Age:  {data.get('backup_age_hours', 0):.1f} hours")
 
+def normalize_miners_response(data):
+    """Return miner rows from legacy arrays or current paginated envelopes."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("miners"), list):
+        return data["miners"]
+    return []
+
 def cmd_miners(args):
     """List active miners."""
     data = fetch_api("/api/miners")
+    miners = normalize_miners_response(data)
     
     if args.count:
         if args.json:
-            print(json.dumps({"count": len(data)}, indent=2))
+            print(json.dumps({"count": len(miners)}, indent=2))
         else:
-            print(f"Active miners: {len(data)}")
+            print(f"Active miners: {len(miners)}")
         return
     
     if args.json:
@@ -121,15 +130,15 @@ def cmd_miners(args):
     # Format as table
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
-    for miner in data[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', 'N/A')[:20]
-        arch = miner.get('arch', 'N/A')
-        last_attest = miner.get('last_attest', 'N/A')
+    for miner in miners[:20]:  # Show top 20
+        miner_id = (miner.get('miner') or miner.get('miner_id') or 'N/A')[:20]
+        arch = miner.get('arch') or miner.get('device_arch') or miner.get('device_family') or 'N/A'
+        last_attest = miner.get('last_attest', miner.get('ts_ok', 'N/A'))
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')
         rows.append([miner_id, arch, str(last_attest)])
     
-    print(f"Active Miners ({len(data)} total, showing 20)\n")
+    print(f"Active Miners ({len(miners)} total, showing 20)\n")
     print(format_table(headers, rows))
 
 def cmd_balance(args):


### PR DESCRIPTION
## Summary
- normalize `rustchain_cli.py miners` responses from both legacy arrays and current `/api/miners` envelopes
- make `miners --count` count actual miner rows instead of envelope keys
- render current miner row fields (`miner`, `device_arch`, `ts_ok`) in table mode

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_wallet_show_regression.py -q`
- `python3 -m py_compile tools/cli/rustchain_cli.py tests/test_wallet_show_regression.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/cli/rustchain_cli.py tests/test_wallet_show_regression.py`

Bounty context: Scottcjn/rustchain-bounties#71