### PR TITLE
fix: render node discord miners envelopes

### DIFF
--- a/discord-bot-nodejs-v2/commands/miners.js
+++ b/discord-bot-nodejs-v2/commands/miners.js
@@ -31,12 +31,17 @@ module.exports = {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       
-      let miners = await response.json();
+      const payload = await response.json();
+      let miners = Array.isArray(payload)
+        ? payload
+        : Array.isArray(payload?.miners)
+          ? payload.miners
+          : [];
       
       // Filter by address if provided
       if (address) {
         miners = miners.filter(m => 
-          m.miner.toLowerCase().includes(address.toLowerCase())
+          getMinerId(m).toLowerCase().includes(address.toLowerCase())
         );
       }
       
@@ -58,13 +63,13 @@ module.exports = {
           .setColor(0x0099FF)
           .setTitle('⛏️ Miner Details')
           .addFields(
-            { name: 'Miner ID', value: `\`${miner.miner}\``, inline: false },
-            { name: 'Hardware', value: `${miner.hardware_type}`, inline: true },
-            { name: 'Architecture', value: `${miner.device_arch}`, inline: true },
-            { name: 'Family', value: `${miner.device_family}`, inline: true },
-            { name: 'Antiquity Multiplier', value: `**${miner.antiquity_multiplier}x**`, inline: true },
-            { name: 'Entropy Score', value: `${miner.entropy_score}`, inline: true },
-            { name: 'Last Attest', value: `${formatTimestamp(miner.last_attest)}`, inline: true }
+            { name: 'Miner ID', value: `\`${getMinerId(miner)}\``, inline: false },
+            { name: 'Hardware', value: `${miner.hardware_type || 'N/A'}`, inline: true },
+            { name: 'Architecture', value: `${miner.device_arch || 'N/A'}`, inline: true },
+            { name: 'Family', value: `${miner.device_family || 'N/A'}`, inline: true },
+            { name: 'Antiquity Multiplier', value: `**${miner.antiquity_multiplier ?? 'N/A'}x**`, inline: true },
+            { name: 'Entropy Score', value: `${miner.entropy_score ?? 'N/A'}`, inline: true },
+            { name: 'Last Attest', value: `${formatTimestamp(miner.last_attest || miner.ts_ok)}`, inline: true }
           )
           .setFooter({ text: 'RustChain Proof-of-Antiquity' })
           .setTimestamp();
@@ -73,7 +78,7 @@ module.exports = {
       } else {
         // Multiple miners list
         const description = miners.map((m, i) => 
-          `**${i + 1}.** ${m.miner}\n   Hardware: ${m.hardware_type} | Multiplier: **${m.antiquity_multiplier}x**`
+          `**${i + 1}.** ${getMinerId(m)}\n   Hardware: ${m.hardware_type || 'N/A'} | Multiplier: **${m.antiquity_multiplier ?? 'N/A'}x**`
         ).join('\n\n');
         
         const embed = new EmbedBuilder()
@@ -99,4 +104,8 @@ function formatTimestamp(unixTime) {
   if (!unixTime) return 'Never';
   const date = new Date(unixTime * 1000);
   return date.toLocaleDateString() + ' ' + date.toLocaleTimeString();
+}
+
+function getMinerId(miner) {
+  return String(miner?.miner || miner?.miner_id || 'unknown');
 }

--- a/tests/test_node_discord_miners_command.js
+++ b/tests/test_node_discord_miners_command.js
@@ -1,0 +1,119 @@
+const assert = require('assert');
+const Module = require('module');
+const path = require('path');
+
+class FakeSlashCommandBuilder {
+  setName() { return this; }
+  setDescription() { return this; }
+  addIntegerOption(callback) {
+    callback({
+      setName() { return this; },
+      setDescription() { return this; },
+      setMinValue() { return this; },
+      setMaxValue() { return this; },
+      setValue() { return this; },
+    });
+    return this;
+  }
+  addStringOption(callback) {
+    callback({
+      setName() { return this; },
+      setDescription() { return this; },
+    });
+    return this;
+  }
+}
+
+class FakeEmbedBuilder {
+  constructor() {
+    this.fields = [];
+  }
+  setColor(color) { this.color = color; return this; }
+  setTitle(title) { this.title = title; return this; }
+  setDescription(description) { this.description = description; return this; }
+  addFields(...fields) { this.fields.push(...fields); return this; }
+  setFooter(footer) { this.footer = footer; return this; }
+  setTimestamp() { this.timestamped = true; return this; }
+}
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'discord.js') {
+    return {
+      SlashCommandBuilder: FakeSlashCommandBuilder,
+      EmbedBuilder: FakeEmbedBuilder,
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+async function run() {
+  const commandPath = path.join(
+    __dirname,
+    '..',
+    'discord-bot-nodejs-v2',
+    'commands',
+    'miners.js',
+  );
+  delete require.cache[require.resolve(commandPath)];
+  const minersCommand = require(commandPath);
+
+  let fetchedUrl = null;
+  global.fetch = async (url) => {
+    fetchedUrl = url;
+    return {
+      ok: true,
+      async json() {
+        return {
+          miners: [
+            {
+              miner: 'alice-miner',
+              hardware_type: 'PowerPC G4',
+              device_arch: 'G4',
+              device_family: 'PowerPC',
+              antiquity_multiplier: 2.5,
+              entropy_score: 0.9,
+              ts_ok: 1700000000,
+            },
+            {
+              miner_id: 'bob-miner',
+              hardware_type: 'SPARC',
+              antiquity_multiplier: 1.5,
+            },
+          ],
+          pagination: { total: 2, limit: 100, offset: 0, count: 2 },
+        };
+      },
+    };
+  };
+
+  const replies = [];
+  const interaction = {
+    options: {
+      getInteger: () => 2,
+      getString: () => '',
+    },
+    deferReply: async () => {},
+    editReply: async (payload) => replies.push(payload),
+  };
+
+  await minersCommand.execute(interaction);
+
+  assert.strictEqual(fetchedUrl, 'https://50.28.86.131/api/miners');
+  assert.strictEqual(replies.length, 1);
+  assert.ok(replies[0].embeds, 'expected miners command to render an embed');
+  const embed = replies[0].embeds[0];
+  assert.strictEqual(embed.title, '⛏️ Top RustChain Miners');
+  assert.ok(embed.description.includes('alice-miner'));
+  assert.ok(embed.description.includes('bob-miner'));
+  assert.ok(embed.description.includes('PowerPC G4'));
+  assert.ok(embed.description.includes('SPARC'));
+}
+
+run().finally(() => {
+  Module._load = originalLoad;
+  delete global.fetch;
+}).catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- normalize the Node.js Discord `/miners` command for both legacy miner arrays and current `/api/miners` envelopes
- support current row fields such as `miner_id` and `ts_ok` while preserving existing display behavior
- add a dependency-free Node regression test with a local `discord.js` stub

## Validation
- `node tests/test_node_discord_miners_command.js`
- `node --check discord-bot-nodejs-v2/commands/miners.js && node --check tests/test_node_discord_miners_command.js`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- discord-bot-nodejs-v2/commands/miners.js tests/test_node_discord_miners_command.js`

Bounty context: Scottcjn/rustchain-bounties#71