### PR TITLE
fix: normalize telegram miners envelopes

### DIFF
--- a/tests/test_telegram_bot_miners_envelope.py
+++ b/tests/test_telegram_bot_miners_envelope.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: MIT
+import asyncio
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "telegram_bot" / "telegram_bot.py"
+
+
+def load_bot_module(monkeypatch):
+    class FakeInlineQueryResultArticle:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeInputTextMessageContent:
+        def __init__(self, text):
+            self.text = text
+
+    class FakeApplication:
+        @classmethod
+        def builder(cls):
+            return cls()
+
+        def token(self, _token):
+            return self
+
+        def build(self):
+            return self
+
+        def add_handler(self, _handler):
+            return None
+
+        def run_polling(self):
+            return None
+
+    fake_telegram = types.SimpleNamespace(
+        Update=object,
+        InlineQueryResultArticle=FakeInlineQueryResultArticle,
+        InputTextMessageContent=FakeInputTextMessageContent,
+    )
+    fake_ext = types.SimpleNamespace(
+        Application=FakeApplication,
+        CommandHandler=lambda *args, **kwargs: (args, kwargs),
+        InlineQueryHandler=lambda *args, **kwargs: (args, kwargs),
+        ContextTypes=types.SimpleNamespace(DEFAULT_TYPE=object),
+    )
+    fake_aiohttp = types.SimpleNamespace(
+        TCPConnector=lambda **kwargs: object(),
+        ClientSession=object,
+        ClientTimeout=lambda **kwargs: object(),
+    )
+
+    monkeypatch.setitem(sys.modules, "aiohttp", fake_aiohttp)
+    monkeypatch.setitem(sys.modules, "dotenv", types.SimpleNamespace(load_dotenv=lambda: None))
+    monkeypatch.setitem(sys.modules, "telegram", fake_telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", fake_ext)
+
+    spec = importlib.util.spec_from_file_location("telegram_bot_module", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cmd_miners_renders_paginated_api_envelope(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    async def fake_fetch(path, params=None):
+        assert path == "/api/miners"
+        assert params is None
+        return {
+            "miners": [
+                {"miner_id": "alice-id", "device_arch": "G4", "antiquity_multiplier": 3},
+                {"miner": "bob", "hardware_type": "SPARC", "antiquity_multiplier": 2},
+            ],
+            "pagination": {"total": 18, "limit": 2, "offset": 0, "count": 2},
+        }
+
+    monkeypatch.setattr(module, "fetch_rustchain", fake_fetch)
+    replies = []
+
+    class FakeMessage:
+        async def reply_text(self, text, **kwargs):
+            replies.append((text, kwargs))
+
+    update = types.SimpleNamespace(message=FakeMessage())
+
+    asyncio.run(module.cmd_miners(update, types.SimpleNamespace()))
+
+    assert len(replies) == 1
+    text, kwargs = replies[0]
+    assert kwargs["parse_mode"] == "Markdown"
+    assert "*Active Miners: 18*" in text
+    assert "`alice-id`" in text
+    assert "`bob`" in text
+    assert "_…and 16 more_" in text
+
+
+def test_inline_query_uses_paginated_miner_total(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    async def fake_fetch(path, params=None):
+        if path == "/api/miners":
+            return {"miners": [{"miner": "alice"}], "pagination": {"total": 9}}
+        if path == "/epoch":
+            return {"epoch": 12, "slot": 3, "epoch_pot": 4, "enrolled_miners": 9}
+        raise AssertionError(path)
+
+    monkeypatch.setattr(module, "fetch_rustchain", fake_fetch)
+    monkeypatch.setattr(module, "fetch_price_data", lambda: None)
+    answers = []
+
+    class FakeInlineQuery:
+        query = "miners"
+
+        async def answer(self, results, **kwargs):
+            answers.append((results, kwargs))
+
+    update = types.SimpleNamespace(inline_query=FakeInlineQuery())
+
+    asyncio.run(module.inline_query(update, types.SimpleNamespace()))
+
+    results, kwargs = answers[0]
+    assert kwargs == {"cache_time": 30}
+    assert results[0].kwargs["title"] == "Active Miners: 9"
+    assert results[0].kwargs["input_message_content"].text == "RustChain has 9 active miners."

--- a/tools/telegram_bot/telegram_bot.py
+++ b/tools/telegram_bot/telegram_bot.py
@@ -94,6 +94,30 @@ async def fetch_price_data() -> dict | None:
         return None
 
 
+def normalize_miners_payload(data: dict | list) -> tuple[list, int] | None:
+    """Return miner rows and advertised total from legacy lists or API envelopes."""
+    if isinstance(data, list):
+        return data, len(data)
+    if not isinstance(data, dict):
+        return None
+
+    miners = data.get("miners") or data.get("data") or []
+    if not isinstance(miners, list):
+        miners = []
+
+    pagination = data.get("pagination") if isinstance(data.get("pagination"), dict) else {}
+    total = pagination.get("total", data.get("total", len(miners)))
+    try:
+        total = int(total)
+    except (TypeError, ValueError):
+        total = len(miners)
+    return miners, max(total, len(miners))
+
+
+def miner_name(row: dict) -> str:
+    return row.get("miner") or row.get("miner_id") or "?"
+
+
 # ---------------------------------------------------------------------------
 # Command handlers
 # ---------------------------------------------------------------------------
@@ -132,18 +156,20 @@ async def cmd_price(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 async def cmd_miners(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     try:
-        miners = await fetch_rustchain("/api/miners")
-        if not isinstance(miners, list):
+        payload = await fetch_rustchain("/api/miners")
+        normalized = normalize_miners_payload(payload)
+        if normalized is None:
             await update.message.reply_text("Unexpected response from /api/miners.")
             return
-        lines = [f"*Active Miners: {len(miners)}*\n"]
+        miners, total = normalized
+        lines = [f"*Active Miners: {total}*\n"]
         for m in miners[:15]:
-            name = m.get("miner", "?")
+            name = miner_name(m)
             hw = m.get("hardware_type", m.get("device_arch", ""))
             mult = m.get("antiquity_multiplier", "")
             lines.append(f"  `{name}` — {hw} (x{mult})")
-        if len(miners) > 15:
-            lines.append(f"\n_…and {len(miners) - 15} more_")
+        if total > len(miners[:15]):
+            lines.append(f"\n_…and {total - len(miners[:15])} more_")
         await update.message.reply_text("\n".join(lines), parse_mode="Markdown")
     except Exception as e:
         logger.error("cmd_miners: %s", e)
@@ -241,9 +267,11 @@ async def mining_alert_loop(app: Application):
     await asyncio.sleep(5)
     while True:
         try:
-            miners = await fetch_rustchain("/api/miners")
-            if isinstance(miners, list):
-                current = {m.get("miner", "") for m in miners}
+            payload = await fetch_rustchain("/api/miners")
+            normalized = normalize_miners_payload(payload)
+            if normalized is not None:
+                miners, _total = normalized
+                current = {miner_name(m) for m in miners if miner_name(m) != "?"}
                 if _last_known_miners:
                     for name in current - _last_known_miners:
                         msg = f"*New Miner Joined!*\n`{name}` is now mining on RustChain."
@@ -335,8 +363,9 @@ async def inline_query(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
     if not query or "miners" in query:
         try:
-            miners = await fetch_rustchain("/api/miners")
-            count = len(miners) if isinstance(miners, list) else "?"
+            payload = await fetch_rustchain("/api/miners")
+            normalized = normalize_miners_payload(payload)
+            count = normalized[1] if normalized is not None else "?"
             results.append(
                 InlineQueryResultArticle(
                     id="miners",


### PR DESCRIPTION
## Summary
- normalize Telegram bot /miners responses from current paginated /api/miners envelopes
- use pagination.total for command and inline miner counts while preserving legacy list responses
- support miner_id rows in command output and miner alerts

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_telegram_bot_miners_envelope.py -q
- python3 -m py_compile tools/telegram_bot/telegram_bot.py tests/test_telegram_bot_miners_envelope.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/telegram_bot/telegram_bot.py tests/test_telegram_bot_miners_envelope.py

Bounty context: Scottcjn/rustchain-bounties#71