### PR TITLE
fix(site): proxy signed header ingestion

### DIFF
--- a/site/nginx-rustchain-org.conf
+++ b/site/nginx-rustchain-org.conf
@@ -138,6 +138,23 @@ server {
         }
     }
 
+    # Signed block header ingestion for v2 miners
+    location /headers/ {
+        proxy_pass http://127.0.0.1:8099;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-RustChain "Proof-of-Antiquity" always;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "POST, GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type, Authorization, X-Admin-Key" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
     # Fee pool stats (RIP-301)
     location /api/fee_pool {
         proxy_pass http://127.0.0.1:8099/api/fee_pool;
@@ -341,6 +358,26 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://rustchain.org https://api.github.com https://50.28.86.131 https://swarmhub.onrender.com; object-src 'none'; base-uri 'self'" always;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "POST, GET, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Content-Type, Authorization, X-Admin-Key" always;
+        if ($request_method = OPTIONS) {
+            return 204;
+        }
+    }
+
+    # Signed block header ingestion for v2 miners
+    location /headers/ {
+        proxy_pass http://127.0.0.1:8099;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://rustchain.org https://api.github.com https://50.28.86.131 https://swarmhub.onrender.com; object-src 'none'; base-uri 'self'" always;
+        add_header X-RustChain "Proof-of-Antiquity" always;
         add_header Access-Control-Allow-Origin "*" always;
         add_header Access-Control-Allow-Methods "POST, GET, OPTIONS" always;
         add_header Access-Control-Allow-Headers "Content-Type, Authorization, X-Admin-Key" always;


### PR DESCRIPTION
## Summary
- add the missing `/headers/` nginx proxy in both rustchain.org server blocks
- forward signed header ingestion requests to the node on port 8099
- mirror miner-facing CORS and OPTIONS handling used by `/attest/` and `/wallet/`

## Live evidence
- Bug report: #5857
- `GET https://rustchain.org/lottery/eligibility?miner_id=RTC5800896ed658aa511D029361b6d7388ddb29248B` returned eligible for slot 24268.
- The local miner then attempted `POST /headers/ingest_signed` and logged `Header rejected: {'error': 'HTTP 404'}`.
- Direct `POST https://rustchain.org/headers/ingest_signed` and `POST https://explorer.rustchain.org/headers/ingest_signed` also returned 404.
- The Flask node source defines `/headers/ingest_signed`, so the public nginx layer is dropping the route before it reaches the node.

## Verification
- Confirmed `site/nginx-rustchain-org.conf` now has two `/headers/` locations, matching the two `/attest/` and `/lottery/` locations.
- Confirmed brace counts are balanced locally.
- Could not run `nginx -t` locally because nginx is not installed on this machine.

Bounty reference: #305
Bug report: #5857