### PR TITLE
fix: normalize telegram 2869 miners envelopes

### DIFF
--- a/tests/test_telegram_bot_2869_helpers.py
+++ b/tests/test_telegram_bot_2869_helpers.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: MIT
+import asyncio
 import importlib.util
 import sys
 from pathlib import Path
@@ -88,3 +89,42 @@ def test_error_text_prefers_internal_error_then_api_error():
     assert telegram_bot._error_text({"_error": "node down", "error": "ignored"}) == "node down"
     assert telegram_bot._error_text({"error": "bad wallet"}) == "bad wallet"
     assert telegram_bot._error_text({"ok": True}) == ""
+
+
+def test_cmd_miners_uses_paginated_total_and_miner_id(monkeypatch):
+    async def fake_miners():
+        return {
+            "miners": [
+                {"miner_id": "alice-id", "device_arch": "G4", "antiquity_multiplier": 3},
+                {"miner": "bob", "hardware_type": "SPARC", "antiquity_multiplier": 2},
+            ],
+            "pagination": {"total": 18, "limit": 2, "offset": 0, "count": 2},
+        }
+
+    class AlwaysAllowed:
+        def is_allowed(self, _user_id):
+            return True
+
+    replies = []
+
+    class FakeMessage:
+        async def reply_text(self, text, **kwargs):
+            replies.append((text, kwargs))
+
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=123),
+        message=FakeMessage(),
+    )
+
+    monkeypatch.setattr(telegram_bot, "api", SimpleNamespace(miners=fake_miners))
+    monkeypatch.setattr(telegram_bot, "rate_limiter", AlwaysAllowed())
+
+    asyncio.run(telegram_bot.cmd_miners(update, SimpleNamespace()))
+
+    assert len(replies) == 1
+    text, kwargs = replies[0]
+    assert kwargs == {"parse_mode": "MarkdownV2"}
+    assert "*Active Miners: 18*" in text
+    assert "`alice\\-id`" in text
+    assert "`bob`" in text
+    assert "_\\.\\.\\.and 16 more_" in text

--- a/tools/telegram-bot-2869/bot.py
+++ b/tools/telegram-bot-2869/bot.py
@@ -158,6 +158,33 @@ def _error_text(data: dict[str, Any]) -> str:
     return ""
 
 
+def _normalize_miners_payload(data: dict[str, Any] | list[Any]) -> tuple[list[dict[str, Any]], int] | None:
+    """Accept legacy miner arrays and current paginated /api/miners envelopes."""
+    if isinstance(data, list):
+        miners = data
+        total = len(data)
+    elif isinstance(data, dict):
+        miners = data.get("miners") or data.get("data") or []
+        pagination = data.get("pagination") if isinstance(data.get("pagination"), dict) else {}
+        total = pagination.get("total", data.get("total", len(miners) if isinstance(miners, list) else 0))
+    else:
+        return None
+
+    if not isinstance(miners, list):
+        return None
+
+    try:
+        total = int(total)
+    except (TypeError, ValueError):
+        total = len(miners)
+
+    return miners, max(total, len(miners))
+
+
+def _miner_name(row: dict[str, Any]) -> str:
+    return str(row.get("miner") or row.get("miner_id") or "?")
+
+
 # ---------------------------------------------------------------------------
 # Command: /start
 # ---------------------------------------------------------------------------
@@ -262,18 +289,19 @@ async def cmd_miners(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text(f"❌ Error: {err}")
         return
 
-    miners = data.get("miners", [])
-    if not isinstance(miners, list):
+    normalized = _normalize_miners_payload(data)
+    if normalized is None:
         await update.message.reply_text("Unexpected response from /api/miners.")
         return
+    miners, total = normalized
 
     if not miners:
         await update.message.reply_text("No active miners found on the network.")
         return
 
-    lines = [f"⛏️ *Active Miners: {len(miners)}*\n"]
+    lines = [f"⛏️ *Active Miners: {total}*\n"]
     for m in miners[:15]:
-        name = m.get("miner", "?")
+        name = _miner_name(m)
         hw = m.get("hardware_type", m.get("device_arch", ""))
         mult = m.get("antiquity_multiplier", "")
         # Escape underscores and special chars for MarkdownV2
@@ -281,8 +309,9 @@ async def cmd_miners(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
         safe_hw = _md_escape(str(hw))
         lines.append(f"  `{safe_name}` — {safe_hw} \\(x{mult}\\)")
 
-    if len(miners) > 15:
-        lines.append(f"\n_\\.\\.\\.and {len(miners) - 15} more_")
+    displayed = min(len(miners), 15)
+    if total > displayed:
+        lines.append(f"\n_\\.\\.\\.and {total - displayed} more_")
 
     await update.message.reply_text("\n".join(lines), parse_mode="MarkdownV2")
 


### PR DESCRIPTION
## Summary
- normalize the Telegram 2869 bot /miners command for current paginated /api/miners responses
- use pagination.total for the active miner count and remaining-row footer
- preserve legacy list support and render miner_id rows when miner is absent

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_telegram_bot_2869_helpers.py -q
- python3 -m py_compile tools/telegram-bot-2869/bot.py tests/test_telegram_bot_2869_helpers.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/telegram-bot-2869/bot.py tests/test_telegram_bot_2869_helpers.py

Bounty context: Scottcjn/rustchain-bounties#71