### PR TITLE
fix: normalize rustchain telegram miners envelopes

### DIFF
--- a/tests/test_rustchain_telegram_bot_miners.py
+++ b/tests/test_rustchain_telegram_bot_miners.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "rustchain-telegram-bot" / "bot.py"
+
+
+class DummyApplication:
+    @staticmethod
+    def builder():
+        return DummyApplication()
+
+    def token(self, *_args, **_kwargs):
+        return self
+
+    def build(self):
+        return self
+
+    def add_handler(self, *_args, **_kwargs):
+        return None
+
+    def run_polling(self, *_args, **_kwargs):
+        return None
+
+
+def load_bot_module(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "test-token")
+    monkeypatch.setitem(sys.modules, "requests", SimpleNamespace(RequestException=Exception))
+    monkeypatch.setitem(sys.modules, "telegram", SimpleNamespace(Update=SimpleNamespace(ALL_TYPES=object())))
+    monkeypatch.setitem(
+        sys.modules,
+        "telegram.ext",
+        SimpleNamespace(
+            Application=DummyApplication,
+            CommandHandler=lambda *args, **kwargs: (args, kwargs),
+            ContextTypes=SimpleNamespace(DEFAULT_TYPE=object),
+        ),
+    )
+
+    spec = importlib.util.spec_from_file_location("rustchain_telegram_bot", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cmd_miners_uses_paginated_total_and_miner_fallback(monkeypatch):
+    module = load_bot_module(monkeypatch)
+    monkeypatch.setattr(
+        module,
+        "api_get",
+        lambda path: {
+            "miners": [
+                {"miner": "alice", "device_arch": "G4", "multiplier": 3, "score": 7},
+                {"miner_id": "bob-id", "device_arch": "SPARC", "multiplier": 2, "score": 4},
+            ],
+            "pagination": {"total": 29, "limit": 2, "offset": 0, "count": 2},
+        },
+    )
+    monkeypatch.setattr(module, "check_rate", lambda _user_id: True)
+    replies = []
+
+    class FakeMessage:
+        async def reply_text(self, text, **kwargs):
+            replies.append((text, kwargs))
+
+    update = SimpleNamespace(effective_user=SimpleNamespace(id=1), message=FakeMessage())
+
+    asyncio.run(module.cmd_miners(update, SimpleNamespace()))
+
+    assert len(replies) == 1
+    text, kwargs = replies[0]
+    assert kwargs == {"parse_mode": "Markdown"}
+    assert "*Active Miners: 29*" in text
+    assert "`alice`" in text
+    assert "`bob-id`" in text
+    assert "... and 27 more" in text

--- a/tools/rustchain-telegram-bot/bot.py
+++ b/tools/rustchain-telegram-bot/bot.py
@@ -70,6 +70,33 @@ def check_rate(user_id: int) -> bool:
     _last_request[user_id] = now
     return True
 
+
+def normalize_miners_payload(data):
+    """Accept legacy miner arrays and current paginated /api/miners envelopes."""
+    if isinstance(data, list):
+        miners = data
+        total = len(data)
+    elif isinstance(data, dict):
+        miners = data.get("miners") or data.get("data") or []
+        pagination = data.get("pagination") if isinstance(data.get("pagination"), dict) else {}
+        total = pagination.get("total", data.get("total", len(miners) if isinstance(miners, list) else 0))
+    else:
+        return None
+
+    if not isinstance(miners, list):
+        return None
+
+    try:
+        total = int(total)
+    except (TypeError, ValueError):
+        total = len(miners)
+
+    return miners, max(total, len(miners))
+
+
+def miner_name(row: dict) -> str:
+    return str(row.get("miner_id") or row.get("miner") or "?")
+
 # ---------------------------------------------------------------------------
 # Command handlers
 # ---------------------------------------------------------------------------
@@ -135,22 +162,27 @@ async def cmd_miners(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None
         await update.message.reply_text("❌ Could not reach RustChain node.")
         return
 
-    # The API may return a list directly or a dict with a miners key
-    miners = data if isinstance(data, list) else data.get("miners", [])
+    normalized = normalize_miners_payload(data)
+    if normalized is None:
+        await update.message.reply_text("Unexpected response from /api/miners.")
+        return
+    miners, total = normalized
+
     if not miners:
         await update.message.reply_text("No active miners found.")
         return
 
-    lines = [f"⛏️ *Active Miners: {len(miners)}*", ""]
+    lines = [f"⛏️ *Active Miners: {total}*", ""]
     for m in miners[:20]:
-        mid = m.get("miner_id", "?")[:16]
+        mid = miner_name(m)[:16]
         arch = m.get("device_arch", "?")
         mult = m.get("multiplier", 1)
         score = m.get("score", 0)
         lines.append(f"`{mid}`  {arch}  {mult}x  score:{score}")
 
-    if len(miners) > 20:
-        lines.append(f"... and {len(miners) - 20} more")
+    displayed = min(len(miners), 20)
+    if total > displayed:
+        lines.append(f"... and {total - displayed} more")
 
     await update.message.reply_text("\n".join(lines), parse_mode="Markdown")
 


### PR DESCRIPTION
## Summary
- normalize the standalone RustChain Telegram bot /miners command for paginated /api/miners envelopes
- use pagination.total for active and remaining miner counts while preserving legacy list responses
- support rows that expose miner instead of miner_id

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_rustchain_telegram_bot_miners.py -q
- python3 -m py_compile tools/rustchain-telegram-bot/bot.py tests/test_rustchain_telegram_bot_miners.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/rustchain-telegram-bot/bot.py tests/test_rustchain_telegram_bot_miners.py

Bounty context: Scottcjn/rustchain-bounties#71