### PR TITLE
fix: show tui miner envelope totals

### DIFF
--- a/tests/test_tui_dashboard_miners.py
+++ b/tests/test_tui_dashboard_miners.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+
+from rich.console import Console
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "tui-dashboard" / "dashboard.py"
+spec = importlib.util.spec_from_file_location("tui_dashboard", MODULE_PATH)
+tui_dashboard = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(tui_dashboard)
+
+
+def test_refresh_uses_paginated_miners_total_and_rows(monkeypatch):
+    responses = {
+        "https://node.example/health": {"ok": True},
+        "https://node.example/epoch": {"epoch": 7},
+        "https://node.example/api/miners": {
+            "miners": [{"miner": "alice"}, {"miner_id": "bob"}],
+            "pagination": {"total": 42, "limit": 2, "offset": 0, "count": 2},
+        },
+        "https://node.example/headers/tip": {},
+    }
+
+    monkeypatch.setattr(tui_dashboard, "fetch_json", lambda url, timeout=8: responses.get(url))
+    data = tui_dashboard.RustChainData("https://node.example")
+    data._fetch_price = lambda: {}
+
+    data.refresh()
+
+    assert data.miners == [{"miner": "alice"}, {"miner_id": "bob"}]
+    assert data.miner_total == 42
+
+
+def test_miners_panel_title_uses_api_total_and_miner_fallback():
+    data = tui_dashboard.RustChainData("https://node.example")
+    data.miners = [
+        {"miner": "alice", "device_arch": "G4"},
+        {"miner_id": "bob", "device_arch": "SPARC"},
+    ]
+    data.miner_total = 42
+
+    panel = tui_dashboard.build_miners_panel(data)
+
+    assert "42 total" in str(panel.title)
+    console = Console(record=True, width=100)
+    console.print(panel)
+    rendered = console.export_text()
+    assert "alice" in rendered
+    assert "bob" in rendered

--- a/tools/tui-dashboard/dashboard.py
+++ b/tools/tui-dashboard/dashboard.py
@@ -78,6 +78,7 @@ class RustChainData:
         self.health: Dict[str, Any] = {}
         self.epoch: Dict[str, Any] = {}
         self.miners: List[Dict[str, Any]] = []
+        self.miner_total: int = 0
         self.tip: Dict[str, Any] = {}
         self.price: Dict[str, Any] = {}
         self.last_refresh: Optional[datetime] = None
@@ -93,10 +94,19 @@ class RustChainData:
         miners_raw = fetch_json(f"{self.base}/api/miners")
         if isinstance(miners_raw, list):
             self.miners = miners_raw
+            self.miner_total = len(miners_raw)
         elif isinstance(miners_raw, dict):
-            self.miners = miners_raw.get("miners", miners_raw.get("data", []))
+            miners = miners_raw.get("miners", miners_raw.get("data", []))
+            self.miners = miners if isinstance(miners, list) else []
+            pagination = miners_raw.get("pagination") if isinstance(miners_raw.get("pagination"), dict) else {}
+            total = pagination.get("total", miners_raw.get("total", len(self.miners)))
+            try:
+                self.miner_total = max(int(total), len(self.miners))
+            except (TypeError, ValueError):
+                self.miner_total = len(self.miners)
         else:
             self.miners = []
+            self.miner_total = 0
 
         tip = fetch_json(f"{self.base}/headers/tip") or {}
         if tip and tip != self.tip:
@@ -241,7 +251,7 @@ def build_miners_panel(data: RustChainData) -> Panel:
         table.add_row("No miners available", "", "", "")
     else:
         for m in miners:
-            miner_id = str(m.get("miner_id", m.get("id", "?")))
+            miner_id = str(m.get("miner_id") or m.get("miner") or m.get("id", "?"))
             if len(miner_id) > 24:
                 miner_id = miner_id[:21] + "..."
             hw = str(m.get("hardware_type", m.get("hardware", "?")))
@@ -253,7 +263,7 @@ def build_miners_panel(data: RustChainData) -> Panel:
                 mult_str = str(mult)
             table.add_row(miner_id, hw, arch, mult_str)
 
-    count = len(data.miners)
+    count = data.miner_total
     title = f"[bold]Active Miners[/bold] [dim]({count} total)[/dim]"
     return Panel(table, title=title, border_style="magenta")
 


### PR DESCRIPTION
## Summary
- preserve the advertised pagination.total from current /api/miners envelopes in the TUI dashboard
- show the API total in the Active Miners panel instead of only the current page length
- render rows that expose miner instead of miner_id

## Validation
- uv run --no-project --with pytest --with flask --with rich python -m pytest tests/test_tui_dashboard_miners.py -q
- python3 -m py_compile tools/tui-dashboard/dashboard.py tests/test_tui_dashboard_miners.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/tui-dashboard/dashboard.py tests/test_tui_dashboard_miners.py

Bounty context: Scottcjn/rustchain-bounties#71