### PR TITLE
fix: normalize prometheus miner envelopes

### DIFF
--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -172,6 +172,27 @@ def test_collect_miners_counts_recent_attestations_and_uses_fallback():
     assert module.rustchain_enrolled_miners_total._value.get() == 5
 
 
+def test_collect_miners_accepts_paginated_api_envelope():
+    module = load_module()
+
+    with (
+        patch.object(module, "fetch_json", return_value={
+            "miners": [
+                {"miner_id": "alice-id", "device_arch": "g4", "last_attest": 1_000},
+                {"miner": "bob", "arch": "sparc", "last_attest_timestamp": 0},
+            ],
+            "pagination": {"total": 9, "limit": 2, "offset": 0, "count": 2},
+        }),
+        patch.object(module.time, "time", return_value=2_000),
+    ):
+        module.collect_miners(fallback_enrolled=0)
+
+    assert module.rustchain_active_miners_total._value.get() == 1
+    assert module.rustchain_enrolled_miners_total._value.get() == 9
+    assert {"miner": "alice-id", "arch": "g4"} in module.rustchain_miner_last_attest_timestamp.calls
+    assert {"miner": "bob", "arch": "sparc"} in module.rustchain_miner_last_attest_timestamp.calls
+
+
 def test_collect_hall_of_fame_fee_pool_and_stats_fallbacks():
     module = load_module()
 

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -233,7 +233,17 @@ def collect_epoch() -> dict[str, int | float]:
 
 def collect_miners(fallback_enrolled: int) -> None:
     payload = fetch_json("/api/miners")
-    if not isinstance(payload, list):
+    if isinstance(payload, list):
+        miners = payload
+        total = len(payload)
+    elif isinstance(payload, dict):
+        miners = payload.get("miners", payload.get("data", []))
+        if not isinstance(miners, list):
+            miners = []
+        pagination = payload.get("pagination") if isinstance(payload.get("pagination"), dict) else {}
+        total = _to_int(pagination.get("total", payload.get("total", len(miners))), len(miners))
+        total = max(total, len(miners))
+    else:
         rustchain_active_miners_total.set(0)
         rustchain_enrolled_miners_total.set(fallback_enrolled)
         rustchain_miner_last_attest_timestamp.clear()
@@ -243,10 +253,10 @@ def collect_miners(fallback_enrolled: int) -> None:
 
     now = time.time()
     active = 0
-    for item in payload:
+    for item in miners:
         if not isinstance(item, dict):
             continue
-        miner = str(item.get("miner", item.get("id", "unknown")))
+        miner = str(item.get("miner", item.get("miner_id", item.get("id", "unknown"))))
         arch = str(item.get("arch", item.get("device_arch", "unknown")))
         last_attest = _to_float(item.get("last_attest", item.get("last_attest_timestamp", 0)))
         rustchain_miner_last_attest_timestamp.labels(miner=miner, arch=arch).set(last_attest)
@@ -255,7 +265,7 @@ def collect_miners(fallback_enrolled: int) -> None:
 
     rustchain_active_miners_total.set(active)
     rustchain_enrolled_miners_total.set(
-        fallback_enrolled if fallback_enrolled > 0 else len(payload)
+        fallback_enrolled if fallback_enrolled > 0 else total
     )
 
 


### PR DESCRIPTION
## Summary
- accept current paginated /api/miners envelopes in the simple Prometheus exporter
- preserve legacy list responses and use pagination.total when epoch fallback is unavailable
- support miner_id labels alongside miner/id fields

## Validation
- uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_prometheus_rustchain_exporter.py -q
- python3 -m py_compile tools/prometheus/rustchain_exporter.py tests/test_prometheus_rustchain_exporter.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/prometheus/rustchain_exporter.py tests/test_prometheus_rustchain_exporter.py

Note: an initial pytest run without requests in the isolated uv environment failed at import time with ModuleNotFoundError: requests; reran with requests and the suite passed.

Bounty context: Scottcjn/rustchain-bounties#71