### PR TITLE
fix: normalize monitoring exporter miners envelopes

### DIFF
--- a/tests/test_monitoring_prometheus_exporter_miners.py
+++ b/tests/test_monitoring_prometheus_exporter_miners.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "monitoring" / "prometheus_exporter.py"
+
+
+class FakeMetric:
+    def __init__(self, *args, **kwargs):
+        self.samples = []
+        self.observations = []
+
+    def labels(self, **labels):
+        self.last_labels = labels
+        return self
+
+    def set(self, value):
+        self.samples.append((self.last_labels, value))
+
+    def inc(self):
+        self.samples.append((self.last_labels, "inc"))
+
+    def info(self, value):
+        self.samples.append((self.last_labels, value))
+
+    def observe(self, value):
+        self.observations.append((self.last_labels, value))
+
+
+def load_exporter_module():
+    prometheus_stub = types.ModuleType("prometheus_client")
+    prometheus_stub.start_http_server = lambda *args, **kwargs: None
+    prometheus_stub.Gauge = FakeMetric
+    prometheus_stub.Counter = FakeMetric
+    prometheus_stub.Info = FakeMetric
+    prometheus_stub.Histogram = FakeMetric
+    sys.modules["prometheus_client"] = prometheus_stub
+
+    spec = importlib.util.spec_from_file_location("monitoring_prometheus_exporter", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_scrape_miners_accepts_paginated_api_envelope(monkeypatch):
+    module = load_exporter_module()
+    exporter = module.RustChainPrometheusExporter("https://node.example")
+    monkeypatch.setattr(
+        exporter,
+        "_make_request",
+        lambda endpoint: {
+            "miners": [
+                {"miner_id": "alice-id", "antiquity_score": 2.5},
+                {"miner": "bob", "antiquity_score": 0.5},
+            ],
+            "pagination": {"total": 12, "limit": 2, "offset": 0, "count": 2},
+        },
+    )
+
+    exporter._scrape_miners()
+
+    assert module.rustchain_active_miners.samples[-1] == ({"node_url": "https://node.example"}, 2)
+    assert module.rustchain_total_miners.samples[-1] == ({"node_url": "https://node.example"}, 12)
+    assert module.rustchain_miner_antiquity_distribution.observations == [
+        ({"node_url": "https://node.example"}, 2.5),
+        ({"node_url": "https://node.example"}, 0.5),
+    ]

--- a/tools/monitoring/prometheus_exporter.py
+++ b/tools/monitoring/prometheus_exporter.py
@@ -260,12 +260,31 @@ class RustChainPrometheusExporter:
     def _scrape_miners(self):
         """GET /api/miners -> active miner count."""
         data = self._make_request('/api/miners')
-        if data and isinstance(data, list):
-            rustchain_active_miners.labels(node_url=self.node_url).set(len(data))
-            rustchain_total_miners.labels(node_url=self.node_url).set(len(data))
+        if isinstance(data, list):
+            miners = data
+            total = len(data)
+        elif isinstance(data, dict):
+            miners = data.get('miners', data.get('data', []))
+            if not isinstance(miners, list):
+                miners = []
+            pagination = data.get('pagination') if isinstance(data.get('pagination'), dict) else {}
+            total = pagination.get('total', data.get('total', len(miners)))
+            try:
+                total = int(total)
+            except (TypeError, ValueError):
+                total = len(miners)
+            total = max(total, len(miners))
+        else:
+            return
+
+        if miners or total:
+            rustchain_active_miners.labels(node_url=self.node_url).set(len(miners))
+            rustchain_total_miners.labels(node_url=self.node_url).set(total)
 
             # v2: miner antiquity score distribution
-            for miner in data:
+            for miner in miners:
+                if not isinstance(miner, dict):
+                    continue
                 antiquity = miner.get('antiquity_score', 0)
                 rustchain_miner_antiquity_distribution.labels(
                     node_url=self.node_url,


### PR DESCRIPTION
## Summary
- accept current paginated /api/miners envelopes in the class-based monitoring Prometheus exporter
- keep active miners based on returned rows while reporting pagination.total as total miners
- preserve legacy list responses and ignore malformed miner rows for antiquity observations

## Validation
- uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_monitoring_prometheus_exporter_miners.py -q
- python3 -m py_compile tools/monitoring/prometheus_exporter.py tests/test_monitoring_prometheus_exporter_miners.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/monitoring/prometheus_exporter.py tests/test_monitoring_prometheus_exporter_miners.py

Bounty context: Scottcjn/rustchain-bounties#71