### PR TITLE
fix: normalize mining video miners envelopes

### DIFF
--- a/tests/test_mining_video_pipeline_miners.py
+++ b/tests/test_mining_video_pipeline_miners.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "mining-video-pipeline"
+    / "mining_video_pipeline.py"
+)
+spec = importlib.util.spec_from_file_location("mining_video_pipeline", MODULE_PATH)
+mining_video_pipeline = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mining_video_pipeline)
+
+
+def test_fetch_miners_accepts_paginated_api_envelope(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "miners": [
+                    {
+                        "miner_id": "alice-id",
+                        "device_arch": "G4",
+                        "device_family": "PowerPC",
+                        "hardware_type": "PowerPC (Vintage)",
+                        "antiquity_multiplier": 3,
+                        "entropy_score": 0.8,
+                    },
+                    {"miner": "bob", "device_arch": "SPARC"},
+                    "bad-row",
+                ],
+                "pagination": {"total": 3, "limit": 3, "offset": 0, "count": 3},
+            }
+
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr(mining_video_pipeline.requests, "get", fake_get)
+
+    miners = mining_video_pipeline.fetch_miners()
+
+    assert calls == [
+        (
+            f"{mining_video_pipeline.RUSTCHAIN_API}/api/miners",
+            {"verify": False, "timeout": 30},
+        )
+    ]
+    assert [miner.miner_id for miner in miners] == ["alice-id", "bob"]
+    assert miners[0].device_arch == "G4"
+    assert miners[0].style == mining_video_pipeline.ARCH_STYLES["PowerPC (Vintage)"]

--- a/tools/mining-video-pipeline/mining_video_pipeline.py
+++ b/tools/mining-video-pipeline/mining_video_pipeline.py
@@ -116,7 +116,7 @@ class MinerData:
         hw_type = data.get("hardware_type", "Unknown/Other")
         style = ARCH_STYLES.get(hw_type, ARCH_STYLES["Unknown/Other"])
         return cls(
-            miner_id=data.get("miner", "unknown"),
+            miner_id=data.get("miner") or data.get("miner_id") or data.get("id") or "unknown",
             device_arch=data.get("device_arch", "unknown"),
             device_family=data.get("device_family", "unknown"),
             hardware_type=hw_type,
@@ -147,7 +147,14 @@ def fetch_miners() -> list[MinerData]:
     """Fetch active miners from RustChain API."""
     resp = requests.get(f"{RUSTCHAIN_API}/api/miners", verify=False, timeout=30)
     resp.raise_for_status()
-    return [MinerData.from_api(m) for m in resp.json()]
+    payload = resp.json()
+    if isinstance(payload, list):
+        miners = payload
+    elif isinstance(payload, dict):
+        miners = payload.get("miners") or payload.get("data") or []
+    else:
+        miners = []
+    return [MinerData.from_api(m) for m in miners if isinstance(m, dict)]
 
 
 def fetch_epoch() -> dict:


### PR DESCRIPTION
## Summary
- accept current paginated /api/miners envelopes in the mining video pipeline
- preserve legacy list responses and ignore malformed rows
- support miner_id/id fallbacks when building MinerData

## Validation
- uv run --no-project --with pytest --with flask --with requests --with pillow python -m pytest tests/test_mining_video_pipeline_miners.py -q
- python3 -m py_compile tools/mining-video-pipeline/mining_video_pipeline.py tests/test_mining_video_pipeline_miners.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/mining-video-pipeline/mining_video_pipeline.py tests/test_mining_video_pipeline_miners.py

Bounty context: Scottcjn/rustchain-bounties#71