### PR TITLE
fix: normalize webhook miner envelopes

### DIFF
--- a/tests/test_webhook_server_helpers.py
+++ b/tests/test_webhook_server_helpers.py
@@ -106,3 +106,44 @@ def test_sign_payload_matches_hmac_sha256_and_event_serializes():
     event = module.WebhookEvent(event_type="new_block", timestamp=123.0, data={"slot": 42})
     assert event.event_type == "new_block"
     assert event.data == {"slot": 42}
+
+
+def test_poller_miners_accepts_paginated_api_envelope(monkeypatch, tmp_path):
+    module = load_module()
+    store = module.SubscriberStore(str(tmp_path / "webhooks.sqlite3"))
+    poller = module.RustChainPoller("https://node.example", store)
+    events = []
+
+    payloads = iter([
+        {
+            "miners": [
+                {"miner_id": "alice", "device_arch": "G4"},
+            ],
+            "pagination": {"total": 1, "limit": 100, "offset": 0, "count": 1},
+        },
+        {
+            "miners": [
+                {"miner_id": "alice", "device_arch": "G4"},
+                {"miner": "bob", "device_arch": "SPARC", "hardware_type": "SPARCstation"},
+            ],
+            "pagination": {"total": 2, "limit": 100, "offset": 0, "count": 2},
+        },
+    ])
+
+    monkeypatch.setattr(poller, "_get", lambda path: next(payloads))
+    monkeypatch.setattr(module, "dispatch_event", lambda event, _store: events.append(event))
+    monkeypatch.setattr(module.time, "time", lambda: 123.0)
+
+    poller._check_miners()
+    poller._check_miners()
+
+    assert poller._prev_miners == {"alice", "bob"}
+    assert len(events) == 1
+    assert events[0].event_type == "miner_joined"
+    assert events[0].timestamp == 123.0
+    assert events[0].data == {
+        "miner": "bob",
+        "hardware_type": "SPARCstation",
+        "device_family": None,
+        "device_arch": "SPARC",
+    }

--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -398,16 +398,33 @@ class RustChainPoller:
 
     def _check_miners(self):
         miners_data = self._get("/api/miners")
-        if miners_data is None or not isinstance(miners_data, list):
+        if isinstance(miners_data, list):
+            miners = miners_data
+        elif isinstance(miners_data, dict):
+            miners = miners_data.get("miners") or miners_data.get("data") or []
+        else:
             return
-        current_miners = {m["miner"] for m in miners_data if "miner" in m}
+        if not isinstance(miners, list):
+            return
+        current_miners = {
+            miner_id
+            for miner_id in ((m.get("miner") or m.get("miner_id") or m.get("id")) for m in miners if isinstance(m, dict))
+            if miner_id
+        }
 
         if self._prev_miners:
             joined = current_miners - self._prev_miners
             left = self._prev_miners - current_miners
 
             for miner_id in joined:
-                miner_info = next((m for m in miners_data if m.get("miner") == miner_id), {})
+                miner_info = next(
+                    (
+                        m for m in miners
+                        if isinstance(m, dict)
+                        and (m.get("miner") or m.get("miner_id") or m.get("id")) == miner_id
+                    ),
+                    {},
+                )
                 dispatch_event(WebhookEvent(
                     event_type="miner_joined",
                     timestamp=time.time(),


### PR DESCRIPTION
## Summary
- accept current paginated /api/miners envelopes in the webhook poller
- preserve legacy list responses and support miner_id/id fallbacks
- keep miner_joined/miner_left events working with current API payloads

## Validation
- uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_webhook_server_helpers.py -q
- python3 -m py_compile tools/webhooks/webhook_server.py tests/test_webhook_server_helpers.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/webhooks/webhook_server.py tests/test_webhook_server_helpers.py

Bounty context: Scottcjn/rustchain-bounties#71