### PR TITLE
fix: follow ledger verifier miner pages

### DIFF
--- a/monitoring/ledger_verify.py
+++ b/monitoring/ledger_verify.py
@@ -28,6 +28,7 @@ import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlencode
 
 # ---------------------------------------------------------------------------
 # Node configuration
@@ -213,6 +214,67 @@ def compute_merkle_root(miner_list: List[dict]) -> str:
 # Node querying
 # ---------------------------------------------------------------------------
 
+def _non_negative_int(value: Any) -> Optional[int]:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _extract_miners_payload(payload: Any) -> Tuple[List[dict], Optional[int], Optional[int], int]:
+    """Return miners plus pagination metadata from legacy and current API shapes."""
+    if isinstance(payload, list):
+        return [m for m in payload if isinstance(m, dict)], None, None, 0
+
+    if not isinstance(payload, dict):
+        return [], None, None, 0
+
+    miners_value = payload.get("miners", [])
+    miners = [m for m in miners_value if isinstance(m, dict)] if isinstance(miners_value, list) else []
+
+    pagination = payload.get("pagination") if isinstance(payload.get("pagination"), dict) else {}
+    total = _non_negative_int(pagination.get("total"))
+    limit = _non_negative_int(pagination.get("limit"))
+    offset = _non_negative_int(pagination.get("offset")) or 0
+    return miners, total, limit, offset
+
+
+def fetch_miners(base: str) -> Tuple[List[dict], Optional[int]]:
+    """Fetch active miners, following paginated /api/miners envelopes when needed."""
+    first_payload = fetch(f"{base}/api/miners")
+    if not first_payload:
+        return [], None
+
+    miners, total, limit, offset = _extract_miners_payload(first_payload)
+    if total is None:
+        return miners, None
+
+    page_size = limit or len(miners) or 100
+    next_offset = offset + len(miners)
+    seen_offsets = {offset}
+
+    while len(miners) < total and next_offset not in seen_offsets:
+        seen_offsets.add(next_offset)
+        query = urlencode({"limit": page_size, "offset": next_offset})
+        page_payload = fetch(f"{base}/api/miners?{query}")
+        if not page_payload:
+            break
+
+        page_miners, page_total, page_limit, page_offset = _extract_miners_payload(page_payload)
+        if page_total is not None:
+            total = page_total
+        if page_limit:
+            page_size = page_limit
+        if not page_miners:
+            break
+
+        miners.extend(page_miners)
+        next_offset = page_offset + len(page_miners)
+
+    return miners, total
+
+
 def query_node(node: dict) -> dict:
     """Query all relevant endpoints for a single node."""
     base = node["url"]
@@ -255,10 +317,9 @@ def query_node(node: dict) -> dict:
         result["raw_data"]["spot_balance"] = balance_data
 
     # Miners list (for Merkle)
-    miners_data = fetch(f"{base}/api/miners")
-    if miners_data:
-        miners = miners_data if isinstance(miners_data, list) else miners_data.get("miners", [])
-        result["active_miner_count"] = len(miners)
+    miners, miner_total = fetch_miners(base)
+    if miners or miner_total is not None:
+        result["active_miner_count"] = miner_total if miner_total is not None else len(miners)
         result["merkle_root"] = compute_merkle_root(miners)
         result["raw_data"]["miners_sample"] = miners[:3]  # Save a sample, not all
 

--- a/tests/test_ledger_verify_miners_pagination.py
+++ b/tests/test_ledger_verify_miners_pagination.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for ledger verifier miner pagination."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "monitoring" / "ledger_verify.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("ledger_verify", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_query_node_fetches_paginated_miners_before_hashing(monkeypatch):
+    module = load_module()
+    fetched_urls = []
+    page_one = [{"miner_id": "alice"}, {"miner_id": "bob"}]
+    page_two = [{"miner_id": "carol"}]
+
+    def fake_fetch(url):
+        fetched_urls.append(url)
+        if url == "https://node.example/health":
+            return {"version": "1.0"}
+        if url == "https://node.example/epoch":
+            return {"epoch": 7, "slot": 3, "enrolled_miners": 3}
+        if url == "https://node.example/api/stats":
+            return {"total_balance": 42, "total_miners": 3}
+        if url == f"https://node.example/wallet/balance?miner_id={module.SPOT_CHECK_WALLET}":
+            return {"balance": 10}
+        if url == "https://node.example/api/miners":
+            return {
+                "miners": page_one,
+                "pagination": {"limit": 2, "offset": 0, "total": 3},
+            }
+        if url == "https://node.example/api/miners?limit=2&offset=2":
+            return {
+                "miners": page_two,
+                "pagination": {"limit": 2, "offset": 2, "total": 3},
+            }
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(module, "fetch", fake_fetch)
+
+    snapshot = module.query_node({
+        "name": "Example",
+        "url": "https://node.example",
+        "id": "node-a",
+    })
+
+    all_miners = page_one + page_two
+    assert snapshot["active_miner_count"] == 3
+    assert snapshot["merkle_root"] == module.compute_merkle_root(all_miners)
+    assert snapshot["raw_data"]["miners_sample"] == all_miners
+    assert "https://node.example/api/miners?limit=2&offset=2" in fetched_urls
+
+
+def test_fetch_miners_keeps_legacy_list_shape(monkeypatch):
+    module = load_module()
+    miners = [{"miner_id": "alice"}, {"miner_id": "bob"}]
+    fetched_urls = []
+
+    def fake_fetch(url):
+        fetched_urls.append(url)
+        return miners
+
+    monkeypatch.setattr(module, "fetch", fake_fetch)
+
+    assert module.fetch_miners("https://node.example") == (miners, None)
+    assert fetched_urls == ["https://node.example/api/miners"]


### PR DESCRIPTION
## Summary
- add a pagination-aware miner fetcher for the cross-node ledger verifier
- use the API pagination total for active miner counts while hashing all fetched miner pages
- cover current paginated envelopes and legacy list responses

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_ledger_verify_miners_pagination.py -q
- python3 -m py_compile monitoring/ledger_verify.py tests/test_ledger_verify_miners_pagination.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- monitoring/ledger_verify.py tests/test_ledger_verify_miners_pagination.py

Bounty context: Scottcjn/rustchain-bounties#71