### PR TITLE
fix: normalize chart widget miners payload

### DIFF
--- a/dashboards/chart-widget/chart-widget.html
+++ b/dashboards/chart-widget/chart-widget.html
@@ -490,6 +490,21 @@ function createChart(containerId, color) {
   return { chart, series: s };
 }
 
+function normalizeMinersPayload(payload) {
+  if (Array.isArray(payload)) {
+    return { miners: payload, total: payload.length };
+  }
+
+  const miners = Array.isArray(payload?.miners)
+    ? payload.miners
+    : (Array.isArray(payload?.data) ? payload.data : []);
+  const total = Number(payload?.pagination?.total);
+  return {
+    miners,
+    total: Number.isFinite(total) ? total : miners.length,
+  };
+}
+
 // ─── Fetch & init ──────────────────────────────────────────────────────────
 async function fetchData() {
   try {
@@ -501,13 +516,14 @@ async function fetchData() {
     if (!epochRes.ok || !minersRes.ok) throw new Error('API error');
 
     const epoch  = await epochRes.json();
-    const miners = await minersRes.json();
+    const minersPayload = await minersRes.json();
+    const { total: activeMiners } = normalizeMinersPayload(minersPayload);
 
     // Update stat cards
     document.getElementById('s-epoch').textContent  = epoch.epoch;
     document.getElementById('s-slot').textContent   = `slot ${epoch.slot.toLocaleString()}`;
     document.getElementById('s-miners').textContent = epoch.enrolled_miners;
-    document.getElementById('s-miner-sub').textContent = `${miners.length} attesting now`;
+    document.getElementById('s-miner-sub').textContent = `${activeMiners} attesting now`;
     document.getElementById('s-pot').textContent    = epoch.epoch_pot.toFixed(2);
     document.getElementById('s-supply').textContent = (epoch.total_supply_rtc / 1e6).toFixed(1) + 'M';
 

--- a/tests/test_chart_widget_miners_payload.py
+++ b/tests/test_chart_widget_miners_payload.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+"""Source checks for the chart widget miner payload handling."""
+
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "dashboards" / "chart-widget" / "chart-widget.html"
+
+
+def test_chart_widget_normalizes_current_miners_envelope():
+    html = SOURCE.read_text()
+
+    assert "function normalizeMinersPayload(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Number(payload?.pagination?.total)" in html
+    assert "const { total: activeMiners } = normalizeMinersPayload(minersPayload);" in html
+    assert "`${activeMiners} attesting now`" in html
+    assert "`${miners.length} attesting now`" not in html


### PR DESCRIPTION
## Summary
- normalize legacy list, current miners envelope, and data-array payloads in the chart widget
- use pagination.total when available so the attesting-now label does not render undefined for current /api/miners responses
- add a source regression test for the widget payload handling

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_chart_widget_miners_payload.py -q
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- dashboards/chart-widget/chart-widget.html tests/test_chart_widget_miners_payload.py

Bounty context: Scottcjn/rustchain-bounties#71