### PR TITLE
fix: normalize mining calculator miners payload

### DIFF
--- a/mining-calculator/index.html
+++ b/mining-calculator/index.html
@@ -463,6 +463,21 @@
             { multiplier: 1.15, count: 2 }, // Apple Silicon
             { multiplier: 1.0, count: 2 }   // Modern x86
         ];
+
+        function normalizeNetworkPayload(payload) {
+            if (Array.isArray(payload)) {
+                return { miners: payload, total: payload.length };
+            }
+
+            const miners = Array.isArray(payload?.miners)
+                ? payload.miners
+                : (Array.isArray(payload?.data) ? payload.data : []);
+            const total = Number(payload?.pagination?.total);
+            return {
+                miners,
+                total: Number.isFinite(total) ? total : miners.length
+            };
+        }
         
         async function fetchNetworkData() {
             try {
@@ -477,15 +492,16 @@
                     throw new Error('Network request failed');
                 }
                 
-                const miners = await response.json();
-                return miners;
+                const payload = await response.json();
+                return normalizeNetworkPayload(payload);
             } catch (error) {
                 console.log('Using default network data:', error);
                 return null;
             }
         }
         
-        function calculateTotalWeight(miners, userMultiplier) {
+        function calculateTotalWeight(networkData, userMultiplier) {
+            const miners = networkData?.miners || [];
             if (!miners || miners.length === 0) {
                 // Use default network composition
                 let total = 0;
@@ -500,6 +516,11 @@
             miners.forEach(miner => {
                 total += miner.multiplier || 1.0;
             });
+
+            if (networkData.total > miners.length) {
+                const averageMultiplier = total / miners.length;
+                total += (networkData.total - miners.length) * averageMultiplier;
+            }
             
             return total;
         }
@@ -526,15 +547,15 @@
             
             if (networkMode === 'auto') {
                 // Fetch from API
-                fetchNetworkData().then(miners => {
+                fetchNetworkData().then(networkData => {
                     loadingDiv.style.display = 'none';
                     
                     let totalWeight;
                     let activeMiners;
                     
-                    if (miners && miners.length > 0) {
-                        totalWeight = calculateTotalWeight(miners, userMultiplier);
-                        activeMiners = miners.length;
+                    if (networkData && networkData.miners.length > 0) {
+                        totalWeight = calculateTotalWeight(networkData, userMultiplier);
+                        activeMiners = networkData.total;
                     } else {
                         // Use default
                         totalWeight = calculateTotalWeight(null, userMultiplier);

--- a/tests/test_mining_calculator_miners_payload.py
+++ b/tests/test_mining_calculator_miners_payload.py
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: MIT
+"""Source checks for mining calculator miner payload handling."""
+
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "mining-calculator" / "index.html"
+
+
+def test_mining_calculator_normalizes_current_miners_envelope():
+    html = SOURCE.read_text()
+
+    assert "function normalizeNetworkPayload(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Number(payload?.pagination?.total)" in html
+    assert "return normalizeNetworkPayload(payload);" in html
+    assert "activeMiners = networkData.total;" in html
+    assert "const miners = networkData?.miners || [];" in html
+    assert "if (miners && miners.length > 0)" not in html


### PR DESCRIPTION
## Summary
- normalize legacy list, current miners envelope, and data-array payloads before mining calculator math
- use pagination.total for the active miner count when the current /api/miners response is paginated
- estimate missing page weight from the fetched page average instead of dropping back to stale defaults
- add a source regression test for the calculator payload path

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_mining_calculator_miners_payload.py -q
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- mining-calculator/index.html tests/test_mining_calculator_miners_payload.py

Bounty context: Scottcjn/rustchain-bounties#71