### PR TITLE
fix: normalize epoch viz miners payload

### DIFF
--- a/integrations/epoch-viz/index.html
+++ b/integrations/epoch-viz/index.html
@@ -357,6 +357,22 @@
         // State
         let epochData = null;
         let minersData = [];
+
+        function normalizeMinersPayload(payload) {
+            if (Array.isArray(payload)) {
+                return payload;
+            }
+
+            if (Array.isArray(payload?.miners)) {
+                return payload.miners;
+            }
+
+            if (Array.isArray(payload?.data)) {
+                return payload.data;
+            }
+
+            return [];
+        }
         
         // Fetch data from RustChain node
         async function fetchEpoch() {
@@ -372,7 +388,7 @@
         async function fetchMiners() {
             try {
                 const resp = await fetch(`${NODE_URL}/api/miners`);
-                minersData = await resp.json();
+                minersData = normalizeMinersPayload(await resp.json());
                 updateMinersDisplay();
                 updateWeightsChart();
             } catch (e) {

--- a/tests/test_epoch_viz_miners_payload.py
+++ b/tests/test_epoch_viz_miners_payload.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: MIT
+"""Source checks for epoch visualizer miner payload handling."""
+
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "integrations" / "epoch-viz" / "index.html"
+
+
+def test_epoch_viz_normalizes_current_miners_envelope():
+    html = SOURCE.read_text()
+
+    assert "function normalizeMinersPayload(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Array.isArray(payload?.data)" in html
+    assert "minersData = normalizeMinersPayload(await resp.json());" in html
+    assert "minersData = await resp.json();" not in html


### PR DESCRIPTION
## Summary
- normalize legacy list, current miners envelope, and data-array payloads before storing epoch visualizer miner state
- keep miner list rendering, reward math, and weight chart array methods working with current /api/miners responses
- add a source regression test for the visualizer payload path

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_epoch_viz_miners_payload.py -q
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- integrations/epoch-viz/index.html tests/test_epoch_viz_miners_payload.py

Bounty context: Scottcjn/rustchain-bounties#71