### PR TITLE
fix: count live stats miners envelope

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -135,6 +135,27 @@
 
     <script>
         const API_BASE = 'https://rustchain.org';
+
+        function getMinerCount(payload) {
+            if (Array.isArray(payload)) {
+                return payload.length;
+            }
+
+            const paginationTotal = Number(payload?.pagination?.total);
+            if (Number.isFinite(paginationTotal)) {
+                return paginationTotal;
+            }
+
+            if (Array.isArray(payload?.miners)) {
+                return payload.miners.length;
+            }
+
+            if (Array.isArray(payload?.data)) {
+                return payload.data.length;
+            }
+
+            return Number(payload?.count) || 0;
+        }
         
         async function fetchStats() {
             try {
@@ -163,7 +184,7 @@
                 // Miners
                 if (minersRes && minersRes.ok) {
                     const miners = await minersRes.json();
-                    document.getElementById('miners').textContent = miners.count || miners.length || '0';
+                    document.getElementById('miners').textContent = getMinerCount(miners);
                 } else {
                     document.getElementById('miners').textContent = '?';
                 }

--- a/tests/test_live_stats_dashboard_miners_payload.py
+++ b/tests/test_live_stats_dashboard_miners_payload.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: MIT
+"""Source checks for the live stats dashboard miner count."""
+
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parents[1] / "dashboard" / "index.html"
+
+
+def test_live_stats_dashboard_counts_current_miners_envelope():
+    html = SOURCE.read_text()
+
+    assert "function getMinerCount(payload)" in html
+    assert "Number(payload?.pagination?.total)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Array.isArray(payload?.data)" in html
+    assert "getMinerCount(miners)" in html
+    assert "miners.count || miners.length || '0'" not in html


### PR DESCRIPTION
## Summary
- add a miner count helper for the root live-stats dashboard
- support legacy list responses, current paginated miners envelopes, data arrays, and count fields
- prevent current /api/miners responses from rendering active miners as 0

## Validation
- uv run --no-project --with pytest --with flask python -m pytest tests/test_live_stats_dashboard_miners_payload.py -q
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- dashboard/index.html tests/test_live_stats_dashboard_miners_payload.py

Bounty context: Scottcjn/rustchain-bounties#71