### PR TITLE
fix: validate hall leaderboard limits

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -280,7 +280,9 @@ def rust_leaderboard():
         conn.row_factory = sqlite3.Row
         c = conn.cursor()
         
-        limit = request.args.get('limit', 50, type=int)
+        limit, error_response = _parse_limit_arg()
+        if error_response:
+            return error_response
         
         c.execute("""
             SELECT fingerprint_hash, miner_id, device_arch, device_model,

--- a/node/tests/test_hall_of_rust_limit_validation.py
+++ b/node/tests/test_hall_of_rust_limit_validation.py
@@ -22,6 +22,15 @@ def test_leaderboard_rejects_non_integer_limit(tmp_path):
     assert response.get_data(as_text=True) == "limit must be an integer"
 
 
+def test_legacy_leaderboard_rejects_non_integer_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/hall/leaderboard?limit=abc")
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "limit must be an integer"
+
+
 def test_leaderboard_rejects_negative_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
@@ -31,10 +40,29 @@ def test_leaderboard_rejects_negative_limit(tmp_path):
     assert response.get_data(as_text=True) == "limit must be non-negative"
 
 
+def test_legacy_leaderboard_rejects_negative_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/hall/leaderboard?limit=-1")
+
+    assert response.status_code == 400
+    assert response.get_data(as_text=True) == "limit must be non-negative"
+
+
 def test_leaderboard_uses_default_for_empty_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
     response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=")
+
+    assert response.status_code == 200
+    assert response.get_json()["leaderboard"] == []
+    assert response.get_json()["total_machines"] == 0
+
+
+def test_legacy_leaderboard_uses_default_for_empty_limit(tmp_path):
+    app = _app_with_hall_db(tmp_path)
+
+    response = app.test_client().get("/hall/leaderboard?limit=")
 
     assert response.status_code == 200
     assert response.get_json()["leaderboard"] == []


### PR DESCRIPTION
## Summary
- route legacy /hall/leaderboard through the same explicit limit parser used by the Hall of Fame API
- reject non-integer and negative limits instead of silently defaulting or allowing unbounded SQLite LIMIT behavior
- extend Hall of Rust limit regression coverage for both leaderboard routes

## Validation
- uv run --no-project --with pytest --with flask python -m pytest node/tests/test_hall_of_rust_limit_validation.py -q
- python3 -m py_compile node/hall_of_rust.py node/tests/test_hall_of_rust_limit_validation.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- node/hall_of_rust.py node/tests/test_hall_of_rust_limit_validation.py

Bounty context: Scottcjn/rustchain-bounties#71