### PR TITLE
fix: normalize rip sync miner rows

### DIFF
--- a/node/rip_node_sync.py
+++ b/node/rip_node_sync.py
@@ -35,6 +35,25 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+def _normalize_peer_rows(payload, key: str) -> List[Dict]:
+    """Normalize legacy list and envelope payloads into attestation dictionaries."""
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = payload.get(key, [])
+    else:
+        return []
+
+    normalized = []
+    for row in rows if isinstance(rows, list) else []:
+        if not isinstance(row, dict):
+            continue
+        miner = row.get("miner") or row.get("miner_id") or row.get("id")
+        if not miner:
+            continue
+        normalized.append({**row, "miner": miner})
+    return normalized
+
 def get_local_attestations() -> Set[str]:
     """Get all miner IDs currently in local attestation pool"""
     try:
@@ -52,12 +71,12 @@ def fetch_peer_attestations(peer_url: str) -> List[Dict]:
         # Try to get attestations from peer's API
         resp = requests.get(f"{peer_url}/api/attestations", timeout=10)
         if resp.status_code == 200:
-            return resp.json().get("attestations", [])
+            return _normalize_peer_rows(resp.json(), "attestations")
         
         # Fallback: get miner list
         resp = requests.get(f"{peer_url}/api/miners", timeout=10)
         if resp.status_code == 200:
-            return resp.json().get("miners", [])
+            return _normalize_peer_rows(resp.json(), "miners")
     except Exception as e:
         logger.warning(f"Failed to fetch from {peer_url}: {e}")
     return []

--- a/tests/test_rip_node_sync_miners.py
+++ b/tests/test_rip_node_sync_miners.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for RIP node sync miner payload normalization."""
+
+from node import rip_node_sync
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_fetch_peer_attestations_accepts_current_miners_envelope(monkeypatch):
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append((url, timeout))
+        if url.endswith("/api/attestations"):
+            return FakeResponse(404, {"error": "not found"})
+        return FakeResponse(200, {
+            "miners": [
+                {"miner_id": "alice", "device_arch": "G4"},
+                {"id": "bob", "device_arch": "x86"},
+                {"device_arch": "missing-id"},
+            ],
+            "pagination": {"total": 3, "limit": 100, "offset": 0},
+        })
+
+    monkeypatch.setattr(rip_node_sync.requests, "get", fake_get)
+
+    assert rip_node_sync.fetch_peer_attestations("https://peer.example") == [
+        {"miner_id": "alice", "device_arch": "G4", "miner": "alice"},
+        {"id": "bob", "device_arch": "x86", "miner": "bob"},
+    ]
+    assert calls == [
+        ("https://peer.example/api/attestations", 10),
+        ("https://peer.example/api/miners", 10),
+    ]
+
+
+def test_fetch_peer_attestations_accepts_legacy_list_payload(monkeypatch):
+    def fake_get(url, timeout):
+        if url.endswith("/api/attestations"):
+            return FakeResponse(200, [{"miner": "carol", "device_arch": "POWER8"}])
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(rip_node_sync.requests, "get", fake_get)
+
+    assert rip_node_sync.fetch_peer_attestations("https://peer.example") == [
+        {"miner": "carol", "device_arch": "POWER8"},
+    ]


### PR DESCRIPTION
## Summary
- normalize peer attestation and miner fallback payloads from legacy lists and current API envelopes
- map miner_id/id fallbacks into the miner key expected by the RIP sync merge path
- skip malformed peer rows before syncing them into the local attestation pool

## Validation
- uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_rip_node_sync_miners.py -q
- python3 -m py_compile node/rip_node_sync.py tests/test_rip_node_sync_miners.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- node/rip_node_sync.py tests/test_rip_node_sync_miners.py

Bounty context: Scottcjn/rustchain-bounties#71