### PR TITLE
fix: normalize beacon site miner rows

### DIFF
--- a/site/beacon/data.js
+++ b/site/beacon/data.js
@@ -521,6 +521,23 @@ function minerToAtlas(m) {
   };
 }
 
+function normalizeMinerRows(payload) {
+  const rows = Array.isArray(payload)
+    ? payload
+    : (Array.isArray(payload?.miners)
+      ? payload.miners
+      : (Array.isArray(payload?.data)
+        ? payload.data
+        : (Array.isArray(payload?.items) ? payload.items : [])));
+
+  return rows.map(row => {
+    if (!row || typeof row !== 'object') return null;
+    const miner = row.miner || row.miner_id || row.id;
+    if (!miner) return null;
+    return { ...row, miner: String(miner) };
+  }).filter(Boolean);
+}
+
 // ============================================================
 // fetchAllAgents() — main data loader called from boot
 // Fetches from all APIs, merges by name, tags sources
@@ -631,8 +648,7 @@ export async function fetchAllAgents(apiBase) {
   try {
     const resp = await fetch('https://rustchain.org/api/miners');
     if (resp.ok) {
-      const miners = await resp.json();
-      const minerList = miners.miners || miners;
+      const minerList = normalizeMinerRows(await resp.json());
       runtime.__rustchain = { miners: minerList, count: minerList.length };
       for (const m of minerList) {
         const canonicalId = resolveFromAliasMap(aliasMap, m.miner);

--- a/tests/test_beacon_site_miners_normalization.py
+++ b/tests/test_beacon_site_miners_normalization.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+JS = Path("site/beacon/data.js").read_text(encoding="utf-8")
+
+
+def test_beacon_site_normalizes_miner_payload_envelopes():
+    assert "function normalizeMinerRows(payload)" in JS
+    assert "Array.isArray(payload?.miners)" in JS
+    assert "Array.isArray(payload?.data)" in JS
+    assert "Array.isArray(payload?.items)" in JS
+    assert "const minerList = normalizeMinerRows(await resp.json());" in JS
+
+
+def test_beacon_site_normalizes_miner_row_ids_before_rendering():
+    assert "const miner = row.miner || row.miner_id || row.id;" in JS
+    assert "return { ...row, miner: String(miner) };" in JS
+    assert "}).filter(Boolean);" in JS
+    assert "runtime.__rustchain = { miners: minerList, count: minerList.length };" in JS


### PR DESCRIPTION
## Summary
- normalize Beacon site RustChain miner responses from raw arrays and miners/data/items envelopes
- map miner_id/id rows to miner before Atlas rendering
- skip malformed miner rows so one bad entry does not abort the loader

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_beacon_site_miners_normalization.py -q
- node --check site/beacon/data.js
- python3 -m py_compile tests/test_beacon_site_miners_normalization.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- site/beacon/data.js tests/test_beacon_site_miners_normalization.py

Bounty context: Scottcjn/rustchain-bounties#71