### PR TITLE
fix: normalize wallet tracker miner rows

### DIFF
--- a/tests/test_wallet_tracker_frontend_security.py
+++ b/tests/test_wallet_tracker_frontend_security.py
@@ -18,3 +18,22 @@ def test_wallet_tracker_escapes_wallet_ids_and_founder_labels():
     assert "<strong>${w.id}</strong>" not in html
     assert "${w.id}\n" not in html
     assert "+ w.founderLabel +" not in html
+
+
+def test_wallet_tracker_normalizes_miner_payload_envelopes():
+    html = TRACKER_HTML.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Array.isArray(payload?.data)" in html
+    assert "Array.isArray(payload?.items)" in html
+    assert "const miners = normalizeMinerRows(await minersResponse.json());" in html
+
+
+def test_wallet_tracker_normalizes_miner_row_ids_before_balance_fetch():
+    html = TRACKER_HTML.read_text(encoding="utf-8")
+
+    assert "const miner = row.miner || row.miner_id || row.id;" in html
+    assert "return { ...row, miner: String(miner) };" in html
+    assert "}).filter(Boolean);" in html
+    assert "const balance = await getBalance(miner.miner);" in html

--- a/wallet-tracker/rtc-wallet-tracker.html
+++ b/wallet-tracker/rtc-wallet-tracker.html
@@ -378,6 +378,23 @@
             return `<span class="${className}">${escapeHtml(w.founderLabel)}</span>`;
         }
 
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload)
+                ? payload
+                : (Array.isArray(payload?.miners)
+                    ? payload.miners
+                    : (Array.isArray(payload?.data)
+                        ? payload.data
+                        : (Array.isArray(payload?.items) ? payload.items : [])));
+
+            return rows.map(row => {
+                if (!row || typeof row !== 'object') return null;
+                const miner = row.miner || row.miner_id || row.id;
+                if (!miner) return null;
+                return { ...row, miner: String(miner) };
+            }).filter(Boolean);
+        }
+
         async function getBalance(minerId) {
             try {
                 const response = await fetch(`${BALANCE_API_URL}?miner_id=${encodeURIComponent(minerId)}`);
@@ -403,7 +420,7 @@
                 const minersResponse = await fetch(MINERS_API_URL);
                 if (!minersResponse.ok) throw new Error('Failed to fetch miners');
 
-                const miners = await minersResponse.json();
+                const miners = normalizeMinerRows(await minersResponse.json());
                 console.log(`Found ${miners.length} miners`);
 
                 // Fetch balances for all miners


### PR DESCRIPTION
## Summary
- normalize wallet tracker miner responses from raw arrays and miners/data/items envelopes
- map miner_id/id rows to miner before balance lookups
- skip malformed miner rows instead of aborting wallet loading

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_wallet_tracker_frontend_security.py -q
- python3 -m py_compile tests/test_wallet_tracker_frontend_security.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- wallet-tracker/rtc-wallet-tracker.html tests/test_wallet_tracker_frontend_security.py

Bounty context: Scottcjn/rustchain-bounties#71