### PR TITLE
fix: normalize earnings calculator miner rows

### DIFF
--- a/tests/test_earnings_calculator_miners_payload.py
+++ b/tests/test_earnings_calculator_miners_payload.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+HTML = Path("tools/earnings_calculator.html").read_text(encoding="utf-8")
+
+
+def test_earnings_calculator_normalizes_miner_payload_envelopes():
+    assert "function normalizeMinerRows(payload)" in HTML
+    assert "Array.isArray(payload?.miners)" in HTML
+    assert "Array.isArray(payload?.data)" in HTML
+    assert "Array.isArray(payload?.items)" in HTML
+    assert "const miners = normalizeMinerRows(await res.json());" in HTML
+
+
+def test_earnings_calculator_ignores_malformed_multiplier_rows():
+    assert "rows.filter(row => row && typeof row === 'object')" in HTML
+    assert "acc + (Number(m.antiquity_multiplier) || 0)" in HTML
+    assert "const liveNetworkSum = miners.reduce((acc, m) =>" in HTML
+    assert "if (liveNetworkSum > 0) networkSum = liveNetworkSum;" in HTML

--- a/tools/earnings_calculator.html
+++ b/tools/earnings_calculator.html
@@ -200,11 +200,24 @@
 
         let networkSum = 20.0; // Fallback sum if API fails
 
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload)
+                ? payload
+                : (Array.isArray(payload?.miners)
+                    ? payload.miners
+                    : (Array.isArray(payload?.data)
+                        ? payload.data
+                        : (Array.isArray(payload?.items) ? payload.items : [])));
+
+            return rows.filter(row => row && typeof row === 'object');
+        }
+
         async function init() {
             try {
                 const res = await fetch(API_MINERS);
-                const miners = await res.json();
-                networkSum = miners.reduce((acc, m) => acc + m.antiquity_multiplier, 0);
+                const miners = normalizeMinerRows(await res.json());
+                const liveNetworkSum = miners.reduce((acc, m) => acc + (Number(m.antiquity_multiplier) || 0), 0);
+                if (liveNetworkSum > 0) networkSum = liveNetworkSum;
                 document.getElementById('loading-bar').style.display = 'none';
             } catch (e) {
                 document.getElementById('loading-bar').innerHTML = "⚠️ Using cached network stats (Node unreachable)";


### PR DESCRIPTION
## Summary
- normalize earnings calculator miner responses from raw arrays and miners/data/items envelopes
- ignore malformed miner rows and non-numeric multipliers
- preserve the cached network fallback unless the live payload produces a positive multiplier sum

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_earnings_calculator_miners_payload.py -q
- python3 -m py_compile tests/test_earnings_calculator_miners_payload.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/earnings_calculator.html tests/test_earnings_calculator_miners_payload.py

Bounty context: Scottcjn/rustchain-bounties#71