### PR TITLE
fix: normalize standalone miner dashboard rows

### DIFF
--- a/tests/test_standalone_miner_dashboard_security.py
+++ b/tests/test_standalone_miner_dashboard_security.py
@@ -28,3 +28,22 @@ def test_fleet_rows_do_not_render_api_fields_with_inner_html():
     assert "appendTextCell(tr, m.machine);" in html
     assert "appendTextCell(tr, m.arch);" in html
     assert 'appendTextCell(tr, m.badge || "-");' in html
+
+
+def test_miner_dashboard_normalizes_miner_payload_envelopes():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "Array.isArray(payload?.miners)" in html
+    assert "Array.isArray(payload?.data)" in html
+    assert "Array.isArray(payload?.items)" in html
+    assert "const miners = normalizeMinerRows(minersRes);" in html
+
+
+def test_miner_dashboard_normalizes_miner_row_ids_before_lookup():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "const miner = row.miner || row.miner_id || row.id;" in html
+    assert 'return Object.assign({}, row, { miner: String(miner) });' in html
+    assert "}).filter(Boolean);" in html
+    assert 'String(m.miner || "").toLowerCase() === minerId.toLowerCase()' in html

--- a/tools/miner_dashboard/index.html
+++ b/tools/miner_dashboard/index.html
@@ -445,6 +445,23 @@
       return null;
     }
 
+    function normalizeMinerRows(payload) {
+      const rows = Array.isArray(payload)
+        ? payload
+        : (Array.isArray(payload?.miners)
+          ? payload.miners
+          : (Array.isArray(payload?.data)
+            ? payload.data
+            : (Array.isArray(payload?.items) ? payload.items : [])));
+
+      return rows.map(row => {
+        if (!row || typeof row !== "object") return null;
+        const miner = row.miner || row.miner_id || row.id;
+        if (!miner) return null;
+        return Object.assign({}, row, { miner: String(miner) });
+      }).filter(Boolean);
+    }
+
     function badgeByScore(score) {
       const s = Number(score) || 0;
       if (s >= 240) return "Oxidized Titan";
@@ -731,7 +748,7 @@
           getJson(API_BASE + "/epoch")
         ]);
 
-        const miners = Array.isArray(minersRes) ? minersRes : (minersRes.miners || []);
+        const miners = normalizeMinerRows(minersRes);
         const minerRow = miners.find(m => String(m.miner || "").toLowerCase() === minerId.toLowerCase()) || null;
         const hallRows = normalizeHallRows(hofRes);
         const hallRow = findHallProfile(hallRows, minerId);


### PR DESCRIPTION
## Summary
- normalize standalone miner dashboard responses from raw arrays and miners/data/items envelopes
- map miner_id/id rows to miner before selected-miner lookup
- skip malformed miner rows before fleet rendering

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_standalone_miner_dashboard_security.py -q
- python3 -m py_compile tests/test_standalone_miner_dashboard_security.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/miner_dashboard/index.html tests/test_standalone_miner_dashboard_security.py

Bounty context: Scottcjn/rustchain-bounties#71