### PR TITLE
fix: render tools miner dashboard rows safely

### DIFF
--- a/tests/test_tools_miner_dashboard_html_security.py
+++ b/tests/test_tools_miner_dashboard_html_security.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+
+HTML = Path("tools/miner-dashboard.html").read_text(encoding="utf-8")
+
+
+def test_tools_miner_dashboard_uses_text_cells_for_reward_rows():
+    assert "function appendTextCell(row, text, className)" in HTML
+    assert "appendTextCell(row, reward.epoch);" in HTML
+    assert "appendTextCell(row, reward.amount);" in HTML
+    assert "appendTextCell(row, new Date(reward.timestamp).toLocaleString());" in HTML
+    assert "appendTextCell(row, '✓ Confirmed', 'status-success');" in HTML
+
+    assert "<td>${reward.epoch}</td>" not in HTML
+    assert "<td>${reward.amount}</td>" not in HTML
+
+
+def test_tools_miner_dashboard_uses_text_cells_for_activity_rows():
+    assert "appendTextCell(row, activity.type);" in HTML
+    assert "appendTextCell(row, activity.details);" in HTML
+    assert "appendTextCell(row, new Date(activity.timestamp).toLocaleString());" in HTML
+
+    assert "<td>${activity.type}</td>" not in HTML
+    assert "<td>${activity.details}</td>" not in HTML
+
+
+def test_tools_miner_dashboard_empty_rows_use_text_content():
+    assert "function renderEmptyRow(tbody, colSpan, message)" in HTML
+    assert "cell.textContent = message;" in HTML
+    assert "renderEmptyRow(rewardTable, 4, 'No rewards yet');" in HTML
+    assert "renderEmptyRow(activityTable, 3, 'No recent activity');" in HTML
+
+    assert "rewardTable.innerHTML = '<tr><td colspan=\"4\"" not in HTML
+    assert "activityTable.innerHTML = '<tr><td colspan=\"3\"" not in HTML

--- a/tools/miner-dashboard.html
+++ b/tools/miner-dashboard.html
@@ -226,6 +226,22 @@
                 loadMinerData();
             }
         };
+
+        function appendTextCell(row, text, className) {
+            const cell = row.insertCell();
+            if (className) cell.className = className;
+            cell.textContent = String(text ?? '');
+            return cell;
+        }
+
+        function renderEmptyRow(tbody, colSpan, message) {
+            const row = tbody.insertRow();
+            const cell = row.insertCell();
+            cell.colSpan = colSpan;
+            cell.style.textAlign = 'center';
+            cell.style.color = '#999';
+            cell.textContent = message;
+        }
         
         async function loadMinerData() {
             const minerId = document.getElementById('minerId').value.trim();
@@ -258,15 +274,13 @@
                 if (data.rewards && data.rewards.length > 0) {
                     data.rewards.forEach(reward => {
                         const row = rewardTable.insertRow();
-                        row.innerHTML = `
-                            <td>${reward.epoch}</td>
-                            <td>${reward.amount}</td>
-                            <td>${new Date(reward.timestamp).toLocaleString()}</td>
-                            <td class="status-success">✓ Confirmed</td>
-                        `;
+                        appendTextCell(row, reward.epoch);
+                        appendTextCell(row, reward.amount);
+                        appendTextCell(row, new Date(reward.timestamp).toLocaleString());
+                        appendTextCell(row, '✓ Confirmed', 'status-success');
                     });
                 } else {
-                    rewardTable.innerHTML = '<tr><td colspan="4" style="text-align: center; color: #999;">No rewards yet</td></tr>';
+                    renderEmptyRow(rewardTable, 4, 'No rewards yet');
                 }
                 
                 // Update activity history
@@ -275,14 +289,12 @@
                 if (data.activity && data.activity.length > 0) {
                     data.activity.forEach(activity => {
                         const row = activityTable.insertRow();
-                        row.innerHTML = `
-                            <td>${activity.type}</td>
-                            <td>${activity.details}</td>
-                            <td>${new Date(activity.timestamp).toLocaleString()}</td>
-                        `;
+                        appendTextCell(row, activity.type);
+                        appendTextCell(row, activity.details);
+                        appendTextCell(row, new Date(activity.timestamp).toLocaleString());
                     });
                 } else {
-                    activityTable.innerHTML = '<tr><td colspan="3" style="text-align: center; color: #999;">No recent activity</td></tr>';
+                    renderEmptyRow(activityTable, 3, 'No recent activity');
                 }
                 
                 document.getElementById('dashboard').style.display = 'block';


### PR DESCRIPTION
## Summary
- replace reward/activity row innerHTML rendering in tools/miner-dashboard.html with textContent cells
- render empty table states through DOM nodes instead of HTML strings
- add regression coverage for reward, activity, and empty row rendering

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_tools_miner_dashboard_html_security.py -q
- python3 -m py_compile tests/test_tools_miner_dashboard_html_security.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/miner-dashboard.html tests/test_tools_miner_dashboard_html_security.py

Bounty context: Scottcjn/rustchain-bounties#71