### PR TITLE
fix: normalize standalone leaderboard rows

### DIFF
--- a/tests/test_standalone_leaderboard_security.py
+++ b/tests/test_standalone_leaderboard_security.py
@@ -8,7 +8,17 @@ def test_leaderboard_normalizes_current_miners_api_envelope():
     html = LEADERBOARD_HTML.read_text(encoding="utf-8")
 
     assert "const minersPayload = await minersRes.json();" in html
-    assert "minersPayload.miners || minersPayload.data || []" in html
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload.miners || payload.data || payload.items || []" in html
+    assert "const miners = normalizeMinerRows(minersPayload);" in html
+
+
+def test_leaderboard_normalizes_miner_row_ids():
+    html = LEADERBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "const miner = row.miner || row.miner_id || row.id;" in html
+    assert "return { ...row, miner: String(miner) };" in html
+    assert "}).filter(Boolean);" in html
 
 
 def test_leaderboard_rows_do_not_render_miner_fields_with_inner_html():
@@ -21,3 +31,12 @@ def test_leaderboard_rows_do_not_render_miner_fields_with_inner_html():
     assert "function appendTextCell(row, text)" in html
     assert "minerCell.title = miner;" in html
     assert "badge.textContent = isVintage ? 'Vintage' : 'Modern';" in html
+
+
+def test_leaderboard_error_row_uses_text_content():
+    html = LEADERBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "function renderErrorRow(err)" in html
+    assert "cell.textContent = `Error: ${err.message}." in html
+    assert "renderErrorRow(err);" in html
+    assert 'class="error">Error: ${err.message}' not in html

--- a/tools/leaderboard.html
+++ b/tools/leaderboard.html
@@ -200,18 +200,37 @@
                 if (!minersRes) throw new Error('Could not connect to RustChain node');
 
                 const minersPayload = await minersRes.json();
-                const miners = Array.isArray(minersPayload)
-                    ? minersPayload
-                    : (minersPayload.miners || minersPayload.data || []);
+                const miners = normalizeMinerRows(minersPayload);
                 const epochData = epochRes ? await epochRes.json() : {};
 
                 updateStats(miners, epochData);
                 updateTable(miners);
             } catch (err) {
-                document.getElementById('leaderboard-body').innerHTML = `
-                    <tr><td colspan="5" class="error">Error: ${err.message}<br>Make sure you've accepted the self-signed certificate at https://rustchain.org</td></tr>
-                `;
+                renderErrorRow(err);
             }
+        }
+
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload)
+                ? payload
+                : (payload.miners || payload.data || payload.items || []);
+
+            return rows.map(row => {
+                if (!row || typeof row !== 'object') return null;
+                const miner = row.miner || row.miner_id || row.id;
+                if (!miner) return null;
+                return { ...row, miner: String(miner) };
+            }).filter(Boolean);
+        }
+
+        function renderErrorRow(err) {
+            const tbody = document.getElementById('leaderboard-body');
+            tbody.innerHTML = '';
+            const row = tbody.insertRow();
+            const cell = row.insertCell();
+            cell.colSpan = 5;
+            cell.className = 'error';
+            cell.textContent = `Error: ${err.message}. Make sure you've accepted the self-signed certificate at https://rustchain.org`;
         }
 
         function updateStats(miners, epochData) {


### PR DESCRIPTION
## Summary
- normalize standalone leaderboard miner responses through a helper that accepts arrays and miners/data/items envelopes
- map miner_id/id fields to miner before rendering rows
- render leaderboard error rows via textContent instead of interpolated innerHTML

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_standalone_leaderboard_security.py -q
- python3 -m py_compile tests/test_standalone_leaderboard_security.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- tools/leaderboard.html tests/test_standalone_leaderboard_security.py

Bounty context: Scottcjn/rustchain-bounties#71