### PR TITLE
fix: normalize network status miner rows

### DIFF
--- a/docs/network-status.html
+++ b/docs/network-status.html
@@ -107,6 +107,18 @@
       return escapeHtml(value ?? fallback);
     }
 
+    function normalizeMinerRows(payload) {
+      const rows = Array.isArray(payload)
+        ? payload
+        : (payload?.miners || payload?.data || payload?.items || []);
+
+      return rows.filter(row => row && typeof row === 'object');
+    }
+
+    function minerArch(row) {
+      return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';
+    }
+
     async function fetchJson(url) {
       const r = await fetch(url, { cache: 'no-store' });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -287,12 +299,12 @@
 
       try {
         const miners = await fetchJson(`${base}/api/miners`);
-        const list = Array.isArray(miners) ? miners : (miners.miners || []);
+        const list = normalizeMinerRows(miners);
         document.getElementById('minerCount').textContent = String(list.length);
 
         const counts = {};
         for (const m of list) {
-          const key = m.arch || m.family || m.machine || 'unknown';
+          const key = minerArch(m);
           counts[key] = (counts[key] || 0) + 1;
         }
         const total = list.length || 1;

--- a/tests/test_docs_network_status_security.py
+++ b/tests/test_docs_network_status_security.py
@@ -41,3 +41,20 @@ def test_architecture_breakdown_escapes_miner_fields():
 
     assert "<span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span>" in html
     assert "<span>${arch}</span><span>${n} (${pct}%)</span>" not in html
+
+
+def test_network_status_normalizes_current_miners_api_envelopes():
+    html = source()
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload?.miners || payload?.data || payload?.items || []" in html
+    assert "const list = normalizeMinerRows(miners);" in html
+    assert "rows.filter(row => row && typeof row === 'object')" in html
+
+
+def test_network_status_architecture_breakdown_uses_current_miner_fields():
+    html = source()
+
+    assert "function minerArch(row)" in html
+    assert "return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';" in html
+    assert "const key = minerArch(m);" in html


### PR DESCRIPTION
## Summary
- normalize docs network-status miner responses from raw arrays and miners/data/items envelopes
- ignore malformed miner rows before counting architecture diversity
- include current device_arch/device_family fields in the architecture breakdown

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_docs_network_status_security.py -q
- python3 -m py_compile tests/test_docs_network_status_security.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check -- docs/network-status.html tests/test_docs_network_status_security.py

Bounty context: Scottcjn/rustchain-bounties#71