### PR TITLE
fix: normalize museum miner rows

### DIFF
--- a/tests/test_museum3d_frontend_security.py
+++ b/tests/test_museum3d_frontend_security.py
@@ -10,3 +10,14 @@ def test_museum3d_detail_panel_uses_text_nodes_for_miner_fields():
     assert "kv.appendChild(key);" in script
     assert "kv.appendChild(value);" in script
     assert 'kv.innerHTML = `<div class="k">${k}</div><div class="v">${String(v || \'\')}</div>`;' not in script
+
+
+def test_museum3d_normalizes_current_miners_api_envelope():
+    script_path = Path(__file__).resolve().parents[1] / "web" / "museum" / "museum3d.js"
+    script = script_path.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in script
+    assert "payload?.miners || payload?.data || payload?.items || []" in script
+    assert "miner: m.miner || m.miner_id || m.id || m.name || ''" in script
+    assert "const list = normalizeMinerRows(miners);" in script
+    assert "const list = Array.isArray(miners) ? miners : (miners?.miners || []);" not in script

--- a/tests/test_museum_frontend_security.py
+++ b/tests/test_museum_frontend_security.py
@@ -9,3 +9,14 @@ def test_museum_architecture_legend_uses_text_nodes_for_miner_fields():
     assert "legend.appendChild(document.createElement('br'));" in script
     assert "legend.appendChild(document.createTextNode(legendEntries[i]));" in script
     assert "legend.innerHTML = entries.slice(0, 6).map(([n, c]) => `${c}x ${n}`).join('<br>')" not in script
+
+
+def test_museum_normalizes_current_miners_api_envelope():
+    script_path = Path(__file__).resolve().parents[1] / "web" / "museum" / "museum.js"
+    script = script_path.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in script
+    assert "payload?.miners || payload?.data || payload?.items || []" in script
+    assert "miner: m.miner || m.miner_id || m.id || m.name || ''" in script
+    assert "state.miners = normalizeMinerRows(miners);" in script
+    assert "state.miners = Array.isArray(miners) ? miners : (miners?.miners || []);" not in script

--- a/web/museum/museum.js
+++ b/web/museum/museum.js
@@ -54,6 +54,18 @@
     return await r.json();
   }
 
+  function normalizeMinerRows(payload) {
+    const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+    if (!Array.isArray(rows)) return [];
+    return rows
+      .filter((m) => m && typeof m === 'object')
+      .map((m) => ({
+        ...m,
+        miner: m.miner || m.miner_id || m.id || m.name || '',
+      }))
+      .filter((m) => m.miner);
+  }
+
   async function fetchJson(url) {
     const r = await fetch(url, { cache: 'no-store' });
     if (!r.ok) return null;
@@ -361,7 +373,7 @@
 
     state.stats = stats;
     state.epoch = epoch;
-    state.miners = Array.isArray(miners) ? miners : (miners?.miners || []);
+    state.miners = normalizeMinerRows(miners);
     state.hunters = hunters;
     state.lastLoaded = Date.now();
 

--- a/web/museum/museum3d.js
+++ b/web/museum/museum3d.js
@@ -375,6 +375,18 @@ import { OrbitControls } from './vendor/OrbitControls.js';
     return await r.json();
   }
 
+  function normalizeMinerRows(payload) {
+    const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+    if (!Array.isArray(rows)) return [];
+    return rows
+      .filter((m) => m && typeof m === 'object')
+      .map((m) => ({
+        ...m,
+        miner: m.miner || m.miner_id || m.id || m.name || '',
+      }))
+      .filter((m) => m.miner);
+  }
+
   function placeMachines(miners) {
     // deterministic layout within each wing
     const byWing = { vintage: [], modern: [], other: [] };
@@ -544,7 +556,7 @@ import { OrbitControls } from './vendor/OrbitControls.js';
   async function refresh() {
     try {
       const miners = await api('/api/miners');
-      const list = Array.isArray(miners) ? miners : (miners?.miners || []);
+      const list = normalizeMinerRows(miners);
       placeMachines(list);
 
       const now = Date.now() / 1000;


### PR DESCRIPTION
## Summary
- normalize 2D and 3D museum `/api/miners` responses from raw arrays plus `miners`, `data`, and `items` envelopes
- map current miner identifiers from `miner`, `miner_id`, `id`, or `name` before rendering and machine placement
- extend existing static museum frontend tests to lock in the normalized response handling

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_museum_frontend_security.py tests/test_museum3d_frontend_security.py -q`
- `python3 -m py_compile tests/test_museum_frontend_security.py tests/test_museum3d_frontend_security.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- web/museum/museum.js web/museum/museum3d.js tests/test_museum_frontend_security.py tests/test_museum3d_frontend_security.py`

Bounty context: Scottcjn/rustchain-bounties#71