### PR TITLE
fix: normalize rtc distribution miner rows

### DIFF
--- a/tests/test_rtc_distribution_dashboard_security.py
+++ b/tests/test_rtc_distribution_dashboard_security.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+DASHBOARD_HTML = (
+    Path(__file__).resolve().parents[1]
+    / "web"
+    / "rtc-distribution-dashboard.html"
+)
+
+
+def test_distribution_dashboard_normalizes_current_miners_api_envelope():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload?.miners || payload?.data || payload?.items || []" in html
+    assert "const list = normalizeMinerRows(data);" in html
+    assert "item.miner || item.miner_id || item.id || item.name" in html
+    assert "const list = Array.isArray(data) ? data : data.miners || [];" not in html
+    assert "const ids = list.map((item) => item.miner).filter(Boolean);" not in html

--- a/web/rtc-distribution-dashboard.html
+++ b/web/rtc-distribution-dashboard.html
@@ -643,10 +643,16 @@
         return response.json();
       }
 
+      function normalizeMinerRows(payload) {
+        const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+        if (!Array.isArray(rows)) return [];
+        return rows.filter((item) => item && typeof item === "object");
+      }
+
       async function getMinerIds() {
         const data = await fetchJson("/api/miners");
-        const list = Array.isArray(data) ? data : data.miners || [];
-        const ids = list.map((item) => item.miner).filter(Boolean);
+        const list = normalizeMinerRows(data);
+        const ids = list.map((item) => item.miner || item.miner_id || item.id || item.name).filter(Boolean);
         return [...new Set([...ids, ...Object.keys(FOUNDER_WALLETS)])];
       }
 


### PR DESCRIPTION
## Summary
- normalize the RTC distribution dashboard `/api/miners` response from raw arrays plus `miners`, `data`, and `items` envelopes
- accept current miner identifier fields (`miner`, `miner_id`, `id`, `name`) before balance lookups
- add a static regression test for the dashboard miner row normalization

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_rtc_distribution_dashboard_security.py -q`
- `python3 -m py_compile tests/test_rtc_distribution_dashboard_security.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- web/rtc-distribution-dashboard.html tests/test_rtc_distribution_dashboard_security.py`

Bounty context: Scottcjn/rustchain-bounties#71