### PR TITLE
fix: count stats dashboard miner rows

### DIFF
--- a/dashboards/rustchain-stats/index.html
+++ b/dashboards/rustchain-stats/index.html
@@ -538,12 +538,19 @@
             return await response.json();
         }
 
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+            return Array.isArray(rows) ? rows.filter((item) => item && typeof item === 'object') : [];
+        }
+
         function updateDashboard(data) {
             const { epoch, health, miners, transactions } = data;
+            const minerRows = normalizeMinerRows(miners);
+            const enrolledMiners = Number(epoch.enrolled_miners ?? minerRows.length);
 
             // Update main stats
             updateStat('epochValue', epoch.epoch || 0, '', previousStats?.epoch?.epoch);
-            updateStat('minersValue', epoch.enrolled_miners || 0, '', previousStats?.epoch?.enrolled_miners);
+            updateStat('minersValue', enrolledMiners, '', previousStats?.minersCount);
             
             // Calculate circulating supply
             const supply = calculateSupply(epoch);
@@ -562,6 +569,7 @@
             previousStats = {
                 epoch: epoch,
                 supply: supply,
+                minersCount: enrolledMiners,
                 transactions: transactions
             };
 

--- a/tests/test_rustchain_stats_dashboard_miners_payload.py
+++ b/tests/test_rustchain_stats_dashboard_miners_payload.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+DASHBOARD_HTML = (
+    Path(__file__).resolve().parents[1]
+    / "dashboards"
+    / "rustchain-stats"
+    / "index.html"
+)
+
+
+def test_rustchain_stats_dashboard_uses_normalized_miners_fallback():
+    html = DASHBOARD_HTML.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload?.miners || payload?.data || payload?.items || []" in html
+    assert "const minerRows = normalizeMinerRows(miners);" in html
+    assert "const enrolledMiners = Number(epoch.enrolled_miners ?? minerRows.length);" in html
+    assert "updateStat('minersValue', enrolledMiners, '', previousStats?.minersCount);" in html
+    assert "minersCount: enrolledMiners" in html
+    assert "updateStat('minersValue', epoch.enrolled_miners || 0, '', previousStats?.epoch?.enrolled_miners);" not in html


### PR DESCRIPTION
## Summary
- normalize `dashboards/rustchain-stats` `/api/miners` responses from raw arrays plus `miners`, `data`, and `items` envelopes
- use the normalized miner row count as the active miner fallback when `/epoch` does not include `enrolled_miners`
- track the normalized count for refresh-to-refresh change indicators

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_rustchain_stats_dashboard_miners_payload.py -q`
- `python3 -m py_compile tests/test_rustchain_stats_dashboard_miners_payload.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- dashboards/rustchain-stats/index.html tests/test_rustchain_stats_dashboard_miners_payload.py`

Bounty context: Scottcjn/rustchain-bounties#71