### PR TITLE
fix: normalize miner dashboard lookup rows

### DIFF
--- a/dashboards/miner-dashboard/index.html
+++ b/dashboards/miner-dashboard/index.html
@@ -420,8 +420,13 @@
             });
             if (!response.ok) throw new Error('Failed to fetch miners');
             const payload = await response.json();
-            const miners = Array.isArray(payload) ? payload : (payload.miners || payload.data || []);
-            return miners.find(m => m.miner === minerId) || null;
+            const miners = normalizeMinerRows(payload);
+            return miners.find((m) => (m.miner || m.miner_id || m.id || m.name) === minerId) || null;
+        }
+
+        function normalizeMinerRows(payload) {
+            const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+            return Array.isArray(rows) ? rows.filter((item) => item && typeof item === 'object') : [];
         }
 
         async function fetchEpochData() {

--- a/tests/test_miner_dashboard_frontend_security.py
+++ b/tests/test_miner_dashboard_frontend_security.py
@@ -25,7 +25,11 @@ def test_history_and_activity_tables_do_not_render_api_fields_with_inner_html():
 def test_dashboard_normalizes_current_api_envelopes():
     html = DASHBOARD_HTML.read_text(encoding="utf-8")
 
-    assert "const miners = Array.isArray(payload) ? payload : (payload.miners || payload.data || []);" in html
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload?.miners || payload?.data || payload?.items || []" in html
+    assert "const miners = normalizeMinerRows(payload);" in html
+    assert "(m.miner || m.miner_id || m.id || m.name) === minerId" in html
+    assert "const miners = Array.isArray(payload) ? payload : (payload.miners || payload.data || []);" not in html
     assert "return Array.isArray(payload) ? payload : (payload.transactions || payload.history || []);" in html
 
 


### PR DESCRIPTION
## Summary
- normalize `dashboards/miner-dashboard` `/api/miners` responses from raw arrays plus `miners`, `data`, and `items` envelopes
- match the requested miner id against current row identifier fields (`miner`, `miner_id`, `id`, `name`)
- extend the existing dashboard static regression test for the normalized lookup path

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_miner_dashboard_frontend_security.py -q`
- `python3 -m py_compile tests/test_miner_dashboard_frontend_security.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- dashboards/miner-dashboard/index.html tests/test_miner_dashboard_frontend_security.py`

Bounty context: Scottcjn/rustchain-bounties#71