### PR TITLE
fix: normalize tools explorer miner rows

### DIFF
--- a/tests/test_tools_explorer_miners_payload.py
+++ b/tests/test_tools_explorer_miners_payload.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+EXPLORER_HTML = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "explorer"
+    / "index.html"
+)
+
+
+def test_tools_explorer_normalizes_current_miners_api_envelope():
+    html = EXPLORER_HTML.read_text(encoding="utf-8")
+
+    assert "function normalizeMinerRows(payload)" in html
+    assert "payload?.miners || payload?.data || payload?.items || []" in html
+    assert "miner: m.miner || m.miner_id || m.id || m.name || \"\"" in html
+    assert "state.miners = normalizeMinerRows(miners);" in html
+    assert "state.miners = Array.isArray(miners) ? miners : (miners.miners || miners.data || []);" not in html

--- a/tools/explorer/index.html
+++ b/tools/explorer/index.html
@@ -359,6 +359,18 @@
       return await res.json();
     }
 
+    function normalizeMinerRows(payload) {
+      const rows = Array.isArray(payload) ? payload : (payload?.miners || payload?.data || payload?.items || []);
+      if (!Array.isArray(rows)) return [];
+      return rows
+        .filter((m) => m && typeof m === "object")
+        .map((m) => ({
+          ...m,
+          miner: m.miner || m.miner_id || m.id || m.name || "",
+        }))
+        .filter((m) => m.miner);
+    }
+
     function applyFiltersAndSort() {
       let rows = [...state.miners];
       if (state.archFilter !== "all") {
@@ -553,7 +565,7 @@
           fetchJson("/agent/stats").catch(() => ({ stats: {} })),
           fetchJson("/agent/jobs").catch(() => ({ jobs: [] })),
         ]);
-        state.miners = Array.isArray(miners) ? miners : (miners.miners || miners.data || []);
+        state.miners = normalizeMinerRows(miners);
         state.agentStats = agentStats;
         state.agentJobs = Array.isArray(agentJobs.jobs) ? agentJobs.jobs : [];
         renderTopCards(health, epoch);


### PR DESCRIPTION
## Summary
- normalize `tools/explorer` `/api/miners` responses from raw arrays plus `miners`, `data`, and `items` envelopes
- map current miner identifier fields (`miner`, `miner_id`, `id`, `name`) before sorting and rendering
- add a static regression test for the standalone tools explorer payload handling

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_tools_explorer_miners_payload.py -q`
- `python3 -m py_compile tests/test_tools_explorer_miners_payload.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/explorer/index.html tests/test_tools_explorer_miners_payload.py`

Bounty context: Scottcjn/rustchain-bounties#71