### PR TITLE
fix: normalize mcp miner envelopes

### DIFF
--- a/integrations/mcp-server/mcp_server.py
+++ b/integrations/mcp-server/mcp_server.py
@@ -102,6 +102,17 @@ class MinerInfo:
     status: str
 
 
+def normalize_miner_rows(payload: Any) -> list[dict[str, Any]]:
+    """Return miner rows from current and legacy /api/miners response shapes."""
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = payload.get("miners") or payload.get("data") or payload.get("items") or []
+    else:
+        return []
+    return [row for row in rows if isinstance(row, dict)]
+
+
 @dataclass
 class BlockInfo:
     epoch: int
@@ -660,14 +671,16 @@ class RustChainMCP:
             if resp.status != 200:
                 return {"error": f"API error: {resp.status}", "miner_id": miner_id}
 
-            miners = await resp.json()
+            miners = normalize_miner_rows(await resp.json())
 
             # Search for matching miner
-            for miner in miners.get("miners", []):
+            for miner in miners:
                 if (
-                    miner.get("miner_id") == miner_id
+                    miner.get("miner") == miner_id
+                    or miner.get("miner_id") == miner_id
                     or miner.get("wallet") == miner_id
                     or miner.get("id") == miner_id
+                    or miner.get("name") == miner_id
                 ):
                     return {"found": True, "miner": miner}
 
@@ -753,14 +766,14 @@ class RustChainMCP:
             if resp.status != 200:
                 return {"error": f"API error: {resp.status}"}
 
-            data = await resp.json()
-            miners = data.get("miners", [])
+            miners = normalize_miner_rows(await resp.json())
 
             # Apply filters
             if hardware_type:
 
                 def matches_hardware(m):
-                    return hardware_type.lower() in m.get("hardware", "").lower()
+                    hardware = m.get("hardware") or m.get("hardware_type") or ""
+                    return hardware_type.lower() in str(hardware).lower()
 
                 miners = [m for m in miners if matches_hardware(m)]
 

--- a/integrations/mcp-server/tests/test_mcp_server.py
+++ b/integrations/mcp-server/tests/test_mcp_server.py
@@ -115,6 +115,33 @@ class TestMinerInfo:
         assert result["found"] is False
         assert "hint" in result
 
+    @pytest.mark.asyncio
+    async def test_get_miner_info_accepts_data_envelope_and_miner_alias(self, mcp_server):
+        """Test miner info lookup with current paginated API row shapes."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "data": [
+                    {
+                        "miner": "miner-from-data",
+                        "hardware_type": "PowerPC G5",
+                        "score": 245.8,
+                    }
+                ],
+                "total": 1,
+            }
+        )
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncContextManagerMock(mock_response))
+        mcp_server.session = mock_session
+
+        result = await mcp_server._tool_get_miner_info({"miner_id": "miner-from-data"})
+
+        assert result["found"] is True
+        assert result["miner"]["miner"] == "miner-from-data"
+
 
 class TestBlockInfo:
     """Tests for block info tools."""
@@ -230,6 +257,30 @@ class TestActiveMiners:
         assert result["count"] == 2
         for miner in result["miners"]:
             assert "PowerPC" in miner["hardware"]
+
+    @pytest.mark.asyncio
+    async def test_get_active_miners_accepts_items_envelope(self, mcp_server):
+        """Test active miner listing with current API envelope variants."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "items": [
+                    {"miner": "m1", "hardware_type": "PowerPC G4", "score": 300},
+                    {"miner": "m2", "hardware_type": "x86_64", "score": 200},
+                ],
+                "total": 2,
+            }
+        )
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(return_value=AsyncContextManagerMock(mock_response))
+        mcp_server.session = mock_session
+
+        result = await mcp_server._tool_get_active_miners({"limit": 10, "hardware_type": "PowerPC"})
+
+        assert result["count"] == 1
+        assert result["miners"][0]["miner"] == "m1"
 
 
 class TestWalletBalance:


### PR DESCRIPTION
## Summary
- normalize `integrations/mcp-server` `/api/miners` responses from raw arrays plus `miners`, `data`, and `items` envelopes
- allow miner info lookup by current row aliases (`miner`, `miner_id`, `wallet`, `id`, `name`)
- let the active-miners hardware filter use `hardware_type` when `hardware` is absent
- add async regressions for `data` and `items` envelope variants

## Validation
- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp python -m pytest integrations/mcp-server/tests/test_mcp_server.py::TestMinerInfo integrations/mcp-server/tests/test_mcp_server.py::TestActiveMiners -q`
- `python3 -m py_compile integrations/mcp-server/mcp_server.py integrations/mcp-server/tests/test_mcp_server.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- integrations/mcp-server/mcp_server.py integrations/mcp-server/tests/test_mcp_server.py`

Bounty context: Scottcjn/rustchain-bounties#71