### PR TITLE
fix: harden backup verifier failures

### DIFF
--- a/tests/test_verify_backup.py
+++ b/tests/test_verify_backup.py
@@ -26,6 +26,23 @@ def _make_db(path: Path, rows: int = 3, epoch: int = 10):
     conn.close()
 
 
+def _make_db_with_balance_column(path: Path, column: str):
+    conn = sqlite3.connect(path)
+    conn.execute(f"CREATE TABLE balances({column} REAL)")
+    conn.execute("CREATE TABLE miner_attest_recent(id INTEGER)")
+    conn.execute("CREATE TABLE headers(id INTEGER)")
+    conn.execute("CREATE TABLE ledger(id INTEGER)")
+    conn.execute("CREATE TABLE epoch_rewards(epoch INTEGER)")
+
+    conn.execute(f"INSERT INTO balances({column}) VALUES (1.0)")
+    conn.execute("INSERT INTO miner_attest_recent(id) VALUES (1)")
+    conn.execute("INSERT INTO headers(id) VALUES (1)")
+    conn.execute("INSERT INTO ledger(id) VALUES (1)")
+    conn.execute("INSERT INTO epoch_rewards(epoch) VALUES (10)")
+    conn.commit()
+    conn.close()
+
+
 def test_verify_pass(tmp_path):
     live = tmp_path / "live.db"
     bak = tmp_path / "bak.db"
@@ -46,3 +63,31 @@ def test_verify_fail_when_epoch_too_old(tmp_path):
     result = verify(str(live), str(bak))
     assert result.ok is False
     assert any("RESULT: FAIL" in line for line in result.lines)
+
+
+def test_verify_reports_missing_table_without_crashing(tmp_path):
+    live = tmp_path / "live.db"
+    bak = tmp_path / "bak.db"
+    _make_db(live, rows=1, epoch=10)
+
+    conn = sqlite3.connect(bak)
+    conn.execute("CREATE TABLE balances(amount REAL)")
+    conn.execute("INSERT INTO balances(amount) VALUES (1.0)")
+    conn.commit()
+    conn.close()
+
+    result = verify(str(live), str(bak))
+    assert result.ok is False
+    assert any("miner_attest_recent: missing in backup" in line for line in result.lines)
+    assert any("RESULT: FAIL" in line for line in result.lines)
+
+
+def test_verify_accepts_balance_rtc_column(tmp_path):
+    live = tmp_path / "live.db"
+    bak = tmp_path / "bak.db"
+    _make_db_with_balance_column(live, "balance_rtc")
+    _make_db_with_balance_column(bak, "balance_rtc")
+
+    result = verify(str(live), str(bak))
+    assert result.ok is True
+    assert any("balances (amount>0): 1" in line for line in result.lines)

--- a/tools/verify_backup.py
+++ b/tools/verify_backup.py
@@ -43,12 +43,31 @@ def query_one(conn: sqlite3.Connection, sql: str) -> str:
     return "" if row is None or row[0] is None else str(row[0])
 
 
+def table_exists(conn: sqlite3.Connection, table: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?;",
+        (table,),
+    ).fetchone()
+    return row is not None
+
+
+def column_names(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row[1]) for row in conn.execute(f"PRAGMA table_info({table});")}
+
+
 def count_rows(conn: sqlite3.Connection, table: str) -> int:
     return int(query_one(conn, f"SELECT COUNT(*) FROM {table};") or 0)
 
 
 def positive_balances(conn: sqlite3.Connection) -> int:
-    return int(query_one(conn, "SELECT COUNT(*) FROM balances WHERE amount > 0;" ) or 0)
+    columns = column_names(conn, "balances")
+    for column in ("amount", "balance_rtc", "balance", "amount_i64"):
+        if column in columns:
+            return int(query_one(conn, f"SELECT COUNT(*) FROM balances WHERE {column} > 0;") or 0)
+    raise sqlite3.OperationalError(
+        "balances table has no supported positive-balance column "
+        "(expected amount, balance_rtc, balance, or amount_i64)"
+    )
 
 
 def epoch_max(conn: sqlite3.Connection) -> int:
@@ -76,6 +95,13 @@ def verify(live_db: str, backup_file: str) -> CheckResult:
                 return CheckResult(False, lines + [log("RESULT: FAIL")])
 
             for t in REQUIRED_TABLES:
+                if not table_exists(bconn, t):
+                    lines.append(log(f"{t}: missing in backup ❌"))
+                    return CheckResult(False, lines + [log("RESULT: FAIL")])
+                if not table_exists(lconn, t):
+                    lines.append(log(f"{t}: missing in live db ❌"))
+                    return CheckResult(False, lines + [log("RESULT: FAIL")])
+
                 b_count = count_rows(bconn, t)
                 l_count = count_rows(lconn, t)
                 table_ok = b_count > 0 and (l_count - b_count) <= max(1, int(l_count * 0.05))
@@ -98,6 +124,9 @@ def verify(live_db: str, backup_file: str) -> CheckResult:
                 return CheckResult(False, lines + [log("RESULT: FAIL")])
 
             return CheckResult(True, lines + [log("RESULT: PASS")])
+        except sqlite3.Error as exc:
+            lines.append(log(f"SQLite error: {exc}"))
+            return CheckResult(False, lines + [log("RESULT: FAIL")])
         finally:
             bconn.close()
             lconn.close()


### PR DESCRIPTION
## Summary
- report missing required backup/live tables as controlled FAIL results instead of raising SQLite tracebacks
- support common positive-balance column names (`amount`, `balance_rtc`, `balance`, `amount_i64`) when validating balances
- cover missing-table and alternate balance-column cases in backup verifier tests

## Validation
- `uv run --no-project --with pytest python -m pytest tests/test_verify_backup.py -q`
- `python3 -m py_compile tools/verify_backup.py tests/test_verify_backup.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/verify_backup.py tests/test_verify_backup.py`
- Manual CLI check against an incomplete SQLite DB now exits 1 with `RESULT: FAIL` instead of crashing

Bounty context: Scottcjn/rustchain-bounties#755
Wallet: RTC5800896ed658aa511D029361b6d7388ddb29248B