### PR TITLE
fix: normalize rustchain mcp client miner rows

### DIFF
--- a/integrations/rustchain-mcp/client.py
+++ b/integrations/rustchain-mcp/client.py
@@ -238,13 +238,22 @@ class RustChainClient:
         params = {"limit": limit}
         data = await self._request("GET", "/api/miners", params=params)
 
-        miners_data = data.get("miners", [])
+        if isinstance(data, list):
+            miners_data = data
+        elif isinstance(data, dict):
+            miners_data = (
+                data.get("miners") or data.get("data") or data.get("items") or []
+            )
+        else:
+            miners_data = []
+
+        if not isinstance(miners_data, list):
+            miners_data = []
+
         miners = [MinerInfo.from_dict(m) for m in miners_data]
 
         if hardware_type:
-            miners = [
-                m for m in miners if hardware_type.lower() in m.hardware.lower()
-            ]
+            miners = [m for m in miners if hardware_type.lower() in m.hardware.lower()]
         if min_score is not None:
             miners = [m for m in miners if m.score >= min_score]
 
@@ -276,6 +285,7 @@ class RustChainClient:
 
 # Convenience functions for simple usage
 
+
 async def get_health(base_url: Optional[str] = None) -> HealthStatus:
     """Get API health status."""
     async with RustChainClient(base_url=base_url) as client:
@@ -290,9 +300,7 @@ async def get_epoch(
         return await client.epoch(epoch_number)
 
 
-async def get_balance(
-    miner_id: str, base_url: Optional[str] = None
-) -> WalletBalance:
+async def get_balance(miner_id: str, base_url: Optional[str] = None) -> WalletBalance:
     """Get wallet balance."""
     async with RustChainClient(base_url=base_url) as client:
         return await client.balance(miner_id)

--- a/integrations/rustchain-mcp/schemas.py
+++ b/integrations/rustchain-mcp/schemas.py
@@ -13,17 +13,18 @@ from typing import Any, Optional
 @dataclass
 class HealthStatus:
     """Response from /api/health endpoint."""
+
     status: str
     timestamp: int
     service: str
     version: Optional[str] = None
     uptime_s: Optional[int] = None
-    
+
     @property
     def is_healthy(self) -> bool:
         """Check if service is healthy."""
         return self.status.lower() in ("ok", "healthy", "running")
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "HealthStatus":
         """Create from API response dict."""
@@ -39,6 +40,7 @@ class HealthStatus:
 @dataclass
 class EpochInfo:
     """Response from /epoch endpoint."""
+
     epoch: int
     slot: int
     height: int
@@ -47,7 +49,7 @@ class EpochInfo:
     active_miners: Optional[int] = None
     total_rewards: Optional[float] = None
     status: Optional[str] = None
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "EpochInfo":
         """Create from API response dict."""
@@ -66,18 +68,19 @@ class EpochInfo:
 @dataclass
 class WalletBalance:
     """Response from /wallet/balance endpoint."""
+
     miner_id: str
     amount_rtc: float
     amount_i64: int
     pending: Optional[float] = None
     staked: Optional[float] = None
     last_updated: Optional[int] = None
-    
+
     @property
     def total_rtc(self) -> float:
         """Total balance including staked."""
         return self.amount_rtc + (self.staked or 0)
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "WalletBalance":
         """Create from API response dict."""
@@ -94,12 +97,13 @@ class WalletBalance:
 @dataclass
 class QueryResult:
     """Generic query result for /api/query endpoint."""
+
     success: bool
     data: Any = field(default_factory=dict)
     error: Optional[str] = None
     count: Optional[int] = None
     query_type: Optional[str] = None
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "QueryResult":
         """Create from API response dict."""
@@ -115,6 +119,7 @@ class QueryResult:
 @dataclass
 class MinerInfo:
     """Miner information from /api/miners endpoint."""
+
     miner_id: str
     wallet: str
     hardware: str
@@ -124,14 +129,17 @@ class MinerInfo:
     status: str
     antiquity_multiplier: Optional[float] = None
     last_attest: Optional[int] = None
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MinerInfo":
         """Create from API response dict."""
         return cls(
-            miner_id=data.get("miner_id", data.get("id", "")),
-            wallet=data.get("wallet", ""),
-            hardware=data.get("hardware", ""),
+            miner_id=data.get(
+                "miner_id",
+                data.get("miner", data.get("id", data.get("name", ""))),
+            ),
+            wallet=data.get("wallet", data.get("miner_id", data.get("miner", ""))),
+            hardware=data.get("hardware", data.get("hardware_type", "")),
             score=data.get("score", 0),
             epochs_mined=data.get("epochs_mined", 0),
             last_seen=data.get("last_seen", 0),
@@ -144,13 +152,14 @@ class MinerInfo:
 @dataclass
 class NetworkStats:
     """Network statistics from /api/stats endpoint."""
+
     current_epoch: int
     total_miners: int
     active_miners: int
     total_supply: float
     network_hashrate: Optional[float] = None
     avg_block_time: Optional[float] = None
-    
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "NetworkStats":
         """Create from API response dict."""
@@ -167,11 +176,12 @@ class NetworkStats:
 @dataclass
 class APIError(Exception):
     """Standardized API error."""
+
     code: str
     message: str
     status_code: int = 500
     details: Optional[dict[str, Any]] = None
-    
+
     @classmethod
     def from_response(cls, status: int, body: dict[str, Any]) -> "APIError":
         """Create from API error response."""
@@ -181,7 +191,7 @@ class APIError(Exception):
             status_code=status,
             details=body.get("details"),
         )
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dict."""
         return {

--- a/integrations/rustchain-mcp/tests/test_client.py
+++ b/integrations/rustchain-mcp/tests/test_client.py
@@ -5,42 +5,56 @@ RustChain MCP - Client Tests
 Unit tests for RustChainClient with mocked HTTP responses.
 """
 
-import pytest
-import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
-
-import sys
 import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
     from rustchain_mcp.client import RustChainClient
-    from rustchain_mcp.schemas import APIError, HealthStatus, EpochInfo, WalletBalance, QueryResult
+    from rustchain_mcp.schemas import (
+        APIError,
+        EpochInfo,
+        HealthStatus,
+        MinerInfo,
+        QueryResult,
+        WalletBalance,
+    )
 except ImportError:
     from client import RustChainClient
-    from schemas import APIError, HealthStatus, EpochInfo, WalletBalance, QueryResult
+    from schemas import (
+        APIError,
+        EpochInfo,
+        HealthStatus,
+        MinerInfo,
+        QueryResult,
+        WalletBalance,
+    )
 
 
 class AsyncContextManager:
     """Simple async context manager for testing."""
-    
+
     def __init__(self, coro_result):
         self._coro_result = coro_result
-    
+
     async def __aenter__(self):
         return self._coro_result
-    
+
     async def __aexit__(self, *args):
         pass
 
 
 class MockResponse:
     """Mock aiohttp response."""
-    
+
     def __init__(self, data, status=200):
         self._data = data
         self.status = status
-    
+
     async def json(self):
         return self._data
 
@@ -51,27 +65,31 @@ class TestRustChainClient:
     @pytest.mark.asyncio
     async def test_health_success(self):
         """Test health check success."""
-        mock_response = MockResponse({
-            "status": "ok",
-            "timestamp": 1234567890,
-            "service": "test-api",
-            "version": "1.0.0",
-        })
-        
+        mock_response = MockResponse(
+            {
+                "status": "ok",
+                "timestamp": 1234567890,
+                "service": "test-api",
+                "version": "1.0.0",
+            }
+        )
+
         mock_close = AsyncMock()
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = mock_close
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             health = await client.health()
-            
+
             assert isinstance(health, HealthStatus)
             assert health.status == "ok"
             assert health.is_healthy is True
@@ -84,44 +102,50 @@ class TestRustChainClient:
             {"error": "SERVICE_DOWN", "message": "Service unavailable"},
             status=503,
         )
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             with pytest.raises(APIError) as exc_info:
                 await client.health()
-            
+
             assert exc_info.value.code == "SERVICE_DOWN"
             assert exc_info.value.status_code == 503
 
     @pytest.mark.asyncio
     async def test_epoch_current(self):
         """Test getting current epoch."""
-        mock_response = MockResponse({
-            "epoch": 95,
-            "slot": 12345,
-            "height": 67890,
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "epoch": 95,
+                "slot": 12345,
+                "height": 67890,
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             epoch = await client.epoch()
-            
+
             assert isinstance(epoch, EpochInfo)
             assert epoch.epoch == 95
             assert epoch.slot == 12345
@@ -129,46 +153,54 @@ class TestRustChainClient:
     @pytest.mark.asyncio
     async def test_epoch_specific(self):
         """Test getting specific epoch."""
-        mock_response = MockResponse({
-            "epoch": 90,
-            "slot": 10000,
-            "height": 60000,
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "epoch": 90,
+                "slot": 10000,
+                "height": 60000,
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             epoch = await client.epoch(90)
             assert epoch.epoch == 90
 
     @pytest.mark.asyncio
     async def test_balance_success(self):
         """Test getting wallet balance."""
-        mock_response = MockResponse({
-            "miner_id": "scott",
-            "amount_rtc": 155.0,
-            "amount_i64": 155000000,
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "miner_id": "scott",
+                "amount_rtc": 155.0,
+                "amount_i64": 155000000,
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             balance = await client.balance("scott")
-            
+
             assert isinstance(balance, WalletBalance)
             assert balance.miner_id == "scott"
             assert balance.amount_rtc == 155.0
@@ -180,84 +212,167 @@ class TestRustChainClient:
             {"error": "NOT_FOUND", "message": "Wallet not found"},
             status=404,
         )
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             with pytest.raises(APIError) as exc_info:
                 await client.balance("unknown")
-            
+
             assert exc_info.value.status_code == 404
 
     @pytest.mark.asyncio
     async def test_query_success(self):
         """Test generic query."""
-        mock_response = MockResponse({
-            "success": True,
-            "data": {"miners": [{"id": "m1"}]},
-            "count": 1,
-            "query_type": "miners",
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "success": True,
+                "data": {"miners": [{"id": "m1"}]},
+                "count": 1,
+                "query_type": "miners",
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             result = await client.query("miners", limit=10)
-            
+
             assert isinstance(result, QueryResult)
             assert result.success is True
             assert result.count == 1
             assert result.query_type == "miners"
 
     @pytest.mark.asyncio
-    async def test_ping_success(self):
-        """Test ping success."""
-        mock_response = MockResponse({
-            "status": "ok",
-            "timestamp": 1234567890,
-            "service": "test",
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+    async def test_miners_accepts_raw_array(self):
+        """Test miners response as a raw array."""
+        mock_response = MockResponse(
+            [
+                {
+                    "miner": "alice",
+                    "wallet": "wallet-1",
+                    "hardware_type": "GPU",
+                    "score": 12.5,
+                    "epochs_mined": 3,
+                    "last_seen": 123,
+                    "status": "active",
+                }
+            ]
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
+            miners = await client.miners()
+
+            assert len(miners) == 1
+            assert isinstance(miners[0], MinerInfo)
+            assert miners[0].miner_id == "alice"
+            assert miners[0].hardware == "GPU"
+
+    @pytest.mark.asyncio
+    async def test_miners_accepts_items_envelope_and_filters_aliases(self):
+        """Test miners response as an items envelope with hardware aliases."""
+        mock_response = MockResponse(
+            {
+                "items": [
+                    {
+                        "name": "gpu-miner",
+                        "hardware_type": "GPU-Rig",
+                        "score": 42,
+                    },
+                    {
+                        "miner_id": "cpu-miner",
+                        "hardware": "CPU",
+                        "score": 7,
+                    },
+                ]
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
+            mock_session = MagicMock()
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
+            mock_session.close = AsyncMock()
+            MockSession.return_value = mock_session
+
+            client = RustChainClient(base_url="https://test.example.com")
+            client._session = mock_session
+            client._owns_session = False
+
+            miners = await client.miners(hardware_type="gpu", min_score=10)
+
+            assert [miner.miner_id for miner in miners] == ["gpu-miner"]
+            assert miners[0].hardware == "GPU-Rig"
+
+    @pytest.mark.asyncio
+    async def test_ping_success(self):
+        """Test ping success."""
+        mock_response = MockResponse(
+            {
+                "status": "ok",
+                "timestamp": 1234567890,
+                "service": "test",
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
+            mock_session = MagicMock()
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
+            mock_session.close = AsyncMock()
+            MockSession.return_value = mock_session
+
+            client = RustChainClient(base_url="https://test.example.com")
+            client._session = mock_session
+            client._owns_session = False
+
             result = await client.ping()
             assert result is True
 
     @pytest.mark.asyncio
     async def test_ping_failure(self):
         """Test ping failure."""
-        with patch('aiohttp.ClientSession') as MockSession:
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
             mock_session.request = MagicMock(side_effect=Exception("Connection error"))
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             result = await client.ping()
             assert result is False
 
@@ -268,54 +383,62 @@ class TestConvenienceFunctions:
     @pytest.mark.asyncio
     async def test_get_health(self):
         """Test get_health convenience function."""
-        mock_response = MockResponse({
-            "status": "ok",
-            "timestamp": 0,
-            "service": "test",
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "status": "ok",
+                "timestamp": 0,
+                "service": "test",
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             try:
                 from rustchain_mcp.client import RustChainClient
             except ImportError:
                 from client import RustChainClient
-            
+
             # Create client directly since get_health uses context manager
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             health = await client.health()
             assert health.status == "ok"
 
     @pytest.mark.asyncio
     async def test_get_balance(self):
         """Test get_balance convenience function."""
-        mock_response = MockResponse({
-            "miner_id": "test",
-            "amount_rtc": 100.0,
-            "amount_i64": 100000000,
-        })
-        
-        with patch('aiohttp.ClientSession') as MockSession:
+        mock_response = MockResponse(
+            {
+                "miner_id": "test",
+                "amount_rtc": 100.0,
+                "amount_i64": 100000000,
+            }
+        )
+
+        with patch("aiohttp.ClientSession") as MockSession:
             mock_session = MagicMock()
-            mock_session.request = MagicMock(return_value=AsyncContextManager(mock_response))
+            mock_session.request = MagicMock(
+                return_value=AsyncContextManager(mock_response)
+            )
             mock_session.close = AsyncMock()
             MockSession.return_value = mock_session
-            
+
             try:
                 from rustchain_mcp.client import RustChainClient
             except ImportError:
                 from client import RustChainClient
-            
+
             client = RustChainClient(base_url="https://test.example.com")
             client._session = mock_session
             client._owns_session = False
-            
+
             balance = await client.balance("test")
             assert balance.miner_id == "test"


### PR DESCRIPTION
## Summary
- accept `/api/miners` responses as a raw array or `miners`/`data`/`items` envelopes in the RustChain MCP client
- map miner identity and hardware aliases (`miner`, `name`, `hardware_type`) through `MinerInfo.from_dict`
- add client tests for raw-array and items-envelope miner payloads with existing hardware/min-score filters

## Validation
- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp python -m pytest integrations/rustchain-mcp/tests/test_client.py -q`
- `python3 -m py_compile integrations/rustchain-mcp/client.py integrations/rustchain-mcp/schemas.py integrations/rustchain-mcp/tests/test_client.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- integrations/rustchain-mcp/client.py integrations/rustchain-mcp/schemas.py integrations/rustchain-mcp/tests/test_client.py`
- `uv run --no-project --with ruff python -m ruff check integrations/rustchain-mcp/client.py integrations/rustchain-mcp/schemas.py integrations/rustchain-mcp/tests/test_client.py`

Bounty context: Scottcjn/rustchain-bounties#71