### PR TITLE
fix: normalize bounties mcp miner rows

### DIFF
--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/client.py
@@ -87,7 +87,7 @@ class RustChainClient:
         *,
         params: Optional[dict[str, Any]] = None,
         json_data: Optional[dict[str, Any]] = None,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """HTTP request with retry and self-signed-cert handling."""
         await self._ensure_session()
         url = f"{self.node_url}{path}"
@@ -145,8 +145,20 @@ class RustChainClient:
         """GET /api/miners — the live API returns `miners` list + `pagination` dict."""
         params: dict[str, Any] = {"limit": min(max(limit, 1), 1000)}
         data = await self._request("GET", "/api/miners", params=params)
-        miners_raw = data.get("miners", [])
-        miners = [MinerInfo.from_dict(m) for m in miners_raw]
+        if isinstance(data, list):
+            miners_raw = data
+            pagination = {}
+        elif isinstance(data, dict):
+            miners_raw = data.get("miners") or data.get("data") or data.get("items") or []
+            pagination = data.get("pagination", {})
+        else:
+            miners_raw = []
+            pagination = {}
+
+        if not isinstance(miners_raw, list):
+            miners_raw = []
+
+        miners = [MinerInfo.from_dict(m) for m in miners_raw if isinstance(m, dict)]
 
         if hardware_type:
             ht = hardware_type.lower()
@@ -155,7 +167,6 @@ class RustChainClient:
         limited = miners[: params["limit"]]
 
         # Live API returns pagination as a nested dict: {"miners": [...], "pagination": {"total": N, ...}}
-        pagination = data.get("pagination", {})
         total_count = pagination.get("total", len(miners))
 
         return {

--- a/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
+++ b/rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
-
 # ---------------------------------------------------------------------------
 # Health  (GET /health)
 # ---------------------------------------------------------------------------
@@ -106,13 +105,16 @@ class MinerInfo:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MinerInfo":
         return cls(
-            miner=data.get("miner", ""),
+            miner=data.get(
+                "miner",
+                data.get("miner_id", data.get("id", data.get("name", ""))),
+            ),
             last_attest=int(data.get("last_attest", 0)),
             device_family=data.get("device_family", "unknown"),
             device_arch=data.get("device_arch", "unknown"),
             entropy_score=float(data.get("entropy_score", 0)),
             antiquity_multiplier=float(data.get("antiquity_multiplier", 1.0)),
-            hardware_type=data.get("hardware_type", "Unknown/Other"),
+            hardware_type=data.get("hardware_type", data.get("hardware", "Unknown/Other")),
             first_attest=data.get("first_attest"),
         )
 

--- a/rustchain-bounties-mcp/tests/test_client_miners.py
+++ b/rustchain-bounties-mcp/tests/test_client_miners.py
@@ -1,0 +1,88 @@
+"""Tests for RustChain bounties MCP miner client normalization."""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from rustchain_bounties_mcp.client import RustChainClient
+
+
+class AsyncContextManager:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class MockResponse:
+    def __init__(self, data, status=200):
+        self._data = data
+        self.status = status
+
+    async def json(self):
+        return self._data
+
+
+def client_for_response(data) -> RustChainClient:
+    response = MockResponse(data)
+    session = MagicMock()
+    session.request = MagicMock(return_value=AsyncContextManager(response))
+
+    client = RustChainClient(node_url="https://node.example")
+    client._session = session
+    client._owns_session = False
+    return client
+
+
+@pytest.mark.asyncio
+async def test_miners_accepts_raw_array_payload():
+    client = client_for_response([
+        {
+            "miner_id": "alice",
+            "hardware": "PowerPC G4",
+            "device_family": "PowerPC",
+            "device_arch": "g4",
+            "entropy_score": 0.9,
+        }
+    ])
+
+    result = await client.miners()
+
+    assert result["total_count"] == 1
+    assert result["miners"][0].miner == "alice"
+    assert result["miners"][0].hardware_type == "PowerPC G4"
+
+
+@pytest.mark.asyncio
+async def test_miners_accepts_data_envelope_and_filters_aliases():
+    client = client_for_response({
+        "data": [
+            {
+                "name": "gpu-miner",
+                "hardware": "GPU Rig",
+                "device_family": "GPU",
+            },
+            {
+                "miner": "cpu-miner",
+                "hardware_type": "CPU",
+                "device_family": "x86",
+            },
+            "not-a-row",
+        ],
+        "pagination": {"total": 3, "offset": 5},
+    })
+
+    result = await client.miners(limit=10, hardware_type="gpu")
+
+    assert result["total_count"] == 3
+    assert result["offset"] == 5
+    assert [miner.miner for miner in result["miners"]] == ["gpu-miner"]
+    assert result["miners"][0].hardware_type == "GPU Rig"


### PR DESCRIPTION
## Summary
- accept RustChain bounties MCP `/api/miners` responses as a raw array or `miners`/`data`/`items` envelopes
- ignore malformed miner rows before schema conversion
- map miner and hardware aliases (`miner_id`, `id`, `name`, `hardware`) in `MinerInfo.from_dict`
- add client tests for raw-array and data-envelope miner payloads

## Validation
- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp python -m pytest rustchain-bounties-mcp/tests/test_client_miners.py -q`
- `uv run --no-project --with pytest --with pytest-asyncio --with aiohttp --with mcp python -m pytest rustchain-bounties-mcp/tests -q`
- `python3 -m py_compile rustchain-bounties-mcp/rustchain_bounties_mcp/client.py rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py rustchain-bounties-mcp/tests/test_client_miners.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- rustchain-bounties-mcp/rustchain_bounties_mcp/client.py rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py rustchain-bounties-mcp/tests/test_client_miners.py`
- `uv run --no-project --with ruff python -m ruff check rustchain-bounties-mcp/rustchain_bounties_mcp/client.py rustchain-bounties-mcp/rustchain_bounties_mcp/schemas.py rustchain-bounties-mcp/tests/test_client_miners.py`

Bounty context: Scottcjn/rustchain-bounties#71