### PR TITLE
fix: normalize miner alert rows

### DIFF
--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -287,6 +287,28 @@ def test_fetch_helpers_parse_success_and_errors(miner_alerts_module, monkeypatch
     monkeypatch.setattr(
         miner_alerts_module.requests,
         "get",
+        lambda *_args, **_kwargs: FakeResponse(
+            {"data": [{"miner_id": "miner-b", "online": False}]}
+        ),
+    )
+    assert miner_alerts_module.fetch_miners() == [
+        {"miner_id": "miner-b", "online": False}
+    ]
+
+    monkeypatch.setattr(
+        miner_alerts_module.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(
+            {"items": [{"miner_id": "miner-c", "online": True}]}
+        ),
+    )
+    assert miner_alerts_module.fetch_miners() == [
+        {"miner_id": "miner-c", "online": True}
+    ]
+
+    monkeypatch.setattr(
+        miner_alerts_module.requests,
+        "get",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
     )
     assert miner_alerts_module.fetch_miners() == []

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -18,19 +18,16 @@ Architecture:
 """
 
 import argparse
-import hashlib
-import json
 import logging
 import os
 import smtplib
 import sqlite3
-import sys
 import time
 from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
 import requests
 from dotenv import load_dotenv
@@ -484,8 +481,11 @@ def fetch_miners() -> List[dict]:
         data = resp.json()
         if isinstance(data, list):
             return data
-        if isinstance(data, dict) and isinstance(data.get("miners"), list):
-            return data["miners"]
+        if isinstance(data, dict):
+            for key in ("miners", "data", "items"):
+                miners = data.get(key)
+                if isinstance(miners, list):
+                    return miners
         return []
     except Exception as e:
         logger.error(f"Failed to fetch miners: {e}")


### PR DESCRIPTION
## Summary
- accept `data` and `items` envelopes in the miner alert `/api/miners` helper, alongside raw arrays and `miners`
- keep malformed miner payloads as an empty list rather than alerting on stale/missing rows
- add regression coverage for `data` and `items` miner payloads
- remove unused imports in the touched alert module so focused ruff checks pass

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_miner_alerts.py -q`
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`
- `uv run --no-project --with ruff python -m ruff check tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`

Bounty context: Scottcjn/rustchain-bounties#71