### PR TITLE
fix: normalize monitoring alerts miner rows

### DIFF
--- a/monitoring/alerts/rustchain_alerts/api.py
+++ b/monitoring/alerts/rustchain_alerts/api.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Optional
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,29 @@ class RustChainClient:
     async def get_miners(self) -> list[MinerInfo]:
         resp = await self._client.get("/api/miners")
         resp.raise_for_status()
-        return [MinerInfo(**m) for m in resp.json()]
+        data = resp.json()
+        if isinstance(data, list):
+            rows = data
+        elif isinstance(data, dict):
+            rows = data.get("miners") or data.get("data") or data.get("items") or []
+        else:
+            rows = []
+
+        if not isinstance(rows, list):
+            rows = []
+
+        miners = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            normalized = dict(row)
+            normalized.setdefault(
+                "miner",
+                row.get("miner_id") or row.get("id") or row.get("name") or "",
+            )
+            normalized.setdefault("hardware_type", row.get("hardware", ""))
+            miners.append(MinerInfo(**normalized))
+        return miners
 
     async def wallet_balance(self, miner_id: str) -> WalletBalance:
         resp = await self._client.get("/wallet/balance", params={"miner_id": miner_id})

--- a/monitoring/alerts/tests/test_api.py
+++ b/monitoring/alerts/tests/test_api.py
@@ -6,7 +6,7 @@ import pytest
 import respx
 import httpx
 
-from rustchain_alerts.api import RustChainClient, MinerInfo, WalletBalance, EpochInfo, HealthInfo
+from rustchain_alerts.api import RustChainClient
 
 
 BASE = "https://test.rustchain.local"
@@ -50,6 +50,24 @@ async def test_get_miners_returns_list():
             miners = await client.get_miners()
             assert len(miners) == 1
             assert miners[0].miner == "miner-abc"
+
+
+@pytest.mark.anyio
+async def test_get_miners_accepts_envelope_and_aliases():
+    with respx.mock(base_url=BASE) as mock:
+        mock.get("/api/miners").mock(return_value=httpx.Response(200, json={
+            "data": [
+                {"miner_id": "miner-def", "hardware": "PowerPC G4"},
+                {"name": "miner-ghi", "hardware_type": "GPU"},
+                "not-a-row",
+            ],
+            "pagination": {"total": 3},
+        }))
+        async with RustChainClient(BASE, verify_ssl=False) as client:
+            miners = await client.get_miners()
+            assert [miner.miner for miner in miners] == ["miner-def", "miner-ghi"]
+            assert miners[0].hardware_type == "PowerPC G4"
+            assert miners[1].hardware_type == "GPU"
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- accept raw arrays plus `miners`/`data`/`items` envelopes in the monitoring alerts `/api/miners` client
- skip malformed miner rows before model parsing
- map common miner and hardware aliases (`miner_id`, `id`, `name`, `hardware`) for alert monitoring
- add regression coverage for envelope payloads and aliases

## Validation
- `uv run --no-project --with pytest --with anyio --with respx --with httpx --with pydantic python -m pytest monitoring/alerts/tests/test_api.py -q`
- `python3 -m py_compile monitoring/alerts/rustchain_alerts/api.py monitoring/alerts/tests/test_api.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- monitoring/alerts/rustchain_alerts/api.py monitoring/alerts/tests/test_api.py`
- `uv run --no-project --with ruff python -m ruff check monitoring/alerts/rustchain_alerts/api.py monitoring/alerts/tests/test_api.py`

Bounty context: Scottcjn/rustchain-bounties#71