### PR TITLE
fix: normalize sdk miner envelopes

### DIFF
--- a/sdk/rustchain/async_client.py
+++ b/sdk/rustchain/async_client.py
@@ -159,7 +159,14 @@ class AsyncRustChainClient:
                 - last_attest (int): Last attestation timestamp
         """
         result = await self._request("GET", "/api/miners")
-        return result if isinstance(result, list) else []
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            for key in ("miners", "data", "items"):
+                miners = result.get(key)
+                if isinstance(miners, list):
+                    return miners
+        return []
 
     async def balance(self, miner_id: str) -> Dict[str, Any]:
         """

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -4,7 +4,7 @@ RustChain Client
 Main client for interacting with RustChain node API.
 """
 
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Any
 import requests
 import json
 from rustchain.exceptions import (
@@ -92,7 +92,7 @@ class RustChainClient:
             # Parse JSON response
             try:
                 return response.json()
-            except json.JSONDecodeError as e:
+            except json.JSONDecodeError:
                 return {"raw_response": response.text}
 
         except requests.exceptions.ConnectionError as e:
@@ -170,7 +170,14 @@ class RustChainClient:
             >>> print(f"Total miners: {len(miners)}")
         """
         result = self._request("GET", "/api/miners")
-        return result if isinstance(result, list) else []
+        if isinstance(result, list):
+            return result
+        if isinstance(result, dict):
+            for key in ("miners", "data", "items"):
+                miners = result.get(key)
+                if isinstance(miners, list):
+                    return miners
+        return []
 
     def balance(self, miner_id: str) -> Dict[str, Any]:
         """

--- a/sdk/tests/test_async_client.py
+++ b/sdk/tests/test_async_client.py
@@ -3,15 +3,11 @@ Unit tests for RustChain Async Client
 """
 
 import pytest
-import asyncio
-from unittest.mock import AsyncMock, Mock, patch, MagicMock
+from unittest.mock import AsyncMock, Mock, patch
 from rustchain.async_client import AsyncRustChainClient
 from rustchain.exceptions import (
     ConnectionError,
     ValidationError,
-    APIError,
-    AttestationError,
-    TransferError,
 )
 
 
@@ -230,6 +226,39 @@ class TestAsyncMinersEndpoint:
                 miners = await client.miners()
 
             assert miners == []
+
+    @pytest.mark.asyncio
+    async def test_miners_envelope_response(self):
+        """Test miners endpoint returning an envelope."""
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value={
+            "items": [
+                {
+                    "miner": "miner-envelope",
+                    "hardware_type": "PowerPC G4",
+                }
+            ],
+            "pagination": {"total": 1},
+        })
+        mock_response.reason = "OK"
+
+        mock_cm = AsyncContextManager(mock_response)
+
+        with patch('aiohttp.ClientSession') as mock_session_class:
+            mock_request = Mock(return_value=mock_cm)
+            mock_session = Mock()
+            mock_session.request = mock_request
+            mock_session.closed = False
+            mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session.__aexit__ = AsyncMock(return_value=None)
+            mock_session.close = AsyncMock()
+            mock_session_class.return_value = mock_session
+
+            async with AsyncRustChainClient("https://rustchain.org") as client:
+                miners = await client.miners()
+
+            assert miners == [{"miner": "miner-envelope", "hardware_type": "PowerPC G4"}]
 
 
 class TestAsyncBalanceEndpoint:

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -3,14 +3,11 @@ Unit tests for RustChain Client (with mocked responses)
 """
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from rustchain import RustChainClient
 from rustchain.exceptions import (
     ConnectionError,
     ValidationError,
-    APIError,
-    AttestationError,
-    TransferError,
 )
 
 
@@ -162,6 +159,27 @@ class TestMinersEndpoint:
             miners = client.miners()
 
         assert miners == []
+
+    @patch("requests.Session.request")
+    def test_miners_envelope_response(self, mock_request):
+        """Test miners endpoint returning an envelope."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "data": [
+                {
+                    "miner": "miner-envelope",
+                    "hardware_type": "PowerPC G4",
+                }
+            ],
+            "pagination": {"total": 1},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        with RustChainClient("https://rustchain.org") as client:
+            miners = client.miners()
+
+        assert miners == [{"miner": "miner-envelope", "hardware_type": "PowerPC G4"}]
 
 
 class TestBalanceEndpoint:


### PR DESCRIPTION
## Summary
- accept `miners`/`data`/`items` envelopes in the sync and async RustChain SDK miner clients
- preserve existing raw-array `/api/miners` behavior
- add sync and async regression coverage for envelope payloads
- remove unused imports in touched SDK test files and an unused JSON exception variable

## Validation
- `PYTHONPATH=sdk uv run --no-project --with pytest --with requests --with aiohttp python -m pytest sdk/tests/test_client_unit.py -q`
- `PYTHONPATH=sdk uv run --no-project --with pytest --with pytest-asyncio --with aiohttp --with requests python -m pytest sdk/tests/test_async_client.py -q`
- `python3 -m py_compile sdk/rustchain/client.py sdk/rustchain/async_client.py sdk/tests/test_client_unit.py sdk/tests/test_async_client.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- sdk/rustchain/client.py sdk/rustchain/async_client.py sdk/tests/test_client_unit.py sdk/tests/test_async_client.py`
- `uv run --no-project --with ruff python -m ruff check sdk/rustchain/client.py sdk/rustchain/async_client.py sdk/tests/test_client_unit.py sdk/tests/test_async_client.py`

Bounty context: Scottcjn/rustchain-bounties#71