### PR TITLE
fix: normalize python sdk miner envelopes

### DIFF
--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -4,14 +4,12 @@ Provides async access to the RustChain network RPC API.
 """
 
 import httpx
-import json
 from typing import Dict, List, Any, Optional
 
 from .exceptions import (
     RustChainError,
     ConnectionError as RCConnectionError,
     APIError,
-    ValidationError,
 )
 
 
@@ -214,7 +212,12 @@ class RustChainClient:
         result = await self._get("/miners")
         if isinstance(result, list):
             return result
-        return result.get("miners", [])
+        if isinstance(result, dict):
+            for key in ("miners", "data", "items"):
+                miners = result.get(key)
+                if isinstance(miners, list):
+                    return miners
+        return []
 
     async def get_attestation_status(self, miner_public_key: str) -> Dict[str, Any]:
         """

--- a/sdk/python/rustchain_sdk/tests/test_client.py
+++ b/sdk/python/rustchain_sdk/tests/test_client.py
@@ -135,6 +135,35 @@ class TestRustChainClientMiners:
         assert isinstance(miners, list)
         assert len(miners) == 1
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_miners_handles_data_envelope(self):
+        """get_miners handles compatible data envelopes."""
+        route = respx.get(f"{DEFAULT_NODE_URL}/miners").mock(
+            return_value=httpx.Response(200, json={
+                "data": [{"public_key": "pk1", "score": 100}],
+                "pagination": {"total": 1},
+            })
+        )
+        async with RustChainClient() as client:
+            miners = await client.get_miners()
+        assert miners == [{"public_key": "pk1", "score": 100}]
+        assert route.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_miners_handles_items_envelope(self):
+        """get_miners handles compatible items envelopes."""
+        route = respx.get(f"{DEFAULT_NODE_URL}/miners").mock(
+            return_value=httpx.Response(200, json={
+                "items": [{"public_key": "pk2", "score": 90}]
+            })
+        )
+        async with RustChainClient() as client:
+            miners = await client.get_miners()
+        assert miners == [{"public_key": "pk2", "score": 90}]
+        assert route.called
+
 
 class TestRustChainClientBalance:
     """Test balance endpoints."""


### PR DESCRIPTION
## Summary
- accept `data` and `items` miner envelopes in `sdk/python/rustchain_sdk`
- preserve existing raw list and `miners` envelope behavior
- return an empty list for unexpected miner payload shapes
- add regression coverage for the compatible envelope shapes

## Validation
- `PYTHONPATH=sdk/python uv run --no-project --with pytest --with pytest-asyncio --with respx --with httpx --with mnemonic --with cryptography python -m pytest sdk/python/rustchain_sdk/tests/test_client.py -q`
- `python3 -m py_compile sdk/python/rustchain_sdk/client.py sdk/python/rustchain_sdk/tests/test_client.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- sdk/python/rustchain_sdk/client.py sdk/python/rustchain_sdk/tests/test_client.py`
- `uv run --no-project --with ruff python -m ruff check sdk/python/rustchain_sdk/client.py`

Bounty context: Scottcjn/rustchain-bounties#71