### PR TITLE
fix: normalize vintage video miner rows

### DIFF
--- a/tests/test_vintage_ai_rustchain_client.py
+++ b/tests/test_vintage_ai_rustchain_client.py
@@ -1,0 +1,45 @@
+"""Tests for the vintage AI video RustChain client."""
+
+import importlib.util
+from pathlib import Path
+
+
+def load_client_module():
+    repo_root = Path(__file__).resolve().parents[1]
+    module_path = repo_root / "vintage_ai_video_pipeline" / "rustchain_client.py"
+    spec = importlib.util.spec_from_file_location("vintage_rustchain_client", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_miners_accepts_envelope_payloads(monkeypatch):
+    module = load_client_module()
+    client = module.RustChainClient(base_url="https://node.example")
+
+    monkeypatch.setattr(
+        client,
+        "_get",
+        lambda endpoint: {
+            "items": [
+                {"miner": "alice", "hardware_type": "PowerPC G4"},
+                {"miner": "bob", "hardware_type": "x86-64"},
+            ],
+            "pagination": {"total": 2},
+        },
+    )
+
+    assert client.get_miners() == [
+        {"miner": "alice", "hardware_type": "PowerPC G4"},
+        {"miner": "bob", "hardware_type": "x86-64"},
+    ]
+
+
+def test_get_miners_returns_empty_list_for_unexpected_payload(monkeypatch):
+    module = load_client_module()
+    client = module.RustChainClient(base_url="https://node.example")
+
+    monkeypatch.setattr(client, "_get", lambda endpoint: {"pagination": {"total": 0}})
+
+    assert client.get_miners() == []

--- a/vintage_ai_video_pipeline/rustchain_client.py
+++ b/vintage_ai_video_pipeline/rustchain_client.py
@@ -109,7 +109,7 @@ class RustChainClient:
             except json.JSONDecodeError as e:
                 if attempt == self.retry_count - 1:
                     raise Exception(f"Invalid JSON response: {str(e)}")
-            except Exception as e:
+            except Exception:
                 if attempt == self.retry_count - 1:
                     raise
 
@@ -140,7 +140,15 @@ class RustChainClient:
         Returns:
             List of miner information dictionaries
         """
-        return self._get("/api/miners")
+        data = self._get("/api/miners")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            for key in ("miners", "data", "items"):
+                miners = data.get(key)
+                if isinstance(miners, list):
+                    return miners
+        return []
 
     def get_miner_eligibility(self, miner_id: str) -> Dict[str, Any]:
         """Check miner's epoch eligibility"""


### PR DESCRIPTION
## Summary
- unwrap `/api/miners` responses when the vintage video client receives raw arrays or common envelopes (`miners`, `data`, `items`)
- return an empty list for unexpected response shapes instead of leaking dictionaries into miner iteration
- add focused regression coverage for enveloped and unexpected miner payloads

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_vintage_ai_rustchain_client.py -q`
- `uv run --no-project --with ruff python -m ruff check vintage_ai_video_pipeline/rustchain_client.py tests/test_vintage_ai_rustchain_client.py`

Bounty context: Scottcjn/rustchain-bounties#71