### PR TITLE
fix: normalize monitor cli miner rows

### DIFF
--- a/tests/test_rustchain_monitor.py
+++ b/tests/test_rustchain_monitor.py
@@ -41,7 +41,10 @@ def test_request_helpers_call_expected_endpoints(rustchain_monitor_module, monke
     calls = []
     responses = {
         "https://node.example/health": {"ok": True},
-        "https://node.example/api/miners": [{"miner": "alice"}],
+        "https://node.example/api/miners": {
+            "items": [{"miner": "alice"}],
+            "pagination": {"total": 1},
+        },
         "https://node.example/epoch": {"epoch": 7},
     }
 
@@ -60,6 +63,18 @@ def test_request_helpers_call_expected_endpoints(rustchain_monitor_module, monke
         ("https://node.example/api/miners", 10),
         ("https://node.example/epoch", 10),
     ]
+
+
+def test_normalize_miners_payload_preserves_unexpected_shapes(rustchain_monitor_module):
+    assert rustchain_monitor_module.normalize_miners_payload([{"miner": "alice"}]) == [
+        {"miner": "alice"}
+    ]
+    assert rustchain_monitor_module.normalize_miners_payload(
+        {"miners": [{"miner": "bob"}]}
+    ) == [{"miner": "bob"}]
+    assert rustchain_monitor_module.normalize_miners_payload(
+        {"pagination": {"total": 0}}
+    ) == {"pagination": {"total": 0}}
 
 
 def test_request_helpers_return_error_dict_on_failure(rustchain_monitor_module, monkeypatch):

--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -12,12 +12,20 @@ Usage:
 """
 
 import argparse
-import json
-import sys
 import requests
 from datetime import datetime
 
 NODE_URL = "https://rustchain.org"
+
+def normalize_miners_payload(data):
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        for key in ("miners", "data", "items"):
+            miners = data.get(key)
+            if isinstance(miners, list):
+                return miners
+    return data
 
 def check_health():
     try:
@@ -32,7 +40,7 @@ def get_miners():
     try:
         resp = requests.get(f"{NODE_URL}/api/miners", timeout=10)
         resp.raise_for_status()
-        return resp.json()
+        return normalize_miners_payload(resp.json())
     except Exception as e:
         return {"error": str(e)}
 
@@ -48,7 +56,7 @@ def print_health(data):
     if "error" in data:
         print(f"❌ Health check failed: {data['error']}")
         return
-    print(f"✅ Node is healthy")
+    print("✅ Node is healthy")
     print(f"   Version: {data.get('version')}")
     print(f"   Uptime: {data.get('uptime_s')}s ({data.get('uptime_s')/3600:.1f} hours)")
     print(f"   Backup age: {data.get('backup_age_hours'):.2f} hours")
@@ -100,12 +108,14 @@ def main():
     if args.health or show_all:
         health = check_health()
         print_health(health)
-        if show_all: print()
+        if show_all:
+            print()
 
     if args.miners or show_all:
         miners = get_miners()
         print_miners(miners)
-        if show_all: print()
+        if show_all:
+            print()
 
     if args.epoch or show_all:
         epoch = get_epoch()


### PR DESCRIPTION
## Summary
- normalize `/api/miners` payloads in `tools/rustchain-monitor` before printing miner rows
- support raw list responses plus common `miners`, `data`, and `items` envelopes
- keep unexpected payloads flowing to the existing unexpected-response path
- remove simple lint issues in the touched monitor file

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_rustchain_monitor.py -q`
- `uv run --no-project --with ruff --with requests python -m ruff check tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py`
- `python3 -m py_compile tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py`

Bounty context: Scottcjn/rustchain-bounties#71