### PR TITLE
fix: repair static builder review templates

### DIFF
--- a/build_static.py
+++ b/build_static.py
@@ -364,6 +364,12 @@ def generate_project_card(project, index):
     )
     
     badge_embed = f'<img src="https://img.shields.io/badge/BCOS-{project.get("bcos_tier", "Unknown")}-{"green" if project.get("bcos_tier") == "L0" else "yellow" if project.get("bcos_tier") == "L1" else "red"}" alt="BCOS {project.get("bcos_tier", "Unknown")}" />'
+    review_note = project.get('review_note')
+    review_html = f'''
+        <div class="project-review">
+            <div class="review-label">Review Note:</div>
+            <div>{review_note}</div>
+        </div>''' if review_note else ''
     
     return f'''
     <div class="project-card" data-project-index="{index}">
@@ -404,10 +410,7 @@ def generate_project_card(project, index):
             </div>
         </div>
         
-        {f'''<div class="project-review">
-            <div class="review-label">Review Note:</div>
-            <div>{project.get('review_note', 'No review available')}</div>
-        </div>''' if project.get('review_note') else ''}
+        {review_html}
         
         <div class="badge-code" title="Click to copy badge embed code">
             {badge_embed}
@@ -417,6 +420,13 @@ def generate_project_card(project, index):
 
 def generate_project_page(project):
     """Generate individual project page HTML"""
+    review_note = project.get('review_note')
+    review_html = f'''
+        <h2>Review Note</h2>
+        <div style="background: #2a2a2a; padding: 15px; border-radius: 4px; border-left: 3px solid #ff6b35;">
+            {review_note}
+        </div>''' if review_note else ''
+
     return f'''<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -491,10 +501,7 @@ def generate_project_page(project):
             <div class="meta-value">{', '.join(project.get('categories', []))}</div>
         </div>
         
-        {f'''<h2>Review Note</h2>
-        <div style="background: #2a2a2a; padding: 15px; border-radius: 4px; border-left: 3px solid #ff6b35;">
-            {project.get('review_note', 'No review available')}
-        </div>''' if project.get('review_note') else ''}
+        {review_html}
     </div>
 </body>
 </html>'''


### PR DESCRIPTION
## Summary
- Fixes invalid nested f-string expressions in `build_static.py` review note templates.
- Preserves the existing rendered markup by preparing the optional review HTML before the outer template f-string.

## Verification
- `python3 -m py_compile build_static.py`
- `python3 build_static.py`

Payout/contact details can be provided privately if needed.