### PR TITLE
fix: normalize issue 765 exporter miner rows

### DIFF
--- a/bounties/issue-765/src/rustchain_exporter.py
+++ b/bounties/issue-765/src/rustchain_exporter.py
@@ -307,13 +307,20 @@ class RustChainNodeClient:
     def get_miners(self) -> List[MinerInfo]:
         """Fetch active miners."""
         data = self._fetch_json('/api/miners')
+        if isinstance(data, dict):
+            for key in ('miners', 'data', 'items'):
+                miners = data.get(key)
+                if isinstance(miners, list):
+                    data = miners
+                    break
+
         if not data or not isinstance(data, list):
             return []
 
         miners = []
         for item in data:
             miner = MinerInfo(
-                miner_id=item.get('miner_id', item.get('id', '')),
+                miner_id=item.get('miner_id', item.get('miner', item.get('id', ''))),
                 hardware_type=item.get('hardware_type', 'Unknown'),
                 device_arch=item.get('device_arch', item.get('arch', 'Unknown')),
                 antiquity_multiplier=item.get('antiquity_multiplier', 1.0),

--- a/bounties/issue-765/tests/test_exporter.py
+++ b/bounties/issue-765/tests/test_exporter.py
@@ -326,6 +326,36 @@ class TestRustChainNodeClient:
         assert miners[0].antiquity_multiplier == 2.5
 
     @patch('rustchain_exporter.requests.Session')
+    def test_get_miners_accepts_enveloped_payload(self, mock_session_class, config):
+        """Test miners fetch with paginated envelope payloads."""
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            'items': [
+                {
+                    'miner': 'live_miner_001',
+                    'hardware_type': 'PowerPC G5',
+                    'device_arch': 'ppc64',
+                    'antiquity_multiplier': 3.0,
+                }
+            ],
+            'pagination': {'total': 1, 'limit': 100, 'offset': 0},
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_session.get.return_value = mock_response
+
+        client = RustChainNodeClient(config)
+        miners = client.get_miners()
+
+        assert len(miners) == 1
+        assert miners[0].miner_id == 'live_miner_001'
+        assert miners[0].hardware_type == 'PowerPC G5'
+        assert miners[0].device_arch == 'ppc64'
+        assert miners[0].antiquity_multiplier == 3.0
+
+    @patch('rustchain_exporter.requests.Session')
     def test_retry_logic(self, mock_session_class, config):
         """Test request retry logic."""
         mock_session = MagicMock()


### PR DESCRIPTION
## Summary
- normalize `/api/miners` payloads in the issue 765 Prometheus exporter before building `MinerInfo` rows
- support raw arrays plus common `miners`, `data`, and `items` envelopes
- accept live miner rows that use `miner` instead of only `miner_id` or `id`
- add focused regression coverage for enveloped miner payloads

## Validation
- `uv run --no-project --with pytest --with requests --with prometheus-client --with psutil --with pyyaml --with flask python -m pytest bounties/issue-765/tests/test_exporter.py -q`
- `python3 -m py_compile bounties/issue-765/src/rustchain_exporter.py bounties/issue-765/tests/test_exporter.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- bounties/issue-765/src/rustchain_exporter.py bounties/issue-765/tests/test_exporter.py`

Note: full-file `ruff check` is not included as a gate because this older bounty implementation currently has unrelated pre-existing lint findings outside this change.

Bounty context: Scottcjn/rustchain-bounties#71