### PR TITLE
fix: harden miner alert row normalization

### DIFF
--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -287,6 +287,34 @@ def test_fetch_helpers_parse_success_and_errors(miner_alerts_module, monkeypatch
     monkeypatch.setattr(
         miner_alerts_module.requests,
         "get",
+        lambda *_args, **_kwargs: FakeResponse(
+            {
+                "data": [
+                    {"miner_id": "miner-b", "online": False},
+                    None,
+                    "bad-row",
+                ]
+            }
+        ),
+    )
+    assert miner_alerts_module.fetch_miners() == [
+        {"miner_id": "miner-b", "online": False}
+    ]
+
+    monkeypatch.setattr(
+        miner_alerts_module.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse(
+            {"items": [{"miner_id": "miner-c", "online": True}, 42]}
+        ),
+    )
+    assert miner_alerts_module.fetch_miners() == [
+        {"miner_id": "miner-c", "online": True}
+    ]
+
+    monkeypatch.setattr(
+        miner_alerts_module.requests,
+        "get",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
     )
     assert miner_alerts_module.fetch_miners() == []

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -483,10 +483,17 @@ def fetch_miners() -> List[dict]:
         resp.raise_for_status()
         data = resp.json()
         if isinstance(data, list):
-            return data
-        if isinstance(data, dict) and isinstance(data.get("miners"), list):
-            return data["miners"]
-        return []
+            rows = data
+        elif isinstance(data, dict):
+            rows = []
+            for key in ("miners", "data", "items"):
+                value = data.get(key)
+                if isinstance(value, list):
+                    rows = value
+                    break
+        else:
+            rows = []
+        return [row for row in rows if isinstance(row, dict)]
     except Exception as e:
         logger.error(f"Failed to fetch miners: {e}")
         return []


### PR DESCRIPTION
## Summary
- accepts raw arrays plus `miners`, `data`, and `items` envelopes from `/api/miners`
- filters malformed/non-object rows before the alert loop calls `miner.get(...)`
- adds regression coverage for enveloped responses containing bad rows

## Validation
- `uv run --no-project --with pytest --with requests --with python-dotenv --with flask python -m pytest tests/test_miner_alerts.py -q` -> 5 passed
- `python3 -m py_compile tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`
- `git diff --check -- tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`

Bounty context: Scottcjn/rustchain-bounties#71
Wallet: RTC5800896ed658aa511D029361b6d7388ddb29248B
