### PR TITLE
fix: normalize reputation miner verification rows

### DIFF
--- a/agent_reputation.py
+++ b/agent_reputation.py
@@ -173,9 +173,21 @@ class ReputationEngine:
             # Try via API /api/miners
             miners_data = self._fetch("/api/miners")
             if miners_data:
-                miners = miners_data if isinstance(miners_data, list) else miners_data.get("miners", [])
+                miners = miners_data if isinstance(miners_data, list) else []
+                if isinstance(miners_data, dict):
+                    for key in ("miners", "data", "items"):
+                        rows = miners_data.get(key)
+                        if isinstance(rows, list):
+                            miners = rows
+                            break
                 for m in miners:
-                    if m.get("wallet_name") == wallet or m.get("wallet") == wallet:
+                    miner_id = (
+                        m.get("wallet_name")
+                        or m.get("wallet")
+                        or m.get("miner")
+                        or m.get("miner_id")
+                    )
+                    if miner_id == wallet:
                         hardware_verified = True
                         break
 
@@ -417,7 +429,7 @@ if __name__ == "__main__":
     print(f"  Level:          {result['level'].upper()} — {result['level_description']}")
     print(f"  Max Job Value:  {result['max_job_value_rtc']} RTC")
     print(f"  Can Post Jobs:  {'✓' if result['can_post_jobs'] else '✗'}")
-    print(f"")
+    print("")
     print(f"  Jobs Completed: {result['jobs_completed']}")
     print(f"  Jobs Accepted:  {result['jobs_accepted']}")
     print(f"  Jobs Disputed:  {result['jobs_disputed']}")

--- a/tests/test_agent_reputation.py
+++ b/tests/test_agent_reputation.py
@@ -130,3 +130,29 @@ def test_refresh_stale_cache_entries_stores_recalculated_result(monkeypatch):
     refreshed, timestamp = engine._cache["agent-a"]
     assert refreshed == {"agent_id": "agent-a", "reputation_score": 99}
     assert timestamp > 0
+
+
+def test_reputation_hardware_check_accepts_miner_envelopes(monkeypatch):
+    wallet = "agent-miner-wallet"
+    engine = agent_reputation.ReputationEngine(db_path="/tmp/does-not-exist.db")
+
+    def fake_fetch(path):
+        if path.startswith("/agent/jobs"):
+            return {"jobs": []}
+        if path == "/api/miners":
+            return {
+                "items": [
+                    {
+                        "miner": wallet,
+                        "hardware_type": "PowerPC G5",
+                    }
+                ],
+                "pagination": {"total": 1},
+            }
+        return None
+
+    monkeypatch.setattr(engine, "_fetch", fake_fetch)
+    result = engine.calculate(wallet)
+
+    assert result["hardware_verified"] is True
+    assert result["reputation_score"] == 10


### PR DESCRIPTION
## Summary
- normalize `/api/miners` responses before the agent reputation hardware-verification fallback scans miner rows
- support raw arrays plus common `miners`, `data`, and `items` envelopes
- match common miner identity fields (`wallet_name`, `wallet`, `miner`, `miner_id`) so live rows can verify hardware attestations
- add focused regression coverage for an enveloped miner payload

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_agent_reputation.py -q`
- `uv run --no-project --with ruff --with flask python -m ruff check agent_reputation.py tests/test_agent_reputation.py`
- `python3 -m py_compile agent_reputation.py tests/test_agent_reputation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- agent_reputation.py tests/test_agent_reputation.py`

Bounty context: Scottcjn/rustchain-bounties#71