### PR TITLE
docs: stop recommending unsupported clawrtc mine dry-run

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -69,8 +69,9 @@ bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```powershell
 # 使用 Python 安装
 pip install clawrtc
-# Windows note: current clawrtc releases do not support miner dry-run.
-# Use Linux/macOS or WSL for `clawrtc mine --dry-run`.
+# Windows note: current clawrtc releases do not support `mine --dry-run`.
+# Use the installer preview path on Linux/macOS/WSL when you need a dry-run.
+bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 clawrtc --help
 ```
 

--- a/docs/UPGRADE_MIGRATION_GUIDE.md
+++ b/docs/UPGRADE_MIGRATION_GUIDE.md
@@ -336,8 +336,8 @@ launchctl start com.rustchain.miner     # macOS
 clawrtc --version
 
 # 运行干跑测试
-# Linux/macOS/WSL only: current Windows clawrtc releases do not support miner dry-run.
-clawrtc mine --dry-run
+# 当前 clawrtc mine 子命令不接受 --dry-run；使用安装器预览路径。
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 
 # 预期：所有 6 项硬件指纹检查执行成功
 ```
@@ -416,7 +416,7 @@ open https://rustchain.org/explorer
 - [ ] 已停止当前矿工
 - [ ] 已下载/安装新版本
 - [ ] 已验证安装（`clawrtc --version`）
-- [ ] 已运行干跑测试（Linux/macOS/WSL: `clawrtc mine --dry-run`）
+- [ ] 已运行干跑测试（Linux/macOS/WSL: `install-miner.sh --dry-run`）
 - [ ] 已启动新矿工
 - [ ] 已验证挖矿状态
 - [ ] 已检查钱包余额（1-2 epoch 后）

--- a/tests/test_miner_dry_run_docs.py
+++ b/tests/test_miner_dry_run_docs.py
@@ -8,3 +8,15 @@ def test_rust_miner_readme_explains_dry_run_behavior():
     assert "preflight checks" in readme
     assert "hardware fingerprint" in readme
     assert "actual mining" in readme
+
+
+def test_clawrtc_docs_do_not_recommend_unsupported_mine_dry_run():
+    docs = "\n".join(
+        [
+            Path("docs/FAQ.md").read_text(encoding="utf-8"),
+            Path("docs/UPGRADE_MIGRATION_GUIDE.md").read_text(encoding="utf-8"),
+        ]
+    )
+
+    assert "clawrtc mine --dry-run" not in docs
+    assert "install-miner.sh --dry-run" in docs


### PR DESCRIPTION
## Summary
- replace user-facing `clawrtc mine --dry-run` guidance with the supported installer dry-run path
- clarify the current `clawrtc mine` limitation in the FAQ/upgrade docs
- add a regression test so these docs do not reintroduce the unsupported command

Fixes #5881.

## Verification
- `uv run --no-project --with pytest python -m pytest tests/test_miner_dry_run_docs.py -q`
- `rg -n "clawrtc mine --dry-run" docs README.md -S` (no matches)
- `git diff --check -- docs/UPGRADE_MIGRATION_GUIDE.md docs/FAQ.md tests/test_miner_dry_run_docs.py`