### PR TITLE
fix: validate beacon contract amounts

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -5,6 +5,7 @@ Provides endpoints for agents, contracts, bounties, reputation, and chat.
 """
 import json
 import html
+import math
 import os
 import time
 import hashlib
@@ -48,6 +49,17 @@ def _required_text_field(data, field_name):
     if not isinstance(value, str) or not value.strip():
         return None, jsonify({'error': f'Missing {field_name}'}), 400
     return value.strip(), None, None
+
+
+def _positive_float_field(data, field_name):
+    value = data.get(field_name)
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None, jsonify({'error': f'{field_name} must be a positive number'}), 400
+    if not math.isfinite(number) or number <= 0:
+        return None, jsonify({'error': f'{field_name} must be a positive number'}), 400
+    return number, None, None
 
 
 def _coinbase_addresses_match(left, right):
@@ -589,12 +601,16 @@ def create_contract():
         # Generate contract ID
         contract_id = f"ctr_{int(time.time())}_{hashlib.blake2b(str(time.time()).encode(), digest_size=4).hexdigest()}"
         
+        amount, amount_error, amount_status = _positive_float_field(data, 'amount')
+        if amount_error:
+            return amount_error, amount_status
+
         contract = {
             'id': contract_id,
             'from': data['from'],
             'to': data['to'],
             'type': data['type'],
-            'amount': float(data['amount']),
+            'amount': amount,
             'currency': data.get('currency', 'RTC'),
             'term': data['term'],
             'state': 'offered',  # Initial state

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -240,6 +240,36 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         data = json.loads(response.data)
         self.assertIn('error', data)
 
+    def test_contract_creation_rejects_invalid_amounts(self):
+        """Contract creation rejects malformed and non-positive amounts."""
+        for amount in ('not-a-number', 0, -1):
+            contract_data = {
+                'from': 'bcn_alice_test',
+                'to': 'bcn_bob_test',
+                'type': 'rent',
+                'amount': amount,
+                'term': '30d',
+            }
+            create_body = json.dumps(contract_data)
+
+            response = self.client.post(
+                '/api/contracts',
+                data=create_body,
+                content_type='application/json',
+                headers=self._signed_headers(
+                    'bcn_alice_test',
+                    'POST',
+                    '/api/contracts',
+                    create_body,
+                ),
+            )
+
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(
+                json.loads(response.data)['error'],
+                'amount must be a positive number',
+            )
+
     def test_bounty_lifecycle_workflow(self):
         """Full bounty lifecycle: create, claim, complete."""
         # Insert a test bounty directly


### PR DESCRIPTION
## Summary
- validate Beacon contract `amount` values as finite positive numbers before inserting contracts
- return a 400 validation error for malformed, zero, negative, or non-finite amounts instead of falling into the generic internal-error path or storing invalid contracts
- add focused behavior coverage for malformed and non-positive contract amounts with signed contract-create requests

## Validation
- `uv run --no-project --with pytest --with flask --with cryptography python -m pytest tests/test_beacon_atlas_behavior.py -q`
- `python3 -m py_compile node/beacon_api.py tests/test_beacon_atlas_behavior.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/beacon_api.py tests/test_beacon_atlas_behavior.py`

Note: full-file `ruff check` is not included as a gate because `node/beacon_api.py` currently has unrelated pre-existing lint findings across older routes outside this change.

Bounty context: Scottcjn/rustchain-bounties#71