### PR TITLE
fix: validate relic market reserve fields

### DIFF
--- a/bounties/issue-2312/src/relic_market_api.py
+++ b/bounties/issue-2312/src/relic_market_api.py
@@ -14,14 +14,14 @@ import time
 import hashlib
 import secrets
 import base64
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Any, Tuple
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
 from dataclasses import dataclass, asdict, field
 from enum import Enum
 import threading
 import logging
 
-from flask import Flask, jsonify, request, Response
+from flask import Flask, jsonify, request
 import nacl.signing
 import nacl.encoding
 
@@ -990,6 +990,20 @@ def _positive_limit(default: int = 10):
     return limit, None
 
 
+def _required_string_field(data: Dict, field_name: str):
+    value = data.get(field_name)
+    if not isinstance(value, str) or not value.strip():
+        return None, (jsonify({"error": f"{field_name} must be a non-empty string"}), 400)
+    return value.strip(), None
+
+
+def _positive_number_field(data: Dict, field_name: str):
+    value = data.get(field_name)
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or value <= 0:
+        return None, (jsonify({"error": f"{field_name} must be a positive number"}), 400)
+    return value, None
+
+
 # ============== API Endpoints ==============
 
 @app.route('/health', methods=['GET'])
@@ -1042,12 +1056,22 @@ def reserve_machine():
     required = ["machine_id", "agent_id", "duration_hours", "payment_rtc"]
     if not all(k in data for k in required):
         return jsonify({"error": "Missing required fields", "required": required}), 400
+
+    machine_id, error = _required_string_field(data, "machine_id")
+    if error:
+        return error
+    agent_id, error = _required_string_field(data, "agent_id")
+    if error:
+        return error
+    payment_rtc, error = _positive_number_field(data, "payment_rtc")
+    if error:
+        return error
     
     reservation, error = reservation_manager.create_reservation(
-        machine_id=data["machine_id"],
-        agent_id=data["agent_id"],
+        machine_id=machine_id,
+        agent_id=agent_id,
         duration_hours=data["duration_hours"],
-        payment_rtc=data["payment_rtc"]
+        payment_rtc=payment_rtc
     )
     
     if error:

--- a/bounties/issue-2312/tests/test_relic_market.py
+++ b/bounties/issue-2312/tests/test_relic_market.py
@@ -15,7 +15,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 from relic_market_api import (
-    VintageMachine, Reservation, ProvenanceReceipt,
+    VintageMachine,
     MachineRegistry, EscrowManager, ReceiptSigner,
     ReservationManager, MCPIntegration, BeaconIntegration,
     AccessDuration, ReservationStatus, app
@@ -527,6 +527,48 @@ class TestAPIEndpoints(unittest.TestCase):
         )
         
         self.assertEqual(response.status_code, 400)
+
+    def test_reserve_machine_rejects_structured_identity_fields(self):
+        base_payload = {
+            "machine_id": "vm-001",
+            "agent_id": "api-agent",
+            "duration_hours": 1,
+            "payment_rtc": 50.0
+        }
+
+        for field in ("machine_id", "agent_id"):
+            with self.subTest(field=field):
+                payload = dict(base_payload)
+                payload[field] = ["not", "a", "string"]
+
+                response = self.client.post(
+                    '/relic/reserve',
+                    json=payload,
+                    content_type='application/json'
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json()["error"],
+                    f"{field} must be a non-empty string",
+                )
+
+    def test_reserve_machine_rejects_invalid_payment_type(self):
+        payload = {
+            "machine_id": "vm-001",
+            "agent_id": "api-agent",
+            "duration_hours": 1,
+            "payment_rtc": "50.0"
+        }
+
+        response = self.client.post(
+            '/relic/reserve',
+            json=payload,
+            content_type='application/json'
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "payment_rtc must be a positive number")
     
     def test_get_reservation(self):
         # Create reservation first


### PR DESCRIPTION
## Summary
- validate `/relic/reserve` `machine_id` and `agent_id` as non-empty strings before reservation creation
- validate `payment_rtc` as a positive numeric JSON value before comparing against machine cost
- return 400 validation errors for structured identity fields or string payments instead of leaking them into reservation logic
- remove stale unused imports from the touched issue-2312 files

## Validation
- `uv run --no-project --with pytest --with flask --with pynacl python -m pytest bounties/issue-2312/tests/test_relic_market.py -q`
- `uv run --no-project --with ruff --with flask --with pynacl python -m ruff check bounties/issue-2312/src/relic_market_api.py bounties/issue-2312/tests/test_relic_market.py`
- `python3 -m py_compile bounties/issue-2312/src/relic_market_api.py bounties/issue-2312/tests/test_relic_market.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- bounties/issue-2312/src/relic_market_api.py bounties/issue-2312/tests/test_relic_market.py`

Bounty context: Scottcjn/rustchain-bounties#71