### PR TITLE
fix: reject malformed genesis validator payloads

### DIFF
--- a/tests/test_poa_validator_tool.py
+++ b/tests/test_poa_validator_tool.py
@@ -83,3 +83,29 @@ def test_validate_genesis_rejects_mismatched_fingerprint(tmp_path):
     )
 
     assert module.validate_genesis(genesis_path) is False
+
+
+def test_validate_genesis_rejects_non_object_json_without_raising(tmp_path):
+    module = load_module()
+    genesis_path = tmp_path / "genesis.json"
+    genesis_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    assert module.validate_genesis(genesis_path) is False
+
+
+def test_validate_genesis_rejects_non_string_fields_without_raising(tmp_path):
+    module = load_module()
+    genesis_path = tmp_path / "genesis.json"
+    genesis_path.write_text(
+        json.dumps({
+            "device": {"model": "PowerMac G4"},
+            "timestamp": ["Mon Jan 01 00:00:00 2001"],
+            "message": "retro proof",
+            "mac_address": 393,
+            "cpu": None,
+            "fingerprint": True,
+        }),
+        encoding="utf-8",
+    )
+
+    assert module.validate_genesis(genesis_path) is False

--- a/tools/validate_genesis.py
+++ b/tools/validate_genesis.py
@@ -5,7 +5,6 @@ import json
 import base64
 import hashlib
 import datetime
-import re
 
 # Example MAC prefixes for Apple (vintage ranges)
 VALID_MAC_PREFIXES = ["00:03:93", "00:0a:27", "00:05:02", "00:0d:93"]
@@ -32,19 +31,29 @@ def recompute_hash(device, timestamp, message):
     sha1 = hashlib.sha1(joined.encode('utf-8')).digest()
     return base64.b64encode(sha1).decode('utf-8')
 
+def _string_field(data, name):
+    value = data.get(name, "")
+    if not isinstance(value, str):
+        return ""
+    return value.strip()
+
 def validate_genesis(path):
     with open(path, 'r') as f:
         data = json.load(f)
 
-    device = data.get("device", "").strip()
-    timestamp = data.get("timestamp", "").strip()
-    message = data.get("message", "").strip()
-    fingerprint = data.get("fingerprint", "").strip()
-    mac = data.get("mac_address", "").strip()
-    cpu = data.get("cpu", "").strip()
-
     print("\nValidating genesis.json...")
     errors = []
+
+    if not isinstance(data, dict):
+        errors.append("Genesis file must contain a JSON object")
+        data = {}
+
+    device = _string_field(data, "device")
+    timestamp = _string_field(data, "timestamp")
+    message = _string_field(data, "message")
+    fingerprint = _string_field(data, "fingerprint")
+    mac = _string_field(data, "mac_address")
+    cpu = _string_field(data, "cpu")
 
     if not is_valid_mac(mac):
         errors.append("MAC address not in known Apple ranges")


### PR DESCRIPTION
## Summary
- reject non-object genesis JSON files as validation failures instead of raising
- coerce non-string genesis fields to invalid empty values before validation
- add regressions for malformed JSON shape and non-string fields

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_poa_validator_tool.py tools/tests/test_poa_validator_helpers.py -q`
- `python3 -m py_compile tools/validate_genesis.py tests/test_poa_validator_tool.py`
- `uv run --no-project --with ruff python -m ruff check tools/validate_genesis.py tests/test_poa_validator_tool.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/validate_genesis.py tests/test_poa_validator_tool.py`

Bounty context: Scottcjn/rustchain-bounties#71