### PR TITLE
Fix BCOS badge JSON body validation

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -439,6 +439,51 @@ class TestFlaskIntegration(unittest.TestCase):
         self.assertTrue(data['success'])
         self.assertIn('cert_id', data)
 
+    def test_generate_badge_rejects_non_json_body(self):
+        """Non-JSON bodies should return JSON 400 responses, not HTML errors."""
+        response = self.client.post(
+            '/api/badge/generate',
+            data='not json',
+            headers={
+                'X-Admin-Key': self.admin_key,
+                'Content-Type': 'text/plain',
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'JSON object body required')
+
+    def test_generate_badge_rejects_non_object_json_body(self):
+        """JSON arrays should fail validation before route code calls .get()."""
+        response = self.client.post(
+            '/api/badge/generate',
+            json=['test/repo', 'L1'],
+            headers={'X-Admin-Key': self.admin_key},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertFalse(data['success'])
+        self.assertEqual(data['error'], 'JSON object body required')
+
+    def test_generate_badge_rejects_scalar_repo_and_tier_fields(self):
+        """Scalar field validation should reject non-strings without 500s."""
+        cases = [
+            ({'repo_name': ['test/repo'], 'tier': 'L1'}, 'Repository name must be a string'),
+            ({'repo_name': 'test/repo', 'tier': True}, 'Tier must be a string'),
+        ]
+
+        for payload, error in cases:
+            with self.subTest(payload=payload):
+                response = self.post_generate_badge(payload)
+
+                self.assertEqual(response.status_code, 200)
+                data = json.loads(response.data)
+                self.assertFalse(data['success'])
+                self.assertEqual(data['error'], error)
+
     def test_generate_badge_missing_repo(self):
         """Test badge generation with missing repo name."""
         response = self.post_generate_badge(

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1124,10 +1124,22 @@ def generate_badge():
     if auth_error:
         return auth_error
 
-    data = request.get_json()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({
+            'success': False,
+            'error': 'JSON object body required',
+        }), 400
 
-    repo_name = data.get('repo_name', '').strip()
-    tier = data.get('tier', 'L1').upper()
+    raw_repo_name = data.get('repo_name', '')
+    if not isinstance(raw_repo_name, str):
+        return jsonify({'success': False, 'error': 'Repository name must be a string'})
+    repo_name = raw_repo_name.strip()
+
+    raw_tier = data.get('tier', 'L1')
+    if not isinstance(raw_tier, str):
+        return jsonify({'success': False, 'error': 'Tier must be a string'})
+    tier = raw_tier.upper()
     raw_trust_score = data.get('trust_score', 75)
     cert_id = data.get('cert_id', '')
     include_qr = data.get('include_qr', False)


### PR DESCRIPTION
## Summary

Fixes #5903.

This hardens the admin-protected BCOS badge generator route against malformed request bodies:

- parse `/api/badge/generate` with `request.get_json(silent=True)`
- reject non-JSON or top-level non-object JSON with a JSON 400 response
- validate `repo_name` is a string before `.strip()`
- validate `tier` is a string before `.upper()`
- keep existing validation behavior for normal bad repo/tier/trust-score values

## Validation

- `python -m pytest -q tests/test_bcos_badge_generator.py -p no:cacheprovider` -> 48 passed, 9 subtests passed
- `python -m py_compile tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py`
- `git diff --check`

## Bounty / payout

Bug bounty pool: #305

RTC payout wallet: `RTC0bc961e7a95d320d2707470643fa35deb1a26d09`