### PR TITLE
fix: tolerate corrupt badge metadata

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -9,11 +9,12 @@ Run with:
 
 import json
 import os
+import sqlite3
 import sys
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -350,6 +351,23 @@ class TestFlaskIntegration(unittest.TestCase):
             content_type='application/json',
         )
 
+    def insert_badge_with_metadata(self, cert_id, metadata):
+        """Insert a badge row with caller-provided raw metadata."""
+        import tools.bcos_badge_generator as bg
+
+        conn = sqlite3.connect(bg.DATABASE)
+        try:
+            conn.execute(
+                '''
+                INSERT INTO badges (cert_id, repo_name, github_url, tier, trust_score, metadata)
+                VALUES (?, ?, ?, ?, ?, ?)
+                ''',
+                (cert_id, 'test/repo', 'https://github.com/test/repo', 'L1', 75, metadata),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
     def test_index_page(self):
         """Test index page loads."""
         response = self.client.get('/')
@@ -598,6 +616,17 @@ class TestFlaskIntegration(unittest.TestCase):
         data = json.loads(response.data)
         self.assertFalse(data['valid'])
 
+    def test_verify_tolerates_corrupt_stored_metadata(self):
+        """Corrupt legacy metadata should not break badge verification."""
+        self.insert_badge_with_metadata('BCOS-CORRUPTVERIFY', '{bad-json')
+
+        response = self.client.get('/api/badge/verify/BCOS-CORRUPTVERIFY')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['valid'])
+        self.assertEqual(data['data']['metadata'], {})
+
     def test_serve_badge_svg(self):
         """Test serving badge SVG."""
         # Generate a badge first
@@ -619,6 +648,16 @@ class TestFlaskIntegration(unittest.TestCase):
         """Test serving non-existent badge."""
         response = self.client.get('/badge/BCOS-NOTFOUND.svg')
         self.assertEqual(response.status_code, 404)
+
+    def test_serve_badge_svg_tolerates_corrupt_stored_metadata(self):
+        """Corrupt legacy metadata should not break badge SVG rendering."""
+        self.insert_badge_with_metadata('BCOS-CORRUPTSVG', 'not-json')
+
+        response = self.client.get('/badge/BCOS-CORRUPTSVG.svg')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'image/svg+xml')
+        self.assertIn(b'<svg', response.data)
 
 
 class TestEdgeCases(unittest.TestCase):

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -32,18 +32,16 @@ import os
 import re
 import secrets
 import sqlite3
-import subprocess
 import sys
 import time
 import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict
 
 # Try to import Flask, provide helpful error if missing
 try:
-    from flask import Flask, render_template_string, request, jsonify, send_from_directory
+    from flask import Flask, render_template_string, request, jsonify
 except ImportError:
     print("Flask not installed. Install with: pip install flask", file=sys.stderr)
     sys.exit(1)
@@ -113,6 +111,17 @@ def is_valid_cert_id(cert_id: object) -> bool:
     if not isinstance(cert_id, str):
         return False
     return bool(CERT_ID_PATTERN.fullmatch(cert_id))
+
+
+def _load_metadata_object(raw_metadata: str) -> Dict:
+    """Return stored metadata when it is valid JSON object data."""
+    if not raw_metadata:
+        return {}
+    try:
+        metadata = json.loads(raw_metadata)
+    except json.JSONDecodeError:
+        return {}
+    return metadata if isinstance(metadata, dict) else {}
 
 # ── Database Functions ──────────────────────────────────────────────
 
@@ -430,7 +439,7 @@ def verify_certificate(cert_id: str, use_cache: bool = True) -> Dict:
             'commitment': result[4],
             'reviewer': result[5],
             'generated_at': result[6],
-            'metadata': json.loads(result[7]) if result[7] else {},
+            'metadata': _load_metadata_object(result[7]),
         }
 
         # Cache the result
@@ -1233,7 +1242,7 @@ def serve_badge_svg(cert_id):
         return 'Badge not found', 404
 
     repo_name, tier, trust_score, metadata = result
-    metadata_dict = json.loads(metadata) if metadata else {}
+    metadata_dict = _load_metadata_object(metadata)
 
     # Increment download count
     increment_download_count(cert_id)


### PR DESCRIPTION
## Summary
- add a safe metadata loader for stored badge metadata
- prevent corrupt or non-object metadata from breaking badge verification and SVG rendering
- add database-backed regressions for corrupt metadata in verify and SVG routes
- remove stale unused imports in touched files

## Validation
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow python -m pytest tests/test_bcos_badge_generator.py -q`
- `python3 -m py_compile tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py`
- `uv run --no-project --with ruff --with flask --with qrcode --with pillow python -m ruff check tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py`

Bounty context: Scottcjn/rustchain-bounties#71