### PR TITLE
fix: validate machine passport JSON bodies

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -9,11 +9,10 @@ Issue: #2309
 """
 
 import os
-import json
 import time
 import hmac
 from typing import Optional
-from flask import Blueprint, request, jsonify, render_template_string
+from flask import Blueprint, request, jsonify
 
 from machine_passport import (
     MachinePassportLedger,
@@ -251,7 +250,9 @@ def create_passport():
     if auth_error is not None:
         return auth_error
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -339,7 +340,9 @@ def update_passport(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -579,7 +582,6 @@ def generate_qr(machine_id: str):
     """
     import tempfile
     import base64
-    from io import BytesIO
     
     ledger = get_ledger()
     passport = ledger.get_passport(machine_id)
@@ -671,7 +673,9 @@ def compute_machine_id_endpoint():
     
     Request Body: Hardware fingerprint data (same as attestation)
     """
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -21,7 +21,7 @@ import time
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -30,7 +30,6 @@ from machine_passport import (
     MachinePassport,
     MachinePassportLedger,
     compute_machine_id,
-    init_machine_passport_schema,
     generate_qr_code,
     generate_passport_pdf,
 )
@@ -568,6 +567,22 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertTrue(data['ok'])
         self.assertIn('machine_id', data)
 
+    def test_create_passport_rejects_non_object_json(self):
+        """Passport creation requires a JSON object body."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+
+        resp = self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json=['name', 'owner_miner_id'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
+
     def test_update_passport_rejects_owner_claim_without_admin_key(self):
         """Client-supplied owner_miner_id is not proof of ownership."""
         os.environ['ADMIN_KEY'] = 'expected-admin-key'
@@ -625,6 +640,31 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(data['ok'])
         compare_digest.assert_called_once_with(b'expected-admin-key', b'expected-admin-key')
+
+    def test_update_passport_rejects_non_object_json(self):
+        """Passport updates require a JSON object body."""
+        os.environ['ADMIN_KEY'] = 'expected-admin-key'
+        self.client.post(
+            '/api/machine-passport',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json={
+                'name': 'Array Update Test',
+                'owner_miner_id': 'miner_owner',
+                'machine_id': 'array_update_test',
+            },
+        )
+
+        resp = self.client.put(
+            '/api/machine-passport/array_update_test',
+            headers={'X-Admin-Key': 'expected-admin-key'},
+            json=['name', 'Unauthorized Rename'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
 
     def test_update_passport_fails_closed_without_admin_key(self):
         """Passport updates fail closed before resource lookup when ADMIN_KEY is missing."""
@@ -701,6 +741,19 @@ class TestAPIEndpoints(unittest.TestCase):
         self.assertEqual(resp.status_code, 404)
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'passport_not_found')
+
+    def test_compute_machine_id_rejects_non_object_json(self):
+        """Machine ID computation requires fingerprint JSON objects."""
+        resp = self.client.post(
+            '/api/machine-passport/compute-machine-id',
+            json=['serial', 'logic-board-id'],
+        )
+        data = json.loads(resp.data)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'invalid_request')
+        self.assertEqual(data['message'], 'JSON object required')
 
 
 class TestIntegration(unittest.TestCase):


### PR DESCRIPTION
## Summary
- reuse the machine passport JSON-object helper for create, update, and compute-machine-id routes
- reject authenticated array/scalar JSON bodies with HTTP 400 instead of allowing invalid data flow or handler errors
- add API regressions for create, update, and compute-machine-id non-object payloads
- remove stale unused imports in touched files

## Validation
- `uv run --no-project --with pytest --with flask --with qrcode --with pillow --with reportlab python -m pytest node/tests/test_machine_passport.py tests/test_machine_passport_array_payload.py -q`
- `python3 -m py_compile node/machine_passport_api.py node/tests/test_machine_passport.py tests/test_machine_passport_array_payload.py`
- `uv run --no-project --with ruff --with flask --with qrcode --with pillow --with reportlab python -m ruff check node/machine_passport_api.py node/tests/test_machine_passport.py tests/test_machine_passport_array_payload.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/machine_passport_api.py node/tests/test_machine_passport.py tests/test_machine_passport_array_payload.py`

Bounty context: Scottcjn/rustchain-bounties#71