### PR TITLE
fix: validate machine passport JSON bodies

### DIFF
--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -251,7 +251,9 @@ def create_passport():
     if auth_error is not None:
         return auth_error
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -339,7 +341,9 @@ def update_passport(machine_id: str):
     if not passport:
         return jsonify({'ok': False, 'error': 'passport_not_found'}), 404
     
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,
@@ -671,7 +675,9 @@ def compute_machine_id_endpoint():
     
     Request Body: Hardware fingerprint data (same as attestation)
     """
-    data = request.get_json()
+    data, error = get_optional_json_object()
+    if error:
+        return error
     if not data:
         return jsonify({
             'ok': False,

--- a/tests/test_machine_passport_array_payload.py
+++ b/tests/test_machine_passport_array_payload.py
@@ -46,6 +46,9 @@ class LedgerStub:
         self.passport_updates.append((machine_id, fields))
         return True
 
+    def create_passport(self, passport):
+        return True, "passport created"
+
 
 @pytest.fixture
 def ledger(monkeypatch):
@@ -63,6 +66,47 @@ def client(ledger, monkeypatch):
 
 
 # --- /repair-log array-payload regressions ------------------------------------
+
+def test_create_passport_rejects_non_object_array_payload(client):
+    response = client.post(
+        "/api/machine-passport",
+        headers=ADMIN_HEADERS,
+        json=["name", "owner_miner_id"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }
+
+
+def test_update_passport_rejects_non_object_array_payload(client, ledger):
+    response = client.put(
+        "/api/machine-passport/machine-1",
+        headers=ADMIN_HEADERS,
+        json=["owner_miner_id"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_request"
+    assert ledger.passport_updates == []
+
+
+def test_compute_machine_id_rejects_non_object_array_payload(client):
+    response = client.post(
+        "/api/machine-passport/compute-machine-id",
+        json=["cpu", "gpu"],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "invalid_request",
+        "message": "JSON object required",
+    }
+
 
 def test_repair_log_rejects_empty_array_payload(client):
     response = client.post(


### PR DESCRIPTION
Fixes authenticated machine passport routes that still parsed JSON bodies directly and then assumed object semantics.

## Summary
- route create/update passport and compute-machine-id through the existing JSON object validator
- keep the existing `JSON body required` response for missing/empty payloads
- reject array/scalar JSON payloads with the existing `invalid_request` / `JSON object required` 400 before handler logic runs
- extend machine passport regressions for create/update/compute-machine-id alongside the existing repair-log/lineage coverage

## Bounty context
Related to RustChain bug bounty / report-a-bug program (#305).

Wallet: `RTC0bc961e7a95d320d2707470643fa35deb1a26d09`

## Tests
- `python -m pytest tests/test_machine_passport_array_payload.py tests/test_machine_passport_event_json_validation.py -q`
- `python -m pytest node/tests/test_machine_passport.py tests/test_machine_passport_array_payload.py tests/test_machine_passport_event_json_validation.py -q`
- `python -m py_compile node/machine_passport_api.py tests/test_machine_passport_array_payload.py`
- `python tools/bcos_spdx_check.py --base-ref origin/main`
- `git diff --check -- node/machine_passport_api.py tests/test_machine_passport_array_payload.py`