### PR TITLE
fix: tolerate corrupt BCOS reports

### DIFF
--- a/node/bcos_routes.py
+++ b/node/bcos_routes.py
@@ -107,9 +107,20 @@ def _verify_commitment(report_json_str: str, claimed_commitment: str) -> bool:
     """Recompute BLAKE2b commitment and compare."""
     try:
         report = json.loads(report_json_str)
+        if not isinstance(report, dict):
+            return False
         return hmac.compare_digest(_report_commitment(report), claimed_commitment)
     except Exception:
         return False
+
+
+def _load_report_object(report_json_str: str):
+    """Load a stored BCOS report only when it is a JSON object."""
+    try:
+        report = json.loads(report_json_str)
+    except (TypeError, json.JSONDecodeError):
+        return None
+    return report if isinstance(report, dict) else None
 
 
 def _verify_ed25519(commitment: str, signature_hex: str, pubkey_hex: str) -> bool:
@@ -304,7 +315,7 @@ def bcos_attest():
         })
     except sqlite3.IntegrityError:
         return jsonify({"error": f"Certificate {cert_id} already exists"}), 409
-    except Exception as e:
+    except Exception:
         import logging
         logging.exception("bcos_handler failed")
         return jsonify({"error": "internal_error"}), 500
@@ -328,10 +339,14 @@ def bcos_verify(cert_id):
                 "hint": "Check the cert_id format: BCOS-xxxxxxxx",
             }), 404
 
-        # Recompute commitment from stored report
-        report = json.loads(row["report_json"])
-        recomputed = _report_commitment(report)
-        commitment_valid = hmac.compare_digest(recomputed, row["commitment"])
+        # Recompute commitment from stored report when it is still parseable.
+        report = _load_report_object(row["report_json"])
+        if report is None:
+            report = {}
+            commitment_valid = False
+        else:
+            recomputed = _report_commitment(report)
+            commitment_valid = hmac.compare_digest(recomputed, row["commitment"])
 
         # Verify Ed25519 signature if present
         sig_valid = None
@@ -361,7 +376,7 @@ def bcos_verify(cert_id):
             "badge_url": _bcos_public_url(f"/bcos/badge/{cert_id}.svg"),
             "pdf_url": _bcos_public_url(f"/bcos/cert/{cert_id}.pdf"),
         })
-    except Exception as e:
+    except Exception:
         import logging
         logging.exception("bcos_handler failed")
         return jsonify({"error": "internal_error"}), 500
@@ -385,7 +400,13 @@ def bcos_certificate_pdf(cert_id):
             return jsonify({"error": f"Certificate {cert_id} not found"}), 404
 
         # Build attestation dict for PDF generator
-        report = json.loads(row["report_json"])
+        report = _load_report_object(row["report_json"])
+        if report is None:
+            return jsonify({
+                "error": "invalid_report",
+                "message": "Stored report JSON is not an object",
+            }), 422
+
         attestation = {
             **report,
             "cert_id": row["cert_id"],
@@ -403,7 +424,7 @@ def bcos_certificate_pdf(cert_id):
             as_attachment=True,
             download_name=f"{cert_id}.pdf",
         )
-    except Exception as e:
+    except Exception:
         import logging
         logging.exception("bcos_handler failed")
         return jsonify({"error": "internal_error"}), 500
@@ -431,7 +452,7 @@ def bcos_badge_svg(cert_id):
 
         return Response(svg, mimetype="image/svg+xml",
                         headers={"Cache-Control": "max-age=300"})
-    except Exception as e:
+    except Exception:
         return Response(
             _generate_badge_svg("ERR", 0),
             mimetype="image/svg+xml",
@@ -494,7 +515,7 @@ def bcos_directory():
             "offset": offset,
             "certificates": certs,
         })
-    except Exception as e:
+    except Exception:
         import logging
         logging.exception("bcos_handler failed")
         return jsonify({"error": "internal_error"}), 500

--- a/node/tests/test_bcos_routes.py
+++ b/node/tests/test_bcos_routes.py
@@ -111,3 +111,45 @@ def test_bcos_attest_stores_matching_commitment(tmp_path, monkeypatch):
     verify_response = app.test_client().get("/bcos/verify/BCOS-valid")
     assert verify_response.status_code == 200
     assert verify_response.get_json()["commitment_valid"] is True
+
+
+def test_bcos_verify_tolerates_corrupt_stored_report(tmp_path):
+    db_path = tmp_path / "bcos.db"
+    with sqlite3.connect(db_path) as conn:
+        init_bcos_table(conn)
+        conn.execute(
+            """
+            INSERT INTO bcos_attestations (
+                cert_id, commitment, repo, commit_sha, tier, trust_score,
+                reviewer, report_json, signature, signer_pubkey, anchored_epoch, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "BCOS-corrupt",
+                "0" * 64,
+                "Scottcjn/Rustchain",
+                "abcdef1234567890",
+                "L1",
+                75,
+                "codex-reviewer",
+                "{not-json",
+                None,
+                None,
+                1,
+                1234567890,
+            ),
+        )
+
+    app = Flask(__name__)
+    register_bcos_routes(app, str(db_path))
+    app.config["TESTING"] = True
+
+    verify_response = app.test_client().get("/bcos/verify/BCOS-corrupt")
+
+    assert verify_response.status_code == 200
+    body = verify_response.get_json()
+    assert body["ok"] is True
+    assert body["verified"] is False
+    assert body["commitment_valid"] is False
+    assert body["score_breakdown"] == {}
+    assert body["checks"] == {}


### PR DESCRIPTION
## Summary
- load stored BCOS reports only when they parse to JSON objects
- keep certificate verification from returning 500 when stored report JSON is corrupt or non-object
- return a clean invalid_report response for PDF generation when stored report data is unusable
- add a regression for verifying a certificate with corrupt stored report JSON
- remove stale unused exception aliases in the touched route file

## Validation
- `uv run --no-project --with pytest --with flask --with pynacl python -m pytest node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py -q`
- `python3 -m py_compile node/bcos_routes.py node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py`
- `uv run --no-project --with ruff --with flask --with pynacl python -m ruff check node/bcos_routes.py node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/bcos_routes.py node/tests/test_bcos_routes.py tests/test_bcos_routes_query_validation.py`

Bounty context: Scottcjn/rustchain-bounties#71