### PR TITLE
fix: validate pending ops response shape

### DIFF
--- a/tests/test_pending_ops.py
+++ b/tests/test_pending_ops.py
@@ -24,7 +24,7 @@ pending_ops = _load_pending_ops()
 
 
 class FakeResponse:
-    def __init__(self, payload: dict):
+    def __init__(self, payload):
         self.payload = payload
 
     def __enter__(self):
@@ -83,6 +83,20 @@ def test_req_uses_unverified_context_when_insecure(monkeypatch):
 
     assert pending_ops._req("GET", "https://node.test/pending/list", "key", insecure=True) == {"ok": True}
     assert seen["context"] is marker
+
+
+def test_req_rejects_non_object_json_response(monkeypatch):
+    def fake_urlopen(req, timeout, context):
+        return FakeResponse(["not", "an", "object"])
+
+    monkeypatch.setattr(pending_ops.urllib.request, "urlopen", fake_urlopen)
+
+    try:
+        pending_ops._req("GET", "https://node.test/pending/list", "key", insecure=False)
+    except ValueError as exc:
+        assert str(exc) == "node response must be a JSON object"
+    else:
+        raise AssertionError("_req accepted a non-object JSON response")
 
 
 def test_cmd_list_formats_url_and_prints_response(monkeypatch, capsys):

--- a/tests/test_pending_ops_cli.py
+++ b/tests/test_pending_ops_cli.py
@@ -81,6 +81,18 @@ def test_req_uses_unverified_ssl_context_when_insecure():
     assert urlopen.call_args.kwargs["context"] is marker
 
 
+def test_req_rejects_non_object_json_response():
+    module = load_module()
+
+    with patch.object(module.urllib.request, "urlopen", return_value=FakeResponse(["not", "an", "object"])):
+        try:
+            module._req("GET", "https://node.example/pending/list", "key", insecure=False)
+        except ValueError as exc:
+            assert str(exc) == "node response must be a JSON object"
+        else:
+            raise AssertionError("_req accepted a non-object JSON response")
+
+
 def test_cmd_list_formats_status_and_limit_query(capsys):
     module = load_module()
     args = argparse.Namespace(

--- a/tools/pending_ops.py
+++ b/tools/pending_ops.py
@@ -30,7 +30,10 @@ def _req(method: str, url: str, admin_key: str, payload: dict | None = None, *, 
     req.add_header("X-Admin-Key", admin_key)
     ctx = ssl._create_unverified_context() if insecure else None
     with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+        body = json.loads(resp.read().decode("utf-8"))
+        if not isinstance(body, dict):
+            raise ValueError("node response must be a JSON object")
+        return body
 
 
 def cmd_list(args: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary
- require pending ops node responses to be JSON objects before returning from `_req`
- fail closed on array/scalar JSON responses instead of letting CLI commands treat them as valid API results
- add regressions for both pending ops test loaders

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_pending_ops.py tests/test_pending_ops_cli.py -q`
- `python3 -m py_compile tools/pending_ops.py tests/test_pending_ops.py tests/test_pending_ops_cli.py`
- `uv run --no-project --with ruff --with flask python -m ruff check tools/pending_ops.py tests/test_pending_ops.py tests/test_pending_ops_cli.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/pending_ops.py tests/test_pending_ops.py tests/test_pending_ops_cli.py`

Bounty context: Scottcjn/rustchain-bounties#71