### PR TITLE
fix: validate agent economy CLI responses

### DIFF
--- a/tests/test_agent_economy_cli.py
+++ b/tests/test_agent_economy_cli.py
@@ -59,6 +59,17 @@ def test_api_get_builds_url_and_parses_json(agent_economy_cli_module, monkeypatc
     assert timeout == 15
 
 
+def test_api_get_rejects_non_object_json_response(agent_economy_cli_module, monkeypatch):
+    def fake_urlopen(request, context, timeout):
+        return FakeResponse(b'["not", "an", "object"]')
+
+    monkeypatch.setattr(agent_economy_cli_module, "BASE_URL", "https://node.example")
+    monkeypatch.setattr(agent_economy_cli_module.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="node response must be a JSON object"):
+        agent_economy_cli_module.api_get("/agent/jobs?status=open")
+
+
 def test_api_post_sends_json_and_parses_success(agent_economy_cli_module, monkeypatch):
     calls = []
 
@@ -85,6 +96,16 @@ def test_api_post_sends_json_and_parses_success(agent_economy_cli_module, monkey
     assert timeout == 15
 
 
+def test_api_post_rejects_non_object_json_response(agent_economy_cli_module, monkeypatch):
+    def fake_urlopen(request, context, timeout):
+        return FakeResponse(b'["not", "an", "object"]')
+
+    monkeypatch.setattr(agent_economy_cli_module.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="node response must be a JSON object"):
+        agent_economy_cli_module.api_post("/agent/jobs/job-1/claim", {})
+
+
 def test_api_post_parses_http_error_body(agent_economy_cli_module, monkeypatch):
     def fake_urlopen(_request, context, timeout):
         assert context is agent_economy_cli_module.SSL_CTX
@@ -102,6 +123,22 @@ def test_api_post_parses_http_error_body(agent_economy_cli_module, monkeypatch):
     assert agent_economy_cli_module.api_post("/agent/jobs/job-1/claim", {}) == {
         "error": "already claimed"
     }
+
+
+def test_api_post_rejects_non_object_http_error_body(agent_economy_cli_module, monkeypatch):
+    def fake_urlopen(_request, context, timeout):
+        raise HTTPError(
+            "https://node.example/agent/jobs/job-1/claim",
+            400,
+            "Bad Request",
+            {},
+            BytesIO(b'["bad", "error"]'),
+        )
+
+    monkeypatch.setattr(agent_economy_cli_module.urllib.request, "urlopen", fake_urlopen)
+
+    with pytest.raises(ValueError, match="node response must be a JSON object"):
+        agent_economy_cli_module.api_post("/agent/jobs/job-1/claim", {})
 
 
 def test_cmd_list_formats_dict_response_and_empty_response(

--- a/tools/agent_economy_cli/rustchain_ae.py
+++ b/tools/agent_economy_cli/rustchain_ae.py
@@ -5,6 +5,7 @@ rustchain-ae — Command-line interface for the RustChain Agent Economy (RIP-302
 import sys
 import json
 import argparse
+import ssl
 import urllib.request
 import urllib.error
 
@@ -12,16 +13,23 @@ BASE_URL = "https://50.28.86.131"
 VERIFY_SSL = False
 
 # Disable SSL verification
-import ssl
 SSL_CTX = ssl.create_default_context()
 SSL_CTX.check_hostname = False
 SSL_CTX.verify_mode = ssl.CERT_NONE
+
+
+def _decode_json_object(raw):
+    data = json.loads(raw.decode())
+    if not isinstance(data, dict):
+        raise ValueError("node response must be a JSON object")
+    return data
+
 
 def api_get(path):
     url = f"{BASE_URL}{path}"
     req = urllib.request.Request(url)
     with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
-        return json.loads(resp.read().decode())
+        return _decode_json_object(resp.read())
 
 def api_post(path, data):
     url = f"{BASE_URL}{path}"
@@ -30,9 +38,9 @@ def api_post(path, data):
         headers={'Content-Type': 'application/json'})
     try:
         with urllib.request.urlopen(req, context=SSL_CTX, timeout=15) as resp:
-            return json.loads(resp.read().decode())
+            return _decode_json_object(resp.read())
     except urllib.error.HTTPError as e:
-        return json.loads(e.read().decode())
+        return _decode_json_object(e.read())
 
 def cmd_list(args):
     """List open jobs in the Agent Economy marketplace"""


### PR DESCRIPTION
## Summary
- add a shared JSON-object decoder for Agent Economy CLI API helpers
- reject array/scalar JSON success responses and HTTP error bodies before callers treat them as valid API results
- add regressions for GET, POST, and HTTP error response shapes
- move the stale `ssl` import with the rest of the module imports

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_agent_economy_cli.py -q`
- `python3 -m py_compile tools/agent_economy_cli/rustchain_ae.py tests/test_agent_economy_cli.py`
- `uv run --no-project --with ruff --with flask python -m ruff check tools/agent_economy_cli/rustchain_ae.py tests/test_agent_economy_cli.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/agent_economy_cli/rustchain_ae.py tests/test_agent_economy_cli.py`

Bounty context: Scottcjn/rustchain-bounties#71