### PR TITLE
fix: validate node health JSON responses

### DIFF
--- a/tools/node-health-cli/node_health.py
+++ b/tools/node-health-cli/node_health.py
@@ -92,7 +92,10 @@ def fetch_json(url: str, timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
             req = Request(url, headers={"Accept": "application/json"})
             with urlopen(req, timeout=timeout) as response:
                 payload = response.read().decode("utf-8")
-            return json.loads(payload)
+            data = json.loads(payload)
+            if not isinstance(data, dict):
+                raise ValueError("JSON response must be an object")
+            return data
         except HTTPError as e:
             last_error = f"HTTP {e.code}: {e.reason}"
             time.sleep(DEFAULT_RETRY_DELAY)
@@ -101,6 +104,9 @@ def fetch_json(url: str, timeout: int = DEFAULT_TIMEOUT) -> Dict[str, Any]:
             time.sleep(DEFAULT_RETRY_DELAY)
         except json.JSONDecodeError as e:
             last_error = f"JSON parse error: {e}"
+            break
+        except ValueError as e:
+            last_error = str(e)
             break
         except Exception as e:
             last_error = f"Unexpected error: {e}"

--- a/tools/node-health-cli/tests/test_node_health.py
+++ b/tools/node-health-cli/tests/test_node_health.py
@@ -8,7 +8,7 @@ import json
 import unittest
 from io import StringIO
 from unittest.mock import patch, MagicMock
-from urllib.error import URLError, HTTPError
+from urllib.error import URLError
 from pathlib import Path
 
 import sys
@@ -18,8 +18,23 @@ from node_health import (
     HealthStatus, EpochStatus, ReachabilityStatus, CheckResult,
     fetch_json, check_health, check_epoch, check_reachability,
     run_checks, format_text, format_json, format_uptime,
-    EXIT_OK, EXIT_HEALTH_FAIL, EXIT_EPOCH_FAIL, EXIT_REACHABILITY_FAIL, EXIT_MULTI_FAIL
+    EXIT_OK, EXIT_HEALTH_FAIL, EXIT_MULTI_FAIL
 )
+
+
+class TestFetchJson(unittest.TestCase):
+    """Test JSON fetch helper validation"""
+
+    @patch('node_health.urlopen')
+    def test_fetch_json_rejects_non_object_response(self, mock_urlopen):
+        """Node health endpoints must return JSON objects."""
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'["not", "an", "object"]'
+        mock_response.__enter__.return_value = mock_response
+        mock_urlopen.return_value = mock_response
+
+        with self.assertRaisesRegex(Exception, "JSON response must be an object"):
+            fetch_json("https://rustchain.org/health", timeout=10)
 
 
 class TestHealthStatus(unittest.TestCase):


### PR DESCRIPTION
## Summary
- require node health JSON responses to be objects before returning from `fetch_json`
- fail the health check cleanly on array/scalar JSON responses instead of letting callers treat them as dictionaries
- add a regression for non-object JSON responses from health endpoints
- remove stale unused imports in the touched test file

## Validation
- `uv run --no-project --with pytest python -m pytest tools/node-health-cli/tests/test_node_health.py -q`
- `python3 -m py_compile tools/node-health-cli/node_health.py tools/node-health-cli/tests/test_node_health.py`
- `uv run --no-project --with ruff python -m ruff check tools/node-health-cli/node_health.py tools/node-health-cli/tests/test_node_health.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/node-health-cli/node_health.py tools/node-health-cli/tests/test_node_health.py`

Bounty context: Scottcjn/rustchain-bounties#71