### PR TITLE
fix: validate rustchainnode JSON responses

### DIFF
--- a/rustchainnode/rustchainnode/node.py
+++ b/rustchainnode/rustchainnode/node.py
@@ -3,9 +3,6 @@ RustChain Node — programmatic API for the rustchainnode package.
 """
 
 import json
-import os
-import time
-import threading
 import logging
 from pathlib import Path
 from typing import Optional
@@ -14,6 +11,13 @@ log = logging.getLogger("rustchainnode")
 
 DEFAULT_PORT = 8099
 DEFAULT_CONFIG_DIR = Path.home() / ".rustchainnode"
+
+
+def _loads_json_object(raw: bytes | str) -> dict:
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("JSON response must be an object")
+    return data
 
 
 class RustChainNode:
@@ -63,7 +67,7 @@ class RustChainNode:
         try:
             import urllib.request
             with urllib.request.urlopen(f"{self.node_url}/health", timeout=5) as r:
-                return json.loads(r.read())
+                return _loads_json_object(r.read())
         except Exception as e:
             return {"ok": False, "error": str(e)}
 
@@ -72,7 +76,7 @@ class RustChainNode:
         try:
             import urllib.request
             with urllib.request.urlopen(f"{self.node_url}/epoch", timeout=5) as r:
-                return json.loads(r.read())
+                return _loads_json_object(r.read())
         except Exception as e:
             return {"error": str(e)}
 

--- a/tests/test_rustchainnode_node.py
+++ b/tests/test_rustchainnode_node.py
@@ -104,6 +104,23 @@ def test_health_and_epoch_return_json_from_node_url(monkeypatch, tmp_path):
     ]
 
 
+def test_health_and_epoch_reject_non_object_json(monkeypatch, tmp_path):
+    module = load_node_module()
+
+    def fake_urlopen(url, timeout):
+        return FakeResponse(["not", "an", "object"])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    node = module.RustChainNode(
+        wallet="wallet-1",
+        config_dir=tmp_path,
+        node_url="https://node.example",
+    )
+
+    assert node.health() == {"ok": False, "error": "JSON response must be an object"}
+    assert node.epoch() == {"error": "JSON response must be an object"}
+
+
 def test_health_reports_urlopen_errors(monkeypatch, tmp_path):
     module = load_node_module()
 


### PR DESCRIPTION
## Summary
- require rustchainnode health and epoch responses to be JSON objects before returning them to callers
- return the existing error shapes for array/scalar JSON payloads instead of passing them through as dict-like responses
- add regression coverage for non-object health and epoch JSON responses
- remove stale unused imports in the touched module

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_rustchainnode_node.py -q`
- `python3 -m py_compile rustchainnode/rustchainnode/node.py tests/test_rustchainnode_node.py`
- `uv run --no-project --with ruff python -m ruff check rustchainnode/rustchainnode/node.py tests/test_rustchainnode_node.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- rustchainnode/rustchainnode/node.py tests/test_rustchainnode_node.py`

Bounty context: Scottcjn/rustchain-bounties#71