### PR TITLE
fix: validate rustchainnode cli JSON responses

### DIFF
--- a/rustchainnode/rustchainnode/cli.py
+++ b/rustchainnode/rustchainnode/cli.py
@@ -19,7 +19,6 @@ import os
 import platform
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 from .hardware import detect_cpu_info, get_optimal_config
@@ -56,11 +55,18 @@ def _resolve_node_url(cfg: dict, force_testnet: bool = False) -> str:
     return configured_url or NODE_URL
 
 
+def _loads_json_object(raw: bytes | str) -> dict:
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise ValueError("JSON response must be an object")
+    return data
+
+
 def _check_health(node_url: str = NODE_URL) -> dict:
     try:
         import urllib.request
         with urllib.request.urlopen(f"{node_url}/health", timeout=5) as r:
-            return json.loads(r.read())
+            return _loads_json_object(r.read())
     except Exception as e:
         return {"ok": False, "error": str(e)}
 
@@ -69,7 +75,7 @@ def _check_epoch(node_url: str = NODE_URL) -> dict:
     try:
         import urllib.request
         with urllib.request.urlopen(f"{node_url}/epoch", timeout=5) as r:
-            return json.loads(r.read())
+            return _loads_json_object(r.read())
     except Exception as e:
         return {"error": str(e)}
 
@@ -108,7 +114,7 @@ def cmd_init(args):
 
     print(f"\n  ✅ Config saved to {CONFIG_FILE}")
     print(f"  Wallet: {wallet} | Port: {port} | Threads: {hw['optimal_threads']}")
-    print(f"\n  Next: rustchainnode start")
+    print("\n  Next: rustchainnode start")
 
 
 def cmd_start(args):
@@ -125,7 +131,7 @@ def cmd_start(args):
     hw = detect_cpu_info()
     node_url = _resolve_node_url(cfg, testnet)
 
-    print(f"🚀 Starting RustChain node...")
+    print("🚀 Starting RustChain node...")
     print(f"   Wallet: {wallet}")
     print(f"   Port: {port}")
     print(f"   CPU: {hw['arch']} | {hw['cpu_count']} threads")
@@ -181,7 +187,7 @@ def cmd_status(args):
 
     health = _check_health(node_url)
     if health.get("ok"):
-        print(f"\n   🟢 Remote node: ONLINE")
+        print("\n   🟢 Remote node: ONLINE")
         print(f"   Version: {health.get('version', '?')}")
     else:
         print(f"\n   🔴 Remote node: OFFLINE ({health.get('error', '?')})")
@@ -274,8 +280,8 @@ WantedBy=multi-user.target
     service_path.write_text(service_content)
 
     print(f"✅ systemd service written to {service_path}")
-    print(f"\nEnable and start:")
-    print(f"  systemctl --user daemon-reload")
+    print("\nEnable and start:")
+    print("  systemctl --user daemon-reload")
     print(f"  systemctl --user enable {service_name}")
     print(f"  systemctl --user start {service_name}")
     print(f"  systemctl --user status {service_name}")
@@ -315,7 +321,7 @@ def _install_launchd(wallet: str):
 """
     plist_path.write_text(plist_content)
     print(f"✅ launchd plist written to {plist_path}")
-    print(f"\nLoad and start:")
+    print("\nLoad and start:")
     print(f"  launchctl load {plist_path}")
     print(f"  launchctl start {plist_label}")
 

--- a/tests/test_rustchainnode_cli.py
+++ b/tests/test_rustchainnode_cli.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 import importlib
+import json
+import urllib.request
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -133,3 +135,34 @@ def test_status_keeps_custom_production_node_url(monkeypatch, tmp_path, capsys):
         ("health", "https://node.example"),
         ("epoch", "https://node.example"),
     ]
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode()
+
+
+def test_cli_health_and_epoch_reject_non_object_json(monkeypatch, tmp_path):
+    module = load_cli_module(monkeypatch, tmp_path)
+
+    def fake_urlopen(url, timeout):
+        return FakeResponse(["not", "an", "object"])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    assert module._check_health("https://node.example") == {
+        "ok": False,
+        "error": "JSON response must be an object",
+    }
+    assert module._check_epoch("https://node.example") == {
+        "error": "JSON response must be an object",
+    }


### PR DESCRIPTION
## Summary
- require rustchainnode CLI health and epoch probe responses to be JSON objects before returning them
- preserve the existing offline/error response shapes for array/scalar JSON payloads
- add regression coverage for non-object CLI probe responses
- clean up stale ruff issues in the touched CLI module

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest tests/test_rustchainnode_cli.py -q`
- `PYTHONPATH=rustchainnode uv run --no-project --with pytest python -m pytest rustchainnode/tests/test_cli_node_url.py -q`
- `python3 -m py_compile rustchainnode/rustchainnode/cli.py tests/test_rustchainnode_cli.py rustchainnode/tests/test_cli_node_url.py`
- `uv run --no-project --with ruff python -m ruff check rustchainnode/rustchainnode/cli.py tests/test_rustchainnode_cli.py rustchainnode/tests/test_cli_node_url.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- rustchainnode/rustchainnode/cli.py tests/test_rustchainnode_cli.py`

Bounty context: Scottcjn/rustchain-bounties#71