### PR TITLE
fix: validate explorer API upstream JSON

### DIFF
--- a/tests/test_explorer_api_query_validation.py
+++ b/tests/test_explorer_api_query_validation.py
@@ -64,6 +64,29 @@ def test_blocks_caps_valid_limit_without_contacting_invalid_input_path(monkeypat
     assert payload["page"] == 1
 
 
+def test_blocks_treats_non_object_tip_response_as_unavailable(monkeypatch):
+    explorer_api = load_explorer_api()
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return ["not", "an", "object"]
+
+    def fake_requests_get(url, params=None, timeout=None):
+        assert url.endswith("/headers/tip")
+        return FakeResponse()
+
+    monkeypatch.setattr(explorer_api.requests, "get", fake_requests_get)
+
+    with explorer_api.app.test_client() as client:
+        response = client.get("/api/blocks")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"ok": False, "error": "node_unavailable"}
+
+
 def test_transactions_rejects_bad_limit_params():
     explorer_api = load_explorer_api()
 
@@ -103,3 +126,21 @@ def test_transactions_caps_valid_limit(monkeypatch):
     assert payload["ok"] is True
     assert payload["limit"] == 100
     assert payload["pending_withdrawals"] == 3
+
+
+def test_get_ignores_non_object_upstream_json(monkeypatch):
+    explorer_api = load_explorer_api()
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return ["not", "an", "object"]
+
+    def fake_requests_get(url, params=None, timeout=None):
+        return FakeResponse()
+
+    monkeypatch.setattr(explorer_api.requests, "get", fake_requests_get)
+
+    assert explorer_api._get("/health") is None

--- a/tools/explorer-api/api.py
+++ b/tools/explorer-api/api.py
@@ -92,9 +92,12 @@ def _get(path: str, params: dict | None = None, timeout: float | None = None):
             timeout=timeout or REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if isinstance(data, dict):
+            return data
     except Exception:
         return None
+    return None
 
 
 def _post(path: str, json_body: dict | None = None, timeout: float | None = None):
@@ -106,9 +109,12 @@ def _post(path: str, json_body: dict | None = None, timeout: float | None = None
             timeout=timeout or REQUEST_TIMEOUT,
         )
         resp.raise_for_status()
-        return resp.json()
+        data = resp.json()
+        if isinstance(data, dict):
+            return data
     except Exception:
         return None
+    return None
 
 
 def _positive_int_arg(name: str, default: int, max_value: int | None = None):


### PR DESCRIPTION
## Summary
- require explorer API upstream helper responses to be JSON objects before returning them to routes
- treat array/scalar upstream JSON as unavailable so existing route error paths handle malformed responses
- add regressions for non-object upstream JSON and `/api/blocks` tip handling

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_explorer_api_query_validation.py -q`
- `python3 -m py_compile tools/explorer-api/api.py tests/test_explorer_api_query_validation.py`
- `uv run --no-project --with ruff python -m ruff check tools/explorer-api/api.py tests/test_explorer_api_query_validation.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/explorer-api/api.py tests/test_explorer_api_query_validation.py`

Bounty context: Scottcjn/rustchain-bounties#71