### PR TITLE
fix: initialise miner header key schema

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1347,6 +1347,13 @@ def init_db():
             )
         """)
 
+        c.execute("""
+            CREATE TABLE IF NOT EXISTS miner_header_keys (
+                miner_id TEXT PRIMARY KEY,
+                pubkey_hex TEXT NOT NULL
+            )
+        """)
+
         # Withdrawal nonce tracking (replay protection)
         c.execute("""
             CREATE TABLE IF NOT EXISTS withdrawal_nonces (

--- a/tests/test_miner_headerkey_schema.py
+++ b/tests/test_miner_headerkey_schema.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for miner header key schema initialisation."""
+
+import sys
+
+
+def test_init_db_creates_miner_header_keys_table(tmp_path):
+    node = sys.modules["integrated_node"]
+    db_path = tmp_path / "node.sqlite"
+    old_db_path = node.DB_PATH
+    old_testing = node.app.config.get("TESTING")
+
+    try:
+        node.DB_PATH = str(db_path)
+        node.init_db()
+        node.app.config["TESTING"] = True
+
+        with node.app.test_client() as client:
+            response = client.post(
+                "/miner/headerkey",
+                headers={"X-API-Key": "0" * 32},
+                json={"miner_id": "miner-one", "pubkey_hex": "a" * 64},
+            )
+
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "ok": True,
+            "miner_id": "miner-one",
+            "pubkey_hex": "a" * 64,
+        }
+    finally:
+        node.DB_PATH = old_db_path
+        node.app.config["TESTING"] = old_testing


### PR DESCRIPTION
## Summary
- create the missing miner_header_keys table during node init_db()
- add a regression test for registering a miner header key against a fresh SQLite DB

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -q tests/test_miner_headerkey_schema.py --tb=short -p no:cacheprovider
- .venv/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_miner_headerkey_schema.py
- direct Flask test-client reproduction now returns 200 JSON for POST /miner/headerkey

BCOS tier: BCOS-L2. Please apply the required project label if external contributors cannot set it directly.

Fixes #5777