### PR TITLE
fix: validate agent economy SDK JSON responses

### DIFF
--- a/sdk/rustchain/agent_economy/client.py
+++ b/sdk/rustchain/agent_economy/client.py
@@ -5,13 +5,12 @@ Main client for interacting with RustChain's Agent Economy APIs.
 Provides unified access to agent wallets, x402 payments, reputation, and analytics.
 """
 
-from typing import Dict, List, Optional, Any, Union
+from typing import Dict, Optional, Any
 import requests
 import json
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
 
-from rustchain.exceptions import RustChainError, ConnectionError, ValidationError, APIError
+from rustchain.exceptions import ConnectionError, ValidationError, APIError
 
 
 @dataclass
@@ -161,9 +160,13 @@ class AgentEconomyClient:
                 ) from e
             
             try:
-                return response.json()
+                data = response.json()
             except json.JSONDecodeError:
                 return {"raw_response": response.text}
+
+            if not isinstance(data, dict):
+                raise APIError("Expected JSON object response")
+            return data
                 
         except requests.exceptions.ConnectionError as e:
             raise ConnectionError(f"Failed to connect to {url}: {e}") from e

--- a/sdk/tests/test_agent_economy.py
+++ b/sdk/tests/test_agent_economy.py
@@ -4,9 +4,8 @@ RustChain Agent Economy SDK - Unit Tests
 Tests for the RIP-302 Agent Economy client and modules.
 """
 
-import pytest
 import unittest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 from datetime import datetime, timedelta
 
 from rustchain.agent_economy import (
@@ -16,11 +15,11 @@ from rustchain.agent_economy import (
     ReputationScore,
 )
 from rustchain.agent_economy.agents import AgentManager, AgentProfile
-from rustchain.agent_economy.payments import PaymentProcessor, PaymentStatus, PaymentIntent
-from rustchain.agent_economy.reputation import ReputationClient, ReputationTier, Attestation
-from rustchain.agent_economy.analytics import AnalyticsClient, AnalyticsPeriod, EarningsReport
+from rustchain.agent_economy.payments import PaymentProcessor, PaymentStatus
+from rustchain.agent_economy.reputation import ReputationClient, ReputationTier
+from rustchain.agent_economy.analytics import AnalyticsClient, AnalyticsPeriod
 from rustchain.agent_economy.bounties import BountyClient, BountyStatus, BountyTier, Bounty
-from rustchain.exceptions import ValidationError, APIError, ConnectionError
+from rustchain.exceptions import ValidationError, APIError
 
 
 class TestAgentWallet(unittest.TestCase):
@@ -216,6 +215,18 @@ class TestAgentEconomyClient(unittest.TestCase):
         
         self.assertEqual(result["status"], "ok")
         mock_request.assert_called_once_with("GET", "/api/agent/health")
+
+    def test_request_rejects_non_object_json(self):
+        """Test successful non-object JSON responses are rejected"""
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = ["not", "an", "object"]
+        response.text = '["not","an","object"]'
+
+        self.client.session.request = Mock(return_value=response)
+
+        with self.assertRaisesRegex(APIError, "Expected JSON object response"):
+            self.client.health()
     
     @patch.object(AgentEconomyClient, '_request')
     def test_get_agent_info(self, mock_request):


### PR DESCRIPTION
## Summary
- require Agent Economy SDK API responses to be JSON objects at the central request boundary
- prevent array/scalar JSON from flowing into subclients that call `.get()` on request results
- add a regression for successful non-object JSON responses
- clean stale unused imports in the touched files

## Validation
- PYTHONPATH=sdk uv run --no-project --with pytest --with requests --with aiohttp python -m pytest sdk/tests/test_agent_economy.py -q
- python3 -m py_compile sdk/rustchain/agent_economy/client.py sdk/tests/test_agent_economy.py
- uv run --no-project --with ruff python -m ruff check sdk/rustchain/agent_economy/client.py sdk/tests/test_agent_economy.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- sdk/rustchain/agent_economy/client.py sdk/tests/test_agent_economy.py