### PR TITLE
fix: validate wallet CLI JSON object responses

### DIFF
--- a/tests/test_wallet_cli_39.py
+++ b/tests/test_wallet_cli_39.py
@@ -1,4 +1,5 @@
-import json
+from types import SimpleNamespace
+
 from tools import rustchain_wallet_cli as cli
 
 
@@ -45,3 +46,32 @@ def test_balance_normalization():
     if "amount_rtc" not in payload and "balance_rtc" in payload:
         payload["amount_rtc"] = payload.get("balance_rtc")
     assert payload["amount_rtc"] == 9.5
+
+
+class FakeResponse:
+    def __init__(self, payload, ok=True, status_code=200):
+        self.payload = payload
+        self.ok = ok
+        self.status_code = status_code
+
+    def json(self):
+        return self.payload
+
+
+def test_safe_json_object_rejects_array_payload(capsys):
+    data, rc = cli._safe_json_object(FakeResponse([{"amount_rtc": 1.0}]))
+
+    assert data is None
+    assert rc == 1
+    assert "not an object" in capsys.readouterr().err
+
+
+def test_cmd_balance_rejects_non_object_json(monkeypatch, capsys):
+    monkeypatch.setattr(cli.requests, "get", lambda *args, **kwargs: FakeResponse(["bad"]))
+
+    rc = cli.cmd_balance(SimpleNamespace(wallet_id="RTCabc"))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "not an object" in captured.err

--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -260,16 +260,25 @@ def _safe_json(r: "requests.Response") -> "tuple[dict | list | None, int]":
         return None, 1
 
 
+def _safe_json_object(r: "requests.Response") -> "tuple[dict | None, int]":
+    data, rc = _safe_json(r)
+    if data is None:
+        return None, rc
+    if not isinstance(data, dict):
+        print("Error: Server returned JSON but not an object", file=sys.stderr)
+        return None, 1
+    return data, rc
+
+
 def cmd_balance(args):
     url = f"{NODE_URL}/wallet/balance"
     r = requests.get(url, params={"miner_id": args.wallet_id}, timeout=12, verify=VERIFY_SSL)
-    data, rc = _safe_json(r)
+    data, rc = _safe_json_object(r)
     if data is None:
         return rc
-    if isinstance(data, dict):
-        if "amount_rtc" not in data and "balance_rtc" in data:
-            data["amount_rtc"] = data.get("balance_rtc")
-        data["wallet_id"] = args.wallet_id
+    if "amount_rtc" not in data and "balance_rtc" in data:
+        data["amount_rtc"] = data.get("balance_rtc")
+    data["wallet_id"] = args.wallet_id
     print(json.dumps(data, indent=2))
     return rc
 
@@ -284,7 +293,7 @@ def cmd_send(args):
 
     url = f"{NODE_URL}/wallet/transfer/signed"
     r = requests.post(url, json=payload, timeout=20, verify=VERIFY_SSL)
-    data, rc = _safe_json(r)
+    data, rc = _safe_json_object(r)
     if data is not None:
         print(json.dumps(data, indent=2))
     return rc
@@ -312,7 +321,7 @@ def cmd_miners(args):
 
 def cmd_epoch(args):
     r = requests.get(f"{NODE_URL}/epoch", timeout=12, verify=VERIFY_SSL)
-    data, rc = _safe_json(r)
+    data, rc = _safe_json_object(r)
     if data is not None:
         print(json.dumps(data, indent=2))
     return rc


### PR DESCRIPTION
## Summary
- add an object-only JSON decoder for wallet CLI commands that require dict responses
- reject array/scalar JSON for balance, send, and epoch instead of printing invalid command output
- preserve list-compatible history and miners behavior
- add regressions for object-shape validation and balance output suppression

## Validation
- uv run --no-project --with pytest --with requests --with cryptography --with mnemonic --with flask python -m pytest tests/test_wallet_cli_39.py -q
- python3 -m py_compile tools/rustchain_wallet_cli.py tests/test_wallet_cli_39.py
- uv run --no-project --with ruff python -m ruff check tools/rustchain_wallet_cli.py tests/test_wallet_cli_39.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/rustchain_wallet_cli.py tests/test_wallet_cli_39.py