### PR TITLE
fix: validate wallet GUI JSON responses

### DIFF
--- a/tests/test_wallet_network_utils.py
+++ b/tests/test_wallet_network_utils.py
@@ -124,6 +124,19 @@ class TestFetchWithRetry(unittest.TestCase):
         mock_get.assert_called_once()
 
     @patch('requests.get')
+    def test_fetch_with_retry_rejects_non_object_json(self, mock_get):
+        """Test successful non-object JSON is rejected before GUI callers use it."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = [{"balance": 100.5}]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        data, error = self.wallet._fetch_with_retry("https://rustchain.org/wallet/balance")
+
+        self.assertIsNone(data)
+        self.assertEqual(error, "API returned JSON but not an object")
+
+    @patch('requests.get')
     @patch('time.sleep')
     def test_fetch_with_retry_success_after_retry(self, mock_sleep, mock_get):
         """Test successful fetch after one retry."""

--- a/wallet/rustchain_wallet_gui.py
+++ b/wallet/rustchain_wallet_gui.py
@@ -223,7 +223,10 @@ class RustChainWallet:
                     resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout)
                 
                 resp.raise_for_status()
-                return resp.json(), None
+                payload = resp.json()
+                if not isinstance(payload, dict):
+                    return None, "API returned JSON but not an object"
+                return payload, None
                 
             except ConnectionError as e:
                 last_error = str(e)

--- a/wallet/rustchain_wallet_secure.py
+++ b/wallet/rustchain_wallet_secure.py
@@ -309,7 +309,10 @@ class SecureFounderWallet:
                     resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout)
                 
                 resp.raise_for_status()
-                return resp.json(), None
+                payload = resp.json()
+                if not isinstance(payload, dict):
+                    return None, "API returned JSON but not an object"
+                return payload, None
                 
             except ConnectionError as e:
                 last_error = str(e)


### PR DESCRIPTION
## Summary
- reject non-object JSON from the wallet GUI retry helpers before callers use dict methods
- apply the same guard to the secure wallet and standard GUI wallet fetch paths
- add a regression for successful array JSON responses from wallet API calls

## Validation
- uv run --no-project --with pytest --with requests --with cryptography --with flask python -m pytest tests/test_wallet_network_utils.py -q
- python3 -m py_compile wallet/rustchain_wallet_secure.py wallet/rustchain_wallet_gui.py tests/test_wallet_network_utils.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- wallet/rustchain_wallet_secure.py wallet/rustchain_wallet_gui.py tests/test_wallet_network_utils.py

Note: full-file ruff currently reports pre-existing lint in these older wallet GUI files, so the focused gate here is tests, byte-compile, BCOS SPDX, and whitespace.