### PR TITLE
Harden Sophia LLM JSON response parsing

### DIFF
--- a/node/sophia_attestation_inspector.py
+++ b/node/sophia_attestation_inspector.py
@@ -18,7 +18,6 @@ import hashlib
 import argparse
 import hmac
 import logging
-import traceback
 from typing import Optional, Tuple, Dict, List
 
 try:
@@ -128,7 +127,7 @@ def _try_ollama_api(ep: str, prompt: str) -> Optional[str]:
     }
     resp = requests.post(url, json=payload, timeout=(10, OLLAMA_TIMEOUT))
     if resp.status_code == 200:
-        return resp.json().get("response", "")
+        return _response_json_object(resp).get("response", "")
     return None
 
 
@@ -147,7 +146,7 @@ def _try_llamaserver_api(ep: str, prompt: str) -> Optional[str]:
     }
     resp = requests.post(url, json=payload, timeout=(10, OLLAMA_TIMEOUT))
     if resp.status_code == 200:
-        return resp.json().get("content", "")
+        return _response_json_object(resp).get("content", "")
     return None
 
 
@@ -161,10 +160,23 @@ def _try_openai_api(ep: str, prompt: str) -> Optional[str]:
     }
     resp = requests.post(url, json=payload, timeout=OLLAMA_TIMEOUT)
     if resp.status_code == 200:
-        choices = resp.json().get("choices", [])
+        choices = _response_json_object(resp).get("choices", [])
         if choices:
             return choices[0].get("text", "")
     return None
+
+
+def _response_json_object(resp) -> Dict:
+    """Return a response JSON object, or an empty dict for invalid/non-object JSON."""
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        log.warning("LLM returned invalid JSON: %s", exc)
+        return {}
+    if not isinstance(body, dict):
+        log.warning("LLM returned %s JSON, expected object", type(body).__name__)
+        return {}
+    return body
 
 
 def _call_ollama(prompt: str, endpoint: str = None) -> Optional[str]:
@@ -235,7 +247,7 @@ def _call_deep_model(prompt: str) -> Optional[str]:
         log.info("Escalating to GPT-OSS 120B on POWER8 for deep analysis...")
         resp = requests.post(url, json=payload, timeout=DEEP_TIMEOUT)
         if resp.status_code == 200:
-            body = resp.json()
+            body = _response_json_object(resp)
             # llama-server returns choices[0].text for /v1/completions
             choices = body.get("choices", [])
             if choices:

--- a/node/tests/test_sophia_attestation_inspector.py
+++ b/node/tests/test_sophia_attestation_inspector.py
@@ -10,6 +10,40 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import sophia_attestation_inspector
 
 
+class _FakeResponse:
+    status_code = 200
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_llm_fallback_continues_after_non_object_json(monkeypatch):
+    posts = iter([
+        _FakeResponse(["not", "an", "object"]),
+        _FakeResponse({"response": "approved"}),
+    ])
+
+    def fake_post(*args, **kwargs):
+        return next(posts)
+
+    monkeypatch.setattr(sophia_attestation_inspector.requests, "post", fake_post)
+
+    assert sophia_attestation_inspector._call_ollama("inspect", endpoint="http://llm") == "approved"
+
+
+def test_deep_model_rejects_non_object_json(monkeypatch):
+    monkeypatch.setattr(
+        sophia_attestation_inspector.requests,
+        "post",
+        lambda *args, **kwargs: _FakeResponse([{"text": "not an object"}]),
+    )
+
+    assert sophia_attestation_inspector._call_deep_model("inspect deeply") is None
+
+
 def test_sophia_inspector_admin_auth_uses_constant_time_compare(monkeypatch):
     app = Flask(__name__)
     app.config["TESTING"] = True


### PR DESCRIPTION
## Summary
- add a shared JSON-object response helper for Sophia LLM HTTP responses
- keep the same-endpoint fallback chain alive when llama-server returns non-object JSON
- make deep-model parsing safely reject non-object JSON responses

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest node/tests/test_sophia_attestation_inspector.py -q`
- `python3 -m py_compile node/sophia_attestation_inspector.py node/tests/test_sophia_attestation_inspector.py`
- `uv run --no-project --with ruff python -m ruff check node/sophia_attestation_inspector.py node/tests/test_sophia_attestation_inspector.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/sophia_attestation_inspector.py node/tests/test_sophia_attestation_inspector.py`