### PR TITLE
Harden Rent-a-Relic MCP JSON parsing

### DIFF
--- a/tests/test_rent_a_relic_mcp_integration.py
+++ b/tests/test_rent_a_relic_mcp_integration.py
@@ -13,11 +13,11 @@ from tools.rent_a_relic import mcp_integration as mcp
 
 
 class FakeResponse:
-    def __init__(self, payload: dict, status_error: Exception | None = None) -> None:
+    def __init__(self, payload: object, status_error: Exception | None = None) -> None:
         self._payload = payload
         self._status_error = status_error
 
-    def json(self) -> dict:
+    def json(self) -> object:
         return self._payload
 
     def raise_for_status(self) -> None:
@@ -89,6 +89,26 @@ def test_client_uses_env_base_url_and_filters_listed_relics(monkeypatch) -> None
         "machines": [{"machine_id": "cheap-ppc", "arch": "ppc32", "rtc_per_hour": 4}],
         "count": 1,
     }
+
+
+def test_client_list_relics_ignores_non_object_json(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse(["not", "an", "object"]),
+    )
+
+    assert mcp.RelicMCPClient().list_relics() == {"machines": [], "count": 0}
+
+
+def test_client_list_relics_ignores_non_list_machines(monkeypatch) -> None:
+    monkeypatch.setattr(
+        mcp.requests,
+        "get",
+        lambda *args, **kwargs: FakeResponse({"machines": {"machine_id": "g3"}}),
+    )
+
+    assert mcp.RelicMCPClient().list_relics() == {"machines": [], "count": 0}
 
 
 def test_client_posts_reservation_and_dispatches_tools(monkeypatch) -> None:
@@ -216,3 +236,28 @@ def test_beacon_handler_surfaces_http_error_response_body() -> None:
     assert result["beacon_id"] == "beacon-conflict"
     assert result["success"] is False
     assert result["error"] == "machine already reserved"
+
+
+def test_beacon_handler_http_error_non_object_body_falls_back_to_exception() -> None:
+    class FailingClient:
+        def reserve_relic(self, **kwargs: object) -> dict:
+            response = FakeResponse(["not", "an", "object"])
+            raise requests.HTTPError("409 Client Error", response=response)
+
+    handler = mcp.BeaconReservationHandler(client=FailingClient())
+
+    result = handler.handle(
+        {
+            "type": "relic_reserve_request",
+            "beacon_id": "beacon-conflict",
+            "agent_id": "agent-a",
+            "machine_id": "g3-beige",
+            "duration_hours": 1,
+            "rtc_amount": 4.0,
+        }
+    )
+
+    assert result["type"] == "relic_error"
+    assert result["beacon_id"] == "beacon-conflict"
+    assert result["success"] is False
+    assert result["error"] == "409 Client Error"

--- a/tools/rent_a_relic/mcp_integration.py
+++ b/tools/rent_a_relic/mcp_integration.py
@@ -24,6 +24,18 @@ def _get_base_url() -> str:
     return os.environ.get("RENT_A_RELIC_BASE_URL", DEFAULT_BASE_URL)
 
 
+def _response_json_object(resp: Any) -> dict:
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        log.warning("Rent-a-Relic API returned invalid JSON: %s", exc)
+        return {}
+    if not isinstance(body, dict):
+        log.warning("Rent-a-Relic API returned %s JSON, expected object", type(body).__name__)
+        return {}
+    return body
+
+
 MCP_TOOLS: list[dict] = [
     {
         "name": "list_relics",
@@ -102,7 +114,10 @@ class RelicMCPClient:
     def list_relics(self, arch_filter: str | None = None, max_rtc_per_hour: float | None = None) -> dict:
         resp = requests.get(f"{self.base_url}/relic/available", timeout=self.timeout)
         resp.raise_for_status()
-        machines = resp.json().get("machines", [])
+        machines = _response_json_object(resp).get("machines", [])
+        if not isinstance(machines, list):
+            machines = []
+        machines = [m for m in machines if isinstance(m, dict)]
         if arch_filter:
             machines = [m for m in machines if m.get("arch") == arch_filter]
         if max_rtc_per_hour is not None:
@@ -196,7 +211,7 @@ class BeaconReservationHandler:
         except requests.HTTPError as exc:
             body = {}
             try:
-                body = exc.response.json()
+                body = _response_json_object(exc.response)
             except Exception:
                 pass
             return self._error_response(beacon_id, body.get("error", str(exc)))


### PR DESCRIPTION
## Summary
- validate Rent-a-Relic API response JSON is an object before reading fields
- ignore malformed `machines` payloads instead of crashing list_relics
- make beacon reservation HTTP error handling fall back cleanly when an error body is not an object

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_rent_a_relic_mcp_integration.py -q`
- `python3 -m py_compile tools/rent_a_relic/mcp_integration.py tests/test_rent_a_relic_mcp_integration.py`
- `uv run --no-project --with ruff python -m ruff check tools/rent_a_relic/mcp_integration.py tests/test_rent_a_relic_mcp_integration.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/rent_a_relic/mcp_integration.py tests/test_rent_a_relic_mcp_integration.py`