### PR TITLE
Harden Ergo raw tx JSON parsing

### DIFF
--- a/node/ergo_raw_tx.py
+++ b/node/ergo_raw_tx.py
@@ -1,11 +1,29 @@
 #!/usr/bin/env python3
 """Raw Ergo TX builder - simplified version."""
-import os, json, sqlite3, time, requests
+import json
+import os
+import sqlite3
 from hashlib import blake2b
+
+import requests
 
 ERGO_NODE = "http://localhost:9053"
 ERGO_API_KEY = os.environ.get("ERGO_API_KEY", "")
 DB_PATH = "/root/rustchain/rustchain_v2.db"
+
+def response_json_object(resp):
+    try:
+        body = resp.json()
+    except ValueError:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+def response_json_list(resp):
+    try:
+        body = resp.json()
+    except ValueError:
+        return []
+    return body if isinstance(body, list) else []
 
 def encode_coll_byte(hex_str):
     data = bytes.fromhex(hex_str)
@@ -34,14 +52,19 @@ class RawTxBuilder:
     def get_unspent_box(self, min_value=2000000):
         resp = self.session.get(ERGO_NODE + "/wallet/boxes/unspent?minConfirmations=0")
         if resp.status_code == 200:
-            for b in resp.json():
-                if b.get("box", {}).get("value", 0) >= min_value:
+            for b in response_json_list(resp):
+                if not isinstance(b, dict):
+                    continue
+                box = b.get("box", {})
+                if not isinstance(box, dict):
+                    continue
+                if box.get("value", 0) >= min_value:
                     return b
         return None
     
     def get_current_height(self):
         resp = self.session.get(ERGO_NODE + "/info")
-        return resp.json().get("fullHeight", 0) if resp.status_code == 200 else 0
+        return response_json_object(resp).get("fullHeight", 0) if resp.status_code == 200 else 0
     
     def get_recent_miners(self, limit=10):
         conn = sqlite3.connect(DB_PATH)
@@ -82,9 +105,6 @@ class RawTxBuilder:
         print("Total out+fee: " + str(min_box + change_value + fee))
         print("Commitment: " + commitment[:32] + "...")
         
-        # Minimal registers
-        miner_str = ",".join(m.get("miner", "")[:6] for m in miners[:5])
-        
         registers = {
             "R4": encode_coll_byte(commitment),
             "R5": encode_int_reg(len(miners))
@@ -116,7 +136,9 @@ class RawTxBuilder:
         if sign_resp.status_code != 200:
             return {"success": False, "error": "Sign: " + sign_resp.text[:100]}
         
-        signed_tx = sign_resp.json()
+        signed_tx = response_json_object(sign_resp)
+        if not signed_tx:
+            return {"success": False, "error": "Sign: invalid response"}
         
         # Debug: print signed tx values
         print("Signed TX outputs:")

--- a/tests/test_ergo_raw_tx.py
+++ b/tests/test_ergo_raw_tx.py
@@ -7,6 +7,29 @@ import pytest
 from node.ergo_raw_tx import RawTxBuilder, encode_coll_byte, encode_int_reg
 
 
+class FakeResponse:
+    def __init__(self, payload, status_code=200, text=""):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self, *, get_response=None, post_responses=None):
+        self.headers = {}
+        self.get_response = get_response
+        self.post_responses = list(post_responses or [])
+
+    def get(self, *_args, **_kwargs):
+        return self.get_response
+
+    def post(self, *_args, **_kwargs):
+        return self.post_responses.pop(0)
+
+
 def test_encode_coll_byte_handles_empty_and_short_payloads():
     assert encode_coll_byte("") == "0e00"
     assert encode_coll_byte("deadbeef") == "0e04deadbeef"
@@ -70,3 +93,47 @@ def test_compute_commitment_handles_empty_miner_list():
 
     assert len(commitment) == 64
     assert commitment == builder.compute_commitment([])
+
+
+def test_get_unspent_box_ignores_non_list_json():
+    builder = RawTxBuilder()
+    builder.session = FakeSession(get_response=FakeResponse({"box": {"value": 9_000_000}}))
+
+    assert builder.get_unspent_box() is None
+
+
+def test_get_unspent_box_skips_malformed_entries():
+    valid_box = {"box": {"value": 3_000_000, "boxId": "box-1"}}
+    builder = RawTxBuilder()
+    builder.session = FakeSession(
+        get_response=FakeResponse(["not-a-box", {"box": "not-an-object"}, valid_box])
+    )
+
+    assert builder.get_unspent_box() == valid_box
+
+
+def test_get_current_height_defaults_for_non_object_json():
+    builder = RawTxBuilder()
+    builder.session = FakeSession(get_response=FakeResponse(["not", "an", "object"]))
+
+    assert builder.get_current_height() == 0
+
+
+def test_anchor_miners_rejects_non_object_signed_transaction(monkeypatch):
+    builder = RawTxBuilder()
+    builder.session = FakeSession(post_responses=[FakeResponse(["signed"]), FakeResponse("tx-id")])
+    monkeypatch.setattr(
+        builder,
+        "get_recent_miners",
+        lambda limit=10: [{"miner": "alice", "device_arch": "x86", "ts_ok": 1}],
+    )
+    monkeypatch.setattr(
+        builder,
+        "get_unspent_box",
+        lambda min_value=3000000: {
+            "box": {"value": 4_000_000, "boxId": "box-1", "ergoTree": "tree"}
+        },
+    )
+    monkeypatch.setattr(builder, "get_current_height", lambda: 100)
+
+    assert builder.anchor_miners() == {"success": False, "error": "Sign: invalid response"}


### PR DESCRIPTION
## Summary
- validate Ergo node JSON response shapes before iterating boxes or reading height fields
- skip malformed unspent-box rows instead of crashing the anchoring flow
- return a controlled signing error when the wallet sign response is not a JSON object

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_ergo_raw_tx.py -q`
- `python3 -m py_compile node/ergo_raw_tx.py tests/test_ergo_raw_tx.py`
- `uv run --no-project --with ruff python -m ruff check node/ergo_raw_tx.py tests/test_ergo_raw_tx.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/ergo_raw_tx.py tests/test_ergo_raw_tx.py`