### PR TITLE
Harden Sophia governor LLM JSON parsing

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -309,6 +309,18 @@ def _extract_json_object(text: str) -> dict[str, Any] | None:
         return None
 
 
+def _response_json_object(response: Any) -> dict[str, Any]:
+    try:
+        body = response.json()
+    except ValueError as exc:
+        log.warning("Governor LLM returned invalid JSON: %s", exc)
+        return {}
+    if not isinstance(body, dict):
+        log.warning("Governor LLM returned %s JSON, expected object", type(body).__name__)
+        return {}
+    return body
+
+
 def _try_ollama_generate(base_url: str, prompt: str) -> tuple[str | None, str | None]:
     if requests is None:
         return None, None
@@ -324,7 +336,7 @@ def _try_ollama_generate(base_url: str, prompt: str) -> tuple[str | None, str | 
         timeout=(4, 12),
     )
     if response.status_code == 200:
-        body = response.json()
+        body = _response_json_object(response)
         return body.get("response", ""), model
     return None, None
 
@@ -339,7 +351,7 @@ def _try_llama_completion(base_url: str, prompt: str) -> tuple[str | None, str |
         timeout=(4, 12),
     )
     if response.status_code == 200:
-        body = response.json()
+        body = _response_json_object(response)
         return body.get("content", ""), model
     return None, None
 
@@ -359,7 +371,7 @@ def _try_openai_completion(base_url: str, prompt: str) -> tuple[str | None, str 
         timeout=(4, 12),
     )
     if response.status_code == 200:
-        body = response.json()
+        body = _response_json_object(response)
         choices = body.get("choices") or []
         if choices:
             return choices[0].get("text", ""), model

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -175,6 +175,58 @@ def test_inbox_url_fallback_is_used_for_phone_home(tmp_db, monkeypatch):
     assert calls == ["https://example.com/api/sophia/governor/ingest"]
 
 
+def test_local_llm_fallback_continues_after_non_object_json(monkeypatch):
+    calls = []
+
+    class DummyResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append(url)
+        if url.endswith("/completion"):
+            return DummyResponse(["not", "an", "object"])
+        if url.endswith("/api/generate"):
+            return DummyResponse(
+                {
+                    "response": (
+                        '{"stance": "watch", "risk_level": "medium", '
+                        '"needs_escalation": true, "message": "fallback ok"}'
+                    )
+                }
+            )
+        return DummyResponse({})
+
+    monkeypatch.setenv("SOPHIA_GOVERNOR_ENABLE_LLM", "1")
+    monkeypatch.setenv("SOPHIA_GOVERNOR_LLM_URL", "http://llm.local")
+    monkeypatch.setattr(
+        "sophia_governor.requests",
+        types.SimpleNamespace(post=fake_post),
+        raising=False,
+    )
+
+    result = sophia_governor._query_local_llm(
+        "pending_transfer",
+        {"amount_rtc": 1250},
+        {"route": ROUTE_LOCAL_ONLY, "stance": "watch", "risk_level": "medium"},
+    )
+
+    assert result == {
+        "provider": "http://llm.local",
+        "model": "elyan-sophia:7b-q4_K_M",
+        "stance": "watch",
+        "risk_level": "medium",
+        "needs_escalation": True,
+        "message": "fallback ok",
+    }
+    assert calls == ["http://llm.local/completion", "http://llm.local/api/generate"]
+
+
 def test_governor_endpoints_require_admin_for_manual_review(client):
     response = client.post(
         "/sophia/governor/review",


### PR DESCRIPTION
## Summary
- validate local LLM HTTP response JSON is an object before reading provider-specific fields
- let the Sophia governor continue to the next same-endpoint API fallback when one LLM API returns non-object JSON
- add regression coverage for llama-server malformed JSON falling back to Ollama generate

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest node/tests/test_sophia_governor.py -q`
- `python3 -m py_compile node/sophia_governor.py node/tests/test_sophia_governor.py`
- `uv run --no-project --with ruff python -m ruff check node/sophia_governor.py node/tests/test_sophia_governor.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/sophia_governor.py node/tests/test_sophia_governor.py`