### PR TITLE
Harden bounty star checker JSON parsing

### DIFF
--- a/tests/test_star_checker.py
+++ b/tests/test_star_checker.py
@@ -73,6 +73,24 @@ def test_check_user_starred_repo_returns_false_on_api_error(monkeypatch):
     assert star_checker.check_user_starred_repo("targetuser", "owner", "repo", "secret") is False
 
 
+def test_check_user_starred_repo_ignores_non_list_json(monkeypatch):
+    def fake_get(url, headers, timeout):
+        return FakeResponse(payload={"message": "not a stargazer list"})
+
+    monkeypatch.setattr(star_checker.requests, "get", fake_get)
+
+    assert star_checker.check_user_starred_repo("targetuser", "owner", "repo", "secret") is False
+
+
+def test_check_user_starred_repo_skips_malformed_rows(monkeypatch):
+    def fake_get(url, headers, timeout):
+        return FakeResponse(payload=["bad-row", {"login": "TargetUser"}])
+
+    monkeypatch.setattr(star_checker.requests, "get", fake_get)
+
+    assert star_checker.check_user_starred_repo("targetuser", "owner", "repo", "secret") is True
+
+
 def test_count_user_stars_fetches_owner_repos_and_counts_matches(monkeypatch):
     checked_repos = []
 
@@ -93,6 +111,32 @@ def test_count_user_stars_fetches_owner_repos_and_counts_matches(monkeypatch):
         ("targetuser", "owner", "beta", "secret"),
         ("targetuser", "owner", "gamma", "secret"),
     ]
+
+
+def test_count_user_stars_ignores_non_list_repo_payload(monkeypatch):
+    def fake_get(url, headers, timeout):
+        return FakeResponse(payload={"message": "not a repo list"})
+
+    monkeypatch.setattr(star_checker.requests, "get", fake_get)
+
+    assert star_checker.count_user_stars("targetuser", "owner", "secret") == 0
+
+
+def test_count_user_stars_skips_repos_without_string_names(monkeypatch):
+    checked_repos = []
+
+    def fake_get(url, headers, timeout):
+        return FakeResponse(payload=[{"name": "alpha"}, {"name": 123}, {"full_name": "owner/beta"}])
+
+    def fake_check_user_starred_repo(username, owner, repo, token):
+        checked_repos.append(repo)
+        return True
+
+    monkeypatch.setattr(star_checker.requests, "get", fake_get)
+    monkeypatch.setattr(star_checker, "check_user_starred_repo", fake_check_user_starred_repo)
+
+    assert star_checker.count_user_stars("targetuser", "owner", "secret") == 1
+    assert checked_repos == ["alpha"]
 
 
 def test_count_user_stars_uses_supplied_repos_without_fetching_owner_repos(monkeypatch):

--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -19,6 +19,18 @@ logger = logging.getLogger(__name__)
 RUSTCHAIN_NODE_URL = "https://50.28.86.131"
 
 
+def _response_json_list(resp) -> list:
+    try:
+        body = resp.json()
+    except ValueError as exc:
+        logger.warning("GitHub API returned invalid JSON: %s", exc)
+        return []
+    if not isinstance(body, list):
+        logger.warning("GitHub API returned %s JSON, expected list", type(body).__name__)
+        return []
+    return [item for item in body if isinstance(item, dict)]
+
+
 def check_user_starred_repo(
     username: str,
     owner: str,
@@ -52,7 +64,7 @@ def check_user_starred_repo(
                 )
                 return False
 
-            stargazers = resp.json()
+            stargazers = _response_json_list(resp)
             if not stargazers:
                 break
 
@@ -100,10 +112,10 @@ def count_user_stars(
                 resp = requests.get(url, headers=headers, timeout=10)
                 if resp.status_code != 200:
                     break
-                data = resp.json()
+                data = _response_json_list(resp)
                 if not data:
                     break
-                repos.extend(r["name"] for r in data)
+                repos.extend(r["name"] for r in data if isinstance(r.get("name"), str))
                 if len(data) < 100:
                     break
                 page += 1


### PR DESCRIPTION
## Summary
- validate GitHub list endpoint JSON before scanning stargazers and owner repos
- skip malformed stargazer/repo rows instead of crashing verification
- add regression tests for non-list payloads and malformed rows

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_star_checker.py -q`
- `python3 -m py_compile tools/bounty_verifier/star_checker.py tests/test_star_checker.py`
- `uv run --no-project --with ruff python -m ruff check tools/bounty_verifier/star_checker.py tests/test_star_checker.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/bounty_verifier/star_checker.py tests/test_star_checker.py`