### PR TITLE
Harden Sophia review Ollama JSON parsing

### DIFF
--- a/node/sophia_governor_review_service.py
+++ b/node/sophia_governor_review_service.py
@@ -221,6 +221,16 @@ def _relay_scott_notification(payload: dict[str, Any]) -> tuple[int, dict[str, A
     return response.status_code, body if isinstance(body, dict) else {"status": "error", "error": "invalid_response"}
 
 
+def _response_json_object(response: Any) -> dict[str, Any]:
+    try:
+        body = response.json()
+    except ValueError as exc:
+        raise RuntimeError(f"Ollama returned invalid JSON: {_text_excerpt(exc, 200)}") from exc
+    if not isinstance(body, dict):
+        raise RuntimeError(f"Ollama returned {type(body).__name__} JSON, expected object")
+    return body
+
+
 def _coerce_entry(data: dict[str, Any]) -> dict[str, Any]:
     entry = data.get("entry")
     return entry if isinstance(entry, dict) else {}
@@ -432,7 +442,7 @@ def _call_ollama(prompt: str) -> tuple[str, str]:
         timeout=(5, 90),
     )
     response.raise_for_status()
-    body = response.json()
+    body = _response_json_object(response)
     review_text = _text_excerpt(body.get("response", ""), 4000)
     if review_text:
         return review_text, OLLAMA_MODEL
@@ -558,7 +568,7 @@ def _rebuild_review_row(review_id: int, request_json: str, db_path: str | None =
     try:
         raw_review_text, model_used = _call_ollama(prompt)
         review_text = _normalize_review_text(raw_review_text, data)
-    except Exception as exc:
+    except Exception:
         review_text = _normalize_review_text(_fallback_review_text(data), data)
         model_used = f"{OLLAMA_MODEL}@error"
     recommended_resolution = _build_recommended_resolution(review_text, data)

--- a/node/tests/test_sophia_governor_review_service.py
+++ b/node/tests/test_sophia_governor_review_service.py
@@ -168,6 +168,24 @@ def test_call_ollama_sends_top_level_think_false(monkeypatch):
     assert captured["json"]["think"] is False
 
 
+def test_call_ollama_rejects_non_object_json(monkeypatch):
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return ["not", "an", "object"]
+
+    monkeypatch.setattr(
+        review_service,
+        "requests",
+        SimpleNamespace(post=lambda *args, **kwargs: FakeResponse()),
+    )
+
+    with pytest.raises(RuntimeError, match="Ollama returned list JSON, expected object"):
+        review_service._call_ollama("prompt")
+
+
 def test_review_endpoint_falls_back_when_model_returns_thinking_only(client, monkeypatch):
     def fake_call(prompt):
         raise RuntimeError("Ollama returned thinking without final answer for model glm-test")


### PR DESCRIPTION
## Summary
- validate Ollama review-service responses are JSON objects before reading fields
- return a controlled RuntimeError for invalid/non-object model responses so existing fallback handling can run
- add regression coverage for non-object Ollama JSON responses

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -m pytest node/tests/test_sophia_governor_review_service.py -q`
- `python3 -m py_compile node/sophia_governor_review_service.py node/tests/test_sophia_governor_review_service.py`
- `uv run --no-project --with ruff python -m ruff check node/sophia_governor_review_service.py node/tests/test_sophia_governor_review_service.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/sophia_governor_review_service.py node/tests/test_sophia_governor_review_service.py`