### PR TITLE
Harden bounty tracker response parsing

### DIFF
--- a/integrations/rustchain-bounties/bounty_tracker.py
+++ b/integrations/rustchain-bounties/bounty_tracker.py
@@ -81,6 +81,14 @@ class BountyTracker:
             "User-Agent": "rustchain-bounty-tracker/1.0",
         })
         self._load_state()
+
+    @staticmethod
+    def _response_json_object(resp) -> Dict[str, Any]:
+        try:
+            data = resp.json()
+        except ValueError:
+            return {}
+        return data if isinstance(data, dict) else {}
     
     def _load_state(self):
         """Load state from file"""
@@ -105,7 +113,7 @@ class BountyTracker:
     
     def scan_bounties(self) -> List[Bounty]:
         """Scan repo for bounty issues"""
-        url = f"https://api.github.com/search/issues"
+        url = "https://api.github.com/search/issues"
         params = {
             "q": f"repo:{self.repo} is:issue state:open label:bounty",
             "per_page": 100,
@@ -114,22 +122,38 @@ class BountyTracker:
         try:
             resp = self.session.get(url, params=params, timeout=30)
             resp.raise_for_status()
-            data = resp.json()
+            data = self._response_json_object(resp)
             
-            for item in data.get("items", []):
+            items = data.get("items", [])
+            if not isinstance(items, list):
+                items = []
+
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
                 issue_number = item.get("number")
+                if not isinstance(issue_number, int):
+                    continue
                 if issue_number in self.bounties:
                     continue
+
+                body = item.get("body", "")
+                body = body if isinstance(body, str) else ""
+                labels = item.get("labels", [])
+                labels = labels if isinstance(labels, list) else []
                 
                 # Parse reward from issue body or labels
-                reward = self._parse_reward(item.get("body", ""), item.get("labels", []))
+                reward = self._parse_reward(body, labels)
                 
                 bounty = Bounty(
                     issue_number=issue_number,
-                    title=item.get("title", ""),
-                    description=item.get("body", "")[:500],
+                    title=str(item.get("title", "")),
+                    description=body[:500],
                     reward_rtc=reward,
-                    labels=[l.get("name") for l in item.get("labels", [])],
+                    labels=[
+                        label.get("name", "") if isinstance(label, dict) else str(label)
+                        for label in labels
+                    ],
                 )
                 self.bounties[issue_number] = bounty
             
@@ -157,7 +181,10 @@ class BountyTracker:
                 return float(match.group(1))
         
         # Default rewards by label
-        label_names = [l.get("name", "") for l in labels] if isinstance(labels[0], dict) else labels
+        label_names = [
+            label.get("name", "") if isinstance(label, dict) else str(label)
+            for label in (labels or [])
+        ]
         
         if "bounty-critical" in label_names:
             return 150.0

--- a/tests/test_bounty_tracker.py
+++ b/tests/test_bounty_tracker.py
@@ -29,6 +29,17 @@ def make_tracker(tmp_path):
     return module, tracker
 
 
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+    def raise_for_status(self):
+        return None
+
+
 def test_bounty_round_trips_through_dict():
     module = load_bounty_tracker_module()
     bounty = module.Bounty(
@@ -67,6 +78,57 @@ def test_parse_reward_falls_back_to_bounty_labels(tmp_path):
     assert tracker._parse_reward("", [{"name": "bounty-standard"}]) == 50.0
     assert tracker._parse_reward("", [{"name": "bounty-micro"}]) == 10.0
     assert tracker._parse_reward("", [{"name": "bounty"}]) == 25.0
+
+
+def test_parse_reward_defaults_when_labels_empty(tmp_path):
+    _module, tracker = make_tracker(tmp_path)
+
+    assert tracker._parse_reward("", []) == 25.0
+
+
+def test_scan_bounties_ignores_non_object_search_response(tmp_path):
+    _module, tracker = make_tracker(tmp_path)
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse(["not", "a", "search", "object"])
+
+    tracker.session = FakeSession()
+
+    assert tracker.scan_bounties() == []
+
+
+def test_scan_bounties_skips_malformed_items(tmp_path):
+    module, tracker = make_tracker(tmp_path)
+
+    class FakeSession:
+        def get(self, *args, **kwargs):
+            return FakeResponse(
+                {
+                    "items": [
+                        "bad-row",
+                        {"number": "not-int", "title": "Bad number"},
+                        {
+                            "number": 12,
+                            "title": "Valid bounty",
+                            "body": None,
+                            "labels": [{"name": "bounty-micro"}, "custom-label"],
+                        },
+                    ]
+                }
+            )
+
+    tracker.session = FakeSession()
+
+    assert tracker.scan_bounties() == [
+        module.Bounty(
+            issue_number=12,
+            title="Valid bounty",
+            description="",
+            reward_rtc=10.0,
+            labels=["bounty-micro", "custom-label"],
+        )
+    ]
 
 
 def test_state_transitions_are_persisted(tmp_path):


### PR DESCRIPTION
## Summary
- validate GitHub search response JSON before scanning bounty issues
- skip malformed search items and tolerate empty label lists during reward parsing
- add regression coverage for non-object responses, malformed items, and unlabeled bounties

## Validation
- `uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_bounty_tracker.py -q`
- `python3 -m py_compile integrations/rustchain-bounties/bounty_tracker.py tests/test_bounty_tracker.py`
- `uv run --no-project --with ruff python -m ruff check integrations/rustchain-bounties/bounty_tracker.py tests/test_bounty_tracker.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- integrations/rustchain-bounties/bounty_tracker.py tests/test_bounty_tracker.py`