### PR TITLE
fix: validate comment moderation GitHub payloads

### DIFF
--- a/tools/comment-moderation-bot/src/github_client.py
+++ b/tools/comment-moderation-bot/src/github_client.py
@@ -75,6 +75,75 @@ class GitHubClient:
             )
             return response
 
+    @staticmethod
+    def _json_object(data: Any, context: str) -> dict[str, Any]:
+        if not isinstance(data, dict):
+            raise ValueError(f"{context} response must be a JSON object")
+        return data
+
+    @staticmethod
+    def _json_list(data: Any, context: str) -> list[Any]:
+        if not isinstance(data, list):
+            raise ValueError(f"{context} response must be a JSON array")
+        return data
+
+    @staticmethod
+    def _required_str(data: dict[str, Any], field: str, context: str) -> str:
+        value = data.get(field)
+        if not isinstance(value, str):
+            raise ValueError(f"{context} response field {field!r} must be a string")
+        return value
+
+    @staticmethod
+    def _required_int(data: dict[str, Any], field: str, context: str) -> int:
+        value = data.get(field)
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"{context} response field {field!r} must be an integer")
+        return value
+
+    @classmethod
+    def _parse_comment(cls, data: Any, context: str) -> CommentData:
+        obj = cls._json_object(data, context)
+        user = cls._json_object(obj.get("user"), context)
+        body = obj.get("body")
+        if body is None:
+            body = ""
+        elif not isinstance(body, str):
+            raise ValueError(f"{context} response field 'body' must be a string or null")
+
+        return CommentData(
+            id=cls._required_int(obj, "id", context),
+            body=body,
+            author_login=cls._required_str(user, "login", context),
+            author_association=cls._required_str(obj, "author_association", context),
+            created_at=cls._required_str(obj, "created_at", context),
+            updated_at=cls._required_str(obj, "updated_at", context),
+            issue_url=cls._required_str(obj, "issue_url", context),
+            html_url=cls._required_str(obj, "html_url", context),
+        )
+
+    @classmethod
+    def _parse_issue(cls, data: Any, context: str) -> IssueData:
+        obj = cls._json_object(data, context)
+        labels = cls._json_list(obj.get("labels", []), context)
+        label_names = []
+        for label in labels:
+            label_obj = cls._json_object(label, context)
+            label_names.append(cls._required_str(label_obj, "name", context))
+
+        comments_count = obj.get("comments", 0)
+        if not isinstance(comments_count, int) or isinstance(comments_count, bool):
+            raise ValueError(f"{context} response field 'comments' must be an integer")
+
+        return IssueData(
+            number=cls._required_int(obj, "number", context),
+            title=cls._required_str(obj, "title", context),
+            state=cls._required_str(obj, "state", context),
+            labels=label_names,
+            created_at=cls._required_str(obj, "created_at", context),
+            comments_count=comments_count,
+        )
+
     async def get_comment(
         self, repo_owner: str, repo_name: str, comment_id: int, installation_id: int
     ) -> CommentData:
@@ -95,16 +164,7 @@ class GitHubClient:
         response.raise_for_status()
         data = response.json()
 
-        return CommentData(
-            id=data["id"],
-            body=data["body"] or "",
-            author_login=data["user"]["login"],
-            author_association=data["author_association"],
-            created_at=data["created_at"],
-            updated_at=data["updated_at"],
-            issue_url=data["issue_url"],
-            html_url=data["html_url"],
-        )
+        return self._parse_comment(data, "GitHub comment")
 
     async def delete_comment(
         self, repo_owner: str, repo_name: str, comment_id: int, installation_id: int
@@ -147,14 +207,7 @@ class GitHubClient:
         response.raise_for_status()
         data = response.json()
 
-        return IssueData(
-            number=data["number"],
-            title=data["title"],
-            state=data["state"],
-            labels=[label["name"] for label in data.get("labels", [])],
-            created_at=data["created_at"],
-            comments_count=data.get("comments", 0),
-        )
+        return self._parse_issue(data, "GitHub issue")
 
     async def get_issue_comments(
         self,
@@ -189,24 +242,13 @@ class GitHubClient:
                 params={"per_page": per_page, "page": page},
             )
             response.raise_for_status()
-            page_data = response.json()
+            page_data = self._json_list(response.json(), "GitHub issue comments")
 
             if not page_data:
                 break
 
             for data in page_data:
-                comments.append(
-                    CommentData(
-                        id=data["id"],
-                        body=data["body"] or "",
-                        author_login=data["user"]["login"],
-                        author_association=data["author_association"],
-                        created_at=data["created_at"],
-                        updated_at=data["updated_at"],
-                        issue_url=data["issue_url"],
-                        html_url=data["html_url"],
-                    )
-                )
+                comments.append(self._parse_comment(data, "GitHub issue comment"))
 
             page += 1
 
@@ -231,8 +273,15 @@ class GitHubClient:
         if response.status_code != 200:
             return []
 
-        data = response.json()
-        return [org["login"] for org in data]
+        data = self._json_list(response.json(), "GitHub user organizations")
+        return [
+            self._required_str(
+                self._json_object(org, "GitHub user organization"),
+                "login",
+                "GitHub user organization",
+            )
+            for org in data
+        ]
 
     async def check_user_permission_level(
         self,
@@ -261,5 +310,5 @@ class GitHubClient:
         if response.status_code != 200:
             return "none"
 
-        data = response.json()
+        data = self._json_object(response.json(), "GitHub permission")
         return data.get("permission", "none")

--- a/tools/comment-moderation-bot/tests/test_github_client.py
+++ b/tools/comment-moderation-bot/tests/test_github_client.py
@@ -1,0 +1,114 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.github_client import GitHubClient
+
+
+@pytest.fixture
+def client() -> GitHubClient:
+    auth = MagicMock()
+    auth.get_auth_headers = AsyncMock(return_value={"Authorization": "Bearer token"})
+    return GitHubClient(auth=auth)
+
+
+def make_response(payload, status_code: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = payload
+    response.raise_for_status = MagicMock()
+    return response
+
+
+def comment_payload(**overrides):
+    payload = {
+        "id": 123,
+        "body": "Looks suspicious",
+        "user": {"login": "octocat"},
+        "author_association": "NONE",
+        "created_at": "2026-05-20T12:00:00Z",
+        "updated_at": "2026-05-20T12:00:00Z",
+        "issue_url": "https://api.github.com/repos/acme/demo/issues/1",
+        "html_url": "https://github.com/acme/demo/issues/1#issuecomment-123",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def issue_payload(**overrides):
+    payload = {
+        "number": 1,
+        "title": "Issue title",
+        "state": "open",
+        "labels": [{"name": "triage"}],
+        "created_at": "2026-05-20T12:00:00Z",
+        "comments": 2,
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.asyncio
+async def test_get_comment_validates_json_object(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response([comment_payload()]))
+
+    with pytest.raises(ValueError, match="GitHub comment response must be a JSON object"):
+        await client.get_comment("acme", "demo", 123, 456)
+
+
+@pytest.mark.asyncio
+async def test_get_comment_validates_user_shape(client: GitHubClient) -> None:
+    client._request = AsyncMock(
+        return_value=make_response(comment_payload(user={"name": "Octo Cat"}))
+    )
+
+    with pytest.raises(ValueError, match="'login' must be a string"):
+        await client.get_comment("acme", "demo", 123, 456)
+
+
+@pytest.mark.asyncio
+async def test_get_comment_allows_null_body(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response(comment_payload(body=None)))
+
+    comment = await client.get_comment("acme", "demo", 123, 456)
+
+    assert comment.body == ""
+    assert comment.author_login == "octocat"
+
+
+@pytest.mark.asyncio
+async def test_get_issue_validates_labels_array(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response(issue_payload(labels={})))
+
+    with pytest.raises(ValueError, match="GitHub issue response must be a JSON array"):
+        await client.get_issue("acme", "demo", 1, 456)
+
+
+@pytest.mark.asyncio
+async def test_get_issue_comments_validates_page_array(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response({"items": [comment_payload()]}))
+
+    with pytest.raises(
+        ValueError, match="GitHub issue comments response must be a JSON array"
+    ):
+        await client.get_issue_comments("acme", "demo", 1, 456)
+
+
+@pytest.mark.asyncio
+async def test_get_issue_comments_validates_each_comment(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response([comment_payload(user=None)]))
+
+    with pytest.raises(
+        ValueError, match="GitHub issue comment response must be a JSON object"
+    ):
+        await client.get_issue_comments("acme", "demo", 1, 456)
+
+
+@pytest.mark.asyncio
+async def test_get_user_orgs_validates_json_array(client: GitHubClient) -> None:
+    client._request = AsyncMock(return_value=make_response({"login": "not-an-array"}))
+
+    with pytest.raises(
+        ValueError, match="GitHub user organizations response must be a JSON array"
+    ):
+        await client.get_user_orgs("octocat", 456)


### PR DESCRIPTION
## Summary
- validate GitHub comment, issue, issue-comment page, org, and permission response JSON shapes before using fields
- preserve null comment bodies as empty strings while rejecting malformed IDs/users/timestamps/labels
- add focused async tests for malformed upstream payloads in the comment moderation GitHub client

## Validation
- uv run --no-project --with pytest --with pytest-asyncio --with httpx --with pyjwt --with cryptography python -m pytest -o addopts='' tools/comment-moderation-bot/tests/test_github_client.py -q
- uv run --no-project --with pytest --with pytest-asyncio --with httpx --with pyjwt --with cryptography --with fastapi --with pydantic --with pydantic-settings --with python-dotenv python -m pytest -o addopts='' tools/comment-moderation-bot/tests -q
- uv run --no-project --with ruff python -m ruff check tools/comment-moderation-bot/src/github_client.py tools/comment-moderation-bot/tests/test_github_client.py
- python3 -m py_compile tools/comment-moderation-bot/src/github_client.py tools/comment-moderation-bot/tests/test_github_client.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/comment-moderation-bot/src/github_client.py tools/comment-moderation-bot/tests/test_github_client.py