### PR TITLE
fix: validate epoch before settlement

### DIFF
--- a/node/settle_epoch.py
+++ b/node/settle_epoch.py
@@ -4,12 +4,23 @@ import time
 
 NODE_URL = "http://localhost:8099"
 
+def _previous_settleable_epoch(epoch_info):
+    if not isinstance(epoch_info, dict):
+        raise ValueError("/epoch response must be a JSON object")
+
+    current_epoch = epoch_info.get("epoch")
+    if not isinstance(current_epoch, int) or isinstance(current_epoch, bool):
+        raise ValueError("/epoch response field 'epoch' must be an integer")
+    if current_epoch <= 0:
+        raise ValueError("/epoch response field 'epoch' must be greater than zero")
+
+    return current_epoch - 1
+
 def trigger_settlement():
     try:
         resp = requests.get(f"{NODE_URL}/epoch", timeout=10)
         epoch_info = resp.json()
-        current_epoch = epoch_info.get("epoch", 0)
-        prev_epoch = current_epoch - 1
+        prev_epoch = _previous_settleable_epoch(epoch_info)
         
         resp = requests.post(f"{NODE_URL}/rewards/settle", 
                            json={"epoch": prev_epoch}, 

--- a/tests/test_settle_epoch.py
+++ b/tests/test_settle_epoch.py
@@ -78,3 +78,66 @@ def test_trigger_settlement_returns_none_when_request_raises(monkeypatch, capsys
 
     assert module.trigger_settlement() is None
     assert "Error: node unavailable" in capsys.readouterr().out
+
+
+def test_trigger_settlement_rejects_missing_epoch(monkeypatch, capsys):
+    module = load_settle_epoch_module()
+    posted = False
+
+    def fake_post(*_args, **_kwargs):
+        nonlocal posted
+        posted = True
+        raise AssertionError("settlement should not be posted")
+
+    monkeypatch.setattr(
+        module.requests,
+        "get",
+        lambda url, timeout: FakeResponse(payload={"height": 42}),
+    )
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    assert module.trigger_settlement() is None
+    assert posted is False
+    assert "field 'epoch' must be an integer" in capsys.readouterr().out
+
+
+def test_trigger_settlement_rejects_zero_epoch(monkeypatch, capsys):
+    module = load_settle_epoch_module()
+    posted = False
+
+    def fake_post(*_args, **_kwargs):
+        nonlocal posted
+        posted = True
+        raise AssertionError("settlement should not be posted")
+
+    monkeypatch.setattr(
+        module.requests,
+        "get",
+        lambda url, timeout: FakeResponse(payload={"epoch": 0}),
+    )
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    assert module.trigger_settlement() is None
+    assert posted is False
+    assert "field 'epoch' must be greater than zero" in capsys.readouterr().out
+
+
+def test_trigger_settlement_rejects_non_object_epoch_response(monkeypatch, capsys):
+    module = load_settle_epoch_module()
+    posted = False
+
+    def fake_post(*_args, **_kwargs):
+        nonlocal posted
+        posted = True
+        raise AssertionError("settlement should not be posted")
+
+    monkeypatch.setattr(
+        module.requests,
+        "get",
+        lambda url, timeout: FakeResponse(payload=[{"epoch": 42}]),
+    )
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    assert module.trigger_settlement() is None
+    assert posted is False
+    assert "/epoch response must be a JSON object" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- require the `/epoch` response to be a JSON object with a positive integer `epoch` before settling
- avoid posting settlement for epoch `-1` when the node omits or malforms the current epoch
- add regression tests covering missing, zero, and non-object epoch responses

## Validation
- uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_settle_epoch.py -q
- python3 -m py_compile node/settle_epoch.py tests/test_settle_epoch.py
- uv run --no-project --with ruff python -m ruff check node/settle_epoch.py tests/test_settle_epoch.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/settle_epoch.py tests/test_settle_epoch.py