### PR TITLE
fix: redact proxy non-json client errors

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -6,7 +6,6 @@ Allows G4 to connect via different port
 
 from flask import Flask, request, jsonify
 import requests
-import json
 from urllib.parse import quote
 
 app = Flask(__name__)
@@ -67,9 +66,11 @@ def proxy(path):
                 return response.json(), response.status_code
             except ValueError:
                 return _generic_upstream_error(response, "invalid json")
-        else:
-            # Non-JSON response (e.g., HTML error page), return as-is with text
-            return response.text, response.status_code
+        if response.status_code >= 400:
+            return _generic_upstream_error(response, "non-json error response")
+
+        # Successful non-JSON response (for example, plain health text).
+        return response.text, response.status_code
 
     except requests.exceptions.Timeout:
         return jsonify({'error': 'Local server timeout'}), 504
@@ -94,7 +95,7 @@ def home():
     })
 
 if __name__ == '__main__':
-    print(f"Starting RustChain proxy on port 8089...")
+    print("Starting RustChain proxy on port 8089...")
     print(f"Forwarding to: {LOCAL_SERVER}")
-    print(f"G4 can connect to: https://rustchain.org:8089")
+    print("G4 can connect to: https://rustchain.org:8089")
     app.run(host='0.0.0.0', port=8089, debug=False)

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -135,3 +135,24 @@ def test_proxy_hides_invalid_json_response_details(monkeypatch):
     assert response.get_json() == {"error": "Local server unavailable"}
     assert "super-secret" not in response.get_data(as_text=True)
     assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)
+
+
+def test_proxy_hides_non_json_client_error_details(monkeypatch):
+    proxy = load_server_proxy()
+
+    class FakeResponse:
+        status_code = 404
+        text = "not found token=super-secret path=/srv/rustchain/private.db"
+        headers = {"Content-Type": "text/html"}
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr(proxy.requests, "get", fake_get)
+
+    response = proxy.app.test_client().get("/api/missing")
+
+    assert response.status_code == 502
+    assert response.get_json() == {"error": "Local server unavailable"}
+    assert "super-secret" not in response.get_data(as_text=True)
+    assert "/srv/rustchain/private.db" not in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary
- stop forwarding non-JSON 4xx upstream bodies from the vintage server proxy
- keep successful plain-text upstream responses working while routing non-JSON error pages through the generic redacted error response
- add regression coverage for leaked token/path text in non-JSON client error bodies

## Validation
- uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_server_proxy_path.py -q
- uv run --no-project --with ruff python -m ruff check node/server_proxy.py tests/test_server_proxy_path.py
- python3 -m py_compile node/server_proxy.py tests/test_server_proxy_path.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/server_proxy.py tests/test_server_proxy_path.py