### PR TITLE
fix: validate anchor verifier JSON responses

### DIFF
--- a/tools/anchor-verifier/test_verify_anchors.py
+++ b/tools/anchor-verifier/test_verify_anchors.py
@@ -5,13 +5,13 @@ Tests for Ergo Anchor Chain Proof Verifier
 Run: python -m pytest tools/anchor-verifier/test_verify_anchors.py -v
 """
 
-import hashlib
 import json
 import os
 import sqlite3
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from verify_anchors import (
@@ -100,6 +100,44 @@ class TestErgoClient(unittest.TestCase):
     def setUp(self):
         self.client = ErgoClient("http://localhost:9053")
 
+    def test_get_transaction_rejects_non_object_json(self):
+        class FakeResponse:
+            def read(self):
+                return b"[]"
+
+        with patch("urllib.request.urlopen", return_value=FakeResponse()):
+            result = self.client.get_transaction("tx-array")
+
+        self.assertIsNone(result)
+
+    def test_get_transaction_uses_unconfirmed_object_after_malformed_confirmed(self):
+        class FakeResponse:
+            def __init__(self, payload: bytes):
+                self.payload = payload
+
+            def read(self):
+                return self.payload
+
+        responses = [
+            FakeResponse(b"[]"),
+            FakeResponse(b'{"id":"tx-unconfirmed","outputs":[]}'),
+        ]
+
+        with patch("urllib.request.urlopen", side_effect=responses):
+            result = self.client.get_transaction("tx-unconfirmed")
+
+        self.assertEqual(result, {"id": "tx-unconfirmed", "outputs": []})
+
+    def test_get_box_by_id_rejects_non_object_json(self):
+        class FakeResponse:
+            def read(self):
+                return b'"not-a-box"'
+
+        with patch("urllib.request.urlopen", return_value=FakeResponse()):
+            result = self.client.get_box_by_id("box-scalar")
+
+        self.assertIsNone(result)
+
     def test_extract_commitment_r5(self):
         """Test extracting commitment from R5 register."""
         commitment = "a" * 64
@@ -140,6 +178,23 @@ class TestErgoClient(unittest.TestCase):
         tx = {}
         result = self.client.extract_commitment_from_tx(tx)
         self.assertIsNone(result)
+
+    def test_extract_ignores_malformed_outputs_shape(self):
+        tx = {"outputs": {"additionalRegisters": {"R5": f"{R5_PREFIX}{'d' * 64}"}}}
+        result = self.client.extract_commitment_from_tx(tx)
+        self.assertIsNone(result)
+
+    def test_extract_skips_non_object_outputs_and_registers(self):
+        commitment = "e" * 64
+        tx = {
+            "outputs": [
+                ["not", "an", "output"],
+                {"additionalRegisters": ["not", "registers"]},
+                {"additionalRegisters": {"R5": f"{R5_PREFIX}{commitment}"}},
+            ]
+        }
+        result = self.client.extract_commitment_from_tx(tx)
+        self.assertEqual(result, commitment)
 
     def test_extract_wrong_prefix(self):
         tx = {

--- a/tools/anchor-verifier/verify_anchors.py
+++ b/tools/anchor-verifier/verify_anchors.py
@@ -26,9 +26,8 @@ import json
 import os
 import sqlite3
 import sys
-import time
-from dataclasses import dataclass, field, asdict
-from typing import List, Optional, Tuple, Dict, Any
+from dataclasses import dataclass, asdict
+from typing import List, Optional
 
 # ── Configuration ────────────────────────────────────────────────
 DEFAULT_DB = os.environ.get(
@@ -87,6 +86,13 @@ class ErgoClient:
     def __init__(self, base_url: str):
         self.base_url = base_url.rstrip("/")
 
+    @staticmethod
+    def _json_object(raw: bytes) -> dict:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError("Ergo node response must be a JSON object")
+        return data
+
     def get_transaction(self, tx_id: str) -> Optional[dict]:
         """Fetch transaction by ID."""
         try:
@@ -94,14 +100,14 @@ class ErgoClient:
             url = f"{self.base_url}/blockchain/transaction/byId/{tx_id}"
             req = urllib.request.Request(url, headers={"Accept": "application/json"})
             resp = urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT)
-            return json.loads(resp.read())
+            return self._json_object(resp.read())
         except Exception:
             # Try unconfirmed pool
             try:
                 url = f"{self.base_url}/transactions/unconfirmed/byTransactionId/{tx_id}"
                 req = urllib.request.Request(url, headers={"Accept": "application/json"})
                 resp = urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT)
-                return json.loads(resp.read())
+                return self._json_object(resp.read())
             except Exception:
                 return None
 
@@ -112,14 +118,22 @@ class ErgoClient:
             url = f"{self.base_url}/blockchain/box/byId/{box_id}"
             req = urllib.request.Request(url, headers={"Accept": "application/json"})
             resp = urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT)
-            return json.loads(resp.read())
+            return self._json_object(resp.read())
         except Exception:
             return None
 
     def extract_commitment_from_tx(self, tx: dict) -> Optional[str]:
         """Extract commitment hash from R5 register of transaction outputs."""
-        for output in tx.get("outputs", []):
+        outputs = tx.get("outputs", [])
+        if not isinstance(outputs, list):
+            return None
+
+        for output in outputs:
+            if not isinstance(output, dict):
+                continue
             registers = output.get("additionalRegisters", {})
+            if not isinstance(registers, dict):
+                continue
 
             # R5 contains commitment hash (0e40 prefix = Coll[Byte] 32 bytes)
             r5 = registers.get("R5", "")


### PR DESCRIPTION
## Summary
- require Ergo transaction and box API responses to be JSON objects before using them
- allow malformed confirmed transaction responses to fall back to the unconfirmed transaction endpoint
- make commitment extraction tolerate malformed `outputs` and `additionalRegisters` shapes
- add regression coverage for non-object Ergo responses and malformed output/register payloads

## Validation
- uv run --no-project --with pytest python -m pytest tools/anchor-verifier/test_verify_anchors.py -q
- python3 -m py_compile tools/anchor-verifier/verify_anchors.py tools/anchor-verifier/test_verify_anchors.py
- uv run --no-project --with ruff python -m ruff check tools/anchor-verifier/verify_anchors.py tools/anchor-verifier/test_verify_anchors.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/anchor-verifier/verify_anchors.py tools/anchor-verifier/test_verify_anchors.py