### PR TITLE
feat(rip-309): Phase 1 - Integrate canonical fingerprint check rotation into reward calculation

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -16,38 +16,14 @@ Key Changes:
 import hashlib
 import json
 import logging
-import random
 import sqlite3
 import time
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import List, Tuple, Dict
 
+from rip_309_measurement_rotation import get_epoch_measurement_config
+
 logger = logging.getLogger(__name__)
-
-ROTATING_FINGERPRINT_CHECKS = (
-    "clock_drift",
-    "cache_timing",
-    "simd_bias",
-    "thermal_drift",
-    "instruction_jitter",
-    "anti_emulation",
-)
-ACTIVE_FINGERPRINT_CHECK_COUNT = 4
-
-
-def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
-    previous_epoch_block_hash = (previous_epoch_block_hash or ("0" * 64)).strip().lower()
-    seed = f"rip-309:{previous_epoch_block_hash}".encode()
-    return hashlib.sha256(seed).hexdigest()
-
-
-def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = ACTIVE_FINGERPRINT_CHECK_COUNT) -> Tuple[str, ...]:
-    nonce = derive_measurement_nonce(previous_epoch_block_hash)
-    ranked = sorted(
-        ROTATING_FINGERPRINT_CHECKS,
-        key=lambda name: hashlib.sha256(f"{nonce}:{name}".encode()).hexdigest(),
-    )
-    return tuple(ranked[:active_count])
 
 # Genesis timestamp (adjust to actual genesis block timestamp)
 GENESIS_TIMESTAMP = 1764706927  # First actual block (Dec 2, 2025)
@@ -600,17 +576,10 @@ def calculate_epoch_rewards_time_aged(
     Returns:
         Dict of {miner_id: reward_urtc}
     """
-    # RIP-309: Rotating fingerprint checks (4-of-6 per epoch)
-    fp_checks = ['clock_drift', 'cache_timing', 'simd_identity',
-                 'thermal_drift', 'instruction_jitter', 'anti_emulation']
-    if prev_block_hash:
-        nonce = hashlib.sha256(prev_block_hash + b"measurement_nonce").digest()
-        seed = int.from_bytes(nonce[:4], 'big')
-        active_checks = set(random.Random(seed).sample(fp_checks, 4))
-    else:
-        # Fallback when no prev_block_hash provided: all checks active (backward compat)
-        active_checks = set(fp_checks)
-    print(f"[RIP-309] Epoch {epoch} active checks: {sorted(active_checks)} (seed derived from prev_block_hash)")
+    # RIP-309: Canonical fingerprint check rotation (4-of-6 per epoch)
+    prev_hash_hex = prev_block_hash.hex() if prev_block_hash else ""
+    rip309_config = get_epoch_measurement_config(prev_hash_hex, epoch)
+    active_checks = set(rip309_config["active_fingerprints"])
 
     chain_age_years = get_chain_age_years(current_slot)
 

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -13,10 +13,10 @@ Key Changes:
 4. Time-aging: Vintage hardware advantage decays over blockchain lifetime
 """
 
+import contextlib
 import json
 import logging
 import sqlite3
-import time
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import List, Tuple, Dict
 
@@ -587,7 +587,7 @@ def calculate_epoch_rewards_time_aged(
     epoch_start_ts = GENESIS_TIMESTAMP + (epoch_start_slot * BLOCK_TIME)
     epoch_end_ts = GENESIS_TIMESTAMP + (epoch_end_slot * BLOCK_TIME)
 
-    with sqlite3.connect(db_path) as conn:
+    with contextlib.closing(sqlite3.connect(db_path)) as conn:
         cursor = conn.cursor()
 
         # Schema compatibility: detect whether fingerprint_checks_json column exists
@@ -746,7 +746,7 @@ if __name__ == "__main__":
         g5_share = 0 if total_weight == 0 else (g5_mult / total_weight) * total_reward
         modern_share = 0 if total_weight == 0 else (modern_mult / total_weight) * total_reward
 
-        print(f"\nReward distribution (1.5 RTC total):")
+        print("\nReward distribution (1.5 RTC total):")
         print(f"  G4: {g4_share / 100_000_000:.6f} RTC ({g4_share/total_reward*100:.1f}%)")
         print(f"  G5: {g5_share / 100_000_000:.6f} RTC ({g5_share/total_reward*100:.1f}%)")
         print(f"  Modern: {modern_share / 100_000_000:.6f} RTC ({modern_share/total_reward*100:.1f}%)")

--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -13,7 +13,6 @@ Key Changes:
 4. Time-aging: Vintage hardware advantage decays over blockchain lifetime
 """
 
-import hashlib
 import json
 import logging
 import sqlite3

--- a/node/tests/test_rip309_fingerprint_rotation.py
+++ b/node/tests/test_rip309_fingerprint_rotation.py
@@ -15,7 +15,7 @@ import unittest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
-from rip_200_round_robin_1cpu1vote import calculate_epoch_rewards_time_aged, GENESIS_TIMESTAMP, BLOCK_TIME
+from rip_200_round_robin_1cpu1vote import calculate_epoch_rewards_time_aged, GENESIS_TIMESTAMP
 from rip_309_measurement_rotation import get_epoch_measurement_config
 
 

--- a/node/tests/test_rip309_fingerprint_rotation.py
+++ b/node/tests/test_rip309_fingerprint_rotation.py
@@ -8,7 +8,6 @@ Tests for 4-of-6 rotating fingerprint checks per epoch.
 import hashlib
 import json
 import os
-import random
 import sqlite3
 import sys
 import tempfile
@@ -17,6 +16,7 @@ import unittest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 from rip_200_round_robin_1cpu1vote import calculate_epoch_rewards_time_aged, GENESIS_TIMESTAMP, BLOCK_TIME
+from rip_309_measurement_rotation import get_epoch_measurement_config
 
 
 def _init_db(conn):
@@ -132,10 +132,8 @@ class TestRip309Rotation(unittest.TestCase):
 
         for i in range(1000):
             h = hashlib.sha256(str(i).encode()).digest()
-            fp_checks = ['clock_drift', 'cache_timing', 'simd_identity',
-                         'thermal_drift', 'instruction_jitter', 'anti_emulation']
-            seed = int.from_bytes(hashlib.sha256(h + b"measurement_nonce").digest()[:4], 'big')
-            active = set(random.Random(seed).sample(fp_checks, 4))
+            config = get_epoch_measurement_config(h.hex(), 1)
+            active = set(config["active_fingerprints"])
             if "anti_emulation" not in active:
                 rewards = calculate_epoch_rewards_time_aged(db_path, 1, 1_000_000, 200, h)
                 self.assertGreater(rewards.get("alice", 0), 0,
@@ -160,10 +158,8 @@ class TestRip309Rotation(unittest.TestCase):
 
         for i in range(1000):
             h = hashlib.sha256(str(i).encode()).digest()
-            fp_checks = ['clock_drift', 'cache_timing', 'simd_identity',
-                         'thermal_drift', 'instruction_jitter', 'anti_emulation']
-            seed = int.from_bytes(hashlib.sha256(h + b"measurement_nonce").digest()[:4], 'big')
-            active = set(random.Random(seed).sample(fp_checks, 4))
+            config = get_epoch_measurement_config(h.hex(), 1)
+            active = set(config["active_fingerprints"])
             if "anti_emulation" in active:
                 rewards = calculate_epoch_rewards_time_aged(db_path, 1, 1_000_000, 200, h)
                 self.assertEqual(rewards.get("alice", 0), 0,


### PR DESCRIPTION
## Summary

Phase 1 implementation of [RIP-309: Rotating Measurement Freshness](https://github.com/Scottcjn/Rustchain/issues/2234).

Integrates the canonical `rip_309_measurement_rotation` module into `rip_200_round_robin_1cpu1vote.py`, replacing three separate duplicate/conflicting implementations of nonce derivation.

## Changes

- **Import canonical module**: `from rip_309_measurement_rotation import get_epoch_measurement_config`
- - **Remove dead code**: Deleted `ROTATING_FINGERPRINT_CHECKS`, `ACTIVE_FINGERPRINT_CHECK_COUNT`, `derive_measurement_nonce()`, and `select_active_fingerprint_checks()` - all superseded by the canonical module
- - **Fix nonce inconsistency**: The old inline implementation used a *different* nonce derivation algorithm than the canonical module, meaning nodes could disagree on which 4-of-6 checks were active for a given epoch. Now all nodes use the same deterministic selection.
- - **Remove `import random`**: No longer needed after removing the inline implementation
## Bug Fixed

The old inline code in `calculate_epoch_rewards_time_aged()` used:
```python
nonce = hashlib.sha256(prev_block_hash + b"measurement_nonce").digest()
```
But the canonical `rip_309_measurement_rotation.py` uses:
```python
hashlib.sha256(bytes.fromhex(prev_block_hash) + b"rip309_measurement_nonce").digest()
```
These produce **different nonces for the same block hash**, meaning the reward calculation was selecting different checks than what the RIP-309 module would select. This PR resolves the inconsistency by using the single source of truth.

## Testing

- `py_compile` passes [OK]
- - `rip_309_measurement_rotation.py` self-test passes [OK] (check activation 60-75% per check, target 66.7%)
- - `rip_200_round_robin_1cpu1vote.py` self-test passes [OK] (time-aged multipliers unchanged)
## Bounty

Closes Phase 1 of #2234 (50 RTC)

Payout wallet: `RTC241359b3438d1222fdc1c3e22fe980657a4bc54e`