### PR TITLE
fix: read bounty verifier wallet balances

### DIFF
--- a/tools/bounty-bot-pro/tests/test_verifier.py
+++ b/tools/bounty-bot-pro/tests/test_verifier.py
@@ -91,3 +91,39 @@ def test_generate_report_uses_verified_reward_inputs_without_network():
     assert "alice-wallet" in report
     assert "12.5 RTC" in report
     assert "**28.0 RTC**" in report
+
+
+def test_verify_wallet_uses_amount_rtc_balance_field(monkeypatch):
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {"amount_rtc": 12.5}
+
+    def fake_get(url, verify, timeout):
+        return Response()
+
+    monkeypatch.setattr(verifier.requests, "get", fake_get)
+    subject = verifier.BountyVerifier.__new__(verifier.BountyVerifier)
+
+    result = subject.verify_wallet("alice-wallet")
+
+    assert result == {"exists": True, "balance": 12.5}
+
+
+def test_verify_wallet_rejects_non_object_balance_response(monkeypatch):
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return [{"amount_rtc": 12.5}]
+
+    def fake_get(url, verify, timeout):
+        return Response()
+
+    monkeypatch.setattr(verifier.requests, "get", fake_get)
+    subject = verifier.BountyVerifier.__new__(verifier.BountyVerifier)
+
+    result = subject.verify_wallet("alice-wallet")
+
+    assert result == {"exists": False, "error": "wallet_response_not_object"}

--- a/tools/bounty-bot-pro/verifier.py
+++ b/tools/bounty-bot-pro/verifier.py
@@ -3,10 +3,8 @@
 import os
 import re
 import json
-import time
 import requests
-import yaml
-from typing import List, Dict, Any, Optional
+from typing import Dict, Any, Optional
 from github import Github, GithubException
 import google.generativeai as genai
 from dotenv import load_dotenv
@@ -69,7 +67,10 @@ class BountyVerifier:
             )
             if resp.status_code == 200:
                 data = resp.json()
-                return {"exists": True, "balance": data.get("balance", 0)}
+                if not isinstance(data, dict):
+                    return {"exists": False, "error": "wallet_response_not_object"}
+                balance = data.get("balance", data.get("amount_rtc", 0))
+                return {"exists": True, "balance": balance}
             return {"exists": False, "error": resp.status_code}
         except Exception as e:
             return {"exists": False, "error": str(e)}
@@ -101,8 +102,10 @@ class BountyVerifier:
         wallet_info = self.verify_wallet(wallet)
         
         payout = stars["count"] * CONFIG["star_reward"]
-        if follows: payout += CONFIG["follow_reward"]
-        if stars["is_star_king"]: payout += CONFIG["star_king_bonus"]
+        if follows:
+            payout += CONFIG["follow_reward"]
+        if stars["is_star_king"]:
+            payout += CONFIG["star_king_bonus"]
         
         report = f"## 🤖 Automated Verification for @{username}\n\n"
         report += "| Check | Result |\n"


### PR DESCRIPTION
## Summary
- read `amount_rtc` from RustChain wallet balance responses when `balance` is absent
- reject non-object wallet balance responses instead of treating malformed payloads as valid wallets
- add focused regression coverage for the live wallet balance field shape and malformed response shape
- clean stale lint issues in the touched verifier file

## Validation
- uv run --no-project --with pytest --with requests --with pyyaml --with flask python -m pytest tools/bounty-bot-pro/tests/test_verifier.py tests/test_bounty_verifier_py_compile.py -q
- python3 -m py_compile tools/bounty-bot-pro/verifier.py tools/bounty-bot-pro/tests/test_verifier.py tests/test_bounty_verifier_py_compile.py
- uv run --no-project --with ruff python -m ruff check tools/bounty-bot-pro/verifier.py tools/bounty-bot-pro/tests/test_verifier.py tests/test_bounty_verifier_py_compile.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/bounty-bot-pro/verifier.py tools/bounty-bot-pro/tests/test_verifier.py tests/test_bounty_verifier_py_compile.py