### PR TITLE
fix: count consensus probe miner envelopes

### DIFF
--- a/node/consensus_probe.py
+++ b/node/consensus_probe.py
@@ -18,6 +18,7 @@ from urllib.request import urlopen
 
 
 Fetcher = Callable[..., dict]
+MINER_LIST_KEYS = ("miners", "data", "items", "results")
 
 
 @dataclass
@@ -42,6 +43,38 @@ def _fetch_json(node_url: str, endpoint: str, timeout_s: int, fetcher: Fetcher):
     return fetcher(url, timeout=timeout_s)
 
 
+def _coerce_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _miner_count(payload) -> int:
+    if isinstance(payload, list):
+        return len(payload)
+    if not isinstance(payload, dict):
+        return 0
+
+    pagination = payload.get("pagination")
+    if isinstance(pagination, dict):
+        total = _coerce_int(pagination.get("total"))
+        if total is not None:
+            return total
+
+    for key in ("total_miners", "total"):
+        total = _coerce_int(payload.get(key))
+        if total is not None:
+            return total
+
+    for key in MINER_LIST_KEYS:
+        rows = payload.get(key)
+        if isinstance(rows, list):
+            return len(rows)
+
+    return 0
+
+
 def collect_snapshot(node_url: str, timeout_s: int = 8, fetcher: Fetcher = _default_fetcher) -> NodeSnapshot:
     try:
         health = _fetch_json(node_url, "/health", timeout_s, fetcher)
@@ -49,14 +82,12 @@ def collect_snapshot(node_url: str, timeout_s: int = 8, fetcher: Fetcher = _defa
         stats = _fetch_json(node_url, "/api/stats", timeout_s, fetcher)
         miners = _fetch_json(node_url, "/api/miners", timeout_s, fetcher)
 
-        miners_count = len(miners) if isinstance(miners, list) else 0
-
         return NodeSnapshot(
             node=node_url,
             ok=bool(health.get("ok", False)),
             version=health.get("version"),
             enrolled_miners=epoch.get("enrolled_miners"),
-            miners_count=miners_count,
+            miners_count=_miner_count(miners),
             total_balance=stats.get("total_balance"),
             error=None,
         )

--- a/node/tests/test_consensus_probe_unit.py
+++ b/node/tests/test_consensus_probe_unit.py
@@ -1,6 +1,4 @@
 # SPDX-License-Identifier: MIT
-import pytest
-
 from node.consensus_probe import (
     NodeSnapshot,
     collect_snapshot,
@@ -53,6 +51,41 @@ def test_collect_snapshot_reads_expected_endpoints():
         ("https://node.example/api/stats", 4),
         ("https://node.example/api/miners", 4),
     ]
+
+
+def test_collect_snapshot_counts_enveloped_miner_total():
+    payloads = {
+        "https://node.example/health": {"ok": True, "version": "2.1.0"},
+        "https://node.example/epoch": {"enrolled_miners": 5},
+        "https://node.example/api/stats": {"total_balance": 12.5},
+        "https://node.example/api/miners": {
+            "miners": [{"id": "a"}, {"id": "b"}],
+            "pagination": {"total": 5, "limit": 2, "offset": 0, "count": 2},
+        },
+    }
+
+    def fetcher(url, timeout):
+        return payloads[url]
+
+    result = collect_snapshot("https://node.example", timeout_s=4, fetcher=fetcher)
+
+    assert result.miners_count == 5
+
+
+def test_collect_snapshot_counts_enveloped_miner_rows_without_total():
+    payloads = {
+        "https://node.example/health": {"ok": True, "version": "2.1.0"},
+        "https://node.example/epoch": {"enrolled_miners": 2},
+        "https://node.example/api/stats": {"total_balance": 12.5},
+        "https://node.example/api/miners": {"data": [{"id": "a"}, {"id": "b"}]},
+    }
+
+    def fetcher(url, timeout):
+        return payloads[url]
+
+    result = collect_snapshot("https://node.example", timeout_s=4, fetcher=fetcher)
+
+    assert result.miners_count == 2
 
 
 def test_collect_snapshot_reports_fetch_errors():

--- a/tests/test_consensus_probe.py
+++ b/tests/test_consensus_probe.py
@@ -65,6 +65,29 @@ def test_collect_snapshot_success():
     assert snap.total_balance == 123.45
 
 
+def test_collect_snapshot_uses_enveloped_miners_total():
+    payloads = {
+        "/health": {"ok": True, "version": "2.2.1-rip200"},
+        "/epoch": {"enrolled_miners": 12},
+        "/api/stats": {"total_balance": 123.45},
+        "/api/miners": {
+            "miners": [{"miner": "a"}, {"miner": "b"}],
+            "pagination": {"total": 12, "limit": 2, "offset": 0, "count": 2},
+        },
+    }
+
+    def fake_fetcher(url, timeout):
+        for endpoint, payload in payloads.items():
+            if url.endswith(endpoint):
+                return payload
+        raise AssertionError(f"unexpected url {url}")
+
+    snap = cp.collect_snapshot("http://node", timeout_s=3, fetcher=fake_fetcher)
+
+    assert snap.error is None
+    assert snap.miners_count == 12
+
+
 def test_collect_snapshot_error():
     def failing_fetcher(url, timeout):
         raise RuntimeError("boom")


### PR DESCRIPTION
## Summary
- teach the cross-node consensus probe to count enveloped /api/miners responses instead of treating them as zero miners
- prefer pagination.total or top-level total fields when the API returns a paginated first page
- add regression coverage for paginated envelopes and envelope rows without totals

## Verification
- uv run --no-project --with pytest --with flask python -m pytest node/tests/test_consensus_probe_unit.py tests/test_consensus_probe.py -q
- python3 -m py_compile node/consensus_probe.py node/tests/test_consensus_probe_unit.py tests/test_consensus_probe.py
- uv run --no-project --with ruff python -m ruff check node/consensus_probe.py node/tests/test_consensus_probe_unit.py tests/test_consensus_probe.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- node/consensus_probe.py node/tests/test_consensus_probe_unit.py tests/test_consensus_probe.py