### PR TITLE
fix: guard tip bot state sha lookup

### DIFF
--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -15,21 +15,20 @@ import hashlib
 import hmac
 import json
 import os
-import tempfile
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from auth import RateLimiter, is_authorized_sender, verify_webhook_signature
 from state import TipState
 from tip_bot import (
-    ParseResult,
     TipCommand,
     build_duplicate_comment,
     build_failure_comment,
     build_success_comment,
     build_unauthorized_comment,
+    github_commit_state,
     main,
     parse_tip_command,
     process_event,
@@ -513,6 +512,53 @@ class TestProcessEvent:
         event = make_event("/tip @alice 10 RTC", sender="attacker")
         process_event(event, config, state, "token", "org/repo")
         assert self.mock_commit.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helper tests
+# ---------------------------------------------------------------------------
+
+class TestGitHubApiHelpers:
+
+    class Response:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            if isinstance(self._payload, Exception):
+                raise self._payload
+            return self._payload
+
+    def test_commit_state_uses_existing_file_sha(self, tmp_path):
+        state_file = tmp_path / "tip_state.json"
+        state_file.write_text('{"tip_log": []}', encoding="utf-8")
+        puts = []
+
+        def fake_put(url, headers, json, timeout):
+            puts.append(json)
+            return self.Response(200, {})
+
+        with patch("tip_bot.requests.get", return_value=self.Response(200, {"sha": "abc123"})), \
+             patch("tip_bot.requests.put", side_effect=fake_put):
+            assert github_commit_state("org/repo", str(state_file), "token") is True
+
+        assert puts[0]["sha"] == "abc123"
+
+    def test_commit_state_ignores_malformed_existing_file_sha(self, tmp_path):
+        state_file = tmp_path / "tip_state.json"
+        state_file.write_text('{"tip_log": []}', encoding="utf-8")
+        puts = []
+
+        def fake_put(url, headers, json, timeout):
+            puts.append(json)
+            return self.Response(201, {})
+
+        with patch("tip_bot.requests.get", return_value=self.Response(200, [])), \
+             patch("tip_bot.requests.put", side_effect=fake_put):
+            assert github_commit_state("org/repo", str(state_file), "token") is True
+
+        assert "sha" not in puts[0]
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -188,6 +188,19 @@ def github_post_comment(repo: str, issue_number: int, body: str, token: str) -> 
     return resp.status_code == 201
 
 
+def _github_content_sha(resp) -> Optional[str]:
+    if resp.status_code != 200:
+        return None
+    try:
+        body = resp.json()
+    except ValueError:
+        return None
+    if not isinstance(body, dict):
+        return None
+    sha = body.get("sha")
+    return sha if isinstance(sha, str) and sha else None
+
+
 def github_commit_state(repo: str, state_file: str, token: str) -> bool:
     """
     Commit the updated state file back to the repository.
@@ -209,7 +222,7 @@ def github_commit_state(repo: str, state_file: str, token: str) -> bool:
 
     # Get current SHA (needed for updates)
     resp = requests.get(url, headers=headers, timeout=15)
-    sha = resp.json().get("sha") if resp.status_code == 200 else None
+    sha = _github_content_sha(resp)
 
     payload: dict = {
         "message": "chore: update tip state [skip ci]",


### PR DESCRIPTION
## Summary
- guard the GitHub Contents API SHA lookup used before committing tip bot state
- ignore malformed or non-object 200 responses instead of raising an AttributeError
- add helper tests for existing-file SHA updates and malformed SHA responses

## Verification
- uv run --no-project --with pytest --with requests --with pyyaml python -m pytest integrations/rustchain-bounties/test_tip_bot.py -q
- python3 -m py_compile integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py
- uv run --no-project --with ruff python -m ruff check integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- integrations/rustchain-bounties/tip_bot.py integrations/rustchain-bounties/test_tip_bot.py