### PR TITLE
fix: harden wrtc price payload parsing

### DIFF
--- a/tests/test_wrtc_price_bot.py
+++ b/tests/test_wrtc_price_bot.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "tools" / "wrtc-price-bot" / "bot.py"
+
+
+def load_module(monkeypatch):
+    telegram = types.ModuleType("telegram")
+    telegram.Update = object
+
+    telegram_ext = types.ModuleType("telegram.ext")
+    telegram_ext.ApplicationBuilder = object
+    telegram_ext.CommandHandler = object
+    telegram_ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object)
+    telegram_ext.JobQueue = object
+
+    dotenv = types.ModuleType("dotenv")
+    dotenv.load_dotenv = lambda: None
+
+    monkeypatch.setitem(sys.modules, "telegram", telegram)
+    monkeypatch.setitem(sys.modules, "telegram.ext", telegram_ext)
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv)
+
+    spec = importlib.util.spec_from_file_location("wrtc_price_bot", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class Response:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_get_price_data_prefers_raydium_pair(monkeypatch):
+    module = load_module(monkeypatch)
+    payload = {
+        "pairs": [
+            {"dexId": "other", "priceUsd": "0.01"},
+            {
+                "dexId": "raydium",
+                "priceUsd": "0.25",
+                "priceNative": "0.002",
+                "priceChange": {"h24": "12.5", "h1": "-1.25"},
+                "liquidity": {"usd": "1500"},
+                "volume": {"h24": "750"},
+                "url": "https://dex.example/pair",
+            },
+        ]
+    }
+
+    monkeypatch.setattr(module.requests, "get", lambda url, timeout: Response(payload))
+
+    data = module.get_price_data()
+
+    assert data == {
+        "price_usd": 0.25,
+        "price_native": "0.002",
+        "h24_change": 12.5,
+        "h1_change": -1.25,
+        "liquidity_usd": 1500.0,
+        "volume_h24": 750.0,
+        "url": "https://dex.example/pair",
+    }
+
+
+def test_get_price_data_ignores_malformed_pairs(monkeypatch):
+    module = load_module(monkeypatch)
+    payload = {
+        "pairs": [
+            ["bad"],
+            {
+                "dexId": "raydium",
+                "priceUsd": "bad",
+                "priceChange": "bad",
+                "liquidity": None,
+                "volume": [],
+            },
+        ]
+    }
+
+    monkeypatch.setattr(module.requests, "get", lambda url, timeout: Response(payload))
+
+    data = module.get_price_data()
+
+    assert data["price_usd"] == 0.0
+    assert data["h24_change"] == 0.0
+    assert data["h1_change"] == 0.0
+    assert data["liquidity_usd"] == 0.0
+    assert data["volume_h24"] == 0.0
+
+
+def test_get_price_data_rejects_non_object_payload(monkeypatch):
+    module = load_module(monkeypatch)
+
+    monkeypatch.setattr(module.requests, "get", lambda url, timeout: Response([]))
+
+    assert module.get_price_data() is None

--- a/tools/wrtc-price-bot/bot.py
+++ b/tools/wrtc-price-bot/bot.py
@@ -7,7 +7,7 @@ import logging
 import requests
 from dotenv import load_dotenv
 from telegram import Update
-from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes, JobQueue
+from telegram.ext import ApplicationBuilder, CommandHandler, ContextTypes
 
 # Configure logging
 logging.basicConfig(
@@ -21,27 +21,45 @@ WRTC_MINT = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
 DEXSCREENER_API = f"https://api.dexscreener.com/latest/dex/tokens/{WRTC_MINT}"
 ALERT_THRESHOLD = 10.0  # 10% movement
 
+def _as_dict(value):
+    return value if isinstance(value, dict) else {}
+
+def _as_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
 def get_price_data():
     """Fetch price data from DexScreener."""
     try:
         response = requests.get(DEXSCREENER_API, timeout=10)
         response.raise_for_status()
         data = response.json()
-        
+
+        if not isinstance(data, dict):
+            return None
+
         pairs = data.get('pairs', [])
+        if not isinstance(pairs, list):
+            return None
+        pairs = [pair for pair in pairs if isinstance(pair, dict)]
         if not pairs:
             return None
-            
+
         # Filter for Raydium pair
         raydium_pair = next((p for p in pairs if p.get('dexId') == 'raydium'), pairs[0])
+        price_change = _as_dict(raydium_pair.get('priceChange'))
+        liquidity = _as_dict(raydium_pair.get('liquidity'))
+        volume = _as_dict(raydium_pair.get('volume'))
         
         return {
-            'price_usd': float(raydium_pair.get('priceUsd', 0)),
+            'price_usd': _as_float(raydium_pair.get('priceUsd')),
             'price_native': raydium_pair.get('priceNative'),
-            'h24_change': raydium_pair.get('priceChange', {}).get('h24', 0),
-            'h1_change': raydium_pair.get('priceChange', {}).get('h1', 0),
-            'liquidity_usd': raydium_pair.get('liquidity', {}).get('usd', 0),
-            'volume_h24': raydium_pair.get('volume', {}).get('h24', 0),
+            'h24_change': _as_float(price_change.get('h24')),
+            'h1_change': _as_float(price_change.get('h1')),
+            'liquidity_usd': _as_float(liquidity.get('usd')),
+            'volume_h24': _as_float(volume.get('h24')),
             'url': raydium_pair.get('url')
         }
     except Exception as e:


### PR DESCRIPTION
## Summary
- validate DexScreener price responses before reading pairs
- ignore malformed pair entries and tolerate malformed nested price/liquidity/volume fields
- add focused regression tests for Raydium pair selection, malformed pair data, and non-object payloads

## Verification
- uv run --no-project --with pytest --with requests --with flask python -m pytest tests/test_wrtc_price_bot.py -q
- python3 -m py_compile tools/wrtc-price-bot/bot.py tests/test_wrtc_price_bot.py
- uv run --no-project --with ruff python -m ruff check tools/wrtc-price-bot/bot.py tests/test_wrtc_price_bot.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/wrtc-price-bot/bot.py tests/test_wrtc_price_bot.py