### PR TITLE
fix: record locust JSON parse failures

### DIFF
--- a/tests/test_locust_load_suite.py
+++ b/tests/test_locust_load_suite.py
@@ -30,6 +30,12 @@ def load_module(monkeypatch, miner_id=None):
     locust.task = lambda _weight: (lambda func: func)
     locust.events = events
     monkeypatch.setitem(sys.modules, "locust", locust)
+
+    urllib3 = types.ModuleType("urllib3")
+    urllib3.exceptions = types.SimpleNamespace(InsecureRequestWarning=Warning)
+    urllib3.disable_warnings = lambda _warning: None
+    monkeypatch.setitem(sys.modules, "urllib3", urllib3)
+
     if miner_id is not None:
         monkeypatch.setenv("RUSTCHAIN_MINER_ID", miner_id)
     else:
@@ -45,9 +51,10 @@ def load_module(monkeypatch, miner_id=None):
 
 
 class FakeResponse:
-    def __init__(self, status_code=200, payload=None):
+    def __init__(self, status_code=200, payload=None, json_error=None):
         self.status_code = status_code
         self.payload = payload if payload is not None else {}
+        self.json_error = json_error
         self.failures = []
 
     def __enter__(self):
@@ -57,6 +64,8 @@ class FakeResponse:
         return False
 
     def json(self):
+        if self.json_error is not None:
+            raise self.json_error
         return self.payload
 
     def failure(self, message):
@@ -118,6 +127,23 @@ def test_tasks_mark_bad_status_and_missing_keys_as_failures(monkeypatch):
     assert headers.failures == ["status 503"]
     assert miners.failures == ["status 500"]
     assert balance.failures == ["missing 'amount_rtc' key"]
+
+
+def test_tasks_mark_invalid_json_as_failures(monkeypatch):
+    module = load_module(monkeypatch)
+    health = FakeResponse(json_error=ValueError("bad json"))
+    epoch = FakeResponse(payload=[])
+    balance = FakeResponse(json_error=ValueError("bad json"))
+    client = FakeClient([health, epoch, balance])
+    user = user_with_client(module, client)
+
+    user.health()
+    user.epoch()
+    user.wallet_balance()
+
+    assert health.failures == ["invalid JSON response"]
+    assert epoch.failures == ["JSON response must be an object"]
+    assert balance.failures == ["invalid JSON response"]
 
 
 def test_wallet_balance_uses_configured_miner_id(monkeypatch):

--- a/tools/load-tests/locustfile.py
+++ b/tools/load-tests/locustfile.py
@@ -12,8 +12,11 @@ Usage:
         locust -f locustfile.py --host https://50.28.86.131
 """
 
-from locust import HttpUser, task, between, events
-import urllib3, time, json, os
+import json
+import os
+
+import urllib3
+from locust import HttpUser, between, events, task
 
 # The production node uses a self-signed cert
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -22,6 +25,18 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 # Optional: miner ID for the balance endpoint (override via env var)
 # ---------------------------------------------------------------------------
 MINER_ID = os.getenv("RUSTCHAIN_MINER_ID", "Ivan-houzhiwen")
+
+
+def _json_or_fail(response):
+    try:
+        body = response.json()
+    except ValueError:
+        response.failure("invalid JSON response")
+        return None
+    if not isinstance(body, dict):
+        response.failure("JSON response must be an object")
+        return None
+    return body
 
 
 class RustChainUser(HttpUser):
@@ -36,8 +51,8 @@ class RustChainUser(HttpUser):
     def health(self):
         with self.client.get("/health", verify=False, catch_response=True) as r:
             if r.status_code == 200:
-                body = r.json()
-                if body.get("ok") is not True:
+                body = _json_or_fail(r)
+                if body is not None and body.get("ok") is not True:
                     r.failure("health.ok is not True")
             else:
                 r.failure(f"status {r.status_code}")
@@ -49,8 +64,8 @@ class RustChainUser(HttpUser):
     def epoch(self):
         with self.client.get("/epoch", verify=False, catch_response=True) as r:
             if r.status_code == 200:
-                body = r.json()
-                if "epoch" not in body:
+                body = _json_or_fail(r)
+                if body is not None and "epoch" not in body:
                     r.failure("missing 'epoch' key")
             else:
                 r.failure(f"status {r.status_code}")
@@ -84,8 +99,8 @@ class RustChainUser(HttpUser):
             catch_response=True,
         ) as r:
             if r.status_code == 200:
-                body = r.json()
-                if "amount_rtc" not in body:
+                body = _json_or_fail(r)
+                if body is not None and "amount_rtc" not in body:
                     r.failure("missing 'amount_rtc' key")
             else:
                 r.failure(f"status {r.status_code}")


### PR DESCRIPTION
## Summary
- add a safe JSON parser for Locust load-test tasks
- record invalid or non-object JSON responses as request failures instead of letting task exceptions escape
- add regression coverage for malformed health, epoch, and wallet balance responses

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_locust_load_suite.py -q
- python3 -m py_compile tools/load-tests/locustfile.py tests/test_locust_load_suite.py
- uv run --no-project --with ruff python -m ruff check tools/load-tests/locustfile.py tests/test_locust_load_suite.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/load-tests/locustfile.py tests/test_locust_load_suite.py