### PR TITLE
fix: harden bottube digest payload shapes

### DIFF
--- a/tools/bottube_digest.py
+++ b/tools/bottube_digest.py
@@ -108,6 +108,23 @@ def fetch_json(url: str) -> Optional[dict]:
         return None
 
 
+def _rows_from_payload(payload, key: str) -> Optional[list]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = payload.get(key, payload)
+    else:
+        return None
+
+    if not isinstance(rows, list):
+        return None
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _stats_from_payload(payload) -> Optional[dict]:
+    return payload if isinstance(payload, dict) else None
+
+
 def fetch_platform_data(base_url: str, weeks: int) -> dict:
     """
     Fetch videos, agents, and stats from the BoTTube API.
@@ -124,26 +141,23 @@ def fetch_platform_data(base_url: str, weeks: int) -> dict:
 
     using_mock = []
 
-    if videos_raw is None:
+    videos = _rows_from_payload(videos_raw, "videos")
+    if videos is None:
         print("[bottube-digest] /api/videos unreachable — using mock data", file=sys.stderr)
         videos = MOCK_VIDEOS
         using_mock.append("videos")
-    else:
-        videos = videos_raw.get("videos", videos_raw) if isinstance(videos_raw, dict) else videos_raw
 
-    if agents_raw is None:
+    agents = _rows_from_payload(agents_raw, "agents")
+    if agents is None:
         print("[bottube-digest] /api/agents unreachable — using mock data", file=sys.stderr)
         agents = MOCK_AGENTS
         using_mock.append("agents")
-    else:
-        agents = agents_raw.get("agents", agents_raw) if isinstance(agents_raw, dict) else agents_raw
 
-    if stats_raw is None:
+    stats = _stats_from_payload(stats_raw)
+    if stats is None:
         print("[bottube-digest] /api/stats unreachable — using mock data", file=sys.stderr)
         stats = MOCK_STATS
         using_mock.append("stats")
-    else:
-        stats = stats_raw
 
     return {
         "videos": videos,

--- a/tools/tests/test_bottube_digest_helpers.py
+++ b/tools/tests/test_bottube_digest_helpers.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: MIT
-import json
 import sys
 from pathlib import Path
 
@@ -8,7 +7,7 @@ TOOLS_DIR = ROOT / "tools"
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
-import bottube_digest
+import bottube_digest  # noqa: E402
 
 
 def test_fmt_number_adds_commas_and_preserves_invalid_values():
@@ -76,6 +75,58 @@ def test_fetch_platform_data_falls_back_per_endpoint(monkeypatch):
     assert data["agents"] == bottube_digest.MOCK_AGENTS
     assert data["stats"] == responses["stats"]
     assert data["using_mock"] == ["agents"]
+
+
+def test_fetch_platform_data_filters_malformed_rows_and_stats(monkeypatch):
+    responses = {
+        "videos": {"videos": [{"title": "API video", "views": 1}, ["bad"]]},
+        "agents": [{"name": "Agent"}, "bad"],
+        "stats": ["bad"],
+    }
+
+    def fake_fetch_json(url):
+        if url.endswith("/api/videos?weeks=2"):
+            return responses["videos"]
+        if url.endswith("/api/agents?weeks=2"):
+            return responses["agents"]
+        if url.endswith("/api/stats?weeks=2"):
+            return responses["stats"]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(bottube_digest, "fetch_json", fake_fetch_json)
+
+    data = bottube_digest.fetch_platform_data("https://example.test/", weeks=2)
+
+    assert data["videos"] == [{"title": "API video", "views": 1}]
+    assert data["agents"] == [{"name": "Agent"}]
+    assert data["stats"] == bottube_digest.MOCK_STATS
+    assert data["using_mock"] == ["stats"]
+
+
+def test_fetch_platform_data_falls_back_for_non_list_rows(monkeypatch):
+    responses = {
+        "videos": {"videos": {"bad": "shape"}},
+        "agents": {"agents": None},
+        "stats": {"milestones": []},
+    }
+
+    def fake_fetch_json(url):
+        if url.endswith("/api/videos?weeks=1"):
+            return responses["videos"]
+        if url.endswith("/api/agents?weeks=1"):
+            return responses["agents"]
+        if url.endswith("/api/stats?weeks=1"):
+            return responses["stats"]
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch.setattr(bottube_digest, "fetch_json", fake_fetch_json)
+
+    data = bottube_digest.fetch_platform_data("https://example.test/", weeks=1)
+
+    assert data["videos"] == bottube_digest.MOCK_VIDEOS
+    assert data["agents"] == bottube_digest.MOCK_AGENTS
+    assert data["stats"] == responses["stats"]
+    assert data["using_mock"] == ["videos", "agents"]
 
 
 def test_build_newsletter_mentions_mock_data_when_fallback_used(monkeypatch):


### PR DESCRIPTION
## Summary
- normalize BoTTube digest video and agent API payloads before newsletter rendering
- fall back to mock data when reachable endpoints return non-list row shapes or non-object stats
- filter malformed row entries instead of letting newsletter sorting/rendering crash

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tools/tests/test_bottube_digest_helpers.py tests/test_bottube_digest.py -q
- python3 -m py_compile tools/bottube_digest.py tools/tests/test_bottube_digest_helpers.py tests/test_bottube_digest.py
- uv run --no-project --with ruff python -m ruff check tools/bottube_digest.py tools/tests/test_bottube_digest_helpers.py tests/test_bottube_digest.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/bottube_digest.py tools/tests/test_bottube_digest_helpers.py tests/test_bottube_digest.py