### PR TITLE
fix: normalize miner score rows

### DIFF
--- a/tests/test_miner_score.py
+++ b/tests/test_miner_score.py
@@ -55,6 +55,28 @@ def test_score_handles_dict_payload_filters_by_id_and_fallback_fields(monkeypatc
     assert "skip-me" not in output
 
 
+def test_score_handles_enveloped_rows_and_skips_malformed_entries(monkeypatch, capsys):
+    payload = {
+        "data": [
+            ["bad"],
+            {
+                "miner_id": "data-miner",
+                "blocks_mined": "not-a-number",
+                "antiquity_multiplier": "bad",
+                "uptime": "bad",
+            },
+        ]
+    }
+    monkeypatch.setattr(miner_score, "api", lambda path: payload)
+
+    miner_score.score()
+
+    output = capsys.readouterr().out
+    assert "data-miner" in output
+    assert "Score: 25" in output
+    assert "blocks:0 mult:1.0 uptime:50%" in output
+
+
 def test_score_defaults_missing_metrics_and_ids(monkeypatch, capsys):
     monkeypatch.setattr(miner_score, "api", lambda path: {"miners": [{}]})
 

--- a/tools/miner_score.py
+++ b/tools/miner_score.py
@@ -1,23 +1,67 @@
 #!/usr/bin/env python3
 """RustChain Miner Score — Calculate composite miner performance score."""
-import json, urllib.request, ssl, os, sys
+import json
+import os
+import ssl
+import sys
+import urllib.request
+
 NODE = os.environ.get("RUSTCHAIN_NODE", "https://rustchain.org")
+
+
 def api(p):
-    ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
-    try: return json.loads(urllib.request.urlopen(f"{NODE}{p}", timeout=10, context=ctx).read())
-    except: return {}
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    try:
+        return json.loads(urllib.request.urlopen(f"{NODE}{p}", timeout=10, context=ctx).read())
+    except Exception:
+        return {}
+
+
+def _miner_rows(payload):
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = []
+        for key in ("miners", "data", "items", "results"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                rows = value
+                break
+    else:
+        rows = []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _as_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_float(value, default=0.0):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def score(miner_id=None):
     miners = api("/api/miners")
-    ml = miners if isinstance(miners, list) else miners.get("miners", [])
+    ml = _miner_rows(miners)
     if miner_id:
         ml = [m for m in ml if m.get("miner_id") == miner_id or m.get("id") == miner_id]
     for m in ml:
-        blocks = int(m.get("blocks_mined", m.get("total_blocks", 0)))
-        mult = float(m.get("antiquity_multiplier", m.get("multiplier", 1)))
-        uptime = float(m.get("uptime", m.get("uptime_pct", 50)))
+        blocks = _as_int(m.get("blocks_mined", m.get("total_blocks", 0)))
+        mult = _as_float(m.get("antiquity_multiplier", m.get("multiplier", 1)), 1.0)
+        uptime = _as_float(m.get("uptime", m.get("uptime_pct", 50)), 50.0)
         s = int(blocks * mult * 0.5 + uptime * 0.5)
         grade = "S" if s > 500 else "A" if s > 200 else "B" if s > 100 else "C" if s > 50 else "D"
         mid = str(m.get("miner_id", m.get("id", "?")))[:16]
         print(f"  {mid}  Score: {s}  Grade: {grade}  (blocks:{blocks} mult:{mult} uptime:{uptime:.0f}%)")
+
+
 if __name__ == "__main__":
     score(sys.argv[1] if len(sys.argv) > 1 else None)


### PR DESCRIPTION
## Summary
- normalize miner score input rows from bare lists and common envelope keys: miners, data, items, results
- skip malformed miner rows instead of crashing during scoring
- tolerate non-numeric block, multiplier, and uptime fields with existing defaults

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_miner_score.py -q
- python3 -m py_compile tools/miner_score.py tests/test_miner_score.py
- uv run --no-project --with ruff python -m ruff check tools/miner_score.py tests/test_miner_score.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main && git diff --check -- tools/miner_score.py tests/test_miner_score.py