### PR TITLE
fix: preserve vintage validator warnings

### DIFF
--- a/tests/test_validate_vintage_submission.py
+++ b/tests/test_validate_vintage_submission.py
@@ -49,6 +49,34 @@ def test_attestation_log_json_requires_core_fields(tmp_path):
     assert result["checks"]["json_valid"] is True
 
 
+def test_photo_validation_preserves_size_and_format_warnings(tmp_path):
+    validator = SubmissionValidator()
+    photo_path = tmp_path / "photo.txt"
+    photo_path.write_bytes(b"tiny")
+
+    result = validator.validate_photo(str(photo_path))
+
+    assert result["status"] == "WARN"
+    assert "too small" in result["message"]
+    assert "Unusual photo format" in result["message"]
+    assert result["checks"]["file_size_bytes"] == 4
+    assert result["checks"]["format"] == ".txt"
+    assert "Photo file is unusually small" in validator.warnings
+
+
+def test_screenshot_validation_preserves_small_file_warning(tmp_path):
+    validator = SubmissionValidator()
+    screenshot_path = tmp_path / "screenshot.png"
+    screenshot_path.write_bytes(b"tiny")
+
+    result = validator.validate_screenshot(str(screenshot_path))
+
+    assert result["status"] == "WARN"
+    assert "too small" in result["message"]
+    assert result["checks"]["file_size_bytes"] == 4
+    assert "Screenshot file is unusually small" in validator.warnings
+
+
 def test_validate_submission_extracts_arch_and_bounty_from_valid_log(tmp_path):
     validator = SubmissionValidator()
     log_path = tmp_path / "attestation.json"

--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -15,12 +15,11 @@ Usage:
 """
 
 import argparse
-import hashlib
 import json
 import os
 import sys
 from datetime import datetime
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional
 
 
 class SubmissionValidator:
@@ -44,26 +43,31 @@ class SubmissionValidator:
             result["message"] = f"Photo file not found: {photo_path}"
             return result
         
+        warning_messages = []
+
         # Check file size (should be reasonable)
         file_size = os.path.getsize(photo_path)
         if file_size < 10000:  # Less than 10KB
-            result["status"] = "WARN"
-            result["message"] = f"Photo file seems too small: {file_size} bytes"
+            warning_messages.append(f"Photo file seems too small: {file_size} bytes")
             self.warnings.append("Photo file is unusually small")
         
         # Check file extension
         ext = os.path.splitext(photo_path)[1].lower()
         if ext not in ['.jpg', '.jpeg', '.png', '.gif', '.bmp']:
-            result["status"] = "WARN"
-            result["message"] = f"Unusual photo format: {ext}"
+            warning_messages.append(f"Unusual photo format: {ext}")
+            self.warnings.append(f"Unusual photo format: {ext}")
         
         # In production, would check:
         # - EXIF timestamp
         # - Image content (machine + monitor)
         # - Metadata consistency
         
-        result["status"] = "PASS"
-        result["message"] = "Photo file exists and appears valid"
+        if warning_messages:
+            result["status"] = "WARN"
+            result["message"] = "; ".join(warning_messages)
+        else:
+            result["status"] = "PASS"
+            result["message"] = "Photo file exists and appears valid"
         result["checks"] = {
             "file_exists": True,
             "file_size_bytes": file_size,
@@ -90,9 +94,11 @@ class SubmissionValidator:
         if file_size < 1000:  # Less than 1KB
             result["status"] = "WARN"
             result["message"] = f"Screenshot file seems too small: {file_size} bytes"
+            self.warnings.append("Screenshot file is unusually small")
+        else:
+            result["status"] = "PASS"
+            result["message"] = "Screenshot file exists"
         
-        result["status"] = "PASS"
-        result["message"] = "Screenshot file exists"
         result["checks"] = {
             "file_exists": True,
             "file_size_bytes": file_size
@@ -263,7 +269,7 @@ class SubmissionValidator:
             sys.path.insert(0, 'vintage_miner')
             from hardware_profiles import get_bounty
             return get_bounty(device_arch)
-        except:
+        except Exception:
             # Default bounty
             return 100
     
@@ -322,7 +328,7 @@ class SubmissionValidator:
                 try:
                     from hardware_profiles import get_era
                     results["era"] = get_era(device_arch)
-                except:
+                except Exception:
                     results["era"] = "Unknown"
         
         if writeup_path:


### PR DESCRIPTION
## Summary
- keep photo validation in WARN when small files or unusual formats are detected
- keep screenshot validation in WARN when the file is unusually small
- add regression coverage for warning status preservation

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_validate_vintage_submission.py -q
- python3 -m py_compile tools/validate_vintage_submission.py tests/test_validate_vintage_submission.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/validate_vintage_submission.py tests/test_validate_vintage_submission.py
- git diff --check