### PR TITLE
fix: preserve empty interaction metadata

### DIFF
--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -3,13 +3,12 @@ Tests for BoTTube Interaction Tracker (tools/bottube_interactions.py)
 """
 
 import pytest
-import time
 import sys
 import os
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from bottube_interactions import InteractionTracker, VALID_TYPES, TYPE_WEIGHTS
+from bottube_interactions import InteractionTracker, VALID_TYPES
 
 
 @pytest.fixture
@@ -41,6 +40,11 @@ class TestRecordInteraction:
         tracker.record_interaction("A", "B", "collab", metadata={"key": "value"})
         history = tracker.get_interaction_history(from_agent="A")
         assert history[0]["metadata"] == {"key": "value"}
+
+    def test_empty_metadata_stored(self, tracker):
+        tracker.record_interaction("A", "B", "collab", metadata={})
+        history = tracker.get_interaction_history(from_agent="A")
+        assert history[0]["metadata"] == {}
 
     def test_video_id_stored(self, tracker):
         tracker.record_interaction("A", "B", "react", video_id="vid_999")

--- a/tools/bottube_interactions.py
+++ b/tools/bottube_interactions.py
@@ -9,7 +9,6 @@ import json
 import time
 import math
 from typing import Optional, Dict, List, Any, Tuple
-from collections import defaultdict
 from contextlib import contextmanager
 
 
@@ -98,7 +97,7 @@ class InteractionTracker:
         if from_agent == to_agent:
             raise ValueError("from_agent and to_agent must be different")
 
-        meta_json = json.dumps(metadata) if metadata else None
+        meta_json = json.dumps(metadata) if metadata is not None else None
         ts = time.time()
 
         with self._conn() as conn:


### PR DESCRIPTION
## Summary
- preserve explicitly provided empty metadata dictionaries in BoTTube interactions
- add regression coverage for empty metadata round-tripping through interaction history
- remove unused imports in the touched interaction files

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_interactions.py -q
- python3 -m py_compile tools/bottube_interactions.py tests/test_interactions.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bottube_interactions.py tests/test_interactions.py
- git diff --check