### PR TITLE
fix: preserve explicit parasocial timestamps

### DIFF
--- a/tests/test_parasocial.py
+++ b/tests/test_parasocial.py
@@ -121,6 +121,17 @@ class TestViewerPattern(unittest.TestCase):
         finally:
             os.unlink(db)
 
+    def test_pattern_preserves_explicit_epoch_timestamp(self):
+        t, db = _fresh()
+        try:
+            t.track_view("epoch_viewer", "v1", 300, watched_at=0, total_video_secs=600)
+            p = t.get_viewer_pattern("epoch_viewer")
+            self.assertEqual(p["peak_hour"], 0)
+            self.assertEqual(p["first_seen"], "1970-01-01T00:00:00+00:00")
+            self.assertEqual(p["last_seen"], "1970-01-01T00:00:00+00:00")
+        finally:
+            os.unlink(db)
+
     def test_engagement_trend_rising(self):
         t, db = _fresh()
         try:

--- a/tools/bottube_parasocial.py
+++ b/tools/bottube_parasocial.py
@@ -75,7 +75,7 @@ class AudienceTracker:
         total_video_secs: float = 600.0,
     ):
         """Record a viewer interaction with a video."""
-        ts = watched_at or int(time.time())
+        ts = watched_at if watched_at is not None else int(time.time())
         with self._conn() as conn:
             conn.execute(
                 """INSERT INTO views (viewer_id, video_id, watched_at, duration, liked, commented)


### PR DESCRIPTION
## Summary
- preserve explicitly supplied `watched_at=0` timestamps in the BoTTube parasocial tracker
- add regression coverage for Unix epoch timestamps in viewer pattern output

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_parasocial.py -q
- python3 -m py_compile tools/bottube_parasocial.py tests/test_parasocial.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bottube_parasocial.py tests/test_parasocial.py
- git diff --check