### PR TITLE
fix: truncate personality text at first sentence

### DIFF
--- a/tests/test_personality.py
+++ b/tests/test_personality.py
@@ -102,6 +102,11 @@ class TestStyleText:
         # Should be truncated to first sentence
         assert len(result) < len(long)
 
+    def test_low_verbosity_uses_earliest_sentence_end(self):
+        eng = make_engine(verbosity=0.1)
+        result = eng.style_text("Question first? Then an excited part! Finally a period.")
+        assert result == "Question first?"
+
     def test_low_formality_lowercases(self):
         eng = make_engine(formality=0.1)
         result = eng.style_text("Hello World")

--- a/tools/bottube_personality.py
+++ b/tools/bottube_personality.py
@@ -9,7 +9,7 @@ import sqlite3
 import random
 import time
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, Dict, List
 from datetime import datetime
 
@@ -208,11 +208,9 @@ class PersonalityEngine:
             result = random.choice(fillers) + result
         elif self.traits.verbosity < 0.2:
             # Keep only the first sentence
-            for sep in (".", "!", "?"):
-                idx = result.find(sep)
-                if idx != -1:
-                    result = result[: idx + 1]
-                    break
+            sentence_ends = [idx for sep in (".", "!", "?") if (idx := result.find(sep)) != -1]
+            if sentence_ends:
+                result = result[: min(sentence_ends) + 1]
 
         # Sarcasm: add a sarcastic suffix
         if self.traits.sarcasm > 0.7 and random.random() < 0.5:


### PR DESCRIPTION
## Summary
- make low-verbosity personality text truncation choose the earliest sentence ending across `.`, `!`, and `?`
- add regression coverage for question-first text
- remove an unused dataclass import in the touched file

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_personality.py -q
- python3 -m py_compile tools/bottube_personality.py tests/test_personality.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bottube_personality.py tests/test_personality.py
- git diff --check