### PR TITLE
fix: enforce collab voter agent cap

### DIFF
--- a/tests/test_bottube_collab.py
+++ b/tests/test_bottube_collab.py
@@ -145,6 +145,17 @@ class TestVoting:
         result = cs.vote(session_id, "bad-proposal-id", "agent-1")
         assert "error" in result
 
+    def test_voters_count_toward_max_agents(self, cs):
+        sess = cs.create_session("vid-voter-cap", max_agents=2)
+        sid = sess["session_id"]
+        proposal = cs.add_proposal(sid, "agent-1", "Response")
+
+        first_vote = cs.vote(sid, proposal["proposal_id"], "agent-2")
+        blocked_vote = cs.vote(sid, proposal["proposal_id"], "agent-3")
+
+        assert first_vote["vote_count"] == 1
+        assert blocked_vote == {"error": "max_agents_reached", "max_agents": 2}
+
 
 # ── Finalization & Publishing ─────────────────────────────────────────────────
 

--- a/tools/bottube_collab.py
+++ b/tools/bottube_collab.py
@@ -10,8 +10,6 @@ Wrap with Flask or FastAPI to expose as an HTTP API.
 import sqlite3
 import time
 import uuid
-import json
-import hashlib
 import threading
 from typing import Optional
 
@@ -238,6 +236,11 @@ class CollabSession:
         if not prop:
             return {"error": "proposal_not_found", "proposal_id": proposal_id}
 
+        # Enforce the same distinct-agent cap for voters as proposals/fragments.
+        agents = self._distinct_agents(session_id)
+        if agent_id not in agents and len(agents) >= sess["max_agents"]:
+            return {"error": "max_agents_reached", "max_agents": sess["max_agents"]}
+
         # Prevent duplicate votes
         existing = self._conn.execute(
             "SELECT vote_id FROM votes WHERE proposal_id=? AND agent_id=?",
@@ -408,7 +411,8 @@ class CollabSession:
     def _distinct_agents(self, session_id: str) -> set:
         rows = self._conn.execute(
             "SELECT DISTINCT agent_id FROM proposals WHERE session_id=? "
-            "UNION SELECT DISTINCT agent_id FROM collaborations WHERE session_id=?",
-            (session_id, session_id),
+            "UNION SELECT DISTINCT agent_id FROM collaborations WHERE session_id=? "
+            "UNION SELECT DISTINCT agent_id FROM votes WHERE session_id=?",
+            (session_id, session_id, session_id),
         ).fetchall()
         return {r["agent_id"] for r in rows}


### PR DESCRIPTION
## Summary
- enforce the session `max_agents` cap for voters in BoTTube collaboration sessions
- include voters in the session distinct-agent set used by the cap
- add regression coverage for a third voter being rejected when max_agents is already reached
- remove unused imports in the touched module

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_bottube_collab.py -q
- python3 -m py_compile tools/bottube_collab.py tests/test_bottube_collab.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bottube_collab.py tests/test_bottube_collab.py
- git diff --check