### PR TITLE
fix: match discovery tags literally

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -221,6 +221,10 @@ class TestFilters(unittest.TestCase):
     def test_get_by_tag_nonexistent(self):
         self.assertEqual(self.disc.get_by_tag("doesnotexist"), [])
 
+    def test_get_by_tag_treats_like_wildcards_literally(self):
+        self.assertEqual(self.disc.get_by_tag("%"), [])
+        self.assertEqual(self.disc.get_by_tag("_"), [])
+
     def test_get_by_agent(self):
         results = self.disc.get_by_agent("alpha")
         ids = {r["video_id"] for r in results}

--- a/tools/bottube_discovery.py
+++ b/tools/bottube_discovery.py
@@ -16,7 +16,6 @@ import sqlite3
 import math
 import re
 import time
-from datetime import datetime, timezone
 from collections import Counter
 from typing import List, Dict, Optional, Tuple
 
@@ -304,13 +303,14 @@ class VideoDiscovery:
         rows = self._conn.execute(
             """
             SELECT * FROM videos
-            WHERE ',' || tags || ',' LIKE ?
             ORDER BY created_at DESC
-            LIMIT ?
             """,
-            (f"%,{tag},%", limit),
         ).fetchall()
-        return [dict(r) for r in rows]
+        return [
+            dict(r)
+            for r in rows
+            if tag in {t for t in r["tags"].split(",") if t}
+        ][:limit]
 
     def get_by_agent(self, agent_id: str, limit: int = 20) -> List[Dict]:
         """Return videos uploaded by *agent_id*."""


### PR DESCRIPTION
## Summary
- make BoTTube discovery tag filtering compare parsed tag values literally instead of using SQL LIKE wildcards
- add regression coverage for `%` and `_` tag queries
- remove unused datetime imports in the touched module

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_discovery.py -q
- python3 -m py_compile tools/bottube_discovery.py tests/test_discovery.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bottube_discovery.py tests/test_discovery.py
- git diff --check