### PR TITLE
fix: report invalid onboarding metadata json

### DIFF
--- a/integrations/bottube_onboarding/example.py
+++ b/integrations/bottube_onboarding/example.py
@@ -128,8 +128,12 @@ def validate_metadata_file(filepath: str) -> int:
         print(f"Error: File not found: {filepath}")
         return 1
     
-    with open(path, 'r') as f:
-        metadata = json.load(f)
+    try:
+        with open(path, 'r') as f:
+            metadata = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"Error: Invalid JSON in {filepath}: {exc.msg}")
+        return 1
     
     checklist = FirstUploadChecklist()
     result = checklist.validate_upload(metadata)

--- a/tests/test_bottube_onboarding_example.py
+++ b/tests/test_bottube_onboarding_example.py
@@ -16,6 +16,16 @@ def test_validate_metadata_file_reports_missing_file(capsys) -> None:
     assert "Error: File not found" in capsys.readouterr().out
 
 
+def test_validate_metadata_file_reports_invalid_json(tmp_path, capsys) -> None:
+    metadata_file = tmp_path / "metadata.json"
+    metadata_file.write_text("{not valid json", encoding="utf-8")
+
+    result = example.validate_metadata_file(str(metadata_file))
+
+    assert result == 1
+    assert "Error: Invalid JSON" in capsys.readouterr().out
+
+
 def test_validate_metadata_file_accepts_valid_upload_metadata(tmp_path, capsys) -> None:
     metadata_file = tmp_path / "metadata.json"
     metadata_file.write_text(


### PR DESCRIPTION
## Summary
- make the BoTTube onboarding metadata validator return a clean error for malformed JSON files
- add regression coverage for invalid metadata JSON input

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_bottube_onboarding_example.py -q
- python3 -m py_compile integrations/bottube_onboarding/example.py tests/test_bottube_onboarding_example.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check integrations/bottube_onboarding/example.py tests/test_bottube_onboarding_example.py
- git diff --check