### PR TITLE
fix: preserve green tracker sessions on update

### DIFF
--- a/tests/test_green_tracker.py
+++ b/tests/test_green_tracker.py
@@ -9,7 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools"))
 
-from green_tracker import GreenTracker, EWASTE_WEIGHTS_KG, NEW_HARDWARE_CO2_KG
+from green_tracker import GreenTracker, EWASTE_WEIGHTS_KG
 
 
 @pytest.fixture
@@ -50,6 +50,17 @@ class TestRegisterMachine:
         stats = tracker.get_machine_stats("dup")
         assert stats["name"] == "New Name"
         assert stats["arch"] == "G5"
+
+    def test_register_duplicate_preserves_existing_sessions(self, tracker):
+        tracker.register_machine("dup-sessions", "Old Name", "G4", 2002, "Poor", "NYC")
+        tracker.record_mining_session("dup-sessions", 1, 1.25, 180.0)
+
+        tracker.register_machine("dup-sessions", "New Name", "G5", 2004, "Good", "LA")
+
+        stats = tracker.get_machine_stats("dup-sessions")
+        assert stats["name"] == "New Name"
+        assert stats["total_epochs"] == 1
+        assert stats["total_rtc_earned"] == 1.25
 
 
 class TestRecordMiningSession:

--- a/tools/green_tracker.py
+++ b/tools/green_tracker.py
@@ -5,7 +5,6 @@ Bounty #2218
 """
 
 import sqlite3
-import json
 import datetime
 from typing import Optional, List, Dict, Any
 
@@ -121,10 +120,18 @@ class GreenTracker:
         with self._connect() as conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO machines
+                INSERT INTO machines
                     (machine_id, name, arch, year_manufactured, condition,
                      location, photo_url, registered_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(machine_id) DO UPDATE SET
+                    name = excluded.name,
+                    arch = excluded.arch,
+                    year_manufactured = excluded.year_manufactured,
+                    condition = excluded.condition,
+                    location = excluded.location,
+                    photo_url = excluded.photo_url,
+                    registered_at = excluded.registered_at
                 """,
                 (machine_id, name, arch, year_manufactured, condition,
                  location, photo_url, now),


### PR DESCRIPTION
## Summary
- update duplicate GreenTracker machine registration in place instead of deleting and reinserting rows
- preserve existing mining session history when a machine record is refreshed
- add regression coverage for duplicate registration with existing sessions
- remove unused imports in touched files

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_green_tracker.py -q
- python3 -m py_compile tools/green_tracker.py tests/test_green_tracker.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/green_tracker.py tests/test_green_tracker.py
- git diff --check