### PR TITLE
fix: upsert phone-only miner alert subscriptions

### DIFF
--- a/tests/test_miner_alerts_db.py
+++ b/tests/test_miner_alerts_db.py
@@ -57,6 +57,32 @@ def test_add_subscription_upserts_and_filters_by_alert_type(tmp_path):
         db.close()
 
 
+def test_add_subscription_upserts_phone_only_subscription(tmp_path):
+    db = AlertDB(str(tmp_path / "alerts.db"))
+    try:
+        first_id = db.add_subscription(
+            "miner-1",
+            phone="+15550001111",
+            alerts={"alert_rewards": 0},
+        )
+        second_id = db.add_subscription(
+            "miner-1",
+            phone="+15550001111",
+            alerts={"alert_rewards": 1},
+        )
+
+        all_subs = db.get_subscriptions("miner-1")
+        reward_subs = db.get_subscriptions("miner-1", "rewards")
+
+        assert second_id == first_id
+        assert len(all_subs) == 1
+        assert all_subs[0]["email"] is None
+        assert all_subs[0]["phone"] == "+15550001111"
+        assert len(reward_subs) == 1
+    finally:
+        db.close()
+
+
 def test_remove_subscription_deactivates_without_deleting(tmp_path):
     db = AlertDB(str(tmp_path / "alerts.db"))
     try:

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -18,19 +18,16 @@ Architecture:
 """
 
 import argparse
-import hashlib
-import json
 import logging
 import os
 import smtplib
 import sqlite3
-import sys
 import time
 from datetime import datetime, timezone
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional
 
 import requests
 from dotenv import load_dotenv
@@ -149,6 +146,34 @@ class AlertDB:
             defaults.update(alerts)
 
         cur = self.conn.cursor()
+        if email is None and phone is not None:
+            cur.execute(
+                """
+                SELECT id FROM subscriptions
+                WHERE miner_id = ? AND email IS NULL AND phone = ?
+                """,
+                (miner_id, phone),
+            )
+            existing = cur.fetchone()
+            if existing:
+                cur.execute("""
+                    UPDATE subscriptions SET
+                        alert_offline = ?,
+                        alert_rewards = ?,
+                        alert_large_transfer = ?,
+                        alert_attestation_fail = ?,
+                        active = 1
+                    WHERE id = ?
+                """, (
+                    defaults["alert_offline"],
+                    defaults["alert_rewards"],
+                    defaults["alert_large_transfer"],
+                    defaults["alert_attestation_fail"],
+                    existing["id"],
+                ))
+                self.conn.commit()
+                return existing["id"]
+
         cur.execute("""
             INSERT INTO subscriptions
                 (miner_id, email, phone, alert_offline, alert_rewards,


### PR DESCRIPTION
## Summary
- make phone-only miner alert subscriptions update the existing row instead of duplicating rows with NULL email values
- preserve the existing email subscription upsert path
- add regression coverage for duplicate phone-only subscription updates
- remove unused imports in the touched miner alerts module

## Tests
- uv run --no-project --with pytest --with requests --with python-dotenv --with flask python -m pytest tests/test_miner_alerts_db.py tests/test_miner_alerts.py -q
- python3 -m py_compile tools/miner_alerts/miner_alerts.py tests/test_miner_alerts_db.py tests/test_miner_alerts.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/miner_alerts/miner_alerts.py tests/test_miner_alerts_db.py tests/test_miner_alerts.py
- git diff --check