### PR TITLE
fix: parse enveloped mining video miner payloads

### DIFF
--- a/tests/test_mining_video_pipeline.py
+++ b/tests/test_mining_video_pipeline.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "mining-video-pipeline"
+    / "mining_video_pipeline.py"
+)
+spec = importlib.util.spec_from_file_location("mining_video_pipeline", MODULE_PATH)
+mining_video_pipeline = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(mining_video_pipeline)
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_fetch_miners_accepts_enveloped_miner_payload(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse(
+            {
+                "miners": [
+                    {
+                        "miner": "miner-a",
+                        "device_arch": "ppc64",
+                        "device_family": "PowerPC",
+                        "hardware_type": "PowerPC (Vintage)",
+                        "antiquity_multiplier": 1.7,
+                        "entropy_score": 42,
+                        "last_attest": 1_700_000_000,
+                    }
+                ],
+                "pagination": {"total": 1},
+            }
+        )
+
+    monkeypatch.setattr(mining_video_pipeline.requests, "get", fake_get)
+
+    miners = mining_video_pipeline.fetch_miners()
+
+    assert calls == [
+        (
+            "https://50.28.86.131/api/miners",
+            {"verify": False, "timeout": 30},
+        )
+    ]
+    assert len(miners) == 1
+    assert miners[0].miner_id == "miner-a"
+    assert miners[0].device_arch == "ppc64"
+    assert miners[0].hardware_type == "PowerPC (Vintage)"
+
+
+def test_fetch_miners_ignores_malformed_envelope_rows(monkeypatch):
+    monkeypatch.setattr(
+        mining_video_pipeline.requests,
+        "get",
+        lambda *_args, **_kwargs: FakeResponse({"miners": [None, "bad"]}),
+    )
+
+    assert mining_video_pipeline.fetch_miners() == []

--- a/tools/mining-video-pipeline/mining_video_pipeline.py
+++ b/tools/mining-video-pipeline/mining_video_pipeline.py
@@ -35,7 +35,6 @@ import json
 import os
 import random
 import subprocess
-import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -147,7 +146,14 @@ def fetch_miners() -> list[MinerData]:
     """Fetch active miners from RustChain API."""
     resp = requests.get(f"{RUSTCHAIN_API}/api/miners", verify=False, timeout=30)
     resp.raise_for_status()
-    return [MinerData.from_api(m) for m in resp.json()]
+    payload = resp.json()
+    if isinstance(payload, dict):
+        rows = payload.get("miners", [])
+    else:
+        rows = payload
+    if not isinstance(rows, list):
+        return []
+    return [MinerData.from_api(m) for m in rows if isinstance(m, dict)]
 
 
 def fetch_epoch() -> dict:
@@ -271,7 +277,7 @@ def generate_video(miner: MinerData, epoch: dict, output_path: str, duration: fl
         # === Top: RustChain branding ===
         draw.rectangle([0, 0, WIDTH, 60], fill=(0, 0, 0))
         draw_glow(draw, 20, 12, "RUSTCHAIN", title_font, (232, 83, 30))
-        draw.text((WIDTH - 250, 22), f"Proof of Antiquity", fill=(120, 120, 140), font=small_font)
+        draw.text((WIDTH - 250, 22), "Proof of Antiquity", fill=(120, 120, 140), font=small_font)
         # Separator line
         draw.rectangle([0, 58, WIDTH, 60], fill=style["accent"])
 
@@ -288,7 +294,6 @@ def generate_video(miner: MinerData, epoch: dict, output_path: str, duration: fl
 
         # Fade in stats
         if progress > 0.1:
-            alpha = min(1.0, (progress - 0.1) * 3)
             draw.text((stats_x, stats_y), f"MINER: {miner.display_name}", fill=style["primary"], font=mono_lg)
             draw.text((stats_x, stats_y + 30), f"ARCH:  {miner.device_arch[:40]}", fill=(180, 180, 190), font=mono)
             draw.text((stats_x, stats_y + 55), f"TYPE:  {miner.hardware_type}", fill=(180, 180, 190), font=mono)


### PR DESCRIPTION
## Summary
- accept both bare-list and {"miners": [...]} /api/miners payloads in the mining video pipeline
- ignore malformed miner rows instead of crashing the pipeline parser
- add regression tests for enveloped and malformed miner payloads
- remove local lint issues in the touched module

## Tests
- uv run --no-project --with pytest --with requests --with pillow --with flask python -m pytest tests/test_mining_video_pipeline.py -q
- python3 -m py_compile tools/mining-video-pipeline/mining_video_pipeline.py tests/test_mining_video_pipeline.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/mining-video-pipeline/mining_video_pipeline.py tests/test_mining_video_pipeline.py
- git diff --check