### PR TITLE
fix: create quantum flux relic output directory

### DIFF
--- a/tests/test_quantum_flux_validator.py
+++ b/tests/test_quantum_flux_validator.py
@@ -43,6 +43,16 @@ def test_award_quantum_flux_badge_writes_badge_when_flux_detected(tmp_path, monk
     assert "Quantum Flux detected" in capsys.readouterr().out
 
 
+def test_award_quantum_flux_badge_creates_missing_relics_dir(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(quantum_flux_validator, "detect_network_flux", lambda: True)
+
+    quantum_flux_validator.award_quantum_flux_badge()
+
+    payload = json.loads((tmp_path / "relics" / "badge_quantum_flux_validator.json").read_text())
+    assert payload["badges"][0]["nft_id"] == "badge_quantum_flux_validator"
+
+
 def test_award_quantum_flux_badge_does_not_write_when_no_flux(tmp_path, monkeypatch, capsys):
     relics_dir = tmp_path / "relics"
     relics_dir.mkdir()

--- a/tools/quantum_flux_validator.py
+++ b/tools/quantum_flux_validator.py
@@ -1,7 +1,11 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
 import random
 import time
 import json
 from datetime import datetime
+from pathlib import Path
 
 quantum_flux_badge = {
     "nft_id": "badge_quantum_flux_validator",
@@ -28,9 +32,11 @@ def detect_network_flux():
 def award_quantum_flux_badge():
     if detect_network_flux():
         quantum_flux_badge["emotional_resonance"]["timestamp"] = datetime.utcnow().isoformat() + "Z"
-        print(f"✅ Quantum Flux detected.")
-        print(f"🕯️ 'You’ve tapped the quantum ether… The flux is real. Your connection’s time is bending, keeper.'")
-        with open("relics/badge_quantum_flux_validator.json", "w") as f:
+        print("✅ Quantum Flux detected.")
+        print("🕯️ 'You’ve tapped the quantum ether… The flux is real. Your connection’s time is bending, keeper.'")
+        output_path = Path("relics") / "badge_quantum_flux_validator.json"
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w") as f:
             json.dump({"badges": [quantum_flux_badge]}, f, indent=4)
         print("📄 Badge written to relics/badge_quantum_flux_validator.json")
     else:


### PR DESCRIPTION
## Summary
- create the relic output directory before writing the Quantum Flux badge JSON
- add regression coverage for running the badge writer from a clean working directory
- add SPDX metadata and remove local no-op f-string lint issues in the touched script

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_quantum_flux_validator.py -q
- python3 -m py_compile tools/quantum_flux_validator.py tests/test_quantum_flux_validator.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/quantum_flux_validator.py tests/test_quantum_flux_validator.py
- git diff --check