### PR TITLE
fix: avoid swallowing bios probe termination

### DIFF
--- a/tests/test_bios_pawpaw_detector.py
+++ b/tests/test_bios_pawpaw_detector.py
@@ -55,3 +55,20 @@ def test_bios_query_failure_returns_none(monkeypatch):
     monkeypatch.setattr(detector.subprocess, "check_output", fake_check_output)
 
     assert detector.get_bios_date() is None
+
+
+def test_bios_query_does_not_swallow_system_exit(monkeypatch):
+    detector = load_detector_module()
+
+    def fake_check_output(args, **kwargs):
+        raise SystemExit("stop")
+
+    monkeypatch.setattr(detector.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(detector.subprocess, "check_output", fake_check_output)
+
+    try:
+        detector.get_bios_date()
+    except SystemExit as exc:
+        assert str(exc) == "stop"
+    else:
+        raise AssertionError("SystemExit should not be swallowed")

--- a/tools/bios_pawpaw_detector.py
+++ b/tools/bios_pawpaw_detector.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+
 import subprocess
 import platform
 import json
@@ -26,7 +29,7 @@ def get_bios_date():
                 if "Release Date" in line:
                     date_str = line.split(":")[1].strip()
                     return datetime.strptime(date_str, "%m/%d/%Y")
-    except:
+    except Exception:
         pass
     return None
 


### PR DESCRIPTION
## Summary
- narrow the BIOS date probe fallback from a bare except to ordinary exceptions
- let process termination signals such as SystemExit propagate instead of being treated as missing BIOS data
- add regression coverage for the termination path
- add SPDX metadata to the touched script

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_bios_pawpaw_detector.py -q
- python3 -m py_compile tools/bios_pawpaw_detector.py tests/test_bios_pawpaw_detector.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/bios_pawpaw_detector.py tests/test_bios_pawpaw_detector.py
- git diff --check