### PR TITLE
fix: clear stale validator badge rewards

### DIFF
--- a/tests/test_validator_core_with_badge.py
+++ b/tests/test_validator_core_with_badge.py
@@ -72,6 +72,7 @@ def test_generate_validator_entry_writes_current_year_proof_and_badge(
 
 def test_generate_validator_entry_skips_badge_when_entropy_is_low(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
+    (tmp_path / "relic_rewards.json").write_text('{"badges": [{"nft_id": "stale"}]}')
     monkeypatch.setattr(validator_badge, "datetime", FixedDatetime)
     monkeypatch.setattr(validator_badge, "simulate_entropy_score", lambda _cpu, _bios: 2.99)
 

--- a/tools/validator_core_with_badge.py
+++ b/tools/validator_core_with_badge.py
@@ -3,6 +3,7 @@
 import json
 import hashlib
 from datetime import datetime
+from pathlib import Path
 
 def simulate_entropy_score(cpu_model, bios_date, current_year=None):
     year = int(bios_date.split("-")[0])
@@ -54,6 +55,8 @@ def generate_validator_entry():
         with open("relic_rewards.json", "w") as b:
             json.dump({"badges": [badge]}, b, indent=4)
         print("NFT badge unlocked and written to relic_rewards.json.")
+    else:
+        Path("relic_rewards.json").unlink(missing_ok=True)
 
 if __name__ == "__main__":
     generate_validator_entry()


### PR DESCRIPTION
## Summary
- remove stale generated relic_rewards.json when a validator run no longer qualifies for a badge
- keep high-entropy reward generation unchanged
- add regression coverage for a low-entropy run after stale reward output exists

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_validator_core_with_badge.py -q
- python3 -m py_compile tools/validator_core_with_badge.py tests/test_validator_core_with_badge.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- uv run --no-project --with ruff ruff check tools/validator_core_with_badge.py tests/test_validator_core_with_badge.py
- git diff --check