### PR TITLE
fix: avoid blocking auto-pay after manual notice

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -19,12 +19,10 @@ Environment variables (set by the GitHub Action):
     REPO_OWNER      — Repository owner username (e.g. Scottcjn)
 """
 
-import json
 import hashlib
 import os
 import re
 import sys
-import time
 
 import requests
 
@@ -49,6 +47,7 @@ PAYMENT_RE = re.compile(
 # already processed for this PR.
 ALREADY_PAID_MARKER = "RTC-AutoPay-Confirmed"
 PAYMENT_STARTED_MARKER = "RTC-AutoPay-Started"
+MANUAL_PAYMENT_MARKER = "RTC-AutoPay-Manual-Required"
 TRUSTED_BOT_LOGINS = {"github-actions[bot]"}
 
 # ---------------------------------------------------------------------------
@@ -138,10 +137,26 @@ def find_existing_payment_marker(comments: list, repo_owner: str,
         body = c.get("body") or ""
         if ALREADY_PAID_MARKER not in body:
             continue
+        if f"{ALREADY_PAID_MARKER}:MANUAL" in body:
+            continue
         if f"payment_key={payment_key}" in body:
             return ALREADY_PAID_MARKER
         if "payment_key=" not in body:
             return ALREADY_PAID_MARKER
+    return ""
+
+
+def find_existing_manual_marker(comments: list, repo_owner: str,
+                                payment_key: str) -> str:
+    """Find a trusted manual-transfer notice for this payment key."""
+    for c in comments:
+        if not trusted_marker_author(c, repo_owner):
+            continue
+        body = c.get("body") or ""
+        if MANUAL_PAYMENT_MARKER in body and f"payment_key={payment_key}" in body:
+            return MANUAL_PAYMENT_MARKER
+        if f"{ALREADY_PAID_MARKER}:MANUAL" in body and f"payment_key={payment_key}" in body:
+            return MANUAL_PAYMENT_MARKER
     return ""
 
 
@@ -214,12 +229,17 @@ def main() -> None:
 
     # --- Check if VPS secrets are configured ------------------------------
     if not vps_host or not admin_key:
+        manual_marker = find_existing_manual_marker(comments, repo_owner, payment_key)
+        if manual_marker:
+            print(f"Manual transfer notice already posted (found trusted {manual_marker}). Skipping.")
+            return
+
         print("::warning::RTC_VPS_HOST or RTC_ADMIN_KEY not configured — posting manual transfer notice.")
         manual_body = (
             f"**RTC Auto-Pay — Manual Transfer Required**\n\n"
             f"Payment directive found: **{payment_amount} RTC** for @{to_wallet}\n\n"
             f"VPS secrets not configured — please process this payment manually.\n\n"
-            f"<!-- {ALREADY_PAID_MARKER}:MANUAL payment_key={payment_key} "
+            f"<!-- {MANUAL_PAYMENT_MARKER} payment_key={payment_key} "
             f"payment_comment_id={payment_comment_id} -->"
         )
         post_comment(repo, pr_number, manual_body)
@@ -244,7 +264,7 @@ def main() -> None:
         print(f"::error::VPS returned error: {e.response.status_code} — {e.response.text}")
         sys.exit(1)
     except requests.exceptions.Timeout:
-        print(f"::error::VPS request timed out after 30s")
+        print("::error::VPS request timed out after 30s")
         sys.exit(1)
 
     ok = result.get("ok", False)

--- a/scripts/test_auto_pay_idempotency.py
+++ b/scripts/test_auto_pay_idempotency.py
@@ -181,3 +181,81 @@ def test_started_marker_does_not_block_retry_after_transfer_connection_failure()
     assert len(transfer_calls) == 2
     assert transfer_calls[0]["idempotency_key"] == transfer_calls[1]["idempotency_key"]
     assert any("RTC-AutoPay-Confirmed" in body for body in comment_posts)
+
+
+def test_manual_transfer_notice_does_not_block_later_auto_pay():
+    auto_pay = load_auto_pay()
+    persisted_comments = [owner_payment_comment()]
+    transfer_calls = []
+    comment_posts = []
+
+    def fake_get(url, headers=None, params=None):
+        page = (params or {}).get("page", 1)
+        return FakeResponse(persisted_comments if page == 1 else [])
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if url.endswith("/wallet/transfer"):
+            transfer_calls.append(json)
+            return FakeResponse({"ok": True, "pending_id": "p1"})
+
+        body = json["body"]
+        comment_posts.append(body)
+        persisted_comments.append({
+            "id": 200 + len(comment_posts),
+            "user": {"login": "github-actions[bot]"},
+            "body": body,
+        })
+        return FakeResponse({"id": 200 + len(comment_posts)})
+
+    no_secrets_env = base_env()
+    no_secrets_env["RTC_VPS_HOST"] = ""
+    no_secrets_env["RTC_ADMIN_KEY"] = ""
+
+    with patch.dict(os.environ, no_secrets_env, clear=True):
+        auto_pay.requests.get = fake_get
+        auto_pay.requests.post = fake_post
+        auto_pay.main()
+        auto_pay.main()
+
+    with patch.dict(os.environ, base_env(), clear=True):
+        auto_pay.requests.get = fake_get
+        auto_pay.requests.post = fake_post
+        auto_pay.main()
+
+    assert len([body for body in comment_posts if "RTC-AutoPay-Manual-Required" in body]) == 1
+    assert len(transfer_calls) == 1
+    assert any("RTC-AutoPay-Confirmed" in body for body in comment_posts)
+
+
+def test_legacy_manual_transfer_notice_does_not_block_later_auto_pay():
+    auto_pay = load_auto_pay()
+    comments = [owner_payment_comment()]
+    payment_key = auto_pay.build_payment_key(
+        "Scottcjn/Rustchain",
+        "123",
+        101,
+        75.0,
+        "contributor",
+    )
+    comments.append({
+        "id": 202,
+        "user": {"login": "github-actions[bot]"},
+        "body": f"<!-- RTC-AutoPay-Confirmed:MANUAL payment_key={payment_key} -->",
+    })
+    transfer_calls = []
+    comment_posts = []
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        if url.endswith("/wallet/transfer"):
+            transfer_calls.append(json)
+            return FakeResponse({"ok": True, "pending_id": "p1"})
+        comment_posts.append(json["body"])
+        return FakeResponse({"id": 999})
+
+    with patch.dict(os.environ, base_env(), clear=True):
+        auto_pay.requests.get = paged_comments(comments)
+        auto_pay.requests.post = fake_post
+        auto_pay.main()
+
+    assert len(transfer_calls) == 1
+    assert any("RTC-AutoPay-Confirmed" in body for body in comment_posts)


### PR DESCRIPTION
## Summary
- add a separate manual-transfer marker for auto-pay comments when VPS secrets are missing
- keep legacy manual notices from being treated as completed payment confirmations
- add regression coverage for retrying with secrets after a manual notice

## Verification
- uv run --no-project --with pytest --with requests python -m pytest scripts/test_auto_pay_idempotency.py -q
- python3 -m py_compile scripts/auto-pay.py scripts/test_auto_pay_idempotency.py
- uv run --no-project --with ruff ruff check scripts/auto-pay.py scripts/test_auto_pay_idempotency.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check