### PR TITLE
fix: clear stale gpu badge output

### DIFF
--- a/tests/test_gpu_display_detector.py
+++ b/tests/test_gpu_display_detector.py
@@ -85,6 +85,21 @@ def test_detect_gpu_and_display_does_not_write_when_no_badges(tmp_path, monkeypa
     assert "No relic badges detected." in capsys.readouterr().out
 
 
+def test_detect_gpu_and_display_removes_stale_badges_when_no_matches(
+    tmp_path, monkeypatch, capsys
+):
+    module = load_module()
+    monkeypatch.chdir(tmp_path)
+    stale_badges = tmp_path / "unlocked_badges.json"
+    stale_badges.write_text('{"badges": [{"badge_id": "badge_voodoo_fx_g"}]}', encoding="utf-8")
+
+    with patch.object(module.subprocess, "check_output", return_value=b"ethernet controller\n"):
+        module.detect_gpu_and_display()
+
+    assert not stale_badges.exists()
+    assert "No relic badges detected." in capsys.readouterr().out
+
+
 def test_detect_gpu_and_display_handles_missing_lspci(tmp_path, monkeypatch, capsys):
     module = load_module()
     monkeypatch.chdir(tmp_path)

--- a/tools/gpu_display_detector.py
+++ b/tools/gpu_display_detector.py
@@ -1,8 +1,11 @@
 # SPDX-License-Identifier: MIT
 import json
-import platform
 import subprocess
 from datetime import datetime
+from pathlib import Path
+
+
+BADGE_OUTPUT = Path("unlocked_badges.json")
 
 
 def _read_lspci_output():
@@ -51,11 +54,13 @@ def detect_gpu_and_display():
 
     if badges:
         badge_entries = [{"badge_id": b, "awarded_at": now} for b in badges]
-        with open("unlocked_badges.json", "w") as f:
+        with BADGE_OUTPUT.open("w") as f:
             json.dump({"badges": badge_entries}, f, indent=4)
         print(f"Unlocked {len(badges)} badge(s):", [b for b in badges])
     else:
+        BADGE_OUTPUT.unlink(missing_ok=True)
         print("No relic badges detected.")
+
 
 if __name__ == "__main__":
     detect_gpu_and_display()


### PR DESCRIPTION
## Summary
- remove stale `unlocked_badges.json` when the GPU/display detector finds no relic badge matches
- centralize the badge output path used by writes and cleanup
- add regression coverage for clearing a stale badge file on a no-match scan

## Verification
- uv run --no-project --with pytest --with flask python -m pytest tests/test_gpu_display_detector.py tests/test_detector_tools_no_shell.py -q
- python3 -m py_compile tools/gpu_display_detector.py tests/test_gpu_display_detector.py tests/test_detector_tools_no_shell.py
- uv run --no-project --with ruff ruff check tools/gpu_display_detector.py tests/test_gpu_display_detector.py tests/test_detector_tools_no_shell.py
- python3 tools/bcos_spdx_check.py --base-ref origin/main
- git diff --check