### PR TITLE
fix: preserve epoch state metadata on settlement

### DIFF
--- a/node/anti_double_mining.py
+++ b/node/anti_double_mining.py
@@ -720,11 +720,19 @@ def settle_epoch_with_anti_double_mining(
                 "device_arch": device_arch
             })
 
-        # Mark epoch as settled
-        db.execute(
-            "INSERT OR REPLACE INTO epoch_state (epoch, settled, settled_ts) VALUES (?, 1, ?)",
-            (epoch, ts_now)
-        )
+        # Mark epoch as settled without replacing the whole row.
+        # INSERT OR REPLACE deletes any existing epoch_state metadata columns
+        # (for example finalized/accepted_blocks/pot) before inserting the
+        # narrow settlement row. Preserve unrelated epoch state fields.
+        updated = db.execute(
+            "UPDATE epoch_state SET settled = 1, settled_ts = ? WHERE epoch = ?",
+            (ts_now, epoch)
+        ).rowcount
+        if updated == 0:
+            db.execute(
+                "INSERT INTO epoch_state (epoch, settled, settled_ts) VALUES (?, 1, ?)",
+                (epoch, ts_now)
+            )
 
         if own_conn:
             db.commit()

--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -231,11 +231,19 @@ def settle_epoch_rip200(db_path, epoch: int, enable_anti_double_mining: bool = T
                 "device_arch": device_arch
             })
 
-        # Mark epoch as settled
-        db.execute(
-            "INSERT OR REPLACE INTO epoch_state (epoch, settled, settled_ts) VALUES (?, 1, ?)",
-            (epoch, ts_now)
-        )
+        # Mark epoch as settled without replacing the whole row.
+        # INSERT OR REPLACE deletes any existing epoch_state metadata columns
+        # (for example finalized/accepted_blocks/pot) before inserting the
+        # narrow settlement row. Preserve unrelated epoch state fields.
+        updated = db.execute(
+            "UPDATE epoch_state SET settled = 1, settled_ts = ? WHERE epoch = ?",
+            (ts_now, epoch)
+        ).rowcount
+        if updated == 0:
+            db.execute(
+                "INSERT INTO epoch_state (epoch, settled, settled_ts) VALUES (?, 1, ?)",
+                (epoch, ts_now)
+            )
 
         db.commit()
 

--- a/node/tests/test_rewards_settle_race.py
+++ b/node/tests/test_rewards_settle_race.py
@@ -112,6 +112,53 @@ class TestRewardsSettleRace(unittest.TestCase):
             rip200.ANTI_DOUBLE_MINING_AVAILABLE = orig_adm
 
 
+    def test_settle_preserves_epoch_state_metadata(self) -> None:
+        try:
+            import rewards_implementation_rip200 as rip200
+        except ImportError:
+            import node.rewards_implementation_rip200 as rip200
+
+        orig_adm = rip200.ANTI_DOUBLE_MINING_AVAILABLE
+        rip200.ANTI_DOUBLE_MINING_AVAILABLE = False
+        rip200.calculate_epoch_rewards_time_aged = lambda *_a, **_k: {"m1": 100}
+        rip200.get_chain_age_years = lambda *_a, **_k: 1.0
+        rip200.get_time_aged_multiplier = lambda *_a, **_k: 1.0
+
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                db_path = os.path.join(td, "test.db")
+                with sqlite3.connect(db_path) as db:
+                    db.executescript(
+                        """
+                        CREATE TABLE epoch_state (
+                            epoch INTEGER PRIMARY KEY,
+                            settled INTEGER DEFAULT 0,
+                            settled_ts INTEGER,
+                            accepted_blocks INTEGER DEFAULT 0,
+                            finalized INTEGER DEFAULT 0
+                        );
+                        CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL);
+                        CREATE TABLE ledger (ts INTEGER, epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT);
+                        CREATE TABLE epoch_rewards (epoch INTEGER, miner_id TEXT, share_i64 INTEGER);
+                        CREATE TABLE miner_attest_recent (miner TEXT, device_arch TEXT);
+                        """
+                    )
+                    db.execute(
+                        "INSERT INTO epoch_state(epoch, settled, settled_ts, accepted_blocks, finalized) VALUES (0, 0, 0, 42, 1)"
+                    )
+                    db.execute("INSERT INTO miner_attest_recent (miner, device_arch) VALUES ('m1', 'x86_64')")
+
+                result = rip200.settle_epoch_rip200(db_path, 0)
+                self.assertTrue(result.get("ok"))
+
+                with sqlite3.connect(db_path) as db:
+                    row = db.execute(
+                        "SELECT settled, accepted_blocks, finalized FROM epoch_state WHERE epoch=0"
+                    ).fetchone()
+                    self.assertEqual(row, (1, 42, 1))
+        finally:
+            rip200.ANTI_DOUBLE_MINING_AVAILABLE = orig_adm
+
 class TestFutureEpochRejection(unittest.TestCase):
     """Settling a future epoch must be rejected outright.
 


### PR DESCRIPTION
## Summary
- replace `INSERT OR REPLACE` settlement writes with update-then-insert so existing epoch_state metadata is preserved
- apply the same fix to the anti-double-mining settlement path
- add regression coverage for accepted_blocks/finalized surviving settlement

## Test
- `PYTHONPATH=node python3 -m pytest node/tests/test_rewards_settle_race.py node/tests/test_anti_double_mining.py -q`

## Bounty
Candidate fix for #305.