### PR TITLE
Fix websocket miner row tracking

### DIFF
--- a/explorer/explorer_websocket_server.py
+++ b/explorer/explorer_websocket_server.py
@@ -177,11 +177,11 @@ class ExplorerState:
 
         new_attestations = {}
         for m in miners:
-            wallet = m.get("wallet_name", m.get("wallet", m.get("wallet_address", "")))
+            wallet = m.get("wallet_name", m.get("wallet", m.get("wallet_address", m.get("miner", ""))))
             ts = m.get("last_attestation_time", m.get("last_attest", m.get("last_seen", 0)))
-            arch = m.get("hardware_type", m.get("arch", m.get("architecture", "unknown")))
+            arch = m.get("hardware_type", m.get("device_arch", m.get("arch", m.get("architecture", "unknown"))))
             mult = m.get("multiplier", m.get("rtc_multiplier", m.get("antiquity_multiplier", 1.0)))
-            miner_id = m.get("miner_id", m.get("id", wallet))
+            miner_id = m.get("miner_id", m.get("id", m.get("miner", wallet)))
             if wallet:
                 new_attestations[wallet] = (ts, arch, mult, miner_id)
 

--- a/tests/test_explorer_websocket_miners.py
+++ b/tests/test_explorer_websocket_miners.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_websocket_module(monkeypatch):
+    socketio_module = types.ModuleType("flask_socketio")
+
+    class SocketIO:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def on(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+    socketio_module.SocketIO = SocketIO
+    socketio_module.emit = lambda *args, **kwargs: None
+    socketio_module.join_room = lambda *args, **kwargs: None
+    socketio_module.leave_room = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "flask_socketio", socketio_module)
+
+    module_path = REPO_ROOT / "explorer" / "explorer_websocket_server.py"
+    spec = importlib.util.spec_from_file_location(
+        "test_explorer_websocket_server_miners",
+        module_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def test_websocket_state_tracks_current_api_miner_rows(monkeypatch):
+    module = load_websocket_module(monkeypatch)
+    state = module.ExplorerState()
+    events = []
+    state.subscribe(events.append)
+
+    state.process_miners([
+        {
+            "miner": "RTCabc",
+            "device_arch": "x86_64",
+            "last_attest": 100,
+            "antiquity_multiplier": 1.25,
+        }
+    ])
+    state.process_miners([
+        {
+            "miner": "RTCabc",
+            "device_arch": "x86_64",
+            "last_attest": 200,
+            "antiquity_multiplier": 1.25,
+        }
+    ])
+
+    assert state.miners["RTCabc"][0] == 200
+    assert events[-1]["type"] == "attestation"
+    assert events[-1]["data"]["miner"] == "RTCabc"
+    assert events[-1]["data"]["miner_id"] == "RTCabc"
+    assert events[-1]["data"]["arch"] == "x86_64"
+    assert events[-1]["data"]["multiplier"] == 1.25


### PR DESCRIPTION
## Summary

- teach the explorer websocket state to recognize current `/api/miners` rows that use `miner`, `device_arch`, `last_attest`, and `antiquity_multiplier`
- preserve existing legacy wallet and architecture field names
- add a regression test proving live-shaped miner rows are tracked and emit attestation updates

## Root cause

`ExplorerState.process_miners()` only keyed miners by `wallet_name`, `wallet`, or `wallet_address`. The current miner API rows expose the miner identifier as `miner`, so websocket state stayed empty for live-shaped rows and later `last_attest` changes could not emit `attestation` events.

## Validation

- `python3 -m pytest -q tests/test_explorer_websocket_miners.py tests/test_realtime_explorer_limit_validation.py explorer/test_explorer_websocket.py` -> 48 passed
- `python3 -m py_compile explorer/explorer_websocket_server.py tests/test_explorer_websocket_miners.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

## Bounty

Bounty context: Scottcjn/rustchain-bounties#71.

Not counted as earned unless maintainers accept, merge, and credit it.
