### PR TITLE
Fix agent CLI response envelopes

### DIFF
--- a/sdk/rustchain_agent_cli.py
+++ b/sdk/rustchain_agent_cli.py
@@ -17,25 +17,68 @@ Install:
 
 import argparse
 import json
+import os
 import sys
 import requests
-from typing import Optional, Dict, List
+from typing import Any, Dict, List, Optional
 
 # API Base URL
-BASE_URL = "https://rustchain.org"
+BASE_URL = "https://50.28.86.131"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _unwrap_dict(payload: Any, key: str) -> Optional[Dict]:
+    """Accept both legacy bare objects and live API envelope objects."""
+    if not isinstance(payload, dict):
+        return None
+    if key in payload:
+        value = payload.get(key)
+        return value if isinstance(value, dict) else None
+    return payload
+
+
+def _unwrap_list(payload: Any, key: str) -> List[Dict]:
+    """Accept both legacy bare lists and live API envelope lists."""
+    if isinstance(payload, dict):
+        payload = payload.get(key, [])
+    if not isinstance(payload, list):
+        return []
+    return [item for item in payload if isinstance(item, dict)]
+
 
 class RustChainAgentCLI:
-    def __init__(self, wallet: str = "cli-user"):
+    def __init__(
+        self,
+        wallet: str = "cli-user",
+        base_url: Optional[str] = None,
+        verify_ssl: Optional[bool] = None,
+    ):
         self.wallet = wallet
-        self.base_url = BASE_URL
+        self.base_url = (
+            base_url
+            or os.getenv("RUSTCHAIN_AGENT_API")
+            or os.getenv("RUSTCHAIN_NODE_URL")
+            or BASE_URL
+        )
+        self.verify_ssl = (
+            verify_ssl
+            if verify_ssl is not None
+            else _env_bool("RUSTCHAIN_AGENT_VERIFY_SSL", False)
+        )
     
     def list_jobs(self, category: Optional[str] = None) -> List[Dict]:
         """List open jobs"""
         url = f"{self.base_url}/agent/jobs"
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
-            jobs = response.json()
+            jobs = _unwrap_list(response.json(), "jobs")
             
             if category:
                 jobs = [j for j in jobs if j.get('category') == category]
@@ -59,7 +102,7 @@ class RustChainAgentCLI:
         }
         
         try:
-            response = requests.post(url, json=data, timeout=10)
+            response = requests.post(url, json=data, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
@@ -72,7 +115,7 @@ class RustChainAgentCLI:
         data = {"worker_wallet": self.wallet}
         
         try:
-            response = requests.post(url, json=data, timeout=10)
+            response = requests.post(url, json=data, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
@@ -89,7 +132,7 @@ class RustChainAgentCLI:
         }
         
         try:
-            response = requests.post(url, json=data, timeout=10)
+            response = requests.post(url, json=data, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
@@ -101,9 +144,9 @@ class RustChainAgentCLI:
         url = f"{self.base_url}/agent/jobs/{job_id}"
         
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
-            return response.json()
+            return _unwrap_dict(response.json(), "job")
         except requests.RequestException as e:
             print(f"Error fetching job: {e}")
             return None
@@ -113,9 +156,9 @@ class RustChainAgentCLI:
         url = f"{self.base_url}/agent/stats"
         
         try:
-            response = requests.get(url, timeout=10)
+            response = requests.get(url, timeout=10, verify=self.verify_ssl)
             response.raise_for_status()
-            return response.json()
+            return _unwrap_dict(response.json(), "stats")
         except requests.RequestException as e:
             print(f"Error fetching stats: {e}")
             return None
@@ -134,7 +177,8 @@ def cmd_list(args):
     print("-" * 75)
     
     for job in jobs:
-        job_id = job.get('id', 'N/A')[:18] + '...' if len(job.get('id', '')) > 20 else job.get('id', 'N/A')
+        raw_job_id = job.get('id') or job.get('job_id') or 'N/A'
+        job_id = raw_job_id[:18] + '...' if len(raw_job_id) > 20 else raw_job_id
         title = job.get('title', '')[:28] + '...' if len(job.get('title', '')) > 30 else job.get('title', '')
         category = job.get('category', 'N/A')
         reward = f"{job.get('reward_rtc', 0)} RTC"
@@ -153,8 +197,8 @@ def cmd_post(args):
     
     if result:
         print(f"\n✅ Job posted successfully!")
-        print(f"   Job ID: {result.get('id')}")
-        print(f"   Title: {result.get('title')}")
+        print(f"   Job ID: {result.get('id') or result.get('job_id')}")
+        print(f"   Title: {result.get('title') or args.title}")
     else:
         print("❌ Failed to post job")
 
@@ -216,7 +260,8 @@ def cmd_stats(args):
     print(f"  Total Jobs:      {stats.get('total_jobs', 'N/A')}")
     print(f"  Open Jobs:      {stats.get('open_jobs', 'N/A')}")
     print(f"  Completed Jobs: {stats.get('completed_jobs', 'N/A')}")
-    print(f"  Total Volume:   {stats.get('total_volume_rtc', 'N/A')} RTC")
+    total_volume = stats.get('total_rtc_volume', stats.get('total_volume_rtc', 'N/A'))
+    print(f"  Total Volume:   {total_volume} RTC")
     print(f"  Active Agents:  {stats.get('active_agents', 'N/A')}")
 
 

--- a/tests/test_rustchain_agent_cli.py
+++ b/tests/test_rustchain_agent_cli.py
@@ -1,0 +1,274 @@
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def rustchain_agent_cli_module():
+    module_path = Path(__file__).resolve().parents[1] / "sdk" / "rustchain_agent_cli.py"
+    spec = importlib.util.spec_from_file_location("rustchain_agent_cli", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_list_jobs_unwraps_live_agent_jobs_envelope(
+    rustchain_agent_cli_module, monkeypatch
+):
+    def fake_get(url, timeout, verify):
+        assert url == "https://node.example/agent/jobs"
+        assert timeout == 10
+        assert verify is False
+        return FakeResponse(
+            {
+                "ok": True,
+                "jobs": [
+                    {"job_id": "job-code", "title": "Code task", "category": "code"},
+                    {
+                        "job_id": "job-writing",
+                        "title": "Writing task",
+                        "category": "writing",
+                    },
+                ],
+            }
+        )
+
+    monkeypatch.setattr(rustchain_agent_cli_module.requests, "get", fake_get)
+
+    cli = rustchain_agent_cli_module.RustChainAgentCLI()
+    cli.base_url = "https://node.example"
+
+    assert cli.list_jobs(category="code") == [
+        {"job_id": "job-code", "title": "Code task", "category": "code"}
+    ]
+
+
+def test_agent_cli_defaults_to_live_agent_node(rustchain_agent_cli_module):
+    cli = rustchain_agent_cli_module.RustChainAgentCLI()
+
+    assert cli.base_url == "https://50.28.86.131"
+    assert cli.verify_ssl is False
+
+
+def test_agent_cli_allows_env_node_and_ssl_override(
+    rustchain_agent_cli_module, monkeypatch
+):
+    monkeypatch.setenv("RUSTCHAIN_AGENT_API", "https://agent.example")
+    monkeypatch.setenv("RUSTCHAIN_AGENT_VERIFY_SSL", "true")
+
+    cli = rustchain_agent_cli_module.RustChainAgentCLI()
+
+    assert cli.base_url == "https://agent.example"
+    assert cli.verify_ssl is True
+
+
+def test_mutating_agent_requests_use_ssl_mode(rustchain_agent_cli_module, monkeypatch):
+    calls = []
+
+    def fake_post(url, json, timeout, verify):
+        assert timeout == 10
+        assert verify is False
+        calls.append((url, json))
+        return FakeResponse({"ok": True, "job_id": "job-1"})
+
+    monkeypatch.setattr(rustchain_agent_cli_module.requests, "post", fake_post)
+
+    cli = rustchain_agent_cli_module.RustChainAgentCLI(wallet="worker-wallet")
+    cli.base_url = "https://node.example"
+
+    assert cli.post_job("Title", "Description", "code", 5, ["cli"]) == {
+        "ok": True,
+        "job_id": "job-1",
+    }
+    assert cli.claim_job("job-1") == {"ok": True, "job_id": "job-1"}
+    assert cli.deliver_job("job-1", "https://example.com/pr", "Done") == {
+        "ok": True,
+        "job_id": "job-1",
+    }
+    assert calls == [
+        (
+            "https://node.example/agent/jobs",
+            {
+                "poster_wallet": "worker-wallet",
+                "title": "Title",
+                "description": "Description",
+                "category": "code",
+                "reward_rtc": 5,
+                "tags": ["cli"],
+            },
+        ),
+        (
+            "https://node.example/agent/jobs/job-1/claim",
+            {"worker_wallet": "worker-wallet"},
+        ),
+        (
+            "https://node.example/agent/jobs/job-1/deliver",
+            {
+                "worker_wallet": "worker-wallet",
+                "deliverable_url": "https://example.com/pr",
+                "result_summary": "Done",
+            },
+        ),
+    ]
+
+
+def test_get_job_unwraps_live_agent_job_envelope(rustchain_agent_cli_module, monkeypatch):
+    def fake_get(url, timeout, verify):
+        assert url == "https://node.example/agent/jobs/job-1"
+        assert timeout == 10
+        assert verify is False
+        return FakeResponse(
+            {
+                "ok": True,
+                "job": {
+                    "job_id": "job-1",
+                    "title": "Ship a fix",
+                    "reward_rtc": 5,
+                },
+            }
+        )
+
+    monkeypatch.setattr(rustchain_agent_cli_module.requests, "get", fake_get)
+
+    cli = rustchain_agent_cli_module.RustChainAgentCLI()
+    cli.base_url = "https://node.example"
+
+    assert cli.get_job("job-1") == {
+        "job_id": "job-1",
+        "title": "Ship a fix",
+        "reward_rtc": 5,
+    }
+
+
+def test_get_stats_unwraps_live_agent_stats_envelope(
+    rustchain_agent_cli_module, monkeypatch
+):
+    def fake_get(url, timeout, verify):
+        assert url == "https://node.example/agent/stats"
+        assert timeout == 10
+        assert verify is False
+        return FakeResponse(
+            {
+                "ok": True,
+                "stats": {
+                    "total_jobs": 4,
+                    "open_jobs": 2,
+                    "completed_jobs": 1,
+                    "total_rtc_volume": 7.5,
+                    "active_agents": 3,
+                },
+            }
+        )
+
+    monkeypatch.setattr(rustchain_agent_cli_module.requests, "get", fake_get)
+
+    cli = rustchain_agent_cli_module.RustChainAgentCLI()
+    cli.base_url = "https://node.example"
+
+    assert cli.get_stats() == {
+        "total_jobs": 4,
+        "open_jobs": 2,
+        "completed_jobs": 1,
+        "total_rtc_volume": 7.5,
+        "active_agents": 3,
+    }
+
+
+def test_cmd_list_prints_live_job_id(rustchain_agent_cli_module, monkeypatch, capsys):
+    class FakeCLI:
+        def __init__(self, wallet):
+            assert wallet == "agent-wallet"
+
+        def list_jobs(self, category):
+            assert category is None
+            return [
+                {
+                    "job_id": "job-live-123",
+                    "title": "Fix live CLI rows",
+                    "category": "code",
+                    "reward_rtc": 5,
+                }
+            ]
+
+    monkeypatch.setattr(rustchain_agent_cli_module, "RustChainAgentCLI", FakeCLI)
+
+    rustchain_agent_cli_module.cmd_list(
+        SimpleNamespace(wallet="agent-wallet", category=None)
+    )
+
+    output = capsys.readouterr().out
+    assert "job-live-123" in output
+    assert "Fix live CLI rows" in output
+
+
+def test_cmd_post_prints_live_job_id(rustchain_agent_cli_module, monkeypatch, capsys):
+    class FakeCLI:
+        def __init__(self, wallet):
+            assert wallet == "poster-wallet"
+
+        def post_job(self, title, description, category, reward, tags):
+            assert title == "Fix live CLI rows"
+            assert description == "Long enough live CLI task description"
+            assert category == "code"
+            assert reward == 5
+            assert tags == ["cli", "agent"]
+            return {"ok": True, "job_id": "job-posted-123", "status": "open"}
+
+    monkeypatch.setattr(rustchain_agent_cli_module, "RustChainAgentCLI", FakeCLI)
+
+    rustchain_agent_cli_module.cmd_post(
+        SimpleNamespace(
+            wallet="poster-wallet",
+            title="Fix live CLI rows",
+            description="Long enough live CLI task description",
+            category="code",
+            reward=5,
+            tags="cli,agent",
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "Job ID: job-posted-123" in output
+    assert "Title: Fix live CLI rows" in output
+
+
+def test_cmd_stats_prints_live_total_rtc_volume(
+    rustchain_agent_cli_module, monkeypatch, capsys
+):
+    class FakeCLI:
+        def __init__(self, wallet):
+            assert wallet == "agent-wallet"
+
+        def get_stats(self):
+            return {
+                "total_jobs": 4,
+                "open_jobs": 2,
+                "completed_jobs": 1,
+                "total_rtc_volume": 7.5,
+                "active_agents": 3,
+            }
+
+    monkeypatch.setattr(rustchain_agent_cli_module, "RustChainAgentCLI", FakeCLI)
+
+    rustchain_agent_cli_module.cmd_stats(SimpleNamespace(wallet="agent-wallet"))
+
+    output = capsys.readouterr().out
+    assert "Total Volume:   7.5 RTC" in output


### PR DESCRIPTION
## Summary
- Unwrap live Agent Economy API response envelopes in `sdk/rustchain_agent_cli.py` for job lists, job details, and marketplace stats.
- Preserve compatibility with legacy bare list/object responses.
- Display live `job_id` rows and the current `total_rtc_volume` stats field.
- Point the SDK CLI at the live Agent Economy node by default, while allowing `RUSTCHAIN_AGENT_API`/`RUSTCHAIN_NODE_URL` and `RUSTCHAIN_AGENT_VERIFY_SSL` overrides.

## Root cause
The live RIP-302 endpoints return JSON envelopes:

- `GET /agent/jobs` -> `{"ok": true, "jobs": [...]}`
- `GET /agent/jobs/<id>` -> `{"ok": true, "job": {...}}`
- `GET /agent/stats` -> `{"ok": true, "stats": {...}}`

The SDK CLI treated those responses as bare lists or bare stats/job objects. That made category filtering iterate dictionary keys, job details print envelope fields instead of job fields, and stats display `N/A` for the live volume key.

The CLI also defaulted to `https://rustchain.org`, where the Agent Economy paths currently return 404. The live Agent Economy node responds at `https://50.28.86.131` with SSL verification disabled, matching the existing `tools/agent_economy_cli/rustchain_ae.py` behavior.

## Validation
- `python3 -m pytest -q tests/test_rustchain_agent_cli.py` -> 9 passed
- `python3 -m pytest -q tests/test_rustchain_agent_cli.py tests/test_agent_economy_cli.py tests/test_agent_jobs_query_validation.py tests/test_agent_dispute_accept_race.py` -> 35 passed
- `python3 -m py_compile sdk/rustchain_agent_cli.py tests/test_rustchain_agent_cli.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- Live smoke: default `RustChainAgentCLI()` used `https://50.28.86.131`, `verify_ssl=False`; `/agent/jobs` returned a list and `/agent/stats` returned the expected stats keys.
