### PR TITLE
Fix admin header alias for protected routes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5516,7 +5516,7 @@ def admin_required(f):
     from functools import wraps
     @wraps(f)
     def decorated(*args, **kwargs):
-        key = request.headers.get("X-API-Key") or ""
+        key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
         if not hmac.compare_digest(key, ADMIN_KEY or ""):
             return jsonify({"ok": False, "reason": "admin_required"}), 401
         return f(*args, **kwargs)

--- a/tests/test_gov_rotate_api.py
+++ b/tests/test_gov_rotate_api.py
@@ -7,8 +7,28 @@ def _admin_headers():
     return {"X-API-Key": "test-admin-key"}
 
 
+def _x_admin_headers():
+    return {"X-Admin-Key": "test-admin-key"}
+
+
 def _member(signer_id=1):
     return {"signer_id": signer_id, "pubkey_hex": "aa"}
+
+
+def test_admin_required_accepts_x_admin_key_alias(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "test-admin-key")
+    integrated_node.app.config["TESTING"] = True
+
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/gov/rotate/stage",
+            headers=_x_admin_headers(),
+            json=["not", "an", "object"],
+        )
+
+    assert resp.status_code != 401
+    assert resp.status_code == 400
+    assert resp.get_json()["reason"] == "json_object_required"
 
 
 def test_gov_rotate_stage_requires_json_object(monkeypatch):


### PR DESCRIPTION
## Summary
- Let the shared integrated-node `admin_required` decorator accept `X-Admin-Key` as well as `X-API-Key`.
- Add a regression around `/gov/rotate/stage` proving `X-Admin-Key` reaches route-level validation instead of being rejected by the decorator.

## Root cause
Most integrated-node admin routes accept both `X-Admin-Key` and `X-API-Key`, and the API docs describe both names. The older `admin_required` decorator only read `X-API-Key`, so protected routes using that decorator, including governance rotation and genesis export routes, rejected otherwise valid `X-Admin-Key` requests with `401 admin_required`.

## Validation
- `python3 -m pytest -q tests/test_gov_rotate_api.py` -> 7 passed
- `python3 -m pytest -q tests/test_gov_rotate_api.py node/tests/test_admin_rate_limit.py tests/test_header_routes_json_validation.py` -> 14 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_gov_rotate_api.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> OK
