### PR TITLE
Fix monitor health partial payloads

### DIFF
--- a/tests/test_rustchain_monitor.py
+++ b/tests/test_rustchain_monitor.py
@@ -109,6 +109,17 @@ def test_print_health_formats_success_and_error(rustchain_monitor_module, capsys
     assert "Health check failed: offline" in output
 
 
+def test_print_health_handles_partial_payload(rustchain_monitor_module, capsys):
+    rustchain_monitor_module.print_health({"ok": True})
+
+    output = capsys.readouterr().out
+    assert "Node is healthy" in output
+    assert "Version: N/A" in output
+    assert "Uptime: N/A" in output
+    assert "Backup age: N/A" in output
+    assert "DB RW: N/A" in output
+
+
 def test_print_miners_limits_rows_and_formats_last_attest(
     rustchain_monitor_module, monkeypatch, capsys
 ):

--- a/tests/test_rustchain_monitor_cli.py
+++ b/tests/test_rustchain_monitor_cli.py
@@ -85,6 +85,19 @@ def test_print_health_renders_success_and_error(capsys):
     assert "Health check failed: offline" in output
 
 
+def test_print_health_handles_partial_payload(capsys):
+    module = load_module()
+
+    module.print_health({"ok": True})
+
+    output = capsys.readouterr().out
+    assert "Node is healthy" in output
+    assert "Version: N/A" in output
+    assert "Uptime: N/A" in output
+    assert "Backup age: N/A" in output
+    assert "DB RW: N/A" in output
+
+
 def test_print_miners_renders_lists_unexpected_and_errors(capsys):
     module = load_module()
 

--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -56,11 +56,24 @@ def print_health(data):
     if "error" in data:
         print(f"❌ Health check failed: {data['error']}")
         return
+    uptime_s = data.get("uptime_s")
+    try:
+        uptime_hours = f"{float(uptime_s) / 3600:.1f} hours"
+        uptime_text = f"{uptime_s}s ({uptime_hours})"
+    except (TypeError, ValueError):
+        uptime_text = "N/A"
+
+    backup_age = data.get("backup_age_hours")
+    try:
+        backup_text = f"{float(backup_age):.2f} hours"
+    except (TypeError, ValueError):
+        backup_text = "N/A"
+
     print("✅ Node is healthy")
-    print(f"   Version: {data.get('version')}")
-    print(f"   Uptime: {data.get('uptime_s')}s ({data.get('uptime_s')/3600:.1f} hours)")
-    print(f"   Backup age: {data.get('backup_age_hours'):.2f} hours")
-    print(f"   DB RW: {data.get('db_rw')}")
+    print(f"   Version: {data.get('version', 'N/A')}")
+    print(f"   Uptime: {uptime_text}")
+    print(f"   Backup age: {backup_text}")
+    print(f"   DB RW: {data.get('db_rw', 'N/A')}")
 
 def print_miners(data):
     if "error" in data:


### PR DESCRIPTION
## Summary
- Make `rustchain-monitor` tolerate successful `/health` responses that omit `uptime_s`, `backup_age_hours`, `version`, or `db_rw`.
- Render unavailable health fields as `N/A` instead of raising during CLI output.
- Add regression coverage in both monitor test modules.

## Root cause
`print_health()` assumed every successful health payload included numeric `uptime_s` and `backup_age_hours` fields:

- `data.get("uptime_s") / 3600`
- `{data.get("backup_age_hours"):.2f}`

If an older node, proxy, or trimmed health endpoint returned `{"ok": true}` or otherwise omitted those fields, the monitor crashed while printing the response instead of showing the available status.

## Validation
- `python3 -m pytest -q tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py` -> 14 passed
- `python3 -m py_compile tools/rustchain-monitor/rustchain_monitor.py tests/test_rustchain_monitor.py tests/test_rustchain_monitor_cli.py`
- `git diff --check`
- `python3 tools/bcos_spdx_check.py --base-ref upstream/main` -> OK

## Bounty context
General bug-fix submission for the RustChain bounty program (#305). No payout is claimed until maintainer acceptance or merge.
