### PR TITLE
Fix discord leaderboard partial status payloads

### DIFF
--- a/tests/test_discord_leaderboard_bot.py
+++ b/tests/test_discord_leaderboard_bot.py
@@ -138,3 +138,30 @@ def test_render_payload_includes_top_miners_rewards_and_architecture(monkeypatch
     assert "alice-miner" in fields["Top Miners"]
     assert "winner-miner-id" in fields["Top Earners (current epoch)"]
     assert "- G4: 1 (50.0%)" in fields["Architecture Distribution"]
+
+
+def test_render_payload_handles_partial_epoch_and_health_payloads(monkeypatch):
+    called = False
+
+    def fake_rewards_for_epoch(session, base, epoch, timeout):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr(discord_leaderboard_bot, "rewards_for_epoch", fake_rewards_for_epoch)
+
+    payload = discord_leaderboard_bot.render_payload(
+        object(),
+        "https://node",
+        1,
+        [{"miner": "alice-miner", "balance_rtc": 4.0, "arch": "G4"}],
+        {"epoch": None},
+        {"ok": True, "uptime_s": None},
+        top_n=1,
+        title_prefix="Daily leaderboard",
+    )
+
+    assert "Epoch: -1" in payload["content"]
+    assert "Node OK: True, Uptime: 0s" in payload["content"]
+    assert "alice-miner" in payload["embeds"][0]["fields"][0]["value"]
+    assert called is False

--- a/tools/discord_leaderboard_bot.py
+++ b/tools/discord_leaderboard_bot.py
@@ -32,6 +32,13 @@ def fmt_rtc(value: float) -> str:
     return f"{value:.6f}"
 
 
+def safe_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def short_id(s: str, keep: int = 14) -> str:
     if len(s) <= keep:
         return s
@@ -126,7 +133,7 @@ def render_payload(session, base: str, timeout: float, rows, epoch, health, top_
     total_balance = sum(x["balance_rtc"] for x in rows)
     dist = architecture_distribution(rows)
     top_table = build_leaderboard_lines(rows, top_n)
-    current_epoch = int(epoch.get("epoch", -1))
+    current_epoch = safe_int(epoch.get("epoch"), -1)
 
     rewards = []
     rewards_text = "No reward rows available for current epoch."
@@ -143,7 +150,7 @@ def render_payload(session, base: str, timeout: float, rows, epoch, health, top_
         arch_lines.append(f"- {arch}: {n} ({pct:.1f}%)")
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-    uptime_s = int(health.get("uptime_s", 0))
+    uptime_s = safe_int(health.get("uptime_s"), 0)
     node_ok = bool(health.get("ok", False))
 
     content = (


### PR DESCRIPTION
## Summary
- Guard Discord leaderboard epoch and health uptime rendering with safe integer coercion.
- Preserve existing fallback values when successful node responses omit or null out status fields.
- Add a regression test proving partial epoch/health payloads still render and skip current-epoch rewards lookup.

## Root cause
The renderer called int() directly on epoch and uptime_s response fields. A successful but partially populated node payload such as {"epoch": null} or {"uptime_s": null} raised TypeError before dry-run output or webhook posting.

## Validation
- python3 -B -m pytest -q tests/test_discord_leaderboard_bot.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile tools/discord_leaderboard_bot.py tests/test_discord_leaderboard_bot.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref upstream/main

Bounty context: Scottcjn/Rustchain#305