### PR TITLE
Fix CLI status partial health payloads

### DIFF
--- a/tests/test_rustchain_cli_status.py
+++ b/tests/test_rustchain_cli_status.py
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "tools" / "cli" / "rustchain_cli.py"
+spec = importlib.util.spec_from_file_location("rustchain_cli", MODULE_PATH)
+rustchain_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rustchain_cli)
+
+
+def test_status_text_handles_partial_health_payload(monkeypatch, capsys):
+    monkeypatch.setattr(
+        rustchain_cli,
+        "fetch_api",
+        lambda endpoint: {
+            "ok": True,
+            "version": "2.2.1",
+            "uptime_s": None,
+            "db_rw": True,
+            "tip_age_slots": None,
+            "backup_age_hours": None,
+        },
+    )
+
+    rustchain_cli.cmd_status(SimpleNamespace(json=False))
+
+    out = capsys.readouterr().out
+    assert "Status:" in out
+    assert "Uptime:      N/A" in out
+    assert "Tip Age:     N/A" in out
+    assert "Backup Age:  N/A" in out

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -87,6 +87,29 @@ def format_table(headers, rows):
     
     return "\n".join(lines)
 
+def _as_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+def _format_uptime(value):
+    seconds = _as_float(value)
+    if seconds is None:
+        return "N/A"
+    return f"{seconds:.0f} seconds ({seconds/3600:.1f} hours)"
+
+def _format_hours(value):
+    hours = _as_float(value)
+    if hours is None:
+        return "N/A"
+    return f"{hours:.1f} hours"
+
+def _format_slots(value):
+    if value is None:
+        return "N/A"
+    return value
+
 def cmd_status(args):
     """Show node health and status."""
     data = fetch_api("/health")
@@ -98,10 +121,10 @@ def cmd_status(args):
     print("=== RustChain Node Status ===")
     print(f"Status:      {'✅ Online' if data.get('ok') else '❌ Offline'}")
     print(f"Version:     {data.get('version', 'N/A')}")
-    print(f"Uptime:      {data.get('uptime_s', 0):.0f} seconds ({data.get('uptime_s', 0)/3600:.1f} hours)")
+    print(f"Uptime:      {_format_uptime(data.get('uptime_s'))}")
     print(f"DB Read/Write: {'✅ Yes' if data.get('db_rw') else '❌ No'}")
-    print(f"Tip Age:     {data.get('tip_age_slots', 0)} slots")
-    print(f"Backup Age:  {data.get('backup_age_hours', 0):.1f} hours")
+    print(f"Tip Age:     {_format_slots(data.get('tip_age_slots'))} slots")
+    print(f"Backup Age:  {_format_hours(data.get('backup_age_hours'))}")
 
 def cmd_miners(args):
     """List active miners."""


### PR DESCRIPTION
## Summary
- Render missing/null status fields in the RustChain CLI status command as N/A instead of formatting them as numbers.
- Keep normal numeric uptime and backup-age output unchanged.
- Add regression coverage for partially populated /health payloads.

## Root cause
The text status path called numeric formatters directly on /health fields. A successful but partial payload such as {"uptime_s": null, "backup_age_hours": null} raised TypeError before the CLI could finish printing status.

## Validation
- python3 -B -m pytest -q tests/test_rustchain_cli_status.py tests/test_wallet_show_regression.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile tools/cli/rustchain_cli.py tests/test_rustchain_cli_status.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref upstream/main

Bounty context: Scottcjn/Rustchain#305