### PR TITLE
Fix Telegram price partial epoch payloads

### DIFF
--- a/tests/test_telegram_bot_2869_helpers.py
+++ b/tests/test_telegram_bot_2869_helpers.py
@@ -88,3 +88,45 @@ def test_error_text_prefers_internal_error_then_api_error():
     assert telegram_bot._error_text({"_error": "node down", "error": "ignored"}) == "node down"
     assert telegram_bot._error_text({"error": "bad wallet"}) == "bad wallet"
     assert telegram_bot._error_text({"ok": True}) == ""
+
+
+def test_price_command_handles_null_epoch_supply(monkeypatch):
+    class FakeApi:
+        async def swap_info(self):
+            return {"reference_price_usd": 0.25}
+
+        async def epoch(self):
+            return {"total_supply_rtc": None}
+
+    class FakeDxClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def get(self, *_args, **_kwargs):
+            return SimpleNamespace(status_code=503, json=lambda: {})
+
+    class FakeMessage:
+        def __init__(self):
+            self.replies = []
+
+        async def reply_text(self, text, **kwargs):
+            self.replies.append((text, kwargs))
+
+    message = FakeMessage()
+    update = SimpleNamespace(effective_user=SimpleNamespace(id=99), message=message)
+    ctx = SimpleNamespace()
+
+    monkeypatch.setattr(telegram_bot, "api", FakeApi())
+    monkeypatch.setattr(telegram_bot.rate_limiter, "is_allowed", lambda user_id: True)
+    monkeypatch.setattr(telegram_bot.httpx, "AsyncClient", lambda *args, **kwargs: FakeDxClient())
+
+    import asyncio
+
+    asyncio.run(telegram_bot.cmd_price(update, ctx))
+
+    assert message.replies
+    assert "Total Supply: `N/A RTC`" in message.replies[0][0]
+    assert "Market Cap: `$0.00`" in message.replies[0][0]

--- a/tools/telegram-bot-2869/bot.py
+++ b/tools/telegram-bot-2869/bot.py
@@ -158,6 +158,10 @@ def _error_text(data: dict[str, Any]) -> str:
     return ""
 
 
+def _valid_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
 # ---------------------------------------------------------------------------
 # Command: /start
 # ---------------------------------------------------------------------------
@@ -377,13 +381,14 @@ async def cmd_price(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     # Get supply from epoch for market cap
     epoch_data = await api.epoch()
     supply = epoch_data.get("total_supply_rtc", 0) if "_error" not in epoch_data else 0
-    mcap = price * supply if isinstance(supply, (int, float)) and supply else 0
+    supply_display = f"{supply:,}" if _valid_number(supply) else "N/A"
+    mcap = price * supply if _valid_number(supply) and supply else 0
 
     text = (
         f"💲 *RTC Price*\n\n"
         f"Price: *${price:.4f}*\n"
         f"Source: `{source}`\n"
-        f"Total Supply: `{supply:,} RTC`\n"
+        f"Total Supply: `{supply_display} RTC`\n"
         f"Market Cap: `${mcap:,.2f}`"
     )
     await update.message.reply_text(text, parse_mode="Markdown")


### PR DESCRIPTION
## Summary
- Render missing/null total_supply_rtc from the Telegram bot price command as N/A instead of formatting it as a number.
- Keep normal numeric supply and market-cap output unchanged.
- Add regression coverage for a partially populated /epoch response.

## Root cause
cmd_price fetched /epoch for total supply and always rendered it with the numeric comma formatter. A successful but partial payload with total_supply_rtc set to null raised TypeError before the bot could send the price response.

## Validation
- python3 -B -m pytest -q tests/test_telegram_bot_2869_helpers.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile tools/telegram-bot-2869/bot.py tests/test_telegram_bot_2869_helpers.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref upstream/main

Bounty context: Scottcjn/Rustchain#305