### PR TITLE
Fix Discord bot partial numeric payloads

### DIFF
--- a/tests/test_discord_bot_commands.py
+++ b/tests/test_discord_bot_commands.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT / "tools" / "discord-bot" / "bot.py"
+
+
+class FakeEmbed:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.fields = []
+        self.timestamp = None
+        self.footer = None
+
+    def add_field(self, **kwargs):
+        self.fields.append(kwargs)
+
+    def set_footer(self, **kwargs):
+        self.footer = kwargs
+
+
+class FakeColor:
+    @staticmethod
+    def green():
+        return "green"
+
+    @staticmethod
+    def red():
+        return "red"
+
+    @staticmethod
+    def blue():
+        return "blue"
+
+    @staticmethod
+    def gold():
+        return "gold"
+
+    @staticmethod
+    def purple():
+        return "purple"
+
+    @staticmethod
+    def teal():
+        return "teal"
+
+
+class FakeTree:
+    def command(self, *_args, **_kwargs):
+        return lambda func: func
+
+    async def sync(self):
+        return None
+
+
+class FakeBot:
+    def __init__(self, *_args, **_kwargs):
+        self.tree = FakeTree()
+        self.user = SimpleNamespace(id=123)
+
+    async def close(self):
+        return None
+
+
+class FakeResponse:
+    async def defer(self, **_kwargs):
+        return None
+
+
+class FakeFollowup:
+    def __init__(self):
+        self.messages = []
+
+    async def send(self, *args, **kwargs):
+        self.messages.append((args, kwargs))
+
+
+def load_discord_bot_module():
+    fake_app_commands = SimpleNamespace(describe=lambda **_kwargs: (lambda func: func))
+    sys.modules["discord"] = SimpleNamespace(
+        app_commands=fake_app_commands,
+        Color=FakeColor,
+        Embed=FakeEmbed,
+        Intents=SimpleNamespace(default=lambda: SimpleNamespace(message_content=False)),
+        Interaction=object,
+    )
+    sys.modules["discord.ext"] = SimpleNamespace(
+        commands=SimpleNamespace(Bot=FakeBot)
+    )
+    sys.modules["discord.ext.commands"] = SimpleNamespace(Bot=FakeBot)
+    sys.modules["discord.app_commands"] = fake_app_commands
+    sys.modules["httpx"] = SimpleNamespace(
+        AsyncClient=lambda *args, **kwargs: SimpleNamespace(aclose=lambda: None),
+        Timeout=lambda *args, **kwargs: None,
+    )
+
+    spec = importlib.util.spec_from_file_location("rustchain_discord_bot", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["rustchain_discord_bot"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_health_command_handles_null_uptime():
+    module = load_discord_bot_module()
+
+    class FakeApi:
+        async def health(self):
+            return {"ok": True, "version": "2.2.1", "uptime_s": None}
+
+    followup = FakeFollowup()
+    interaction = SimpleNamespace(response=FakeResponse(), followup=followup)
+    module.bot.api = FakeApi()
+
+    asyncio.run(module.cmd_health(interaction))
+
+    embed = followup.messages[0][1]["embed"]
+    fields = {field["name"]: field["value"] for field in embed.fields}
+    assert fields["Uptime"] == "N/A"
+
+
+def test_epoch_command_handles_null_numeric_fields():
+    module = load_discord_bot_module()
+
+    class FakeApi:
+        async def epoch(self):
+            return {
+                "epoch": 42,
+                "slot": None,
+                "height": None,
+                "blocks_per_epoch": None,
+                "enrolled_miners": None,
+                "epoch_pot": None,
+            }
+
+    followup = FakeFollowup()
+    interaction = SimpleNamespace(response=FakeResponse(), followup=followup)
+    module.bot.api = FakeApi()
+
+    asyncio.run(module.cmd_epoch(interaction))
+
+    embed = followup.messages[0][1]["embed"]
+    fields = {field["name"]: field["value"] for field in embed.fields}
+    assert fields["Slot"] == "N/A"
+    assert fields["Height"] == "N/A"
+    assert fields["Epoch Pot"] == "N/A"
+
+
+def test_balance_command_handles_null_amount():
+    module = load_discord_bot_module()
+
+    class FakeApi:
+        async def balance(self, miner_id):
+            return {"miner_id": miner_id, "amount_rtc": None}
+
+    followup = FakeFollowup()
+    interaction = SimpleNamespace(response=FakeResponse(), followup=followup)
+    module.bot.api = FakeApi()
+
+    asyncio.run(module.cmd_balance(interaction, "alice-miner"))
+
+    embed = followup.messages[0][1]["embed"]
+    fields = {field["name"]: field["value"] for field in embed.fields}
+    assert fields["Balance"] == "N/A"

--- a/tools/discord-bot/bot.py
+++ b/tools/discord-bot/bot.py
@@ -43,6 +43,24 @@ DISCORD_TOKEN = os.getenv("DISCORD_TOKEN", "")
 API_TIMEOUT = float(os.getenv("API_TIMEOUT", "10"))
 
 
+def _format_uptime(value) -> str:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return "N/A"
+    return f"{value:,}s (~{value // 3600}h)"
+
+
+def _format_count(value) -> str:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return "N/A"
+    return f"{value:,}"
+
+
+def _format_rtc(value) -> str:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return "N/A"
+    return f"{value:.6f} RTC"
+
+
 # ---------------------------------------------------------------------------
 # API client
 # ---------------------------------------------------------------------------
@@ -148,7 +166,7 @@ async def cmd_health(interaction: discord.Interaction):
     )
     embed.add_field(name="Status", value="Online" if ok else "Offline", inline=True)
     embed.add_field(name="Version", value=version, inline=True)
-    embed.add_field(name="Uptime", value=f"{uptime:,}s (~{uptime // 3600}h)", inline=True)
+    embed.add_field(name="Uptime", value=_format_uptime(uptime), inline=True)
     embed.timestamp = datetime.now(timezone.utc)
     embed.set_footer(text=RUSTCHAIN_URL)
     await interaction.followup.send(embed=embed)
@@ -168,15 +186,15 @@ async def cmd_epoch(interaction: discord.Interaction):
 
     embed = discord.Embed(title="RustChain Epoch", color=discord.Color.blue())
     embed.add_field(name="Epoch", value=str(data.get("epoch", "?")), inline=True)
-    embed.add_field(name="Slot", value=f"{data.get('slot', 0):,}", inline=True)
-    embed.add_field(name="Height", value=f"{data.get('height', 0):,}", inline=True)
+    embed.add_field(name="Slot", value=_format_count(data.get("slot")), inline=True)
+    embed.add_field(name="Height", value=_format_count(data.get("height")), inline=True)
 
     if "blocks_per_epoch" in data:
         embed.add_field(name="Blocks/Epoch", value=str(data["blocks_per_epoch"]), inline=True)
     if "enrolled_miners" in data:
         embed.add_field(name="Enrolled Miners", value=str(data["enrolled_miners"]), inline=True)
     if "epoch_pot" in data:
-        embed.add_field(name="Epoch Pot", value=f"{data['epoch_pot']:.6f} RTC", inline=True)
+        embed.add_field(name="Epoch Pot", value=_format_rtc(data["epoch_pot"]), inline=True)
 
     embed.timestamp = datetime.now(timezone.utc)
     embed.set_footer(text=RUSTCHAIN_URL)
@@ -206,7 +224,7 @@ async def cmd_balance(interaction: discord.Interaction, miner_id: str):
 
     embed = discord.Embed(title="Wallet Balance", color=discord.Color.gold())
     embed.add_field(name="Miner", value=mid, inline=True)
-    embed.add_field(name="Balance", value=f"{amount:.6f} RTC", inline=True)
+    embed.add_field(name="Balance", value=_format_rtc(amount), inline=True)
     embed.timestamp = datetime.now(timezone.utc)
     embed.set_footer(text=RUSTCHAIN_URL)
     await interaction.followup.send(embed=embed)


### PR DESCRIPTION
## Summary
- Render missing or non-numeric Discord bot health uptime, epoch slot/height/pot, and balance amount values as N/A instead of crashing while building embeds.
- Keep normal numeric embed output unchanged.
- Add regression coverage for partial /health, /epoch, and /wallet/balance payloads using lightweight Discord/httpx stubs.

## Root cause
The Discord bot command handlers directly used numeric formatters and floor division on API response fields. Successful but partial payloads such as uptime_s null, slot null, epoch_pot null, or amount_rtc null raised TypeError before the bot could send its embed.

## Validation
- python3 -B -m pytest -q tests/test_discord_bot_commands.py --tb=short -p no:cacheprovider
- python3 -B -m py_compile tools/discord-bot/bot.py tests/test_discord_bot_commands.py
- git diff --check
- python3 tools/bcos_spdx_check.py --base-ref upstream/main

Bounty context: Scottcjn/Rustchain#305