### PR TITLE
fix: validate glitch register personality payloads

### DIFF
--- a/issue2288/glitch_system/src/api.py
+++ b/issue2288/glitch_system/src/api.py
@@ -7,11 +7,8 @@ and configuring the glitch engine.
 """
 
 from flask import Blueprint, jsonify, request, Response
-from typing import Dict, Any
 import hmac
-import json
 import os
-import time
 
 try:
     from .glitch_engine import GlitchEngine, GlitchConfig
@@ -183,10 +180,28 @@ def register_agent(agent_id: str) -> Response:
     template = data.get("template")
     personality_data = data.get("personality")
     
-    from .personality import PersonalityProfile
-    
     personality = None
+    if personality_data is not None and not isinstance(personality_data, dict):
+        return jsonify({"error": "personality must be an object"}), 400
     if personality_data:
+        try:
+            from .personality import CommunicationStyle, EmotionalRange, PersonalityProfile
+        except ImportError:
+            from personality import CommunicationStyle, EmotionalRange, PersonalityProfile
+
+        for nested_key in ("traits", "response_characteristics", "quirks", "metadata"):
+            if nested_key in personality_data and not isinstance(personality_data[nested_key], dict):
+                return jsonify({"error": f"personality.{nested_key} must be an object"}), 400
+        if (
+            "communication_style" in personality_data
+            and personality_data["communication_style"] not in {style.value for style in CommunicationStyle}
+        ):
+            return jsonify({"error": "invalid communication_style"}), 400
+        if (
+            "emotional_range" in personality_data
+            and personality_data["emotional_range"] not in {value.value for value in EmotionalRange}
+        ):
+            return jsonify({"error": "invalid emotional_range"}), 400
         personality = PersonalityProfile.from_dict(personality_data)
     
     persona = engine.register_agent(agent_id, personality, template)

--- a/tests/test_glitch_api_input_validation.py
+++ b/tests/test_glitch_api_input_validation.py
@@ -118,3 +118,26 @@ def test_process_accepts_valid_json_body(client):
         "processed": "processed:hello",
         "glitch_occurred": False,
     }
+
+
+@pytest.mark.parametrize(
+    "personality, expected_error",
+    (
+        (["bad"], "personality must be an object"),
+        ("bad", "personality must be an object"),
+        ({"traits": []}, "personality.traits must be an object"),
+        ({"response_characteristics": []}, "personality.response_characteristics must be an object"),
+        ({"quirks": []}, "personality.quirks must be an object"),
+        ({"metadata": []}, "personality.metadata must be an object"),
+        ({"communication_style": "bogus"}, "invalid communication_style"),
+        ({"emotional_range": "bogus"}, "invalid emotional_range"),
+    ),
+)
+def test_register_rejects_malformed_personality_payloads(client, personality, expected_error):
+    response = client.post(
+        "/api/glitch/agents/test-agent/register",
+        json={"personality": personality},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": expected_error}


### PR DESCRIPTION
## Summary
- reject malformed `personality` payloads on `/api/glitch/agents/<id>/register` before `PersonalityProfile.from_dict()` runs
- validate nested personality sections and enum fields so arrays/strings/bad enum values return JSON 400 responses instead of Flask 500s
- add regression coverage for malformed custom personality payloads

## Reproduction
Before this change, these requests returned 500 from `PersonalityProfile.from_dict()` or enum construction:

```python
client.post('/api/glitch/agents/bot/register', json={'personality': ['bad']})
client.post('/api/glitch/agents/bot/register', json={'personality': {'traits': []}})
client.post('/api/glitch/agents/bot/register', json={'personality': {'communication_style': 'bogus'}})
```

## Validation
- `python -m py_compile issue2288\glitch_system\src\api.py tests\test_glitch_api_input_validation.py`
- `uv run --no-project --with pytest --with flask python -m pytest tests\test_glitch_api_input_validation.py -q --noconftest -o addopts=''` -> 17 passed
- `uv run --no-project --with ruff python -m ruff check issue2288/glitch_system/src/api.py tests/test_glitch_api_input_validation.py` -> all checks passed
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check` -> clean
- direct Flask test-client probe confirmed malformed personality payloads now return HTTP 400 JSON instead of 500

Bounty context: Scottcjn/Rustchain#305
RTC wallet: `RTC9dc7130503bf246d9ca11e2c5b402d5129077f56`