### PR TITLE
fix: validate sync push payloads

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -179,11 +179,17 @@ def register_sync_endpoints(app, db_path, admin_key):
         if not data or not isinstance(data, dict):
             return jsonify({"error": "Invalid payload"}), 400
 
+        valid_tables = set(sync_manager.SYNC_TABLES)
+        for table, rows in data.items():
+            if table not in valid_tables:
+                return jsonify({"error": f"invalid table: {table}"}), 400
+            if not isinstance(rows, list):
+                return jsonify({"error": f"{table} rows must be an array"}), 400
+            if any(not isinstance(row, dict) for row in rows):
+                return jsonify({"error": f"{table} rows must be objects"}), 400
+
         success = True
         for table, rows in data.items():
-            if not isinstance(rows, list):
-                success = False
-                continue
             if not sync_manager.apply_sync_payload(table, rows):
                 success = False
 

--- a/node/tests/test_rustchain_sync_endpoints.py
+++ b/node/tests/test_rustchain_sync_endpoints.py
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: MIT
 
+import hashlib
+import hmac
+import json
 import os
 import sys
 
-from flask import Flask
 import pytest
+from flask import Flask
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -25,6 +28,13 @@ class DummySyncManager:
     def get_table_data(self, table, limit=200, offset=0):
         self.calls.append((table, limit, offset))
         return [{"table": table, "limit": limit, "offset": offset}]
+
+    def apply_sync_payload(self, table, rows):
+        self.calls.append((table, rows))
+        return True
+
+    def get_merkle_root(self):
+        return "test-merkle-root"
 
 
 def test_require_admin_uses_constant_time_compare(monkeypatch, tmp_path):
@@ -184,3 +194,59 @@ def test_sync_pull_rejects_unknown_table(monkeypatch, tmp_path):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "invalid table: unknown"}
+
+
+def _signed_sync_headers(body: bytes, secret: str = "sync-secret"):
+    peer_id = "peer-a"
+    timestamp = 1_700_000_000
+    nonce = hashlib.sha256(body).hexdigest()[:16]
+    body_hash = hashlib.sha256(body).hexdigest()
+    signing_payload = f"{peer_id}\n{timestamp}\n{nonce}\n{body_hash}".encode("utf-8")
+    signature = hmac.new(
+        secret.encode("utf-8"),
+        signing_payload,
+        hashlib.sha256,
+    ).hexdigest()
+    return {
+        "X-Admin-Key": secret,
+        "X-Peer-ID": peer_id,
+        "X-Sync-Timestamp": str(timestamp),
+        "X-Sync-Nonce": nonce,
+        "X-Sync-Signature": signature,
+    }
+
+
+def _post_sync_push(client, payload):
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return client.post(
+        "/api/sync/push",
+        data=body,
+        content_type="application/json",
+        headers=_signed_sync_headers(body),
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "error"),
+    [
+        ({"unknown": []}, "invalid table: unknown"),
+        ({"headers": {"bad": "shape"}}, "headers rows must be an array"),
+        ({"headers": ["not-a-row"]}, "headers rows must be objects"),
+    ],
+)
+def test_sync_push_rejects_malformed_table_payloads(monkeypatch, tmp_path, payload, error):
+    monkeypatch.setattr(rustchain_sync_endpoints, "RustChainSyncManager", DummySyncManager)
+    monkeypatch.setattr(rustchain_sync_endpoints.time, "time", lambda: 1_700_000_000.0)
+
+    app = Flask(__name__)
+    rustchain_sync_endpoints.register_sync_endpoints(
+        app,
+        str(tmp_path / "rustchain.db"),
+        "sync-secret",
+    )
+    client = app.test_client()
+
+    response = _post_sync_push(client, payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": error}

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -87,7 +87,7 @@ class MinerSetup:
                 result = subprocess.run(["sysctl", "hw.memsize"], capture_output=True, text=True)
                 if result.returncode == 0:
                     hardware_info["memory_mb"] = int(result.stdout.split(":")[1].strip()) // (1024 * 1024)
-        except:
+        except Exception:
             pass
             
         # Basic GPU detection
@@ -100,7 +100,7 @@ class MinerSetup:
                 result = subprocess.run(["wmic", "path", "win32_VideoController", "get", "name"], capture_output=True, text=True)
                 if result.returncode == 0 and len(result.stdout.strip().split('\n')) > 2:
                     hardware_info["gpu_available"] = True
-        except:
+        except Exception:
             pass
             
         self.log(f"CPU Cores: {hardware_info['cpu_cores']}")
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",


### PR DESCRIPTION
## Summary
- reject unknown /api/sync/push table names before sync application
- reject non-array table payloads and non-object row entries with deterministic 400 responses
- add signed sync-push route coverage for malformed payload shapes

## Tests
- uv run --no-project --with pytest --with flask python -m pytest node/tests/test_rustchain_sync_endpoints.py -q
- bounded py_compile check for node/rustchain_sync_endpoints.py and node/tests/test_rustchain_sync_endpoints.py
- uv run --no-project --with pytest --with flask python -m pytest tests/test_install_miner_checksums.py tests/test_setup_miner_downloads.py -q

Note: local ruff via uv previously hung in this environment, so focused tests and compile check were used for this narrow patch.