### PR TITLE
fix: validate beacon identity pubkeys

### DIFF
--- a/node/beacon_identity.py
+++ b/node/beacon_identity.py
@@ -183,11 +183,15 @@ def learn_key_from_envelope(
     if not agent_id or not pubkey_hex:
         return False, "missing_agent_id_or_pubkey"
 
-    # Verify agent_id is consistent with declared pubkey
+    # Verify agent_id is consistent with a valid Ed25519 public key.
     try:
-        expected_id = agent_id_from_pubkey(bytes.fromhex(pubkey_hex))
-    except ValueError:
+        pubkey_bytes = bytes.fromhex(pubkey_hex)
+    except (TypeError, ValueError):
         return False, "invalid_pubkey_encoding"
+    if len(pubkey_bytes) != 32:
+        return False, "invalid_pubkey_length"
+
+    expected_id = agent_id_from_pubkey(pubkey_bytes)
 
     if expected_id != agent_id:
         return False, "agent_id_pubkey_mismatch"

--- a/node/tests/test_beacon_identity.py
+++ b/node/tests/test_beacon_identity.py
@@ -166,6 +166,24 @@ class TestLearnKeyFromEnvelope:
         assert accepted is False
         assert reason == "invalid_pubkey_encoding"
 
+    def test_rejects_non_string_pubkey(self, init_db, db_path):
+        bi = init_db
+        envelope = {"agent_id": "bcn_000000000000", "pubkey": ["00"]}
+        accepted, reason = bi.learn_key_from_envelope(envelope, db_path)
+        assert accepted is False
+        assert reason == "invalid_pubkey_encoding"
+
+    def test_rejects_wrong_length_pubkey(self, init_db, db_path):
+        bi = init_db
+        pubkey_bytes = b"\x01" * 31
+        agent_id = bi.agent_id_from_pubkey(pubkey_bytes)
+
+        envelope = {"agent_id": agent_id, "pubkey": pubkey_bytes.hex()}
+        accepted, reason = bi.learn_key_from_envelope(envelope, db_path)
+
+        assert accepted is False
+        assert reason == "invalid_pubkey_length"
+
     def test_rejects_mismatched_agent_id(self, init_db, db_path):
         bi = init_db
         wrong_agent = "bcn_000000000000"

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -87,7 +87,7 @@ class MinerSetup:
                 result = subprocess.run(["sysctl", "hw.memsize"], capture_output=True, text=True)
                 if result.returncode == 0:
                     hardware_info["memory_mb"] = int(result.stdout.split(":")[1].strip()) // (1024 * 1024)
-        except:
+        except Exception:
             pass
             
         # Basic GPU detection
@@ -100,7 +100,7 @@ class MinerSetup:
                 result = subprocess.run(["wmic", "path", "win32_VideoController", "get", "name"], capture_output=True, text=True)
                 if result.returncode == 0 and len(result.stdout.strip().split('\n')) > 2:
                     hardware_info["gpu_available"] = True
-        except:
+        except Exception:
             pass
             
         self.log(f"CPU Cores: {hardware_info['cpu_cores']}")
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",


### PR DESCRIPTION
## Summary
- reject non-string/non-hex beacon identity pubkeys without raising TypeError
- require TOFU envelope pubkeys to decode to exactly 32 bytes before deriving the Beacon agent ID
- add regression coverage for malformed and wrong-length pubkey payloads

## Tests
- PYTHONPATH=node uv run --no-project --with pytest --with flask --with cryptography python -m pytest node/tests/test_beacon_identity.py -q
- bounded py_compile check for node/beacon_identity.py and node/tests/test_beacon_identity.py
- uv run --no-project --with pytest --with flask python -m pytest tests/test_install_miner_checksums.py tests/test_setup_miner_downloads.py -q

Note: local ruff via uv previously hung in this environment, so focused tests and compile check were used for this narrow patch.