### PR TITLE
Fix quickstart FAQ troubleshooting link

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -415,7 +415,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 - **GitHub Issues:** https://github.com/Scottcjn/Rustchain/issues
 - **Discord:** https://discord.gg/VqVVS2CW9Q
 - **Moltbook:** https://www.moltbook.com/m/rustchain
-- **FAQ:** [FAQ_TROUBLESHOOTING.md](FAQ_TROUBLESHOOTING.md)
+- **FAQ:** [FAQ_TROUBLESHOOTING.md](./FAQ_TROUBLESHOOTING.md)
 
 ---
 


### PR DESCRIPTION
Fixes #5715.\n\n## Summary\n- Prefix the FAQ troubleshooting link in docs/QUICKSTART.md with ./ so it resolves within docs/.\n\n## Verification\n- git diff --check