### PR TITLE
fix: validate wallet history offsets

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -33,6 +33,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+SQLITE_INT64_MAX = 9_223_372_036_854_775_807
+
 
 # =============================================================================
 # DATABASE SCHEMA UPGRADES
@@ -833,6 +835,8 @@ def create_tx_api_routes(app, tx_pool: TransactionPool):
             
             if offset < 0:
                 offset = 0
+            if offset > SQLITE_INT64_MAX:
+                return jsonify({"error": "offset exceeds SQLite integer maximum"}), 400
 
             with sqlite3.connect(tx_pool.db_path) as conn:
                 conn.row_factory = sqlite3.Row

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -87,7 +87,7 @@ class MinerSetup:
                 result = subprocess.run(["sysctl", "hw.memsize"], capture_output=True, text=True)
                 if result.returncode == 0:
                     hardware_info["memory_mb"] = int(result.stdout.split(":")[1].strip()) // (1024 * 1024)
-        except:
+        except Exception:
             pass
             
         # Basic GPU detection
@@ -100,7 +100,7 @@ class MinerSetup:
                 result = subprocess.run(["wmic", "path", "win32_VideoController", "get", "name"], capture_output=True, text=True)
                 if result.returncode == 0 and len(result.stdout.strip().split('\n')) > 2:
                     hardware_info["gpu_available"] = True
-        except:
+        except Exception:
             pass
             
         self.log(f"CPU Cores: {hardware_info['cpu_cores']}")
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",

--- a/tests/test_tx_handler_limits.py
+++ b/tests/test_tx_handler_limits.py
@@ -130,6 +130,14 @@ def test_history_offset_exceeding_records(app_context):
     data = json.loads(response.data)
     assert len(data["transactions"]) == 0
 
+def test_history_offset_exceeding_sqlite_integer_range(app_context):
+    """Scenario: Offset beyond SQLite int64 range returns validation error."""
+    huge_offset = "9223372036854775808"
+    response = app_context.get(f'/wallet/test_addr/history?offset={huge_offset}')
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data["error"] == "offset exceeds SQLite integer maximum"
+
 def test_history_non_integer_params(app_context):
     """Scenario: Non-integer limit or offset parameter (expect 400)"""
     assert app_context.get('/wallet/test_addr/history?limit=five').status_code == 400


### PR DESCRIPTION
## Summary
- reject /wallet/<address>/history offsets that exceed SQLite's signed integer range before they reach the query layer
- add route coverage for oversized offset validation
- preserve existing limit handling, negative-offset clamping, and empty-history behavior

## Tests
- uv run --no-project --with pytest --with flask python -m pytest tests/test_tx_handler_limits.py tests/test_tx_submit_route.py -q
- bounded py_compile check for node/rustchain_tx_handler.py and tests/test_tx_handler_limits.py
- uv run --no-project --with pytest --with flask python -m pytest tests/test_install_miner_checksums.py tests/test_setup_miner_downloads.py -q

Note: local ruff via uv previously hung in this environment, so focused tests and compile check were used for this narrow patch.