### PR TITLE
fix: clamp claim history limits

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -616,6 +616,13 @@ def get_claim_history(
         }
     """
     try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = 20
+    if limit < 0:
+        limit = 0
+
+    try:
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -87,7 +87,7 @@ class MinerSetup:
                 result = subprocess.run(["sysctl", "hw.memsize"], capture_output=True, text=True)
                 if result.returncode == 0:
                     hardware_info["memory_mb"] = int(result.stdout.split(":")[1].strip()) // (1024 * 1024)
-        except:
+        except Exception:
             pass
             
         # Basic GPU detection
@@ -100,7 +100,7 @@ class MinerSetup:
                 result = subprocess.run(["wmic", "path", "win32_VideoController", "get", "name"], capture_output=True, text=True)
                 if result.returncode == 0 and len(result.stdout.strip().split('\n')) > 2:
                     hardware_info["gpu_available"] = True
-        except:
+        except Exception:
             pass
             
         self.log(f"CPU Cores: {hardware_info['cpu_cores']}")
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",

--- a/tests/test_claims_integration.py
+++ b/tests/test_claims_integration.py
@@ -263,6 +263,36 @@ class TestEndToEndClaimFlow:
         assert history["total_claimed_urtc"] == final_status["reward_urtc"]
         assert len(history["claims"]) == 1
         assert history["claims"][0]["status"] == "settled"
+
+    def test_claim_history_negative_limit_returns_no_rows(self, integration_db, current_ts):
+        """Negative limits must not ask SQLite for an unlimited result set."""
+        miner_id = "test-miner-history-limit"
+
+        with sqlite3.connect(integration_db) as conn:
+            for index in range(3):
+                conn.execute("""
+                    INSERT INTO claims (
+                        claim_id, miner_id, epoch, wallet_address,
+                        reward_urtc, status, submitted_at, signature,
+                        public_key, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?, ?)
+                """, (
+                    f"claim-history-limit-{index}",
+                    miner_id,
+                    index,
+                    "RTC1HistoryLimitWallet12345",
+                    100,
+                    current_ts + index,
+                    "mock_signature",
+                    "mock_public_key",
+                    current_ts,
+                    current_ts,
+                ))
+
+        history = get_claim_history(integration_db, miner_id, limit=-1)
+
+        assert history["total_claims"] == 3
+        assert history["claims"] == []
     
     def test_claim_rejection_flow(self, integration_db, current_ts, current_slot):
         """Test: Submit → Verify → Reject"""


### PR DESCRIPTION
## Summary
- clamp negative claim history limits to zero before issuing SQLite LIMIT queries
- add regression coverage that preserves total claim counts without returning unlimited rows

## Verification
- `uv run --no-project --with pytest --with flask --with pynacl python -m pytest tests/test_claims_integration.py -q`
- `uv run --no-project python -m py_compile node/claims_submission.py tests/test_claims_integration.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.