### PR TITLE
fix: clamp settlement claim limits

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -49,6 +49,15 @@ class TransactionFailedError(SettlementError):
     pass
 
 
+def _normalize_claim_limit(max_claims: int, default: int = 100) -> int:
+    """Return a non-negative SQLite LIMIT value for claim batch queries."""
+    try:
+        max_claims = int(max_claims)
+    except (TypeError, ValueError):
+        max_claims = default
+    return max(0, max_claims)
+
+
 def get_pending_claims(
     db_path: str,
     max_claims: int = 100
@@ -59,6 +68,8 @@ def get_pending_claims(
     Returns:
         List of claim records sorted by submission time
     """
+    max_claims = _normalize_claim_limit(max_claims)
+
     try:
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row
@@ -334,6 +345,8 @@ def reserve_claims_for_settlement(
     to overwrite the final transaction hash.  SQLite serializes BEGIN IMMEDIATE
     transactions, so each approved claim can move into at most one batch.
     """
+    max_claims = _normalize_claim_limit(max_claims)
+
     conn = sqlite3.connect(db_path, timeout=30, isolation_level=None)
     conn.row_factory = sqlite3.Row
     try:
@@ -614,6 +627,8 @@ def process_claims_batch(
         "failed_count": 0,
         "error": None
     }
+
+    max_claims = _normalize_claim_limit(max_claims)
     
     # Get pending claims for dry-run/batch-condition reporting.  Non-dry-run
     # processing reserves rows atomically after the batch id is generated.

--- a/node/tests/test_claims_settlement_reservation.py
+++ b/node/tests/test_claims_settlement_reservation.py
@@ -203,3 +203,46 @@ def test_concurrent_workers_atomically_reserve_rewards_pool_funds(tmp_path, monk
             "Insufficient funds: need 2100 (1000 claims + 1100 fee), have 0",
         )
     ]
+
+
+def test_negative_max_claims_does_not_reserve_unbounded_batch(tmp_path, monkeypatch):
+    db_path = str(tmp_path / "claims.db")
+    _init_db(db_path)
+    _insert_claim(db_path, "claim-0", 1000, 1)
+    _insert_claim(db_path, "claim-1", 1000, 2)
+    _insert_claim(db_path, "claim-2", 1000, 3)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO rewards_pool (pool_name, balance_urtc) VALUES ('epoch_rewards', 10000)"
+        )
+
+    broadcasts = []
+    monkeypatch.setattr(
+        claims_settlement,
+        "sign_and_broadcast_transaction",
+        lambda tx_data, db_path: broadcasts.append(tx_data) or (True, "0xabc", None),
+    )
+
+    result = claims_settlement.process_claims_batch(
+        db_path,
+        max_claims=-1,
+        min_batch_size=1,
+        max_wait_seconds=0,
+    )
+
+    assert result["processed"] is False
+    assert result["error"] == "Batch conditions not met"
+    assert result["batch_id"] is None
+    assert broadcasts == []
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT claim_id, status, settlement_batch FROM claims ORDER BY submitted_at"
+        ).fetchall()
+
+    assert rows == [
+        ("claim-0", "approved", None),
+        ("claim-1", "approved", None),
+        ("claim-2", "approved", None),
+    ]

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -87,7 +87,7 @@ class MinerSetup:
                 result = subprocess.run(["sysctl", "hw.memsize"], capture_output=True, text=True)
                 if result.returncode == 0:
                     hardware_info["memory_mb"] = int(result.stdout.split(":")[1].strip()) // (1024 * 1024)
-        except:
+        except Exception:
             pass
             
         # Basic GPU detection
@@ -100,7 +100,7 @@ class MinerSetup:
                 result = subprocess.run(["wmic", "path", "win32_VideoController", "get", "name"], capture_output=True, text=True)
                 if result.returncode == 0 and len(result.stdout.strip().split('\n')) > 2:
                     hardware_info["gpu_available"] = True
-        except:
+        except Exception:
             pass
             
         self.log(f"CPU Cores: {hardware_info['cpu_cores']}")
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",


### PR DESCRIPTION
## Summary
- normalize settlement claim limits before preview and reservation queries
- prevent negative `max_claims` from becoming an unbounded SQLite settlement batch
- add regression coverage that confirms claims remain approved and no broadcast occurs

## Verification
- `uv run --no-project --with pytest python -m pytest node/tests/test_claims_settlement_reservation.py -q`
- `uv run --no-project python -m py_compile node/claims_settlement.py node/tests/test_claims_settlement_reservation.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.