### PR TITLE
fix: use urtc units in claim eligibility

### DIFF
--- a/node/claims_eligibility.py
+++ b/node/claims_eligibility.py
@@ -67,6 +67,8 @@ try:
 except ImportError:
     PER_EPOCH_URTC = 150_000_000  # 1.5 RTC in uRTC (default)
 
+URTC_PER_RTC = 1_000_000
+
 
 class ClaimsEligibilityError(Exception):
     """Base exception for claims eligibility errors"""
@@ -612,7 +614,7 @@ def check_claim_eligibility(
     # Calculate reward amount
     reward_urtc = calculate_epoch_reward(db_path, miner_id, epoch, current_slot)
     result["reward_urtc"] = reward_urtc
-    result["reward_rtc"] = reward_urtc / 100_000_000
+    result["reward_rtc"] = reward_urtc / URTC_PER_RTC
     
     # All checks passed
     result["eligible"] = True
@@ -727,7 +729,7 @@ def get_eligible_epochs(
         "miner_id": miner_id,
         "epochs": eligible_epochs,
         "total_unclaimed_urtc": total_unclaimed,
-        "total_unclaimed_rtc": total_unclaimed / 100_000_000
+        "total_unclaimed_rtc": total_unclaimed / URTC_PER_RTC
     }
 
 

--- a/node/tests/test_claims_eligibility_helpers.py
+++ b/node/tests/test_claims_eligibility_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import claims_eligibility
 from claims_eligibility import (
     BLOCK_TIME,
     GENESIS_TIMESTAMP,
@@ -114,3 +115,38 @@ def test_is_epoch_settled_uses_database_state_when_present(tmp_path):
 
     assert is_epoch_settled(str(db), 3, current_slot=10_000) is False
     assert is_epoch_settled(str(db), 4, current_slot=10_000) is True
+
+
+def test_check_claim_eligibility_reports_rtc_with_urtc_unit(monkeypatch):
+    monkeypatch.setattr(claims_eligibility, "is_epoch_settled", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        claims_eligibility,
+        "get_miner_attestation",
+        lambda *args, **kwargs: {
+            "last_seen_ts": GENESIS_TIMESTAMP,
+            "device_arch": "modern",
+        },
+    )
+    monkeypatch.setattr(claims_eligibility, "get_chain_age_years", lambda current_slot: 0)
+    monkeypatch.setattr(claims_eligibility, "get_time_aged_multiplier", lambda *args: 1.0)
+    monkeypatch.setattr(
+        claims_eligibility,
+        "check_epoch_participation",
+        lambda *args, **kwargs: (True, {"fingerprint_passed": 1, "entropy_score": 0.5}),
+    )
+    monkeypatch.setattr(claims_eligibility, "get_wallet_address", lambda *args: "RTC" + "A" * 20)
+    monkeypatch.setattr(claims_eligibility, "check_pending_claim", lambda *args: False)
+    monkeypatch.setattr(claims_eligibility, "HAVE_FLEET_IMMUNE", False)
+    monkeypatch.setattr(claims_eligibility, "calculate_epoch_reward", lambda *args: 1_500_000)
+
+    result = claims_eligibility.check_claim_eligibility(
+        db_path="unused.db",
+        miner_id="miner1",
+        epoch=1,
+        current_slot=10_000,
+        current_ts=GENESIS_TIMESTAMP,
+    )
+
+    assert result["eligible"] is True
+    assert result["reward_urtc"] == 1_500_000
+    assert result["reward_rtc"] == 1.5

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -185,7 +185,7 @@ class RustChainMiner:
         try:
             with open(config_file, 'r') as f:
                 return json.load(f)
-        except:
+        except Exception:
             return {
                 "threads": 1,
                 "wallet_address": "RTC_DEFAULT_WALLET",


### PR DESCRIPTION
## Summary
- use the project-wide uRTC conversion unit when claims eligibility reports RTC amounts
- keep total unclaimed RTC summaries consistent with claim submission responses
- add regression coverage for eligibility reward display units

## Verification
- `uv run --no-project --with pytest python -m pytest node/tests/test_claims_eligibility_helpers.py -q`
- `uv run --no-project python -m py_compile node/claims_eligibility.py node/tests/test_claims_eligibility_helpers.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.