### PR TITLE
fix: validate ROM fingerprint shapes

### DIFF
--- a/node/rom_clustering_server.py
+++ b/node/rom_clustering_server.py
@@ -181,8 +181,17 @@ class ROMClusteringServer:
         Returns:
             (is_valid, reason, details)
         """
+        if not isinstance(miner_id, str) or not miner_id.strip():
+            return False, "invalid_rom_report", {"field": "miner_id"}
+        if not isinstance(rom_hash, str) or not rom_hash.strip():
+            return False, "invalid_rom_report", {"field": "rom_hash"}
+        if not isinstance(hash_type, str) or not hash_type.strip():
+            return False, "invalid_rom_report", {"field": "hash_type"}
+
         now = int(time.time())
-        rom_hash_lower = rom_hash.lower()
+        miner_id = miner_id.strip()
+        rom_hash_lower = rom_hash.strip().lower()
+        hash_type = hash_type.strip().lower()
 
         conn = self._get_conn()
         cur = conn.cursor()
@@ -390,16 +399,29 @@ def integrate_with_attestation(
     """
     miner_id = attestation_data.get("miner_id") or attestation_data.get("miner")
     fingerprint = attestation_data.get("fingerprint", {})
+    if not isinstance(fingerprint, dict):
+        return False, "invalid_fingerprint"
 
     # Check if fingerprint includes ROM data
-    rom_check = fingerprint.get("checks", {}).get("rom_fingerprint", {})
+    checks = fingerprint.get("checks", {})
+    if not isinstance(checks, dict):
+        return False, "invalid_fingerprint_checks"
+
+    rom_check = checks.get("rom_fingerprint", {})
+    if "rom_fingerprint" in checks and not isinstance(rom_check, dict):
+        return False, "invalid_rom_fingerprint"
 
     if not rom_check or rom_check.get("skipped"):
         # No ROM data reported - OK for modern hardware
         return True, "no_rom_data"
 
     rom_data = rom_check.get("data", {})
+    if not isinstance(rom_data, dict):
+        return False, "invalid_rom_fingerprint_data"
+
     rom_hashes = rom_data.get("rom_hashes", {})
+    if not isinstance(rom_hashes, dict):
+        return False, "invalid_rom_hashes"
 
     # Process each reported ROM hash
     for platform, rom_hash in rom_hashes.items():

--- a/node/tests/test_rom_clustering_server.py
+++ b/node/tests/test_rom_clustering_server.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from rom_clustering_server import ROMClusteringServer, init_rom_tables
+from rom_clustering_server import (
+    ROMClusteringServer,
+    init_rom_tables,
+    integrate_with_attestation,
+)
 
 
 def test_rom_cluster_upsert_keeps_one_row_per_rom_hash(tmp_path):
@@ -158,3 +162,43 @@ def test_init_rom_tables_merges_partial_legacy_duplicate_cluster_miners(tmp_path
     assert json.loads(row[2]) == ["miner-a", "miner-b", "miner-c"]
     assert row[3:] == (10, 30)
     assert flag_cluster_id == row[0]
+
+
+def test_process_rom_report_rejects_non_string_rom_hash(tmp_path):
+    db_path = str(tmp_path / "roms.db")
+    server = ROMClusteringServer(db_path)
+
+    result = server.process_rom_report("miner-1", {"hash": "ab" * 20})
+
+    assert result == (False, "invalid_rom_report", {"field": "rom_hash"})
+
+
+def test_integrate_with_attestation_rejects_malformed_fingerprint_shapes(tmp_path):
+    db_path = str(tmp_path / "roms.db")
+    server = ROMClusteringServer(db_path)
+
+    assert integrate_with_attestation(
+        {"miner_id": "miner-1", "fingerprint": []},
+        server,
+    ) == (False, "invalid_fingerprint")
+    assert integrate_with_attestation(
+        {"miner_id": "miner-1", "fingerprint": {"checks": []}},
+        server,
+    ) == (False, "invalid_fingerprint_checks")
+    assert integrate_with_attestation(
+        {"miner_id": "miner-1", "fingerprint": {"checks": {"rom_fingerprint": []}}},
+        server,
+    ) == (False, "invalid_rom_fingerprint")
+    assert integrate_with_attestation(
+        {
+            "miner_id": "miner-1",
+            "fingerprint": {
+                "checks": {
+                    "rom_fingerprint": {
+                        "data": {"rom_hashes": []},
+                    },
+                },
+            },
+        },
+        server,
+    ) == (False, "invalid_rom_hashes")


### PR DESCRIPTION
## Summary
- reject malformed ROM report fields before normalizing or storing them
- validate attestation fingerprint/check/ROM hash container shapes before reading nested values
- add regression coverage for non-string ROM hashes and malformed fingerprint payloads

## Verification
- `uv run --no-project --with pytest python -m pytest node/tests/test_rom_clustering_server.py -q`
- `uv run --no-project python -m py_compile node/rom_clustering_server.py node/tests/test_rom_clustering_server.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.