### PR TITLE
fix: validate secure p2p block shapes

### DIFF
--- a/node/rustchain_p2p_sync_secure.py
+++ b/node/rustchain_p2p_sync_secure.py
@@ -215,6 +215,9 @@ class BlockValidator:
         Returns: (is_valid, error_message)
         """
         try:
+            if not isinstance(block_data, dict):
+                return False, "Block must be a JSON object"
+
             # 1. Check required fields
             required_fields = ['block_index', 'hash', 'previous_hash', 'timestamp', 'miner', 'transactions']
             for field in required_fields:
@@ -232,9 +235,13 @@ class BlockValidator:
                 return False, "Block timestamp in future"
 
             # 4. Validate transactions
-            for tx in block_data.get('transactions', []):
+            transactions = block_data.get('transactions', [])
+            if not isinstance(transactions, list):
+                return False, "Block transactions must be a list"
+            for tx in transactions:
                 if not self._validate_transaction(tx):
-                    return False, f"Invalid transaction: {tx.get('tx_hash', 'unknown')}"
+                    tx_hash = tx.get('tx_hash', 'unknown') if isinstance(tx, dict) else 'unknown'
+                    return False, f"Invalid transaction: {tx_hash}"
 
             # NEW: Verify producer signature
             if not self._verify_block_signature(block_data):
@@ -265,6 +272,8 @@ class BlockValidator:
 
     def _validate_transaction(self, tx: Dict) -> bool:
         """Validate transaction structure"""
+        if not isinstance(tx, dict):
+            return False
         required_tx_fields = ['tx_hash', 'sender', 'recipient', 'amount_nano']
         return all(field in tx for field in required_tx_fields)
 

--- a/node/tests/test_p2p_sync_secure_validator.py
+++ b/node/tests/test_p2p_sync_secure_validator.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rustchain_p2p_sync_secure import BlockValidator
+
+
+def _validator_with_hash_and_signature_bypassed():
+    validator = BlockValidator()
+    validator._validate_block_hash = lambda block: True
+    validator._verify_block_signature = lambda block: True
+    validator._verify_miner_pubkey_match = lambda block: True
+    return validator
+
+
+def _valid_block(**overrides):
+    block = {
+        "block_index": 1,
+        "hash": "abc",
+        "previous_hash": "0" * 64,
+        "timestamp": 1,
+        "miner": "RTC" + "a" * 40,
+        "transactions": [],
+        "signature": "00",
+        "pubkey_hex": "11",
+        "message_hex": "22",
+    }
+    block.update(overrides)
+    return block
+
+
+def test_validate_block_rejects_non_object_block():
+    validator = _validator_with_hash_and_signature_bypassed()
+
+    valid, reason = validator.validate_block(["not", "a", "block"])
+
+    assert valid is False
+    assert reason == "Block must be a JSON object"
+
+
+def test_validate_block_rejects_non_list_transactions():
+    validator = _validator_with_hash_and_signature_bypassed()
+
+    valid, reason = validator.validate_block(_valid_block(transactions={"tx_hash": "tx1"}))
+
+    assert valid is False
+    assert reason == "Block transactions must be a list"
+
+
+def test_validate_block_rejects_non_object_transaction_without_exception():
+    validator = _validator_with_hash_and_signature_bypassed()
+
+    valid, reason = validator.validate_block(_valid_block(transactions=["tx1"]))
+
+    assert valid is False
+    assert reason == "Invalid transaction: unknown"


### PR DESCRIPTION
## Summary
- reject non-object secure P2P block payloads before required-field validation
- reject non-list transaction containers and non-object transaction entries deterministically
- add focused validator tests that bypass hash/signature checks to cover only payload-shape handling

## Verification
- `uv run --no-project --with pytest --with requests --with flask --with cryptography python -m pytest node/tests/test_p2p_sync_secure_validator.py -q`
- `uv run --no-project --with requests --with flask --with cryptography python -m py_compile node/rustchain_p2p_sync_secure.py node/tests/test_p2p_sync_secure_validator.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.