### PR TITLE
fix: validate poa hardware payloads

### DIFF
--- a/node/rip_proof_of_antiquity_hardware.py
+++ b/node/rip_proof_of_antiquity_hardware.py
@@ -53,7 +53,23 @@ def calculate_shannon_entropy(data: bytes) -> float:
 
 def analyze_cpu_timing(signals: Dict) -> Dict:
     """Analyze CPU timing characteristics from attestation signals"""
+    if not isinstance(signals, dict):
+        return {
+            "valid": False,
+            "reason": "invalid_signals",
+            "tier": "modern",
+            "confidence": 0.0
+        }
+
     timing = signals.get("cpu_timing", {})
+    if not isinstance(timing, dict):
+        return {
+            "valid": False,
+            "reason": "invalid_cpu_timing",
+            "tier": "modern",
+            "confidence": 0.0
+        }
+
     samples = timing.get("samples", [])
 
     if not samples or len(samples) < 10:
@@ -117,7 +133,12 @@ def analyze_cpu_timing(signals: Dict) -> Dict:
 
 def analyze_ram_patterns(signals: Dict) -> Dict:
     """Analyze RAM access patterns"""
+    if not isinstance(signals, dict):
+        return {"valid": False, "reason": "invalid_signals"}
+
     ram = signals.get("ram_timing", {})
+    if not isinstance(ram, dict):
+        return {"valid": False, "reason": "invalid_ram_timing"}
 
     if not ram:
         return {"valid": False, "reason": "no_ram_data"}
@@ -148,6 +169,9 @@ def analyze_ram_patterns(signals: Dict) -> Dict:
 
 def calculate_entropy_score(signals: Dict) -> float:
     """Calculate hardware entropy score from attestation signals (0.0 to 1.0)"""
+    if not isinstance(signals, dict):
+        return 0.0
+
     score = 0.0
 
     # 1. Shannon entropy of provided samples (40%)
@@ -181,6 +205,11 @@ def calculate_entropy_score(signals: Dict) -> float:
 
 def validate_hardware_proof(signals: Dict, claimed_arch: str) -> Tuple[bool, Dict]:
     """Comprehensive hardware proof validation"""
+    if not isinstance(signals, dict):
+        signals = {}
+    if not isinstance(claimed_arch, str):
+        claimed_arch = "unknown"
+
     analysis = {
         "entropy_score": 0.0,
         "cpu_timing": {},
@@ -240,8 +269,24 @@ def get_antiquity_multiplier(tier: str) -> float:
 
 def server_side_validation(data: Dict) -> Tuple[bool, Dict]:
     """Server-side validation for /attest/submit endpoint"""
+    if not isinstance(data, dict):
+        return False, {
+            "accepted": False,
+            "entropy_score": 0.0,
+            "antiquity_tier": "modern",
+            "reward_multiplier": get_antiquity_multiplier("modern"),
+            "confidence": 0.0,
+            "warnings": ["invalid_payload"],
+            "reason": "invalid_payload",
+        }
+
     device = data.get("device", {})
+    if not isinstance(device, dict):
+        device = {}
+
     signals = data.get("signals", {})
+    if not isinstance(signals, dict):
+        signals = {}
 
     claimed_arch = device.get("arch", "unknown")
     claimed_family = device.get("family", "unknown")

--- a/node/tests/test_poa_hardware_validation.py
+++ b/node/tests/test_poa_hardware_validation.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rip_proof_of_antiquity_hardware import (
+    analyze_cpu_timing,
+    analyze_ram_patterns,
+    calculate_entropy_score,
+    server_side_validation,
+)
+
+
+def test_server_side_validation_rejects_non_object_payload():
+    valid, result = server_side_validation(["not", "an", "object"])
+
+    assert valid is False
+    assert result["accepted"] is False
+    assert result["reason"] == "invalid_payload"
+    assert result["warnings"] == ["invalid_payload"]
+
+
+def test_server_side_validation_handles_malformed_device_and_signals():
+    valid, result = server_side_validation({
+        "device": ["not", "an", "object"],
+        "signals": ["not", "an", "object"],
+    })
+
+    assert valid is False
+    assert result["accepted"] is False
+    assert result["reason"] == "hardware_proof_insufficient"
+    assert "cpu_timing_invalid" in result["warnings"]
+    assert "ram_timing_missing" in result["warnings"]
+
+
+def test_signal_analyzers_reject_non_object_shapes():
+    assert analyze_cpu_timing([])["reason"] == "invalid_signals"
+    assert analyze_cpu_timing({"cpu_timing": []})["reason"] == "invalid_cpu_timing"
+    assert analyze_ram_patterns([])["reason"] == "invalid_signals"
+    assert analyze_ram_patterns({"ram_timing": []})["reason"] == "invalid_ram_timing"
+    assert calculate_entropy_score([]) == 0.0


### PR DESCRIPTION
## Summary
- reject non-object PoA hardware attestation payloads deterministically
- normalize malformed device/signals containers before entropy, CPU timing, and RAM timing analysis
- add focused tests for malformed payload and signal shapes

## Verification
- `uv run --no-project --with pytest python -m pytest node/tests/test_poa_hardware_validation.py -q`
- `uv run --no-project python -m py_compile node/rip_proof_of_antiquity_hardware.py node/tests/test_poa_hardware_validation.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.