### PR TITLE
Make setup_miner.py help non-mutating

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -6,6 +6,7 @@ Automated setup for RustChain Universal Miner
 
 import os
 import sys
+import argparse
 import subprocess
 import platform
 import json
@@ -30,6 +31,15 @@ MINER_ARTIFACTS = {
         "sha256": "5b69ebc210e4e8e32975b711dcb1ca08e07b731ddfe4f9f2f9a7e68c1e246a9d",
     },
 }
+
+
+def build_arg_parser():
+    """Build the setup script CLI parser."""
+    return argparse.ArgumentParser(
+        prog="setup_miner.py",
+        description="Install and configure a RustChain miner for the current platform.",
+    )
+
 
 class MinerSetup:
     def __init__(self):
@@ -405,6 +415,13 @@ WantedBy=multi-user.target
             self.log(f"Setup failed: {e}")
             sys.exit(1)
 
-if __name__ == "__main__":
+def main(argv=None):
+    parser = build_arg_parser()
+    parser.parse_args(sys.argv[1:] if argv is None else argv)
     setup = MinerSetup()
     setup.run_setup()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_setup_miner_downloads.py
+++ b/tests/test_setup_miner_downloads.py
@@ -1,5 +1,8 @@
 import hashlib
+import os
 from pathlib import Path
+import subprocess
+import sys
 
 import setup_miner
 
@@ -34,3 +37,35 @@ def test_setup_miner_downloads_current_verified_artifact():
     assert "urlparse(miner_url)" in source
     assert "hashlib.sha256(content).hexdigest()" in source
     assert "create_local_miner(miner_file)" not in source
+
+
+def test_setup_miner_help_is_non_mutating(tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "setup_miner.py"), "--help"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "usage: setup_miner.py" in result.stdout
+    assert not (tmp_path / "rustchain_miner").exists()
+
+
+def test_setup_miner_rejects_unknown_args_before_setup(tmp_path):
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "setup_miner.py"), "--unknown"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 2
+    assert "unrecognized arguments: --unknown" in result.stderr
+    assert not (tmp_path / "rustchain_miner").exists()


### PR DESCRIPTION
## Summary

Fixes #5985 by parsing CLI arguments before the setup flow starts.

Changes:

- add an argparse parser for `setup_miner.py`
- make `python3 setup_miner.py --help` print usage and exit before setup work
- reject unknown arguments before creating directories or downloading miner artifacts
- add regression tests that run the script with a temporary HOME and confirm no `rustchain_miner` directory is created

## Verification

- `tmp_home=$(mktemp -d) && HOME="$tmp_home" python3 setup_miner.py --help ...` confirmed no setup directory is created
- `tmp_home=$(mktemp -d) && HOME="$tmp_home" python3 setup_miner.py --unknown ...` exits 2 before setup work
- `python3 -m py_compile setup_miner.py tests/test_setup_miner_downloads.py`
- `uv run --with pytest --with flask pytest tests/test_setup_miner_downloads.py` → 5 passed
- `git diff --check`
