### PR TITLE
fix: validate beacon anchor fields

### DIFF
--- a/node/beacon_anchor.py
+++ b/node/beacon_anchor.py
@@ -54,6 +54,18 @@ def _canonical_signing_payload(envelope: dict) -> bytes:
     ).encode("utf-8")
 
 
+def _invalid_text_fields(envelope: dict, fields: tuple[str, ...]) -> list[str]:
+    """Return required fields whose values are present but not non-empty strings."""
+    invalid = []
+    for field in fields:
+        value = envelope.get(field)
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str):
+            invalid.append(field)
+    return invalid
+
+
 def _ensure_payload_hash_version_column(conn: sqlite3.Connection):
     """
     Preserve existing hashes as legacy version 1 and mark new hashes as version 2.
@@ -90,6 +102,9 @@ def verify_envelope_signature(envelope: dict) -> tuple[bool, str]:
     sig_hex = envelope.get("sig", "")
     pubkey_hex = envelope.get("pubkey", "")
     agent_id = envelope.get("agent_id", "")
+
+    if _invalid_text_fields(envelope, ("sig", "pubkey", "agent_id")):
+        return False, "invalid_signature_fields"
 
     if not all([sig_hex, pubkey_hex, agent_id]):
         return False, "missing_signature_fields"
@@ -159,6 +174,10 @@ def store_envelope(envelope: dict, db_path=DB_PATH) -> dict:
     nonce = envelope.get("nonce", "")
     sig = envelope.get("sig", "")
     pubkey = envelope.get("pubkey", "")
+
+    invalid_fields = _invalid_text_fields(envelope, REQUIRED_ENVELOPE_FIELDS)
+    if invalid_fields:
+        return {"ok": False, "error": f"invalid_field:{invalid_fields[0]}"}
 
     if not all(envelope.get(field, "") for field in REQUIRED_ENVELOPE_FIELDS):
         return {"ok": False, "error": "missing_fields"}

--- a/node/tests/test_beacon_anchor_field_validation.py
+++ b/node/tests/test_beacon_anchor_field_validation.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from beacon_anchor import store_envelope, verify_envelope_signature
+
+
+def _envelope(**overrides):
+    envelope = {
+        "agent_id": "bcn_test",
+        "kind": "hello",
+        "nonce": "nonce-1",
+        "sig": "00",
+        "pubkey": "11",
+    }
+    envelope.update(overrides)
+    return envelope
+
+
+def test_store_envelope_rejects_structured_required_fields():
+    assert store_envelope(_envelope(kind=[])) == {
+        "ok": False,
+        "error": "invalid_field:kind",
+    }
+    assert store_envelope(_envelope(nonce={"value": "nonce-1"})) == {
+        "ok": False,
+        "error": "invalid_field:nonce",
+    }
+
+
+def test_verify_envelope_signature_rejects_structured_signature_fields():
+    assert verify_envelope_signature(_envelope(sig=[])) == (
+        False,
+        "invalid_signature_fields",
+    )
+    assert verify_envelope_signature(_envelope(pubkey={"hex": "11"})) == (
+        False,
+        "invalid_signature_fields",
+    )


### PR DESCRIPTION
## Summary
- reject structured required Beacon envelope fields before kind checks, signature verification, or storage
- reject structured signature identity fields before hex decoding
- add focused regression tests for invalid Beacon anchor field shapes

## Verification
- `uv run --no-project --with pytest python -m pytest node/tests/test_beacon_anchor_field_validation.py -q`
- `uv run --no-project python -m py_compile node/beacon_anchor.py node/tests/test_beacon_anchor_field_validation.py`

Note: this branch also carries the current setup miner checksum compatibility files needed by repository CI.