### PR TITLE
fix: align TLS verify helper env handling

### DIFF
--- a/node/tls_config.py
+++ b/node/tls_config.py
@@ -19,9 +19,16 @@ def get_tls_verify() -> Union[str, bool]:
     """Return the appropriate TLS verify parameter for requests/httpx.
 
     Returns:
-        str: Path to pinned cert file if it exists.
-        bool: True to use system CA bundle as fallback.
+        str: Path to explicit CA bundle or pinned cert file if available.
+        bool: False for explicit local opt-out, otherwise True for system CA.
     """
+    tls_verify_env = os.environ.get("RUSTCHAIN_TLS_VERIFY", "true").strip().lower()
+    ca_bundle = os.environ.get("RUSTCHAIN_CA_BUNDLE", "").strip()
+
+    if tls_verify_env in ("false", "0", "no"):
+        return False
+    if ca_bundle:
+        return ca_bundle
     if os.path.exists(_CERT_PATH):
         return _CERT_PATH
     return True

--- a/tests/test_tls_config.py
+++ b/tests/test_tls_config.py
@@ -46,6 +46,23 @@ def test_ssl_context_verifies_by_default(monkeypatch):
     assert context.check_hostname is True
 
 
+def test_requests_tls_verify_honors_explicit_ca_bundle(monkeypatch, tmp_path):
+    ca_bundle = tmp_path / "ca.pem"
+    ca_bundle.write_text("test-ca", encoding="utf-8")
+    monkeypatch.delenv("RUSTCHAIN_TLS_VERIFY", raising=False)
+    monkeypatch.setenv("RUSTCHAIN_CA_BUNDLE", str(ca_bundle))
+
+    assert tls_config.get_tls_verify() == str(ca_bundle)
+
+
+def test_requests_tls_verify_can_use_explicit_local_opt_out(monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_TLS_VERIFY", "false")
+    monkeypatch.setenv("RUSTCHAIN_CA_BUNDLE", "/tmp/ca.pem")
+    monkeypatch.setattr(tls_config.os.path, "exists", lambda path: True)
+
+    assert tls_config.get_tls_verify() is False
+
+
 def test_ssl_context_can_use_explicit_local_opt_out(monkeypatch):
     monkeypatch.setenv("RUSTCHAIN_TLS_VERIFY", "false")
     monkeypatch.delenv("RUSTCHAIN_CA_BUNDLE", raising=False)


### PR DESCRIPTION
## Summary
- make requests/httpx TLS verify helpers honor RUSTCHAIN_CA_BUNDLE like SSL contexts do
- make explicit RUSTCHAIN_TLS_VERIFY=false opt out consistently return False before CA/pinned certs
- add regression coverage for CA bundle and local opt-out precedence

## Verification
- python3 -m py_compile node/tls_config.py tests/test_tls_config.py
- direct Python assertions for RUSTCHAIN_CA_BUNDLE and RUSTCHAIN_TLS_VERIFY=false get_tls_verify behavior

Note: python3 -m pytest tests/test_tls_config.py could not run locally because pytest is not installed in the active interpreter, though it is declared in repo requirements.