### PR TITLE
fix: validate payout preflight RTC address hex

### DIFF
--- a/node/payout_preflight.py
+++ b/node/payout_preflight.py
@@ -8,10 +8,11 @@ from typing import Any, Dict, Optional, Tuple
 
 MICRO_RTC = Decimal("1000000")
 MAX_I64 = 2**63 - 1
+_RTC_ADDRESS_RE = re.compile(r"RTC[0-9A-Fa-f]{40}")
 
 
 def _is_rtc_address(value: str) -> bool:
-    return value.startswith("RTC") and len(value) == 43
+    return bool(_RTC_ADDRESS_RE.fullmatch(value))
 
 
 def _is_bcn_address(value: str) -> bool:

--- a/payout_preflight.py
+++ b/payout_preflight.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, Optional, Tuple
 
 MICRO_RTC = Decimal("1000000")
 MAX_I64 = 2**63 - 1
+_RTC_ADDRESS_RE = re.compile(r"RTC[0-9A-Fa-f]{40}")
 
 
 @dataclass(frozen=True)
@@ -19,6 +20,10 @@ class PreflightResult:
     ok: bool
     error: str
     details: Dict[str, Any]
+
+
+def _is_rtc_address(value: str) -> bool:
+    return bool(_RTC_ADDRESS_RE.fullmatch(value))
 
 
 def _as_dict(payload: Any) -> Tuple[Optional[Dict[str, Any]], str]:
@@ -127,9 +132,9 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
     if ierr:
         return PreflightResult(ok=False, error=ierr, details={})
 
-    if not (from_address.startswith("RTC") and len(from_address) == 43):
+    if not _is_rtc_address(from_address):
         return PreflightResult(ok=False, error="invalid_from_address_format", details={})
-    if not (to_address.startswith("RTC") and len(to_address) == 43):
+    if not _is_rtc_address(to_address):
         return PreflightResult(ok=False, error="invalid_to_address_format", details={})
     if from_address == to_address:
         return PreflightResult(ok=False, error="from_to_must_differ", details={})

--- a/tests/test_payout_preflight.py
+++ b/tests/test_payout_preflight.py
@@ -293,8 +293,20 @@ class TestValidateWalletTransferSigned:
                 assert result.ok is False
                 assert result.error == "invalid_from_address_format"
 
+      def test_invalid_from_address_characters(self):
+                payload = self._valid_payload(from_address="RTC" + "g" * 40)
+                result = validate_wallet_transfer_signed(payload)
+                assert result.ok is False
+                assert result.error == "invalid_from_address_format"
+
+      def test_invalid_to_address_characters(self):
+                payload = self._valid_payload(to_address="RTC" + "z" * 40)
+                result = validate_wallet_transfer_signed(payload)
+                assert result.ok is False
+                assert result.error == "invalid_to_address_format"
+
       def test_self_transfer_rejected(self):
-                addr = self._make_address("x")
+                addr = self._make_address("c")
                 payload = self._valid_payload(from_address=addr, to_address=addr)
                 result = validate_wallet_transfer_signed(payload)
                 assert result.ok is False


### PR DESCRIPTION
## Summary
- require signed-transfer RTC addresses in payout preflight to use a 40-character hex suffix
- apply the same validation to the root compatibility module and node module
- add regression coverage for invalid from/to address characters

## Verification
- python3 -m py_compile payout_preflight.py node/payout_preflight.py tests/test_payout_preflight.py
- direct Python assertions for valid RTC addresses and invalid from/to suffix characters in both modules

Note: python3 -m pytest tests/test_payout_preflight.py could not run locally because pytest is not installed in the active interpreter, though it is declared in repo requirements.