### PR TITLE
fix: varint encode long Ergo byte registers

### DIFF
--- a/node/ergo_raw_tx.py
+++ b/node/ergo_raw_tx.py
@@ -28,9 +28,12 @@ def response_json_list(resp):
 def encode_coll_byte(hex_str):
     data = bytes.fromhex(hex_str)
     length = len(data)
-    if length < 128:
-        return "0e" + format(length, "02x") + hex_str
-    return "0e" + format(0x80 | (length & 0x7f), "02x") + format(length >> 7, "02x") + hex_str
+    encoded_length = ""
+    while length >= 128:
+        encoded_length += format(0x80 | (length & 0x7f), "02x")
+        length >>= 7
+    encoded_length += format(length, "02x")
+    return "0e" + encoded_length + hex_str
 
 def encode_int_reg(n):
     zigzag = (n << 1) ^ (n >> 31) if n >= 0 else (((-n) << 1) - 1)

--- a/tests/test_ergo_raw_tx.py
+++ b/tests/test_ergo_raw_tx.py
@@ -43,6 +43,12 @@ def test_encode_coll_byte_uses_extended_length_at_128_bytes():
     assert encode_coll_byte(boundary_payload) == "0e8001" + boundary_payload
 
 
+def test_encode_coll_byte_uses_multi_byte_varint_lengths():
+    payload = "cc" * 16_384
+
+    assert encode_coll_byte(payload) == "0e808001" + payload
+
+
 def test_encode_coll_byte_rejects_odd_length_hex_strings():
     with pytest.raises(ValueError):
         encode_coll_byte("abc")


### PR DESCRIPTION
## Summary
- encode Coll[Byte] register lengths with full varint encoding instead of a fixed two-byte extended form
- preserve existing short and 128-byte boundary encodings
- add regression coverage for a 16,384-byte payload length

## Verification
- python3 -m py_compile node/ergo_raw_tx.py tests/test_ergo_raw_tx.py
- direct Python assertions for empty, 127-byte, 128-byte, and 16,384-byte Coll[Byte] encodings using a requests stub

Note: full pytest could not run locally because the active interpreter is missing pytest/requests dependencies.