### PR TITLE
fix: preserve fleet score miner columns

### DIFF
--- a/rips/python/rustchain/fleet_immune_system.py
+++ b/rips/python/rustchain/fleet_immune_system.py
@@ -1061,7 +1061,7 @@ def register_fleet_endpoints(app, DB_PATH):
         with sqlite3.connect(DB_PATH) as db:
             if miner:
                 rows = db.execute("""
-                    SELECT epoch, fleet_score, ip_signal, timing_signal,
+                    SELECT miner, epoch, fleet_score, ip_signal, timing_signal,
                            fingerprint_signal, effective_multiplier
                     FROM fleet_scores WHERE miner = ?
                     ORDER BY epoch DESC LIMIT ?

--- a/tests/test_fleet_scores_limit_validation.py
+++ b/tests/test_fleet_scores_limit_validation.py
@@ -79,6 +79,22 @@ def test_fleet_scores_respects_valid_limit(client):
     assert [row["miner"] for row in response.get_json()["scores"]] == ["miner-a", "miner-b"]
 
 
+def test_fleet_scores_filtered_by_miner_preserves_columns(client):
+    response = authed_get(client, "/admin/fleet/scores?miner=miner-b")
+
+    assert response.status_code == 200
+    assert response.get_json()["scores"] == [
+        {
+            "miner": "miner-b",
+            "epoch": 1,
+            "fleet_score": 0.7,
+            "ip_signal": 0.6,
+            "timing_signal": 0.5,
+            "fingerprint_signal": 0.4,
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "query, expected_error",
     (


### PR DESCRIPTION
## Summary
- include the miner column when `/admin/fleet/scores?miner=...` fetches filtered score rows
- prevent the filtered response from shifting epoch/fleet_score values under the wrong JSON keys
- add regression coverage for the filtered miner response

## Verification
- `python3 -m py_compile rips/python/rustchain/fleet_immune_system.py tests/test_fleet_scores_limit_validation.py`
- direct sqlite mapping assertion for filtered fleet score rows

Note: full endpoint/pytest execution could not run locally because the active interpreter is missing Flask/pytest dependencies.
