### PR TITLE
Hide GPU render database error details

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -55,6 +55,9 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             return jsonify({"error": "Unauthorized - admin key required"}), 401
         return None
 
+    def _database_error_response():
+        return jsonify({"error": "Database operation failed"}), 500
+
     def _ensure_escrow_secret_column(db):
         """Best-effort migration for older DBs."""
         try:
@@ -109,7 +112,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             db.commit()
             return jsonify({"ok": True, "message": "GPU attestation recorded"})
         except sqlite3.Error as e:
-            return jsonify({"error": str(e)}), 500
+            return _database_error_response()
         finally:
             db.close()
 
@@ -172,7 +175,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             # escrow_secret is intentionally returned once to allow participant-auth for release/refund.
             return jsonify({"ok": True, "job_id": job_id, "status": "locked", "escrow_secret": escrow_secret})
         except sqlite3.Error as e:
-            return jsonify({"error": str(e)}), 500
+            return _database_error_response()
         finally:
             db.close()
 
@@ -230,7 +233,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             db.commit()
             return jsonify({"ok": True, "status": "released"})
         except sqlite3.Error as e:
-            return jsonify({"error": str(e)}), 500
+            return _database_error_response()
         finally:
             db.close()
 
@@ -288,7 +291,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             db.commit()
             return jsonify({"ok": True, "status": "refunded"})
         except sqlite3.Error as e:
-            return jsonify({"error": str(e)}), 500
+            return _database_error_response()
         finally:
             db.close()
 

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -201,3 +201,14 @@ def test_gpu_release_rejects_structured_escrow_secret(tmp_path):
     assert response.get_json() == {"error": "escrow_secret must be a string"}
     assert _balance(db_path, "victim") == 20.0
     assert _balance(db_path, "attacker") == 0.0
+
+
+def test_gpu_attest_hides_sqlite_schema_errors(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post("/api/gpu/attest", json={"miner_id": "miner-1"})
+
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Database operation failed"}


### PR DESCRIPTION
Fixes #5520

## Summary
- return a generic 500 response for GPU render SQLite failures
- keep detailed DB schema/exception text out of API responses
- add regression coverage for `/api/gpu/attest` schema-error leakage

## Tests
- `pytest -q tests/test_gpu_render_endpoints_security.py -q`
- `python3 -m py_compile node/gpu_render_endpoints.py`
- `git diff --check`