### PR TITLE
fix: validate bounty verifier wallet hex

### DIFF
--- a/tests/test_bounty_verifier.py
+++ b/tests/test_bounty_verifier.py
@@ -394,13 +394,31 @@ class TestBountyVerifier:
     def test_extract_wallet_label(self):
         """Test extracting wallet with label."""
         verifier = BountyVerifier(Config())
-        
+
         text = "Wallet: 1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35"
         wallet = verifier._extract_wallet(text)
         
         assert wallet is not None
         assert "1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35" in wallet
-    
+
+    def test_extract_wallet_rejects_non_hex_labeled_value(self):
+        """Do not turn arbitrary labeled alphanumeric text into an RTC wallet."""
+        verifier = BountyVerifier(Config())
+
+        text = "Wallet: zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+        wallet = verifier._extract_wallet(text)
+
+        assert wallet is None
+
+    def test_extract_wallet_rejects_short_rtc_value(self):
+        """RTC addresses must include the full 40-character hex suffix."""
+        verifier = BountyVerifier(Config())
+
+        text = "Wallet: RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2"
+        wallet = verifier._extract_wallet(text)
+
+        assert wallet is None
+
     def test_extract_urls(self):
         """Test extracting URLs from text."""
         verifier = BountyVerifier(Config())

--- a/tools/bounty_verifier/verifier.py
+++ b/tools/bounty_verifier/verifier.py
@@ -48,9 +48,9 @@ class BountyVerifier:
     
     # Regex patterns for parsing claim comments
     WALLET_PATTERNS = [
-        r"(?<![A-Za-z0-9])(RTC[A-Za-z0-9]{38,40})(?![A-Za-z0-9])",  # RustChain address format
-        r"(?i)wallet[:\s]+([A-Za-z0-9]{34,44})",
-        r"(?i)address[:\s]+([A-Za-z0-9]{34,44})",
+        r"(?<![A-Za-z0-9])(RTC[0-9A-Fa-f]{40})(?![A-Za-z0-9])",  # RustChain address format
+        r"(?i)wallet[:\s]+(?:RTC)?([0-9A-Fa-f]{40})(?![A-Za-z0-9])",
+        r"(?i)address[:\s]+(?:RTC)?([0-9A-Fa-f]{40})(?![A-Za-z0-9])",
     ]
     
     URL_PATTERN = r"https?://[^\s<>\[\]\"']+"


### PR DESCRIPTION
## Summary
- require bounty-verifier RTC wallet matches to use a full 40-character hex suffix
- keep support for bare 40-character hex values after Wallet:/Address: labels by normalizing them to RTC-prefixed addresses
- add regression coverage for non-hex labeled values and short RTC values

## Verification
- `python3 -m py_compile tools/bounty_verifier/verifier.py tests/test_bounty_verifier.py`
- direct parser assertions for RTC-prefixed hex, bare labeled hex, non-hex labeled text, and short RTC values using a yaml stub

Note: full pytest could not run locally because the active interpreter is missing pytest/yaml dependencies.
