### PR TITLE
fix: skip malformed bounty tracker state

### DIFF
--- a/integrations/rustchain-bounties/bounty_tracker.py
+++ b/integrations/rustchain-bounties/bounty_tracker.py
@@ -96,10 +96,17 @@ class BountyTracker:
         if path.exists():
             try:
                 data = json.loads(path.read_text(encoding="utf-8"))
-                for b_data in data.get("bounties", []):
+                if not isinstance(data, dict):
+                    return
+                bounties = data.get("bounties", [])
+                if not isinstance(bounties, list):
+                    return
+                for b_data in bounties:
+                    if not isinstance(b_data, dict):
+                        continue
                     bounty = Bounty.from_dict(b_data)
                     self.bounties[bounty.issue_number] = bounty
-            except (json.JSONDecodeError, KeyError):
+            except (json.JSONDecodeError, KeyError, TypeError, ValueError):
                 pass
     
     def _save_state(self):

--- a/tests/test_bounty_tracker.py
+++ b/tests/test_bounty_tracker.py
@@ -195,6 +195,44 @@ def test_invalid_state_file_starts_empty(tmp_path):
     assert tracker.bounties == {}
 
 
+def test_malformed_state_shape_starts_empty(tmp_path):
+    state_file = tmp_path / "bad_state_shape.json"
+    state_file.write_text(json.dumps(["not", "an", "object"]))
+
+    module = load_bounty_tracker_module()
+    tracker = module.BountyTracker(
+        github_token="token",
+        repo="owner/repo",
+        state_file=str(state_file),
+    )
+
+    assert tracker.bounties == {}
+
+
+def test_malformed_state_entries_are_skipped(tmp_path):
+    state_file = tmp_path / "mixed_state.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "bounties": [
+                    "bad-row",
+                    {"issue_number": 11, "title": "Valid", "description": "", "reward_rtc": 2.0},
+                ]
+            }
+        )
+    )
+
+    module = load_bounty_tracker_module()
+    tracker = module.BountyTracker(
+        github_token="token",
+        repo="owner/repo",
+        state_file=str(state_file),
+    )
+
+    assert list(tracker.bounties) == [11]
+    assert tracker.bounties[11].title == "Valid"
+
+
 def test_saved_state_contains_serialized_bounties(tmp_path):
     module, tracker = make_tracker(tmp_path)
     tracker.bounties[9] = module.Bounty(9, "Serialize me", "body", 3.0)


### PR DESCRIPTION
## Summary
- make bounty tracker state loading tolerate valid JSON with the wrong top-level shape
- skip malformed bounty entries instead of crashing startup
- add regression coverage for non-object state and mixed valid/malformed bounty rows

## Verification
- `python3 -m py_compile integrations/rustchain-bounties/bounty_tracker.py tests/test_bounty_tracker.py`
- direct import assertions for malformed top-level state and mixed malformed/valid bounty entries using a `requests` stub
