### PR TITLE
fix: preserve github 204 follow status

### DIFF
--- a/tests/test_bounty_verifier.py
+++ b/tests/test_bounty_verifier.py
@@ -293,6 +293,33 @@ class TestGitHubClient:
         mock_urlopen.assert_not_called()
 
     @patch('tools.bounty_verifier.github_client.urlopen')
+    def test_check_following_treats_204_as_following(self, mock_urlopen):
+        """GitHub returns 204 No Content when a user follows the target."""
+
+        class FakeResponse:
+            def __init__(self, status, payload=b"{}"):
+                self.status = status
+                self.headers = {}
+                self._payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return self._payload
+
+        client = GitHubClient(token="test_token")
+        mock_urlopen.side_effect = [
+            FakeResponse(200, b'{"login":"user"}'),
+            FakeResponse(204, b""),
+        ]
+
+        assert client.check_following("user") is True
+
+    @patch('tools.bounty_verifier.github_client.urlopen')
     def test_get_starred_repos_count_cached(self, mock_urlopen):
         """Test star count uses cache."""
         import time

--- a/tools/bounty_verifier/github_client.py
+++ b/tools/bounty_verifier/github_client.py
@@ -103,6 +103,7 @@ class GitHubClient:
             try:
                 with urlopen(req, timeout=30) as response:
                     response_headers = dict(response.headers)
+                    response_headers["status"] = str(response.status)
                     self._update_rate_limit(response_headers)
                     
                     if response.status == 204:  # No content


### PR DESCRIPTION
## Summary
- preserve HTTP response status in the bounty verifier GitHub client response metadata
- fix `check_following()` so GitHub's 204 No Content follow response is treated as following
- add regression coverage for the 204 follow path

## Verification
- `python3 -m py_compile tools/bounty_verifier/github_client.py tests/test_bounty_verifier.py`
- direct `check_following()` simulation for user lookup plus 204 follow response using a `yaml` stub
