### PR TITLE
fix: validate tip bot state shape

### DIFF
--- a/integrations/rustchain-bounties/state.py
+++ b/integrations/rustchain-bounties/state.py
@@ -42,11 +42,14 @@ class TipState:
             try:
                 with open(self.state_file) as f:
                     data = json.load(f)
+                if not isinstance(data, dict):
+                    raise ValueError("state root must be an object")
                 # Migrate if needed
                 if data.get("version") != self.VERSION:
                     data = self._migrate(data)
+                self._validate(data)
                 return data
-            except (json.JSONDecodeError, KeyError):
+            except (json.JSONDecodeError, KeyError, ValueError):
                 pass
         return {"processed_comment_ids": [], "tip_log": [], "version": self.VERSION}
 
@@ -55,7 +58,15 @@ class TipState:
         data.setdefault("processed_comment_ids", [])
         data.setdefault("tip_log", [])
         data["version"] = self.VERSION
+        self._validate(data)
         return data
+
+    def _validate(self, data: dict[str, Any]) -> None:
+        """Reject corrupt state shapes that would break idempotency checks."""
+        if not isinstance(data.get("processed_comment_ids"), list):
+            raise ValueError("processed_comment_ids must be a list")
+        if not isinstance(data.get("tip_log"), list):
+            raise ValueError("tip_log must be a list")
 
     def save(self) -> None:
         with open(self.state_file, "w") as f:

--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -410,6 +410,26 @@ class TestTipState:
         s = TipState(path)
         assert s.tip_log == []
 
+    def test_non_object_state_file_resets(self, tmp_path):
+        path = str(tmp_path / "bad_shape.json")
+        with open(path, "w") as f:
+            json.dump([], f)
+
+        s = TipState(path)
+
+        assert s.tip_log == []
+        assert s.is_processed("org/repo/111") is False
+
+    def test_invalid_state_collections_reset(self, tmp_path):
+        path = str(tmp_path / "bad_collections.json")
+        with open(path, "w") as f:
+            json.dump({"version": 1, "processed_comment_ids": {}, "tip_log": None}, f)
+
+        s = TipState(path)
+
+        assert s.tip_log == []
+        assert s.get_pending_payouts() == []
+
 
 # ---------------------------------------------------------------------------
 # End-to-end process_event tests (GitHub API mocked)


### PR DESCRIPTION
## Summary
- reset the GitHub tip bot state when the JSON root is not an object
- validate loaded/migrated state collection fields before idempotency checks use them
- cover non-object and wrong-collection state files in the existing tip bot tests

## Verification
- `python3 -m py_compile integrations/rustchain-bounties/state.py integrations/rustchain-bounties/test_tip_bot.py`
- direct `TipState` schema repro for list-root, wrong collection shapes, and valid state
- `python3 -m pytest integrations/rustchain-bounties/test_tip_bot.py -q` could not run locally because this Xcode Python environment has no `pytest` module
