### PR TITLE
fix: validate spl bridge quote inputs

### DIFF
--- a/integrations/solana-spl/sdk.py
+++ b/integrations/solana-spl/sdk.py
@@ -246,6 +246,11 @@ class WRtcBridge:
         Returns:
             BridgeQuote with expected amounts and fees
         """
+        if amount < 0:
+            raise ValueError("Bridge amount must be non-negative")
+        if not 0 <= slippage_bps <= 10000:
+            raise ValueError("Slippage must be between 0 and 10000 basis points")
+
         # Calculate fee
         fee = (amount * self.bridge_fee_bps) // 10000
         
@@ -283,6 +288,9 @@ class WRtcBridge:
         Returns:
             BridgeTransaction with status tracking
         """
+        if amount < 0:
+            raise ValueError("Bridge amount must be non-negative")
+
         # In production, this would:
         # 1. Lock tokens on source chain
         # 2. Emit bridge event

--- a/integrations/solana-spl/tests/test_sdk.py
+++ b/integrations/solana-spl/tests/test_sdk.py
@@ -128,6 +128,19 @@ class TestWRtcBridge:
         quote2 = bridge.get_bridge_quote(amount, "wRTC", "RTC", slippage_bps=100)
         assert quote2.slippage_bps == 100
         assert quote2.min_receive < quote1.min_receive  # Higher slippage = lower min
+
+    def test_negative_bridge_quote_rejected(self, bridge):
+        """Test negative bridge quote amount is rejected."""
+        with pytest.raises(ValueError, match="Bridge amount"):
+            bridge.get_bridge_quote(-1, "wRTC", "RTC")
+
+    def test_invalid_slippage_rejected(self, bridge):
+        """Test out-of-range slippage is rejected."""
+        with pytest.raises(ValueError, match="Slippage"):
+            bridge.get_bridge_quote(1000, "wRTC", "RTC", slippage_bps=-1)
+
+        with pytest.raises(ValueError, match="Slippage"):
+            bridge.get_bridge_quote(1000, "wRTC", "RTC", slippage_bps=10001)
     
     def test_initiate_bridge(self, bridge):
         """Test initiating bridge transaction."""
@@ -137,6 +150,11 @@ class TestWRtcBridge:
         assert tx.status == "pending"
         assert tx.from_amount == amount
         assert tx.to_amount < amount  # Fee deducted
+
+    def test_negative_initiate_bridge_rejected(self, bridge):
+        """Test negative bridge transaction amount is rejected."""
+        with pytest.raises(ValueError, match="Bridge amount"):
+            bridge.initiate_bridge(-1, "wRTC", "RustChainAddress")
 
 
 class TestWRtcSDK:


### PR DESCRIPTION
## Summary
- reject negative wRTC bridge quote amounts before fee/output calculation
- reject out-of-range slippage basis points before computing min receive
- reject negative bridge initiation amounts so placeholder transactions cannot carry negative values

## Verification
- `python3 -m py_compile integrations/solana-spl/sdk.py integrations/solana-spl/tests/test_sdk.py`
- direct SDK checks for negative quote amount, invalid slippage bounds, negative initiation amount, and zero quote behavior
- `python3 -m pytest integrations/solana-spl/tests/test_sdk.py -q` could not run locally because this Xcode Python environment has no `pytest` module
