### PR TITLE
fix: reject empty mcp wallet resource ids

### DIFF
--- a/integrations/rustchain-mcp/mcp_server.py
+++ b/integrations/rustchain-mcp/mcp_server.py
@@ -408,6 +408,8 @@ class RustChainMCP:
 
         elif uri.startswith("rustchain://wallet/"):
             miner_id = uri.split("/")[-1]
+            if not miner_id:
+                raise ValueError("miner_id is required")
             balance = await self.client.balance(miner_id)
             data = {
                 "miner_id": balance.miner_id,

--- a/integrations/rustchain-mcp/tests/test_mcp_server.py
+++ b/integrations/rustchain-mcp/tests/test_mcp_server.py
@@ -194,6 +194,14 @@ class TestResourceTemplates:
         assert "balance_rtc" in data
 
     @pytest.mark.asyncio
+    async def test_read_resource_wallet_requires_id(self, server):
+        """Test wallet resource rejects a missing miner id."""
+        with pytest.raises(ValueError) as exc_info:
+            await server._read_resource_impl("rustchain://wallet/")
+
+        assert "miner_id is required" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_read_resource_docs(self, server):
         """Test reading rustchain://docs/api resource."""
         content, mime_type = await server._read_resource_impl(


### PR DESCRIPTION
## Summary
- reject `rustchain://wallet/` resource reads before they call the balance client with an empty miner id
- add coverage for the missing wallet resource id path

## Verification
- `python3 -m py_compile integrations/rustchain-mcp/mcp_server.py integrations/rustchain-mcp/tests/test_mcp_server.py`
- direct async `_read_resource_impl("rustchain://wallet/")` repro with an `aiohttp` test stub, confirming the client balance method is not called
- `python3 -m pytest integrations/rustchain-mcp/tests/test_mcp_server.py -q` could not run locally because this Xcode Python environment is missing `aiohttp` and `pytest`
