### PR TITLE
fix: normalize mcp api error bodies

### DIFF
--- a/integrations/rustchain-mcp/schemas.py
+++ b/integrations/rustchain-mcp/schemas.py
@@ -183,8 +183,10 @@ class APIError(Exception):
     details: Optional[dict[str, Any]] = None
 
     @classmethod
-    def from_response(cls, status: int, body: dict[str, Any]) -> "APIError":
+    def from_response(cls, status: int, body: Any) -> "APIError":
         """Create from API error response."""
+        if not isinstance(body, dict):
+            body = {"message": str(body)}
         return cls(
             code=body.get("error", body.get("code", "UNKNOWN_ERROR")),
             message=body.get("message", body.get("error_description", "Unknown error")),

--- a/integrations/rustchain-mcp/tests/test_schemas.py
+++ b/integrations/rustchain-mcp/tests/test_schemas.py
@@ -223,6 +223,14 @@ class TestAPIError:
         assert error.message == "Miner not found"
         assert error.status_code == 404
 
+    def test_from_response_with_non_object_body(self):
+        """Test non-object error response bodies still become APIError."""
+        error = APIError.from_response(502, ["bad gateway"])
+
+        assert error.code == "UNKNOWN_ERROR"
+        assert error.message == "['bad gateway']"
+        assert error.status_code == 502
+
     def test_to_dict(self):
         """Test converting APIError to dict."""
         error = APIError(


### PR DESCRIPTION
## Summary
- normalize non-object MCP API error response bodies before building `APIError`
- preserve structured error handling for list/string upstream error payloads instead of leaking internal attribute errors
- add schema coverage for a non-object error response body

## Verification
- `python3 -m py_compile integrations/rustchain-mcp/schemas.py integrations/rustchain-mcp/tests/test_schemas.py`
- direct `APIError.from_response()` checks for non-object and normal dict error payloads
- `python3 -m pytest integrations/rustchain-mcp/tests/test_schemas.py -q` could not run locally because this Xcode Python environment has no `pytest` module
