### PR TITLE
fix: validate spl escrow total cap

### DIFF
--- a/integrations/solana-spl/spl_deployment.py
+++ b/integrations/solana-spl/spl_deployment.py
@@ -105,6 +105,11 @@ class BridgeEscrowConfig:
             return False
         if self.per_tx_limit > self.daily_mint_cap:
             return False
+        if self.total_supply_cap is not None:
+            if self.total_supply_cap <= 0:
+                return False
+            if self.per_tx_limit > self.total_supply_cap:
+                return False
         return True
 
 

--- a/integrations/solana-spl/tests/test_spl_deployment.py
+++ b/integrations/solana-spl/tests/test_spl_deployment.py
@@ -154,6 +154,28 @@ class TestBridgeEscrowConfig:
         
         assert config.validate() is False
 
+    def test_non_positive_total_supply_cap(self):
+        """Test validation fails with a non-positive total supply cap."""
+        config = BridgeEscrowConfig(
+            escrow_authority="BridgePDA",
+            mint_address="MintAddress",
+            total_supply_cap=0
+        )
+
+        assert config.validate() is False
+
+    def test_total_supply_cap_below_per_tx_limit(self):
+        """Test validation fails when total cap cannot cover one transaction."""
+        config = BridgeEscrowConfig(
+            escrow_authority="BridgePDA",
+            mint_address="MintAddress",
+            daily_mint_cap=10_000,
+            per_tx_limit=1_000,
+            total_supply_cap=500
+        )
+
+        assert config.validate() is False
+
 
 class TestSPLTokenDeployment:
     """Test SPLTokenDeployment class."""


### PR DESCRIPTION
## Summary
- reject non-positive `total_supply_cap` values in SPL bridge escrow config validation
- reject total supply caps below `per_tx_limit` so the config cannot approve an impossible single mint
- add focused escrow config tests for both invalid total cap shapes

## Verification
- `python3 -m py_compile integrations/solana-spl/spl_deployment.py integrations/solana-spl/tests/test_spl_deployment.py`
- direct `BridgeEscrowConfig.validate()` checks for zero total cap, total cap below per-tx limit, and a valid bounded total cap
- `python3 -m pytest integrations/solana-spl/tests/test_spl_deployment.py -q` could not run locally because this Xcode Python environment has no `pytest` module
