### PR TITLE
fix: skip malformed openapi security paths

### DIFF
--- a/docs/api/validate_openapi.py
+++ b/docs/api/validate_openapi.py
@@ -230,9 +230,11 @@ class OpenAPIValidator:
             
         # Check security usage in operations
         for path, path_item in self.spec.get('paths', {}).items():
+            if not isinstance(path_item, dict):
+                continue
             for method in ['get', 'post', 'put', 'patch', 'delete']:
                 operation = path_item.get(method)
-                if operation:
+                if isinstance(operation, dict):
                     security = operation.get('security', [])
                     for sec_req in security:
                         if isinstance(sec_req, dict):

--- a/tests/test_openapi_validator.py
+++ b/tests/test_openapi_validator.py
@@ -96,6 +96,30 @@ def test_validate_references_and_security_report_undefined_names():
     assert "Undefined security scheme 'ApiKeyAuth' used in GET /wallet" in validator.errors
 
 
+def test_validate_security_skips_malformed_path_items():
+    module = load_validator_module()
+    validator = module.OpenAPIValidator("unused.yaml")
+    validator.spec = {
+        "paths": {
+            "/broken": [],
+            "/also-broken": {"get": []},
+            "/wallet": {
+                "get": {
+                    "security": [{"ApiKeyAuth": []}],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            },
+        },
+        "components": {"securitySchemes": {}},
+    }
+
+    assert validator.validate_security() is False
+
+    assert validator.errors == [
+        "Undefined security scheme 'ApiKeyAuth' used in GET /wallet"
+    ]
+
+
 def test_validate_accepts_minimal_valid_spec(tmp_path, capsys):
     module = load_validator_module()
     spec_path = write_spec(


### PR DESCRIPTION
## Summary
- make OpenAPI security validation skip malformed path items that path validation already reports
- avoid crashing on non-object operation entries while still reporting real undefined security schemes
- add regression coverage for malformed path and operation shapes in security validation

## Verification
- `python3 -m py_compile docs/api/validate_openapi.py tests/test_openapi_validator.py`
- direct `validate_security()` repro with a local `yaml` stub for malformed path items, malformed operation entries, and one undefined security scheme
- `python3 -m pytest tests/test_openapi_validator.py -q` could not run locally because this Xcode Python environment has no `pytest` module; direct import without a stub also needs PyYAML
