### PR TITLE
fix: harden postman checklist generation

### DIFF
--- a/docs/postman/validate_postman_collection.py
+++ b/docs/postman/validate_postman_collection.py
@@ -166,27 +166,32 @@ def generate_checklist(collection: Dict[str, Any]) -> str:
     
     def process_items(items, folder_name=""):
         for item in items:
+            if not isinstance(item, dict):
+                continue
             if 'request' in item:
-                request = item['request']
+                request = item['request'] if isinstance(item['request'], dict) else {}
                 method = request.get('method', 'GET')
                 name = item.get('name', 'Unknown')
                 url = request.get('url', {})
                 
                 if isinstance(url, dict):
-                    path = '/'.join(url.get('path', []))
+                    path_parts = url.get('path', [])
+                    path = '/'.join(path_parts) if isinstance(path_parts, list) else ""
                     full_url = f"{{{{base_url}}}}/{path}" if path else "N/A"
                 else:
                     full_url = url
+                responses = item.get('response', [])
                 
                 checklist.append({
                     'folder': folder_name,
                     'name': name,
                     'method': method,
                     'url': full_url,
-                    'has_examples': 'response' in item and len(item['response']) > 0
+                    'has_examples': isinstance(responses, list) and len(responses) > 0
                 })
             elif 'item' in item:
-                process_items(item['item'], item.get('name', ''))
+                children = item['item'] if isinstance(item['item'], list) else []
+                process_items(children, item.get('name', ''))
     
     process_items(collection['item'])
     return checklist

--- a/tests/test_postman_collection_validator.py
+++ b/tests/test_postman_collection_validator.py
@@ -88,3 +88,47 @@ def test_generate_checklist_preserves_string_urls():
 
     assert checklist[0]["url"] == "https://rustchain.org/health"
     assert checklist[0]["has_examples"] is False
+
+
+def test_generate_checklist_skips_malformed_items_and_defaults_bad_shapes():
+    collection = {
+        "item": [
+            "not an item",
+            {
+                "name": "Broken folder",
+                "item": "not a list",
+            },
+            {
+                "name": "Bad request",
+                "request": "not an object",
+                "response": {"name": "not a list"},
+            },
+            {
+                "name": "Bad path",
+                "request": {
+                    "method": "POST",
+                    "url": {"path": "api/stats"},
+                },
+                "response": [{"name": "ok"}],
+            },
+        ]
+    }
+
+    checklist = postman_validator.generate_checklist(collection)
+
+    assert checklist == [
+        {
+            "folder": "",
+            "name": "Bad request",
+            "method": "GET",
+            "url": "N/A",
+            "has_examples": False,
+        },
+        {
+            "folder": "",
+            "name": "Bad path",
+            "method": "POST",
+            "url": "N/A",
+            "has_examples": True,
+        },
+    ]


### PR DESCRIPTION
## Summary
- skip malformed non-object Postman collection entries during checklist generation
- default malformed request, response, and URL path shapes instead of raising type errors
- add regression coverage for malformed checklist items while preserving normal folder/path flattening

## Verification
- `python3 -m py_compile docs/postman/validate_postman_collection.py tests/test_postman_collection_validator.py`
- direct `generate_checklist()` assertions for malformed items and normal Postman URL path flattening
- `python3 -m pytest tests/test_postman_collection_validator.py -q` could not run locally because this Xcode Python environment has no `pytest` module
