### PR TITLE
fix: reject non-object i18n roots

### DIFF
--- a/i18n/validate_i18n.py
+++ b/i18n/validate_i18n.py
@@ -112,6 +112,8 @@ def validate_translation_file(filepath: Path) -> Tuple[bool, List[str]]:
         data = json.loads(content)
     except json.JSONDecodeError as e:
         return False, [f"JSON 格式错误：{e}"]
+    if not isinstance(data, dict):
+        return False, [f"JSON 根节点必须是对象：{filepath.name}"], []
     
     # 验证结构
     valid, struct_errors = validate_json_structure(data)

--- a/tests/test_i18n_validator.py
+++ b/tests/test_i18n_validator.py
@@ -114,3 +114,14 @@ def test_validate_translation_file_reports_structure_count_and_placeholder_issue
     assert any("20" in error for error in errors)
     assert any("en_us" in warning for warning in warnings)
     assert any("bad_placeholder" in warning for warning in warnings)
+
+
+def test_validate_translation_file_rejects_non_object_json_root(tmp_path):
+    path = tmp_path / "array.json"
+    path.write_text(json.dumps([]), encoding="utf-8")
+
+    valid, errors, warnings = validator.validate_translation_file(path)
+
+    assert valid is False
+    assert errors == ["JSON 根节点必须是对象：array.json"]
+    assert warnings == []


### PR DESCRIPTION
## Summary
- reject translation JSON files whose root value is not an object
- return a normal validation error tuple instead of crashing later on dict-only methods
- add regression coverage for array-root translation files

## Verification
- `python3 -m py_compile i18n/validate_i18n.py tests/test_i18n_validator.py`
- direct `validate_translation_file()` checks for an array-root file and an existing valid translation shape
- `python3 -m pytest tests/test_i18n_validator.py -q` could not run locally because this Xcode Python environment has no `pytest` module
