### PR TITLE
fix: reset malformed status history

### DIFF
--- a/static/status/monitor.py
+++ b/static/status/monitor.py
@@ -64,6 +64,8 @@ def check_nodes():
         try:
             with open(DATA_FILE, 'r') as f:
                 history = json.load(f)
+            if not isinstance(history, list):
+                history = []
         except: pass
     
     history.append({"time": datetime.now().isoformat(), "nodes": results})

--- a/tests/test_static_status_monitor.py
+++ b/tests/test_static_status_monitor.py
@@ -95,3 +95,27 @@ def test_check_nodes_appends_history_and_keeps_recent_entries(tmp_path, monkeypa
     assert history[0]["time"] == "old-1"
     assert history[-1]["nodes"][0]["status"] == "down"
     assert history[-1]["nodes"][0]["error"] == "HTTP 503"
+
+
+def test_check_nodes_resets_non_list_history_file(tmp_path, monkeypatch):
+    monitor = load_monitor_module()
+    data_file = tmp_path / "node_status.json"
+    data_file.write_text(json.dumps({"time": "old", "nodes": []}))
+
+    monkeypatch.setattr(monitor, "DATA_FILE", str(data_file))
+    monkeypatch.setattr(
+        monitor,
+        "NODES",
+        [{"name": "Node A", "url": "https://node-a/health", "location": "A"}],
+    )
+
+    response = Mock()
+    response.status_code = 503
+    monkeypatch.setattr(monitor.requests, "get", Mock(return_value=response))
+
+    monitor.check_nodes()
+
+    history = json.loads(data_file.read_text())
+    assert isinstance(history, list)
+    assert len(history) == 1
+    assert history[0]["nodes"][0]["status"] == "down"


### PR DESCRIPTION
## Summary
- reset `node_status.json` history when the existing file contains valid JSON that is not a list
- keep the status monitor from crashing on `history.append(...)` after malformed history state
- add regression coverage for the non-list history file case

## Verification
- `python3 -m py_compile static/status/monitor.py tests/test_static_status_monitor.py`
- direct dependency-stubbed exercise of `check_nodes()` with a dict-shaped history file and mocked node response

Note: this local Xcode Python environment does not have `requests` or `pytest` installed, so the direct exercise stubs `requests` and `python3 -m pytest tests/test_static_status_monitor.py -q` could not run locally.
