### PR TITLE
fix: validate pending ops list limit

### DIFF
--- a/tests/test_pending_ops.py
+++ b/tests/test_pending_ops.py
@@ -173,6 +173,18 @@ def test_main_rejects_missing_admin_key(monkeypatch, capsys):
     assert "missing --admin-key or RC_ADMIN_KEY" in captured.err
 
 
+def test_main_rejects_non_positive_list_limit(capsys):
+    try:
+        pending_ops.main(["--admin-key", "secret", "list", "--limit", "0"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:
+        raise AssertionError("non-positive limit was accepted")
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "limit must be a positive integer" in captured.err
+
+
 def test_main_prints_http_error_body(monkeypatch, capsys):
     class FakeHTTPError(urllib.error.HTTPError):
         def read(self):

--- a/tools/pending_ops.py
+++ b/tools/pending_ops.py
@@ -22,6 +22,16 @@ import urllib.error
 import urllib.request
 
 
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("limit must be a positive integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("limit must be a positive integer")
+    return parsed
+
+
 def _req(method: str, url: str, admin_key: str, payload: dict | None = None, *, insecure: bool) -> dict:
     data = None if payload is None else json.dumps(payload).encode("utf-8")
     req = urllib.request.Request(url, data=data, method=method.upper())
@@ -63,7 +73,7 @@ def main(argv: list[str]) -> int:
 
     sp = sub.add_parser("list", help="List pending transfers")
     sp.add_argument("--status", default="pending", choices=["pending", "confirmed", "voided", "all"])
-    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--limit", type=positive_int, default=100)
     sp.set_defaults(fn=cmd_list)
 
     sp = sub.add_parser("confirm", help="Confirm ready pending transfers")


### PR DESCRIPTION
## Summary
- validate `pending_ops.py list --limit` with a positive-integer argparse type
- reject zero, negative, and non-integer limits before constructing the `/pending/list` node URL
- add regression coverage for the CLI parser path

## Verification
- `python3 -m py_compile tools/pending_ops.py tests/test_pending_ops.py`
- direct `positive_int()` checks for valid and invalid limits
- direct `main([... "list", "--limit", "0"])` exercise confirming argparse exits with code 2

Note: `python3 -m pytest tests/test_pending_ops.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
