### PR TITLE
fix: handle missing backup file

### DIFF
--- a/tests/test_verify_backup.py
+++ b/tests/test_verify_backup.py
@@ -65,6 +65,18 @@ def test_verify_fail_when_epoch_too_old(tmp_path):
     assert any("RESULT: FAIL" in line for line in result.lines)
 
 
+def test_verify_reports_missing_backup_file_without_crashing(tmp_path):
+    live = tmp_path / "live.db"
+    missing_backup = tmp_path / "missing.db"
+    _make_db(live, rows=5, epoch=10)
+
+    result = verify(str(live), str(missing_backup))
+
+    assert result.ok is False
+    assert any("backup file missing" in line for line in result.lines)
+    assert any("RESULT: FAIL" in line for line in result.lines)
+
+
 def test_verify_reports_missing_table_without_crashing(tmp_path):
     live = tmp_path / "live.db"
     bak = tmp_path / "bak.db"

--- a/tools/verify_backup.py
+++ b/tools/verify_backup.py
@@ -80,6 +80,8 @@ def verify(live_db: str, backup_file: str) -> CheckResult:
 
     if not os.path.exists(live_db):
         return CheckResult(False, lines + [log(f"RESULT: FAIL (live db missing: {live_db})")])
+    if not os.path.exists(backup_file):
+        return CheckResult(False, lines + [log(f"RESULT: FAIL (backup file missing: {backup_file})")])
 
     with tempfile.TemporaryDirectory(prefix="backup-verify-") as td:
         copied = os.path.join(td, Path(backup_file).name)


### PR DESCRIPTION
## Summary
- make `verify_backup.verify()` return a failed `CheckResult` when the selected backup file is missing
- avoid an uncaught `copy2()` failure if a backup disappears between discovery and verification
- add regression coverage for the missing-backup path

## Verification
- `python3 -m py_compile tools/verify_backup.py tests/test_verify_backup.py`
- direct `verify()` exercise with an existing live DB and missing backup path

Note: `python3 -m pytest tests/test_verify_backup.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
