### PR TITLE
fix: reject non-object vintage attestation logs

### DIFF
--- a/tests/test_validate_vintage_submission.py
+++ b/tests/test_validate_vintage_submission.py
@@ -49,6 +49,18 @@ def test_attestation_log_json_requires_core_fields(tmp_path):
     assert result["checks"]["json_valid"] is True
 
 
+def test_attestation_log_rejects_non_object_json_root(tmp_path):
+    validator = SubmissionValidator()
+    log_path = tmp_path / "attestation.json"
+    log_path.write_text('"miner_id device_arch fingerprint_hash timestamp"')
+
+    result = validator.validate_attestation_log(str(log_path))
+
+    assert result["status"] == "FAIL"
+    assert result["message"] == "Attestation log JSON root must be an object"
+    assert result["checks"]["json_valid"] is True
+
+
 def test_photo_validation_preserves_size_and_format_warnings(tmp_path):
     validator = SubmissionValidator()
     photo_path = tmp_path / "photo.txt"

--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -126,6 +126,10 @@ class SubmissionValidator:
             try:
                 log_data = json.loads(content)
                 result["checks"]["json_valid"] = True
+                if not isinstance(log_data, dict):
+                    result["message"] = "Attestation log JSON root must be an object"
+                    result["status"] = "FAIL"
+                    return result
                 
                 # Check required fields
                 required_fields = [


### PR DESCRIPTION
## Summary
- reject attestation-log JSON whose root value is not an object
- avoid treating JSON strings/lists as field containers before later dict-only access
- add regression coverage for a JSON string containing all required field names

## Verification
- `python3 -m py_compile tools/validate_vintage_submission.py tests/test_validate_vintage_submission.py`
- direct `SubmissionValidator.validate_attestation_log()` exercise for a non-object JSON root

Note: `python3 -m pytest tests/test_validate_vintage_submission.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
