### PR TITLE
fix: guard genesis validator helper types

### DIFF
--- a/tests/test_poa_validator_tool.py
+++ b/tests/test_poa_validator_tool.py
@@ -40,6 +40,14 @@ def test_timestamp_validation_rejects_future_and_pre_macintosh_dates():
     assert module.is_reasonable_timestamp("Sat Jan 01 00:00:00 1983") is False
 
 
+def test_validation_helpers_reject_non_string_values_without_raising():
+    module = load_module()
+
+    assert module.is_valid_mac(None) is False
+    assert module.is_valid_cpu({"cpu": "PowerPC G4"}) is False
+    assert module.is_reasonable_timestamp(["Mon Jan 01 00:00:00 2001"]) is False
+
+
 def test_recompute_hash_is_stable_for_same_genesis_fields():
     module = load_module()
 

--- a/tools/validate_genesis.py
+++ b/tools/validate_genesis.py
@@ -10,13 +10,19 @@ import datetime
 VALID_MAC_PREFIXES = ["00:03:93", "00:0a:27", "00:05:02", "00:0d:93"]
 
 def is_valid_mac(mac):
+    if not isinstance(mac, str):
+        return False
     prefix = mac.lower()[0:8]
     return any(prefix.startswith(p.lower()) for p in VALID_MAC_PREFIXES)
 
 def is_valid_cpu(cpu):
+    if not isinstance(cpu, str):
+        return False
     return any(kw in cpu.lower() for kw in ["powerpc", "g3", "g4", "7400", "7450"])
 
 def is_reasonable_timestamp(ts):
+    if not isinstance(ts, str):
+        return False
     try:
         parsed = datetime.datetime.strptime(ts.strip(), "%a %b %d %H:%M:%S %Y")
         now = datetime.datetime.now()


### PR DESCRIPTION
## Summary
- make the public genesis validation helpers reject non-string inputs instead of raising
- keep `is_valid_mac()`, `is_valid_cpu()`, and `is_reasonable_timestamp()` safe for direct use with parsed JSON values
- add regression coverage for non-string helper inputs

## Verification
- `python3 -m py_compile tools/validate_genesis.py tests/test_poa_validator_tool.py`
- direct helper checks for non-string MAC, CPU, and timestamp values plus a known valid MAC

Note: `python3 -m pytest tests/test_poa_validator_tool.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
