### PR TITLE
fix: handle miner checklist disk errors

### DIFF
--- a/tests/test_miner_checklist.py
+++ b/tests/test_miner_checklist.py
@@ -75,6 +75,25 @@ def test_preflight_reports_failures_when_dependencies_are_missing(capsys):
     assert "Fix issues above first." in output
 
 
+def test_preflight_reports_disk_failure_when_disk_usage_errors(capsys):
+    module = load_module()
+
+    with (
+        patch.object(module.shutil, "which", return_value="/usr/local/bin/clawrtc"),
+        patch.object(module.os.path, "exists", return_value=True),
+        patch.object(module.shutil, "disk_usage", side_effect=OSError("disk unavailable")),
+        patch.object(module.urllib.request, "urlopen", return_value=object()),
+    ):
+        module.preflight()
+
+    output = capsys.readouterr().out
+    assert "[PASS] clawrtc installed" in output
+    assert "[PASS] Wallet exists" in output
+    assert "[FAIL] Disk > 1GB free" in output
+    assert "[PASS] Node reachable" in output
+    assert "Fix issues above first." in output
+
+
 def test_preflight_calls_health_endpoint_with_timeout_and_context():
     module = load_module()
     urlopen_calls = []

--- a/tools/miner_checklist.py
+++ b/tools/miner_checklist.py
@@ -11,7 +11,11 @@ def preflight():
     ok &= check("Python 3.8+", __import__("sys").version_info >= (3, 8))
     ok &= check("clawrtc installed", shutil.which("clawrtc") is not None)
     ok &= check("Wallet exists", os.path.exists(os.path.expanduser("~/.clawrtc/wallets")))
-    ok &= check("Disk > 1GB free", shutil.disk_usage("/").free > 1e9)
+    try:
+        disk_ok = shutil.disk_usage("/").free > 1e9
+    except OSError:
+        disk_ok = False
+    ok &= check("Disk > 1GB free", disk_ok)
     try:
         ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
         urllib.request.urlopen("https://rustchain.org/health", timeout=5, context=ctx)


### PR DESCRIPTION
## Summary
- handle `shutil.disk_usage("/")` failures in the miner preflight checklist
- report the disk check as failed instead of aborting the whole preflight
- add regression coverage that keeps later checks running after a disk usage error

## Verification
- `python3 -m py_compile tools/miner_checklist.py tests/test_miner_checklist.py`
- direct patched `preflight()` run where `disk_usage()` raises and node reachability still runs

Note: `python3 -m pytest tests/test_miner_checklist.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
