### PR TITLE
fix: tolerate malformed large tx deltas

### DIFF
--- a/tools/tests/test_webhook_client_helpers.py
+++ b/tools/tests/test_webhook_client_helpers.py
@@ -60,3 +60,21 @@ def test_format_unknown_event_pretty_prints_json_payload():
     assert "Event:     custom_event" in text
     assert '"nested"' in text
     assert '"ok": true' in text
+
+
+def test_format_large_tx_tolerates_non_numeric_delta():
+    text = webhook_client.format_event(
+        "large_tx",
+        {
+            "miner": "miner-a",
+            "delta": "not-a-number",
+            "direction": "out",
+            "previous_balance": 10,
+            "new_balance": 8,
+        },
+        0,
+    )
+
+    assert "Miner:     miner-a" in text
+    assert "Delta:     ? RTC (out)" in text
+    assert "Balance:   10 -> 8 RTC" in text

--- a/tools/webhooks/webhook_client.py
+++ b/tools/webhooks/webhook_client.py
@@ -20,6 +20,8 @@ Usage:
   # 3. Watch events stream in
 """
 
+from __future__ import annotations
+
 import argparse
 import hashlib
 import hmac
@@ -73,8 +75,12 @@ def format_event(event_type: str, data: dict, ts: float) -> str:
         lines.append(f"  Miner:     {data.get('miner', '?')}")
 
     elif event_type == "large_tx":
+        try:
+            delta = f"{float(data.get('delta', 0)):+.6f}"
+        except (TypeError, ValueError):
+            delta = "?"
         lines.append(f"  Miner:     {data.get('miner', '?')}")
-        lines.append(f"  Delta:     {data.get('delta', 0):+.6f} RTC ({data.get('direction', '?')})")
+        lines.append(f"  Delta:     {delta} RTC ({data.get('direction', '?')})")
         lines.append(f"  Balance:   {data.get('previous_balance', '?')} -> {data.get('new_balance', '?')} RTC")
 
     else:


### PR DESCRIPTION
## Summary
- make the webhook client importable on Python versions where `str | None` annotations are otherwise evaluated at import time
- tolerate malformed `large_tx.delta` values while formatting webhook console output
- add regression coverage for a non-numeric large transaction delta

## Verification
- `python3 -m py_compile tools/webhooks/webhook_client.py tools/tests/test_webhook_client_helpers.py`
- direct `format_event("large_tx", ...)` checks for malformed and numeric delta values

Note: `python3 -m pytest tools/tests/test_webhook_client_helpers.py -q` could not run in this local environment because the Xcode Python does not have pytest installed.
