### PR TITLE
Diagnose wallet API redirects before JSON parsing

### DIFF
--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -137,7 +137,13 @@ class RustChainClient:
         """
         try:
             client = await self._get_client()
-            response = await client.get(path, params=params)
+            response = await client.get(path, params=params, follow_redirects=False)
+            if 300 <= response.status_code < 400:
+                location = response.headers.get("location", "")
+                raise APIError(
+                    f"API redirected: HTTP {response.status_code} to {location}",
+                    status_code=response.status_code,
+                )
             response.raise_for_status()
             return response.json()
         except httpx.ConnectError as e:

--- a/sdk/rustchain/async_client.py
+++ b/sdk/rustchain/async_client.py
@@ -97,7 +97,15 @@ class AsyncRustChainClient:
                 json=json_payload,
                 headers=headers,
                 timeout=aiohttp.ClientTimeout(total=self.timeout),
+                allow_redirects=False,
             ) as response:
+                if 300 <= response.status < 400:
+                    location = response.headers.get("Location", "")
+                    raise APIError(
+                        f"API redirected: HTTP {response.status} to {location}",
+                        status_code=response.status,
+                    )
+
                 # Check for HTTP errors
                 if response.status >= 400:
                     raise APIError(

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -78,7 +78,15 @@ class RustChainClient:
                 json=json_payload,
                 headers=headers,
                 timeout=self.timeout,
+                allow_redirects=False,
             )
+
+            if 300 <= response.status_code < 400:
+                location = response.headers.get("Location", "")
+                raise APIError(
+                    f"API redirected: HTTP {response.status_code} to {location}",
+                    status_code=response.status_code,
+                )
 
             # Check for HTTP errors
             try:

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -6,6 +6,7 @@ import pytest
 from unittest.mock import Mock, patch
 from rustchain import RustChainClient
 from rustchain.exceptions import (
+    APIError,
     ConnectionError,
     ValidationError,
 )
@@ -55,6 +56,7 @@ class TestHealthEndpoint:
     def test_health_success(self, mock_request):
         """Test successful health check"""
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "ok": True,
             "uptime_s": 55556,
@@ -189,6 +191,7 @@ class TestBalanceEndpoint:
     def test_balance_success(self, mock_request):
         """Test successful balance query"""
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.json.return_value = {
             "miner_pk": "test_wallet_address",
             "balance": 123.456,
@@ -207,6 +210,21 @@ class TestBalanceEndpoint:
         mock_request.assert_called_once()
         assert mock_request.call_args.kwargs["url"] == "https://rustchain.org/wallet/balance"
         assert mock_request.call_args.kwargs["params"] == {"miner_id": "test_wallet_address"}
+        assert mock_request.call_args.kwargs["allow_redirects"] is False
+
+    @patch("requests.Session.request")
+    def test_balance_redirect_reports_location(self, mock_request):
+        mock_response = Mock()
+        mock_response.status_code = 307
+        mock_response.headers = {"Location": "http://redirect.netprotect.mk/passthrough"}
+        mock_request.return_value = mock_response
+
+        with pytest.raises(APIError) as exc_info:
+            with RustChainClient("https://rustchain.org") as client:
+                client.balance("test_wallet_address")
+
+        assert "API redirected: HTTP 307 to http://redirect.netprotect.mk/passthrough" in str(exc_info.value)
+        assert exc_info.value.status_code == 307
 
     def test_balance_empty_miner_id(self):
         """Test balance with empty miner_id raises ValidationError"""


### PR DESCRIPTION
Fixes #5990.\n\n## Summary\n- disable automatic redirects for wallet/API client requests\n- surface 3xx responses as explicit APIError diagnostics with redirect target\n- cover sync wallet balance redirect handling in unit tests\n\n## Test\n- python3 -m pytest sdk/tests/test_client_unit.py::TestBalanceEndpoint sdk/tests/test_async_client.py::TestAsyncBalanceEndpoint sdk/python/rustchain_sdk/tests/test_client.py::TestRustChainClientBalance -q