### PR TITLE
fix: validate green tracker leaderboard limit

### DIFF
--- a/tests/test_green_tracker.py
+++ b/tests/test_green_tracker.py
@@ -105,6 +105,13 @@ class TestGetLeaderboard:
         lb = populated.get_leaderboard(2)
         assert len(lb) <= 2
 
+    def test_leaderboard_rejects_non_positive_limit(self, populated):
+        with pytest.raises(ValueError, match="positive integer"):
+            populated.get_leaderboard(0)
+
+        with pytest.raises(ValueError, match="positive integer"):
+            populated.get_leaderboard(-1)
+
     def test_leaderboard_top_is_g5(self, populated):
         lb = populated.get_leaderboard(10)
         assert lb[0]["machine_id"] == "g5-001"

--- a/tools/green_tracker.py
+++ b/tools/green_tracker.py
@@ -234,6 +234,9 @@ class GreenTracker:
 
     def get_leaderboard(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Return top machines ranked by RTC earned."""
+        if limit < 1:
+            raise ValueError("limit must be a positive integer")
+
         with self._connect() as conn:
             rows = conn.execute(
                 """


### PR DESCRIPTION
## Summary
- reject non-positive GreenTracker leaderboard limits before reaching SQLite
- add regression coverage for zero and negative limits

## Verification
- `python3 -m py_compile tools/green_tracker.py tests/test_green_tracker.py`
- direct `GreenTracker(':memory:')` exercise confirming positive limits still rank correctly and `0`/`-1` raise `ValueError`

Note: `python3 -m pytest tests/test_green_tracker.py -q` could not run locally because this Xcode Python environment does not have `pytest` installed.
