### PR TITLE
fix: ignore blank article author filters

### DIFF
--- a/tests/test_article_checker.py
+++ b/tests/test_article_checker.py
@@ -144,6 +144,25 @@ def test_check_article_warns_but_passes_when_author_is_missing(monkeypatch):
     assert details["warning"] == "Author 'alice' not found in article text"
 
 
+def test_check_article_ignores_blank_expected_author(monkeypatch):
+    _enable_fake_parser(monkeypatch)
+    monkeypatch.setattr(
+        article_checker.requests,
+        "get",
+        lambda url, headers, timeout, allow_redirects: FakeResponse(text="<p>RTC bounty guide</p>"),
+    )
+
+    passed, details = article_checker.ArticleChecker().check_article(
+        "https://example.test/rtc",
+        expected_author="   ",
+    )
+
+    assert passed is True
+    assert details["mentions_rustchain"] == "True"
+    assert "author_found" not in details
+    assert "warning" not in details
+
+
 def test_check_article_handles_request_timeout(monkeypatch):
     _enable_fake_parser(monkeypatch)
 

--- a/tools/bounty_verifier/article_checker.py
+++ b/tools/bounty_verifier/article_checker.py
@@ -69,6 +69,7 @@ class ArticleChecker:
                 return False, details
 
             # Optional author check (best-effort)
+            expected_author = expected_author.strip() if expected_author else None
             if expected_author:
                 author_found = expected_author.lower() in text
                 details["author_found"] = str(author_found)


### PR DESCRIPTION
## Summary
- normalize `expected_author` before best-effort article author matching
- treat blank/whitespace-only author filters as absent instead of matching whitespace in article text
- add regression coverage for the blank-author case

## Verification
- `python3 -m py_compile tools/bounty_verifier/article_checker.py tests/test_article_checker.py`
- direct stubbed `ArticleChecker.check_article()` exercise confirming whitespace-only authors are ignored and real missing authors still produce `author_found=False`

Note: the local Xcode Python environment does not have `requests`, `beautifulsoup4`, or `pytest` installed, so the direct check stubs those dependencies and `python3 -m pytest tests/test_article_checker.py -q` cannot run locally.
