### PR TITLE
Fix setup_miner --help side effects

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -4,6 +4,7 @@ RustChain Miner Setup Script
 Automated setup for RustChain Universal Miner
 """
 
+import argparse
 import os
 import sys
 import subprocess
@@ -15,6 +16,8 @@ import hashlib
 import time
 from urllib.parse import urlparse
 from pathlib import Path
+
+DESCRIPTION = "Automated setup for RustChain Universal Miner."
 
 MINER_ARTIFACTS = {
     "Linux": {
@@ -405,6 +408,17 @@ WantedBy=multi-user.target
             self.log(f"Setup failed: {e}")
             sys.exit(1)
 
+def build_parser():
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser.set_defaults(func=lambda _args: MinerSetup().run_setup())
+    return parser
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+
+
 if __name__ == "__main__":
-    setup = MinerSetup()
-    setup.run_setup()
+    main()

--- a/tests/test_setup_miner_cli.py
+++ b/tests/test_setup_miner_cli.py
@@ -1,0 +1,24 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_setup_miner_help_is_non_mutating(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "setup_miner.py"), "--help"],
+        cwd=ROOT,
+        env={"HOME": str(home)},
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout
+    assert "RustChain Miner Setup" not in result.stdout
+    assert not (home / "rustchain_miner").exists()


### PR DESCRIPTION
Fixes #5985.\n\nChanges:\n- Add an argparse entrypoint so `python setup_miner.py --help` exits before setup work.\n- Keep default no-arg behavior unchanged.\n- Add regression coverage proving help does not create `~/rustchain_miner`.\n\nVerification:\n- `python3 -m pytest tests/test_setup_miner_cli.py tests/test_setup_miner_downloads.py -q`\n- `git diff --check`