### PR TITLE
fix: handle bare bcos spdx base refs

### DIFF
--- a/tests/test_bcos_spdx_check.py
+++ b/tests/test_bcos_spdx_check.py
@@ -45,3 +45,52 @@ def test_git_diff_name_status_parses_valid_rows(monkeypatch):
         ("M", "tools/old.py"),
         ("R100", "old.py\tnew.py"),
     ]
+
+
+def test_ensure_base_ref_returns_existing_ref(monkeypatch):
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        return ""
+
+    monkeypatch.setattr(bcos_spdx_check, "_run", fake_run)
+
+    assert bcos_spdx_check._ensure_base_ref("origin/main") == "origin/main"
+    assert calls == [["git", "rev-parse", "--verify", "origin/main"]]
+
+
+def test_ensure_base_ref_fetches_remote_branch_when_missing(monkeypatch):
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        if cmd == ["git", "rev-parse", "--verify", "upstream/main"]:
+            raise RuntimeError("missing")
+        return ""
+
+    monkeypatch.setattr(bcos_spdx_check, "_run", fake_run)
+
+    assert bcos_spdx_check._ensure_base_ref("upstream/main") == "upstream/main"
+    assert calls == [
+        ["git", "rev-parse", "--verify", "upstream/main"],
+        ["git", "fetch", "upstream", "main", "--depth=1"],
+    ]
+
+
+def test_ensure_base_ref_normalizes_missing_bare_branch(monkeypatch):
+    calls = []
+
+    def fake_run(cmd):
+        calls.append(cmd)
+        if cmd == ["git", "rev-parse", "--verify", "main"]:
+            raise RuntimeError("missing")
+        return ""
+
+    monkeypatch.setattr(bcos_spdx_check, "_run", fake_run)
+
+    assert bcos_spdx_check._ensure_base_ref("main") == "origin/main"
+    assert calls == [
+        ["git", "rev-parse", "--verify", "main"],
+        ["git", "fetch", "origin", "main", "--depth=1"],
+    ]

--- a/tools/bcos_spdx_check.py
+++ b/tools/bcos_spdx_check.py
@@ -58,6 +58,20 @@ def _git_diff_name_status(base_ref: str) -> List[Tuple[str, str]]:
     return rows
 
 
+def _ensure_base_ref(base_ref: str) -> str:
+    try:
+        _run(["git", "rev-parse", "--verify", base_ref])
+        return base_ref
+    except Exception:
+        if "/" in base_ref:
+            remote, branch = base_ref.split("/", 1)
+            _run(["git", "fetch", remote, branch, "--depth=1"])
+            return base_ref
+
+        _run(["git", "fetch", "origin", base_ref, "--depth=1"])
+        return f"origin/{base_ref}"
+
+
 def _top_lines(path: Path, max_lines: int = 25) -> List[str]:
     try:
         with path.open("r", encoding="utf-8", errors="replace") as f:
@@ -101,10 +115,7 @@ def main(argv: List[str]) -> int:
     os.chdir(repo_root)
 
     # Ensure base ref exists locally.
-    try:
-        _run(["git", "rev-parse", "--verify", base_ref])
-    except Exception:
-        _run(["git", "fetch", "origin", base_ref.split("/", 1)[1], "--depth=1"])
+    base_ref = _ensure_base_ref(base_ref)
 
     changes = _git_diff_name_status(base_ref)
     added = [p for st, p in changes if st == "A"]
@@ -133,4 +144,3 @@ def main(argv: List[str]) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))
-


### PR DESCRIPTION
## Summary
- add a small `_ensure_base_ref()` helper for BCOS SPDX checking
- handle missing bare branch refs such as `--base-ref main` without raising `IndexError`
- preserve remote/branch refs while fetching from the requested remote when needed

## Verification
- `python3 -m py_compile tools/bcos_spdx_check.py tests/test_bcos_spdx_check.py`
- direct `_ensure_base_ref('main')` exercise with `_run` stubbed to simulate a missing local ref and confirm it fetches `origin main` then returns `origin/main`

Note: `python3 -m pytest tests/test_bcos_spdx_check.py -q` could not run locally because this Xcode Python environment does not have `pytest` installed.
