### PR TITLE
fix: validate badge qr flag type

### DIFF
--- a/tests/test_bcos_badge_generator.py
+++ b/tests/test_bcos_badge_generator.py
@@ -563,6 +563,24 @@ class TestFlaskIntegration(unittest.TestCase):
                 self.assertFalse(data['success'])
                 self.assertEqual(data['error'], 'Trust score must be a number')
 
+    def test_generate_badge_rejects_non_boolean_include_qr(self):
+        """include_qr should not treat truthy strings as enabling QR output."""
+        for include_qr in ['false', 'true', 1, None]:
+            with self.subTest(include_qr=include_qr):
+                response = self.post_generate_badge(
+                    {
+                        'repo_name': 'test/repo',
+                        'tier': 'L1',
+                        'trust_score': 75,
+                        'include_qr': include_qr,
+                    }
+                )
+
+                self.assertEqual(response.status_code, 200)
+                data = json.loads(response.data)
+                self.assertFalse(data['success'])
+                self.assertEqual(data['error'], 'include_qr must be a boolean')
+
     def test_generate_badge_rejects_attribute_breaking_cert_id(self):
         """User-supplied cert IDs must not break generated embed attributes."""
         payload = {

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1152,6 +1152,8 @@ def generate_badge():
     raw_trust_score = data.get('trust_score', 75)
     cert_id = data.get('cert_id', '')
     include_qr = data.get('include_qr', False)
+    if not isinstance(include_qr, bool):
+        return jsonify({'success': False, 'error': 'include_qr must be a boolean'})
 
     # Validation
     if not repo_name:


### PR DESCRIPTION
## Summary
- validate `include_qr` on the BCOS badge generation endpoint as a real boolean
- reject string/numeric/null QR flags instead of letting truthy strings such as `"false"` enable QR output
- add regression coverage for invalid `include_qr` payload values

## Verification
- `python3 -m py_compile tools/bcos_badge_generator.py tests/test_bcos_badge_generator.py`
- direct stubbed `generate_badge()` exercise confirming `include_qr='false'` is rejected, `include_qr=False` omits QR markup, and `include_qr=True` includes QR markup

Note: the local Xcode Python environment does not have Flask installed, so the direct route check used a tiny fake Flask/request harness rather than running the Flask unittest case locally.
