### PR TITLE
Reject non-object OTC confirm JSON

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -917,6 +917,9 @@ def match_order(order_id):
 def confirm_order(order_id):
     """Confirm settlement -- verifies HTLC preimage, releases escrow."""
     data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object required"}), 400
+
     wallet = str(data.get("wallet", "")).strip()
     quote_tx = str(data.get("quote_tx", "")).strip()
     secret = str(data.get("secret", "")).strip()

--- a/tests/test_otc_bridge_query_validation.py
+++ b/tests/test_otc_bridge_query_validation.py
@@ -258,3 +258,13 @@ def test_escrow_helper_returns_generic_error_on_exception(tmp_path, monkeypatch)
     )
 
     assert result == {"ok": False, "error": otc_bridge.GENERIC_INTERNAL_ERROR}
+
+def test_confirm_order_rejects_non_object_json(tmp_path, monkeypatch):
+    otc_bridge = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(otc_bridge, "check_rate_limit", lambda _ip: True)
+
+    client = otc_bridge.app.test_client()
+    response = client.post("/api/orders/otc_test/confirm", json=["seller", "0xabc", "secret"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}


### PR DESCRIPTION
Fixes #5976.\n\n## Summary\n- reject non-object JSON bodies on OTC confirm route before reading fields\n- add regression coverage for array payloads\n\n## Tests\n- `python3 -m pytest tests/test_otc_bridge_query_validation.py -q`