### PR TITLE
[UTXO-BUG] Bound persisted mempool transaction payloads

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1460,6 +1460,49 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.mempool_get_block_candidates(), [])
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
 
+    def test_mempool_canonicalizes_payload_before_persistence(self):
+        """Ignored caller fields must not bypass mempool payload limits."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+        blob = 'x' * 200_000
+
+        ok = self.db.mempool_add({
+            'tx_id': 'canon' * 16,
+            'tx_type': 'transfer',
+            'inputs': [{
+                'box_id': box['box_id'],
+                'ignored_proof_blob': blob,
+            }],
+            'outputs': [{
+                'address': 'bob',
+                'value_nrtc': 100 * UNIT,
+                'ignored_output_blob': blob,
+            }],
+            'fee_nrtc': 0,
+            'ignored_top_level_blob': blob,
+        })
+
+        self.assertTrue(ok)
+        candidates = self.db.mempool_get_block_candidates()
+        self.assertEqual(len(candidates), 1)
+        self.assertNotIn('ignored_top_level_blob', candidates[0])
+        self.assertNotIn('ignored_proof_blob', candidates[0]['inputs'][0])
+        self.assertNotIn('ignored_output_blob', candidates[0]['outputs'][0])
+
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                "SELECT tx_data_json FROM utxo_mempool WHERE tx_id = ?",
+                ('canon' * 16,),
+            ).fetchone()
+            self.assertIsNotNone(row)
+            self.assertLess(
+                len(row['tx_data_json'].encode('utf-8')),
+                len(blob),
+            )
+        finally:
+            conn.close()
+
     def test_mempool_rejects_oversized_output_text_without_locking_input(self):
         """Reject oversized output fields before storing tx_data_json."""
         cases = [

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -46,6 +46,7 @@ MAX_OUTPUTS = 100
 MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
 MAX_MEMPOOL_TX_ID_BYTES = 128
+MAX_MEMPOOL_TX_JSON_BYTES = 2_000_000
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
 MAX_SQLITE_INT64 = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
@@ -479,6 +480,50 @@ class UtxoDB:
                 return False
 
         return True
+
+    def _canonical_mempool_tx(self, tx: dict, tx_type: str,
+                              inputs: List[dict], outputs: List[dict],
+                              data_inputs: List[str], fee: int,
+                              timestamp: int) -> Optional[dict]:
+        """Return the bounded transaction shape persisted in the mempool."""
+        canonical_inputs = []
+        for inp in inputs:
+            if not isinstance(inp, dict):
+                return None
+            box_id = inp.get('box_id')
+            if not isinstance(box_id, str) or not box_id.strip():
+                return None
+            canonical_inputs.append({'box_id': box_id})
+
+        if len(canonical_inputs) != len({i['box_id'] for i in canonical_inputs}):
+            return None
+
+        canonical_outputs = [
+            {
+                'address': out['address'],
+                'value_nrtc': out['value_nrtc'],
+                'tokens_json': out.get('tokens_json', '[]'),
+                'registers_json': out.get('registers_json', '{}'),
+            }
+            for out in outputs
+        ]
+
+        canonical_tx = {
+            'tx_id': tx['tx_id'],
+            'tx_type': tx_type,
+            'inputs': canonical_inputs,
+            'outputs': canonical_outputs,
+            'data_inputs': data_inputs,
+            'fee_nrtc': fee,
+            'timestamp': timestamp,
+        }
+        encoded = json.dumps(
+            canonical_tx, sort_keys=True, separators=(',', ':')
+        )
+        encoded_len = _utf8_len(encoded)
+        if encoded_len is None or encoded_len > MAX_MEMPOOL_TX_JSON_BYTES:
+            return None
+        return canonical_tx
 
     # -- transaction application ---------------------------------------------
 
@@ -987,6 +1032,14 @@ class UtxoDB:
                         conn.execute("ROLLBACK")
                 return False
 
+            canonical_tx = self._canonical_mempool_tx(
+                tx, tx_type, inputs, outputs, data_inputs, fee, timestamp
+            )
+            if canonical_tx is None:
+                if manage_tx:
+                        conn.execute("ROLLBACK")
+                return False
+
             # Insert into mempool
             # FIX(#2179): Use INSERT OR ABORT instead of INSERT OR IGNORE.
             # With IGNORE, a duplicate tx_id silently skips the insert but
@@ -998,8 +1051,8 @@ class UtxoDB:
                    VALUES (?,?,?,?,?)""",
                 (
                     tx_id,
-                    json.dumps(tx),
-                    tx.get('fee_nrtc', 0),
+                    json.dumps(canonical_tx, sort_keys=True, separators=(',', ':')),
+                    fee,
                     now,
                     now + MAX_TX_AGE_SECONDS,
                 ),


### PR DESCRIPTION
## Summary
- canonicalize `mempool_add()` transaction payloads before storing `tx_data_json`
- drop ignored caller-controlled top-level/input/output fields from block-candidate payloads
- add regression coverage for oversized ignored fields that previously bypassed field-specific size checks

## Finding
`mempool_add()` validated a normalized view of the transaction, but persisted the original caller-supplied `tx` object. A valid one-output transfer could include large ignored blobs on the top-level transaction, input entries, or output entries; current `main` accepted the transaction, stored the oversized JSON in `utxo_mempool.tx_data_json`, and returned the ignored fields from `mempool_get_block_candidates()`.

This is adjacent to prior oversized-field hardening, but distinct: those checks bound meaningful fields such as `tx_id`, output addresses, and output metadata. This change prevents irrelevant caller fields from bypassing validation and inflating the persisted/candidate mempool payload.

## Validation
- Reproduced on `origin/main` (`35b89c8`): `mempool_add=True`, stored `tx_data_json` was `600366` bytes, ignored fields survived in candidates
- `PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py::TestUtxoDB::test_mempool_canonicalizes_payload_before_persistence --tb=short`
- `PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py --tb=short` -> `89 passed, 14 subtests passed`
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

Bounty context: Scottcjn/rustchain-bounties#2819
