### PR TITLE
[UTXO-BUG] Bound UTXO data input fanout

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -17,7 +17,7 @@ import utxo_db as utxo_db_module
 from utxo_db import (
     UtxoDB, coin_select, compute_box_id, address_to_proposition,
     proposition_to_address, UNIT, DUST_THRESHOLD, MAX_COINBASE_OUTPUT_NRTC,
-    MAX_OUTPUTS, MAX_SQLITE_INT64, MAX_UTXO_ADDRESS_BYTES,
+    MAX_OUTPUTS, MAX_DATA_INPUTS, MAX_SQLITE_INT64, MAX_UTXO_ADDRESS_BYTES,
     MAX_UTXO_METADATA_BYTES, MAX_MEMPOOL_TX_ID_BYTES,
 )
 
@@ -45,6 +45,21 @@ class TestUtxoDB(unittest.TestCase):
             'timestamp': int(time.time()),
             '_allow_minting': True,
         }, block_height=block_height)
+
+    def _create_data_input_refs(self, count: int, start_height: int = 2) -> list:
+        refs = []
+        for idx in range(count):
+            address = f'data_ref_{idx}'
+            self.assertTrue(self.db.apply_transaction({
+                'tx_type': 'mining_reward',
+                'inputs': [],
+                'outputs': [{'address': address, 'value_nrtc': UNIT}],
+                'fee_nrtc': 0,
+                'timestamp': int(time.time()) + idx,
+                '_allow_minting': True,
+            }, block_height=start_height + idx))
+            refs.append(self.db.get_unspent_for_address(address)[0]['box_id'])
+        return refs
 
     # -- box operations ------------------------------------------------------
 
@@ -480,6 +495,33 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('bob'), 0)
         self.assertIsNone(self.db.get_box(alice_box['box_id'])['spent_at'])
 
+    def test_too_many_data_inputs_rejected_before_history_write(self):
+        """Bound read-only data-input fan-out before persisting tx history."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+        data_inputs = self._create_data_input_refs(MAX_DATA_INPUTS + 1)
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': alice_box['box_id'], 'spending_proof': 'sig'}],
+            'data_inputs': data_inputs,
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }, block_height=MAX_DATA_INPUTS + 10)
+
+        self.assertFalse(ok)
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                """SELECT COUNT(*) AS n FROM utxo_transactions
+                   WHERE tx_type = 'transfer'"""
+            ).fetchone()
+            self.assertEqual(row['n'], 0)
+        finally:
+            conn.close()
+
     # -- state root ----------------------------------------------------------
 
     def test_empty_state_root(self):
@@ -858,6 +900,33 @@ class TestUtxoDB(unittest.TestCase):
         ok = self.db.mempool_add(tx)
         self.assertFalse(ok)
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+
+    def test_mempool_rejects_too_many_data_inputs_without_locking_input(self):
+        """Bound data-input fan-out before storing mempool payloads."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        box = self.db.get_unspent_for_address('alice')[0]
+        data_inputs = self._create_data_input_refs(MAX_DATA_INPUTS + 1)
+
+        tx = {
+            'tx_id': 'datacap' * 8,
+            'inputs': [{'box_id': box['box_id']}],
+            'data_inputs': data_inputs,
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        ok = self.db.mempool_add(tx)
+
+        self.assertFalse(ok)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+        conn = self.db._conn()
+        try:
+            row = conn.execute(
+                "SELECT COUNT(*) AS n FROM utxo_mempool"
+            ).fetchone()
+            self.assertEqual(row['n'], 0)
+        finally:
+            conn.close()
 
     def test_mempool_rejects_data_input_overlap_without_locking_input(self):
         """Mempool rejects txs that consume their read-only context."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -43,6 +43,7 @@ MAX_POOL_SIZE = 10_000
 # Anti-UTXO-bloat: maximum outputs per transaction
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
 MAX_OUTPUTS = 100
+MAX_DATA_INPUTS = 100
 MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
 MAX_MEMPOOL_TX_ID_BYTES = 128
@@ -386,6 +387,8 @@ class UtxoDB:
     def _normalize_data_inputs(self, data_inputs: list) -> Optional[List[str]]:
         """Return validated read-only UTXO box IDs, or None on invalid input."""
         if not isinstance(data_inputs, list):
+            return None
+        if len(data_inputs) > MAX_DATA_INPUTS:
             return None
 
         normalized = []


### PR DESCRIPTION
## Summary
- Add `MAX_DATA_INPUTS = 100` for read-only UTXO data inputs.
- Reuse the existing shared `_normalize_data_inputs()` path so both direct transaction application and public mempool admission reject excessive data-input fanout.
- Add regressions for confirmed transaction history and mempool admission so oversized read-only context cannot inflate persisted JSON or lock spend inputs.

## Finding
`data_inputs` are read-only, but they were only validated for shape, uniqueness, existence, and freshness. A transaction could reference many valid existing UTXOs without spending them, inflating `utxo_mempool.tx_data_json`, block-candidate JSON, and confirmed `utxo_transactions.data_inputs_json` while preserving otherwise valid spend semantics.

Reproduced on current `main` before the fix with one spend input plus 150 valid read-only data-input boxes:

```text
mempool_add True
mempool_json_bytes 10498
candidate_data_inputs 150
apply_transaction True
history_data_inputs_bytes 10200
```

This is distinct from the earlier data-input existence/freshness fixes and from raw ignored-payload canonicalization: this patch bounds valid read-only references before mempool/history persistence.

## Validation
```text
PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py::TestUtxoDB::test_too_many_data_inputs_rejected_before_history_write node/test_utxo_db.py::TestUtxoDB::test_mempool_rejects_too_many_data_inputs_without_locking_input --tb=short
# 2 passed

PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py --tb=short
# 90 passed, 14 subtests passed

python3 -B -m py_compile node/utxo_db.py node/test_utxo_db.py
git diff --check origin/main...HEAD -- node/utxo_db.py node/test_utxo_db.py
python3 tools/bcos_spdx_check.py --base-ref origin/main
# BCOS SPDX check: OK
```
