### PR TITLE
Fix documentation relative links

### DIFF
--- a/docs/CLAIMS_GUIDE.md
+++ b/docs/CLAIMS_GUIDE.md
@@ -433,7 +433,7 @@ Rewards are calculated based on:
 2. **Antiquity Multiplier** - Bonus for vintage hardware (1.0x - 3.0x)
 3. **Fleet Adjustments** - Penalties for suspicious fleet activity
 
-See [RIP-200](WHITEPAPER.md#3-rip-200-round-robin-consensus) for full details.
+See [RIP-200](./WHITEPAPER.md#3-rip-200-round-robin-consensus) for full details.
 
 ### Settlement Process
 

--- a/docs/INSTALLATION_WALKTHROUGH.md
+++ b/docs/INSTALLATION_WALKTHROUGH.md
@@ -120,13 +120,20 @@ GitHub doesn't support direct asciinema embedding, but you can:
 
 1. **Link to the cast file:**
    ```markdown
-   [Watch Installation](docs/asciinema/miner_install.cast)
+   [Watch Installation](./asciinema/miner_install.cast)
    ```
 
 2. **Convert to GIF and embed:**
-   ```markdown
-   ![Miner Installation](docs/asciinema/miner_install.gif)
+   ```bash
+   agg docs/asciinema/miner_install.cast docs/asciinema/miner_install.gif
    ```
+
+   Then embed the generated GIF:
+   ```markdown
+   ![Installation walkthrough](./asciinema/miner_install.gif)
+   ```
+
+   > Note: generate `miner_install.gif` before referencing it in documentation.
 
 3. **Use asciinema.org hosting:**
    ```bash
@@ -147,7 +154,7 @@ For HTML docs, use the asciinema player:
 Or host locally:
 
 ```html
-<asciinema-player src="docs/asciinema/miner_install.cast"></asciinema-player>
+<asciinema-player src="./asciinema/miner_install.cast"></asciinema-player>
 <script src="https://cdn.jsdelivr.net/npm/asciinema-player@3/dist/bundle/asciinema-player.min.js"></script>
 ```
 
@@ -161,7 +168,7 @@ Add to your README.md:
 See the [Installation Walkthrough](docs/INSTALLATION_WALKTHROUGH.md) for a visual guide with asciinema recordings.
 
 Quick preview:
-![Installation Preview](docs/asciinema/miner_install.gif)
+[Watch the installation walkthrough cast](docs/asciinema/miner_install.cast)
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix docs-local relative links in `docs/CLAIMS_GUIDE.md` and `docs/INSTALLATION_WALKTHROUGH.md`
- point docs examples at paths that resolve from their rendered location under `docs/`
- avoid referencing an uncommitted `miner_install.gif` preview in examples and link to the existing `.cast` recording instead

## Validation
- checked edited Markdown local links with a small Python link check
- `git diff --check`

/claim #305
