### PR TITLE
Fix explorer invalid last_seen handling

### DIFF
--- a/explorer/app.py
+++ b/explorer/app.py
@@ -48,20 +48,22 @@ def get_miners():
                     try:
                         timestamp = datetime.fromtimestamp(miner['last_seen'])
                         miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
-                    except:
+                    except (TypeError, ValueError, OSError, OverflowError):
                         miner['last_seen_formatted'] = 'Unknown'
                 
                 # Set status based on last seen
-                if 'last_seen' in miner:
-                    time_diff = datetime.now().timestamp() - miner['last_seen']
+                try:
+                    last_seen = float(miner['last_seen'])
+                except (KeyError, TypeError, ValueError):
+                    miner['status'] = 'unknown'
+                else:
+                    time_diff = datetime.now().timestamp() - last_seen
                     if time_diff < 300:  # 5 minutes
                         miner['status'] = 'online'
                     elif time_diff < 3600:  # 1 hour
                         miner['status'] = 'idle'
                     else:
                         miner['status'] = 'offline'
-                else:
-                    miner['status'] = 'unknown'
             
             return jsonify(miners_data)
         else:
@@ -121,12 +123,16 @@ def get_miner_detail(miner_id):
                     try:
                         timestamp = datetime.fromtimestamp(miner['last_seen'])
                         miner['last_seen_formatted'] = timestamp.strftime('%Y-%m-%d %H:%M:%S')
-                    except:
+                    except (TypeError, ValueError, OSError, OverflowError):
                         miner['last_seen_formatted'] = 'Unknown'
                 
                 # Calculate status
-                if 'last_seen' in miner:
-                    time_diff = datetime.now().timestamp() - miner['last_seen']
+                try:
+                    last_seen = float(miner['last_seen'])
+                except (KeyError, TypeError, ValueError):
+                    miner['status'] = 'unknown'
+                else:
+                    time_diff = datetime.now().timestamp() - last_seen
                     if time_diff < 300:
                         miner['status'] = 'online'
                     elif time_diff < 3600:

--- a/tests/test_explorer_last_seen_validation.py
+++ b/tests/test_explorer_last_seen_validation.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+from unittest.mock import Mock, patch
+
+from explorer.app import app as explorer_app
+
+
+def _mock_miners_response(miner):
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {"miners": [miner]}
+    return response
+
+
+def test_miners_api_handles_invalid_last_seen_without_500():
+    miner = {"id": "miner-bad-time", "last_seen": "not-a-timestamp"}
+
+    with (
+        explorer_app.test_client() as client,
+        patch("explorer.app.requests.get", return_value=_mock_miners_response(miner)),
+    ):
+        response = client.get("/api/miners")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["miners"][0]["last_seen_formatted"] == "Unknown"
+    assert body["miners"][0]["status"] == "unknown"
+
+
+def test_miner_detail_handles_invalid_last_seen_without_500():
+    miner = {"id": "miner-bad-time", "last_seen": "not-a-timestamp"}
+
+    with (
+        explorer_app.test_client() as client,
+        patch("explorer.app.requests.get", return_value=_mock_miners_response(miner)),
+    ):
+        response = client.get("/api/miner/miner-bad-time")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["last_seen_formatted"] == "Unknown"
+    assert body["status"] == "unknown"


### PR DESCRIPTION
## Summary
- handle non-numeric `last_seen` values in explorer miner responses without raising `TypeError`
- set malformed/missing timestamps to `Unknown` / `unknown` instead of returning a 500
- add regression coverage for `/api/miners` and `/api/miner/<id>`

## Tests
- `python -m pytest tests/test_explorer_last_seen_validation.py -q`
- `python -m pytest tests/test_explorer_api_errors.py tests/test_explorer_miners_normalization.py tests/test_explorer_last_seen_validation.py -q`
- `python -m py_compile explorer/app.py tests/test_explorer_last_seen_validation.py`
- `git diff --check`

/claim #305
