### PR TITLE
Fix passport PDF malformed repair dates

### DIFF
--- a/node/machine_passport.py
+++ b/node/machine_passport.py
@@ -42,6 +42,14 @@ except ImportError:
     print("[WARN] reportlab library not available - PDF generation disabled")
 
 
+def _format_repair_date(repair_date: Any) -> str:
+    """Format a repair timestamp for PDF output without crashing on bad data."""
+    try:
+        return datetime.fromtimestamp(float(repair_date)).strftime('%Y-%m-%d')
+    except (TypeError, ValueError, OSError, OverflowError):
+        return 'Unknown'
+
+
 @dataclass
 class MachinePassport:
     """Data structure for a machine passport."""
@@ -732,11 +740,10 @@ def generate_passport_pdf(passport_data: Dict, output_path: str) -> Tuple[bool, 
         if repair_log:
             repair_data = [['Date', 'Type', 'Description', 'Parts']]
             for entry in repair_log[:10]:  # Limit to 10 entries
-                repair_date = datetime.fromtimestamp(entry['repair_date']).strftime('%Y-%m-%d')
                 repair_data.append([
-                    repair_date,
-                    entry['repair_type'],
-                    entry['description'][:40] + '...' if len(entry['description']) > 40 else entry['description'],
+                    _format_repair_date(entry.get('repair_date')),
+                    entry.get('repair_type', 'N/A'),
+                    str(entry.get('description', ''))[:40],
                     entry.get('parts_replaced', 'N/A') or 'N/A',
                 ])
             

--- a/node/tests/test_machine_passport.py
+++ b/node/tests/test_machine_passport.py
@@ -849,6 +849,17 @@ class TestIntegration(unittest.TestCase):
         self.assertEqual(updated.name, 'Old Faithful (Upgraded)')
 
 
+
+class TestMachinePassportPdfRobustness(unittest.TestCase):
+    """Regression tests for PDF export input robustness."""
+
+    def test_format_repair_date_handles_malformed_values(self):
+        from machine_passport import _format_repair_date
+
+        self.assertEqual(_format_repair_date('not-a-timestamp'), 'Unknown')
+        self.assertEqual(_format_repair_date(None), 'Unknown')
+        self.assertEqual(_format_repair_date(0), '1970-01-01')
+
 def run_tests():
     """Run all tests and return results."""
     loader = unittest.TestLoader()
@@ -860,6 +871,7 @@ def run_tests():
     suite.addTests(loader.loadTestsFromTestCase(TestMachinePassportLedger))
     suite.addTests(loader.loadTestsFromTestCase(TestQRCodeGeneration))
     suite.addTests(loader.loadTestsFromTestCase(TestPDFGeneration))
+    suite.addTests(loader.loadTestsFromTestCase(TestMachinePassportPdfRobustness))
     suite.addTests(loader.loadTestsFromTestCase(TestAPIEndpoints))
     suite.addTests(loader.loadTestsFromTestCase(TestIntegration))
     


### PR DESCRIPTION
## Summary
- avoid crashing Machine Passport PDF export when a repair entry has a malformed or missing `repair_date`
- render invalid repair dates as `Unknown` instead of raising from `datetime.fromtimestamp()`
- keep repair table rendering tolerant of missing optional repair fields

## Tests
- `python -m pytest node/tests/test_machine_passport.py::TestMachinePassportPdfRobustness -q`
- `python node/tests/test_machine_passport.py`
- `python -m py_compile node/machine_passport.py node/tests/test_machine_passport.py`
- `git diff --check`

/claim #305
