### PR TITLE
Fix withdrawal history limit validation

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5501,7 +5501,14 @@ def withdrawal_history(miner_pk):
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
     if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
-    limit = request.args.get('limit', 50, type=int)
+    raw_limit = request.args.get('limit', '50')
+    if raw_limit == '':
+        raw_limit = '50'
+    try:
+        limit = int(raw_limit)
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 500))
 
     with sqlite3.connect(DB_PATH) as c:
         rows = c.execute("""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -161,3 +161,12 @@ def test_attest_debug_fails_closed_when_admin_key_unconfigured(client, monkeypat
 
     assert response.status_code == 503
     assert response.get_json()["error"] == "Admin key not configured"
+
+def test_withdraw_history_rejects_malformed_limit(client):
+    response = client.get(
+        '/withdraw/history/miner_abc?limit=abc',
+        headers={'X-Admin-Key': '0' * 32},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "limit must be an integer"}


### PR DESCRIPTION
## Summary
- make `/withdraw/history/<miner_pk>` reject malformed `limit` query values with a structured 400 response
- preserve the default limit for omitted/empty values and clamp valid values to a bounded range
- add regression coverage for non-integer `limit` input

## Tests
- `python -m pytest tests/test_api.py::test_withdraw_history_rejects_malformed_limit -q`
- `python -m pytest tests/test_api.py -q`
- `python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_api.py`
- `git diff --check`

/claim #305
