### PR TITLE
fix: handle missing backup file before copy2 (issue #6085)

### DIFF
--- a/tests/test_verify_backup.py
+++ b/tests/test_verify_backup.py
@@ -91,3 +91,16 @@ def test_verify_accepts_balance_rtc_column(tmp_path):
     result = verify(str(live), str(bak))
     assert result.ok is True
     assert any("balances (amount>0): 1" in line for line in result.lines)
+
+
+def test_verify_returns_failed_check_result_when_backup_missing(tmp_path):
+    """Regression: verify() must not raise when backup file disappears before copy2()."""
+    live = tmp_path / "live.db"
+    bak = tmp_path / "bak.db"
+    _make_db(live, rows=3, epoch=10)
+    # bak does not exist on disk
+
+    result = verify(str(live), str(bak))
+    assert result.ok is False
+    assert any("backup file missing" in line for line in result.lines)
+    assert any("RESULT: FAIL" in line for line in result.lines)

--- a/tools/verify_backup.py
+++ b/tools/verify_backup.py
@@ -81,6 +81,9 @@ def verify(live_db: str, backup_file: str) -> CheckResult:
     if not os.path.exists(live_db):
         return CheckResult(False, lines + [log(f"RESULT: FAIL (live db missing: {live_db})")])
 
+    if not os.path.exists(backup_file):
+        return CheckResult(False, lines + [log(f"RESULT: FAIL (backup file missing: {backup_file})")])
+
     with tempfile.TemporaryDirectory(prefix="backup-verify-") as td:
         copied = os.path.join(td, Path(backup_file).name)
         copy2(backup_file, copied)


### PR DESCRIPTION
## Summary

- add existence check for `backup_file` in `verify()` before `copy2()` is called
- returns a failed `CheckResult` with `"RESULT: FAIL (backup file missing: ...)"` instead of raising

## Fix

`tools/verify_backup.py`: guard `copy2(backup_file, copied)` with `os.path.exists(backup_file)` check (analogous to the existing `live_db` guard).

## Verification

```bash
python -m pytest tests/test_verify_backup.py -v
# 5 passed
```

Issue: [Scottcjn/Rustchain#6085](https://github.com/Scottcjn/Rustchain/issues/6085)