### PR TITLE
fix: fail closed for admin report routes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5183,8 +5183,7 @@ def reject_v1_mine():
 @app.route('/withdraw/register', methods=['POST'])
 def register_withdrawal_key():
     # SECURITY: Registering withdrawal keys allows fund extraction; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     """Register sr25519 public key for withdrawals"""
     data = request.get_json(silent=True)
@@ -5498,8 +5497,7 @@ def withdrawal_status(withdrawal_id):
 def withdrawal_history(miner_pk):
     """Get withdrawal history for miner"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes withdrawal history
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     limit = request.args.get('limit', 50, type=int)
 
@@ -5554,7 +5552,7 @@ def admin_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         key = request.headers.get("X-API-Key") or ""
-        if not hmac.compare_digest(key, ADMIN_KEY or ""):
+        if not ADMIN_KEY or not key or not hmac.compare_digest(key, ADMIN_KEY):
             return jsonify({"ok": False, "reason": "admin_required"}), 401
         return f(*args, **kwargs)
     return decorated
@@ -6787,8 +6785,7 @@ def api_miner_dashboard(miner_id):
 def api_miner_attestations(miner_id: str):
     """Best-effort attestation history for a single miner (museum detail view)."""
     # SECURITY FIX 2026-02-15: Require admin key - exposes miner attestation history/timing
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     try:
         limit = int(request.args.get("limit", "120") or 120)
@@ -6833,8 +6830,7 @@ def api_miner_attestations(miner_id: str):
 def api_balances():
     """Return wallet balances (best-effort across schema variants)."""
     # SECURITY FIX 2026-02-15: Require admin key - dumps all wallet balances
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
+    if not is_admin(request):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
     try:
         limit = int(request.args.get("limit", "2000") or 2000)
@@ -7128,7 +7124,7 @@ def ops_readiness():
     """Single PASS/FAIL aggregator for all go/no-go checks"""
     # SECURITY FIX 2026-02-15: Only show detailed checks to admin
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = hmac.compare_digest(admin_key, ADMIN_KEY or "")
+    is_admin_request = bool(ADMIN_KEY and admin_key and hmac.compare_digest(admin_key, ADMIN_KEY))
     out = {"ok": True, "checks": []}
 
     # Health check
@@ -7184,7 +7180,7 @@ def ops_readiness():
         out["ok"] = False
 
     # Strip detailed checks for non-admin requests
-    if not is_admin:
+    if not is_admin_request:
         return jsonify({"ok": out["ok"]}), (200 if out["ok"] else 503)
     return jsonify(out), (200 if out["ok"] else 503)
 

--- a/tests/test_wallet_transfer_admin_key_unset.py
+++ b/tests/test_wallet_transfer_admin_key_unset.py
@@ -48,6 +48,13 @@ ADMIN_GATED_ENDPOINTS = [
     ("GET", "/wallet/balances/all", None),
 ]
 
+MODULE_ADMIN_KEY_ENDPOINTS = [
+    ("GET", "/api/miner/test-miner/attestations", None),
+    ("GET", "/api/balances", None),
+    ("POST", "/gov/rotate/stage", {"epoch_effective": 1, "threshold": 1, "members": []}),
+    ("GET", "/genesis/export", None),
+]
+
 
 def _request(client, method, path, body):
     if method == "GET":
@@ -117,3 +124,32 @@ def test_wallet_transfer_does_not_authenticate_empty_to_empty(monkeypatch, clien
         headers={"X-Admin-Key": "anything"},
     )
     assert resp3.status_code == 503
+
+
+@pytest.mark.parametrize("method,path,body", MODULE_ADMIN_KEY_ENDPOINTS)
+def test_module_admin_key_routes_reject_empty_module_admin_key(
+    monkeypatch, client, method, path, body
+):
+    """Admin routes must not authenticate an empty module-level admin key."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "a" * 32)
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "")
+
+    resp = _request(client, method, path, body)
+
+    assert resp.status_code == 401, (
+        f"{method} {path}: expected 401 when module ADMIN_KEY is empty, "
+        f"got {resp.status_code} (body={resp.get_data(as_text=True)[:200]})"
+    )
+
+
+def test_ops_readiness_does_not_show_details_with_empty_module_admin_key(
+    monkeypatch, client
+):
+    """Readiness remains public, but empty module keys must not unlock details."""
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "")
+
+    resp = client.get("/ops/readiness")
+
+    assert resp.status_code in {200, 503}
+    payload = resp.get_json() or {}
+    assert "checks" not in payload


### PR DESCRIPTION
Related: #4588

## BCOS Checklist (Required For Non-Doc PRs)

- [x] BCOS-L2 requested for auth-boundary hardening
- [x] No new code files added
- [x] Test evidence included below

## What Changed

- Routes that expose admin-only wallet, withdrawal, balance, attestation, and governance data now fail closed instead of comparing submitted keys against an empty fallback.
- `/ops/readiness` no longer exposes detailed checks when the module admin key is empty.
- Added regression coverage for the remaining empty module-key cases.

## Testing / Evidence

- `python3 -m pytest tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py -q` -> 38 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py tests/test_api.py tests/test_gov_rotate_api.py`
- `git diff --check HEAD~1..HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK