### PR TITLE
Fix setup_miner.py --help side effects

### DIFF
--- a/setup_miner.py
+++ b/setup_miner.py
@@ -4,6 +4,7 @@ RustChain Miner Setup Script
 Automated setup for RustChain Universal Miner
 """
 
+import argparse
 import os
 import sys
 import subprocess
@@ -405,6 +406,13 @@ WantedBy=multi-user.target
             self.log(f"Setup failed: {e}")
             sys.exit(1)
 
-if __name__ == "__main__":
+def main():
+    parser = argparse.ArgumentParser(description="RustChain Miner Setup")
+    parser.parse_args()
+
     setup = MinerSetup()
     setup.run_setup()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_setup_miner_help.py
+++ b/tests/test_setup_miner_help.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_setup_miner_help_is_non_mutating(tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "setup_miner.py"), "--help"],
+        cwd=ROOT,
+        env={"HOME": str(home)},
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert "usage:" in result.stdout.lower()
+    assert "RustChain Miner Setup" in result.stdout
+    assert not (home / "rustchain_miner").exists()


### PR DESCRIPTION
Fixes #5985.

## Summary
- add argparse handling before setup execution
- add regression test that `--help` exits cleanly and does not create `~/rustchain_miner`

## Verification
- `python3 -m pytest -q tests/test_setup_miner_help.py`
- `git diff --check`