### PR TITLE
fix: support node block schema in p2p export

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -36,6 +36,44 @@ def _parse_int_query_arg(
     return value
 
 
+def _block_table_columns(conn: sqlite3.Connection) -> set[str]:
+    return {row[1] for row in conn.execute("PRAGMA table_info(blocks)").fetchall()}
+
+
+def _json_dict_or_empty(raw_value) -> Dict:
+    if raw_value in (None, ""):
+        return {}
+    if isinstance(raw_value, dict):
+        return raw_value
+    try:
+        decoded = json.loads(raw_value)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _canonical_block_data(row: sqlite3.Row) -> Dict:
+    header = {}
+    for field in (
+        "prev_hash",
+        "timestamp",
+        "merkle_root",
+        "state_root",
+        "attestations_hash",
+        "producer",
+        "producer_sig",
+    ):
+        if field in row.keys() and row[field] is not None:
+            header[field] = row[field]
+
+    body = _json_dict_or_empty(row["body_json"] if "body_json" in row.keys() else None)
+    for field in ("tx_count", "attestation_count"):
+        if field in row.keys() and row[field] is not None:
+            body.setdefault(field, row[field])
+
+    return {"header": header, "body": body}
+
+
 # ============================================================================
 # PEER DISCOVERY & MANAGEMENT
 # ============================================================================
@@ -469,17 +507,54 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
 
         # Fetch blocks from database
         with sqlite3.connect(peer_manager.db_path) as conn:
-            rows = conn.execute("""
-                SELECT height, hash, data FROM blocks
-                WHERE height >= ?
-                ORDER BY height ASC
-                LIMIT ?
-            """, (start, limit)).fetchall()
+            conn.row_factory = sqlite3.Row
+            columns = _block_table_columns(conn)
+            blocks = []
 
-            blocks = [
-                {"height": row[0], "hash": row[1], "data": json.loads(row[2])}
-                for row in rows
-            ]
+            if {"height", "hash", "data"}.issubset(columns):
+                rows = conn.execute("""
+                    SELECT height, hash, data FROM blocks
+                    WHERE height >= ?
+                    ORDER BY height ASC
+                    LIMIT ?
+                """, (start, limit)).fetchall()
+
+                blocks = [
+                    {"height": row["height"], "hash": row["hash"], "data": _json_dict_or_empty(row["data"])}
+                    for row in rows
+                ]
+            elif {"height", "block_hash"}.issubset(columns):
+                select_columns = ["height", "block_hash AS hash"]
+                for optional in (
+                    "prev_hash",
+                    "timestamp",
+                    "merkle_root",
+                    "state_root",
+                    "attestations_hash",
+                    "producer",
+                    "producer_sig",
+                    "tx_count",
+                    "attestation_count",
+                    "body_json",
+                ):
+                    if optional in columns:
+                        select_columns.append(optional)
+
+                rows = conn.execute(f"""
+                    SELECT {", ".join(select_columns)} FROM blocks
+                    WHERE height >= ?
+                    ORDER BY height ASC
+                    LIMIT ?
+                """, (start, limit)).fetchall()
+
+                blocks = [
+                    {
+                        "height": row["height"],
+                        "hash": row["hash"],
+                        "data": _canonical_block_data(row),
+                    }
+                    for row in rows
+                ]
 
         return jsonify({"ok": True, "blocks": blocks, "count": len(blocks)})
 

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -52,6 +52,88 @@ def test_p2p_sync_flask_routes_use_flask_request_and_jsonify(tmp_path):
     ]
 
 
+def test_p2p_blocks_reads_canonical_block_schema(tmp_path):
+    """The P2P blocks endpoint should work against the node block table."""
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                prev_hash TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                merkle_root TEXT NOT NULL,
+                state_root TEXT NOT NULL,
+                attestations_hash TEXT NOT NULL,
+                producer TEXT NOT NULL,
+                producer_sig TEXT NOT NULL,
+                tx_count INTEGER NOT NULL,
+                attestation_count INTEGER NOT NULL,
+                body_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks (
+                height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                attestations_hash, producer, producer_sig, tx_count, attestation_count,
+                body_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                2,
+                "canonical-hash",
+                "parent-hash",
+                1234567890,
+                "merkle-root",
+                "state-root",
+                "attestations-hash",
+                "miner-1",
+                "sig-1",
+                3,
+                4,
+                '{"transactions": ["tx-1"]}',
+                1234567899,
+            ),
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.get("/api/blocks?start=2&limit=1")
+
+    assert response.status_code == 200
+    assert response.get_json()["blocks"] == [
+        {
+            "height": 2,
+            "hash": "canonical-hash",
+            "data": {
+                "header": {
+                    "prev_hash": "parent-hash",
+                    "timestamp": 1234567890,
+                    "merkle_root": "merkle-root",
+                    "state_root": "state-root",
+                    "attestations_hash": "attestations-hash",
+                    "producer": "miner-1",
+                    "producer_sig": "sig-1",
+                },
+                "body": {
+                    "tx_count": 3,
+                    "attestation_count": 4,
+                    "transactions": ["tx-1"],
+                },
+            },
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     ("query", "message"),
     [


### PR DESCRIPTION
Fixes #6111
Related: #4342

## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] No new code files added
- [x] Test evidence included below

## What Changed

- Let the legacy P2P `/api/blocks` export read both the older `hash`/`data` table shape and the canonical node `block_hash`/`body_json` schema.
- Rebuild the P2P block payload from canonical block metadata so peers still receive `hash` plus `data.header`/`data.body`.
- Added a regression test for a canonical node block table.

## Testing / Evidence

- `python3 -m pytest node/tests/test_p2p_sync_flask_imports.py node/tests/test_p2p_sync_routes.py -q` -> 17 passed
- `python3 -m py_compile node/rustchain_p2p_sync.py node/tests/test_p2p_sync_flask_imports.py node/tests/test_p2p_sync_routes.py`
- `git diff --check HEAD~1..HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK