### PR TITLE
Validate UTXO transfer public keys

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -239,6 +239,29 @@ class TestUtxoEndpoints(unittest.TestCase):
         data = r.get_json()
         self.assertIn('does not match', data['error'])
 
+    def test_transfer_rejects_malformed_public_key(self):
+        """Malformed public keys must not escape as endpoint exceptions."""
+        old_addr_from_pk = utxo_endpoints._addr_from_pk_fn
+
+        def malformed_public_key(_pubkey_hex):
+            raise ValueError("non-hexadecimal number found in fromhex() arg")
+
+        try:
+            utxo_endpoints._addr_from_pk_fn = malformed_public_key
+            r = self.client.post('/utxo/transfer', json={
+                'from_address': 'RTC_test_aabbccdd',
+                'to_address': 'bob',
+                'amount_rtc': 10.0,
+                'public_key': 'not-hex',
+                'signature': 'sig' * 22,
+                'nonce': 123,
+            })
+        finally:
+            utxo_endpoints._addr_from_pk_fn = old_addr_from_pk
+
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.get_json()['error'], 'Invalid public_key')
+
     def test_transfer_with_fee(self):
         self._seed_coinbase('RTC_test_aabbccdd', 100 * UNIT)
 

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -450,8 +450,13 @@ def utxo_transfer():
             'dust_threshold_nrtc': DUST_THRESHOLD,
         }), 400
 
-    # Verify pubkey → address
-    expected_addr = _addr_from_pk_fn(public_key)
+    # Verify pubkey -> address.  The production converter decodes hex key
+    # material, so malformed public_key values must stay on the validation path
+    # rather than becoming endpoint 500s.
+    try:
+        expected_addr = _addr_from_pk_fn(public_key)
+    except Exception:
+        return jsonify({'error': 'Invalid public_key'}), 400
     if from_address != expected_addr:
         return jsonify({
             'error': 'Public key does not match from_address',


### PR DESCRIPTION
## Summary

- handle malformed `public_key` converter failures in `POST /utxo/transfer`
- return a deterministic `400 {"error": "Invalid public_key"}` instead of letting `address_from_pubkey()` exceptions escape
- add regression coverage that simulates the production converter raising on invalid hex key material

Bug report: #6114

## Duplicate boundary

This is adjacent to #4377 but narrower and still present on current `main`: #4377 covered non-object JSON and non-string field types. Current `main` already validates that `public_key` is a string, but malformed string key material can still raise inside the production `address_from_pubkey()` converter.

## Validation

- `PYTHONPATH=node /tmp/rustchain-utxo-venv/bin/python -B -m pytest -q node/test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_rejects_malformed_public_key node/test_utxo_endpoints.py::TestUtxoEndpoints::test_transfer_pubkey_mismatch --tb=short -p no:cacheprovider` -> 2 passed
- `PYTHONPATH=node /tmp/rustchain-utxo-venv/bin/python -B -m pytest -q node/test_utxo_endpoints.py --tb=short -p no:cacheprovider` -> 28 passed, 3 subtests passed
- `PYTHONPATH=node /tmp/rustchain-utxo-venv/bin/python -B -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py` -> passed
- `git diff --check -- node/utxo_endpoints.py node/test_utxo_endpoints.py` -> passed

Bounty route: #2819 low-severity UTXO endpoint validation gap / code-quality issue.
