### PR TITLE
fix: fail closed for remaining integrated admin routes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4589,17 +4589,44 @@ def kv_set(key, val):
             db.execute("INSERT INTO settings(key,val) VALUES(?,?)", (key, str(val)))
         db.commit()
 
+def _configured_admin_key():
+    if "ADMIN_KEY" in globals():
+        return str(globals().get("ADMIN_KEY") or "")
+    return str(os.environ.get("RC_ADMIN_KEY", "") or "")
+
+
 def is_admin(req):
     """Check if request has valid admin API key.
 
     Uses hmac.compare_digest for constant-time comparison to prevent
     timing side-channel attacks that could leak the admin key byte-by-byte.
     """
-    need = os.environ.get("RC_ADMIN_KEY", "")
+    need = _configured_admin_key()
     got = req.headers.get("X-Admin-Key", "") or req.headers.get("X-API-Key", "")
     if not need or not got:
         return False
     return hmac.compare_digest(need, got)
+
+
+def _admin_key_unset_response():
+    return jsonify({
+        "ok": False,
+        "error": "Admin key not configured",
+        "reason": "admin_key_unset",
+        "code": "ADMIN_KEY_UNSET",
+    }), 503
+
+
+def _admin_required_response():
+    return jsonify({"ok": False, "reason": "admin_required"}), 401
+
+
+def _require_admin_request(req):
+    if not _configured_admin_key():
+        return _admin_key_unset_response()
+    if not is_admin(req):
+        return _admin_required_response()
+    return None
 
 
 def ensure_wallet_review_tables(conn):
@@ -5183,9 +5210,9 @@ def reject_v1_mine():
 @app.route('/withdraw/register', methods=['POST'])
 def register_withdrawal_key():
     # SECURITY: Registering withdrawal keys allows fund extraction; require admin key.
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
-        return jsonify({"error": "Unauthorized - admin key required"}), 401
+    admin_error = _require_admin_request(request)
+    if admin_error:
+        return admin_error
     """Register sr25519 public key for withdrawals"""
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
@@ -5498,9 +5525,9 @@ def withdrawal_status(withdrawal_id):
 def withdrawal_history(miner_pk):
     """Get withdrawal history for miner"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes withdrawal history
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
-        return jsonify({"error": "Unauthorized - admin key required"}), 401
+    admin_error = _require_admin_request(request)
+    if admin_error:
+        return admin_error
     limit = request.args.get('limit', 50, type=int)
 
     with sqlite3.connect(DB_PATH) as c:
@@ -5553,9 +5580,9 @@ def admin_required(f):
     from functools import wraps
     @wraps(f)
     def decorated(*args, **kwargs):
-        key = request.headers.get("X-API-Key") or ""
-        if not hmac.compare_digest(key, ADMIN_KEY or ""):
-            return jsonify({"ok": False, "reason": "admin_required"}), 401
+        admin_error = _require_admin_request(request)
+        if admin_error:
+            return admin_error
         return f(*args, **kwargs)
     return decorated
 
@@ -6787,9 +6814,9 @@ def api_miner_dashboard(miner_id):
 def api_miner_attestations(miner_id: str):
     """Best-effort attestation history for a single miner (museum detail view)."""
     # SECURITY FIX 2026-02-15: Require admin key - exposes miner attestation history/timing
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
-        return jsonify({"error": "Unauthorized - admin key required"}), 401
+    admin_error = _require_admin_request(request)
+    if admin_error:
+        return admin_error
     try:
         limit = int(request.args.get("limit", "120") or 120)
     except (TypeError, ValueError):
@@ -6833,9 +6860,9 @@ def api_miner_attestations(miner_id: str):
 def api_balances():
     """Return wallet balances (best-effort across schema variants)."""
     # SECURITY FIX 2026-02-15: Require admin key - dumps all wallet balances
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
-        return jsonify({"error": "Unauthorized - admin key required"}), 401
+    admin_error = _require_admin_request(request)
+    if admin_error:
+        return admin_error
     try:
         limit = int(request.args.get("limit", "2000") or 2000)
     except (TypeError, ValueError):
@@ -7005,11 +7032,9 @@ def metrics_mac():
 def attest_debug():
     """Debug endpoint: show miner's enrollment eligibility"""
     # SECURITY FIX 2026-02-15: Require admin key - exposes internal config + MAC hashes
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    if not ADMIN_KEY:
-        return jsonify({"error": "Admin key not configured"}), 503
-    if not hmac.compare_digest(admin_key, ADMIN_KEY):
-        return jsonify({"error": "Unauthorized - admin key required"}), 401
+    admin_error = _require_admin_request(request)
+    if admin_error:
+        return admin_error
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         return jsonify({"error": "Invalid JSON body"}), 400
@@ -7127,8 +7152,7 @@ METRICS_SNAPSHOT = {}
 def ops_readiness():
     """Single PASS/FAIL aggregator for all go/no-go checks"""
     # SECURITY FIX 2026-02-15: Only show detailed checks to admin
-    admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
-    is_admin = hmac.compare_digest(admin_key, ADMIN_KEY or "")
+    admin_view = is_admin(request)
     out = {"ok": True, "checks": []}
 
     # Health check
@@ -7184,7 +7208,7 @@ def ops_readiness():
         out["ok"] = False
 
     # Strip detailed checks for non-admin requests
-    if not is_admin:
+    if not admin_view:
         return jsonify({"ok": out["ok"]}), (200 if out["ok"] else 503)
     return jsonify(out), (200 if out["ok"] else 503)
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4590,9 +4590,12 @@ def kv_set(key, val):
         db.commit()
 
 def _configured_admin_key():
+    raw_key = os.environ.get("RC_ADMIN_KEY")
     if "ADMIN_KEY" in globals():
-        return str(globals().get("ADMIN_KEY") or "")
-    return str(os.environ.get("RC_ADMIN_KEY", "") or "")
+        raw_key = globals().get("ADMIN_KEY")
+    if not isinstance(raw_key, str):
+        return ""
+    return raw_key.strip()
 
 
 def is_admin(req):
@@ -4623,8 +4626,19 @@ def _admin_required_response():
 
 def _require_admin_request(req):
     if not _configured_admin_key():
+        app.logger.warning(
+            "admin route hit with no key configured: %s %s",
+            req.method,
+            req.path,
+        )
         return _admin_key_unset_response()
     if not is_admin(req):
+        app.logger.warning(
+            "admin auth failure from %s: %s %s",
+            req.remote_addr,
+            req.method,
+            req.path,
+        )
         return _admin_required_response()
     return None
 

--- a/tests/test_wallet_transfer_admin_key_unset.py
+++ b/tests/test_wallet_transfer_admin_key_unset.py
@@ -38,6 +38,13 @@ def client():
 # Endpoints that previously fell through to compare_digest with empty env.
 # Each entry: (method, path, json_body_or_none, expected_503_when_unset)
 ADMIN_GATED_ENDPOINTS = [
+    ("POST", "/withdraw/register", {"miner_pk": "a", "pubkey_sr25519": "00"}),
+    ("GET", "/withdraw/history/a", None),
+    ("POST", "/gov/rotate/stage", {"epoch_effective": 1, "members": []}),
+    ("GET", "/genesis/export", None),
+    ("GET", "/api/miner/a/attestations", None),
+    ("GET", "/api/balances", None),
+    ("POST", "/ops/attest/debug", {"miner": "a"}),
     ("POST", "/wallet/transfer", {"from_miner": "a", "to_miner": "b", "amount_rtc": 1}),
     ("POST", "/rewards/settle", {"epoch": 1}),
     ("GET", "/pending/list", None),
@@ -59,6 +66,7 @@ def _request(client, method, path, body):
 def test_admin_endpoint_returns_503_when_admin_key_unset(monkeypatch, client, method, path, body):
     """When RC_ADMIN_KEY is empty, endpoint must return 503 ADMIN_KEY_UNSET, not 401."""
     monkeypatch.setenv("RC_ADMIN_KEY", "")
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "")
 
     resp = _request(client, method, path, body)
 
@@ -97,6 +105,7 @@ def test_wallet_transfer_does_not_authenticate_empty_to_empty(monkeypatch, clien
     without a configured key, regardless of header content.
     """
     monkeypatch.setenv("RC_ADMIN_KEY", "")
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "")
 
     # No header at all
     resp1 = client.post("/wallet/transfer", json={"from_miner": "a", "to_miner": "b", "amount_rtc": 1})

--- a/tests/test_wallet_transfer_admin_key_unset.py
+++ b/tests/test_wallet_transfer_admin_key_unset.py
@@ -126,3 +126,48 @@ def test_wallet_transfer_does_not_authenticate_empty_to_empty(monkeypatch, clien
         headers={"X-Admin-Key": "anything"},
     )
     assert resp3.status_code == 503
+
+
+@pytest.mark.parametrize("configured_key", ["", "   ", 0, True, object()])
+def test_withdraw_register_rejects_invalid_configured_admin_key(
+    monkeypatch,
+    client,
+    configured_key,
+):
+    """Whitespace-only and non-string admin keys are treated as unset, not coerced."""
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", configured_key)
+
+    resp = client.post(
+        "/withdraw/register",
+        json={"miner_pk": "a", "pubkey_sr25519": "00"},
+        headers={"X-Admin-Key": str(configured_key).strip()},
+    )
+
+    assert resp.status_code == 503
+    payload = resp.get_json() or {}
+    assert payload.get("code") == "ADMIN_KEY_UNSET"
+
+
+def test_withdraw_register_logs_unset_admin_key(monkeypatch, client, caplog):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", " ")
+
+    with caplog.at_level("WARNING"):
+        client.post(
+            "/withdraw/register",
+            json={"miner_pk": "a", "pubkey_sr25519": "00"},
+        )
+
+    assert "admin route hit with no key configured" in caplog.text
+
+
+def test_withdraw_register_logs_wrong_admin_key(monkeypatch, client, caplog):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "a" * 32)
+
+    with caplog.at_level("WARNING"):
+        client.post(
+            "/withdraw/register",
+            json={"miner_pk": "a", "pubkey_sr25519": "00"},
+            headers={"X-Admin-Key": "wrong"},
+        )
+
+    assert "admin auth failure" in caplog.text


### PR DESCRIPTION
## Summary
- route remaining integrated-node admin gates through one fail-closed request helper
- return `ADMIN_KEY_UNSET` when no module-level admin key is configured instead of treating empty state like a bad caller key
- preserve legacy admin tests that patch `ADMIN_KEY` directly
- cover withdrawal, governance, genesis export, miner attestation, balances, and ops debug admin routes in the existing unset-key regression

Fixes #4588

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider tests/test_wallet_transfer_admin_key_unset.py tests/test_gov_rotate_api.py tests/test_api.py::test_attest_debug_fails_closed_when_admin_key_unconfigured -q` -> 38 passed
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_transfer_admin_key_unset.py`
- `git diff --check`

Bounty context: Scottcjn/rustchain-bounties#71 / issue #4588 security hardening.
Wallet/miner ID: `kebanks2`