### PR TITLE
fix: gate profile badge debug mode

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -3,6 +3,7 @@
 
 from flask import Flask, request, jsonify, render_template_string
 import html as html_utils
+import os
 import sqlite3
 import json
 import urllib.parse
@@ -12,6 +13,15 @@ from datetime import datetime
 app = Flask(__name__)
 
 DB_PATH = "rustchain.db"
+
+
+def debug_enabled() -> bool:
+    return os.environ.get("RUSTCHAIN_PROFILE_BADGE_DEBUG", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 def init_badge_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -268,4 +278,4 @@ def list_badges():
 
 if __name__ == '__main__':
     init_badge_db()
-    app.run(debug=True, port=5003)
+    app.run(debug=debug_enabled(), port=5003)

--- a/tests/test_profile_badge_generator_security.py
+++ b/tests/test_profile_badge_generator_security.py
@@ -50,3 +50,17 @@ def test_badge_generator_preview_uses_dom_api_not_returned_html():
     assert "previewImage.alt = data.alt_text || 'RustChain Badge';" in source
     assert "badgePreview.appendChild(previewImage);" in source
     assert "badgePreview').innerHTML = data.preview_html" not in source
+
+
+def test_debug_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("RUSTCHAIN_PROFILE_BADGE_DEBUG", raising=False)
+    module = load_profile_badge_module(tmp_path)
+
+    assert module.debug_enabled() is False
+
+
+def test_debug_can_be_enabled_explicitly(tmp_path, monkeypatch):
+    monkeypatch.setenv("RUSTCHAIN_PROFILE_BADGE_DEBUG", "true")
+    module = load_profile_badge_module(tmp_path)
+
+    assert module.debug_enabled() is True


### PR DESCRIPTION
## Summary
- Fixes #6119
- Adds an explicit `RUSTCHAIN_PROFILE_BADGE_DEBUG` opt-in for the profile badge Flask debugger
- Keeps debug mode off by default and covers both default-off and explicit-on behavior

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider tests/test_profile_badge_generator.py tests/test_profile_badge_generator_security.py -q` -> 9 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m py_compile profile_badge_generator.py tests/test_profile_badge_generator.py tests/test_profile_badge_generator_security.py` -> passed
- `git diff --check` -> passed

## Bounty
Wallet/miner ID: `kebanks2`