### PR TITLE
fix: handle enveloped miners payload in CLI

### DIFF
--- a/tests/test_rustchain_cli_miners.py
+++ b/tests/test_rustchain_cli_miners.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the standalone RustChain miners CLI command."""
+
+from argparse import Namespace
+import os
+import sys
+from unittest.mock import patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools", "cli"))
+
+import rustchain_cli
+
+
+def test_miners_command_formats_current_enveloped_api_shape(capsys):
+    payload = {
+        "miners": [
+            {
+                "miner": "RTC1234567890abcdef",
+                "device_arch": "POWER8",
+                "last_attest": 1779490467,
+            }
+        ],
+        "pagination": {"count": 1, "limit": 100, "offset": 0, "total": 1},
+    }
+
+    with patch.object(rustchain_cli, "fetch_api", return_value=payload):
+        rustchain_cli.cmd_miners(Namespace(count=False, json=False))
+
+    output = capsys.readouterr().out
+    assert "Active Miners (1 total, showing 20)" in output
+    assert "RTC1234567890abcdef" in output
+    assert "POWER8" in output
+
+
+def test_miners_count_uses_enveloped_miner_rows(capsys):
+    payload = {
+        "miners": [{"miner": "RTC1"}, {"miner": "RTC2"}],
+        "pagination": {"count": 2, "limit": 100, "offset": 0, "total": 2},
+    }
+
+    with patch.object(rustchain_cli, "fetch_api", return_value=payload):
+        rustchain_cli.cmd_miners(Namespace(count=True, json=False))
+
+    assert capsys.readouterr().out.strip() == "Active miners: 2"

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -106,12 +106,15 @@ def cmd_status(args):
 def cmd_miners(args):
     """List active miners."""
     data = fetch_api("/api/miners")
+    miners = data.get("miners", []) if isinstance(data, dict) else data
+    if not isinstance(miners, list):
+        miners = []
     
     if args.count:
         if args.json:
-            print(json.dumps({"count": len(data)}, indent=2))
+            print(json.dumps({"count": len(miners)}, indent=2))
         else:
-            print(f"Active miners: {len(data)}")
+            print(f"Active miners: {len(miners)}")
         return
     
     if args.json:
@@ -121,15 +124,15 @@ def cmd_miners(args):
     # Format as table
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
-    for miner in data[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', 'N/A')[:20]
-        arch = miner.get('arch', 'N/A')
+    for miner in miners[:20]:  # Show top 20
+        miner_id = miner.get('miner_id', miner.get('miner', 'N/A'))[:20]
+        arch = miner.get('arch', miner.get('device_arch', 'N/A'))
         last_attest = miner.get('last_attest', 'N/A')
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')
         rows.append([miner_id, arch, str(last_attest)])
     
-    print(f"Active Miners ({len(data)} total, showing 20)\n")
+    print(f"Active Miners ({len(miners)} total, showing 20)\n")
     print(format_table(headers, rows))
 
 def cmd_balance(args):


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Normalize the current `/api/miners` envelope before the CLI count and table paths use miner rows.
- Preserve the raw `--json` response while accepting both legacy `miner_id`/`arch` rows and current `miner`/`device_arch` rows for table display.
- Add regression coverage for the enveloped live API shape and corrected count handling.

Fixes #6121.

## Testing / Evidence

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m pytest tests\test_rustchain_cli_miners.py tests\test_wallet_show_regression.py -q
```

```text
.........                                                                [100%]
9 passed in 0.93s
```

Before the fix, the live default-node command crashed at the dict slice in `cmd_miners`:

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' tools\cli\rustchain_cli.py miners
```

```text
for miner in data[:20]:
KeyError: slice(None, 20, None)
```

After the fix, the same live command renders the current miner table and `miners --count` reports the miner row count from the envelope.