### PR TITLE
fix: validate epoch enroll signature field types

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4120,6 +4120,17 @@ def enroll_epoch():
     # unauthorized-enrollment / miner_id-hijack vector.
     # Unsigned enrollment is rejected by default. Operators running private
     # legacy migrations can temporarily set ENROLL_ALLOW_UNSIGNED_LEGACY=1.
+    for field_name, code in (
+        ("signature", "INVALID_SIGNATURE_TYPE"),
+        ("public_key", "INVALID_PUBLIC_KEY_TYPE"),
+    ):
+        if field_name in data and data[field_name] is not None and not isinstance(data[field_name], str):
+            return jsonify({
+                "ok": False,
+                "error": code.lower(),
+                "message": f"Field '{field_name}' must be a string",
+                "code": code,
+            }), 400
     sig_hex = (data.get('signature') or '').strip().lower()
     pubkey_hex = (data.get('public_key') or '').strip().lower()
     epoch = slot_to_epoch(current_slot())

--- a/node/tests/test_enroll_signature_verification.py
+++ b/node/tests/test_enroll_signature_verification.py
@@ -499,6 +499,40 @@ class TestEnrollSignatureVerification(unittest.TestCase):
         self.assertEqual(status, 400)
         self.assertEqual(body["code"], "INCOMPLETE_SIGNATURE")
 
+    def test_enrollment_rejects_non_string_signature_before_crash(self):
+        """Non-string enrollment signatures must be validation failures, not exceptions."""
+        mod, _ = self._load_module("rustchain_enroll_sig_type_guard", "enroll_sig_type_guard.db")
+
+        status, body = self._enroll(
+            mod,
+            {
+                "miner_pubkey": "RTC_ENROLL_SIG_TYPE",
+                "miner_id": "miner_sig_type",
+                "signature": True,
+                "public_key": "00" * 32,
+            },
+        )
+
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_SIGNATURE_TYPE")
+
+    def test_enrollment_rejects_non_string_public_key_before_crash(self):
+        """Non-string enrollment public keys must be validation failures, not exceptions."""
+        mod, _ = self._load_module("rustchain_enroll_pubkey_type_guard", "enroll_pubkey_type_guard.db")
+
+        status, body = self._enroll(
+            mod,
+            {
+                "miner_pubkey": "RTC_ENROLL_PUBKEY_TYPE",
+                "miner_id": "miner_pubkey_type",
+                "signature": "00" * 64,
+                "public_key": ["not", "a", "key"],
+            },
+        )
+
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_PUBLIC_KEY_TYPE")
+
     @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
     def test_enrollment_pubkey_mismatch_with_attacker_key(self):
         """Attacker cannot enroll victim's pubkey using attacker's signing key."""


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Reject non-string `/epoch/enroll` `signature` and `public_key` values before the route normalizes them with `.strip().lower()`.
- Return structured 400 responses with `INVALID_SIGNATURE_TYPE` and `INVALID_PUBLIC_KEY_TYPE`, matching the existing `/attest/submit` validation style.
- Add regression coverage for boolean `signature` and list-valued `public_key` inputs.

Fixes #6123.

## Testing / Evidence

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m pytest node\tests\test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_enrollment_rejects_non_string_signature_before_crash node\tests\test_enroll_signature_verification.py::TestEnrollSignatureVerification::test_enrollment_rejects_non_string_public_key_before_crash -q
```

```text
..                                                                       [100%]
2 passed in 1.69s
```

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_enroll_signature_verification.py
```

```text
# passed
```

```powershell
git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py node\tests\test_enroll_signature_verification.py
```

```text
# passed
```

Note: running the full `node\tests\test_enroll_signature_verification.py` currently has unrelated failures on current main because its shared helper submits `fingerprint: {}` and the attestation route now rejects that with `MISSING_FINGERPRINT`. The two new enrollment type-validation regressions pass independently.