### PR TITLE
fix: reject malformed governance vote public keys

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5911,7 +5911,10 @@ def governance_vote():
     vote = str(data.get('vote', '')).strip().lower()
     nonce = str(data.get('nonce', '')).strip()
     signature = str(data.get('signature', '')).strip()
-    public_key = str(data.get('public_key', '')).strip()
+    public_key_raw = data.get('public_key', '')
+    if public_key_raw is not None and not isinstance(public_key_raw, str):
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
+    public_key = (public_key_raw or '').strip()
 
     if not all([proposal_id, wallet, vote in ('yes', 'no'), nonce, signature, public_key]):
         return jsonify({
@@ -5919,7 +5922,10 @@ def governance_vote():
             "error": "proposal_id, wallet, vote(yes/no), nonce, signature, public_key are required",
         }), 400
 
-    expected_wallet = address_from_pubkey(public_key)
+    try:
+        expected_wallet = address_from_pubkey(public_key)
+    except ValueError:
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
     if wallet != expected_wallet:
         return jsonify({
             "ok": False,

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -97,6 +97,25 @@ def test_governance_vote_rejects_invalid_proposal_id():
     )
 
 
+def test_governance_vote_rejects_malformed_public_key_before_address_decode():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/governance/vote",
+            json={
+                "proposal_id": 1,
+                "wallet": "RTC-test",
+                "vote": "yes",
+                "nonce": "n-1",
+                "signature": "ab" * 64,
+                "public_key": ["not", "hex"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"ok": False, "error": "invalid_public_key"}
+
+
 def test_governance_vote_flow_and_lifecycle_finalization():
     with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Reject non-string `/governance/vote` `public_key` values before address derivation.
- Catch malformed public-key hex at `address_from_pubkey()` and return a structured 400 instead of raising.
- Add a regression that proves malformed JSON public-key input returns `invalid_public_key`.

Fixes #6125.

## Testing / Evidence

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m pytest tests\test_governance_api.py::test_governance_vote_rejects_malformed_public_key_before_address_decode tests\test_governance_api.py::test_governance_vote_rejects_invalid_proposal_id tests\test_governance_api.py::test_governance_vote_flow_and_lifecycle_finalization -q
```

```text
...                                                                      [100%]
3 passed in 1.11s
```

```powershell
& 'C:\Users\ahmed\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe' -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_governance_api.py
```

```text
# passed
```

```powershell
git diff --check -- node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_governance_api.py
```

```text
# passed
```