### PR TITLE
Validate signed transfer public keys

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8639,7 +8639,7 @@ def wallet_transfer_signed():
     signature = str(data.get("signature", "")).strip()
     raw_public_key = data.get("public_key", "")
     if raw_public_key is not None and not isinstance(raw_public_key, str):
-        return jsonify({"error": "invalid_public_key"}), 400
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
     public_key = (raw_public_key or "").strip()
     memo = str(data.get("memo", ""))
     amount_rtc = pre.details["amount_rtc"]
@@ -8673,8 +8673,8 @@ def wallet_transfer_signed():
     else:
         try:
             expected_address = address_from_pubkey(public_key)
-        except ValueError:
-            return jsonify({"error": "invalid_public_key"}), 400
+        except (ValueError, TypeError):
+            return jsonify({"ok": False, "error": "invalid_public_key"}), 400
         if from_address != expected_address:
             return jsonify({
                 "error": "Public key does not match from_address",

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8637,7 +8637,10 @@ def wallet_transfer_signed():
     nonce_int = pre.details["nonce"]
     chain_id = pre.details.get("chain_id")
     signature = str(data.get("signature", "")).strip()
-    public_key = str(data.get("public_key", "")).strip()
+    raw_public_key = data.get("public_key", "")
+    if raw_public_key is not None and not isinstance(raw_public_key, str):
+        return jsonify({"error": "invalid_public_key"}), 400
+    public_key = (raw_public_key or "").strip()
     memo = str(data.get("memo", ""))
     amount_rtc = pre.details["amount_rtc"]
     fee_rtc = pre.details["fee_rtc"]
@@ -8668,7 +8671,10 @@ def wallet_transfer_signed():
             }), 400
         public_key = atlas_pubkey  # Use Atlas pubkey for verification
     else:
-        expected_address = address_from_pubkey(public_key)
+        try:
+            expected_address = address_from_pubkey(public_key)
+        except ValueError:
+            return jsonify({"error": "invalid_public_key"}), 400
         if from_address != expected_address:
             return jsonify({
                 "error": "Public key does not match from_address",

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -140,7 +140,22 @@ def test_signed_transfer_rejects_malformed_public_key_before_address_decode():
         response = client.post("/wallet/transfer/signed", json=payload)
 
     assert response.status_code == 400
-    assert response.get_json() == {"error": "invalid_public_key"}
+    assert response.get_json() == {"ok": False, "error": "invalid_public_key"}
+
+
+def test_signed_transfer_rejects_empty_public_key_as_missing_required_field():
+    integrated_node.app.config["TESTING"] = True
+    payload = _payload()
+    payload["public_key"] = ""
+
+    with integrated_node.app.test_client() as client:
+        response = client.post("/wallet/transfer/signed", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "missing_required_fields",
+        "details": {"missing": ["public_key"]},
+    }
 
 
 def test_signed_transfer_rejects_duplicate_nonce(signed_transfer_client):

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -131,6 +131,18 @@ def _payload(amount_rtc: float = 1.5, nonce: int = 1733420000000) -> dict:
     }
 
 
+def test_signed_transfer_rejects_malformed_public_key_before_address_decode():
+    integrated_node.app.config["TESTING"] = True
+    payload = _payload()
+    payload["public_key"] = ["not", "hex"]
+
+    with integrated_node.app.test_client() as client:
+        response = client.post("/wallet/transfer/signed", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "invalid_public_key"}
+
+
 def test_signed_transfer_rejects_duplicate_nonce(signed_transfer_client):
     client, db_path = signed_transfer_client
 


### PR DESCRIPTION
## Summary

Fixes #6127.

`/wallet/transfer/signed` now rejects malformed `public_key` values before deriving an RTC address. The route previously coerced non-string JSON values with `str(...)`, then passed malformed strings into `address_from_pubkey()`, where invalid hex raised `ValueError` instead of returning a structured 400.

## Changes

- reject non-string `public_key` values with `400 {"error": "invalid_public_key"}`
- catch malformed public-key decode failures before sender address comparison
- add a regression test for the malformed public-key request path

## Verification

```text
python -m pytest tests\test_signed_transfer_replay.py::test_signed_transfer_rejects_malformed_public_key_before_address_decode tests\test_signed_transfer_replay.py::test_signed_transfer_rejects_duplicate_nonce tests\test_signed_transfer_replay.py::test_signed_transfer_uses_preflight_amount_i64_without_float_loss -q
3 passed in 0.33s

python -m py_compile node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_signed_transfer_replay.py

git diff --check
```