### PR TITLE
fix: validate integrated p2p add_peer body

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8153,17 +8153,33 @@ try:
     @require_peer_auth
     def p2p_add_peer():
         """Add a new peer to the network"""
-        try:
-            data = request.json
-            peer_url = data.get('peer_url')
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({"ok": False, "error": "JSON object required"}), 400
 
-            if not peer_url:
-                return jsonify({"ok": False, "error": "peer_url required"}), 400
+        peer_url = data.get('peer_url')
+        if peer_url is None:
+            return jsonify({"ok": False, "error": "peer_url required"}), 400
+        if not isinstance(peer_url, str):
+            return jsonify({"ok": False, "error": "peer_url must be a string"}), 400
 
-            success = peer_manager.add_peer(peer_url)
-            return jsonify({"ok": success})
-        except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 400
+        peer_url = peer_url.strip()
+        if not peer_url:
+            return jsonify({"ok": False, "error": "peer_url required"}), 400
+
+        result = peer_manager.add_peer(peer_url)
+        if isinstance(result, tuple):
+            success, message = result
+        else:
+            success, message = bool(result), None
+
+        if not success:
+            return jsonify({"ok": False, "error": message or "peer add failed"}), 400
+
+        response = {"ok": True}
+        if message:
+            response["message"] = message
+        return jsonify(response)
 
     # Start background sync unless an integration test explicitly disables it.
     if os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START") != "1":

--- a/node/tests/test_integrated_p2p_add_peer.py
+++ b/node/tests/test_integrated_p2p_add_peer.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+
+import hmac
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+P2P_KEY = "integration-p2p-test-key"
+
+
+class TestIntegratedP2PAddPeer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls._prev_p2p_key = os.environ.get("RC_P2P_KEY")
+        cls._prev_disable_p2p = os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START")
+
+        os.environ["RUSTCHAIN_DB_PATH"] = str(Path(cls._tmp.name) / "node.db")
+        os.environ["RC_ADMIN_KEY"] = "0" * 32
+        os.environ["RC_P2P_KEY"] = P2P_KEY
+        os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = "1"
+
+        if str(NODE_DIR) not in sys.path:
+            sys.path.insert(0, str(NODE_DIR))
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_p2p_add_peer_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, value in (
+            ("RUSTCHAIN_DB_PATH", cls._prev_db_path),
+            ("RC_ADMIN_KEY", cls._prev_admin_key),
+            ("RC_P2P_KEY", cls._prev_p2p_key),
+            ("RUSTCHAIN_DISABLE_P2P_AUTO_START", cls._prev_disable_p2p),
+        ):
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        cls._tmp.cleanup()
+
+    def _auth_headers(self, body):
+        timestamp = str(int(time.time()))
+        signature = hmac.new(
+            P2P_KEY.encode("utf-8"),
+            f"{body}{timestamp}".encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return {
+            "Content-Type": "application/json",
+            "X-Peer-Signature": signature,
+            "X-Peer-Timestamp": timestamp,
+        }
+
+    def post_add_peer(self, payload):
+        body = json.dumps(payload)
+        return self.client.post(
+            "/p2p/add_peer",
+            data=body,
+            headers=self._auth_headers(body),
+        )
+
+    def test_add_peer_rejects_non_object_json(self):
+        response = self.post_add_peer(["peer_url", "http://peer.example:8088"])
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": False, "error": "JSON object required"},
+        )
+
+    def test_add_peer_rejects_non_string_peer_url(self):
+        response = self.post_add_peer({"peer_url": ["http://peer.example:8088"]})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": False, "error": "peer_url must be a string"},
+        )
+
+    def test_add_peer_returns_boolean_ok_for_secure_peer_manager(self):
+        response = self.post_add_peer({"peer_url": "http://peer.example:8088"})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": True, "message": "Peer added successfully"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Fixes #6129 by validating the authenticated `/p2p/add_peer` JSON body before accessing `peer_url`.
- Rejects non-object JSON, missing, non-string, and blank `peer_url` values with deterministic `400` responses.
- Normalizes `SecurePeerManager.add_peer(...)` tuple results so `ok` stays boolean and the manager message is returned separately.
- Adds focused integrated route coverage with signed P2P requests.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider node/tests/test_integrated_p2p_add_peer.py -q` -> 3 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider node/tests/test_p2p_sync_routes.py node/tests/test_integrated_p2p_add_peer.py -q` -> 10 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_p2p_add_peer.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check` -> passed

## Bounty
Bug bounty route: #305
Wallet/miner ID: `kebanks2`
