### PR TITLE
fix: validate integrated p2p block pagination

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8124,6 +8124,21 @@ try:
         local_port=8099
     )
 
+    def _parse_p2p_blocks_int_arg(raw_value, name, default, minimum=None, maximum=None):
+        if raw_value is None or raw_value == "":
+            value = default
+        else:
+            try:
+                value = int(raw_value)
+            except (TypeError, ValueError):
+                raise ValueError(f"{name} must be an integer")
+
+        if minimum is not None and value < minimum:
+            raise ValueError(f"{name} must be >= {minimum}")
+        if maximum is not None and value > maximum:
+            return maximum
+        return value
+
     # P2P Endpoints
     @app.route('/p2p/stats', methods=['GET'])
     def p2p_stats():
@@ -8141,8 +8156,12 @@ try:
     def p2p_get_blocks():
         """Get blocks for sync"""
         try:
-            start_height = int(request.args.get('start', 0))
-            limit = min(int(request.args.get('limit', 100)), 1000)
+            start_height = _parse_p2p_blocks_int_arg(
+                request.args.get('start'), "start", 0, minimum=0
+            )
+            limit = _parse_p2p_blocks_int_arg(
+                request.args.get('limit'), "limit", 100, minimum=1, maximum=1000
+            )
 
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8162,7 +8162,10 @@ try:
             limit = _parse_p2p_blocks_int_arg(
                 request.args.get('limit'), "limit", 100, minimum=1, maximum=1000
             )
+        except ValueError as e:
+            return jsonify({"ok": False, "error": str(e)}), 400
 
+        try:
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})
         except Exception as e:

--- a/node/tests/test_integrated_p2p_blocks_pagination.py
+++ b/node/tests/test_integrated_p2p_blocks_pagination.py
@@ -98,6 +98,26 @@ class TestIntegratedP2PBlocksPagination(unittest.TestCase):
         self.assertEqual(response.get_json(), {"ok": False, "error": "limit must be >= 1"})
         self.assertEqual(self.block_sync.calls, [])
 
+    def test_blocks_rejects_non_integer_start(self):
+        response = self.get_blocks("start=abc")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": False, "error": "start must be an integer"},
+        )
+        self.assertEqual(self.block_sync.calls, [])
+
+    def test_blocks_rejects_non_integer_limit(self):
+        response = self.get_blocks("limit=notanumber")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": False, "error": "limit must be an integer"},
+        )
+        self.assertEqual(self.block_sync.calls, [])
+
     def test_blocks_caps_oversized_limit_before_sync(self):
         response = self.get_blocks("start=7&limit=5000")
 

--- a/node/tests/test_integrated_p2p_blocks_pagination.py
+++ b/node/tests/test_integrated_p2p_blocks_pagination.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+
+import hmac
+import hashlib
+import importlib.util
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+P2P_KEY = "integration-p2p-blocks-test-key"
+
+
+class RecordingBlockSync:
+    def __init__(self):
+        self.calls = []
+
+    def get_blocks_for_sync(self, start_height, limit):
+        self.calls.append((start_height, limit))
+        return [{"block_index": start_height, "limit": limit}]
+
+
+class TestIntegratedP2PBlocksPagination(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        cls._prev_p2p_key = os.environ.get("RC_P2P_KEY")
+        cls._prev_disable_p2p = os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START")
+
+        os.environ["RUSTCHAIN_DB_PATH"] = str(Path(cls._tmp.name) / "node.db")
+        os.environ["RC_ADMIN_KEY"] = "0" * 32
+        os.environ["RC_P2P_KEY"] = P2P_KEY
+        os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = "1"
+
+        if str(NODE_DIR) not in sys.path:
+            sys.path.insert(0, str(NODE_DIR))
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_p2p_blocks_pagination_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+        cls.block_sync = RecordingBlockSync()
+        cls.mod.block_sync = cls.block_sync
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, value in (
+            ("RUSTCHAIN_DB_PATH", cls._prev_db_path),
+            ("RC_ADMIN_KEY", cls._prev_admin_key),
+            ("RC_P2P_KEY", cls._prev_p2p_key),
+            ("RUSTCHAIN_DISABLE_P2P_AUTO_START", cls._prev_disable_p2p),
+        ):
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.block_sync.calls.clear()
+
+    def _auth_headers(self):
+        timestamp = str(int(time.time()))
+        signature = hmac.new(
+            P2P_KEY.encode("utf-8"),
+            timestamp.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+        return {
+            "X-Peer-Signature": signature,
+            "X-Peer-Timestamp": timestamp,
+        }
+
+    def get_blocks(self, query):
+        return self.client.get(f"/p2p/blocks?{query}", headers=self._auth_headers())
+
+    def test_blocks_rejects_negative_start(self):
+        response = self.get_blocks("start=-1")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"ok": False, "error": "start must be >= 0"})
+        self.assertEqual(self.block_sync.calls, [])
+
+    def test_blocks_rejects_negative_limit(self):
+        response = self.get_blocks("limit=-1")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json(), {"ok": False, "error": "limit must be >= 1"})
+        self.assertEqual(self.block_sync.calls, [])
+
+    def test_blocks_caps_oversized_limit_before_sync(self):
+        response = self.get_blocks("start=7&limit=5000")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.block_sync.calls, [(7, 1000)])
+        self.assertEqual(
+            response.get_json(),
+            {"ok": True, "blocks": [{"block_index": 7, "limit": 1000}]},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add bounded integer parsing for the authenticated integrated `/p2p/blocks` route
- reject negative `start` and `limit` values before calling block sync
- keep the existing oversized limit cap at 1000 with focused signed-route regression coverage

Fixes #6131.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider node/tests/test_integrated_p2p_blocks_pagination.py -q` -> 3 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m pytest -p no:cacheprovider node/tests/test_p2p_sync_routes.py node/tests/test_integrated_p2p_blocks_pagination.py -q` -> 10 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_p2p_blocks_pagination.py`
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-admin-venv/bin/python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check`
