### PR TITLE
fix: handle enveloped miners API in CLI

### DIFF
--- a/tests/test_cli_miners_envelope.py
+++ b/tests/test_cli_miners_envelope.py
@@ -1,0 +1,66 @@
+import importlib.util
+import pathlib
+import types
+
+
+CLI_PATH = pathlib.Path(__file__).resolve().parents[1] / "tools" / "cli" / "rustchain_cli.py"
+spec = importlib.util.spec_from_file_location("rustchain_cli", CLI_PATH)
+rustchain_cli = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rustchain_cli)
+
+
+def test_normalize_miners_payload_accepts_current_envelope():
+    payload = {
+        "miners": [
+            {
+                "miner": "RTC14f06ee294f327f5685d3de5e1ed501cffab33e7",
+                "device_arch": "M4",
+                "last_attest": 1779502031,
+            }
+        ],
+        "pagination": {"total": 1},
+    }
+
+    assert rustchain_cli.normalize_miners_payload(payload) == payload["miners"]
+
+
+def test_cmd_miners_count_uses_enveloped_miner_rows(monkeypatch, capsys):
+    monkeypatch.setattr(
+        rustchain_cli,
+        "fetch_api",
+        lambda endpoint: {
+            "miners": [
+                {"miner": "RTC1", "device_arch": "x86_64"},
+                {"miner": "RTC2", "device_arch": "M4"},
+            ],
+            "pagination": {"total": 2},
+        },
+    )
+
+    rustchain_cli.cmd_miners(types.SimpleNamespace(count=True, json=False))
+
+    assert capsys.readouterr().out.strip() == "Active miners: 2"
+
+
+def test_cmd_miners_table_accepts_current_field_names(monkeypatch, capsys):
+    monkeypatch.setattr(
+        rustchain_cli,
+        "fetch_api",
+        lambda endpoint: {
+            "miners": [
+                {
+                    "miner": "RTC14f06ee294f327f5685d3de5e1ed501cffab33e7",
+                    "device_arch": "M4",
+                    "last_attest": "N/A",
+                }
+            ],
+            "pagination": {"total": 1},
+        },
+    )
+
+    rustchain_cli.cmd_miners(types.SimpleNamespace(count=False, json=False))
+
+    out = capsys.readouterr().out
+    assert "Active Miners (1 total, showing 20)" in out
+    assert "RTC14f06ee294f327f" in out
+    assert "M4" in out

--- a/tests/test_cli_miners_envelope.py
+++ b/tests/test_cli_miners_envelope.py
@@ -59,8 +59,32 @@ def test_cmd_miners_table_accepts_current_field_names(monkeypatch, capsys):
     )
 
     rustchain_cli.cmd_miners(types.SimpleNamespace(count=False, json=False))
-
     out = capsys.readouterr().out
     assert "Active Miners (1 total, showing 20)" in out
     assert "RTC14f06ee294f327f" in out
     assert "M4" in out
+
+
+def test_cmd_miners_table_handles_null_miner_fields(monkeypatch, capsys):
+    monkeypatch.setattr(
+        rustchain_cli,
+        "fetch_api",
+        lambda endpoint: {
+            "miners": [
+                {
+                    "miner_id": None,
+                    "miner": None,
+                    "arch": None,
+                    "device_arch": None,
+                    "last_attest": "N/A",
+                }
+            ],
+            "pagination": {"total": 1},
+        },
+    )
+
+    rustchain_cli.cmd_miners(types.SimpleNamespace(count=False, json=False))
+    out = capsys.readouterr().out
+    assert "Active Miners (1 total, showing 20)" in out
+    assert "N/A" in out
+

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -103,15 +103,25 @@ def cmd_status(args):
     print(f"Tip Age:     {data.get('tip_age_slots', 0)} slots")
     print(f"Backup Age:  {data.get('backup_age_hours', 0):.1f} hours")
 
+def normalize_miners_payload(data):
+    """Return miner rows from either the legacy list or current enveloped API shape."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict) and isinstance(data.get("miners"), list):
+        return data["miners"]
+    return []
+
+
 def cmd_miners(args):
     """List active miners."""
     data = fetch_api("/api/miners")
+    miners = normalize_miners_payload(data)
     
     if args.count:
         if args.json:
-            print(json.dumps({"count": len(data)}, indent=2))
+            print(json.dumps({"count": len(miners)}, indent=2))
         else:
-            print(f"Active miners: {len(data)}")
+            print(f"Active miners: {len(miners)}")
         return
     
     if args.json:
@@ -121,15 +131,15 @@ def cmd_miners(args):
     # Format as table
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
-    for miner in data[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', 'N/A')[:20]
-        arch = miner.get('arch', 'N/A')
+    for miner in miners[:20]:  # Show top 20
+        miner_id = miner.get('miner_id', miner.get('miner', 'N/A'))[:20]
+        arch = miner.get('arch', miner.get('device_arch', 'N/A'))
         last_attest = miner.get('last_attest', 'N/A')
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')
         rows.append([miner_id, arch, str(last_attest)])
     
-    print(f"Active Miners ({len(data)} total, showing 20)\n")
+    print(f"Active Miners ({len(miners)} total, showing 20)\n")
     print(format_table(headers, rows))
 
 def cmd_balance(args):

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -132,8 +132,8 @@ def cmd_miners(args):
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
     for miner in miners[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', miner.get('miner', 'N/A'))[:20]
-        arch = miner.get('arch', miner.get('device_arch', 'N/A'))
+        miner_id = str(miner.get('miner_id') or miner.get('miner') or 'N/A')[:20]
+        arch = miner.get('arch') or miner.get('device_arch') or 'N/A'
         last_attest = miner.get('last_attest', 'N/A')
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')


### PR DESCRIPTION
Summary
- Normalize `/api/miners` responses in the standalone CLI so both the legacy list and the current `{miners, pagination}` envelope work.
- Keep `--json` output raw, but make count/table modes use normalized miner rows.
- Accept current miner field names (`miner`, `device_arch`) while preserving legacy `miner_id`/`arch` support.

Validation
- `python -m py_compile tools/cli/rustchain_cli.py tests/test_cli_miners_envelope.py`
- Direct regression checks for enveloped count/table rendering passed.
- Live node check: `python tools/cli/rustchain_cli.py miners --count` returned 13 and table rendering no longer crashes.
- `git diff --check`

Fixes #6121
