### PR TITLE
Validate withdrawal history and P2P request limits

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5501,7 +5501,11 @@ def withdrawal_history(miner_pk):
     admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
     if not admin_key or not hmac.compare_digest(admin_key, ADMIN_KEY or ""):
         return jsonify({"error": "Unauthorized - admin key required"}), 401
-    limit = request.args.get('limit', 50, type=int)
+    try:
+        limit = int(request.args.get('limit', '50') or 50)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be an integer"}), 400
+    limit = max(1, min(limit, 200))
 
     with sqlite3.connect(DB_PATH) as c:
         rows = c.execute("""
@@ -8141,8 +8145,19 @@ try:
     def p2p_get_blocks():
         """Get blocks for sync"""
         try:
-            start_height = int(request.args.get('start', 0))
-            limit = min(int(request.args.get('limit', 100)), 1000)
+            try:
+                start_height = int(request.args.get('start', 0))
+            except (TypeError, ValueError):
+                return jsonify({"ok": False, "error": "start must be an integer"}), 400
+            try:
+                limit = int(request.args.get('limit', 100))
+            except (TypeError, ValueError):
+                return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+            if start_height < 0:
+                return jsonify({"ok": False, "error": "start must be >= 0"}), 400
+            if limit < 1:
+                return jsonify({"ok": False, "error": "limit must be >= 1"}), 400
+            limit = min(limit, 1000)
 
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})
@@ -8154,14 +8169,19 @@ try:
     def p2p_add_peer():
         """Add a new peer to the network"""
         try:
-            data = request.json
+            data = request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"ok": False, "error": "JSON body must be an object"}), 400
             peer_url = data.get('peer_url')
 
-            if not peer_url:
+            if not isinstance(peer_url, str) or not peer_url.strip():
                 return jsonify({"ok": False, "error": "peer_url required"}), 400
 
-            success = peer_manager.add_peer(peer_url)
-            return jsonify({"ok": success})
+            result = peer_manager.add_peer(peer_url)
+            if isinstance(result, tuple):
+                success, message = result
+                return jsonify({"ok": bool(success), "message": message})
+            return jsonify({"ok": bool(result)})
         except Exception as e:
             return jsonify({"ok": False, "error": str(e)}), 400
 

--- a/node/tests/test_integrated_p2p_validation.py
+++ b/node/tests/test_integrated_p2p_validation.py
@@ -1,0 +1,86 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class TestIntegratedP2PValidation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_auto_start = os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
+        os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = "1"
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location("rustchain_integrated_p2p_validation_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_auto_start is None:
+            os.environ.pop("RUSTCHAIN_DISABLE_P2P_AUTO_START", None)
+        else:
+            os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = cls._prev_auto_start
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        self.mod.block_sync.get_blocks_for_sync = MagicMock(return_value=[])
+
+    @staticmethod
+    def _allow_peer_auth(func):
+        return func.__wrapped__ if hasattr(func, "__wrapped__") else func
+
+    def test_integrated_p2p_blocks_rejects_unsafe_pagination_before_sync(self):
+        with self.mod.app.test_request_context("/p2p/blocks?start=0&limit=-1"):
+            response, status = self._allow_peer_auth(self.mod.p2p_get_blocks)()
+
+        self.assertEqual(status, 400)
+        self.assertEqual(response.get_json(), {"ok": False, "error": "limit must be >= 1"})
+        self.mod.block_sync.get_blocks_for_sync.assert_not_called()
+
+    def test_integrated_p2p_blocks_caps_oversized_limit(self):
+        with self.mod.app.test_request_context("/p2p/blocks?start=0&limit=5000"):
+            response = self._allow_peer_auth(self.mod.p2p_get_blocks)()
+
+        self.assertEqual(response.get_json(), {"ok": True, "blocks": []})
+        self.mod.block_sync.get_blocks_for_sync.assert_called_once_with(0, 1000)
+
+    def test_integrated_add_peer_rejects_non_object_json(self):
+        with self.mod.app.test_request_context("/p2p/add_peer", method="POST", json=[]):
+            response, status = self._allow_peer_auth(self.mod.p2p_add_peer)()
+
+        self.assertEqual(status, 400)
+        self.assertEqual(response.get_json(), {"ok": False, "error": "JSON body must be an object"})
+
+    def test_integrated_add_peer_returns_boolean_ok_and_message(self):
+        self.mod.peer_manager.add_peer = MagicMock(return_value=(True, "Peer added successfully"))
+
+        with self.mod.app.test_request_context("/p2p/add_peer", method="POST", json={"peer_url": "http://peer.example:8088"}):
+            response = self._allow_peer_auth(self.mod.p2p_add_peer)()
+
+        self.assertEqual(response.get_json(), {"ok": True, "message": "Peer added successfully"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_withdraw_history_limit_validation.py
+++ b/tests/test_withdraw_history_limit_validation.py
@@ -1,0 +1,60 @@
+import sqlite3
+
+import integrated_node
+
+
+def test_withdrawal_history_rejects_non_integer_limit(monkeypatch, tmp_path):
+    db_path = tmp_path / "withdrawals.sqlite"
+    with sqlite3.connect(db_path) as db:
+        db.execute("CREATE TABLE withdrawals (withdrawal_id TEXT, miner_pk TEXT, amount REAL, fee REAL, destination TEXT, status TEXT, created_at INTEGER, processed_at INTEGER, tx_hash TEXT, error_msg TEXT)")
+        db.execute("CREATE TABLE balances (miner_pk TEXT, balance_rtc REAL)")
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    with integrated_node.app.test_client() as client:
+        response = client.get(
+            "/withdraw/history/miner1?limit=notanumber",
+            headers={"X-Admin-Key": "0" * 32},
+        )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "limit must be an integer"
+
+
+def test_withdrawal_history_clamps_limit(monkeypatch, tmp_path):
+    db_path = tmp_path / "withdrawals.sqlite"
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            """
+            CREATE TABLE withdrawals (
+                withdrawal_id TEXT,
+                miner_pk TEXT,
+                amount REAL,
+                fee REAL,
+                destination TEXT,
+                status TEXT,
+                created_at INTEGER,
+                processed_at INTEGER,
+                tx_hash TEXT,
+                error_msg TEXT
+            )
+            """
+        )
+        db.execute("CREATE TABLE balances (miner_pk TEXT, balance_rtc REAL)")
+        db.execute("INSERT INTO balances VALUES (?, ?)", ("miner1", 123.0))
+        for idx in range(250):
+            db.execute(
+                "INSERT INTO withdrawals VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (f"w{idx}", "miner1", 1, 0, "dest", "done", idx, idx, "tx", None),
+            )
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+
+    with integrated_node.app.test_client() as client:
+        response = client.get(
+            "/withdraw/history/miner1?limit=100000",
+            headers={"X-Admin-Key": "0" * 32},
+        )
+
+    assert response.status_code == 200
+    assert len(response.get_json()["withdrawals"]) == 200


### PR DESCRIPTION
Fixes unsafe request handling in the integrated node.\n\nSummary:\n- Reject non-integer withdrawal history limits instead of silently defaulting.\n- Clamp withdrawal history limits to 1..200.\n- Reject invalid/negative P2P block pagination before sync.\n- Reject non-object /p2p/add_peer JSON bodies and preserve peer-manager messages.\n\nValidation:\n- python3 -m pytest tests/test_withdraw_history_limit_validation.py node/tests/test_integrated_p2p_validation.py -q -> 6 passed\n- git diff --check -> passed\n- python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_withdraw_history_limit_validation.py node/tests/test_integrated_p2p_validation.py -> passed\n\nBounty: issue #305 bug report bounty candidate.