### PR TITLE
Validate legacy faucet 0x wallet addresses

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -21,6 +21,7 @@ app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 DATABASE = 'faucet.db'
 RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
+ETH_WALLET_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
 
 # Rate limiting settings (per 24 hours)
 MAX_DRIP_AMOUNT = 0.5  # RTC
@@ -176,9 +177,7 @@ def try_record_drip(wallet, ip_address, amount):
 
 def is_valid_wallet_address(wallet):
     """Accept legacy Ethereum-style wallets and native RTC wallets."""
-    return (wallet.startswith('0x') and len(wallet) >= 10) or bool(
-        RTC_WALLET_RE.fullmatch(wallet)
-    )
+    return bool(ETH_WALLET_RE.fullmatch(wallet) or RTC_WALLET_RE.fullmatch(wallet))
 
 
 # HTML Template

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -46,6 +46,22 @@ def test_legacy_faucet_rejects_unknown_wallet_prefix(client):
     assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
 
 
+@pytest.mark.parametrize(
+    "wallet",
+    [
+        "0x1234567890",
+        "0xabcdefghij",
+        "0x9d7caca3039130d3b26d41f7343d8f4ef45923",
+        "0x9d7caca3039130d3b26d41f7343d8f4ef45923600",
+    ],
+)
+def test_legacy_faucet_rejects_malformed_ethereum_wallet(client, wallet):
+    response = client.post("/faucet/drip", json={"wallet": wallet})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+
 def test_legacy_faucet_rejects_malformed_native_rtc_wallet(client):
     response = client.post("/faucet/drip", json={"wallet": "RTCzzzzzzzzzz"})
 
@@ -55,6 +71,17 @@ def test_legacy_faucet_rejects_malformed_native_rtc_wallet(client):
 
 def test_legacy_faucet_accepts_native_rtc_wallet(client):
     wallet = "RTC9d7caca3039130d3b26d41f7343d8f4ef4592360"
+
+    response = client.post("/faucet/drip", json={"wallet": wallet})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["wallet"] == wallet
+
+
+def test_legacy_faucet_accepts_ethereum_wallet(client):
+    wallet = "0x9d7caca3039130d3b26d41f7343d8f4ef4592360"
 
     response = client.post("/faucet/drip", json={"wallet": wallet})
 


### PR DESCRIPTION
## Summary
- tighten legacy faucet Ethereum-style wallet validation to require `0x` plus exactly 40 hex characters
- preserve native RTC wallet validation with the existing `RTC` plus 40 hex character format
- add regression coverage for short, non-hex, under-length, over-length, and valid Ethereum-style faucet wallets

## Why
Issue #6136 showed the legacy faucet accepted arbitrary `0x`-prefixed strings of length 10 or more. Those fake addresses could be rotated to bypass per-wallet faucet rate limits and pollute drip records.

## Validation
- `uv run --with pytest --with flask pytest tests/test_legacy_faucet_json_validation.py -q` -> 11 passed
- `python3 -m py_compile faucet.py tests/test_legacy_faucet_json_validation.py`
- `git diff --check -- faucet.py tests/test_legacy_faucet_json_validation.py`

Fixes #6136
