### PR TITLE
fix: tighten legacy faucet wallet validation

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -21,6 +21,7 @@ app = Flask(__name__)
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
 DATABASE = 'faucet.db'
 RTC_WALLET_RE = re.compile(r'^RTC[0-9a-fA-F]{40}$')
+ETH_WALLET_RE = re.compile(r'^0x[0-9a-fA-F]{40}$')
 
 # Rate limiting settings (per 24 hours)
 MAX_DRIP_AMOUNT = 0.5  # RTC
@@ -176,9 +177,7 @@ def try_record_drip(wallet, ip_address, amount):
 
 def is_valid_wallet_address(wallet):
     """Accept legacy Ethereum-style wallets and native RTC wallets."""
-    return (wallet.startswith('0x') and len(wallet) >= 10) or bool(
-        RTC_WALLET_RE.fullmatch(wallet)
-    )
+    return bool(ETH_WALLET_RE.fullmatch(wallet) or RTC_WALLET_RE.fullmatch(wallet))
 
 
 # HTML Template

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -36,6 +36,29 @@ def test_legacy_faucet_rejects_non_string_wallet(client):
     assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
 
 
+
+def test_legacy_faucet_rejects_short_0x_wallet(client):
+    response = client.post("/faucet/drip", json={"wallet": "0x123456789"})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+def test_legacy_faucet_rejects_non_hex_0x_wallet(client):
+    response = client.post("/faucet/drip", json={"wallet": "0x" + "z" * 40})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "Invalid wallet address"}
+
+def test_legacy_faucet_accepts_canonical_0x_wallet(client):
+    wallet = "0x9d7caca3039130d3b26d41f7343d8f4ef4592360"
+
+    response = client.post("/faucet/drip", json={"wallet": wallet})
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["ok"] is True
+    assert data["wallet"] == wallet
+
 def test_legacy_faucet_rejects_unknown_wallet_prefix(client):
     response = client.post(
         "/faucet/drip",


### PR DESCRIPTION
Fixes #6136.\n\n## Summary\n- require legacy faucet 0x wallets to be canonical 40-hex Ethereum-style addresses\n- keep native RTC wallet validation unchanged\n- add regressions for short/non-hex 0x values and canonical 0x acceptance\n\n## Tests\n- `python3 -m pytest tests/test_legacy_faucet_json_validation.py -q --tb=short`\n- `python3 -m py_compile faucet.py`\n- `git diff --check`