### PR TITLE
Reject malformed signed transfer public keys

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8668,7 +8668,10 @@ def wallet_transfer_signed():
             }), 400
         public_key = atlas_pubkey  # Use Atlas pubkey for verification
     else:
-        expected_address = address_from_pubkey(public_key)
+        try:
+            expected_address = address_from_pubkey(public_key)
+        except (TypeError, ValueError):
+            return jsonify({"error": "invalid_public_key"}), 400
         if from_address != expected_address:
             return jsonify({
                 "error": "Public key does not match from_address",

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -131,6 +131,23 @@ def _payload(amount_rtc: float = 1.5, nonce: int = 1733420000000) -> dict:
     }
 
 
+
+def test_signed_transfer_rejects_malformed_public_key(signed_transfer_client, monkeypatch):
+    client, _ = signed_transfer_client
+
+    def raise_on_unvalidated_public_key(public_key):
+        raise ValueError("non-hex public key")
+
+    monkeypatch.setattr(integrated_node, "address_from_pubkey", raise_on_unvalidated_public_key)
+
+    payload = _payload(nonce=1733420005555)
+    payload["public_key"] = ["not", "hex"]
+
+    response = client.post("/wallet/transfer/signed", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_public_key"
+
 def test_signed_transfer_rejects_duplicate_nonce(signed_transfer_client):
     client, db_path = signed_transfer_client
 


### PR DESCRIPTION
Fixes #6127.\n\nSummary:\n- catch malformed public key derivation on `/wallet/transfer/signed`\n- return deterministic `400 {"error":"invalid_public_key"}` instead of raising\n- add regression for non-string/malformed `public_key`\n\nVerification:\n- `python3 -m pytest tests/test_signed_transfer_replay.py -q --tb=short -k 'malformed_public_key or duplicate_nonce'`\n- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_signed_transfer_replay.py`\n- `git diff --check`