### PR TITLE
Reject malformed governance public keys

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5911,7 +5911,10 @@ def governance_vote():
     vote = str(data.get('vote', '')).strip().lower()
     nonce = str(data.get('nonce', '')).strip()
     signature = str(data.get('signature', '')).strip()
-    public_key = str(data.get('public_key', '')).strip()
+    public_key_raw = data.get('public_key', '')
+    if not isinstance(public_key_raw, str):
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
+    public_key = public_key_raw.strip()
 
     if not all([proposal_id, wallet, vote in ('yes', 'no'), nonce, signature, public_key]):
         return jsonify({
@@ -5919,7 +5922,10 @@ def governance_vote():
             "error": "proposal_id, wallet, vote(yes/no), nonce, signature, public_key are required",
         }), 400
 
-    expected_wallet = address_from_pubkey(public_key)
+    try:
+        expected_wallet = address_from_pubkey(public_key)
+    except ValueError:
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
     if wallet != expected_wallet:
         return jsonify({
             "ok": False,

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -76,6 +76,25 @@ def test_governance_vote_rejects_non_object_json():
     assert resp.get_json()["error"] == "JSON object required"
 
 
+
+def test_governance_vote_rejects_malformed_public_key():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/governance/vote",
+            json={
+                "proposal_id": 1,
+                "wallet": "RTC-test",
+                "vote": "yes",
+                "nonce": "n-1",
+                "signature": "ab" * 64,
+                "public_key": ["not", "hex"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_public_key"
+
 def test_governance_vote_rejects_invalid_proposal_id():
     integrated_node.app.config["TESTING"] = True
     with integrated_node.app.test_client() as client:


### PR DESCRIPTION
Fixes #6125.\n\n## Summary\n- reject non-string governance vote public_key values\n- catch public-key decode failures before wallet comparison\n- add regression for malformed public_key payloads\n\n## Tests\n- python3 -m pytest tests/test_governance_api.py -q