### PR TITLE
Disable profile badge debug mode by default

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -3,6 +3,7 @@
 
 from flask import Flask, request, jsonify, render_template_string
 import html as html_utils
+import os
 import sqlite3
 import json
 import urllib.parse
@@ -12,6 +13,16 @@ from datetime import datetime
 app = Flask(__name__)
 
 DB_PATH = "rustchain.db"
+
+
+def debug_enabled():
+    return os.environ.get("RUSTCHAIN_PROFILE_BADGE_DEBUG", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
 
 def init_badge_db():
     with sqlite3.connect(DB_PATH) as conn:
@@ -268,4 +279,4 @@ def list_badges():
 
 if __name__ == '__main__':
     init_badge_db()
-    app.run(debug=True, port=5003)
+    app.run(debug=debug_enabled(), port=5003)

--- a/tests/test_profile_badge_generator_security.py
+++ b/tests/test_profile_badge_generator_security.py
@@ -50,3 +50,13 @@ def test_badge_generator_preview_uses_dom_api_not_returned_html():
     assert "previewImage.alt = data.alt_text || 'RustChain Badge';" in source
     assert "badgePreview.appendChild(previewImage);" in source
     assert "badgePreview').innerHTML = data.preview_html" not in source
+
+
+def test_debug_mode_requires_explicit_environment_opt_in(tmp_path, monkeypatch):
+    module = load_profile_badge_module(tmp_path)
+
+    monkeypatch.delenv("RUSTCHAIN_PROFILE_BADGE_DEBUG", raising=False)
+    assert module.debug_enabled() is False
+
+    monkeypatch.setenv("RUSTCHAIN_PROFILE_BADGE_DEBUG", "true")
+    assert module.debug_enabled() is True


### PR DESCRIPTION
Fixes #6119.

## Summary
- Add an explicit `RUSTCHAIN_PROFILE_BADGE_DEBUG` opt-in helper.
- Run the profile badge Flask app with debug disabled by default.
- Add regression coverage for default-off and explicit opt-in behavior.

## Testing
```
python3 -m pytest tests/test_profile_badge_generator_security.py tests/test_profile_badge_generator.py -q
# 8 passed in 0.26s
```