### PR TITLE
Validate integrated P2P blocks pagination

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -326,6 +326,22 @@ def _attest_is_valid_positive_int(value, max_value=4096):
     return 1 <= coerced <= max_value
 
 
+def _parse_p2p_blocks_pagination(args):
+    try:
+        start_height = int(args.get('start', 0))
+    except (ValueError, TypeError):
+        return None, ("start must be an integer", 400)
+    try:
+        limit = int(args.get('limit', 100))
+    except (ValueError, TypeError):
+        return None, ("limit must be an integer", 400)
+    if start_height < 0:
+        return None, ("start must be >= 0", 400)
+    if limit < 1:
+        return None, ("limit must be >= 1", 400)
+    return (start_height, min(limit, 1000)), None
+
+
 def client_ip_from_request(req) -> str:
     """Return trusted client IP, honoring proxy headers only for allowlisted peers."""
     remote_addr = _normalize_client_ip(getattr(req, "remote_addr", ""))
@@ -8141,8 +8157,11 @@ try:
     def p2p_get_blocks():
         """Get blocks for sync"""
         try:
-            start_height = int(request.args.get('start', 0))
-            limit = min(int(request.args.get('limit', 100)), 1000)
+            pagination, error_response = _parse_p2p_blocks_pagination(request.args)
+            if error_response:
+                message, status_code = error_response
+                return jsonify({"ok": False, "error": message}), status_code
+            start_height, limit = pagination
 
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})

--- a/tests/test_integrated_p2p_blocks_pagination.py
+++ b/tests/test_integrated_p2p_blocks_pagination.py
@@ -1,0 +1,35 @@
+import integrated_node
+
+
+class DummyBlockSync:
+    def __init__(self):
+        self.calls = []
+
+    def get_blocks_for_sync(self, start_height, limit):
+        self.calls.append((start_height, limit))
+        return []
+
+
+def test_parse_p2p_blocks_pagination_rejects_unsafe_values():
+    invalid = [
+        ({"start": "abc"}, "start must be an integer"),
+        ({"start": "-1"}, "start must be >= 0"),
+        ({"limit": "abc"}, "limit must be an integer"),
+        ({"limit": "0"}, "limit must be >= 1"),
+        ({"limit": "-1"}, "limit must be >= 1"),
+    ]
+
+    for args, expected_error in invalid:
+        values, error_response = integrated_node._parse_p2p_blocks_pagination(args)
+
+        assert values is None
+        assert error_response == (expected_error, 400)
+
+
+def test_parse_p2p_blocks_pagination_caps_limit():
+    values, error_response = integrated_node._parse_p2p_blocks_pagination(
+        {"start": "7", "limit": "5000"}
+    )
+
+    assert error_response is None
+    assert values == (7, 1000)


### PR DESCRIPTION
Fixes #6131

## Summary
- reject non-integer `start` / `limit` query params for integrated `/p2p/blocks`
- reject negative `start` and non-positive `limit`
- keep oversized limits capped at 1000 before calling `block_sync.get_blocks_for_sync`

## Tests
- `python3 -m pytest tests/test_integrated_p2p_blocks_pagination.py -q`
- `python3 -m pytest node/tests/test_p2p_sync_flask_imports.py -q`
- `git diff --check`