### PR TITLE
Fix P2P block export for canonical schema

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -469,8 +469,16 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
 
         # Fetch blocks from database
         with sqlite3.connect(peer_manager.db_path) as conn:
-            rows = conn.execute("""
-                SELECT height, hash, data FROM blocks
+            columns = {row[1] for row in conn.execute("PRAGMA table_info(blocks)")}
+            if {"hash", "data"}.issubset(columns):
+                hash_column = "hash"
+                data_column = "data"
+            else:
+                hash_column = "block_hash"
+                data_column = "body_json"
+
+            rows = conn.execute(f"""
+                SELECT height, {hash_column}, {data_column} FROM blocks
                 WHERE height >= ?
                 ORDER BY height ASC
                 LIMIT ?

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -52,6 +52,51 @@ def test_p2p_sync_flask_routes_use_flask_request_and_jsonify(tmp_path):
     ]
 
 
+
+def test_p2p_blocks_exports_canonical_node_schema(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER,
+                block_hash TEXT,
+                prev_hash TEXT,
+                timestamp REAL,
+                merkle_root TEXT,
+                state_root TEXT,
+                attestations_hash TEXT,
+                producer TEXT,
+                producer_sig TEXT,
+                tx_count INTEGER,
+                attestation_count INTEGER,
+                body_json TEXT,
+                created_at REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks (height, block_hash, body_json)
+            VALUES (?, ?, ?)
+            """,
+            (1, "canonical-hash", '{"canonical": true}'),
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.get("/api/blocks?start=1&limit=1")
+
+    assert response.status_code == 200
+    assert response.get_json()["blocks"] == [
+        {"height": 1, "hash": "canonical-hash", "data": {"canonical": True}}
+    ]
+
 @pytest.mark.parametrize(
     ("query", "message"),
     [


### PR DESCRIPTION
Fixes #6111.

Summary:
- Detects whether the blocks table uses legacy `hash`/`data` or canonical `block_hash`/`body_json` columns.
- Keeps the existing `/api/blocks` response shape unchanged for peers.
- Adds regression coverage for canonical node block schema export.

Verification:
- `python3 -m pytest node/tests/test_p2p_sync_flask_imports.py -q`
- `python3 -m py_compile node/rustchain_p2p_sync.py node/tests/test_p2p_sync_flask_imports.py`
- `git diff --check`