### PR TITLE
Diagnose wallet API redirects

### DIFF
--- a/wallet/rustchain_wallet_gui.py
+++ b/wallet/rustchain_wallet_gui.py
@@ -218,10 +218,14 @@ class RustChainWallet:
         for attempt in range(1, max_retries + 1):
             try:
                 if method == "GET":
-                    resp = requests.get(url, verify=VERIFY_SSL, timeout=timeout)
+                    resp = requests.get(url, verify=VERIFY_SSL, timeout=timeout, allow_redirects=False)
                 else:
-                    resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout)
+                    resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout, allow_redirects=False)
                 
+                if resp.is_redirect:
+                    location = resp.headers.get("Location", "unknown")
+                    return None, f"API redirected: HTTP {resp.status_code} to {location}"
+
                 resp.raise_for_status()
                 payload = resp.json()
                 if not isinstance(payload, dict):

--- a/wallet/rustchain_wallet_secure.py
+++ b/wallet/rustchain_wallet_secure.py
@@ -304,10 +304,14 @@ class SecureFounderWallet:
         for attempt in range(1, max_retries + 1):
             try:
                 if method == "GET":
-                    resp = requests.get(url, verify=VERIFY_SSL, timeout=timeout)
+                    resp = requests.get(url, verify=VERIFY_SSL, timeout=timeout, allow_redirects=False)
                 else:
-                    resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout)
+                    resp = requests.post(url, json=data, verify=VERIFY_SSL, timeout=timeout, allow_redirects=False)
                 
+                if resp.is_redirect:
+                    location = resp.headers.get("Location", "unknown")
+                    return None, f"API redirected: HTTP {resp.status_code} to {location}"
+
                 resp.raise_for_status()
                 payload = resp.json()
                 if not isinstance(payload, dict):


### PR DESCRIPTION
Fixes #5990.

## Summary
- disable automatic redirects for wallet JSON API calls
- return a clear `API redirected: HTTP ... to ...` diagnostic before JSON parsing
- apply the behavior to both GUI wallet clients

## Tests
- `python3 -m py_compile wallet/rustchain_wallet_gui.py wallet/rustchain_wallet_secure.py`
- `git diff --check`
- manual mocked redirect probe for both wallet clients
