### PR TITLE
Fix integrated P2P add_peer response handling

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8154,14 +8154,23 @@ try:
     def p2p_add_peer():
         """Add a new peer to the network"""
         try:
-            data = request.json
+            data = request.get_json(silent=True)
+            if not isinstance(data, dict):
+                return jsonify({"ok": False, "error": "JSON object required"}), 400
+
             peer_url = data.get('peer_url')
 
             if not peer_url:
                 return jsonify({"ok": False, "error": "peer_url required"}), 400
 
-            success = peer_manager.add_peer(peer_url)
-            return jsonify({"ok": success})
+            result = peer_manager.add_peer(peer_url)
+            if isinstance(result, tuple):
+                success, message = result
+                if success:
+                    return jsonify({"ok": True, "message": message})
+                return jsonify({"ok": False, "error": message}), 400
+
+            return jsonify({"ok": bool(result)})
         except Exception as e:
             return jsonify({"ok": False, "error": str(e)}), 400
 

--- a/node/tests/test_integrated_p2p_add_peer_route.py
+++ b/node/tests/test_integrated_p2p_add_peer_route.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from functools import wraps
+from unittest.mock import Mock
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def load_module(monkeypatch):
+    def passthrough_auth(func):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            return func(*args, **kwargs)
+        return decorated
+
+    monkeypatch.setenv("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+    monkeypatch.setenv("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+    monkeypatch.setattr("rustchain_p2p_sync_secure.create_p2p_auth_middleware", lambda _auth: passthrough_auth)
+    spec = importlib.util.spec_from_file_location("rustchain_integrated_p2p_add_peer_test", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def auth_headers():
+    return {"X-Peer-Token": "0123456789abcdef0123456789abcdef"}
+
+
+def test_p2p_add_peer_rejects_non_object_json(monkeypatch):
+    mod = load_module(monkeypatch)
+
+    response = mod.app.test_client().post(
+        "/p2p/add_peer",
+        json=["peer_url", "http://peer.example:8088"],
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "JSON object required"}
+
+
+def test_p2p_add_peer_unpacks_tuple_failure(monkeypatch):
+    mod = load_module(monkeypatch)
+    mod.peer_manager.add_peer = Mock(return_value=(False, "max peers reached"))
+
+    response = mod.app.test_client().post(
+        "/p2p/add_peer",
+        json={"peer_url": "http://peer.example:8088"},
+        headers=auth_headers(),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "max peers reached"}


### PR DESCRIPTION
Fixes #6129.\n\n## Summary\n- reject non-object JSON payloads before accessing peer_url\n- unpack (success, message) tuple results from peer_manager.add_peer\n- return 400 with error details when add_peer rejects a peer\n\n## Tests\n- pytest -q node/tests/test_integrated_p2p_add_peer_route.py