### PR TITLE
[UTXO-BUG] Reject malformed spend input shapes

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1028,6 +1028,46 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
         self.assertEqual(self.db.get_balance('attacker'), 0)
 
+    def test_malformed_inputs_rejected_without_exception(self):
+        """Malformed spend inputs should fail closed instead of raising."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box_id = self.db.get_unspent_for_address('alice')[0]['box_id']
+
+        malformed_inputs = [
+            'not-a-list',
+            [{}],
+            [{'box_id': ''}],
+            [{'box_id': box_id}, {'missing_box_id': box_id}],
+        ]
+
+        for inputs in malformed_inputs:
+            with self.subTest(inputs=inputs):
+                ok = self.db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': inputs,
+                    'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                }, block_height=10)
+                self.assertFalse(ok)
+
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+
+    def test_mempool_malformed_inputs_rejected_without_locking(self):
+        """Malformed mempool inputs should not create orphan input locks."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box_id = self.db.get_unspent_for_address('alice')[0]['box_id']
+
+        ok = self.db.mempool_add({
+            'tx_id': 'bad-input-shape',
+            'inputs': [{'missing_box_id': box_id}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        })
+
+        self.assertFalse(ok)
+        self.assertFalse(self.db.mempool_check_double_spend(box_id))
+
     def test_self_transfer(self):
         """Self-transfer (from == to) must work correctly."""
         self._apply_coinbase('alice', 100 * UNIT)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -399,6 +399,27 @@ class UtxoDB:
 
         return normalized
 
+    def _normalize_inputs(self, inputs: Any) -> Optional[List[dict]]:
+        """Return spend inputs with validated box IDs, or None on invalid input."""
+        if not isinstance(inputs, list):
+            return None
+
+        normalized = []
+        for inp in inputs:
+            if not isinstance(inp, dict):
+                return None
+
+            box_id = inp.get('box_id')
+            if not isinstance(box_id, str) or not box_id.strip():
+                return None
+
+            normalized.append({
+                'box_id': box_id,
+                'spending_proof': inp.get('spending_proof', ''),
+            })
+
+        return normalized
+
     def _normalize_tx_type(self, tx: dict) -> Optional[str]:
         """Return a supported transaction type, defaulting only when absent."""
         if 'tx_type' not in tx:
@@ -517,6 +538,9 @@ class UtxoDB:
         # on-chain auditability, but cryptographic verification is the sole
         # responsibility of the caller (utxo_endpoints.py).
         inputs = tx.get('inputs', [])
+        inputs = self._normalize_inputs(inputs)
+        if inputs is None:
+            return False
         outputs = tx.get('outputs', [])
         fee = tx.get('fee_nrtc', 0)
         tx_type = self._normalize_tx_type(tx)
@@ -882,6 +906,11 @@ class UtxoDB:
                 return False
 
             inputs = tx.get('inputs', [])
+            inputs = self._normalize_inputs(inputs)
+            if inputs is None:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
             tx_type = self._normalize_tx_type(tx)
             if tx_type is None:
                 if manage_tx:


### PR DESCRIPTION
## Summary
- add shared UTXO spend-input normalization so malformed input shapes fail closed instead of raising `TypeError`/`KeyError`
- use the same validation before mempool admission, so malformed pending transactions cannot reach later input-lock logic
- add regression coverage for malformed direct transactions and malformed mempool inputs

## Security impact
`UtxoDB.apply_transaction()` currently validates many malformed transaction fields by returning `False`, but malformed `inputs` such as a non-list or dicts missing `box_id` can raise before the normal validation/rollback path. If an untrusted block/transaction processing path passes such a transaction to the UTXO state-transition engine, it can turn invalid transaction data into an exception instead of a deterministic rejection. This patch keeps that path fail-closed and aligns mempool/direct transaction validation.

Suggested bounty tier: low/code-quality validation gap under rustchain-bounties#2819.

## Validation
- `PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py::TestUtxoDB::test_malformed_inputs_rejected_without_exception node/test_utxo_db.py::TestUtxoDB::test_mempool_malformed_inputs_rejected_without_locking node/test_utxo_db.py::TestUtxoDB::test_transfer node/test_utxo_db.py::TestUtxoDB::test_mempool_accepts_exact_input_output --tb=short` -> 4 passed, 4 subtests passed
- `PYTHONPATH=node uv run --no-project --with pytest python -B -m pytest -q node/test_utxo_db.py --tb=short` -> 90 passed, 18 subtests passed
- `python3 -B -m py_compile node/utxo_db.py node/test_utxo_db.py` -> passed
- `git diff --check -- node/utxo_db.py node/test_utxo_db.py` -> passed
