### PR TITLE
Fix CLI miners command for paginated /api/miners envelope

### DIFF
--- a/tests/test_rustchain_cli_miners_envelope.py
+++ b/tests/test_rustchain_cli_miners_envelope.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools", "cli"))
+import rustchain_cli
+
+
+def test_miners_count_handles_enveloped_response(capsys, monkeypatch):
+    payload = {
+        "miners": [
+            {"miner": "m1", "device_arch": "x86"},
+            {"miner": "m2", "device_arch": "arm64"},
+            {"miner": "m3", "device_arch": "ppc"},
+        ],
+        "count": 3,
+        "offset": 0,
+    }
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))
+    out = capsys.readouterr().out
+    assert "Active miners: 3" in out
+
+
+def test_miners_table_uses_current_row_keys(capsys, monkeypatch):
+    payload = {
+        "miners": [
+            {"miner": "wallet-1", "device_arch": "x86_64", "last_seen": 1710000000},
+        ],
+        "count": 1,
+    }
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=False, json=False))
+    out = capsys.readouterr().out
+    assert "wallet-1" in out
+    assert "x86_64" in out
+    assert "Active Miners (1 total, showing 20)" in out
+
+
+def test_miners_json_preserves_raw_envelope(capsys, monkeypatch):
+    payload = {"miners": [{"miner": "wallet-1"}], "count": 1}
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=False, json=True))
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["count"] == 1
+    assert parsed["miners"][0]["miner"] == "wallet-1"
+
+
+def test_miners_rejects_invalid_non_list_payload(monkeypatch):
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: {"unexpected": "shape"})
+    with pytest.raises(rustchain_cli.RustChainAPIError, match="Unexpected /api/miners response format"):
+        rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))

--- a/tests/test_rustchain_cli_miners_envelope.py
+++ b/tests/test_rustchain_cli_miners_envelope.py
@@ -54,3 +54,9 @@ def test_miners_rejects_invalid_non_list_payload(monkeypatch):
     monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: {"unexpected": "shape"})
     with pytest.raises(rustchain_cli.RustChainAPIError, match="Unexpected /api/miners response format"):
         rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))
+
+
+def test_miners_rejects_non_object_entries(monkeypatch):
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: {"miners": ["bad-entry"]})
+    with pytest.raises(rustchain_cli.RustChainAPIError, match="Unexpected /api/miners entry format"):
+        rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -91,12 +91,16 @@ def format_table(headers, rows):
 def normalize_miners_payload(data):
     """Normalize /api/miners response across legacy and paginated envelopes."""
     if isinstance(data, list):
-        return data
-    if isinstance(data, dict):
+        miners = data
+    elif isinstance(data, dict):
         miners = data.get("miners")
-        if isinstance(miners, list):
-            return miners
-    raise RustChainAPIError("Unexpected /api/miners response format")
+        if not isinstance(miners, list):
+            raise RustChainAPIError("Unexpected /api/miners response format")
+    else:
+        raise RustChainAPIError("Unexpected /api/miners response format")
+    if not all(isinstance(entry, dict) for entry in miners):
+        raise RustChainAPIError("Unexpected /api/miners entry format")
+    return miners
 
 def cmd_status(args):
     """Show node health and status."""

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -87,6 +87,17 @@ def format_table(headers, rows):
     
     return "\n".join(lines)
 
+
+def normalize_miners_payload(data):
+    """Normalize /api/miners response across legacy and paginated envelopes."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        miners = data.get("miners")
+        if isinstance(miners, list):
+            return miners
+    raise RustChainAPIError("Unexpected /api/miners response format")
+
 def cmd_status(args):
     """Show node health and status."""
     data = fetch_api("/health")
@@ -106,12 +117,13 @@ def cmd_status(args):
 def cmd_miners(args):
     """List active miners."""
     data = fetch_api("/api/miners")
+    miners = normalize_miners_payload(data)
     
     if args.count:
         if args.json:
-            print(json.dumps({"count": len(data)}, indent=2))
+            print(json.dumps({"count": len(miners)}, indent=2))
         else:
-            print(f"Active miners: {len(data)}")
+            print(f"Active miners: {len(miners)}")
         return
     
     if args.json:
@@ -121,15 +133,20 @@ def cmd_miners(args):
     # Format as table
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
-    for miner in data[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', 'N/A')[:20]
-        arch = miner.get('arch', 'N/A')
-        last_attest = miner.get('last_attest', 'N/A')
+    for miner in miners[:20]:  # Show top 20
+        miner_id = str(miner.get("miner_id") or miner.get("miner") or "N/A")[:20]
+        arch = miner.get("arch") or miner.get("device_arch") or "N/A"
+        last_attest = (
+            miner.get("last_attest")
+            or miner.get("last_attestation")
+            or miner.get("last_seen")
+            or "N/A"
+        )
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')
         rows.append([miner_id, arch, str(last_attest)])
     
-    print(f"Active Miners ({len(data)} total, showing 20)\n")
+    print(f"Active Miners ({len(miners)} total, showing 20)\n")
     print(format_table(headers, rows))
 
 def cmd_balance(args):


### PR DESCRIPTION
Fixes #6121

## Summary
- normalize `/api/miners` payload in CLI to support both:
  - legacy list response
  - current envelope shape `{ "miners": [...], ... }`
- fix `miners --count` to count miner rows instead of envelope keys
- keep `--json` behavior raw (prints API response unchanged)
- accept both legacy and current miner row fields in table output:
  - id: `miner_id` or `miner`
  - arch: `arch` or `device_arch`
  - attestation time: `last_attest` / `last_attestation` / `last_seen`
- raise a deterministic CLI API error for invalid response shapes

## Validation
- `pytest -q tests/test_rustchain_cli_miners_envelope.py` -> 4 passed
- `pytest -q tests/test_wallet_show_regression.py -k 'main_reports_api_errors_at_cli_boundary or balance_response_parsing'` -> 2 passed

/claim #6121