### PR TITLE
Quickstart: route Windows PowerShell users to Windows installer

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,17 +29,27 @@ That is it. No GPU required. No special hardware. No account signup.
 
 ## Step 1: Install the Miner
 
-Open a terminal (on macOS: search for "Terminal"; on Windows: use PowerShell) and run:
+Open a terminal:
+
+- Linux/macOS (or Windows with WSL/Git Bash): use the Bash installer
+- Windows PowerShell: use the Windows installer path under `miners/windows/`
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_miner_setup.bat -OutFile rustchain_miner_setup.bat
+.\rustchain_miner_setup.bat
 ```
 
 **What this does:**
 
 1. Detects your operating system and CPU architecture
 2. Installs Python 3 if you do not have it (Linux only -- macOS/Windows users need Python
-   pre-installed)
+   pre-installed unless using the Windows setup script above)
 3. Downloads the miner script to `~/.rustchain/`
 4. Creates a Python virtual environment with dependencies
 5. Asks you to pick a wallet name

--- a/tests/test_rustchain_cli_miners_envelope.py
+++ b/tests/test_rustchain_cli_miners_envelope.py
@@ -1,0 +1,56 @@
+import argparse
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "tools", "cli"))
+import rustchain_cli
+
+
+def test_miners_count_handles_enveloped_response(capsys, monkeypatch):
+    payload = {
+        "miners": [
+            {"miner": "m1", "device_arch": "x86"},
+            {"miner": "m2", "device_arch": "arm64"},
+            {"miner": "m3", "device_arch": "ppc"},
+        ],
+        "count": 3,
+        "offset": 0,
+    }
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))
+    out = capsys.readouterr().out
+    assert "Active miners: 3" in out
+
+
+def test_miners_table_uses_current_row_keys(capsys, monkeypatch):
+    payload = {
+        "miners": [
+            {"miner": "wallet-1", "device_arch": "x86_64", "last_seen": 1710000000},
+        ],
+        "count": 1,
+    }
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=False, json=False))
+    out = capsys.readouterr().out
+    assert "wallet-1" in out
+    assert "x86_64" in out
+    assert "Active Miners (1 total, showing 20)" in out
+
+
+def test_miners_json_preserves_raw_envelope(capsys, monkeypatch):
+    payload = {"miners": [{"miner": "wallet-1"}], "count": 1}
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: payload)
+    rustchain_cli.cmd_miners(argparse.Namespace(count=False, json=True))
+    out = capsys.readouterr().out
+    parsed = json.loads(out)
+    assert parsed["count"] == 1
+    assert parsed["miners"][0]["miner"] == "wallet-1"
+
+
+def test_miners_rejects_invalid_non_list_payload(monkeypatch):
+    monkeypatch.setattr(rustchain_cli, "fetch_api", lambda endpoint: {"unexpected": "shape"})
+    with pytest.raises(rustchain_cli.RustChainAPIError, match="Unexpected /api/miners response format"):
+        rustchain_cli.cmd_miners(argparse.Namespace(count=True, json=False))

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -87,6 +87,17 @@ def format_table(headers, rows):
     
     return "\n".join(lines)
 
+
+def normalize_miners_payload(data):
+    """Normalize /api/miners response across legacy and paginated envelopes."""
+    if isinstance(data, list):
+        return data
+    if isinstance(data, dict):
+        miners = data.get("miners")
+        if isinstance(miners, list):
+            return miners
+    raise RustChainAPIError("Unexpected /api/miners response format")
+
 def cmd_status(args):
     """Show node health and status."""
     data = fetch_api("/health")
@@ -106,12 +117,13 @@ def cmd_status(args):
 def cmd_miners(args):
     """List active miners."""
     data = fetch_api("/api/miners")
+    miners = normalize_miners_payload(data)
     
     if args.count:
         if args.json:
-            print(json.dumps({"count": len(data)}, indent=2))
+            print(json.dumps({"count": len(miners)}, indent=2))
         else:
-            print(f"Active miners: {len(data)}")
+            print(f"Active miners: {len(miners)}")
         return
     
     if args.json:
@@ -121,15 +133,20 @@ def cmd_miners(args):
     # Format as table
     headers = ["Miner ID", "Architecture", "Last Attestation"]
     rows = []
-    for miner in data[:20]:  # Show top 20
-        miner_id = miner.get('miner_id', 'N/A')[:20]
-        arch = miner.get('arch', 'N/A')
-        last_attest = miner.get('last_attest', 'N/A')
+    for miner in miners[:20]:  # Show top 20
+        miner_id = str(miner.get("miner_id") or miner.get("miner") or "N/A")[:20]
+        arch = miner.get("arch") or miner.get("device_arch") or "N/A"
+        last_attest = (
+            miner.get("last_attest")
+            or miner.get("last_attestation")
+            or miner.get("last_seen")
+            or "N/A"
+        )
         if isinstance(last_attest, (int, float)):
             last_attest = datetime.fromtimestamp(last_attest).strftime('%Y-%m-%d %H:%M')
         rows.append([miner_id, arch, str(last_attest)])
     
-    print(f"Active Miners ({len(data)} total, showing 20)\n")
+    print(f"Active Miners ({len(miners)} total, showing 20)\n")
     print(format_table(headers, rows))
 
 def cmd_balance(args):


### PR DESCRIPTION
Fixes #6149

## Summary
- clarify Step 1 install guidance by separating Linux/macOS Bash path from Windows PowerShell path
- keep existing Bash one-liner for Linux/macOS/WSL/Git Bash users
- add native PowerShell flow that downloads and runs `miners/windows/rustchain_miner_setup.bat`
- update installer behavior note so Windows users are not told to run Linux-only install logic

## Validation
- verified the referenced Windows installer artifact exists at `miners/windows/rustchain_miner_setup.bat`
- checked updated quickstart snippets and headings render correctly in markdown

/claim #6149