### PR TITLE
Reject malformed public_key values in governance vote endpoint

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5911,10 +5911,9 @@ def governance_vote():
     vote = str(data.get('vote', '')).strip().lower()
     nonce = str(data.get('nonce', '')).strip()
     signature = str(data.get('signature', '')).strip()
-    raw_public_key = data.get('public_key', '')
-    if not isinstance(raw_public_key, str):
+    public_key = _validated_public_key(data.get('public_key', ''))
+    if public_key is None:
         return jsonify({"ok": False, "error": "invalid_public_key"}), 400
-    public_key = raw_public_key.strip()
 
     if not all([proposal_id, wallet, vote in ('yes', 'no'), nonce, signature, public_key]):
         return jsonify({
@@ -8270,6 +8269,18 @@ def address_from_pubkey(public_key_hex: str) -> str:
     """Generate RTC address from public key: RTC + first 40 chars of SHA256(pubkey)"""
     pubkey_hash = hashlib.sha256(bytes.fromhex(public_key_hex)).hexdigest()[:40]
     return f"RTC{pubkey_hash}"
+
+
+def _validated_public_key(raw_public_key):
+    """Return normalized Ed25519 public key hex or ``None`` when invalid."""
+    if not isinstance(raw_public_key, str):
+        return None
+    public_key = raw_public_key.strip().lower()
+    if len(public_key) != 64:
+        return None
+    if not re.fullmatch(r"[0-9a-f]{64}", public_key):
+        return None
+    return public_key
 
 def _wallet_transfer_signed_messages(
     from_address,

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5911,7 +5911,10 @@ def governance_vote():
     vote = str(data.get('vote', '')).strip().lower()
     nonce = str(data.get('nonce', '')).strip()
     signature = str(data.get('signature', '')).strip()
-    public_key = str(data.get('public_key', '')).strip()
+    raw_public_key = data.get('public_key', '')
+    if not isinstance(raw_public_key, str):
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
+    public_key = raw_public_key.strip()
 
     if not all([proposal_id, wallet, vote in ('yes', 'no'), nonce, signature, public_key]):
         return jsonify({
@@ -5919,7 +5922,10 @@ def governance_vote():
             "error": "proposal_id, wallet, vote(yes/no), nonce, signature, public_key are required",
         }), 400
 
-    expected_wallet = address_from_pubkey(public_key)
+    try:
+        expected_wallet = address_from_pubkey(public_key)
+    except Exception:
+        return jsonify({"ok": False, "error": "invalid_public_key"}), 400
     if wallet != expected_wallet:
         return jsonify({
             "ok": False,

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -116,6 +116,25 @@ def test_governance_vote_rejects_malformed_public_key():
     assert resp.get_json()["error"] == "invalid_public_key"
 
 
+def test_governance_vote_rejects_non_hex_public_key_string():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/governance/vote",
+            json={
+                "proposal_id": 1,
+                "wallet": "RTC-test",
+                "vote": "yes",
+                "nonce": "n-2",
+                "signature": "ab" * 64,
+                "public_key": "not-a-hex-key",
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_public_key"
+
+
 def test_governance_vote_flow_and_lifecycle_finalization():
     with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -97,6 +97,25 @@ def test_governance_vote_rejects_invalid_proposal_id():
     )
 
 
+def test_governance_vote_rejects_malformed_public_key():
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as client:
+        resp = client.post(
+            "/governance/vote",
+            json={
+                "proposal_id": 1,
+                "wallet": "RTC-test",
+                "vote": "yes",
+                "nonce": "n-1",
+                "signature": "ab" * 64,
+                "public_key": ["not", "hex"],
+            },
+        )
+
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "invalid_public_key"
+
+
 def test_governance_vote_flow_and_lifecycle_finalization():
     with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")


### PR DESCRIPTION
Fixes #6125

## Summary
- reject non-string `public_key` values in `POST /governance/vote`
- catch public key decode/conversion failures around `address_from_pubkey`
- return deterministic `400 {"ok": false, "error": "invalid_public_key"}` for malformed key material
- add regression coverage proving malformed `public_key` no longer crashes the endpoint

## Validation
- `pytest -q tests/test_governance_api.py -k "governance_vote_rejects_malformed_public_key or governance_vote_rejects_non_object_json or governance_vote_rejects_invalid_proposal_id"`
- 3 passed

/claim #6125