### PR TITLE
Validate /epoch/enroll signature and public_key field types

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3654,8 +3654,25 @@ def _submit_attestation_impl():
     # signature + public_key at the top level.  If both fields are present we
     # MUST verify — this prevents an MITM from changing the miner (wallet) field
     # in transit and claiming another miner's hardware rewards (wallet hijack).
-    sig_hex = (data.get('signature') or '').strip().lower()
-    pubkey_hex = (data.get('public_key') or '').strip().lower()
+    raw_signature = data.get('signature')
+    raw_public_key = data.get('public_key')
+    if raw_signature is not None and not isinstance(raw_signature, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_signature_type",
+            "message": "signature must be a string when provided",
+            "code": "INVALID_SIGNATURE_TYPE",
+        }), 400
+    if raw_public_key is not None and not isinstance(raw_public_key, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_public_key_type",
+            "message": "public_key must be a string when provided",
+            "code": "INVALID_PUBLIC_KEY_TYPE",
+        }), 400
+
+    sig_hex = (raw_signature or '').strip().lower()
+    pubkey_hex = (raw_public_key or '').strip().lower()
     miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
     if sig_hex and pubkey_hex:
@@ -4120,8 +4137,25 @@ def enroll_epoch():
     # unauthorized-enrollment / miner_id-hijack vector.
     # Unsigned enrollment is rejected by default. Operators running private
     # legacy migrations can temporarily set ENROLL_ALLOW_UNSIGNED_LEGACY=1.
-    sig_hex = (data.get('signature') or '').strip().lower()
-    pubkey_hex = (data.get('public_key') or '').strip().lower()
+    raw_signature = data.get('signature')
+    raw_public_key = data.get('public_key')
+    if raw_signature is not None and not isinstance(raw_signature, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_signature_type",
+            "message": "signature must be a string when provided",
+            "code": "INVALID_SIGNATURE_TYPE",
+        }), 400
+    if raw_public_key is not None and not isinstance(raw_public_key, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_public_key_type",
+            "message": "public_key must be a string when provided",
+            "code": "INVALID_PUBLIC_KEY_TYPE",
+        }), 400
+
+    sig_hex = (raw_signature or '').strip().lower()
+    pubkey_hex = (raw_public_key or '').strip().lower()
     epoch = slot_to_epoch(current_slot())
 
     if sig_hex and pubkey_hex:

--- a/node/tests/test_enroll_signature_verification.py
+++ b/node/tests/test_enroll_signature_verification.py
@@ -499,6 +499,32 @@ class TestEnrollSignatureVerification(unittest.TestCase):
         self.assertEqual(status, 400)
         self.assertEqual(body["code"], "INCOMPLETE_SIGNATURE")
 
+    def test_enrollment_rejects_non_string_signature_type(self):
+        mod, _ = self._load_module("rustchain_enroll_sig_type", "enroll_sig_type.db")
+        payload = {
+            "miner_pubkey": "RTC_TYPE_SIG",
+            "miner_id": "miner_type_sig",
+            "device": {"family": "x86_64", "arch": "default"},
+            "signature": True,
+            "public_key": "00" * 32,
+        }
+        status, body = self._enroll(mod, payload)
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_SIGNATURE_TYPE")
+
+    def test_enrollment_rejects_non_string_public_key_type(self):
+        mod, _ = self._load_module("rustchain_enroll_pubkey_type", "enroll_pubkey_type.db")
+        payload = {
+            "miner_pubkey": "RTC_TYPE_PUB",
+            "miner_id": "miner_type_pub",
+            "device": {"family": "x86_64", "arch": "default"},
+            "signature": "ab" * 64,
+            "public_key": ["not", "a", "string"],
+        }
+        status, body = self._enroll(mod, payload)
+        self.assertEqual(status, 400)
+        self.assertEqual(body["code"], "INVALID_PUBLIC_KEY_TYPE")
+
     @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
     def test_enrollment_pubkey_mismatch_with_attacker_key(self):
         """Attacker cannot enroll victim's pubkey using attacker's signing key."""


### PR DESCRIPTION
Fixes #6123

## Summary
- harden `/epoch/enroll` to reject non-string `signature` and `public_key` fields before normalization
- return deterministic structured 400 errors for malformed types:
  - `INVALID_SIGNATURE_TYPE`
  - `INVALID_PUBLIC_KEY_TYPE`
- add regressions in enrollment signature tests for both malformed payload cases

## Validation
- `pytest -q node/tests/test_enroll_signature_verification.py -k "non_string_signature_type or non_string_public_key_type"`
- 2 passed

/claim #6123