### PR TITLE
Reject malformed public_key values in signed wallet transfer

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8637,7 +8637,10 @@ def wallet_transfer_signed():
     nonce_int = pre.details["nonce"]
     chain_id = pre.details.get("chain_id")
     signature = str(data.get("signature", "")).strip()
-    public_key = str(data.get("public_key", "")).strip()
+    raw_public_key = data.get("public_key", "")
+    if not isinstance(raw_public_key, str):
+        return jsonify({"error": "invalid_public_key"}), 400
+    public_key = raw_public_key.strip()
     memo = str(data.get("memo", ""))
     amount_rtc = pre.details["amount_rtc"]
     fee_rtc = pre.details["fee_rtc"]
@@ -8668,7 +8671,10 @@ def wallet_transfer_signed():
             }), 400
         public_key = atlas_pubkey  # Use Atlas pubkey for verification
     else:
-        expected_address = address_from_pubkey(public_key)
+        try:
+            expected_address = address_from_pubkey(public_key)
+        except Exception:
+            return jsonify({"error": "invalid_public_key"}), 400
         if from_address != expected_address:
             return jsonify({
                 "error": "Public key does not match from_address",

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8265,6 +8265,18 @@ def address_from_pubkey(public_key_hex: str) -> str:
     pubkey_hash = hashlib.sha256(bytes.fromhex(public_key_hex)).hexdigest()[:40]
     return f"RTC{pubkey_hash}"
 
+
+def _validated_public_key(raw_public_key):
+    """Return normalized Ed25519 public key hex or ``None`` when invalid."""
+    if not isinstance(raw_public_key, str):
+        return None
+    public_key = raw_public_key.strip().lower()
+    if len(public_key) != 64:
+        return None
+    if not re.fullmatch(r"[0-9a-f]{64}", public_key):
+        return None
+    return public_key
+
 def _wallet_transfer_signed_messages(
     from_address,
     to_address,
@@ -8638,9 +8650,9 @@ def wallet_transfer_signed():
     chain_id = pre.details.get("chain_id")
     signature = str(data.get("signature", "")).strip()
     raw_public_key = data.get("public_key", "")
-    if not isinstance(raw_public_key, str):
+    public_key = _validated_public_key(raw_public_key)
+    if not is_bcn_address(from_address) and public_key is None:
         return jsonify({"error": "invalid_public_key"}), 400
-    public_key = raw_public_key.strip()
     memo = str(data.get("memo", ""))
     amount_rtc = pre.details["amount_rtc"]
     fee_rtc = pre.details["fee_rtc"]
@@ -8663,6 +8675,8 @@ def wallet_transfer_signed():
             }), 404
         # Use the Atlas pubkey — client may omit public_key for bcn_ wallets
         atlas_pubkey = bcn_info["pubkey_hex"]
+        if isinstance(raw_public_key, str) and raw_public_key.strip() and public_key is None:
+            return jsonify({"error": "invalid_public_key"}), 400
         if public_key and public_key != atlas_pubkey:
             return jsonify({
                 "error": "Public key does not match Beacon Atlas registration",

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -169,6 +169,16 @@ def test_signed_transfer_rejects_non_string_public_key(signed_transfer_client):
     assert response.get_json()["error"] == "invalid_public_key"
 
 
+def test_signed_transfer_rejects_non_hex_public_key_string(signed_transfer_client):
+    client, db_path = signed_transfer_client
+    payload = _payload()
+    payload["public_key"] = "not-a-hex-key"
+
+    response = client.post("/wallet/transfer/signed", json=payload)
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_public_key"
+
+
 def test_insufficient_balance_does_not_burn_nonce(signed_transfer_client):
     client, db_path = signed_transfer_client
     payload = _payload(amount_rtc=5.0, nonce=1733420009999)

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -159,6 +159,16 @@ def test_signed_transfer_rejects_duplicate_nonce(signed_transfer_client):
     assert pending_count == 1
 
 
+def test_signed_transfer_rejects_non_string_public_key(signed_transfer_client):
+    client, db_path = signed_transfer_client
+    payload = _payload()
+    payload["public_key"] = ["not", "hex"]
+
+    response = client.post("/wallet/transfer/signed", json=payload)
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "invalid_public_key"
+
+
 def test_insufficient_balance_does_not_burn_nonce(signed_transfer_client):
     client, db_path = signed_transfer_client
     payload = _payload(amount_rtc=5.0, nonce=1733420009999)


### PR DESCRIPTION
Fixes #6127

## Summary
- validate `public_key` type in `POST /wallet/transfer/signed` before normalization
- return deterministic `400 {"error":"invalid_public_key"}` when `public_key` is not a string
- guard `address_from_pubkey(public_key)` with exception handling to fail closed on malformed key material
- add regression test for non-string `public_key` payload path

## Validation
- `pytest -q tests/test_signed_transfer_replay.py -k "rejects_non_string_public_key or rejects_duplicate_nonce"`
- 2 passed

/claim #6127