### PR TITLE
fix: preserve GPU escrow recipient balances

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -297,6 +297,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 return jsonify({"error": "Job was already processed"}), 409
 
             # Refund to original requester
+            _ensure_balance_row(db, job["from_wallet"])
             credited = db.execute(
                 "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
                 (job["amount_rtc"], job["from_wallet"]),

--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -65,6 +65,12 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
         except sqlite3.Error:
             pass
 
+    def _ensure_balance_row(db, wallet):
+        db.execute(
+            "INSERT OR IGNORE INTO balances (miner_pk, balance_rtc) VALUES (?, 0.0)",
+            (wallet,),
+        )
+
     # 1. GPU Node Attestation (Extension)
     @app.route("/api/gpu/attest", methods=["POST"])
     def gpu_attest():
@@ -154,6 +160,7 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
             res = db.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (from_wallet,)).fetchone()
             if not res or res[0] < amount:
                 return jsonify({"error": "Insufficient balance for escrow"}), 400
+            _ensure_balance_row(db, to_wallet)
 
             # Lock funds
             db.execute("UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?", (amount, from_wallet))
@@ -226,7 +233,13 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 return jsonify({"error": "Job was already processed"}), 409
 
             # Transfer to provider
-            db.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?", (job["amount_rtc"], job["to_wallet"]))
+            credited = db.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+                (job["amount_rtc"], job["to_wallet"]),
+            )
+            if credited.rowcount != 1:
+                db.rollback()
+                return jsonify({"error": "escrow recipient wallet missing"}), 409
             db.commit()
             return jsonify({"ok": True, "status": "released"})
         except sqlite3.Error as e:
@@ -284,7 +297,13 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 return jsonify({"error": "Job was already processed"}), 409
 
             # Refund to original requester
-            db.execute("UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?", (job["amount_rtc"], job["from_wallet"]))
+            credited = db.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+                (job["amount_rtc"], job["from_wallet"]),
+            )
+            if credited.rowcount != 1:
+                db.rollback()
+                return jsonify({"error": "escrow payer wallet missing"}), 409
             db.commit()
             return jsonify({"ok": True, "status": "refunded"})
         except sqlite3.Error as e:

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -49,7 +49,8 @@ def _init_db(db_path):
 
 def _balance(db_path, wallet):
     with sqlite3.connect(db_path) as conn:
-        return conn.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (wallet,)).fetchone()[0]
+        row = conn.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (wallet,)).fetchone()
+        return row[0] if row else None
 
 
 def _escrow_payload():
@@ -115,6 +116,39 @@ def test_gpu_admin_can_create_and_release_escrow(tmp_path):
     released = client.post(
         "/api/gpu/release",
         json={"job_id": "job-1", "actor_wallet": "victim", "escrow_secret": escrow_secret},
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert released.status_code == 200
+    assert released.get_json() == {"ok": True, "status": "released"}
+    assert _balance(db_path, "victim") == 20.0
+    assert _balance(db_path, "attacker") == 5.0
+
+
+def test_gpu_escrow_release_preserves_funds_for_new_provider_wallet(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM balances WHERE miner_pk = ?", ("attacker",))
+
+    created = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+    assert created.status_code == 200
+    assert _balance(db_path, "victim") == 20.0
+    assert _balance(db_path, "attacker") == 0.0
+
+    released = client.post(
+        "/api/gpu/release",
+        json={
+            "job_id": "job-1",
+            "actor_wallet": "victim",
+            "escrow_secret": created.get_json()["escrow_secret"],
+        },
         headers={"X-Admin-Key": ADMIN_KEY},
     )
 

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -158,6 +158,37 @@ def test_gpu_escrow_release_preserves_funds_for_new_provider_wallet(tmp_path):
     assert _balance(db_path, "attacker") == 5.0
 
 
+def test_gpu_refund_materializes_missing_payer_wallet(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    client = _create_app(db_path).test_client()
+
+    created = client.post(
+        "/api/gpu/escrow",
+        json=_escrow_payload(),
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+    assert created.status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM balances WHERE miner_pk = ?", ("victim",))
+
+    refunded = client.post(
+        "/api/gpu/refund",
+        json={
+            "job_id": "job-1",
+            "actor_wallet": "attacker",
+            "escrow_secret": created.get_json()["escrow_secret"],
+        },
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert refunded.status_code == 200
+    assert refunded.get_json() == {"ok": True, "status": "refunded"}
+    assert _balance(db_path, "victim") == 5.0
+    assert _balance(db_path, "attacker") == 0.0
+
+
 def test_gpu_admin_endpoints_fail_closed_without_configured_key(tmp_path):
     db_path = tmp_path / "gpu.db"
     _init_db(db_path)


### PR DESCRIPTION
Fixes #6161

## Summary

Fixes a GPU escrow accounting edge case where `/api/gpu/release` could return success and mark an escrow `released` even though the provider wallet had no `balances` row and therefore received no credit.

## Root cause

`/api/gpu/escrow` verified only the payer balance row before debiting it. Later, `/api/gpu/release` updated the provider balance with:

```python
UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?
```

but did not check whether that update matched a row. If `to_wallet` was absent, SQLite updated zero rows, the endpoint still committed `status='released'`, and the total recorded balance dropped by the escrow amount.

## Fix

- Create a zero-balance row for `to_wallet` at escrow creation time.
- Check `rowcount` when crediting release/refund balances.
- Roll back the settlement state transition if a required balance row is unexpectedly missing.
- Add a regression proving a new provider wallet receives the released amount and total balances remain conserved.

## Validation

```text
uv run --no-project --with pytest --with flask python -m pytest tests/test_gpu_render_endpoints_security.py -q
# 11 passed

python3 -m py_compile node/gpu_render_endpoints.py tests/test_gpu_render_endpoints_security.py
git diff --check
```

Local PoC on `origin/main` before the patch:

```text
{'create_status': 200, 'release_status': 200, 'release_json': {'ok': True, 'status': 'released'}, 'victim': 20.0, 'attacker': None, 'total': 20.0, 'escrow_status': 'released'}
```

After the patch:

```text
{'create_status': 200, 'release_status': 200, 'release_json': {'ok': True, 'status': 'released'}, 'victim': 20.0, 'attacker': 5.0, 'total': 25.0, 'escrow_status': 'released'}
```

Bounty context: submitting as a focused bug fix for #305 / #71. No award, wallet credit, payout, or payment receipt is asserted until maintainer approval/merge/credit exists.
