### PR TITLE
Fix /api/blocks export for canonical blocks table schema

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -467,17 +467,31 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
         except ValueError as exc:
             return jsonify({"ok": False, "error": str(exc)}), 400
 
-        # Fetch blocks from database
+        # Fetch blocks from database (supports legacy and canonical schemas)
         with sqlite3.connect(peer_manager.db_path) as conn:
-            rows = conn.execute("""
-                SELECT height, hash, data FROM blocks
+            columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(blocks)").fetchall()
+            }
+            hash_column = "hash" if "hash" in columns else "block_hash"
+            data_column = "data" if "data" in columns else "body_json"
+
+            rows = conn.execute(
+                f"""
+                SELECT height, {hash_column}, {data_column} FROM blocks
                 WHERE height >= ?
                 ORDER BY height ASC
                 LIMIT ?
-            """, (start, limit)).fetchall()
+                """,
+                (start, limit),
+            ).fetchall()
 
             blocks = [
-                {"height": row[0], "hash": row[1], "data": json.loads(row[2])}
+                {
+                    "height": row[0],
+                    "hash": row[1],
+                    "data": json.loads(row[2]) if isinstance(row[2], str) else row[2],
+                }
                 for row in rows
             ]
 

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -124,3 +124,53 @@ def test_p2p_blocks_caps_oversized_limit(tmp_path):
     assert body["count"] == 1000
     assert body["blocks"][0]["height"] == 1
     assert body["blocks"][-1]["height"] == 1000
+
+
+def test_p2p_blocks_supports_canonical_block_schema(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER,
+                block_hash TEXT,
+                prev_hash TEXT,
+                timestamp INTEGER,
+                merkle_root TEXT,
+                state_root TEXT,
+                attestations_hash TEXT,
+                producer TEXT,
+                producer_sig TEXT,
+                tx_count INTEGER,
+                attestation_count INTEGER,
+                body_json TEXT,
+                created_at INTEGER
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks (
+                height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                attestations_hash, producer, producer_sig, tx_count,
+                attestation_count, body_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                1, "canonical-hash-1", "prev-hash-0", 1, "merkle", "state",
+                "att-hash", "miner", "sig", 1, 0, '{"ok": true, "tx": 1}', 1
+            ),
+        )
+        conn.commit()
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.get("/api/blocks?start=1&limit=1")
+    assert response.status_code == 200
+    assert response.get_json()["blocks"] == [
+        {"height": 1, "hash": "canonical-hash-1", "data": {"ok": True, "tx": 1}}
+    ]


### PR DESCRIPTION
Fixes #6111

## Summary
- make legacy P2P `/api/blocks` export route schema-compatible with both:
  - legacy `hash` + `data`
  - canonical `block_hash` + `body_json`
- choose export columns dynamically via `PRAGMA table_info(blocks)`
- preserve existing response shape (`height`, `hash`, `data`) while sourcing from canonical columns when needed
- add regression test proving canonical node schema exports blocks successfully

## Validation
- `pytest -q node/tests/test_p2p_sync_flask_imports.py`
- 10 passed

/claim #6111