### PR TITLE
fix: remove BOM from Postman collection

### DIFF
--- a/docs/postman/RustChain.postman_collection.json
+++ b/docs/postman/RustChain.postman_collection.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "name": "RustChain API",
     "description": "Postman collection for RustChain public APIs.",


### PR DESCRIPTION
## What changed

Removed the leading UTF-8 BOM from `docs/postman/RustChain.postman_collection.json`.

## Why

Strict JSON tools that read the collection as plain UTF-8 fail on the BOM byte sequence before parsing the otherwise valid JSON. Removing the BOM keeps the collection content unchanged while making the file compatible with strict JSON parsers and automation that does not use `utf-8-sig`.

## Validation

- `python3 - <<'PY' ... json.load(open("docs/postman/RustChain.postman_collection.json", encoding="utf-8")) ... PY` -> passed
- `python3 -m json.tool docs/postman/RustChain.postman_collection.json` -> passed
- `python3 -m py_compile docs/postman/validate_postman_collection.py` -> passed
- `python3 docs/postman/validate_postman_collection.py` -> passed
- `git diff --check origin/main...HEAD` -> passed

Focused pytest was previously run by the worker in its validation environment and passed for `tests/test_postman_collection_validator.py`; rerunning it in the current shell failed because `pytest` is not installed in the active Python environment.

## Risk / scope boundary

Single-file data cleanup only. The JSON structure and collection contents are unchanged apart from removing the leading BOM.


---
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
