### PR TITLE
Validate Hall of Rust JSON bodies

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -147,10 +147,18 @@ def estimate_manufacture_year(model, arch):
 
 # ============== API ENDPOINTS ==============
 
+def _get_json_object_body():
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({"error": "JSON object required"}), 400)
+    return data, None
+
 @hall_bp.route('/hall/induct', methods=['POST'])
 def induct_machine():
     """Automatically induct a machine into the Hall of Rust on first attestation."""
-    data = request.json or {}
+    data, error = _get_json_object_body()
+    if error:
+        return error
     
     # Generate fingerprint hash from hardware identifiers
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
@@ -303,7 +311,9 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
-    data = request.json or {}
+    data, error = _get_json_object_body()
+    if error:
+        return error
     
     try:
         from flask import current_app

--- a/tests/test_explorer_hall_of_rust_current_year.py
+++ b/tests/test_explorer_hall_of_rust_current_year.py
@@ -25,6 +25,50 @@ def client_for(module, db_path):
     return app.test_client()
 
 
+def test_induct_rejects_non_object_json(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/induct", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_eulogy_rejects_non_object_json_without_mutating(tmp_path):
+    hall = load_explorer_hall()
+    db_path = tmp_path / "hall.db"
+    hall.init_hall_tables(str(db_path))
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        INSERT INTO hall_of_rust (
+            fingerprint_hash, miner_id, device_arch, device_model,
+            manufacture_year, first_attestation, last_attestation,
+            rust_score, nickname, eulogy, created_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        ("fp-1", "miner-1", "G4", "PowerMac3,6", 2003, 1, 1, 101, "Old", "Original", 1),
+    )
+    conn.commit()
+    conn.close()
+    client = client_for(hall, db_path)
+
+    response = client.post("/hall/eulogy/fp-1", json=["nickname"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT nickname, eulogy, is_deceased FROM hall_of_rust WHERE fingerprint_hash = ?",
+        ("fp-1",),
+    ).fetchone()
+    conn.close()
+    assert row == ("Old", "Original", 0)
+
+
 def test_explorer_rust_score_uses_current_year_for_age_bonus(monkeypatch):
     hall = load_explorer_hall()
     monkeypatch.setattr(hall, "current_utc_year", lambda: 2026)


### PR DESCRIPTION
## Summary
- Fixes #6134 by requiring JSON object bodies before Hall of Rust write endpoints reach handler logic.
- Rejects arrays, strings, scalars, and missing parsed bodies with deterministic `400 {"error": "JSON object required"}` responses.
- Adds regressions for `/hall/induct` and `/hall/eulogy/<fingerprint>`, including a no-mutation check for rejected eulogy payloads.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-proxy-allowlist-venv/bin/python -m pytest -p no:cacheprovider tests/test_explorer_hall_of_rust_current_year.py -q` -> 5 passed
- `PYTHONDONTWRITEBYTECODE=1 /tmp/rustchain-proxy-allowlist-venv/bin/python -m py_compile explorer/hall_of_rust.py tests/test_explorer_hall_of_rust_current_year.py`
- `git diff --check`

Bug report: #6134