### PR TITLE
fix: add UPnP peer announcement for NAT nodes

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -25,6 +25,7 @@ from typing import Dict, List, Optional, Set, Tuple, Any
 from collections import defaultdict, OrderedDict
 import logging
 import requests
+from urllib.parse import urlparse
 
 # ---------------------------------------------------------------------------
 # P2P HMAC secret — MUST be set via the RC_P2P_SECRET environment variable.
@@ -378,6 +379,16 @@ class GossipLayer:
         # Load initial state from DB
         self._load_state_from_db()
 
+    @staticmethod
+    def _valid_peer_url(peer_url: Any) -> Optional[str]:
+        if not isinstance(peer_url, str):
+            return None
+        peer_url = peer_url.strip().rstrip("/")
+        parsed = urlparse(peer_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            return None
+        return peer_url
+
     def _load_state_from_db(self):
         """Load existing state into CRDTs and initialize P2P tables"""
         try:
@@ -648,6 +659,8 @@ class GossipLayer:
 
         if msg_type == MessageType.PING:
             return self._handle_ping(msg)
+        elif msg_type == MessageType.PEER_ANNOUNCE:
+            return self._handle_peer_announce(msg)
         elif msg_type == MessageType.INV_ATTESTATION:
             return self._handle_inv_attestation(msg)
         elif msg_type == MessageType.INV_EPOCH:
@@ -669,6 +682,28 @@ class GossipLayer:
             self.broadcast(msg, exclude_peer=msg.sender_id)
 
         return {"status": "ok"}
+
+    def _handle_peer_announce(self, msg: GossipMessage) -> Dict:
+        """Accept a signed peer announcement for NAT-discovered public URLs."""
+        payload = msg.payload if isinstance(msg.payload, dict) else {}
+        peer_id = payload.get("node_id") or msg.sender_id
+        peer_url = self._valid_peer_url(payload.get("url"))
+
+        if not isinstance(peer_id, str) or not peer_id.strip():
+            return {"status": "invalid_peer_announce", "reason": "node_id required"}
+        if peer_id == self.node_id:
+            return {"status": "ignored_self_announce"}
+        if peer_url is None:
+            return {"status": "invalid_peer_announce", "reason": "valid peer url required"}
+
+        with self.lock:
+            self.peers[peer_id.strip()] = peer_url
+
+        if msg.ttl > 0:
+            msg.ttl -= 1
+            self.broadcast(msg, exclude_peer=msg.sender_id)
+
+        return {"status": "peer_added", "node_id": peer_id.strip(), "url": peer_url}
 
     def _handle_ping(self, msg: GossipMessage) -> Dict:
         """Respond to ping with pong"""
@@ -1236,10 +1271,17 @@ class RustChainP2PNode:
     Manages gossip, CRDT state, and epoch consensus.
     """
 
-    def __init__(self, node_id: str, db_path: str, peers: Dict[str, str]):
+    def __init__(
+        self,
+        node_id: str,
+        db_path: str,
+        peers: Dict[str, str],
+        advertised_url: Optional[str] = None,
+    ):
         self.node_id = node_id
         self.db_path = db_path
         self.peers = peers
+        self.advertised_url = advertised_url
 
         # Initialize components
         self.gossip = GossipLayer(node_id, peers, db_path)
@@ -1257,6 +1299,7 @@ class RustChainP2PNode:
         self.running = True
         self.sync_thread = threading.Thread(target=self._sync_loop, daemon=True)
         self.sync_thread.start()
+        self.announce_peer()
         logger.info(f"P2P Node {self.node_id} started with {len(self.peers)} peers")
 
     def stop(self):
@@ -1313,6 +1356,17 @@ class RustChainP2PNode:
             ts_ok,
             attestation.get("device_arch", "unknown")
         )
+
+    def announce_peer(self):
+        """Broadcast this node's reachable URL when NAT traversal found one."""
+        if not self.advertised_url:
+            return
+
+        msg = self.gossip.create_message(MessageType.PEER_ANNOUNCE, {
+            "node_id": self.node_id,
+            "url": self.advertised_url,
+        })
+        self.gossip.broadcast(msg)
 
 
 # =============================================================================
@@ -1417,6 +1471,7 @@ def register_p2p_endpoints(app, p2p_node: RustChainP2PNode):
             "node_id": p2p_node.node_id,
             "running": p2p_node.running,
             "peer_count": len(p2p_node.peers),
+            "advertised_url": getattr(p2p_node, "advertised_url", None),
             "attestation_count": len(p2p_node.gossip.attestation_crdt.data),
             "settled_epochs": len(p2p_node.gossip.epoch_crdt.items)
         })

--- a/node/rustchain_p2p_init.py
+++ b/node/rustchain_p2p_init.py
@@ -6,7 +6,9 @@ RustChain P2P Initialization Helper
 Updated 2025-12-17: Added POWER8 Funnel URL for public access
 """
 
+import ipaddress
 import os
+from urllib.parse import urlparse
 
 # All RustChain nodes - includes both Tailscale and public URLs
 PEER_NODES = {
@@ -18,6 +20,75 @@ PEER_NODES = {
     "node4": "http://100.94.28.32:8099",           # POWER8 S824 (Tailscale)
     "node4_public": "https://sophiapower8.tailbac22e.ts.net"  # POWER8 (Funnel - public!)
 }
+
+
+def _env_flag(name, default=False):
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_private_host(host):
+    try:
+        return ipaddress.ip_address(host).is_private
+    except ValueError:
+        return False
+
+
+def _valid_public_url(raw_url):
+    if not raw_url:
+        return None
+    parsed = urlparse(raw_url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return raw_url.strip().rstrip("/")
+
+
+def _discover_upnp_external_url(local_ip, local_port):
+    """Return a public P2P URL via UPnP IGD when miniupnpc is available."""
+    try:
+        import miniupnpc
+    except ImportError:
+        return None
+
+    try:
+        upnp = miniupnpc.UPnP()
+        upnp.discoverdelay = int(os.environ.get("RC_P2P_UPNP_DISCOVER_DELAY_MS", "200"))
+        if upnp.discover() <= 0:
+            return None
+        upnp.selectigd()
+        external_ip = upnp.externalipaddress()
+        if not external_ip:
+            return None
+
+        description = os.environ.get("RC_P2P_UPNP_DESCRIPTION", "RustChain P2P")
+        try:
+            upnp.addportmapping(local_port, "TCP", local_ip, local_port, description, "")
+        except Exception as exc:
+            print(f"[P2P] UPnP port mapping failed: {exc}")
+            return None
+
+        return f"http://{external_ip}:{local_port}"
+    except Exception as exc:
+        print(f"[P2P] UPnP discovery failed: {exc}")
+        return None
+
+
+def resolve_advertised_url(local_ip, local_port=8099):
+    """Choose the URL this node should advertise to peers."""
+    explicit_url = _valid_public_url(os.environ.get("RC_P2P_EXTERNAL_URL"))
+    if explicit_url:
+        return explicit_url
+
+    if (
+        _is_private_host(local_ip)
+        and _env_flag("RC_P2P_ENABLE_UPNP", default=True)
+        and not _env_flag("RC_P2P_DISABLE_UPNP")
+    ):
+        return _discover_upnp_external_url(local_ip, local_port)
+
+    return None
 
 
 def init_p2p(app, db_path, node_id=None):
@@ -65,7 +136,14 @@ def init_p2p(app, db_path, node_id=None):
         s.close()
     except:
         pass
-    
+
+    local_ip = None
+    if my_ips:
+        local_ip = next((ip for ip in my_ips if "." in ip and not ip.startswith("127.")), None)
+
+    p2p_port = int(os.environ.get("RC_P2P_PORT", "8099"))
+    advertised_url = resolve_advertised_url(local_ip or "127.0.0.1", p2p_port)
+
     for k, v in PEER_NODES.items():
         if k == node_id:
             continue
@@ -79,8 +157,10 @@ def init_p2p(app, db_path, node_id=None):
 
     print(f"[P2P] Initializing node {node_id} with {len(peers)} peers")
     print(f"[P2P] Peers: {list(peers.keys())}")
+    if advertised_url:
+        print(f"[P2P] Advertising public P2P URL: {advertised_url}")
 
-    p2p_node = RustChainP2PNode(node_id, db_path, peers)
+    p2p_node = RustChainP2PNode(node_id, db_path, peers, advertised_url=advertised_url)
     register_p2p_endpoints(app, p2p_node)
     p2p_node.start()
 

--- a/node/tests/test_p2p_nat_upnp.py
+++ b/node/tests/test_p2p_nat_upnp.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import sys
+import types
+from pathlib import Path
+
+from flask import Flask
+
+os.environ.setdefault("RC_P2P_SECRET", "unit-test-secret-0123456789abcdef")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import rustchain_p2p_gossip as gossip
+import rustchain_p2p_init as p2p_init
+
+
+def test_external_url_override_wins(monkeypatch):
+    monkeypatch.setenv("RC_P2P_EXTERNAL_URL", "https://home-node.example:8099/")
+
+    assert p2p_init.resolve_advertised_url("192.168.1.20", 8099) == (
+        "https://home-node.example:8099"
+    )
+
+
+def test_private_host_uses_upnp_when_available(monkeypatch):
+    class FakeUPnP:
+        discoverdelay = None
+
+        def discover(self):
+            return 1
+
+        def selectigd(self):
+            return None
+
+        def externalipaddress(self):
+            return "203.0.113.7"
+
+        def addportmapping(self, external_port, proto, local_ip, local_port, desc, remote):
+            assert external_port == 8099
+            assert proto == "TCP"
+            assert local_ip == "192.168.1.20"
+            assert local_port == 8099
+            return True
+
+    monkeypatch.delenv("RC_P2P_EXTERNAL_URL", raising=False)
+    monkeypatch.setitem(sys.modules, "miniupnpc", types.SimpleNamespace(UPnP=FakeUPnP))
+
+    assert p2p_init.resolve_advertised_url("192.168.1.20", 8099) == "http://203.0.113.7:8099"
+
+
+def test_peer_announce_adds_signed_public_peer(tmp_path):
+    db_path = tmp_path / "p2p.db"
+    receiver = gossip.GossipLayer("node-a", {}, db_path=str(db_path))
+    sender = gossip.GossipLayer("node-b", {}, db_path=str(tmp_path / "sender.db"))
+
+    msg = sender.create_message(
+        gossip.MessageType.PEER_ANNOUNCE,
+        {"node_id": "node-b", "url": "https://node-b.example:8099"},
+    )
+
+    result = receiver.handle_message(msg)
+
+    assert result["status"] == "peer_added"
+    assert receiver.peers["node-b"] == "https://node-b.example:8099"
+
+
+def test_p2p_health_reports_advertised_url(tmp_path):
+    node = gossip.RustChainP2PNode(
+        "node-a",
+        str(tmp_path / "p2p.db"),
+        {},
+        advertised_url="https://node-a.example:8099",
+    )
+    app = Flask(__name__)
+    gossip.register_p2p_endpoints(app, node)
+
+    response = app.test_client().get("/p2p/health")
+
+    assert response.status_code == 200
+    assert response.get_json()["advertised_url"] == "https://node-a.example:8099"


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

Fixes #2585.

- Added optional UPnP IGD discovery during P2P startup so a node on a private LAN can map its P2P port and resolve an externally reachable URL.
- Added `RC_P2P_EXTERNAL_URL` as an explicit override and `RC_P2P_ENABLE_UPNP` / `RC_P2P_DISABLE_UPNP` controls for operators.
- Added signed `peer_announce` handling so a NAT-discovered URL is shared with existing peers instead of staying local-only.
- Exposed the current `advertised_url` on `/p2p/health` for operator verification.


## Testing / Evidence

- `python3 -B -m py_compile node/rustchain_p2p_init.py node/rustchain_p2p_gossip.py node/tests/test_p2p_nat_upnp.py`
- `python -B -m pytest -q node/tests/test_p2p_nat_upnp.py node/tests/test_p2p_gossip_routes.py node/tests/test_p2p_endpoint_auth.py tests/test_p2p_demo_peer_config.py --tb=short -p no:cacheprovider` -> 14 passed
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check origin/main...HEAD`
- hidden Unicode scan of changed files -> OK

Note: focused tests ran on Python 3.9 with the latest compatible `requests` release because the current repo requirement needs Python 3.10+.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
