### PR TITLE
feat: add bridge dashboard history metrics

### DIFF
--- a/bridge-dashboard/README.md
+++ b/bridge-dashboard/README.md
@@ -154,6 +154,7 @@ docker run -p 8080:80 rustchain-bridge-dashboard
 | `/bridge/dashboard/metrics` | GET | Aggregated metrics for dashboard |
 | `/bridge/dashboard/health` | GET | Comprehensive health status |
 | `/bridge/dashboard/transactions` | GET | Recent transactions with filtering |
+| `/bridge/dashboard/history` | GET | Bucketed completed bridge volume and wrap/unwrap counts |
 | `/bridge/dashboard/price` | GET | wRTC price from Raydium/DexScreener |
 | `/bridge/dashboard/chart` | GET | Historical price chart data |
 
@@ -193,6 +194,28 @@ docker run -p 8080:80 rustchain-bridge-dashboard
   "circulating_change_24h": 12.5,
   "total_transactions": 42,
   "last_updated": 1742851200
+}
+```
+
+### GET /bridge/dashboard/history
+
+```json
+{
+  "period": "24h",
+  "bucket": "1h",
+  "start_time": 1742764800,
+  "end_time": 1742851200,
+  "points": [
+    {
+      "timestamp": 1742847600,
+      "completed_count": 2,
+      "total_volume_rtc": 125.75,
+      "wrap_volume_rtc": 100.5,
+      "unwrap_volume_rtc": 25.25,
+      "wrap_count": 1,
+      "unwrap_count": 1
+    }
+  ]
 }
 ```
 

--- a/bridge/dashboard_api.py
+++ b/bridge/dashboard_api.py
@@ -6,6 +6,7 @@ Extends bridge_api.py with dashboard-specific endpoints:
 - GET /bridge/dashboard/metrics - Aggregated metrics for dashboard
 - GET /bridge/dashboard/health - Bridge health status
 - GET /bridge/dashboard/transactions - Recent transactions with filtering
+- GET /bridge/dashboard/history - Bucketed bridge volume and transaction history
 - GET /bridge/dashboard/price - wRTC price data from Raydium/DexScreener
 - GET /bridge/dashboard/chart - Historical price chart data
 
@@ -323,6 +324,121 @@ def get_dashboard_transactions():
         "wrap_count": wrap_count,
         "unwrap_count": unwrap_count,
         "total_volume_24h": round(total_volume_24h, 2),
+    })
+
+
+@dashboard_bp.route("/history", methods=["GET"])
+def get_bridge_history():
+    """
+    Get bucketed bridge history for monitoring charts.
+
+    Query params:
+    - period: '1h' | '24h' | '7d' | '30d' (default: '24h')
+    - bucket: '5m' | '15m' | '1h' | '1d' (default chosen from period)
+
+    Returns:
+    {
+        "period": "24h",
+        "bucket": "1h",
+        "start_time": int,
+        "end_time": int,
+        "points": [
+            {
+                "timestamp": int,
+                "completed_count": int,
+                "total_volume_rtc": float,
+                "wrap_volume_rtc": float,
+                "unwrap_volume_rtc": float,
+                "wrap_count": int,
+                "unwrap_count": int
+            }
+        ]
+    }
+    """
+    periods = {
+        "1h": 3600,
+        "24h": 86400,
+        "7d": 604800,
+        "30d": 2592000,
+    }
+    buckets = {
+        "5m": 300,
+        "15m": 900,
+        "1h": 3600,
+        "1d": 86400,
+    }
+    default_buckets = {
+        "1h": "5m",
+        "24h": "1h",
+        "7d": "1d",
+        "30d": "1d",
+    }
+
+    period = request.args.get("period", "24h").lower()
+    if period not in periods:
+        return jsonify({"error": "period must be one of: 1h, 24h, 7d, 30d"}), 400
+
+    bucket = request.args.get("bucket", default_buckets[period]).lower()
+    if bucket not in buckets:
+        return jsonify({"error": "bucket must be one of: 5m, 15m, 1h, 1d"}), 400
+
+    period_seconds = periods[period]
+    bucket_seconds = buckets[bucket]
+    if bucket_seconds > period_seconds:
+        return jsonify({"error": "bucket cannot be larger than period"}), 400
+    if period_seconds // bucket_seconds > 720:
+        return jsonify({"error": "too many history buckets requested"}), 400
+
+    end_time = int(time.time())
+    start_time = end_time - period_seconds
+    first_bucket = (start_time // bucket_seconds) * bucket_seconds
+    bucket_count = ((end_time - first_bucket) // bucket_seconds) + 1
+
+    points = []
+    for index in range(bucket_count):
+        timestamp = first_bucket + (index * bucket_seconds)
+        points.append({
+            "timestamp": timestamp,
+            "completed_count": 0,
+            "total_volume_rtc": 0.0,
+            "wrap_volume_rtc": 0.0,
+            "unwrap_volume_rtc": 0.0,
+            "wrap_count": 0,
+            "unwrap_count": 0,
+        })
+
+    with get_db() as conn:
+        rows = conn.execute(
+            """
+            SELECT created_at, amount_rtc, target_chain
+            FROM bridge_locks
+            WHERE state = ? AND created_at >= ? AND created_at <= ?
+            ORDER BY created_at ASC
+            """,
+            (STATE_COMPLETE, start_time, end_time),
+        ).fetchall()
+
+    for row in rows:
+        index = int((row["created_at"] - first_bucket) // bucket_seconds)
+        if index < 0 or index >= len(points):
+            continue
+        amount = _amount_from_base(row["amount_rtc"])
+        point = points[index]
+        point["completed_count"] += 1
+        point["total_volume_rtc"] = round(point["total_volume_rtc"] + amount, 6)
+        if row["target_chain"] == "solana":
+            point["wrap_count"] += 1
+            point["wrap_volume_rtc"] = round(point["wrap_volume_rtc"] + amount, 6)
+        elif row["target_chain"] == "base":
+            point["unwrap_count"] += 1
+            point["unwrap_volume_rtc"] = round(point["unwrap_volume_rtc"] + amount, 6)
+
+    return jsonify({
+        "period": period,
+        "bucket": bucket,
+        "start_time": start_time,
+        "end_time": end_time,
+        "points": points,
     })
 
 

--- a/bridge/test_dashboard_api.py
+++ b/bridge/test_dashboard_api.py
@@ -8,6 +8,7 @@ Coverage:
 - Dashboard metrics endpoint
 - Health check endpoint
 - Transactions endpoint
+- History endpoint
 - Price endpoint
 - Chart endpoint
 """
@@ -67,7 +68,7 @@ def insert_sample_lock(db_path, lock_data):
     """Insert sample lock into database with unique tx_hash."""
     import uuid
     with get_db() as conn:
-        now = int(time.time())
+        now = lock_data.get('created_at', int(time.time()))
         tx_hash = lock_data.get('tx_hash', f'test-tx-{uuid.uuid4().hex[:8]}')
         conn.execute(
             """
@@ -314,6 +315,86 @@ class TestDashboardTransactions:
         assert isinstance(data['wrap_count'], int)
         assert isinstance(data['unwrap_count'], int)
         assert isinstance(data['total_volume_24h'], (int, float))
+
+
+class TestBridgeHistory:
+    """Test /bridge/dashboard/history endpoint."""
+
+    def test_history_endpoint_exists(self, client):
+        """History endpoint returns bucketed monitoring points."""
+        response = client.get('/bridge/dashboard/history')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        assert data['period'] == '24h'
+        assert data['bucket'] == '1h'
+        assert isinstance(data['points'], list)
+        assert data['points']
+        assert {
+            'timestamp',
+            'completed_count',
+            'total_volume_rtc',
+            'wrap_volume_rtc',
+            'unwrap_volume_rtc',
+            'wrap_count',
+            'unwrap_count',
+        }.issubset(data['points'][0])
+
+    def test_history_aggregates_wrap_and_unwrap_volume(self, app, client):
+        """Completed locks are grouped into the requested bucket by target chain."""
+        import uuid
+
+        now = int(time.time())
+        bucket_start = (now // 3600) * 3600
+
+        insert_sample_lock(app.config['BRIDGE_DB_PATH'], {
+            'lock_id': f'lock_history_wrap_{uuid.uuid4().hex[:8]}',
+            'sender_wallet': 'wallet-history-wrap',
+            'amount_rtc': 25.5,
+            'target_chain': 'solana',
+            'target_wallet': '7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU',
+            'tx_hash': f'tx-history-wrap-{uuid.uuid4().hex[:8]}',
+            'state': STATE_COMPLETE,
+            'created_at': bucket_start + 60,
+        })
+        insert_sample_lock(app.config['BRIDGE_DB_PATH'], {
+            'lock_id': f'lock_history_unwrap_{uuid.uuid4().hex[:8]}',
+            'sender_wallet': 'wallet-history-unwrap',
+            'amount_rtc': 10.25,
+            'target_chain': 'base',
+            'target_wallet': '0x4215a73199d56b7e9c71575bec1632cd1d36908f',
+            'tx_hash': f'tx-history-unwrap-{uuid.uuid4().hex[:8]}',
+            'state': STATE_COMPLETE,
+            'created_at': bucket_start + 120,
+        })
+
+        response = client.get('/bridge/dashboard/history?period=24h&bucket=1h')
+
+        assert response.status_code == 200
+        data = json.loads(response.data)
+        point = next(item for item in data['points'] if item['timestamp'] == bucket_start)
+        assert point['completed_count'] >= 2
+        assert point['wrap_count'] >= 1
+        assert point['unwrap_count'] >= 1
+        assert point['wrap_volume_rtc'] >= 25.5
+        assert point['unwrap_volume_rtc'] >= 10.25
+        assert point['total_volume_rtc'] >= 35.75
+
+    @pytest.mark.parametrize(
+        "query, expected_error",
+        [
+            ("period=12h", "period must be one of: 1h, 24h, 7d, 30d"),
+            ("period=1h&bucket=1d", "bucket cannot be larger than period"),
+            ("period=24h&bucket=2h", "bucket must be one of: 5m, 15m, 1h, 1d"),
+        ],
+    )
+    def test_history_rejects_invalid_queries(self, client, query, expected_error):
+        """Invalid history query parameters return clear 400 errors."""
+        response = client.get(f'/bridge/dashboard/history?{query}')
+
+        assert response.status_code == 400
+        data = json.loads(response.data)
+        assert data['error'] == expected_error
 
 
 class TestWrtcPrice:


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Adds `GET /bridge/dashboard/history` for bucketed bridge monitoring history.
- Aggregates completed bridge locks into configurable periods and buckets with total, wrap, and unwrap volume/counts.
- Documents the endpoint response shape in the bridge dashboard README.

Closes #2565


## Testing / Evidence

- `python3 -m py_compile bridge/dashboard_api.py bridge/test_dashboard_api.py`
- `python3 -m pytest bridge/test_dashboard_api.py -q` (`27 passed`)
- `git diff --check origin/main...HEAD`
- hidden Unicode scan for changed files
- `python3 tools/bcos_spdx_check.py --base-ref origin/main`

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
