### PR TITLE
feat: add attestation pool monitoring

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1377,6 +1377,7 @@ def init_db():
         )""")
         c.execute("CREATE INDEX IF NOT EXISTS idx_attest_history_miner ON miner_attest_history(miner)")
         c.execute("CREATE INDEX IF NOT EXISTS idx_attest_history_ts ON miner_attest_history(miner, ts_ok)")
+        c.execute("CREATE INDEX IF NOT EXISTS idx_attest_history_ts_only ON miner_attest_history(ts_ok)")
 
         # Issue #2276: Hardware fingerprint replay defense tables
         if HAVE_REPLAY_DEFENSE:

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6120,6 +6120,179 @@ def _sqlite_table_columns(conn, table_name):
     return {row[1] for row in rows}
 
 
+ATTESTATION_POOL_ACTIVE_WINDOW_SECONDS = 3600
+ATTESTATION_POOL_HISTORY_WINDOW_SECONDS = 86400
+
+
+def _table_exists(conn, table_name: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table_name,),
+    ).fetchone() is not None
+
+
+def _attestation_pool_snapshot(now_ts: Optional[int] = None) -> dict:
+    """Aggregate current and recent attestation-pool health for dashboards."""
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    active_cutoff = now_ts - ATTESTATION_POOL_ACTIVE_WINDOW_SECONDS
+    history_cutoff = now_ts - ATTESTATION_POOL_HISTORY_WINDOW_SECONDS
+    snapshot = {
+        "ok": True,
+        "generated_at": now_ts,
+        "windows": {
+            "active_seconds": ATTESTATION_POOL_ACTIVE_WINDOW_SECONDS,
+            "history_seconds": ATTESTATION_POOL_HISTORY_WINDOW_SECONDS,
+        },
+        "pool": {
+            "active_miners": 0,
+            "stale_miners": 0,
+            "known_miners": 0,
+            "recent_attestations_24h": 0,
+            "fingerprint_passed_active": 0,
+            "avg_entropy_active": 0.0,
+            "oldest_active_attest": None,
+            "newest_active_attest": None,
+        },
+        "by_device_arch": [],
+        "history": [],
+        "tables": {
+            "miner_attest_recent": False,
+            "miner_attest_history": False,
+        },
+    }
+
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.row_factory = sqlite3.Row
+        has_recent = _table_exists(conn, "miner_attest_recent")
+        has_history = _table_exists(conn, "miner_attest_history")
+        snapshot["tables"]["miner_attest_recent"] = has_recent
+        snapshot["tables"]["miner_attest_history"] = has_history
+        if not has_recent:
+            return snapshot
+
+        recent_cols = _sqlite_table_columns(conn, "miner_attest_recent")
+        if "ts_ok" not in recent_cols:
+            return snapshot
+        fp_expr = "COALESCE(fingerprint_passed, 0)" if "fingerprint_passed" in recent_cols else "0"
+        entropy_expr = "COALESCE(entropy_score, 0.0)" if "entropy_score" in recent_cols else "0.0"
+
+        row = conn.execute(
+            f"""
+            SELECT
+                COUNT(*) AS known_miners,
+                SUM(CASE WHEN ts_ok >= ? THEN 1 ELSE 0 END) AS active_miners,
+                SUM(CASE WHEN ts_ok < ? THEN 1 ELSE 0 END) AS stale_miners,
+                SUM(CASE WHEN ts_ok >= ? AND {fp_expr} THEN 1 ELSE 0 END) AS fingerprint_passed_active,
+                AVG(CASE WHEN ts_ok >= ? THEN {entropy_expr} ELSE NULL END) AS avg_entropy_active,
+                MIN(CASE WHEN ts_ok >= ? THEN ts_ok ELSE NULL END) AS oldest_active_attest,
+                MAX(CASE WHEN ts_ok >= ? THEN ts_ok ELSE NULL END) AS newest_active_attest
+            FROM miner_attest_recent
+            """,
+            (active_cutoff, active_cutoff, active_cutoff, active_cutoff, active_cutoff, active_cutoff),
+        ).fetchone()
+        if row:
+            snapshot["pool"].update({
+                "known_miners": int(row["known_miners"] or 0),
+                "active_miners": int(row["active_miners"] or 0),
+                "stale_miners": int(row["stale_miners"] or 0),
+                "fingerprint_passed_active": int(row["fingerprint_passed_active"] or 0),
+                "avg_entropy_active": round(float(row["avg_entropy_active"] or 0.0), 6),
+                "oldest_active_attest": int(row["oldest_active_attest"]) if row["oldest_active_attest"] else None,
+                "newest_active_attest": int(row["newest_active_attest"]) if row["newest_active_attest"] else None,
+            })
+
+        if "device_arch" in recent_cols:
+            arch_rows = conn.execute(
+                """
+                SELECT COALESCE(NULLIF(device_arch, ''), 'unknown') AS device_arch, COUNT(*) AS miners
+                FROM miner_attest_recent
+                WHERE ts_ok >= ?
+                GROUP BY COALESCE(NULLIF(device_arch, ''), 'unknown')
+                ORDER BY miners DESC, device_arch ASC
+                LIMIT 20
+                """,
+                (active_cutoff,),
+            ).fetchall()
+            snapshot["by_device_arch"] = [
+                {"device_arch": r["device_arch"], "active_miners": int(r["miners"] or 0)}
+                for r in arch_rows
+            ]
+
+        if has_history:
+            history_cols = _sqlite_table_columns(conn, "miner_attest_history")
+            if "ts_ok" not in history_cols:
+                return snapshot
+            hist_rows = conn.execute(
+                """
+                SELECT CAST((ts_ok / 3600) AS INTEGER) AS hour_bucket, COUNT(*) AS attestations
+                FROM miner_attest_history
+                WHERE ts_ok >= ?
+                GROUP BY hour_bucket
+                ORDER BY hour_bucket ASC
+                """,
+                (history_cutoff,),
+            ).fetchall()
+            snapshot["history"] = [
+                {
+                    "hour_bucket": int(r["hour_bucket"]),
+                    "attestations": int(r["attestations"] or 0),
+                }
+                for r in hist_rows
+            ]
+            snapshot["pool"]["recent_attestations_24h"] = sum(
+                bucket["attestations"] for bucket in snapshot["history"]
+            )
+
+    return snapshot
+
+
+def _prom_label_value(value) -> str:
+    return str(value).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _attestation_pool_prometheus_text(now_ts: Optional[int] = None) -> str:
+    try:
+        snap = _attestation_pool_snapshot(now_ts=now_ts)
+    except Exception:
+        return "rustchain_attestation_pool_scrape_ok 0\nrustchain_attestation_pool_scrape_error 1\n"
+
+    pool = snap["pool"]
+    lines = [
+        "# HELP rustchain_attestation_pool_active_miners Active miners with a recent attestation.",
+        "# TYPE rustchain_attestation_pool_active_miners gauge",
+        f"rustchain_attestation_pool_active_miners {pool['active_miners']}",
+        "# HELP rustchain_attestation_pool_stale_miners Miners whose latest attestation is outside the active window.",
+        "# TYPE rustchain_attestation_pool_stale_miners gauge",
+        f"rustchain_attestation_pool_stale_miners {pool['stale_miners']}",
+        "# HELP rustchain_attestation_pool_known_miners Miners tracked in the attestation pool.",
+        "# TYPE rustchain_attestation_pool_known_miners gauge",
+        f"rustchain_attestation_pool_known_miners {pool['known_miners']}",
+        "# HELP rustchain_attestation_pool_recent_attestations_24h Attestation history entries in the last 24 hours.",
+        "# TYPE rustchain_attestation_pool_recent_attestations_24h gauge",
+        f"rustchain_attestation_pool_recent_attestations_24h {pool['recent_attestations_24h']}",
+        "# HELP rustchain_attestation_pool_fingerprint_passed_active Active miners whose latest attestation passed fingerprint checks.",
+        "# TYPE rustchain_attestation_pool_fingerprint_passed_active gauge",
+        f"rustchain_attestation_pool_fingerprint_passed_active {pool['fingerprint_passed_active']}",
+        "# HELP rustchain_attestation_pool_avg_entropy_active Average entropy score for active miners.",
+        "# TYPE rustchain_attestation_pool_avg_entropy_active gauge",
+        f"rustchain_attestation_pool_avg_entropy_active {pool['avg_entropy_active']}",
+    ]
+    for row in snap["by_device_arch"]:
+        arch = _prom_label_value(row["device_arch"])
+        lines.append(
+            f'rustchain_attestation_pool_active_miners_by_arch{{device_arch="{arch}"}} {row["active_miners"]}'
+        )
+    lines.append("rustchain_attestation_pool_scrape_ok 1")
+    lines.append("")
+    return "\n".join(lines)
+
+
+@app.route("/api/attestation-pool", methods=["GET"])
+def api_attestation_pool():
+    """Aggregate attestation-pool monitoring for dashboards."""
+    return jsonify(_attestation_pool_snapshot())
+
+
 def _json_object_or_none(raw):
     if not raw:
         return None
@@ -6950,7 +7123,11 @@ def api_ready():
 @app.route('/api/metrics', methods=['GET'])
 def metrics():
     """Prometheus metrics endpoint"""
-    return Response(generate_latest(), content_type=CONTENT_TYPE_LATEST)
+    payload = generate_latest()
+    if isinstance(payload, str):
+        payload = payload.encode("utf-8")
+    payload += _attestation_pool_prometheus_text().encode("utf-8")
+    return Response(payload, content_type=CONTENT_TYPE_LATEST)
 
 
 @app.route('/rewards/settle', methods=['POST'])

--- a/node/tests/test_attestation_pool_monitoring.py
+++ b/node/tests/test_attestation_pool_monitoring.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class _NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+class TestAttestationPoolMonitoring(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
+        cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "attestation-pool.db")
+        os.environ["RC_ADMIN_KEY"] = "0123456789abcdef0123456789abcdef"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        prometheus_client = None
+        prev_metrics = None
+        try:
+            import prometheus_client
+
+            prev_metrics = (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            )
+            prometheus_client.Counter = _NoopMetric
+            prometheus_client.Gauge = _NoopMetric
+            prometheus_client.Histogram = _NoopMetric
+        except ModuleNotFoundError:
+            pass
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_attestation_pool_monitoring_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        try:
+            spec.loader.exec_module(cls.mod)
+        finally:
+            if prometheus_client is not None and prev_metrics is not None:
+                (
+                    prometheus_client.Counter,
+                    prometheus_client.Gauge,
+                    prometheus_client.Histogram,
+                ) = prev_metrics
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls._prev_db_path is None:
+            os.environ.pop("RUSTCHAIN_DB_PATH", None)
+        else:
+            os.environ["RUSTCHAIN_DB_PATH"] = cls._prev_db_path
+        if cls._prev_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute("DROP TABLE IF EXISTS miner_attest_recent")
+            conn.execute("DROP TABLE IF EXISTS miner_attest_history")
+
+    def test_attestation_pool_endpoint_handles_missing_tables(self):
+        resp = self.client.get("/api/attestation-pool")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertTrue(body["ok"])
+        self.assertFalse(body["tables"]["miner_attest_recent"])
+        self.assertEqual(body["pool"]["active_miners"], 0)
+        self.assertEqual(body["history"], [])
+
+    def test_attestation_pool_reports_current_and_history_counts(self):
+        now = 1_800_000_000
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute(
+                """
+                CREATE TABLE miner_attest_recent (
+                    miner TEXT PRIMARY KEY,
+                    ts_ok INTEGER,
+                    device_family TEXT,
+                    device_arch TEXT,
+                    entropy_score REAL,
+                    fingerprint_passed INTEGER
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE miner_attest_history (
+                    miner TEXT,
+                    ts_ok INTEGER,
+                    device_family TEXT,
+                    device_arch TEXT,
+                    entropy_score REAL,
+                    fingerprint_passed INTEGER
+                )
+                """
+            )
+            conn.executemany(
+                """
+                INSERT INTO miner_attest_recent
+                    (miner, ts_ok, device_family, device_arch, entropy_score, fingerprint_passed)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    ("alice", now - 60, "x86", "x86_64", 0.91, 1),
+                    ("bob", now - 90, "apple", "m2", 0.73, 0),
+                    ("carol", now - 7200, "ppc", "g4", 0.52, 1),
+                ],
+            )
+            conn.executemany(
+                """
+                INSERT INTO miner_attest_history
+                    (miner, ts_ok, device_family, device_arch, entropy_score, fingerprint_passed)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    ("alice", now - 60, "x86", "x86_64", 0.91, 1),
+                    ("alice", now - 3700, "x86", "x86_64", 0.88, 1),
+                    ("bob", now - 90, "apple", "m2", 0.73, 0),
+                    ("old", now - 90_000, "x86", "x86_64", 0.1, 0),
+                ],
+            )
+
+        snap = self.mod._attestation_pool_snapshot(now_ts=now)
+
+        self.assertEqual(snap["pool"]["known_miners"], 3)
+        self.assertEqual(snap["pool"]["active_miners"], 2)
+        self.assertEqual(snap["pool"]["stale_miners"], 1)
+        self.assertEqual(snap["pool"]["fingerprint_passed_active"], 1)
+        self.assertEqual(snap["pool"]["recent_attestations_24h"], 3)
+        self.assertEqual(
+            snap["by_device_arch"],
+            [
+                {"device_arch": "m2", "active_miners": 1},
+                {"device_arch": "x86_64", "active_miners": 1},
+            ],
+        )
+
+    def test_prometheus_metrics_include_attestation_pool_lines(self):
+        now = 1_800_000_000
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute(
+                """
+                CREATE TABLE miner_attest_recent (
+                    miner TEXT PRIMARY KEY,
+                    ts_ok INTEGER,
+                    device_arch TEXT,
+                    entropy_score REAL,
+                    fingerprint_passed INTEGER
+                )
+                """
+            )
+            conn.execute(
+                "INSERT INTO miner_attest_recent VALUES (?, ?, ?, ?, ?)",
+                ("alice", now - 10, 'riscv"dev', 0.5, 1),
+            )
+
+        text = self.mod._attestation_pool_prometheus_text(now_ts=now)
+
+        self.assertIn("rustchain_attestation_pool_active_miners 1", text)
+        self.assertIn("rustchain_attestation_pool_stale_miners 0", text)
+        self.assertIn('device_arch="riscv\\"dev"', text)
+        self.assertIn("rustchain_attestation_pool_scrape_ok 1", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_attestation_pool_monitoring.py
+++ b/node/tests/test_attestation_pool_monitoring.py
@@ -169,6 +169,20 @@ class TestAttestationPoolMonitoring(unittest.TestCase):
             ],
         )
 
+    def test_attestation_history_schema_has_timestamp_index(self):
+        self.mod.init_db()
+
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            indexes = {
+                row[1]: [
+                    col[2]
+                    for col in conn.execute(f"PRAGMA index_info({row[1]})").fetchall()
+                ]
+                for row in conn.execute("PRAGMA index_list(miner_attest_history)").fetchall()
+            }
+
+        self.assertEqual(indexes["idx_attest_history_ts_only"], ["ts_ok"])
+
     def test_prometheus_metrics_include_attestation_pool_lines(self):
         now = 1_800_000_000
         with sqlite3.connect(self.mod.DB_PATH) as conn:
@@ -185,14 +199,14 @@ class TestAttestationPoolMonitoring(unittest.TestCase):
             )
             conn.execute(
                 "INSERT INTO miner_attest_recent VALUES (?, ?, ?, ?, ?)",
-                ("alice", now - 10, 'riscv"dev', 0.5, 1),
+                ("alice", now - 10, 'riscv"dev\\gpu\nrack', 0.5, 1),
             )
 
         text = self.mod._attestation_pool_prometheus_text(now_ts=now)
 
         self.assertIn("rustchain_attestation_pool_active_miners 1", text)
         self.assertIn("rustchain_attestation_pool_stale_miners 0", text)
-        self.assertIn('device_arch="riscv\\"dev"', text)
+        self.assertIn('device_arch="riscv\\"dev\\\\gpu\\nrack"', text)
         self.assertIn("rustchain_attestation_pool_scrape_ok 1", text)
 
 


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Adds `GET /api/attestation-pool` for aggregate attestation pool monitoring: active/stale/known miners, recent 24h history, fingerprint pass count, average entropy, and active miner counts by device architecture.
- Appends attestation pool gauges to `/metrics` and `/api/metrics` so existing Prometheus scraping can monitor the pool without a separate endpoint.
- Adds focused tests for missing-table behavior, populated pool summaries, Prometheus label escaping, and existing metrics/miner routes.

Fixes #2528


## Testing / Evidence

- `PYTHONDONTWRITEBYTECODE=1 .venv-py314-validation/bin/python -m pytest -p no:cacheprovider node/tests/test_attestation_pool_monitoring.py node/tests/test_integrated_metrics_route.py node/tests/test_api_miners_rate_limit.py -q --tb=short --noconftest -o addopts=''` -> 6 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m pytest -p no:cacheprovider node/tests/test_attestation_pool_monitoring.py -q --tb=short --noconftest -o addopts=''` -> 3 passed
- `.venv-py314-validation/bin/python -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_attestation_pool_monitoring.py node/tests/test_integrated_metrics_route.py node/tests/test_api_miners_rate_limit.py` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check origin/main...HEAD` -> passed
- Hidden/bidirectional Unicode scan on changed files -> passed

Note: the Python 3.9 preflight venv can run the new focused test. Some existing related tests use `tempfile.TemporaryDirectory(ignore_cleanup_errors=...)`, so I also ran the combined focused suite under Python 3.14 where that existing test setup is supported.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
