### PR TITLE
feat: add proposer duty calendar

### DIFF
--- a/docs/proposer-duty-calendar-demo.md
+++ b/docs/proposer-duty-calendar-demo.md
@@ -1,0 +1,25 @@
+# Proposer Duty Calendar Demo
+
+The proposer duty calendar is available from:
+
+```bash
+curl "http://localhost:5000/epoch/proposer-duty-calendar?lookahead=2&history_limit=0"
+```
+
+With `RC_NODE_ID=node2` and `RC_P2P_PEERS=node1=https://node1.example,node3=https://node3.example`, epoch `4` returns a deterministic round-robin schedule:
+
+```json
+{
+  "current_epoch": 4,
+  "current_proposer": "node2",
+  "current_node_is_proposer": true,
+  "node_count": 3,
+  "schedule": [
+    {"epoch": 4, "proposer": "node2", "offset": 0, "is_current": true},
+    {"epoch": 5, "proposer": "node3", "offset": 1, "is_current": false},
+    {"epoch": 6, "proposer": "node1", "offset": 2, "is_current": false}
+  ]
+}
+```
+
+The TUI dashboard reads the same endpoint and renders the upcoming duties in a `Proposer Duties` panel next to recent blocks.

--- a/node/proposer_duty_calendar.py
+++ b/node/proposer_duty_calendar.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: MIT
+"""
+Round-robin proposer duty calendar helpers.
+
+RustChain's P2P epoch proposer is selected deterministically from the sorted
+node set with ``nodes[epoch % len(nodes)]``. These helpers expose that schedule
+for dashboards without importing the full P2P node runtime.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from typing import Dict, Iterable, List, Optional
+from urllib.parse import urlparse
+
+
+DEFAULT_LOOKAHEAD = 12
+DEFAULT_HISTORY_LIMIT = 8
+
+
+def parse_peer_config(raw_peers: str) -> Dict[str, str]:
+    """Parse RC_P2P_PEERS entries formatted as node_id=url."""
+    peers: Dict[str, str] = {}
+    for item in (raw_peers or "").split(","):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" not in item:
+            continue
+        node_id, peer_url = (part.strip() for part in item.split("=", 1))
+        if not node_id or not peer_url:
+            continue
+        parsed = urlparse(peer_url)
+        if parsed.scheme and parsed.netloc:
+            peers[node_id] = peer_url.rstrip("/")
+    return peers
+
+
+def normalize_nodes(node_id: str, peers: Optional[Dict[str, str]] = None) -> List[str]:
+    """Return the sorted node IDs used by round-robin proposer selection."""
+    node_ids = set((peers or {}).keys())
+    if node_id:
+        node_ids.add(node_id)
+    return sorted(node_ids)
+
+
+def build_proposer_schedule(
+    current_epoch: int,
+    nodes: Iterable[str],
+    lookahead: int = DEFAULT_LOOKAHEAD,
+) -> List[Dict[str, object]]:
+    """Build proposer duties from current_epoch through the lookahead window."""
+    node_list = sorted(set(nodes))
+    if not node_list:
+        return []
+
+    start_epoch = max(int(current_epoch), 0)
+    window = max(int(lookahead), 0)
+    schedule = []
+    for offset in range(window + 1):
+        epoch = start_epoch + offset
+        proposer = node_list[epoch % len(node_list)]
+        schedule.append(
+            {
+                "epoch": epoch,
+                "proposer": proposer,
+                "offset": offset,
+                "is_current": offset == 0,
+            }
+        )
+    return schedule
+
+
+def load_vote_history(
+    db_path: str,
+    current_epoch: int,
+    history_limit: int = DEFAULT_HISTORY_LIMIT,
+) -> List[Dict[str, object]]:
+    """Load recent proposer vote history from p2p_epoch_votes when available."""
+    if not db_path:
+        return []
+
+    lower_bound = max(int(current_epoch) - max(int(history_limit), 0), 0)
+    try:
+        with sqlite3.connect(db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT epoch, proposal_hash, voter, vote, ts
+                FROM p2p_epoch_votes
+                WHERE epoch >= ? AND epoch <= ?
+                ORDER BY epoch DESC, ts DESC
+                """,
+                (lower_bound, int(current_epoch)),
+            ).fetchall()
+    except sqlite3.Error:
+        return []
+
+    grouped: Dict[tuple, Dict[str, object]] = {}
+    vote_counts: Dict[tuple, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for epoch, proposal_hash, voter, vote, ts in rows:
+        key = (int(epoch), str(proposal_hash))
+        grouped.setdefault(
+            key,
+            {
+                "epoch": int(epoch),
+                "proposal_hash": str(proposal_hash),
+                "latest_ts": int(ts or 0),
+                "voters": [],
+            },
+        )
+        grouped[key]["latest_ts"] = max(int(grouped[key]["latest_ts"]), int(ts or 0))
+        grouped[key]["voters"].append(str(voter))
+        vote_counts[key][str(vote)] += 1
+
+    history = []
+    for key, item in grouped.items():
+        item["votes"] = dict(sorted(vote_counts[key].items()))
+        item["vote_count"] = sum(vote_counts[key].values())
+        item["voters"] = sorted(set(item["voters"]))
+        history.append(item)
+
+    history.sort(key=lambda item: (item["epoch"], item["latest_ts"]), reverse=True)
+    return history
+
+
+def build_proposer_duty_calendar(
+    current_epoch: int,
+    node_id: str,
+    peers: Optional[Dict[str, str]] = None,
+    db_path: str = "",
+    lookahead: int = DEFAULT_LOOKAHEAD,
+    history_limit: int = DEFAULT_HISTORY_LIMIT,
+) -> Dict[str, object]:
+    """Return dashboard-ready proposer duty calendar, metrics, and history."""
+    nodes = normalize_nodes(node_id, peers)
+    schedule = build_proposer_schedule(current_epoch, nodes, lookahead)
+    current_duty = schedule[0] if schedule else None
+
+    return {
+        "current_epoch": max(int(current_epoch), 0),
+        "node_id": node_id,
+        "nodes": nodes,
+        "node_count": len(nodes),
+        "lookahead": max(int(lookahead), 0),
+        "current_proposer": current_duty["proposer"] if current_duty else None,
+        "current_node_is_proposer": (
+            bool(current_duty) and current_duty["proposer"] == node_id
+        ),
+        "schedule": schedule,
+        "history": load_vote_history(db_path, current_epoch, history_limit),
+        "metrics": {
+            "scheduled_epochs": len(schedule),
+            "history_limit": max(int(history_limit), 0),
+            "history_available": bool(db_path),
+        },
+    }

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3890,6 +3890,41 @@ def get_epoch():
         "total_supply_rtc": TOTAL_SUPPLY_RTC
     })
 
+@app.route('/epoch/proposer-duty-calendar', methods=['GET'])
+def get_proposer_duty_calendar():
+    """Return the deterministic round-robin proposer duty calendar."""
+    from proposer_duty_calendar import build_proposer_duty_calendar, parse_peer_config
+
+    slot = current_slot()
+    epoch = slot_to_epoch(slot)
+    node_id = os.environ.get("RC_NODE_ID", "node1")
+    peers = parse_peer_config(os.environ.get("RC_P2P_PEERS", ""))
+
+    try:
+        lookahead = int(request.args.get("lookahead", 12))
+    except (TypeError, ValueError):
+        return jsonify({"error": "lookahead must be an integer"}), 400
+    try:
+        history_limit = int(request.args.get("history_limit", 8))
+    except (TypeError, ValueError):
+        return jsonify({"error": "history_limit must be an integer"}), 400
+
+    if lookahead < 0 or lookahead > 256:
+        return jsonify({"error": "lookahead must be between 0 and 256"}), 400
+    if history_limit < 0 or history_limit > 256:
+        return jsonify({"error": "history_limit must be between 0 and 256"}), 400
+
+    return jsonify(
+        build_proposer_duty_calendar(
+            current_epoch=epoch,
+            node_id=node_id,
+            peers=peers,
+            db_path=DB_PATH,
+            lookahead=lookahead,
+            history_limit=history_limit,
+        )
+    )
+
 @app.route('/epoch/enroll', methods=['POST'])
 def enroll_epoch():
     """Enroll in current epoch"""

--- a/node/tests/test_proposer_duty_calendar.py
+++ b/node/tests/test_proposer_duty_calendar.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import importlib.util
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(NODE_DIR))
+
+from proposer_duty_calendar import (  # noqa: E402
+    build_proposer_duty_calendar,
+    build_proposer_schedule,
+    parse_peer_config,
+)
+
+
+def test_build_proposer_schedule_uses_sorted_round_robin_nodes():
+    schedule = build_proposer_schedule(
+        current_epoch=4,
+        nodes=["node3", "node1", "node2"],
+        lookahead=3,
+    )
+
+    assert [row["epoch"] for row in schedule] == [4, 5, 6, 7]
+    assert [row["proposer"] for row in schedule] == [
+        "node2",
+        "node3",
+        "node1",
+        "node2",
+    ]
+    assert schedule[0]["is_current"] is True
+
+
+def test_parse_peer_config_ignores_malformed_entries():
+    peers = parse_peer_config(
+        "node2=https://node2.example,node3=http://127.0.0.1:9002,bad,no_url="
+    )
+
+    assert peers == {
+        "node2": "https://node2.example",
+        "node3": "http://127.0.0.1:9002",
+    }
+
+
+def test_calendar_includes_recent_vote_history():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "votes.db")
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE p2p_epoch_votes (
+                    epoch INTEGER NOT NULL,
+                    proposal_hash TEXT NOT NULL,
+                    voter TEXT NOT NULL,
+                    vote TEXT NOT NULL,
+                    ts INTEGER NOT NULL,
+                    PRIMARY KEY (epoch, proposal_hash, voter)
+                )
+                """
+            )
+            conn.executemany(
+                "INSERT INTO p2p_epoch_votes VALUES (?, ?, ?, ?, ?)",
+                [
+                    (4, "hash-a", "node1", "accept", 100),
+                    (4, "hash-a", "node2", "accept", 101),
+                    (3, "hash-b", "node3", "reject", 90),
+                ],
+            )
+
+        calendar = build_proposer_duty_calendar(
+            current_epoch=4,
+            node_id="node2",
+            peers={"node1": "https://node1.example", "node3": "https://node3.example"},
+            db_path=db_path,
+            lookahead=1,
+            history_limit=2,
+        )
+
+    assert calendar["current_proposer"] == "node2"
+    assert calendar["current_node_is_proposer"] is True
+    assert calendar["metrics"]["scheduled_epochs"] == 2
+    assert calendar["history"][0]["epoch"] == 4
+    assert calendar["history"][0]["votes"] == {"accept": 2}
+    assert calendar["history"][0]["voters"] == ["node1", "node2"]
+
+
+class _NoopMetric:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def inc(self, *args, **kwargs):
+        pass
+
+    def dec(self, *args, **kwargs):
+        pass
+
+    def set(self, *args, **kwargs):
+        pass
+
+    def observe(self, *args, **kwargs):
+        pass
+
+    def labels(self, *args, **kwargs):
+        return self
+
+
+def test_integrated_route_returns_calendar_payload(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "route.db")
+        monkeypatch.setenv("RUSTCHAIN_DB_PATH", db_path)
+        monkeypatch.setenv("RC_ADMIN_KEY", "0" * 32)
+        monkeypatch.setenv("RC_NODE_ID", "node2")
+        monkeypatch.setenv(
+            "RC_P2P_PEERS",
+            "node1=https://node1.example,node3=https://node3.example",
+        )
+
+        prometheus_client = None
+        previous_metrics = None
+        try:
+            import prometheus_client
+
+            previous_metrics = (
+                prometheus_client.Counter,
+                prometheus_client.Gauge,
+                prometheus_client.Histogram,
+            )
+            prometheus_client.Counter = _NoopMetric
+            prometheus_client.Gauge = _NoopMetric
+            prometheus_client.Histogram = _NoopMetric
+        except ModuleNotFoundError:
+            pass
+        try:
+            spec = importlib.util.spec_from_file_location(
+                "rustchain_integrated_proposer_calendar_test",
+                NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py",
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+        finally:
+            if prometheus_client is not None and previous_metrics is not None:
+                (
+                    prometheus_client.Counter,
+                    prometheus_client.Gauge,
+                    prometheus_client.Histogram,
+                ) = previous_metrics
+
+        module.DB_PATH = db_path
+        monkeypatch.setattr(module, "current_slot", lambda: 4 * module.EPOCH_SLOTS)
+
+        response = module.app.test_client().get(
+            "/epoch/proposer-duty-calendar?lookahead=2&history_limit=0"
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["node_id"] == "node2"
+    assert payload["current_epoch"] == 4
+    assert payload["current_proposer"] == "node2"
+    assert payload["current_node_is_proposer"] is True
+    assert [row["proposer"] for row in payload["schedule"]] == [
+        "node2",
+        "node3",
+        "node1",
+    ]

--- a/tools/tui-dashboard/dashboard.py
+++ b/tools/tui-dashboard/dashboard.py
@@ -80,6 +80,7 @@ class RustChainData:
         self.miners: List[Dict[str, Any]] = []
         self.tip: Dict[str, Any] = {}
         self.price: Dict[str, Any] = {}
+        self.proposer_calendar: Dict[str, Any] = {}
         self.last_refresh: Optional[datetime] = None
         self.latency_ms: float = 0.0
         self.block_history: List[Dict[str, Any]] = []
@@ -109,6 +110,7 @@ class RustChainData:
             self.block_history = self.block_history[:20]
         self.tip = tip
 
+        self.proposer_calendar = fetch_json(f"{self.base}/epoch/proposer-duty-calendar?lookahead=8&history_limit=6") or {}
         self.price = self._fetch_price()
         self.latency_ms = (time.time() - t0) * 1000
         self.last_refresh = datetime.now(timezone.utc)
@@ -288,6 +290,31 @@ def build_blocks_panel(data: RustChainData) -> Panel:
     return Panel(table, title="[bold]Recent Blocks[/bold]", border_style="blue")
 
 
+def build_proposer_calendar_panel(data: RustChainData) -> Panel:
+    """Upcoming round-robin proposer duties."""
+    table = Table(expand=True, show_lines=False, pad_edge=False)
+    table.add_column("Epoch", style="bold white", justify="right", max_width=8)
+    table.add_column("Proposer", style="cyan", max_width=24)
+    table.add_column("Duty", style="yellow", max_width=10)
+
+    calendar = data.proposer_calendar or {}
+    schedule = calendar.get("schedule") or []
+    if not schedule:
+        table.add_row("—", "calendar unavailable", "")
+    else:
+        current_node = calendar.get("node_id")
+        for row in schedule[:8]:
+            proposer = str(row.get("proposer", "?"))
+            duty = "now" if row.get("is_current") else f"+{row.get('offset', '?')}"
+            if proposer == current_node:
+                duty = f"{duty} local"
+            table.add_row(str(row.get("epoch", "?")), proposer, duty)
+
+    current = calendar.get("current_proposer", "?")
+    title = f"[bold]Proposer Duties[/bold] [dim](current: {current})[/dim]"
+    return Panel(table, title=title, border_style="cyan")
+
+
 def build_price_panel(data: RustChainData) -> Panel:
     """wRTC price ticker panel."""
     p = data.price
@@ -365,6 +392,7 @@ def build_layout(data: RustChainData, interval: int) -> Layout:
 
     layout["bottom"].split_row(
         Layout(name="miners", ratio=3),
+        Layout(name="duties", ratio=2),
         Layout(name="blocks", ratio=2),
     )
 
@@ -373,6 +401,7 @@ def build_layout(data: RustChainData, interval: int) -> Layout:
     layout["epoch"].update(build_epoch_panel(data))
     layout["price"].update(build_price_panel(data))
     layout["miners"].update(build_miners_panel(data))
+    layout["duties"].update(build_proposer_calendar_panel(data))
     layout["blocks"].update(build_blocks_panel(data))
 
     return layout


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top
- [x] Provide test evidence below

## What Changed

- Adds a `/epoch/proposer-duty-calendar` endpoint for the deterministic round-robin proposer schedule.
- Includes recent proposer vote history from `p2p_epoch_votes` when available, plus schedule metrics for dashboards.
- Shows the upcoming proposer duties in the TUI dashboard and adds a short demo note with sample endpoint output.

Fixes #2567


## Testing / Evidence

- `.venv-bounty-validation/bin/python -m pytest -q node/tests/test_proposer_duty_calendar.py` -> 4 passed, 1 warning
- `.venv-bounty-validation/bin/python -m py_compile node/proposer_duty_calendar.py tools/tui-dashboard/dashboard.py node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_proposer_duty_calendar.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo $PWD --changed-files-from-git origin/main...HEAD` -> passed

Note: I also tried the repository-wide `.venv-bounty-validation/bin/python -m pytest -q`; in this local checkout it exited with code `-1` before producing actionable failure output, so I used the focused route/helper/TUI validation above.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
