### PR TITLE
feat: add lightweight SPV client helpers

### DIFF
--- a/node/spv_client.py
+++ b/node/spv_client.py
@@ -143,9 +143,11 @@ class SPVClient:
         block_hash = _header_hash(header)
         prev_hash = _header_prev_hash(header)
 
-        if height > 0 and prev_hash:
+        if height > 0:
+            if not prev_hash:
+                raise ValueError("non-genesis header must include previous hash")
             previous = self.headers_by_height.get(height - 1)
-            if previous and _header_hash(previous) != prev_hash:
+            if previous is None or _header_hash(previous) != prev_hash:
                 raise ValueError("header does not extend the known chain")
 
         self.headers_by_height[height] = dict(header)

--- a/node/spv_client.py
+++ b/node/spv_client.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: MIT
+"""
+Lightweight SPV helpers for RustChain clients.
+
+The module keeps the SPV surface intentionally small: clients store block
+headers, verify transaction inclusion from Merkle branches, and pre-filter
+interesting transaction identifiers before asking a full node for proofs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+HashFn = Callable[[bytes], bytes]
+MerkleBranch = Sequence[Tuple[str, str]]
+
+
+def _sha256(data: bytes) -> bytes:
+    return hashlib.sha256(data).digest()
+
+
+def _coerce_hash(value: str) -> bytes:
+    try:
+        return bytes.fromhex(value)
+    except ValueError as exc:
+        raise ValueError("hash values must be hex encoded") from exc
+
+
+def _header_height(header: Mapping[str, object]) -> int:
+    value = header.get("height", header.get("slot"))
+    if not isinstance(value, int):
+        raise ValueError("header must include integer height or slot")
+    return value
+
+
+def _header_hash(header: Mapping[str, object]) -> str:
+    value = header.get("hash", header.get("block_hash"))
+    if not isinstance(value, str) or not value:
+        raise ValueError("header must include hash or block_hash")
+    return value
+
+
+def _header_prev_hash(header: Mapping[str, object]) -> Optional[str]:
+    value = header.get("prev_hash", header.get("previous_hash"))
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("previous hash must be a string")
+    return value
+
+
+def verify_merkle_proof(
+    tx_hash: str,
+    merkle_root: str,
+    branch: MerkleBranch,
+    hash_fn: HashFn = _sha256,
+) -> bool:
+    """
+    Verify that ``tx_hash`` is included in ``merkle_root``.
+
+    Branch entries are ``(side, sibling_hash)`` tuples where ``side`` is
+    ``"left"`` when the sibling is left of the current hash and ``"right"``
+    when the sibling is right of it.
+    """
+    current = _coerce_hash(tx_hash)
+    expected_root = _coerce_hash(merkle_root)
+
+    for side, sibling_hash in branch:
+        sibling = _coerce_hash(sibling_hash)
+        if side == "left":
+            current = hash_fn(sibling + current)
+        elif side == "right":
+            current = hash_fn(current + sibling)
+        else:
+            raise ValueError("proof side must be 'left' or 'right'")
+
+    return current == expected_root
+
+
+@dataclass
+class BloomFilter:
+    """
+    Compact probabilistic filter for transaction IDs or addresses.
+
+    The filter uses double hashing to derive ``hash_count`` bit positions from
+    SHA-256 and BLAKE2b. It is deterministic and dependency-free so mobile,
+    IoT, and test clients can use it without a full node stack.
+    """
+
+    size_bits: int = 2048
+    hash_count: int = 7
+    _bits: int = 0
+
+    def __post_init__(self) -> None:
+        if self.size_bits <= 0:
+            raise ValueError("size_bits must be positive")
+        if self.hash_count <= 0:
+            raise ValueError("hash_count must be positive")
+
+    def _positions(self, item: bytes) -> Iterable[int]:
+        h1 = int.from_bytes(hashlib.sha256(item).digest(), "big")
+        h2 = int.from_bytes(hashlib.blake2b(item, digest_size=32).digest(), "big")
+        for index in range(self.hash_count):
+            yield (h1 + index * h2) % self.size_bits
+
+    def add(self, item: str | bytes) -> None:
+        data = item if isinstance(item, bytes) else item.encode("utf-8")
+        for position in self._positions(data):
+            self._bits |= 1 << position
+
+    def __contains__(self, item: str | bytes) -> bool:
+        data = item if isinstance(item, bytes) else item.encode("utf-8")
+        return all(self._bits & (1 << position) for position in self._positions(data))
+
+    def to_hex(self) -> str:
+        byte_length = (self.size_bits + 7) // 8
+        return self._bits.to_bytes(byte_length, "big").hex()
+
+    @classmethod
+    def from_hex(cls, value: str, size_bits: int = 2048, hash_count: int = 7) -> "BloomFilter":
+        bloom = cls(size_bits=size_bits, hash_count=hash_count)
+        bloom._bits = int.from_bytes(bytes.fromhex(value), "big")
+        return bloom
+
+
+@dataclass
+class SPVClient:
+    """
+    Header-only SPV state with transaction inclusion checks.
+
+    A full node still supplies headers and Merkle proofs; this client validates
+    the small proof material locally and does not require block bodies.
+    """
+
+    bloom_filter: BloomFilter = field(default_factory=BloomFilter)
+    headers_by_height: Dict[int, Mapping[str, object]] = field(default_factory=dict)
+    headers_by_hash: Dict[str, Mapping[str, object]] = field(default_factory=dict)
+
+    def add_header(self, header: Mapping[str, object]) -> None:
+        height = _header_height(header)
+        block_hash = _header_hash(header)
+        prev_hash = _header_prev_hash(header)
+
+        if height > 0 and prev_hash:
+            previous = self.headers_by_height.get(height - 1)
+            if previous and _header_hash(previous) != prev_hash:
+                raise ValueError("header does not extend the known chain")
+
+        self.headers_by_height[height] = dict(header)
+        self.headers_by_hash[block_hash] = dict(header)
+
+    def add_headers(self, headers: Iterable[Mapping[str, object]]) -> None:
+        for header in sorted(headers, key=_header_height):
+            self.add_header(header)
+
+    @property
+    def tip(self) -> Optional[Mapping[str, object]]:
+        if not self.headers_by_height:
+            return None
+        return self.headers_by_height[max(self.headers_by_height)]
+
+    def watch(self, item: str | bytes) -> None:
+        self.bloom_filter.add(item)
+
+    def wants_transaction(self, tx_id: str) -> bool:
+        return tx_id in self.bloom_filter
+
+    def verify_transaction(
+        self,
+        tx_hash: str,
+        block_hash: str,
+        proof: MerkleBranch,
+        hash_fn: HashFn = _sha256,
+    ) -> bool:
+        header = self.headers_by_hash.get(block_hash)
+        if header is None:
+            return False
+        merkle_root = header.get("merkle_root")
+        if not isinstance(merkle_root, str):
+            return False
+        return verify_merkle_proof(tx_hash, merkle_root, proof, hash_fn=hash_fn)

--- a/node/tests/test_spv_client.py
+++ b/node/tests/test_spv_client.py
@@ -73,6 +73,27 @@ def test_spv_client_rejects_non_extending_header():
         )
 
 
+def test_spv_client_rejects_non_genesis_header_without_previous_hash():
+    client = SPVClient()
+
+    with pytest.raises(ValueError, match="previous hash"):
+        client.add_header({"height": 5, "hash": "f" * 64, "merkle_root": "0" * 64})
+
+
+def test_spv_client_rejects_header_without_known_previous_height():
+    client = SPVClient()
+
+    with pytest.raises(ValueError, match="does not extend"):
+        client.add_header(
+            {
+                "height": 5,
+                "hash": "f" * 64,
+                "prev_hash": "e" * 64,
+                "merkle_root": "0" * 64,
+            }
+        )
+
+
 def test_bloom_filter_matches_watched_items_and_round_trips():
     bloom = BloomFilter(size_bits=256, hash_count=5)
     bloom.add("RTC-wallet-address")

--- a/node/tests/test_spv_client.py
+++ b/node/tests/test_spv_client.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: MIT
+
+import hashlib
+
+import pytest
+
+from node.spv_client import BloomFilter, SPVClient, verify_merkle_proof
+
+
+def _hash_pair(left: str, right: str) -> str:
+    return hashlib.sha256(bytes.fromhex(left) + bytes.fromhex(right)).hexdigest()
+
+
+def _leaf(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def test_merkle_proof_verifies_transaction_inclusion():
+    tx_a = _leaf("tx-a")
+    tx_b = _leaf("tx-b")
+    tx_c = _leaf("tx-c")
+    tx_d = _leaf("tx-d")
+    left_root = _hash_pair(tx_a, tx_b)
+    right_root = _hash_pair(tx_c, tx_d)
+    root = _hash_pair(left_root, right_root)
+
+    proof = [("left", tx_a), ("right", right_root)]
+
+    assert verify_merkle_proof(tx_b, root, proof)
+    assert not verify_merkle_proof(_leaf("other-tx"), root, proof)
+
+
+def test_spv_client_stores_headers_only_and_checks_known_block_proof():
+    tx_a = _leaf("tx-a")
+    tx_b = _leaf("tx-b")
+    merkle_root = _hash_pair(tx_a, tx_b)
+    client = SPVClient()
+
+    client.add_headers(
+        [
+            {
+                "height": 0,
+                "hash": "0" * 64,
+                "prev_hash": None,
+                "merkle_root": "0" * 64,
+            },
+            {
+                "height": 1,
+                "hash": "1" * 64,
+                "prev_hash": "0" * 64,
+                "merkle_root": merkle_root,
+            },
+        ]
+    )
+
+    assert client.tip["height"] == 1
+    assert client.verify_transaction(tx_b, "1" * 64, [("left", tx_a)])
+    assert not client.verify_transaction(tx_b, "2" * 64, [("left", tx_a)])
+
+
+def test_spv_client_rejects_non_extending_header():
+    client = SPVClient()
+    client.add_header({"height": 0, "hash": "a" * 64, "merkle_root": "0" * 64})
+
+    with pytest.raises(ValueError, match="does not extend"):
+        client.add_header(
+            {
+                "height": 1,
+                "hash": "b" * 64,
+                "prev_hash": "c" * 64,
+                "merkle_root": "0" * 64,
+            }
+        )
+
+
+def test_bloom_filter_matches_watched_items_and_round_trips():
+    bloom = BloomFilter(size_bits=256, hash_count=5)
+    bloom.add("RTC-wallet-address")
+    bloom.add(bytes.fromhex("ab" * 32))
+
+    assert "RTC-wallet-address" in bloom
+    assert bytes.fromhex("ab" * 32) in bloom
+    assert "definitely-unwatched" not in bloom
+
+    restored = BloomFilter.from_hex(bloom.to_hex(), size_bits=256, hash_count=5)
+    assert "RTC-wallet-address" in restored


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Added a dependency-free SPV helper module for header-only client state.
- Added Merkle branch verification for transaction inclusion proofs.
- Added a compact Bloom filter so clients can watch relevant transaction IDs or addresses before requesting full-node proofs.
- Added focused pytest coverage for Merkle proofs, header chain checks, and Bloom filter round-tripping.

Fixes #2737


## Testing / Evidence

- `.venv-bounty-validation/bin/python -m pytest node/tests/test_spv_client.py -q` -> 6 passed
- `.venv-bounty-validation/bin/python -m py_compile node/spv_client.py node/tests/test_spv_client.py`
- `.venv-bounty-validation/bin/python -m ruff check node/spv_client.py node/tests/test_spv_client.py` -> All checks passed
- `.venv-bounty-validation/bin/python -m mypy node/spv_client.py node/tests/test_spv_client.py` -> Success
- `git diff --check origin/main...HEAD`
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

I also ran `.venv-bounty-validation/bin/python -m pytest -q`; repo-wide collection stopped on unrelated missing optional dependencies (`aiohttp`, `requests`, `matplotlib`, and Discord-related test imports), so validation remains focused on the new SPV module.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
