### PR TITLE
fix: require admin auth on lock ledger GET endpoints

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -686,7 +686,15 @@ def register_lock_ledger_routes(app):
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):
-        """Get locks for a specific miner."""
+        """Get locks for a specific miner. Requires admin key."""
+        # SECURITY: Exposes miner lock balances — admin key required
+        admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+        expected_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not expected_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — endpoint disabled"}), 503
+        if not hmac.compare_digest(admin_key, expected_key):
+            return jsonify({"error": "Unauthorized — admin key required"}), 401
+
         status = request.args.get("status")
         limit, error_response = parse_bounded_int_arg("limit", 100, 1, 500)
         if error_response is not None:
@@ -722,7 +730,15 @@ def register_lock_ledger_routes(app):
     
     @app.route('/api/lock/<int:lock_id>', methods=['GET'])
     def get_lock(lock_id: int):
-        """Get a specific lock by ID."""
+        """Get a specific lock by ID. Requires admin key."""
+        # SECURITY: Exposes detailed lock info including miner_id and amounts — admin key required
+        admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+        expected_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not expected_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — endpoint disabled"}), 503
+        if not hmac.compare_digest(admin_key, expected_key):
+            return jsonify({"error": "Unauthorized — admin key required"}), 401
+
         conn = sqlite3.connect(DB_PATH)
         try:
             lock = get_lock_by_id(conn, lock_id)
@@ -749,7 +765,15 @@ def register_lock_ledger_routes(app):
     
     @app.route('/api/lock/pending-unlock', methods=['GET'])
     def get_pending_unlocks_endpoint():
-        """Get locks ready to be released."""
+        """Get locks ready to be released. Requires admin key."""
+        # SECURITY: Exposes pending unlocks with miner IDs and amounts — admin key required
+        admin_key = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
+        expected_key = os.environ.get("RC_ADMIN_KEY", "")
+        if not expected_key:
+            return jsonify({"error": "RC_ADMIN_KEY not configured — endpoint disabled"}), 503
+        if not hmac.compare_digest(admin_key, expected_key):
+            return jsonify({"error": "Unauthorized — admin key required"}), 401
+
         limit, error_response = parse_bounded_int_arg("limit", 100, 1, 500)
         if error_response is not None:
             return error_response


### PR DESCRIPTION
## Summary

Three GET endpoints in `node/lock_ledger.py` exposed sensitive lock ledger data without any authentication:

| Endpoint | Data Exposed |
|---|---|
| `GET /api/lock/miner/<miner_id>` | Miner locked RTC balance, lock history |
| `GET /api/lock/<id>` | Full lock details including miner_id + amounts |
| `GET /api/lock/pending-unlock` | Pending unlock queue (miner IDs + amounts + unlock times) |

An unauthenticated attacker could enumerate all miners locked RTC balances, unlock schedules, and lock types — enabling targeted attacks on high-value lock targets.

## Fix

Add admin key authentication (matching the existing pattern for POST endpoints which already require auth):

- Check X-Admin-Key or X-API-Key header
- Compare against RC_ADMIN_KEY env var via hmac.compare_digest
- Return 401 for unauthorized, 503 if key not configured

## Severity

Medium - Information disclosure enabling reconnaissance for financial attacks on lock targets.

## Testing

- GET /api/lock/miner/<miner_id> returns 401 without key
- GET /api/lock/<id> returns 401 without key
- GET /api/lock/pending-unlock returns 401 without key
- Same endpoints return expected data with valid admin key

Closes RustChain issue (if applicable).