### PR TITLE
fix: validate peer URL scheme and reject private addresses in /p2p/announce

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -446,6 +446,22 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
 
         peer_url = peer_url.strip()
 
+        # SECURITY: Validate URL scheme and reject private/internal addresses
+        if not peer_url:
+            return jsonify({"ok": False, "error": "peer_url required"}), 400
+        if not peer_url.startswith(("http://", "https://")):
+            return jsonify({"ok": False, "error": "peer_url must start with http:// or https://"}), 400
+        try:
+            from urllib.parse import urlparse
+            parsed = urlparse(peer_url)
+            hostname = parsed.hostname or ""
+            if hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1"):
+                return jsonify({"ok": False, "error": "peer_url must be a public address"}), 400
+            if hostname.startswith(("10.", "192.168.", "172.16.")):
+                return jsonify({"ok": False, "error": "peer_url must not be a private address"}), 400
+        except Exception:
+            return jsonify({"ok": False, "error": "invalid peer_url format"}), 400
+
         if peer_url:
             success = peer_manager.add_peer(peer_url)
             return jsonify({"ok": success, "peers": len(peer_manager.get_active_peers())})


### PR DESCRIPTION
## Summary

The /p2p/announce endpoint accepted arbitrary strings as peer URLs without validating the URL scheme or rejecting internal/private addresses.

An attacker could register localhost, 127.0.0.1, or private network addresses (10.x, 192.168.x, 172.16.x) as peers, potentially enabling:
- SSRF-like attacks where the node syncs from a malicious local service
- Polluting the peer list with unreachable or internal endpoints
- Network enumeration by observing which internal addresses get rejected

## Fix

Add URL validation:
- Require http:// or https:// scheme
- Reject localhost, 127.0.0.1, 0.0.0.0, ::1
- Reject private address ranges (10.x, 192.168.x, 172.16.x)

## Severity

Medium - Peer list pollution and potential SSRF vector