### PR TITLE
fix: forward auth headers through proxy to prevent admin auth bypass

### DIFF
--- a/node/server_proxy.py
+++ b/node/server_proxy.py
@@ -42,18 +42,31 @@ def proxy(path):
         return jsonify({'error': 'Invalid API path'}), 400
 
     try:
+        # SECURITY: Forward auth and identity headers to preserve admin checks
+        # on the backend. Without these, requests through the proxy bypass
+        # admin authentication on all protected endpoints.
+        SAFE_HEADERS = (
+            'content-type', 'accept', 'authorization',
+            'x-admin-key', 'x-api-key', 'x-agent-id', 'x-agent-key',
+            'x-agent-signature', 'x-agent-pubkey', 'x-agent-timestamp',
+            'x-agent-nonce',
+        )
+        forward_headers = {
+            k: v for k, v in request.headers.items()
+            if k.lower() in SAFE_HEADERS
+        }
+
         if request.method == 'POST':
             # Forward POST requests with JSON data
-            headers = {'Content-Type': 'application/json'}
             response = requests.post(
                 url,
                 json=request.json,
-                headers=headers,
+                headers=forward_headers,
                 timeout=10
             )
         else:
-            # Forward GET requests
-            response = requests.get(url, timeout=10)
+            # Forward GET requests with auth headers
+            response = requests.get(url, headers=forward_headers, timeout=10)
 
         # Return the response from local server
         if response.status_code >= 500:


### PR DESCRIPTION
## Summary

The server proxy (node/server_proxy.py on port 8089) stripped all request headers when forwarding to the backend, including X-Admin-Key, X-API-Key, and beacon agent identity headers.

This meant any request routed through the proxy bypassed admin authentication on all protected endpoints:

- Admin operations: bridge void, wallet transfers, lock release
- Agent operations: beacon join, contract creation, bounty claims
- Information disclosure: admin-only status and list endpoints

An attacker with network access to the proxy port could perform any admin operation without credentials.

## Fix

Forward a safe allowlist of headers through the proxy:
- Auth: X-Admin-Key, X-API-Key, Authorization
- Beacon identity: X-Agent-Id, X-Agent-Key, X-Agent-Signature, X-Agent-Pubkey, X-Agent-Timestamp, X-Agent-Nonce
- Standard: Content-Type, Accept

## Severity

High - Complete admin authentication bypass via proxy endpoint