### PR TITLE
fix: return 400 for missing badge username

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -174,7 +174,7 @@ def create_badge():
     custom_message = text_field(data, 'custom_message')
     
     if not username:
-        return jsonify({'success': False, 'error': 'Username required'})
+        return jsonify({'success': False, 'error': 'Username required'}), 400
     
     badge_colors = {
         'contributor': 'blue',

--- a/test_profile_badge_generator.py
+++ b/test_profile_badge_generator.py
@@ -5,27 +5,17 @@ and the /api/badge/create, /api/badge/stats, /api/badge/list endpoints."""
 import json
 import os
 import sqlite3
-import tempfile
 import pytest
 
-# We need to import the module; patch DB_PATH before import so tests use a temp DB
-_test_db = tempfile.mktemp(suffix=".db")
-os.environ["PROFILE_BADGE_TEST_DB"] = _test_db
-
 import profile_badge_generator as pbg
-pbg.DB_PATH = _test_db
 
 
 @pytest.fixture(autouse=True)
-def fresh_db():
+def fresh_db(tmp_path):
     """Re-init the DB before each test for isolation."""
+    pbg.DB_PATH = str(tmp_path / "profile_badges.db")
     pbg.init_badge_db()
     yield
-    # cleanup
-    try:
-        os.unlink(_test_db)
-    except FileNotFoundError:
-        pass
 
 
 # ─── text_field ────────────────────────────────────────────────────
@@ -92,6 +82,7 @@ def test_create_badge_missing_username(client):
         "badge_type": "contributor"
     })
     data = resp.get_json()
+    assert resp.status_code == 400
     assert data["success"] is False
     assert "error" in data
 


### PR DESCRIPTION
## Summary

Fixes #6198.

- Return HTTP 400 when `/api/badge/create` receives a valid JSON object without a required `username`.
- Keep the existing JSON error body unchanged.
- Update the profile badge tests to assert the missing-username status code.
- Make the test DB fixture use a per-test `tmp_path` SQLite database so the suite runs deterministically on Windows without stale data or locked temp files.

## Validation

- `python -m pytest test_profile_badge_generator.py -q` -> 17 passed
- `python -m py_compile profile_badge_generator.py test_profile_badge_generator.py`
- `git diff --check`
- Mojibake marker check on edited files: no `Ã`, `Â`, or `�`

I received RTC compensation for this review.