### PR TITLE
fix: keep GPU pricing reads read-only

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -394,7 +394,7 @@ class GPURenderProtocol:
     # Pricing Oracle
     # -------------------------------------------------------------------
 
-    def get_fair_market_rates(self, job_type=None) -> dict:
+    def get_fair_market_rates(self, job_type=None, *, record_history: bool = False) -> dict:
         """Calculate fair market rates from active GPU node pricing."""
         normalized_job_type = _normalize_job_type(job_type) if job_type else None
         if job_type and normalized_job_type is None:
@@ -431,20 +431,25 @@ class GPURenderProtocol:
                                 "RTC/1k_chars" if jt == "tts" else "RTC/1k_tokens",
                     }
 
-                    # Record to pricing history
-                    conn.execute(
-                        """INSERT INTO pricing_history
-                           (job_type, device_arch, avg_price, min_price,
-                            max_price, sample_count, recorded_at)
-                           VALUES (?,?,?,?,?,?,?)""",
-                        (jt, "all", rates[jt]["avg"], rates[jt]["min"],
-                         rates[jt]["max"], len(prices), int(time.time())),
-                    )
+                    if record_history:
+                        conn.execute(
+                            """INSERT INTO pricing_history
+                               (job_type, device_arch, avg_price, min_price,
+                                max_price, sample_count, recorded_at)
+                               VALUES (?,?,?,?,?,?,?)""",
+                            (jt, "all", rates[jt]["avg"], rates[jt]["min"],
+                             rates[jt]["max"], len(prices), int(time.time())),
+                        )
 
-            conn.commit()
+            if record_history:
+                conn.commit()
             return {"rates": rates, "timestamp": int(time.time())}
         finally:
             conn.close()
+
+    def record_fair_market_rates_snapshot(self, job_type=None) -> dict:
+        """Calculate current rates and append one explicit pricing history snapshot."""
+        return self.get_fair_market_rates(job_type, record_history=True)
 
     def detect_price_manipulation(self, job_type: str, proposed_price: float) -> dict:
         """Check if a proposed price deviates significantly from market rates."""

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -1,6 +1,7 @@
 """Tests for GPU Render Protocol (Bounty #30)."""
 import os
 import sys
+import sqlite3
 import tempfile
 import unittest
 
@@ -143,6 +144,53 @@ class TestGPURenderProtocol(unittest.TestCase):
         self.assertAlmostEqual(r["avg"], 0.5, places=2)
         self.assertAlmostEqual(r["min"], 0.3)
         self.assertAlmostEqual(r["max"], 0.7)
+
+    def test_pricing_reads_do_not_append_history(self):
+        self.proto.attest_gpu("miner-1", {
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "price_render_minute": 0.5,
+        })
+
+        for _ in range(5):
+            rates = self.proto.get_fair_market_rates("render")
+            self.assertIn("render", rates["rates"])
+
+        with sqlite3.connect(self.db) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM pricing_history").fetchone()[0]
+        self.assertEqual(count, 0)
+
+    def test_explicit_pricing_snapshot_appends_one_history_row(self):
+        self.proto.attest_gpu("miner-1", {
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "price_render_minute": 0.5,
+        })
+
+        rates = self.proto.record_fair_market_rates_snapshot("render")
+
+        self.assertIn("render", rates["rates"])
+        with sqlite3.connect(self.db) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM pricing_history").fetchone()[0]
+        self.assertEqual(count, 1)
+
+    def test_price_checks_do_not_append_pricing_history(self):
+        self.proto.attest_gpu("miner-1", {
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "price_render_minute": 0.5,
+        })
+
+        for _ in range(5):
+            check = self.proto.detect_price_manipulation("render", 0.6)
+            self.assertFalse(check["manipulated"])
+
+        with sqlite3.connect(self.db) as conn:
+            count = conn.execute("SELECT COUNT(*) FROM pricing_history").fetchone()[0]
+        self.assertEqual(count, 0)
 
     def test_price_manipulation_detection(self):
         self.proto.attest_gpu("miner-1", {


### PR DESCRIPTION
Fixes #6200.

## Summary

- make GPU pricing reads read-only by default instead of appending `pricing_history` rows
- add `record_fair_market_rates_snapshot()` for callers that intentionally want to persist a pricing sample
- add regressions proving repeated pricing reads and pricing checks do not grow history, while an explicit snapshot appends one row

## Why

`get_fair_market_rates()` is used by read/pricing-check paths, including `/render/pricing` and `/render/pricing/check`. Before this change, each pricing calculation inserted a persistent history row whenever active priced GPU nodes existed, so repeated reads could grow SQLite storage without any explicit write operation.

## Verification

- `uv run --with pytest --with flask pytest tests/test_gpu_render_protocol.py -q` -> 33 passed
- `python3 -m py_compile node/gpu_render_protocol.py tests/test_gpu_render_protocol.py`
- `git diff --check`
