### PR TITLE
fix: return 400 for missing badge username

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -174,7 +174,7 @@ def create_badge():
     custom_message = text_field(data, 'custom_message')
     
     if not username:
-        return jsonify({'success': False, 'error': 'Username required'})
+        return jsonify({'success': False, 'error': 'Username required'}), 400
     
     badge_colors = {
         'contributor': 'blue',

--- a/test_profile_badge_generator.py
+++ b/test_profile_badge_generator.py
@@ -92,8 +92,21 @@ def test_create_badge_missing_username(client):
         "badge_type": "contributor"
     })
     data = resp.get_json()
+    assert resp.status_code == 400
     assert data["success"] is False
     assert "error" in data
+
+
+def test_create_badge_blank_username(client):
+    resp = client.post("/api/badge/create", json={
+        "username": "   ",
+        "wallet": "RTCabc123",
+        "badge_type": "contributor"
+    })
+    data = resp.get_json()
+    assert resp.status_code == 400
+    assert data["success"] is False
+    assert data["error"] == "Username required"
 
 
 def test_create_badge_default_type(client):

--- a/test_profile_badge_generator.py
+++ b/test_profile_badge_generator.py
@@ -3,29 +3,18 @@
 and the /api/badge/create, /api/badge/stats, /api/badge/list endpoints."""
 
 import json
-import os
 import sqlite3
-import tempfile
 import pytest
 
-# We need to import the module; patch DB_PATH before import so tests use a temp DB
-_test_db = tempfile.mktemp(suffix=".db")
-os.environ["PROFILE_BADGE_TEST_DB"] = _test_db
-
 import profile_badge_generator as pbg
-pbg.DB_PATH = _test_db
 
 
 @pytest.fixture(autouse=True)
-def fresh_db():
-    """Re-init the DB before each test for isolation."""
+def fresh_db(tmp_path):
+    """Use a fresh per-test badge database for isolation on every platform."""
+    pbg.DB_PATH = str(tmp_path / "profile_badges.db")
     pbg.init_badge_db()
     yield
-    # cleanup
-    try:
-        os.unlink(_test_db)
-    except FileNotFoundError:
-        pass
 
 
 # ─── text_field ────────────────────────────────────────────────────

--- a/test_profile_badge_generator.py
+++ b/test_profile_badge_generator.py
@@ -95,7 +95,8 @@ def test_create_badge_blank_username(client):
     data = resp.get_json()
     assert resp.status_code == 400
     assert data["success"] is False
-    assert data["error"] == "Username required"
+    assert "username" in data["error"].lower()
+    assert "required" in data["error"].lower()
 
 
 def test_create_badge_default_type(client):


### PR DESCRIPTION
## Summary
- Return HTTP 400 when /api/badge/create receives a missing or blank username
- Add regression coverage for missing and whitespace-only usernames

Fixes #6198

## Test Plan
- python3 -m pytest test_profile_badge_generator.py -q
- python3 -m py_compile profile_badge_generator.py test_profile_badge_generator.py