### PR TITLE
fix: fail closed unverified faucet github identities

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -21,7 +21,7 @@ def app(tmp_path, monkeypatch):
     [
         (None, None, 0.5),
         ("", None, 0.5),
-        ("alice", None, 1.0),
+        ("alice", None, 0.5),
         ("alice", 364, 1.0),
         ("alice", 365, 2.0),
     ],
@@ -102,6 +102,32 @@ def test_github_old_account_gets_2rtc_limit(tmp_path, monkeypatch):
     assert r1.status_code == 200
     assert r2.status_code == 200
     assert r3.status_code == 429
+
+
+def test_unverified_github_names_share_ip_only_limit(tmp_path, monkeypatch):
+    db_path = tmp_path / "faucet.db"
+    monkeypatch.setattr(faucet, "github_account_age_days", lambda *_args, **_kwargs: None)
+    app = faucet.create_app({"DB_PATH": str(db_path), "DRY_RUN": True})
+    app.config.update(TESTING=True)
+    c = app.test_client()
+    headers = {"X-Forwarded-For": "203.0.113.9"}
+
+    r1 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w1", "github_username": "ghost-user-1"},
+        headers=headers,
+    )
+    r2 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w2", "github_username": "ghost-user-2"},
+        headers=headers,
+    )
+
+    assert r1.status_code == 200
+    assert r1.get_json()["amount"] == 0.5
+    assert r2.status_code == 429
+    assert r2.get_json()["error"] == "rate_limited"
+    assert r2.get_json()["daily_limit"] == 0.5
 
 
 def test_transfer_failure_does_not_expose_upstream_body(tmp_path, monkeypatch):

--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -130,6 +130,36 @@ def test_unverified_github_names_share_ip_only_limit(tmp_path, monkeypatch):
     assert r2.get_json()["daily_limit"] == 0.5
 
 
+def test_github_lookup_failure_shares_ip_only_limit(tmp_path, monkeypatch):
+    db_path = tmp_path / "faucet.db"
+
+    def failed_get(*_args, **_kwargs):
+        raise RuntimeError("github unavailable")
+
+    monkeypatch.setattr(faucet.requests, "get", failed_get)
+    app = faucet.create_app({"DB_PATH": str(db_path), "DRY_RUN": True})
+    app.config.update(TESTING=True)
+    c = app.test_client()
+    headers = {"X-Forwarded-For": "203.0.113.10"}
+
+    r1 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w1", "github_username": "temporary-user-1"},
+        headers=headers,
+    )
+    r2 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w2", "github_username": "temporary-user-2"},
+        headers=headers,
+    )
+
+    assert r1.status_code == 200
+    assert r1.get_json()["amount"] == 0.5
+    assert r2.status_code == 429
+    assert r2.get_json()["error"] == "rate_limited"
+    assert r2.get_json()["daily_limit"] == 0.5
+
+
 def test_transfer_failure_does_not_expose_upstream_body(tmp_path, monkeypatch):
     db_path = tmp_path / "faucet.db"
     monkeypatch.setattr(faucet, "github_account_age_days", lambda *_args, **_kwargs: 30)

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -77,9 +77,9 @@ def github_account_age_days(username: str, token: str | None = None) -> int | No
 
 
 def _limit_for_identity(github_username: str | None, account_age_days: int | None) -> float:
-    if not github_username:
+    if not github_username or account_age_days is None:
         return 0.5
-    if account_age_days is not None and account_age_days >= 365:
+    if account_age_days >= 365:
         return 2.0
     return 1.0
 
@@ -195,12 +195,13 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
             return jsonify({"ok": False, "error": "wallet_required"}), 400
 
         age_days = github_account_age_days(github_username or "", cfg.get("GITHUB_TOKEN")) if github_username else None
-        daily_limit = _limit_for_identity(github_username, age_days)
-        drip_amount = 1.0 if github_username else 0.5
+        verified_github_username = github_username if age_days is not None else None
+        daily_limit = _limit_for_identity(verified_github_username, age_days)
+        drip_amount = 1.0 if verified_github_username else 0.5
 
         conn = sqlite3.connect(cfg["DB_PATH"])
         try:
-            used = _sum_last_24h(conn, github_username, ip)
+            used = _sum_last_24h(conn, verified_github_username, ip)
             if used + drip_amount > daily_limit:
                 return jsonify(
                     {
@@ -208,7 +209,7 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
                         "error": "rate_limited",
                         "daily_limit": daily_limit,
                         "used": round(used, 3),
-                        "next_available": _next_available(conn, github_username, ip),
+                        "next_available": _next_available(conn, verified_github_username, ip),
                     }
                 ), 429
 
@@ -219,7 +220,7 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
             now = _utcnow().isoformat()
             cur = conn.execute(
                 "INSERT INTO faucet_claims(wallet, github_username, ip, amount, created_at) VALUES(?,?,?,?,?)",
-                (wallet, github_username, ip, drip_amount, now),
+                (wallet, verified_github_username, ip, drip_amount, now),
             )
             conn.commit()
 


### PR DESCRIPTION
## Summary

Fixes #6204.

The testnet faucet previously treated any non-empty `github_username` as a GitHub identity even when account lookup returned `None`. That let a requester rotate arbitrary/nonexistent usernames and avoid the anonymous IP-only faucet cap.

This change only grants GitHub identity limits after `github_account_age_days()` succeeds. Unverified names fail closed to the anonymous IP bucket and 0.5 RTC daily limit.

## Validation

- `uv run --no-project --with pytest --with flask --with requests python -m pytest tests/test_faucet.py -q` -> 19 passed
- `python3 -m py_compile tools/testnet_faucet.py tests/test_faucet.py` -> passed
- `git diff --check` -> passed

## Safety

Local Flask test client only; no live faucet writes, real transfers, private keys, wallet files, seed phrases, or production traffic were used.