### PR TITLE
fix: add Windows-specific install instructions and detect MSYS/Git Bash

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,16 +29,32 @@ That is it. No GPU required. No special hardware. No account signup.
 
 ## Step 1: Install the Miner
 
-Open a terminal (on macOS: search for "Terminal"; on Windows: use PowerShell) and run:
+**Linux / macOS:**
+
+Open a terminal (on macOS: search for "Terminal") and run:
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
 ```
 
-**What this does:**
+**Windows:**
+
+The one-line installer above requires Bash and is designed for Linux/macOS.
+Windows users should use the dedicated Windows miner installer instead:
+
+1. Install [Python 3.8+](https://python.org/downloads) and check "Add to PATH" during setup
+2. Download the Windows miner from the [`miners/windows/`](../miners/windows/) directory
+3. Run `rustchain_miner_setup.bat` or follow the instructions in
+   [`miners/windows/README.md`](../miners/windows/README.md)
+
+**Windows users with WSL or Git Bash** can also use the Linux one-liner above, but note
+that the anti-emulation fingerprint check detects WSL and assigns near-zero rewards.
+For full rewards, run the miner on bare-metal Windows using the native installer.
+
+**What the installer does (Linux/macOS):**
 
 1. Detects your operating system and CPU architecture
-2. Installs Python 3 if you do not have it (Linux only -- macOS/Windows users need Python
+2. Installs Python 3 if you do not have it (Linux only -- macOS users need Python
    pre-installed)
 3. Downloads the miner script to `~/.rustchain/`
 4. Creates a Python virtual environment with dependencies

--- a/install-miner.sh
+++ b/install-miner.sh
@@ -63,8 +63,8 @@ detect_platform() {
             echo "macos" ;;
  MINGW*|MSYS*|CYGWIN*)
  echo "windows"
- echo -e "${YELLOW}[!] Detected Windows via MSYS/Git Bash. For full hardware rewards, use the native Windows miner instead.${NC}"
- echo -e "${YELLOW}[!] See miners/windows/README.md for the recommended installer.${NC}" ;;
+ echo -e "${YELLOW}[!] Detected Windows via MSYS/Git Bash. For full hardware rewards, use the native Windows miner instead.${NC}" >&2
+ echo -e "${YELLOW}[!] See miners/windows/README.md for the recommended installer.${NC}" >&2 ;;
  *) echo "unknown"; exit 1 ;;
     esac
 }

--- a/install-miner.sh
+++ b/install-miner.sh
@@ -61,7 +61,11 @@ detect_platform() {
         Darwin)
             [ "$arch" != "x86_64" ] && [ "$arch" != "arm64" ] && { echo -e "${RED}[!] Unsupported macOS architecture: $arch (Supported: x86_64, arm64)${NC}"; exit 1; }
             echo "macos" ;;
-        *) echo "unknown"; exit 1 ;;
+ MINGW*|MSYS*|CYGWIN*)
+ echo "windows"
+ echo -e "${YELLOW}[!] Detected Windows via MSYS/Git Bash. For full hardware rewards, use the native Windows miner instead.${NC}"
+ echo -e "${YELLOW}[!] See miners/windows/README.md for the recommended installer.${NC}" ;;
+ *) echo "unknown"; exit 1 ;;
     esac
 }
 


### PR DESCRIPTION
## Summary

Fix onboarding gaps where Windows users following the Quickstart would hit a hard failure.

### Fixes

**#6149 — Quickstart points Windows PowerShell users at Bash installer**
- Split Step 1 into **Linux/macOS** and **Windows** sections
- Direct Windows users to `miners/windows/` native installer (`rustchain_miner_setup.bat`)
- Add explicit warning that WSL/Git Bash users get near-zero rewards due to anti-emulation detection
- Updated "What this does" to correctly scope to Linux/macOS only

**#6157 — install-miner.sh exits on Windows despite docs claiming support**
- Add `MINGW*|MSYS*|CYGWIN*` pattern to `detect_platform()` case statement
- Output `windows` as platform instead of `unknown` + `exit 1`
- Print warning pointing to the native Windows miner installer

**#5715 — QUICKSTART.md FAQ link uses relative path**
- The relative link `(FAQ_TROUBLESHOOTING.md)` is correct since both files are in `docs/` — no code change needed, but verified the link resolves correctly.

### Validation
- `bash -n install-miner.sh` — syntax OK
- `git diff --check` — no whitespace errors
- Quickstart.md verified to contain Windows section, miners/windows links, WSL warning

### Impact
Every Windows user following the official Quickstart currently hits a hard failure at the very first step. This is the most common desktop OS — fixing the onboarding path removes a major contributor drop-off point.

### Wallet
`RTC49769c6ea57d2d259711a42a1734d01bc27c8d90`