### PR TITLE
fix: return 400 when username is missing from /api/badge/create

### DIFF
--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -174,7 +174,7 @@ def create_badge():
     custom_message = text_field(data, 'custom_message')
     
     if not username:
-        return jsonify({'success': False, 'error': 'Username required'})
+        return jsonify({'success': False, 'error': 'Username required'}), 400
     
     badge_colors = {
         'contributor': 'blue',

--- a/tests/test_badge_create_missing_username.py
+++ b/tests/test_badge_create_missing_username.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for badge create returning 400 when username is missing.
+Issue: #6198 — POST /api/badge/create returned 200 with error body instead of 400.
+"""
+import sqlite3
+import pytest
+import profile_badge_generator as badges
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "badges_missing_username.db"
+    monkeypatch.setattr(badges, "DB_PATH", str(db_path))
+    badges.app.config["TESTING"] = True
+    badges.init_badge_db()
+    return badges.app.test_client()
+
+
+class TestBadgeCreateMissingUsername:
+    """POST /api/badge/create should return 400 when username is missing."""
+
+    def test_missing_username_returns_400(self, client):
+        """Request with no username field should return 400, not 200."""
+        resp = client.post("/api/badge/create", json={
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "Username required" in data["error"]
+
+    def test_blank_username_returns_400(self, client):
+        """Request with empty username string should return 400."""
+        resp = client.post("/api/badge/create", json={
+            "username": "",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+
+    def test_whitespace_username_returns_400(self, client):
+        """Request with whitespace-only username should return 400."""
+        resp = client.post("/api/badge/create", json={
+            "username": "   ",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+
+    def test_valid_username_returns_200(self, client):
+        """Valid request with username should still return 200."""
+        resp = client.post("/api/badge/create", json={
+            "username": "testuser",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Fixes #6198

`POST /api/badge/create` previously returned HTTP 200 with `{'success': False, 'error': 'Username required'}` when the username field was missing or blank. This is inconsistent with other validation errors on the same endpoint which correctly return 400.

## Changes

- **profile_badge_generator.py**: Added `, 400` status code to the missing-username error response
- **tests/test_badge_create_missing_username.py**: 4 new regression tests covering:
  - Missing username field → 400
  - Blank username string → 400
  - Whitespace-only username → 400
  - Valid username → still 200

## Testing

```
4 passed in tests/test_badge_create_missing_username.py
5 passed in tests/test_profile_badge_generator.py (existing tests unaffected)
```

Found and reported during RustChain bug bounty program.