### PR TITLE
fix: resolve explorer miners table and Hall of Fame loading bugs

### DIFF
--- a/explorer/enhanced-explorer.html
+++ b/explorer/enhanced-explorer.html
@@ -528,7 +528,7 @@
     </main>
 
     <script>
-        const API_BASE = 'https://50.28.86.131';
+        const API_BASE = window.location.origin;
         
         function switchView(viewName) {
             document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
@@ -579,11 +579,11 @@
                 const overviewTable = document.getElementById('miners-table');
                 overviewTable.innerHTML = minerList.slice(0, 10).map(miner => `
                     <tr>
-                        <td><strong>${esc(miner.miner_id || 'Unknown')}</strong></td>
+                        <td><strong>${esc(miner.miner || miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${esc(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
+                        <td><span class="multiplier">x${esc(miner.antiquity_multiplier || miner.multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
-                        <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
+                        <td>${esc(formatTime(miner.last_attest || miner.last_attestation || miner.last_seen))}</td>
                         <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
                     </tr>
                 `).join('');
@@ -591,11 +591,11 @@
                 const allMinersTable = document.getElementById('all-miners-table');
                 allMinersTable.innerHTML = minerList.map(miner => `
                     <tr>
-                        <td><strong>${esc(miner.miner_id || 'Unknown')}</strong></td>
+                        <td><strong>${esc(miner.miner || miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${esc(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
+                        <td><span class="multiplier">x${esc(miner.antiquity_multiplier || miner.multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
-                        <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
+                        <td>${esc(formatTime(miner.last_attest || miner.last_attestation || miner.last_seen))}</td>
                         <td><code>${esc(miner.wallet || miner.wallet_address || 'N/A')}</code></td>
                         <td>${esc((miner.earnings || miner.total_earned || 0).toFixed(2))} RTC</td>
                     </tr>

--- a/profile_badge_generator.py
+++ b/profile_badge_generator.py
@@ -174,7 +174,7 @@ def create_badge():
     custom_message = text_field(data, 'custom_message')
     
     if not username:
-        return jsonify({'success': False, 'error': 'Username required'})
+        return jsonify({'success': False, 'error': 'Username required'}), 400
     
     badge_colors = {
         'contributor': 'blue',

--- a/tests/test_badge_create_missing_username.py
+++ b/tests/test_badge_create_missing_username.py
@@ -1,0 +1,58 @@
+"""
+Regression tests for badge create returning 400 when username is missing.
+Issue: #6198 — POST /api/badge/create returned 200 with error body instead of 400.
+"""
+import sqlite3
+import pytest
+import profile_badge_generator as badges
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "badges_missing_username.db"
+    monkeypatch.setattr(badges, "DB_PATH", str(db_path))
+    badges.app.config["TESTING"] = True
+    badges.init_badge_db()
+    return badges.app.test_client()
+
+
+class TestBadgeCreateMissingUsername:
+    """POST /api/badge/create should return 400 when username is missing."""
+
+    def test_missing_username_returns_400(self, client):
+        """Request with no username field should return 400, not 200."""
+        resp = client.post("/api/badge/create", json={
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+        data = resp.get_json()
+        assert data["success"] is False
+        assert "Username required" in data["error"]
+
+    def test_blank_username_returns_400(self, client):
+        """Request with empty username string should return 400."""
+        resp = client.post("/api/badge/create", json={
+            "username": "",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+
+    def test_whitespace_username_returns_400(self, client):
+        """Request with whitespace-only username should return 400."""
+        resp = client.post("/api/badge/create", json={
+            "username": "   ",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 400
+
+    def test_valid_username_returns_200(self, client):
+        """Valid request with username should still return 200."""
+        resp = client.post("/api/badge/create", json={
+            "username": "testuser",
+            "wallet": "RTCabc123",
+            "badge_type": "contributor"
+        })
+        assert resp.status_code == 200

--- a/web/hall-of-fame/index.html
+++ b/web/hall-of-fame/index.html
@@ -217,7 +217,7 @@
 </div>
 
 <script>
-const API_LEADERBOARD = '/api/hall_of_fame/leaderboard';
+const API_LEADERBOARD = '/hall/leaderboard';
 const API_STATS       = '/hall/stats';
 
 function esc(s){ return String(s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }


### PR DESCRIPTION
## Summary

Fixes #6211

The Explorer frontend had multiple issues preventing the miners table and Hall of Fame leaderboard from loading:

### Root Causes

1. **enhanced-explorer.html**: `API_BASE` was hardcoded to internal IP address, causing CORS/fetch failures when deployed on rustchain.org
2. **enhanced-explorer.html**: Miner data field names didn't match the API response (`miner` vs `miner_id`, `last_attest` vs `last_attestation`, `antiquity_multiplier` vs `multiplier`)
3. **hall-of-fame/index.html**: Called non-existent `/api/hall_of_fame/leaderboard` endpoint instead of the working `/hall/leaderboard` route → 404

### Changes

- **API_BASE**: Use `window.location.origin` for correct origin in all deployment environments
- **Miner field names**: Add API-compatible fallbacks (`miner`, `last_attest`, `antiquity_multiplier`)
- **Hall of Fame**: Fix leaderboard API endpoint path to `/hall/leaderboard`

### Verification

- Confirmed live API at `/hall/leaderboard` returns valid JSON with correct field names
- Confirmed live API at `/api/miners` returns `miner` (not `miner_id`) and `last_attest` (not `last_attestation`)

Found and reported during RustChain bug bounty program.