### PR TITLE
fix: quarantine equivocating epoch voters

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -356,6 +356,7 @@ class GossipLayer:
         self.balance_crdt = PNCounter()
         self.epoch_crdt = GSet()
         self._epoch_votes: Dict[Tuple[int, str], Dict[str, str]] = {}
+        self._slashed_validators: Dict[str, Dict[str, Any]] = {}
 
         # Phase F (#2256): per-peer Ed25519 identity, dual-mode signing.
         # Only loaded/generated when needed by the current signing mode;
@@ -401,6 +402,15 @@ class GossipLayer:
                     )
                 """)
                 conn.execute("CREATE INDEX IF NOT EXISTS idx_p2p_epoch_votes_epoch ON p2p_epoch_votes(epoch)")
+                conn.execute("""
+                    CREATE TABLE IF NOT EXISTS p2p_slashed_validators (
+                        validator TEXT PRIMARY KEY,
+                        first_epoch INTEGER NOT NULL,
+                        reason TEXT NOT NULL,
+                        evidence TEXT NOT NULL,
+                        ts INTEGER NOT NULL
+                    )
+                """)
                 conn.commit()
 
                 # Load attestations
@@ -431,9 +441,22 @@ class GossipLayer:
                     key = (epoch, proposal_hash)
                     self._epoch_votes.setdefault(key, {})[voter] = vote
 
+                rows = conn.execute("""
+                    SELECT validator, first_epoch, reason, evidence, ts
+                    FROM p2p_slashed_validators
+                """).fetchall()
+                for validator, first_epoch, reason, evidence, ts in rows:
+                    self._slashed_validators[validator] = {
+                        "first_epoch": first_epoch,
+                        "reason": reason,
+                        "evidence": evidence,
+                        "ts": ts,
+                    }
+
                 logger.info(f"Loaded {len(self.attestation_crdt.data)} attestations, "
                            f"{len(self.epoch_crdt.items)} settled epochs, "
-                           f"{sum(len(votes) for votes in self._epoch_votes.values())} epoch votes")
+                           f"{sum(len(votes) for votes in self._epoch_votes.values())} epoch votes, "
+                           f"{len(self._slashed_validators)} slashed validators")
         except Exception as e:
             logger.error(f"Failed to load state from DB: {e}")
 
@@ -864,6 +887,45 @@ class GossipLayer:
         self.broadcast(vote)
         return {"status": "voted", "vote": "reject", "reason": reason}
 
+    def _find_conflicting_epoch_vote(
+        self,
+        epoch: int,
+        proposal_hash: str,
+        voter: str,
+    ) -> Optional[Tuple[str, str]]:
+        """Return an existing same-epoch vote for a different proposal."""
+        for (seen_epoch, seen_proposal), votes in self._epoch_votes.items():
+            if seen_epoch == epoch and seen_proposal != proposal_hash and voter in votes:
+                return seen_proposal, votes[voter]
+        return None
+
+    def _slash_validator(
+        self,
+        validator: str,
+        epoch: int,
+        reason: str,
+        evidence: Dict[str, Any],
+    ) -> None:
+        """Persist local slashing evidence and quarantine the validator."""
+        ts = int(time.time())
+        evidence_json = json.dumps(evidence, sort_keys=True)
+        self._slashed_validators.setdefault(validator, {
+            "first_epoch": epoch,
+            "reason": reason,
+            "evidence": evidence_json,
+            "ts": ts,
+        })
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO p2p_slashed_validators
+                (validator, first_epoch, reason, evidence, ts)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (validator, epoch, reason, evidence_json, ts),
+            )
+            conn.commit()
+
     def _handle_epoch_vote(self, msg: GossipMessage) -> Dict:
         """Handle epoch vote - collect votes and commit when quorum reached.
 
@@ -878,6 +940,9 @@ class GossipLayer:
           only the specific proposal_hash that reached quorum finalizes.
         - Idempotent per (epoch, proposal_hash, voter) — duplicate votes
           silently ignored.
+        - Same-epoch votes by one voter for different proposals are slashing
+          evidence. The validator is quarantined locally before the conflicting
+          vote can influence quorum.
         """
         payload = msg.payload
         epoch = payload.get("epoch")
@@ -899,6 +964,39 @@ class GossipLayer:
                 f"authenticated sender {voter}; rejecting vote"
             )
             return {"status": "error", "reason": "voter_identity_mismatch"}
+
+        if voter in self._slashed_validators:
+            return {
+                "status": "error",
+                "reason": "validator_slashed",
+                "voter": voter,
+            }
+
+        conflicting_vote = self._find_conflicting_epoch_vote(epoch, proposal_hash, voter)
+        if conflicting_vote is not None:
+            previous_proposal, previous_vote = conflicting_vote
+            evidence = {
+                "epoch": epoch,
+                "validator": voter,
+                "previous_proposal_hash": previous_proposal,
+                "previous_vote": previous_vote,
+                "conflicting_proposal_hash": proposal_hash,
+                "conflicting_vote": vote,
+            }
+            try:
+                self._slash_validator(voter, epoch, "epoch_vote_equivocation", evidence)
+            except Exception as e:
+                logger.error(f"Failed to persist slashing evidence for {voter}: {e}")
+                return {"status": "error", "reason": "slash_persist_failed"}
+            logger.warning(
+                f"Epoch {epoch}: slashed {voter} for voting on conflicting "
+                f"proposals {previous_proposal[:12]} and {proposal_hash[:12]}"
+            )
+            return {
+                "status": "slashed",
+                "reason": "epoch_vote_equivocation",
+                "voter": voter,
+            }
 
         # Phase C: index by (epoch, proposal_hash) — not just epoch.
         key = (epoch, proposal_hash)

--- a/node/tests/test_p2p_hardening_phase2.py
+++ b/node/tests/test_p2p_hardening_phase2.py
@@ -180,6 +180,70 @@ def test_epoch_votes_survive_restart_and_reject_retransmit():
     assert restarted._epoch_votes[key] == {"node2": "accept"}
 
 
+def test_same_epoch_conflicting_vote_slashes_validator():
+    """A voter cannot vote on two different proposals for the same epoch."""
+    peers = {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"}
+    target = _mk_layer("node1", peers)
+    voter = _mk_layer("node2", db_path=target.db_path)
+    voter.broadcast = lambda *args, **kwargs: None
+
+    first = voter.create_message(
+        mod.MessageType.EPOCH_VOTE,
+        {"epoch": 13, "proposal_hash": "proposal-a", "vote": "accept"},
+    )
+    conflict = voter.create_message(
+        mod.MessageType.EPOCH_VOTE,
+        {"epoch": 13, "proposal_hash": "proposal-b", "vote": "accept"},
+    )
+
+    assert target.handle_message(first)["status"] == "ok"
+    result = target.handle_message(conflict)
+
+    assert result["status"] == "slashed"
+    assert result["reason"] == "epoch_vote_equivocation"
+    assert target._epoch_votes[(13, "proposal-a")] == {"node2": "accept"}
+    assert (13, "proposal-b") not in target._epoch_votes
+    assert target._slashed_validators["node2"]["reason"] == "epoch_vote_equivocation"
+
+    with sqlite3.connect(target.db_path) as conn:
+        row = conn.execute(
+            "SELECT first_epoch, reason, evidence "
+            "FROM p2p_slashed_validators WHERE validator = ?",
+            ("node2",),
+        ).fetchone()
+    assert row[0] == 13
+    assert row[1] == "epoch_vote_equivocation"
+    assert '"previous_proposal_hash": "proposal-a"' in row[2]
+    assert '"conflicting_proposal_hash": "proposal-b"' in row[2]
+
+
+def test_slashed_validator_stays_quarantined_after_restart():
+    """Persisted slashing evidence blocks future epoch votes after restart."""
+    peers = {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"}
+    target = _mk_layer("node1", peers)
+    voter = _mk_layer("node2", db_path=target.db_path)
+    voter.broadcast = lambda *args, **kwargs: None
+
+    assert target.handle_message(voter.create_message(
+        mod.MessageType.EPOCH_VOTE,
+        {"epoch": 14, "proposal_hash": "proposal-a", "vote": "accept"},
+    ))["status"] == "ok"
+    assert target.handle_message(voter.create_message(
+        mod.MessageType.EPOCH_VOTE,
+        {"epoch": 14, "proposal_hash": "proposal-b", "vote": "reject"},
+    ))["status"] == "slashed"
+
+    restarted = _mk_layer("node1", peers, db_path=target.db_path)
+    future_vote = voter.create_message(
+        mod.MessageType.EPOCH_VOTE,
+        {"epoch": 15, "proposal_hash": "proposal-c", "vote": "accept"},
+    )
+    result = restarted.handle_message(future_vote)
+
+    assert restarted._slashed_validators["node2"]["reason"] == "epoch_vote_equivocation"
+    assert result["status"] == "error"
+    assert result["reason"] == "validator_slashed"
+
 # Phase E regression
 def test_phase_e_future_timestamp_attestation_rejected():
     """Phase E: attestations with ts_ok far in the future are rejected."""


### PR DESCRIPTION
Fixes #2327.

## What changed
- Added a local `p2p_slashed_validators` ledger for authenticated P2P epoch voters that equivocate by voting on different proposal hashes in the same epoch.
- Rejects the conflicting vote before it can affect quorum, persists the evidence, and blocks future epoch votes from the slashed validator after restart.
- Added focused regression coverage for same-epoch equivocation and persisted quarantine behavior.

## Why it matters
RustChain already separates quorum by `(epoch, proposal_hash)`, but an authenticated validator could still participate in multiple conflicting proposals for the same epoch. This change turns that behavior into local slashing evidence and excludes the validator from future epoch votes, covering the consensus double-vote slice of #2327 without broad tokenomics changes.

## Validation
- `PYTHONPATH=node PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m pytest -p no:cacheprovider node/tests/test_p2p_hardening_phase2.py node/tests/test_p2p_state_epoch_sync.py -q` -> 16 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_hardening_phase2.py` -> passed
- `PYTHONPATH=node PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `git diff --check origin/main...HEAD` -> passed
- Hidden Unicode scan for `origin/main...HEAD` -> passed, 0 findings across 2 files

## Scope / risk
This PR intentionally implements the P2P epoch-vote slashing/quarantine path only. It does not introduce a broader stake-burning economy or change account balances.

RTC wallet: `RTC47bc28896a1a4bf240d1fd780f4559b242bcd945`
