### PR TITLE
feat: add state diff API

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6135,6 +6135,201 @@ def _explorer_amount_rtc(amount_i64):
 
 
 EXPLORER_TRANSACTIONS_MAX_OFFSET = 10_000
+STATE_DIFF_MAX_BLOCK_RANGE = 1_000
+
+
+def _state_diff_height_arg(name):
+    raw = request.args.get(name)
+    if raw is None:
+        return None, jsonify({"ok": False, "error": f"{name} is required"}), 400
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return None, jsonify({"ok": False, "error": f"{name} must be an integer"}), 400
+    if value < 0:
+        return None, jsonify({"ok": False, "error": f"{name} must be non-negative"}), 400
+    return value, None, None
+
+
+def _state_diff_amount_i64(tx):
+    for key in ("amount_i64", "amount_urtc", "value_i64", "value_urtc"):
+        if key in tx and tx[key] is not None:
+            try:
+                return int(tx[key])
+            except (TypeError, ValueError):
+                return None
+    for key in ("amount_rtc", "amount"):
+        if key in tx and tx[key] is not None:
+            try:
+                return int(round(float(tx[key]) * int(globals().get("UNIT", 1_000_000))))
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _state_diff_tx_parties(tx):
+    from_addr = (
+        tx.get("from_addr")
+        or tx.get("from_address")
+        or tx.get("from")
+        or tx.get("sender")
+        or tx.get("miner_id")
+    )
+    to_addr = (
+        tx.get("to_addr")
+        or tx.get("to_address")
+        or tx.get("to")
+        or tx.get("recipient")
+    )
+    return from_addr, to_addr
+
+
+def _state_diff_body(row):
+    for column in ("body_json", "data"):
+        if column in row.keys():
+            body = _json_object_or_none(row[column])
+            if body is not None:
+                return body
+    return {}
+
+
+def _state_diff_block_changes(row):
+    body = _state_diff_body(row)
+    transactions = body.get("transactions", [])
+    if not isinstance(transactions, list):
+        transactions = []
+
+    changes = []
+    storage_diffs = []
+    balance_deltas = {}
+    for index, tx in enumerate(transactions):
+        if not isinstance(tx, dict):
+            continue
+        tx_hash = tx.get("tx_hash") or tx.get("hash") or tx.get("id")
+        from_addr, to_addr = _state_diff_tx_parties(tx)
+        amount_i64 = _state_diff_amount_i64(tx)
+
+        if amount_i64 is not None and from_addr:
+            balance_deltas[from_addr] = balance_deltas.get(from_addr, 0) - amount_i64
+            changes.append({
+                "block_height": int(row["height"]),
+                "tx_index": index,
+                "tx_hash": tx_hash,
+                "wallet": from_addr,
+                "delta_i64": -amount_i64,
+                "direction": "debit",
+            })
+        if amount_i64 is not None and to_addr:
+            balance_deltas[to_addr] = balance_deltas.get(to_addr, 0) + amount_i64
+            changes.append({
+                "block_height": int(row["height"]),
+                "tx_index": index,
+                "tx_hash": tx_hash,
+                "wallet": to_addr,
+                "delta_i64": amount_i64,
+                "direction": "credit",
+            })
+
+        tx_storage_diff = tx.get("storage_diff") or tx.get("storage_diffs")
+        if isinstance(tx_storage_diff, list):
+            storage_diffs.extend(tx_storage_diff)
+        elif isinstance(tx_storage_diff, dict):
+            storage_diffs.append(tx_storage_diff)
+
+    return changes, balance_deltas, storage_diffs
+
+
+@app.route("/api/state/diff", methods=["GET"])
+def api_state_diff():
+    """Return block-backed state changes for a bounded height range."""
+    start_height, error_response, status = _state_diff_height_arg("start")
+    if error_response is not None:
+        return error_response, status
+    end_height, error_response, status = _state_diff_height_arg("end")
+    if error_response is not None:
+        return error_response, status
+    if end_height < start_height:
+        return jsonify({"ok": False, "error": "end must be greater than or equal to start"}), 400
+    if end_height - start_height > STATE_DIFF_MAX_BLOCK_RANGE:
+        return jsonify({
+            "ok": False,
+            "error": f"range cannot exceed {STATE_DIFF_MAX_BLOCK_RANGE} blocks",
+        }), 400
+
+    with sqlite3.connect(DB_PATH) as db:
+        db.row_factory = sqlite3.Row
+        columns = _sqlite_table_columns(db, "blocks")
+        if not columns:
+            return jsonify({"ok": False, "error": "block_history_unavailable"}), 404
+        hash_col = "block_hash" if "block_hash" in columns else "hash" if "hash" in columns else None
+        if "height" not in columns or not hash_col:
+            return jsonify({"ok": False, "error": "block_history_unavailable"}), 404
+
+        select_columns = ["height", f"{hash_col} AS block_hash"]
+        for optional in ("state_root", "body_json", "data"):
+            if optional in columns:
+                select_columns.append(optional)
+        rows = db.execute(
+            f"""
+            SELECT {", ".join(select_columns)}
+            FROM blocks
+            WHERE height BETWEEN ? AND ?
+            ORDER BY height ASC
+            """,
+            (start_height, end_height),
+        ).fetchall()
+
+    found_heights = {int(row["height"]) for row in rows}
+    missing_blocks = [
+        height for height in range(start_height, end_height + 1)
+        if height not in found_heights
+    ]
+    if missing_blocks and (start_height in missing_blocks or end_height in missing_blocks):
+        return jsonify({
+            "ok": False,
+            "error": "block_range_boundary_missing",
+            "missing_blocks": missing_blocks,
+        }), 404
+
+    balance_deltas = {}
+    state_changes = []
+    storage_diffs = []
+    state_roots = []
+    for row in rows:
+        if "state_root" in row.keys():
+            state_roots.append({
+                "height": int(row["height"]),
+                "block_hash": row["block_hash"],
+                "state_root": row["state_root"],
+            })
+        changes, block_balance_deltas, block_storage_diffs = _state_diff_block_changes(row)
+        state_changes.extend(changes)
+        storage_diffs.extend(block_storage_diffs)
+        for wallet, delta_i64 in block_balance_deltas.items():
+            balance_deltas[wallet] = balance_deltas.get(wallet, 0) + delta_i64
+
+    balances = [
+        {
+            "wallet": wallet,
+            "delta_i64": delta_i64,
+            "delta_rtc": _explorer_amount_rtc(delta_i64),
+        }
+        for wallet, delta_i64 in sorted(balance_deltas.items())
+        if delta_i64 != 0
+    ]
+
+    return jsonify({
+        "ok": True,
+        "start_height": start_height,
+        "end_height": end_height,
+        "block_count": len(rows),
+        "missing_blocks": missing_blocks,
+        "state_roots": state_roots,
+        "state_changes": state_changes,
+        "balance_diffs": balances,
+        "storage_diffs": storage_diffs,
+        "storage_diff_status": "tracked" if storage_diffs else "not_tracked_in_block_body",
+    })
 
 
 @app.route("/api/blocks", methods=["GET"])

--- a/tests/test_state_diff_api.py
+++ b/tests/test_state_diff_api.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for the public state diff API."""
+
+import json
+import sqlite3
+import sys
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    db_path = tmp_path / "state-diff.sqlite3"
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as c:
+        yield c, db_path
+
+
+def _seed_blocks(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                state_root TEXT NOT NULL,
+                body_json TEXT NOT NULL
+            )
+            """
+        )
+        blocks = [
+            (
+                10,
+                "hash10",
+                "state10",
+                {
+                    "transactions": [
+                        {
+                            "tx_hash": "tx1",
+                            "from_addr": "alice",
+                            "to_addr": "bob",
+                            "amount_urtc": 2_500_000,
+                        }
+                    ]
+                },
+            ),
+            (
+                11,
+                "hash11",
+                "state11",
+                {
+                    "transactions": [
+                        {
+                            "tx_hash": "tx2",
+                            "from_addr": "bob",
+                            "to_addr": "carol",
+                            "amount_i64": 500_000,
+                            "storage_diff": {"key": "memo", "after": "ok"},
+                        }
+                    ]
+                },
+            ),
+        ]
+        for height, block_hash, state_root, body in blocks:
+            conn.execute(
+                """
+                INSERT INTO blocks (height, block_hash, state_root, body_json)
+                VALUES (?, ?, ?, ?)
+                """,
+                (height, block_hash, state_root, json.dumps(body)),
+            )
+
+
+def test_state_diff_returns_block_range_balance_and_storage_diffs(client):
+    flask_client, db_path = client
+    _seed_blocks(db_path)
+
+    response = flask_client.get("/api/state/diff?start=10&end=11")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["start_height"] == 10
+    assert body["end_height"] == 11
+    assert body["block_count"] == 2
+    assert body["missing_blocks"] == []
+    assert body["state_roots"] == [
+        {"height": 10, "block_hash": "hash10", "state_root": "state10"},
+        {"height": 11, "block_hash": "hash11", "state_root": "state11"},
+    ]
+    assert body["balance_diffs"] == [
+        {"wallet": "alice", "delta_i64": -2_500_000, "delta_rtc": -2.5},
+        {"wallet": "bob", "delta_i64": 2_000_000, "delta_rtc": 2.0},
+        {"wallet": "carol", "delta_i64": 500_000, "delta_rtc": 0.5},
+    ]
+    assert body["state_changes"][0] == {
+        "block_height": 10,
+        "tx_index": 0,
+        "tx_hash": "tx1",
+        "wallet": "alice",
+        "delta_i64": -2_500_000,
+        "direction": "debit",
+    }
+    assert body["storage_diffs"] == [{"key": "memo", "after": "ok"}]
+    assert body["storage_diff_status"] == "tracked"
+
+
+@pytest.mark.parametrize(
+    "query,error",
+    (
+        ("end=11", "start is required"),
+        ("start=ten&end=11", "start must be an integer"),
+        ("start=-1&end=11", "start must be non-negative"),
+        ("start=12&end=11", "end must be greater than or equal to start"),
+    ),
+)
+def test_state_diff_rejects_invalid_ranges(client, query, error):
+    flask_client, _ = client
+
+    response = flask_client.get(f"/api/state/diff?{query}")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": error}
+
+
+def test_state_diff_reports_missing_boundary_block(client):
+    flask_client, db_path = client
+    _seed_blocks(db_path)
+
+    response = flask_client.get("/api/state/diff?start=9&end=11")
+
+    assert response.status_code == 404
+    assert response.get_json() == {
+        "ok": False,
+        "error": "block_range_boundary_missing",
+        "missing_blocks": [9],
+    }

--- a/tests/test_state_diff_api.py
+++ b/tests/test_state_diff_api.py
@@ -7,7 +7,6 @@ import sys
 
 import pytest
 
-
 integrated_node = sys.modules["integrated_node"]
 
 
@@ -139,3 +138,30 @@ def test_state_diff_reports_missing_boundary_block(client):
         "error": "block_range_boundary_missing",
         "missing_blocks": [9],
     }
+
+
+def test_state_diff_reports_partial_diff_for_missing_interior_block(client):
+    flask_client, db_path = client
+    _seed_blocks(db_path)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("DELETE FROM blocks WHERE height = ?", (11,))
+        conn.execute(
+            """
+            INSERT INTO blocks (height, block_hash, state_root, body_json)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                12,
+                "hash12",
+                "state12",
+                json.dumps({"transactions": []}),
+            ),
+        )
+
+    response = flask_client.get("/api/state/diff?start=10&end=12")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["block_count"] == 2
+    assert body["missing_blocks"] == [11]


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## Issue

Addresses #2361.

## What Changed

- Adds `GET /api/state/diff?start=<height>&end=<height>` for a bounded block range.
- Returns block state roots, per-transaction state changes, aggregate wallet balance deltas, missing block heights, and any storage diff metadata already present in block transaction bodies.
- Adds focused regression coverage for valid diffs, invalid range parameters, missing boundary blocks, and partial diffs when an interior block is absent.

## Testing / Evidence

- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m pytest -p no:cacheprovider tests/test_state_diff_api.py -q` -> 7 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m pytest -p no:cacheprovider tests/test_state_diff_api.py tests/test_realtime_explorer_limit_validation.py -q` -> 16 passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_state_diff_api.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m ruff check tests/test_state_diff_api.py` -> passed
- `PYTHONDONTWRITEBYTECODE=1 .venv-bounty-validation/bin/python -m mypy tests/test_state_diff_api.py` -> passed
- Hidden Unicode scan over changed files -> OK, 2 paths scanned
- `git diff --check origin/main...HEAD` -> passed

## Scope / Risk

This is a read-only API slice for #2361. It does not add historical state snapshot storage or mutate chain state; storage diffs are surfaced when transaction bodies already carry that metadata. If a requested range has both boundary blocks but an interior block is absent, the endpoint returns `ok: true` with `missing_blocks` populated so callers can treat the response as a partial diff.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
