### PR TITLE
feat: add weighted fork-choice duty balancing

### DIFF
--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -247,7 +247,7 @@ class BlockProducer:
 
     def get_round_robin_producer(self, slot: int) -> Optional[str]:
         """
-        Deterministic round-robin block producer selection.
+        Deterministic weighted-fair block producer selection.
 
         Returns wallet address of the selected producer for this slot.
         """
@@ -257,8 +257,92 @@ class BlockProducer:
         if not attested_miners:
             return None
 
-        producer_index = slot % len(attested_miners)
-        return attested_miners[producer_index][0]
+        rotation = self._build_balanced_producer_rotation(attested_miners)
+        producer_index = slot % len(rotation)
+        return rotation[producer_index]
+
+    @staticmethod
+    def _miner_selection_weight(attested_miner) -> float:
+        """Return a bounded producer-selection weight for an attested miner."""
+        device_info = attested_miner[2] if len(attested_miner) > 2 and attested_miner[2] else {}
+
+        explicit_weight = device_info.get("weight")
+        if explicit_weight is not None:
+            try:
+                return min(max(float(explicit_weight), 1.0), 10.0)
+            except (TypeError, ValueError):
+                pass
+
+        family = str(device_info.get("family") or "").lower()
+        arch = str(attested_miner[1] or device_info.get("arch") or "").lower()
+        combined = f"{family} {arch}"
+
+        if "g5" in combined:
+            return 2.0
+        if "g4" in combined or "powerpc" in combined or "ppc" in combined:
+            return 2.5
+        if "power8" in combined or "power9" in combined:
+            return 1.5
+
+        return 1.0
+
+    @classmethod
+    def _build_balanced_producer_rotation(cls, attested_miners) -> List[str]:
+        """
+        Build a deterministic weighted-fair rotation for the active miners.
+
+        Equal weights preserve the previous alphabetical round-robin order. When
+        miners carry explicit or device-derived weights, the cycle repeats each
+        miner proportional to its bounded weight while spreading duties across
+        the cycle instead of clustering them.
+        """
+        weighted_miners = [
+            (miner[0], cls._miner_selection_weight(miner))
+            for miner in attested_miners
+        ]
+        if not weighted_miners:
+            return []
+
+        cycle_len = sum(max(1, int(round(weight))) for _, weight in weighted_miners)
+        assigned = {miner_id: 0 for miner_id, _ in weighted_miners}
+        rotation = []
+
+        for _ in range(cycle_len):
+            miner_id, _ = min(
+                weighted_miners,
+                key=lambda item: (
+                    assigned[item[0]] / item[1],
+                    item[0],
+                ),
+            )
+            assigned[miner_id] += 1
+            rotation.append(miner_id)
+
+        return rotation
+
+    def get_producer_balance_summary(self, start_slot: int, slots: int = 32) -> Dict:
+        """Return scheduled producer duties over a bounded future slot window."""
+        slots = max(1, min(int(slots), 256))
+        current_ts = self.get_slot_start_time(start_slot)
+        attested_miners = self.get_attested_miners(current_ts)
+        rotation = self._build_balanced_producer_rotation(attested_miners)
+
+        duty_counts = {miner[0]: 0 for miner in attested_miners}
+        schedule = []
+        if rotation:
+            for offset in range(slots):
+                slot = start_slot + offset
+                producer = rotation[slot % len(rotation)]
+                duty_counts[producer] += 1
+                schedule.append({"slot": slot, "producer": producer})
+
+        return {
+            "start_slot": start_slot,
+            "slots": slots,
+            "rotation_size": len(rotation),
+            "duty_counts": duty_counts,
+            "schedule": schedule,
+        }
 
     def is_my_turn(self, slot: int = None) -> bool:
         """Check if it's this node's turn to produce a block"""
@@ -821,6 +905,7 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
         return jsonify({
             "slot": slot,
             "expected_producer": expected_producer,
+            "balance": producer.get_producer_balance_summary(slot, slots=16),
             "slot_start": slot_start,
             "slot_end": slot_end,
             "time_remaining": max(0, slot_end - int(time.time())),
@@ -835,10 +920,15 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
 
         return jsonify({
             "count": len(miners),
+            "balance": producer.get_producer_balance_summary(
+                producer.get_current_slot(),
+                slots=max(len(miners), 1)
+            ),
             "producers": [
                 {
                     "wallet": m[0],
                     "arch": m[1],
+                    "selection_weight": producer._miner_selection_weight(m),
                     "device_info": m[2]
                 }
                 for m in miners

--- a/node/tests/test_block_producer_balancing.py
+++ b/node/tests/test_block_producer_balancing.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for weighted-fair block producer duty balancing."""
+
+import hashlib
+import json
+import os
+import sys
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+crypto = types.ModuleType("rustchain_crypto")
+
+
+class CanonicalBlockHeader:
+    pass
+
+
+class MerkleTree:
+    root_hex = "0" * 64
+
+
+class SignedTransaction:
+    pass
+
+
+class Ed25519Signer:
+    pass
+
+
+def canonical_json(obj):
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True).encode()
+
+
+def blake2b256_hex(data):
+    return hashlib.blake2b(data, digest_size=32).hexdigest()
+
+
+crypto.CanonicalBlockHeader = CanonicalBlockHeader
+crypto.MerkleTree = MerkleTree
+crypto.SignedTransaction = SignedTransaction
+crypto.Ed25519Signer = Ed25519Signer
+crypto.canonical_json = canonical_json
+crypto.blake2b256_hex = blake2b256_hex
+sys.modules["rustchain_crypto"] = crypto
+
+tx_handler = types.ModuleType("rustchain_tx_handler")
+
+
+class TransactionPool:
+    pass
+
+
+tx_handler.TransactionPool = TransactionPool
+sys.modules["rustchain_tx_handler"] = tx_handler
+
+from rustchain_block_producer import BlockProducer  # noqa: E402
+
+
+def _miner(wallet, arch="modern_x86", **device_info):
+    info = {"arch": arch, "family": "", "model": "", "year": 2025}
+    info.update(device_info)
+    return (wallet, arch, info)
+
+
+def test_equal_weights_preserve_round_robin_order():
+    rotation = BlockProducer._build_balanced_producer_rotation([
+        _miner("alice"),
+        _miner("bob"),
+        _miner("carol"),
+    ])
+
+    assert rotation == ["alice", "bob", "carol"]
+
+
+def test_weighted_rotation_spreads_higher_weight_duties():
+    rotation = BlockProducer._build_balanced_producer_rotation([
+        _miner("alice", weight=2),
+        _miner("bob", weight=1),
+        _miner("carol", weight=1),
+    ])
+
+    assert rotation.count("alice") == 2
+    assert rotation.count("bob") == 1
+    assert rotation.count("carol") == 1
+    assert rotation == ["alice", "bob", "carol", "alice"]
+
+
+def test_device_family_supplies_selection_weight():
+    rotation = BlockProducer._build_balanced_producer_rotation([
+        _miner("g4-miner", "ppc", family="PowerPC G4"),
+        _miner("modern-miner", "x86_64", family="modern_x86"),
+    ])
+
+    assert rotation.count("g4-miner") == 2
+    assert rotation.count("modern-miner") == 1
+
+
+def test_balance_summary_counts_future_slot_duties(monkeypatch):
+    producer = BlockProducer.__new__(BlockProducer)
+    producer.get_slot_start_time = lambda slot: 1_700_000_000 + slot
+    producer.get_attested_miners = lambda current_ts: [
+        _miner("alice", weight=2),
+        _miner("bob", weight=1),
+    ]
+
+    summary = producer.get_producer_balance_summary(0, slots=6)
+
+    assert summary["rotation_size"] == 3
+    assert summary["duty_counts"] == {"alice": 4, "bob": 2}
+    assert [entry["producer"] for entry in summary["schedule"]] == [
+        "alice",
+        "bob",
+        "alice",
+        "alice",
+        "bob",
+        "alice",
+    ]


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top
- [x] Provide test evidence

## What Changed

- Adds deterministic weighted-fair producer duty balancing for attested miners.
- Preserves the previous alphabetical round-robin order when miners have equal weights.
- Exposes a bounded future duty summary on block producer APIs so operators can inspect upcoming distribution.
- Adds regression tests for equal rotation, weighted rotation, device-derived weights, and duty summary counts.

Fixes #2370.

## Testing / Evidence

- `python -m pytest -q node/tests/test_block_producer_balancing.py` -> `4 passed`
- `python -m py_compile node/rustchain_block_producer.py node/tests/test_block_producer_balancing.py` -> passed
- `python -m ruff check node/rustchain_block_producer.py node/tests/test_block_producer_balancing.py --select E9,F63,F7,F82` -> passed
- `git diff --check origin/main...HEAD` -> passed
- Hidden Unicode scan over `origin/main...HEAD` -> passed, 2 files scanned

Full `python -m pytest -q` collection reaches unrelated GPU miner tests that exit during import with `PyTorch with CUDA support required`; the focused producer/fork-choice tests above avoid that hardware-specific path.

## Scope / Risk

This only changes block producer duty selection and reporting. It does not change transaction validation, reward settlement, wallet handling, or P2P quorum rules.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
