### PR TITLE
fix: enforce signed transfer nonce ordering

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8249,6 +8249,21 @@ def wallet_transfer_signed():
                 "code": "REPLAY_DETECTED",
                 "nonce": nonce,
             }), 400
+        previous_nonce = c.execute(
+            """
+            SELECT MAX(CAST(nonce AS INTEGER)) FROM transfer_nonces
+            WHERE from_address = ? AND nonce != ?
+            """,
+            (from_address, nonce),
+        ).fetchone()[0]
+        if previous_nonce is not None and int(previous_nonce) >= nonce_int:
+            conn.rollback()
+            return jsonify({
+                "error": "Signed transfer nonce must increase for this wallet",
+                "code": "OUT_OF_ORDER_NONCE",
+                "nonce": nonce,
+                "latest_nonce": int(previous_nonce),
+            }), 400
 
         # Check sender balance (using from_address as wallet ID)
         sender_balance = _balance_i64_for_wallet(c, from_address)

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -112,6 +112,41 @@ def test_signed_transfer_rejects_duplicate_nonce(signed_transfer_client):
     assert pending_count == 1
 
 
+def test_signed_transfer_rejects_out_of_order_nonce(signed_transfer_client):
+    client, db_path = signed_transfer_client
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("RTC" + "a" * 40, 10_000_000),
+        )
+        conn.commit()
+
+    first = client.post(
+        "/wallet/transfer/signed",
+        json=_payload(nonce=1733420000002),
+    )
+    assert first.status_code == 200
+
+    stale = client.post(
+        "/wallet/transfer/signed",
+        json=_payload(nonce=1733420000001),
+    )
+    assert stale.status_code == 400
+    body = stale.get_json()
+    assert body["code"] == "OUT_OF_ORDER_NONCE"
+    assert body["latest_nonce"] == 1733420000002
+
+    with sqlite3.connect(db_path) as conn:
+        nonces = conn.execute(
+            "SELECT nonce FROM transfer_nonces ORDER BY nonce"
+        ).fetchall()
+        pending_count = conn.execute("SELECT COUNT(*) FROM pending_ledger").fetchone()[0]
+
+    assert nonces == [("1733420000002",)]
+    assert pending_count == 1
+
+
 def test_insufficient_balance_does_not_burn_nonce(signed_transfer_client):
     client, db_path = signed_transfer_client
     payload = _payload(amount_rtc=5.0, nonce=1733420009999)


### PR DESCRIPTION
## Summary
- reject signed wallet transfers when the sender tries to submit a nonce lower than or equal to an already accepted nonce
- keep the existing duplicate-nonce replay response for exact replays
- add a regression test proving stale nonces do not reserve a nonce or create a pending transfer

## Why
This adds a deterministic same-wallet ordering rule for `/wallet/transfer/signed`, addressing the transaction ordering fairness gap described in #2326 without changing the broader mempool or confirmation model. A node can still queue valid transfers, but it can no longer accept a later signed nonce from a wallet and then accept an older nonce from that same wallet afterward.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 uv run --no-project --python 3.12 --with pytest --with flask --with cryptography --with pynacl --with flask-cors --with httpx python -m pytest -p no:cacheprovider tests/test_signed_transfer_replay.py -q` -> 10 passed
- `python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_signed_transfer_replay.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- hidden Unicode scan on changed files -> passed

## Scope / risk
This is intentionally limited to signed transfer admission. It does not add encrypted mempool, batch auction, cross-wallet fair ordering, or consensus-level ordering changes.

Note: accepted signed-transfer nonces are expected to be numeric. The monotonicity check compares stored numeric nonce values, so legacy cleanup/migration should normalize any non-numeric historical nonce rows before relying on ordering semantics.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
