### PR TITLE
feat: add block-bound randomness beacon

### DIFF
--- a/docs/randomness-beacon-demo.md
+++ b/docs/randomness-beacon-demo.md
@@ -1,0 +1,29 @@
+# Randomness beacon validation
+
+This change adds a block-bound randomness record whenever `BlockProducer.save_block`
+commits a block. The beacon value is derived from public proof material:
+
+- block height
+- block hash
+- previous block hash
+- previous randomness beacon
+- Merkle root
+- attestations hash
+- producer
+- block timestamp
+
+The API exposes the latest beacon at `/api/randomness/latest` and a specific
+height at `/api/randomness/<height>`. Responses include `verified: true` when the
+returned randomness matches the included proof.
+
+Focused validation:
+
+```bash
+PYTHONPATH=node .venv-bounty-validation/bin/python -m pytest -q node/tests/test_randomness_beacon.py
+```
+
+Expected result:
+
+```text
+3 passed
+```

--- a/docs/randomness-beacon-demo.md
+++ b/docs/randomness-beacon-demo.md
@@ -25,5 +25,5 @@ PYTHONPATH=node .venv-bounty-validation/bin/python -m pytest -q node/tests/test_
 Expected result:
 
 ```text
-3 passed
+4 passed
 ```

--- a/docs/randomness-beacon-demo.md
+++ b/docs/randomness-beacon-demo.md
@@ -25,5 +25,5 @@ PYTHONPATH=node .venv-bounty-validation/bin/python -m pytest -q node/tests/test_
 Expected result:
 
 ```text
-4 passed
+5 passed
 ```

--- a/node/randomness_beacon.py
+++ b/node/randomness_beacon.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+"""Chain-bound randomness beacon helpers for RustChain blocks."""
+
+import json
+from hashlib import blake2b
+from typing import Dict
+
+
+GENESIS_RANDOMNESS = "0" * 64
+RANDOMNESS_DOMAIN = "rustchain:onchain-randomness:v1"
+
+
+def _canonical_json(data: Dict) -> bytes:
+    return json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def build_randomness_proof(
+    *,
+    height: int,
+    block_hash: str,
+    prev_hash: str,
+    prev_randomness: str = GENESIS_RANDOMNESS,
+    merkle_root: str = "",
+    attestations_hash: str = "",
+    producer: str = "",
+    timestamp: int = 0,
+) -> Dict:
+    """Return the canonical public proof inputs for a block randomness value."""
+    return {
+        "domain": RANDOMNESS_DOMAIN,
+        "height": int(height),
+        "block_hash": str(block_hash),
+        "prev_hash": str(prev_hash),
+        "prev_randomness": str(prev_randomness or GENESIS_RANDOMNESS),
+        "merkle_root": str(merkle_root),
+        "attestations_hash": str(attestations_hash),
+        "producer": str(producer),
+        "timestamp": int(timestamp),
+    }
+
+
+def derive_randomness(proof: Dict) -> str:
+    """Derive the beacon value from canonical proof material."""
+    return blake2b(_canonical_json(proof), digest_size=32).hexdigest()
+
+
+def build_randomness_record(
+    *,
+    height: int,
+    block_hash: str,
+    prev_hash: str,
+    prev_randomness: str = GENESIS_RANDOMNESS,
+    merkle_root: str = "",
+    attestations_hash: str = "",
+    producer: str = "",
+    timestamp: int = 0,
+) -> Dict:
+    """Build the stored randomness beacon record for one committed block."""
+    proof = build_randomness_proof(
+        height=height,
+        block_hash=block_hash,
+        prev_hash=prev_hash,
+        prev_randomness=prev_randomness,
+        merkle_root=merkle_root,
+        attestations_hash=attestations_hash,
+        producer=producer,
+        timestamp=timestamp,
+    )
+    return {
+        "randomness": derive_randomness(proof),
+        "proof": proof,
+    }
+
+
+def verify_randomness_record(randomness: str, proof: Dict) -> bool:
+    """Verify a stored beacon value against its public proof material."""
+    return str(randomness) == derive_randomness(proof)

--- a/node/randomness_beacon.py
+++ b/node/randomness_beacon.py
@@ -5,7 +5,6 @@ import json
 from hashlib import blake2b
 from typing import Dict
 
-
 GENESIS_RANDOMNESS = "0" * 64
 RANDOMNESS_DOMAIN = "rustchain:onchain-randomness:v1"
 

--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -35,6 +35,11 @@ from rustchain_crypto import (
     blake2b256_hex,
     canonical_json
 )
+from randomness_beacon import (
+    GENESIS_RANDOMNESS,
+    build_randomness_record,
+    verify_randomness_record,
+)
 from rustchain_tx_handler import TransactionPool
 
 logging.basicConfig(
@@ -440,9 +445,29 @@ class BlockProducer:
                         tx_count INTEGER NOT NULL,
                         attestation_count INTEGER NOT NULL,
                         body_json TEXT NOT NULL,
+                        randomness_beacon TEXT,
+                        randomness_proof_json TEXT,
                         created_at INTEGER NOT NULL
                     )
                 """)
+                _ensure_block_randomness_columns(conn)
+
+                prev_randomness = _latest_randomness(conn)
+                randomness_record = build_randomness_record(
+                    height=block.height,
+                    block_hash=block.hash,
+                    prev_hash=block.header.prev_hash,
+                    prev_randomness=prev_randomness,
+                    merkle_root=block.header.merkle_root,
+                    attestations_hash=block.header.attestations_hash,
+                    producer=block.header.producer,
+                    timestamp=block.header.timestamp,
+                )
+                randomness_proof_json = json.dumps(
+                    randomness_record["proof"],
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
 
                 # Insert block
                 cursor.execute("""
@@ -450,8 +475,8 @@ class BlockProducer:
                         height, block_hash, prev_hash, timestamp,
                         merkle_root, state_root, attestations_hash,
                         producer, producer_sig, tx_count, attestation_count,
-                        body_json, created_at
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        body_json, randomness_beacon, randomness_proof_json, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     block.height,
                     block.hash,
@@ -465,6 +490,8 @@ class BlockProducer:
                     len(block.body.transactions),
                     len(block.body.attestations),
                     json.dumps(block.body.to_dict()),
+                    randomness_record["randomness"],
+                    randomness_proof_json,
                     int(time.time())
                 ))
 
@@ -649,6 +676,11 @@ def _row_to_block(row: sqlite3.Row) -> Dict:
             block["body"] = json.loads(block["body_json"])
         except (TypeError, ValueError):
             pass
+    if block.get("randomness_proof_json"):
+        try:
+            block["randomness_proof"] = json.loads(block["randomness_proof_json"])
+        except (TypeError, ValueError):
+            pass
     return block
 
 
@@ -669,6 +701,30 @@ def _blocks_table_missing(exc: sqlite3.Error) -> bool:
         isinstance(exc, sqlite3.OperationalError)
         and "no such table: blocks" in str(exc).lower()
     )
+
+
+def _sqlite_table_columns(conn: sqlite3.Connection, table: str) -> set:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _ensure_block_randomness_columns(conn: sqlite3.Connection):
+    columns = _sqlite_table_columns(conn, "blocks")
+    if "randomness_beacon" not in columns:
+        conn.execute("ALTER TABLE blocks ADD COLUMN randomness_beacon TEXT")
+    if "randomness_proof_json" not in columns:
+        conn.execute("ALTER TABLE blocks ADD COLUMN randomness_proof_json TEXT")
+
+
+def _latest_randomness(conn: sqlite3.Connection) -> str:
+    try:
+        row = conn.execute(
+            "SELECT randomness_beacon FROM blocks "
+            "WHERE randomness_beacon IS NOT NULL "
+            "ORDER BY height DESC LIMIT 1"
+        ).fetchone()
+    except sqlite3.Error:
+        return GENESIS_RANDOMNESS
+    return row[0] if row and row[0] else GENESIS_RANDOMNESS
 
 
 def create_block_api_routes(app, producer: BlockProducer, validator: BlockValidator):
@@ -708,6 +764,60 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
             if row:
                 return jsonify(dict(row))
             return jsonify({"error": "Block not found"}), 404
+
+    def _randomness_response(row):
+        proof = json.loads(row["randomness_proof_json"])
+        randomness = row["randomness_beacon"]
+        return {
+            "ok": True,
+            "height": row["height"],
+            "block_hash": row["block_hash"],
+            "randomness": randomness,
+            "proof": proof,
+            "verified": verify_randomness_record(randomness, proof),
+        }
+
+    @app.route('/block/randomness/latest', methods=['GET'])
+    @app.route('/api/randomness/latest', methods=['GET'])
+    def get_latest_randomness():
+        """Return the latest stored on-chain randomness beacon."""
+        with sqlite3.connect(producer.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT height, block_hash, randomness_beacon, randomness_proof_json "
+                    "FROM blocks WHERE randomness_beacon IS NOT NULL "
+                    "ORDER BY height DESC LIMIT 1"
+                ).fetchone()
+            except sqlite3.Error as exc:
+                if _blocks_table_missing(exc):
+                    return jsonify({"ok": False, "error": "No blocks found"}), 404
+                logger.exception("Randomness lookup failed")
+                return jsonify({"ok": False, "error": "Block database unavailable"}), 500
+        if not row:
+            return jsonify({"ok": False, "error": "No blocks found"}), 404
+        return jsonify(_randomness_response(row))
+
+    @app.route('/block/randomness/<int:height>', methods=['GET'])
+    @app.route('/api/randomness/<int:height>', methods=['GET'])
+    def get_randomness_by_height(height: int):
+        """Return the stored on-chain randomness beacon for a block height."""
+        with sqlite3.connect(producer.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            try:
+                row = conn.execute(
+                    "SELECT height, block_hash, randomness_beacon, randomness_proof_json "
+                    "FROM blocks WHERE height = ? AND randomness_beacon IS NOT NULL",
+                    (height,),
+                ).fetchone()
+            except sqlite3.Error as exc:
+                if _blocks_table_missing(exc):
+                    return jsonify({"ok": False, "error": "Block not found"}), 404
+                logger.exception("Randomness lookup failed")
+                return jsonify({"ok": False, "error": "Block database unavailable"}), 500
+        if not row:
+            return jsonify({"ok": False, "error": "Block not found"}), 404
+        return jsonify(_randomness_response(row))
 
     @app.route('/v1/blocks/batch', methods=['POST'])
     @app.route('/api/blocks/batch', methods=['POST'])

--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -801,6 +801,7 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
         with sqlite3.connect(producer.db_path) as conn:
             conn.row_factory = sqlite3.Row
             try:
+                _ensure_block_randomness_columns(conn)
                 row = conn.execute(
                     "SELECT height, block_hash, randomness_beacon, randomness_proof_json "
                     "FROM blocks WHERE randomness_beacon IS NOT NULL "
@@ -822,6 +823,7 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
         with sqlite3.connect(producer.db_path) as conn:
             conn.row_factory = sqlite3.Row
             try:
+                _ensure_block_randomness_columns(conn)
                 row = conn.execute(
                     "SELECT height, block_hash, randomness_beacon, randomness_proof_json "
                     "FROM blocks WHERE height = ? AND randomness_beacon IS NOT NULL",

--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -766,7 +766,17 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
             return jsonify({"error": "Block not found"}), 404
 
     def _randomness_response(row):
-        proof = json.loads(row["randomness_proof_json"])
+        try:
+            proof = json.loads(row["randomness_proof_json"])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            logger.exception(
+                "Stored randomness proof is invalid for block height %s",
+                row["height"],
+            )
+            return {
+                "ok": False,
+                "error": "Stored randomness proof is invalid",
+            }, 500
         randomness = row["randomness_beacon"]
         return {
             "ok": True,
@@ -776,6 +786,13 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
             "proof": proof,
             "verified": verify_randomness_record(randomness, proof),
         }
+
+    def _jsonify_randomness_response(row):
+        response = _randomness_response(row)
+        if isinstance(response, tuple):
+            body, status_code = response
+            return jsonify(body), status_code
+        return jsonify(response)
 
     @app.route('/block/randomness/latest', methods=['GET'])
     @app.route('/api/randomness/latest', methods=['GET'])
@@ -796,7 +813,7 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
                 return jsonify({"ok": False, "error": "Block database unavailable"}), 500
         if not row:
             return jsonify({"ok": False, "error": "No blocks found"}), 404
-        return jsonify(_randomness_response(row))
+        return _jsonify_randomness_response(row)
 
     @app.route('/block/randomness/<int:height>', methods=['GET'])
     @app.route('/api/randomness/<int:height>', methods=['GET'])
@@ -817,7 +834,7 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
                 return jsonify({"ok": False, "error": "Block database unavailable"}), 500
         if not row:
             return jsonify({"ok": False, "error": "Block not found"}), 404
-        return jsonify(_randomness_response(row))
+        return _jsonify_randomness_response(row)
 
     @app.route('/v1/blocks/batch', methods=['POST'])
     @app.route('/api/blocks/batch', methods=['POST'])

--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -12,33 +12,33 @@ Phase 1 & 2 Implementation:
 Implements secure block production for Proof of Antiquity consensus.
 """
 
-import sqlite3
-import time
-import threading
-import logging
 import json
+import logging
 import os
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass, field
 
 try:
     import redis
 except ImportError:  # pragma: no cover - Redis is optional for local nodes/tests.
     redis = None
 
-from rustchain_crypto import (
-    CanonicalBlockHeader,
-    MerkleTree,
-    SignedTransaction,
-    Ed25519Signer,
-    blake2b256_hex,
-    canonical_json
-)
 from randomness_beacon import (
     GENESIS_RANDOMNESS,
     build_randomness_record,
     verify_randomness_record,
+)
+from rustchain_crypto import (
+    CanonicalBlockHeader,
+    Ed25519Signer,
+    MerkleTree,
+    SignedTransaction,
+    blake2b256_hex,
+    canonical_json,
 )
 from rustchain_tx_handler import TransactionPool
 
@@ -589,7 +589,7 @@ class BlockValidator:
                 )
                 result = cursor.fetchone()
                 if result and result[0] != block.header.prev_hash:
-                    return False, f"Invalid prev_hash"
+                    return False, "Invalid prev_hash"
 
         # 5. Validate producer signature (if we have pubkey)
         if producer_pubkey:
@@ -729,7 +729,7 @@ def _latest_randomness(conn: sqlite3.Connection) -> str:
 
 def create_block_api_routes(app, producer: BlockProducer, validator: BlockValidator):
     """Create Flask routes for block API"""
-    from flask import request, jsonify
+    from flask import jsonify, request
 
     @app.route('/block/latest', methods=['GET'])
     def get_latest_block():
@@ -978,8 +978,8 @@ def create_block_api_routes(app, producer: BlockProducer, validator: BlockValida
 # =============================================================================
 
 if __name__ == "__main__":
-    import tempfile
     import os
+    import tempfile
 
     print("=" * 70)
     print("RustChain Block Producer - Test Suite")
@@ -999,7 +999,7 @@ if __name__ == "__main__":
         addr, pub, priv = generate_wallet_keypair()
         signer = Ed25519Signer(bytes.fromhex(priv))
 
-        print(f"\n=== Test Wallet ===")
+        print("\n=== Test Wallet ===")
         print(f"Address: {addr}")
 
         # Seed balance
@@ -1031,14 +1031,14 @@ if __name__ == "__main__":
             wallet_address=addr
         )
 
-        print(f"\n=== Slot Info ===")
+        print("\n=== Slot Info ===")
         slot = producer.get_current_slot()
         print(f"Current slot: {slot}")
         print(f"Expected producer: {producer.get_round_robin_producer(slot)}")
         print(f"Is my turn: {producer.is_my_turn()}")
 
         # Create a test transaction
-        print(f"\n=== Creating Test Transaction ===")
+        print("\n=== Creating Test Transaction ===")
         addr2, _, _ = generate_wallet_keypair()
 
         tx = SignedTransaction(
@@ -1055,7 +1055,7 @@ if __name__ == "__main__":
         print(f"TX submitted: {success}, {result}")
 
         # Produce block
-        print(f"\n=== Producing Block ===")
+        print("\n=== Producing Block ===")
         block = producer.produce_block()
 
         if block:
@@ -1067,12 +1067,12 @@ if __name__ == "__main__":
             print(f"Attestation count: {len(block.body.attestations)}")
 
             # Save block
-            print(f"\n=== Saving Block ===")
+            print("\n=== Saving Block ===")
             saved = producer.save_block(block)
             print(f"Saved: {saved}")
 
             # Validate
-            print(f"\n=== Validating Block ===")
+            print("\n=== Validating Block ===")
             validator = BlockValidator(db_path)
             # Need to fake the expected producer since we only have one attester
             is_valid, error = block.validate_structure()
@@ -1080,7 +1080,7 @@ if __name__ == "__main__":
 
             # Check block in DB
             latest = producer.get_latest_block()
-            print(f"\n=== Latest Block in DB ===")
+            print("\n=== Latest Block in DB ===")
             print(f"Height: {latest['height']}")
             print(f"Hash: {latest['block_hash'][:32]}...")
 

--- a/node/tests/test_randomness_beacon.py
+++ b/node/tests/test_randomness_beacon.py
@@ -173,3 +173,68 @@ def test_randomness_routes_return_verified_latest_and_height(tmp_path):
     assert height_body["height"] == 0
     assert height_body["verified"] is True
     assert latest_body["proof"]["prev_randomness"] == height_body["randomness"]
+
+
+def test_randomness_route_handles_corrupt_stored_proof(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    producer = BlockProducer(str(db_path), EmptyPool())
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                prev_hash TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                merkle_root TEXT NOT NULL,
+                state_root TEXT NOT NULL,
+                attestations_hash TEXT NOT NULL,
+                producer TEXT NOT NULL,
+                producer_sig TEXT NOT NULL,
+                tx_count INTEGER NOT NULL,
+                attestation_count INTEGER NOT NULL,
+                body_json TEXT NOT NULL,
+                randomness_beacon TEXT,
+                randomness_proof_json TEXT,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks (
+                height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                attestations_hash, producer, producer_sig, tx_count,
+                attestation_count, body_json, randomness_beacon,
+                randomness_proof_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                0,
+                "1" * 64,
+                "0" * 64,
+                123456789,
+                "a" * 64,
+                "c" * 64,
+                "b" * 64,
+                "RTC-test-producer",
+                "d" * 128,
+                0,
+                0,
+                "{}",
+                "e" * 64,
+                "{not-json",
+                123456789,
+            ),
+        )
+
+    app = Flask(__name__)
+    create_block_api_routes(app, producer, BlockValidator(str(db_path)))
+    response = app.test_client().get("/api/randomness/latest")
+
+    assert response.status_code == 500
+    assert response.get_json() == {
+        "ok": False,
+        "error": "Stored randomness proof is invalid",
+    }

--- a/node/tests/test_randomness_beacon.py
+++ b/node/tests/test_randomness_beacon.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import sqlite3
+import sys
+import types
+from types import SimpleNamespace
+
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+crypto_stub = types.ModuleType("rustchain_crypto")
+crypto_stub.CanonicalBlockHeader = object
+crypto_stub.Ed25519Signer = object
+crypto_stub.SignedTransaction = object
+crypto_stub.blake2b256_hex = lambda payload: "0" * 64
+crypto_stub.canonical_json = lambda payload: json.dumps(payload, sort_keys=True).encode("utf-8")
+
+
+class _MerkleTree:
+    root_hex = "0" * 64
+
+    def add_leaf_hash(self, _tx_hash):
+        return None
+
+
+crypto_stub.MerkleTree = _MerkleTree
+sys.modules.setdefault("rustchain_crypto", crypto_stub)
+
+tx_handler_stub = types.ModuleType("rustchain_tx_handler")
+tx_handler_stub.TransactionPool = object
+sys.modules.setdefault("rustchain_tx_handler", tx_handler_stub)
+
+from randomness_beacon import (  # noqa: E402
+    GENESIS_RANDOMNESS,
+    build_randomness_record,
+    verify_randomness_record,
+)
+from rustchain_block_producer import (  # noqa: E402
+    BlockProducer,
+    BlockValidator,
+    create_block_api_routes,
+)
+
+
+class EmptyPool:
+    def confirm_transaction(self, *_args, **_kwargs):
+        raise AssertionError("empty blocks should not confirm transactions")
+
+
+class StubBody:
+    transactions = []
+    attestations = []
+
+    def to_dict(self):
+        return {
+            "transactions": [],
+            "attestations": [],
+            "merkle_root": "a" * 64,
+            "attestations_hash": "b" * 64,
+            "tx_count": 0,
+            "attestation_count": 0,
+        }
+
+
+def _block(height, block_hash, prev_hash="0" * 64, timestamp=123456789):
+    return SimpleNamespace(
+        height=height,
+        hash=block_hash,
+        header=SimpleNamespace(
+            prev_hash=prev_hash,
+            timestamp=timestamp,
+            merkle_root="a" * 64,
+            state_root="c" * 64,
+            attestations_hash="b" * 64,
+            producer="RTC-test-producer",
+            producer_sig="d" * 128,
+        ),
+        body=StubBody(),
+    )
+
+
+def test_randomness_record_is_verifiable_and_chain_bound():
+    first = build_randomness_record(
+        height=1,
+        block_hash="1" * 64,
+        prev_hash="0" * 64,
+        prev_randomness=GENESIS_RANDOMNESS,
+        merkle_root="a" * 64,
+        attestations_hash="b" * 64,
+        producer="RTC-test-producer",
+        timestamp=123,
+    )
+    second = build_randomness_record(
+        height=2,
+        block_hash="2" * 64,
+        prev_hash="1" * 64,
+        prev_randomness=first["randomness"],
+        merkle_root="a" * 64,
+        attestations_hash="b" * 64,
+        producer="RTC-test-producer",
+        timestamp=124,
+    )
+
+    assert verify_randomness_record(first["randomness"], first["proof"])
+    assert verify_randomness_record(second["randomness"], second["proof"])
+    assert first["randomness"] != second["randomness"]
+    assert second["proof"]["prev_randomness"] == first["randomness"]
+
+
+def test_save_block_adds_randomness_columns_to_existing_blocks_table(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                prev_hash TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                merkle_root TEXT NOT NULL,
+                state_root TEXT NOT NULL,
+                attestations_hash TEXT NOT NULL,
+                producer TEXT NOT NULL,
+                producer_sig TEXT NOT NULL,
+                tx_count INTEGER NOT NULL,
+                attestation_count INTEGER NOT NULL,
+                body_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+
+    producer = BlockProducer(str(db_path), EmptyPool())
+    assert producer.save_block(_block(0, "1" * 64))
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT randomness_beacon, randomness_proof_json FROM blocks WHERE height = 0"
+        ).fetchone()
+
+    proof = json.loads(row[1])
+    assert proof["prev_randomness"] == GENESIS_RANDOMNESS
+    assert verify_randomness_record(row[0], proof)
+
+
+def test_randomness_routes_return_verified_latest_and_height(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    producer = BlockProducer(str(db_path), EmptyPool())
+    first = _block(0, "1" * 64)
+    second = _block(1, "2" * 64, prev_hash="1" * 64, timestamp=123456790)
+
+    assert producer.save_block(first)
+    assert producer.save_block(second)
+
+    app = Flask(__name__)
+    create_block_api_routes(app, producer, BlockValidator(str(db_path)))
+    client = app.test_client()
+
+    latest = client.get("/api/randomness/latest")
+    by_height = client.get("/api/randomness/0")
+
+    assert latest.status_code == 200
+    latest_body = latest.get_json()
+    assert latest_body["height"] == 1
+    assert latest_body["verified"] is True
+
+    assert by_height.status_code == 200
+    height_body = by_height.get_json()
+    assert height_body["height"] == 0
+    assert height_body["verified"] is True
+    assert latest_body["proof"]["prev_randomness"] == height_body["randomness"]

--- a/node/tests/test_randomness_beacon.py
+++ b/node/tests/test_randomness_beacon.py
@@ -175,6 +175,72 @@ def test_randomness_routes_return_verified_latest_and_height(tmp_path):
     assert latest_body["proof"]["prev_randomness"] == height_body["randomness"]
 
 
+def test_randomness_routes_migrate_existing_blocks_table_before_lookup(tmp_path):
+    db_path = tmp_path / "rustchain.db"
+    producer = BlockProducer(str(db_path), EmptyPool())
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE blocks (
+                height INTEGER PRIMARY KEY,
+                block_hash TEXT UNIQUE NOT NULL,
+                prev_hash TEXT NOT NULL,
+                timestamp INTEGER NOT NULL,
+                merkle_root TEXT NOT NULL,
+                state_root TEXT NOT NULL,
+                attestations_hash TEXT NOT NULL,
+                producer TEXT NOT NULL,
+                producer_sig TEXT NOT NULL,
+                tx_count INTEGER NOT NULL,
+                attestation_count INTEGER NOT NULL,
+                body_json TEXT NOT NULL,
+                created_at INTEGER NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            INSERT INTO blocks (
+                height, block_hash, prev_hash, timestamp, merkle_root, state_root,
+                attestations_hash, producer, producer_sig, tx_count,
+                attestation_count, body_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                0,
+                "1" * 64,
+                "0" * 64,
+                123456789,
+                "a" * 64,
+                "c" * 64,
+                "b" * 64,
+                "RTC-test-producer",
+                "d" * 128,
+                0,
+                0,
+                "{}",
+                123456789,
+            ),
+        )
+
+    app = Flask(__name__)
+    create_block_api_routes(app, producer, BlockValidator(str(db_path)))
+    client = app.test_client()
+
+    latest = client.get("/api/randomness/latest")
+    by_height = client.get("/api/randomness/0")
+
+    assert latest.status_code == 404
+    assert latest.get_json() == {"ok": False, "error": "No blocks found"}
+    assert by_height.status_code == 404
+    assert by_height.get_json() == {"ok": False, "error": "Block not found"}
+
+    with sqlite3.connect(db_path) as conn:
+        columns = {row[1] for row in conn.execute("PRAGMA table_info(blocks)")}
+    assert {"randomness_beacon", "randomness_proof_json"}.issubset(columns)
+
+
 def test_randomness_route_handles_corrupt_stored_proof(tmp_path):
     db_path = tmp_path / "rustchain.db"
     producer = BlockProducer(str(db_path), EmptyPool())


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (also accepted: `bcos:l1`, `bcos:l2`)
- [x] If adding new code files, include SPDX header near the top (example: `# SPDX-License-Identifier: MIT`)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

Addresses a first, focused slice of #2341 by adding a block-bound randomness beacon to committed blocks.

- Adds `node/randomness_beacon.py` for canonical proof material, beacon derivation, and verification.
- Stores `randomness_beacon` and `randomness_proof_json` when `BlockProducer.save_block()` commits a block, including migration for existing `blocks` tables.
- Adds `/api/randomness/latest` and `/api/randomness/<height>` aliases, plus matching `/block/randomness/...` routes, returning the beacon, public proof, and `verified` status.
- Adds focused tests covering chain-bound derivation, existing-table migration, read-route migration, and route output.
- Adds `docs/randomness-beacon-demo.md` with reviewer-facing validation notes.

## Scope / Risk Boundary

This does not replace producer selection with VRF or add a full RANDAO commit-reveal protocol. It gives the chain an auditable per-block randomness output derived from committed block data, which is a small reviewable foundation for the broader on-chain randomness request.

## Testing / Evidence

- `PYTHONPATH=node .venv-bounty-validation/bin/python -m pytest -q node/tests/test_randomness_beacon.py` -> 5 passed
- `.venv-bounty-validation/bin/python -m py_compile node/randomness_beacon.py node/rustchain_block_producer.py node/tests/test_randomness_beacon.py` -> passed
- `.venv-bounty-validation/bin/python -m ruff check node/randomness_beacon.py node/rustchain_block_producer.py node/tests/test_randomness_beacon.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python3 tools/bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK
- Hidden Unicode scan over changed files -> ok, 0 findings
- `.venv-bounty-validation/bin/python -m pytest -q` -> blocked by unrelated full-suite missing optional deps (`aiohttp`, `requests`, `yaml`, `matplotlib`) after local preflight; focused randomness tests pass.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
