### PR TITLE
feat: add EIP-1559 fee market helpers

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -304,6 +304,21 @@ curl -sk -X POST https://rustchain.org/wallet/transfer/signed \
 }
 ```
 
+### Fee market compatibility
+
+RustChain keeps legacy signed-transfer fees backward compatible while exposing
+EIP-1559-compatible fee math for new callers and block builders:
+
+- Legacy transfers may continue to provide `fee_rtc`; that fixed fee is treated
+  as a priority tip until a block context supplies a base fee.
+- EIP-1559-style callers can split fees into a burned base fee and a
+  priority tip using `base_fee_per_gas_nrtc`, `max_fee_per_gas_nrtc`,
+  `max_priority_fee_per_gas_nrtc`, and `gas_limit`.
+- The next base fee follows the bounded EIP-1559 adjustment formula:
+  `parent_base_fee + parent_base_fee * gas_delta / target_gas / 8` when the
+  parent block is above target gas, and the corresponding subtraction when it
+  is below target gas.
+
 ---
 
 ## Attestation

--- a/docs/API.md
+++ b/docs/API.md
@@ -311,6 +311,10 @@ EIP-1559-compatible fee math for new callers and block builders:
 
 - Legacy transfers may continue to provide `fee_rtc`; that fixed fee is treated
   as a priority tip until a block context supplies a base fee.
+- Legacy fixed fees preserve the exact total in `priority_tip_nrtc` and
+  `total_fee_nrtc`; if a fee is not evenly divisible by `gas_limit`,
+  `priority_fee_per_gas_nrtc` rounds down and should not be used to
+  reconstruct the total by multiplication.
 - EIP-1559-style callers can split fees into a burned base fee and a
   priority tip using `base_fee_per_gas_nrtc`, `max_fee_per_gas_nrtc`,
   `max_priority_fee_per_gas_nrtc`, and `gas_limit`.

--- a/node/fee_market.py
+++ b/node/fee_market.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+"""EIP-1559-compatible fee market helpers for RustChain."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+DEFAULT_BASE_FEE_NRTC = 1_000
+DEFAULT_TARGET_GAS = 15_000_000
+DEFAULT_ELASTICITY_MULTIPLIER = 2
+DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR = 8
+
+
+@dataclass(frozen=True)
+class FeeBreakdown:
+    """Effective fee split for one transaction."""
+
+    gas_limit: int
+    base_fee_per_gas_nrtc: int
+    priority_fee_per_gas_nrtc: int
+    burned_fee_nrtc: int
+    priority_tip_nrtc: int
+    total_fee_nrtc: int
+
+
+def calculate_next_base_fee(
+    parent_base_fee_nrtc: int,
+    parent_gas_used: int,
+    target_gas: int = DEFAULT_TARGET_GAS,
+    max_change_denominator: int = DEFAULT_BASE_FEE_MAX_CHANGE_DENOMINATOR,
+) -> int:
+    """Calculate the next block base fee using EIP-1559 bounded adjustment."""
+
+    _require_nonnegative_int(parent_base_fee_nrtc, "parent_base_fee_nrtc")
+    _require_nonnegative_int(parent_gas_used, "parent_gas_used")
+    _require_positive_int(target_gas, "target_gas")
+    _require_positive_int(max_change_denominator, "max_change_denominator")
+
+    if parent_gas_used == target_gas:
+        return parent_base_fee_nrtc
+
+    gas_delta = abs(parent_gas_used - target_gas)
+    fee_delta = (
+        parent_base_fee_nrtc * gas_delta // target_gas // max_change_denominator
+    )
+
+    if parent_gas_used > target_gas:
+        return parent_base_fee_nrtc + max(fee_delta, 1)
+
+    return max(parent_base_fee_nrtc - fee_delta, 0)
+
+
+def calculate_effective_priority_fee(
+    max_fee_per_gas_nrtc: int,
+    max_priority_fee_per_gas_nrtc: int,
+    base_fee_per_gas_nrtc: int,
+) -> int:
+    """Return the miner/validator tip per gas after the base fee is reserved."""
+
+    _require_nonnegative_int(max_fee_per_gas_nrtc, "max_fee_per_gas_nrtc")
+    _require_nonnegative_int(
+        max_priority_fee_per_gas_nrtc, "max_priority_fee_per_gas_nrtc"
+    )
+    _require_nonnegative_int(base_fee_per_gas_nrtc, "base_fee_per_gas_nrtc")
+
+    available_for_tip = max_fee_per_gas_nrtc - base_fee_per_gas_nrtc
+    if available_for_tip < 0:
+        raise ValueError("max_fee_per_gas_nrtc is below base_fee_per_gas_nrtc")
+
+    return min(max_priority_fee_per_gas_nrtc, available_for_tip)
+
+
+def calculate_eip1559_fee_breakdown(
+    gas_limit: int,
+    max_fee_per_gas_nrtc: int,
+    max_priority_fee_per_gas_nrtc: int,
+    base_fee_per_gas_nrtc: int,
+) -> FeeBreakdown:
+    """Split an EIP-1559 transaction fee into burned base fee and priority tip."""
+
+    _require_positive_int(gas_limit, "gas_limit")
+    priority_fee_per_gas = calculate_effective_priority_fee(
+        max_fee_per_gas_nrtc,
+        max_priority_fee_per_gas_nrtc,
+        base_fee_per_gas_nrtc,
+    )
+    burned_fee = gas_limit * base_fee_per_gas_nrtc
+    priority_tip = gas_limit * priority_fee_per_gas
+
+    return FeeBreakdown(
+        gas_limit=gas_limit,
+        base_fee_per_gas_nrtc=base_fee_per_gas_nrtc,
+        priority_fee_per_gas_nrtc=priority_fee_per_gas,
+        burned_fee_nrtc=burned_fee,
+        priority_tip_nrtc=priority_tip,
+        total_fee_nrtc=burned_fee + priority_tip,
+    )
+
+
+def legacy_fee_breakdown(
+    fee_nrtc: int,
+    *,
+    gas_limit: int = 1,
+    base_fee_per_gas_nrtc: Optional[int] = None,
+) -> FeeBreakdown:
+    """Represent a legacy fixed fee as a backward-compatible priority tip."""
+
+    _require_nonnegative_int(fee_nrtc, "fee_nrtc")
+    _require_positive_int(gas_limit, "gas_limit")
+    if base_fee_per_gas_nrtc is not None:
+        _require_nonnegative_int(base_fee_per_gas_nrtc, "base_fee_per_gas_nrtc")
+        burned_fee = gas_limit * base_fee_per_gas_nrtc
+        if fee_nrtc < burned_fee:
+            raise ValueError("fee_nrtc is below required base fee")
+        priority_tip = fee_nrtc - burned_fee
+        priority_fee_per_gas = priority_tip // gas_limit
+        return FeeBreakdown(
+            gas_limit=gas_limit,
+            base_fee_per_gas_nrtc=base_fee_per_gas_nrtc,
+            priority_fee_per_gas_nrtc=priority_fee_per_gas,
+            burned_fee_nrtc=burned_fee,
+            priority_tip_nrtc=priority_tip,
+            total_fee_nrtc=fee_nrtc,
+        )
+
+    return FeeBreakdown(
+        gas_limit=gas_limit,
+        base_fee_per_gas_nrtc=0,
+        priority_fee_per_gas_nrtc=fee_nrtc // gas_limit,
+        burned_fee_nrtc=0,
+        priority_tip_nrtc=fee_nrtc,
+        total_fee_nrtc=fee_nrtc,
+    )
+
+
+def _require_nonnegative_int(value: int, name: str) -> None:
+    if type(value) is not int or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _require_positive_int(value: int, name: str) -> None:
+    if type(value) is not int or value <= 0:
+        raise ValueError(f"{name} must be a positive integer")

--- a/node/test_fee_market.py
+++ b/node/test_fee_market.py
@@ -66,6 +66,17 @@ class TestFeeMarket(unittest.TestCase):
         self.assertEqual(breakdown.priority_tip_nrtc, 5_000)
         self.assertEqual(breakdown.total_fee_nrtc, 5_000)
 
+    def test_legacy_fee_breakdown_preserves_remainder_in_total_fields(self):
+        breakdown = legacy_fee_breakdown(10, gas_limit=3)
+
+        self.assertEqual(breakdown.priority_fee_per_gas_nrtc, 3)
+        self.assertEqual(breakdown.priority_tip_nrtc, 10)
+        self.assertEqual(breakdown.total_fee_nrtc, 10)
+        self.assertNotEqual(
+            breakdown.priority_fee_per_gas_nrtc * breakdown.gas_limit,
+            breakdown.priority_tip_nrtc,
+        )
+
     def test_legacy_fee_can_be_split_once_base_fee_is_known(self):
         breakdown = legacy_fee_breakdown(
             5_000,

--- a/node/test_fee_market.py
+++ b/node/test_fee_market.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+"""Tests for EIP-1559-compatible fee market helpers."""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from fee_market import (
+    calculate_effective_priority_fee,
+    calculate_eip1559_fee_breakdown,
+    calculate_next_base_fee,
+    legacy_fee_breakdown,
+)
+
+
+class TestFeeMarket(unittest.TestCase):
+    def test_base_fee_unchanged_at_target_gas(self):
+        self.assertEqual(calculate_next_base_fee(1_000, 15_000_000), 1_000)
+
+    def test_base_fee_increases_when_parent_block_is_above_target(self):
+        self.assertEqual(calculate_next_base_fee(1_000, 30_000_000), 1_125)
+
+    def test_base_fee_decreases_when_parent_block_is_below_target(self):
+        self.assertEqual(calculate_next_base_fee(1_000, 7_500_000), 938)
+
+    def test_base_fee_increase_is_at_least_one_when_congested(self):
+        self.assertEqual(calculate_next_base_fee(1, 15_000_001), 2)
+
+    def test_effective_priority_fee_is_capped_by_max_fee_minus_base_fee(self):
+        self.assertEqual(
+            calculate_effective_priority_fee(
+                max_fee_per_gas_nrtc=120,
+                max_priority_fee_per_gas_nrtc=50,
+                base_fee_per_gas_nrtc=100,
+            ),
+            20,
+        )
+
+    def test_fee_breakdown_splits_burn_and_tip(self):
+        breakdown = calculate_eip1559_fee_breakdown(
+            gas_limit=21_000,
+            max_fee_per_gas_nrtc=150,
+            max_priority_fee_per_gas_nrtc=10,
+            base_fee_per_gas_nrtc=100,
+        )
+
+        self.assertEqual(breakdown.burned_fee_nrtc, 2_100_000)
+        self.assertEqual(breakdown.priority_tip_nrtc, 210_000)
+        self.assertEqual(breakdown.total_fee_nrtc, 2_310_000)
+
+    def test_fee_breakdown_rejects_max_fee_below_base_fee(self):
+        with self.assertRaisesRegex(ValueError, "below base_fee"):
+            calculate_eip1559_fee_breakdown(
+                gas_limit=21_000,
+                max_fee_per_gas_nrtc=99,
+                max_priority_fee_per_gas_nrtc=1,
+                base_fee_per_gas_nrtc=100,
+            )
+
+    def test_legacy_fixed_fee_remains_backward_compatible(self):
+        breakdown = legacy_fee_breakdown(5_000)
+
+        self.assertEqual(breakdown.burned_fee_nrtc, 0)
+        self.assertEqual(breakdown.priority_tip_nrtc, 5_000)
+        self.assertEqual(breakdown.total_fee_nrtc, 5_000)
+
+    def test_legacy_fee_can_be_split_once_base_fee_is_known(self):
+        breakdown = legacy_fee_breakdown(
+            5_000,
+            gas_limit=10,
+            base_fee_per_gas_nrtc=100,
+        )
+
+        self.assertEqual(breakdown.burned_fee_nrtc, 1_000)
+        self.assertEqual(breakdown.priority_tip_nrtc, 4_000)
+        self.assertEqual(breakdown.total_fee_nrtc, 5_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## BCOS Checklist

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top
- [x] Provide test evidence

## What Changed

- Added `node/fee_market.py` with EIP-1559-compatible base-fee adjustment, effective priority-fee capping, fee burn/tip split, and legacy fixed-fee compatibility helpers.
- Added focused tests covering base-fee movement, max-fee/priority-fee interactions, burn/tip accounting, invalid fee caps, and legacy `fee_nrtc` behavior.
- Documented how the helpers preserve current `fee_rtc` behavior while exposing EIP-1559-style fee inputs for future block-builder integration.
- Review follow-up: documented and tested legacy fixed-fee rounding semantics so callers do not reconstruct totals from a rounded per-gas field and lose the remainder.

## Why It Matters

Fixes #2352 by adding the fee calculation layer needed for base fee and priority fee support without changing existing signed-transfer behavior in the same PR. This keeps the change reviewable and leaves chain-level activation as a separate integration step.

## Testing / Evidence

- `.venv-bounty-validation/bin/python -B -m pytest -q node/test_fee_market.py node/test_utxo_db.py` -> 81 passed
- `.venv-bounty-validation/bin/python -B -m py_compile node/fee_market.py node/test_fee_market.py` -> passed
- `.venv-bounty-validation/bin/python -m ruff check docs/API.md node/fee_market.py node/test_fee_market.py` -> All checks passed
- `.venv-bounty-validation/bin/python tools/bcos_spdx_check.py --base-ref upstream/main` -> BCOS SPDX check: OK
- `git diff --check upstream/main...HEAD` -> passed
- `rg -n "\xEF\xBB\xBF|\u200b|\u202e" docs/API.md node/fee_market.py node/test_fee_market.py` -> no matches

## Scope / Risk Boundary

- This PR adds the fee-market calculation primitive and documentation.
- It does not activate mandatory base fees on live transfer endpoints.
- It does not change UTXO conservation rules, mempool ordering, or account-model dual-write behavior.
- The review follow-up is limited to legacy fee rounding semantics documentation and regression coverage.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
