### PR TITLE
Fix Windows install path mismatch in docs + installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 ```
 
-Works on Linux (x86_64, ppc64le, aarch64, mips, sparc, m68k, riscv64, ia64, s390x), macOS (Intel, Apple Silicon, PowerPC), IBM POWER8, and Windows. If it runs Python, it can mine.
+Use the Bash installer on Linux, macOS, WSL, and Git Bash. For native Windows PowerShell, run `miners/windows/rustchain_miner_setup.bat` instead. If it runs Python, it can mine.
 
 ```bash
 # Install with a specific wallet name

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,15 +29,24 @@ That is it. No GPU required. No special hardware. No account signup.
 
 ## Step 1: Install the Miner
 
-Open a terminal (on macOS: search for "Terminal"; on Windows: use PowerShell) and run:
+Open a terminal and choose the install path for your platform:
+
+- **Linux/macOS/WSL/Git Bash**
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
 ```
 
+- **Windows PowerShell (native path)**
+
+```powershell
+curl.exe -L https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_miner_setup.bat -o rustchain_miner_setup.bat
+.\rustchain_miner_setup.bat
+```
+
 **What this does:**
 
-1. Detects your operating system and CPU architecture
+1. Detects your operating system and CPU architecture (Linux/macOS installer path)
 2. Installs Python 3 if you do not have it (Linux only -- macOS/Windows users need Python
    pre-installed)
 3. Downloads the miner script to `~/.rustchain/`

--- a/install-miner.sh
+++ b/install-miner.sh
@@ -61,11 +61,19 @@ detect_platform() {
         Darwin)
             [ "$arch" != "x86_64" ] && [ "$arch" != "arm64" ] && { echo -e "${RED}[!] Unsupported macOS architecture: $arch (Supported: x86_64, arm64)${NC}"; exit 1; }
             echo "macos" ;;
+        MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
         *) echo "unknown"; exit 1 ;;
     esac
 }
 
 PLATFORM=$(detect_platform)
+if [ "$PLATFORM" = "windows" ]; then
+    echo -e "${YELLOW}[!] Windows shell detected.${NC}"
+    echo -e "${YELLOW}    Use the native Windows installer instead:${NC}"
+    echo -e "${CYAN}    https://github.com/Scottcjn/Rustchain/blob/main/miners/windows/README.md${NC}"
+    echo -e "${CYAN}    or run miners/windows/rustchain_miner_setup.bat${NC}"
+    exit 1
+fi
 echo -e "${GREEN}[+] Platform: $PLATFORM ($(uname -m))${NC}"
 
 # Python Auto-Install


### PR DESCRIPTION
Fixes #6157

## Proposed Changes
- add explicit Windows shell detection in `install-miner.sh` (`MINGW/MSYS/CYGWIN`)
- fail fast on Windows with actionable guidance to the native Windows installer path
- update `docs/QUICKSTART.md` Step 1 with a native PowerShell install flow
- clarify README quickstart text: Bash installer is for Linux/macOS/WSL/Git Bash

## Proof
- `bash -n install-miner.sh` passes
- docs now include a dedicated Windows command path (`rustchain_miner_setup.bat`)

## Checklist
- [x] PR targets `main`
- [x] Focused change set
- [x] Docs updated where mismatch occurred

/claim #6157