### PR TITLE
fix(attest): return 400 for non-string signature/public_key values (#5697)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3651,11 +3651,32 @@ def _submit_attestation_impl():
 
     # SECURITY: Verify Ed25519 signature on attestation report if present.
     # The rustchain-miner signs (miner_id|wallet|nonce|commitment) and includes
-    # signature + public_key at the top level.  If both fields are present we
+    # signature + public_key at the top level. If both fields are present we
     # MUST verify — this prevents an MITM from changing the miner (wallet) field
     # in transit and claiming another miner's hardware rewards (wallet hijack).
-    sig_hex = (data.get('signature') or '').strip().lower()
-    pubkey_hex = (data.get('public_key') or '').strip().lower()
+
+    # FIX #5697: Validate that signature and public_key are strings before
+    # calling .strip().lower(). Non-string values (e.g. int, list, bool) used
+    # to crash with AttributeError → 500. Now they return 400 with a clear code.
+    raw_sig = data.get('signature')
+    raw_pubkey = data.get('public_key')
+    if raw_sig is not None and not isinstance(raw_sig, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_signature_type",
+            "message": "signature must be a string if provided",
+            "code": "INVALID_SIGNATURE_TYPE",
+        }), 400
+    if raw_pubkey is not None and not isinstance(raw_pubkey, str):
+        return jsonify({
+            "ok": False,
+            "error": "invalid_public_key_type",
+            "message": "public_key must be a string if provided",
+            "code": "INVALID_PUBLIC_KEY_TYPE",
+        }), 400
+
+    sig_hex = (raw_sig or '').strip().lower()
+    pubkey_hex = (raw_pubkey or '').strip().lower()
     miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
     if sig_hex and pubkey_hex:


### PR DESCRIPTION
## Summary
Fixes #5697 — `/attest/submit` returns 500 (Internal Error) when `signature` or `public_key` fields contain non-string values (e.g. `int`, `list`, `bool`).

## Bug
The endpoint reads `data.get("signature")` and `data.get("public_key")`, then immediately calls `.strip().lower()` on them. If the value is non-string (e.g. `12345` or `["not", "a", "key"]`), this throws `AttributeError`, which the outer `try/except` catches and returns as a generic 500.

## Fix
Added explicit type validation before string operations:
- Return `400 INVALID_SIGNATURE_TYPE` if `signature` is non-string
- Return `400 INVALID_PUBLIC_KEY_TYPE` if `public_key` is non-string
- `None` values (field absent) still pass through to the existing empty-string path for backward compatibility

## Testing
This fix makes the existing tests pass:
- `test_non_string_signature_rejected_before_handler_crash` (line 250)
- `test_non_string_public_key_rejected_before_handler_crash` (line 265)

## Proof
```
# Before: POST /attest/submit with signature=12345 → 500 Internal Error
# After: POST /attest/submit with signature=12345 → 400 INVALID_SIGNATURE_TYPE
```

wallet: RTC9ab88c2c06a3fd1c6009a81050040d459abed0dd
bounty: #6231