### PR TITLE
docs: make QUICKSTART FAQ link explicit

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -415,7 +415,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 - **GitHub Issues:** https://github.com/Scottcjn/Rustchain/issues
 - **Discord:** https://discord.gg/VqVVS2CW9Q
 - **Moltbook:** https://www.moltbook.com/m/rustchain
-- **FAQ:** [FAQ_TROUBLESHOOTING.md](FAQ_TROUBLESHOOTING.md)
+- **FAQ:** [FAQ_TROUBLESHOOTING.md](./FAQ_TROUBLESHOOTING.md)
 
 ---
 


### PR DESCRIPTION
Refs #5715

Small docs-only fix: make the QUICKSTART FAQ link explicit with `./FAQ_TROUBLESHOOTING.md`.

This keeps the rendered link unambiguous for GitHub/docs tooling.