### PR TITLE
fix(bridge): enforce RTC hex+40 format and Solana base58 validation (#6193, #6195)

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -21,6 +21,7 @@ import hashlib
 import logging
 import os
 import math
+import re
 from typing import Optional, Tuple, Dict, Any
 from decimal import Decimal
 from dataclasses import dataclass
@@ -228,15 +229,15 @@ def validate_chain_address_format(chain: str, address: str) -> Tuple[bool, str]:
         return False, "Address is required"
     
     if chain == "rustchain":
-        if not address.startswith("RTC"):
-            return False, "RustChain addresses must start with 'RTC'"
-        if len(address) < 10:
-            return False, "RustChain address too short"
+        if not re.match(r"^RTC[0-9a-fA-F]{40}$", address):
+            return False, "RustChain address must be RTC + 40 hex characters"
     
     elif chain == "solana":
         # Solana addresses are base58, 32-44 chars
         if len(address) < 32 or len(address) > 44:
             return False, "Invalid Solana address length"
+        if not all(c in "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz" for c in address):
+            return False, "Invalid Solana address: contains non-base58 characters"
     
     elif chain == "ergo":
         # Ergo addresses start with '9' or '3'

--- a/node/test_bridge_address_validation_6193_6195.py
+++ b/node/test_bridge_address_validation_6193_6195.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for Issue #6193: Bridge Solana address validation accepts arbitrary
+addresses without base58 check.
+
+Also covers Issue #6195: Bridge RTC address validation inconsistent with faucet.
+
+Tests import and exercise the REAL validate_chain_address_format from
+node/bridge_api.py — no local mirrors.
+
+Run: python -m pytest node/test_bridge_address_validation_6193_6195.py -v
+"""
+
+import pytest
+import sys
+import os
+
+# Ensure the node directory is on the path
+sys.path.insert(0, os.path.dirname(__file__))
+
+from bridge_api import validate_chain_address_format
+
+
+# =============================================================================
+# Issue #6195: RTC address validation (must match faucet format RTC + 40 hex)
+# =============================================================================
+
+class TestRTCAddressValidation:
+    """Issue #6195: RTC address must match faucet format RTC[0-9a-fA-F]{40}."""
+
+    def test_valid_rtc_address_lowercase(self):
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "a" * 40)
+        assert ok is True
+
+    def test_valid_rtc_address_uppercase(self):
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "A" * 40)
+        assert ok is True
+
+    def test_valid_rtc_address_mixed_case(self):
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "aAbB" * 10)
+        assert ok is True
+
+    def test_valid_rtc_all_digits(self):
+        """0-9 are valid hex digits."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "0" * 40)
+        assert ok is True
+
+    def test_rejects_non_hex_characters(self):
+        """RTC addresses with non-hex characters like 'Z' must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "Z" * 40)
+        assert ok is False
+        assert "40 hex" in msg
+
+    def test_rejects_special_characters(self):
+        """RTC addresses with special characters must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC!@#$%^&*()_+12345")
+        assert ok is False
+
+    def test_rejects_too_short(self):
+        """RTC addresses with fewer than 40 hex chars after prefix must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTCabc")
+        assert ok is False
+
+    def test_rejects_39_hex_chars(self):
+        """One character short of 40 hex chars must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "a" * 39)
+        assert ok is False
+
+    def test_rejects_41_hex_chars(self):
+        """One character over 40 hex chars must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "a" * 41)
+        assert ok is False
+
+    def test_rejects_missing_rtc_prefix(self):
+        """Addresses without RTC prefix must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "a" * 43)
+        assert ok is False
+
+    def test_rejects_empty_address(self):
+        """Empty address must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "")
+        assert ok is False
+        assert "required" in msg.lower()
+
+    def test_rejects_rtc_only(self):
+        """Just 'RTC' with no hex chars must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC")
+        assert ok is False
+
+    def test_rejects_spaces_in_hex(self):
+        """Spaces in the hex portion must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "RTC" + "a" * 20 + " " + "b" * 19)
+        assert ok is False
+
+    def test_rejects_lowercase_rtc_prefix(self):
+        """Lowercase 'rtc' prefix must be rejected."""
+        ok, msg = validate_chain_address_format("rustchain", "rtc" + "a" * 40)
+        assert ok is False
+
+
+# =============================================================================
+# Issue #6193: Solana base58 validation
+# =============================================================================
+
+class TestSolanaAddressBase58Validation:
+    """Issue #6193: Solana addresses must contain only base58 characters."""
+
+    def test_valid_solana_address(self):
+        ok, msg = validate_chain_address_format("solana", "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU")
+        assert ok is True
+
+    def test_rejects_zero_character(self):
+        """0 is not in the base58 alphabet and must be rejected."""
+        ok, msg = validate_chain_address_format("solana", "0" * 32)
+        assert ok is False
+        assert "base58" in msg.lower()
+
+    def test_rejects_uppercase_I(self):
+        """I is not in the base58 alphabet and must be rejected."""
+        ok, msg = validate_chain_address_format("solana", "I" * 32)
+        assert ok is False
+        assert "base58" in msg.lower()
+
+    def test_rejects_uppercase_O(self):
+        """O is not in the base58 alphabet and must be rejected."""
+        ok, msg = validate_chain_address_format("solana", "O" * 32)
+        assert ok is False
+
+    def test_rejects_lowercase_l(self):
+        """l (lowercase L) is not in the base58 alphabet and must be rejected."""
+        ok, msg = validate_chain_address_format("solana", "l" * 32)
+        assert ok is False
+
+    def test_rejects_spaces(self):
+        """Spaces are not in the base58 alphabet."""
+        ok, msg = validate_chain_address_format("solana", "7xKXtg2CW87d97TXJSDpbD5jBk heTqA83TZRuJosgAs")
+        assert ok is False
+
+    def test_rejects_special_characters(self):
+        """Special characters are not in the base58 alphabet."""
+        ok, msg = validate_chain_address_format("solana", "!" * 32)
+        assert ok is False
+
+    def test_rejects_0x_prefix(self):
+        """0x prefix (Ethereum-style) is not valid base58 for Solana."""
+        ok, msg = validate_chain_address_format("solana", "0x" + "1" * 40)
+        assert ok is False
+
+    def test_valid_all_ones(self):
+        """All 1s is technically valid base58 (though suspicious)."""
+        ok, msg = validate_chain_address_format("solana", "1" * 32)
+        assert ok is True
+
+    def test_too_short(self):
+        ok, msg = validate_chain_address_format("solana", "short")
+        assert ok is False
+        assert "length" in msg.lower()
+
+    def test_too_long(self):
+        ok, msg = validate_chain_address_format("solana", "1" * 45)
+        assert ok is False
+
+    def test_rejects_plus_sign(self):
+        """+ is not in base58."""
+        ok, msg = validate_chain_address_format("solana", "+" + "1" * 31)
+        assert ok is False
+
+    def test_rejects_slash(self):
+        """/ is not in base58."""
+        ok, msg = validate_chain_address_format("solana", "/" + "1" * 31)
+        assert ok is False
+
+
+# =============================================================================
+# Other chains (regression check)
+# =============================================================================
+
+class TestBaseAddressValidation:
+    """Regression: Base address validation still works."""
+
+    def test_valid_base_address(self):
+        ok, msg = validate_chain_address_format("base", "0x" + "a" * 40)
+        assert ok is True
+
+    def test_rejects_no_0x_prefix(self):
+        ok, msg = validate_chain_address_format("base", "a" * 40)
+        assert ok is False
+
+
+class TestErgoAddressValidation:
+    """Regression: Ergo address validation still works."""
+
+    def test_valid_ergo_9_prefix(self):
+        ok, msg = validate_chain_address_format("ergo", "9" + "a" * 40)
+        assert ok is True
+
+    def test_rejects_wrong_prefix(self):
+        ok, msg = validate_chain_address_format("ergo", "4" + "a" * 40)
+        assert ok is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_p2p_blocks.py
+++ b/tests/test_p2p_blocks.py
@@ -1,0 +1,1 @@
+import pytest


### PR DESCRIPTION
## Summary

Consolidates and fixes both #6193 and #6195 in a single PR, addressing review feedback from MolhamHamwi on PRs #6223 and #6224.

### Changes to `node/bridge_api.py`
1. **RTC address validation** (#6195): Replaces the loose `startswith("RTC") + len < 10` check with a strict `re.match(r"^RTC[0-9a-fA-F]{40}$", address)` regex — now enforces the same format as the faucet.
2. **Solana base58 validation** (#6193): After the length check, validates that all characters belong to the base58 alphabet `123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`, rejecting invalid chars like `0`, `O`, `I`, `l`.
3. Added `import re` to the module imports.

### New test file `node/test_bridge_address_validation_6193_6195.py`
- **31 tests** covering RTC, Solana, Base, and Ergo address validation.
- Tests **import the real `validate_chain_address_format`** from `bridge_api.py` — no local mirrors. This addresses the review feedback that the previous PRs used test-local mirrors that could pass even while production code was broken.
- Covers: valid/invalid RTC formats, non-hex chars, short/long addresses, missing prefix, spaces, and Solana base58 edge cases (0, O, I, l, special chars, 0x prefix).

### Addresses review feedback
- **MolhamHamwi** on PR #6223: "the production bridge validator appears to have an indentation regression" and "tests can pass even while the production function has the indentation/syntax regression"
- **MolhamHamwi** on PR #6224: "the tests currently define a local mirror of validate_chain_address_format instead of importing the production function"

This PR fixes both issues: production code has correct indentation (verified with `py_compile`), and tests import from the real module.

### Verification
```bash
python -m py_compile node/bridge_api.py  # passes
PYTHONPATH=node:. python -m pytest node/test_bridge_address_validation_6193_6195.py -v  # 31 passed
```

Fixes #6193, Fixes #6195
Supersedes #6223 and #6224