### PR TITLE
fix(faucet): enforce strict 0x+40 hex and RTC wallet validation (#6136)

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -175,10 +175,17 @@ def try_record_drip(wallet, ip_address, amount):
 
 
 def is_valid_wallet_address(wallet):
-    """Accept legacy Ethereum-style wallets and native RTC wallets."""
-    return (wallet.startswith('0x') and len(wallet) >= 10) or bool(
-        RTC_WALLET_RE.fullmatch(wallet)
-    )
+    """Accept legacy Ethereum-style wallets and native RTC wallets.
+
+    For 0x-prefixed addresses, enforces exactly 42 chars (0x + 40 hex),
+    matching standard Ethereum address format.
+    For RTC addresses, enforces RTC + exactly 40 hex chars.
+    """
+    if wallet.startswith('0x'):
+        if len(wallet) != 42:
+            return False
+        return all(c in '0123456789abcdefABCDEF' for c in wallet[2:])
+    return bool(RTC_WALLET_RE.fullmatch(wallet))
 
 
 # HTML Template

--- a/test_faucet_wallet_validation_6136.py
+++ b/test_faucet_wallet_validation_6136.py
@@ -1,0 +1,95 @@
+"""
+Unit tests for Issue #6136: Faucet wallet validation accepts arbitrary
+0x-prefixed strings (10+ chars) — allows bypass of RTC wallet format.
+
+Tests import the real is_valid_wallet_address from faucet.py.
+
+Run: python -m pytest test_faucet_wallet_validation_6136.py -v
+"""
+
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from faucet import is_valid_wallet_address
+
+
+class TestRTCWalletValidation:
+    """RTC wallet addresses must match RTC[0-9a-fA-F]{40}."""
+
+    def test_valid_rtc_wallet(self):
+        assert is_valid_wallet_address("RTC" + "a" * 40) is True
+
+    def test_valid_rtc_uppercase(self):
+        assert is_valid_wallet_address("RTC" + "A" * 40) is True
+
+    def test_valid_rtc_mixed_case(self):
+        assert is_valid_wallet_address("RTC" + "aAbB" * 10) is True
+
+    def test_rejects_non_hex_chars(self):
+        assert is_valid_wallet_address("RTC" + "Z" * 40) is False
+
+    def test_rejects_too_short(self):
+        assert is_valid_wallet_address("RTC" + "a" * 39) is False
+
+    def test_rejects_too_long(self):
+        assert is_valid_wallet_address("RTC" + "a" * 41) is False
+
+    def test_rejects_no_rtc_prefix(self):
+        assert is_valid_wallet_address("a" * 43) is False
+
+    def test_rejects_rtc_only(self):
+        assert is_valid_wallet_address("RTC") is False
+
+
+class TestEthereumStyleWalletValidation:
+    """0x-prefixed addresses must be exactly 42 chars (0x + 40 hex)."""
+
+    def test_valid_ethereum_address(self):
+        assert is_valid_wallet_address("0x" + "a" * 40) is True
+
+    def test_valid_ethereum_uppercase(self):
+        assert is_valid_wallet_address("0x" + "A" * 40) is True
+
+    def test_rejects_short_0x_prefix(self):
+        """0x + 8 chars (10 total) must be rejected — issue #6136."""
+        assert is_valid_wallet_address("0x" + "1" * 8) is False
+
+    def test_rejects_short_0x_uppercase(self):
+        """0xAAAAAAAAAA (10 chars) must be rejected — issue #6136."""
+        assert is_valid_wallet_address("0xAAAAAAAAAA") is False
+
+    def test_rejects_0x_non_hex_chars(self):
+        """0x + non-hex chars must be rejected."""
+        assert is_valid_wallet_address("0x" + "g" * 40) is False
+
+    def test_rejects_short_0x_non_hex(self):
+        """Short 0x with non-hex chars must be rejected."""
+        assert is_valid_wallet_address("0x" + "g" * 8) is False
+
+    def test_rejects_0x_41_hex(self):
+        """0x + 41 hex chars (43 total) must be rejected."""
+        assert is_valid_wallet_address("0x" + "a" * 41) is False
+
+    def test_rejects_0x_39_hex(self):
+        """0x + 39 hex chars (41 total) must be rejected."""
+        assert is_valid_wallet_address("0x" + "a" * 39) is False
+
+
+class TestInvalidWalletFormats:
+    """Other invalid wallet formats."""
+
+    def test_rejects_plain_string(self):
+        assert is_valid_wallet_address("not_a_wallet") is False
+
+    def test_rejects_empty_string(self):
+        assert is_valid_wallet_address("") is False
+
+    def test_rejects_1x_prefix(self):
+        assert is_valid_wallet_address("1x" + "a" * 40) is False
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_p2p_blocks.py
+++ b/tests/test_p2p_blocks.py
@@ -1,0 +1,1 @@
+import pytest


### PR DESCRIPTION
## Summary

Fixes the faucet wallet validation bypass described in #6136.

### Problem
The `is_valid_wallet_address()` function in `faucet.py` accepted **any** `0x`-prefixed string that was 10+ characters long, without verifying:
1. That the string was exactly 42 characters (0x + 40 hex) — standard Ethereum format
2. That the characters after `0x` were valid hex digits

This allowed strings like `0x12345`, `0xAAAAAAAAAA`, and `0x` + non-hex chars to pass validation, enabling rate-limit bypass by rotating arbitrary `0x`-prefixed strings.

### Fix
Updated `is_valid_wallet_address()` to:
1. For `0x`-prefixed addresses: enforce exactly 42 characters and validate all post-prefix characters are valid hex (`0-9a-fA-F`)
2. For RTC addresses: unchanged — already strict via `RTC_WALLET_RE` regex

### Test Coverage
19 tests in `test_faucet_wallet_validation_6136.py` covering:
- Valid RTC wallets (lowercase, uppercase, mixed)
- Invalid RTC wallets (non-hex chars, wrong length, no prefix)
- Valid Ethereum-style wallets (0x + 40 hex)
- Invalid 0x wallets that previously passed: short strings, non-hex chars
- Other invalid formats

### Verification
```bash
python -m py_compile faucet.py  # passes
python -m pytest test_faucet_wallet_validation_6136.py -v  # 19 passed
```

Fixes #6136