### PR TITLE
fix(gpu): remove pricing history writes from read-only get_fair_market_rates (#6200)

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -431,18 +431,35 @@ class GPURenderProtocol:
                                 "RTC/1k_chars" if jt == "tts" else "RTC/1k_tokens",
                     }
 
-                    # Record to pricing history
-                    conn.execute(
-                        """INSERT INTO pricing_history
-                           (job_type, device_arch, avg_price, min_price,
-                            max_price, sample_count, recorded_at)
-                           VALUES (?,?,?,?,?,?,?)""",
-                        (jt, "all", rates[jt]["avg"], rates[jt]["min"],
-                         rates[jt]["max"], len(prices), int(time.time())),
-                    )
-
-            conn.commit()
+            # Pricing history recording removed from read path (issue #6200):
+            # GET /render/pricing should not cause persistent SQLite writes.
+            # Use record_pricing_sample() for intentional writes.
             return {"rates": rates, "timestamp": int(time.time())}
+        finally:
+            conn.close()
+
+    def record_pricing_sample(self, job_type: str, rates: dict) -> dict:
+        """Explicitly record a pricing sample to history.
+
+        This should only be called from write paths (e.g., after a job is
+        created or a node attests), not from read-only pricing queries.
+        Moved from get_fair_market_rates per issue #6200.
+        """
+        if job_type not in rates:
+            return {"error": f"No rate data for {job_type}"}
+        conn = self._get_conn()
+        try:
+            r = rates[job_type]
+            conn.execute(
+                """INSERT INTO pricing_history
+                (job_type, device_arch, avg_price, min_price,
+                max_price, sample_count, recorded_at)
+                VALUES (?,?,?,?,?,?,?)""",
+                (job_type, "all", r["avg"], r["min"],
+                r["max"], r["providers"], int(time.time())),
+            )
+            conn.commit()
+            return {"ok": True, "job_type": job_type}
         finally:
             conn.close()
 

--- a/node/test_gpu_pricing_read_no_write_6200.py
+++ b/node/test_gpu_pricing_read_no_write_6200.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for Issue #6200: GPU pricing reads should not append persistent
+history rows.
+
+Verifies that:
+1. Repeated calls to get_fair_market_rates() do not insert rows into
+   pricing_history (the read path is now write-free).
+2. record_pricing_sample() explicitly writes to pricing_history when called
+   from write paths.
+
+Run: python -m pytest node/test_gpu_pricing_read_no_write_6200.py -v
+"""
+
+import pytest
+import os
+import sqlite3
+import tempfile
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from gpu_render_protocol import GPURenderProtocol
+
+
+class TestGPUPricingReadNoWrite:
+    """Issue #6200: GET /render/pricing must not cause persistent writes."""
+
+    def setup_method(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.db_path = os.path.join(self.tmpdir, "gpu_test.db")
+        self.proto = GPURenderProtocol(db_path=self.db_path)
+        # Attest a GPU node so get_fair_market_rates has data
+        self.proto.attest_gpu("miner-1", {
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "price_render_minute": 0.5,
+        })
+
+    def _count_pricing_history(self):
+        with sqlite3.connect(self.db_path) as conn:
+            return conn.execute("SELECT COUNT(*) FROM pricing_history").fetchone()[0]
+
+    def test_single_read_no_history_rows(self):
+        """A single pricing read should not add any pricing_history rows."""
+        self.proto.get_fair_market_rates("render")
+        assert self._count_pricing_history() == 0
+
+    def test_repeated_reads_no_history_growth(self):
+        """Repeated pricing reads should not grow pricing_history."""
+        for _ in range(5):
+            self.proto.get_fair_market_rates("render")
+        assert self._count_pricing_history() == 0
+
+    def test_all_job_types_read_no_history(self):
+        """Reading all job types at once should not write history."""
+        self.proto.get_fair_market_rates()
+        assert self._count_pricing_history() == 0
+
+    def test_record_pricing_sample_writes(self):
+        """Explicit record_pricing_sample should write to pricing_history."""
+        rates = self.proto.get_fair_market_rates("render")
+        assert "rates" in rates
+        result = self.proto.record_pricing_sample("render", rates["rates"])
+        assert result["ok"] is True
+        assert self._count_pricing_history() == 1
+
+    def test_record_pricing_sample_repeated(self):
+        """Multiple explicit recordings should grow history."""
+        rates = self.proto.get_fair_market_rates("render")
+        for _ in range(3):
+            self.proto.record_pricing_sample("render", rates["rates"])
+        assert self._count_pricing_history() == 3
+
+    def test_record_pricing_sample_invalid_job_type(self):
+        """Recording with invalid job_type should return error."""
+        result = self.proto.record_pricing_sample("invalid_type", {})
+        assert "error" in result
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_p2p_blocks.py
+++ b/tests/test_p2p_blocks.py
@@ -1,0 +1,1 @@
+import pytest


### PR DESCRIPTION
## Summary

Fixes the GPU pricing write amplification vulnerability described in #6200.

### Problem
`get_fair_market_rates()` — the function backing `GET /render/pricing` — appended a row to `pricing_history` on every invocation when active GPU nodes had nonzero prices. This turned a read endpoint into a write-amplification/storage-growth path. An unauthenticated caller could repeatedly grow the SQLite/WAL files just by requesting current rates.

### Fix
1. **Removed** the `INSERT INTO pricing_history` and `conn.commit()` from `get_fair_market_rates()` — the read path is now write-free.
2. **Added** `record_pricing_sample(job_type, rates)` — an explicit method for writing pricing history, intended to be called only from write paths (e.g., after job creation or node attestation).

### Test Coverage
6 tests in `node/test_gpu_pricing_read_no_write_6200.py`:
- Single read causes 0 history rows
- Repeated reads cause 0 history rows
- All-job-types read causes 0 history rows
- Explicit `record_pricing_sample` writes correctly
- Repeated explicit recordings grow history
- Invalid job_type returns error

### Verification
```bash
python -m py_compile node/gpu_render_protocol.py  # passes
PYTHONPATH=node:. python -m pytest node/test_gpu_pricing_read_no_write_6200.py -v  # 6 passed
```

Fixes #6200