### PR TITLE
fix: replace print() with logging in BCOS anchor action

### DIFF
--- a/.github/actions/bcos-action/anchor.py
+++ b/.github/actions/bcos-action/anchor.py
@@ -6,10 +6,13 @@ Anchors the BCOS attestation to the RustChain blockchain.
 """
 
 import json
+import logging
 import os
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
 
 def main():
     """Anchor the BCOS attestation to RustChain."""
@@ -22,7 +25,7 @@ def main():
     merged_commit = os.environ.get("MERGED_COMMIT", "")
     
     if not all([cert_id, commitment, repo, pr_number, merged_commit]):
-        print("⚠️ Missing required environment variables. Skipping anchor.")
+        logger.warning("⚠️ Missing required environment variables. Skipping anchor.")
         return
     
     # Build attestation payload
@@ -51,16 +54,16 @@ def main():
     try:
         response = urlopen(req)
         result = json.loads(response.read().decode('utf-8'))
-        print(f"✅ Attestation anchored successfully!")
-        print(f"Transaction: {result.get('tx_hash', 'N/A')}")
-        print(f"Block: {result.get('block_number', 'N/A')}")
+        logger.info("✅ Attestation anchored successfully!")
+        logger.info("Transaction: %s", result.get('tx_hash', 'N/A'))
+        logger.info("Block: %s", result.get('block_number', 'N/A'))
     except HTTPError as e:
         error_body = e.read().decode() if e.fp else ""
-        print(f"⚠️ Failed to anchor: {e.code}")
+        logger.warning("⚠️ Failed to anchor: %s", e.code)
         if error_body:
-            print(f"Response: {error_body}")
+            logger.warning("Response: %s", error_body)
     except Exception as e:
-        print(f"⚠️ Anchor skipped (node may be unavailable): {e}")
+        logger.warning("⚠️ Anchor skipped (node may be unavailable): %s", e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace `print()` usage in `.github/actions/bcos-action/anchor.py` with `logging`
- add lightweight logger setup and keep existing message content
- switch success/failure output to `logger.info` / `logger.warning`

## Validation
- `python3 -m py_compile .github/actions/bcos-action/anchor.py`

Closes #6229