### PR TITLE
Bounty: Input validation gaps (A6, A9-A11)

### DIFF
--- a/node/test_utxo_a9_a10_a11_poc.py
+++ b/node/test_utxo_a9_a10_a11_poc.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MIT
+"""
+Batch PoC: A9 (address_to_proposition no validation), A10 (hex decode error handling),
+A11 (_normalize_outputs no MAX_OUTPUTS_BYTES)
+
+A9: address_to_proposition on L106 accepts ANY string — empty, 10MB, null bytes
+A10: proposition_to_address on L112 crashes on odd-length/invalid hex via bytes.fromhex()
+A11: _normalize_outputs has no MAX_OUTPUTS_BYTES check on tx_data_json serialization
+"""
+
+import sys
+import os
+import json
+
+sys.path.insert(0, os.path.dirname(__file__))
+from utxo_db import address_to_proposition, proposition_to_address, UtxoDB, P2PK_PREFIX
+
+
+# --- A9: address_to_proposition no address validation ---
+
+def test_a9_empty_address():
+    """Empty string accepted with no validation"""
+    result = address_to_proposition("")
+    prefix_hex = P2PK_PREFIX.hex()
+    assert result.startswith(prefix_hex), "Should at least have prefix"
+    print("[A9] Empty address → %s... (len=%d)" % (result[:20], len(result)))
+    return True
+
+
+def test_a9_10k_address():
+    """10KB address accepted with no length check"""
+    huge = "A" * 10000
+    result = address_to_proposition(huge)
+    print("[A9] 10KB address accepted → len=%d bytes" % len(result))
+    return True
+
+
+def test_a9_null_bytes():
+    """Null bytes in address accepted"""
+    result = address_to_proposition("valid\x00address")
+    print("[A9] Address with null byte accepted: %s..." % result[:30])
+    return True
+
+
+# --- A10: proposition_to_address no hex decode error handling ---
+
+def test_a10_odd_length():
+    """Odd-length hex raises ValueError — no graceful handling"""
+    try:
+        result = proposition_to_address("aabbc")  # 5 chars, odd
+        print("[A10] Odd-length hex accepted: %s (BUG: should fail)" % result)
+        return False
+    except ValueError as e:
+        print("[A10] Odd-length hex raises ValueError: %s (graceful? NO — unhandled)" % e)
+        return True
+
+
+def test_a10_invalid_hex():
+    """Invalid hex chars raise ValueError — caller must catch"""
+    try:
+        result = proposition_to_address("zzzzz")
+        print("[A10] Invalid hex accepted: %s (BUG)" % result)
+        return False
+    except ValueError as e:
+        print("[A10] Invalid hex raises ValueError: %s" % e)
+        return True
+
+
+# --- A11: _normalize_outputs no MAX_OUTPUTS_BYTES check ---
+
+def test_a11_unbounded_output_size():
+    """_normalize_outputs accepts oversized tx_data_json"""
+    # Build an output with huge tokens_json — must go through apply_transaction path
+    # which calls _normalize_outputs. Direct access via UtxoDB test.
+    db_path = "/tmp/test_a11_outputs.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    db = UtxoDB(db_path)
+    db.init_tables()
+
+    # Create setup boxes
+    from utxo_db import UNIT
+    db.add_box(dict(
+        box_id="big_output_source", value_nrtc=100 * UNIT,
+        proposition="b0b", owner_address="alice",
+        creation_height=1, transaction_id="tx_genesis", output_index=0,
+    ))
+
+    # Create output with ~100KB tokens_json (way over any reasonable limit)
+    huge_tokens = json.dumps({"data": "X" * 100_000})
+    huge_outputs = [dict(
+        address="bob", value_nrtc=50 * UNIT,
+        tokens_json=huge_tokens
+    )]
+
+    try:
+        applied = db.apply_transaction(dict(
+            tx_id="big_output_tx",
+            tx_type="transfer",
+            inputs=[{"box_id": "big_output_source", "spending_proof": "sig"}],
+            outputs=huge_outputs,
+            fee_nrtc=0,
+            timestamp=1000,
+        ), block_height=200)
+        if applied:
+            print("[A11] Output with ~100KB tokens_json ACCEPTED — no MAX_OUTPUTS_BYTES check")
+        else:
+            print("[A11] Output rejected by other validation")
+    except Exception as e:
+        print("[A11] Exception: %s: %s" % (type(e).__name__, e))
+
+    os.remove(db_path)
+    return True
+
+
+def test_a11_oversized_register():
+    """registers_json with ~50KB content accepted"""
+    db_path = "/tmp/test_a11_register.db"
+    if os.path.exists(db_path):
+        os.remove(db_path)
+    db = UtxoDB(db_path)
+    db.init_tables()
+    from utxo_db import UNIT
+    db.add_box(dict(
+        box_id="big_reg_source", value_nrtc=100 * UNIT,
+        proposition="b0b", owner_address="alice",
+        creation_height=1, transaction_id="tx_gen2", output_index=0,
+    ))
+
+    huge_register = json.dumps({"R4": "X" * 50000})
+    try:
+        applied = db.apply_transaction(dict(
+            tx_id="big_reg_tx",
+            tx_type="transfer",
+            inputs=[{"box_id": "big_reg_source", "spending_proof": "sig"}],
+            outputs=[dict(address="bob", value_nrtc=50 * UNIT, registers_json=huge_register)],
+            fee_nrtc=0,
+            timestamp=1000,
+        ), block_height=200)
+        if applied:
+            print("[A11] Output with 50KB registers_json ACCEPTED — no size check")
+        else:
+            print("[A11] Output rejected")
+    except Exception as e:
+        print("[A11] Exception: %s: %s" % (type(e).__name__, e))
+
+    os.remove(db_path)
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        ("A9 empty address", test_a9_empty_address),
+        ("A9 10KB address", test_a9_10k_address),
+        ("A9 null bytes", test_a9_null_bytes),
+        ("A10 odd-length hex", test_a10_odd_length),
+        ("A10 invalid hex", test_a10_invalid_hex),
+        ("A11 unbounded output size", test_a11_unbounded_output_size),
+        ("A11 oversized register", test_a11_oversized_register),
+    ]
+    results = []
+    for name, fn in tests:
+        try:
+            ok = fn()
+            results.append((name, "PASS" if ok else "FAIL"))
+        except Exception as e:
+            results.append((name, "EXCEPTION: %s" % e))
+
+    print("\n=== RESULTS ===")
+    for name, status in results:
+        print("  %s\t%s" % (status, name))
+    all_pass = all(s == "PASS" for _, s in results)
+    print("\nOVERALL: %s" % ("ALL PASS" if all_pass else "SOME FAILED"))

--- a/node/test_utxo_a9_a10_a11_poc.py
+++ b/node/test_utxo_a9_a10_a11_poc.py
@@ -11,6 +11,7 @@ A11: _normalize_outputs has no MAX_OUTPUTS_BYTES check on tx_data_json serializa
 import sys
 import os
 import json
+import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from utxo_db import address_to_proposition, proposition_to_address, UtxoDB, P2PK_PREFIX
@@ -24,7 +25,6 @@ def test_a9_empty_address():
     prefix_hex = P2PK_PREFIX.hex()
     assert result.startswith(prefix_hex), "Should at least have prefix"
     print("[A9] Empty address → %s... (len=%d)" % (result[:20], len(result)))
-    return True
 
 
 def test_a9_10k_address():
@@ -32,14 +32,12 @@ def test_a9_10k_address():
     huge = "A" * 10000
     result = address_to_proposition(huge)
     print("[A9] 10KB address accepted → len=%d bytes" % len(result))
-    return True
 
 
 def test_a9_null_bytes():
     """Null bytes in address accepted"""
     result = address_to_proposition("valid\x00address")
     print("[A9] Address with null byte accepted: %s..." % result[:30])
-    return True
 
 
 # --- A10: proposition_to_address no hex decode error handling ---
@@ -48,22 +46,18 @@ def test_a10_odd_length():
     """Odd-length hex raises ValueError — no graceful handling"""
     try:
         result = proposition_to_address("aabbc")  # 5 chars, odd
-        print("[A10] Odd-length hex accepted: %s (BUG: should fail)" % result)
-        return False
+        pytest.fail("Odd-length hex accepted: %s (BUG: should fail)" % result)
     except ValueError as e:
         print("[A10] Odd-length hex raises ValueError: %s (graceful? NO — unhandled)" % e)
-        return True
 
 
 def test_a10_invalid_hex():
     """Invalid hex chars raise ValueError — caller must catch"""
     try:
         result = proposition_to_address("zzzzz")
-        print("[A10] Invalid hex accepted: %s (BUG)" % result)
-        return False
+        pytest.fail("Invalid hex accepted: %s (BUG)" % result)
     except ValueError as e:
         print("[A10] Invalid hex raises ValueError: %s" % e)
-        return True
 
 
 # --- A11: _normalize_outputs no MAX_OUTPUTS_BYTES check ---
@@ -78,7 +72,6 @@ def test_a11_unbounded_output_size():
     db = UtxoDB(db_path)
     db.init_tables()
 
-    # Create setup boxes
     from utxo_db import UNIT
     db.add_box(dict(
         box_id="big_output_source", value_nrtc=100 * UNIT,
@@ -110,7 +103,6 @@ def test_a11_unbounded_output_size():
         print("[A11] Exception: %s: %s" % (type(e).__name__, e))
 
     os.remove(db_path)
-    return True
 
 
 def test_a11_oversized_register():
@@ -145,7 +137,6 @@ def test_a11_oversized_register():
         print("[A11] Exception: %s: %s" % (type(e).__name__, e))
 
     os.remove(db_path)
-    return True
 
 
 if __name__ == "__main__":
@@ -161,8 +152,8 @@ if __name__ == "__main__":
     results = []
     for name, fn in tests:
         try:
-            ok = fn()
-            results.append((name, "PASS" if ok else "FAIL"))
+            fn()
+            results.append((name, "PASS"))
         except Exception as e:
             results.append((name, "EXCEPTION: %s" % e))
 

--- a/node/test_utxo_add_box_conflict_poc.py
+++ b/node/test_utxo_add_box_conflict_poc.py
@@ -16,6 +16,7 @@ This should use INSERT OR IGNORE (or catch IntegrityError for logging).
 import sys
 import os
 import sqlite3
+import pytest
 
 sys.path.insert(0, os.path.dirname(__file__))
 from utxo_db import UtxoDB, UNIT
@@ -56,8 +57,7 @@ def test_add_box_duplicate_own_conn_raises():
     # Second insert with same box_id — should raise IntegrityError
     try:
         db.add_box(box)
-        print("[BUG] Duplicate add_box ACCEPTED — should have raised IntegrityError")
-        return False
+        pytest.fail("Duplicate add_box ACCEPTED — should have raised IntegrityError")
     except sqlite3.IntegrityError:
         print("[OK] Duplicate add_box raised IntegrityError as expected")
     except Exception as e:
@@ -69,8 +69,6 @@ def test_add_box_duplicate_own_conn_raises():
     conn.close()
     assert count == 1, "Expected 1 box, got %d" % count
     print("[OK] Exactly 1 box in DB (count=%d)" % count)
-
-    return True
 
 
 def test_add_box_batch_crash():
@@ -97,7 +95,7 @@ def test_add_box_batch_crash():
             ), conn=conn)
             print("[BUG] Duplicate in batch ACCEPTED — data integrity lost")
             conn.rollback()
-            return False
+            pytest.fail("Duplicate in batch ACCEPTED — data integrity lost")
         except sqlite3.IntegrityError:
             print("[OK] Duplicate in batch raised IntegrityError")
             # The batch transaction is now doomed — any further ops in this
@@ -108,8 +106,6 @@ def test_add_box_batch_crash():
         print("[OK] Batch rolled back cleanly")
     finally:
         conn.close()
-
-    return True
 
 
 def test_add_box_duplicate_cleanup_no_connection_leak():
@@ -143,10 +139,7 @@ def test_add_box_duplicate_cleanup_no_connection_leak():
         db.add_box(box2)
         print("[OK] Second add_box succeeded — no connection leak")
     except Exception as e:
-        print("[BUG] Connection leak: %s: %s" % (type(e).__name__, e))
-        return False
-
-    return True
+        pytest.fail("Connection leak: %s: %s" % (type(e).__name__, e))
 
 
 if __name__ == "__main__":
@@ -157,8 +150,8 @@ if __name__ == "__main__":
         ("test_add_box_duplicate_cleanup_no_connection_leak", test_add_box_duplicate_cleanup_no_connection_leak),
     ]:
         try:
-            ok = fn()
-            results.append((name, "PASS" if ok else "FAIL"))
+            fn()
+            results.append((name, "PASS"))
         except Exception as e:
             results.append((name, "EXCEPTION: %s" % e))
 

--- a/node/test_utxo_add_box_conflict_poc.py
+++ b/node/test_utxo_add_box_conflict_poc.py
@@ -1,0 +1,170 @@
+# SPDX-License-Identifier: MIT
+"""
+PoC: A6 — add_box() no PRIMARY KEY conflict handling
+
+add_box() (line 237) does a plain INSERT INTO utxo_boxes with no
+INSERT OR IGNORE / INSERT OR REPLACE / ON CONFLICT clause and no
+try/except around conn.execute().  If a box_id already exists:
+
+  - With external conn (batch mode): IntegrityError crashes entire batch
+  - With own conn: IntegrityError on execute() propagates unhandled,
+    connection close in finally only runs after the exception passes
+
+This should use INSERT OR IGNORE (or catch IntegrityError for logging).
+"""
+
+import sys
+import os
+import sqlite3
+
+sys.path.insert(0, os.path.dirname(__file__))
+from utxo_db import UtxoDB, UNIT
+
+DB_PATH = "/tmp/test_a6_conflict.db"
+
+
+def _reset_db():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+
+
+def _setup_db():
+    _reset_db()
+    db = UtxoDB(DB_PATH)
+    db.init_tables()
+    return db
+
+
+def test_add_box_duplicate_own_conn_raises():
+    """A6: add_box() with own conn raises unhandled IntegrityError on duplicate box_id"""
+    db = _setup_db()
+
+    box = dict(
+        box_id="duplicate_box_001",
+        value_nrtc=50 * UNIT,
+        proposition="b0b",
+        owner_address="alice",
+        creation_height=100,
+        transaction_id="tx_a",
+        output_index=0,
+    )
+
+    # First insert works fine
+    db.add_box(box)
+    print("[OK] First add_box succeeded")
+
+    # Second insert with same box_id — should raise IntegrityError
+    try:
+        db.add_box(box)
+        print("[BUG] Duplicate add_box ACCEPTED — should have raised IntegrityError")
+        return False
+    except sqlite3.IntegrityError:
+        print("[OK] Duplicate add_box raised IntegrityError as expected")
+    except Exception as e:
+        print("[INFO] Duplicate raised unexpected exception: %s: %s" % (type(e).__name__, e))
+
+    # Verify only one box exists
+    conn = sqlite3.connect(DB_PATH)
+    count = conn.execute("SELECT COUNT(*) FROM utxo_boxes").fetchone()[0]
+    conn.close()
+    assert count == 1, "Expected 1 box, got %d" % count
+    print("[OK] Exactly 1 box in DB (count=%d)" % count)
+
+    return True
+
+
+def test_add_box_batch_crash():
+    """A6: duplicate add_box crashes entire batch via external conn"""
+    db = _setup_db()
+    conn = db._conn()
+    try:
+        conn.execute("BEGIN IMMEDIATE")
+
+        # First box — works
+        db.add_box(dict(
+            box_id="batch_box_001", value_nrtc=10 * UNIT,
+            proposition="a", owner_address="alice",
+            creation_height=100, transaction_id="tx1", output_index=0,
+        ), conn=conn)
+        print("[OK] Batch first add_box succeeded")
+
+        # Second box with SAME box_id — should gracefully handle, NOT crash batch
+        try:
+            db.add_box(dict(
+                box_id="batch_box_001", value_nrtc=20 * UNIT,
+                proposition="b", owner_address="bob",
+                creation_height=100, transaction_id="tx1", output_index=1,
+            ), conn=conn)
+            print("[BUG] Duplicate in batch ACCEPTED — data integrity lost")
+            conn.rollback()
+            return False
+        except sqlite3.IntegrityError:
+            print("[OK] Duplicate in batch raised IntegrityError")
+            # The batch transaction is now doomed — any further ops in this
+            # transaction will fail with "cannot commit - no transaction is active"
+            # due to SQLite's automatic rollback on constraint violation.
+
+        conn.rollback()
+        print("[OK] Batch rolled back cleanly")
+    finally:
+        conn.close()
+
+    return True
+
+
+def test_add_box_duplicate_cleanup_no_connection_leak():
+    """Verify own_conn mode doesn't leak connections on IntegrityError"""
+    db = _setup_db()
+
+    box = dict(
+        box_id="leak_test_001",
+        value_nrtc=50 * UNIT,
+        proposition="a", owner_address="carol",
+        creation_height=100, transaction_id="tx_l", output_index=0,
+    )
+
+    # First insert
+    db.add_box(box)
+
+    # Second insert — should not crash and should close its own conn
+    try:
+        db.add_box(box)
+        print("[BUG] No error on duplicate (should at least warn)")
+    except sqlite3.IntegrityError:
+        print("[OK] IntegrityError raised and connection closed in finally")
+    except Exception as e:
+        print("[INFO] Unexpected: %s: %s" % (type(e).__name__, e))
+
+    # Verify no leak — try another add with unique box_id
+    box2 = dict(box_id="leak_test_002", value_nrtc=1 * UNIT,
+                 proposition="a", owner_address="carol",
+                 creation_height=100, transaction_id="tx_l2", output_index=1)
+    try:
+        db.add_box(box2)
+        print("[OK] Second add_box succeeded — no connection leak")
+    except Exception as e:
+        print("[BUG] Connection leak: %s: %s" % (type(e).__name__, e))
+        return False
+
+    return True
+
+
+if __name__ == "__main__":
+    results = []
+    for name, fn in [
+        ("test_add_box_duplicate_own_conn_raises", test_add_box_duplicate_own_conn_raises),
+        ("test_add_box_batch_crash", test_add_box_batch_crash),
+        ("test_add_box_duplicate_cleanup_no_connection_leak", test_add_box_duplicate_cleanup_no_connection_leak),
+    ]:
+        try:
+            ok = fn()
+            results.append((name, "PASS" if ok else "FAIL"))
+        except Exception as e:
+            results.append((name, "EXCEPTION: %s" % e))
+
+    print("\n=== RESULTS ===")
+    for name, status in results:
+        print("  %s\t%s" % (status, name))
+    all_pass = all(s == "PASS" for _, s in results)
+    print("\nOVERALL: %s" % ("ALL PASS" if all_pass else "SOME FAILED"))
+    sys.exit(0 if all_pass else 1)


### PR DESCRIPTION
## Summary

4 input validation gaps in UTXO helper functions.

### A6 — add_box() no PRIMARY KEY conflict handling
**File:** `node/utxo_db.py`, add_box() L237
**Severity:** MEDIUM
Plain INSERT with no ON CONFLICT clause. Duplicate box_id crashes entire batch transaction via IntegrityError.

### A9 — address_to_proposition no address validation
**File:** `node/utxo_db.py`, address_to_proposition() L106
**Severity:** LOW
Empty string, 10KB strings, null-bytes all accepted with zero validation.

### A10 — proposition_to_address crashes on invalid hex
**File:** `node/utxo_db.py`, proposition_to_address() L112
**Severity:** LOW
bytes.fromhex() raises unhandled ValueError on odd-length or invalid hex input.

### A11 — _normalize_outputs no MAX_OUTPUTS_BYTES check
**File:** `node/utxo_db.py`, _normalize_outputs()
**Severity:** LOW
No total serialized size bound on tx_data_json in normalized outputs.

PoC files: `node/test_utxo_add_box_conflict_poc.py`, `node/test_utxo_a9_a10_a11_poc.py`

BCOS-L2
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`