### PR TITLE
fix(utxo_db): add MAX_TX_DATA_JSON_BYTES limit to mempool_add serialization (A13)

### DIFF
--- a/node/test_utxo_tx_data_json_size_poc.py
+++ b/node/test_utxo_tx_data_json_size_poc.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+PoC: mempool_add tx_data_json unbounded size (A13)
+
+Bug: json.dumps(tx) at line 1013 serializes entire tx dict with NO size limit.
+Giant spending_proof strings pass through unvalidated, consuming unbounded
+disk/memory. With MAX_POOL_SIZE=10K, 1K giant txs = GBs storage.
+
+Fix: Add MAX_TX_DATA_JSON_BYTES limit before INSERT, or strip spending_proof
+from serialization (it's documented as unused by this layer).
+"""
+
+import unittest
+import tempfile
+import os
+import time
+
+from utxo_db import UtxoDB, UNIT
+
+
+class TestTxDataJsonUnbounded(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db = UtxoDB(self.tmp.name)
+        self.db.init_tables()
+        # Fund alice with coinbase (under MAX_COINBASE_OUTPUT_NRTC)
+        self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'alice', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def _get_box(self):
+        return self.db.get_unspent_for_address('alice')[0]['box_id']
+
+    def _make_tx(self, tx_id_hex, box_id, proof):
+        return {
+            'tx_id': tx_id_hex,
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box_id, 'spending_proof': proof}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 45 * UNIT}],
+            'fee_nrtc': 5 * UNIT,
+            'timestamp': int(time.time()),
+        }
+
+    def test_normal_tx_size(self):
+        """Baseline — normal tx admitted."""
+        box_id = self._get_box()
+        ok = self.db.mempool_add(self._make_tx('aa' * 32, box_id, 'sig'))
+        self.assertTrue(ok)
+
+    def test_giant_spending_proof_accepted(self):
+        """BUG: 100KB spending_proof accepted — no size limit."""
+        box_id = self._get_box()
+        proof = 'X' * 100_000
+        ok = self.db.mempool_add(self._make_tx('bb' * 32, box_id, proof))
+        self.assertTrue(ok, "100KB tx_data_json should pass (256KB limit)")
+
+    def test_extreme_proof_rejected(self):
+        """512KB spending_proof — now rejected with 256KB limit."""
+        box_id = self._get_box()
+        proof = 'Z' * 500_000  # 500KB spending_proof → tx ~500KB+ → rejected
+        ok = self.db.mempool_add(self._make_tx('dd' * 32, box_id, proof))
+        self.assertFalse(ok, "500KB tx_data_json should be rejected (256KB limit)")
+        print("  500KB tx: rejected ✓ — fix working")
+
+    def test_giant_proof_stored_size(self):
+        """Check actual stored size of giant proof tx_data_json."""
+        box_id = self._get_box()
+        proof = 'Y' * 50_000
+        ok = self.db.mempool_add(self._make_tx('cc' * 32, box_id, proof))
+        self.assertTrue(ok)
+
+        conn = self.db._conn()
+        row = conn.execute(
+            "SELECT LENGTH(tx_data_json) AS sz FROM utxo_mempool WHERE tx_id = ?",
+            ('cc' * 32,)
+        ).fetchone()
+        self.assertGreater(row['sz'], 50_000,
+            "Giant proof stored at full size")
+        print(f"  Stored tx_data_json: {row['sz']:,} bytes "
+              f"({row['sz']/1024:.1f} KB) — NO SIZE LIMIT")
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestTxDataJsonUnbounded)
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+
+    print("\n" + "=" * 70)
+    if result.wasSuccessful():
+        print("⚠️  Bug CONFIRMED: tx_data_json has NO size limit on serialization")
+        print("Giant spending_proof passes through, filling storage unboundedly")
+    print("=" * 70)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -47,6 +47,7 @@ MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
 MAX_MEMPOOL_TX_ID_BYTES = 128
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
+MAX_TX_DATA_JSON_BYTES = 262_144  # 256KB max serialized tx size
 MAX_SQLITE_INT64 = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
 SUPPORTED_TX_TYPES = {'transfer', 'mining_reward'}
@@ -992,13 +993,18 @@ class UtxoDB:
             # With IGNORE, a duplicate tx_id silently skips the insert but
             # execution continues to claim inputs — creating orphan entries
             # that lock UTXOs with no corresponding mempool transaction.
+            tx_data_json = json.dumps(tx)
+            if len(tx_data_json) > MAX_TX_DATA_JSON_BYTES:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
             cursor = conn.execute(
                 """INSERT OR ABORT INTO utxo_mempool
                    (tx_id, tx_data_json, fee_nrtc, submitted_at, expires_at)
                    VALUES (?,?,?,?,?)""",
                 (
                     tx_id,
-                    json.dumps(tx),
+                    tx_data_json,
                     tx.get('fee_nrtc', 0),
                     now,
                     now + MAX_TX_AGE_SECONDS,


### PR DESCRIPTION
## Description

Bug: `json.dumps(tx)` at line 1013 serializes the entire transaction dict with NO size limit. An attacker can include giant `spending_proof` strings (100KB+) or arbitrary extra fields, consuming unbounded disk/memory per mempool slot.

## Impact

Mempool DoS via storage exhaustion. With `MAX_POOL_SIZE=10K`, 1K giant txs = GBs of storage. Each giant tx also gets loaded back into memory on `mempool_get_block_candidates()`.

## Fix

Added `MAX_TX_DATA_JSON_BYTES = 262_144` (256KB) constant and a check before the INSERT. If `json.dumps(tx)` exceeds this limit, the transaction is rejected.

## Testing

- 4 new tests in `test_utxo_tx_data_json_size_poc.py`
- Normal tx (~1KB): passes ✓
- Medium tx (100KB spending_proof): passes ✓
- Giant tx (500KB spending_proof): rejected ✓
- Stored size check: validates actual DB row size
- 92 existing tests PASS + 14 subtests
- 0 regressions

## Severity

**BCOS-L2** — Medium. Storage DoS vector, requires crafted input.

## Files Changed

- `node/utxo_db.py` — add MAX_TX_DATA_JSON_BYTES + size check before INSERT
- `node/test_utxo_tx_data_json_size_poc.py` — PoC (SPDX: MIT)

## DA-Verify

No injection vectors.

Closes A13
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`