### PR TITLE
fix(utxo_db): prevent multiple mining_reward at same block_height (C16)

### DIFF
--- a/node/test_utxo_concurrent_stress_poc.py
+++ b/node/test_utxo_concurrent_stress_poc.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+B4: 1000 Parallel Transfers Stress Test
+
+Stress test the UTXO mempool under high concurrency. Tests for:
+1. Double-spend acceptance (race: two threads claim same input)
+2. Mempool overfill (race: MAX_POOL_SIZE exceeded under load)
+3. Lost inputs (race: mempool_add returns False but input still locked)
+4. Thread safety of BEGIN IMMEDIATE under concurrent writes
+"""
+
+import threading
+import time
+import tempfile
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+from utxo_db import UtxoDB, UNIT, MAX_POOL_SIZE
+
+DB_PATH = "/tmp/test_b4_stress.db"
+NUM_THREADS = 20
+TX_PER_THREAD = 50  # 1000 total
+
+
+def setup_db():
+    if os.path.exists(DB_PATH):
+        os.remove(DB_PATH)
+    db = UtxoDB(DB_PATH)
+    db.init_tables()
+    # Create 1000 fund boxes
+    for i in range(1000):
+        db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': f'user_{i}', 'value_nrtc': 10 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=i + 1)
+    return db
+
+
+results = {}
+lock = threading.Lock()
+
+
+def worker(worker_id, box_ids, output_dir):
+    """Submit TX_PER_THREAD transfers, each claiming a unique box."""
+    db = UtxoDB(DB_PATH)
+    local_ok = 0
+    local_fail = 0
+    local_errors = 0
+
+    for idx, bid in enumerate(box_ids):
+        tx_id_hex = f"w{worker_id}_tx{idx}_{'x' * 32}"[:64]
+        try:
+            ok = db.mempool_add({
+                'tx_id': tx_id_hex,
+                'tx_type': 'transfer',
+                'inputs': [{'box_id': bid, 'spending_proof': 'sig'}],
+                'outputs': [{'address': 'recipient', 'value_nrtc': 9 * UNIT}],
+                'fee_nrtc': 1 * UNIT,
+                'timestamp': int(time.time()),
+            })
+            if ok:
+                local_ok += 1
+            else:
+                local_fail += 1
+        except Exception as e:
+            local_errors += 1
+
+    with lock:
+        results[worker_id] = (local_ok, local_fail, local_errors)
+
+
+def main():
+    db = setup_db()
+
+    # Collect all box_ids
+    all_boxes = []
+    for i in range(1000):
+        boxes = db.get_unspent_for_address(f'user_{i}')
+        all_boxes.extend(b['box_id'] for b in boxes)
+
+    total_boxes = len(all_boxes)
+    print(f"Total available boxes: {total_boxes}")
+    print(f"Threads: {NUM_THREADS}, TX per thread: {TX_PER_THREAD}")
+    print(f"Expected total: {min(total_boxes, NUM_THREADS * TX_PER_THREAD)}")
+
+    # Assign boxes round-robin to workers
+    boxes_per_worker = [[] for _ in range(NUM_THREADS)]
+    for idx, bid in enumerate(all_boxes):
+        boxes_per_worker[idx % NUM_THREADS].append(bid)
+
+    # Launch threads
+    threads = []
+    start = time.time()
+    for w_id in range(NUM_THREADS):
+        t = threading.Thread(target=worker, args=(w_id, boxes_per_worker[w_id], DB_PATH))
+        threads.append(t)
+        t.start()
+
+    for t in threads:
+        t.join()
+    elapsed = time.time() - start
+
+    # Aggregate
+    total_ok = sum(v[0] for v in results.values())
+    total_fail = sum(v[1] for v in results.values())
+    total_err = sum(v[2] for v in results.values())
+
+    print(f"\n=== B4 STRESS TEST RESULTS ===")
+    print(f"Time: {elapsed:.2f}s")
+    print(f"Accepted (ok):  {total_ok}")
+    print(f"Rejected:       {total_fail}")
+    print(f"Errors:         {total_err}")
+    print(f"Throughput:     {total_ok/elapsed:.0f} tx/s")
+
+    # Verify no double-spends in mempool
+    conn = db._conn()
+    input_count = conn.execute(
+        "SELECT COUNT(*) FROM utxo_mempool_inputs"
+    ).fetchone()[0]
+    mempool_count = conn.execute(
+        "SELECT COUNT(*) FROM utxo_mempool"
+    ).fetchone()[0]
+    pool_size = conn.execute(
+        "SELECT COUNT(*) FROM utxo_mempool"
+    ).fetchone()[0]
+    conn.close()
+
+    print(f"\nMempool TX count:  {mempool_count}")
+    print(f"Mempool input claims: {input_count}")
+    print(f"Pool usage:       {pool_size}/{MAX_POOL_SIZE}")
+
+    issues = []
+    if total_err > 0:
+        issues.append(f"⚠️  {total_err} exceptions — possible race condition bug!")
+    if mempool_count != total_ok:
+        issues.append(f"⚠️  Mempool count ({mempool_count}) ≠ accepted ({total_ok}) — lost TX!")
+    if total_ok > total_boxes:
+        issues.append(f"⚠️  More accepted ({total_ok}) than available boxes ({total_boxes}) — DOUBLE-SPEND!")
+    if pool_size >= MAX_POOL_SIZE:
+        issues.append(f"⚠️  Pool full ({pool_size}/{MAX_POOL_SIZE}) — possible overfill race")
+
+    if issues:
+        print("\n=== ISSUES DETECTED ===")
+        for i in issues:
+            print(f"  {i}")
+        print("\nB4: Bug(s) confirmed — race conditions exist under load!")
+        return False
+    else:
+        print("\n✅ B4: No race conditions detected in 1000 concurrent transfers")
+        return True
+
+
+if __name__ == '__main__':
+    sys.exit(0 if main() else 1)

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -574,8 +574,8 @@ class TestUtxoDB(unittest.TestCase):
     # -- integrity -----------------------------------------------------------
 
     def test_integrity_ok(self):
-        self._apply_coinbase('alice', 100 * UNIT)
-        self._apply_coinbase('bob', 50 * UNIT)
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        self._apply_coinbase('bob', 50 * UNIT, block_height=2)
         result = self.db.integrity_check(expected_total=150 * UNIT)
         self.assertTrue(result['ok'])
         self.assertTrue(result['models_agree'])

--- a/node/test_utxo_multiple_mining_reward_poc.py
+++ b/node/test_utxo_multiple_mining_reward_poc.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+C16: Multiple mining_reward in the same block — fix verification
+
+Bug: apply_transaction permitted multiple mining_reward transactions at
+the same block_height. Each mining_reward with different content could
+produce a unique tx_id, allowing multiple coinbase outputs per block.
+
+Fix: Added per-block check — if a mining_reward already exists at the
+given block_height, subsequent mining_reward txs are rejected.
+"""
+
+import unittest
+import tempfile
+import os
+import time
+
+from utxo_db import UtxoDB, UNIT, MAX_COINBASE_OUTPUT_NRTC
+
+
+class TestMultipleMiningReward(unittest.TestCase):
+    """C16: Multiple mining_reward txs at same block_height — now rejected."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db = UtxoDB(self.tmp.name)
+        self.db.init_tables()
+
+    def tearDown(self):
+        os.unlink(self.tmp.name)
+
+    def test_first_mining_reward_accepted(self):
+        """First mining_reward at height 1 — accepted."""
+        ok = self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'alice', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+        self.assertTrue(ok, "First mining_reward should succeed")
+
+    def test_second_mining_reward_same_height_rejected(self):
+        """FIX: Second mining_reward at SAME height — rejected."""
+        self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'alice', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+
+        ok = self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'bob', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+        self.assertFalse(ok,
+            "FIX: Second mining_reward at same height should be rejected!")
+        print("  ✅ Second mining_reward at height 1: rejected")
+
+    def test_different_heights_accepted(self):
+        """Different block heights — both mining_rewards accepted."""
+        self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'alice', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+        ok = self.db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': 'alice', 'value_nrtc': 50 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=2)
+        self.assertTrue(ok, "Different heights — both should succeed")
+
+
+if __name__ == '__main__':
+    suite = unittest.TestLoader().loadTestsFromTestCase(TestMultipleMiningReward)
+    runner = unittest.TextTestRunner(verbosity=2)
+    result = runner.run(suite)
+    print("\n" + "=" * 60)
+    print("C16 FIXED" if result.wasSuccessful() else "C16 ISSUES")
+    print("=" * 60)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -550,6 +550,19 @@ class UtxoDB:
                     conn.execute("ROLLBACK")
                 return False
 
+            # -- prevent multiple mining_reward per block ------------------------
+            # Without this, a buggy internal caller could create multiple coinbase
+            # outputs at the same height, inflating supply beyond the intended
+            # block reward (MAX_COINBASE_OUTPUT_NRTC is per-output, not per-block).
+            if tx_type in MINTING_TX_TYPES:
+                row = conn.execute(
+                    """SELECT COUNT(*) AS n FROM utxo_transactions
+                       WHERE tx_type = 'mining_reward' AND block_height = ?""",
+                    (block_height,),
+                ).fetchone()
+                if row['n'] > 0:
+                    return abort()
+
             # -- reject duplicate input box_ids --------------------------------
             # Keyed on box_id alone (the PK of the UTXO being consumed).
             # Different spending_proof values for the same box_id are still


### PR DESCRIPTION
## Description

C16: `apply_transaction` permitted multiple `mining_reward` transactions at the same `block_height`. Each mining_reward with different content produced a unique tx_id. The only guard was `MAX_COINBASE_OUTPUT_NRTC` (per-output, not per-block).

## Impact

A buggy internal caller could create multiple coinbase outputs at the same height, inflating supply beyond the intended per-block block reward. Example: two 100 RTC mining_rewards at height 1 = 200 RTC, exceeding MAX_COINBASE_OUTPUT_NRTC (150 RTC).

## Fix

Added a per-block check inside the write transaction (under BEGIN IMMEDIATE). If a mining_reward already exists at the given block_height, subsequent mining_reward txs are rejected with proper rollback.

## Testing

- 3 new tests in test_utxo_multiple_mining_reward_poc.py
- First mining_reward at height 1: accepted
- Second mining_reward at same height: rejected (FIX VERIFIED)
- Different heights: both accepted
- B4 stress test (1000 concurrent transfers): no race conditions detected
- 91 existing tests PASS + 14 subtests
- 0 regressions

## Severity

BCOS-L1 — Internal fund creation. Requires privileged caller (epoch settlement). Defense-in-depth.

## Files Changed

- node/utxo_db.py — per-block mining_reward guard inside try block
- node/test_utxo_db.py — fix integrity test to use different block heights
- node/test_utxo_multiple_mining_reward_poc.py — PoC (SPDX: MIT)
- node/test_utxo_concurrent_stress_poc.py — B4 stress test (SPDX: MIT)

## DA-Verify

No injection vectors.

Closes C16, B4

---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`