### PR TITLE
fix(ergo_anchor): cap pagination offset at 10K to prevent SQLite DoS

### DIFF
--- a/node/rustchain_ergo_anchor.py
+++ b/node/rustchain_ergo_anchor.py
@@ -538,7 +538,7 @@ def create_anchor_api_routes(app, anchor_service: AnchorService):
         if error:
             return jsonify({"error": error}), 400
 
-        offset, error = parse_int_query_arg('offset', 0, 0)
+        offset, error = parse_int_query_arg('offset', 0, 0, max_value=10_000)
         if error:
             return jsonify({"error": error}), 400
 


### PR DESCRIPTION
## Description

Unbounded offset parameter in `GET /anchor/list` allows SQLite DoS via offset scanning.

### Finding: C15 — SQLite DoS via Unbounded Pagination Offset

**File:** `node/rustchain_ergo_anchor.py`  
**Endpoint:** `GET /anchor/list`

**Attack:** `GET /anchor/list?offset=999999999`  
→ SQLite scans 1B+ rows before returning results.

### Root Cause

`parse_int_query_arg('offset', 0, 0)` at line 541 passes no `max_value`. The `limit` parameter (line 537) already has `max_value=100`, but offset was unbounded.

### Fix

`parse_int_query_arg('offset', 0, 0, max_value=10_000)` — caps offset at 10K.

### Severity

BCOS-L2: Denial of Service via pagination

Same pattern as C13 (PR #6255) and C14 (PR #6256).
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`