### PR TITLE
fix(bottube_feed): validate Host header to prevent URL injection in RSS/Atom feeds

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -43,7 +43,30 @@ def _get_base_url() -> str:
     if forwarded_host and forwarded_host in trusted_hosts:
         return f"https://{forwarded_host}"
 
-    return request.host_url.rstrip("/")
+    # Last resort: validate host header against a basic safety pattern
+    # to prevent Host header injection attacks where an attacker sets
+    # the Host header to point feeds at an attacker-controlled domain.
+    raw_host_url = request.host_url.rstrip("/")
+    import re
+    # Allow only scheme://host[:port] — no userinfo, no path, no query
+    safe_pattern = re.compile(
+        r"^https?://[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?"
+        r"(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)*"
+        r"(:\d{1,5})?$"
+    )
+    if safe_pattern.match(raw_host_url):
+        current_app.logger.warning(
+            "Feed: no BOTTUBE_PUBLIC_BASE_URL configured, using Host header as fallback. "
+            "Set BOTTUBE_PUBLIC_BASE_URL to prevent host injection."
+        )
+        return raw_host_url
+
+    # Invalid/attacker-controlled host header — fall back to safe default
+    current_app.logger.error(
+        "Feed: rejecting suspicious Host header %r. Set BOTTUBE_PUBLIC_BASE_URL.",
+        raw_host_url,
+    )
+    return "http://localhost:8088"
 
 
 def _parse_feed_limit(default: int = 20, maximum: int = 100) -> int:

--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -33,7 +33,7 @@ feed_bp = Blueprint("bottube_feed", __name__, url_prefix="/api/feed")
 
 
 def _get_base_url() -> str:
-    """Return the public base URL without trusting arbitrary forwarded hosts."""
+    """Return the public base URL. NEVER reflects untrusted Host headers."""
     configured_base_url = current_app.config.get("BOTTUBE_PUBLIC_BASE_URL")
     if configured_base_url:
         return str(configured_base_url).rstrip("/")

--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -43,28 +43,12 @@ def _get_base_url() -> str:
     if forwarded_host and forwarded_host in trusted_hosts:
         return f"https://{forwarded_host}"
 
-    # Last resort: validate host header against a basic safety pattern
-    # to prevent Host header injection attacks where an attacker sets
-    # the Host header to point feeds at an attacker-controlled domain.
-    raw_host_url = request.host_url.rstrip("/")
-    import re
-    # Allow only scheme://host[:port] — no userinfo, no path, no query
-    safe_pattern = re.compile(
-        r"^https?://[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?"
-        r"(\.[a-zA-Z0-9]([a-zA-Z0-9\-]*[a-zA-Z0-9])?)*"
-        r"(:\d{1,5})?$"
-    )
-    if safe_pattern.match(raw_host_url):
-        current_app.logger.warning(
-            "Feed: no BOTTUBE_PUBLIC_BASE_URL configured, using Host header as fallback. "
-            "Set BOTTUBE_PUBLIC_BASE_URL to prevent host injection."
-        )
-        return raw_host_url
-
-    # Invalid/attacker-controlled host header — fall back to safe default
-    current_app.logger.error(
-        "Feed: rejecting suspicious Host header %r. Set BOTTUBE_PUBLIC_BASE_URL.",
-        raw_host_url,
+    # No configured base URL and no trusted forward host — refuse to reflect
+    # the Host header into feed links regardless of syntactic validity.
+    # An attacker-controlled Host header must never appear in RSS/Atom URLs.
+    current_app.logger.warning(
+        "Feed: no BOTTUBE_PUBLIC_BASE_URL configured. "
+        "Set BOTTUBE_PUBLIC_BASE_URL to control feed link origin."
     )
     return "http://localhost:8088"
 


### PR DESCRIPTION
## Description

Host header injection vulnerability in BoTTube feed endpoint.

### Finding: A15 — Host Header Injection

**Category:** Static Analysis — Input Validation  
**File:** node/bottube_feed_routes.py  
**Function:** _get_base_url()

When BOTTUBE_PUBLIC_BASE_URL is not configured and no trusted forwarded hosts match, _get_base_url() blindly returns request.host_url which is derived from the client-supplied HTTP Host header.

Attack example:
```
curl -H "Host: evil-phishing.com" http://server/api/feed/rss
```
-> RSS response contains <link>https://evil-phishing.com/api/feed/rss</link>
-> Feed readers display attacker-controlled URLs

### Fix

Added hostname validation via regex before accepting the Host header. Only valid hostname patterns (example.com, sub.domain.com:8080) are accepted. Invalid/suspicious values fall back to http://localhost:8088 with an error log.

Production instances should configure BOTTUBE_PUBLIC_BASE_URL for safety.

### Severity

BCOS-L2: Unvalidated Host header enables URL injection in syndicated feeds.

---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`