### PR TITLE
fix(utxo/transfer): cap memo length at 1024 chars to prevent DoS

### DIFF
--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -404,6 +404,8 @@ def utxo_transfer():
     memo = data.get('memo', '')
     if not isinstance(memo, str):
         return jsonify({'error': 'memo must be a string'}), 400
+    if len(memo) > 1024:
+        return jsonify({'error': 'memo cannot exceed 1024 characters'}), 400
     # FIX(#2867 M2): exact Decimal parsing with bounds check (was float()).
     try:
         amount_rtc = _parse_rtc_amount(data.get('amount_rtc', 0))


### PR DESCRIPTION
## Description

Missing length validation on memo field in /utxo/transfer endpoint allows unbounded storage DOS.

### Finding: A16 — Unbounded memo field in UTXO transfer

**Category:** Static Analysis — Input Validation  
**File:** node/utxo_endpoints.py  
**Endpoint:** POST /utxo/transfer

The memo field is type-checked (must be string) but has no length limit. An attacker can submit a 1MB+ memo that:
1. Gets stored in ledger entries (dual-write path uses memo[:30])
2. Included in canonical signed payload (excessive memory)
3. Echoed back in JSON response

### Fix

Reject memo longer than 1024 characters.

### Severity

BCOS-L2: Unbounded input field enables storage/memory exhaustion.

---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`