### PR TITLE
fix(gpu/attest): validate pricing fields to prevent negative/absurd prices

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -81,6 +81,14 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
         # For the bounty, we implement the protocol storage and API.
         db = get_db()
         try:
+            # Validate pricing fields using existing _parse_positive_amount
+            price_render = _parse_positive_amount(data.get("price_render_minute", 0.1))
+            price_tts = _parse_positive_amount(data.get("price_tts_1k_chars", 0.05))
+            price_stt = _parse_positive_amount(data.get("price_stt_minute", 0.1))
+            price_llm = _parse_positive_amount(data.get("price_llm_1k_tokens", 0.02))
+            if None in (price_render, price_tts, price_stt, price_llm):
+                return jsonify({"error": "GPU pricing fields must be finite positive numbers"}), 400
+
             db.execute(
                 """
                 INSERT OR REPLACE INTO gpu_attestations (
@@ -95,10 +103,10 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                     data.get("vram_gb"),
                     data.get("cuda_version"),
                     data.get("benchmark_score", 0),
-                    data.get("price_render_minute", 0.1),
-                    data.get("price_tts_1k_chars", 0.05),
-                    data.get("price_stt_minute", 0.1),
-                    data.get("price_llm_1k_tokens", 0.02),
+                    price_render,
+                    price_tts,
+                    price_stt,
+                    price_llm,
                     1 if data.get("supports_render") else 0,
                     1 if data.get("supports_tts") else 0,
                     1 if data.get("supports_stt") else 0,


### PR DESCRIPTION
## Description

Missing price validation in GPU attestation endpoint allows storing negative/non-finite pricing.

### Finding: A17 — Unvalidated GPU pricing fields

**Category:** Static Analysis — Input Validation  
**File:** node/gpu_render_endpoints.py  
**Endpoint:** POST /api/gpu/attest

All 4 pricing fields (price_render_minute, price_tts_1k_chars, price_stt_minute, price_llm_1k_tokens) are stored directly with data.get() and no validation. An attacker can set negative, zero, Infinity, or NaN prices.

_parse_positive_amount() already existed in the file (used by /api/gpu/escrow) but was dead code for the attest endpoint.

### Fix

Parse all 4 pricing fields through _parse_positive_amount() before storage.

### Severity

BCOS-L2: Unvalidated pricing enables financial manipulation via negative/zero/Infinity values.

---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`