### PR TITLE
fix(beacon): cap agent/contract field lengths to prevent unbounded TEXT DoS

### DIFF
--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -1,0 +1,35 @@
+# BATTLESHIP PROGRESS
+
+## Unbounded offset/pagination (Row C, Col 13-15)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| C13 | governance.py | offset | #6255 | Open |
+| C14 | machine_passport_api.py | offset | #6256 | Open |
+| C15 | ergo_anchor.py | offset | #6257 | Open |
+
+## Unbounded TEXT / input (Row A, Col 15-18)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
+| A16 | utxo_endpoints.py | memo | #6259 | Open |
+| A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
+| A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+
+## Exhausted cells (grid complete)
+| Cell | File | Vulnerability | PR |
+|------|------|---------------|----|
+| A1-A5 | utxo_db.py | Mempool/input bounds | #6237 |
+| A6, A9-A11 | utxo_db.py | Input validation | #6241 |
+| A7 | utxo_db.py | Box ID endianness | #6243 |
+| A12 | utxo_db.py | TX type normalize | #6242 |
+| A13 | utxo_db.py | TX data JSON size | #6245 |
+| A14 | utxo_db.py | Spending proof size | #6246 |
+| B1-B3, C1 | utxo_db.py | Dynamic race conds | #6239 |
+| C2-C4, D1 | utxo_db.py | Adversarial vulns | #6240 |
+| C7 | utxo_db.py | Genesis migration | #6249 |
+| C8 | rewards.py | ADM double-credit | #6250 |
+| C9 | governance.py | Vote tally race | #6251 |
+| C10 | coalition.py | Vote tally race | #6252 |
+| C11 | bridge.py | Confirm cap | #6253 |
+| C12 | bridge.py | Req confirm cap | #6254 |
+| C16 | utxo_db.py | Mining reward dup | #6247 |

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -23,6 +23,14 @@ beacon_api = Blueprint('beacon_api', __name__)
 DB_PATH = 'rustchain_v2.db'
 BEACON_AUTH_WINDOW_SECONDS = 300
 
+# Maximum field lengths to prevent SQLite/DOS via unbounded TEXT fields
+MAX_AGENT_ID_LENGTH = 128       # agent identifier
+MAX_PUBKEY_HEX_LENGTH = 128     # Ed25519 pubkey (~44 bytes in base64, 64 in hex)
+MAX_AGENT_NAME_LENGTH = 256     # human-readable name
+MAX_CURRENCY_LENGTH = 16        # currency code (e.g. 'RTC', 'USDC')
+MAX_CONTRACT_TYPE_LENGTH = 64   # contract type identifier
+MAX_CONTRACT_TERM_LENGTH = 1024 # contract term/description
+
 # In-memory cache for bounties (synced from GitHub)
 bounty_cache = {
     'data': [],
@@ -392,6 +400,26 @@ def beacon_join():
             return jsonify({'error': 'Invalid name: must be a string'}), 400
         if coinbase_address is not None and not isinstance(coinbase_address, str):
             return jsonify({'error': 'Invalid coinbase_address: must be a string'}), 400
+
+        # Validate field lengths to prevent unbounded TEXT storage
+        if len(agent_id) > MAX_AGENT_ID_LENGTH:
+            return jsonify({
+                'error': 'agent_id too long',
+                'max_length': MAX_AGENT_ID_LENGTH,
+                'actual_length': len(agent_id),
+            }), 400
+        if len(pubkey_hex) > MAX_PUBKEY_HEX_LENGTH:
+            return jsonify({
+                'error': 'pubkey_hex too long',
+                'max_length': MAX_PUBKEY_HEX_LENGTH,
+                'actual_length': len(pubkey_hex),
+            }), 400
+        if name and len(name) > MAX_AGENT_NAME_LENGTH:
+            return jsonify({
+                'error': 'name too long',
+                'max_length': MAX_AGENT_NAME_LENGTH,
+                'actual_length': len(name),
+            }), 400
         
         # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
         if coinbase_address:
@@ -605,14 +633,37 @@ def create_contract():
         if amount_error:
             return amount_error, amount_status
 
+        # Validate field lengths to prevent unbounded TEXT storage
+        contract_type = data['type']
+        contract_term = data['term']
+        contract_currency = data.get('currency', 'RTC')
+        if len(contract_type) > MAX_CONTRACT_TYPE_LENGTH:
+            return jsonify({
+                'error': 'type too long',
+                'max_length': MAX_CONTRACT_TYPE_LENGTH,
+                'actual_length': len(contract_type),
+            }), 400
+        if len(contract_term) > MAX_CONTRACT_TERM_LENGTH:
+            return jsonify({
+                'error': 'term too long',
+                'max_length': MAX_CONTRACT_TERM_LENGTH,
+                'actual_length': len(contract_term),
+            }), 400
+        if len(contract_currency) > MAX_CURRENCY_LENGTH:
+            return jsonify({
+                'error': 'currency too long',
+                'max_length': MAX_CURRENCY_LENGTH,
+                'actual_length': len(contract_currency),
+            }), 400
+
         contract = {
             'id': contract_id,
             'from': data['from'],
             'to': data['to'],
-            'type': data['type'],
+            'type': contract_type,
             'amount': amount,
-            'currency': data.get('currency', 'RTC'),
-            'term': data['term'],
+            'currency': contract_currency,
+            'term': contract_term,
             'state': 'offered',  # Initial state
             'created_at': int(time.time()),
         }


### PR DESCRIPTION
## Description
Adds length validation for string fields in beacon_api.py endpoints before DB storage. Previously agent_id, pubkey_hex, name, contract type, term, and currency had no max length — attackers could submit 1MB+ values to bloat relay_agents and beacon_contracts tables.

## Fields Capped
| Endpoint | Field | Max Length |
|---|---|---|
| POST /beacon/join | agent_id | 128 |
| POST /beacon/join | pubkey_hex | 128 |
| POST /beacon/join | name | 256 |
| POST /api/contracts | type | 64 |
| POST /api/contracts | term | 1024 |
| POST /api/contracts | currency | 16 |

Relates to battleship cell **A19** (beacon_api field length limits).
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`