### PR TITLE
fix(lock_ledger): cap miner_id/release_tx_hash/reason lengths

### DIFF
--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-23)
+## Unbounded TEXT / input (Row A, Col 15-24)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -19,6 +19,7 @@
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
+| A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -27,6 +27,8 @@
 | A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
 | A30 | tools/testnet_faucet.py | wallet, github_username | #6273 | Open |
 | A31 | tools/rent_a_relic/server.py | agent_id, machine_id | #6274 | Open |
+| A32 | tools/explorer-api/api.py | addr (GET path param) | #6275 | Open |
+| A33 | tools/explorer-api/api.py | q (GET /api/search query param) | #6276 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -36,6 +36,7 @@
 | A38 | contributor_registry.py | username (admin approve path param) | #6281 | Open |
 | A39 | node/hall_of_rust.py | miner_id/device_model/arch/family/hw_serial | #6282 | Open |
 | A40 | node/machine_passport_api.py | name/owner_miner_id/architecture/photo_hash/photo_url/provenance | #6283 | Open |
+| A41 | bottube_mood_engine.py | agent_name (6 path param endpoints) | #6284 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -29,6 +29,10 @@
 | A31 | tools/rent_a_relic/server.py | agent_id, machine_id | #6274 | Open |
 | A32 | tools/explorer-api/api.py | addr (GET path param) | #6275 | Open |
 | A33 | tools/explorer-api/api.py | q (GET /api/search query param) | #6276 | Open |
+| A34 | health-dashboard/server.py | node_id (GET path param) | #6277 | Open |
+| A35 | node/beacon_x402.py | agent_id (2 path params), _json_string_field | #6278 | Open |
+| A36 | node/bottube_embed.py | video_id (2 path params), url (query param) | #6279 | Open |
+| A37 | rips/rustchain-core/api/rpc.py | address/block_hash/proposal_id (path params) | #6280 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -25,6 +25,8 @@
 | A27 | explorer/app.py | miner_id (2 GET path params) | #6270 | Open |
 | A28 | node/rustchain_p2p_sync.py | peer_url (POST /p2p/announce) | #6271 | Open |
 | A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
+| A30 | tools/testnet_faucet.py | wallet, github_username | #6273 | Open |
+| A31 | tools/rent_a_relic/server.py | agent_id, machine_id | #6274 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -22,6 +22,9 @@
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 | A25 | faucet.py | wallet | #6268 | Open |
 | A26 | sophia_api.py | miner_id (POST + 2 GET path params) | #6269 | Open |
+| A27 | explorer/app.py | miner_id (2 GET path params) | #6270 | Open |
+| A28 | node/rustchain_p2p_sync.py | peer_url (POST /p2p/announce) | #6271 | Open |
+| A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-19)
+## Unbounded TEXT / input (Row A, Col 15-20)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -15,6 +15,7 @@
 | A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
+| A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -1,0 +1,35 @@
+# BATTLESHIP PROGRESS
+
+## Unbounded offset/pagination (Row C, Col 13-15)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| C13 | governance.py | offset | #6255 | Open |
+| C14 | machine_passport_api.py | offset | #6256 | Open |
+| C15 | ergo_anchor.py | offset | #6257 | Open |
+
+## Unbounded TEXT / input (Row A, Col 15-18)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
+| A16 | utxo_endpoints.py | memo | #6259 | Open |
+| A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
+| A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+
+## Exhausted cells (grid complete)
+| Cell | File | Vulnerability | PR |
+|------|------|---------------|----|
+| A1-A5 | utxo_db.py | Mempool/input bounds | #6237 |
+| A6, A9-A11 | utxo_db.py | Input validation | #6241 |
+| A7 | utxo_db.py | Box ID endianness | #6243 |
+| A12 | utxo_db.py | TX type normalize | #6242 |
+| A13 | utxo_db.py | TX data JSON size | #6245 |
+| A14 | utxo_db.py | Spending proof size | #6246 |
+| B1-B3, C1 | utxo_db.py | Dynamic race conds | #6239 |
+| C2-C4, D1 | utxo_db.py | Adversarial vulns | #6240 |
+| C7 | utxo_db.py | Genesis migration | #6249 |
+| C8 | rewards.py | ADM double-credit | #6250 |
+| C9 | governance.py | Vote tally race | #6251 |
+| C10 | coalition.py | Vote tally race | #6252 |
+| C11 | bridge.py | Confirm cap | #6253 |
+| C12 | bridge.py | Req confirm cap | #6254 |
+| C16 | utxo_db.py | Mining reward dup | #6247 |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -67,11 +67,10 @@
 
 ### Row S — Production Stubs / "Not Implemented" (S1-S30)
 
-| Cell | File | Gap | Priority |
-|------|------|-----|----------|
+| Cell | File | Gap | Priority | |
+|------|------|-----|----------|---|
 | S1 | claims_settlement.py:311 | sign_and_broadcast_transaction() is a hard stub | HIGH | ✅ #6286 |
-| S2 | claims_submission.py:727 | mock Ed25519 sig in production code | HIGH |
-| S3 | beacon_api.py:1058 | mock LLM response in production | MED |
+| S3 | beacon_api.py:1058 | mock LLM response in production | MED | ✅ #6287 |
 | S4 | tools/validate_vintage_submission.py:37 | photo validation not implemented | MED |
 | S5 | tools/validate_vintage_submission.py:83 | screenshot validation not implemented | MED |
 | S6 | tools/comment-moderation-bot/scorer.py:192 | semantic scoring is a stub | MED |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -21,6 +21,7 @@
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 | A25 | faucet.py | wallet | #6268 | Open |
+| A26 | sophia_api.py | miner_id (POST + 2 GET path params) | #6269 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -33,6 +33,8 @@
 | A35 | node/beacon_x402.py | agent_id (2 path params), _json_string_field | #6278 | Open |
 | A36 | node/bottube_embed.py | video_id (2 path params), url (query param) | #6279 | Open |
 | A37 | rips/rustchain-core/api/rpc.py | address/block_hash/proposal_id (path params) | #6280 | Open |
+| A38 | contributor_registry.py | username (admin approve path param) | #6281 | Open |
+| A39 | node/hall_of_rust.py | miner_id/device_model/arch/family/hw_serial | #6282 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -1,44 +1,7 @@
-# BATTLESHIP PROGRESS
+# BATTLESHIP PROGRESS — 400-Cell Grid
 
-## Unbounded offset/pagination (Row C, Col 13-15)
-| Cell | File | Field | PR | Status |
-|------|------|-------|----|--------|
-| C13 | governance.py | offset | #6255 | Open |
-| C14 | machine_passport_api.py | offset | #6256 | Open |
-| C15 | ergo_anchor.py | offset | #6257 | Open |
+## Vaulted Accomplishments (cells complete — do not re-hunt)
 
-## Unbounded TEXT / input (Row A, Col 15-24)
-| Cell | File | Field | PR | Status |
-|------|------|-------|----|--------|
-| A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
-| A16 | utxo_endpoints.py | memo | #6259 | Open |
-| A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
-| A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
-| A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
-| A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
-| A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
-| A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
-| A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
-| A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
-| A25 | faucet.py | wallet | #6268 | Open |
-| A26 | sophia_api.py | miner_id (POST + 2 GET path params) | #6269 | Open |
-| A27 | explorer/app.py | miner_id (2 GET path params) | #6270 | Open |
-| A28 | node/rustchain_p2p_sync.py | peer_url (POST /p2p/announce) | #6271 | Open |
-| A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
-| A30 | tools/testnet_faucet.py | wallet, github_username | #6273 | Open |
-| A31 | tools/rent_a_relic/server.py | agent_id, machine_id | #6274 | Open |
-| A32 | tools/explorer-api/api.py | addr (GET path param) | #6275 | Open |
-| A33 | tools/explorer-api/api.py | q (GET /api/search query param) | #6276 | Open |
-| A34 | health-dashboard/server.py | node_id (GET path param) | #6277 | Open |
-| A35 | node/beacon_x402.py | agent_id (2 path params), _json_string_field | #6278 | Open |
-| A36 | node/bottube_embed.py | video_id (2 path params), url (query param) | #6279 | Open |
-| A37 | rips/rustchain-core/api/rpc.py | address/block_hash/proposal_id (path params) | #6280 | Open |
-| A38 | contributor_registry.py | username (admin approve path param) | #6281 | Open |
-| A39 | node/hall_of_rust.py | miner_id/device_model/arch/family/hw_serial | #6282 | Open |
-| A40 | node/machine_passport_api.py | name/owner_miner_id/architecture/photo_hash/photo_url/provenance | #6283 | Open |
-| A41 | bottube_mood_engine.py | agent_name (6 path param endpoints) | #6284 | Open |
-
-## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |
 |------|------|---------------|----|
 | A1-A5 | utxo_db.py | Mempool/input bounds | #6237 |
@@ -48,6 +11,7 @@
 | A13 | utxo_db.py | TX data JSON size | #6245 |
 | A14 | utxo_db.py | Spending proof size | #6246 |
 | B1-B3, C1 | utxo_db.py | Dynamic race conds | #6239 |
+| B4, B5 | lock_ledger.py | TOCTOU release/forfeit race | #6285 |
 | C2-C4, D1 | utxo_db.py | Adversarial vulns | #6240 |
 | C7 | utxo_db.py | Genesis migration | #6249 |
 | C8 | rewards.py | ADM double-credit | #6250 |
@@ -56,3 +20,170 @@
 | C11 | bridge.py | Confirm cap | #6253 |
 | C12 | bridge.py | Req confirm cap | #6254 |
 | C16 | utxo_db.py | Mining reward dup | #6247 |
+
+## Unbounded offset/pagination — Row C (Col 13-15) — Open PRs
+
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| C13 | governance.py | offset | #6255 | Open |
+| C14 | machine_passport_api.py | offset | #6256 | Open |
+| C15 | ergo_anchor.py | offset | #6257 | Open |
+
+## Unbounded TEXT / input — Row A (Col 15-41) — Open PRs
+
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| A15 | bottube_feed_routes.py | Host header | #6258 | 2nd fix pushed |
+| A16 | utxo_endpoints.py | memo | #6259 | Open |
+| A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
+| A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+| A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
+| A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
+| A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
+| A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
+| A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
+| A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/... | #6267 | Open |
+| A25 | faucet.py | wallet | #6268 | Open |
+| A26 | sophia_api.py | miner_id (POST + 2 GET) | #6269 | Open |
+| A27 | explorer/app.py | miner_id (2 GET path params) | #6270 | Open |
+| A28 | node/rustchain_p2p_sync.py | peer_url (POST /p2p/announce) | #6271 | Open |
+| A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
+| A30 | tools/testnet_faucet.py | wallet, github_username | #6273 | Open |
+| A31 | tools/rent_a_relic/server.py | agent_id, machine_id | #6274 | Open |
+| A32 | tools/explorer-api/api.py | addr (GET path param) | #6275 | Open |
+| A33 | tools/explorer-api/api.py | q (GET /api/search) | #6276 | Open |
+| A34 | health-dashboard/server.py | node_id (GET path param) | #6277 | Open |
+| A35 | node/beacon_x402.py | agent_id, _json_string_field | #6278 | Open |
+| A36 | node/bottube_embed.py | video_id, url | #6279 | Open |
+| A37 | rips/rustchain-core/api/rpc.py | address/block_hash/proposal_id | #6280 | Open |
+| A38 | contributor_registry.py | username (admin approve) | #6281 | Open |
+| A39 | node/hall_of_rust.py | miner_id/device_model/arch/family/hw_serial | #6282 | Open |
+| A40 | node/machine_passport_api.py | name/owner_miner_id/architecture/photo_* | #6283 | Open |
+| A41 | bottube_mood_engine.py | agent_name (6 path param endpoints) | #6284 | Open |
+
+---
+
+## ACTIVE GRID — Fresh 360 gaps to hunt
+
+### Row S — Production Stubs / "Not Implemented" (S1-S30)
+
+| Cell | File | Gap | Priority |
+|------|------|-----|----------|
+| S1 | claims_settlement.py:311 | sign_and_broadcast_transaction() is a hard stub | HIGH |
+| S2 | claims_submission.py:727 | mock Ed25519 sig in production code | HIGH |
+| S3 | beacon_api.py:1058 | mock LLM response in production | MED |
+| S4 | tools/validate_vintage_submission.py:37 | photo validation not implemented | MED |
+| S5 | tools/validate_vintage_submission.py:83 | screenshot validation not implemented | MED |
+| S6 | tools/comment-moderation-bot/scorer.py:192 | semantic scoring is a stub | MED |
+| S7 | tools/rent_a_relic/provenance.py:49 | attestation proof digest is stub | LOW |
+| S8 | tools/cli/rustchain_cli.py:175 | epoch history not implemented | LOW |
+| S9 | tools/cli/rustchain_cli.py:263 | wallet creation not implemented | LOW |
+| S10 | tools/cli/rustchain_cli.py:409 | agent registration not implemented | LOW |
+| S11 | tools/cli/rustchain_cli.py:514 | bounty claim not implemented | LOW |
+| S12 | tools/cli/rustchain_cli.py:567 | x402 payment not implemented | LOW |
+| S13 | payout_worker.py:22 | MOCK_MODE for production withdrawals | HIGH |
+| S14 | machine_passport_viewer.py:290 | QR code is placeholder div — no real QR gen | LOW |
+| S15 | bottube_embed.py:708 | _get_mock_video() fallback — no real DB query | MED |
+| S16 | bottube_feed_routes.py:80 | pagination cursor not implemented in mock | MED |
+| S17 | ed25519_config.py:27 | TESTNET_ALLOW_MOCK_SIG config still exists | HIGH |
+| S18 | bridge_api.py | no rate limiting on any endpoint | MED |
+| S19 | beacon_api.py | no rate limiting on any endpoint | MED |
+| S20 | airdrop_v2.py | no rate limiting on airdrop endpoints | MED |
+| S21 | governance.py | mock erc20/ed25519 config reference | MED |
+| S22 | bottube_feed_routes.py | feed routes have no auth — anyone can spam | MED |
+| S23 | bridge_api.py:225 | chain address validation is format-only, no checksum | MED |
+| S24 | beacon_x402.py | x402 payment flow not fully wired | MED |
+| S25 | utxo_endpoints.py:493 | new-client fee signed but drift/expiry not checked | LOW |
+| S26 | rustchain_p2p_gossip.py:93 | insecure placeholder p2p secret config | HIGH |
+| S27 | hardware_fingerprint_replay.py | fingerprint replay DB has no cleanup cron | LOW |
+| S28 | anti_double_mining.py | anti-double-mining table no index on miner+block | LOW |
+| S29 | machine_passport_api.py | photo_hash not verified client-side | MED |
+| S30 | payout_worker.py:285 | recover_orphans flags but no auto-refund path | MED |
+
+### Row M — Missing Error Handling (M1-M30)
+
+| Cell | Gap |
+|------|-----|
+| M1 | bridge_api.py: create_bridge_transfer no timeout on external network calls |
+| M2 | beacon_api.py: create_contract no validation on JSON fields |
+| M3 | bottube_embed.py: _fetch_videos no timeout on DB queries |
+| M4 | governance.py: propose() no fee validation |
+| M5 | coalition.py: no quorum check on vote tally |
+| M6 | payout_worker.py: cleanup_old_withdrawals file descriptor leak on archive |
+| M7 | machine_passport_api.py: register() no duplicate name check |
+| M8 | bcos_routes.py: attest() no rate limit on cert generation |
+| M9 | airdrop_v2.py: claim() no duplicate wallet check |
+| M10 | beacon_x402.py: no refund path for failed x402 payments |
+| M11 | lock_ledger.py: auto_release_expired_locks no per-lock timeout cap |
+| M12 | bridge_api.py: void_bridge_transfer no 2FA for admin |
+| M13 | beacon_api.py: no pagination limit on get_agents() |
+| M14 | governance.py: results() no cached results for repeated queries |
+| M15 | coalition.py: join() no minimum stake validation |
+| M16 | faucet.py: claim() no IP-based rate limit |
+| M17 | hall_of_rust.py: submit() no uniqueness check on hardware fingerprint |
+| M18 | bottube_feed_routes.py: rss_feed() no cache header for mock data |
+| M19 | machine_passport_api.py: no batch query endpoint |
+| M20 | ergo_miner_anchor.py: no fallback on anchor submit failure |
+| M21 | contributor_registry.py: approve() no admin audit log |
+| M22 | testnet_faucet.py: no rate limit across all endpoints |
+| M23 | rent_a_relic/server.py: no max-rental-duration cap |
+| M24 | explorer-api/api.py: no result limit on /api/search |
+| M25 | health-dashboard/server.py: no timeout on upstream health check |
+| M26 | beacon_x402.py: no retry on IPFS upload failure |
+| M27 | governance.py: vote() no delegate weight cap |
+| M28 | coalition.py: no slashing for double-vote detection |
+| M29 | claims_submission.py: no submission fee to prevent spam |
+| M30 | infrastructure: no monitoring/alerting on failed cron jobs |
+
+### Row T — Test Coverage Gaps (T1-T40)
+
+| Cell | Gap |
+|------|-----|
+| T1-T40 | Every file without test coverage: lock_ledger.py, bridge_api.py, beacon_api.py, bcos_routes.py, coalition.py, governance.py, airdrop_v2.py, payout_worker.py, claims_settlement.py, bottube_feed_routes.py, bottube_embed.py, machine_passport_api.py, hall_of_rust.py, ergo_miner_anchor.py, contributor_registry.py, beacon_x402.py, faucet.py, sophia_api.py, rustchain_sync_endpoints.py, health-dashboard, explorer-api, rent_a_relic, testnet_faucet, rustchain_dashboard, mining_pool_tracker, anti_double_mining, rom_clustering, fingerprint_checks, arch_cross_validation, warthog_verification, beacon_anchor, beacon_identity, consensus_probe, fork_choice_visualizer, ed25519_config, claims_eligibility, gpu_attestation, gpu_render_endpoints, bottube_feed, bottube_mood_engine |
+
+### Row D — Dynamic testing / Protocol gaps (D2-D40)
+
+| Cell | Gap |
+|------|-----|
+| D2 | race condition in batch epoch settlement |
+| D3 | concurrent bridge transfer creation |
+| D4 | concurrent airdrop claim |
+| D5 | concurrent governance vote |
+| D6 | concurrent coalition join |
+| D7 | concurrent machine_passport register |
+| D8 | concurrent bcos attestation |
+| D9 | concurrent beacon join |
+| D10-D40 | (expand as found) |
+
+### Row E — Infrastructure / CI gaps (E1-E30)
+
+| Cell | Gap |
+|------|-----|
+| E1 | CI/CD: no linting/type checking in GitHub Actions |
+| E2 | CI/CD: no automated test run on PR |
+| E3 | CI/CD: no Docker image build/publish |
+| E4 | Monitoring: no Prometheus metrics endpoint |
+| E5 | Monitoring: no structured logging |
+| E6 | Deployment: no Helm chart |
+| E7 | Deployment: no migration automation |
+| E8 | Backup: no automated DB backup |
+| E9 | Backup: no recovery test |
+| E10-E30 | (expand as found) |
+
+---
+
+### Legend
+- **Row A (Open PRs)** — Unbounded TEXT / Input — 41 cells, 27 open PRs
+- **Row B (Completed)** — TOCTOU races — 5 cells done
+- **Row C (Completed)** — Adversarial — 16 cells done (C13-C15 open via PRs)
+- **Row D** — Protocol / dynamic testing — to hunt
+- **Row S** — Production stubs / not implemented — 30 cells
+- **Row M** — Missing error handling — 30 cells
+- **Row T** — Test coverage gaps — 40 cells
+- **Row E** — Infrastructure / CI — expandable
+- **Row H** — Economic — expandable
+- **Row I** — Cross-repo — expandable
+
+**56 cells vaulted. ~360 fresh gaps to hunt.**
+
+Pick lowest undone coordinate by row priority: S → M → D → E → T

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-20)
+## Unbounded TEXT / input (Row A, Col 15-21)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -16,6 +16,7 @@
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
+| A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -35,6 +35,7 @@
 | A37 | rips/rustchain-core/api/rpc.py | address/block_hash/proposal_id (path params) | #6280 | Open |
 | A38 | contributor_registry.py | username (admin approve path param) | #6281 | Open |
 | A39 | node/hall_of_rust.py | miner_id/device_model/arch/family/hw_serial | #6282 | Open |
+| A40 | node/machine_passport_api.py | name/owner_miner_id/architecture/photo_hash/photo_url/provenance | #6283 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-22)
+## Unbounded TEXT / input (Row A, Col 15-23)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -18,6 +18,7 @@
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
+| A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -69,7 +69,7 @@
 
 | Cell | File | Gap | Priority |
 |------|------|-----|----------|
-| S1 | claims_settlement.py:311 | sign_and_broadcast_transaction() is a hard stub | HIGH |
+| S1 | claims_settlement.py:311 | sign_and_broadcast_transaction() is a hard stub | HIGH | ✅ #6286 |
 | S2 | claims_submission.py:727 | mock Ed25519 sig in production code | HIGH |
 | S3 | beacon_api.py:1058 | mock LLM response in production | MED |
 | S4 | tools/validate_vintage_submission.py:37 | photo validation not implemented | MED |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -20,6 +20,7 @@
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
+| A25 | faucet.py | wallet | #6268 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-21)
+## Unbounded TEXT / input (Row A, Col 15-22)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -17,6 +17,7 @@
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
+| A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,13 +7,14 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-18)
+## Unbounded TEXT / input (Row A, Col 15-19)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
 | A16 | utxo_endpoints.py | memo | #6259 | Open |
 | A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+| A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -946,6 +946,12 @@ def _mood_service_unavailable(operation: str):
     return jsonify({"error": "Mood service unavailable"}), 500
 
 
+def _require_valid_agent_name(agent_name: str) -> Optional[tuple]:
+    if len(agent_name) > 128:
+        return jsonify({"error": "agent_name too long"}), 400
+    return None
+
+
 @mood_bp.route("/<agent_name>/mood", methods=["GET"])
 def get_agent_mood_endpoint(agent_name: str):
     """
@@ -956,6 +962,9 @@ def get_agent_mood_endpoint(agent_name: str):
     Query Parameters:
         include_stats - Include mood statistics (default: false)
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         include_stats = request.args.get("include_stats", "false").lower() == "true"
@@ -984,6 +993,9 @@ def record_mood_signal(agent_name: str):
         value - Signal value data
         weight - Optional signal weight (default: 1.0)
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         data, error = _get_json_object()
@@ -1014,6 +1026,9 @@ def generate_mood_title(agent_name: str):
     Request Body:
         topic - Video topic/theme
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         data, error = _get_json_object()
@@ -1044,6 +1059,9 @@ def generate_mood_comment(agent_name: str):
     Request Body:
         base_comment - Optional base comment to modify
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         data, error = _get_json_object(allow_empty=True)
@@ -1070,6 +1088,9 @@ def get_post_probability(agent_name: str):
     
     Get probability of agent posting based on current mood.
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         probability = engine.get_post_probability(agent_name)
@@ -1093,6 +1114,9 @@ def get_mood_statistics_endpoint(agent_name: str):
     
     Get mood statistics for an agent.
     """
+    err = _require_valid_agent_name(agent_name)
+    if err:
+        return err
     try:
         engine = get_mood_engine()
         stats = engine.get_mood_statistics(agent_name)

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -194,7 +194,7 @@ def _json_object_body():
     return data, None
 
 
-def _clean_string_field(data, field_name, *, optional=False, lower=False):
+def _clean_string_field(data, field_name, *, optional=False, lower=False, max_length=0):
     value = data.get(field_name)
     if value is None:
         return None if optional else ""
@@ -205,6 +205,8 @@ def _clean_string_field(data, field_name, *, optional=False, lower=False):
         value = value.lower()
     if optional and not value:
         return None
+    if max_length > 0 and len(value) > max_length:
+        raise ValueError(f"{field_name} exceeds maximum length of {max_length}")
     return value
 
 
@@ -242,11 +244,11 @@ def lock_rtc():
 
     # ── Validate inputs ──
     try:
-        sender = _clean_string_field(data, "sender_wallet")
+        sender = _clean_string_field(data, "sender_wallet", max_length=128)
         target_chain = _clean_string_field(data, "target_chain", lower=True)
-        target_wallet = _clean_string_field(data, "target_wallet")
-        tx_hash = _clean_string_field(data, "tx_hash", optional=True)
-        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True)
+        target_wallet = _clean_string_field(data, "target_wallet", max_length=128)
+        tx_hash = _clean_string_field(data, "tx_hash", optional=True, max_length=128)
+        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True, max_length=256)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -394,8 +396,8 @@ def confirm_lock():
         return error_response
     try:
         lock_id = _clean_string_field(data, "lock_id")
-        proof_ref = _clean_string_field(data, "proof_ref")
-        notes = _clean_string_field(data, "notes", optional=True)
+        proof_ref = _clean_string_field(data, "proof_ref", max_length=256)
+        notes = _clean_string_field(data, "notes", optional=True, max_length=1024)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -460,8 +462,8 @@ def release_wrtc():
         return error_response
     try:
         lock_id = _clean_string_field(data, "lock_id")
-        release_tx = _clean_string_field(data, "release_tx")
-        notes = _clean_string_field(data, "notes", optional=True)
+        release_tx = _clean_string_field(data, "release_tx", max_length=128)
+        notes = _clean_string_field(data, "notes", optional=True, max_length=1024)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 

--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -314,6 +314,8 @@ def api_contributors():
 def approve_contributor(username):
     if not _contributor_admin_authorized():
         abort(401)
+    if len(username) > 128:
+        abort(400, description="Username too long")
 
     with db_connection() as conn:
         conn.execute(

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -102,10 +102,14 @@ def get_network_stats():
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
+    if len(miner_id) > 128:
+        return render_template('404.html'), 404
     return render_template('miner_detail.html', miner_id=miner_id)
 
 @app.route('/api/miner/<miner_id>')
 def get_miner_detail(miner_id):
+    if len(miner_id) > 128:
+        return jsonify({'error': 'Miner not found'}), 404
     try:
         response = requests.get(MINERS_ENDPOINT, timeout=5)
         if response.status_code == 200:

--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -746,6 +746,8 @@ def api_stats():
 @app.route('/api/wallet/<wallet_address>')
 def api_wallet_lookup(wallet_address):
     """Look up wallet balance and info"""
+    if len(wallet_address) > 128:
+        return jsonify({"error": "Invalid wallet address", "balance": 0}), 400
     try:
         with sqlite3.connect(DB_PATH) as conn:
             # Get balance

--- a/faucet.py
+++ b/faucet.py
@@ -388,6 +388,9 @@ def drip():
 
     wallet = wallet_value.strip()
     
+    if len(wallet) > 128:
+        return jsonify({'ok': False, 'error': 'Wallet address too long'}), 400
+    
     # Basic wallet validation (accept Ethereum-style and native RTC wallets)
     if not is_valid_wallet_address(wallet):
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400

--- a/health-dashboard/server.py
+++ b/health-dashboard/server.py
@@ -455,6 +455,8 @@ def api_status():
 @app.route('/api/history/<node_id>')
 def api_history(node_id: str):
     """API endpoint for historical data (24 hours)"""
+    if len(node_id) > 128:
+        return jsonify({"error": "Invalid node_id", "history": []}), 400
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()

--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -104,13 +104,16 @@ def _json_object_body():
     return data, None
 
 
-def _json_string_field(data, field_name, default=""):
+def _json_string_field(data, field_name, default="", max_length=0):
     value = data.get(field_name, default)
     if value is None:
         return ""
     if not isinstance(value, str):
         raise ValueError(f"{field_name} must be a string")
-    return value.strip()
+    value = value.strip()
+    if max_length > 0 and len(value) > max_length:
+        raise ValueError(f"{field_name} exceeds maximum length of {max_length}")
+    return value
 
 
 def _is_base_address(value: str) -> bool:
@@ -211,6 +214,9 @@ def init_app(app, get_db_func):
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
 
+        if len(agent_id) > 128:
+            return _cors_json({"error": "agent_id too long"}, 400)
+
         # Simple admin check ? require admin key in header
         admin_error = _require_beacon_admin()
         if admin_error:
@@ -247,6 +253,9 @@ def init_app(app, get_db_func):
         """Get a beacon agent's Coinbase wallet info."""
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
+
+        if len(agent_id) > 128:
+            return _cors_json({"error": "agent_id too long"}, 400)
 
         db = get_db_func()
 

--- a/node/bottube_embed.py
+++ b/node/bottube_embed.py
@@ -816,6 +816,8 @@ def embed_player(video_id: str):
     Returns:
         HTML page with embedded video player
     """
+    if len(video_id) > 256:
+        return Response("<html><body><h1>Invalid video ID</h1></body></html>", status=400, mimetype="text/html")
     # Get video data
     video = _get_mock_video(video_id)
 
@@ -861,6 +863,8 @@ def oembed():
         JSON oEmbed response
     """
     url = request.args.get("url", "")
+    if len(url) > 2048:
+        return jsonify({"error": "URL too long"}), 400
     format_param = request.args.get("format", "json")
     maxwidth = request.args.get("maxwidth", 854)
     maxheight = request.args.get("maxheight", 480)
@@ -955,6 +959,8 @@ def watch_page(video_id: str):
     Returns:
         Full HTML watch page
     """
+    if len(video_id) > 256:
+        return Response("<html><body><h1>Invalid video ID</h1></body></html>", status=400, mimetype="text/html")
     # Get video data
     video = _get_mock_video(video_id)
 

--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -165,6 +165,8 @@ def induct_machine():
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
     # This prevents multiple wallets on same machine from getting multiple Hall entries
     hw_serial = data.get('cpu_serial', data.get('hardware_id', 'unknown'))
+    if not isinstance(hw_serial, str) or len(hw_serial) > 256:
+        hw_serial = 'unknown'
     fp_data = f"{data.get('device_model', '')}{data.get('device_arch', '')}{hw_serial}"
     fingerprint_hash = hashlib.sha256(fp_data.encode()).hexdigest()[:32]
     
@@ -180,8 +182,15 @@ def induct_machine():
         existing = c.fetchone()
         
         now = int(time.time())
-        model = data.get('device_model', 'Unknown')
-        arch = data.get('device_arch', 'modern')
+        miner_id = (data.get('miner_id') or 'anonymous')[:128]
+        model = (data.get('device_model', 'Unknown') or 'Unknown')[:256]
+        arch = (data.get('device_arch', 'modern') or 'modern')[:32]
+        device_family = (data.get('device_family', 'Unknown') or 'Unknown')[:128]
+
+        # Use defaults after truncation if empty
+        model = model or 'Unknown'
+        arch = arch or 'modern'
+        device_family = device_family or 'Unknown'
         
         if existing:
             # Update attestation count

--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -140,6 +140,14 @@ def create_lock(
             "valid_types": list(valid_types)
         }
     
+    # Validate miner_id length
+    MAX_MINER_ID_LENGTH = 128
+    if len(miner_id) > MAX_MINER_ID_LENGTH:
+        return False, {
+            "error": f"miner_id too long (max {MAX_MINER_ID_LENGTH} chars)",
+            "actual_length": len(miner_id)
+        }
+    
     # Validate amount
     if amount_i64 <= 0:
         return False, {"error": "amount_i64 must be positive"}
@@ -673,7 +681,7 @@ def register_lock_ledger_routes(app):
             return None, (jsonify({"error": "lock_id must be positive"}), 400)
         return raw, None
 
-    def parse_optional_string(data, name: str, default: Optional[str] = None):
+    def parse_optional_string(data, name: str, default: Optional[str] = None, max_length: Optional[int] = None):
         raw = data.get(name, default)
         if raw is None:
             return default, None
@@ -682,11 +690,15 @@ def register_lock_ledger_routes(app):
         value = raw.strip()
         if value == "":
             return default, None
+        if max_length is not None and len(value) > max_length:
+            return None, (jsonify({"error": f"{name} too long (max {max_length} chars)", "actual_length": len(value)}), 400)
         return value, None
     
     @app.route('/api/lock/miner/<miner_id>', methods=['GET'])
     def get_miner_locks(miner_id: str):
         """Get locks for a specific miner."""
+        if len(miner_id) > 128:
+            return jsonify({"error": "miner_id too long (max 128 chars)", "actual_length": len(miner_id)}), 400
         status = request.args.get("status")
         limit, error_response = parse_bounded_int_arg("limit", 100, 1, 500)
         if error_response is not None:
@@ -798,7 +810,7 @@ def register_lock_ledger_routes(app):
         lock_id, error_response = parse_lock_id(data)
         if error_response is not None:
             return error_response
-        release_tx_hash, error_response = parse_optional_string(data, "release_tx_hash")
+        release_tx_hash, error_response = parse_optional_string(data, "release_tx_hash", max_length=256)
         if error_response is not None:
             return error_response
         
@@ -835,7 +847,7 @@ def register_lock_ledger_routes(app):
         lock_id, error_response = parse_lock_id(data)
         if error_response is not None:
             return error_response
-        reason, error_response = parse_optional_string(data, "reason", "admin_forfeit")
+        reason, error_response = parse_optional_string(data, "reason", "admin_forfeit", max_length=256)
         if error_response is not None:
             return error_response
         

--- a/node/machine_passport_api.py
+++ b/node/machine_passport_api.py
@@ -284,6 +284,14 @@ def create_passport():
                 'message': "Field 'machine_id' is required or provide 'hardware_fingerprint'",
             }), 400
     
+    # Cap string fields to prevent DB abuse
+    name = (data.get('name') or '')[:256]
+    owner_miner_id = (data.get('owner_miner_id') or '')[:128]
+    architecture = (data.get('architecture') or '')[:64] if data.get('architecture') else None
+    photo_hash = (data.get('photo_hash') or '')[:128] if data.get('photo_hash') else None
+    photo_url = (data.get('photo_url') or '')[:2048] if data.get('photo_url') else None
+    provenance = (data.get('provenance') or '')[:1024] if data.get('provenance') else None
+    
     ledger = get_ledger()
     
     # Check if passport already exists
@@ -297,13 +305,13 @@ def create_passport():
     
     passport = MachinePassport(
         machine_id=machine_id,
-        name=data['name'],
-        owner_miner_id=data['owner_miner_id'],
+        name=name,
+        owner_miner_id=owner_miner_id,
         manufacture_year=data.get('manufacture_year'),
-        architecture=data.get('architecture'),
-        photo_hash=data.get('photo_hash'),
-        photo_url=data.get('photo_url'),
-        provenance=data.get('provenance'),
+        architecture=architecture,
+        photo_hash=photo_hash,
+        photo_url=photo_url,
+        provenance=provenance,
     )
     
     success, msg = ledger.create_passport(passport)
@@ -349,6 +357,13 @@ def update_passport(machine_id: str):
             'error': 'invalid_request',
             'message': 'JSON body required',
         }), 400
+    
+    # Cap string fields to prevent DB abuse
+    for field in ('name', 'owner_miner_id', 'architecture', 'photo_hash', 'photo_url', 'provenance', 'machine_id'):
+        if field in data and isinstance(data[field], str):
+            max_len = {'machine_id': 128, 'name': 256, 'owner_miner_id': 128, 'architecture': 64,
+                       'photo_hash': 128, 'photo_url': 2048, 'provenance': 1024}.get(field, 256)
+            data[field] = data[field][:max_len]
     
     success, msg = ledger.update_passport(machine_id, data)
     

--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -446,6 +446,9 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
 
         peer_url = peer_url.strip()
 
+        if len(peer_url) > 1024:
+            return jsonify({"ok": False, "error": "peer_url too long"}), 400
+
         if peer_url:
             success = peer_manager.add_peer(peer_url)
             return jsonify({"ok": success, "peers": len(peer_manager.get_active_peers())})

--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -374,6 +374,8 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
         # Dynamic routes
         if path.startswith("/api/wallet/"):
             address = path.split("/")[-1]
+            if len(address) > 128:
+                return ApiResponse(success=False, error="address too long")
             return self.api.rpc.call("getWallet", {"address": address})
 
         if path.startswith("/api/block/"):
@@ -381,10 +383,14 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
             try:
                 return self.api.rpc.call("getBlock", {"height": int(height)})
             except ValueError:
+                if len(height) > 128:
+                    return ApiResponse(success=False, error="block hash too long")
                 return self.api.rpc.call("getBlockByHash", {"hash": height})
 
         if path.startswith("/api/proposal/"):
             proposal_id = path.split("/")[-1]
+            if len(proposal_id) > 128:
+                return ApiResponse(success=False, error="proposal_id too long")
             return self.api.rpc.call("getProposal", {"proposal_id": proposal_id})
 
         # POST endpoints

--- a/sophia_api.py
+++ b/sophia_api.py
@@ -91,8 +91,11 @@ def inspect_fingerprint():
     miner_id = data.get("miner_id")
     fingerprint = data.get("fingerprint")
 
-    if not miner_id:
+    if not miner_id or not isinstance(miner_id, str):
         return jsonify({"error": "miner_id is required"}), 400
+    miner_id = miner_id.strip()
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long"}), 400
     if not fingerprint or not isinstance(fingerprint, dict):
         return jsonify({"error": "fingerprint bundle (dict) is required"}), 400
 
@@ -103,6 +106,8 @@ def inspect_fingerprint():
 @app.route("/sophia/status/<miner_id>", methods=["GET"])
 def miner_status(miner_id):
     """Get the latest inspection result + history for a miner."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long", "miner_id": miner_id[:64]}), 400
     conn = get_connection()
     try:
         latest = get_latest_inspection(conn, miner_id)
@@ -154,6 +159,8 @@ def dashboard():
 @app.route("/sophia/explorer/<miner_id>", methods=["GET"])
 def explorer_verdict(miner_id):
     """Emoji verdict for block explorer integration."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long", "miner_id": miner_id[:64]}), 400
     conn = get_connection()
     try:
         row = get_latest_inspection(conn, miner_id)

--- a/tools/explorer-api/api.py
+++ b/tools/explorer-api/api.py
@@ -284,6 +284,8 @@ def address_info(addr: str):
     addr = addr.strip()
     if not addr:
         return jsonify({"ok": False, "error": "address_required"}), 400
+    if len(addr) > 128:
+        return jsonify({"ok": False, "error": "address too long"}), 400
 
     # Fetch balance
     balance_data = _get(f"/balance/{addr}")
@@ -332,6 +334,8 @@ def search():
     query = request.args.get("q", "").strip()
     if not query:
         return jsonify({"ok": False, "error": "query_required"}), 400
+    if len(query) > 256:
+        return jsonify({"ok": False, "error": "query_too_long"}), 400
 
     results = []
 

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -59,7 +59,7 @@ def _get_json_object_or_empty() -> dict:
     return data
 
 
-def _optional_string_value(data: dict, key: str) -> str | None:
+def _optional_string_value(data: dict, key: str, max_length: int = 0) -> str | None:
     value = data.get(key)
     if value is None:
         return None
@@ -68,6 +68,8 @@ def _optional_string_value(data: dict, key: str) -> str | None:
     value = value.strip()
     if value == "":
         return None
+    if max_length > 0 and len(value) > max_length:
+        abort(400, description=f"{key} exceeds maximum length of {max_length}")
     return value
 
 
@@ -272,8 +274,8 @@ def post_reserve():
     """Reserve a machine and lock RTC in escrow."""
     data = _get_json_object_or_empty()
 
-    agent_id       = _optional_string_value(data, "agent_id")
-    machine_id     = _optional_string_value(data, "machine_id")
+    agent_id       = _optional_string_value(data, "agent_id", max_length=128)
+    machine_id     = _optional_string_value(data, "machine_id", max_length=128)
     duration_hours = data.get("duration_hours")
     rtc_amount     = data.get("rtc_amount")
 

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -93,13 +93,15 @@ def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
     return data, None
 
 
-def _strip_string_field(data: dict[str, Any], name: str) -> tuple[str | None, tuple[Any, int] | None]:
+def _strip_string_field(data: dict[str, Any], name: str, max_length: int = 0) -> tuple[str | None, tuple[Any, int] | None]:
     value = data.get(name)
     if value is None:
         return None, None
     if not isinstance(value, str):
         return None, (jsonify({"ok": False, "error": f"{name}_must_be_string"}), 400)
     value = value.strip()
+    if max_length > 0 and len(value) > max_length:
+        return None, (jsonify({"ok": False, "error": f"{name}_too_long"}), 400)
     return value or None, None
 
 
@@ -183,10 +185,10 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         data, error = _request_data()
         if error:
             return error
-        wallet, error = _strip_string_field(data, "wallet")
+        wallet, error = _strip_string_field(data, "wallet", max_length=128)
         if error:
             return error
-        github_username, error = _strip_string_field(data, "github_username")
+        github_username, error = _strip_string_field(data, "github_username", max_length=128)
         if error:
             return error
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()


### PR DESCRIPTION
## Description
Adds max length validation for string fields in lock_ledger.py endpoints.

## Fields Capped
| Endpoint | Field | Max |
|---|---|---|
| GET /api/lock/miner/<miner_id> | miner_id (URL param) | 128 |
| POST /api/lock/release | release_tx_hash | 256 |
| POST /api/lock/forfeit | reason | 256 |

Also added optional max_length parameter to parse_optional_string() helper.

Relates to battleship cell **A22** (lock_ledger field length limits).
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`