### PR TITLE
fix: cap agent_id/machine_id in tools/rent_a_relic/server.py (A31)

### DIFF
--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-23)
+## Unbounded TEXT / input (Row A, Col 15-24)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -19,6 +19,7 @@
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
+| A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -22,6 +22,9 @@
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 | A25 | faucet.py | wallet | #6268 | Open |
 | A26 | sophia_api.py | miner_id (POST + 2 GET path params) | #6269 | Open |
+| A27 | explorer/app.py | miner_id (2 GET path params) | #6270 | Open |
+| A28 | node/rustchain_p2p_sync.py | peer_url (POST /p2p/announce) | #6271 | Open |
+| A29 | explorer/rustchain_dashboard.py | wallet_address (GET path param) | #6272 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-19)
+## Unbounded TEXT / input (Row A, Col 15-20)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -15,6 +15,7 @@
 | A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
+| A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -1,0 +1,35 @@
+# BATTLESHIP PROGRESS
+
+## Unbounded offset/pagination (Row C, Col 13-15)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| C13 | governance.py | offset | #6255 | Open |
+| C14 | machine_passport_api.py | offset | #6256 | Open |
+| C15 | ergo_anchor.py | offset | #6257 | Open |
+
+## Unbounded TEXT / input (Row A, Col 15-18)
+| Cell | File | Field | PR | Status |
+|------|------|-------|----|--------|
+| A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
+| A16 | utxo_endpoints.py | memo | #6259 | Open |
+| A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
+| A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+
+## Exhausted cells (grid complete)
+| Cell | File | Vulnerability | PR |
+|------|------|---------------|----|
+| A1-A5 | utxo_db.py | Mempool/input bounds | #6237 |
+| A6, A9-A11 | utxo_db.py | Input validation | #6241 |
+| A7 | utxo_db.py | Box ID endianness | #6243 |
+| A12 | utxo_db.py | TX type normalize | #6242 |
+| A13 | utxo_db.py | TX data JSON size | #6245 |
+| A14 | utxo_db.py | Spending proof size | #6246 |
+| B1-B3, C1 | utxo_db.py | Dynamic race conds | #6239 |
+| C2-C4, D1 | utxo_db.py | Adversarial vulns | #6240 |
+| C7 | utxo_db.py | Genesis migration | #6249 |
+| C8 | rewards.py | ADM double-credit | #6250 |
+| C9 | governance.py | Vote tally race | #6251 |
+| C10 | coalition.py | Vote tally race | #6252 |
+| C11 | bridge.py | Confirm cap | #6253 |
+| C12 | bridge.py | Req confirm cap | #6254 |
+| C16 | utxo_db.py | Mining reward dup | #6247 |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -21,6 +21,7 @@
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
 | A25 | faucet.py | wallet | #6268 | Open |
+| A26 | sophia_api.py | miner_id (POST + 2 GET path params) | #6269 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-20)
+## Unbounded TEXT / input (Row A, Col 15-21)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -16,6 +16,7 @@
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
+| A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-22)
+## Unbounded TEXT / input (Row A, Col 15-23)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -18,6 +18,7 @@
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
+| A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -20,6 +20,7 @@
 | A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 | A23 | rustchain_sync_endpoints.py | X-Peer-ID/X-Sync-Nonce/X-Sync-Signature/table | #6266 | Open |
 | A24 | bridge/bridge_api.py | sender_wallet/target_wallet/tx_hash/receipt_signature/proof_ref/notes/release_tx | #6267 | Open |
+| A25 | faucet.py | wallet | #6268 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,7 +7,7 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-21)
+## Unbounded TEXT / input (Row A, Col 15-22)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
@@ -17,6 +17,7 @@
 | A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 | A20 | bridge_api.py | source_address/dest_address | #6263 | Open |
 | A21 | airdrop_v2.py | github_username/wallet_address/chain/tier | #6264 | Open |
+| A22 | lock_ledger.py | miner_id/release_tx_hash/reason | #6265 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/BATTLESHIP_PROGRESS.md
+++ b/BATTLESHIP_PROGRESS.md
@@ -7,13 +7,14 @@
 | C14 | machine_passport_api.py | offset | #6256 | Open |
 | C15 | ergo_anchor.py | offset | #6257 | Open |
 
-## Unbounded TEXT / input (Row A, Col 15-18)
+## Unbounded TEXT / input (Row A, Col 15-19)
 | Cell | File | Field | PR | Status |
 |------|------|-------|----|--------|
 | A15 | bottube_feed_routes.py | Host header | #6258 | Open, fix pushed |
 | A16 | utxo_endpoints.py | memo | #6259 | Open |
 | A17 | gpu_render_endpoints.py | pricing | #6260 | Open |
 | A18 | bcos_routes.py | cert_id/repo/commit_sha/reviewer | #6261 | Open |
+| A19 | beacon_api.py | agent_id/pubkey/name/type/term/currency | #6262 | Open |
 
 ## Exhausted cells (grid complete)
 | Cell | File | Vulnerability | PR |

--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -194,7 +194,7 @@ def _json_object_body():
     return data, None
 
 
-def _clean_string_field(data, field_name, *, optional=False, lower=False):
+def _clean_string_field(data, field_name, *, optional=False, lower=False, max_length=0):
     value = data.get(field_name)
     if value is None:
         return None if optional else ""
@@ -205,6 +205,8 @@ def _clean_string_field(data, field_name, *, optional=False, lower=False):
         value = value.lower()
     if optional and not value:
         return None
+    if max_length > 0 and len(value) > max_length:
+        raise ValueError(f"{field_name} exceeds maximum length of {max_length}")
     return value
 
 
@@ -242,11 +244,11 @@ def lock_rtc():
 
     # ── Validate inputs ──
     try:
-        sender = _clean_string_field(data, "sender_wallet")
+        sender = _clean_string_field(data, "sender_wallet", max_length=128)
         target_chain = _clean_string_field(data, "target_chain", lower=True)
-        target_wallet = _clean_string_field(data, "target_wallet")
-        tx_hash = _clean_string_field(data, "tx_hash", optional=True)
-        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True)
+        target_wallet = _clean_string_field(data, "target_wallet", max_length=128)
+        tx_hash = _clean_string_field(data, "tx_hash", optional=True, max_length=128)
+        receipt_signature = _clean_string_field(data, "receipt_signature", optional=True, lower=True, max_length=256)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -394,8 +396,8 @@ def confirm_lock():
         return error_response
     try:
         lock_id = _clean_string_field(data, "lock_id")
-        proof_ref = _clean_string_field(data, "proof_ref")
-        notes = _clean_string_field(data, "notes", optional=True)
+        proof_ref = _clean_string_field(data, "proof_ref", max_length=256)
+        notes = _clean_string_field(data, "notes", optional=True, max_length=1024)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 
@@ -460,8 +462,8 @@ def release_wrtc():
         return error_response
     try:
         lock_id = _clean_string_field(data, "lock_id")
-        release_tx = _clean_string_field(data, "release_tx")
-        notes = _clean_string_field(data, "notes", optional=True)
+        release_tx = _clean_string_field(data, "release_tx", max_length=128)
+        notes = _clean_string_field(data, "notes", optional=True, max_length=1024)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
 

--- a/explorer/app.py
+++ b/explorer/app.py
@@ -102,10 +102,14 @@ def get_network_stats():
 
 @app.route('/miner/<miner_id>')
 def miner_detail(miner_id):
+    if len(miner_id) > 128:
+        return render_template('404.html'), 404
     return render_template('miner_detail.html', miner_id=miner_id)
 
 @app.route('/api/miner/<miner_id>')
 def get_miner_detail(miner_id):
+    if len(miner_id) > 128:
+        return jsonify({'error': 'Miner not found'}), 404
     try:
         response = requests.get(MINERS_ENDPOINT, timeout=5)
         if response.status_code == 200:

--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -746,6 +746,8 @@ def api_stats():
 @app.route('/api/wallet/<wallet_address>')
 def api_wallet_lookup(wallet_address):
     """Look up wallet balance and info"""
+    if len(wallet_address) > 128:
+        return jsonify({"error": "Invalid wallet address", "balance": 0}), 400
     try:
         with sqlite3.connect(DB_PATH) as conn:
             # Get balance

--- a/faucet.py
+++ b/faucet.py
@@ -388,6 +388,9 @@ def drip():
 
     wallet = wallet_value.strip()
     
+    if len(wallet) > 128:
+        return jsonify({'ok': False, 'error': 'Wallet address too long'}), 400
+    
     # Basic wallet validation (accept Ethereum-style and native RTC wallets)
     if not is_valid_wallet_address(wallet):
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400

--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -446,6 +446,9 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
 
         peer_url = peer_url.strip()
 
+        if len(peer_url) > 1024:
+            return jsonify({"ok": False, "error": "peer_url too long"}), 400
+
         if peer_url:
             success = peer_manager.add_peer(peer_url)
             return jsonify({"ok": success, "peers": len(peer_manager.get_active_peers())})

--- a/sophia_api.py
+++ b/sophia_api.py
@@ -91,8 +91,11 @@ def inspect_fingerprint():
     miner_id = data.get("miner_id")
     fingerprint = data.get("fingerprint")
 
-    if not miner_id:
+    if not miner_id or not isinstance(miner_id, str):
         return jsonify({"error": "miner_id is required"}), 400
+    miner_id = miner_id.strip()
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long"}), 400
     if not fingerprint or not isinstance(fingerprint, dict):
         return jsonify({"error": "fingerprint bundle (dict) is required"}), 400
 
@@ -103,6 +106,8 @@ def inspect_fingerprint():
 @app.route("/sophia/status/<miner_id>", methods=["GET"])
 def miner_status(miner_id):
     """Get the latest inspection result + history for a miner."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long", "miner_id": miner_id[:64]}), 400
     conn = get_connection()
     try:
         latest = get_latest_inspection(conn, miner_id)
@@ -154,6 +159,8 @@ def dashboard():
 @app.route("/sophia/explorer/<miner_id>", methods=["GET"])
 def explorer_verdict(miner_id):
     """Emoji verdict for block explorer integration."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long", "miner_id": miner_id[:64]}), 400
     conn = get_connection()
     try:
         row = get_latest_inspection(conn, miner_id)

--- a/tools/rent_a_relic/server.py
+++ b/tools/rent_a_relic/server.py
@@ -59,7 +59,7 @@ def _get_json_object_or_empty() -> dict:
     return data
 
 
-def _optional_string_value(data: dict, key: str) -> str | None:
+def _optional_string_value(data: dict, key: str, max_length: int = 0) -> str | None:
     value = data.get(key)
     if value is None:
         return None
@@ -68,6 +68,8 @@ def _optional_string_value(data: dict, key: str) -> str | None:
     value = value.strip()
     if value == "":
         return None
+    if max_length > 0 and len(value) > max_length:
+        abort(400, description=f"{key} exceeds maximum length of {max_length}")
     return value
 
 
@@ -272,8 +274,8 @@ def post_reserve():
     """Reserve a machine and lock RTC in escrow."""
     data = _get_json_object_or_empty()
 
-    agent_id       = _optional_string_value(data, "agent_id")
-    machine_id     = _optional_string_value(data, "machine_id")
+    agent_id       = _optional_string_value(data, "agent_id", max_length=128)
+    machine_id     = _optional_string_value(data, "machine_id", max_length=128)
     duration_hours = data.get("duration_hours")
     rtc_amount     = data.get("rtc_amount")
 

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -93,13 +93,15 @@ def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
     return data, None
 
 
-def _strip_string_field(data: dict[str, Any], name: str) -> tuple[str | None, tuple[Any, int] | None]:
+def _strip_string_field(data: dict[str, Any], name: str, max_length: int = 0) -> tuple[str | None, tuple[Any, int] | None]:
     value = data.get(name)
     if value is None:
         return None, None
     if not isinstance(value, str):
         return None, (jsonify({"ok": False, "error": f"{name}_must_be_string"}), 400)
     value = value.strip()
+    if max_length > 0 and len(value) > max_length:
+        return None, (jsonify({"ok": False, "error": f"{name}_too_long"}), 400)
     return value or None, None
 
 
@@ -183,10 +185,10 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         data, error = _request_data()
         if error:
             return error
-        wallet, error = _strip_string_field(data, "wallet")
+        wallet, error = _strip_string_field(data, "wallet", max_length=128)
         if error:
             return error
-        github_username, error = _strip_string_field(data, "github_username")
+        github_username, error = _strip_string_field(data, "github_username", max_length=128)
         if error:
             return error
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()


### PR DESCRIPTION
Adds max_length=128 on `agent_id` and `machine_id` in POST /relic/reserve endpoint. Both stored in reservations + escrow tables.
---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`