### PR TITLE
fix(bridge): add 5s DB timeout to all sqlite3.connect calls (M1)

### DIFF
--- a/bridge/bridge_api.py
+++ b/bridge/bridge_api.py
@@ -65,7 +65,7 @@ _db_lock = threading.Lock()
 
 
 def get_db():
-    conn = sqlite3.connect(BRIDGE_DB_PATH)
+    conn = sqlite3.connect(BRIDGE_DB_PATH, timeout=5.0)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -57,6 +57,7 @@ BRIDGE_DEFAULT_CONFIRMATIONS = int(os.environ.get("RC_BRIDGE_DEFAULT_CONFIRMATIO
 BRIDGE_LOCK_EXPIRY_SECONDS = int(os.environ.get("RC_BRIDGE_LOCK_EXPIRY_SECONDS", "604800"))  # 7 days
 BRIDGE_MIN_AMOUNT_RTC = float(os.environ.get("RC_BRIDGE_MIN_AMOUNT_RTC", "1.0"))
 BRIDGE_UNIT = 1000000  # Micro-units per RTC
+DB_TIMEOUT = 5.0  # seconds: timeout for SQLite connection locks
 logger = logging.getLogger(__name__)
 
 
@@ -791,7 +792,7 @@ def register_bridge_routes(app):
             bridge_type=details["bridge_type"]
         )
         
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, timeout=5.0)
         try:
             success, result = create_bridge_transfer(conn, req, admin_initiated)
             if success:
@@ -811,7 +812,7 @@ def register_bridge_routes(app):
         if not tx_hash:
             return jsonify({"error": "tx_hash or id parameter required"}), 400
         
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, timeout=5.0)
         try:
             transfer = get_bridge_transfer_by_hash(conn, tx_hash)
             if not transfer:
@@ -835,7 +836,7 @@ def register_bridge_routes(app):
         if error:
             return jsonify({"error": error}), 400
         
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, timeout=5.0)
         try:
             transfers = list_bridge_transfers(
                 conn,
@@ -879,7 +880,7 @@ def register_bridge_routes(app):
         if not tx_hash:
             return jsonify({"error": "tx_hash required"}), 400
         
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, timeout=5.0)
         try:
             success, result = void_bridge_transfer(conn, tx_hash, reason, voided_by)
             if success:
@@ -925,7 +926,7 @@ def register_bridge_routes(app):
         if not tx_hash or not external_tx_hash:
             return jsonify({"error": "tx_hash and external_tx_hash required"}), 400
 
-        conn = sqlite3.connect(DB_PATH)
+        conn = sqlite3.connect(DB_PATH, timeout=5.0)
         try:
             success, result = update_external_confirmation(
                 conn, tx_hash, external_tx_hash, confirmations, required_confirmations


### PR DESCRIPTION
## Summary
M1 - MED: bridge_api.py: create_bridge_transfer no timeout on external network calls

The create_bridge_transfer() function uses BEGIN IMMEDIATE but the SQLite connection had no timeout, meaning it could block indefinitely if another transaction held the DB lock.

## Fix
- Added DB_TIMEOUT = 5.0 constant
- All 5 sqlite3.connect(DB_PATH) calls now pass timeout=5.0
- Covers: initiate_bridge, get_bridge_status, list_bridges, void_bridge, update_external

When the DB write-lock is held longer than 5 seconds, sqlite3.OperationalError is raised and caught by the existing try/except handlers, returning an error instead of hanging indefinitely.

## Testing
- 58/58 tests pass in test_bridge_lock_ledger.py
- Syntax and compile verified

**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`