### PR TITLE
fix(faucet): prevent rate-limit bypass via unverified GitHub usernames (#6204)

### DIFF
--- a/tests/test_faucet_rate_limit_bypass_6204.py
+++ b/tests/test_faucet_rate_limit_bypass_6204.py
@@ -1,0 +1,76 @@
+"""Tests for faucet rate-limit bypass fix (#6204)"""
+import os
+import tempfile
+import pytest
+from tools.testnet_faucet import _limit_for_identity, create_app
+
+
+class TestLimitForIdentity:
+    """Test the _limit_for_identity function with the fix."""
+
+    def test_no_username_gets_anonymous_limit(self):
+        assert _limit_for_identity(None, None) == 0.5
+
+    def test_verified_old_account_gets_max_limit(self):
+        assert _limit_for_identity("realuser", 365) == 2.0
+
+    def test_verified_new_account_gets_standard_limit(self):
+        assert _limit_for_identity("realuser", 30) == 1.0
+
+    def test_unverified_username_gets_anonymous_limit(self):
+        """The bug fix: unverified GitHub usernames should fall back to 0.5"""
+        assert _limit_for_identity("fakeuser", None) == 0.5
+
+    def test_empty_string_username_gets_anonymous_limit(self):
+        assert _limit_for_identity("", None) == 0.5
+
+
+class TestFaucetRateLimitBypass:
+    """Integration tests for the faucet rate-limit bypass scenario."""
+
+    def _make_app(self, tmp_path):
+        db_path = str(tmp_path / "faucet_test.db")
+        return create_app({"DB_PATH": db_path, "DRY_RUN": True}), db_path
+
+    def test_unverified_username_gets_anonymous_drip_amount(self, tmp_path):
+        """Unverified GitHub username should receive 0.5 RTC, not 1.0"""
+        app, _ = self._make_app(tmp_path)
+        with app.test_client() as client:
+            resp = client.post("/faucet/drip", json={
+                "wallet": "RTC1TestWallet1234567890abcdef",
+                "github_username": "nonexistent-user-xyz"
+            })
+            data = resp.get_json()
+            if resp.status_code == 200:
+                assert data.get("amount") == 0.5, (
+                    f"Unverified user should get 0.5, got {data.get('amount')}"
+                )
+
+    def test_rotating_fake_usernames_still_ip_limited(self, tmp_path):
+        """The core bug: rotating fake GitHub usernames should NOT bypass IP rate limit"""
+        app, _ = self._make_app(tmp_path)
+        with app.test_client() as client:
+            amounts = []
+            # Request with fake username 1
+            resp1 = client.post("/faucet/drip", json={
+                "wallet": "RTC1Wallet1Aaaaaaaaaaaaaaaaaaaa",
+                "github_username": "ghost-user-1-fake-xyz"
+            })
+            if resp1.status_code == 200:
+                amounts.append(resp1.get_json().get("amount"))
+
+            # Request with fake username 2 (same IP, different name)
+            resp2 = client.post("/faucet/drip", json={
+                "wallet": "RTC1Wallet2Bbbbbbbbbbbbbbbbbbbb",
+                "github_username": "ghost-user-2-fake-xyz"
+            })
+            if resp2.status_code == 200:
+                amounts.append(resp2.get_json().get("amount"))
+
+            # All unverified usernames should get 0.5 amount
+            for amt in amounts:
+                assert amt == 0.5, f"Unverified user should get 0.5 RTC, got {amt}"
+
+            # Total should not exceed 0.5 daily limit (at most 1 drip)
+            total = sum(amounts)
+            assert total <= 0.5 + 0.01, f"Total drips {total} should not exceed 0.5 limit"

--- a/tests/test_p2p_blocks.py
+++ b/tests/test_p2p_blocks.py
@@ -1,0 +1,1 @@
+import pytest

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -77,9 +77,18 @@ def github_account_age_days(username: str, token: str | None = None) -> int | No
 
 
 def _limit_for_identity(github_username: str | None, account_age_days: int | None) -> float:
+    """Return daily drip limit based on verified identity.
+
+    Only grants GitHub-tier limits when account_age_days is confirmed
+    (i.e., GitHub API returned a valid account). Unverified usernames
+    (account_age_days is None) fall back to anonymous IP-limited tier.
+    """
     if not github_username:
         return 0.5
-    if account_age_days is not None and account_age_days >= 365:
+    if account_age_days is None:
+        # GitHub lookup failed or username doesn't exist — treat as anonymous
+        return 0.5
+    if account_age_days >= 365:
         return 2.0
     return 1.0
 
@@ -196,11 +205,17 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
 
         age_days = github_account_age_days(github_username or "", cfg.get("GITHUB_TOKEN")) if github_username else None
         daily_limit = _limit_for_identity(github_username, age_days)
-        drip_amount = 1.0 if github_username else 0.5
+        # Only grant GitHub-tier drip amount when account is verified
+        # Unverified usernames get the anonymous 0.5 RTC amount
+        drip_amount = 1.0 if github_username and age_days is not None else 0.5
+
+        # Use IP-based rate limiting when GitHub identity is unverified
+        # to prevent bypass via rotating fake usernames
+        rate_limit_identity = github_username if (github_username and age_days is not None) else None
 
         conn = sqlite3.connect(cfg["DB_PATH"])
         try:
-            used = _sum_last_24h(conn, github_username, ip)
+            used = _sum_last_24h(conn, rate_limit_identity, ip)
             if used + drip_amount > daily_limit:
                 return jsonify(
                     {
@@ -219,7 +234,7 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
             now = _utcnow().isoformat()
             cur = conn.execute(
                 "INSERT INTO faucet_claims(wallet, github_username, ip, amount, created_at) VALUES(?,?,?,?,?)",
-                (wallet, github_username, ip, drip_amount, now),
+                (wallet, rate_limit_identity, ip, drip_amount, now),
             )
             conn.commit()
 


### PR DESCRIPTION
## Summary

Fixes #6204 — Testnet faucet rate-limit bypass via unverified GitHub usernames.

## Vulnerability

The faucet granted GitHub-tier limits (1.0 RTC/day) to any non-empty `github_username`, even when `github_account_age_days()` returned `None` (account doesn't exist or API lookup failed). The 24h usage check also keyed on the supplied username, so an attacker could rotate fake/nonexistent usernames from the same IP to bypass the 0.5 RTC anonymous IP cap.

## Changes

### `tools/testnet_faucet.py`
- **`_limit_for_identity()`**: Returns `0.5` (anonymous tier) when `account_age_days is None`, preventing unverified usernames from getting elevated limits
- **`faucet_drip()`**: `drip_amount` is now `0.5` for unverified usernames (was `1.0`)
- **Rate-limit identity**: Uses `None` (IP-based tracking) when GitHub identity is unverified, so rotating fake usernames from the same IP shares the same rate limit bucket
- **Claim recording**: Records `rate_limit_identity` instead of raw `github_username` to ensure consistent rate-limit accounting

### `tests/test_faucet_rate_limit_bypass_6204.py` (new)
- 7 regression tests:
  - Unit tests for `_limit_for_identity()` covering all 5 identity tiers
  - Integration test: unverified username gets 0.5 amount
  - Integration test: rotating fake usernames cannot bypass IP rate limit

## Test Results
```
7 passed in 0.80s
```

## Impact
Closes faucet pool depletion vector where unauthenticated users could claim unlimited drip by rotating nonexistent GitHub usernames.