### PR TITLE
fix: reject negative BoTTube feed limits

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -50,7 +50,10 @@ def _parse_feed_limit(default: int = 20, maximum: int = 100) -> int:
     raw_limit = request.args.get("limit")
     if raw_limit in (None, ""):
         return default
-    return max(1, min(int(raw_limit), maximum))
+    limit = int(raw_limit)
+    if limit < 0:
+        raise ValueError("limit must be non-negative")
+    return max(1, min(limit, maximum))
 
 
 def _get_db_connection():

--- a/tests/test_bottube_feed_routes.py
+++ b/tests/test_bottube_feed_routes.py
@@ -110,6 +110,13 @@ class TestFeedRoutes(unittest.TestCase):
         response = self.client.get("/api/feed/rss?limit=invalid")
         self.assertEqual(response.status_code, 400)
 
+    def test_feed_negative_limit_rejected(self):
+        """Test negative limits are rejected across feed variants."""
+        for path in ("/api/feed/rss", "/api/feed/atom", "/api/feed"):
+            with self.subTest(path=path):
+                response = self.client.get(f"{path}?limit=-1")
+                self.assertEqual(response.status_code, 400)
+
     def test_rss_feed_excessive_limit(self):
         """Test RSS feed caps limit to 100."""
         response = self.client.get("/api/feed/rss?limit=999")


### PR DESCRIPTION
Reject negative limit values for /api/feed, /api/feed/rss, and /api/feed/atom with HTTP 400 while preserving existing max-100 clamping for valid inputs.\n\nTests: PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_bottube_feed_routes.py -q