### PR TITLE
Fix faucet rate-limit timestamp parsing

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -74,13 +74,23 @@ def get_last_drip_time(identifier, is_wallet=False):
     result = c.fetchone()
     conn.close()
     return result[0] if result else None
+
+
+def parse_drip_timestamp(timestamp):
+    """Parse a stored drip timestamp as UTC when SQLite returns it without tzinfo."""
+    drip_time = datetime.fromisoformat(timestamp.replace('Z', '+00:00'))
+    if drip_time.tzinfo is None:
+        return drip_time.replace(tzinfo=timezone.utc)
+    return drip_time
+
+
 def can_drip(identifier, is_wallet=False):
     """Check if the IP or Wallet can request a drip (rate limiting)."""
     last_time = get_last_drip_time(identifier, is_wallet)
     if not last_time:
         return True
     
-    last_drip = datetime.fromisoformat(last_time.replace('Z', '+00:00'))
+    last_drip = parse_drip_timestamp(last_time)
     now = datetime.now(timezone.utc)
     hours_since = (now - last_drip).total_seconds() / 3600
 
@@ -93,7 +103,7 @@ def get_next_available(identifier, is_wallet=False):
     if not last_time:
         return None
     
-    last_drip = datetime.fromisoformat(last_time.replace('Z', '+00:00'))
+    last_drip = parse_drip_timestamp(last_time)
     next_available = last_drip + timedelta(hours=RATE_LIMIT_HOURS)
     now = datetime.now(timezone.utc)
     
@@ -134,7 +144,7 @@ def try_record_drip(wallet, ip_address, amount):
         ''', (ip_address,))
         row = c.fetchone()
         if row:
-            last_drip = datetime.fromisoformat(row[0].replace('Z', '+00:00'))
+            last_drip = parse_drip_timestamp(row[0])
             now = datetime.now(timezone.utc)
             hours_since = (now - last_drip).total_seconds() / 3600
             if hours_since < RATE_LIMIT_HOURS:
@@ -151,7 +161,7 @@ def try_record_drip(wallet, ip_address, amount):
         ''', (wallet,))
         row = c.fetchone()
         if row:
-            last_drip = datetime.fromisoformat(row[0].replace('Z', '+00:00'))
+            last_drip = parse_drip_timestamp(row[0])
             now = datetime.now(timezone.utc)
             hours_since = (now - last_drip).total_seconds() / 3600
             if hours_since < RATE_LIMIT_HOURS:

--- a/tests/test_legacy_faucet_json_validation.py
+++ b/tests/test_legacy_faucet_json_validation.py
@@ -1,4 +1,5 @@
 import pytest
+from concurrent.futures import ThreadPoolExecutor
 
 import faucet
 
@@ -62,3 +63,27 @@ def test_legacy_faucet_accepts_native_rtc_wallet(client):
     data = response.get_json()
     assert data["ok"] is True
     assert data["wallet"] == wallet
+
+
+def test_legacy_faucet_records_rate_limit_check_atomically(tmp_path, monkeypatch):
+    monkeypatch.setattr(faucet, "DATABASE", str(tmp_path / "faucet.db"))
+    faucet.init_db()
+
+    wallet = "RTC9d7caca3039130d3b26d41f7343d8f4ef4592360"
+    ip_address = "203.0.113.10"
+
+    def attempt_drip():
+        return faucet.try_record_drip(wallet, ip_address, faucet.MAX_DRIP_AMOUNT)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        results = list(executor.map(lambda _: attempt_drip(), range(8)))
+
+    successes = [result for result in results if result[0]]
+    failures = [result for result in results if not result[0]]
+
+    assert len(successes) == 1
+    assert len(failures) == 7
+    assert all(result[1] in {"IP rate limit exceeded", "Wallet rate limit exceeded"} for result in failures)
+
+    assert faucet.can_drip(ip_address) is False
+    assert faucet.can_drip(wallet, is_wallet=True) is False


### PR DESCRIPTION
Fixes #4887

## Summary
- Treat SQLite naive drip timestamps as UTC before rate-limit calculations.
- Add concurrent regression coverage for the legacy faucet atomic drip recorder.
- Verify only one same wallet/IP drip can be recorded under concurrent attempts.

## Validation
- `./.venv/Scripts/python.exe -m pytest -q tests/test_legacy_faucet_json_validation.py tests/test_faucet.py`
- `./.venv/Scripts/python.exe -m py_compile faucet.py tests/test_legacy_faucet_json_validation.py`
- `git diff --check`

Reviewed before submission.
