### PR TITLE
fix(beacon): add JSON field validation to create_contract (M2)

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -101,7 +101,7 @@ def init_beacon_tables(db_path=DB_PATH):
                 updated_at INTEGER
             )
         """)
-        
+
         # Bounties table (synced from GitHub)
         conn.execute("""
             CREATE TABLE IF NOT EXISTS beacon_bounties (
@@ -122,7 +122,7 @@ def init_beacon_tables(db_path=DB_PATH):
                 updated_at INTEGER
             )
         """)
-        
+
         # Reputation table
         conn.execute("""
             CREATE TABLE IF NOT EXISTS beacon_reputation (
@@ -135,7 +135,7 @@ def init_beacon_tables(db_path=DB_PATH):
                 last_updated INTEGER
             )
         """)
-        
+
         # Chat messages table
         conn.execute("""
             CREATE TABLE IF NOT EXISTS beacon_chat (
@@ -333,17 +333,17 @@ def get_agent(agent_id):
 def beacon_join():
     """
     Register or update a relay agent in the beacon atlas.
-    
+
     Accepts JSON with:
         - agent_id: Unique agent identifier (required)
         - pubkey_hex: Hex-encoded public key (required, must be valid hex)
         - name: Optional human-readable name
         - coinbase_address: Optional Base network address for payments
-    
+
     Returns:
         - 200: Agent registered/updated successfully
         - 400: Invalid input (missing fields, invalid pubkey_hex format)
-    
+
     Upsert behavior: Duplicate agent_id updates existing record.
     """
     if request.method == 'OPTIONS':
@@ -375,10 +375,10 @@ def beacon_join():
         pubkey_clean = pubkey_hex.strip()
         if pubkey_clean.startswith('0x') or pubkey_clean.startswith('0X'):
             pubkey_clean = pubkey_clean[2:]
-        
+
         if not pubkey_clean:
             return jsonify({'error': 'Invalid pubkey_hex: empty after prefix removal'}), 400
-        
+
         try:
             # Validate it's proper hex
             bytes.fromhex(pubkey_clean)
@@ -392,7 +392,7 @@ def beacon_join():
             return jsonify({'error': 'Invalid name: must be a string'}), 400
         if coinbase_address is not None and not isinstance(coinbase_address, str):
             return jsonify({'error': 'Invalid coinbase_address: must be a string'}), 400
-        
+
         # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
         if coinbase_address:
             cb_clean = coinbase_address.strip()
@@ -468,7 +468,7 @@ def beacon_join():
 def beacon_atlas():
     """
     Get list of all registered relay agents in the beacon atlas.
-    
+
     Returns array of agent objects with:
         - agent_id: Unique identifier
         - pubkey_hex: Public key (hex)
@@ -476,7 +476,7 @@ def beacon_atlas():
         - status: Agent status (active, inactive, etc.)
         - created_at: Registration timestamp
         - updated_at: Last update timestamp
-    
+
     Query params:
         - status: Optional filter by status (e.g., ?status=active)
     """
@@ -489,22 +489,22 @@ def beacon_atlas():
 
     try:
         db = get_db()
-        
+
         # Optional status filter
         status_filter = request.args.get('status')
-        
+
         if status_filter:
             rows = db.execute(
-                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at 
-                   FROM relay_agents 
-                   WHERE status = ? 
+                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at
+                   FROM relay_agents
+                   WHERE status = ?
                    ORDER BY created_at DESC""",
                 (status_filter,)
             ).fetchall()
         else:
             rows = db.execute(
-                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at 
-                   FROM relay_agents 
+                """SELECT agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at
+                   FROM relay_agents
                    ORDER BY created_at DESC"""
             ).fetchall()
 
@@ -542,7 +542,7 @@ def get_contracts():
         rows = db.execute(
             "SELECT * FROM beacon_contracts ORDER BY created_at DESC"
         ).fetchall()
-        
+
         contracts = []
         for row in rows:
             contracts.append({
@@ -556,7 +556,7 @@ def get_contracts():
                 'state': row['state'],
                 'created_at': row['created_at'],
             })
-        
+
         return jsonify(contracts)
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
@@ -565,7 +565,7 @@ def get_contracts():
 @beacon_api.route('/api/contracts', methods=['POST'])
 def create_contract():
     """Create a new contract between agents.
-    
+
     Requires Beacon Ed25519 signature headers to authenticate the contract creator.
     Validates that the from_agent exists in the relay_agents table.
     """
@@ -574,15 +574,19 @@ def create_contract():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid or missing JSON body'}), 400
-        
+
         # Validate required fields
         required = ['from', 'to', 'type', 'amount', 'term']
         for field in required:
             if field not in data:
                 return jsonify({'error': f'Missing field: {field}'}), 400
-        
+
+        # Validate from_agent is a non-empty string (catches arrays, objects, etc.)
         from_agent = data['from']
-        
+        if not isinstance(from_agent, str) or not from_agent.strip():
+            return jsonify({'error': 'from: must be a non-empty string'}), 400
+        from_agent = from_agent.strip()
+
         # Verify from_agent exists in relay_agents table
         db = get_db()
         existing = db.execute(
@@ -597,30 +601,51 @@ def create_contract():
         _, auth_error = _authenticate_contract_agent(db, [from_agent], body_bytes)
         if auth_error:
             return auth_error
-        
+
         # Generate contract ID
         contract_id = f"ctr_{int(time.time())}_{hashlib.blake2b(str(time.time()).encode(), digest_size=4).hexdigest()}"
-        
+
         amount, amount_error, amount_status = _positive_float_field(data, 'amount')
         if amount_error:
             return amount_error, amount_status
 
+        # Validate string fields
+        to_agent = str(data.get('to', '')).strip()
+        if not to_agent:
+            return jsonify({'error': 'to: must be a non-empty string'}), 400
+
+        contract_type_val = str(data.get('type', '')).strip()
+        if not contract_type_val:
+            return jsonify({'error': 'type: must be a non-empty string'}), 400
+
+        term_text = str(data.get('term', '')).strip()
+        if not term_text:
+            return jsonify({'error': 'term: must be a non-empty string'}), 400
+
+        # Validate currency if provided
+        currency_val = str(data.get('currency', 'RTC')).strip().upper()
+        ALLOWED_CURRENCIES = {'RTC', 'ERC', 'ERG', 'USD'}
+        if currency_val not in ALLOWED_CURRENCIES:
+            return jsonify({
+                'error': f'currency: must be one of: {", ".join(sorted(ALLOWED_CURRENCIES))}'
+            }), 400
+
         contract = {
             'id': contract_id,
             'from': data['from'],
-            'to': data['to'],
-            'type': data['type'],
+            'to': to_agent,
+            'type': contract_type_val,
             'amount': amount,
-            'currency': data.get('currency', 'RTC'),
-            'term': data['term'],
+            'currency': currency_val,
+            'term': term_text,
             'state': 'offered',  # Initial state
             'created_at': int(time.time()),
         }
-        
+
         # Store in database
         db = get_db()
         db.execute(
-            """INSERT INTO beacon_contracts 
+            """INSERT INTO beacon_contracts
                (id, from_agent, to_agent, type, amount, currency, term, state, created_at)
                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (contract['id'], contract['from'], contract['to'], contract['type'],
@@ -628,9 +653,9 @@ def create_contract():
              contract['state'], contract['created_at'])
         )
         db.commit()
-        
+
         return jsonify(contract), 201
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 
@@ -638,7 +663,7 @@ def create_contract():
 @beacon_api.route('/api/contracts/<contract_id>', methods=['PUT'])
 def update_contract(contract_id):
     """Update contract state (accept, complete, breach).
-    
+
     Requires Beacon Ed25519 signature headers to verify caller is a party to the contract.
     Validates state transitions to prevent invalid jumps.
     """
@@ -648,14 +673,14 @@ def update_contract(contract_id):
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid or missing JSON body'}), 400
         new_state = data.get('state')
-        
+
         if not new_state:
             return jsonify({'error': 'Missing state field'}), 400
-        
+
         valid_states = {'offered', 'active', 'renewed', 'completed', 'breached', 'expired', 'rejected'}
         if new_state not in valid_states:
             return jsonify({'error': f'Invalid state: {new_state}'}), 400
-        
+
         # Valid state transitions — prevent arbitrary jumps
         allowed_transitions = {
             'offered': {'active', 'rejected', 'expired'},
@@ -666,33 +691,33 @@ def update_contract(contract_id):
             'expired': set(),    # terminal state
             'rejected': set(),   # terminal state
         }
-        
+
         db = get_db()
-        
+
         # Fetch current contract to verify ownership and current state
         contract = db.execute(
             "SELECT id, from_agent, to_agent, state FROM beacon_contracts WHERE id = ?",
             (contract_id,)
         ).fetchone()
-        
+
         if not contract:
             return jsonify({'error': 'Contract not found'}), 404
-        
+
         current_state = contract['state']
-        
+
         # Validate state transition
         if new_state not in allowed_transitions.get(current_state, set()):
             return jsonify({
                 'error': f'Invalid state transition: {current_state} -> {new_state}'
             }), 400
-        
+
         from_agent = contract['from_agent']
         to_agent = contract['to_agent'] if 'to_agent' in contract.keys() else ''
 
         caller_agent, auth_error = _authenticate_contract_agent(db, [from_agent, to_agent], body_bytes)
         if auth_error:
             return auth_error
-        
+
         # Only to_agent can accept or reject an offered contract
         if current_state == 'offered' and new_state == 'active':
             if caller_agent != to_agent:
@@ -704,22 +729,22 @@ def update_contract(contract_id):
                 return jsonify({
                     'error': 'Only the recipient (to_agent) can reject this contract'
                 }), 403
-        
+
         # Only from_agent can mark as breached
         if new_state == 'breached':
             if caller_agent != from_agent:
                 return jsonify({
                     'error': 'Only the contract creator (from_agent) can mark as breached'
                 }), 403
-        
+
         db.execute(
             "UPDATE beacon_contracts SET state = ?, updated_at = ? WHERE id = ?",
             (new_state, int(time.time()), contract_id)
         )
         db.commit()
-        
+
         return jsonify({'ok': True, 'contract_id': contract_id, 'state': new_state})
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 
@@ -736,7 +761,7 @@ def get_bounties():
         rows = db.execute(
             "SELECT * FROM beacon_bounties WHERE state = 'open' ORDER BY reward_rtc DESC"
         ).fetchall()
-        
+
         bounties = []
         for row in rows:
             bounties.append({
@@ -753,7 +778,7 @@ def get_bounties():
                 'completed_by': row['completed_by'],
                 'desc': row['description'] or '',
             })
-        
+
         return jsonify(bounties)
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
@@ -773,16 +798,16 @@ def sync_bounties():
         provided_key = request.headers.get("X-Admin-Key", "")
         if not hmac.compare_digest(provided_key, admin_key):
             return jsonify({'error': 'Unauthorized — admin key required to sync bounties'}), 401
-        
+
         # GitHub repos to scan
         repos = [
             {'owner': 'Scottcjn', 'repo': 'rustchain-bounties'},
             {'owner': 'Scottcjn', 'repo': 'Rustchain'},
             {'owner': 'Scottcjn', 'repo': 'bottube'},
         ]
-        
+
         all_bounties = []
-        
+
         # SSL verification: enabled by default, set RC_DISABLE_SSL_VERIFY=1 to skip
         ctx = ssl.create_default_context()
         if os.environ.get('RC_DISABLE_SSL_VERIFY', '0') == '1':
@@ -790,19 +815,19 @@ def sync_bounties():
             logging.warning('[beacon_api] SSL verification disabled via RC_DISABLE_SSL_VERIFY — not recommended for production')
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
-        
+
         for repo in repos:
             try:
                 url = f"https://api.github.com/repos/{repo['owner']}/{repo['repo']}/issues?state=open&labels=bounty&per_page=30"
-                
+
                 req = urllib.request.Request(url, headers={'Accept': 'application/vnd.github.v3+json'})
                 with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
                     issues = json.loads(resp.read().decode())
-                
+
                 for issue in issues:
                     if 'pull_request' in issue:
                         continue
-                    
+
                     # Extract reward from title
                     reward_text = None
                     reward_rtc = None
@@ -814,10 +839,10 @@ def sync_bounties():
                         num_match = re.search(r'(\d+(?:\.\d+)?)', reward_text)
                         if num_match:
                             reward_rtc = float(num_match.group(1).replace(',', ''))
-                    
+
                     if not reward_text:
                         continue
-                    
+
                     # Determine difficulty from labels
                     difficulty = 'ANY'
                     label_map = {
@@ -830,7 +855,7 @@ def sync_bounties():
                         if label_name in label_map:
                             difficulty = label_map[label_name]
                             break
-                    
+
                     bounty = {
                         'id': f"gh_{repo['repo']}_{issue['number']}",
                         'github_number': issue['number'],
@@ -846,17 +871,17 @@ def sync_bounties():
                         'created_at': int(time.time()),
                     }
                     all_bounties.append(bounty)
-                
+
             except Exception as e:
                 print(f"Failed to fetch bounties from {repo['repo']}: {e}")
                 continue
-        
+
         # Store in database
         db = get_db()
         for bounty in all_bounties:
             db.execute(
                 """INSERT INTO beacon_bounties
-                   (id, github_number, title, reward_rtc, reward_text, difficulty, 
+                   (id, github_number, title, reward_rtc, reward_text, difficulty,
                     github_repo, github_url, state, description, labels, created_at, updated_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                    ON CONFLICT(id) DO UPDATE SET
@@ -875,11 +900,11 @@ def sync_bounties():
                  bounty['github_repo'], bounty['github_url'], bounty['state'],
                  bounty['description'], bounty['labels'], bounty['created_at'], bounty['created_at'])
             )
-        
+
         db.commit()
-        
+
         return jsonify({'synced': len(all_bounties), 'ok': True})
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 
@@ -902,19 +927,19 @@ def claim_bounty(bounty_id):
         agent_id, field_error, status = _required_text_field(data, 'agent_id')
         if field_error:
             return field_error, status
-        
+
         db = get_db()
         db.execute(
             "UPDATE beacon_bounties SET state = 'claimed', claimant_agent = ?, updated_at = ? WHERE id = ?",
             (agent_id, int(time.time()), bounty_id)
         )
         db.commit()
-        
+
         if db.total_changes == 0:
             return jsonify({'error': 'Bounty not found'}), 404
-        
+
         return jsonify({'ok': True, 'bounty_id': bounty_id, 'claimant': agent_id})
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 
@@ -937,7 +962,7 @@ def complete_bounty(bounty_id):
         agent_id, field_error, status = _required_text_field(data, 'agent_id')
         if field_error:
             return field_error, status
-        
+
         db = get_db()
 
         # Verify bounty exists and is in claimable state
@@ -955,7 +980,7 @@ def complete_bounty(bounty_id):
             (agent_id, int(time.time()), bounty_id)
         )
         db.commit()
-        
+
         # Update agent reputation
         rep = db.execute("SELECT * FROM beacon_reputation WHERE agent_id = ?", (agent_id,)).fetchone()
         if rep:
@@ -969,9 +994,9 @@ def complete_bounty(bounty_id):
                 (agent_id, int(time.time()))
             )
         db.commit()
-        
+
         return jsonify({'ok': True, 'bounty_id': bounty_id, 'completed_by': agent_id})
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 
@@ -986,7 +1011,7 @@ def get_reputation():
     try:
         db = get_db()
         rows = db.execute("SELECT * FROM beacon_reputation ORDER BY score DESC").fetchall()
-        
+
         reputations = []
         for row in rows:
             reputations.append({
@@ -997,7 +1022,7 @@ def get_reputation():
                 'contracts_breached': row['contracts_breached'],
                 'total_rtc_earned': row['total_rtc_earned'],
             })
-        
+
         return jsonify(reputations)
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
@@ -1009,10 +1034,10 @@ def get_agent_reputation(agent_id):
     try:
         db = get_db()
         row = db.execute("SELECT * FROM beacon_reputation WHERE agent_id = ?", (agent_id,)).fetchone()
-        
+
         if not row:
             return jsonify({'error': 'Agent not found'}), 404
-        
+
         return jsonify({
             'agent_id': row['agent_id'],
             'score': row['score'],
@@ -1042,19 +1067,19 @@ def chat():
         message, field_error, status = _required_text_field(data, 'message')
         if field_error:
             return field_error, status
-        
+
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400
         safe_agent_id = html.escape(str(agent_id), quote=True)
         safe_message = html.escape(str(message), quote=True)
-        
+
         # Store user message
         db = get_db()
         db.execute(
             "INSERT INTO beacon_chat (agent_id, role, content, created_at) VALUES (?, ?, ?, ?)",
             (agent_id, 'user', safe_message, int(time.time()))
         )
-        
+
         # Generate mock response (in production, call LLM)
         responses = [
             f"Acknowledged. I am {safe_agent_id}. How can I assist?",
@@ -1065,20 +1090,20 @@ def chat():
         ]
         import random
         response = random.choice(responses)
-        
+
         # Store agent response
         db.execute(
             "INSERT INTO beacon_chat (agent_id, role, content, created_at) VALUES (?, ?, ?, ?)",
             (agent_id, 'assistant', response, int(time.time()))
         )
         db.commit()
-        
+
         return jsonify({
             'response': response,
             'agent': safe_agent_id,
             'timestamp': int(time.time()),
         })
-        
+
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -609,18 +609,21 @@ def create_contract():
         if amount_error:
             return amount_error, amount_status
 
-        # Validate string fields
-        to_agent = str(data.get('to', '')).strip()
-        if not to_agent:
-            return jsonify({'error': 'to: must be a non-empty string'}), 400
+        # Validate string fields — reject non-string JSON types (lists, dicts)
+        to_val = data.get("to")
+        if not isinstance(to_val, str) or not to_val.strip():
+            return jsonify({"error": "to: must be a non-empty string"}), 400
+        to_agent = to_val.strip()
 
-        contract_type_val = str(data.get('type', '')).strip()
-        if not contract_type_val:
-            return jsonify({'error': 'type: must be a non-empty string'}), 400
+        type_val = data.get("type")
+        if not isinstance(type_val, str) or not type_val.strip():
+            return jsonify({"error": "type: must be a non-empty string"}), 400
+        contract_type_val = type_val.strip()
 
-        term_text = str(data.get('term', '')).strip()
-        if not term_text:
-            return jsonify({'error': 'term: must be a non-empty string'}), 400
+        term_val = data.get("term")
+        if not isinstance(term_val, str) or not term_val.strip():
+            return jsonify({"error": "term: must be a non-empty string"}), 400
+        term_text = term_val.strip()
 
         # Validate currency if provided
         currency_val = str(data.get('currency', 'RTC')).strip().upper()


### PR DESCRIPTION
Clean replacement for #6300.
- 'from' validated as non-empty string (was accepting arrays/objects → 500)
- 'to', 'type', 'term' validated as non-empty strings
- 'currency' validated against allowed set: RTC, ERC, ERG, USD
- No unrelated files, no trailing whitespace
Closes #6300 when merged.

---
**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`