### PR TITLE
fix(airdrop): use round() to prevent float precision loss in bridge lock amount conversion (#6374)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -1418,7 +1418,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
                 400,
             )
 
-        amount_uwrtc = int(amount_wrtc * 1_000_000)
+        amount_uwrtc = int(round(amount_wrtc * 1_000_000))
 
         success, message, lock = airdrop.create_bridge_lock(
             from_address, to_address, from_chain, to_chain, amount_uwrtc


### PR DESCRIPTION
## Summary

Fixes #6374 — floating-point precision loss in bridge lock amount conversion.

**Problem:** `int(amount_wrtc * 1_000_000)` truncates the floating-point result, causing up to 1 micro-wRTC loss per transaction:
- `33.33 * 1_000_000 = 33329999.999999996` → `int(...)` = `33329999` (expected: 33330000)

**Fix:** Use `int(round(amount_wrtc * 1_000_000))` to round before truncation, giving correct results for all typical decimal amounts.

**Verification:**
```python
>>> int(round(33.33 * 1_000_000))
33330000  ✓
>>> int(round(0.01 * 1_000_000))
10000  ✓
>>> int(round(999.999 * 1_000_000))
999999000  ✓
```

One-line fix, no behavioral change for integer amounts. No new dependencies.