### PR TITLE
fix: align governance UI with API contract

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -379,29 +379,33 @@ RustChain 使用链上治理系统：
 
 ```bash
 # 创建提案
-curl -sk -X POST https://rustchain.org/governance/propose \
+curl -sk -X POST https://rustchain.org/api/governance/propose \
  -H 'Content-Type: application/json' \
  -d '{
- "wallet":"RTC...",
+ "miner_id":"<ed25519_pubkey_hex>",
  "title":"启用参数 X",
- "description":"理由和实现细节"
+ "description":"理由和实现细节",
+ "proposal_type":"feature_activation",
+ "parameter_key":"",
+ "parameter_value":"",
+ "timestamp":1700000000,
+ "signature":"<ed25519_signature_hex>"
  }'
 
 # 列出提案
-curl -sk https://rustchain.org/governance/proposals
+curl -sk https://rustchain.org/api/governance/proposals
 
 # 提案详情
-curl -sk https://rustchain.org/governance/proposal/1
+curl -sk https://rustchain.org/api/governance/proposal/1
 
 # 提交签名投票
-curl -sk -X POST https://rustchain.org/governance/vote \
+curl -sk -X POST https://rustchain.org/api/governance/vote \
  -H 'Content-Type: application/json' \
  -d '{
  "proposal_id":1,
- "wallet":"RTC...",
- "vote":"yes",
- "nonce":"1700000000",
- "public_key":"<ed25519_pubkey_hex>",
+ "miner_id":"<ed25519_pubkey_hex>",
+ "vote":"for",
+ "timestamp":1700000000,
  "signature":"<ed25519_signature_hex>"
  }'
 ```

--- a/tests/test_governance_ui_contract.py
+++ b/tests/test_governance_ui_contract.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class GovernanceUiContractTest(unittest.TestCase):
+    def test_governance_page_uses_backend_api_contract(self):
+        html = (ROOT / "web" / "governance.html").read_text(encoding="utf-8")
+
+        self.assertIn("api('/api/governance/propose'", html)
+        self.assertIn("api('/api/governance/vote'", html)
+        self.assertIn("api('/api/governance/proposals'", html)
+        self.assertNotIn("api('/governance/", html)
+
+        self.assertIn("miner_id:", html)
+        self.assertIn("proposal_type:", html)
+        self.assertIn("timestamp,", html)
+        self.assertIn("signature:", html)
+
+        self.assertIn('<option value="for">for</option>', html)
+        self.assertIn('<option value="against">against</option>', html)
+        self.assertIn('<option value="abstain">abstain</option>', html)
+        self.assertNotIn('<option value="yes">yes</option>', html)
+        self.assertNotIn('<option value="no">no</option>', html)
+
+        self.assertIn("p.proposed_by", html)
+        self.assertIn("p.votes_for", html)
+        self.assertIn("p.votes_against", html)
+        self.assertIn("p.votes_abstain", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/governance.html
+++ b/web/governance.html
@@ -20,20 +20,30 @@
 
   <div class="card">
     <h2>Create Proposal</h2>
-    <input id="p_wallet" placeholder="Proposer wallet (RTC...)" />
+    <input id="p_miner" placeholder="Miner public key hex" />
     <input id="p_title" placeholder="Title" />
+    <select id="p_type">
+      <option value="feature_activation">feature_activation</option>
+      <option value="parameter_change">parameter_change</option>
+      <option value="emergency">emergency</option>
+    </select>
+    <input id="p_param_key" placeholder="Parameter key (required for parameter_change)" />
+    <input id="p_param_value" placeholder="Parameter value (optional)" />
     <textarea id="p_desc" rows="4" placeholder="Description"></textarea>
+    <input id="p_signature" placeholder="Signature hex for propose:<miner_id>:<timestamp>" />
     <button onclick="createProposal()">Submit Proposal</button>
   </div>
 
   <div class="card">
     <h2>Vote</h2>
     <input id="v_proposal" placeholder="Proposal ID" />
-    <input id="v_wallet" placeholder="Wallet (RTC...)" />
-    <select id="v_vote"><option value="yes">yes</option><option value="no">no</option></select>
-    <input id="v_nonce" placeholder="Nonce (any unique string)" />
-    <input id="v_pub" placeholder="Public key hex" />
-    <textarea id="v_sig" rows="3" placeholder="Signature hex"></textarea>
+    <input id="v_miner" placeholder="Miner public key hex" />
+    <select id="v_vote">
+      <option value="for">for</option>
+      <option value="against">against</option>
+      <option value="abstain">abstain</option>
+    </select>
+    <textarea id="v_sig" rows="3" placeholder="Signature hex for vote:<miner_id>:<timestamp>"></textarea>
     <button onclick="submitVote()">Submit Vote</button>
   </div>
 
@@ -71,37 +81,49 @@ async function api(path, method='GET', body=null){
 }
 
 async function createProposal(){
-  await api('/governance/propose', 'POST', {
-    wallet: document.getElementById('p_wallet').value.trim(),
+  const timestamp = Math.floor(Date.now() / 1000);
+  await api('/api/governance/propose', 'POST', {
+    miner_id: document.getElementById('p_miner').value.trim(),
     title: document.getElementById('p_title').value.trim(),
-    description: document.getElementById('p_desc').value.trim()
+    description: document.getElementById('p_desc').value.trim(),
+    proposal_type: document.getElementById('p_type').value,
+    parameter_key: document.getElementById('p_param_key').value.trim(),
+    parameter_value: document.getElementById('p_param_value').value.trim(),
+    timestamp,
+    signature: document.getElementById('p_signature').value.trim()
   });
   await loadProposals();
 }
 
 async function submitVote(){
-  await api('/governance/vote', 'POST', {
+  const timestamp = Math.floor(Date.now() / 1000);
+  await api('/api/governance/vote', 'POST', {
     proposal_id: Number(document.getElementById('v_proposal').value.trim()),
-    wallet: document.getElementById('v_wallet').value.trim(),
+    miner_id: document.getElementById('v_miner').value.trim(),
     vote: document.getElementById('v_vote').value,
-    nonce: document.getElementById('v_nonce').value.trim(),
-    public_key: document.getElementById('v_pub').value.trim(),
+    timestamp,
     signature: document.getElementById('v_sig').value.trim()
   });
   await loadProposals();
 }
 
 async function loadProposals(){
-  const data = await api('/governance/proposals');
+  const data = await api('/api/governance/proposals');
   const list = document.getElementById('list');
   list.innerHTML = '';
   for (const p of (data.proposals || [])) {
+    p.proposer_wallet = p.proposed_by ?? p.proposer_wallet;
+    p.yes_weight = p.votes_for ?? p.yes_weight;
+    p.no_weight = p.votes_against ?? p.no_weight;
+    p.abstain_weight = p.votes_abstain ?? p.abstain_weight;
     const div = document.createElement('div');
     div.className = 'card';
     div.innerHTML = `<b>#${safeNumber(p.id)} ${escapeHtml(p.title)}</b><br>
       <span class="muted">${escapeHtml(p.proposer_wallet)} • ${escapeHtml(p.status)}</span><br>
       ${escapeHtml(p.description)}<br>
-      yes=${safeNumber(p.yes_weight).toFixed(4)} no=${safeNumber(p.no_weight).toFixed(4)}`;
+      yes=${safeNumber(p.yes_weight).toFixed(4)}
+      no=${safeNumber(p.no_weight).toFixed(4)}
+      abstain=${safeNumber(p.abstain_weight).toFixed(4)}`;
     list.appendChild(div);
   }
 }


### PR DESCRIPTION
## Summary
- Aligns the governance web page with the backend governance blueprint routes under `/api/governance/*`.
- Updates the governance form payloads to use the backend contract fields: `miner_id`, `proposal_type`, `timestamp`, `signature`, and `for` / `against` / `abstain` votes.
- Updates the FAQ governance curl examples and adds a regression test for the UI/API contract.

## Root Cause
The static governance page and FAQ documented older `/governance/*` paths plus `wallet`, `nonce`, and `yes` / `no` fields, while `node/governance.py` exposes `/api/governance/*` and validates `miner_id`, `timestamp`, `signature`, and `for` / `against` / `abstain`.

## Validation
- `python3 tests/test_governance_ui_contract.py` -> OK
- `python3 -m py_compile tests/test_governance_ui_contract.py`
- `git diff --check`

## Bounty
Low-risk small bug/docs/UI contract fix for the ongoing bug bounty.
Wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
