### PR TITLE
docs: use attest submit endpoint in protocol guide

### DIFF
--- a/docs/RUSTCHAIN_PROTOCOL.md
+++ b/docs/RUSTCHAIN_PROTOCOL.md
@@ -193,7 +193,7 @@ The attestation server doesn't trust self-reported data. It performs:
 | `/api/miners` | GET | List active miners |
 | `/epoch` | GET | Current epoch info |
 | `/wallet/balance?miner_id=X` | GET | Check wallet balance |
-| `/attest` | POST | Submit hardware fingerprint |
+| `/attest/submit` | POST | Submit hardware fingerprint |
 
 ---
 
@@ -308,13 +308,13 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=scott-laptop"
 }
 ```
 
-### POST /attest
+### POST /attest/submit
 
 Submit hardware fingerprint (miner only).
 
 **Request**:
 ```bash
-curl -sk -X POST https://rustchain.org/attest \
+curl -sk -X POST https://rustchain.org/attest/submit \
   -H "Content-Type: application/json" \
   -d '{
     "miner_id": "scott-laptop",

--- a/tests/test_rustchain_protocol_attest_docs.py
+++ b/tests/test_rustchain_protocol_attest_docs.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_rustchain_protocol_documents_attest_submit_route():
+    text = (ROOT / "docs" / "RUSTCHAIN_PROTOCOL.md").read_text(encoding="utf-8")
+
+    assert "| `/attest/submit` | POST | Submit hardware fingerprint |" in text
+    assert "### POST /attest/submit" in text
+    assert "curl -sk -X POST https://rustchain.org/attest/submit" in text
+    assert "| `/attest` | POST | Submit hardware fingerprint |" not in text
+    assert "### POST /attest\n" not in text
+    assert "curl -sk -X POST https://rustchain.org/attest \\" not in text


### PR DESCRIPTION
## Summary
- updates `docs/RUSTCHAIN_PROTOCOL.md` to document the implemented attestation submission route, `POST /attest/submit`, instead of the stale `POST /attest` path
- adds a focused regression test so the protocol guide keeps the backend route name

## Root cause
The backend exposes attestation submission at `/attest/submit` (`node/rustchain_v2_integrated_v2.2.1_rip200.py`), but the protocol guide still listed `/attest` in both the endpoint table and curl example. That sends integrators to the wrong path.

## Impact
Low severity documentation/API contract mismatch: new miner implementers copying the protocol guide can call the wrong attestation endpoint and fail before reaching the structured submit validation path.

## Validation
- `curl -sk -o /tmp/attest_submit_resp.txt -w '%{http_code}\n' -X POST https://rustchain.org/attest/submit -H 'Content-Type: application/json' -d '{}'` -> `400` with structured missing miner response
- `python3 - <<'PY' ... test_rustchain_protocol_documents_attest_submit_route ... PY` -> passed
- `python3 -m py_compile tests/test_rustchain_protocol_attest_docs.py`
- `git diff --check`

Bounty claim: #305 low/small-bug docs contract mismatch
RTC wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
