### PR TITLE
docs: fix Discord miner API jq examples

### DIFF
--- a/discord_presence_README.md
+++ b/discord_presence_README.md
@@ -83,7 +83,7 @@ When your miner runs, it displays your miner ID (wallet address):
 List all active miners:
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq '.[].miner'
+curl -sk https://rustchain.org/api/miners | jq -r '.miners[].miner'
 ```
 
 ### Option 3: From Wallet
@@ -142,7 +142,7 @@ Your miner must be:
 Check your miner status:
 
 ```bash
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner=="YOUR_MINER_ID")'
+curl -sk https://rustchain.org/api/miners | jq '.miners[] | select(.miner=="YOUR_MINER_ID")'
 ```
 
 ### Balance shows 0.0 or "Error getting balance"

--- a/tests/test_discord_presence_readme.py
+++ b/tests/test_discord_presence_readme.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_discord_presence_readme_uses_current_miners_response_shape():
+    text = (ROOT / "discord_presence_README.md").read_text(encoding="utf-8")
+
+    assert "jq -r '.miners[].miner'" in text
+    assert "jq '.miners[] | select(.miner==\"YOUR_MINER_ID\")'" in text
+    assert "jq '.[].miner'" not in text
+    assert "jq '.[] | select(.miner==\"YOUR_MINER_ID\")'" not in text


### PR DESCRIPTION
## Summary
- updates `discord_presence_README.md` examples for the current `/api/miners` response shape
- changes miner listing/filtering examples from root-array jq selectors to `.miners[]`
- adds a focused regression test for these docs examples

## Root cause
`/api/miners` currently returns an object shaped like `{ "miners": [...], "pagination": ... }`, but the Discord Rich Presence README still used root-array jq expressions such as `.[].miner`. Copying those commands fails against the live API.

## Impact
Low severity docs/API contract mismatch: users following the Discord Rich Presence setup cannot list or filter their miner ID from the documented command.

## Reproduction
Old command against the live endpoint:

```bash
curl -sk https://rustchain.org/api/miners | jq -r '.[].miner'
# jq: Cannot index array with string "miner"
```

## Validation
- `curl -sk https://rustchain.org/api/miners | jq -r '.miners[].miner' | head -3` -> printed live miner IDs
- `curl -sk https://rustchain.org/api/miners | jq '.miners[] | select(.miner=="RTC14f06ee294f327f5685d3de5e1ed501cffab33e7")'` -> returned the selected live miner object
- `python3 - <<'PY' ... test_discord_presence_readme_uses_current_miners_response_shape ... PY` -> passed
- `python3 -m py_compile tests/test_discord_presence_readme.py`
- `git diff --check`

Bounty claim: #305 low/small-bug docs contract mismatch
RTC wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
