### PR TITLE
docs: fix developer tutorial miners response examples

### DIFF
--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -142,7 +142,7 @@ In a new terminal:
 tail -f ~/.rustchain/miner.log
 
 # Verify your miner is visible on the network
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner_id contains "YOUR_WALLET_NAME")'
+curl -sk https://rustchain.org/api/miners | jq '.miners[] | select(.miner | contains("YOUR_WALLET_NAME"))'
 
 # Check your balance (after a few minutes of mining)
 curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET_NAME" | jq .
@@ -374,10 +374,10 @@ tail -f ~/.rustchain/miner.log | grep "rewards"
 ```bash
 # Check if your miner is registered
 curl -sk https://rustchain.org/api/miners | jq \
-  '.[] | select(.miner_id == "my-vintage-miner")'
+  '.miners[] | select(.miner == "my-vintage-miner")'
 
 # View all active miners
-curl -sk https://rustchain.org/api/miners | jq 'length'
+curl -sk https://rustchain.org/api/miners | jq '.miners | length'
 
 # Check current epoch
 curl -sk https://rustchain.org/epoch | jq .
@@ -509,7 +509,7 @@ check_miner() {
     
     # Check miner visibility
     MINER=$(curl -sk "$NODE/api/miners" | jq -r \
-        ".[] | select(.miner_id == \"$WALLET\") | .miner_id")
+        ".miners[] | select(.miner == \"$WALLET\") | .miner")
     if [ -z "$MINER" ]; then
         echo "❌ Miner not visible on network"
         return 1
@@ -787,7 +787,7 @@ Pending rewards: 0.00 RTC (after hours of mining)
 **Diagnosis:**
 ```bash
 # Verify miner is visible on network
-curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner_id == "YOUR_WALLET")'
+curl -sk https://rustchain.org/api/miners | jq '.miners[] | select(.miner == "YOUR_WALLET")'
 
 # Check epoch settlement status
 curl -sk https://rustchain.org/epoch | jq .
@@ -943,7 +943,7 @@ WALLET = "my-vintage-miner"
 def get_optimal_interval():
     """Adjust mining interval based on network congestion."""
     epoch_data = requests.get(f"{NODE}/epoch", verify=False).json()
-    miners_count = len(requests.get(f"{NODE}/api/miners", verify=False).json())
+    miners_count = len(requests.get(f"{NODE}/api/miners", verify=False).json().get("miners", []))
     
     # More miners = longer intervals to reduce load
     if miners_count > 100:

--- a/tests/test_developer_tutorial_miners_docs.py
+++ b/tests/test_developer_tutorial_miners_docs.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_developer_tutorial_uses_current_miners_response_shape():
+    text = (ROOT / "docs" / "RUSTCHAIN_DEVELOPER_TUTORIAL.md").read_text(encoding="utf-8")
+
+    assert "jq '.miners[] | select(.miner | contains(\"YOUR_WALLET_NAME\"))'" in text
+    assert "'.miners[] | select(.miner == \"my-vintage-miner\")'" in text
+    assert "jq '.miners | length'" in text
+    assert ".miners[] | select(.miner == \\\"$WALLET\\\") | .miner" in text
+    assert "jq '.miners[] | select(.miner == \"YOUR_WALLET\")'" in text
+    assert '.json().get("miners", [])' in text
+
+    assert "jq '.[] | select(.miner_id" not in text
+    assert "jq 'length'" not in text
+    assert 'len(requests.get(f"{NODE}/api/miners", verify=False).json())' not in text


### PR DESCRIPTION
## Summary
- updates `docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md` examples for the current `/api/miners` response shape
- changes root-array and `miner_id` examples to `.miners[]` and `.miner`
- updates the Python snippet to count `payload["miners"]` instead of the top-level object
- adds a focused regression test for the tutorial examples

## Root cause
The live `/api/miners` endpoint returns an object shaped like `{ "miners": [...], "pagination": ... }`, and each miner entry uses the `miner` field. Several developer tutorial snippets still treated the response as a root array with `miner_id`, so copied commands fail against the current API.

## Impact
Low severity docs/API contract mismatch: developers following the tutorial cannot verify miner visibility or active miner counts using the documented commands.

## Reproduction
Old command against the live endpoint:

```bash
curl -sk https://rustchain.org/api/miners | jq '.[] | select(.miner_id == "RTC14f06ee294f327f5685d3de5e1ed501cffab33e7")'
# jq: Cannot index array with string "miner_id"
```

## Validation
- `curl --max-time 10 -sk https://rustchain.org/api/miners -o /tmp/miners2.json` then parsed `.miners` with Python -> live miner count and selected miner matched
- `python3 - <<'PY' ... test_developer_tutorial_uses_current_miners_response_shape ... PY` -> passed
- `python3 -m py_compile tests/test_developer_tutorial_miners_docs.py`
- `git diff --check`

Bounty claim: #305 low/small-bug docs contract mismatch
RTC wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
