### PR TITLE
docs: fix sprint FAQ miner multiplier command

### DIFF
--- a/docs/sprint/faq-troubleshooting.md
+++ b/docs/sprint/faq-troubleshooting.md
@@ -186,7 +186,7 @@ curl -sSL https://rustchain.org/install.sh | bash
 **Fix:**
 ```bash
 # Check your assigned multiplier:
-curl -sk "https://rustchain.org/api/miner-info?id=YOUR_WALLET" | jq .multiplier
+curl -sk https://rustchain.org/api/miners | jq '.miners[] | select(.miner == "YOUR_WALLET") | .antiquity_multiplier'
 
 # Check total network weight this epoch:
 curl -sk https://rustchain.org/epoch | jq .total_weight

--- a/tests/test_sprint_faq_miners_docs.py
+++ b/tests/test_sprint_faq_miners_docs.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sprint_faq_uses_live_miners_endpoint_for_multiplier():
+    text = (ROOT / "docs" / "sprint" / "faq-troubleshooting.md").read_text(encoding="utf-8")
+
+    assert "https://rustchain.org/api/miners" in text
+    assert 'jq \'.miners[] | select(.miner == "YOUR_WALLET") | .antiquity_multiplier\'' in text
+    assert "https://rustchain.org/api/miner-info" not in text
+    assert "jq .multiplier" not in text


### PR DESCRIPTION
## Summary
- replaces the stale sprint FAQ `/api/miner-info` multiplier command with the current `/api/miners` response shape
- adds a focused regression test so this troubleshooting snippet does not drift back to the removed endpoint

## Root cause
`docs/sprint/faq-troubleshooting.md` told users to query `https://rustchain.org/api/miner-info?id=YOUR_WALLET` and read `.multiplier`, but that route is not available on the live node. The current miner data is exposed through `/api/miners`, with each miner's multiplier under `.miners[].antiquity_multiplier`.

## Impact
Low severity docs/API contract mismatch: users troubleshooting unexpectedly low rewards copy a command that returns 404 instead of their assigned multiplier.

## Reproduction
Old command against the live endpoint:

```bash
curl --max-time 10 -sk -o /tmp/minerinfo404.txt -w '%{http_code}\n' 'https://rustchain.org/api/miner-info?id=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7'
# 404
```

## Validation
- `curl --max-time 10 -sk https://rustchain.org/api/miners -o /tmp/miners4.json` then parsed `.miners[].antiquity_multiplier` with Python -> selected live miner returned `1.05`
- `python3 - <<'PY' ... test_sprint_faq_uses_live_miners_endpoint_for_multiplier ... PY` -> passed
- `python3 -m py_compile tests/test_sprint_faq_miners_docs.py`
- `git diff --check`

Bounty claim: #305 low/small-bug docs contract mismatch
RTC wallet: `RTC74b80ab40602e5ae31819912b2fca974484e5dab`
