### PR TITLE
docs: fix developer tutorial transaction endpoints

### DIFF
--- a/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
+++ b/docs/RUSTCHAIN_DEVELOPER_TUTORIAL.md
@@ -418,35 +418,36 @@ RustChain transactions are simple value transfers between wallets:
 
 ```json
 {
-  "from": "sender-wallet",
-  "to": "recipient-wallet",
-  "amount": 10.0,
-  "timestamp": "2026-03-13T10:30:00Z",
-  "signature": "base64-encoded-signature"
+  "from_address": "RTC...",
+  "to_address": "RTC...",
+  "amount_rtc": 10.0,
+  "nonce": 1771187406,
+  "public_key": "hex-encoded-public-key",
+  "signature": "hex-encoded-signature"
 }
 ```
 
 ### Sending RTC via API
 
 ```bash
-# Send 5 RTC to another wallet
-curl -sk -X POST https://rustchain.org/api/transaction \
+# Send 5 RTC to another wallet with a signed payload
+curl -sk -X POST https://rustchain.org/wallet/transfer/signed \
   -H "Content-Type: application/json" \
   -d '{
-    "from": "my-vintage-miner",
-    "to": "recipient-wallet",
-    "amount": 5.0
+    "from_address": "RTC_SENDER_ADDRESS",
+    "to_address": "RTC_RECIPIENT_ADDRESS",
+    "amount_rtc": 5.0,
+    "nonce": 1771187406,
+    "public_key": "hex-encoded-public-key",
+    "signature": "hex-encoded-signature"
   }' | jq .
 ```
 
 ### Transaction Status
 
 ```bash
-# Check transaction by ID
-curl -sk "https://rustchain.org/api/transaction/TX_ID" | jq .
-
 # List transactions for a wallet
-curl -sk "https://rustchain.org/api/wallet/my-vintage-miner/transactions" | jq .
+curl -sk "https://rustchain.org/wallet/history?miner_id=RTC_WALLET_ADDRESS&limit=10" | jq .
 ```
 
 ### Using the CLI Helper
@@ -516,10 +517,9 @@ check_miner() {
     fi
     
     # Check balance
-    BALANCE=$(curl -sk "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.balance')
-    PENDING=$(curl -sk "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.pending_rewards')
+    BALANCE=$(curl -sk "$NODE/wallet/balance?miner_id=$WALLET" | jq -r '.amount_rtc')
     
-    echo "✅ Miner online | Balance: $BALANCE RTC | Pending: $PENDING RTC"
+    echo "✅ Miner online | Balance: $BALANCE RTC"
     return 0
 }
 
@@ -603,7 +603,7 @@ def get_miner_data():
         
         return {
             'balance': balance_resp.json(),
-            'total_miners': len(miners_resp.json()),
+            'total_miners': len(miners_resp.json().get('miners', [])),
             'epoch': epoch_resp.json()
         }
     except Exception as e:
@@ -622,9 +622,7 @@ def render_dashboard(data):
         return
     
     balance = data['balance']
-    print(f"\n💰 Balance: {balance.get('balance', 'N/A')} RTC")
-    print(f"⏳ Pending: {balance.get('pending_rewards', 'N/A')} RTC")
-    print(f"📊 Multiplier: ×{balance.get('cpu_multiplier', 'N/A')}")
+    print(f"\n💰 Balance: {balance.get('amount_rtc', 'N/A')} RTC")
     
     print(f"\n🌐 Network:")
     print(f"   Active Miners: {data['total_miners']}")
@@ -987,10 +985,18 @@ def pay():
     if balance < amount:
         return jsonify({'error': 'Insufficient balance'}), 400
     
-    # Process transaction
+    # Submit a signed transfer. The caller must provide a payload signed by
+    # their wallet; this service should not handle private keys.
     tx_resp = requests.post(
-        f"{NODE}/api/transaction",
-        json={'from': from_wallet, 'to': to_wallet, 'amount': amount},
+        f"{NODE}/wallet/transfer/signed",
+        json={
+            'from_address': from_wallet,
+            'to_address': to_wallet,
+            'amount_rtc': amount,
+            'nonce': data['nonce'],
+            'public_key': data['public_key'],
+            'signature': data['signature'],
+        },
         verify=False
     )
     
@@ -1012,7 +1018,7 @@ if __name__ == '__main__':
    ```bash
    # Alert on large balance changes
    curl -sk "https://rustchain.org/wallet/balance?miner_id=YOUR_WALLET" | \
-     jq 'if .balance < 10 then "⚠️ Low balance alert" else "OK" end'
+     jq 'if .amount_rtc < 10 then "⚠️ Low balance alert" else "OK" end'
    ```
 
 ---
@@ -1057,10 +1063,10 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=WALLET_NAME" | jq .
 # Current epoch
 curl -sk https://rustchain.org/epoch | jq .
 
-# Send transaction
-curl -sk -X POST https://rustchain.org/api/transaction \
+# Send signed transaction
+curl -sk -X POST https://rustchain.org/wallet/transfer/signed \
   -H "Content-Type: application/json" \
-  -d '{"from":"SENDER","to":"RECIPIENT","amount":10}' | jq .
+  -d '{"from_address":"RTC_SENDER","to_address":"RTC_RECIPIENT","amount_rtc":10,"nonce":1771187406,"public_key":"HEX_PUBLIC_KEY","signature":"HEX_SIGNATURE"}' | jq .
 ```
 
 ### Related Documentation
@@ -1117,9 +1123,8 @@ curl -sk -X POST https://rustchain.org/api/transaction \
 | GET | `/epoch` | Current epoch info |
 | GET | `/api/miners` | List active miners |
 | GET | `/wallet/balance?miner_id=X` | Get wallet balance |
-| POST | `/api/transaction` | Send RTC |
-| GET | `/api/transaction/ID` | Get transaction details |
-| GET | `/api/wallet/ID/transactions` | Wallet transaction history |
+| POST | `/wallet/transfer/signed` | Send RTC with an Ed25519-signed payload |
+| GET | `/wallet/history?miner_id=X` | Wallet transaction history |
 
 ### Example Responses
 
@@ -1143,10 +1148,8 @@ curl -sk -X POST https://rustchain.org/api/transaction \
 // GET /wallet/balance?miner_id=my-wallet
 {
   "miner_id": "my-wallet",
-  "balance": 125.75,
-  "pending_rewards": 2.5,
-  "last_heartbeat": "2026-03-13T10:30:00Z",
-  "cpu_multiplier": 3.5
+  "amount_i64": 125750000,
+  "amount_rtc": 125.75
 }
 ```
 

--- a/tests/test_developer_tutorial_transaction_endpoints.py
+++ b/tests/test_developer_tutorial_transaction_endpoints.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+DOC = Path(__file__).resolve().parents[1] / "docs" / "RUSTCHAIN_DEVELOPER_TUTORIAL.md"
+
+
+def test_developer_tutorial_uses_current_transaction_endpoints():
+    text = DOC.read_text(encoding="utf-8")
+
+    assert "/wallet/transfer/signed" in text
+    assert "/wallet/history?miner_id=" in text
+    assert "from_address" in text
+    assert "to_address" in text
+    assert "amount_rtc" in text
+    assert "amount_i64" in text
+
+    stale_endpoints = [
+        "https://rustchain.org/api/transaction",
+        "/api/transaction",
+        "/api/wallet/my-vintage-miner/transactions",
+        "/api/wallet/ID/transactions",
+        "jq -r '.balance'",
+        "balance.get('balance'",
+        "if .balance < 10",
+    ]
+    for endpoint in stale_endpoints:
+        assert endpoint not in text


### PR DESCRIPTION
## Summary
- replace stale /api/transaction examples in the developer tutorial with the current /wallet/transfer/signed endpoint
- replace stale wallet transaction history examples with /wallet/history?miner_id=...
- update wallet-balance examples to use the live amount_rtc/amount_i64 response shape
- add a regression test so the tutorial does not reintroduce the old transaction routes or old balance field examples

## Reproduction
- The current node source exposes /wallet/transfer/signed and /wallet/history, but not the documented /api/transaction routes.
- Live check: POST /wallet/transfer/signed with an empty JSON body returns a structured 400 listing required signed-transfer fields.
- Live check: GET /wallet/history?miner_id=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7&limit=1 returns 200 with transaction history.
- Live check: GET /api/wallet/my-vintage-miner/transactions returns 404.
- Live check: GET /wallet/balance?miner_id=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7 returns amount_i64 and amount_rtc, not balance/pending_rewards/cpu_multiplier.

## Validation
- python3 - <<'PY'
import importlib.util
from pathlib import Path
path = Path('tests/test_developer_tutorial_transaction_endpoints.py')
spec = importlib.util.spec_from_file_location('doc_test', path)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
mod.test_developer_tutorial_uses_current_transaction_endpoints()
print('developer tutorial API docs test passed')
PY
- python3 -m py_compile tests/test_developer_tutorial_transaction_endpoints.py
- git diff --check