### PR TITLE
docs: fix Hall of Fame API path

### DIFF
--- a/docs/api/EXAMPLES.md
+++ b/docs/api/EXAMPLES.md
@@ -98,7 +98,7 @@ curl -sk https://rustchain.org/api/stats | jq
 ### Get Hall of Fame
 
 ```bash
-curl -sk https://rustchain.org/api/hall_of_fame | jq
+curl -sk https://rustchain.org/api/hall_of_fame/leaderboard | jq
 ```
 
 ### Get Fee Pool Statistics
@@ -295,7 +295,7 @@ class RustChainClient:
     
     def get_hall_of_fame(self) -> Dict[str, Any]:
         """Get Hall of Fame leaderboard."""
-        resp = self.session.get(f"{self.base_url}/api/hall_of_fame")
+        resp = self.session.get(f"{self.base_url}/api/hall_of_fame/leaderboard")
         resp.raise_for_status()
         return resp.json()
     
@@ -533,7 +533,7 @@ class RustChainClient {
   }
 
   async getHallOfFame() {
-    return this.request('/api/hall_of_fame');
+    return this.request('/api/hall_of_fame/leaderboard');
   }
 
   async getFeePool() {
@@ -1137,7 +1137,7 @@ cmd_stats() {
 
 cmd_hall_of_fame() {
     print_header "Hall of Fame"
-    $CURL "$BASE_URL/api/hall_of_fame" | jq
+    $CURL "$BASE_URL/api/hall_of_fame/leaderboard" | jq
 }
 
 cmd_fee_pool() {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -43,7 +43,7 @@ open http://localhost:8080/swagger.html
 | GET | `/api/miners` | List active miners |
 | GET | `/api/nodes` | List connected nodes |
 | GET | `/api/stats` | Network statistics |
-| GET | `/api/hall_of_fame` | Hall of Fame leaderboard |
+| GET | `/api/hall_of_fame/leaderboard` | Hall of Fame leaderboard |
 | GET | `/api/fee_pool` | RIP-301 fee pool stats |
 | GET | `/api/settlement/{epoch}` | Historical settlement data |
 | GET | `/wallet/balance?miner_id=X` | Wallet balance |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -240,7 +240,7 @@ paths:
                 total_miners: 25
                 active_miners: 10
 
-  /api/hall_of_fame:
+  /api/hall_of_fame/leaderboard:
     get:
       tags:
         - Miners

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -84,7 +84,7 @@ RustChain API - Complete Collection
 | GET | `/epoch` | Current epoch, slot, enrolled miners |
 | GET | `/api/stats` | Network statistics |
 | GET | `/api/miners` | Active miners with attestation data |
-| GET | `/api/hall_of_fame` | Hall of Fame leaderboard |
+| GET | `/api/hall_of_fame/leaderboard` | Hall of Fame leaderboard |
 | GET | `/api/fee_pool` | RIP-301 fee pool statistics |
 | GET | `/balance?miner_id=X` | Miner balance lookup |
 | GET | `/lottery/eligibility?miner_id=X` | Epoch eligibility check |
@@ -205,7 +205,7 @@ Use this checklist to verify all endpoints:
 - [ ] GET `/epoch` - Returns current epoch info
 - [ ] GET `/api/stats` - Returns network statistics
 - [ ] GET `/api/miners` - Returns active miners list
-- [ ] GET `/api/hall_of_fame` - Returns leaderboard
+- [ ] GET `/api/hall_of_fame/leaderboard` - Returns leaderboard
 
 ### Fee Pool
 - [ ] GET `/api/fee_pool` - Returns fee pool statistics

--- a/docs/postman/RustChain_API.postman_collection.json
+++ b/docs/postman/RustChain_API.postman_collection.json
@@ -209,9 +209,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/api/hall_of_fame",
+              "raw": "{{base_url}}/api/hall_of_fame/leaderboard",
               "host": ["{{base_url}}"],
-              "path": ["api", "hall_of_fame"]
+              "path": ["api", "hall_of_fame", "leaderboard"]
             },
             "description": "Leaderboard for 5 categories of miners/participants."
           },
@@ -224,7 +224,7 @@
               "body": "{\n  \"top_miners\": [\n    {\n      \"rank\": 1,\n      \"miner_id\": \"eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC\",\n      \"category\": \"vintage_computing\",\n      \"score\": 450.5,\n      \"blocks_mined\": 125\n    }\n  ],\n  \"categories\": [\n    \"vintage_computing\",\n    \"antiquity_champion\",\n    \"entropy_master\",\n    \"block_producer\",\n    \"community_contributor\"\n  ]\n}",
               "originalRequest": {
                 "method": "GET",
-                "url": "{{base_url}}/api/hall_of_fame"
+                "url": "{{base_url}}/api/hall_of_fame/leaderboard"
               }
             }
           ]

--- a/tests/test_hall_of_fame_api_docs.py
+++ b/tests/test_hall_of_fame_api_docs.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = [
+    ROOT / "docs" / "api" / "README.md",
+    ROOT / "docs" / "api" / "EXAMPLES.md",
+    ROOT / "docs" / "api" / "openapi.yaml",
+    ROOT / "docs" / "postman" / "README.md",
+    ROOT / "docs" / "postman" / "RustChain_API.postman_collection.json",
+]
+
+
+def test_hall_of_fame_docs_use_leaderboard_api_path():
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in DOCS)
+
+    assert "/api/hall_of_fame/leaderboard" in combined
+    assert "const API_LEADERBOARD = '/api/hall_of_fame/leaderboard'" in (
+        ROOT / "web" / "hall-of-fame" / "index.html"
+    ).read_text(encoding="utf-8")
+
+    stale_patterns = [
+        "https://rustchain.org/api/hall_of_fame | jq",
+        "BASE_URL/api/hall_of_fame\"",
+        "base_url}/api/hall_of_fame\"",
+        "base_url}}/api/hall_of_fame\"",
+        "request('/api/hall_of_fame')",
+        "  /api/hall_of_fame:",
+        "| GET | `/api/hall_of_fame` |",
+        "\"path\": [\"api\", \"hall_of_fame\"]",
+    ]
+    for pattern in stale_patterns:
+        assert pattern not in combined


### PR DESCRIPTION
## Summary
- update API README, examples, OpenAPI spec, Postman README, and Postman collection from the stale bare `/api/hall_of_fame` route to `/api/hall_of_fame/leaderboard`
- add a regression test that checks docs stay aligned with the Hall of Fame frontend/source API path

## Reproduction
- Current source defines `@hall_bp.route("/api/hall_of_fame/leaderboard")` and `@hall_bp.route("/api/hall_of_fame/machine")` in `node/hall_of_rust.py`.
- The Hall of Fame frontend fetches `/api/hall_of_fame/leaderboard`.
- The docs and Postman collection previously advertised bare `/api/hall_of_fame`, which is not the route used by the implementation or frontend.

## Validation
- Directly executed `tests/test_hall_of_fame_api_docs.py` assertions
- `python3 -m py_compile tests/test_hall_of_fame_api_docs.py`
- `git diff --check`
- `rg -n "api/hall_of_fame(?!/leaderboard|/machine)" docs web node -P` returns no matches