### PR TITLE
docs: fix Postman balance route metadata

### DIFF
--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -86,7 +86,7 @@ RustChain API - Complete Collection
 | GET | `/api/miners` | Active miners with attestation data |
 | GET | `/api/hall_of_fame` | Hall of Fame leaderboard |
 | GET | `/api/fee_pool` | RIP-301 fee pool statistics |
-| GET | `/balance?miner_id=X` | Miner balance lookup |
+| GET | `/wallet/balance?miner_id=X` | Miner balance lookup |
 | GET | `/lottery/eligibility?miner_id=X` | Epoch eligibility check |
 | GET | `/explorer` | Block explorer HTML page |
 
@@ -146,7 +146,8 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe651
 Expected response:
 ```json
 {
-  "balance": 150.5,
+  "amount_i64": 150500000,
+  "amount_rtc": 150.5,
   "miner_id": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC"
 }
 ```
@@ -211,7 +212,7 @@ Use this checklist to verify all endpoints:
 - [ ] GET `/api/fee_pool` - Returns fee pool statistics
 
 ### Wallet
-- [ ] GET `/balance?miner_id=X` - Returns miner balance
+- [ ] GET `/wallet/balance?miner_id=X` - Returns miner balance
 - [ ] GET `/lottery/eligibility?miner_id=X` - Returns eligibility status
 
 ### Explorer

--- a/docs/postman/RustChain_API.postman_collection.json
+++ b/docs/postman/RustChain_API.postman_collection.json
@@ -273,9 +273,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{base_url}}/balance?miner_id={{miner_id}}",
+              "raw": "{{base_url}}/wallet/balance?miner_id={{miner_id}}",
               "host": ["{{base_url}}"],
-              "path": ["balance"],
+              "path": ["wallet", "balance"],
               "query": [
                 {
                   "key": "miner_id",
@@ -292,10 +292,10 @@
               "status": "OK",
               "code": 200,
               "_postman_previewlanguage": "json",
-              "body": "{\n  \"balance\": 150.5,\n  \"miner_id\": \"eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC\",\n  \"amount_i64\": 150500000\n}",
+              "body": "{\n  \"amount_i64\": 150500000,\n  \"amount_rtc\": 150.5,\n  \"miner_id\": \"eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC\"\n}",
               "originalRequest": {
                 "method": "GET",
-                "url": "{{base_url}}/balance?miner_id={{miner_id}}"
+                "url": "{{base_url}}/wallet/balance?miner_id={{miner_id}}"
               }
             },
             {
@@ -306,7 +306,7 @@
               "body": "{\n  \"error\": \"MINER_NOT_FOUND\",\n  \"message\": \"Unknown miner ID\"\n}",
               "originalRequest": {
                 "method": "GET",
-                "url": "{{base_url}}/balance?miner_id={{miner_id}}"
+                "url": "{{base_url}}/wallet/balance?miner_id={{miner_id}}"
               }
             }
           ]

--- a/tests/test_postman_balance_endpoint_docs.py
+++ b/tests/test_postman_balance_endpoint_docs.py
@@ -1,0 +1,28 @@
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "docs" / "postman" / "README.md"
+COLLECTION = ROOT / "docs" / "postman" / "RustChain_API.postman_collection.json"
+
+
+def test_postman_balance_docs_use_wallet_balance_endpoint():
+    readme = README.read_text(encoding="utf-8")
+    collection = json.loads(COLLECTION.read_text(encoding="utf-8"))
+    collection_text = json.dumps(collection, sort_keys=True)
+
+    assert "/wallet/balance?miner_id=X" in readme
+    assert "{{base_url}}/wallet/balance?miner_id={{miner_id}}" in collection_text
+    assert '"path": ["wallet", "balance"]' in COLLECTION.read_text(encoding="utf-8")
+    assert "amount_rtc" in collection_text
+
+    stale_patterns = [
+        "`/balance?miner_id=X`",
+        "{{base_url}}/balance?miner_id={{miner_id}}",
+        '"path": ["balance"]',
+        '"balance": 150.5',
+    ]
+    combined = readme + "\n" + COLLECTION.read_text(encoding="utf-8")
+    for pattern in stale_patterns:
+        assert pattern not in combined


### PR DESCRIPTION
## Summary
- update remaining Postman README metadata from stale `/balance?miner_id=X` to `/wallet/balance?miner_id=X`
- update the detailed Postman collection route/path/originalRequest values to `/wallet/balance`
- update balance response examples to the live `amount_i64` / `amount_rtc` schema
- add a regression test for the Postman balance docs and collection

## Reproduction
- `https://rustchain.org/balance?miner_id=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7` returns 404.
- `https://rustchain.org/wallet/balance?miner_id=RTC14f06ee294f327f5685d3de5e1ed501cffab33e7` returns 200 with `amount_i64`, `amount_rtc`, and `miner_id`.
- Current source exposes `/wallet/balance`; `/balance/<miner_pk>` is a different path form and does not support the documented query-string URL.

## Prior related fix
PR #5231 fixed one README example command. This PR fixes the remaining table/checklist metadata and the Postman collection entries that still pointed at the stale query-string `/balance` route.

## Validation
- Directly executed `tests/test_postman_balance_endpoint_docs.py` assertions
- `python3 -m py_compile tests/test_postman_balance_endpoint_docs.py`
- `python3 -m json.tool docs/postman/RustChain_API.postman_collection.json`
- `git diff --check`
- `rg` check confirmed no stale `/balance?miner_id` or old `balance` example remains in the target Postman files