### PR TITLE
fix: register API stats route

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6080,6 +6080,9 @@ def get_balance(miner_pk):
         "balance_rtc": balance_i64 / ACCOUNT_UNIT,
         "amount_i64": balance_i64,
     })
+
+
+@app.route('/api/stats', methods=['GET'])
 def get_stats():
     """Get system statistics"""
     epoch = slot_to_epoch(current_slot())

--- a/tests/test_api_stats_route_registration.py
+++ b/tests/test_api_stats_route_registration.py
@@ -1,0 +1,31 @@
+import sqlite3
+import sys
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_api_stats_route_returns_network_statistics(monkeypatch, tmp_path):
+    db_path = tmp_path / "api_stats.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.execute("CREATE TABLE balances (miner_pk TEXT, amount_i64 INTEGER)")
+        conn.execute("CREATE TABLE withdrawals (status TEXT)")
+        conn.execute("INSERT INTO balances VALUES ('miner-a', 125000000)")
+        conn.execute("INSERT INTO balances VALUES ('miner-b', 0)")
+        conn.execute("INSERT INTO withdrawals VALUES ('pending')")
+        conn.execute("INSERT INTO withdrawals VALUES ('paid')")
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    monkeypatch.setattr(integrated_node, "current_slot", lambda: 12345)
+    monkeypatch.setattr(integrated_node, "slot_to_epoch", lambda slot: 85)
+
+    integrated_node.app.config["TESTING"] = True
+    response = integrated_node.app.test_client().get("/api/stats")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["epoch"] == 85
+    assert data["total_miners"] == 2
+    assert data["total_balance"] == 125.0
+    assert data["pending_withdrawals"] == 1
+    assert data["version"] == "2.2.1-security-hardened"


### PR DESCRIPTION
## Summary
- register the missing `GET /api/stats` Flask route in the integrated node
- add a regression test that proves the endpoint returns network statistics instead of 404

## Validation
- `.venv/bin/python -m pytest tests/test_api_stats_route_registration.py -q`
- `git diff --check`

Bounty context: Scottcjn/Rustchain#305