### PR TITLE
docs: fix settlement endpoint examples

### DIFF
--- a/docs/api/EXAMPLES.md
+++ b/docs/api/EXAMPLES.md
@@ -110,7 +110,7 @@ curl -sk https://rustchain.org/api/fee_pool | jq
 ### Get Settlement Data
 
 ```bash
-curl -sk https://rustchain.org/api/settlement/75 | jq
+curl -sk https://rustchain.org/rewards/epoch/75 | jq
 ```
 
 ### Submit Hardware Attestation
@@ -307,7 +307,7 @@ class RustChainClient:
     
     def get_settlement(self, epoch: int) -> Dict[str, Any]:
         """Get settlement data for a specific epoch."""
-        resp = self.session.get(f"{self.base_url}/api/settlement/{epoch}")
+        resp = self.session.get(f"{self.base_url}/rewards/epoch/{epoch}")
         resp.raise_for_status()
         return resp.json()
     
@@ -541,7 +541,7 @@ class RustChainClient {
   }
 
   async getSettlement(epoch) {
-    return this.request(`/api/settlement/${epoch}`);
+    return this.request(`/rewards/epoch/${epoch}`);
   }
 
   async getSwapInfo() {
@@ -1153,7 +1153,7 @@ cmd_settlement() {
         exit 1
     fi
     print_header "Settlement for Epoch: $epoch"
-    $CURL "$BASE_URL/api/settlement/$epoch" | jq
+    $CURL "$BASE_URL/rewards/epoch/$epoch" | jq
 }
 
 cmd_swap_info() {

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -45,7 +45,7 @@ open http://localhost:8080/swagger.html
 | GET | `/api/stats` | Network statistics |
 | GET | `/api/hall_of_fame` | Hall of Fame leaderboard |
 | GET | `/api/fee_pool` | RIP-301 fee pool stats |
-| GET | `/api/settlement/{epoch}` | Historical settlement data |
+| GET | `/rewards/epoch/{epoch}` | Historical settlement data |
 | GET | `/wallet/balance?miner_id=X` | Wallet balance |
 | GET | `/wallet/history?miner_id=X` | Transaction history |
 | GET | `/wallet/swap-info` | Swap/bridge information |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -291,7 +291,7 @@ paths:
                 total_fees_collected_rtc: 0
                 withdrawal_fee_rtc: 0.01
 
-  /api/settlement/{epoch}:
+  /rewards/epoch/{epoch}:
     get:
       tags:
         - Epoch & Network

--- a/tests/test_settlement_endpoint_docs.py
+++ b/tests/test_settlement_endpoint_docs.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def test_settlement_docs_use_rewards_epoch_route():
+    readme = Path("docs/api/README.md").read_text(encoding="utf-8")
+    examples = Path("docs/api/EXAMPLES.md").read_text(encoding="utf-8")
+    openapi = Path("docs/api/openapi.yaml").read_text(encoding="utf-8")
+
+    assert "/api/settlement/{epoch}" not in readme
+    assert "/api/settlement/75" not in examples
+    assert "/api/settlement/{epoch}:" not in openapi
+
+    assert "/rewards/epoch/{epoch}" in readme
+    assert "https://rustchain.org/rewards/epoch/75" in examples
+    assert 'f"{self.base_url}/rewards/epoch/{epoch}"' in examples
+    assert "this.request(`/rewards/epoch/${epoch}`);" in examples
+    assert '"$BASE_URL/rewards/epoch/$epoch"' in examples
+    assert "/rewards/epoch/{epoch}:" in openapi


### PR DESCRIPTION
## Summary
- update public API docs from `/api/settlement/{epoch}` to the actual integrated-node route `/rewards/epoch/{epoch}`
- align curl, Python, JavaScript, and shell examples with the real endpoint
- add a regression test that blocks the stale route from reappearing in `docs/api`

## Validation
- `.venv/bin/python -m pytest tests/test_settlement_endpoint_docs.py -q`
- `.venv/bin/python -m py_compile tests/test_settlement_endpoint_docs.py`
- `git diff --check`

Bounty context: Scottcjn/Rustchain#305