### PR TITLE
fix: load beacon premium routes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -595,6 +595,24 @@ try:
 except Exception as e:
     print(f"[WARN] rustchain_x402 not loaded: {e}")
 
+
+def _beacon_x402_get_db():
+    conn = getattr(g, "_beacon_x402_db", None)
+    if conn is None:
+        db_path = os.environ.get("RUSTCHAIN_DB_PATH") or os.environ.get("DB_PATH") or "./rustchain_v2.db"
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        g._beacon_x402_db = conn
+    return conn
+
+
+try:
+    import beacon_x402
+    beacon_x402.init_app(app, _beacon_x402_get_db)
+    print("[x402] Beacon premium endpoints loaded")
+except Exception as e:
+    print(f"[WARN] beacon_x402 not loaded: {e}")
+
 @app.before_request
 def _start_timer():
     g._ts = time.time()
@@ -604,6 +622,14 @@ def _start_timer():
         allowed, retry_after = _check_admin_rate_limit(get_client_ip(), rate_limit_path)
         if not allowed:
             return _admin_rate_limit_response(retry_after)
+
+
+@app.teardown_appcontext
+def _close_beacon_x402_db(_exc):
+    conn = getattr(g, "_beacon_x402_db", None)
+    if conn is not None:
+        conn.close()
+        g._beacon_x402_db = None
 
 def _normalize_client_ip(raw_value) -> str:
     """Normalize a peer/header IP string down to the first address token."""

--- a/tests/test_beacon_premium_reputation_route.py
+++ b/tests/test_beacon_premium_reputation_route.py
@@ -1,0 +1,15 @@
+import sys
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_premium_reputation_route_is_registered():
+    integrated_node.app.config["TESTING"] = True
+    response = integrated_node.app.test_client().get("/api/premium/reputation")
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["total"] == 0
+    assert data["reputation"] == []
+    assert "exported_at" in data


### PR DESCRIPTION
## Summary
- initialize `beacon_x402` inside the integrated RustChain node so documented premium routes are actually registered
- provide a request-scoped SQLite helper for the module and close it on teardown
- add a regression test that proves `GET /api/premium/reputation` no longer returns 404

## Validation
- `.venv/bin/python -m pytest tests/test_beacon_premium_reputation_route.py -q`
- `.venv/bin/python -m py_compile tests/test_beacon_premium_reputation_route.py node/rustchain_v2_integrated_v2.2.1_rip200.py`
- `git diff --check`

Bounty context: Scottcjn/Rustchain#305