### PR TITLE
docs: fix premium endpoint hosts

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -54,8 +54,6 @@ open http://localhost:8080/swagger.html
 | GET | `/governance/proposals` | List proposals |
 | GET | `/governance/proposal/{id}` | Proposal details |
 | GET | `/governance/ui` | Governance UI (HTML) |
-| GET | `/api/premium/videos` | Premium video export |
-| GET | `/api/premium/analytics/{agent}` | Agent analytics |
 | GET | `/api/premium/reputation` | Reputation data |
 
 ### Signed Write Endpoints (Ed25519 Signature)
@@ -496,3 +494,5 @@ curl -sk https://rustchain.org/health
 
 - GitHub: https://github.com/Scottcjn/rustchain-bounties
 - Documentation: https://github.com/Scottcjn/Rustchain/tree/main/docs
+BoTTube premium endpoints are documented separately in `docs/api-reference.md`
+because they run on `https://bottube.ai`, not the main RustChain `base_url`.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1286,47 +1286,6 @@ paths:
                 errors: []
                 processed_at: 1709859600
 
-  /api/premium/videos:
-    get:
-      tags:
-        - Premium
-      summary: Bulk video export
-      description: |
-        Bulk video export endpoint (BoTTube integration).
-        Supports x402 payment protocol (free during beta).
-      operationId: getPremiumVideos
-      responses:
-        '200':
-          description: Video data retrieved
-          content:
-            application/json:
-              schema:
-                type: object
-
-  /api/premium/analytics/{agent}:
-    get:
-      tags:
-        - Premium
-      summary: Agent analytics
-      description: |
-        Deep analytics for a specific agent.
-        Supports x402 payment protocol (free during beta).
-      operationId: getPremiumAnalytics
-      parameters:
-        - name: agent
-          in: path
-          required: true
-          schema:
-            type: string
-          description: Agent identifier
-      responses:
-        '200':
-          description: Analytics retrieved
-          content:
-            application/json:
-              schema:
-                type: object
-
   /api/premium/reputation:
     get:
       tags:

--- a/docs/postman/RustChain.postman_collection.json
+++ b/docs/postman/RustChain.postman_collection.json
@@ -119,20 +119,6 @@
       "name": "Premium (x402)",
       "item": [
         {
-          "name": "Premium Videos",
-          "request": {
-            "method": "GET",
-            "url": "{{base_url}}/api/premium/videos"
-          }
-        },
-        {
-          "name": "Premium Analytics",
-          "request": {
-            "method": "GET",
-            "url": "{{base_url}}/api/premium/analytics/{{agent}}"
-          }
-        },
-        {
           "name": "Premium Reputation",
           "request": {
             "method": "GET",

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -93,8 +93,8 @@ clawrtc wallet coinbase link 0xYourBaseAddress
 ```
 
 **x402 高级 API 端点**已上线（目前免费，用于验证流程）：
-- `GET /api/premium/videos` - 批量视频导出（BoTTube）
-- `GET /api/premium/analytics/<agent>` - 深度智能体分析（BoTTube）
+- `GET https://bottube.ai/api/premium/videos` - 批量视频导出（BoTTube）
+- `GET https://bottube.ai/api/premium/analytics/<agent>` - 深度智能体分析（BoTTube）
 - `GET /api/premium/reputation` - 完整声誉导出（Beacon Atlas）
 - `GET /wallet/swap-info` - USDC/wRTC 兑换指南（RustChain）
 

--- a/tests/test_premium_endpoint_host_docs.py
+++ b/tests/test_premium_endpoint_host_docs.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+def test_premium_videos_and_analytics_are_not_listed_under_main_base_url():
+    readme = Path("docs/api/README.md").read_text(encoding="utf-8")
+    openapi = Path("docs/api/openapi.yaml").read_text(encoding="utf-8")
+    postman = Path("docs/postman/RustChain.postman_collection.json").read_text(encoding="utf-8")
+    api_reference = Path("docs/api-reference.md").read_text(encoding="utf-8")
+    zh_readme = Path("docs/zh-CN/README.md").read_text(encoding="utf-8")
+
+    assert "/api/premium/videos" not in readme
+    assert "/api/premium/analytics/{agent}" not in readme
+    assert "/api/premium/videos:" not in openapi
+    assert "/api/premium/analytics/{agent}:" not in openapi
+    assert "{{base_url}}/api/premium/videos" not in postman
+    assert "{{base_url}}/api/premium/analytics/{{agent}}" not in postman
+
+    assert "https://bottube.ai/api/premium/videos" in api_reference
+    assert "https://bottube.ai/api/premium/analytics/scott" in api_reference
+    assert "https://bottube.ai/api/premium/videos" in zh_readme
+    assert "https://bottube.ai/api/premium/analytics/<agent>" in zh_readme


### PR DESCRIPTION
## Summary
- stop documenting BoTTube premium video and analytics endpoints as if they were served from the main RustChain `base_url`
- remove those two external routes from the RustChain OpenAPI and Postman collection
- update the Chinese README to show the real `https://bottube.ai` host and add a regression test

## Validation
- `.venv/bin/python -m pytest tests/test_premium_endpoint_host_docs.py -q`
- `.venv/bin/python -m py_compile tests/test_premium_endpoint_host_docs.py`
- `git diff --check`

Bounty context: Scottcjn/Rustchain#305