### PR TITLE
docs: fix premium endpoint copy hosts

### DIFF
--- a/README_ES.md
+++ b/README_ES.md
@@ -105,8 +105,8 @@ clawrtc wallet coinbase link 0xTuDireccionBase
 ```
 
 **Endpoints premium de API x402** están activos (actualmente gratuitos mientras se demuestra el flujo):
-- `GET /api/premium/videos` - Exportación masiva de videos (BoTTube)
-- `GET /api/premium/analytics/<agent>` - Análisis profundo de agentes (BoTTube)
+- `GET https://bottube.ai/api/premium/videos` - Exportación masiva de videos (BoTTube)
+- `GET https://bottube.ai/api/premium/analytics/<agent>` - Análisis profundo de agentes (BoTTube)
 - `GET /api/premium/reputation` - Exportación completa de reputación (Beacon Atlas)
 - `GET /wallet/swap-info` - Guía de swap USDC/wRTC (RustChain)
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -107,8 +107,8 @@ clawrtc wallet coinbase link 0xYourBaseAddress
 ```
 
 **x402プレミアムAPIエンドポイント**が稼働中（現在はフローを検証するため無料）：
-- `GET /api/premium/videos` - 一括動画エクスポート（BoTTube）
-- `GET /api/premium/analytics/<agent>` - 詳細エージェント分析（BoTTube）
+- `GET https://bottube.ai/api/premium/videos` - 一括動画エクスポート（BoTTube）
+- `GET https://bottube.ai/api/premium/analytics/<agent>` - 詳細エージェント分析（BoTTube）
 - `GET /api/premium/reputation` - 完全なレピュテーションエクスポート（Beacon Atlas）
 - `GET /wallet/swap-info` - USDC/wRTCスワップガイダンス（RustChain）
 

--- a/tests/test_premium_endpoint_copy_hosts.py
+++ b/tests/test_premium_endpoint_copy_hosts.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+def test_localized_premium_endpoint_copy_uses_bottube_host():
+    readme_es = Path("README_ES.md").read_text(encoding="utf-8")
+    readme_ja = Path("README_JA.md").read_text(encoding="utf-8")
+    wallets = Path("web/wallets.html").read_text(encoding="utf-8")
+
+    assert "GET https://bottube.ai/api/premium/videos" in readme_es
+    assert "GET https://bottube.ai/api/premium/analytics/<agent>" in readme_es
+    assert "GET https://bottube.ai/api/premium/videos" in readme_ja
+    assert "GET https://bottube.ai/api/premium/analytics/<agent>" in readme_ja
+    assert "https://bottube.ai/api/premium/videos" in wallets
+    assert "https://bottube.ai/api/premium/analytics/&lt;agent&gt;" in wallets
+
+    assert "GET /api/premium/videos" not in readme_es
+    assert "GET /api/premium/analytics/<agent>" not in readme_es
+    assert "GET /api/premium/videos" not in readme_ja
+    assert "GET /api/premium/analytics/<agent>" not in readme_ja

--- a/web/wallets.html
+++ b/web/wallets.html
@@ -270,12 +270,12 @@ curl https://bottube.ai/api/agents/me/coinbase-wallet \
                         <th>Price</th>
                     </tr>
                     <tr>
-                        <td><code>/api/premium/videos</code></td>
+                        <td><code>https://bottube.ai/api/premium/videos</code></td>
                         <td>Bulk video metadata export</td>
                         <td class="free">FREE</td>
                     </tr>
                     <tr>
-                        <td><code>/api/premium/analytics/&lt;agent&gt;</code></td>
+                        <td><code>https://bottube.ai/api/premium/analytics/&lt;agent&gt;</code></td>
                         <td>Deep agent analytics</td>
                         <td class="free">FREE</td>
                     </tr>


### PR DESCRIPTION
## Summary
- update the Spanish and Japanese READMEs so BoTTube premium video and analytics examples show the real `https://bottube.ai` host
- fix the wallets web page copy so it no longer implies those two premium endpoints are served from the main RustChain host
- add a regression test covering the localized copy and wallet UI text

## Validation
- `.venv/bin/python -m pytest tests/test_premium_endpoint_copy_hosts.py -q`
- `.venv/bin/python -m py_compile tests/test_premium_endpoint_copy_hosts.py`
- `git diff --check`

Bounty context: Scottcjn/Rustchain#305