### PR TITLE
docs: fix settlement reference endpoints

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -449,12 +449,12 @@ Returns HTML page (not JSON).
 
 ### Settlement Data
 
-#### GET /api/settlement/{epoch}
+#### GET /rewards/epoch/{epoch}
 
 Query historical settlement data for a specific epoch.
 
 ```bash
-curl -sk https://rustchain.org/api/settlement/75
+curl -sk https://rustchain.org/rewards/epoch/75
 ```
 
 **Response**:

--- a/docs/epoch-settlement.md
+++ b/docs/epoch-settlement.md
@@ -384,13 +384,13 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=scott"
 }
 ```
 
-### GET /api/settlement/{epoch}
+### GET /rewards/epoch/{epoch}
 
 Query historical settlement data.
 
 **Request**:
 ```bash
-curl -sk https://rustchain.org/api/settlement/75
+curl -sk https://rustchain.org/rewards/epoch/75
 ```
 
 **Response**:
@@ -450,7 +450,7 @@ tail -f /var/log/rustchain/node.log | grep SETTLEMENT
 
 ```bash
 # Check if settlement completed
-curl -sk https://rustchain.org/api/settlement/75 | jq '.ergo_tx_id'
+curl -sk https://rustchain.org/rewards/epoch/75 | jq '.ergo_tx_id'
 
 # Verify on Ergo explorer
 curl "https://api.ergoplatform.com/api/v1/transactions/abc123..."
@@ -470,7 +470,7 @@ If settlement takes >10 minutes:
 If your reward seems wrong:
 - Verify you were active at epoch end (check `last_attest`)
 - Calculate expected share: `1.5 × (your_multiplier / total_weight)`
-- Query settlement data: `/api/settlement/{epoch}`
+- Query settlement data: `/rewards/epoch/{epoch}`
 
 ### Missing Reward
 

--- a/tests/test_settlement_reference_docs.py
+++ b/tests/test_settlement_reference_docs.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_settlement_reference_docs_use_rewards_epoch_endpoint():
+    repo_root = Path(__file__).resolve().parents[1]
+    files = [
+        repo_root / "docs" / "api-reference.md",
+        repo_root / "docs" / "epoch-settlement.md",
+    ]
+
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        assert "/api/settlement/{epoch}" not in text
+        assert "/api/settlement/75" not in text
+        assert "/rewards/epoch/{epoch}" in text
+        assert "/rewards/epoch/75" in text


### PR DESCRIPTION
## Summary\n- update stale settlement endpoint references in api-reference and epoch-settlement docs\n- replace old /api/settlement examples with the live /rewards/epoch endpoint\n- add a regression test covering both documents\n\n## Testing\n- ./.venv/bin/python -m pytest tests/test_settlement_reference_docs.py -q\n- ./.venv/bin/python -m py_compile tests/test_settlement_reference_docs.py\n- git diff --check