### PR TITLE
docs: add macOS Homebrew prerequisite to quickstart (#6414)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -20,6 +20,7 @@ You need two things:
 
 - **A computer** -- literally any computer. Linux, macOS, Windows, Raspberry Pi, PowerPC
   Mac, even a SPARC workstation. If it runs Python, it can mine.
+- **macOS only:** Python 3 via Homebrew -- run `brew install python3` before the installer.
 - **An internet connection** -- your miner talks to the RustChain network to prove your
   hardware is real.
 
@@ -42,7 +43,7 @@ from the Windows miner bundle.
 **What this does:**
 
 1. Detects your operating system and CPU architecture
-2. Installs Python 3 if you do not have it (Linux only -- macOS/Windows users need Python
+2. Installs Python 3 if you do not have it (Linux only -- macOS users should run `brew install python3` first; Windows
    pre-installed)
 3. Downloads the miner script to `~/.rustchain/`
 4. Creates a Python virtual environment with dependencies


### PR DESCRIPTION
## Summary

Adds macOS Homebrew prerequisite (`brew install python3`) to the top of the QUICKSTART guide so macOS users don't have to search for it in the troubleshooting section.

## Changes

1. **Prerequisites section:** Added `brew install python3` as a macOS-specific prerequisite
2. **Step 1 install note:** Updated the caveat to point macOS users to the prerequisite

## Before

The macOS Python prerequisite was only mentioned at the very end in the troubleshooting section (line 367). New macOS users following the guide top-to-bottom would hit a missing Python error without clear guidance.

## After

macOS users see `brew install python3` in the prerequisites before they even start the installer.

---

Closes #6414