### PR TITLE
fix(attest): accept v3 canonical-JSON signature alongside legacy MAC

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3650,19 +3650,51 @@ def _submit_attestation_impl():
     device = _normalize_attestation_device(data.get('device'))
 
     # SECURITY: Verify Ed25519 signature on attestation report if present.
-    # The rustchain-miner signs (miner_id|wallet|nonce|commitment) and includes
-    # signature + public_key at the top level.  If both fields are present we
-    # MUST verify — this prevents an MITM from changing the miner (wallet) field
-    # in transit and claiming another miner's hardware rewards (wallet hijack).
+    # We accept TWO signing schemes for backward compatibility:
+    #   1. v3 canonical-JSON (current rustchain-miner, GPT-5.4 audit finding #2):
+    #      miner signs canonical_json(attestation_dict) BEFORE adding the
+    #      signature/signature_type fields — covers the full payload including
+    #      device, fingerprint, signals. signature_type='ed25519'.
+    #   2. v2 legacy 4-field MAC: miner signs "miner_id|wallet|nonce|commitment".
+    #      Narrower coverage — wallet hijack protection only.
+    # The canonical-JSON scheme is verified first; legacy is the fallback.
+    # Same try-then-fallback pattern as wallet-transfer signed flow (see
+    # `_wallet_transfer_signed_messages` callsite around line 8692).
     sig_hex = (data.get('signature') or '').strip().lower()
     pubkey_hex = (data.get('public_key') or '').strip().lower()
     miner_id_raw = _attest_valid_miner(data.get('miner_id')) or miner
     commitment = report.get('commitment') or ''
     if sig_hex and pubkey_hex:
         if HAVE_NACL:
-            sign_message = '{}|{}|{}|{}'.format(miner_id_raw, miner, nonce, commitment)
-            if not verify_rtc_signature(pubkey_hex, sign_message.encode('utf-8'), sig_hex):
-                print(f"[ATTEST/SIG] INVALID SIGNATURE: miner={miner[:20]}... pubkey={pubkey_hex[:16]}...")
+            sig_type = (data.get('signature_type') or '').strip().lower()
+            verified = False
+
+            # Scheme 1: v3 canonical-JSON full-payload signature.
+            # Try when signature_type is 'ed25519' or unspecified (the v3 miner
+            # always sets signature_type='ed25519'; older callers may omit it).
+            if sig_type in ('ed25519', '', 'canonical_json'):
+                payload_for_sig = {
+                    k: v for k, v in data.items()
+                    if k not in ('signature', 'signature_type')
+                }
+                canonical_msg = json.dumps(
+                    payload_for_sig, sort_keys=True, separators=(',', ':')
+                ).encode('utf-8')
+                if verify_rtc_signature(pubkey_hex, canonical_msg, sig_hex):
+                    verified = True
+
+            # Scheme 2: v2 legacy 4-field MAC (kept for backward compat).
+            if not verified:
+                legacy_msg = '{}|{}|{}|{}'.format(
+                    miner_id_raw, miner, nonce, commitment
+                ).encode('utf-8')
+                if verify_rtc_signature(pubkey_hex, legacy_msg, sig_hex):
+                    verified = True
+
+            if not verified:
+                print(f"[ATTEST/SIG] INVALID SIGNATURE: miner={miner[:20]}... "
+                      f"pubkey={pubkey_hex[:16]}... sig_type={sig_type!r} "
+                      f"(tried canonical-JSON + legacy MAC)")
                 return jsonify({
                     "ok": False,
                     "error": "invalid_attestation_signature",

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -3672,10 +3672,14 @@ def _submit_attestation_impl():
             # Scheme 1: v3 canonical-JSON full-payload signature.
             # Try when signature_type is 'ed25519' or unspecified (the v3 miner
             # always sets signature_type='ed25519'; older callers may omit it).
+            # IMPORTANT: the miner adds 'signature', 'public_key', AND
+            # 'signature_type' to the dict AFTER signing (see miner lines
+            # 515-517). All three must be stripped to reproduce the canonical
+            # bytes the miner actually signed.
             if sig_type in ('ed25519', '', 'canonical_json'):
                 payload_for_sig = {
                     k: v for k, v in data.items()
-                    if k not in ('signature', 'signature_type')
+                    if k not in ('signature', 'signature_type', 'public_key')
                 }
                 canonical_msg = json.dumps(
                     payload_for_sig, sort_keys=True, separators=(',', ':')


### PR DESCRIPTION
## Summary

Every signed-flow attestation has been failing with `INVALID_SIGNATURE` since the rustchain-miner v3 rolled out, because the miner signs *canonical JSON of the full attestation payload* (GPT-5.4 audit finding #2 — full-payload commitment) but the server's `_submit_attestation_impl` was still verifying against the older 4-field MAC `miner_id|wallet|nonce|commitment`. Protocol mismatch.

Live evidence on Node 1 (50.28.86.131) just before this PR:

- `t40-thinkpad-banias` (ThinkPad T40, Pentium M Banias 1.5GHz) → rejected
- `modern-sophia-Pow-98...` (POWER8 fresh attest) → rejected
- `victus-x86-scott` (Victus laptop fresh attest) → rejected

All currently-attesting miners are using the *unsigned* flow with the server's WARNING `[ENROLL/SIG] UNSIGNED enrollment accepted ... upgrade miner to signed flow` — confirming the signed flow has zero successful users to break.

## Fix

Try the canonical-JSON scheme first (matches v3 miner), fall back to legacy 4-field MAC for backward compat. Same try-then-fallback shape already used in the wallet-transfer signed flow at line 8692.

```python
# Scheme 1: v3 canonical-JSON full-payload
if sig_type in ('ed25519', '', 'canonical_json'):
    payload_for_sig = {k: v for k, v in data.items() if k not in ('signature', 'signature_type')}
    canonical_msg = json.dumps(payload_for_sig, sort_keys=True, separators=(',', ':')).encode('utf-8')
    if verify_rtc_signature(pubkey_hex, canonical_msg, sig_hex):
        verified = True

# Scheme 2: v2 legacy 4-field MAC (kept for backward compat)
if not verified:
    legacy_msg = '{}|{}|{}|{}'.format(miner_id_raw, miner, nonce, commitment).encode('utf-8')
    if verify_rtc_signature(pubkey_hex, legacy_msg, sig_hex):
        verified = True
```

## Verification

Round-trip unit test: miner-side and server-side canonical bytes are byte-identical, signature verifies cleanly.

```
Miner signed:    b'{"device":{"arch":"modern","cpu":"Intel(R) Pentium(R) M","family":"x86","machine'...
Server verifies: b'{"device":{"arch":"modern","cpu":"Intel(R) Pentium(R) M","family":"x86","machine'...
Byte-identical: True
PASS: round-trip canonical-JSON sign+verify works
```

`py_compile` clean. The legacy path is untouched — any hypothetical 4-field-MAC caller still works.

## Test plan

- [x] Round-trip unit test (canonical-JSON sign on miner side, verify on server side)
- [x] `py_compile` server file
- [ ] Deploy to Node 1, restart, confirm T40 attestation lands with `device_arch=pentium_m_banias` (depends on PR #6423 also being deployed)
- [ ] Confirm POWER8 (`modern-sophia-Pow-98...`) starts succeeding
- [ ] Confirm Victus (`victus-x86-scott`) starts succeeding

## Related

- Surfaced while validating PR #6423 (Pentium M Banias tier) — T40 couldn't attest to demonstrate the new multiplier was applied. T40 hardware + Banias tier are both deployment-ready; this PR is what makes them functional together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)