### PR TITLE
docs: fix clawrtc miner command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Don't just code — mine! Install the miner and earn RTC while you contribute:
 
 ```bash
 pip install clawrtc
-clawrtc --wallet YOUR_NAME
+clawrtc mine --wallet YOUR_NAME
 ```
 
 Vintage hardware (PowerPC G4/G5, POWER8) earns **2-2.5x** more than modern PCs.


### PR DESCRIPTION
Fixes #6368.\n\nThe installed clawrtc CLI exposes mining via the `mine` subcommand, so the docs command should be `clawrtc mine --wallet YOUR_NAME` instead of passing `--wallet` at the root command.\n\nEvidence from prior bounty validation: root-level dry-run/miner args were rejected by clawrtc 1.8.0.\n\nWallet: Thanhdn1984