### PR TITLE
fix(fingerprint): accept POWER8 cache profile via simd_identity arch tag

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1898,10 +1898,32 @@ def _has_powerpc_simd_evidence(fingerprint: dict) -> bool:
 
 
 def _has_powerpc_cache_profile(fingerprint: dict) -> bool:
+    """Verify cache fingerprint is consistent with a PowerPC machine.
+
+    Looks for an explicit PowerPC arch tag in EITHER `cache_timing.data.arch`
+    (legacy fingerprint format) OR `simd_identity.data.arch` (v3 format —
+    POWER8 reports `arch="ppc64le"` there, not in cache_timing). Falls back
+    to a ratio-based heuristic for fingerprints that don't expose arch at all.
+
+    POWER8 specifically reports very flat L1/L2/L3 timings (~445ns each — huge
+    unified caches + PSE prefetch dominate latency) so the ratio thresholds
+    designed for x86/ARM hierarchies reject genuine POWER8 silicon. The arch
+    tag is a stronger signal than ratio in this case; if a miner claims and
+    proves PowerPC (PowerPC SIMD evidence already passed upstream — see
+    `_has_powerpc_simd_evidence`), trust the explicit arch label.
+    """
     cache_data = _fingerprint_check_data(fingerprint, "cache_timing")
     arch_hint = str(cache_data.get("arch") or cache_data.get("architecture") or "").lower()
     if "powerpc" in arch_hint or "ppc" in arch_hint:
         return True
+
+    # v3 fingerprint_checks.py places the arch label in simd_identity, not
+    # cache_timing. Accept either source.
+    simd_data = _fingerprint_check_data(fingerprint, "simd_identity")
+    simd_arch = str(simd_data.get("arch") or simd_data.get("architecture") or "").lower()
+    if "powerpc" in simd_arch or "ppc" in simd_arch:
+        return True
+
     l2_l1_ratio = float(cache_data.get("l2_l1_ratio", 0.0) or 0.0)
     l3_l2_ratio = float(cache_data.get("l3_l2_ratio", 0.0) or 0.0)
     hierarchy_ratio = float(cache_data.get("hierarchy_ratio", 0.0) or 0.0)


### PR DESCRIPTION
## Summary

`_has_powerpc_cache_profile` was rejecting genuine POWER8 silicon because POWER8's L1/L2/L3 cache timings are essentially flat by design (~445ns each), violating the `l2_l1_ratio >= 1.05` ratio threshold tuned for x86/ARM cache hierarchies.

The function already had an arch-tag shortcut that bypassed the ratio check, but it only looked at `cache_timing.data.arch` — and the v3 `fingerprint_checks.py` places the arch label in `simd_identity.data.arch` instead. Fix accepts either source.

## Live evidence

POWER8 S824 fingerprint captured 2026-05-27:

```json
{
  "cache_timing": {
    "passed": false,
    "data": {
      "l1_ns": 444.56, "l2_ns": 444.77, "l3_ns": 445.43,
      "l2_l1_ratio": 1.0, "l3_l2_ratio": 1.001,
      "fail_reason": "no_cache_hierarchy"
    }
  },
  "simd_identity": {
    "passed": true,
    "data": {"arch": "ppc64le", "has_altivec": true, ...}
  }
}
```

Server log before fix:
```
[FINGERPRINT] REJECT: claims power8 but lacks PowerPC cache profile
[FINGERPRINT] FINGERPRINT FAILED - will receive ZERO rewards
```

POWER8 was passing every OTHER gate (PowerPC CPU brand, AltiVec SIMD evidence, clock drift, thermal, jitter, anti-emulation) but getting zero rewards because of this single ratio threshold mismatch with real POWER8 silicon behavior.

## Why this is safe

The function is called only AFTER:
- `claimed_arch in POWERPC_ARCHES` (must claim ppc)
- `_powerpc_cpu_brand_matches(claimed_device)` (CPU brand must contain "powerpc"/"ppc"/"ibm power"/"g3"/"g4"/"g5"/"7447"/etc.)
- `_has_powerpc_simd_evidence(fingerprint)` (AltiVec or VSX SIMD evidence)

A spoofer can't reach this function without already passing the PowerPC CPU brand + SIMD evidence gates. Accepting the explicit arch tag from simd_identity (which is on the same payload that just passed SIMD verification) doesn't introduce new spoof surface.

## Test plan

- [x] Unit test against real POWER8 fingerprint → returns True
- [x] Unit test backward-compat: arch in `cache_timing.data` (legacy fingerprint format) → returns True
- [x] Unit test real x86 with proper hierarchy → returns True via existing ratio fallback (no regression)
- [x] py_compile clean
- [ ] Deploy to Node 1, confirm POWER8 attestation now reports fingerprint_passed=1
- [ ] Confirm POWER8 receives RTC at next epoch settlement (1.5x POWER8 multiplier)

## Related

Part of the "v3 fingerprint format compatibility" thread alongside #6428 (hw-binding entropy field names). Same shape of bug: server validation was looking for v3 field locations in legacy spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)