### PR TITLE
fix: add total_enrolled to /api/miners pagination (#6412)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6346,10 +6346,19 @@ def api_miners():
                 "antiquity_multiplier": mult
             })
     
+    epoch = current_slot() // 144
+    try:
+        c = sqlite3.connect(DB_PATH)
+        enrolled = c.execute("SELECT COUNT(*) FROM epoch_enroll WHERE epoch = ?", (epoch,)).fetchone()[0]
+        c.close()
+    except Exception:
+        enrolled = 0
+
     response = jsonify({
         "miners": miners,
         "pagination": {
             "total": total_count,
+            "total_enrolled": enrolled,
             "limit": limit,
             "offset": offset,
             "count": len(miners)

--- a/node/test_temp.py
+++ b/node/test_temp.py
@@ -1,0 +1,1 @@
+# Test: test/legacy-sig-fee

--- a/node/test_temp.py
+++ b/node/test_temp.py
@@ -1,1 +1,0 @@
-# Test: test/legacy-sig-fee


### PR DESCRIPTION
## Fix: Align /api/miners and /epoch miner counts

## Problem
`/api/miners` returned fewer miners than `/epoch.enrolled_miners` because:
- `/api/miners` queries `miner_attest_recent` (active in last 1 hour)  
- `/epoch` queries `epoch_enroll` (all enrolled this epoch)

## Fix
Added `total_enrolled` field to `/api/miners` pagination response, matching the count from `/epoch`.

## Before
```json
{"total": 2, ...}
```

## After
```json
{"total": 2, "total_enrolled": 21, ...}
```

Closes #6412