### PR TITLE
fix(hall_of_rust): cap unbounded string fields, fix raw payload bypass (A39)

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -178,6 +178,8 @@ def induct_machine():
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
     # This prevents multiple wallets on same machine from getting multiple Hall entries
     hw_serial = data.get('cpu_serial', data.get('hardware_id', 'unknown'))
+    if not isinstance(hw_serial, str) or len(hw_serial) > 256:
+        hw_serial = 'unknown'
     fp_data = f"{data.get('device_model', '')}{data.get('device_arch', '')}{hw_serial}"
     fingerprint_hash = hashlib.sha256(fp_data.encode()).hexdigest()[:32]
     
@@ -193,8 +195,15 @@ def induct_machine():
         existing = c.fetchone()
         
         now = int(time.time())
-        model = data.get('device_model', 'Unknown')
-        arch = data.get('device_arch', 'modern')
+        miner_id = (data.get('miner_id') or 'anonymous')[:128]
+        model = (data.get('device_model', 'Unknown') or 'Unknown')[:256]
+        arch = (data.get('device_arch', 'modern') or 'modern')[:32]
+        device_family = (data.get('device_family', 'Unknown') or 'Unknown')[:128]
+
+        # Use defaults after truncation if empty
+        model = model or 'Unknown'
+        arch = arch or 'modern'
+        device_family = device_family or 'Unknown'
         
         if existing:
             # Update attestation count
@@ -223,8 +232,8 @@ def induct_machine():
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             fingerprint_hash,
-            data.get('miner_id', 'anonymous'),
-            data.get('device_family', 'Unknown'),
+            miner_id,
+            device_family,
             arch,
             model,
             mfg_year,


### PR DESCRIPTION
## Summary
Clean replacement for #6282 — only `node/hall_of_rust.py`.

## Bug
- `hw_serial` had no type/len validation — non-string values crash, long values stored verbatim
- `miner_id`, `device_family` had no length caps
- INSERT used `data.get("miner_id", "anonymous")` (raw payload) while local variables had no truncation

## Fix
- `hw_serial`: validate isinstance(str) + cap at 256 chars
- `miner_id`: cap at 128 chars, used in INSERT instead of raw data.get()
- `device_model`: cap at 256 chars
- `device_arch`: cap at 32 chars
- `device_family`: cap at 128 chars, used in INSERT instead of raw data.get()
- All capped variables consistently used in INSERT

**BCOS-L2**

**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`