### PR TITLE
fix(contributor_registry): cap username at 128 chars (A38)

### DIFF
--- a/contributor_registry.py
+++ b/contributor_registry.py
@@ -314,6 +314,8 @@ def api_contributors():
 def approve_contributor(username):
     if not _contributor_admin_authorized():
         abort(401)
+    if len(username) > 128:
+        abort(400, description="Username too long")
 
     with db_connection() as conn:
         conn.execute(


### PR DESCRIPTION
## Summary
Clean replacement for #6281 — only `contributor_registry.py`.

**Fix:** `approve_contributor()` now rejects usernames > 128 chars with 400 error.

**BCOS-L2**  
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`