### PR TITLE
fix(health-dashboard): cap node_id at 128 chars (A34)

### DIFF
--- a/health-dashboard/server.py
+++ b/health-dashboard/server.py
@@ -455,6 +455,8 @@ def api_status():
 @app.route('/api/history/<node_id>')
 def api_history(node_id: str):
     """API endpoint for historical data (24 hours)"""
+    if len(node_id) > 128:
+        return jsonify({"error": "Invalid node_id", "history": []}), 400
     conn = sqlite3.connect(DB_PATH)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()


### PR DESCRIPTION
Clean replacement for #6277. Adds length cap on `node_id` path param.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`