### PR TITLE
fix(explorer-api): cap addr at 128 and search query at 256 (A32, A33)

### DIFF
--- a/tools/explorer-api/api.py
+++ b/tools/explorer-api/api.py
@@ -295,6 +295,8 @@ def address_info(addr: str):
     addr = addr.strip()
     if not addr:
         return jsonify({"ok": False, "error": "address_required"}), 400
+    if len(addr) > 128:
+        return jsonify({"ok": False, "error": "address too long"}), 400
 
     # Fetch balance
     balance_data = _get(f"/balance/{addr}")
@@ -343,6 +345,8 @@ def search():
     query = request.args.get("q", "").strip()
     if not query:
         return jsonify({"ok": False, "error": "query_required"}), 400
+    if len(query) > 256:
+        return jsonify({"ok": False, "error": "query_too_long"}), 400
 
     results = []
 


### PR DESCRIPTION
Clean replacement for #6275 (A32) and #6276 (A33) — same file.

- `address_info()`: addr > 128 → 400
- `search()`: query > 256 → 400

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`