### PR TITLE
fix(testnet_faucet): cap wallet/github_username at 128 chars (A30)

### DIFF
--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -102,13 +102,15 @@ def _request_data() -> tuple[dict[str, Any] | None, tuple[Any, int] | None]:
     return data, None
 
 
-def _strip_string_field(data: dict[str, Any], name: str) -> tuple[str | None, tuple[Any, int] | None]:
+def _strip_string_field(data: dict[str, Any], name: str, max_length: int = 0) -> tuple[str | None, tuple[Any, int] | None]:
     value = data.get(name)
     if value is None:
         return None, None
     if not isinstance(value, str):
         return None, (jsonify({"ok": False, "error": f"{name}_must_be_string"}), 400)
     value = value.strip()
+    if max_length > 0 and len(value) > max_length:
+        return None, (jsonify({"ok": False, "error": f"{name}_too_long"}), 400)
     return value or None, None
 
 
@@ -192,10 +194,10 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         data, error = _request_data()
         if error:
             return error
-        wallet, error = _strip_string_field(data, "wallet")
+        wallet, error = _strip_string_field(data, "wallet", max_length=128)
         if error:
             return error
-        github_username, error = _strip_string_field(data, "github_username")
+        github_username, error = _strip_string_field(data, "github_username", max_length=128)
         if error:
             return error
         ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()


### PR DESCRIPTION
Clean replacement for #6273. Adds max_length param to `_strip_string_field` helper, caps wallet and github_username at 128.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`