### PR TITLE
fix(faucet): cap wallet address at 128 chars (A25)

### DIFF
--- a/faucet.py
+++ b/faucet.py
@@ -394,7 +394,10 @@ def drip():
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400
 
     wallet = wallet_value.strip()
-    
+
+    if len(wallet) > 128:
+        return jsonify({'ok': False, 'error': 'Wallet address too long'}), 400
+
     # Basic wallet validation (accept Ethereum-style and native RTC wallets)
     if not is_valid_wallet_address(wallet):
         return jsonify({'ok': False, 'error': 'Invalid wallet address'}), 400


### PR DESCRIPTION
Clean replacement for #6268. Adds length cap before existing format validation.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`