### PR TITLE
fix(sophia_api): cap miner_id at 128 in 3 endpoints (A26)

### DIFF
--- a/sophia_api.py
+++ b/sophia_api.py
@@ -93,6 +93,8 @@ def inspect_fingerprint():
 
     if not miner_id:
         return jsonify({"error": "miner_id is required"}), 400
+    if not isinstance(miner_id, str) or len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long"}), 400
     if not fingerprint or not isinstance(fingerprint, dict):
         return jsonify({"error": "fingerprint bundle (dict) is required"}), 400
 
@@ -103,6 +105,8 @@ def inspect_fingerprint():
 @app.route("/sophia/status/<miner_id>", methods=["GET"])
 def miner_status(miner_id):
     """Get the latest inspection result + history for a miner."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long"}), 400
     conn = get_connection()
     try:
         latest = get_latest_inspection(conn, miner_id)
@@ -154,6 +158,8 @@ def dashboard():
 @app.route("/sophia/explorer/<miner_id>", methods=["GET"])
 def explorer_verdict(miner_id):
     """Emoji verdict for block explorer integration."""
+    if len(miner_id) > 128:
+        return jsonify({"error": "miner_id too long"}), 400
     conn = get_connection()
     try:
         row = get_latest_inspection(conn, miner_id)


### PR DESCRIPTION
Clean replacement for #6269. Caps miner_id in POST /sophia/inspect, GET /sophia/status/<miner_id>, and GET /sophia/explorer/<miner_id>.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`