### PR TITLE
fix(p2p_sync): cap peer_url at 2048 chars (A28)

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -72,6 +72,8 @@ class PeerManager:
 
     def add_peer(self, peer_url: str) -> bool:
         """Add a new peer to the network"""
+        if len(peer_url) > 2048:
+            return False  # URL too long
         if peer_url == self.local_url:
             return False  # Don't add self
 


### PR DESCRIPTION
Clean replacement for #6271. Caps peer_url in add_peer().

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`