### PR TITLE
fix(dashboard): cap wallet_address at 128 chars (A29)

### DIFF
--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -791,6 +791,8 @@ def api_stats():
 @app.route('/api/wallet/<wallet_address>')
 def api_wallet_lookup(wallet_address):
     """Look up wallet balance and info"""
+    if len(wallet_address) > 128:
+        return jsonify({"error": "Wallet address too long"}), 400
     try:
         with sqlite3.connect(DB_PATH) as conn:
             # Get balance


### PR DESCRIPTION
Clean replacement for #6272. Caps wallet_address in /api/wallet/<wallet_address>.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`