### PR TITLE
fix(sync): cap table param at 128 chars (A23)

### DIFF
--- a/node/rustchain_sync_endpoints.py
+++ b/node/rustchain_sync_endpoints.py
@@ -131,6 +131,8 @@ def register_sync_endpoints(app, db_path, admin_key):
         - offset: row offset (default 0)
         """
         table = request.args.get("table", "").strip()
+        if len(table) > 128:
+            return jsonify({"error": "table name too long"}), 400
         limit, error = _parse_sync_int_arg("limit", 200, 1, 1000)
         if error:
             return jsonify({"error": error}), 400


### PR DESCRIPTION
Clean replacement for #6266. Caps table query param in /api/sync/pull.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`