### PR TITLE
fix(beacon_x402): cap agent_id at 128, add max_length to _json_string_field (A35)

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -108,13 +108,16 @@ def _json_object_body():
     return data, None
 
 
-def _json_string_field(data, field_name, default=""):
+def _json_string_field(data, field_name, default="", max_length=0):
     value = data.get(field_name, default)
     if value is None:
         return ""
     if not isinstance(value, str):
         raise ValueError(f"{field_name} must be a string")
-    return value.strip()
+    value = value.strip()
+    if max_length > 0 and len(value) > max_length:
+        raise ValueError(f"{field_name} exceeds maximum length of {max_length}")
+    return value
 
 
 def _is_base_address(value: str) -> bool:
@@ -215,6 +218,9 @@ def init_app(app, get_db_func):
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
 
+        if len(agent_id) > 128:
+            return _cors_json({"error": "agent_id too long"}, 400)
+
         # Simple admin check ? require admin key in header
         admin_error = _require_beacon_admin()
         if admin_error:
@@ -252,6 +258,10 @@ def init_app(app, get_db_func):
         """Get a beacon agent's Coinbase wallet info."""
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
+
+        if len(agent_id) > 128:
+            return _cors_json({"error": "agent_id too long"}, 400)
+
         # SECURITY: Require admin key — exposes coinbase_address for any beacon agent
         admin_key = os.environ.get("RC_ADMIN_KEY", "")
         if not admin_key:


### PR DESCRIPTION
Clean replacement for #6278 (caps only, no admin key removal). Adds max_length to `_json_string_field` and caps agent_id on both wallet endpoints.

**BCOS-L2**
**RTC Wallet:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`