### PR TITLE
fix: reject malformed UTXO inputs

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -110,6 +110,30 @@ class TestUtxoDB(unittest.TestCase):
         # Balance unchanged
         self.assertEqual(self.db.get_balance('alice'), 50 * UNIT)
 
+    def test_apply_transaction_rejects_malformed_inputs(self):
+        self._apply_coinbase('alice', 50 * UNIT)
+
+        malformed_inputs = [
+            [{}],
+            ['not-a-dict'],
+            {'box_id': 'not-a-list'},
+            [{'box_id': ''}],
+            [{'box_id': '   '}],
+        ]
+
+        for inputs in malformed_inputs:
+            with self.subTest(inputs=inputs):
+                ok = self.db.apply_transaction({
+                    'tx_type': 'transfer',
+                    'inputs': inputs,
+                    'outputs': [{'address': 'bob', 'value_nrtc': 50 * UNIT}],
+                    'fee_nrtc': 0,
+                }, block_height=10)
+
+                self.assertFalse(ok)
+                self.assertEqual(self.db.get_balance('alice'), 50 * UNIT)
+                self.assertEqual(self.db.get_balance('bob'), 0)
+
     def test_transfer_with_fee(self):
         self._apply_coinbase('alice', 100 * UNIT)
         alice_boxes = self.db.get_unspent_for_address('alice')
@@ -623,6 +647,29 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
+
+    def test_mempool_rejects_malformed_inputs_without_locking(self):
+        self._apply_coinbase('alice', 100 * UNIT)
+
+        malformed_inputs = [
+            [{}],
+            ['not-a-dict'],
+            {'box_id': 'not-a-list'},
+            [{'box_id': ''}],
+            [{'box_id': '   '}],
+        ]
+
+        for idx, inputs in enumerate(malformed_inputs):
+            with self.subTest(inputs=inputs):
+                ok = self.db.mempool_add({
+                    'tx_id': f'malformed-{idx}',
+                    'inputs': inputs,
+                    'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+                    'fee_nrtc': 0,
+                })
+
+                self.assertFalse(ok)
+                self.assertEqual(self.db.mempool_get_block_candidates(), [])
 
     def test_mempool_size_limit_checked_inside_write_transaction(self):
         """Concurrent admissions must not bypass MAX_POOL_SIZE."""

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -134,6 +134,11 @@ class TestUtxoDB(unittest.TestCase):
                 self.assertEqual(self.db.get_balance('alice'), 50 * UNIT)
                 self.assertEqual(self.db.get_balance('bob'), 0)
 
+    def test_apply_transaction_rejects_non_object_transactions(self):
+        for tx in (None, [], 'not-a-dict', 123):
+            with self.subTest(tx=tx):
+                self.assertFalse(self.db.apply_transaction(tx, block_height=10))
+
     def test_transfer_with_fee(self):
         self._apply_coinbase('alice', 100 * UNIT)
         alice_boxes = self.db.get_unspent_for_address('alice')

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -545,6 +545,8 @@ class UtxoDB:
 
         Returns True on success, False on validation failure.
         """
+        if not isinstance(tx, dict):
+            return False
         own = conn is None
 
         ts = tx.get('timestamp', int(time.time()))

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -325,7 +325,7 @@ class UtxoDB:
                 check = conn.execute(
                     "SELECT spent_at, spent_by_tx FROM utxo_boxes WHERE box_id = ?",
                     (box_id,),
-                ).fetchone() if not own else None
+                ).fetchone()
                 if check is not None:
                     raise ValueError(
                         f"Double-spend attempt: box {box_id[:16]} already spent "
@@ -417,6 +417,22 @@ class UtxoDB:
 
         if len(normalized) != len(set(normalized)):
             return None
+
+        return normalized
+
+    def _normalize_inputs(self, inputs: Any) -> Optional[List[dict]]:
+        """Return validated spending inputs, or None on invalid shape."""
+        if not isinstance(inputs, list):
+            return None
+
+        normalized = []
+        for inp in inputs:
+            if not isinstance(inp, dict):
+                return None
+            box_id = inp.get('box_id')
+            if not isinstance(box_id, str) or not box_id.strip():
+                return None
+            normalized.append(dict(inp))
 
         return normalized
 
@@ -558,7 +574,8 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
             return False
-        if not isinstance(inputs, list):
+        inputs = self._normalize_inputs(inputs)
+        if inputs is None:
             return False
         if len(inputs) > MAX_INPUTS:
             return False
@@ -953,6 +970,11 @@ class UtxoDB:
                 if manage_tx:
                     conn.execute("ROLLBACK")
                 return False
+            inputs = self._normalize_inputs(inputs)
+            if inputs is None:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
             data_inputs = tx.get('data_inputs', [])
             now = int(time.time())
             timestamp = tx.get('timestamp', now)
@@ -969,10 +991,6 @@ class UtxoDB:
                     conn.execute("ROLLBACK")
                 return False
 
-            if not isinstance(inputs, list):
-                if manage_tx:
-                    conn.execute("ROLLBACK")
-                return False
             if len(inputs) > MAX_INPUTS:
                 if manage_tx:
                     conn.execute("ROLLBACK")


### PR DESCRIPTION
## Summary
- reject malformed UTXO spending input shapes before transaction/mempool validation indexes `box_id`
- keep malformed mempool transactions from being admitted or leaving candidates behind
- make the owned-connection `spend_box()` path raise `ValueError` on already-spent boxes, matching the existing double-spend test expectation

## Impact
Before this patch, malformed `inputs` such as `[{}]`, `['not-a-dict']`, or a dict instead of a list raised `KeyError`/`TypeError` in `apply_transaction()` instead of returning `False`. That turns user-controlled invalid transaction shape into an exception path at the UTXO validation boundary. The full UTXO test module also exposed an existing double-spend regression: `spend_box()` did not raise on already-spent boxes when it owned the SQLite connection.

## Tests
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db.TestUtxoDB.test_apply_transaction_rejects_malformed_inputs node.test_utxo_db.TestUtxoDB.test_mempool_rejects_malformed_inputs_without_locking node.test_utxo_db.TestUtxoDB.test_spend_box_double_spend_raises`
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db`

Bounty context: https://github.com/Scottcjn/rustchain-bounties/issues/2819
