### PR TITLE
fix: reject oversized SPV bloom filters

### DIFF
--- a/node/spv_client.py
+++ b/node/spv_client.py
@@ -121,7 +121,10 @@ class BloomFilter:
     @classmethod
     def from_hex(cls, value: str, size_bits: int = 2048, hash_count: int = 7) -> "BloomFilter":
         bloom = cls(size_bits=size_bits, hash_count=hash_count)
-        bloom._bits = int.from_bytes(bytes.fromhex(value), "big")
+        bits = int.from_bytes(bytes.fromhex(value), "big")
+        if bits.bit_length() > bloom.size_bits:
+            raise ValueError("serialized bloom filter exceeds configured size")
+        bloom._bits = bits
         return bloom
 
 

--- a/node/tests/test_spv_client.py
+++ b/node/tests/test_spv_client.py
@@ -105,3 +105,8 @@ def test_bloom_filter_matches_watched_items_and_round_trips():
 
     restored = BloomFilter.from_hex(bloom.to_hex(), size_bits=256, hash_count=5)
     assert "RTC-wallet-address" in restored
+
+
+def test_bloom_filter_rejects_oversized_serialized_bits():
+    with pytest.raises(ValueError, match="exceeds configured size"):
+        BloomFilter.from_hex("ffff", size_bits=8, hash_count=1)


### PR DESCRIPTION
## Summary
- reject serialized Bloom filters whose set bits exceed the configured `size_bits`
- preserve shorter serialized values by padding through the existing `to_hex()` behavior
- add a regression test for oversized SPV Bloom filter payloads

## Impact
`BloomFilter.from_hex("ffff", size_bits=8)` accepted a 16-bit serialized value into an 8-bit filter. Calling `to_hex()` on the resulting filter then raised `OverflowError: int too big to convert`, so malformed peer/client-supplied SPV filter state could create an object that crashes later serialization.

## Tests
- `PYTHONPATH=. ./.venv/bin/python -m pytest -q node/tests/test_spv_client.py`
- `python3 -m py_compile node/spv_client.py`
- `git diff --check`

Bounty context: https://github.com/Scottcjn/rustchain-bounties/issues/520
