### PR TITLE
fix: reject overprecision node bridge amounts

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -20,10 +20,9 @@ import hmac
 import hashlib
 import logging
 import os
-import math
 import re
 from typing import Optional, Tuple, Dict, Any
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from dataclasses import dataclass
 from enum import Enum
 
@@ -181,18 +180,14 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
     
     # Validate amount
     amount_raw = data.get("amount_rtc", 0)
-    if isinstance(amount_raw, bool):
-        return ValidationResult(ok=False, error="amount_rtc must be a number")
     try:
-        amount_rtc = float(amount_raw)
-    except (TypeError, ValueError):
-        return ValidationResult(ok=False, error="amount_rtc must be a number")
+        amount_i64 = parse_bridge_amount_i64(amount_raw)
+    except ValueError as exc:
+        return ValidationResult(ok=False, error=str(exc))
     
-    if not math.isfinite(amount_rtc):
-        return ValidationResult(ok=False, error="amount_rtc must be finite")
-    if amount_rtc <= 0:
+    if amount_i64 <= 0:
         return ValidationResult(ok=False, error="amount_rtc must be positive")
-    if amount_rtc < BRIDGE_MIN_AMOUNT_RTC:
+    if amount_i64 < int(Decimal(str(BRIDGE_MIN_AMOUNT_RTC)) * BRIDGE_UNIT):
         return ValidationResult(ok=False, error=f"amount_rtc must be >= {BRIDGE_MIN_AMOUNT_RTC} RTC")
     
     # Validate bridge type (optional)
@@ -217,11 +212,28 @@ def validate_bridge_request(data: Optional[Dict]) -> ValidationResult:
             "dest_chain": dest_chain,
             "source_address": source_address,
             "dest_address": dest_address,
-            "amount_rtc": amount_rtc,
+            "amount_rtc": amount_i64 / BRIDGE_UNIT,
             "memo": memo,
             "bridge_type": bridge_type
         }
     )
+
+
+def parse_bridge_amount_i64(raw_amount) -> int:
+    """Parse RTC bridge amount exactly into bridge micro-units."""
+    if isinstance(raw_amount, bool):
+        raise ValueError("amount_rtc must be a number")
+    try:
+        amount = Decimal(str(raw_amount))
+    except (InvalidOperation, ValueError):
+        raise ValueError("amount_rtc must be a number")
+    if not amount.is_finite():
+        raise ValueError("amount_rtc must be finite")
+
+    scaled = amount * BRIDGE_UNIT
+    if scaled != scaled.to_integral_value():
+        raise ValueError("amount_rtc supports at most 6 decimal places")
+    return int(scaled)
 
 
 def validate_chain_address_format(chain: str, address: str) -> Tuple[bool, str]:
@@ -319,7 +331,7 @@ def create_bridge_transfer(
     now = int(time.time())
     current_epoch = slot_to_epoch(current_slot())
     
-    amount_i64 = int(Decimal(str(request.amount_rtc)) * BRIDGE_UNIT)
+    amount_i64 = parse_bridge_amount_i64(request.amount_rtc)
     tx_hash = generate_bridge_tx_hash(
         request.direction,
         request.source_chain,

--- a/node/test_bridge_initiate_type_validation.py
+++ b/node/test_bridge_initiate_type_validation.py
@@ -55,7 +55,7 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
             "source_chain": "solana",
             "dest_chain": "rustchain",
             "source_address": "S" * 32,
-            "dest_address": "RTCdestination12345",
+            "dest_address": "RTC" + "a" * 40,
             "amount_rtc": 1.0,
         }
 
@@ -82,6 +82,32 @@ class TestBridgeInitiateTypeValidation(unittest.TestCase):
                 payload = {**self.valid_payload(), "amount_rtc": amount_rtc}
                 response = self.client.post("/api/bridge/initiate", json=payload)
                 self.assertEqual(response.status_code, 400)
+
+    def test_overprecision_amount_returns_400(self):
+        payload = {**self.valid_payload(), "amount_rtc": "1.0000004"}
+
+        response = self.client.post("/api/bridge/initiate", json=payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("at most 6 decimal places", response.get_json()["error"])
+
+    def test_six_decimal_amount_is_stored_exactly(self):
+        payload = {**self.valid_payload(), "amount_rtc": "1.000001"}
+
+        response = self.client.post("/api/bridge/initiate", json=payload)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["amount_rtc"], 1.000001)
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                "SELECT amount_i64 FROM bridge_transfers WHERE tx_hash = ?",
+                (body["tx_hash"],),
+            ).fetchone()
+        finally:
+            conn.close()
+        self.assertEqual(row[0], 1_000_001)
 
     def test_mixed_case_chain_uses_normalized_value_for_address_validation(self):
         payload = {


### PR DESCRIPTION
## Summary
- parse `/api/bridge/initiate` `amount_rtc` values as exact Decimal fixed-point amounts
- reject values that cannot be represented by `BRIDGE_UNIT = 1_000_000` micro-units
- preserve existing boolean/non-numeric/non-finite/minimum validation
- canonicalize accepted amounts before creating the bridge transfer
- add endpoint regressions for over-precision rejection and exact six-decimal storage

Fixes #6470.

## Security impact
The old validator accepted values like `1.0000004` even though bridge transfers are stored in 6-decimal micro-units. That made the accepted/requested API amount differ from the ledger amount used for accounting.

## Tests
- `python3 -m py_compile node/bridge_api.py node/test_bridge_initiate_type_validation.py`
- `PYTHONPATH=node ./.venv/bin/python -m unittest node.test_bridge_initiate_type_validation -v`
