### PR TITLE
fix: cap utxo transaction input count

### DIFF
--- a/node/test_utxo_no_max_inputs_apply_poc.py
+++ b/node/test_utxo_no_max_inputs_apply_poc.py
@@ -28,12 +28,12 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from utxo_db import UtxoDB, UNIT, MAX_OUTPUTS, coin_select
+from utxo_db import MAX_INPUTS, MAX_OUTPUTS, UtxoDB, UNIT, coin_select
 
 
 class TestApplyTransactionNoMaxInputs(unittest.TestCase):
     """
-    apply_transaction() accepts unlimited inputs — block production DoS.
+    apply_transaction() rejects transactions over the input-count boundary.
     """
 
     def setUp(self):
@@ -60,38 +60,35 @@ class TestApplyTransactionNoMaxInputs(unittest.TestCase):
             ids.append(self.db.get_unspent_for_address(f'a{i}')[0]['box_id'])
         return ids
 
-    def test_apply_tx_accepts_unbounded_inputs(self):
+    def test_apply_tx_accepts_inputs_at_limit(self):
         """
-        apply_transaction with 100 inputs — no MAX_INPUTS guard.
-        EXPECT: Should reject > MAX_OUTPUTS (100). 
-        ACTUAL: Accepted. 100 UPDATE queries inside write lock.
+        apply_transaction with exactly MAX_INPUTS remains valid.
         """
-        box_ids = self._create_boxes(100)
+        box_ids = self._create_boxes(MAX_INPUTS)
         inputs = [{'box_id': bid, 'spending_proof': 'sig'} for bid in box_ids]
 
         start = time.time()
         ok = self.db.apply_transaction({
             'tx_type': 'transfer',
             'inputs': inputs,
-            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'outputs': [{'address': 'bob', 'value_nrtc': MAX_INPUTS * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
         }, block_height=200)
         elapsed = time.time() - start
 
-        print(f"[A2] apply_tx 100 inputs: {ok} ({elapsed:.4f}s)")
+        print(f"[A2] apply_tx {MAX_INPUTS} inputs: {ok} ({elapsed:.4f}s)")
         self.assertTrue(ok,
-            "apply_transaction accepted 100 inputs — no MAX_INPUTS guard exists")
+            "apply_transaction should accept transactions at MAX_INPUTS")
 
         # Verify it actually processed
         bob_bal = self.db.get_balance('bob')
-        self.assertEqual(bob_bal, 100 * UNIT,
+        self.assertEqual(bob_bal, MAX_INPUTS * UNIT,
             "apply_transaction correctly processed all 100 inputs")
 
-    def test_apply_tx_perf_baseline(self):
+    def test_apply_tx_rejects_inputs_over_limit(self):
         """
-        Performance baseline: 500 inputs → measure block production impact.
-        A mempooll tx with 500+ inputs consumed by a miner delays block production.
+        500 inputs should be rejected before per-input block application work.
         """
         box_ids = self._create_boxes(500)
         inputs = [{'box_id': bid, 'spending_proof': 'sig'} for bid in box_ids]
@@ -107,37 +104,31 @@ class TestApplyTransactionNoMaxInputs(unittest.TestCase):
         elapsed = time.time() - start
 
         qps = 500 / elapsed
-        print(f"[A2 perf] 500 inputs: {ok} ({elapsed:.4f}s, {qps:.0f} updates/sec)")
-        self.assertTrue(ok)
-        # At 100K+ updates/sec, a 10K-input tx takes ~100ms of locked time
-        # In production with HDD or remote DB, this is worse
-        print(f"  → DoS surface: 10K inputs ~ {10_000/qps:.2f}s under write lock")
+        print(f"[A2 perf] 500 inputs: accepted={ok} ({elapsed:.4f}s, rate={qps:.0f}/sec)")
+        self.assertFalse(ok)
 
-    def test_no_max_inputs_constant(self):
-        """Verify no MAX_INPUTS constant exists in utxo_db.py."""
+    def test_max_inputs_constant_exists(self):
+        """Verify MAX_INPUTS exists in utxo_db.py."""
         with open(__file__.replace('test_utxo_no_max_inputs_apply_poc.py',
                                    'utxo_db.py'), 'r') as f:
             src = f.read()
         has = 'MAX_INPUTS' in src and 'MAX_INPUT' in src
         print(f"[A2] MAX_INPUTS constant exists: {has}")
-        # Since A1 proved this false, this is documentation
-        self.assertFalse('MAX_INPUTS' in src,
-            "A2: No MAX_INPUTS constant — same root cause as A1")
+        self.assertTrue('MAX_INPUTS' in src)
 
     def test_max_outputs_exists_inputs_doesnt(self):
         """
-        Confirm asymmetry: MAX_OUTPUTS=100 exists but no MAX_INPUTS.
-        The codebase protects against output bloat but not input bloat.
+        Confirm input and output sides use the same anti-bloat bound.
         """
         self.assertEqual(MAX_OUTPUTS, 100,
             "MAX_OUTPUTS = 100 exists as anti-bloat guard")
-        # No analogous MAX_INPUTS — this asymmetry IS the vulnerability
+        self.assertEqual(MAX_INPUTS, MAX_OUTPUTS)
 
 
 class TestCoinSelectEnforces20ButDbLayerDoesnt(unittest.TestCase):
     """
-    coin_select() caps at 20 inputs via heuristic but apply_transaction
-    has no hard limit. The networking/rpc layer is the only defense.
+    coin_select() caps at 20 inputs via heuristic and the DB layer now has
+    a hard consensus-boundary limit as defense in depth.
     """
 
     def setUp(self):

--- a/node/test_utxo_no_max_inputs_poc.py
+++ b/node/test_utxo_no_max_inputs_poc.py
@@ -25,18 +25,14 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from utxo_db import UtxoDB, UNIT
+from utxo_db import MAX_INPUTS, UtxoDB, UNIT
 
 
 class TestMempoolNoMaxInputsBoundary(unittest.TestCase):
     """
-    🔴 2 tests intentionally fail — they prove the bug exists.
-    test_EXPECTED_FAILURE_mempool_accepts_unbounded_inputs — 200-input tx ACCEPTED (should reject)
-    test_EXPECTED_FAILURE_mempool_dos_magnitude — 500-input tx ACCEPTED (should reject)
-    These fail with: AssertionError: True is not false
-    To run: pytest -k 'not EXPECTED_FAILURE' to skip them.
+    Regression tests for the input-count DoS boundary.
     """
-    """mempool_add() accepts transactions with unlimited inputs → DoS vector."""
+    """mempool_add() rejects transactions over the input-count boundary."""
 
     def setUp(self):
         self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
@@ -66,11 +62,10 @@ class TestMempoolNoMaxInputsBoundary(unittest.TestCase):
             box_ids.append(boxes[0]['box_id'])
         return box_ids
 
-    def test_EXPECTED_FAILURE_mempool_accepts_unbounded_inputs(self):
+    def test_mempool_rejects_inputs_over_limit(self):
         """
-        🔴 INTENTIONALLY FAILS — proves the bug exists.
-        Submits 200-input tx. Should be rejected (no MAX_INPUTS guard).
-        ACTUAL: Accepted — proving the vulnerability.
+        Submits a tx over MAX_INPUTS. It must be rejected before per-input
+        mempool checks run under the write lock.
         """
         box_ids = self._create_unspent_boxes(200)
         inputs = [{'box_id': bid, 'spending_proof': 'sig'} for bid in box_ids]
@@ -88,14 +83,12 @@ class TestMempoolNoMaxInputsBoundary(unittest.TestCase):
         })
         elapsed = time.time() - start
 
-        # BUG: This should be False — mempool_add has no MAX_INPUTS check
-        # The 200 SELECT queries ran inside a write lock
         print(f"[A1] 200-input tx accepted: {ok} ({elapsed:.3f}s, {200/elapsed:.0f} queries/sec)")
         self.assertFalse(ok,
             "CRITICAL: mempool_add should reject excessive inputs "
             "(200 SELECT queries inside BEGIN IMMEDIATE = DoS vector)")
 
-    def test_EXPECTED_FAILURE_mempool_dos_magnitude(self):
+    def test_mempool_rejects_large_input_dos_vector(self):
         """
         Measure the cost — 500-input tx to quantify the DoS surface.
         Each input adds a SELECT query. Attacker can scale to 5000+
@@ -122,37 +115,23 @@ class TestMempoolNoMaxInputsBoundary(unittest.TestCase):
             "CRITICAL: 500 inputs should be rejected "
             f"({elapsed:.3f}s of locked DB time is unbounded DoS)")
 
-    def test_apply_transaction_also_no_bound(self):
+    def test_apply_transaction_rejects_inputs_over_limit(self):
         """
-        Same bug in apply_transaction() — also no MAX_INPUTS guard.
-        Block application would lock during production.
+        Same input cap is enforced during block application.
         """
-        self.db.apply_transaction({
-            'tx_type': 'mining_reward',
-            'inputs': [],
-            'outputs': [{'address': 'fund', 'value_nrtc': 100 * UNIT}],
-            'fee_nrtc': 0,
-            'timestamp': int(time.time()),
-            '_allow_minting': True,
-        }, block_height=1)
-        boxes = self.db.get_unspent_for_address('fund')
-        bid = boxes[0]['box_id']
-
-        # 3000 identical inputs — duplicate check at line 560-562 rejects dupes
-        # So we skip that and just verify apply_transaction also has no guard
-        # (mempool_add is the primary attack surface since it's user-facing)
-        # This test documents the gap in apply_transaction
-        inputs_payload = [{'box_id': bid, 'spending_proof': 'sig'}]
+        box_ids = self._create_unspent_boxes(MAX_INPUTS + 1)
+        inputs_payload = [{'box_id': bid, 'spending_proof': 'sig'} for bid in box_ids]
         start = time.time()
         ok = self.db.apply_transaction({
             'tx_type': 'transfer',
             'inputs': inputs_payload,
-            'outputs': [{'address': 'bob', 'value_nrtc': 1 * UNIT}],
+            'outputs': [{'address': 'bob', 'value_nrtc': (MAX_INPUTS + 1) * UNIT}],
             'fee_nrtc': 0,
             'timestamp': int(time.time()),
-        }, block_height=2)
+        }, block_height=MAX_INPUTS + 10)
         elapsed = time.time() - start
-        print(f"[A1 apply_tx] 1-input tx: {ok} ({elapsed:.3f}s) — baseline (no MAX_INPUTS guard either)")
+        print(f"[A1 apply_tx] {MAX_INPUTS + 1}-input tx accepted: {ok} ({elapsed:.3f}s)")
+        self.assertFalse(ok)
 
 
 class TestDualInputCheckMissing(unittest.TestCase):
@@ -160,10 +139,8 @@ class TestDualInputCheckMissing(unittest.TestCase):
     Cross-reference: utxo_endpoints.py may also lack input count checks.
     """
 
-    def test_max_inputs_constant_missing(self):
-        """
-        Verify MAX_INPUTS constant is absent from utxo_db.py.
-        """
+    def test_max_inputs_constant_exists(self):
+        """Verify the DB layer has a MAX_INPUTS cap matching MAX_OUTPUTS."""
         with open(__file__.replace('test_utxo_no_max_inputs_poc.py',
                                    'utxo_db.py'), 'r') as f:
             src = f.read()
@@ -172,8 +149,9 @@ class TestDualInputCheckMissing(unittest.TestCase):
         print(f"[A1 constants] MAX_OUTPUTS={has_max_outputs}, MAX_INPUTS={has_max_inputs}")
         self.assertTrue(has_max_outputs,
             "MAX_OUTPUTS should exist (checking project baseline)")
-        self.assertFalse(has_max_inputs,
-            "BUG CONFIRMED: No MAX_INPUTS constant exists in utxo_db.py")
+        self.assertTrue(has_max_inputs,
+            "MAX_INPUTS should exist as the input-side DoS guard")
+        self.assertEqual(MAX_INPUTS, 100)
 
 
 if __name__ == '__main__':

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -42,6 +42,7 @@ MAX_POOL_SIZE = 10_000
 
 # Anti-UTXO-bloat: maximum outputs per transaction
 # Without this, a single tx creates unlimited outputs, bloating the UTXO set.
+MAX_INPUTS = 100
 MAX_OUTPUTS = 100
 MAX_UTXO_ADDRESS_BYTES = 256
 MAX_UTXO_METADATA_BYTES = 8_192
@@ -557,6 +558,10 @@ class UtxoDB:
         # Require _allow_minting=True (internal flag) to permit mining_reward.
         if tx_type in MINTING_TX_TYPES and not tx.get('_allow_minting'):
             return False
+        if not isinstance(inputs, list):
+            return False
+        if len(inputs) > MAX_INPUTS:
+            return False
         outputs = self._normalize_outputs(outputs)
         if outputs is None:
             return False
@@ -964,6 +969,14 @@ class UtxoDB:
                     conn.execute("ROLLBACK")
                 return False
 
+            if not isinstance(inputs, list):
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
+            if len(inputs) > MAX_INPUTS:
+                if manage_tx:
+                    conn.execute("ROLLBACK")
+                return False
             if not inputs:
                 if manage_tx:
                     conn.execute("ROLLBACK")


### PR DESCRIPTION
## Summary
- add `MAX_INPUTS = 100` alongside the existing `MAX_OUTPUTS = 100` UTXO anti-bloat limit
- reject transactions over the input cap in both `mempool_add()` and `apply_transaction()`
- update the existing no-max-input PoCs into passing regression tests
- preserve a valid exactly-`MAX_INPUTS` block-application path

Fixes #6472.

## Security impact
Before this patch, a transaction could carry hundreds or thousands of inputs. `mempool_add()` performs per-input mempool-claim and UTXO-existence checks under `BEGIN IMMEDIATE`, and `apply_transaction()` also scales linearly while applying a block transaction. This makes UTXO validation cost and write-lock duration attacker-controlled.

## Tests
- `python3 -m py_compile node/utxo_db.py node/test_utxo_no_max_inputs_poc.py node/test_utxo_no_max_inputs_apply_poc.py`
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/test_utxo_no_max_inputs_poc.py node/test_utxo_no_max_inputs_apply_poc.py`

Additional check:
- `PYTHONPATH=node ./.venv/bin/python -m unittest node.test_utxo_db -q` still has the existing unrelated failure in `test_spend_box_double_spend_raises`, which is covered by a separate open PR.
