### PR TITLE
fix: sync root payout preflight validation

### DIFF
--- a/payout_preflight.py
+++ b/payout_preflight.py
@@ -26,6 +26,10 @@ def _is_rtc_address(value: str) -> bool:
     return bool(_RTC_ADDRESS_RE.fullmatch(value))
 
 
+def _is_bcn_address(value: str) -> bool:
+    return value.startswith("bcn_") and len(value) >= 8
+
+
 def _as_dict(payload: Any) -> Tuple[Optional[Dict[str, Any]], str]:
     if not isinstance(payload, dict):
         return None, "invalid_json_body"
@@ -110,7 +114,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
     if err:
         return PreflightResult(ok=False, error=err, details={})
 
-    required = ["from_address", "to_address", "amount_rtc", "nonce", "signature", "public_key"]
+    required = ["from_address", "to_address", "amount_rtc", "nonce", "signature"]
     missing = [k for k in required if k not in data or data.get(k) in (None, "")]
     if missing:
         return PreflightResult(ok=False, error="missing_required_fields", details={"missing": missing})
@@ -131,13 +135,20 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
         )
     if ierr:
         return PreflightResult(ok=False, error=ierr, details={})
+    fee_rtc, ferr = _safe_decimal(data.get("fee_rtc", 0))
+    if ferr:
+        return PreflightResult(ok=False, error=ferr, details={"field": "fee_rtc"})
+    if fee_rtc is None or fee_rtc < 0:
+        return PreflightResult(ok=False, error="fee_must_be_non_negative", details={})
 
-    if not _is_rtc_address(from_address):
+    if not (_is_rtc_address(from_address) or _is_bcn_address(from_address)):
         return PreflightResult(ok=False, error="invalid_from_address_format", details={})
-    if not _is_rtc_address(to_address):
+    if not (_is_rtc_address(to_address) or _is_bcn_address(to_address)):
         return PreflightResult(ok=False, error="invalid_to_address_format", details={})
     if from_address == to_address:
         return PreflightResult(ok=False, error="from_to_must_differ", details={})
+    if _is_rtc_address(from_address) and not data.get("public_key"):
+        return PreflightResult(ok=False, error="missing_required_fields", details={"missing": ["public_key"]})
 
     try:
         nonce_int = int(str(data.get("nonce")))
@@ -158,6 +169,7 @@ def validate_wallet_transfer_signed(payload: Any) -> PreflightResult:
             "to_address": to_address,
             "amount_rtc": float(amount_rtc),
             "amount_i64": amount_i64,
+            "fee_rtc": float(fee_rtc),
             "nonce": nonce_int,
             "chain_id": chain_id or None,
         },

--- a/tests/test_payout_preflight.py
+++ b/tests/test_payout_preflight.py
@@ -273,6 +273,41 @@ class TestValidateWalletTransferSigned:
                 assert result.ok is True
                 assert result.error == ""
                 assert result.details["nonce"] == 1
+                assert result.details["fee_rtc"] == 0.0
+
+      def test_signed_transfer_accepts_fee_rtc(self):
+                result = validate_wallet_transfer_signed(self._valid_payload(fee_rtc="0.25"))
+                assert result.ok is True
+                assert result.details["fee_rtc"] == 0.25
+
+      def test_signed_transfer_rejects_negative_fee_rtc(self):
+                result = validate_wallet_transfer_signed(self._valid_payload(fee_rtc="-0.01"))
+                assert result.ok is False
+                assert result.error == "fee_must_be_non_negative"
+
+      def test_signed_transfer_accepts_bcn_sender_without_public_key(self):
+                result = validate_wallet_transfer_signed({
+                              "from_address": "bcn_sender001",
+                              "to_address": self._make_address("b"),
+                              "amount_rtc": 10.0,
+                              "nonce": 1,
+                              "signature": "sig_abc123",
+                })
+                assert result.ok is True
+
+      def test_signed_transfer_accepts_bcn_recipient(self):
+                result = validate_wallet_transfer_signed(self._valid_payload(
+                              to_address="bcn_receiver001",
+                ))
+                assert result.ok is True
+
+      def test_rtc_sender_still_requires_public_key(self):
+                payload = self._valid_payload()
+                payload.pop("public_key")
+                result = validate_wallet_transfer_signed(payload)
+                assert result.ok is False
+                assert result.error == "missing_required_fields"
+                assert result.details["missing"] == ["public_key"]
 
       def test_missing_required_fields(self):
                 result = validate_wallet_transfer_signed({


### PR DESCRIPTION
Fixes https://github.com/Scottcjn/Rustchain/issues/6474

This syncs the repo-root `payout_preflight.py` compatibility copy with `node/payout_preflight.py` for signed-transfer validation. The integrated server imports the root module first when run from the repo root, so drift here changes payout validation behavior depending on deployment/import path.

Changes:
- allow `bcn_...` Beacon wallets on signed transfers, matching the node module
- preserve public-key requirement for native `RTC...` senders
- validate optional `fee_rtc` and reject negative fees
- include `fee_rtc` in successful preflight details
- add regression tests for the root module

Verification:
- `PYTHONPATH=. ./.venv/bin/python -m pytest -q tests/test_payout_preflight.py test_payout_preflight.py`
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/tests/test_payout_preflight.py`
- `python3 -m py_compile payout_preflight.py node/payout_preflight.py`
