### PR TITLE
test: include fingerprint evidence in attest signature fixtures

### DIFF
--- a/node/tests/test_attest_signature_verification.py
+++ b/node/tests/test_attest_signature_verification.py
@@ -119,7 +119,13 @@ class TestAttestSignatureVerification(unittest.TestCase):
             "report": {"nonce": nonce, "commitment": commitment},
             "device": {"family": "x86_64", "arch": "default", "model": "test-box", "cores": 4},
             "signals": {"hostname": "test-host", "macs": []},
-            "fingerprint": {},
+            "fingerprint": {
+                "checks": {
+                    "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+                    "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+                },
+                "all_passed": True,
+            },
         }
         if sig_hex is not None:
             payload["signature"] = sig_hex
@@ -239,7 +245,13 @@ class TestAttestSignatureVerification(unittest.TestCase):
             "report": {"nonce": nonce, "commitment": "deadbeef"},
             "device": {"family": "x86_64", "arch": "default", "model": "test-box", "cores": 4},
             "signals": {"hostname": "test-host", "macs": []},
-            "fingerprint": {},
+            "fingerprint": {
+                "checks": {
+                    "anti_emulation": {"passed": True, "data": {"vm_indicators": []}},
+                    "clock_drift": {"passed": True, "data": {"cv": 0.05, "samples": 64}},
+                },
+                "all_passed": True,
+            },
         }
         status, body = self._submit(mod, payload)
 


### PR DESCRIPTION
Fixes https://github.com/Scottcjn/Rustchain/issues/6478

The attestation signature regression suite had fixtures with `fingerprint: {}`. Current attestation validation requires `fingerprint.checks`, so two tests failed with `422 MISSING_FINGERPRINT` before reaching the signature paths they are supposed to verify.

This updates the shared signature fixture and the unsigned-attestation fixture with minimal valid fingerprint evidence, matching the challenge-binding tests.

Verification:
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/tests/test_attest_signature_verification.py`
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/tests/test_attest_submit_challenge_binding.py`
- `python3 -m py_compile node/tests/test_attest_signature_verification.py`
