### PR TITLE
fix: reject competing mempool-claimed utxo spends

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -695,6 +695,50 @@ class TestUtxoDB(unittest.TestCase):
             self.db.mempool_check_double_spend(boxes[0]['box_id'])
         )
 
+    def test_apply_rejects_input_claimed_by_other_mempool_tx(self):
+        """Direct/block spends must not override another pending mempool claim."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        mempool_tx = {
+            'tx_id': 'pending-claim',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+        }
+        self.assertTrue(self.db.mempool_add(mempool_tx))
+
+        competing_tx = {
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }
+
+        self.assertFalse(self.db.apply_transaction(competing_tx, block_height=10))
+        self.assertEqual(self.db.get_balance('carol'), 0)
+        self.assertTrue(self.db.mempool_check_double_spend(box['box_id']))
+
+    def test_apply_allows_matching_mempool_candidate(self):
+        """Mining the same mempool tx_id should still spend and evict it."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+        tx = {
+            'tx_id': 'candidate-claim',
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }
+
+        self.assertTrue(self.db.mempool_add(tx))
+        self.assertTrue(self.db.apply_transaction(tx, block_height=10))
+        self.assertEqual(self.db.get_balance('bob'), 100 * UNIT)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+
     def test_mempool_rejects_malformed_inputs_without_locking(self):
         self._apply_coinbase('alice', 100 * UNIT)
 
@@ -872,9 +916,9 @@ class TestUtxoDB(unittest.TestCase):
     def test_mempool_block_candidates_drop_spent_inputs(self):
         """Block candidates must not include txs whose inputs were confirmed.
 
-        A mempool transaction can be invalidated by a direct UTXO transfer path
-        that confirms the same input first. The stale mempool entry must not keep
-        returning to block producers until expiry.
+        Stale mempool entries can exist after a restart, prior bug, or
+        manual state repair. They must not keep returning to block producers
+        until expiry.
         """
         self._apply_coinbase('alice', 100 * UNIT, block_height=1)
         box = self.db.get_unspent_for_address('alice')[0]
@@ -887,13 +931,15 @@ class TestUtxoDB(unittest.TestCase):
             'fee_nrtc': 1000,
         }))
 
-        ok = self.db.apply_transaction({
-            'tx_type': 'transfer',
-            'inputs': [{'box_id': box['box_id'], 'spending_proof': 'sig'}],
-            'outputs': [{'address': 'carol', 'value_nrtc': 100 * UNIT}],
-            'fee_nrtc': 0,
-        }, block_height=2)
-        self.assertTrue(ok)
+        conn = self.db._conn()
+        try:
+            conn.execute(
+                "UPDATE utxo_boxes SET spent_at = ?, spent_by_tx = ? WHERE box_id = ?",
+                (int(time.time()), "external-confirmed", box['box_id']),
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
         candidates = self.db.mempool_get_block_candidates()
         self.assertEqual(candidates, [])

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -624,6 +624,14 @@ class UtxoDB:
             input_box_ids = [i['box_id'] for i in inputs]
             if len(input_box_ids) != len(set(input_box_ids)):
                 return abort()
+            claimed_by_tx_id = tx.get('tx_id') if isinstance(tx.get('tx_id'), str) else None
+            for box_id in input_box_ids:
+                claim = conn.execute(
+                    "SELECT tx_id FROM utxo_mempool_inputs WHERE box_id = ?",
+                    (box_id,),
+                ).fetchone()
+                if claim and claim['tx_id'] != claimed_by_tx_id:
+                    return abort()
             data_inputs = self._normalize_data_inputs(data_inputs)
             if data_inputs is None:
                 return abort()


### PR DESCRIPTION
## Summary
- reject `apply_transaction()` spends whose regular inputs are already claimed by another mempool transaction
- still allow applying the same mempool candidate when the claim belongs to the candidate `tx_id`
- keep stale-candidate cleanup coverage for externally-spent inputs

Fixes #6482.

## Validation
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/test_utxo_db.py node/test_utxo_endpoint_overrides_mempool_poc.py node/test_utxo_mempool_apply_concurrent_toctou_poc.py` -> 97 passed, 28 subtests passed
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/test_utxo_mempool_bug.py node/test_utxo_no_max_inputs_poc.py node/test_utxo_no_max_inputs_apply_poc.py node/test_utxo_tx_data_json_size_poc.py` -> 14 passed
- `python3 -m py_compile node/utxo_db.py node/test_utxo_db.py`
- `git diff --check`
