### PR TITLE
fix: sanitize public utxo mempool response

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -161,6 +161,39 @@ class TestUtxoEndpoints(unittest.TestCase):
         data = r.get_json()
         self.assertEqual(data['count'], 0)
 
+    def test_mempool_response_strips_spending_proof_and_injected_fields(self):
+        self._seed_coinbase('alice', 100 * UNIT)
+        box = self.utxo_db.get_unspent_for_address('alice')[0]
+        self.assertTrue(self.utxo_db.mempool_add({
+            'tx_id': 'signed-pending',
+            'tx_type': 'transfer',
+            'inputs': [{
+                'box_id': box['box_id'],
+                'spending_proof': 'ab' * 64,
+            }],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+            'priority': 'critical',
+            'fake_from': 'system',
+        }))
+
+        r = self.client.get('/utxo/mempool')
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(data['count'], 1)
+        tx = data['transactions'][0]
+        self.assertEqual(set(tx.keys()), {
+            'tx_id', 'tx_type', 'fee_nrtc', 'timestamp', 'inputs', 'outputs'
+        })
+        self.assertEqual(tx['inputs'], [{'box_id': box['box_id']}])
+        self.assertNotIn('spending_proof', tx['inputs'][0])
+        self.assertNotIn('_allow_minting', tx)
+        self.assertNotIn('priority', tx)
+        self.assertNotIn('fake_from', tx)
+
     # -- transfer endpoint ---------------------------------------------------
 
     def test_transfer_success(self):

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -90,6 +90,40 @@ def _nrtc_to_rtc_float(amount_nrtc: int) -> float:
     return float(Decimal(amount_nrtc) / Decimal(UNIT))
 
 
+def _public_mempool_transaction(tx: dict) -> dict:
+    """Return a public-safe view of a pending UTXO transaction."""
+    public_tx = {
+        'tx_id': tx.get('tx_id'),
+        'tx_type': tx.get('tx_type'),
+        'fee_nrtc': tx.get('fee_nrtc', 0),
+    }
+    if 'timestamp' in tx:
+        public_tx['timestamp'] = tx.get('timestamp')
+    if 'data_inputs' in tx:
+        data_inputs = tx.get('data_inputs')
+        public_tx['data_inputs'] = data_inputs if isinstance(data_inputs, list) else []
+
+    inputs = []
+    for inp in tx.get('inputs', []):
+        if isinstance(inp, dict) and isinstance(inp.get('box_id'), str):
+            inputs.append({'box_id': inp['box_id']})
+    public_tx['inputs'] = inputs
+
+    outputs = []
+    for out in tx.get('outputs', []):
+        if not isinstance(out, dict):
+            continue
+        clean = {}
+        if isinstance(out.get('address'), str):
+            clean['address'] = out['address']
+        if isinstance(out.get('value_nrtc'), int):
+            clean['value_nrtc'] = out['value_nrtc']
+        if clean:
+            outputs.append(clean)
+    public_tx['outputs'] = outputs
+    return public_tx
+
+
 def _ensure_signed_float_preserves_nrtc(amount: Decimal, nrtc: int,
                                         field_name: str) -> None:
     """
@@ -314,9 +348,10 @@ def utxo_integrity():
 def utxo_mempool():
     """View current UTXO mempool pending transactions (limit 50)."""
     candidates = _utxo_db.mempool_get_block_candidates(max_count=50)
+    public_candidates = [_public_mempool_transaction(tx) for tx in candidates]
     return jsonify({
-        'count': len(candidates),
-        'transactions': candidates,
+        'count': len(public_candidates),
+        'transactions': public_candidates,
     })
 
 


### PR DESCRIPTION
## Summary
- sanitize the public `GET /utxo/mempool` response instead of returning raw block-candidate transactions
- strip `spending_proof` from transaction inputs
- whitelist public transaction fields so attacker-injected metadata is not reflected to public mempool consumers

Fixes #6484.

## Validation
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/test_utxo_endpoints.py` -> 28 passed, 3 subtests passed
- `python3 -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py`
- `git diff --check`

## Note
`mempool_get_block_candidates()` remains unchanged because it is the internal raw candidate API; this PR sanitizes the public endpoint boundary.
