### PR TITLE
fix: harden p2p peer url validation

### DIFF
--- a/node/rustchain_p2p_sync.py
+++ b/node/rustchain_p2p_sync.py
@@ -9,7 +9,9 @@ import sqlite3
 import time
 import json
 import threading
+import ipaddress
 from typing import List, Dict
+from urllib.parse import urlparse
 
 from flask import jsonify, request
 
@@ -34,6 +36,42 @@ def _parse_int_query_arg(
     if maximum is not None and value > maximum:
         return maximum
     return value
+
+
+def _validate_public_peer_url(peer_url: str) -> str | None:
+    """Return an error message when peer_url is not safe to contact."""
+    try:
+        parsed = urlparse(peer_url)
+    except Exception:
+        return "invalid peer_url format"
+
+    if parsed.scheme not in ("http", "https"):
+        return "peer_url must start with http:// or https://"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return "invalid peer_url format"
+
+    normalized_host = hostname.rstrip(".").lower()
+    if normalized_host == "localhost" or normalized_host.endswith(".localhost"):
+        return "peer_url must be a public address"
+
+    try:
+        address = ipaddress.ip_address(normalized_host)
+    except ValueError:
+        return None
+
+    if (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+    ):
+        return "peer_url must be a public address"
+
+    return None
 
 
 # ============================================================================
@@ -451,18 +489,9 @@ def add_p2p_endpoints(app, peer_manager, block_sync, tx_gossip):
         # SECURITY: Validate URL scheme and reject private/internal addresses
         if not peer_url:
             return jsonify({"ok": False, "error": "peer_url required"}), 400
-        if not peer_url.startswith(("http://", "https://")):
-            return jsonify({"ok": False, "error": "peer_url must start with http:// or https://"}), 400
-        try:
-            from urllib.parse import urlparse
-            parsed = urlparse(peer_url)
-            hostname = parsed.hostname or ""
-            if hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1"):
-                return jsonify({"ok": False, "error": "peer_url must be a public address"}), 400
-            if hostname.startswith(("10.", "192.168.", "172.16.")):
-                return jsonify({"ok": False, "error": "peer_url must not be a private address"}), 400
-        except Exception:
-            return jsonify({"ok": False, "error": "invalid peer_url format"}), 400
+        peer_url_error = _validate_public_peer_url(peer_url)
+        if peer_url_error:
+            return jsonify({"ok": False, "error": peer_url_error}), 400
 
         if peer_url:
             success = peer_manager.add_peer(peer_url)

--- a/node/tests/test_p2p_sync_flask_imports.py
+++ b/node/tests/test_p2p_sync_flask_imports.py
@@ -37,19 +37,49 @@ def test_p2p_sync_flask_routes_use_flask_request_and_jsonify(tmp_path):
     rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
     client = app.test_client()
 
-    announce = client.post("/p2p/announce", json={"peer_url": "http://10.0.0.2:8088"})
+    announce = client.post("/p2p/announce", json={"peer_url": "https://node.example.com:8088"})
     assert announce.status_code == 200
     assert announce.get_json() == {"ok": True, "peers": 1}
 
     peers = client.get("/p2p/peers")
     assert peers.status_code == 200
-    assert peers.get_json()["peers"] == ["http://10.0.0.2:8088"]
+    assert peers.get_json()["peers"] == ["https://node.example.com:8088"]
 
     blocks = client.get("/api/blocks?start=1&limit=1")
     assert blocks.status_code == 200
     assert blocks.get_json()["blocks"] == [
         {"height": 1, "hash": "block-hash", "data": {"ok": True}}
     ]
+
+
+@pytest.mark.parametrize(
+    "peer_url",
+    [
+        "http://localhost:8088",
+        "http://127.0.0.1:8088",
+        "http://0.0.0.0:8088",
+        "http://10.0.0.2:8088",
+        "http://172.17.0.1:8088",
+        "http://172.31.255.255:8088",
+        "http://192.168.0.10:8088",
+        "http://169.254.169.254:8088",
+        "http://[::1]:8088",
+        "http://[fd00::1]:8088",
+        "http://[fe80::1]:8088",
+    ],
+)
+def test_p2p_announce_rejects_private_or_internal_peer_urls(tmp_path, peer_url):
+    db_path = tmp_path / "rustchain.db"
+    peer_manager = rustchain_p2p_sync.PeerManager(str(db_path), "127.0.0.1")
+
+    app = Flask(__name__)
+    rustchain_p2p_sync.add_p2p_endpoints(app, peer_manager, None, None)
+    client = app.test_client()
+
+    response = client.post("/p2p/announce", json={"peer_url": peer_url})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "peer_url must be a public address"}
 
 
 


### PR DESCRIPTION
## Summary
- replace string-prefix peer URL filtering with parser + `ipaddress` validation
- reject private, loopback, link-local, multicast, reserved, and unspecified literal peer hosts
- add regression coverage for 172.17/172.31, metadata IP, localhost, and IPv6 internal peer URLs

Fixes #6486.

## Validation
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q node/tests/test_p2p_sync_flask_imports.py node/tests/test_p2p_nat_upnp.py node/tests/test_p2p_handshake_negotiation.py`
- `python3 -m py_compile node/rustchain_p2p_sync.py node/tests/test_p2p_sync_flask_imports.py`
- `git diff --check`