### PR TITLE
fix: bound ergo bridge rpc calls

### DIFF
--- a/src/bridge/ergo_connector.py
+++ b/src/bridge/ergo_connector.py
@@ -1,16 +1,36 @@
 # ErgoBridgeConnector: Interface for connecting RustChain to Ergo mainnet
-import json
 import requests
+from numbers import Real
+from urllib.parse import quote
+
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 10
+
 
 class ErgoBridgeConnector:
-    def __init__(self, ergo_rpc_url, rustchain_node_url, contract_address):
+    def __init__(
+        self,
+        ergo_rpc_url,
+        rustchain_node_url,
+        contract_address,
+        request_timeout=DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ):
+        if (
+            isinstance(request_timeout, bool)
+            or not isinstance(request_timeout, Real)
+            or request_timeout <= 0
+        ):
+            raise ValueError("request_timeout must be a positive number")
         self.ergo_rpc_url = ergo_rpc_url
         self.rustchain_node_url = rustchain_node_url
         self.contract_address = contract_address
+        self.request_timeout = request_timeout
 
     def get_merkle_root(self):
         # Get Merkle root from RustChain node
-        response = requests.get(f'{self.rustchain_node_url}/get_merkle_root')
+        response = requests.get(
+            f'{self.rustchain_node_url}/get_merkle_root',
+            timeout=self.request_timeout,
+        )
         if response.status_code == 200:
             return response.json()['merkle_root']
         else:
@@ -19,14 +39,22 @@ class ErgoBridgeConnector:
     def submit_merkle_root_to_ergo(self, merkle_root):
         # Submit Merkle root to Ergo contract
         data = {"contract_address": self.contract_address, "merkle_root": merkle_root}
-        response = requests.post(f'{self.ergo_rpc_url}/submit_merkle_root', json=data)
+        response = requests.post(
+            f'{self.ergo_rpc_url}/submit_merkle_root',
+            json=data,
+            timeout=self.request_timeout,
+        )
         if response.status_code != 200:
             raise Exception('Failed to submit Merkle root to Ergo')
         return response.json()
 
     def verify_contract(self):
         # Verify if the contract exists on Ergo
-        response = requests.get(f'{self.ergo_rpc_url}/verify_contract/{self.contract_address}')
+        contract_path = quote(self.contract_address, safe="")
+        response = requests.get(
+            f'{self.ergo_rpc_url}/verify_contract/{contract_path}',
+            timeout=self.request_timeout,
+        )
         if response.status_code == 200:
             return response.json()['status'] == 'exists'
         else:

--- a/tests/test_ergo_bridge_connector.py
+++ b/tests/test_ergo_bridge_connector.py
@@ -39,21 +39,21 @@ def connector():
 def test_get_merkle_root_returns_node_payload(monkeypatch, connector):
     calls = []
 
-    def fake_get(url):
-        calls.append(url)
+    def fake_get(url, timeout):
+        calls.append((url, timeout))
         return FakeResponse(200, {"merkle_root": "abc123"})
 
     monkeypatch.setattr("ergo_connector.requests.get", fake_get)
 
     assert connector.get_merkle_root() == "abc123"
-    assert calls == ["https://rustchain.example/get_merkle_root"]
+    assert calls == [("https://rustchain.example/get_merkle_root", 10)]
 
 
 def test_submit_merkle_root_posts_contract_payload(monkeypatch, connector):
     posts = []
 
-    def fake_post(url, json):
-        posts.append((url, json))
+    def fake_post(url, json, timeout):
+        posts.append((url, json, timeout))
         return FakeResponse(200, {"tx_id": "tx-1"})
 
     monkeypatch.setattr("ergo_connector.requests.post", fake_post)
@@ -63,6 +63,7 @@ def test_submit_merkle_root_posts_contract_payload(monkeypatch, connector):
         (
             "https://ergo.example/submit_merkle_root",
             {"contract_address": "contract-123", "merkle_root": "root-456"},
+            10,
         )
     ]
 
@@ -75,10 +76,44 @@ def test_verify_contract_distinguishes_existing_contract(monkeypatch, connector)
         ]
     )
 
-    monkeypatch.setattr("ergo_connector.requests.get", lambda url: next(responses))
+    monkeypatch.setattr("ergo_connector.requests.get", lambda url, timeout: next(responses))
 
     assert connector.verify_contract() is True
     assert connector.verify_contract() is False
+
+
+def test_verify_contract_url_encodes_contract_path(monkeypatch):
+    connector = ErgoBridgeConnector(
+        ergo_rpc_url="https://ergo.example",
+        rustchain_node_url="https://rustchain.example",
+        contract_address="../admin?debug=true",
+    )
+    calls = []
+
+    def fake_get(url, timeout):
+        calls.append((url, timeout))
+        return FakeResponse(200, {"status": "exists"})
+
+    monkeypatch.setattr("ergo_connector.requests.get", fake_get)
+
+    assert connector.verify_contract() is True
+    assert calls == [
+        (
+            "https://ergo.example/verify_contract/..%2Fadmin%3Fdebug%3Dtrue",
+            10,
+        )
+    ]
+
+
+@pytest.mark.parametrize("timeout", [0, -1, False, "10"])
+def test_connector_rejects_non_positive_request_timeout(timeout):
+    with pytest.raises(ValueError, match="request_timeout must be a positive number"):
+        ErgoBridgeConnector(
+            ergo_rpc_url="https://ergo.example",
+            rustchain_node_url="https://rustchain.example",
+            contract_address="contract-123",
+            request_timeout=timeout,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add a default 10-second timeout to every Ergo bridge connector HTTP request
- allow callers to configure the timeout, rejecting non-positive or non-numeric values
- URL-encode the contract address when building the `verify_contract` path
- extend connector tests to assert timeout propagation and path encoding

Fixes #6488.

## Validation
- `./.venv/bin/python -m pytest -q tests/test_ergo_bridge_connector.py`
- `python3 -m py_compile src/bridge/ergo_connector.py tests/test_ergo_bridge_connector.py`
- `git diff --check`