### PR TITLE
fix: validate webhook admin payloads

### DIFF
--- a/tests/test_webhook_server_helpers.py
+++ b/tests/test_webhook_server_helpers.py
@@ -2,10 +2,13 @@
 """Unit tests for the RustChain webhook dispatcher helpers."""
 
 import importlib.util
+import io
 import json
 import sys
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -23,6 +26,16 @@ def load_module():
 
 def fake_addrinfo(ip):
     return [(None, None, None, None, (ip, 443))]
+
+
+def make_admin_handler(module, payload):
+    body = json.dumps(payload).encode()
+    handler = object.__new__(module.WebhookAdminHandler)
+    handler.headers = {"Content-Length": str(len(body))}
+    handler.rfile = io.BytesIO(body)
+    handler.responses = []
+    handler._send_json = lambda status, response: handler.responses.append((status, response))
+    return handler
 
 
 def test_validate_webhook_url_rejects_bad_scheme_and_missing_host():
@@ -147,3 +160,43 @@ def test_poller_miners_accepts_paginated_api_envelope(monkeypatch, tmp_path):
         "device_family": None,
         "device_arch": "SPARC",
     }
+
+
+@pytest.mark.parametrize("payload", [["not", "object"], "string", 1])
+def test_webhook_admin_read_body_rejects_non_object_json(payload):
+    module = load_module()
+    handler = make_admin_handler(module, payload)
+
+    with pytest.raises(ValueError, match="JSON object body required"):
+        handler._read_body()
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"url": ["https://example.com/hook"]}, "url must be a string"),
+        ({"url": "https://example.com/hook", "events": "new_block"}, "events must be a list of strings"),
+        ({"url": "https://example.com/hook", "events": [1]}, "events must be a list of strings"),
+        ({"url": "https://example.com/hook", "id": {"bad": "id"}}, "id must be a string"),
+        ({"url": "https://example.com/hook", "secret": {"bad": "secret"}}, "secret must be a string"),
+    ],
+)
+def test_webhook_admin_subscribe_rejects_malformed_fields(monkeypatch, payload, message):
+    module = load_module()
+    handler = make_admin_handler(module, payload)
+    handler.store = module.SubscriberStore(":memory:")
+    monkeypatch.setattr(module, "validate_webhook_url", lambda url: None)
+
+    handler._handle_subscribe()
+
+    assert handler.responses == [(400, {"error": message})]
+
+
+def test_webhook_admin_unsubscribe_rejects_non_string_id():
+    module = load_module()
+    handler = make_admin_handler(module, {"id": {"bad": "id"}})
+    handler.store = module.SubscriberStore(":memory:")
+
+    handler._handle_unsubscribe()
+
+    assert handler.responses == [(400, {"error": "id must be a string"})]

--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -534,7 +534,10 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
         if length == 0:
             return {}
         raw = self.rfile.read(length)
-        return json.loads(raw)
+        body = json.loads(raw)
+        if not isinstance(body, dict):
+            raise ValueError("JSON object body required")
+        return body
 
     # FIX(#2867 M3): Authenticate admin API requests
     def _check_api_key(self) -> bool:
@@ -597,6 +600,9 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
         if not url:
             self._send_json(400, {"error": "url is required"})
             return
+        if not isinstance(url, str):
+            self._send_json(400, {"error": "url must be a string"})
+            return
 
         error = validate_webhook_url(url)
         if error:
@@ -604,7 +610,12 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
             return
 
         events_raw = body.get("events")
-        if events_raw:
+        if events_raw is not None:
+            if not isinstance(events_raw, list) or not all(
+                isinstance(event, str) for event in events_raw
+            ):
+                self._send_json(400, {"error": "events must be a list of strings"})
+                return
             events = set(events_raw) & ALL_EVENT_TYPES
             if not events:
                 self._send_json(400, {
@@ -616,7 +627,13 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
             events = set(ALL_EVENT_TYPES)
 
         sub_id = body.get("id") or hashlib.sha256(url.encode()).hexdigest()[:12]
+        if not isinstance(sub_id, str):
+            self._send_json(400, {"error": "id must be a string"})
+            return
         secret = body.get("secret")
+        if secret is not None and not isinstance(secret, str):
+            self._send_json(400, {"error": "secret must be a string"})
+            return
 
         sub = Subscriber(id=sub_id, url=url, secret=secret, events=events)
         self.store.add(sub)
@@ -642,6 +659,9 @@ class WebhookAdminHandler(BaseHTTPRequestHandler):
         sub_id = body.get("id")
         if not sub_id:
             self._send_json(400, {"error": "id is required"})
+            return
+        if not isinstance(sub_id, str):
+            self._send_json(400, {"error": "id must be a string"})
             return
 
         if self.store.remove(sub_id):


### PR DESCRIPTION
## Summary
- require webhook admin request bodies to be JSON objects before handlers call `.get()`
- validate subscribe `url`, `events`, `id`, and `secret` field types before use or storage
- validate unsubscribe `id` type before calling the store
- add regression coverage for non-object JSON and malformed admin fields

Fixes #6490.

## Validation
- `./.venv/bin/python -m pytest -q tests/test_webhook_server_helpers.py tools/webhooks/test_webhook_server.py`
- `python3 -m py_compile tools/webhooks/webhook_server.py tests/test_webhook_server_helpers.py tools/webhooks/test_webhook_server.py`
- `git diff --check`