### PR TITLE
fix: avoid trusting faucet forwarded ip by default

### DIFF
--- a/tests/test_faucet.py
+++ b/tests/test_faucet.py
@@ -21,7 +21,7 @@ def app(tmp_path, monkeypatch):
     [
         (None, None, 0.5),
         ("", None, 0.5),
-        ("alice", None, 1.0),
+        ("alice", None, 0.5),
         ("alice", 364, 1.0),
         ("alice", 365, 2.0),
     ],
@@ -77,15 +77,49 @@ def test_drip_rejects_non_string_fields(app, payload, error):
     assert r.get_json() == {"ok": False, "error": error}
 
 
-def test_ip_only_limit(app):
+def test_ip_only_limit_uses_remote_addr_by_default(app):
     c = app.test_client()
-    h = {"X-Forwarded-For": "1.2.3.4"}
-    r1 = c.post("/faucet/drip", json={"wallet": "w1"}, headers=h)
+    r1 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w1"},
+        headers={"X-Forwarded-For": "1.2.3.4"},
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
     assert r1.status_code == 200
 
-    r2 = c.post("/faucet/drip", json={"wallet": "w2"}, headers=h)
+    r2 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w2"},
+        headers={"X-Forwarded-For": "5.6.7.8"},
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
     assert r2.status_code == 429
     assert r2.get_json()["error"] == "rate_limited"
+
+
+def test_ip_only_limit_can_trust_proxy_when_configured(tmp_path, monkeypatch):
+    db_path = tmp_path / "faucet.db"
+    monkeypatch.setattr(faucet, "github_account_age_days", lambda *_args, **_kwargs: 30)
+    app = faucet.create_app({"DB_PATH": str(db_path), "DRY_RUN": True, "TRUST_PROXY": True})
+    app.config.update(TESTING=True)
+    c = app.test_client()
+    remote = {"REMOTE_ADDR": "10.0.0.5"}
+
+    r1 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w1"},
+        headers={"X-Forwarded-For": "1.2.3.4"},
+        environ_base=remote,
+    )
+    r2 = c.post(
+        "/faucet/drip",
+        json={"wallet": "w2"},
+        headers={"X-Forwarded-For": "5.6.7.8"},
+        environ_base=remote,
+    )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
 
 
 def test_github_old_account_gets_2rtc_limit(tmp_path, monkeypatch):

--- a/tools/testnet_faucet.py
+++ b/tools/testnet_faucet.py
@@ -114,6 +114,15 @@ def _strip_string_field(data: dict[str, Any], name: str, max_length: int = 0) ->
     return value or None, None
 
 
+def _client_ip(trust_proxy: bool = False) -> str:
+    if trust_proxy:
+        forwarded_for = request.headers.get("X-Forwarded-For", "")
+        first_forwarded = forwarded_for.split(",")[0].strip()
+        if first_forwarded:
+            return first_forwarded
+    return request.remote_addr or "unknown"
+
+
 def _sum_last_24h(conn: sqlite3.Connection, github_username: str | None, ip: str) -> float:
     since = (_utcnow() - timedelta(hours=24)).isoformat()
     if github_username:
@@ -179,6 +188,7 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         "FAUCET_POOL_WALLET": os.getenv("FAUCET_POOL_WALLET", "faucet_pool"),
         "GITHUB_TOKEN": os.getenv("GITHUB_TOKEN", ""),
         "DRY_RUN": os.getenv("FAUCET_DRY_RUN", "1") == "1",
+        "TRUST_PROXY": os.getenv("FAUCET_TRUST_PROXY", "0") == "1",
     }
     if config:
         cfg.update(config)
@@ -200,7 +210,7 @@ def create_app(config: dict[str, Any] | None = None) -> Flask:
         github_username, error = _strip_string_field(data, "github_username", max_length=128)
         if error:
             return error
-        ip = request.headers.get("X-Forwarded-For", request.remote_addr or "unknown").split(",")[0].strip()
+        ip = _client_ip(bool(cfg.get("TRUST_PROXY")))
 
         if not wallet:
             return jsonify({"ok": False, "error": "wallet_required"}), 400


### PR DESCRIPTION
## Summary
- stop trusting `X-Forwarded-For` for faucet rate limiting unless trusted-proxy mode is explicitly enabled
- add `FAUCET_TRUST_PROXY=1` / `TRUST_PROXY` config for deployments behind a trusted reverse proxy
- cover direct-client spoofing and trusted-proxy behavior in faucet tests
- align the unverified GitHub username limit test with the existing anonymous-tier behavior

Fixes #6492.

## Validation
- `./.venv/bin/python -m pytest -q tests/test_faucet.py`
- `python3 -m py_compile tools/testnet_faucet.py tests/test_faucet.py`
- `git diff --check`