### PR TITLE
fix: validate airdrop github usernames

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -65,6 +65,7 @@ MIN_SOL_BALANCE_LAMPORTS = int(0.1 * 1e9)  # 0.1 SOL
 MIN_ETH_BALANCE_WEI = int(0.01 * 1e18)  # 0.01 ETH
 MIN_WALLET_AGE_DAYS = 7
 MIN_GITHUB_AGE_DAYS = 30
+GITHUB_USERNAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
 
 # Airdrop allocation
 TOTAL_SOLANA_ALLOCATION = 30_000 * 1_000_000  # 30k wRTC (6 decimals)
@@ -300,6 +301,10 @@ class AirdropV2:
     def _normalize_github_username(github_username: str) -> str:
         return (github_username or "").strip().casefold()
 
+    @staticmethod
+    def _is_valid_github_username(github_username: str) -> bool:
+        return bool(GITHUB_USERNAME_RE.fullmatch(github_username))
+
     def check_eligibility(
         self,
         github_username: str,
@@ -322,6 +327,11 @@ class AirdropV2:
             EligibilityResult with tier and reward info
         """
         github_username = self._normalize_github_username(github_username)
+        if not self._is_valid_github_username(github_username):
+            return EligibilityResult(
+                eligible=False,
+                reason="Invalid GitHub username",
+            )
         chain_lower = chain.lower()
         if chain_lower not in ["solana", "base"]:
             return EligibilityResult(
@@ -764,6 +774,8 @@ class AirdropV2:
             (success, message, claim_record)
         """
         github_username = self._normalize_github_username(github_username)
+        if not self._is_valid_github_username(github_username):
+            return False, "Invalid GitHub username", None
         chain_lower = chain.lower()
 
         if self._has_claimed(github_username, wallet_address, chain_lower):
@@ -1276,6 +1288,16 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
             return None, (jsonify({"ok": False, "error": f"{name}_too_long"}), 400)
         return value, None
 
+    def github_username_field(data: Dict[str, Any], name: str):
+        value, error = string_field(data, name, max_length=39)
+        if error:
+            return value, error
+        if value and not AirdropV2._is_valid_github_username(
+            AirdropV2._normalize_github_username(value)
+        ):
+            return None, (jsonify({"ok": False, "error": f"{name} must be a valid GitHub username"}), 400)
+        return value, None
+
     def optional_string_field(data: Dict[str, Any], name: str):
         if name not in data or data.get(name) is None:
             return None, None
@@ -1300,7 +1322,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         if error:
             return error
 
-        github_username, error = string_field(data, "github_username")
+        github_username, error = github_username_field(data, "github_username")
         if error:
             return error
         wallet_address, error = string_field(data, "wallet_address")
@@ -1336,7 +1358,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         if error:
             return error
 
-        github_username, error = string_field(data, "github_username", max_length=128)
+        github_username, error = github_username_field(data, "github_username")
         if error:
             return error
         wallet_address, error = string_field(data, "wallet_address", max_length=128)

--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -138,6 +138,85 @@ def test_airdrop_eligibility_rejects_structured_text_field(tmp_path):
     assert response.get_json() == {"ok": False, "error": "github_username must be a string"}
 
 
+@pytest.mark.parametrize(
+    "github_username",
+    [
+        "../octocat",
+        "alice/bob",
+        "alice?tab=repositories",
+        "-alice",
+        "alice-",
+    ],
+)
+def test_airdrop_eligibility_rejects_invalid_github_username(tmp_path, github_username):
+    client, _db_path = _make_client(tmp_path)
+
+    response = client.post(
+        "/api/airdrop/eligibility",
+        json={
+            "github_username": github_username,
+            "wallet_address": "wallet-1",
+            "chain": "base",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "github_username must be a valid GitHub username",
+    }
+
+
+def test_airdrop_eligibility_rejects_overlong_github_username(tmp_path):
+    client, _db_path = _make_client(tmp_path)
+
+    response = client.post(
+        "/api/airdrop/eligibility",
+        json={
+            "github_username": "a" * 40,
+            "wallet_address": "wallet-1",
+            "chain": "base",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "github_username_too_long"}
+
+
+def test_airdrop_claim_rejects_invalid_github_username_before_network(tmp_path):
+    client, _db_path = _make_client(tmp_path)
+
+    response = client.post(
+        "/api/airdrop/claim",
+        json={
+            "github_username": "alice/bob",
+            "wallet_address": "wallet-1",
+            "chain": "base",
+            "tier": "contributor",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "ok": False,
+        "error": "github_username must be a valid GitHub username",
+    }
+
+
+def test_airdrop_service_rejects_invalid_github_username_without_api_calls(tmp_path, monkeypatch):
+    airdrop = AirdropV2(str(tmp_path / "airdrop.db"))
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("GitHub API should not be called for malformed usernames")
+
+    monkeypatch.setattr(airdrop, "_check_github_account", fail_if_called)
+
+    result = airdrop.check_eligibility("../octocat", "wallet-1", "base")
+
+    assert result.eligible is False
+    assert result.reason == "Invalid GitHub username"
+
+
 def test_bridge_lock_rejects_structured_amount(tmp_path):
     client, _db_path = _make_client(tmp_path)
 


### PR DESCRIPTION
## Summary
- add GitHub username syntax validation to airdrop eligibility and claim processing
- reject malformed usernames at route boundaries before outbound GitHub API calls
- keep the service method fail-closed for direct Python callers too
- add regression coverage for path/query-like username inputs and overlong names

Fixes #6496.

## Validation
- `./.venv/bin/python -m pytest -q tests/test_airdrop_bridge_admin_auth.py`
- `python3 -m py_compile node/airdrop_v2.py tests/test_airdrop_bridge_admin_auth.py`
- `git diff --check`