### PR TITLE
fix: bound airdrop bridge lock amounts

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -69,6 +69,7 @@ MIN_GITHUB_AGE_DAYS = 30
 # Airdrop allocation
 TOTAL_SOLANA_ALLOCATION = 30_000 * 1_000_000  # 30k wRTC (6 decimals)
 TOTAL_BASE_ALLOCATION = 20_000 * 1_000_000  # 20k wRTC (6 decimals)
+MAX_BRIDGE_LOCK_UWRTC = max(TOTAL_SOLANA_ALLOCATION, TOTAL_BASE_ALLOCATION)
 
 # Rate limiting
 CLAIM_COOLDOWN_SECONDS = 86400 * 30  # 30 days between claims
@@ -948,6 +949,8 @@ class AirdropV2:
         # Validate amount
         if amount_uwrtc <= 0:
             return False, "Amount must be positive", None
+        if amount_uwrtc > MAX_BRIDGE_LOCK_UWRTC:
+            return False, "Amount exceeds maximum bridge lock", None
 
         # Generate lock ID
         lock_id = self._generate_id(
@@ -1293,6 +1296,17 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
             return None, (jsonify({"ok": False, "error": f"{name} must be a finite number"}), 400)
         return parsed, None
 
+    def bridge_amount_field(data: Dict[str, Any], name: str):
+        value, error = finite_amount_field(data, name)
+        if error:
+            return value, error
+        if value <= 0:
+            return None, (jsonify({"ok": False, "error": f"{name} must be positive"}), 400)
+        max_wrtc = MAX_BRIDGE_LOCK_UWRTC / 1_000_000
+        if value > max_wrtc:
+            return None, (jsonify({"ok": False, "error": f"{name} exceeds maximum bridge lock"}), 400)
+        return value, None
+
     @app.route("/api/airdrop/eligibility", methods=["POST"])
     def check_airdrop_eligibility():
         """Check airdrop eligibility."""
@@ -1409,7 +1423,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         to_chain, error = string_field(data, "to_chain")
         if error:
             return error
-        amount_wrtc, error = finite_amount_field(data, "amount_wrtc")
+        amount_wrtc, error = bridge_amount_field(data, "amount_wrtc")
         if error:
             return error
 

--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -156,6 +156,49 @@ def test_bridge_lock_rejects_structured_amount(tmp_path):
     assert response.get_json() == {"ok": False, "error": "amount_wrtc must be a finite number"}
 
 
+@pytest.mark.parametrize(
+    ("amount_wrtc", "message"),
+    [
+        (0, "amount_wrtc must be positive"),
+        (-1, "amount_wrtc must be positive"),
+        (1e100, "amount_wrtc exceeds maximum bridge lock"),
+        (30000.000001, "amount_wrtc exceeds maximum bridge lock"),
+    ],
+)
+def test_bridge_lock_rejects_out_of_range_amounts(tmp_path, amount_wrtc, message):
+    client, _db_path = _make_client(tmp_path)
+
+    response = client.post(
+        "/api/bridge/lock",
+        json={
+            "from_address": "solana-source",
+            "to_address": "base-destination",
+            "from_chain": "solana",
+            "to_chain": "base",
+            "amount_wrtc": amount_wrtc,
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": message}
+
+
+def test_airdrop_service_rejects_oversized_bridge_lock(tmp_path):
+    airdrop = AirdropV2(str(tmp_path / "airdrop.db"))
+
+    success, message, lock = airdrop.create_bridge_lock(
+        "solana-source",
+        "base-destination",
+        "solana",
+        "base",
+        30_000 * 1_000_000 + 1,
+    )
+
+    assert success is False
+    assert message == "Amount exceeds maximum bridge lock"
+    assert lock is None
+
+
 def test_bridge_confirm_rejects_structured_source_tx(tmp_path, monkeypatch):
     client, _db_path = _make_client(tmp_path)
     monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")


### PR DESCRIPTION
## Summary
- cap public bridge-lock amounts to the configured max bridge allocation
- reject non-positive bridge amounts before lock creation
- keep the same max-amount guard in `AirdropV2.create_bridge_lock()` for direct callers
- add regression coverage for oversized finite amounts such as `1e100`

Fixes #6498.

## Validation
- `./.venv/bin/python -m pytest -q tests/test_airdrop_bridge_admin_auth.py`
- `python3 -m py_compile node/airdrop_v2.py tests/test_airdrop_bridge_admin_auth.py`
- `git diff --check`