### PR TITLE
fix: bound airdrop bridge string fields

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -66,6 +66,8 @@ MIN_ETH_BALANCE_WEI = int(0.01 * 1e18)  # 0.01 ETH
 MIN_WALLET_AGE_DAYS = 7
 MIN_GITHUB_AGE_DAYS = 30
 GITHUB_USERNAME_RE = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$")
+MAX_BRIDGE_ADDRESS_LENGTH = 128
+MAX_BRIDGE_TX_LENGTH = 256
 
 # Airdrop allocation
 TOTAL_SOLANA_ALLOCATION = 30_000 * 1_000_000  # 30k wRTC (6 decimals)
@@ -950,6 +952,11 @@ class AirdropV2:
         Returns:
             (success, message, lock_record)
         """
+        if len(from_address) > MAX_BRIDGE_ADDRESS_LENGTH:
+            return False, "Source address too long", None
+        if len(to_address) > MAX_BRIDGE_ADDRESS_LENGTH:
+            return False, "Destination address too long", None
+
         # Validate chains
         if from_chain not in ["solana", "base", "rustchain"]:
             return False, f"Invalid source chain: {from_chain}", None
@@ -1032,6 +1039,9 @@ class AirdropV2:
         Returns:
             (success, message)
         """
+        if len(source_tx) > MAX_BRIDGE_TX_LENGTH:
+            return False, "Source transaction too long"
+
         conn = self._get_conn()
         cursor = conn.cursor()
 
@@ -1065,6 +1075,9 @@ class AirdropV2:
         Returns:
             (success, message)
         """
+        if len(dest_tx) > MAX_BRIDGE_TX_LENGTH:
+            return False, "Destination transaction too long"
+
         conn = self._get_conn()
         cursor = conn.cursor()
 
@@ -1433,10 +1446,10 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         if error:
             return error
 
-        from_address, error = string_field(data, "from_address")
+        from_address, error = string_field(data, "from_address", max_length=MAX_BRIDGE_ADDRESS_LENGTH)
         if error:
             return error
-        to_address, error = string_field(data, "to_address")
+        to_address, error = string_field(data, "to_address", max_length=MAX_BRIDGE_ADDRESS_LENGTH)
         if error:
             return error
         from_chain, error = string_field(data, "from_chain")
@@ -1482,7 +1495,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         data, error = parse_json_object_body(require_body=False)
         if error:
             return error
-        source_tx, error = string_field(data, "source_tx")
+        source_tx, error = string_field(data, "source_tx", max_length=MAX_BRIDGE_TX_LENGTH)
         if error:
             return error
 
@@ -1506,7 +1519,7 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         data, error = parse_json_object_body(require_body=False)
         if error:
             return error
-        dest_tx, error = string_field(data, "dest_tx")
+        dest_tx, error = string_field(data, "dest_tx", max_length=MAX_BRIDGE_TX_LENGTH)
         if error:
             return error
 

--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -290,3 +290,101 @@ def test_bridge_confirm_rejects_structured_source_tx(tmp_path, monkeypatch):
 
     assert response.status_code == 400
     assert response.get_json() == {"ok": False, "error": "source_tx must be a string"}
+
+
+@pytest.mark.parametrize(
+    ("field", "error"),
+    [
+        ("from_address", "from_address_too_long"),
+        ("to_address", "to_address_too_long"),
+    ],
+)
+def test_bridge_lock_rejects_overlong_addresses(tmp_path, field, error):
+    client, _db_path = _make_client(tmp_path)
+    payload = {
+        "from_address": "solana-source",
+        "to_address": "base-destination",
+        "from_chain": "solana",
+        "to_chain": "base",
+        "amount_wrtc": 1,
+    }
+    payload[field] = "x" * 129
+
+    response = client.post("/api/bridge/lock", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": error}
+
+
+@pytest.mark.parametrize(
+    ("path", "payload", "error"),
+    [
+        (
+            "/api/bridge/lock/test-lock/confirm",
+            {"source_tx": "x" * 257},
+            "source_tx_too_long",
+        ),
+        (
+            "/api/bridge/lock/test-lock/release",
+            {"dest_tx": "x" * 257},
+            "dest_tx_too_long",
+        ),
+    ],
+)
+def test_bridge_admin_routes_reject_overlong_tx_ids(
+    tmp_path, monkeypatch, path, payload, error
+):
+    client, _db_path = _make_client(tmp_path)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+
+    response = client.post(
+        path,
+        headers={"X-Admin-Key": "expected-admin"},
+        json=payload,
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": error}
+
+
+@pytest.mark.parametrize(
+    ("from_address", "to_address", "message"),
+    [
+        ("x" * 129, "base-destination", "Source address too long"),
+        ("solana-source", "x" * 129, "Destination address too long"),
+    ],
+)
+def test_airdrop_service_rejects_overlong_bridge_addresses(
+    tmp_path, from_address, to_address, message
+):
+    _client, db_path = _make_client(tmp_path)
+    airdrop = AirdropV2(str(db_path))
+
+    success, actual_message, lock = airdrop.create_bridge_lock(
+        from_address,
+        to_address,
+        "solana",
+        "base",
+        1_000_000,
+    )
+
+    assert success is False
+    assert actual_message == message
+    assert lock is None
+
+
+@pytest.mark.parametrize(
+    ("method", "message"),
+    [
+        ("confirm_bridge_lock", "Source transaction too long"),
+        ("release_bridge_lock", "Destination transaction too long"),
+    ],
+)
+def test_airdrop_service_rejects_overlong_bridge_tx_ids(tmp_path, method, message):
+    _client, db_path = _make_client(tmp_path)
+    airdrop = AirdropV2(str(db_path))
+
+    success, actual_message = getattr(airdrop, method)("lock-id", "x" * 257)
+
+    assert success is False
+    assert actual_message == message


### PR DESCRIPTION
Fixes #6500.

## Summary
- add explicit length caps for bridge wallet addresses and tx ids
- enforce the caps in both Flask route parsing and AirdropV2 service methods
- add regression coverage for public bridge lock and admin confirm/release inputs

## Testing
- `./.venv/bin/python -m pytest -q tests/test_airdrop_bridge_admin_auth.py`
- `python3 -m py_compile node/airdrop_v2.py tests/test_airdrop_bridge_admin_auth.py`
- `git diff --check`