### PR TITLE
fix: fail closed beacon x402 premium exports

### DIFF
--- a/node/beacon_x402.py
+++ b/node/beacon_x402.py
@@ -149,7 +149,17 @@ def _check_x402_payment(price_str, action_name):
     Check for x402 payment. Returns (passed, response_or_none).
     When price is "0", always passes.
     """
-    if not X402_CONFIG_OK or is_free(price_str):
+    if not X402_CONFIG_OK:
+        log.warning(
+            "Rejected premium Beacon x402 action=%s because payment config is unavailable",
+            action_name,
+        )
+        return False, _cors_json({
+            "error": "Payment verification unavailable",
+            "message": "Beacon x402 premium exports are disabled until payment configuration is available.",
+        }, 503)
+
+    if is_free(price_str):
         return True, None
 
     payment_header = request.headers.get("X-PAYMENT", "")
@@ -258,24 +268,13 @@ def init_app(app, get_db_func):
         """Get a beacon agent's Coinbase wallet info."""
         if request.method == "OPTIONS":
             return _cors_json({"ok": True})
-        # SECURITY: Require admin key — exposes coinbase_address for any beacon agent
-        admin_key = os.environ.get("RC_ADMIN_KEY", "")
-        if not admin_key:
-            return _cors_json({"error": "RC_ADMIN_KEY not configured"}), 503
-        provided = request.headers.get("X-Admin-Key", "")
-        if not hmac.compare_digest(provided, admin_key):
-            return _cors_json({"error": "Unauthorized — admin key required"}), 401
-
         if len(agent_id) > 128:
             return _cors_json({"error": "agent_id too long"}, 400)
 
         # SECURITY: Require admin key — exposes coinbase_address for any beacon agent
-        admin_key = os.environ.get("RC_ADMIN_KEY", "")
-        if not admin_key:
-            return _cors_json({"error": "RC_ADMIN_KEY not configured"}), 503
-        provided = request.headers.get("X-Admin-Key", "")
-        if not hmac.compare_digest(provided, admin_key):
-            return _cors_json({"error": "Unauthorized — admin key required"}), 401
+        admin_error = _require_beacon_admin()
+        if admin_error:
+            return admin_error
 
         db = get_db_func()
         _ensure_x402_tables(db)

--- a/tests/test_beacon_x402_payment_gate.py
+++ b/tests/test_beacon_x402_payment_gate.py
@@ -77,6 +77,29 @@ def _make_beacon_wallet_client_without_x402_schema(tmp_path, monkeypatch):
     return app.test_client(), db_path
 
 
+def _make_beacon_client_without_x402_config(tmp_path, monkeypatch):
+    db_path = tmp_path / "beacon.db"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(beacon_x402.X402_BEACON_SCHEMA)
+        conn.execute("CREATE TABLE reputation (agent_id TEXT, score REAL)")
+        conn.execute("INSERT INTO reputation VALUES (?, ?)", ("agent-victim", 99.9))
+        conn.execute("CREATE TABLE contracts (contract_id TEXT, created_at REAL)")
+        conn.execute("INSERT INTO contracts VALUES (?, ?)", ("contract-secret", 1.0))
+
+    monkeypatch.setattr(beacon_x402, "X402_CONFIG_OK", False)
+    monkeypatch.setattr(beacon_x402, "_run_migrations", lambda _db_path: None)
+
+    def get_db():
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    beacon_x402.init_app(app, get_db)
+    return app.test_client(), db_path
+
+
 def test_beacon_wallet_post_creates_x402_tables_on_route_db(tmp_path, monkeypatch):
     client, db_path = _make_beacon_wallet_client_without_x402_schema(tmp_path, monkeypatch)
     address = "0x1234567890123456789012345678901234567890"
@@ -100,7 +123,10 @@ def test_beacon_wallet_post_creates_x402_tables_on_route_db(tmp_path, monkeypatc
 def test_beacon_wallet_get_creates_x402_tables_on_route_db(tmp_path, monkeypatch):
     client, db_path = _make_beacon_wallet_client_without_x402_schema(tmp_path, monkeypatch)
 
-    response = client.get("/api/agents/agent-1/wallet")
+    response = client.get(
+        "/api/agents/agent-1/wallet",
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
 
     assert response.status_code == 200
     assert response.get_json()["coinbase_address"] is None
@@ -139,6 +165,29 @@ def test_paid_beacon_reputation_rejects_unverified_payment_header(tmp_path, monk
     with sqlite3.connect(db_path) as conn:
         count = conn.execute("SELECT COUNT(*) FROM x402_beacon_payments").fetchone()[0]
     assert count == 0
+
+
+def test_beacon_reputation_fails_closed_without_x402_config(tmp_path, monkeypatch):
+    client, _db_path = _make_beacon_client_without_x402_config(tmp_path, monkeypatch)
+
+    response = client.get("/api/premium/reputation")
+
+    body = response.get_json()
+    assert response.status_code == 503
+    assert body["error"] == "Payment verification unavailable"
+    assert "reputation" not in body
+
+
+def test_beacon_contract_export_fails_closed_without_x402_config(tmp_path, monkeypatch):
+    client, _db_path = _make_beacon_client_without_x402_config(tmp_path, monkeypatch)
+
+    response = client.get("/api/premium/contracts/export")
+
+    body = response.get_json()
+    assert response.status_code == 503
+    assert body["error"] == "Payment verification unavailable"
+    assert "contracts" not in body
+
 
 def test_free_contract_export_handles_missing_contracts_table(tmp_path, monkeypatch):
     client, _db_path = _make_paid_beacon_client(tmp_path, monkeypatch)

--- a/tests/test_beacon_x402_wallet.py
+++ b/tests/test_beacon_x402_wallet.py
@@ -102,9 +102,19 @@ def test_set_agent_wallet_preserves_valid_address(client):
     assert response.get_json()["coinbase_address"] == "0x1234567890123456789012345678901234567890"
 
 def test_get_agent_wallet_returns_relay_wallet(client):
-    response = client.get("/api/agents/relay-1/wallet")
+    response = client.get(
+        "/api/agents/relay-1/wallet",
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
 
     assert response.status_code == 200
     body = response.get_json()
     assert body["source"] == "relay"
     assert body["coinbase_address"] == "0x1234567890123456789012345678901234567890"
+
+
+def test_get_agent_wallet_requires_admin_key(client):
+    response = client.get("/api/agents/relay-1/wallet")
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "Unauthorized - admin key required"


### PR DESCRIPTION
Fixes #6507.

## Summary
- fail closed when Beacon x402 premium exports cannot verify payment because payment config is unavailable
- keep explicit free pricing behavior available when x402 config is loaded and the configured price is free
- normalize Beacon agent wallet reads through the existing Beacon admin helper
- add regression coverage for missing config, paid challenges, unverified payment headers, and admin-protected wallet reads

## Testing
- `PYTHONPATH=node ./.venv/bin/python -m pytest -q tests/test_beacon_x402_payment_gate.py tests/test_beacon_x402_wallet.py tests/test_beacon_premium_reputation_route.py`
- `python3 -m py_compile node/beacon_x402.py tests/test_beacon_x402_payment_gate.py tests/test_beacon_x402_wallet.py tests/test_beacon_premium_reputation_route.py`
- `git diff --check`