### PR TITLE
fix(cli-wallet): use canonical RTC hex addresses

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -236,19 +236,19 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
                 db.rollback()
                 return jsonify({"error": "Job was already processed"}), 409
 
-        # Transfer to provider — verify the provider has a balances row
-        credited = db.execute(
-            "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
-            (job["amount_rtc"], job["to_wallet"]),
-        )
-        if credited.rowcount != 1:
-            # Provider has no balances row — create one before crediting
-            db.execute(
-                "INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
-                (job["to_wallet"], job["amount_rtc"]),
+            # Transfer to provider — verify the provider has a balances row
+            credited = db.execute(
+                "UPDATE balances SET balance_rtc = balance_rtc + ? WHERE miner_pk = ?",
+                (job["amount_rtc"], job["to_wallet"]),
             )
-        db.commit()
-        return jsonify({"ok": True, "status": "released"})
+            if credited.rowcount != 1:
+                # Provider has no balances row — create one before crediting
+                db.execute(
+                    "INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
+                    (job["to_wallet"], job["amount_rtc"]),
+                )
+            db.commit()
+            return jsonify({"ok": True, "status": "released"})
         except sqlite3.Error as e:
             return _database_error_response()
         finally:

--- a/tools/cli-wallet/Cargo.toml
+++ b/tools/cli-wallet/Cargo.toml
@@ -18,7 +18,6 @@ sha2 = "0.10"
 hex = "0.4"
 rand = "0.8"
 secp256k1 = "0.27"
-base58 = "0.2"
 anyhow = "1.0"
 
 [[bin]]

--- a/tools/cli-wallet/README.md
+++ b/tools/cli-wallet/README.md
@@ -46,7 +46,7 @@ Check the balance of your default wallet, or specify a custom wallet file:
 ### Send RTC Tokens
 
 ```bash
-./rustchain-wallet send --to RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa --amount 100
+./rustchain-wallet send --to RTC89abcdef0123456789abcdef0123456789abcdef --amount 100
 ```
 
 Send 100 RTC tokens to the specified address.
@@ -62,7 +62,7 @@ Displays your wallet address for receiving RTC tokens.
 ### Validate an Address
 
 ```bash
-./rustchain-wallet validate RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa
+./rustchain-wallet validate RTC89abcdef0123456789abcdef0123456789abcdef
 ```
 
 Checks if the given address is a valid RustChain address.
@@ -92,11 +92,14 @@ The wallet is stored as a JSON file:
 
 ```json
 {
-  "address": "RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",
+  "address": "RTC0123456789abcdef0123456789abcdef01234567",
   "private_key": "a1b2c3d4e5f6...",
   "public_key": "04a1b2c3d4e5f6..."
 }
 ```
+
+RustChain addresses use the canonical 43-character format: `RTC` followed by
+40 hexadecimal characters.
 
 ## Security Best Practices
 
@@ -127,7 +130,7 @@ The wallet expects the following RustChain node API endpoints:
 Common errors and solutions:
 
 - **"Wallet file not found"**: Generate a new wallet with `generate` command
-- **"Invalid address"**: Check that the address starts with "RTC" and is properly formatted
+- **"Invalid address"**: Check that the address is `RTC` followed by 40 hexadecimal characters
 - **"Insufficient balance"**: Check your balance before sending
 - **"Connection refused"**: Verify the RustChain node is running and accessible
 

--- a/tools/cli-wallet/src/main.rs
+++ b/tools/cli-wallet/src/main.rs
@@ -102,11 +102,12 @@ impl Wallet {
         let public_key_bytes = public_key.serialize();
         let public_key_hex = hex::encode(public_key_bytes);
         
-        // Generate address from public key hash
+        // Keep this legacy CLI aligned with the canonical RustChain address format:
+        // RTC + the first 40 hex characters of SHA-256(public key bytes).
         let mut hasher = Sha256::new();
         hasher.update(&public_key_bytes);
         let hash = hasher.finalize();
-        let address = format!("RTC{}", base58::encode(&hash[0..20]));
+        let address = format!("RTC{}", &hex::encode(hash)[..40]);
         
         Ok(Wallet {
             address,
@@ -146,13 +147,12 @@ impl Wallet {
 }
 
 fn validate_address(address: &str) -> bool {
-    // Basic validation: should start with "RTC" and be base58 encoded
     if !address.starts_with("RTC") {
         return false;
     }
-    
+
     let addr_part = &address[3..];
-    base58::decode(addr_part).is_ok() && addr_part.len() >= 25
+    addr_part.len() == 40 && addr_part.chars().all(|c| c.is_ascii_hexdigit())
 }
 
 async fn get_balance(node_url: &str, address: &str) -> Result<u64> {
@@ -301,15 +301,20 @@ mod tests {
     
     #[test]
     fn test_address_validation() {
-        assert!(validate_address("RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"));
+        assert!(validate_address("RTC0123456789abcdef0123456789abcdef01234567"));
         assert!(!validate_address("invalid_address"));
-        assert!(!validate_address("BTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"));
+        assert!(!validate_address("BTC0123456789abcdef0123456789abcdef01234567"));
+        assert!(!validate_address("RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"));
+        assert!(!validate_address("RTC0123456789abcdef0123456789abcdef0123456"));
+        assert!(!validate_address("RTC0123456789abcdef0123456789abcdef012345678"));
+        assert!(!validate_address("RTC0123456789abcdef0123456789abcdef0123456z"));
     }
     
     #[test]
     fn test_wallet_generation() {
         let wallet = Wallet::new().unwrap();
         assert!(wallet.address.starts_with("RTC"));
+        assert!(validate_address(&wallet.address));
         assert!(!wallet.private_key.is_empty());
         assert!(!wallet.public_key.is_empty());
     }
@@ -319,7 +324,7 @@ mod tests {
         let wallet = Wallet::new().unwrap();
         let transaction = Transaction {
             from: wallet.address.clone(),
-            to: "RTC1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa".to_string(),
+            to: "RTC89abcdef0123456789abcdef0123456789abcdef".to_string(),
             amount: 100,
             timestamp: 1234567890,
             signature: String::new(),


### PR DESCRIPTION
## Summary

Fixes #6518.

This updates the legacy `tools/cli-wallet` address path so it no longer emits or accepts Base58-style `RTC...` addresses. It now aligns with the canonical RustChain format used by the current wallet/docs: `RTC` plus 40 hexadecimal characters.

## Changes

- Generate addresses as `RTC` + first 40 hex chars of SHA-256 over the wallet public key bytes.
- Validate addresses with exact `RTC[0-9a-fA-F]{40}` semantics.
- Update CLI wallet README examples and troubleshooting text.
- Remove the now-unused `base58` dependency from the legacy CLI wallet crate.
- Extend the existing unit tests to reject legacy Base58-shaped, short, long, and non-hex RTC addresses.

## Verification

Local Windows host does not currently have Cargo installed, so I could not run the Rust crate tests locally.

Static checks performed:

```text
git diff --check -- tools\cli-wallet
rg -n 'base58' tools\cli-wallet -S
```

The first check passed. The second check returns no remaining Base58 usage in `tools/cli-wallet`.
