### PR TITLE
feat(linux-miner): Ed25519 signing — parity with PR #6432

### DIFF
--- a/miners/linux/miner_crypto.py
+++ b/miners/linux/miner_crypto.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""
+RustChain Miner Cryptographic Module — Lightweight Ed25519
+==========================================================
+Provides real Ed25519 signing for attestation payloads.
+Replaces the sha512(message+wallet) pseudo-signature.
+
+Dependencies:
+  pip install PyNaCl   (or: apt install python3-nacl)
+
+Keystore: ~/.rustchain/miner_key.json (encrypted with machine-id)
+"""
+
+import hashlib
+import json
+import os
+import sys
+
+# Try PyNaCl first (preferred), fall back to pure-Python ed25519
+try:
+    from nacl.signing import SigningKey, VerifyKey
+    from nacl.encoding import HexEncoder
+    NACL_AVAILABLE = True
+except ImportError:
+    NACL_AVAILABLE = False
+
+KEYSTORE_DIR = os.path.expanduser("~/.rustchain")
+KEYSTORE_FILE = os.path.join(KEYSTORE_DIR, "miner_key.json")
+
+
+def _get_machine_entropy() -> bytes:
+    """Get machine-specific entropy for keystore encryption seed."""
+    parts = []
+    # machine-id (Linux)
+    for path in ["/etc/machine-id", "/var/lib/dbus/machine-id"]:
+        try:
+            with open(path, "r") as f:
+                parts.append(f.read().strip())
+                break
+        except OSError:
+            pass
+    # macOS hardware UUID
+    if not parts:
+        try:
+            import subprocess
+            out = subprocess.run(
+                ["system_profiler", "SPHardwareDataType"],
+                capture_output=True, text=True, timeout=5
+            ).stdout
+            for line in out.splitlines():
+                if "UUID" in line:
+                    parts.append(line.split(":")[-1].strip())
+                    break
+        except Exception:
+            pass
+    if not parts:
+        parts.append("fallback-no-machine-id")
+    return hashlib.sha256("|".join(parts).encode()).digest()
+
+
+def generate_keypair() -> dict:
+    """Generate a new Ed25519 keypair. Returns dict with hex keys."""
+    if not NACL_AVAILABLE:
+        raise RuntimeError("PyNaCl required: pip install PyNaCl")
+    sk = SigningKey.generate()
+    vk = sk.verify_key
+    return {
+        "private_key": sk.encode(encoder=HexEncoder).decode(),
+        "public_key": vk.encode(encoder=HexEncoder).decode(),
+    }
+
+
+def save_keystore(keypair: dict, path: str = KEYSTORE_FILE) -> None:
+    """Save keypair to disk. XOR-obscured with machine entropy (not full encryption)."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    entropy = _get_machine_entropy()
+    # XOR the private key with machine entropy for basic at-rest protection
+    pk_bytes = bytes.fromhex(keypair["private_key"])
+    obscured = bytes(a ^ b for a, b in zip(pk_bytes, entropy))
+    data = {
+        "version": 1,
+        "public_key": keypair["public_key"],
+        "obscured_private": obscured.hex(),
+    }
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+    os.chmod(path, 0o600)
+    print(f"[CRYPTO] Keypair saved to {path}")
+
+
+def load_keystore(path: str = KEYSTORE_FILE) -> dict:
+    """Load keypair from disk."""
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r") as f:
+        data = json.load(f)
+    if data.get("version") != 1:
+        return {}
+    entropy = _get_machine_entropy()
+    obscured = bytes.fromhex(data["obscured_private"])
+    pk_bytes = bytes(a ^ b for a, b in zip(obscured, entropy))
+    return {
+        "private_key": pk_bytes.hex(),
+        "public_key": data["public_key"],
+    }
+
+
+def get_or_create_keypair(path: str = KEYSTORE_FILE) -> dict:
+    """Load existing keypair or generate a new one."""
+    existing = load_keystore(path)
+    if existing and existing.get("private_key"):
+        # Validate the key loads correctly
+        try:
+            sk = SigningKey(bytes.fromhex(existing["private_key"]))
+            vk = sk.verify_key
+            if vk.encode(encoder=HexEncoder).decode() == existing["public_key"]:
+                return existing
+        except Exception:
+            print("[CRYPTO] Existing key corrupted, generating new one")
+    kp = generate_keypair()
+    save_keystore(kp, path)
+    return kp
+
+
+def sign_payload(payload_bytes: bytes, private_key_hex: str) -> str:
+    """Sign bytes with Ed25519 private key. Returns hex signature."""
+    if not NACL_AVAILABLE:
+        raise RuntimeError("PyNaCl required for signing")
+    sk = SigningKey(bytes.fromhex(private_key_hex))
+    signed = sk.sign(payload_bytes)
+    return signed.signature.hex()
+
+
+def verify_signature(payload_bytes: bytes, signature_hex: str, public_key_hex: str) -> bool:
+    """Verify an Ed25519 signature."""
+    if not NACL_AVAILABLE:
+        return False
+    try:
+        vk = VerifyKey(bytes.fromhex(public_key_hex))
+        vk.verify(payload_bytes, bytes.fromhex(signature_hex))
+        return True
+    except Exception:
+        return False
+
+
+def canonical_json(obj: dict) -> bytes:
+    """Produce canonical JSON bytes for signing (sorted keys, no whitespace)."""
+    return json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+if __name__ == "__main__":
+    print("RustChain Miner Crypto Module")
+    print("=" * 50)
+
+    if not NACL_AVAILABLE:
+        print("ERROR: PyNaCl not installed. Run: pip install PyNaCl")
+        sys.exit(1)
+
+    # Demo: generate, sign, verify
+    kp = get_or_create_keypair()
+    print(f"Public Key:  {kp['public_key']}")
+    print(f"Private Key: {kp['private_key'][:16]}... (truncated)")
+
+    test_payload = canonical_json({"test": "data", "nonce": "abc123"})
+    sig = sign_payload(test_payload, kp["private_key"])
+    print(f"Signature:   {sig[:32]}... ({len(sig)} hex chars)")
+
+    ok = verify_signature(test_payload, sig, kp["public_key"])
+    print(f"Verify:      {'PASS' if ok else 'FAIL'}")
+
+    # Tamper test
+    tampered = canonical_json({"test": "TAMPERED", "nonce": "abc123"})
+    bad = verify_signature(tampered, sig, kp["public_key"])
+    print(f"Tamper test: {'FAIL (good!)' if not bad else 'PASS (BAD!)'}")

--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -9,6 +9,19 @@ import warnings
 import os, sys, json, time, hashlib, uuid, math, requests, socket, subprocess, platform, statistics, re
 from datetime import datetime
 
+# ── Ed25519 signing (GPT-5.4 audit finding #2) ──
+# If miner_crypto.py + PyNaCl are available, sign every attestation with
+# Ed25519 over the canonical JSON of the full payload, and sign every
+# enrollment with the 3-field MAC server expects. Server-side acceptance:
+# PR #6426 (canonical-JSON) + the existing 3-field MAC path for enrollment.
+# Without signing, miner falls back to legacy sha512 / unsigned — server
+# accepts with WARNING but offers no wallet-hijack protection.
+try:
+    from miner_crypto import get_or_create_keypair, sign_payload  # noqa: F401
+    CRYPTO_AVAILABLE = True
+except ImportError:
+    CRYPTO_AVAILABLE = False
+
 # Import fingerprint checks
 try:
     from fingerprint_checks import validate_all_checks
@@ -198,6 +211,16 @@ class LocalMiner:
         self.attestation_valid_until = 0
         self.last_entropy = {}
         self.fingerprint_data = {}
+
+        # Ed25519 keypair — generated/loaded once per install. Used to sign
+        # /attest/submit (canonical JSON) and /epoch/enroll (3-field MAC).
+        # Persisted via miner_crypto.get_or_create_keypair so reinstall
+        # preserves identity.
+        self.keypair = {}
+        self.public_key = ""
+        if CRYPTO_AVAILABLE:
+            self.keypair = get_or_create_keypair()
+            self.public_key = self.keypair.get("public_key", "")
         self.fingerprint_passed = False
         self.verbose = verbose
         self.show_payload = show_payload
@@ -523,6 +546,23 @@ class LocalMiner:
             "warthog": self.warthog.collect_proof() if self.warthog else None
         }
 
+        # ── Ed25519 signature (GPT-5.4 audit finding #2) ──
+        # Sign canonical JSON of the full attestation BEFORE adding signature
+        # fields. Server (PR #6426) strips signature/public_key/signature_type
+        # before re-canonicalizing for verification.
+        if CRYPTO_AVAILABLE and self.keypair:
+            try:
+                payload_bytes = json.dumps(
+                    attestation, sort_keys=True, separators=(",", ":")
+                ).encode()
+                attestation["signature"] = sign_payload(
+                    payload_bytes, self.keypair["private_key"]
+                )
+                attestation["public_key"] = self.public_key
+                attestation["signature_type"] = "ed25519"
+            except Exception:
+                pass  # Fall through unsigned; server accepts with warning
+
         try:
             resp = self._post(
                 "/attest/submit",
@@ -583,14 +623,42 @@ class LocalMiner:
 
         print(f"\n📝 [{datetime.now().strftime('%H:%M:%S')}] Enrolling...")
 
+        # Fetch current epoch so we can sign the enrollment. Server expects
+        # 3-field MAC (miner_pubkey|miner_id|epoch) verified against the
+        # SAME Ed25519 key used during attestation (cross-checked via
+        # signing_pubkey column in miner_attest_recent). Race with epoch
+        # rollover is mild — server returns invalid_enrollment_signature on
+        # mismatch and the miner retries on next cycle.
+        current_epoch = None
+        try:
+            ep_resp = requests.get(
+                f"{self.node_url}/epoch", timeout=10, verify=TLS_VERIFY
+            )
+            if ep_resp.ok:
+                current_epoch = ep_resp.json().get("epoch")
+        except Exception:
+            pass
+
+        miner_id = self._miner_id()
         payload = {
             "miner_pubkey": self.wallet,
-            "miner_id": self._miner_id(),
+            "miner_id": miner_id,
             "device": {
                 "family": self.hw_info["family"],
                 "arch": self.hw_info["arch"]
             }
         }
+
+        # Ed25519-sign the enrollment if we have a keypair AND a fresh epoch.
+        if CRYPTO_AVAILABLE and self.keypair and current_epoch is not None:
+            enroll_message = f"{self.wallet}|{miner_id}|{current_epoch}"
+            try:
+                payload["signature"] = sign_payload(
+                    enroll_message.encode(), self.keypair["private_key"]
+                )
+                payload["public_key"] = self.public_key
+            except Exception:
+                pass  # Best-effort; server still accepts unsigned with warning
 
         try:
             resp = self._post(


### PR DESCRIPTION
## Summary

Canonical Linux miner at `miners/linux/rustchain_linux_miner.py` had zero signing infrastructure. Every attestation and enrollment went through the unsigned-flow path — vulnerable to wallet hijack via MITM (TLS strip / cert compromise → attacker substitutes their own wallet on your attestation payload, server has no way to detect).

PR #6432 closed that gap for Windows. This PR brings Linux to parity.

## Changes

| File | Change |
|------|--------|
| `miners/linux/rustchain_linux_miner.py` | +60 lines: try-import miner_crypto, init keypair in `__init__`, sign canonical JSON before `/attest/submit`, fetch epoch + sign 3-field MAC for `/epoch/enroll` |
| `miners/linux/miner_crypto.py` | NEW (copied from `miners/windows/`). Ed25519 keypair gen + sign + verify helpers. PyNaCl + stdlib only. |

## Backward compatibility

If PyNaCl isn't installed OR `miner_crypto.py` is missing, `CRYPTO_AVAILABLE=False` and the miner falls back to unsigned (server accepts with WARNING). So upgrading is opt-in via PyNaCl install; existing deploys without PyNaCl keep working unchanged.

## Server-side compatibility

- `/attest/submit` canonical-JSON path: accepted by server since PR #6426 (server strips `signature` + `public_key` + `signature_type` before re-canonicalizing).
- `/epoch/enroll` 3-field MAC path: server expected `(miner_pubkey|miner_id|epoch)` since the [unsigned path was added](https://github.com/Scottcjn/Rustchain/blob/main/node/rustchain_v2_integrated_v2.2.1_rip200.py#L4155) — this PR makes Linux miners actually fill the optional `signature`/`public_key` fields server has been silently waiting for.

## Live-verified (2026-05-27/28 session)

OUR-fleet Linux miners all running this pattern (via dev miner deploy ahead of canonical-repo merge):

| Wallet | Verdict |
|--------|---------|
| `t40-thinkpad-banias` (T40 Pentium M Banias) | ✅ Ed25519 signed, no UNSIGNED warnings |
| `power8-s824-sophia` (POWER8 S824) | ✅ Replaced literal `"0"*128` mock-sig with real Ed25519 |
| `victus-x86-scott` (workstation) | ✅ Ed25519 signed |
| `modern-sophia-Pow-9862e3be` (C4130 GPU server) | ✅ Ed25519 signed |

Server log shows their attestation rows now populate `signing_pubkey` column; absence of `[ENROLL/SIG] UNSIGNED enrollment accepted` warnings confirms enrollment signing also accepted.

## Test plan

- [x] `py_compile` clean on `rustchain_linux_miner.py` and `miner_crypto.py`
- [x] Signing pattern matches `miners/windows/rustchain_windows_miner.py` (PR #6432) line-for-line
- [x] Real-deployment verification on 4 OUR-fleet hosts (T40, POWER8, Victus, C4130)
- [ ] Add PyNaCl to install docs / `clawrtc` package requirements (already done in PR #6432 for the Windows-bundled package; pip/npm package `clawrtc` 1.8.0 carries PyNaCl as a runtime dep)

## Related

Final entry in the session-2026-05-27 fix chain — server-side: #6423, #6426, #6428, #6429, #6430. Client-side: #6432 (Windows), this PR (Linux). Distribution: v3.1.1-miner release + Discussion #6467 announcement + clawrtc 1.8.0 npm/pip bundles pending Scott's auth refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)