### PR TITLE
fix: harden bridge confirmation thresholds

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -54,6 +54,7 @@ except ImportError:
 # =============================================================================
 
 BRIDGE_DEFAULT_CONFIRMATIONS = int(os.environ.get("RC_BRIDGE_DEFAULT_CONFIRMATIONS", "12"))
+BRIDGE_MAX_CONFIRMATIONS = int(os.environ.get("RC_BRIDGE_MAX_CONFIRMATIONS", "1000"))
 BRIDGE_LOCK_EXPIRY_SECONDS = int(os.environ.get("RC_BRIDGE_LOCK_EXPIRY_SECONDS", "604800"))  # 7 days
 BRIDGE_MIN_AMOUNT_RTC = float(os.environ.get("RC_BRIDGE_MIN_AMOUNT_RTC", "1.0"))
 BRIDGE_UNIT = 1000000  # Micro-units per RTC
@@ -665,9 +666,38 @@ def update_external_confirmation(
             "error": "Cannot update completed/failed/voided transfer",
             "current_status": transfer["status"]
         }
+
+    try:
+        confirmations = int(confirmations)
+    except (TypeError, ValueError):
+        return False, {"error": "confirmations must be an integer"}
+    if confirmations < 0 or confirmations > BRIDGE_MAX_CONFIRMATIONS:
+        return False, {
+            "error": f"confirmations must be between 0 and {BRIDGE_MAX_CONFIRMATIONS}"
+        }
     
     now = int(time.time())
-    req_conf = required_confirmations or transfer["required_confirmations"] or BRIDGE_DEFAULT_CONFIRMATIONS
+    existing_req_conf = transfer["required_confirmations"] or BRIDGE_DEFAULT_CONFIRMATIONS
+    if required_confirmations is None:
+        req_conf = existing_req_conf
+    else:
+        try:
+            req_conf = int(required_confirmations)
+        except (TypeError, ValueError):
+            return False, {"error": "required_confirmations must be an integer"}
+        if req_conf < existing_req_conf:
+            return False, {
+                "error": "required_confirmations cannot be lowered",
+                "required_confirmations": existing_req_conf,
+            }
+        if req_conf > BRIDGE_MAX_CONFIRMATIONS:
+            return False, {
+                "error": (
+                    f"required_confirmations must be between "
+                    f"{existing_req_conf} and {BRIDGE_MAX_CONFIRMATIONS}"
+                ),
+                "required_confirmations": existing_req_conf,
+            }
     
     # Determine new status
     if confirmations >= req_conf:

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -1058,6 +1058,76 @@ class TestIntegration:
         
         conn.close()
 
+    def test_external_confirmation_rejects_lowered_required_threshold(self, setup_test_db, funded_miner):
+        """Bridge callbacks must not lower the stored confirmation threshold."""
+        bridge_api = setup_test_db["bridge_api"]
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+
+        req = bridge_api.BridgeTransferRequest(
+            direction="deposit",
+            source_chain="rustchain",
+            dest_chain="solana",
+            source_address=funded_miner,
+            dest_address="4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            amount_rtc=10.0
+        )
+        success, result = bridge_api.create_bridge_transfer(conn, req)
+        assert success is True
+        tx_hash = result["tx_hash"]
+
+        success, result = bridge_api.update_external_confirmation(
+            conn,
+            tx_hash,
+            external_tx_hash="ext_tx_threshold",
+            confirmations=1,
+            required_confirmations=1,
+        )
+
+        assert success is False
+        assert result["error"] == "required_confirmations cannot be lowered"
+        locks = lock_ledger.get_locks_by_miner(conn, funded_miner)
+        assert locks[0].status == "locked"
+        transfer = bridge_api.get_bridge_transfer_by_hash(conn, tx_hash)
+        assert transfer["status"] == "pending"
+        assert transfer["required_confirmations"] == bridge_api.BRIDGE_DEFAULT_CONFIRMATIONS
+        conn.close()
+
+    def test_external_confirmation_helper_rejects_unbounded_counts(self, setup_test_db, funded_miner):
+        """Core helper enforces bounds even when bypassing the HTTP parser."""
+        bridge_api = setup_test_db["bridge_api"]
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+
+        req = bridge_api.BridgeTransferRequest(
+            direction="deposit",
+            source_chain="rustchain",
+            dest_chain="solana",
+            source_address=funded_miner,
+            dest_address="4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            amount_rtc=10.0
+        )
+        success, result = bridge_api.create_bridge_transfer(conn, req)
+        assert success is True
+        tx_hash = result["tx_hash"]
+
+        success, result = bridge_api.update_external_confirmation(
+            conn,
+            tx_hash,
+            external_tx_hash="ext_tx_unbounded",
+            confirmations=bridge_api.BRIDGE_MAX_CONFIRMATIONS + 1,
+        )
+
+        assert success is False
+        assert result["error"] == (
+            f"confirmations must be between 0 and {bridge_api.BRIDGE_MAX_CONFIRMATIONS}"
+        )
+        locks = lock_ledger.get_locks_by_miner(conn, funded_miner)
+        assert locks[0].status == "locked"
+        transfer = bridge_api.get_bridge_transfer_by_hash(conn, tx_hash)
+        assert transfer["status"] == "pending"
+        conn.close()
+
     def test_void_releases_lock(self, setup_test_db, funded_miner):
         """Test that voiding a transfer releases the lock."""
         bridge_api = setup_test_db["bridge_api"]


### PR DESCRIPTION
## Summary

Fixes #6521 by moving bridge confirmation threshold enforcement into `update_external_confirmation()` instead of relying only on the HTTP parser.

## Changes

- Adds a configurable `BRIDGE_MAX_CONFIRMATIONS` ceiling.
- Rejects non-integer, negative, and over-ceiling confirmation counts in the core helper.
- Rejects callback attempts to lower an existing `required_confirmations` threshold.
- Adds regression tests for lowered thresholds and direct helper bypass of route parsing.

## Verification

- `./.venv/bin/python -m pytest -q tests/test_bridge_lock_ledger.py::TestIntegration::test_full_deposit_flow tests/test_bridge_lock_ledger.py::TestIntegration::test_external_confirmation_rejects_lowered_required_threshold tests/test_bridge_lock_ledger.py::TestIntegration::test_external_confirmation_helper_rejects_unbounded_counts` -> 3 passed
- `PYTHONPYCACHEPREFIX=/private/tmp/rustchain-pycache python3 -m py_compile node/bridge_api.py tests/test_bridge_lock_ledger.py`
- `git diff --check`

Note: the full `tests/test_bridge_lock_ledger.py` suite currently has unrelated failures on current `main` around existing address/auth expectations; the targeted bridge confirmation regressions pass.