### PR TITLE
[UTXO-BUG] fix /api/nodes unbounded node_registry SELECT — cascading HTTP DoS

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6551,9 +6551,24 @@ def _parse_oui_enforce(value):
         return None
 
 
+# Health-status cache for /api/nodes: url -> (online: bool|None, checked_at: float)
+# Populated lazily; decouples outbound probes from the request path.
+_NODE_HEALTH_CACHE: dict = {}
+_NODE_HEALTH_CACHE_TTL = 60.0   # seconds before a cached status is considered stale
+_MAX_INLINE_PROBES = 3          # max outbound health probes issued per request
+
+
 @app.route("/api/nodes")
 def api_nodes():
-    """Return list of all registered attestation nodes"""
+    """Return paginated registered attestation nodes with cached health status.
+
+    RIP-200 Bounty #6527: Added pagination (limit, offset) and decoupled health
+    probes via a module-level TTL cache with a per-request probe cap to prevent
+    unauthenticated blocking fan-out DoS.
+    """
+    import time as _time
+    import requests as _requests
+
     def _is_admin() -> bool:
         need = os.environ.get("RC_ADMIN_KEY", "")
         got = request.headers.get("X-Admin-Key", "") or request.headers.get("X-API-Key", "")
@@ -6577,13 +6592,30 @@ def api_nodes():
             # Non-IP hosts (DNS names) are assumed public.
             return False
 
+    # Pagination params (mirrors /api/miners convention)
+    try:
+        raw_limit = request.args.get("limit")
+        limit = int(raw_limit) if raw_limit not in (None, "") else 20
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "limit must be an integer"}), 400
+    try:
+        raw_offset = request.args.get("offset")
+        offset = int(raw_offset) if raw_offset not in (None, "") else 0
+    except (ValueError, TypeError):
+        return jsonify({"ok": False, "error": "offset must be an integer"}), 400
+    limit = min(max(limit, 1), 50)
+    offset = max(offset, 0)
+
     nodes = []
+    total = 0
     try:
         with sqlite3.connect(DB_PATH) as conn:
             c = conn.cursor()
+            total = c.execute("SELECT COUNT(*) FROM node_registry").fetchone()[0]
             c.execute(
                 "SELECT node_id, wallet_address, url, name, registered_at, is_active"
-                " FROM node_registry LIMIT 200"
+                " FROM node_registry LIMIT ? OFFSET ?",
+                (limit, offset),
             )
             for row in c.fetchall():
                 nodes.append({
@@ -6592,32 +6624,54 @@ def api_nodes():
                     "url": row[2],
                     "name": row[3],
                     "registered_at": row[4],
-                    "is_active": bool(row[5])
+                    "is_active": bool(row[5]),
                 })
     except Exception as e:
         print(f"Error fetching nodes: {e}")
-    
-    # Also add live status check
-    # SECURITY: Only probe URLs that are NOT internal/private to prevent SSRF
-    import requests
+
+    # Health status: serve from TTL cache; issue at most _MAX_INLINE_PROBES outbound
+    # requests per call so a single unauthenticated request cannot hold a worker for
+    # 200 * timeout seconds.
+    now = _time.time()
+    probes_issued = 0
+    admin = _is_admin()
+
     for node in nodes:
         raw_url = node.get("url") or ""
-        if raw_url and not _should_redact_url(raw_url):
-            try:
-                resp = requests.get(f"{raw_url}/health", timeout=3)
-                node["online"] = resp.status_code == 200
-            except Exception:
-                node["online"] = False
-        else:
-            # Skip health check for internal/private URLs (SSRF prevention)
+        private = bool(raw_url and _should_redact_url(raw_url))
+
+        if not raw_url or private:
             node["online"] = None
+        else:
+            cached = _NODE_HEALTH_CACHE.get(raw_url)
+            fresh = cached is not None and (now - cached[1]) < _NODE_HEALTH_CACHE_TTL
+            if fresh:
+                node["online"] = cached[0]
+            elif probes_issued < _MAX_INLINE_PROBES:
+                try:
+                    resp = _requests.get(f"{raw_url}/health", timeout=3)
+                    status = resp.status_code == 200
+                except Exception:
+                    status = False
+                _NODE_HEALTH_CACHE[raw_url] = (status, now)
+                node["online"] = status
+                probes_issued += 1
+            else:
+                # Probe budget exhausted; return last known status or unknown.
+                node["online"] = cached[0] if cached is not None else None
 
         # SECURITY: don't leak private/VPN URLs to unauthenticated clients.
-        if (not _is_admin()) and raw_url and _should_redact_url(raw_url):
+        if not admin and private:
             node["url"] = None
             node["url_redacted"] = True
-    
-    return jsonify({"nodes": nodes, "count": len(nodes)})
+
+    return jsonify({
+        "nodes": nodes,
+        "count": len(nodes),
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+    })
 
 
 @app.route("/api/miners", methods=["GET"])

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6581,7 +6581,10 @@ def api_nodes():
     try:
         with sqlite3.connect(DB_PATH) as conn:
             c = conn.cursor()
-            c.execute("SELECT node_id, wallet_address, url, name, registered_at, is_active FROM node_registry")
+            c.execute(
+                "SELECT node_id, wallet_address, url, name, registered_at, is_active"
+                " FROM node_registry LIMIT 200"
+            )
             for row in c.fetchall():
                 nodes.append({
                     "node_id": row[0],

--- a/node/test_api_nodes_limit_poc.py
+++ b/node/test_api_nodes_limit_poc.py
@@ -1,81 +1,120 @@
 # SPDX-License-Identifier: MIT
 """
-PoC: /api/nodes loads every row from node_registry and issues one
-synchronous HTTP health-check per row, with no upper bound.
+Real-route regression for the /api/nodes LIMIT 200 fix.
 
-With 250 registered nodes each health-check timeout is 3 seconds, so a
-single unauthenticated request can hold a Flask worker thread for up to
-750 seconds and force 250 sequential outbound TCP connections.
-
-Fix: add LIMIT 200 to the SELECT so at most 200 rows are fetched and at
-most 200 health-checks are issued per request.
+Seeds 250 rows into the app's actual SQLite DB, monkeypatches requests.get so
+no outbound connections are made, calls GET /api/nodes through the real Flask
+test client, and asserts both the returned node count and the number of
+health-check attempts are at most 200.
 """
 
-import sqlite3
-import tempfile
+import importlib
 import os
+import sqlite3
+import sys
+import tempfile
+import types
 import unittest
+from unittest.mock import MagicMock, patch
 
-
-_SELECT_UNBOUNDED = (
-    "SELECT node_id, wallet_address, url, name, registered_at, is_active"
-    " FROM node_registry"
-)
-_SELECT_BOUNDED = (
-    "SELECT node_id, wallet_address, url, name, registered_at, is_active"
-    " FROM node_registry LIMIT 200"
-)
+_NODE_FILE = os.path.join(os.path.dirname(__file__),
+                          "rustchain_v2_integrated_v2.2.1_rip200.py")
+_MODULE_NAME = "rustchain_node"
 _NODE_COUNT = 250
+_LIMIT = 200
 
 
-def _make_db(path: str, n: int) -> None:
-    conn = sqlite3.connect(path)
-    conn.execute(
-        """CREATE TABLE node_registry (
-            node_id TEXT PRIMARY KEY,
-            wallet_address TEXT,
-            url TEXT,
-            name TEXT,
-            registered_at INTEGER,
-            is_active INTEGER
-        )"""
-    )
-    conn.executemany(
-        "INSERT INTO node_registry VALUES (?,?,?,?,?,?)",
-        [(f"node-{i}", f"RTC{'a'*40}", f"http://10.0.0.{i}/", f"n{i}", 0, 1)
-         for i in range(n)],
-    )
-    conn.commit()
-    conn.close()
+def _load_app(db_path: str):
+    """Import the node module with RUSTCHAIN_DB_PATH pointed at db_path."""
+    node_dir = os.path.dirname(_NODE_FILE)
+    if node_dir not in sys.path:
+        sys.path.insert(0, node_dir)
+    os.environ["RUSTCHAIN_DB_PATH"] = db_path
+    os.environ.setdefault("RC_ADMIN_KEY", "test-admin-key-not-real-padded-to-32ch")
+    # Remove a cached import so the module re-evaluates DB_PATH.
+    sys.modules.pop(_MODULE_NAME, None)
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, _NODE_FILE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MODULE_NAME] = mod
+    spec.loader.exec_module(mod)
+    return mod.app
 
 
-class TestApiNodesLimit(unittest.TestCase):
+def _seed_db(path: str, n: int) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            """CREATE TABLE IF NOT EXISTS node_registry (
+                node_id TEXT PRIMARY KEY,
+                wallet_address TEXT,
+                url TEXT,
+                name TEXT,
+                registered_at INTEGER,
+                is_active INTEGER
+            )"""
+        )
+        conn.executemany(
+            "INSERT OR IGNORE INTO node_registry VALUES (?,?,?,?,?,?)",
+            [
+                (f"node-{i}", f"RTC{'a' * 40}",
+                 f"http://203.0.113.{i % 254 + 1}/",
+                 f"n{i}", 0, 1)
+                for i in range(n)
+            ],
+        )
+        conn.commit()
 
-    def setUp(self):
-        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
-        self._tmp.close()
-        _make_db(self._tmp.name, _NODE_COUNT)
 
-    def tearDown(self):
-        os.unlink(self._tmp.name)
+class TestApiNodesRealRoute(unittest.TestCase):
 
-    def test_unbounded_query_returns_all_rows(self):
-        """Documents the vulnerable behaviour: all 250 nodes are returned."""
-        conn = sqlite3.connect(self._tmp.name)
-        rows = conn.execute(_SELECT_UNBOUNDED).fetchall()
-        conn.close()
-        self.assertEqual(len(rows), _NODE_COUNT,
-                         "Unbounded query should load every row (vulnerability)")
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        cls._tmp.close()
+        _seed_db(cls._tmp.name, _NODE_COUNT)
+        cls.flask_app = _load_app(cls._tmp.name)
+        cls.flask_app.config["TESTING"] = True
 
-    def test_bounded_query_caps_at_200(self):
-        """Fixed behaviour: LIMIT 200 prevents loading more than 200 rows."""
-        conn = sqlite3.connect(self._tmp.name)
-        rows = conn.execute(_SELECT_BOUNDED).fetchall()
-        conn.close()
-        self.assertLessEqual(len(rows), 200,
-                             "Bounded query must return at most 200 rows")
-        self.assertEqual(len(rows), 200,
-                         "With 250 nodes the cap should be exactly 200")
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls._tmp.name)
+        sys.modules.pop(_MODULE_NAME, None)
+
+    def _fake_get(self, url, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    def test_node_count_capped_at_200(self):
+        """Real handler must return at most 200 nodes when registry has 250."""
+        mock_get = MagicMock(side_effect=self._fake_get)
+        with patch("requests.get", mock_get):
+            with self.flask_app.test_client() as client:
+                rv = client.get("/api/nodes")
+
+        self.assertEqual(rv.status_code, 200)
+        data = rv.get_json()
+        nodes = data.get("nodes", [])
+        self.assertLessEqual(
+            len(nodes), _LIMIT,
+            f"Handler returned {len(nodes)} nodes; expected at most {_LIMIT}",
+        )
+        self.assertEqual(
+            len(nodes), _LIMIT,
+            f"With {_NODE_COUNT} rows the cap should be exactly {_LIMIT}",
+        )
+
+    def test_health_check_calls_capped_at_200(self):
+        """Handler must issue at most 200 health-check requests when registry has 250."""
+        mock_get = MagicMock(side_effect=self._fake_get)
+        with patch("requests.get", mock_get):
+            with self.flask_app.test_client() as client:
+                client.get("/api/nodes")
+
+        self.assertLessEqual(
+            mock_get.call_count, _LIMIT,
+            f"Handler made {mock_get.call_count} health-check calls; "
+            f"expected at most {_LIMIT}",
+        )
 
 
 if __name__ == "__main__":

--- a/node/test_api_nodes_limit_poc.py
+++ b/node/test_api_nodes_limit_poc.py
@@ -82,6 +82,7 @@ class TestApiNodesRealRoute(unittest.TestCase):
         sys.modules.pop(_MODULE_NAME, None)
         cls.flask_app = None
         gc.collect()
+        gc.collect()  # second pass: __del__ of one object may enqueue others
         try:
             os.unlink(cls._tmp.name)
         except OSError:

--- a/node/test_api_nodes_limit_poc.py
+++ b/node/test_api_nodes_limit_poc.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+"""
+PoC: /api/nodes loads every row from node_registry and issues one
+synchronous HTTP health-check per row, with no upper bound.
+
+With 250 registered nodes each health-check timeout is 3 seconds, so a
+single unauthenticated request can hold a Flask worker thread for up to
+750 seconds and force 250 sequential outbound TCP connections.
+
+Fix: add LIMIT 200 to the SELECT so at most 200 rows are fetched and at
+most 200 health-checks are issued per request.
+"""
+
+import sqlite3
+import tempfile
+import os
+import unittest
+
+
+_SELECT_UNBOUNDED = (
+    "SELECT node_id, wallet_address, url, name, registered_at, is_active"
+    " FROM node_registry"
+)
+_SELECT_BOUNDED = (
+    "SELECT node_id, wallet_address, url, name, registered_at, is_active"
+    " FROM node_registry LIMIT 200"
+)
+_NODE_COUNT = 250
+
+
+def _make_db(path: str, n: int) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        """CREATE TABLE node_registry (
+            node_id TEXT PRIMARY KEY,
+            wallet_address TEXT,
+            url TEXT,
+            name TEXT,
+            registered_at INTEGER,
+            is_active INTEGER
+        )"""
+    )
+    conn.executemany(
+        "INSERT INTO node_registry VALUES (?,?,?,?,?,?)",
+        [(f"node-{i}", f"RTC{'a'*40}", f"http://10.0.0.{i}/", f"n{i}", 0, 1)
+         for i in range(n)],
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestApiNodesLimit(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self._tmp.close()
+        _make_db(self._tmp.name, _NODE_COUNT)
+
+    def tearDown(self):
+        os.unlink(self._tmp.name)
+
+    def test_unbounded_query_returns_all_rows(self):
+        """Documents the vulnerable behaviour: all 250 nodes are returned."""
+        conn = sqlite3.connect(self._tmp.name)
+        rows = conn.execute(_SELECT_UNBOUNDED).fetchall()
+        conn.close()
+        self.assertEqual(len(rows), _NODE_COUNT,
+                         "Unbounded query should load every row (vulnerability)")
+
+    def test_bounded_query_caps_at_200(self):
+        """Fixed behaviour: LIMIT 200 prevents loading more than 200 rows."""
+        conn = sqlite3.connect(self._tmp.name)
+        rows = conn.execute(_SELECT_BOUNDED).fetchall()
+        conn.close()
+        self.assertLessEqual(len(rows), 200,
+                             "Bounded query must return at most 200 rows")
+        self.assertEqual(len(rows), 200,
+                         "With 250 nodes the cap should be exactly 200")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/test_api_nodes_limit_poc.py
+++ b/node/test_api_nodes_limit_poc.py
@@ -1,11 +1,14 @@
 # SPDX-License-Identifier: MIT
 """
-Real-route regression for the /api/nodes LIMIT 200 fix.
+Real-route regression for the /api/nodes pagination + decoupled health-probe fix.
 
 Seeds 250 rows into the app's actual SQLite DB, monkeypatches requests.get so
 no outbound connections are made, calls GET /api/nodes through the real Flask
-test client, and asserts both the returned node count and the number of
-health-check attempts are at most 200.
+test client, and verifies:
+  - default page size is capped at 20 (not 200+)
+  - limit/offset pagination works correctly
+  - at most _MAX_INLINE_PROBES outbound health probes are issued per request
+  - response includes pagination metadata (total, offset, limit)
 """
 
 import gc
@@ -14,7 +17,7 @@ import os
 import sqlite3
 import sys
 import tempfile
-import types
+import time
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +25,9 @@ _NODE_FILE = os.path.join(os.path.dirname(__file__),
                           "rustchain_v2_integrated_v2.2.1_rip200.py")
 _MODULE_NAME = "rustchain_node"
 _NODE_COUNT = 250
-_LIMIT = 200
+_DEFAULT_LIMIT = 20
+_MAX_LIMIT = 50
+_MAX_INLINE_PROBES = 3
 
 
 def _load_app(db_path: str):
@@ -32,13 +37,12 @@ def _load_app(db_path: str):
         sys.path.insert(0, node_dir)
     os.environ["RUSTCHAIN_DB_PATH"] = db_path
     os.environ.setdefault("RC_ADMIN_KEY", "test-admin-key-not-real-padded-to-32ch")
-    # Remove a cached import so the module re-evaluates DB_PATH.
     sys.modules.pop(_MODULE_NAME, None)
     spec = importlib.util.spec_from_file_location(_MODULE_NAME, _NODE_FILE)
     mod = importlib.util.module_from_spec(spec)
     sys.modules[_MODULE_NAME] = mod
     spec.loader.exec_module(mod)
-    return mod.app
+    return mod.app, mod
 
 
 def _seed_db(path: str, n: int) -> None:
@@ -56,8 +60,10 @@ def _seed_db(path: str, n: int) -> None:
         conn.executemany(
             "INSERT OR IGNORE INTO node_registry VALUES (?,?,?,?,?,?)",
             [
+                # Use hostname URLs so _should_redact_url returns False (non-IP hosts
+                # are assumed public) and probe/cache logic is exercised in tests.
                 (f"node-{i}", f"RTC{'a' * 40}",
-                 f"http://203.0.113.{i % 254 + 1}/",
+                 f"http://node{i}.test.example.com:{9000 + i}/",
                  f"n{i}", 0, 1)
                 for i in range(n)
             ],
@@ -65,65 +71,154 @@ def _seed_db(path: str, n: int) -> None:
         conn.commit()
 
 
-class TestApiNodesRealRoute(unittest.TestCase):
+def _fake_get(url, **kwargs):
+    resp = MagicMock()
+    resp.status_code = 200
+    return resp
+
+
+class TestApiNodesPaginationAndProbeCap(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         cls._tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
         cls._tmp.close()
         _seed_db(cls._tmp.name, _NODE_COUNT)
-        cls.flask_app = _load_app(cls._tmp.name)
+        cls.flask_app, cls.mod = _load_app(cls._tmp.name)
         cls.flask_app.config["TESTING"] = True
 
     @classmethod
     def tearDownClass(cls):
-        # Release module and app references first so Windows releases the SQLite
-        # file handle before we attempt to unlink.
         sys.modules.pop(_MODULE_NAME, None)
         cls.flask_app = None
+        cls.mod = None
         gc.collect()
-        gc.collect()  # second pass: __del__ of one object may enqueue others
+        gc.collect()
         try:
             os.unlink(cls._tmp.name)
         except OSError:
             pass
 
-    def _fake_get(self, url, **kwargs):
-        resp = MagicMock()
-        resp.status_code = 200
-        return resp
+    def _clear_health_cache(self):
+        """Reset the module-level health cache between tests."""
+        self.mod._NODE_HEALTH_CACHE.clear()
 
-    def test_node_count_capped_at_200(self):
-        """Real handler must return at most 200 nodes when registry has 250."""
-        mock_get = MagicMock(side_effect=self._fake_get)
-        with patch("requests.get", mock_get):
+    def test_default_page_size_is_bounded(self):
+        """Default /api/nodes must return at most _DEFAULT_LIMIT nodes."""
+        self._clear_health_cache()
+        with patch("requests.get", side_effect=_fake_get):
             with self.flask_app.test_client() as client:
                 rv = client.get("/api/nodes")
-
         self.assertEqual(rv.status_code, 200)
         data = rv.get_json()
-        nodes = data.get("nodes", [])
-        self.assertLessEqual(
-            len(nodes), _LIMIT,
-            f"Handler returned {len(nodes)} nodes; expected at most {_LIMIT}",
-        )
-        self.assertEqual(
-            len(nodes), _LIMIT,
-            f"With {_NODE_COUNT} rows the cap should be exactly {_LIMIT}",
-        )
+        self.assertLessEqual(len(data["nodes"]), _DEFAULT_LIMIT)
+        self.assertEqual(len(data["nodes"]), _DEFAULT_LIMIT,
+                         "Default page should be exactly _DEFAULT_LIMIT rows")
 
-    def test_health_check_calls_capped_at_200(self):
-        """Handler must issue at most 200 health-check requests when registry has 250."""
-        mock_get = MagicMock(side_effect=self._fake_get)
+    def test_pagination_metadata_present(self):
+        """Response must include total, offset and limit fields."""
+        self._clear_health_cache()
+        with patch("requests.get", side_effect=_fake_get):
+            with self.flask_app.test_client() as client:
+                rv = client.get("/api/nodes?limit=10&offset=0")
+        data = rv.get_json()
+        self.assertIn("total", data)
+        self.assertIn("offset", data)
+        self.assertIn("limit", data)
+        self.assertEqual(data["total"], _NODE_COUNT)
+        self.assertEqual(data["offset"], 0)
+        self.assertEqual(data["limit"], 10)
+
+    def test_offset_advances_page(self):
+        """Consecutive pages must return non-overlapping node sets."""
+        self._clear_health_cache()
+        with patch("requests.get", side_effect=_fake_get):
+            with self.flask_app.test_client() as client:
+                rv1 = client.get("/api/nodes?limit=10&offset=0")
+                rv2 = client.get("/api/nodes?limit=10&offset=10")
+        ids1 = {n["node_id"] for n in rv1.get_json()["nodes"]}
+        ids2 = {n["node_id"] for n in rv2.get_json()["nodes"]}
+        self.assertEqual(len(ids1), 10)
+        self.assertEqual(len(ids2), 10)
+        self.assertTrue(ids1.isdisjoint(ids2), "Pages must not overlap")
+
+    def test_limit_capped_at_max(self):
+        """Requesting more than _MAX_LIMIT nodes must be silently capped."""
+        self._clear_health_cache()
+        with patch("requests.get", side_effect=_fake_get):
+            with self.flask_app.test_client() as client:
+                rv = client.get(f"/api/nodes?limit=1000")
+        data = rv.get_json()
+        self.assertLessEqual(len(data["nodes"]), _MAX_LIMIT)
+
+    def test_health_probe_calls_capped_per_request(self):
+        """A single /api/nodes call must issue at most _MAX_INLINE_PROBES outbound requests."""
+        self._clear_health_cache()
+        mock_get = MagicMock(side_effect=_fake_get)
         with patch("requests.get", mock_get):
             with self.flask_app.test_client() as client:
-                client.get("/api/nodes")
-
+                client.get("/api/nodes?limit=50&offset=0")
         self.assertLessEqual(
-            mock_get.call_count, _LIMIT,
-            f"Handler made {mock_get.call_count} health-check calls; "
-            f"expected at most {_LIMIT}",
+            mock_get.call_count, _MAX_INLINE_PROBES,
+            f"Handler made {mock_get.call_count} probes; expected at most {_MAX_INLINE_PROBES}",
         )
+
+    def test_cached_health_status_reused(self):
+        """Second request for the same page must not issue any new probes."""
+        self._clear_health_cache()
+        # Use a page size <= _MAX_INLINE_PROBES so the first request fully
+        # populates the cache for every node on the page.
+        page_size = _MAX_INLINE_PROBES
+        mock_get = MagicMock(side_effect=_fake_get)
+        with patch("requests.get", mock_get):
+            with self.flask_app.test_client() as client:
+                client.get(f"/api/nodes?limit={page_size}&offset=0")
+        self.assertLessEqual(mock_get.call_count, page_size,
+                             "First request probed more nodes than the page size")
+
+        # Second identical request must serve every node from cache.
+        mock_get2 = MagicMock(side_effect=_fake_get)
+        with patch("requests.get", mock_get2):
+            with self.flask_app.test_client() as client:
+                client.get(f"/api/nodes?limit={page_size}&offset=0")
+        self.assertEqual(mock_get2.call_count, 0,
+                         "Second identical request must use cache and issue zero probes")
+
+    def test_stale_cache_probes_again(self):
+        """After TTL expires, the next request should re-probe up to the cap."""
+        self._clear_health_cache()
+        # Pre-populate cache with an expired timestamp.
+        expired_ts = time.time() - self.mod._NODE_HEALTH_CACHE_TTL - 1
+        with self.flask_app.test_client() as client:
+            # Fetch to get node URLs from the first page.
+            mock_get = MagicMock(side_effect=_fake_get)
+            with patch("requests.get", mock_get):
+                rv = client.get("/api/nodes?limit=5&offset=0")
+            for node in rv.get_json()["nodes"]:
+                url = node.get("url")
+                if url:
+                    self.mod._NODE_HEALTH_CACHE[url] = (True, expired_ts)
+
+        mock_get2 = MagicMock(side_effect=_fake_get)
+        with patch("requests.get", mock_get2):
+            with self.flask_app.test_client() as client:
+                client.get("/api/nodes?limit=5&offset=0")
+        self.assertGreater(mock_get2.call_count, 0,
+                           "Should re-probe at least one stale cache entry")
+        self.assertLessEqual(mock_get2.call_count, _MAX_INLINE_PROBES,
+                             "Re-probe count must still be bounded by the cap")
+
+    def test_invalid_limit_returns_400(self):
+        """Non-integer limit must return HTTP 400."""
+        with self.flask_app.test_client() as client:
+            rv = client.get("/api/nodes?limit=abc")
+        self.assertEqual(rv.status_code, 400)
+
+    def test_invalid_offset_returns_400(self):
+        """Non-integer offset must return HTTP 400."""
+        with self.flask_app.test_client() as client:
+            rv = client.get("/api/nodes?offset=xyz")
+        self.assertEqual(rv.status_code, 400)
 
 
 if __name__ == "__main__":

--- a/node/test_api_nodes_limit_poc.py
+++ b/node/test_api_nodes_limit_poc.py
@@ -8,6 +8,7 @@ test client, and asserts both the returned node count and the number of
 health-check attempts are at most 200.
 """
 
+import gc
 import importlib
 import os
 import sqlite3
@@ -76,8 +77,15 @@ class TestApiNodesRealRoute(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        os.unlink(cls._tmp.name)
+        # Release module and app references first so Windows releases the SQLite
+        # file handle before we attempt to unlink.
         sys.modules.pop(_MODULE_NAME, None)
+        cls.flask_app = None
+        gc.collect()
+        try:
+            os.unlink(cls._tmp.name)
+        except OSError:
+            pass
 
     def _fake_get(self, url, **kwargs):
         resp = MagicMock()


### PR DESCRIPTION
## Bug

`GET /api/nodes` fetches every row from `node_registry` with no LIMIT, then issues one synchronous `requests.get(..., timeout=3)` health-check per row:

```python
# BEFORE (vulnerable)
c.execute("SELECT node_id, wallet_address, url, name, registered_at, is_active FROM node_registry")
for row in c.fetchall():          # loads every registered node into memory
    ...
    resp = requests.get(f"{raw_url}/health", timeout=3)  # one blocking HTTP call per node
```

The endpoint is unauthenticated. With N registered nodes a single request:

- loads N rows into memory
- opens N sequential outbound TCP connections, each blocking for up to 3 s
- holds the Flask worker thread for up to 3 N seconds

At 250 nodes that is 750 s of wall-clock hold time per request. Any caller can use this to saturate all available worker threads with a small number of concurrent requests.

## Fix

```python
# AFTER (fixed)
c.execute(
    "SELECT node_id, wallet_address, url, name, registered_at, is_active"
    " FROM node_registry LIMIT 200"
)
```

Capping the SELECT at 200 rows bounds both the memory load and the number of health-check calls regardless of registry size.

## Test

`node/test_api_nodes_limit_poc.py` (new file, 2 tests):

1. `test_unbounded_query_returns_all_rows` — documents the vulnerable behaviour: 250 inserted nodes, all 250 returned
2. `test_bounded_query_caps_at_200` — verifies the fix: same 250 nodes, at most 200 returned

```
Ran 2 tests in 0.04s
OK
```

## Bounty Reference

Issue [#2819](https://github.com/Scottcjn/rustchain-bounties/issues/2819) — unauthenticated DoS, Medium severity.

**RTC Wallet:** RTC64aa3fc417e75224e1574acae906fea34d94d140