### PR TITLE
fix: protect gpu attestation writes

### DIFF
--- a/node/gpu_render_endpoints.py
+++ b/node/gpu_render_endpoints.py
@@ -74,6 +74,9 @@ def register_gpu_render_endpoints(app, db_path, admin_key):
         data, body_error = _json_object_body()
         if body_error:
             return body_error
+        auth_error = _require_admin_key()
+        if auth_error:
+            return auth_error
         miner_id, field_error = _string_field(data, "miner_id")
         if field_error:
             return field_error

--- a/tests/test_gpu_render_endpoints_security.py
+++ b/tests/test_gpu_render_endpoints_security.py
@@ -47,9 +47,38 @@ def _init_db(db_path):
         conn.execute("INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)", ("attacker", 0.0))
 
 
+def _init_gpu_attestation_table(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE gpu_attestations (
+                miner_id TEXT PRIMARY KEY,
+                gpu_model TEXT,
+                vram_gb REAL,
+                cuda_version TEXT,
+                benchmark_score REAL,
+                price_render_minute REAL,
+                price_tts_1k_chars REAL,
+                price_stt_minute REAL,
+                price_llm_1k_tokens REAL,
+                supports_render INTEGER,
+                supports_tts INTEGER,
+                supports_stt INTEGER,
+                supports_llm INTEGER,
+                last_attestation INTEGER
+            )
+            """
+        )
+
+
 def _balance(db_path, wallet):
     with sqlite3.connect(db_path) as conn:
         return conn.execute("SELECT balance_rtc FROM balances WHERE miner_pk = ?", (wallet,)).fetchone()[0]
+
+
+def _attestation_count(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM gpu_attestations").fetchone()[0]
 
 
 def _escrow_payload():
@@ -140,6 +169,42 @@ def test_gpu_admin_endpoints_fail_closed_without_configured_key(tmp_path):
     assert _balance(db_path, "victim") == 25.0
 
 
+def test_gpu_attest_requires_admin_key_before_write(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    _init_gpu_attestation_table(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post("/api/gpu/attest", json={"miner_id": "victim"})
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized - admin key required"}
+    assert _attestation_count(db_path) == 0
+
+
+def test_gpu_attest_accepts_configured_admin_key(tmp_path):
+    db_path = tmp_path / "gpu.db"
+    _init_db(db_path)
+    _init_gpu_attestation_table(db_path)
+    client = _create_app(db_path).test_client()
+
+    response = client.post(
+        "/api/gpu/attest",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json={
+            "miner_id": "miner-1",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "benchmark_score": 95,
+            "price_render_minute": 0.5,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"ok": True, "message": "GPU attestation recorded"}
+    assert _attestation_count(db_path) == 1
+
+
 @pytest.mark.parametrize(
     ("path", "headers"),
     [
@@ -208,7 +273,11 @@ def test_gpu_attest_hides_sqlite_schema_errors(tmp_path):
     _init_db(db_path)
     client = _create_app(db_path).test_client()
 
-    response = client.post("/api/gpu/attest", json={"miner_id": "miner-1"})
+    response = client.post(
+        "/api/gpu/attest",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json={"miner_id": "miner-1"},
+    )
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "Database operation failed"}


### PR DESCRIPTION
## Summary

Fixes #6532 by requiring the configured admin/API key before `POST /api/gpu/attest` writes GPU provider attestation data.

## Changes

- Adds the existing GPU admin-key guard to the attestation write path.
- Preserves existing malformed-JSON behavior by keeping JSON object validation before auth.
- Adds regression coverage proving unauthenticated attestation requests do not write and configured admin requests still work.

## Verification

- `./.venv/bin/python -m pytest -q tests/test_gpu_render_endpoints_security.py` -> 13 passed
- `PYTHONPYCACHEPREFIX=/private/tmp/rustchain-pycache python3 -m py_compile node/gpu_render_endpoints.py tests/test_gpu_render_endpoints_security.py`
- `git diff --check`
