### PR TITLE
[UTXO-BUG] Bound mempool candidate scan

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -880,6 +880,68 @@ class TestUtxoDB(unittest.TestCase):
         # Highest fee first
         self.assertEqual(candidates[0]['tx_id'], 'high' * 16)
 
+    def test_mempool_block_candidates_limits_sql_scan(self):
+        """Candidate selection must not materialize the whole mempool."""
+        self._apply_coinbase('alice', 100 * UNIT, block_height=1)
+        self._apply_coinbase('carol', 120 * UNIT, block_height=2)
+        boxes = self.db.get_unspent_for_address('alice')
+        boxes += self.db.get_unspent_for_address('carol')
+
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': 'low_' * 16,
+            'inputs': [{'box_id': boxes[0]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }))
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': 'high' * 16,
+            'inputs': [{'box_id': boxes[1]['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 120 * UNIT - 5000}],
+            'fee_nrtc': 5000,
+        }))
+
+        original_conn = self.db._conn
+        candidate_queries = []
+
+        class RecordingConnection(utxo_db_module.sqlite3.Connection):
+            def execute(self, sql, parameters=()):
+                if (
+                    "FROM utxo_mempool" in sql
+                    and "ORDER BY fee_nrtc DESC" in sql
+                ):
+                    candidate_queries.append((sql, tuple(parameters)))
+                return super().execute(sql, parameters)
+
+        def recording_conn():
+            c = utxo_db_module.sqlite3.connect(
+                self.tmp.name,
+                timeout=30,
+                factory=RecordingConnection,
+            )
+            try:
+                c.row_factory = utxo_db_module.sqlite3.Row
+                c.execute("PRAGMA journal_mode=WAL")
+                c.execute("PRAGMA foreign_keys=ON")
+                return c
+            except Exception:
+                c.close()
+                raise
+
+        self.db._conn = recording_conn
+        try:
+            candidates = self.db.mempool_get_block_candidates(max_count=1)
+        finally:
+            self.db._conn = original_conn
+
+        self.assertEqual(len(candidates), 1)
+        self.assertTrue(candidate_queries)
+        sql, params = candidate_queries[-1]
+        self.assertIn("LIMIT ?", sql)
+        self.assertEqual(
+            params[-1],
+            utxo_db_module.MAX_MEMPOOL_CANDIDATE_SCAN_FACTOR,
+        )
+
     def test_mempool_block_candidates_ignore_expired_transactions(self):
         self._apply_coinbase('alice', 100 * UNIT, block_height=1)
         box = self.db.get_unspent_for_address('alice')[0]

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -50,6 +50,7 @@ MAX_UTXO_METADATA_BYTES = 8_192
 MAX_MEMPOOL_TX_ID_BYTES = 128
 MAX_TX_AGE_SECONDS = 3_600  # 1 hour mempool expiry
 MAX_TX_DATA_JSON_BYTES = 262_144  # 256KB max serialized tx size
+MAX_MEMPOOL_CANDIDATE_SCAN_FACTOR = 4
 MAX_SQLITE_INT64 = 2**63 - 1
 P2PK_PREFIX = b'\x00\x08'   # Pay-to-Public-Key proposition prefix
 SUPPORTED_TX_TYPES = {'transfer', 'mining_reward'}
@@ -1248,12 +1249,17 @@ class UtxoDB:
         conn = self._conn()
         try:
             now = int(time.time())
+            scan_limit = min(
+                MAX_POOL_SIZE,
+                max_count * MAX_MEMPOOL_CANDIDATE_SCAN_FACTOR,
+            )
             rows = conn.execute(
                 """SELECT tx_id, tx_data_json FROM utxo_mempool
                    WHERE expires_at > ?
                    ORDER BY fee_nrtc DESC
+                   LIMIT ?
                 """,
-                (now,),
+                (now, scan_limit),
             ).fetchall()
             candidates = []
             stale_tx_ids = []


### PR DESCRIPTION
## Summary
- Fixes a Medium mempool DoS candidate from the UTXO red-team bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2819
- Bounds `mempool_get_block_candidates()` so it no longer materializes the entire live mempool before honoring `max_count`.
- Adds a regression test that records the SQLite candidate query and fails if the SQL `LIMIT` is removed.

## Vulnerability class
Medium: Mempool DoS.

`GET /utxo/mempool` requests 50 candidates, and block production paths request small candidate sets, but the old query selected every unexpired mempool row ordered by fee and fetched all rows into Python before stopping at `max_count`. With `MAX_POOL_SIZE = 10_000` and `MAX_TX_DATA_JSON_BYTES = 262_144`, a filled mempool can make one candidate request materialize a very large SQLite result set and parse/scan rows that will never be returned.

## Fix
The candidate query now applies `LIMIT ?` using a bounded overfetch window (`max_count * 4`, capped at `MAX_POOL_SIZE`). This keeps stale-entry cleanup for the scanned window while preventing low-count candidate requests from forcing a full-pool fetch.

## Validation
- `PYTHONPATH=node python3 -m unittest node.test_utxo_db` -> 96 tests OK
- `python3 -m compileall -q node/utxo_db.py node/test_utxo_db.py`
- `git show --check --stat --oneline HEAD`

Bounty wallet/miner ID for payout if accepted: `jonathanpopham`