### PR TITLE
Fix UTXO mempool tx_id spoof bypass

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -739,6 +739,36 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
         self.assertEqual(self.db.mempool_get_block_candidates(), [])
 
+    def test_apply_rejects_spoofed_matching_mempool_tx_id(self):
+        """A caller must not bypass a mempool claim by reusing its tx_id."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+
+        mempool_tx = {
+            'tx_id': 'victim_tx',
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': int(time.time()),
+        }
+        self.assertTrue(self.db.mempool_add(mempool_tx))
+
+        competing_tx = {
+            'tx_id': 'victim_tx',
+            'tx_type': 'transfer',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'mallory', 'value_nrtc': 100 * UNIT}],
+            'fee_nrtc': 0,
+            'timestamp': mempool_tx['timestamp'],
+        }
+
+        self.assertFalse(self.db.apply_transaction(competing_tx, block_height=10))
+        self.assertEqual(self.db.get_balance('alice'), 100 * UNIT)
+        self.assertEqual(self.db.get_balance('bob'), 0)
+        self.assertEqual(self.db.get_balance('mallory'), 0)
+        self.assertTrue(self.db.mempool_check_double_spend(box['box_id']))
+
     def test_mempool_rejects_malformed_inputs_without_locking(self):
         self._apply_coinbase('alice', 100 * UNIT)
 

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -739,6 +739,22 @@ class TestUtxoDB(unittest.TestCase):
         self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
         self.assertEqual(self.db.mempool_get_block_candidates(), [])
 
+    def test_apply_allows_matching_mempool_candidate_with_defaults(self):
+        """Equivalent defaulted mempool fields should still match apply."""
+        self._apply_coinbase('alice', 100 * UNIT)
+        box = self.db.get_unspent_for_address('alice')[0]
+        tx = {
+            'tx_id': 'candidate-defaults',
+            'inputs': [{'box_id': box['box_id']}],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT}],
+        }
+
+        self.assertTrue(self.db.mempool_add(tx))
+        self.assertTrue(self.db.apply_transaction(tx, block_height=10))
+        self.assertEqual(self.db.get_balance('bob'), 100 * UNIT)
+        self.assertFalse(self.db.mempool_check_double_spend(box['box_id']))
+        self.assertEqual(self.db.mempool_get_block_candidates(), [])
+
     def test_apply_rejects_spoofed_matching_mempool_tx_id(self):
         """A caller must not bypass a mempool claim by reusing its tx_id."""
         self._apply_coinbase('alice', 100 * UNIT)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -531,7 +531,8 @@ class UtxoDB:
                                   outputs: List[dict],
                                   data_inputs: List[str],
                                   fee: int,
-                                  timestamp: int) -> bool:
+                                  timestamp: int,
+                                  timestamp_explicit: bool) -> bool:
         """Return True only when a mempool claim is for this exact tx body."""
         row = conn.execute(
             "SELECT tx_data_json FROM utxo_mempool WHERE tx_id = ?",
@@ -553,6 +554,11 @@ class UtxoDB:
         )
         mempool_fee = mempool_tx.get("fee_nrtc", 0)
         mempool_timestamp = mempool_tx.get("timestamp")
+
+        if "timestamp" not in mempool_tx:
+            if timestamp_explicit:
+                return False
+            mempool_timestamp = timestamp
 
         if (
             mempool_tx_type is None
@@ -708,7 +714,7 @@ class UtxoDB:
                 if claim_tx_id not in verified_claim_ids:
                     if not self._mempool_claim_matches_tx(
                         conn, claim_tx_id, tx_type, inputs, outputs,
-                        data_inputs, fee, ts
+                        data_inputs, fee, ts, "timestamp" in tx
                     ):
                         return abort()
                     verified_claim_ids.add(claim_tx_id)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -524,6 +524,69 @@ class UtxoDB:
 
         return True
 
+    def _mempool_claim_matches_tx(self, conn: sqlite3.Connection,
+                                  tx_id: str,
+                                  tx_type: str,
+                                  inputs: List[dict],
+                                  outputs: List[dict],
+                                  data_inputs: List[str],
+                                  fee: int,
+                                  timestamp: int) -> bool:
+        """Return True only when a mempool claim is for this exact tx body."""
+        row = conn.execute(
+            "SELECT tx_data_json FROM utxo_mempool WHERE tx_id = ?",
+            (tx_id,),
+        ).fetchone()
+        if not row:
+            return False
+
+        try:
+            mempool_tx = json.loads(row["tx_data_json"])
+        except (TypeError, json.JSONDecodeError):
+            return False
+
+        mempool_tx_type = self._normalize_tx_type(mempool_tx)
+        mempool_inputs = self._normalize_inputs(mempool_tx.get("inputs", []))
+        mempool_outputs = self._normalize_outputs(mempool_tx.get("outputs", []))
+        mempool_data_inputs = self._normalize_data_inputs(
+            mempool_tx.get("data_inputs", [])
+        )
+        mempool_fee = mempool_tx.get("fee_nrtc", 0)
+        mempool_timestamp = mempool_tx.get("timestamp")
+
+        if (
+            mempool_tx_type is None
+            or mempool_inputs is None
+            or mempool_outputs is None
+            or mempool_data_inputs is None
+            or not _is_nonnegative_int64(mempool_fee)
+            or not _is_nonnegative_int64(mempool_timestamp)
+        ):
+            return False
+
+        def input_ids(items: List[dict]) -> List[str]:
+            return sorted(item["box_id"] for item in items)
+
+        def output_intent(items: List[dict]) -> List[dict]:
+            return [
+                {
+                    "address": item["address"],
+                    "value_nrtc": item["value_nrtc"],
+                    "tokens_json": item.get("tokens_json", "[]"),
+                    "registers_json": item.get("registers_json", "{}"),
+                }
+                for item in items
+            ]
+
+        return (
+            mempool_tx_type == tx_type
+            and input_ids(mempool_inputs) == input_ids(inputs)
+            and sorted(mempool_data_inputs) == sorted(data_inputs)
+            and output_intent(mempool_outputs) == output_intent(outputs)
+            and mempool_fee == fee
+            and mempool_timestamp == timestamp
+        )
+
     # -- transaction application ---------------------------------------------
 
     def apply_transaction(self, tx: dict, block_height: int,
@@ -624,19 +687,31 @@ class UtxoDB:
             input_box_ids = [i['box_id'] for i in inputs]
             if len(input_box_ids) != len(set(input_box_ids)):
                 return abort()
-            claimed_by_tx_id = tx.get('tx_id') if isinstance(tx.get('tx_id'), str) else None
-            for box_id in input_box_ids:
-                claim = conn.execute(
-                    "SELECT tx_id FROM utxo_mempool_inputs WHERE box_id = ?",
-                    (box_id,),
-                ).fetchone()
-                if claim and claim['tx_id'] != claimed_by_tx_id:
-                    return abort()
             data_inputs = self._normalize_data_inputs(data_inputs)
             if data_inputs is None:
                 return abort()
             if set(input_box_ids) & set(data_inputs):
                 return abort()
+
+            claimed_by_tx_id = tx.get('tx_id') if isinstance(tx.get('tx_id'), str) else None
+            verified_claim_ids = set()
+            for box_id in input_box_ids:
+                claim = conn.execute(
+                    "SELECT tx_id FROM utxo_mempool_inputs WHERE box_id = ?",
+                    (box_id,),
+                ).fetchone()
+                if not claim:
+                    continue
+                claim_tx_id = claim['tx_id']
+                if claim_tx_id != claimed_by_tx_id:
+                    return abort()
+                if claim_tx_id not in verified_claim_ids:
+                    if not self._mempool_claim_matches_tx(
+                        conn, claim_tx_id, tx_type, inputs, outputs,
+                        data_inputs, fee, ts
+                    ):
+                        return abort()
+                    verified_claim_ids.add(claim_tx_id)
 
             # -- validate inputs exist and are unspent -----------------------
             input_total = 0


### PR DESCRIPTION
## Summary

Fix a mempool claim bypass in `UtxoDB.apply_transaction()`.

PR #6483 correctly made `apply_transaction()` reject a transaction that spends an input claimed by a different pending mempool transaction. However, the bypass condition still trusts a caller-supplied `tx_id`: a competing transaction can reuse the pending mempool transaction's `tx_id` while changing the transaction body and outputs.

This patch verifies that a mempool claim authorizes only the exact pending transaction body stored in `utxo_mempool.tx_data_json`.

## Impact

Before this patch:

1. Alice has one 100 RTC UTXO.
2. Mempool contains `victim_tx` spending Alice's UTXO to Bob.
3. A caller applies a different transaction with `tx_id = "victim_tx"` and the same input, but output to Mallory.
4. `apply_transaction()` accepts it because the mempool lock belongs to the same string `tx_id`.

Observed vulnerable result:

```text
mempool add victim: True
mempool lock exists before: True
apply spoofed competing tx: True
alice balance: 0
bob balance: 0
mallory balance: 10000000000
mempool candidates after: []
```

This is a lock-check bypass: the mempool claim is treated as satisfied by a different transaction body.

## Fix

- Load the stored mempool transaction by claimed `tx_id`.
- Normalize tx type, inputs, outputs, data inputs, fee, and timestamp through existing normalizers.
- Allow the mempool-claim bypass only when the stored mempool transaction matches the transaction being applied.
- Keep the legitimate path where the exact mempool candidate is mined/applied.

## Tests

Focused:

```text
python -m unittest test_utxo_db.TestUtxoDB.test_apply_allows_matching_mempool_candidate test_utxo_db.TestUtxoDB.test_apply_rejects_spoofed_matching_mempool_tx_id test_utxo_db.TestUtxoDB.test_apply_rejects_input_claimed_by_other_mempool_tx
Ran 3 tests in 0.292s
OK
```

Full UTXO suite:

```text
python -m unittest test_utxo_db
Ran 96 tests in 9.745s
OK
```

Repro helper prepared outside the repo:

```text
python ..\rustchain-repro-mempool-txid-spoof.py
```

On current `origin/main` (`9e5f0c6`), the helper shows the spoof succeeds:

```text
apply spoofed competing tx: True
alice balance: 0
mallory balance: 10000000000
```

On this patch branch, it shows the spoof is rejected and the mempool candidate remains:

```text
apply spoofed competing tx: False
alice balance: 10000000000
mallory balance: 0
```

## Bounty

Red Team UTXO bounty #2819.

Requested review: High / 100 RTC, because the bounty's High tier covers lock/unlock logic errors and bypasses of lock checks.

RTC payout address: `RTC6de503be5fbf1fb3797fd7eddc65dfde9188aa4d`
