### PR TITLE
[UTXO-BUG] Fix dual-write reward settlement

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -44,9 +44,10 @@ except Exception as e:
 # UTXO Layer (Phase 1 — dual-write alongside account model)
 UTXO_DUAL_WRITE = os.environ.get("UTXO_DUAL_WRITE", "0") == "1"
 try:
-    from utxo_db import UtxoDB
+    from utxo_db import UtxoDB, MAX_OUTPUTS as UTXO_MAX_OUTPUTS
     HAVE_UTXO = True
 except ImportError:
+    UTXO_MAX_OUTPUTS = 100
     HAVE_UTXO = False
     if UTXO_DUAL_WRITE:
         print("[WARN] utxo_db.py not found but UTXO_DUAL_WRITE=1 — disabling")
@@ -3481,6 +3482,7 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
     from decimal import Decimal, ROUND_DOWN
 
     with closing(sqlite3.connect(DB_PATH)) as conn:
+        conn.row_factory = sqlite3.Row
         c = conn.cursor()
 
         # REPLAY PROTECTION: Check if epoch already settled
@@ -3579,6 +3581,7 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
         # ATOMIC TRANSACTION: Wrap all updates in explicit transaction
         try:
             c.execute("BEGIN TRANSACTION")
+            utxo_reward_outputs = []
 
             # Distribute rewards with precision
             for pk, weight in miners:
@@ -3596,26 +3599,43 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                     (amount_i64, amount_i64, pk)
                 )
 
-                # Sync to UTXO layer only when the dual-write feature is enabled.
-                # A rejected UTXO write must abort the surrounding account-model
-                # settlement or the two ledgers diverge while the epoch is marked
-                # settled.
                 if UTXO_DUAL_WRITE:
+                    utxo_reward_outputs.append({
+                        "address": pk,
+                        "value_nrtc": amount_nrtc,
+                    })
+                # Update metrics with decimal value for accuracy
+                balance_gauge.labels(miner_pk=pk).set(float(amount_decimal))
+
+            # Sync to UTXO layer only when the dual-write feature is enabled.
+            # The UTXO layer permits one mining_reward transaction per block
+            # height, so epoch rewards must be batched instead of written as one
+            # mint transaction per miner at the same height.
+            if UTXO_DUAL_WRITE and utxo_reward_outputs:
+                max_outputs = max(1, int(UTXO_MAX_OUTPUTS))
+                reward_batches = [
+                    utxo_reward_outputs[i:i + max_outputs]
+                    for i in range(0, len(utxo_reward_outputs), max_outputs)
+                ]
+                if len(reward_batches) > EPOCH_SLOTS:
+                    raise RuntimeError(
+                        "UTXO reward settlement exceeds epoch mint capacity"
+                    )
+                for batch_index, outputs in enumerate(reward_batches):
                     utxo_tx = {
                         "tx_type": "mining_reward",
                         "inputs": [],
-                        "outputs": [{"address": pk, "value_nrtc": amount_nrtc}],
+                        "outputs": outputs,
                         "_allow_minting": True
                     }
                     utxo_ok = UtxoDB(DB_PATH).apply_transaction(
-                        utxo_tx, epoch * 144, conn=conn
+                        utxo_tx, epoch * EPOCH_SLOTS + batch_index, conn=conn
                     )
                     if not utxo_ok:
                         raise RuntimeError(
-                            f"UTXO reward settlement failed for {pk[:20]}..."
+                            "UTXO reward settlement failed for "
+                            f"batch {batch_index + 1}/{len(reward_batches)}"
                         )
-                # Update metrics with decimal value for accuracy
-                balance_gauge.labels(miner_pk=pk).set(float(amount_decimal))
 
             # Mark epoch as settled - use UPDATE with WHERE settled=0 to prevent race
             result = c.execute(

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -1,8 +1,11 @@
 import importlib.util
+from contextlib import closing
+import gc
 import os
 import sqlite3
 import sys
 import tempfile
+import types
 import unittest
 
 
@@ -31,6 +34,11 @@ class _NoopMetric:
 
 
 class TestIntegratedBalanceScale(unittest.TestCase):
+    @staticmethod
+    def _cleanup_tempdir(tmpdir):
+        gc.collect()
+        tmpdir.cleanup()
+
     @classmethod
     def setUpClass(cls):
         cls._import_tmp = tempfile.TemporaryDirectory()
@@ -42,16 +50,15 @@ class TestIntegratedBalanceScale(unittest.TestCase):
         if NODE_DIR not in sys.path:
             sys.path.insert(0, NODE_DIR)
 
-        import prometheus_client
+        prev_prometheus = sys.modules.get("prometheus_client")
+        fake_prometheus = types.ModuleType("prometheus_client")
+        fake_prometheus.Counter = _NoopMetric
+        fake_prometheus.Gauge = _NoopMetric
+        fake_prometheus.Histogram = _NoopMetric
+        fake_prometheus.generate_latest = lambda *args, **kwargs: b""
+        fake_prometheus.CONTENT_TYPE_LATEST = "text/plain"
+        sys.modules["prometheus_client"] = fake_prometheus
 
-        prev_metrics = (
-            prometheus_client.Counter,
-            prometheus_client.Gauge,
-            prometheus_client.Histogram,
-        )
-        prometheus_client.Counter = _NoopMetric
-        prometheus_client.Gauge = _NoopMetric
-        prometheus_client.Histogram = _NoopMetric
         spec = importlib.util.spec_from_file_location(
             "rustchain_integrated_balance_scale_test",
             MODULE_PATH,
@@ -60,11 +67,10 @@ class TestIntegratedBalanceScale(unittest.TestCase):
         try:
             spec.loader.exec_module(cls.mod)
         finally:
-            (
-                prometheus_client.Counter,
-                prometheus_client.Gauge,
-                prometheus_client.Histogram,
-            ) = prev_metrics
+            if prev_prometheus is None:
+                sys.modules.pop("prometheus_client", None)
+            else:
+                sys.modules["prometheus_client"] = prev_prometheus
 
     @classmethod
     def tearDownClass(cls):
@@ -76,7 +82,9 @@ class TestIntegratedBalanceScale(unittest.TestCase):
             os.environ.pop("RC_ADMIN_KEY", None)
         else:
             os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
-        cls._import_tmp.cleanup()
+        sys.modules.pop("rustchain_integrated_balance_scale_test", None)
+        cls.mod = None
+        cls._cleanup_tempdir(cls._import_tmp)
 
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -92,10 +100,10 @@ class TestIntegratedBalanceScale(unittest.TestCase):
         self.mod.DB_PATH = self._prev_module_db
         self.mod.UTXO_DUAL_WRITE = self._prev_utxo_dual_write
         self.mod.UtxoDB = self._prev_utxo_db
-        self._tmp.cleanup()
+        self._cleanup_tempdir(self._tmp)
 
     def _init_db(self):
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             db.executescript(
                 """
                 CREATE TABLE epoch_state (
@@ -136,16 +144,17 @@ class TestIntegratedBalanceScale(unittest.TestCase):
                 "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
                 ("miner-scale",),
             )
+            db.commit()
 
     def _stored_balance(self):
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             return db.execute(
                 "SELECT amount_i64, balance_rtc FROM balances WHERE miner_id = ?",
                 ("miner-scale",),
             ).fetchone()
 
     def _add_epoch_miner(self, miner_id, weight):
-        with sqlite3.connect(self.db_path) as db:
+        with closing(sqlite3.connect(self.db_path)) as db:
             db.execute(
                 "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
                 (7, miner_id, weight),
@@ -158,6 +167,7 @@ class TestIntegratedBalanceScale(unittest.TestCase):
                 "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
                 (miner_id,),
             )
+            db.commit()
 
     def test_finalize_epoch_writes_account_rewards_in_micro_rtc(self):
         self.mod.finalize_epoch(7, 0.01, b"")

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -144,6 +144,21 @@ class TestIntegratedBalanceScale(unittest.TestCase):
                 ("miner-scale",),
             ).fetchone()
 
+    def _add_epoch_miner(self, miner_id, weight):
+        with sqlite3.connect(self.db_path) as db:
+            db.execute(
+                "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                (7, miner_id, weight),
+            )
+            db.execute(
+                "INSERT INTO miner_attest_recent (miner, fingerprint_checks_json) VALUES (?, ?)",
+                (miner_id, "{}"),
+            )
+            db.execute(
+                "INSERT INTO balances (miner_id, amount_i64, balance_rtc) VALUES (?, 0, 0)",
+                (miner_id,),
+            )
+
     def test_finalize_epoch_writes_account_rewards_in_micro_rtc(self):
         self.mod.finalize_epoch(7, 0.01, b"")
 
@@ -175,6 +190,60 @@ class TestIntegratedBalanceScale(unittest.TestCase):
         self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], 144_000_000)
         self.assertEqual(calls[0][1]["outputs"][0]["value_nrtc"], int(1.44 * self.mod.UTXO_UNIT))
         self.assertTrue(calls[0][3])
+
+    def test_finalize_epoch_passes_row_connection_to_utxo_db(self):
+        calls = []
+
+        class RowCheckingUtxoDB:
+            def __init__(self, db_path):
+                self.db_path = db_path
+
+            def apply_transaction(self, tx, height, conn=None):
+                calls.append(conn.row_factory if conn is not None else None)
+                return conn is not None and conn.row_factory is sqlite3.Row
+
+        self.mod.UTXO_DUAL_WRITE = True
+        self.mod.UtxoDB = RowCheckingUtxoDB
+
+        self.mod.finalize_epoch(7, 0.01, b"")
+
+        self.assertEqual(calls, [sqlite3.Row])
+
+    def test_finalize_epoch_batches_multi_miner_utxo_rewards(self):
+        self._add_epoch_miner("miner-scale-2", 1.0)
+        calls = []
+        seen_heights = set()
+
+        class HeightCheckingUtxoDB:
+            def __init__(self, db_path):
+                self.db_path = db_path
+
+            def apply_transaction(self, tx, height, conn=None):
+                if height in seen_heights:
+                    return False
+                seen_heights.add(height)
+                calls.append((tx, height, conn is not None))
+                return True
+
+        self.mod.UTXO_DUAL_WRITE = True
+        self.mod.UtxoDB = HeightCheckingUtxoDB
+
+        self.mod.finalize_epoch(7, 0.01, b"")
+
+        self.assertEqual(len(calls), 1)
+        tx, height, had_conn = calls[0]
+        self.assertTrue(had_conn)
+        self.assertEqual(height, 7 * self.mod.EPOCH_SLOTS)
+        self.assertEqual(tx["tx_type"], "mining_reward")
+        self.assertEqual(tx["inputs"], [])
+        self.assertEqual(
+            sorted(out["address"] for out in tx["outputs"]),
+            ["miner-scale", "miner-scale-2"],
+        )
+        self.assertEqual(
+            sorted(out["value_nrtc"] for out in tx["outputs"]),
+            [72_000_000, 72_000_000],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fixes a UTXO dual-write reward-settlement failure in the Phase 1/2 migration path covered by the Red Team UTXO bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2819
- Configures the `finalize_epoch()` SQLite connection with `sqlite3.Row` before passing it into `UtxoDB.apply_transaction()`, which expects row-style access.
- Batches all miner reward outputs into one or more mining_reward transactions instead of applying one mining_reward per miner at the same block height.

## Vulnerability class
High/Medium: UTXO dual-write reward settlement failure.

With `UTXO_DUAL_WRITE=1`, `finalize_epoch()` passed a plain SQLite connection into the UTXO layer. `UtxoDB.apply_transaction()` uses `row["n"]`/named-row access, so that path can fail before UTXO rewards are written. After that is fixed, the old per-miner loop still attempts multiple `mining_reward` transactions at `epoch * 144`; the UTXO layer correctly permits only one mining reward per block height, so multi-miner epochs can fail and roll back settlement.

Impact: enabling UTXO dual-write can prevent epoch rewards from settling for normal multi-miner epochs, leaving the migration path unusable until fixed.

## Fix
- Set `conn.row_factory = sqlite3.Row` before creating the epoch cursor.
- Collect miner UTXO reward outputs during the account update loop.
- Apply batched mining_reward transactions after reward calculation, using one block height per batch inside the epoch window.
- Cap batch size with the UTXO layer `MAX_OUTPUTS` value.

## Validation
- Added regression coverage in `node/tests/test_integrated_balance_scale.py` for row-style UTXO connections and multi-miner UTXO reward batching.
- `python3 -m compileall -q node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_balance_scale.py`
- `git show --check --stat --oneline HEAD`

Bounty wallet/miner ID for payout if accepted: `jonathanpopham`