### PR TITLE
[AGENT-BUG] Expire claimed jobs and refund escrow after TTL

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -515,6 +515,17 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Only the assigned worker can deliver"}), 403
 
             now = int(time.time())
+            if now > j["expires_at"]:
+                c.execute("""
+                    UPDATE agent_jobs SET status = 'expired'
+                    WHERE job_id = ? AND status = ?
+                """, (job_id, STATUS_CLAIMED))
+                if c.rowcount:
+                    _refund_escrow(c, j)
+                    _update_reputation(c, j["poster_wallet"], "jobs_expired")
+                    conn.commit()
+                return jsonify({"error": "Job has expired"}), 410
+
             c.execute("""
                 UPDATE agent_jobs
                 SET status = 'delivered', deliverable_url = ?,
@@ -808,16 +819,19 @@ def register_agent_economy(app: Flask, db_path: str):
             # Expire old jobs first
             now = int(time.time())
             expired = c.execute("""
-                SELECT job_id, poster_wallet, escrow_i64, platform_fee_i64, reward_i64
+                SELECT *
                 FROM agent_jobs
-                WHERE status = 'open' AND expires_at < ?
+                WHERE status IN ('open', 'claimed') AND expires_at < ?
             """, (now,)).fetchall()
             for ej in expired:
-                _adjust_balance(c, ESCROW_WALLET, -ej["escrow_i64"])
-                _adjust_balance(c, ej["poster_wallet"], ej["escrow_i64"])
-                c.execute("UPDATE agent_jobs SET status = 'expired' WHERE job_id = ?",
-                         (ej["job_id"],))
-                _update_reputation(c, ej["poster_wallet"], "jobs_expired")
+                job = dict(ej)
+                c.execute("""
+                    UPDATE agent_jobs SET status = 'expired'
+                    WHERE job_id = ? AND status IN ('open', 'claimed')
+                """, (job["job_id"],))
+                if c.rowcount:
+                    _refund_escrow(c, job)
+                    _update_reputation(c, job["poster_wallet"], "jobs_expired")
             if expired:
                 conn.commit()
 

--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -483,6 +483,24 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     # POST /agent/jobs/<job_id>/deliver — Submit deliverable
     # -----------------------------------------------------------------------
+    def _expire_refundable_job(c: sqlite3.Cursor, job: dict, now: int) -> bool:
+        """Expire an open/claimed job and refund escrow once."""
+        if job["status"] not in (STATUS_OPEN, STATUS_CLAIMED):
+            return False
+        if now <= job["expires_at"]:
+            return False
+
+        c.execute("""
+            UPDATE agent_jobs SET status = 'expired'
+            WHERE job_id = ? AND status IN (?, ?)
+        """, (job["job_id"], STATUS_OPEN, STATUS_CLAIMED))
+        if c.rowcount == 0:
+            return False
+
+        _refund_escrow(c, job)
+        _update_reputation(c, job["poster_wallet"], "jobs_expired")
+        return True
+
     @app.route("/agent/jobs/<job_id>/deliver", methods=["POST"])
     def agent_deliver_job(job_id):
         data, error = _get_json_object(required=False)
@@ -515,15 +533,8 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Only the assigned worker can deliver"}), 403
 
             now = int(time.time())
-            if now > j["expires_at"]:
-                c.execute("""
-                    UPDATE agent_jobs SET status = 'expired'
-                    WHERE job_id = ? AND status = ?
-                """, (job_id, STATUS_CLAIMED))
-                if c.rowcount:
-                    _refund_escrow(c, j)
-                    _update_reputation(c, j["poster_wallet"], "jobs_expired")
-                    conn.commit()
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
                 return jsonify({"error": "Job has expired"}), 410
 
             c.execute("""
@@ -755,6 +766,15 @@ def register_agent_economy(app: Flask, db_path: str):
             if j["poster_wallet"] != poster:
                 return jsonify({"error": "Only the poster can cancel"}), 403
 
+            now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                return jsonify({
+                    "error": "Job has expired",
+                    "status": STATUS_EXPIRED,
+                    "refunded_rtc": j["escrow_i64"] / 1000000,
+                }), 410
+
             if j["status"] not in (STATUS_OPEN, STATUS_DISPUTED):
                 return jsonify({
                     "error": f"Can only cancel open or disputed jobs (current: {j['status']})"
@@ -821,17 +841,10 @@ def register_agent_economy(app: Flask, db_path: str):
             expired = c.execute("""
                 SELECT *
                 FROM agent_jobs
-                WHERE status IN ('open', 'claimed') AND expires_at < ?
-            """, (now,)).fetchall()
+                WHERE status IN (?, ?) AND expires_at < ?
+            """, (STATUS_OPEN, STATUS_CLAIMED, now)).fetchall()
             for ej in expired:
-                job = dict(ej)
-                c.execute("""
-                    UPDATE agent_jobs SET status = 'expired'
-                    WHERE job_id = ? AND status IN ('open', 'claimed')
-                """, (job["job_id"],))
-                if c.rowcount:
-                    _refund_escrow(c, job)
-                    _update_reputation(c, job["poster_wallet"], "jobs_expired")
+                _expire_refundable_job(c, dict(ej), now)
             if expired:
                 conn.commit()
 
@@ -884,6 +897,10 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Job not found"}), 404
 
             j = dict(job)
+            now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                j["status"] = STATUS_EXPIRED
 
             # Get activity log
             log_rows = c.execute("""

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -1,3 +1,5 @@
+import sqlite3
+import time
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,21 @@ def make_client(tmp_path: Path):
     app = Flask(__name__)
     register_agent_economy(app, str(tmp_path / "agent_jobs.db"))
     return app.test_client()
+
+
+def make_funded_client(tmp_path: Path):
+    db_path = tmp_path / "agent_jobs.db"
+    app = Flask(__name__)
+    register_agent_economy(app, str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("poster-1", 2_000_000),
+        )
+    return app.test_client(), db_path
 
 
 def test_agent_jobs_rejects_malformed_query_numbers(tmp_path):
@@ -102,3 +119,70 @@ def test_agent_job_post_rejects_invalid_ttl_values(tmp_path, ttl):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def test_claimed_expired_job_is_refunded_and_removed_from_claimed_listing(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (int(time.time()) - 1, job_id),
+        )
+
+    response = client.get("/agent/jobs?status=claimed")
+
+    assert response.status_code == 200
+    assert response.get_json()["jobs"] == []
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
+def test_worker_cannot_deliver_after_claimed_job_expires(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (int(time.time()) - 1, job_id),
+        )
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/deliver",
+        json={"worker_wallet": "worker-1", "result_summary": "late delivery"},
+    )
+
+    assert response.status_code == 410
+    assert response.get_json() == {"error": "Job has expired"}
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -153,6 +153,78 @@ def test_claimed_expired_job_is_refunded_and_removed_from_claimed_listing(tmp_pa
     assert balances["poster-1"] == 2_000_000
 
 
+def test_claimed_expired_job_detail_refunds_and_returns_expired(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (int(time.time()) - 1, job_id),
+        )
+
+    response = client.get(f"/agent/jobs/{job_id}")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["ok"] is True
+    assert payload["job"]["status"] == "expired"
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
+def test_cancel_on_expired_claimed_job_refunds_instead_of_locking(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (int(time.time()) - 1, job_id),
+        )
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/cancel", json={"poster_wallet": "poster-1"}
+    )
+
+    assert response.status_code == 410
+    assert response.get_json() == {
+        "error": "Job has expired",
+        "status": "expired",
+        "refunded_rtc": 1.05,
+    }
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
 def test_worker_cannot_deliver_after_claimed_job_expires(tmp_path):
     client, db_path = make_funded_client(tmp_path)
 


### PR DESCRIPTION
## Summary

- expire claimed RIP-302 agent jobs after their TTL instead of leaving escrow locked indefinitely
- refund escrow to the poster when stale claimed jobs are expired by listing or late delivery
- add regression coverage for claimed-job expiry from `/agent/jobs` and `/deliver`

## Finding

RIP-302 documents that timed-out jobs return escrow to the poster, and the `STATUS_EXPIRED` comment says TTL passed without completion. The current implementation only expires `open` jobs in `GET /agent/jobs`; after a worker claims a job, the poster cannot cancel it and list/detail routes leave it in `claimed` even after `expires_at`.

Repro before this patch:

```text
post 201 status=open escrow_total_rtc=1.05
claim 200 status=claimed
manually set expires_at to past
GET /agent/jobs?status=claimed => returns the expired claimed job
POST /agent/jobs/{job_id}/cancel => 409 current: claimed
balances => agent_escrow: 1.05 RTC, poster not refunded
```

That creates a griefing/lockup path: a worker can claim a job and disappear, leaving poster funds trapped in `agent_escrow` with no poster-controlled recovery path.

## Fix

- `GET /agent/jobs` now expires both `open` and `claimed` jobs whose TTL has passed, refunds their escrow, and increments `jobs_expired`.
- `/agent/jobs/{job_id}/deliver` now rejects late delivery for expired claimed jobs, marks the job expired, and refunds escrow before returning `410`.

Delivered jobs are intentionally left unchanged in this patch to avoid changing the review/dispute flow after a worker has submitted work.

## Validation

```text
python -m pytest tests/test_agent_jobs_query_validation.py -q
18 passed

python -m pytest tests/test_agent_dispute_accept_race.py tests/test_agent_economy_error_redaction.py tests/test_agent_jobs_query_validation.py -q
25 passed

python -m py_compile rip302_agent_economy.py tests/test_agent_jobs_query_validation.py
git diff --check
```
