### PR TITLE
Harden explorer API table rendering

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -479,9 +479,9 @@ function renderBlocksTable() {
     container.innerHTML = state.blocks.map(block => `
         <tr>
             <td><strong class="text-accent">#${formatNumber(block.height, 0)}</strong></td>
-            <td class="mono" title="${escapeHtml(block.hash)}">${shortenHash(block.hash || '0x')}</td>
+            <td class="mono" title="${escapeHtml(block.hash)}">${escapeHtml(shortenHash(block.hash || '0x'))}</td>
             <td class="mono">${formatTimestamp(block.timestamp)}</td>
-            <td><span class="badge badge-info">${block.miners_count || 0} miners</span></td>
+            <td><span class="badge badge-info">${formatNumber(block.miners_count || 0, 0)} miners</span></td>
             <td class="text-success">${formatNumber(block.reward || 0, 2)} RTC</td>
         </tr>
     `).join('');
@@ -515,10 +515,10 @@ function renderTransactionsTable() {
     
     container.innerHTML = state.transactions.map(tx => `
         <tr>
-            <td class="mono" title="${escapeHtml(tx.hash)}">${shortenHash(tx.hash || '0x', 6)}</td>
+            <td class="mono" title="${escapeHtml(tx.hash)}">${escapeHtml(shortenHash(tx.hash || '0x', 6))}</td>
             <td class="mono">${escapeHtml(tx.type || 'transfer')}</td>
-            <td class="mono" title="${escapeHtml(tx.from)}">${shortenAddress(tx.from || '0x')}</td>
-            <td class="mono" title="${escapeHtml(tx.to)}">${shortenAddress(tx.to || '0x')}</td>
+            <td class="mono" title="${escapeHtml(tx.from)}">${escapeHtml(shortenAddress(tx.from || '0x'))}</td>
+            <td class="mono" title="${escapeHtml(tx.to)}">${escapeHtml(shortenAddress(tx.to || '0x'))}</td>
             <td class="text-success">${formatNumber(tx.amount || 0, 6)} RTC</td>
             <td class="mono">${formatRelativeTime(tx.timestamp)}</td>
         </tr>

--- a/tests/test_explorer_miners_normalization.py
+++ b/tests/test_explorer_miners_normalization.py
@@ -71,3 +71,75 @@ console.log(JSON.stringify(result));
     assert data["tier"] == "vintage"
     assert data["number"] == "0"
     assert "Search Results: 1 found" in data["searchHtml"]
+
+
+def test_explorer_escapes_api_values_in_block_and_transaction_tables():
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(JS)};
+const elements = {{}};
+const element = () => ({{
+  innerHTML: '',
+  addEventListener() {{}},
+  dataset: {{}},
+}});
+const context = {{
+  window: {{ EXPLORER_API_BASE: 'https://example.test' }},
+  document: {{
+    addEventListener() {{}},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element();
+      return elements[id];
+    }},
+    querySelectorAll() {{ return []; }},
+  }},
+  setInterval() {{}},
+  setTimeout() {{ return 1; }},
+  clearTimeout() {{}},
+  AbortController: class {{ constructor() {{ this.signal = {{}}; }} abort() {{}} }},
+  fetch: async () => ({{ ok: true, json: async () => ({{}}) }}),
+  console: {{ error() {{}}, warn() {{}}, log() {{}} }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+const payload = '<img src=x onerror=alert(1)>';
+context.payload = payload;
+vm.runInContext(`
+state.loading.blocks = false;
+state.loading.transactions = false;
+state.blocks = [{{
+  height: 7,
+  hash: payload,
+  timestamp: Date.now() / 1000,
+  miners_count: payload,
+  reward: 1
+}}];
+state.transactions = [{{
+  hash: payload,
+  type: payload,
+  from: payload,
+  to: payload,
+  amount: 1,
+  timestamp: Date.now() / 1000
+}}];
+renderBlocksTable();
+renderTransactionsTable();
+`, context);
+console.log(JSON.stringify({{
+  blocksHtml: elements['blocks-tbody'].innerHTML,
+  txHtml: elements['transactions-tbody'].innerHTML,
+}}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert "<img" not in data["blocksHtml"]
+    assert "<img" not in data["txHtml"]
+    assert "&lt;img" in data["blocksHtml"]
+    assert "&lt;img" in data["txHtml"]
+    assert "0 miners" in data["blocksHtml"]


### PR DESCRIPTION
## Summary

Fixes an API-response-injection / DOM-XSS hardening gap in the static explorer tables.

The block and transaction renderers assign API-provided values into `innerHTML` rows. Some values were already escaped, but these visible cells were not:

- displayed block hash from `shortenHash(block.hash)`
- displayed `block.miners_count`
- displayed transaction hash/from/to values from `shortenHash()` / `shortenAddress()`

A malicious or compromised API/proxy response could provide HTML such as `<img src=x onerror=alert(1)>` and have it parsed in the explorer table.

## Changes

- Escape the displayed shortened block hash.
- Numeric-coerce `block.miners_count` through `formatNumber(..., 0)`.
- Escape displayed shortened transaction hash/from/to values.
- Add a Node VM regression test that injects `<img onerror>` into block and transaction payloads and asserts no raw `<img>` reaches the generated table HTML.

## Validation

- `python -m pytest tests/test_explorer_miners_normalization.py -q` -> 4 passed
- `node --check explorer/static/js/explorer.js`
- `git diff --check`

Bounty context: https://github.com/Scottcjn/rustchain-bounties/issues/68
Wallet: `RTC6de503be5fbf1fb3797fd7eddc65dfde9188aa4d`