### PR TITLE
[UTXO-BUG] Preserve legacy genesis balance precision

### DIFF
--- a/node/test_utxo_genesis_migration_units.py
+++ b/node/test_utxo_genesis_migration_units.py
@@ -77,6 +77,53 @@ class TestGenesisMigrationUnits(unittest.TestCase):
         self.assertEqual(db.get_balance("alice"), 10 * UNIT)
         self.assertTrue(result["integrity"]["models_agree"])
 
+    def test_legacy_balance_rtc_fallback_does_not_truncate_real_math(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE balances (
+                miner_pk TEXT PRIMARY KEY,
+                balance_rtc REAL NOT NULL
+            )
+        """)
+        conn.executemany(
+            "INSERT INTO balances VALUES (?, ?)",
+            [
+                ("alice", 0.29),
+                ("bob", 0.58),
+            ],
+        )
+        conn.commit()
+        conn.close()
+
+        balances = load_account_balances(self.db_path)
+        self.assertEqual(balances, [
+            ("alice", 29_000_000),
+            ("bob", 58_000_000),
+        ])
+
+        result = migrate(self.db_path, dry_run=False)
+        db = UtxoDB(self.db_path)
+
+        self.assertEqual(result["total_nrtc"], 87_000_000)
+        self.assertEqual(db.get_balance("alice"), 29_000_000)
+        self.assertEqual(db.get_balance("bob"), 58_000_000)
+        self.assertTrue(result["integrity"]["models_agree"])
+
+    def test_legacy_balance_rtc_fallback_rejects_sub_nrtc_values(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("""
+            CREATE TABLE balances (
+                miner_pk TEXT PRIMARY KEY,
+                balance_rtc REAL NOT NULL
+            )
+        """)
+        conn.execute("INSERT INTO balances VALUES (?, ?)", ("alice", 0.000000001))
+        conn.commit()
+        conn.close()
+
+        with self.assertRaises(ValueError):
+            load_account_balances(self.db_path)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -17,6 +17,7 @@ Rules:
 """
 
 import argparse
+from decimal import Decimal, InvalidOperation
 import hashlib
 import json
 import sqlite3
@@ -31,6 +32,24 @@ GENESIS_TX_PREFIX = "rustchain_genesis:"
 GENESIS_HEIGHT = 0
 ACCOUNT_UNIT = 1_000_000  # Account-model amount_i64 is micro-RTC.
 ACCOUNT_TO_UTXO_SCALE = UNIT // ACCOUNT_UNIT
+
+
+def _legacy_balance_rtc_to_nrtc(value) -> int:
+    """Convert legacy balance_rtc text/REAL to exact nanoRTC units."""
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"invalid legacy balance_rtc value: {value!r}") from exc
+    if not amount.is_finite() or amount <= 0:
+        raise ValueError(f"invalid legacy balance_rtc value: {value!r}")
+    nrtc = amount * UNIT
+    integral = nrtc.to_integral_value()
+    if nrtc != integral:
+        raise ValueError(
+            "legacy balance_rtc has more than 8 decimal places: "
+            f"{value!r}"
+        )
+    return int(integral)
 
 
 def _is_locked_error(exc: Exception) -> bool:
@@ -78,13 +97,15 @@ def load_account_balances(db_path: str, conn=None) -> list:
         # Try alternate column names
         rows = conn.execute(
             """SELECT miner_pk AS miner_id,
-                      CAST(balance_rtc * ? AS INTEGER) AS amount_nrtc
+                      CAST(balance_rtc AS TEXT) AS balance_rtc
                FROM balances
                WHERE balance_rtc > 0
-               ORDER BY miner_pk ASC""",
-            (UNIT,),
+               ORDER BY miner_pk ASC"""
         ).fetchall()
-        return [(r['miner_id'], int(r['amount_nrtc'])) for r in rows]
+        return [
+            (r['miner_id'], _legacy_balance_rtc_to_nrtc(r['balance_rtc']))
+            for r in rows
+        ]
     finally:
         if own:
             conn.close()


### PR DESCRIPTION
## Summary

Fixes a UTXO genesis migration precision bug in the legacy `balance_rtc` fallback path.

When the `balances` table does not expose `amount_i64`, `load_account_balances()` fell back to:

```sql
CAST(balance_rtc * 100000000 AS INTEGER)
```

SQLite `REAL` arithmetic can produce slightly-low binary values, so decimal balances such as `0.29` and `0.58` migrate as `28,999,999` and `57,999,999` nRTC instead of `29,000,000` and `58,000,000`. The migration then computes `total_account` from the same truncated values, so the final integrity check can report `models_agree=True` while the UTXO genesis set silently under-credits holders.

## Impact

This affects the account-to-UTXO genesis migration fallback schema (`miner_pk`, `balance_rtc`). If used, fractional legacy balances can permanently lose nanoRTC during genesis conversion while producing a successful migration result and state root. That is a supply/conservation mismatch at the migration boundary.

## Fix

- Select `CAST(balance_rtc AS TEXT)` instead of multiplying/casting in SQLite.
- Convert with `Decimal` in Python against the UTXO `UNIT`.
- Reject legacy values that are non-finite, non-positive, invalid, or cannot be represented exactly at 8 decimal places.
- Add regressions for `0.29` + `0.58` and sub-nRTC legacy values.

## Verification

- `PYTHONPATH=node /tmp/rustchain6537-py311-venv/bin/python -m compileall -q node/utxo_genesis_migration.py node/test_utxo_genesis_migration_units.py`
- `PYTHONPATH=node /tmp/rustchain6537-py311-venv/bin/python -m unittest node.test_utxo_genesis_migration_units` -> `Ran 4 tests ... OK`
- `PYTHONPATH=node /tmp/rustchain6537-py311-venv/bin/python -m unittest node.test_utxo_db node.test_utxo_genesis_migration_units` -> `Ran 99 tests ... OK`
- Reproducer for the old arithmetic: `sqlite3 ':memory:' "SELECT CAST(0.29 * 100000000 AS INTEGER), CAST(0.58 * 100000000 AS INTEGER);"` -> `28999999|57999999`

Bounty context: rustchain-bounties#2819 genesis migration / conservation issue.

Payout address if accepted: `RTC4730a64f821a590972e8b37781fae5d568b5865c`.
