### PR TITLE
fix(producer): drive duty weights from epoch_enroll — single source of truth (#6463)

### DIFF
--- a/node/rustchain_block_producer.py
+++ b/node/rustchain_block_producer.py
@@ -55,6 +55,7 @@ logger = logging.getLogger(__name__)
 
 GENESIS_TIMESTAMP = 1764706927  # Production chain launch (Dec 2, 2025)
 BLOCK_TIME = 600  # 10 minutes (600 seconds)
+EPOCH_SLOTS = 144  # 24 hours at 10-min blocks
 MAX_TXS_PER_BLOCK = 1000
 ATTESTATION_TTL = 600  # 10 minutes
 MAX_BATCH_BLOCKS = 100
@@ -262,15 +263,56 @@ class BlockProducer:
         if not attested_miners:
             return None
 
-        rotation = self._build_balanced_producer_rotation(attested_miners)
+        epoch = start_slot // max(EPOCH_SLOTS, 1)
+        # #6463: exclude miners with zero epoch_enroll weight from producer duty
+        _db_path = getattr(self, 'db_path', None)
+        active_miners = [
+            m for m in attested_miners
+            if BlockProducer._miner_selection_weight(m, epoch, _db_path) > 0
+        ]
+        rotation = self._build_balanced_producer_rotation(active_miners, epoch, _db_path)
         producer_index = slot % len(rotation)
         return rotation[producer_index]
 
     @staticmethod
-    def _miner_selection_weight(attested_miner) -> float:
-        """Return a bounded producer-selection weight for an attested miner."""
+    def _miner_selection_weight(attested_miner, epoch: Optional[int] = None, db_path: Optional[str] = None) -> float:
+        """Return a bounded producer-selection weight for an attested miner.
+
+        Fix for #6463: the authoritative reward weight lives in epoch_enroll.
+        If a miner has zero enroll weight (e.g. VM/emulator fingerprint fail),
+        their producer-duty weight must also be zero to preserve the
+        single-source-of-truth invariant for hardware weighting.
+
+        Args:
+            attested_miner: (miner_id, arch, device_info) tuple
+            epoch: epoch number (if None, heuristic-only mode)
+            db_path: path to the blockchain DB (if None, heuristic-only mode)
+        """
+        miner_id = attested_miner[0]
         device_info = attested_miner[2] if len(attested_miner) > 2 and attested_miner[2] else {}
 
+        # --- Single source of truth: check epoch_enroll weight first ---
+        if epoch is not None and db_path is not None:
+            try:
+                with sqlite3.connect(db_path) as conn:
+                    row = conn.execute(
+                        "SELECT weight FROM epoch_enroll WHERE epoch = ? AND miner_pk = ?",
+                        (epoch, miner_id),
+                    ).fetchone()
+                    if row is not None:
+                        enroll_weight = row[0]
+                        # Zero enroll weight => zero duty weight (VM/emulator excluded)
+                        if enroll_weight == 0:
+                            return 0.0
+                        # Enroll weight is authoritative — use it directly (bounded)
+                        try:
+                            return min(max(float(enroll_weight), 1.0), 10.0)
+                        except (TypeError, ValueError):
+                            pass  # fall through to heuristic
+            except sqlite3.OperationalError:
+                pass  # epoch_enroll table may not exist in test — fall through
+
+        # --- Fallback: device heuristic (only when no epoch_enroll row exists) ---
         explicit_weight = device_info.get("weight")
         if explicit_weight is not None:
             try:
@@ -292,7 +334,7 @@ class BlockProducer:
         return 1.0
 
     @classmethod
-    def _build_balanced_producer_rotation(cls, attested_miners) -> List[str]:
+    def _build_balanced_producer_rotation(cls, attested_miners, epoch: Optional[int] = None, db_path: Optional[str] = None) -> List[str]:
         """
         Build a deterministic weighted-fair rotation for the active miners.
 
@@ -300,11 +342,18 @@ class BlockProducer:
         miners carry explicit or device-derived weights, the cycle repeats each
         miner proportional to its bounded weight while spreading duties across
         the cycle instead of clustering them.
+
+        Fix for #6463: miners with zero epoch_enroll weight are excluded from
+        the rotation entirely, preserving the single-source-of-truth invariant.
         """
+        # Create a temporary instance to access _miner_selection_weight (needs db_path)
+        # For backward compat with classmethod calls, weight defaults to heuristic
         weighted_miners = [
-            (miner[0], cls._miner_selection_weight(miner))
+            (miner[0], cls._miner_selection_weight(miner, epoch, db_path))
             for miner in attested_miners
         ]
+        # Exclude miners with zero duty weight (VM/emulator with zero enroll weight)
+        weighted_miners = [(mid, w) for mid, w in weighted_miners if w > 0]
         if not weighted_miners:
             return []
 
@@ -330,7 +379,14 @@ class BlockProducer:
         slots = max(1, min(int(slots), 256))
         current_ts = self.get_slot_start_time(start_slot)
         attested_miners = self.get_attested_miners(current_ts)
-        rotation = self._build_balanced_producer_rotation(attested_miners)
+        epoch = start_slot // max(EPOCH_SLOTS, 1)
+        # #6463: exclude miners with zero epoch_enroll weight from producer duty
+        _db_path = getattr(self, 'db_path', None)
+        active_miners = [
+            m for m in attested_miners
+            if BlockProducer._miner_selection_weight(m, epoch, _db_path) > 0
+        ]
+        rotation = self._build_balanced_producer_rotation(active_miners, epoch, _db_path)
 
         duty_counts = {miner[0]: 0 for miner in attested_miners}
         schedule = []

--- a/node/tests/test_block_producer_enroll_weight.py
+++ b/node/tests/test_block_producer_enroll_weight.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for #6463 fix: epoch_enroll weight as single source of truth for producer duty.
+
+Miners with zero epoch_enroll weight (VM/emulator) must get zero duty weight,
+regardless of device heuristics or explicit weight in device_info.
+"""
+
+import hashlib
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import types
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Stub out randomness_beacon
+beacon = types.ModuleType("randomness_beacon")
+GENESIS_RANDOMNESS = "0" * 64
+def build_randomness_record(*a, **kw):
+    return {}
+def verify_randomness_record(*a, **kw):
+    return True
+class BeaconClient:
+    pass
+beacon.GENESIS_RANDOMNESS = GENESIS_RANDOMNESS
+beacon.build_randomness_record = build_randomness_record
+beacon.verify_randomness_record = verify_randomness_record
+beacon.BeaconClient = BeaconClient
+sys.modules["randomness_beacon"] = beacon
+
+# Stub out rustchain_crypto
+crypto = types.ModuleType("rustchain_crypto")
+
+class CanonicalBlockHeader:
+    pass
+
+class MerkleTree:
+    root_hex = "0" * 64
+
+class SignedTransaction:
+    pass
+
+class Ed25519Signer:
+    pass
+
+def canonical_json(obj):
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True).encode()
+
+def blake2b256_hex(data):
+    return hashlib.blake2b(data, digest_size=32).hexdigest()
+
+crypto.CanonicalBlockHeader = CanonicalBlockHeader
+crypto.MerkleTree = MerkleTree
+crypto.SignedTransaction = SignedTransaction
+crypto.Ed25519Signer = Ed25519Signer
+crypto.canonical_json = canonical_json
+crypto.blake2b256_hex = blake2b256_hex
+sys.modules["rustchain_crypto"] = crypto
+
+# Stub out rustchain_tx_handler
+tx_handler = types.ModuleType("rustchain_tx_handler")
+class TransactionPool:
+    pass
+tx_handler.TransactionPool = TransactionPool
+sys.modules["rustchain_tx_handler"] = tx_handler
+
+from rustchain_block_producer import BlockProducer  # noqa: E402
+
+
+def _miner(wallet, arch="modern_x86", **device_info):
+    info = {"arch": arch, "family": "", "model": "", "year": 2025}
+    info.update(device_info)
+    return (wallet, arch, info)
+
+
+def _make_db_with_epoch_enroll(db_path, epoch, enrollments):
+    """Create a DB with epoch_enroll table populated with the given enrollments."""
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS epoch_enroll "
+        "(epoch INTEGER, miner_pk TEXT, weight INTEGER, PRIMARY KEY (epoch, miner_pk))"
+    )
+    for miner_pk, weight in enrollments:
+        conn.execute(
+            "INSERT OR REPLACE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+            (epoch, miner_pk, weight),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_zero_enroll_weight_yields_zero_duty_weight():
+    """Miner with zero epoch_enroll weight must get zero producer duty weight."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        epoch = 1
+        _make_db_with_epoch_enroll(db_path, epoch, [
+            ("alice", 5),
+            ("vm-miner", 0),
+        ])
+
+        alice_weight = BlockProducer._miner_selection_weight(_miner("alice"), epoch=epoch, db_path=db_path)
+        vm_weight = BlockProducer._miner_selection_weight(_miner("vm-miner"), epoch=epoch, db_path=db_path)
+
+        assert alice_weight > 0, f"Alice should have positive duty weight, got {alice_weight}"
+        assert vm_weight == 0.0, f"VM miner with zero enroll weight should have zero duty weight, got {vm_weight}"
+
+
+def test_zero_enroll_weight_excluded_from_rotation():
+    """Miner with zero enroll weight must not appear in the producer rotation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        epoch = 1
+        _make_db_with_epoch_enroll(db_path, epoch, [
+            ("alice", 3),
+            ("vm-miner", 0),
+        ])
+
+        rotation = BlockProducer._build_balanced_producer_rotation(
+            [_miner("alice"), _miner("vm-miner")],
+            epoch=epoch,
+            db_path=db_path,
+        )
+
+        assert "vm-miner" not in rotation, "Zero-enroll-weight miner must not appear in rotation"
+        assert "alice" in rotation, "Normal miner must appear in rotation"
+
+
+def test_enroll_weight_overrides_device_heuristic():
+    """Even if device_info claims high weight, epoch_enroll is authoritative."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        epoch = 1
+        _make_db_with_epoch_enroll(db_path, epoch, [
+            ("g4-miner", 1),
+        ])
+
+        # device heuristic would give 2.5 for G4, but enroll says 1
+        weight = BlockProducer._miner_selection_weight(
+            _miner("g4-miner", "ppc", family="PowerPC G4"),
+            epoch=epoch,
+            db_path=db_path,
+        )
+        assert weight == 1.0, f"Enroll weight (1) should override device heuristic (2.5), got {weight}"
+
+
+def test_fallback_to_heuristic_when_no_enroll_row():
+    """If no epoch_enroll row exists, device heuristic is used as fallback."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        epoch = 99  # no enrollments for this epoch
+        _make_db_with_epoch_enroll(db_path, epoch=1, enrollments=[("someone", 5)])
+
+        weight = BlockProducer._miner_selection_weight(
+            _miner("g4-miner", "ppc", family="PowerPC G4"),
+            epoch=epoch,
+            db_path=db_path,
+        )
+        # No enroll row -> fallback to device heuristic -> G4 = 2.5
+        assert weight == 2.5, f"Expected heuristic fallback weight 2.5, got {weight}"
+
+
+def test_multiple_zero_enroll_miners_all_excluded():
+    """Multiple VM miners with zero enroll weight are all excluded from rotation."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test.db")
+        epoch = 1
+        _make_db_with_epoch_enroll(db_path, epoch, [
+            ("alice", 2),
+            ("vm1", 0),
+            ("vm2", 0),
+            ("bob", 1),
+        ])
+
+        rotation = BlockProducer._build_balanced_producer_rotation(
+            [_miner("alice"), _miner("vm1"), _miner("vm2"), _miner("bob")],
+            epoch=epoch,
+            db_path=db_path,
+        )
+
+        assert "vm1" not in rotation
+        assert "vm2" not in rotation
+        assert "alice" in rotation
+        assert "bob" in rotation
+        assert rotation.count("alice") == 2
+        assert rotation.count("bob") == 1


### PR DESCRIPTION
## Summary

Fix for #6463: post-merge audit of #6218 found that `_miner_selection_weight` uses local device heuristics as a parallel weighting path, diverging from the authoritative `epoch_enroll.weight`.

### Problem
A VM miner or failed-fingerprint miner could be selected as block producer with non-zero duty weight (via device_info or arch heuristics) even when their `epoch_enroll` weight is zero — breaking the single-source-of-truth invariant.

### Fix
1. **`_miner_selection_weight`** now accepts optional `epoch` + `db_path` params. When both provided, it queries `epoch_enroll` first:
   - Zero enroll weight → returns 0.0 (excludes VM/emulator miners)
   - Non-zero enroll weight → uses it as authoritative (bounded 1.0–10.0)
   - No enroll row → falls back to device heuristic (backward compatible)

2. **`_build_balanced_producer_rotation`** accepts optional `db_path` and passes it through, filtering out zero-weight miners.

3. **`get_round_robin_producer`** and **`get_producer_balance_summary`** now filter miners with zero enroll weight before building the rotation.

4. **Backward compatible**: `db_path` defaults to `None`, so existing callers get heuristic-only behavior unchanged.

### Tests (5 new, all pass)
```
test_zero_enroll_weight_yields_zero_duty_weight
test_zero_enroll_weight_excluded_from_rotation  
test_enroll_weight_overrides_device_heuristic
test_fallback_to_heuristic_when_no_enroll_row
test_multiple_zero_enroll_miners_all_excluded
```

All 4 existing tests in `test_block_producer_balancing.py` continue to pass.

### Bounty
10 RTC (Medium, consensus-adjacent invariant) per #6463