### PR TITLE
fix: populate pyproject.toml with project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.backends._legacy:_Backend"
+
+[project]
+name = "rustchain"
+version = "0.1.0"
+description = "DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.10"
+authors = [
+    { name = "RustChain Contributors" },
+]
+keywords = [
+    "blockchain",
+    "depin",
+    "proof-of-antiquity",
+    "vintage-hardware",
+    "ai",
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "flask>=3.1.3",
+    "requests>=2.34.2",
+    "aiohttp>=3.13.5",
+    "cryptography>=46.0.7",
+    "PyNaCl>=1.6.2",
+    "PyYAML>=6.0.1",
+    "Flask-Cors>=4.0.0",
+    "mnemonic>=0.21",
+    "pycryptodome>=3.20.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9.0.3",
+    "matplotlib>=3.10.9",
+    "seaborn>=0.13.2",
+]
+
+[project.urls]
+Homepage = "https://github.com/Scottcjn/Rustchain"
+Repository = "https://github.com/Scottcjn/Rustchain"
+Issues = "https://github.com/Scottcjn/Rustchain/issues"
+Explorer = "https://rustchain.org/explorer/"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
+exclude = ["tests*", "benchmarks*", "audits*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68.0", "wheel"]
-build-backend = "setuptools.backends._legacy:_Backend"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "rustchain"


### PR DESCRIPTION
## Summary

The `pyproject.toml` was empty (0 bytes), causing `pip install -e .` to fail with a build-system discovery error. This PR populates it with proper project metadata.

### Changes

- **[build-system]**: Added setuptools backend with required dependencies
- **[project]**: Added name, version, description, license (Apache-2.0), Python version requirement
- **Dependencies**: Migrated all dependencies from `requirements.txt` to `pyproject.toml`
- **Optional deps**: Added `[dev]` group with pytest, matplotlib, seaborn
- **Project URLs**: Homepage, repository, issues, explorer
- **pytest config**: Added test paths and file patterns

### Verification

```bash
# The pyproject.toml is now valid TOML
python3 -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"

# pip install -e . should now work
pip install -e .
```

Closes #6551