### PR TITLE
Prevent governance proposal nonce replay

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6153,10 +6153,12 @@ def governance_propose():
         conn.row_factory = sqlite3.Row
         c = conn.cursor()
         _ensure_governance_tables(c)
+        conn.execute("BEGIN IMMEDIATE")
 
         balance_i64 = _balance_i64_for_wallet(c, proposer_wallet)
         balance_rtc = balance_i64 / 1_000_000.0
         if balance_rtc <= GOVERNANCE_MIN_PROPOSER_BALANCE_RTC:
+            conn.rollback()
             return jsonify({
                 "ok": False,
                 "error": "insufficient_balance_to_propose",
@@ -6165,6 +6167,14 @@ def governance_propose():
             }), 403
 
         now = int(time.time())
+        if not _reserve_governance_nonce(c, proposer_wallet, nonce, now):
+            conn.rollback()
+            return jsonify({
+                "ok": False,
+                "error": "nonce_already_used",
+                "nonce": nonce,
+            }), 409
+
         ends_at = now + GOVERNANCE_ACTIVE_SECONDS
         c.execute(
             """
@@ -9156,6 +9166,25 @@ def _ensure_governance_tables(c: sqlite3.Cursor) -> None:
             FOREIGN KEY (proposal_id) REFERENCES governance_proposals(id)
         )
     """)
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS governance_nonces (
+            wallet TEXT NOT NULL,
+            nonce TEXT NOT NULL,
+            used_at INTEGER NOT NULL,
+            PRIMARY KEY (wallet, nonce)
+        )
+    """)
+
+
+def _reserve_governance_nonce(c: sqlite3.Cursor, wallet: str, nonce: str, used_at: int) -> bool:
+    c.execute(
+        """
+        INSERT OR IGNORE INTO governance_nonces (wallet, nonce, used_at)
+        VALUES (?, ?, ?)
+        """,
+        (wallet, nonce, used_at),
+    )
+    return c.rowcount == 1
 
 
 def _get_active_miner_antiquity_multiplier(c: sqlite3.Cursor, wallet: str):

--- a/node/tests/test_integrated_governance_propose_nonce_replay.py
+++ b/node/tests/test_integrated_governance_propose_nonce_replay.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+
+
+def load_integrated_module(db_path: str, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key-" + "0" * 32)
+    monkeypatch.setenv("RUSTCHAIN_DB_PATH", db_path)
+    monkeypatch.syspath_prepend(str(NODE_DIR))
+    sys.modules.pop("payout_preflight", None)
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_integrated_governance_propose_nonce_test",
+        MODULE_PATH,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.DB_PATH = db_path
+    module.app.config["DB_PATH"] = db_path
+    module.app.config["TESTING"] = True
+    return module
+
+
+def test_governance_propose_rejects_replayed_nonce(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = str(Path(tmpdir) / "governance.db")
+        mod = load_integrated_module(db_path, monkeypatch)
+
+        monkeypatch.setattr(mod, "verify_rtc_signature", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(mod, "address_from_pubkey", lambda _public_key: "RTCwallet")
+
+        conn = sqlite3.connect(db_path)
+        try:
+            cur = conn.cursor()
+            mod._ensure_governance_tables(cur)
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+            )
+            conn.execute("INSERT INTO balances VALUES ('RTCwallet', 11000000)")
+            conn.commit()
+        finally:
+            conn.close()
+
+        payload = {
+            "wallet": "RTCwallet",
+            "title": "Replay protected proposal",
+            "description": "This signed proposal must only be accepted once.",
+            "nonce": "proposal-nonce-1",
+            "signature": "aa" * 64,
+            "public_key": "bb" * 32,
+        }
+
+        with mod.app.test_client() as client:
+            first = client.post("/governance/propose", json=payload)
+            replay = client.post("/governance/propose", json=payload)
+
+        assert first.status_code == 201
+        assert replay.status_code == 409
+        assert replay.get_json() == {
+            "ok": False,
+            "error": "nonce_already_used",
+            "nonce": "proposal-nonce-1",
+        }
+
+        conn = sqlite3.connect(db_path)
+        try:
+            proposal_count = conn.execute("SELECT COUNT(*) FROM governance_proposals").fetchone()[0]
+            nonce_count = conn.execute(
+                "SELECT COUNT(*) FROM governance_nonces WHERE wallet = ? AND nonce = ?",
+                ("RTCwallet", "proposal-nonce-1"),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        assert proposal_count == 1
+        assert nonce_count == 1

--- a/node/tests/test_integrated_governance_propose_nonce_replay.py
+++ b/node/tests/test_integrated_governance_propose_nonce_replay.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import importlib.util
+import gc
 import sqlite3
 import sys
 import tempfile
@@ -8,6 +9,7 @@ from pathlib import Path
 
 NODE_DIR = Path(__file__).resolve().parents[1]
 MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+MODULE_NAME = "rustchain_integrated_governance_propose_nonce_test"
 
 
 def load_integrated_module(db_path: str, monkeypatch):
@@ -16,10 +18,11 @@ def load_integrated_module(db_path: str, monkeypatch):
     monkeypatch.syspath_prepend(str(NODE_DIR))
     sys.modules.pop("payout_preflight", None)
     spec = importlib.util.spec_from_file_location(
-        "rustchain_integrated_governance_propose_nonce_test",
+        MODULE_NAME,
         MODULE_PATH,
     )
     module = importlib.util.module_from_spec(spec)
+    sys.modules[MODULE_NAME] = module
     spec.loader.exec_module(module)
     module.DB_PATH = db_path
     module.app.config["DB_PATH"] = db_path
@@ -28,55 +31,66 @@ def load_integrated_module(db_path: str, monkeypatch):
 
 
 def test_governance_propose_rejects_replayed_nonce(monkeypatch):
-    with tempfile.TemporaryDirectory() as tmpdir:
-        db_path = str(Path(tmpdir) / "governance.db")
+    tempdir = tempfile.TemporaryDirectory()
+    try:
+        db_path = str(Path(tempdir.name) / "governance.db")
         mod = load_integrated_module(db_path, monkeypatch)
-
-        monkeypatch.setattr(mod, "verify_rtc_signature", lambda *_args, **_kwargs: True)
-        monkeypatch.setattr(mod, "address_from_pubkey", lambda _public_key: "RTCwallet")
-
-        conn = sqlite3.connect(db_path)
         try:
-            cur = conn.cursor()
-            mod._ensure_governance_tables(cur)
-            conn.execute(
-                "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
-            )
-            conn.execute("INSERT INTO balances VALUES ('RTCwallet', 11000000)")
-            conn.commit()
+            monkeypatch.setattr(mod, "verify_rtc_signature", lambda *_args, **_kwargs: True)
+            monkeypatch.setattr(mod, "address_from_pubkey", lambda _public_key: "RTCwallet")
+
+            conn = sqlite3.connect(db_path)
+            try:
+                cur = conn.cursor()
+                mod._ensure_governance_tables(cur)
+                conn.execute(
+                    "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+                )
+                conn.execute("INSERT INTO balances VALUES ('RTCwallet', 11000000)")
+                conn.commit()
+            finally:
+                conn.close()
+
+            payload = {
+                "wallet": "RTCwallet",
+                "title": "Replay protected proposal",
+                "description": "This signed proposal must only be accepted once.",
+                "nonce": "proposal-nonce-1",
+                "signature": "aa" * 64,
+                "public_key": "bb" * 32,
+            }
+
+            with mod.app.test_client() as client:
+                first = client.post("/governance/propose", json=payload)
+                replay = client.post("/governance/propose", json=payload)
+
+            assert first.status_code == 201
+            assert replay.status_code == 409
+            assert replay.get_json() == {
+                "ok": False,
+                "error": "nonce_already_used",
+                "nonce": "proposal-nonce-1",
+            }
+
+            conn = sqlite3.connect(db_path)
+            try:
+                proposal_count = conn.execute("SELECT COUNT(*) FROM governance_proposals").fetchone()[0]
+                nonce_count = conn.execute(
+                    "SELECT COUNT(*) FROM governance_nonces WHERE wallet = ? AND nonce = ?",
+                    ("RTCwallet", "proposal-nonce-1"),
+                ).fetchone()[0]
+            finally:
+                conn.close()
+
+            assert proposal_count == 1
+            assert nonce_count == 1
         finally:
-            conn.close()
-
-        payload = {
-            "wallet": "RTCwallet",
-            "title": "Replay protected proposal",
-            "description": "This signed proposal must only be accepted once.",
-            "nonce": "proposal-nonce-1",
-            "signature": "aa" * 64,
-            "public_key": "bb" * 32,
-        }
-
-        with mod.app.test_client() as client:
-            first = client.post("/governance/propose", json=payload)
-            replay = client.post("/governance/propose", json=payload)
-
-        assert first.status_code == 201
-        assert replay.status_code == 409
-        assert replay.get_json() == {
-            "ok": False,
-            "error": "nonce_already_used",
-            "nonce": "proposal-nonce-1",
-        }
-
-        conn = sqlite3.connect(db_path)
+            sys.modules.pop(MODULE_NAME, None)
+            mod = None
+            gc.collect()
+    finally:
+        gc.collect()
         try:
-            proposal_count = conn.execute("SELECT COUNT(*) FROM governance_proposals").fetchone()[0]
-            nonce_count = conn.execute(
-                "SELECT COUNT(*) FROM governance_nonces WHERE wallet = ? AND nonce = ?",
-                ("RTCwallet", "proposal-nonce-1"),
-            ).fetchone()[0]
-        finally:
-            conn.close()
-
-        assert proposal_count == 1
-        assert nonce_count == 1
+            tempdir.cleanup()
+        except OSError:
+            pass


### PR DESCRIPTION
## Summary
- add a `governance_nonces` table keyed by `(wallet, nonce)`
- reserve proposal nonces inside the proposal creation transaction with `BEGIN IMMEDIATE`
- reject replayed signed `/governance/propose` payloads with `409 nonce_already_used` before inserting duplicate proposals
- add an integrated regression test that submits the same signed proposal twice and verifies only one proposal/nonce row is stored

Fixes #6553.

## Tests
- `/tmp/rustchain-test-venv/bin/python -B -m pytest -q node/tests/test_integrated_governance_propose_nonce_replay.py --tb=short`
- `/tmp/rustchain-test-venv/bin/python -B -m pytest -q node/tests/test_integrated_governance_vote_race.py --tb=short`
- `/tmp/rustchain-test-venv/bin/python -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_governance_propose_nonce_replay.py`
- `git diff --check`

Bounty: claiming the 25 RTC medium-tier fix listed in #6553. Payout address can be provided by the account owner if accepted; otherwise reserve at `github:gaoaaa52-del` per the issue instructions.

RTC wallet / miner ID: `gaoaaa52-del`
