### PR TITLE
fix(gpu): add admin auth to 3 unauthenticated GET endpoints

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -32,6 +32,7 @@ import hmac
 import math
 import secrets
 from functools import wraps
+from flask import request
 
 logger = logging.getLogger("gpu_render_protocol")
 
@@ -44,6 +45,17 @@ def _normalize_job_type(job_type):
         return None
     normalized = job_type.strip().lower()
     return normalized if normalized in VALID_JOB_TYPES else None
+
+
+def _admin_key_required():
+    """Return (None, None) on success or (error_dict, status_code) on failure."""
+    admin_key = os.environ.get("RC_ADMIN_KEY", "")
+    if not admin_key:
+        return {'error': 'RC_ADMIN_KEY not configured — endpoint disabled'}, 503
+    provided_key = request.headers.get("X-Admin-Key", "")
+    if not hmac.compare_digest(provided_key, admin_key):
+        return {'error': 'Unauthorized — admin key required'}, 401
+    return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -574,6 +586,9 @@ def register_routes(app):
 
     @app.route("/gpu/nodes", methods=["GET"])
     def gpu_nodes():
+        err, status = _admin_key_required()
+        if err is not None:
+            return jsonify(err), status
         job_type = request.args.get("job_type")
         device_arch = request.args.get("device_arch")
         nodes = protocol.list_gpu_nodes(job_type, device_arch)
@@ -667,12 +682,18 @@ def register_routes(app):
 
     @app.route("/render/escrow/<job_id>", methods=["GET"])
     def get_escrow(job_id):
+        err, status = _admin_key_required()
+        if err is not None:
+            return jsonify(err), status
         result = protocol.get_escrow(job_id)
         status_code = 200 if "error" not in result else 404
         return jsonify(result), status_code
 
     @app.route("/render/pricing", methods=["GET"])
     def get_pricing():
+        err, status = _admin_key_required()
+        if err is not None:
+            return jsonify(err), status
         job_type = request.args.get("job_type")
         result = protocol.get_fair_market_rates(job_type)
         return jsonify(result)


### PR DESCRIPTION
## Summary

Three GPU Render Protocol GET endpoints were accessible without authentication, exposing sensitive financial and infrastructure data.

## Vulnerabilities Fixed

### 1. GET /gpu/nodes — GPU Infrastructure Reconnaissance (MEDIUM)

**Severity:** MEDIUM

**Exposure:** Full GPU hardware fingerprints, benchmark scores, pricing rates, supported models, attestation timestamps, and device architectures were returned to any unauthenticated caller.

**Impact:** Attackers could enumerate all active GPU providers, their hardware specs, and pricing without authorization.

**Fix:** Added `RC_ADMIN_KEY` / `X-Admin-Key` auth check at the top of the handler.

### 2. GET /render/escrow/<job_id> — Escrow Financial Surveillance (MEDIUM)

**Severity:** MEDIUM

**Exposure:** All escrowed render jobs exposed `from_wallet`, `to_wallet`, `amount_rtc`, `job_type`, and internal metadata to any caller.

**Impact:** Real-time monitoring of GPU compute escrow activity, including which wallets are paying for what jobs.

**Fix:** Added admin key auth check. Returns 401/503 when key is missing or invalid.

### 3. GET /render/pricing — Fair Market Rate Intelligence (LOW/MEDIUM)

**Severity:** MEDIUM

**Exposure:** Fair market rates (avg/min/max pricing per job type) across all active GPU providers exposed without auth.

**Impact:** Competitors could scrape pricing data without any commitment or relationship.

**Fix:** Added admin key auth check.

## Changes

- Added `_admin_key_required()` helper (tuple return: error_dict+status or None+None)
- Added `from flask import request` to module imports
- Applied auth check to `gpu_nodes()`, `get_escrow()`, and `get_pricing()` route handlers

## Testing

```bash
# Without key — should return 401
curl http://localhost:PORT/gpu/nodes
# → {"error": "Unauthorized — admin key required"}

# With key — should return data
curl -H "X-Admin-Key: $RC_ADMIN_KEY" http://localhost:PORT/gpu/nodes
# → {"nodes": [...], "count": N}
```

## Bounty

Bounty #73 — Code Review | Wallet: `RTC6d1f27d28961279f1034d9561c2403697eb55602`