### PR TITLE
Fix agent claimed job expiry refund race

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -298,6 +298,29 @@ def register_agent_economy(app: Flask, db_path: str):
 
     init_agent_economy_tables(db_path)
 
+    def _expire_refundable_job(c: sqlite3.Cursor, job: dict, now: int) -> bool:
+        """Expire an open/claimed job past TTL and refund escrow once."""
+        if job["status"] not in (STATUS_OPEN, STATUS_CLAIMED):
+            return False
+        if int(job["expires_at"]) >= now:
+            return False
+
+        c.execute("""
+            UPDATE agent_jobs
+            SET status = ?
+            WHERE job_id = ?
+              AND status IN (?, ?)
+              AND expires_at < ?
+        """, (STATUS_EXPIRED, job["job_id"], STATUS_OPEN, STATUS_CLAIMED, now))
+        if c.rowcount == 0:
+            return False
+
+        _refund_escrow(c, job)
+        _update_reputation(c, job["poster_wallet"], "jobs_expired")
+        _log_job_action(c, job["job_id"], "expired", job["poster_wallet"],
+                       f"status={job['status']}")
+        return True
+
     # -----------------------------------------------------------------------
     # POST /agent/jobs — Create a new job (locks escrow)
     # -----------------------------------------------------------------------
@@ -444,10 +467,7 @@ def register_agent_economy(app: Flask, db_path: str):
 
             now = int(time.time())
             if now > j["expires_at"]:
-                # Auto-expire
-                c.execute("UPDATE agent_jobs SET status = 'expired' WHERE job_id = ?",
-                         (job_id,))
-                _refund_escrow(c, j)
+                _expire_refundable_job(c, j, now)
                 conn.commit()
                 return jsonify({"error": "Job has expired"}), 410
 
@@ -515,12 +535,23 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Only the assigned worker can deliver"}), 403
 
             now = int(time.time())
+            if now > j["expires_at"]:
+                _expire_refundable_job(c, j, now)
+                conn.commit()
+                return jsonify({"error": "Job has expired"}), 410
+
             c.execute("""
                 UPDATE agent_jobs
                 SET status = 'delivered', deliverable_url = ?,
                     deliverable_hash = ?, result_summary = ?, delivered_at = ?
-                WHERE job_id = ?
-            """, (deliverable_url, deliverable_hash, result_summary, now, job_id))
+                WHERE job_id = ? AND status = ?
+            """, (deliverable_url, deliverable_hash, result_summary, now, job_id, STATUS_CLAIMED))
+            if c.rowcount == 0:
+                conn.rollback()
+                return jsonify({
+                    "error": "Job state changed under concurrent request — please retry",
+                    "code": "STATE_RACE",
+                }), 409
 
             _log_job_action(c, job_id, "delivered", worker,
                            f"url={deliverable_url}")
@@ -744,6 +775,23 @@ def register_agent_economy(app: Flask, db_path: str):
             if j["poster_wallet"] != poster:
                 return jsonify({"error": "Only the poster can cancel"}), 403
 
+            now = int(time.time())
+            if j["status"] == STATUS_CLAIMED and now > j["expires_at"]:
+                if _expire_refundable_job(c, j, now):
+                    conn.commit()
+                    return jsonify({
+                        "ok": True,
+                        "job_id": job_id,
+                        "status": STATUS_EXPIRED,
+                        "refunded_rtc": j["escrow_i64"] / 1000000,
+                        "message": "Job expired. Escrow refunded."
+                    })
+                conn.rollback()
+                return jsonify({
+                    "error": "Job state changed under concurrent request — please retry",
+                    "code": "STATE_RACE",
+                }), 409
+
             if j["status"] not in (STATUS_OPEN, STATUS_DISPUTED):
                 return jsonify({
                     "error": f"Can only cancel open or disputed jobs (current: {j['status']})"
@@ -808,16 +856,12 @@ def register_agent_economy(app: Flask, db_path: str):
             # Expire old jobs first
             now = int(time.time())
             expired = c.execute("""
-                SELECT job_id, poster_wallet, escrow_i64, platform_fee_i64, reward_i64
+                SELECT *
                 FROM agent_jobs
-                WHERE status = 'open' AND expires_at < ?
-            """, (now,)).fetchall()
+                WHERE status IN (?, ?) AND expires_at < ?
+            """, (STATUS_OPEN, STATUS_CLAIMED, now)).fetchall()
             for ej in expired:
-                _adjust_balance(c, ESCROW_WALLET, -ej["escrow_i64"])
-                _adjust_balance(c, ej["poster_wallet"], ej["escrow_i64"])
-                c.execute("UPDATE agent_jobs SET status = 'expired' WHERE job_id = ?",
-                         (ej["job_id"],))
-                _update_reputation(c, ej["poster_wallet"], "jobs_expired")
+                _expire_refundable_job(c, dict(ej), now)
             if expired:
                 conn.commit()
 
@@ -870,6 +914,13 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Job not found"}), 404
 
             j = dict(job)
+
+            now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                job = c.execute("SELECT * FROM agent_jobs WHERE job_id = ?",
+                               (job_id,)).fetchone()
+                j = dict(job)
 
             # Get activity log
             log_rows = c.execute("""

--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -467,9 +467,14 @@ def register_agent_economy(app: Flask, db_path: str):
 
             now = int(time.time())
             if now > j["expires_at"]:
-                _expire_refundable_job(c, j, now)
-                conn.commit()
-                return jsonify({"error": "Job has expired"}), 410
+                if _expire_refundable_job(c, j, now):
+                    conn.commit()
+                    return jsonify({"error": "Job has expired"}), 410
+                conn.rollback()
+                return jsonify({
+                    "error": "Job state changed under concurrent request — please retry",
+                    "code": "STATE_RACE",
+                }), 409
 
             # Claim it
             c.execute("""
@@ -536,9 +541,14 @@ def register_agent_economy(app: Flask, db_path: str):
 
             now = int(time.time())
             if now > j["expires_at"]:
-                _expire_refundable_job(c, j, now)
-                conn.commit()
-                return jsonify({"error": "Job has expired"}), 410
+                if _expire_refundable_job(c, j, now):
+                    conn.commit()
+                    return jsonify({"error": "Job has expired"}), 410
+                conn.rollback()
+                return jsonify({
+                    "error": "Job state changed under concurrent request — please retry",
+                    "code": "STATE_RACE",
+                }), 409
 
             c.execute("""
                 UPDATE agent_jobs

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -130,6 +130,14 @@ def _balance(db_path: Path, wallet: str) -> int:
     return row[0] if row else 0
 
 
+def _balance_with_connect(connect, db_path: Path, wallet: str) -> int:
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?", (wallet,)
+        ).fetchone()
+    return row[0] if row else 0
+
+
 def _create_claimed_job(client):
     post = client.post(
         "/agent/jobs",
@@ -146,6 +154,19 @@ def _create_claimed_job(client):
     )
     assert claim.status_code == 200
     return job_id
+
+
+def _create_open_job(client):
+    post = client.post(
+        "/agent/jobs",
+        json=_valid_job_payload(
+            title="Build open expiry refund",
+            description="Build a complete open expiry refund regression test.",
+            ttl_seconds=3600,
+        ),
+    )
+    assert post.status_code == 201
+    return post.get_json()["job_id"]
 
 
 def _expire_job(db_path: Path, job_id: str):
@@ -215,6 +236,113 @@ def test_worker_cannot_deliver_after_claimed_job_expires(tmp_path):
     assert _balance(db_path, "worker-1") == 0
     assert _balance(db_path, "founder_community") == 0
     assert _balance(db_path, "agent_escrow") == 0
+
+
+def test_claim_returns_state_race_if_expiry_refund_loses_status_race(
+    tmp_path, monkeypatch
+):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_open_job(client)
+    _expire_job(db_path, job_id)
+
+    real_connect = sqlite3.connect
+
+    class RacingCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def execute(self, sql, params=()):
+            normalized = " ".join(sql.split())
+            if normalized.startswith("UPDATE agent_jobs SET status = ?"):
+                with real_connect(db_path) as conn:
+                    conn.execute(
+                        "UPDATE agent_jobs SET status = ? WHERE job_id = ?",
+                        ("cancelled", job_id),
+                    )
+            return self._cursor.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class RacingConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def cursor(self, *args, **kwargs):
+            return RacingCursor(self._conn.cursor(*args, **kwargs))
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    def racing_connect(*args, **kwargs):
+        return RacingConnection(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr(rip302_agent_economy.sqlite3, "connect", racing_connect)
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "STATE_RACE"
+    assert _balance_with_connect(real_connect, db_path, "poster-1") == 950_000
+    assert _balance_with_connect(real_connect, db_path, "agent_escrow") == 1_050_000
+
+
+def test_deliver_returns_state_race_if_expiry_refund_loses_status_race(
+    tmp_path, monkeypatch
+):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_claimed_job(client)
+    _expire_job(db_path, job_id)
+
+    real_connect = sqlite3.connect
+
+    class RacingCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def execute(self, sql, params=()):
+            normalized = " ".join(sql.split())
+            if normalized.startswith("UPDATE agent_jobs SET status = ?"):
+                with real_connect(db_path) as conn:
+                    conn.execute(
+                        "UPDATE agent_jobs SET status = ? WHERE job_id = ?",
+                        ("delivered", job_id),
+                    )
+            return self._cursor.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class RacingConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def cursor(self, *args, **kwargs):
+            return RacingCursor(self._conn.cursor(*args, **kwargs))
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    def racing_connect(*args, **kwargs):
+        return RacingConnection(real_connect(*args, **kwargs))
+
+    monkeypatch.setattr(rip302_agent_economy.sqlite3, "connect", racing_connect)
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/deliver",
+        json={"worker_wallet": "worker-1", "result_summary": "late work"},
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["code"] == "STATE_RACE"
+    assert _balance_with_connect(real_connect, db_path, "poster-1") == 950_000
+    assert _balance_with_connect(real_connect, db_path, "worker-1") == 0
+    assert _balance_with_connect(real_connect, db_path, "founder_community") == 0
+    assert _balance_with_connect(real_connect, db_path, "agent_escrow") == 1_050_000
 
 
 def test_stale_deliver_cannot_resurrect_refunded_expired_job(

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+import sqlite3
+import threading
 
 import pytest
 from flask import Flask
 
+import rip302_agent_economy
 from rip302_agent_economy import register_agent_economy
 
 
@@ -102,3 +105,197 @@ def test_agent_job_post_rejects_invalid_ttl_values(tmp_path, ttl):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def _make_funded_client(tmp_path: Path):
+    db_path = tmp_path / "agent_jobs.db"
+    app = Flask(__name__)
+    register_agent_economy(app, str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("poster-1", 2_000_000),
+        )
+    return app, db_path
+
+
+def _balance(db_path: Path, wallet: str) -> int:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?", (wallet,)
+        ).fetchone()
+    return row[0] if row else 0
+
+
+def _create_claimed_job(client):
+    post = client.post(
+        "/agent/jobs",
+        json=_valid_job_payload(
+            title="Build expiry refund",
+            description="Build a complete expiry refund regression test.",
+            ttl_seconds=3600,
+        ),
+    )
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    claim = client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    )
+    assert claim.status_code == 200
+    return job_id
+
+
+def _expire_job(db_path: Path, job_id: str):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (1, job_id),
+        )
+
+
+def test_claimed_expired_job_is_refunded_and_removed_from_claimed_listing(tmp_path):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_claimed_job(client)
+    _expire_job(db_path, job_id)
+
+    response = client.get("/agent/jobs?status=claimed")
+
+    assert response.status_code == 200
+    assert response.get_json()["jobs"] == []
+    with sqlite3.connect(db_path) as conn:
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert _balance(db_path, "poster-1") == 2_000_000
+    assert _balance(db_path, "agent_escrow") == 0
+
+
+def test_detail_and_cancel_refund_expired_claimed_job_once(tmp_path):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_claimed_job(client)
+    _expire_job(db_path, job_id)
+
+    detail = client.get(f"/agent/jobs/{job_id}")
+    cancel = client.post(
+        f"/agent/jobs/{job_id}/cancel", json={"poster_wallet": "poster-1"}
+    )
+
+    assert detail.status_code == 200
+    assert detail.get_json()["job"]["status"] == "expired"
+    assert cancel.status_code == 409
+    assert _balance(db_path, "poster-1") == 2_000_000
+    assert _balance(db_path, "agent_escrow") == 0
+
+
+def test_worker_cannot_deliver_after_claimed_job_expires(tmp_path):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_claimed_job(client)
+    _expire_job(db_path, job_id)
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/deliver",
+        json={"worker_wallet": "worker-1", "result_summary": "late work"},
+    )
+
+    assert response.status_code == 410
+    assert response.get_json() == {"error": "Job has expired"}
+    with sqlite3.connect(db_path) as conn:
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert _balance(db_path, "poster-1") == 2_000_000
+    assert _balance(db_path, "worker-1") == 0
+    assert _balance(db_path, "founder_community") == 0
+    assert _balance(db_path, "agent_escrow") == 0
+
+
+def test_stale_deliver_cannot_resurrect_refunded_expired_job(
+    tmp_path, monkeypatch
+):
+    app, db_path = _make_funded_client(tmp_path)
+    client = app.test_client()
+    job_id = _create_claimed_job(client)
+
+    real_connect = sqlite3.connect
+    deliver_about_to_write = threading.Event()
+    listing_finished = threading.Event()
+
+    class DelayedCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def execute(self, sql, params=()):
+            normalized = " ".join(sql.split())
+            if normalized.startswith("UPDATE agent_jobs SET status = 'delivered'"):
+                deliver_about_to_write.set()
+                assert listing_finished.wait(timeout=5)
+            return self._cursor.execute(sql, params)
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class DelayedConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def cursor(self, *args, **kwargs):
+            return DelayedCursor(self._conn.cursor(*args, **kwargs))
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    def delayed_connect(*args, **kwargs):
+        conn = real_connect(*args, **kwargs)
+        if threading.current_thread().name == "stale-deliver":
+            return DelayedConnection(conn)
+        return conn
+
+    monkeypatch.setattr(rip302_agent_economy.sqlite3, "connect", delayed_connect)
+
+    deliver_response = {}
+
+    def deliver_with_stale_read():
+        with app.test_client() as stale_client:
+            deliver_response["response"] = stale_client.post(
+                f"/agent/jobs/{job_id}/deliver",
+                json={"worker_wallet": "worker-1", "result_summary": "late work"},
+            )
+
+    deliver_thread = threading.Thread(
+        target=deliver_with_stale_read, name="stale-deliver"
+    )
+    deliver_thread.start()
+
+    assert deliver_about_to_write.wait(timeout=5)
+    _expire_job(db_path, job_id)
+    listing = client.get("/agent/jobs?status=claimed")
+    assert listing.status_code == 200
+    listing_finished.set()
+    deliver_thread.join(timeout=5)
+    assert not deliver_thread.is_alive()
+
+    assert deliver_response["response"].status_code == 409
+    assert deliver_response["response"].get_json()["code"] == "STATE_RACE"
+
+    accept = client.post(
+        f"/agent/jobs/{job_id}/accept", json={"poster_wallet": "poster-1"}
+    )
+    assert accept.status_code == 409
+
+    with sqlite3.connect(db_path) as conn:
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert _balance(db_path, "poster-1") == 2_000_000
+    assert _balance(db_path, "worker-1") == 0
+    assert _balance(db_path, "founder_community") == 0
+    assert _balance(db_path, "agent_escrow") == 0


### PR DESCRIPTION
## Summary

Fixes #6556.

This is the clean follow-up for the claimed-agent-job TTL escrow lockup without the stale-deliver resurrection regression from #6539.

Changes:
- Adds a guarded `_expire_refundable_job(...)` helper for open/claimed jobs past TTL. It moves the job to `expired` first with a status/TTL guarded `UPDATE`, then refunds escrow only if that transition wins.
- Expands expiry coverage from open-only listing cleanup to claimed jobs as well, plus direct job detail, poster cancel, and late worker deliver paths.
- Hardens `/agent/jobs/<job_id>/deliver` with `AND status = 'claimed'` plus a `rowcount` conflict check, so a stale worker request cannot resurrect a job that was just expired/refunded by another route.
- Adds regression coverage for list/detail/cancel/deliver expiry and the specific stale-deliver-vs-listing race called out in #6556.

## Validation

- `/tmp/rustchain-test-venv/bin/python -B -m pytest -q tests/test_agent_jobs_query_validation.py --tb=short` -> 20 passed
- `/tmp/rustchain-test-venv/bin/python -B -m pytest -q tests/test_agent_dispute_accept_race.py tests/test_agent_economy_error_redaction.py tests/test_agent_jobs_query_validation.py --tb=short` -> 27 passed
- `/tmp/rustchain-test-venv/bin/python -B -m py_compile rip302_agent_economy.py tests/test_agent_jobs_query_validation.py` -> passed
- `git diff --check -- rip302_agent_economy.py tests/test_agent_jobs_query_validation.py` -> passed

RTC wallet / miner ID: `gaoaaa52-del`
