### PR TITLE
Require admin key for GPU protocol attestation writes

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -542,11 +542,23 @@ def register_routes(app):
         data[name] = value
         return None
 
+    def _require_admin_key():
+        expected = os.environ.get("RC_ADMIN_KEY", "").strip()
+        if not expected:
+            return jsonify({"error": "RC_ADMIN_KEY not configured"}), 503
+        provided = (request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or "").strip()
+        if not provided or not hmac.compare_digest(provided, expected):
+            return jsonify({"error": "Unauthorized - admin key required"}), 401
+        return None
+
     @app.route("/gpu/attest", methods=["POST"])
     def gpu_attest():
         data, error_response = _json_object_body()
         if error_response is not None:
             return error_response
+        auth_error = _require_admin_key()
+        if auth_error is not None:
+            return auth_error
         data = dict(data)
         miner_id, error_response = _string_field(data, "miner_id")
         if error_response is not None:

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -287,9 +287,11 @@ def test_gpu_protocol_pricing_check_rejects_boolean_price(tmp_path, monkeypatch)
 
 
 def test_gpu_protocol_pricing_check_normalizes_job_type(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
     client = _route_client(tmp_path, monkeypatch)
     client.post(
         "/gpu/attest",
+        headers={"X-Admin-Key": "test-admin-key"},
         json={
             "miner_id": "miner-1",
             "gpu_model": "RTX 4090",
@@ -307,6 +309,68 @@ def test_gpu_protocol_pricing_check_normalizes_job_type(tmp_path, monkeypatch):
     assert response.status_code == 200
     assert response.get_json()["manipulated"] is True
     assert response.get_json()["reason"] == "price_too_high"
+
+
+def test_gpu_protocol_attest_requires_admin_key_before_write(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/gpu/attest",
+        json={
+            "miner_id": "miner-1",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized - admin key required"}
+    nodes = client.get("/gpu/nodes").get_json()
+    assert nodes["count"] == 0
+
+
+def test_gpu_protocol_attest_fails_closed_without_admin_key(tmp_path, monkeypatch):
+    monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/gpu/attest",
+        headers={"X-Admin-Key": "test-admin-key"},
+        json={
+            "miner_id": "miner-1",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "RC_ADMIN_KEY not configured"}
+    nodes = client.get("/gpu/nodes").get_json()
+    assert nodes["count"] == 0
+
+
+def test_gpu_protocol_attest_accepts_api_key_header(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin-key")
+    client = _route_client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/gpu/attest",
+        headers={"X-API-Key": "test-admin-key"},
+        json={
+            "miner_id": "miner-1",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["status"] == "attested"
+    nodes = client.get("/gpu/nodes").get_json()
+    assert nodes["count"] == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- require `RC_ADMIN_KEY` via `X-Admin-Key` or `X-API-Key` before `POST /gpu/attest` writes provider attestations
- preserve non-object JSON validation before auth so existing bad-request behavior stays stable
- add regression tests for unauthorized writes, fail-closed missing server key, and authorized attestation writes

Fixes #6560

## Verification
- `./.venv/bin/python -m pytest -q tests/test_gpu_render_protocol.py`
- `PYTHONPYCACHEPREFIX=/private/tmp/rustchain-pycache python3 -m py_compile node/gpu_render_protocol.py tests/test_gpu_render_protocol.py`
- `git diff --check`
