### PR TITLE
Add total count header to miners API

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6842,6 +6842,7 @@ def api_miners():
             "count": len(miners)
         }
     })
+    response.headers["X-Total-Count"] = str(total_count)
     add_rate_limit_headers(response, rate_info)
     return response
 

--- a/node/tests/test_api_miners_rate_limit.py
+++ b/node/tests/test_api_miners_rate_limit.py
@@ -111,10 +111,35 @@ class TestApiMinersRateLimit(unittest.TestCase):
         )
 
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(
-            resp.get_json()["pagination"],
-            {"total": 0, "limit": 100, "offset": 0, "count": 0},
+        pagination = resp.get_json()["pagination"]
+        self.assertEqual(pagination["total"], 0)
+        self.assertEqual(pagination["limit"], 100)
+        self.assertEqual(pagination["offset"], 0)
+        self.assertEqual(pagination["count"], 0)
+
+    def test_api_miners_exposes_total_count_header(self):
+        now = int(self.mod.time.time())
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute("DELETE FROM miner_attest_recent")
+            conn.executemany(
+                "INSERT INTO miner_attest_recent "
+                "(miner, ts_ok, device_family, device_arch, entropy_score) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [
+                    ("miner-a", now - 10, "x86", "x86_64", 0.5),
+                    ("miner-b", now - 20, "x86", "x86_64", 0.6),
+                ],
+            )
+
+        resp = self.client.get(
+            "/api/miners?limit=1&offset=0",
+            environ_base={"REMOTE_ADDR": "203.0.113.23"},
         )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers["X-Total-Count"], "2")
+        self.assertEqual(resp.get_json()["pagination"]["total"], 2)
+        self.assertEqual(len(resp.get_json()["miners"]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add the requested `X-Total-Count` response header to `GET /api/miners`
- keep the existing paginated JSON response shape unchanged
- add regression coverage proving the header reports the full active miner count even when a page returns fewer rows

Fixes #6565.

## Validation
- `/tmp/bottube-test-venv312/bin/python -B -m pytest -q node/tests/test_api_miners_rate_limit.py --tb=short` -> 6 passed
- `/tmp/bottube-test-venv312/bin/python -B -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_api_miners_rate_limit.py` -> passed
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_api_miners_rate_limit.py` -> passed

Note: a Python 3.9 run of this existing test file fails before reaching this patch because `tempfile.TemporaryDirectory(ignore_cleanup_errors=True)` requires a newer Python. The validation above used Python 3.12.

RTC wallet / miner ID: `gaoaaa52-del`
