### PR TITLE
Safely expire claimed agent jobs

### DIFF
--- a/rip302_agent_economy.py
+++ b/rip302_agent_economy.py
@@ -483,6 +483,24 @@ def register_agent_economy(app: Flask, db_path: str):
     # -----------------------------------------------------------------------
     # POST /agent/jobs/<job_id>/deliver — Submit deliverable
     # -----------------------------------------------------------------------
+    def _expire_refundable_job(c: sqlite3.Cursor, job: dict, now: int) -> bool:
+        """Expire an open/claimed job and refund escrow exactly once."""
+        if job["status"] not in (STATUS_OPEN, STATUS_CLAIMED):
+            return False
+        if now <= job["expires_at"]:
+            return False
+
+        c.execute("""
+            UPDATE agent_jobs SET status = 'expired'
+            WHERE job_id = ? AND status IN (?, ?)
+        """, (job["job_id"], STATUS_OPEN, STATUS_CLAIMED))
+        if c.rowcount == 0:
+            return False
+
+        _refund_escrow(c, job)
+        _update_reputation(c, job["poster_wallet"], "jobs_expired")
+        return True
+
     @app.route("/agent/jobs/<job_id>/deliver", methods=["POST"])
     def agent_deliver_job(job_id):
         data, error = _get_json_object(required=False)
@@ -515,12 +533,25 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Only the assigned worker can deliver"}), 403
 
             now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                return jsonify({"error": "Job has expired"}), 410
+
             c.execute("""
                 UPDATE agent_jobs
                 SET status = 'delivered', deliverable_url = ?,
                     deliverable_hash = ?, result_summary = ?, delivered_at = ?
-                WHERE job_id = ?
-            """, (deliverable_url, deliverable_hash, result_summary, now, job_id))
+                WHERE job_id = ? AND status = ? AND expires_at >= ?
+            """, (
+                deliverable_url, deliverable_hash, result_summary,
+                now, job_id, STATUS_CLAIMED, now
+            ))
+            if c.rowcount == 0:
+                conn.rollback()
+                return jsonify({
+                    "error": "Job state changed under concurrent request - please retry",
+                    "code": "STATE_RACE",
+                }), 409
 
             _log_job_action(c, job_id, "delivered", worker,
                            f"url={deliverable_url}")
@@ -744,6 +775,15 @@ def register_agent_economy(app: Flask, db_path: str):
             if j["poster_wallet"] != poster:
                 return jsonify({"error": "Only the poster can cancel"}), 403
 
+            now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                return jsonify({
+                    "error": "Job has expired",
+                    "status": STATUS_EXPIRED,
+                    "refunded_rtc": j["escrow_i64"] / 1000000,
+                }), 410
+
             if j["status"] not in (STATUS_OPEN, STATUS_DISPUTED):
                 return jsonify({
                     "error": f"Can only cancel open or disputed jobs (current: {j['status']})"
@@ -808,16 +848,12 @@ def register_agent_economy(app: Flask, db_path: str):
             # Expire old jobs first
             now = int(time.time())
             expired = c.execute("""
-                SELECT job_id, poster_wallet, escrow_i64, platform_fee_i64, reward_i64
+                SELECT *
                 FROM agent_jobs
-                WHERE status = 'open' AND expires_at < ?
-            """, (now,)).fetchall()
+                WHERE status IN (?, ?) AND expires_at < ?
+            """, (STATUS_OPEN, STATUS_CLAIMED, now)).fetchall()
             for ej in expired:
-                _adjust_balance(c, ESCROW_WALLET, -ej["escrow_i64"])
-                _adjust_balance(c, ej["poster_wallet"], ej["escrow_i64"])
-                c.execute("UPDATE agent_jobs SET status = 'expired' WHERE job_id = ?",
-                         (ej["job_id"],))
-                _update_reputation(c, ej["poster_wallet"], "jobs_expired")
+                _expire_refundable_job(c, dict(ej), now)
             if expired:
                 conn.commit()
 
@@ -870,6 +906,10 @@ def register_agent_economy(app: Flask, db_path: str):
                 return jsonify({"error": "Job not found"}), 404
 
             j = dict(job)
+            now = int(time.time())
+            if _expire_refundable_job(c, j, now):
+                conn.commit()
+                j["status"] = STATUS_EXPIRED
 
             # Get activity log
             log_rows = c.execute("""

--- a/tests/test_agent_jobs_query_validation.py
+++ b/tests/test_agent_jobs_query_validation.py
@@ -1,3 +1,5 @@
+import sqlite3
+import time
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,29 @@ def make_client(tmp_path: Path):
     app = Flask(__name__)
     register_agent_economy(app, str(tmp_path / "agent_jobs.db"))
     return app.test_client()
+
+
+def make_funded_client(tmp_path: Path):
+    db_path = tmp_path / "agent_jobs.db"
+    app = Flask(__name__)
+    register_agent_economy(app, str(db_path))
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("poster-1", 2_000_000),
+        )
+    return app.test_client(), db_path
+
+
+def _expire_job(db_path: Path, job_id: str):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "UPDATE agent_jobs SET expires_at = ? WHERE job_id = ?",
+            (int(time.time()) - 1, job_id),
+        )
 
 
 def test_agent_jobs_rejects_malformed_query_numbers(tmp_path):
@@ -102,3 +127,131 @@ def test_agent_job_post_rejects_invalid_ttl_values(tmp_path, ttl):
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "ttl_seconds must be an integer"}
+
+
+def test_claimed_expired_job_is_refunded_and_removed_from_claimed_listing(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+    _expire_job(db_path, job_id)
+
+    response = client.get("/agent/jobs?status=claimed")
+
+    assert response.status_code == 200
+    assert response.get_json()["jobs"] == []
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
+def test_cancel_on_expired_claimed_job_refunds_instead_of_locking(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+    _expire_job(db_path, job_id)
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/cancel", json={"poster_wallet": "poster-1"}
+    )
+
+    assert response.status_code == 410
+    assert response.get_json() == {
+        "error": "Job has expired",
+        "status": "expired",
+        "refunded_rtc": 1.05,
+    }
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        status = conn.execute(
+            "SELECT status FROM agent_jobs WHERE job_id = ?", (job_id,)
+        ).fetchone()[0]
+    assert status == "expired"
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
+def test_late_delivery_after_expiry_refund_cannot_resurrect_job(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+    _expire_job(db_path, job_id)
+
+    expired = client.get(f"/agent/jobs/{job_id}")
+    assert expired.status_code == 200
+    assert expired.get_json()["job"]["status"] == "expired"
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/deliver",
+        json={"worker_wallet": "worker-1", "result_summary": "late delivery"},
+    )
+
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "error": "Job must be in 'claimed' status (current: expired)"
+    }
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT status, delivered_at FROM agent_jobs WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+    assert row == ("expired", None)
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000
+
+
+def test_worker_cannot_deliver_after_claimed_job_expires(tmp_path):
+    client, db_path = make_funded_client(tmp_path)
+
+    post = client.post("/agent/jobs", json=_valid_job_payload(ttl_seconds=3600))
+    assert post.status_code == 201
+    job_id = post.get_json()["job_id"]
+    assert client.post(
+        f"/agent/jobs/{job_id}/claim", json={"worker_wallet": "worker-1"}
+    ).status_code == 200
+    _expire_job(db_path, job_id)
+
+    response = client.post(
+        f"/agent/jobs/{job_id}/deliver",
+        json={"worker_wallet": "worker-1", "result_summary": "late delivery"},
+    )
+
+    assert response.status_code == 410
+    assert response.get_json() == {"error": "Job has expired"}
+    with sqlite3.connect(db_path) as conn:
+        balances = dict(conn.execute(
+            "SELECT miner_id, amount_i64 FROM balances"
+        ).fetchall())
+        row = conn.execute(
+            "SELECT status, delivered_at FROM agent_jobs WHERE job_id = ?",
+            (job_id,),
+        ).fetchone()
+    assert row == ("expired", None)
+    assert balances["agent_escrow"] == 0
+    assert balances["poster-1"] == 2_000_000


### PR DESCRIPTION
## Summary

Fixes #6556 with a clean replacement for the rejected #6539 approach.

Claimed jobs past TTL currently keep escrow locked because only `open` jobs are expired in `GET /agent/jobs`, and posters cannot cancel a `claimed` job. This patch adds a guarded expire-and-refund path for `open` and `claimed` jobs while preventing the stale-read resurrection regression called out in #6539.

## What changed

- Adds `_expire_refundable_job(...)`, which transitions only `open`/`claimed` jobs past TTL to `expired` and refunds escrow only if that guarded transition wins.
- `GET /agent/jobs` now expires both `open` and `claimed` stale jobs before listing.
- `GET /agent/jobs/<job_id>` expires/refunds a stale claimed job before returning details.
- `POST /agent/jobs/<job_id>/cancel` gives the poster a recovery path for expired claimed jobs, returning `410` with refund info.
- `POST /agent/jobs/<job_id>/deliver` now:
  - expires/refunds stale claimed jobs and returns `410`, and
  - updates to `delivered` only with `WHERE job_id = ? AND status = 'claimed' AND expires_at >= ?`, returning a state-race `409` if the job was already expired/refunded or otherwise changed.

That last guard is the key difference from #6539: a refunded job cannot later be resurrected into `delivered`.

## Regression coverage

New tests cover:

- claimed expired jobs are refunded and removed from the claimed listing
- poster cancel on an expired claimed job refunds instead of returning `409 current: claimed`
- `claim -> TTL pass -> detail read expires/refunds -> late deliver` cannot resurrect the job
- direct late delivery after TTL returns `410`, leaves status `expired`, leaves `delivered_at` unset, and keeps escrow at zero

## Validation

- `python -m pytest tests/test_agent_jobs_query_validation.py -q` -> 20 passed
- `python -m pytest tests/test_agent_dispute_accept_race.py tests/test_agent_economy_error_redaction.py tests/test_agent_jobs_query_validation.py -q` -> 27 passed
- `python -m py_compile rip302_agent_economy.py tests\test_agent_jobs_query_validation.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main` -> OK
- `git diff --check`

Bounty context: #6556 / #71
Wallet: `RTC6de503be5fbf1fb3797fd7eddc65dfde9188aa4d`