### PR TITLE
fix(gpu): require admin-key auth on POST /gpu/attest to prevent provider impersonation (#6560)

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -488,7 +488,7 @@ class GPURenderProtocol:
 # Flask route registration (integrates with existing RustChain node)
 # ---------------------------------------------------------------------------
 
-def register_routes(app):
+def register_routes(app, admin_key: str = ""):
     """Register GPU Render Protocol routes with a Flask app."""
     from flask import jsonify, request
 
@@ -542,11 +542,22 @@ def register_routes(app):
         data[name] = value
         return None
 
+    def _require_admin_key():
+        if not admin_key:
+            return jsonify({"error": "Admin key not configured - attest endpoint disabled"}), 503
+        provided = request.headers.get("X-Admin-Key") or request.headers.get("X-API-Key") or ""
+        if not hmac.compare_digest(provided, admin_key):
+            return jsonify({"error": "Unauthorized - admin key required for GPU attestation"}), 401
+        return None
+
     @app.route("/gpu/attest", methods=["POST"])
     def gpu_attest():
         data, error_response = _json_object_body()
         if error_response is not None:
             return error_response
+        auth_error = _require_admin_key()
+        if auth_error is not None:
+            return auth_error
         data = dict(data)
         miner_id, error_response = _string_field(data, "miner_id")
         if error_response is not None:

--- a/tests/test_gpu_attest_admin_auth_6560.py
+++ b/tests/test_gpu_attest_admin_auth_6560.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: MIT
+"""Tests for GPU attestation admin-key authentication (issue #6560)."""
+
+import sqlite3
+import pytest
+from flask import Flask
+
+from node.gpu_render_protocol import GPURenderProtocol, register_routes
+
+
+ADMIN_KEY = "test-admin-key-6560"
+
+
+def _create_app(admin_key=ADMIN_KEY):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    register_routes(app, admin_key=admin_key)
+    return app
+
+
+@pytest.fixture
+def client(tmp_path):
+    db_path = tmp_path / "gpu_test.db"
+    app = _create_app(admin_key=ADMIN_KEY)
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def no_key_client():
+    """App registered with no admin key."""
+    app = _create_app(admin_key="")
+    with app.test_client() as c:
+        yield c
+
+
+class TestAttestRequiresAdminKey:
+    """POST /gpu/attest must reject unauthenticated requests."""
+
+    def test_attest_no_key_returns_401(self, client):
+        """Request without X-Admin-Key header returns 401."""
+        resp = client.post("/gpu/attest", json={
+            "miner_id": "impersonator",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        })
+        assert resp.status_code == 401
+        data = resp.get_json()
+        assert "admin key required" in data["error"].lower() or "unauthorized" in data["error"].lower()
+
+    def test_attest_wrong_key_returns_401(self, client):
+        """Request with incorrect key returns 401."""
+        resp = client.post("/gpu/attest", json={
+            "miner_id": "impersonator",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        }, headers={"X-Admin-Key": "wrong-key"})
+        assert resp.status_code == 401
+
+    def test_attest_correct_key_succeeds(self, client):
+        """Request with correct key returns 200."""
+        resp = client.post("/gpu/attest", json={
+            "miner_id": "legitimate-miner",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        }, headers={"X-Admin-Key": ADMIN_KEY})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "error" not in data
+
+    def test_attest_x_api_key_header_accepted(self, client):
+        """X-API-Key header is also accepted (consistent with other admin endpoints)."""
+        resp = client.post("/gpu/attest", json={
+            "miner_id": "legitimate-miner-2",
+            "gpu_model": "RX 7900 XTX",
+            "vram_gb": 24,
+            "device_arch": "amd_gpu",
+        }, headers={"X-API-Key": ADMIN_KEY})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "error" not in data
+
+    def test_attest_no_admin_configured_returns_503(self, no_key_client):
+        """If no admin key is configured, attest endpoint is disabled (503)."""
+        resp = no_key_client.post("/gpu/attest", json={
+            "miner_id": "anyone",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+        }, headers={"X-Admin-Key": "anything"})
+        assert resp.status_code == 503
+
+    def test_read_endpoints_still_public(self, client):
+        """GET /gpu/nodes remains publicly accessible."""
+        resp = client.get("/gpu/nodes")
+        assert resp.status_code == 200
+
+
+class TestAttestCannotImpersonate:
+    """After the fix, unauthenticated callers cannot insert attestations."""
+
+    def test_unauthenticated_attest_does_not_create_record(self, client):
+        """A failed auth attempt should not write to the database."""
+        # First, add a legitimate attestation
+        client.post("/gpu/attest", json={
+            "miner_id": "real-miner",
+            "gpu_model": "RTX 4090",
+            "vram_gb": 24,
+            "device_arch": "nvidia_gpu",
+            "benchmark_score": 95.0,
+        }, headers={"X-Admin-Key": ADMIN_KEY})
+
+        # Try to overwrite without auth
+        resp = client.post("/gpu/attest", json={
+            "miner_id": "real-miner",
+            "gpu_model": "FAKE GPU",
+            "vram_gb": 1,
+            "device_arch": "nvidia_gpu",
+        })
+        assert resp.status_code == 401
+
+        # Verify original attestation is unchanged
+        nodes_resp = client.get("/gpu/nodes")
+        nodes = nodes_resp.get_json()["nodes"]
+        real = [n for n in nodes if n.get("miner_id") == "real-miner"]
+        assert len(real) == 1
+        assert real[0]["gpu_model"] == "RTX 4090"


### PR DESCRIPTION
## Summary

Fixes #6560

`POST /gpu/attest` in `node/gpu_render_protocol.py` accepted unauthenticated writes for arbitrary `miner_id` values. Any remote caller could impersonate or overwrite GPU providers and poison the provider data returned by `/gpu/nodes`, including model, architecture, benchmark, capability flags, and price fields.

## Changes

- Add `admin_key` parameter to `register_routes(app, admin_key="")` in `gpu_render_protocol.py`
- Add `_require_admin_key()` guard on `POST /gpu/attest`, consistent with the pattern in `gpu_render_endpoints.py`
- Both `X-Admin-Key` and `X-API-Key` headers are accepted (same as existing admin endpoints)
- When no admin key is configured, the endpoint returns 503 (disabled)
- `GET /gpu/nodes` remains publicly readable (no auth required)
- Uses `hmac.compare_digest` for timing-safe key comparison

## Test Coverage

7 new tests in `tests/test_gpu_attest_admin_auth_6560.py`:
- No key → 401
- Wrong key → 401  
- Correct key → 200
- X-API-Key header accepted → 200
- No admin key configured → 503
- GET /gpu/nodes still public → 200
- Unauthenticated attest cannot overwrite existing records

All 7 tests pass.