### PR TITLE
Fix Beacon join public key length validation

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -399,7 +399,7 @@ def beacon_join():
 
         try:
             # Validate it's proper hex
-            bytes.fromhex(pubkey_clean)
+            pubkey_bytes = bytes.fromhex(pubkey_clean)
         except ValueError:
             return jsonify({'error': 'Invalid pubkey_hex: must be valid hexadecimal string'}), 400
 
@@ -410,6 +410,8 @@ def beacon_join():
             return jsonify({'error': 'Invalid name: must be a string'}), 400
         if coinbase_address is not None and not isinstance(coinbase_address, str):
             return jsonify({'error': 'Invalid coinbase_address: must be a string'}), 400
+        if len(pubkey_bytes) != 32:
+            return jsonify({'error': 'Invalid pubkey_hex: must be 32 bytes'}), 400
 
         # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
         if coinbase_address:

--- a/node/tests/test_beacon_api_join.py
+++ b/node/tests/test_beacon_api_join.py
@@ -1,0 +1,44 @@
+from flask import Flask
+
+import beacon_api
+
+
+def _client(tmp_path, monkeypatch):
+    db_path = tmp_path / "beacon.db"
+    monkeypatch.setattr(beacon_api, "DB_PATH", str(db_path))
+    beacon_api.init_beacon_tables(str(db_path))
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    app.register_blueprint(beacon_api.beacon_api)
+    return app.test_client()
+
+
+def test_beacon_join_rejects_non_ed25519_pubkey_length(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/beacon/join",
+        json={
+            "agent_id": "short-key-agent",
+            "pubkey_hex": "00",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "Invalid pubkey_hex: must be 32 bytes"
+
+
+def test_beacon_join_accepts_32_byte_ed25519_pubkey(tmp_path, monkeypatch):
+    client = _client(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/beacon/join",
+        json={
+            "agent_id": "valid-key-agent",
+            "pubkey_hex": "11" * 32,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True


### PR DESCRIPTION
## What Changed

- Reject `/beacon/join` `pubkey_hex` values that decode to anything other than a 32-byte Ed25519 public key.
- Add route-level regression coverage for the rejected one-byte key and the accepted 32-byte key path.
- Preserve existing optional-field validation order in the Beacon join route.

Closes #6615

## Testing / Evidence

- `python -m py_compile node/beacon_api.py node/tests/test_beacon_api_join.py tests/test_beacon_join_routing.py`
- `python -m pytest -q node/tests/test_beacon_api_join.py tests/test_beacon_join_routing.py --tb=short` -> 25 passed
- `git diff --check -- node/beacon_api.py node/tests/test_beacon_api_join.py tests/test_beacon_join_routing.py`