### PR TITLE
Reject peer-synced nonzero balances for unknown wallets

### DIFF
--- a/node/rustchain_sync.py
+++ b/node/rustchain_sync.py
@@ -215,13 +215,21 @@ class RustChainSyncManager:
                             break
 
                     if candidate_balance_col and candidate_balance_col in sanitized:
+                        try:
+                            remote_val = int(sanitized[candidate_balance_col])
+                        except (TypeError, ValueError):
+                            self.logger.warning(
+                                f"Rejected sync: invalid balance value for "
+                                f"{sanitized[pk]}"
+                            )
+                            continue
+
                         cursor.execute(
                             f"SELECT {candidate_balance_col} FROM {table_name} WHERE {pk} = ?",
                             (sanitized[pk],),
                         )
                         local_row = cursor.fetchone()
                         if local_row and local_row[0] is not None:
-                            remote_val = int(sanitized[candidate_balance_col])
                             local_val = int(local_row[0])
                             if remote_val != local_val:
                                 self.logger.warning(
@@ -230,6 +238,12 @@ class RustChainSyncManager:
                                     f"remote={remote_val})"
                                 )
                                 continue
+                        elif remote_val != 0:
+                            self.logger.warning(
+                                f"Rejected sync: New balance row with nonzero "
+                                f"value for {sanitized[pk]} (remote={remote_val})"
+                            )
+                            continue
 
                 # Safe upsert (avoid INSERT OR REPLACE data loss semantics)
                 columns = list(sanitized.keys())

--- a/node/test_sync_balance_inflation.py
+++ b/node/test_sync_balance_inflation.py
@@ -58,6 +58,14 @@ class TestSyncBalanceInflation(unittest.TestCase):
             ).fetchone()
             return row[0] if row else 0
 
+    def _has_balance_row(self, miner_id: str) -> bool:
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM balances WHERE miner_id = ?",
+                (miner_id,),
+            ).fetchone()
+            return row is not None
+
     # -- Tests ---------------------------------------------------------------
 
     def test_balance_increase_rejected(self):
@@ -88,18 +96,26 @@ class TestSyncBalanceInflation(unittest.TestCase):
         self.assertEqual(after, 5_000_000,
                          "Balance must not decrease via peer sync")
 
-    def test_new_wallet_from_sync_allowed(self):
-        """New wallets (no local row yet) CAN be created via sync.
-
-        This allows initial balance propagation for newly registered miners.
-        """
+    def test_new_wallet_nonzero_balance_rejected(self):
+        """Peers must not mint funds by creating unknown balance rows."""
         self.sync.apply_sync_payload("balances", [
             {"miner_id": "miner-bob", "amount_i64": 2_000_000},  # 2 RTC
         ])
 
+        self.assertFalse(self._has_balance_row("miner-bob"),
+                         "New nonzero balance row must not be created via sync")
+
+    def test_new_wallet_zero_balance_placeholder_allowed(self):
+        """Zero-balance placeholders may still propagate identity rows."""
+        self.sync.apply_sync_payload("balances", [
+            {"miner_id": "miner-bob", "amount_i64": 0},
+        ])
+
         bob_balance = self._get_balance("miner-bob")
-        self.assertEqual(bob_balance, 2_000_000,
-                         "New wallet should be created via sync")
+        self.assertEqual(bob_balance, 0,
+                         "Zero-balance placeholder should stay zero")
+        self.assertTrue(self._has_balance_row("miner-bob"),
+                        "Zero-balance placeholder row should be allowed")
 
     def test_unchanged_balance_passes(self):
         """Sync with identical balance value should succeed (no-op upsert)."""

--- a/tests/test_sync_balance_inflation.py
+++ b/tests/test_sync_balance_inflation.py
@@ -1,0 +1,71 @@
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
+from rustchain_sync import RustChainSyncManager
+
+
+def _init_balances_db(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE balances (
+                miner_id TEXT PRIMARY KEY,
+                amount_i64 INTEGER NOT NULL DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("miner-alice", 5_000_000),
+        )
+        conn.commit()
+
+
+def _balance_row(db_path: Path, miner_id: str):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+            (miner_id,),
+        ).fetchone()
+
+
+class TestSyncBalanceInflation(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmpdir.name) / "sync.db"
+        _init_balances_db(self.db_path)
+        self.sync = RustChainSyncManager(str(self.db_path), "test_admin_key")
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_rejects_nonzero_balance_for_unknown_wallet(self):
+        self.assertTrue(
+            self.sync.apply_sync_payload(
+                "balances",
+                [{"miner_id": "miner-bob", "amount_i64": 2_000_000}],
+            )
+        )
+
+        self.assertIsNone(_balance_row(self.db_path, "miner-bob"))
+
+    def test_allows_zero_balance_placeholder_for_unknown_wallet(self):
+        self.assertTrue(
+            self.sync.apply_sync_payload(
+                "balances",
+                [{"miner_id": "miner-bob", "amount_i64": 0}],
+            )
+        )
+
+        row = _balance_row(self.db_path, "miner-bob")
+        self.assertIsNotNone(row)
+        self.assertEqual(row[0], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #6617.

Peer sync already rejected remote balance changes for wallets that had a local balance row, but it still allowed a sync-authorized peer to create a brand-new `balances` row with an arbitrary positive `amount_i64`. This PR rejects nonzero balance rows for unknown wallets before the generic upsert path can insert them.

Zero-balance placeholders remain allowed so sync can still propagate an identity/registration row without minting funds.

## Tests

- `python3 node/test_sync_balance_inflation.py`
- `python3 -m py_compile node/rustchain_sync.py node/test_sync_balance_inflation.py`
- `git diff --cached --check` before commit