### PR TITLE
Fix ROM clustering duplicate threshold

### DIFF
--- a/node/rom_clustering_server.py
+++ b/node/rom_clustering_server.py
@@ -165,6 +165,10 @@ class ROMClusteringServer:
         self.cluster_threshold = cluster_threshold
         init_rom_tables(db_path)
 
+    def _effective_cluster_threshold(self) -> int:
+        # Keep the first report valid; a duplicate ROM starts at two miners.
+        return max(2, int(self.cluster_threshold))
+
     def _get_conn(self):
         return sqlite3.connect(self.db_path)
 
@@ -229,11 +233,10 @@ class ROMClusteringServer:
         """, (rom_hash_lower, miner_id))
 
         other_miners = [row[0] for row in cur.fetchall()]
+        all_miners = [miner_id] + other_miners
 
-        if len(other_miners) >= self.cluster_threshold:
+        if len(all_miners) >= self._effective_cluster_threshold():
             # Clustering detected!
-            all_miners = [miner_id] + other_miners
-
             # Record the cluster
             import json
             cur.execute("""

--- a/node/rom_fingerprint_db.py
+++ b/node/rom_fingerprint_db.py
@@ -290,6 +290,10 @@ class ROMClusterDetector:
         self.cluster_threshold = cluster_threshold
         self.rom_reports: Dict[str, List[str]] = {}  # hash -> list of miner_ids
 
+    def _effective_cluster_threshold(self) -> int:
+        # Keep the first report valid; a duplicate ROM starts at two miners.
+        return max(2, int(self.cluster_threshold))
+
     def report_rom(self, miner_id: str, rom_hash: str, hash_type: str = "sha1") -> Tuple[bool, str]:
         """
         Record a ROM hash report from a miner.
@@ -314,7 +318,7 @@ class ROMClusterDetector:
             return False, f"known_emulator_rom:{rom_info.get('platform')}:{rom_info.get('models', [])}"
 
         # Check for clustering (multiple miners with same ROM)
-        if len(self.rom_reports[key]) > self.cluster_threshold:
+        if len(self.rom_reports[key]) >= self._effective_cluster_threshold():
             other_miners = [m for m in self.rom_reports[key] if m != miner_id]
             return False, f"rom_clustering_detected:shared_with:{other_miners}"
 
@@ -328,7 +332,7 @@ class ROMClusterDetector:
         """Get list of miners involved in clustering."""
         suspicious = set()
         for miners in self.rom_reports.values():
-            if len(miners) > self.cluster_threshold:
+            if len(miners) >= self._effective_cluster_threshold():
                 suspicious.update(miners)
         return list(suspicious)
 

--- a/node/tests/test_rom_clustering_server.py
+++ b/node/tests/test_rom_clustering_server.py
@@ -33,6 +33,15 @@ def test_rom_cluster_upsert_keeps_one_row_per_rom_hash(tmp_path):
     assert rows[0][1] == 3
 
 
+def test_default_threshold_flags_second_unique_miner(tmp_path):
+    db_path = str(tmp_path / "default-threshold-roms.db")
+    server = ROMClusteringServer(db_path)
+    rom_hash = "12" * 20
+
+    assert server.process_rom_report("miner-1", rom_hash)[1] == "unique_rom"
+    assert server.process_rom_report("miner-2", rom_hash)[1] == "rom_clustering"
+
+
 def test_init_rom_tables_deduplicates_legacy_cluster_rows_before_unique_index(tmp_path):
     db_path = str(tmp_path / "legacy-roms.db")
     rom_hash = "cd" * 20

--- a/node/tests/test_rom_fingerprint_db_unit.py
+++ b/node/tests/test_rom_fingerprint_db_unit.py
@@ -60,6 +60,17 @@ def test_rom_cluster_detector_flags_second_unique_miner_when_threshold_exceeded(
     assert set(detector.get_suspicious_miners()) == {"miner-a", "miner-b"}
 
 
+def test_rom_cluster_detector_default_threshold_flags_duplicate_miner():
+    detector = rom_db.ROMClusterDetector()
+
+    assert detector.report_rom("miner-a", "unique_hash") == (True, "unique_rom")
+    ok, reason = detector.report_rom("miner-b", "unique_hash")
+
+    assert ok is False
+    assert reason == "rom_clustering_detected:shared_with:['miner-a']"
+    assert set(detector.get_suspicious_miners()) == {"miner-a", "miner-b"}
+
+
 def test_rom_cluster_detector_rejects_known_emulator_rom_immediately():
     detector = rom_db.ROMClusterDetector(cluster_threshold=99)
 

--- a/tests/test_rom_clustering_threshold.py
+++ b/tests/test_rom_clustering_threshold.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: MIT
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NODE_DIR = REPO_ROOT / "node"
+sys.path.insert(0, str(NODE_DIR))
+
+from rom_clustering_server import ROMClusteringServer
+from rom_fingerprint_db import ROMClusterDetector
+
+
+def test_server_default_threshold_flags_second_unique_miner(tmp_path):
+    server = ROMClusteringServer(str(tmp_path / "roms.db"))
+    rom_hash = "12" * 20
+
+    assert server.process_rom_report("miner-a", rom_hash)[1] == "unique_rom"
+    assert server.process_rom_report("miner-b", rom_hash)[1] == "rom_clustering"
+
+
+def test_detector_default_threshold_flags_second_unique_miner():
+    detector = ROMClusterDetector()
+
+    assert detector.report_rom("miner-a", "unique_rom_hash") == (True, "unique_rom")
+    ok, reason = detector.report_rom("miner-b", "unique_rom_hash")
+
+    assert ok is False
+    assert reason == "rom_clustering_detected:shared_with:['miner-a']"
+    assert set(detector.get_suspicious_miners()) == {"miner-a", "miner-b"}


### PR DESCRIPTION
## Summary

Fixes #6619.

The default ROM clustering threshold is documented as `2`, meaning any duplicate ROM across distinct miners should be suspicious. The server-side implementation counted only `other_miners`, while the in-memory detector used a strict `>` check, so the second distinct miner with the same ROM hash still passed as `unique_rom`.

This PR normalizes the effective threshold so:

- the first report remains valid
- the second distinct miner sharing a ROM hash triggers clustering under the default threshold
- existing `cluster_threshold=1` tests keep their current behavior

## Tests

Local environment does not have pytest installed, so I directly executed the pytest-style test functions and compiled the touched files:

- Direct test invocation for affected ROM clustering tests: 7 targeted tests passed
- `python3 -m py_compile node/rom_clustering_server.py node/rom_fingerprint_db.py node/tests/test_rom_clustering_server.py node/tests/test_rom_fingerprint_db_unit.py`
- `git diff --check -- node/rom_clustering_server.py node/rom_fingerprint_db.py node/tests/test_rom_clustering_server.py node/tests/test_rom_fingerprint_db_unit.py`