### PR TITLE
fix(tests): add seaborn importorskip — unblocks tests/ collection

### DIFF
--- a/tests/test_pse_analyze_results.py
+++ b/tests/test_pse_analyze_results.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 pytest.importorskip("matplotlib")
+pytest.importorskip("seaborn")
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "benchmarks" / "pse" / "analyze_results.py"
 SPEC = importlib.util.spec_from_file_location("pse_analyze_results", MODULE_PATH)


### PR DESCRIPTION
## Summary

`benchmarks/pse/analyze_results.py` imports seaborn at module top (line 17). The test file at `tests/test_pse_analyze_results.py` only skipped on matplotlib. On CI hosts with matplotlib but not seaborn, pytest collection failed with `ModuleNotFoundError` — breaking the entire `tests/` suite collection.

## Reproduction (before fix)

```
$ python3 -m pytest tests/ --collect-only -q
ERROR tests/test_pse_analyze_results.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

## After fix

```
$ python3 -m pytest tests/ --collect-only -q
3236 tests collected in 3.31s
```

## Change

One line added:

```python
 pytest.importorskip("matplotlib")
+pytest.importorskip("seaborn")
```

## Why now

Surfaced in Codex authoritative code-state audit (2026-05-29) as part of [#6626 production drift transparency](https://github.com/Scottcjn/Rustchain/issues/6626) Codex action #2: "clean up test collection boundaries."

## Verification

Local `pytest --collect-only` succeeds in 3.31s with 3,236 tests collected, 0 errors.

Closes the test-collection-boundary half of [#6626](https://github.com/Scottcjn/Rustchain/issues/6626) Codex action item #2.