### PR TITLE
[UTXO-BUG] fix claims_settlement get_verifying_claims unbounded fetchall() — OOM DoS

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -99,29 +99,34 @@ def get_pending_claims(
         return []
 
 
+_VERIFYING_CLAIMS_LIMIT = 500
+
+
 def get_verifying_claims(
     db_path: str,
     older_than_seconds: int = 300
 ) -> List[Dict[str, Any]]:
     """
     Get claims stuck in 'verifying' status for too long
-    
+
     These should be auto-approved or flagged for manual review.
+    Returns at most _VERIFYING_CLAIMS_LIMIT rows to prevent OOM on large tables.
     """
     threshold = int(time.time()) - older_than_seconds
-    
+
     try:
         with sqlite3.connect(db_path) as conn:
             conn.row_factory = sqlite3.Row
             cursor = conn.cursor()
-            
+
             cursor.execute("""
                 SELECT * FROM claims
                 WHERE status = 'verifying'
                 AND submitted_at < ?
                 ORDER BY submitted_at ASC
-            """, (threshold,))
-            
+                LIMIT ?
+            """, (threshold, _VERIFYING_CLAIMS_LIMIT))
+
             claims = []
             for row in cursor.fetchall():
                 claims.append({
@@ -132,7 +137,7 @@ def get_verifying_claims(
                     "reward_urtc": row["reward_urtc"],
                     "submitted_at": row["submitted_at"]
                 })
-            
+
             return claims
     except sqlite3.Error as e:
         print(f"[SETTLEMENT] Error getting verifying claims: {e}")

--- a/node/test_claims_verifying_fetchall_poc.py
+++ b/node/test_claims_verifying_fetchall_poc.py
@@ -1,0 +1,109 @@
+"""
+PoC: get_verifying_claims() had no LIMIT on its SQL query.
+fetchall() would materialize every 'verifying' claim into RAM on each
+settlement cycle, enabling OOM DoS by flooding the claims table with
+submissions that remain stuck in 'verifying'.
+
+Before fix: query had no LIMIT clause.
+After fix:  query adds LIMIT 500 (_VERIFYING_CLAIMS_LIMIT).
+"""
+import sqlite3
+import time
+import unittest
+import tempfile
+import os
+
+from claims_settlement import get_verifying_claims, _VERIFYING_CLAIMS_LIMIT
+
+
+def _make_db(path: str) -> None:
+    with sqlite3.connect(path) as conn:
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS claims (
+                claim_id TEXT PRIMARY KEY,
+                miner_id TEXT,
+                epoch INTEGER,
+                wallet_address TEXT,
+                reward_urtc INTEGER,
+                submitted_at INTEGER,
+                status TEXT
+            )
+        """)
+        conn.commit()
+
+
+_claim_counter = 0
+
+
+def _insert_claims(path: str, count: int, status: str = "verifying", ts_offset: int = -600):
+    global _claim_counter
+    ts = int(time.time()) + ts_offset
+    with sqlite3.connect(path) as conn:
+        for i in range(count):
+            conn.execute(
+                "INSERT INTO claims VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (f"claim_{_claim_counter}", f"miner_{_claim_counter}", 1, f"RTC{'0' * 40}", 1000, ts - i, status)
+            )
+            _claim_counter += 1
+        conn.commit()
+
+
+class TestVerifyingClaimsLimit(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        self.db_path = self.tmp.name
+        self.tmp.close()
+        _make_db(self.db_path)
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_respects_limit_when_many_rows(self):
+        """With more rows than _VERIFYING_CLAIMS_LIMIT, only the limit is returned."""
+        over_limit = _VERIFYING_CLAIMS_LIMIT + 100
+        _insert_claims(self.db_path, over_limit)
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertLessEqual(len(result), _VERIFYING_CLAIMS_LIMIT,
+                             f"Expected at most {_VERIFYING_CLAIMS_LIMIT} rows, got {len(result)}")
+
+    def test_returns_all_when_under_limit(self):
+        """With fewer rows than the limit, all are returned."""
+        count = 10
+        _insert_claims(self.db_path, count)
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertEqual(len(result), count)
+
+    def test_filters_by_status(self):
+        """Only 'verifying' claims are returned."""
+        _insert_claims(self.db_path, 5, status="verifying")
+        _insert_claims(self.db_path, 3, status="approved")
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertEqual(len(result), 5)
+
+    def test_filters_by_age(self):
+        """Claims newer than older_than_seconds are excluded."""
+        _insert_claims(self.db_path, 5, status="verifying", ts_offset=-600)
+        _insert_claims(self.db_path, 3, status="verifying", ts_offset=600)
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertEqual(len(result), 5)
+
+    def test_empty_table(self):
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertEqual(result, [])
+
+    def test_result_shape(self):
+        _insert_claims(self.db_path, 1)
+        result = get_verifying_claims(self.db_path, older_than_seconds=300)
+        self.assertEqual(len(result), 1)
+        row = result[0]
+        self.assertIn("claim_id", row)
+        self.assertIn("miner_id", row)
+        self.assertIn("epoch", row)
+        self.assertIn("wallet_address", row)
+        self.assertIn("reward_urtc", row)
+        self.assertIn("submitted_at", row)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`get_verifying_claims()` in `claims_settlement.py` runs an unbounded `SELECT * FROM claims WHERE status = 'verifying'` with no `LIMIT` clause. The function is called on every settlement cycle to flag stale claims. With a large or artificially flooded claims table, `fetchall()` materializes every matching row into RAM, causing OOM and crashing the node.

## Problem

```python
cursor.execute("""
    SELECT * FROM claims
    WHERE status = 'verifying'
    AND submitted_at < ?
    ORDER BY submitted_at ASC
""", (threshold,))
# fetchall() with no upper bound
for row in cursor.fetchall():
```

The `/claims/submit` endpoint is the entry point. An attacker can submit thousands of claim requests that transition to `verifying` status (or a bug leaves many claims stuck there). The next settlement run fetches all of them into memory at once.

## Fix

Added `_VERIFYING_CLAIMS_LIMIT = 500` and `LIMIT ?` to the query:

```python
cursor.execute("""
    SELECT * FROM claims
    WHERE status = 'verifying'
    AND submitted_at < ?
    ORDER BY submitted_at ASC
    LIMIT ?
""", (threshold, _VERIFYING_CLAIMS_LIMIT))
```

500 rows is sufficient for any realistic settlement batch. The caller only reads and logs stale claims for manual review — it does not auto-approve them — so a cap does not change correctness.

## Tests

`node/test_claims_verifying_fetchall_poc.py` — 6 tests:

- With more rows than the limit, only the limit is returned
- With fewer rows than the limit, all are returned
- Filters by `verifying` status correctly
- Filters by age threshold correctly
- Empty table returns empty list
- Result shape includes all expected fields

```
python3 -m pytest node/test_claims_verifying_fetchall_poc.py -v
6 passed in 0.10s
```

## Severity

**Medium** — unauthenticated OOM DoS vector on the settlement cycle.

**Bounty wallet:** `RTC64aa3fc417e75224e1574acae906fea34d94d140`