### PR TITLE
[UTXO-BUG] Skip cross-transaction data-input conflicts in block candidates

### DIFF
--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -833,6 +833,40 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(candidates, [])
         self.assertFalse(self.db.mempool_check_double_spend(alice_box['box_id']))
 
+    def test_mempool_block_candidates_skip_internal_data_input_conflicts(self):
+        """A candidate set must be valid when applied sequentially.
+
+        One pending transaction can spend a box that another pending
+        transaction uses as a read-only data_input. Both are individually
+        valid against the current UTXO set, but including both in one block
+        candidate batch makes the later transaction fail once the first spend
+        has been applied.
+        """
+        self._apply_coinbase('oracle', 100 * UNIT, block_height=1)
+        self._apply_coinbase('alice', 100 * UNIT, block_height=2)
+        oracle_box = self.db.get_unspent_for_address('oracle')[0]
+        alice_box = self.db.get_unspent_for_address('alice')[0]
+
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': 'read_oracle' * 6,
+            'inputs': [{'box_id': alice_box['box_id']}],
+            'data_inputs': [oracle_box['box_id']],
+            'outputs': [{'address': 'bob', 'value_nrtc': 100 * UNIT - 1000}],
+            'fee_nrtc': 1000,
+        }))
+        self.assertTrue(self.db.mempool_add({
+            'tx_id': 'spend_oracle' * 5,
+            'inputs': [{'box_id': oracle_box['box_id']}],
+            'outputs': [
+                {'address': 'oracle-next', 'value_nrtc': 100 * UNIT - 2000}
+            ],
+            'fee_nrtc': 2000,
+        }))
+
+        candidates = self.db.mempool_get_block_candidates(max_count=10)
+        self.assertEqual([tx['tx_id'] for tx in candidates], ['spend_oracle' * 5])
+        self.assertTrue(self.db.mempool_check_double_spend(alice_box['box_id']))
+
     def test_mempool_nonexistent_input_rejected(self):
         tx = {
             'tx_id': 'cccc' * 16,

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -833,7 +833,7 @@ class TestUtxoDB(unittest.TestCase):
         self.assertEqual(candidates, [])
         self.assertFalse(self.db.mempool_check_double_spend(alice_box['box_id']))
 
-    def test_mempool_block_candidates_skip_internal_data_input_conflicts(self):
+    def test_mempool_block_candidates_skip_cross_transaction_data_input_conflicts(self):
         """A candidate set must be valid when applied sequentially.
 
         One pending transaction can spend a box that another pending

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1055,6 +1055,8 @@ class UtxoDB:
             ).fetchall()
             candidates = []
             stale_tx_ids = []
+            selected_spend_inputs = set()
+            selected_data_inputs = set()
 
             for row in rows:
                 tx_id = row['tx_id']
@@ -1086,7 +1088,17 @@ class UtxoDB:
                         stale_tx_ids.append(tx_id)
                         break
                 else:
+                    input_set = set(input_ids)
+                    data_input_set = set(data_inputs)
+                    if (
+                        input_set & selected_data_inputs
+                        or data_input_set & selected_spend_inputs
+                    ):
+                        continue
+
                     candidates.append(tx)
+                    selected_spend_inputs.update(input_set)
+                    selected_data_inputs.update(data_input_set)
                     if len(candidates) >= max_count:
                         break
 


### PR DESCRIPTION
## Summary

This PR fixes a cross-transaction mempool block-candidate conflict involving read-only data inputs.

A pending transaction can spend a box that another pending transaction only reads as a `data_input`. Each transaction may be valid against the current UTXO set on its own, but they cannot both be included in the same block candidate batch because applying the spender first makes the reader's data input spent.

This is a corrected/reframed follow-up to #6622, per maintainer feedback. The implementation is framed around the actual invariant protected by the code and regression test.

Bounty context: Scottcjn/rustchain-bounties#12584

## Changes

- Track selected spend inputs and selected data inputs separately while constructing block candidates.
- Skip candidate combinations where a selected transaction would spend a box another selected transaction reads as a data input, or read a box another selected transaction spends.
- Preserve existing rejection for data inputs that are already spent in the confirmed UTXO set.
- Rename the regression test to describe the actual cross-transaction invariant.

## Validation

From `node/`:

```bash
python -B -m unittest test_utxo_db.TestUtxoDB.test_mempool_block_candidates_skip_cross_transaction_data_input_conflicts test_utxo_db.TestUtxoDB.test_mempool_block_candidates_drop_spent_data_inputs test_utxo_db.TestUtxoDB.test_mempool_block_candidates
```

Result: `Ran 3 tests in 0.188s - OK`.