### PR TITLE
Harden canonical Beacon join identity binding

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -193,6 +193,23 @@ def _clean_pubkey_hex(pubkey_hex):
     return pubkey_clean
 
 
+def _agent_id_from_pubkey(pubkey_bytes):
+    """根据 Ed25519 公钥派生规范 Beacon agent_id。"""
+    return f"bcn_{hashlib.sha256(pubkey_bytes).hexdigest()[:12]}"
+
+
+def _is_canonical_agent_id(agent_id):
+    """识别 bcn_<12 hex> 规范 ID，兼容历史非规范测试/本地标签。"""
+    if not isinstance(agent_id, str):
+        return False
+    suffix = agent_id[4:]
+    return (
+        agent_id.startswith('bcn_')
+        and len(suffix) == 12
+        and all(ch in '0123456789abcdef' for ch in suffix)
+    )
+
+
 def _canonical_agent_request(agent_id, timestamp, nonce, body_bytes):
     body_hash = hashlib.sha256(body_bytes or b'').hexdigest()
     return '\n'.join([
@@ -412,6 +429,13 @@ def beacon_join():
             return jsonify({'error': 'Invalid coinbase_address: must be a string'}), 400
         if len(pubkey_bytes) != 32:
             return jsonify({'error': 'Invalid pubkey_hex: must be 32 bytes'}), 400
+
+        if _is_canonical_agent_id(agent_id):
+            expected_agent_id = _agent_id_from_pubkey(pubkey_bytes)
+            if agent_id != expected_agent_id:
+                return jsonify({
+                    'error': 'Invalid agent_id: canonical bcn_<hash> must match pubkey_hex'
+                }), 400
 
         # Validate coinbase_address if provided (should be 0x-prefixed, 40 hex chars)
         if coinbase_address:

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -11,9 +11,16 @@ import sys
 import os
 import tempfile
 import sqlite3
+import hashlib
 
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _canonical_agent_id(pubkey_hex):
+    """根据 Ed25519 公钥派生规范 Beacon agent_id。"""
+    clean = pubkey_hex[2:] if pubkey_hex.startswith(('0x', '0X')) else pubkey_hex
+    return f"bcn_{hashlib.sha256(bytes.fromhex(clean)).hexdigest()[:12]}"
 
 
 class TestBeaconJoinRouting(unittest.TestCase):
@@ -189,6 +196,53 @@ class TestBeaconJoinRouting(unittest.TestCase):
             ).fetchone()
             self.assertEqual(row[0], payload1['pubkey_hex'])
             self.assertEqual(row[1], 'Victim')
+
+    def test_join_rejects_canonical_agent_id_pubkey_mismatch(self):
+        """POST /beacon/join 拒绝抢占另一个公钥的规范 bcn_ ID。"""
+        victim_pubkey = '0x' + '11' * 32
+        attacker_pubkey = '0x' + '22' * 32
+        victim_agent_id = _canonical_agent_id(victim_pubkey)
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps({
+                'agent_id': victim_agent_id,
+                'pubkey_hex': attacker_pubkey,
+                'name': 'Squatter',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        data = json.loads(response.data)
+        self.assertIn('agent_id', data['error'])
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                "SELECT agent_id FROM relay_agents WHERE agent_id = ?",
+                (victim_agent_id,),
+            ).fetchone()
+            self.assertIsNone(row)
+
+    def test_join_accepts_matching_canonical_agent_id(self):
+        """POST /beacon/join 接受由 pubkey_hex 派生出的规范 bcn_ ID。"""
+        pubkey = '0x' + '33' * 32
+        agent_id = _canonical_agent_id(pubkey)
+
+        response = self.client.post(
+            '/beacon/join',
+            data=json.dumps({
+                'agent_id': agent_id,
+                'pubkey_hex': pubkey,
+                'name': 'Canonical Agent',
+            }),
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['agent_id'], agent_id)
 
     def test_join_invalid_pubkey_hex_returns_400(self):
         """POST /beacon/join returns 400 for invalid pubkey_hex."""


### PR DESCRIPTION
﻿## Summary
- Reject `/beacon/join` attempts that claim a canonical `bcn_<12 hex>` Beacon agent ID derived from a different Ed25519 public key.
- Preserve compatibility for existing non-canonical local/test agent labels while protecting the canonical Beacon namespace.
- Add regression coverage for the mismatch reject path and the matching canonical success path.

## Security impact
Beacon already treats canonical IDs as `bcn_` + the first 12 hex chars of `sha256(pubkey)` in signed-envelope paths. Before this patch, unauthenticated `/beacon/join` accepted a canonical-looking ID with any unrelated `pubkey_hex`. A first requester could squat another key's canonical agent ID, bind it to their own signing key/payment metadata, and then authenticate contract actions under that claimed ID until the real owner is blocked by the immutable pubkey rule.

## Fix
For canonical IDs only, derive the expected ID from `pubkey_hex` and reject mismatches before inserting into `relay_agents`.

## Validation
- Red before fix: `tests/test_beacon_join_routing.py::TestBeaconJoinRouting::test_join_rejects_canonical_agent_id_pubkey_mismatch` returned `200 != 400`.
- `python -m pytest tests/test_beacon_join_routing.py node/tests/test_beacon_api_join.py -q` -> `27 passed`
- `python -m py_compile node/beacon_api.py tests/test_beacon_join_routing.py`
- `git diff --check`
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`

Notes: I also ran `tests/test_beacon_atlas_behavior.py`; its remaining failures are existing auth-expectation mismatches where unauthenticated list/reputation endpoints now return `401`, not regressions from this join binding patch.

Bounty context: prepared for rustchain-bounties issue #66. No production testing was performed.
