### PR TITLE
feat(bridge): public read-only federation routes (Layer 1 of federation arc)

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -1,0 +1,365 @@
+"""Public read-only federation routes for bridge state + events.
+
+Separate from the admin-keyed routes in `bridge_api.py` (which handle
+mutation: initiate, void, update-external-confirmation). These routes are:
+
+- **Public** (no admin key required) — the federation design note proposes
+  reconciliation surfaces that anyone can audit without privileged access.
+- **Read-only** — never write to `bridge_transfers` or `lock_ledger`.
+- **Aggregate-friendly** — `bridge.state.get` returns the bridged-supply
+  counter shape (per design note §3.2), not per-transfer detail.
+- **Future-cross-side** — the data shape is designed so a future MergeWork
+  bridge MCP can mirror it field-for-field for reconciliation comparison.
+
+See:
+  - https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_DESIGN_NOTE.md
+    §6.4 (Reconciliation as MCP read-only surface)
+    §3.2 (The invariant: locked-on-one-side == mirrored-on-other-side)
+
+Closes Layer 1 of the federation design work; Layers 2 (bridged-supply
+snapshot mechanic), 3 (RFC iteration), 4 (MCP tool sketches) are tracked
+separately.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from typing import Any, Dict, List, Optional
+
+from flask import jsonify, request
+
+
+# Status values surfaced as public state (per existing bridge_api schema).
+PUBLIC_STATUS_VALUES = ("pending", "locked", "confirming", "completed", "voided", "failed")
+
+# Bounded defaults for public endpoints.
+DEFAULT_EVENTS_LIMIT = 50
+MAX_EVENTS_LIMIT = 200
+
+DEFAULT_TRANSFERS_LIMIT = 50
+MAX_TRANSFERS_LIMIT = 200
+
+# Default time window for events: 24 hours.
+DEFAULT_EVENTS_WINDOW_SECONDS = 24 * 3600
+MAX_EVENTS_WINDOW_SECONDS = 30 * 24 * 3600
+
+
+def _get_db_path() -> str:
+    """Resolve DB_PATH the same way bridge_api.py does."""
+    return os.environ.get("DB_PATH", "rustchain_v2.db")
+
+
+def _parse_int_arg(value: Optional[str], default: int, min_value: int, max_value: int) -> int:
+    """Parse + clamp an integer query parameter."""
+    if value in (None, ""):
+        return default
+    try:
+        n = int(value)
+    except (ValueError, TypeError):
+        return default
+    return max(min_value, min(n, max_value))
+
+
+def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
+    """Compute the aggregate bridged-supply state.
+
+    Returns a dict matching the shape described in FEDERATION_DESIGN_NOTE §3.2:
+
+        {
+            "locked_in_rtc": <total RTC sitting in locked/confirming on this side>,
+            "completed_in_rtc": <total RTC ever moved to other side>,
+            "voided_in_rtc": <total RTC ever voided>,
+            "by_status": {<status>: {"count": N, "total_rtc": X}, ...},
+            "by_direction": {"deposit": {...}, "withdraw": {...}},
+            "last_event_at": <epoch seconds of most recent state change>,
+            "computed_at": <epoch seconds when this aggregate was produced>,
+        }
+
+    No sensitive per-transfer details exposed.
+    """
+    cursor = conn.cursor()
+
+    # by_status
+    cursor.execute(
+        "SELECT status, COUNT(*), COALESCE(SUM(amount_rtc), 0.0) "
+        "FROM bridge_transfers GROUP BY status"
+    )
+    by_status: Dict[str, Dict[str, Any]] = {}
+    for status, n, total in cursor.fetchall():  # fetchall-ok: bounded-by-schema
+        by_status[status] = {"count": int(n), "total_rtc": float(total)}
+
+    # by_direction (deposit / withdraw)
+    cursor.execute(
+        "SELECT direction, COUNT(*), COALESCE(SUM(amount_rtc), 0.0) "
+        "FROM bridge_transfers GROUP BY direction"
+    )
+    by_direction: Dict[str, Dict[str, Any]] = {}
+    for direction, n, total in cursor.fetchall():  # fetchall-ok: bounded-by-schema
+        by_direction[direction] = {"count": int(n), "total_rtc": float(total)}
+
+    # "Locked in" = pending + locked + confirming (RTC committed but not yet
+    # mirrored on the other side AND not yet voided).
+    locked_in = sum(
+        by_status.get(s, {}).get("total_rtc", 0.0)
+        for s in ("pending", "locked", "confirming")
+    )
+    completed_in = by_status.get("completed", {}).get("total_rtc", 0.0)
+    voided_in = by_status.get("voided", {}).get("total_rtc", 0.0)
+
+    # last_event_at: most recent created_at across all transfers
+    last_event = cursor.execute(
+        "SELECT COALESCE(MAX(created_at), 0) FROM bridge_transfers"
+    ).fetchone()  # fetchall-ok: pragma-result (single MAX)
+    last_event_at = int(last_event[0]) if last_event else 0
+
+    return {
+        "locked_in_rtc": float(locked_in),
+        "completed_in_rtc": float(completed_in),
+        "voided_in_rtc": float(voided_in),
+        "by_status": by_status,
+        "by_direction": by_direction,
+        "last_event_at": last_event_at,
+        "computed_at": int(time.time()),
+    }
+
+
+def _recent_events(conn: sqlite3.Connection, limit: int, window_seconds: int) -> List[Dict[str, Any]]:
+    """List recent bridge state-change events, public-safe fields only.
+
+    Returns a list of dicts of the form:
+
+        {
+            "tx_hash": <bridge tx_hash>,
+            "direction": "deposit" | "withdraw",
+            "source_chain": ...,
+            "dest_chain": ...,
+            "amount_rtc": ...,
+            "status": ...,
+            "external_confirmations": ...,
+            "required_confirmations": ...,
+            "created_at": ...,
+        }
+
+    Sensitive fields explicitly NOT exposed:
+        - source_address / dest_address (privacy)
+        - external_tx_hash (could leak external chain identifiers)
+        - bridge_fee_i64 (operator-internal)
+        - lock_epoch (operator-internal)
+        - id (internal row id)
+    """
+    cutoff = int(time.time()) - max(0, window_seconds)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT tx_hash, direction, source_chain, dest_chain,
+               amount_rtc, status, external_confirmations,
+               required_confirmations, created_at
+        FROM bridge_transfers
+        WHERE created_at >= ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT ?
+        """,
+        (cutoff, limit),
+    )
+    rows = cursor.fetchall()  # fetchall-ok: already-paginated (LIMIT ?)
+    return [
+        {
+            "tx_hash": r[0],
+            "direction": r[1],
+            "source_chain": r[2],
+            "dest_chain": r[3],
+            "amount_rtc": float(r[4]),
+            "status": r[5],
+            "external_confirmations": int(r[6]) if r[6] is not None else 0,
+            "required_confirmations": int(r[7]) if r[7] is not None else 0,
+            "created_at": int(r[8]),
+        }
+        for r in rows
+    ]
+
+
+def _recent_transfers_public(
+    conn: sqlite3.Connection,
+    status_filter: Optional[str],
+    direction_filter: Optional[str],
+    limit: int,
+    offset: int,
+) -> Dict[str, Any]:
+    """List recent transfers (paginated), public-safe fields only.
+
+    Same field set as _recent_events but with optional status/direction filter
+    + pagination. Returns:
+
+        {
+            "transfers": [...],
+            "total": <total count matching filters>,
+            "limit": ...,
+            "offset": ...,
+        }
+    """
+    cursor = conn.cursor()
+
+    where = ["1=1"]
+    params: List[Any] = []
+    if status_filter in PUBLIC_STATUS_VALUES:
+        where.append("status = ?")
+        params.append(status_filter)
+    if direction_filter in ("deposit", "withdraw"):
+        where.append("direction = ?")
+        params.append(direction_filter)
+    where_sql = " AND ".join(where)
+
+    # Total count (bounded by schema cardinality).
+    total = cursor.execute(
+        f"SELECT COUNT(*) FROM bridge_transfers WHERE {where_sql}",
+        tuple(params),
+    ).fetchone()[0]  # fetchall-ok: pragma-result (single COUNT)
+
+    cursor.execute(
+        f"""
+        SELECT tx_hash, direction, source_chain, dest_chain,
+               amount_rtc, status, external_confirmations,
+               required_confirmations, created_at
+        FROM bridge_transfers
+        WHERE {where_sql}
+        ORDER BY created_at DESC, id DESC
+        LIMIT ? OFFSET ?
+        """,
+        tuple(params) + (limit, offset),
+    )
+    rows = cursor.fetchall()  # fetchall-ok: already-paginated (LIMIT ?)
+    transfers = [
+        {
+            "tx_hash": r[0],
+            "direction": r[1],
+            "source_chain": r[2],
+            "dest_chain": r[3],
+            "amount_rtc": float(r[4]),
+            "status": r[5],
+            "external_confirmations": int(r[6]) if r[6] is not None else 0,
+            "required_confirmations": int(r[7]) if r[7] is not None else 0,
+            "created_at": int(r[8]),
+        }
+        for r in rows
+    ]
+
+    return {
+        "transfers": transfers,
+        "total": int(total),
+        "limit": limit,
+        "offset": offset,
+    }
+
+
+def register_federation_routes(app):
+    """Register public read-only federation routes on a Flask app.
+
+    Call AFTER `register_bridge_routes(app)` so the mutation routes are
+    already in place — these read routes don't depend on the mutation
+    routes, but the order keeps blueprint registration deterministic.
+    """
+
+    @app.route("/bridge/state", methods=["GET"])
+    def bridge_state():
+        """Aggregate bridged-supply state. Public, no auth required.
+
+        Returns the shape described in FEDERATION_DESIGN_NOTE §3.2.
+        """
+        db_path = _get_db_path()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                state = _aggregate_bridge_state(conn)
+        except sqlite3.Error as exc:
+            return jsonify({"ok": False, "error": f"db_error: {exc.__class__.__name__}"}), 503
+        return jsonify({"ok": True, "state": state})
+
+    @app.route("/bridge/events", methods=["GET"])
+    def bridge_events():
+        """Recent bridge state-change events, public-safe fields only.
+
+        Query params:
+            limit:  1..MAX_EVENTS_LIMIT (default 50)
+            window_seconds: 0..MAX_EVENTS_WINDOW_SECONDS (default 24h)
+        """
+        limit = _parse_int_arg(
+            request.args.get("limit"),
+            default=DEFAULT_EVENTS_LIMIT,
+            min_value=1,
+            max_value=MAX_EVENTS_LIMIT,
+        )
+        window = _parse_int_arg(
+            request.args.get("window_seconds"),
+            default=DEFAULT_EVENTS_WINDOW_SECONDS,
+            min_value=0,
+            max_value=MAX_EVENTS_WINDOW_SECONDS,
+        )
+        db_path = _get_db_path()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                events = _recent_events(conn, limit=limit, window_seconds=window)
+        except sqlite3.Error as exc:
+            return jsonify({"ok": False, "error": f"db_error: {exc.__class__.__name__}"}), 503
+        return jsonify({
+            "ok": True,
+            "count": len(events),
+            "limit": limit,
+            "window_seconds": window,
+            "events": events,
+        })
+
+    @app.route("/bridge/transfers/recent", methods=["GET"])
+    def bridge_transfers_recent():
+        """Paginated public list of bridge transfers.
+
+        Query params:
+            limit:  1..MAX_TRANSFERS_LIMIT (default 50)
+            offset: >= 0
+            status: pending|locked|confirming|completed|voided|failed (optional)
+            direction: deposit|withdraw (optional)
+
+        Sensitive fields (addresses, external_tx_hash, internal id) are
+        intentionally omitted.
+        """
+        limit = _parse_int_arg(
+            request.args.get("limit"),
+            default=DEFAULT_TRANSFERS_LIMIT,
+            min_value=1,
+            max_value=MAX_TRANSFERS_LIMIT,
+        )
+        try:
+            offset = max(0, int(request.args.get("offset", 0)))
+        except (ValueError, TypeError):
+            offset = 0
+        status_filter = request.args.get("status")
+        direction_filter = request.args.get("direction")
+
+        db_path = _get_db_path()
+        try:
+            with sqlite3.connect(db_path) as conn:
+                payload = _recent_transfers_public(
+                    conn,
+                    status_filter=status_filter,
+                    direction_filter=direction_filter,
+                    limit=limit,
+                    offset=offset,
+                )
+        except sqlite3.Error as exc:
+            return jsonify({"ok": False, "error": f"db_error: {exc.__class__.__name__}"}), 503
+        return jsonify({"ok": True, **payload})
+
+
+__all__ = [
+    "register_federation_routes",
+    "_aggregate_bridge_state",
+    "_recent_events",
+    "_recent_transfers_public",
+    "PUBLIC_STATUS_VALUES",
+    "DEFAULT_EVENTS_LIMIT",
+    "MAX_EVENTS_LIMIT",
+    "DEFAULT_EVENTS_WINDOW_SECONDS",
+    "MAX_EVENTS_WINDOW_SECONDS",
+    "DEFAULT_TRANSFERS_LIMIT",
+    "MAX_TRANSFERS_LIMIT",
+]

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -145,8 +145,10 @@ except ImportError as _e:
 try:
     from bridge_api import register_bridge_routes, init_bridge_schema
     from lock_ledger import register_lock_ledger_routes, init_lock_ledger_schema
+    from bridge_federation_routes import register_federation_routes
     HAVE_BRIDGE = True
     print("[RIP-0305 Track C] Bridge API + Lock Ledger modules loaded")
+    print("[FEDERATION] Bridge federation read-only routes loaded")
 except ImportError as _e:
     HAVE_BRIDGE = False
     print(f"[RIP-0305 Track C] Bridge modules not available: {_e}")
@@ -1368,7 +1370,9 @@ if HAVE_BRIDGE:
     try:
         register_bridge_routes(app)
         register_lock_ledger_routes(app)
+        register_federation_routes(app)
         print("[RIP-0305 Track C] Bridge API + Lock Ledger endpoints registered")
+        print("[FEDERATION] Bridge federation read-only endpoints registered")
     except Exception as e:
         print(f"[RIP-0305 Track C] Failed to register bridge endpoints: {e}")
 

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -1,0 +1,314 @@
+"""Tests for node/bridge_federation_routes.py — public read-only federation routes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, "node")
+
+import bridge_api as ba  # noqa: E402
+import bridge_federation_routes as fed  # noqa: E402
+
+
+# ---------- fixtures ---------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """Fresh sqlite db with bridge_transfers schema initialized."""
+    p = tmp_path / "fed_routes.db"
+    with sqlite3.connect(p) as conn:
+        ba.init_bridge_schema(conn.cursor())
+        conn.commit()
+    monkeypatch.setenv("DB_PATH", str(p))
+    return str(p)
+
+
+@pytest.fixture
+def app(db_path):
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    fed.register_federation_routes(app)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _seed(db_path, rows):
+    """Helper to insert bridge_transfers test rows.
+
+    Each row dict can override any column; sensible defaults applied.
+    """
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.cursor()
+        for i, row in enumerate(rows):
+            r = {
+                "direction": row.get("direction", "deposit"),
+                "source_chain": row.get("source_chain", "rustchain"),
+                "dest_chain": row.get("dest_chain", "ergo"),
+                "source_address": row.get("source_address", f"miner_{i}"),
+                "dest_address": row.get("dest_address", f"ergo_addr_{i}"),
+                "amount_i64": row.get("amount_i64", 1_000_000),
+                "amount_rtc": row.get("amount_rtc", 1.0),
+                "bridge_type": row.get("bridge_type", "bottube"),
+                "bridge_fee_i64": row.get("bridge_fee_i64", 0),
+                "external_tx_hash": row.get("external_tx_hash"),
+                "external_confirmations": row.get("external_confirmations", 0),
+                "required_confirmations": row.get("required_confirmations", 12),
+                "status": row.get("status", "pending"),
+                "lock_epoch": row.get("lock_epoch", 1),
+                "created_at": row.get("created_at", now - i),
+                "updated_at": row.get("updated_at", now - i),
+                "tx_hash": row.get("tx_hash", f"hash_{i}"),
+            }
+            cur.execute(
+                """
+                INSERT INTO bridge_transfers (
+                    direction, source_chain, dest_chain,
+                    source_address, dest_address,
+                    amount_i64, amount_rtc,
+                    bridge_type, bridge_fee_i64,
+                    external_tx_hash, external_confirmations, required_confirmations,
+                    status, lock_epoch, created_at, updated_at, tx_hash
+                ) VALUES (:direction, :source_chain, :dest_chain,
+                          :source_address, :dest_address,
+                          :amount_i64, :amount_rtc,
+                          :bridge_type, :bridge_fee_i64,
+                          :external_tx_hash, :external_confirmations, :required_confirmations,
+                          :status, :lock_epoch, :created_at, :updated_at, :tx_hash)
+                """,
+                r,
+            )
+        conn.commit()
+
+
+# ---------- /bridge/state ----------------------------------------------------
+
+
+def test_state_empty(client):
+    resp = client.get("/bridge/state")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["ok"] is True
+    s = body["state"]
+    assert s["locked_in_rtc"] == 0.0
+    assert s["completed_in_rtc"] == 0.0
+    assert s["voided_in_rtc"] == 0.0
+    assert s["by_status"] == {}
+    assert s["by_direction"] == {}
+    assert s["last_event_at"] == 0
+    assert s["computed_at"] > 0
+
+
+def test_state_aggregates_by_status_and_direction(client, db_path):
+    _seed(db_path, [
+        {"status": "pending", "amount_rtc": 10.0, "direction": "deposit"},
+        {"status": "locked", "amount_rtc": 20.0, "direction": "deposit"},
+        {"status": "confirming", "amount_rtc": 5.0, "direction": "deposit"},
+        {"status": "completed", "amount_rtc": 100.0, "direction": "withdraw"},
+        {"status": "voided", "amount_rtc": 7.0, "direction": "deposit"},
+    ])
+    body = client.get("/bridge/state").get_json()
+    s = body["state"]
+    # locked_in = pending + locked + confirming = 10 + 20 + 5
+    assert s["locked_in_rtc"] == 35.0
+    assert s["completed_in_rtc"] == 100.0
+    assert s["voided_in_rtc"] == 7.0
+    assert s["by_status"]["pending"] == {"count": 1, "total_rtc": 10.0}
+    assert s["by_status"]["locked"] == {"count": 1, "total_rtc": 20.0}
+    assert s["by_direction"]["deposit"]["count"] == 4
+    assert s["by_direction"]["deposit"]["total_rtc"] == 42.0  # 10+20+5+7
+    assert s["by_direction"]["withdraw"] == {"count": 1, "total_rtc": 100.0}
+
+
+def test_state_last_event_at_reflects_max_created_at(client, db_path):
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 100, "status": "pending"},
+        {"created_at": base, "status": "completed"},
+        {"created_at": base - 50, "status": "locked"},
+    ])
+    s = client.get("/bridge/state").get_json()["state"]
+    assert s["last_event_at"] == base
+
+
+# ---------- /bridge/events ---------------------------------------------------
+
+
+def test_events_empty(client):
+    resp = client.get("/bridge/events")
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body == {
+        "ok": True,
+        "count": 0,
+        "limit": fed.DEFAULT_EVENTS_LIMIT,
+        "window_seconds": fed.DEFAULT_EVENTS_WINDOW_SECONDS,
+        "events": [],
+    }
+
+
+def test_events_returns_recent_in_descending_order(client, db_path):
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 100, "tx_hash": "old"},
+        {"created_at": base - 10, "tx_hash": "newer"},
+        {"created_at": base - 50, "tx_hash": "middle"},
+    ])
+    body = client.get("/bridge/events").get_json()
+    assert [e["tx_hash"] for e in body["events"]] == ["newer", "middle", "old"]
+
+
+def test_events_excludes_sensitive_fields(client, db_path):
+    _seed(db_path, [{
+        "source_address": "miner_alice",
+        "dest_address": "ergo_bob",
+        "external_tx_hash": "ergo_external_tx_xxx",
+        "tx_hash": "hash_redact_test",
+        "status": "completed",
+        "amount_rtc": 42.0,
+    }])
+    e = client.get("/bridge/events").get_json()["events"][0]
+    # exposed (safe) fields
+    assert "tx_hash" in e
+    assert "direction" in e
+    assert "amount_rtc" in e
+    assert e["status"] == "completed"
+    # explicitly NOT exposed
+    assert "source_address" not in e
+    assert "dest_address" not in e
+    assert "external_tx_hash" not in e
+    assert "id" not in e
+    assert "bridge_fee_i64" not in e
+    assert "lock_epoch" not in e
+
+
+def test_events_window_seconds_clamps_old_rows(client, db_path):
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 10_000, "tx_hash": "ten_thousand_ago"},
+        {"created_at": base - 10, "tx_hash": "recent"},
+    ])
+    body = client.get("/bridge/events?window_seconds=100").get_json()
+    assert [e["tx_hash"] for e in body["events"]] == ["recent"]
+
+
+def test_events_limit_clamped_to_max(client, db_path):
+    # request limit > MAX_EVENTS_LIMIT should clamp
+    _seed(db_path, [{"created_at": int(time.time()) - i} for i in range(5)])
+    body = client.get(f"/bridge/events?limit={fed.MAX_EVENTS_LIMIT + 5000}").get_json()
+    assert body["limit"] == fed.MAX_EVENTS_LIMIT
+
+
+def test_events_limit_invalid_falls_back_to_default(client):
+    body = client.get("/bridge/events?limit=not_a_number").get_json()
+    assert body["limit"] == fed.DEFAULT_EVENTS_LIMIT
+
+
+# ---------- /bridge/transfers/recent ----------------------------------------
+
+
+def test_transfers_recent_empty(client):
+    body = client.get("/bridge/transfers/recent").get_json()
+    assert body == {
+        "ok": True,
+        "transfers": [],
+        "total": 0,
+        "limit": fed.DEFAULT_TRANSFERS_LIMIT,
+        "offset": 0,
+    }
+
+
+def test_transfers_recent_pagination(client, db_path):
+    _seed(db_path, [{"tx_hash": f"h{i}", "created_at": int(time.time()) - i} for i in range(10)])
+    body = client.get("/bridge/transfers/recent?limit=3&offset=0").get_json()
+    assert body["total"] == 10
+    assert body["limit"] == 3
+    assert body["offset"] == 0
+    assert len(body["transfers"]) == 3
+    assert [t["tx_hash"] for t in body["transfers"]] == ["h0", "h1", "h2"]
+
+    body2 = client.get("/bridge/transfers/recent?limit=3&offset=3").get_json()
+    assert [t["tx_hash"] for t in body2["transfers"]] == ["h3", "h4", "h5"]
+
+
+def test_transfers_recent_status_filter(client, db_path):
+    _seed(db_path, [
+        {"tx_hash": "p1", "status": "pending"},
+        {"tx_hash": "c1", "status": "completed"},
+        {"tx_hash": "p2", "status": "pending"},
+    ])
+    body = client.get("/bridge/transfers/recent?status=pending").get_json()
+    assert body["total"] == 2
+    assert {t["tx_hash"] for t in body["transfers"]} == {"p1", "p2"}
+
+
+def test_transfers_recent_direction_filter(client, db_path):
+    _seed(db_path, [
+        {"tx_hash": "d1", "direction": "deposit"},
+        {"tx_hash": "w1", "direction": "withdraw"},
+    ])
+    body = client.get("/bridge/transfers/recent?direction=withdraw").get_json()
+    assert body["total"] == 1
+    assert body["transfers"][0]["tx_hash"] == "w1"
+
+
+def test_transfers_recent_invalid_status_ignored(client, db_path):
+    _seed(db_path, [{"tx_hash": "x"}])
+    body = client.get("/bridge/transfers/recent?status=__not_a_status__").get_json()
+    assert body["total"] == 1
+
+
+def test_transfers_recent_excludes_sensitive_fields(client, db_path):
+    _seed(db_path, [{
+        "tx_hash": "redact_check",
+        "source_address": "secret_src",
+        "dest_address": "secret_dst",
+        "external_tx_hash": "secret_external",
+    }])
+    t = client.get("/bridge/transfers/recent").get_json()["transfers"][0]
+    assert t["tx_hash"] == "redact_check"
+    for field in ("source_address", "dest_address", "external_tx_hash",
+                  "id", "bridge_fee_i64", "lock_epoch"):
+        assert field not in t
+
+
+def test_transfers_recent_limit_clamped(client):
+    body = client.get(f"/bridge/transfers/recent?limit={fed.MAX_TRANSFERS_LIMIT + 1000}").get_json()
+    assert body["limit"] == fed.MAX_TRANSFERS_LIMIT
+
+
+def test_transfers_recent_offset_negative_clamps_to_zero(client):
+    body = client.get("/bridge/transfers/recent?offset=-50").get_json()
+    assert body["offset"] == 0
+
+
+# ---------- routes do not require admin key ---------------------------------
+
+
+def test_routes_do_not_check_admin_key(client, db_path):
+    # No X-Admin-Key header — all 3 routes should still return 200.
+    for path in ("/bridge/state", "/bridge/events", "/bridge/transfers/recent"):
+        resp = client.get(path)
+        assert resp.status_code == 200, f"{path} should not require admin key"
+
+
+def test_routes_ignore_admin_key_when_present(client, db_path):
+    # Routes are explicitly public; supplying a bogus admin key MUST NOT cause
+    # a 401 — the routes don't check auth at all.
+    headers = {"X-Admin-Key": "bogus"}
+    for path in ("/bridge/state", "/bridge/events", "/bridge/transfers/recent"):
+        resp = client.get(path, headers=headers)
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Adds **3 public read-only Flask routes** on top of the existing `bridge_transfers` + `lock_ledger` schema, providing the **bridge state + events + paginated transfers** surface that the federation design note §6.4 calls for and Codex's code-state audit §5 identified as missing.

This is **Layer 1 of the federation design work**:
- Layer 1 (this PR): public read APIs — shipped
- Layer 2 ([spec](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_BRIDGED_SUPPLY_SPEC.md)): bridged-supply snapshot mechanic — spec DRAFT, build follows
- Layer 3: RFC iteration of design note + relayer signatures
- Layer 4: MCP tools wiring on top of these routes

## What this adds

### `node/bridge_federation_routes.py` (~290 LOC)

1. **`GET /bridge/state`** — aggregate bridged-supply state
   - `locked_in_rtc` = sum(pending+locked+confirming)
   - `completed_in_rtc`, `voided_in_rtc`
   - `by_status` + `by_direction` breakdown
   - `last_event_at` + `computed_at`
   - Matches the shape in [federation design note §3.2 invariant](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_DESIGN_NOTE.md)

2. **`GET /bridge/events?limit=&window_seconds=`**
   - Recent state-change events
   - `limit`: 1..200 (default 50), `window_seconds`: 0..30d (default 24h)
   - Public-safe fields only (see redaction list below)

3. **`GET /bridge/transfers/recent?limit=&offset=&status=&direction=`**
   - Paginated transfer list with optional status/direction filter
   - Same public-safe field set as events

### Sensitive fields intentionally NOT exposed

- `source_address` / `dest_address` (privacy)
- `external_tx_hash` (could leak external chain identifiers)
- `bridge_fee_i64` (operator-internal)
- `lock_epoch` (operator-internal)
- `id` (internal row id)

Tests assert exclusion explicitly:
`test_events_excludes_sensitive_fields` and
`test_transfers_recent_excludes_sensitive_fields`.

### Public-by-design

These routes are **explicitly public** — no admin key required.

- `test_routes_do_not_check_admin_key` asserts 200 with no auth header
- `test_routes_ignore_admin_key_when_present` asserts 200 even with bogus X-Admin-Key (no 401)

## What's intentionally NOT in this PR

- **No mutation routes.** Those stay in `bridge_api.py` (admin-keyed).
- **No relayer-set signatures.** Those are Layer 3, waiting on ramimbo sign-off on snapshot row format + signing protocol.
- **No per-epoch snapshot mechanic.** Layer 2 spec is at [FEDERATION_BRIDGED_SUPPLY_SPEC.md](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_BRIDGED_SUPPLY_SPEC.md). Implementation follows after the spec gets joint review.
- **No drift checker / auto-pause.** Layer 3.

## Tests

```
$ python3 -m pytest -q node/tests/test_bridge_federation_routes.py
...................                                                      [100%]
19 passed in 0.16s
```

Coverage:
- Empty-DB happy path (3 routes)
- Aggregate computation across mixed status/direction
- `last_event_at` reflects MAX(created_at)
- Events: descending order, window clamping, limit clamping, invalid-input fallback
- Sensitive-field exclusion (events + transfers/recent)
- Pagination (limit + offset)
- Status + direction filters
- Invalid status filter ignored gracefully
- Negative offset clamps to 0
- Public-no-auth-required + bogus-admin-key-ignored

## Wire-in

`register_federation_routes(app)` is called from the main node file (`rustchain_v2_integrated_v2.2.1_rip200.py`) after `register_bridge_routes` + `register_lock_ledger_routes`, gated by the existing `HAVE_BRIDGE` flag. No-op import if the bridge module isn't available.

## Out of scope

- Caching layer (these endpoints hit the DB on every request; if traffic grows, add an in-memory TTL cache — not needed yet)
- Cross-side reconciliation (Layer 2)
- Relayer signing infrastructure (Layer 3)
- MCP tool wiring (Layer 4, in claim-portal repo)

## Source

- [Federation Design Note §6.4](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_DESIGN_NOTE.md) — "Reconciliation as MCP read-only surface"
- [Codex authoritative code-state audit (2026-05-29) §5](https://github.com/Scottcjn/Rustchain/issues/6626) — identified missing public reconciliation surfaces
- Federation discussion: [Scottcjn/Rustchain#6522](https://github.com/Scottcjn/Rustchain/issues/6522), [ramimbo/mergework#571](https://github.com/ramimbo/mergework/issues/571)