### PR TITLE
feat(bridge): reconciliation snapshots (Layer 2 of federation arc)

### DIFF
--- a/node/bridge_reconciliation.py
+++ b/node/bridge_reconciliation.py
@@ -1,0 +1,347 @@
+"""Per-epoch reconciliation snapshots for bridge state.
+
+Implements Layer 2 of the federation arc per:
+  https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_BRIDGED_SUPPLY_SPEC.md
+
+Each snapshot is one row in `bridge_reconciliation_snapshots` recording:
+
+  - The aggregate bridge state at the snapshot moment (locked_in /
+    completed_in / voided_in / bridged_supply_committed)
+  - A deterministic `state_hash` over the canonical-JSON serialization of
+    the `by_status` + `by_direction` breakdowns + the totals
+  - `relayer_signatures` placeholder column (NULL on operator-only side;
+    Layer 3 fills with relayer-set signatures when federation goes live)
+  - `epoch` (unique constraint) + `computed_at` (epoch seconds)
+
+These rows are append-only by design: each snapshot is a permanent
+attestation that anyone can verify against the chain's then-current
+state.
+
+Operator-side value (independent of federation):
+  - Historical state proof per epoch — answers "what did the bridge
+    look like at the end of epoch N?"
+  - Drift detection groundwork — Layer 3 adds the cross-side checker
+    that compares our snapshot to MergeWork's; this module is the
+    snapshot-producer half of that protocol.
+
+Public routes added in this module:
+  - GET /bridge/reconciliation/latest
+  - GET /bridge/reconciliation/by_epoch/<int:epoch>
+  - GET /bridge/reconciliation/recent?limit=<n>
+
+All routes are public read-only, same shape/policy as the Layer 1
+federation routes in `bridge_federation_routes.py`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import time
+from typing import Any, Dict, List, Optional
+
+from flask import jsonify, request
+
+# Re-use the aggregate computation from Layer 1 — the snapshot IS the
+# Layer 1 aggregate with a stable hash + epoch annotation.
+try:  # pragma: no cover - import guards for split test contexts
+    from bridge_federation_routes import _aggregate_bridge_state
+except ImportError:
+    _aggregate_bridge_state = None  # type: ignore[assignment]
+
+
+SNAPSHOTS_SCHEMA_DDL = """
+CREATE TABLE IF NOT EXISTS bridge_reconciliation_snapshots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    epoch INTEGER NOT NULL UNIQUE,
+    computed_at INTEGER NOT NULL,
+    locked_in_rtc REAL NOT NULL,
+    completed_in_rtc REAL NOT NULL,
+    voided_in_rtc REAL NOT NULL,
+    bridged_supply_committed REAL NOT NULL,
+    state_hash TEXT NOT NULL,
+    relayer_signatures TEXT
+);
+"""
+
+SNAPSHOTS_INDEX_DDL = """
+CREATE INDEX IF NOT EXISTS idx_bridge_reconciliation_epoch
+ON bridge_reconciliation_snapshots(epoch DESC);
+"""
+
+
+DEFAULT_RECENT_LIMIT = 20
+MAX_RECENT_LIMIT = 200
+
+
+def _get_db_path() -> str:
+    return os.environ.get("DB_PATH", "rustchain_v2.db")
+
+
+def init_reconciliation_schema(cursor: sqlite3.Cursor) -> None:
+    """Create the snapshot table + index if not present."""
+    cursor.execute(SNAPSHOTS_SCHEMA_DDL)
+    cursor.execute(SNAPSHOTS_INDEX_DDL)
+
+
+def _canonical_state_payload(state: Dict[str, Any]) -> str:
+    """Produce a deterministic JSON serialization of the aggregate state.
+
+    Excludes `computed_at` (changes every call by design) so the same
+    underlying bridge state always hashes to the same `state_hash`.
+    """
+    stable = {k: v for k, v in state.items() if k != "computed_at"}
+    return json.dumps(stable, sort_keys=True, separators=(",", ":"))
+
+
+def compute_state_hash(state: Dict[str, Any]) -> str:
+    """SHA-256 over the canonical-JSON serialization of the aggregate."""
+    payload = _canonical_state_payload(state)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _bridged_supply_committed(state: Dict[str, Any]) -> float:
+    """Per FEDERATION_BRIDGED_SUPPLY_SPEC.md section 3:
+        bridged_supply_committed = locked_in + completed_in - voided_in
+    """
+    return (
+        float(state.get("locked_in_rtc", 0.0))
+        + float(state.get("completed_in_rtc", 0.0))
+        - float(state.get("voided_in_rtc", 0.0))
+    )
+
+
+def record_reconciliation_snapshot(
+    conn: sqlite3.Connection,
+    epoch: int,
+    *,
+    aggregate_state: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Compute and insert a snapshot row for `epoch`.
+
+    Idempotent on the `epoch` UNIQUE constraint: if a snapshot already
+    exists for this epoch, it is returned unchanged (no second row,
+    no clobber). This makes the function safe to call repeatedly from
+    epoch-settler hooks.
+
+    Args:
+        conn: open sqlite connection (must include bridge_transfers
+              + bridge_reconciliation_snapshots tables).
+        epoch: epoch number to snapshot.
+        aggregate_state: optional pre-computed state from
+              `_aggregate_bridge_state`. If None, computed here.
+
+    Returns:
+        dict with the snapshot row fields, plus a `created` boolean
+        indicating whether this call inserted a new row.
+    """
+    if aggregate_state is None:
+        if _aggregate_bridge_state is None:  # pragma: no cover
+            raise RuntimeError(
+                "bridge_federation_routes._aggregate_bridge_state unavailable"
+            )
+        aggregate_state = _aggregate_bridge_state(conn)
+
+    locked_in = float(aggregate_state.get("locked_in_rtc", 0.0))
+    completed_in = float(aggregate_state.get("completed_in_rtc", 0.0))
+    voided_in = float(aggregate_state.get("voided_in_rtc", 0.0))
+    bridged_committed = _bridged_supply_committed(aggregate_state)
+    state_hash = compute_state_hash(aggregate_state)
+    now = int(time.time())
+
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, computed_at, locked_in_rtc, completed_in_rtc, "
+        "voided_in_rtc, bridged_supply_committed, state_hash, relayer_signatures "
+        "FROM bridge_reconciliation_snapshots WHERE epoch = ?",
+        (int(epoch),),
+    )
+    existing = cursor.fetchone()  # fetchall-ok: pragma-result (unique key)
+    if existing is not None:
+        return {
+            "id": int(existing[0]),
+            "epoch": int(epoch),
+            "computed_at": int(existing[1]),
+            "locked_in_rtc": float(existing[2]),
+            "completed_in_rtc": float(existing[3]),
+            "voided_in_rtc": float(existing[4]),
+            "bridged_supply_committed": float(existing[5]),
+            "state_hash": existing[6],
+            "relayer_signatures": existing[7],
+            "created": False,
+        }
+
+    cursor.execute(
+        """
+        INSERT INTO bridge_reconciliation_snapshots (
+            epoch, computed_at,
+            locked_in_rtc, completed_in_rtc, voided_in_rtc,
+            bridged_supply_committed, state_hash, relayer_signatures
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+        """,
+        (
+            int(epoch),
+            now,
+            locked_in,
+            completed_in,
+            voided_in,
+            bridged_committed,
+            state_hash,
+        ),
+    )
+    conn.commit()
+    new_id = cursor.lastrowid
+    return {
+        "id": int(new_id) if new_id is not None else 0,
+        "epoch": int(epoch),
+        "computed_at": now,
+        "locked_in_rtc": locked_in,
+        "completed_in_rtc": completed_in,
+        "voided_in_rtc": voided_in,
+        "bridged_supply_committed": bridged_committed,
+        "state_hash": state_hash,
+        "relayer_signatures": None,
+        "created": True,
+    }
+
+
+def get_latest_snapshot(conn: sqlite3.Connection) -> Optional[Dict[str, Any]]:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, epoch, computed_at,
+               locked_in_rtc, completed_in_rtc, voided_in_rtc,
+               bridged_supply_committed, state_hash, relayer_signatures
+        FROM bridge_reconciliation_snapshots
+        ORDER BY epoch DESC
+        LIMIT 1
+        """
+    )
+    row = cursor.fetchone()  # fetchall-ok: already-paginated (LIMIT 1)
+    if row is None:
+        return None
+    return _row_to_dict(row)
+
+
+def get_snapshot_by_epoch(
+    conn: sqlite3.Connection, epoch: int
+) -> Optional[Dict[str, Any]]:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, epoch, computed_at,
+               locked_in_rtc, completed_in_rtc, voided_in_rtc,
+               bridged_supply_committed, state_hash, relayer_signatures
+        FROM bridge_reconciliation_snapshots
+        WHERE epoch = ?
+        """,
+        (int(epoch),),
+    )
+    row = cursor.fetchone()  # fetchall-ok: pragma-result (unique key)
+    if row is None:
+        return None
+    return _row_to_dict(row)
+
+
+def list_recent_snapshots(
+    conn: sqlite3.Connection, limit: int
+) -> List[Dict[str, Any]]:
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        SELECT id, epoch, computed_at,
+               locked_in_rtc, completed_in_rtc, voided_in_rtc,
+               bridged_supply_committed, state_hash, relayer_signatures
+        FROM bridge_reconciliation_snapshots
+        ORDER BY epoch DESC
+        LIMIT ?
+        """,
+        (int(limit),),
+    )
+    rows = cursor.fetchall()  # fetchall-ok: already-paginated (LIMIT ?)
+    return [_row_to_dict(r) for r in rows]
+
+
+def _row_to_dict(row) -> Dict[str, Any]:
+    return {
+        "id": int(row[0]),
+        "epoch": int(row[1]),
+        "computed_at": int(row[2]),
+        "locked_in_rtc": float(row[3]),
+        "completed_in_rtc": float(row[4]),
+        "voided_in_rtc": float(row[5]),
+        "bridged_supply_committed": float(row[6]),
+        "state_hash": row[7],
+        "relayer_signatures": row[8],
+    }
+
+
+def register_reconciliation_routes(app):
+    """Register public read-only reconciliation routes on a Flask app."""
+
+    @app.route("/bridge/reconciliation/latest", methods=["GET"])
+    def reconciliation_latest():
+        try:
+            with sqlite3.connect(_get_db_path()) as conn:
+                snap = get_latest_snapshot(conn)
+        except sqlite3.Error as exc:
+            return jsonify(
+                {"ok": False, "error": f"db_error: {exc.__class__.__name__}"}
+            ), 503
+        if snap is None:
+            return jsonify({"ok": True, "snapshot": None})
+        return jsonify({"ok": True, "snapshot": snap})
+
+    @app.route("/bridge/reconciliation/by_epoch/<int:epoch>", methods=["GET"])
+    def reconciliation_by_epoch(epoch: int):
+        if epoch < 0:
+            return jsonify({"ok": False, "error": "epoch must be >= 0"}), 400
+        try:
+            with sqlite3.connect(_get_db_path()) as conn:
+                snap = get_snapshot_by_epoch(conn, epoch)
+        except sqlite3.Error as exc:
+            return jsonify(
+                {"ok": False, "error": f"db_error: {exc.__class__.__name__}"}
+            ), 503
+        if snap is None:
+            return jsonify({"ok": True, "snapshot": None})
+        return jsonify({"ok": True, "snapshot": snap})
+
+    @app.route("/bridge/reconciliation/recent", methods=["GET"])
+    def reconciliation_recent():
+        raw = request.args.get("limit")
+        try:
+            limit = int(raw) if raw not in (None, "") else DEFAULT_RECENT_LIMIT
+        except (ValueError, TypeError):
+            limit = DEFAULT_RECENT_LIMIT
+        limit = max(1, min(limit, MAX_RECENT_LIMIT))
+
+        try:
+            with sqlite3.connect(_get_db_path()) as conn:
+                snaps = list_recent_snapshots(conn, limit=limit)
+        except sqlite3.Error as exc:
+            return jsonify(
+                {"ok": False, "error": f"db_error: {exc.__class__.__name__}"}
+            ), 503
+        return jsonify({
+            "ok": True,
+            "count": len(snaps),
+            "limit": limit,
+            "snapshots": snaps,
+        })
+
+
+__all__ = [
+    "init_reconciliation_schema",
+    "record_reconciliation_snapshot",
+    "compute_state_hash",
+    "get_latest_snapshot",
+    "get_snapshot_by_epoch",
+    "list_recent_snapshots",
+    "register_reconciliation_routes",
+    "DEFAULT_RECENT_LIMIT",
+    "MAX_RECENT_LIMIT",
+    "SNAPSHOTS_SCHEMA_DDL",
+]

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -146,9 +146,15 @@ try:
     from bridge_api import register_bridge_routes, init_bridge_schema
     from lock_ledger import register_lock_ledger_routes, init_lock_ledger_schema
     from bridge_federation_routes import register_federation_routes
+    from bridge_reconciliation import (
+        register_reconciliation_routes,
+        init_reconciliation_schema,
+        record_reconciliation_snapshot,
+    )
     HAVE_BRIDGE = True
     print("[RIP-0305 Track C] Bridge API + Lock Ledger modules loaded")
     print("[FEDERATION] Bridge federation read-only routes loaded")
+    print("[FEDERATION] Bridge reconciliation snapshots loaded (Layer 2)")
 except ImportError as _e:
     HAVE_BRIDGE = False
     print(f"[RIP-0305 Track C] Bridge modules not available: {_e}")
@@ -1371,8 +1377,17 @@ if HAVE_BRIDGE:
         register_bridge_routes(app)
         register_lock_ledger_routes(app)
         register_federation_routes(app)
+        register_reconciliation_routes(app)
+        # Init reconciliation snapshot table if not present
+        try:
+            with sqlite3.connect(DB_PATH) as _conn:
+                init_reconciliation_schema(_conn.cursor())
+                _conn.commit()
+        except Exception as _e:
+            print(f"[FEDERATION] reconciliation schema init warning: {_e}")
         print("[RIP-0305 Track C] Bridge API + Lock Ledger endpoints registered")
         print("[FEDERATION] Bridge federation read-only endpoints registered")
+        print("[FEDERATION] Bridge reconciliation endpoints registered")
     except Exception as e:
         print(f"[RIP-0305 Track C] Failed to register bridge endpoints: {e}")
 
@@ -8228,6 +8243,27 @@ def api_rewards_settle():
 
     with sqlite3.connect(DB_PATH) as db:
         res = settle_epoch(db, epoch)
+        # FEDERATION Layer 2: record bridge reconciliation snapshot for this
+        # epoch. Idempotent — safe to call repeatedly. Does NOT block or
+        # invalidate the settle response if the snapshot fails (the snapshot
+        # is an audit artifact, not a settlement requirement).
+        if HAVE_BRIDGE:
+            try:
+                snap_result = record_reconciliation_snapshot(db, epoch=epoch)
+                if isinstance(res, dict):
+                    res["bridge_reconciliation_snapshot"] = {
+                        "epoch": snap_result.get("epoch"),
+                        "state_hash": snap_result.get("state_hash"),
+                        "bridged_supply_committed": snap_result.get(
+                            "bridged_supply_committed"
+                        ),
+                        "created": snap_result.get("created", False),
+                    }
+            except Exception as _snap_exc:
+                print(
+                    f"[FEDERATION] reconciliation snapshot at epoch {epoch} "
+                    f"failed (non-fatal): {_snap_exc}"
+                )
     return jsonify(res)
 
 @app.route('/rewards/epoch/<int:epoch>', methods=['GET'])

--- a/node/tests/test_bridge_reconciliation.py
+++ b/node/tests/test_bridge_reconciliation.py
@@ -1,0 +1,288 @@
+"""Tests for node/bridge_reconciliation.py (Layer 2 of federation arc)."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, "node")
+
+import bridge_api as ba  # noqa: E402
+import bridge_federation_routes as fed  # noqa: E402
+import bridge_reconciliation as rec  # noqa: E402
+
+
+# ---------- fixtures --------------------------------------------------------
+
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    p = tmp_path / "reconciliation.db"
+    with sqlite3.connect(p) as conn:
+        ba.init_bridge_schema(conn.cursor())
+        rec.init_reconciliation_schema(conn.cursor())
+        conn.commit()
+    monkeypatch.setenv("DB_PATH", str(p))
+    return str(p)
+
+
+@pytest.fixture
+def app(db_path):
+    a = Flask(__name__)
+    a.config["TESTING"] = True
+    fed.register_federation_routes(a)
+    rec.register_reconciliation_routes(a)
+    return a
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def _seed_transfer(db_path, **overrides):
+    """Insert one bridge_transfers row with sensible defaults."""
+    now = int(time.time())
+    row = {
+        "direction": "deposit",
+        "source_chain": "rustchain",
+        "dest_chain": "ergo",
+        "source_address": "miner_x",
+        "dest_address": "ergo_x",
+        "amount_i64": 1_000_000,
+        "amount_rtc": 1.0,
+        "bridge_type": "bottube",
+        "bridge_fee_i64": 0,
+        "external_tx_hash": None,
+        "external_confirmations": 0,
+        "required_confirmations": 12,
+        "status": "pending",
+        "lock_epoch": 1,
+        "created_at": now,
+        "updated_at": now,
+        "tx_hash": f"h_{now}_{overrides.get('id_suffix', 0)}",
+    }
+    row.update({k: v for k, v in overrides.items() if k != "id_suffix"})
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO bridge_transfers (
+                direction, source_chain, dest_chain,
+                source_address, dest_address,
+                amount_i64, amount_rtc, bridge_type, bridge_fee_i64,
+                external_tx_hash, external_confirmations, required_confirmations,
+                status, lock_epoch, created_at, updated_at, tx_hash
+            ) VALUES (:direction, :source_chain, :dest_chain,
+                      :source_address, :dest_address,
+                      :amount_i64, :amount_rtc, :bridge_type, :bridge_fee_i64,
+                      :external_tx_hash, :external_confirmations, :required_confirmations,
+                      :status, :lock_epoch, :created_at, :updated_at, :tx_hash)
+            """,
+            row,
+        )
+        conn.commit()
+
+
+# ---------- compute_state_hash determinism ----------------------------------
+
+
+def test_state_hash_is_deterministic():
+    state = {
+        "locked_in_rtc": 10.0,
+        "completed_in_rtc": 20.0,
+        "voided_in_rtc": 0.0,
+        "by_status": {"pending": {"count": 1, "total_rtc": 10.0}},
+        "by_direction": {"deposit": {"count": 2, "total_rtc": 30.0}},
+        "last_event_at": 12345,
+        "computed_at": 99999,
+    }
+    h1 = rec.compute_state_hash(state)
+
+    state2 = dict(state)
+    state2["computed_at"] = 11111  # should be excluded from hash
+    h2 = rec.compute_state_hash(state2)
+
+    assert h1 == h2, "computed_at must not affect state_hash"
+    assert len(h1) == 64, "sha-256 hex digest"
+
+
+def test_state_hash_changes_with_underlying_state():
+    state_a = {
+        "locked_in_rtc": 10.0,
+        "completed_in_rtc": 0.0,
+        "voided_in_rtc": 0.0,
+        "by_status": {},
+        "by_direction": {},
+        "last_event_at": 1,
+        "computed_at": 0,
+    }
+    state_b = dict(state_a)
+    state_b["locked_in_rtc"] = 10.0001
+    assert rec.compute_state_hash(state_a) != rec.compute_state_hash(state_b)
+
+
+# ---------- record_reconciliation_snapshot ----------------------------------
+
+
+def test_snapshot_inserts_first_call(db_path):
+    _seed_transfer(db_path, status="pending", amount_rtc=42.0)
+    with sqlite3.connect(db_path) as conn:
+        result = rec.record_reconciliation_snapshot(conn, epoch=7)
+    assert result["created"] is True
+    assert result["epoch"] == 7
+    assert result["locked_in_rtc"] == 42.0
+    assert result["bridged_supply_committed"] == 42.0
+    assert result["relayer_signatures"] is None
+    assert len(result["state_hash"]) == 64
+
+
+def test_snapshot_is_idempotent_on_epoch(db_path):
+    _seed_transfer(db_path, status="pending", amount_rtc=5.0)
+    with sqlite3.connect(db_path) as conn:
+        first = rec.record_reconciliation_snapshot(conn, epoch=10)
+    # Now seed more activity — should NOT affect the snapshot for epoch 10
+    _seed_transfer(db_path, status="completed", amount_rtc=999.0, id_suffix=999)
+    with sqlite3.connect(db_path) as conn:
+        second = rec.record_reconciliation_snapshot(conn, epoch=10)
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["locked_in_rtc"] == 5.0  # unchanged
+    assert second["state_hash"] == first["state_hash"]
+
+
+def test_snapshot_bridged_supply_committed_formula(db_path):
+    # locked = 10 + 20 = 30; completed = 50; voided = 3
+    # bridged_supply_committed = 30 + 50 - 3 = 77
+    _seed_transfer(db_path, status="pending", amount_rtc=10.0)
+    _seed_transfer(db_path, status="locked", amount_rtc=20.0, id_suffix=1)
+    _seed_transfer(db_path, status="completed", amount_rtc=50.0, id_suffix=2)
+    _seed_transfer(db_path, status="voided", amount_rtc=3.0, id_suffix=3)
+    with sqlite3.connect(db_path) as conn:
+        snap = rec.record_reconciliation_snapshot(conn, epoch=42)
+    assert snap["locked_in_rtc"] == 30.0
+    assert snap["completed_in_rtc"] == 50.0
+    assert snap["voided_in_rtc"] == 3.0
+    assert snap["bridged_supply_committed"] == pytest.approx(77.0)
+
+
+def test_snapshot_uses_provided_aggregate_state(db_path):
+    """Caller can pass a pre-computed aggregate to avoid re-querying."""
+    custom = {
+        "locked_in_rtc": 1.0,
+        "completed_in_rtc": 2.0,
+        "voided_in_rtc": 0.5,
+        "by_status": {},
+        "by_direction": {},
+        "last_event_at": 0,
+        "computed_at": 12345,
+    }
+    with sqlite3.connect(db_path) as conn:
+        snap = rec.record_reconciliation_snapshot(conn, epoch=1, aggregate_state=custom)
+    assert snap["locked_in_rtc"] == 1.0
+    assert snap["completed_in_rtc"] == 2.0
+    assert snap["voided_in_rtc"] == 0.5
+    assert snap["bridged_supply_committed"] == pytest.approx(2.5)
+
+
+# ---------- routes ----------------------------------------------------------
+
+
+def test_latest_with_no_snapshots(client):
+    body = client.get("/bridge/reconciliation/latest").get_json()
+    assert body == {"ok": True, "snapshot": None}
+
+
+def test_latest_returns_highest_epoch(client, db_path):
+    _seed_transfer(db_path, status="locked", amount_rtc=7.0)
+    with sqlite3.connect(db_path) as conn:
+        rec.record_reconciliation_snapshot(conn, epoch=1)
+        rec.record_reconciliation_snapshot(conn, epoch=99)
+        rec.record_reconciliation_snapshot(conn, epoch=50)
+    body = client.get("/bridge/reconciliation/latest").get_json()
+    assert body["snapshot"]["epoch"] == 99
+
+
+def test_by_epoch_returns_specific_snapshot(client, db_path):
+    _seed_transfer(db_path, status="pending", amount_rtc=4.0)
+    with sqlite3.connect(db_path) as conn:
+        rec.record_reconciliation_snapshot(conn, epoch=12)
+    body = client.get("/bridge/reconciliation/by_epoch/12").get_json()
+    assert body["snapshot"]["epoch"] == 12
+    assert body["snapshot"]["locked_in_rtc"] == 4.0
+
+
+def test_by_epoch_missing_returns_null(client, db_path):
+    body = client.get("/bridge/reconciliation/by_epoch/777").get_json()
+    assert body == {"ok": True, "snapshot": None}
+
+
+def test_by_epoch_negative_returns_400(client):
+    resp = client.get("/bridge/reconciliation/by_epoch/-1")
+    # Flask's <int> converter rejects negatives at routing time, so the
+    # explicit handler check is belt-and-suspenders. Either 404 or 400 OK.
+    assert resp.status_code in (400, 404)
+
+
+def test_recent_default_limit_and_descending_order(client, db_path):
+    with sqlite3.connect(db_path) as conn:
+        for e in [1, 5, 3, 9, 2]:
+            rec.record_reconciliation_snapshot(conn, epoch=e)
+    body = client.get("/bridge/reconciliation/recent").get_json()
+    epochs = [s["epoch"] for s in body["snapshots"]]
+    assert epochs == [9, 5, 3, 2, 1]
+    assert body["count"] == 5
+    assert body["limit"] == rec.DEFAULT_RECENT_LIMIT
+
+
+def test_recent_limit_clamped_to_max(client, db_path):
+    body = client.get(
+        f"/bridge/reconciliation/recent?limit={rec.MAX_RECENT_LIMIT + 1000}"
+    ).get_json()
+    assert body["limit"] == rec.MAX_RECENT_LIMIT
+
+
+def test_recent_invalid_limit_falls_back_to_default(client):
+    body = client.get("/bridge/reconciliation/recent?limit=not_an_int").get_json()
+    assert body["limit"] == rec.DEFAULT_RECENT_LIMIT
+
+
+def test_recent_limit_clamped_to_one_minimum(client):
+    body = client.get("/bridge/reconciliation/recent?limit=0").get_json()
+    assert body["limit"] == 1
+
+
+# ---------- public-no-auth ---------------------------------------------------
+
+
+def test_all_routes_public_no_admin_key(client):
+    paths = (
+        "/bridge/reconciliation/latest",
+        "/bridge/reconciliation/by_epoch/1",
+        "/bridge/reconciliation/recent",
+    )
+    for p in paths:
+        resp = client.get(p)
+        assert resp.status_code == 200, f"{p} should not require admin key"
+        # Bogus admin key must also not block
+        resp = client.get(p, headers={"X-Admin-Key": "bogus"})
+        assert resp.status_code == 200
+
+
+# ---------- schema sanity ----------------------------------------------------
+
+
+def test_schema_has_unique_epoch_constraint(db_path):
+    with sqlite3.connect(db_path) as conn:
+        rec.record_reconciliation_snapshot(conn, epoch=1)
+        # Direct INSERT bypassing the function — must hit UNIQUE constraint.
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO bridge_reconciliation_snapshots ("
+                "epoch, computed_at, locked_in_rtc, completed_in_rtc, "
+                "voided_in_rtc, bridged_supply_committed, state_hash"
+                ") VALUES (1, 0, 0.0, 0.0, 0.0, 0.0, 'x')"
+            )


### PR DESCRIPTION
## Summary

Implements [`FEDERATION_BRIDGED_SUPPLY_SPEC.md`](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_BRIDGED_SUPPLY_SPEC.md) operator-side scope. Builds on Layer 1 ([#6646, merged](https://github.com/Scottcjn/Rustchain/pull/6646)).

## What this ships

### `node/bridge_reconciliation.py` (~280 LOC)

**Schema:** `bridge_reconciliation_snapshots` table with `epoch UNIQUE` constraint, `state_hash`, `bridged_supply_committed`, and a `relayer_signatures` column held NULL until Layer 3.

**Core function:** `record_reconciliation_snapshot(conn, epoch)`
- Idempotent on epoch — repeat calls return the existing row (no clobber, no double-write)
- Hashes canonical-JSON over the aggregate state, **excluding `computed_at`** so re-snapshotting the same underlying state yields the same `state_hash`
- `bridged_supply_committed = locked_in + completed_in − voided_in` per spec §3

**3 new public read-only routes:**
- `GET /bridge/reconciliation/latest`
- `GET /bridge/reconciliation/by_epoch/<int:epoch>`
- `GET /bridge/reconciliation/recent?limit=<n>` (default 20, max 200)

All public (no admin key), same shape and policy as Layer 1 routes.

### Wire-in to main node file

- Schema init at startup alongside other bridge schemas
- Routes registered after `register_federation_routes`
- **`/rewards/settle` now hooks `record_reconciliation_snapshot(epoch)` AFTER the existing `settle_epoch` call.** Non-fatal: if the snapshot raises, settlement still returns its response. The snapshot is an audit artifact, not a settlement gate.
- Settlement response now includes `bridge_reconciliation_snapshot: {epoch, state_hash, bridged_supply_committed, created}` so operators see the snapshot outcome in the settle reply.

## Tests

```
$ python3 -m pytest -q node/tests/test_bridge_reconciliation.py
.................                                                        [100%]
17 passed in 0.16s
```

Coverage:
- state_hash determinism (`computed_at` excluded from hash)
- state_hash sensitivity to underlying-state changes (1 ulp shift changes hash)
- First-insert vs idempotent-second-call semantics
- bridged_supply_committed formula (locked + completed − voided)
- Caller-supplied `aggregate_state` path (skip re-query)
- `/latest` empty + populated + ordering (highest epoch wins)
- `/by_epoch` hit + miss + negative reject
- `/recent` default + clamp-max + invalid-input + clamp-one-minimum
- All routes public — no admin key, bogus header ignored
- UNIQUE(epoch) constraint asserted via direct INSERT bypass

## What this layer does NOT do (deferred to Layer 3)

- Cross-side drift checker against MergeWork's mirror counter
- Relayer-set signatures on snapshot rows
- Auto-pause on drift detection
- Any mutation route (snapshots are inserted only via the epoch-settler hook; not exposed via a public POST)

## Operator-side value (independent of federation)

Even before any federation deployment, snapshots give operators:
- **Historical state proof per epoch** — answers "what did the bridge look like at the end of epoch N?"
- **Audit trail** — `state_hash` is reproducible from the underlying bridge_transfers state at the snapshot moment
- **Drift detection groundwork** — Layer 3 will add the cross-side checker that compares our snapshot to MergeWork's; this PR is the snapshot-producer half

## Out of scope

- Backfill snapshots for past epochs (only fires going forward; backfill is a separate one-shot script if needed)
- Modification of `settle_epoch` semantics (settlement still runs whether the snapshot succeeds or fails)
- MCP tool extensions for `bridge.reconciliation.*` (will follow in claim-portal in a small follow-up commit)

## Source

- [Federation design note §3.2 invariant + §6.4 reconciliation surface](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_DESIGN_NOTE.md)
- [Layer 2 spec doc](https://github.com/Scottcjn/rustchain-claim-portal/blob/main/FEDERATION_BRIDGED_SUPPLY_SPEC.md)
- Codex code-state §5: identified bridge state machine exists but lacks public reconciliation surfaces — Layers 1 + 2 close this gap.