### PR TITLE
test: fix 3 stale test files drifted from security hardening (21 failures)

### DIFF
--- a/tests/test_tx_handler_limits.py
+++ b/tests/test_tx_handler_limits.py
@@ -16,29 +16,40 @@ from flask import Flask
 from node.rustchain_tx_handler import TransactionPool, create_tx_api_routes
 
 @pytest.fixture
-def app_context():
+def app_context(monkeypatch):
     """Set up a test Flask app with an isolated TransactionPool database."""
+    # These GET endpoints are admin-gated (PR #6295: prevents unauthorized
+    # transaction surveillance / wallet-balance exposure). Configure a known
+    # admin key for the duration of the test (monkeypatch auto-restores it)
+    # and have the client send it on every request, so these tests exercise
+    # the limit/validation logic rather than bouncing off the 401 gate.
+    admin_key = "test-admin-key-0123456789abcdef"
+    monkeypatch.setenv("RC_ADMIN_KEY", admin_key)
+
     db_fd, db_path = tempfile.mkstemp()
     app = Flask(__name__)
     app.config['TESTING'] = True
-    
+
     pool = TransactionPool(db_path)
     create_tx_api_routes(app, pool)
-    
+
     # Seed some data for history tests
     with sqlite3.connect(db_path) as conn:
         conn.execute("INSERT INTO balances (wallet, balance_urtc) VALUES (?, ?)", ("test_addr", 1000000))
         for i in range(10):
             conn.execute(
-                """INSERT INTO transaction_history 
+                """INSERT INTO transaction_history
                    (tx_hash, from_addr, to_addr, amount_urtc, nonce, timestamp, signature, public_key, confirmed_at)
                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (f"hash_{i}", "test_addr", "recv_addr", 100, i, 1000, "sig", "pub", 2000 + i)
             )
-    
+
     client = app.test_client()
+    # Werkzeug maps the WSGI env var HTTP_X_ADMIN_KEY back to the
+    # "X-Admin-Key" request header that require_admin() reads.
+    client.environ_base['HTTP_X_ADMIN_KEY'] = admin_key
     yield client
-    
+
     os.close(db_fd)
     os.unlink(db_path)
 

--- a/tests/test_utxo_security_audit.py
+++ b/tests/test_utxo_security_audit.py
@@ -502,7 +502,10 @@ class TestGenesisMigrationSafety(unittest.TestCase):
 
     def test_genesis_rerun_blocked(self):
         """check_existing_genesis must return True after first migration."""
-        from utxo_genesis_migration import check_existing_genesis
+        from utxo_genesis_migration import (
+            check_existing_genesis, compute_genesis_tx_id, GENESIS_HEIGHT,
+        )
+        import json
 
         tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
         tmp.close()
@@ -510,15 +513,39 @@ class TestGenesisMigrationSafety(unittest.TestCase):
             db = UtxoDB(tmp.name)
             db.init_tables()
 
-            # Simulate one genesis box at height 0
-            db.apply_transaction({
-                'tx_type': 'mining_reward',
-                'inputs': [],
-                'outputs': [{'address': 'genesis_wallet', 'value_nrtc': 100 * UNIT}],
-                'fee_nrtc': 0,
-                'timestamp': int(time.time()),
-                '_allow_minting': True,
-            }, block_height=0)  # height 0 = genesis
+            # Insert one real genesis transaction (tx_type='genesis'), mirroring
+            # what the genesis migration writes. check_existing_genesis keys off
+            # tx_type='genesis', NOT block height — a mining_reward tx at height
+            # 0 would not register as genesis (this is what the old test got
+            # wrong). Pattern matches test_rollback_then_remigrate_idempotent.
+            conn = db._conn()
+            now = int(time.time())
+            tx_id = compute_genesis_tx_id('genesis_wallet')
+            prop = address_to_proposition('genesis_wallet')
+            box_id = compute_box_id(100 * UNIT, prop, GENESIS_HEIGHT, tx_id, 0)
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """INSERT INTO utxo_boxes
+                   (box_id, value_nrtc, proposition, owner_address,
+                    creation_height, transaction_id, output_index,
+                    tokens_json, registers_json, created_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (box_id, 100 * UNIT, prop, 'genesis_wallet', GENESIS_HEIGHT,
+                 tx_id, 0, '[]', json.dumps({'R4': 'genesis'}), now),
+            )
+            conn.execute(
+                """INSERT INTO utxo_transactions
+                   (tx_id, tx_type, inputs_json, outputs_json,
+                    data_inputs_json, fee_nrtc, timestamp,
+                    block_height, status)
+                   VALUES (?,?,?,?,?,?,?,?,?)""",
+                (tx_id, 'genesis', '[]',
+                 json.dumps([{'box_id': box_id, 'value_nrtc': 100 * UNIT,
+                              'owner': 'genesis_wallet'}]),
+                 '[]', 0, now, GENESIS_HEIGHT, 'confirmed'),
+            )
+            conn.execute("COMMIT")
+            conn.close()
 
             self.assertTrue(check_existing_genesis(db))
         finally:

--- a/tests/test_wallet_network_utils.py
+++ b/tests/test_wallet_network_utils.py
@@ -114,6 +114,7 @@ class TestFetchWithRetry(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"balance": 100.5}
         mock_response.raise_for_status = MagicMock()
+        mock_response.is_redirect = False  # not a redirect (allow_redirects=False guard)
         mock_get.return_value = mock_response
         
         data, error = self.wallet._fetch_with_retry("https://rustchain.org/wallet/balance")
@@ -129,6 +130,7 @@ class TestFetchWithRetry(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = [{"balance": 100.5}]
         mock_response.raise_for_status = MagicMock()
+        mock_response.is_redirect = False  # not a redirect (allow_redirects=False guard)
         mock_get.return_value = mock_response
 
         data, error = self.wallet._fetch_with_retry("https://rustchain.org/wallet/balance")
@@ -144,7 +146,8 @@ class TestFetchWithRetry(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"balance": 100.5}
         mock_response.raise_for_status = MagicMock()
-        
+        mock_response.is_redirect = False  # not a redirect (allow_redirects=False guard)
+
         mock_get.side_effect = [
             ConnectionError("Connection failed"),
             mock_response
@@ -204,6 +207,7 @@ class TestFetchWithRetry(unittest.TestCase):
         mock_response = MagicMock()
         mock_response.json.return_value = {"ok": True}
         mock_response.raise_for_status = MagicMock()
+        mock_response.is_redirect = False  # not a redirect (allow_redirects=False guard)
         mock_post.return_value = mock_response
         
         post_data = {"from": "RTC123", "to": "RTC456", "amount": 10.0}


### PR DESCRIPTION
Fixes 3 stale test files (21 failures) on red main — all test-only, production code unchanged:

1. **test_tx_handler_limits** (16): /tx/pending + /wallet/<a>/history admin-gated since #6295 → anonymous calls 401. Fixture now sets RC_ADMIN_KEY (monkeypatch) + sends X-Admin-Key.
2. **test_wallet_network_utils** (4): _fetch_with_retry now allow_redirects=False + resp.is_redirect (SSRF guard); MagicMock is_redirect is truthy. Mocks set is_redirect=False.
3. **test_utxo_security_audit::test_genesis_rerun_blocked** (1): check_existing_genesis keys off tx_type='genesis'; test inserted mining_reward at height 0. Now inserts real genesis-typed tx.

52/52 pass in these files (was 21 failing), verified against current main, self-contained.

Remaining ~31 failures triaged separately (mostly same auth-drift pattern + a stale miners/checksums.sha256 for the linux miner that affects real installer integrity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)