### PR TITLE
Add SDK retry and eligibility support

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -118,7 +118,9 @@ Main client for interacting with RustChain node API.
 RustChainClient(
     base_url: str,
     verify_ssl: bool = True,
-    timeout: int = 30
+    timeout: int = 30,
+    retry_count: int = 3,
+    retry_backoff: float = 0.5
 )
 ```
 
@@ -126,6 +128,14 @@ RustChainClient(
 - `base_url`: Base URL of RustChain node (e.g., "https://rustchain.org")
 - `verify_ssl`: Whether to verify SSL certificates (default: True)
 - `timeout`: Request timeout in seconds (default: 30)
+- `retry_count`: Total attempts for transient failures such as timeouts, connection errors, 429, and 5xx responses
+- `retry_backoff`: Initial exponential backoff delay in seconds between retry attempts
+
+For self-signed or IP-based node certificates, pass `verify_ssl=False`:
+
+```python
+client = RustChainClient("https://50.28.86.131", verify_ssl=False)
+```
 
 #### Methods
 
@@ -189,6 +199,23 @@ balance = client.balance("wallet_address")
 - `balance` (float): Current balance in RTC
 - `epoch_rewards` (float): Rewards in current epoch
 - `total_earned` (float): Total RTC earned
+
+##### check_eligibility(miner_id)
+
+Check current epoch mining eligibility.
+
+```python
+eligibility = client.check_eligibility("wallet_address")
+```
+
+**Parameters:**
+- `miner_id`: Miner wallet address or miner identifier
+
+**Returns:**
+- `eligible` (bool): Whether the miner is eligible in the current epoch
+- `reason` (str): Eligibility reason when provided by the node
+- `epoch` (int): Current epoch when provided
+- `slot` (int): Current slot when provided
 
 ##### transfer(from_addr, to_addr, amount, signature=None, fee=0.01)
 

--- a/sdk/rustchain/client.py
+++ b/sdk/rustchain/client.py
@@ -3,10 +3,12 @@ RustChain Client
 
 Main client for interacting with RustChain node API.
 """
+# SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
 import requests
 import json
+import time
 from rustchain.exceptions import (
     RustChainError,
     ConnectionError,
@@ -32,10 +34,14 @@ class RustChainClient:
         base_url: str,
         verify_ssl: bool = True,
         timeout: int = 30,
+        retry_count: int = 3,
+        retry_backoff: float = 0.5,
     ):
         self.base_url = base_url.rstrip("/")
         self.verify_ssl = verify_ssl
         self.timeout = timeout
+        self.retry_count = max(1, retry_count)
+        self.retry_backoff = max(0.0, retry_backoff)
 
         # Initialize session for connection pooling
         self.session = requests.Session()
@@ -48,7 +54,7 @@ class RustChainClient:
         params: Dict = None,
         data: Dict = None,
         json_payload: Dict = None,
-    ) -> Dict:
+    ) -> Any:
         """
         Make HTTP request to RustChain node.
 
@@ -69,46 +75,62 @@ class RustChainClient:
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         headers = {"Content-Type": "application/json"}
 
-        try:
-            response = self.session.request(
-                method=method,
-                url=url,
-                params=params,
-                data=data,
-                json=json_payload,
-                headers=headers,
-                timeout=self.timeout,
-                allow_redirects=False,
-            )
-
-            if 300 <= response.status_code < 400:
-                location = response.headers.get("Location", "")
-                raise APIError(
-                    f"API redirected: HTTP {response.status_code} to {location}",
-                    status_code=response.status_code,
+        last_error: Optional[Exception] = None
+        for attempt in range(self.retry_count):
+            try:
+                response = self.session.request(
+                    method=method,
+                    url=url,
+                    params=params,
+                    data=data,
+                    json=json_payload,
+                    headers=headers,
+                    timeout=self.timeout,
+                    allow_redirects=False,
                 )
 
-            # Check for HTTP errors
-            try:
-                response.raise_for_status()
-            except requests.HTTPError as e:
-                raise APIError(
-                    f"HTTP {response.status_code}: {e}",
-                    status_code=response.status_code,
-                ) from e
+                if 300 <= response.status_code < 400:
+                    location = response.headers.get("Location", "")
+                    raise APIError(
+                        f"API redirected: HTTP {response.status_code} to {location}",
+                        status_code=response.status_code,
+                    )
 
-            # Parse JSON response
-            try:
-                return response.json()
-            except json.JSONDecodeError:
-                return {"raw_response": response.text}
+                if response.status_code in (429, 500, 502, 503, 504) and attempt < self.retry_count - 1:
+                    self._sleep_before_retry(attempt)
+                    continue
 
-        except requests.exceptions.ConnectionError as e:
-            raise ConnectionError(f"Failed to connect to {url}: {e}") from e
-        except requests.exceptions.Timeout as e:
-            raise ConnectionError(f"Request timeout to {url}: {e}") from e
-        except requests.exceptions.RequestException as e:
-            raise ConnectionError(f"Request failed: {e}") from e
+                # Check for HTTP errors
+                try:
+                    response.raise_for_status()
+                except requests.HTTPError as e:
+                    raise APIError(
+                        f"HTTP {response.status_code}: {e}",
+                        status_code=response.status_code,
+                    ) from e
+
+                # Parse JSON response
+                try:
+                    return response.json()
+                except json.JSONDecodeError:
+                    return {"raw_response": response.text}
+
+            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                last_error = e
+                if attempt < self.retry_count - 1:
+                    self._sleep_before_retry(attempt)
+                    continue
+                if isinstance(e, requests.exceptions.Timeout):
+                    raise ConnectionError(f"Request timeout to {url}: {e}") from e
+                raise ConnectionError(f"Failed to connect to {url}: {e}") from e
+            except requests.exceptions.RequestException as e:
+                raise ConnectionError(f"Request failed: {e}") from e
+
+        raise ConnectionError(f"Request failed after {self.retry_count} attempts: {last_error}")
+
+    def _sleep_before_retry(self, attempt: int) -> None:
+        if self.retry_backoff > 0:
+            time.sleep(self.retry_backoff * (2 ** attempt))
 
     def _request_object(
         self,
@@ -234,6 +256,31 @@ class RustChainClient:
             raise ValidationError("miner_id must be a non-empty string")
 
         return self._request_object("GET", "/wallet/balance", params={"miner_id": miner_id})
+
+    def check_eligibility(self, miner_id: str) -> Dict[str, Any]:
+        """
+        Check current epoch mining eligibility for a miner.
+
+        Args:
+            miner_id: Miner wallet address or miner identifier
+
+        Returns:
+            Dict with eligibility information from `/lottery/eligibility`.
+
+        Raises:
+            ConnectionError: If connection fails
+            APIError: If API returns error
+            ValidationError: If miner_id is invalid
+
+        Example:
+            >>> client = RustChainClient("https://rustchain.org")
+            >>> eligibility = client.check_eligibility("wallet_address")
+            >>> print(eligibility["eligible"])
+        """
+        if not miner_id or not isinstance(miner_id, str):
+            raise ValidationError("miner_id must be a non-empty string")
+
+        return self._request_object("GET", "/lottery/eligibility", params={"miner_id": miner_id})
 
     def transfer(
         self,

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -37,6 +37,13 @@ class TestRustChainClient:
         assert client.timeout == 60
         client.close()
 
+    def test_init_with_retry_settings(self):
+        """Test client initialization with retry settings"""
+        client = RustChainClient("https://rustchain.org", retry_count=5, retry_backoff=0.25)
+        assert client.retry_count == 5
+        assert client.retry_backoff == 0.25
+        client.close()
+
     def test_init_strips_trailing_slash(self):
         """Test that trailing slash is stripped from base URL"""
         client = RustChainClient("https://rustchain.org/")
@@ -254,6 +261,88 @@ class TestBalanceEndpoint:
                 client.balance(None)
 
         assert "miner_id" in str(exc_info.value)
+
+
+class TestEligibilityEndpoint:
+    """Test /lottery/eligibility endpoint"""
+
+    @patch("requests.Session.request")
+    def test_check_eligibility_success(self, mock_request):
+        """Test successful eligibility query"""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "eligible": True,
+            "reason": "attested_and_enrolled",
+            "epoch": 91,
+            "slot": 13227,
+        }
+        mock_response.raise_for_status = Mock()
+        mock_request.return_value = mock_response
+
+        with RustChainClient("https://rustchain.org") as client:
+            result = client.check_eligibility("aliceRTC")
+
+        assert result["eligible"] is True
+        assert result["reason"] == "attested_and_enrolled"
+        assert mock_request.call_args.kwargs["url"] == "https://rustchain.org/lottery/eligibility"
+        assert mock_request.call_args.kwargs["params"] == {"miner_id": "aliceRTC"}
+        assert mock_request.call_args.kwargs["allow_redirects"] is False
+
+    def test_check_eligibility_empty_miner_id(self):
+        """Test eligibility with empty miner_id raises ValidationError"""
+        with pytest.raises(ValidationError) as exc_info:
+            with RustChainClient("https://rustchain.org") as client:
+                client.check_eligibility("")
+
+        assert "miner_id" in str(exc_info.value)
+
+
+class TestRequestRetry:
+    """Test retry behavior for transient failures"""
+
+    @patch("time.sleep")
+    @patch("requests.Session.request")
+    def test_retries_transient_connection_error(self, mock_request, mock_sleep):
+        """Retry connection errors before succeeding"""
+        import requests
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True}
+        mock_response.raise_for_status = Mock()
+        mock_request.side_effect = [
+            requests.exceptions.ConnectionError("temporary"),
+            mock_response,
+        ]
+
+        with RustChainClient("https://rustchain.org", retry_count=2, retry_backoff=0.01) as client:
+            result = client.health()
+
+        assert result["ok"] is True
+        assert mock_request.call_count == 2
+        mock_sleep.assert_called_once_with(0.01)
+
+    @patch("time.sleep")
+    @patch("requests.Session.request")
+    def test_retries_http_503(self, mock_request, mock_sleep):
+        """Retry transient HTTP server errors"""
+        first = Mock()
+        first.status_code = 503
+
+        second = Mock()
+        second.status_code = 200
+        second.raise_for_status = Mock()
+        second.json.return_value = {"ok": True}
+
+        mock_request.side_effect = [first, second]
+
+        with RustChainClient("https://rustchain.org", retry_count=2, retry_backoff=0.01) as client:
+            result = client.health()
+
+        assert result["ok"] is True
+        assert mock_request.call_count == 2
+        mock_sleep.assert_called_once_with(0.01)
 
 
 class TestTransferEndpoint:

--- a/sdk/tests/test_client_unit.py
+++ b/sdk/tests/test_client_unit.py
@@ -63,7 +63,7 @@ class TestHealthEndpoint:
     @patch("requests.Session.request")
     def test_health_success(self, mock_request):
         """Test successful health check"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "ok": True,
@@ -99,7 +99,7 @@ class TestHealthEndpoint:
     @patch("requests.Session.request")
     def test_health_rejects_non_object_json(self, mock_request):
         """Object-returning endpoints reject array/scalar JSON payloads."""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = ["not", "an", "object"]
         mock_response.raise_for_status = Mock()
         mock_request.return_value = mock_response
@@ -115,7 +115,7 @@ class TestEpochEndpoint:
     @patch("requests.Session.request")
     def test_epoch_success(self, mock_request):
         """Test successful epoch query"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = {
             "epoch": 74,
             "slot": 10745,
@@ -142,7 +142,7 @@ class TestMinersEndpoint:
     @patch("requests.Session.request")
     def test_miners_success(self, mock_request):
         """Test successful miners query"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = [
             {
                 "miner": "eafc6f14eab6d5c5362fe651e5e6c23581892a37RTC",
@@ -172,7 +172,7 @@ class TestMinersEndpoint:
     @patch("requests.Session.request")
     def test_miners_empty_list(self, mock_request):
         """Test miners endpoint returning empty list"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = []
         mock_response.raise_for_status = Mock()
         mock_request.return_value = mock_response
@@ -185,7 +185,7 @@ class TestMinersEndpoint:
     @patch("requests.Session.request")
     def test_miners_envelope_response(self, mock_request):
         """Test miners endpoint returning an envelope."""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = {
             "data": [
                 {
@@ -210,7 +210,7 @@ class TestBalanceEndpoint:
     @patch("requests.Session.request")
     def test_balance_success(self, mock_request):
         """Test successful balance query"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "miner_pk": "test_wallet_address",
@@ -234,7 +234,7 @@ class TestBalanceEndpoint:
 
     @patch("requests.Session.request")
     def test_balance_redirect_reports_location(self, mock_request):
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.status_code = 307
         mock_response.headers = {"Location": "http://redirect.netprotect.mk/passthrough"}
         mock_request.return_value = mock_response
@@ -269,7 +269,7 @@ class TestEligibilityEndpoint:
     @patch("requests.Session.request")
     def test_check_eligibility_success(self, mock_request):
         """Test successful eligibility query"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.status_code = 200
         mock_response.json.return_value = {
             "eligible": True,
@@ -307,7 +307,7 @@ class TestRequestRetry:
         """Retry connection errors before succeeding"""
         import requests
 
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.status_code = 200
         mock_response.json.return_value = {"ok": True}
         mock_response.raise_for_status = Mock()
@@ -330,7 +330,7 @@ class TestRequestRetry:
         first = Mock()
         first.status_code = 503
 
-        second = Mock()
+        second = Mock(status_code=200)
         second.status_code = 200
         second.raise_for_status = Mock()
         second.json.return_value = {"ok": True}
@@ -351,7 +351,7 @@ class TestTransferEndpoint:
     @patch("requests.Session.request")
     def test_transfer_success(self, mock_request):
         """Test successful transfer"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = {
             "success": True,
             "tx_id": "tx_abc123",
@@ -375,7 +375,7 @@ class TestTransferEndpoint:
     @patch("requests.Session.request")
     def test_transfer_with_signature(self, mock_request):
         """Test transfer with signature"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = {
             "success": True,
             "tx_id": "tx_def456",
@@ -434,7 +434,7 @@ class TestAttestationEndpoint:
     @patch("requests.Session.request")
     def test_submit_attestation_success(self, mock_request):
         """Test successful attestation submission"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = {
             "success": True,
             "epoch": 74,
@@ -499,7 +499,7 @@ class TestTransferHistory:
     @patch("requests.Session.request")
     def test_transfer_history_success(self, mock_request):
         """Test successful transfer history query"""
-        mock_response = Mock()
+        mock_response = Mock(status_code=200)
         mock_response.json.return_value = [
             {
                 "tx_id": "tx_abc123",


### PR DESCRIPTION
## Summary

Improves the pip-installable Python SDK surface for Scottcjn/rustchain-bounties#36.

This PR fills two concrete SDK acceptance gaps:

- Adds configurable retry behavior to the synchronous `RustChainClient` for transient failures.
- Adds `check_eligibility(miner_id)` wrapping `/lottery/eligibility`.
- Documents retry settings, self-signed/IP certificate usage, and eligibility calls in `sdk/README.md`.
- Adds unit coverage for retry configuration, transient retry behavior, and eligibility request routing.

## Details

`RustChainClient` now accepts:

```python
RustChainClient(
    base_url="https://rustchain.org",
    verify_ssl=True,
    timeout=30,
    retry_count=3,
    retry_backoff=0.5,
)
```

Retry behavior covers:

- connection errors
- timeouts
- HTTP 429
- HTTP 500/502/503/504

Client-side 4xx responses are not retried so validation/API feedback remains immediate.

## Validation

Ran locally with bundled Python:

```powershell
python -B -m py_compile sdk\rustchain\client.py sdk\tests\test_client_unit.py
git diff --check
```

Results:

- `py_compile` passed
- `git diff --check` passed

Could not run the pytest suite in this runtime because `pytest` is not installed. A live import smoke test was also blocked because this runtime does not include the SDK dependency `requests`; the package already declares `requests>=2.28.0` in `sdk/pyproject.toml`.

## Bounty

Related to Scottcjn/rustchain-bounties#36.

I received RTC compensation for this contribution.