### PR TITLE
Add state transition audit events

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -36,6 +36,63 @@ contract_store = []
 chat_sessions = {}
 
 
+def _ensure_state_transition_events_table(db):
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS state_transition_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            epoch INTEGER,
+            actor TEXT,
+            details_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_state_transition_events_entity
+        ON state_transition_events(entity_type, entity_id, ts DESC)
+        """
+    )
+    db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_state_transition_events_epoch
+        ON state_transition_events(epoch, ts DESC)
+        """
+    )
+
+
+def _record_state_transition_event(
+    db,
+    event_type,
+    entity_type,
+    entity_id,
+    *,
+    actor=None,
+    details=None,
+    ts=None,
+):
+    _ensure_state_transition_events_table(db)
+    db.execute(
+        """
+        INSERT INTO state_transition_events
+            (ts, event_type, entity_type, entity_id, actor, details_json)
+        VALUES (?, ?, ?, ?, ?, ?)
+        """,
+        (
+            int(ts if ts is not None else time.time()),
+            event_type,
+            entity_type,
+            str(entity_id),
+            actor,
+            json.dumps(details or {}, sort_keys=True),
+        ),
+    )
+
+
 def _coinbase_addresses_match(left, right):
     """Compare optional EVM-style payment addresses without case sensitivity."""
     return (left or '').strip().casefold() == (right or '').strip().casefold()
@@ -143,6 +200,7 @@ def init_beacon_tables(db_path=DB_PATH):
                 PRIMARY KEY (agent_id, nonce)
             )
         """)
+        _ensure_state_transition_events_table(conn)
 
         # Create indexes
         conn.execute("CREATE INDEX IF NOT EXISTS idx_contracts_from ON beacon_contracts(from_agent)")
@@ -355,7 +413,7 @@ def beacon_join():
         
         try:
             # Validate it's proper hex
-            bytes.fromhex(pubkey_clean)
+            pubkey_bytes = bytes.fromhex(pubkey_clean)
         except ValueError:
             return jsonify({'error': 'Invalid pubkey_hex: must be valid hexadecimal string'}), 400
 
@@ -416,12 +474,27 @@ def beacon_join():
                     updated_at = ?
                 WHERE agent_id = ?
             """, (name, now, agent_id))
+            event_type = "beacon_agent_updated"
         else:
             # New agent — insert with pubkey_hex
             db.execute("""
                 INSERT INTO relay_agents (agent_id, pubkey_hex, name, status, coinbase_address, created_at, updated_at)
                 VALUES (?, ?, ?, 'active', ?, ?, ?)
             """, (agent_id, pubkey_hex, name, coinbase_address, now, now))
+            event_type = "beacon_agent_registered"
+        _record_state_transition_event(
+            db,
+            event_type,
+            "beacon_agent",
+            agent_id,
+            actor=agent_id,
+            details={
+                "name": name,
+                "coinbase_address_present": bool(coinbase_address),
+                "pubkey_fingerprint": hashlib.sha256(pubkey_bytes).hexdigest()[:16],
+            },
+            ts=now,
+        )
 
         db.commit()
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1160,6 +1160,66 @@ if HAVE_BOTTUBE_FEED:
     except Exception as e:
         print(f"[BoTTube Feed] Failed to register feed endpoints: {e}")
 
+
+def _ensure_state_transition_events_table(db):
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS state_transition_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts INTEGER NOT NULL,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL,
+            entity_id TEXT NOT NULL,
+            epoch INTEGER,
+            actor TEXT,
+            details_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_state_transition_events_entity
+        ON state_transition_events(entity_type, entity_id, ts DESC)
+        """
+    )
+    db.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_state_transition_events_epoch
+        ON state_transition_events(epoch, ts DESC)
+        """
+    )
+
+
+def record_state_transition_event(
+    db,
+    event_type: str,
+    entity_type: str,
+    entity_id: str,
+    *,
+    epoch=None,
+    actor=None,
+    details=None,
+    ts=None,
+):
+    _ensure_state_transition_events_table(db)
+    db.execute(
+        """
+        INSERT INTO state_transition_events
+            (ts, event_type, entity_type, entity_id, epoch, actor, details_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            int(ts if ts is not None else time.time()),
+            event_type,
+            entity_type,
+            str(entity_id),
+            epoch,
+            actor,
+            json.dumps(details or {}, sort_keys=True),
+        ),
+    )
+
+
 def init_db():
     """Initialize all database tables"""
     with sqlite3.connect(DB_PATH) as c:
@@ -1172,6 +1232,7 @@ def init_db():
         c.execute("CREATE TABLE IF NOT EXISTS epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER, PRIMARY KEY (epoch, miner_pk))")
         ensure_epoch_enroll_integer_weights(c)
         c.execute("CREATE TABLE IF NOT EXISTS balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)")
+        _ensure_state_transition_events_table(c)
         ensure_fingerprint_history_table(c)
         ensure_epoch_fingerprint_rotation_table(c)
 
@@ -2360,6 +2421,20 @@ def record_attestation_success(miner: str, device: dict, fingerprint_passed: boo
             INSERT INTO miner_attest_history (miner, ts_ok, device_family, device_arch, entropy_score, fingerprint_passed, fingerprint_checks_json)
             VALUES (?, ?, ?, ?, ?, ?, ?)
         """, (miner, now, verified_device["device_family"], verified_device["device_arch"], entropy_score, new_fp, fingerprint_checks_json))
+        record_state_transition_event(
+            conn,
+            "miner_attestation_success",
+            "miner",
+            miner,
+            actor=miner,
+            details={
+                "device_family": verified_device["device_family"],
+                "device_arch": verified_device["device_arch"],
+                "fingerprint_passed": bool(new_fp),
+                "source_ip_present": bool(source_ip),
+            },
+            ts=now,
+        )
         conn.commit()
 
         # RIP-201: Record fleet immune system signals
@@ -3217,6 +3292,21 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                 "UPDATE epoch_state SET settled = 1, settled_ts = ? WHERE epoch = ? AND settled = 0",
                 (int(time.time()), epoch)
             )
+            record_state_transition_event(
+                c,
+                "epoch_finalized",
+                "epoch",
+                str(epoch),
+                epoch=epoch,
+                details={
+                    "miner_count": len(miners),
+                    "total_weight_units": int(total_weight),
+                    "per_block_rtc": str(per_block_rtc),
+                    "epoch_slots": EPOCH_SLOTS,
+                    "settled_rows": result.rowcount,
+                    "excluded_zero_weight_miners": len(zero_weight_miners),
+                },
+            )
 
             # Commit transaction atomically
             c.execute("COMMIT")
@@ -4070,10 +4160,27 @@ def enroll_epoch():
         # attacker could overwrite a legitimate miner's weight (e.g. 2.5) with
         # a near-zero value (1e-9) by calling this endpoint with failed-fingerprint
         # or default device data.
-        c.execute(
+        enroll_result = c.execute(
             "INSERT OR IGNORE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
             (epoch, miner_pk, weight_units)
         )
+        if enroll_result.rowcount:
+            record_state_transition_event(
+                c,
+                "miner_epoch_enrolled",
+                "miner",
+                miner_pk,
+                epoch=epoch,
+                actor=miner_id,
+                details={
+                    "miner_id": miner_id,
+                    "weight_units": int(weight_units),
+                    "weight": weight,
+                    "fingerprint_failed": bool(fingerprint_failed),
+                    "active_fingerprint_pass_count": rotation_eval["active_pass_count"],
+                    "active_fingerprint_total": rotation_eval["active_total"],
+                },
+            )
 
         # Register a real Ed25519 pubkey for block-header verification when available.
         header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner_pk)

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -73,6 +73,7 @@ class TestBeaconJoinRouting(unittest.TestCase):
         """Reset database state before each test."""
         with sqlite3.connect(self.test_db_path) as conn:
             conn.execute("DELETE FROM relay_agents")
+            conn.execute("DELETE FROM state_transition_events")
             conn.commit()
 
     # ============================================================
@@ -99,6 +100,21 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertEqual(data['agent_id'], 'bcn_test_agent_001')
         self.assertEqual(data['status'], 'active')
         self.assertIn('timestamp', data)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT event_type, entity_type, entity_id, actor, details_json
+                FROM state_transition_events
+                """
+            ).fetchone()
+        self.assertEqual(row[0], 'beacon_agent_registered')
+        self.assertEqual(row[1], 'beacon_agent')
+        self.assertEqual(row[2], 'bcn_test_agent_001')
+        self.assertEqual(row[3], 'bcn_test_agent_001')
+        details = json.loads(row[4])
+        self.assertEqual(details['name'], 'Test Agent')
+        self.assertFalse(details['coinbase_address_present'])
 
     def test_join_upsert_duplicate_agent(self):
         """POST /beacon/join upserts mutable fields for duplicate agent_id.

--- a/tests/test_state_transition_events.py
+++ b/tests/test_state_transition_events.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for state-transition audit events."""
+
+import json
+import sqlite3
+import sys
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def test_record_state_transition_event_creates_queryable_audit_row(tmp_path):
+    db_path = tmp_path / "state-events.sqlite3"
+
+    with sqlite3.connect(db_path) as conn:
+        integrated_node.record_state_transition_event(
+            conn,
+            "epoch_finalized",
+            "epoch",
+            "7",
+            epoch=7,
+            actor="settler",
+            details={"miner_count": 2, "total_weight_units": 3000},
+            ts=12345,
+        )
+        row = conn.execute(
+            """
+            SELECT ts, event_type, entity_type, entity_id, epoch, actor, details_json
+            FROM state_transition_events
+            """
+        ).fetchone()
+
+    assert row[:6] == (12345, "epoch_finalized", "epoch", "7", 7, "settler")
+    assert json.loads(row[6]) == {"miner_count": 2, "total_weight_units": 3000}
+
+
+def test_record_attestation_success_writes_miner_audit_event(monkeypatch, tmp_path):
+    db_path = tmp_path / "attestation-events.sqlite3"
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path))
+    integrated_node.app.config["DB_PATH"] = str(db_path)
+    integrated_node.init_db()
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS miner_attest_recent (
+                miner TEXT PRIMARY KEY,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                source_ip TEXT,
+                signing_pubkey TEXT,
+                fingerprint_checks_json TEXT DEFAULT '{}'
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS miner_attest_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                miner TEXT NOT NULL,
+                ts_ok INTEGER NOT NULL,
+                device_family TEXT,
+                device_arch TEXT,
+                entropy_score REAL DEFAULT 0.0,
+                fingerprint_passed INTEGER DEFAULT 0,
+                fingerprint_checks_json TEXT DEFAULT '{}'
+            )
+            """
+        )
+
+    integrated_node.record_attestation_success(
+        "miner-audit-1",
+        {"family": "x86", "arch": "default"},
+        fingerprint_passed=True,
+        source_ip="127.0.0.1",
+        fingerprint={"checks": {"clock_drift": {"passed": True}}},
+        entropy_score=0.9,
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT event_type, entity_type, entity_id, actor, details_json
+            FROM state_transition_events
+            WHERE event_type = 'miner_attestation_success'
+            """
+        ).fetchone()
+
+    assert row[:4] == (
+        "miner_attestation_success",
+        "miner",
+        "miner-audit-1",
+        "miner-audit-1",
+    )
+    details = json.loads(row[4])
+    assert details["fingerprint_passed"] is True
+    assert details["source_ip_present"] is True


### PR DESCRIPTION
## What changed

- Added an append-only `state_transition_events` audit table with entity and epoch indexes.
- Recorded audit events for miner attestation success, epoch enrollment, epoch finalization, and Beacon agent registration/update.
- Added regression coverage for direct audit event writes, attestation audit logging, and `/beacon/join` audit logging.

## Why it matters

This gives RustChain a durable state-transition trail for the core flows called out in #2316, so operators can inspect when miners joined an epoch, when attestations succeeded, when epochs finalized, and when Beacon agents registered or refreshed.

## Validation

- `.venv-bounty-validation/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/beacon_api.py tests/test_state_transition_events.py tests/test_beacon_join_routing.py` -> passed
- `.venv-bounty-validation/bin/python -m pytest -q tests/test_state_transition_events.py tests/test_beacon_join_routing.py --tb=short` -> 27 passed
- `git diff --check origin/main...HEAD` -> passed
- Hidden Unicode scan over `origin/main...HEAD` -> passed

## Scope/risk

This is a focused audit-log slice. It does not attempt a full replay engine or rebuild historical state from old rows; it starts recording the relevant transitions going forward without changing existing validation or payout logic.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
