### PR TITLE
fix(rewards): import hmac for admin endpoints

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -12,6 +12,7 @@ Issue #1449: Anti-Double-Mining Enforcement
 import sqlite3
 import time
 import os
+import hmac
 try:
     from flask import request, jsonify
 except ImportError:
@@ -286,7 +287,6 @@ def register_rewards_rip200(app, DB_PATH):
     @app.route('/rewards/settle', methods=['POST'])
     def settle_rewards():
         # ── Authentication: settlement is a privileged operation ──────
-        import hmac
         settle_key = os.environ.get("RC_SETTLE_KEY", "")
         if not settle_key:
             return jsonify({"error": "RC_SETTLE_KEY not configured — settle endpoint disabled"}), 503

--- a/tests/test_rewards_admin_hmac_import.py
+++ b/tests/test_rewards_admin_hmac_import.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: MIT
+
+import sqlite3
+import sys
+
+from flask import Flask
+
+
+rewards = sys.modules["rewards_mod"]
+ADMIN_KEY = "abcdefghijklmnopqrstuvwxyz123456"
+
+
+def _app_with_balances(tmp_path, monkeypatch):
+    db_path = tmp_path / "rewards.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER)")
+        db.execute("INSERT INTO balances VALUES (?, ?)", ("alice", 1_000_000))
+
+    monkeypatch.setenv("RC_ADMIN_KEY", ADMIN_KEY)
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+    rewards.register_rewards_rip200(app, str(db_path))
+    return app
+
+
+def test_wallet_balance_admin_guard_uses_module_hmac(tmp_path, monkeypatch):
+    app = _app_with_balances(tmp_path, monkeypatch)
+
+    response = app.test_client().get(
+        "/wallet/balance?miner_id=alice",
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["amount_i64"] == 1_000_000
+
+
+def test_wallet_balance_rejects_wrong_admin_key_without_500(tmp_path, monkeypatch):
+    app = _app_with_balances(tmp_path, monkeypatch)
+
+    response = app.test_client().get(
+        "/wallet/balance?miner_id=alice",
+        headers={"X-Admin-Key": "wrong"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"].startswith("Unauthorized")
+
+
+def test_all_balances_admin_guard_uses_module_hmac(tmp_path, monkeypatch):
+    app = _app_with_balances(tmp_path, monkeypatch)
+
+    response = app.test_client().get(
+        "/wallet/balances/all",
+        headers={"X-Admin-Key": ADMIN_KEY},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["total_urtc"] == 1_000_000

--- a/tests/test_rewards_admin_hmac_import.py
+++ b/tests/test_rewards_admin_hmac_import.py
@@ -1,12 +1,16 @@
 # SPDX-License-Identifier: MIT
 
+import os
 import sqlite3
 import sys
 
 from flask import Flask
 
 
-rewards = sys.modules["rewards_mod"]
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "node"))
+
+import rewards_implementation_rip200 as rewards
+
 ADMIN_KEY = "abcdefghijklmnopqrstuvwxyz123456"
 
 


### PR DESCRIPTION
## Summary

- move `hmac` to module scope in `node/rewards_implementation_rip200.py`
- add regression coverage for the RIP-200 admin wallet endpoints
- verify wrong admin keys still return 401 instead of crashing

Fixes #6668.

## Why

`/rewards/settle` imported `hmac` inside its route function, but sibling routes registered by `register_rewards_rip200()` also call `hmac.compare_digest()`. Those routes hit `NameError` at runtime when `RC_ADMIN_KEY` is configured:

- `GET /wallet/balance`
- `GET /wallet/balances/all`
- `GET /lottery/eligibility`
- `GET /consensus/round_robin_status`

## Validation

```text
python3 -m py_compile node/rewards_implementation_rip200.py tests/test_rewards_admin_hmac_import.py
uv run --no-project --with pytest --with flask python -m pytest -q tests/test_rewards_admin_hmac_import.py node/tests/test_rewards_settle_endpoint.py
8 passed in 0.12s
git diff --check
```

Payout/miner id: `keon0711`
Disclosure: submitted as a RustChain bug bounty candidate; no payout is asserted unless maintainers accept it.
