### PR TITLE
Fix RIP-200 hmac import scope

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -12,6 +12,7 @@ Issue #1449: Anti-Double-Mining Enforcement
 import sqlite3
 import time
 import os
+import hmac
 try:
     from flask import request, jsonify
 except ImportError:
@@ -272,7 +273,6 @@ def register_rewards_rip200(app, DB_PATH):
     @app.route('/rewards/settle', methods=['POST'])
     def settle_rewards():
         # ── Authentication: settlement is a privileged operation ──────
-        import hmac
         settle_key = os.environ.get("RC_SETTLE_KEY", "")
         if not settle_key:
             return jsonify({"error": "RC_SETTLE_KEY not configured — settle endpoint disabled"}), 503


### PR DESCRIPTION
## Summary
- move `hmac` import to module scope in `node/rewards_implementation_rip200.py`
- keeps `compare_digest` available for all registered RIP-200 routes instead of only the settle handler

## Test
- `python3 -m compileall -q node/rewards_implementation_rip200.py`

Fixes #6668

Bounty/miner id: `keon0711`
