### PR TITLE
feat(green-tracker): add keon0711 MacBook Air M2

### DIFF
--- a/community/machines/keon0711-macbook-air-m2.json
+++ b/community/machines/keon0711-macbook-air-m2.json
@@ -1,0 +1,21 @@
+{
+  "machine_name": "keon0711 MacBook Air M2",
+  "model": "MacBook Air (2022)",
+  "model_identifier": "Mac14,2",
+  "year_manufactured": 2022,
+  "architecture": "Apple Silicon M2 (arm64)",
+  "cpu_cores": "8 (4P + 4E)",
+  "memory_gb": 16,
+  "power_draw_watts": 15,
+  "usage": [
+    "Codex-assisted RustChain bounty work",
+    "GitHub automation",
+    "local development",
+    "RustChain miner dry-run testing"
+  ],
+  "description": "MacBook Air with Apple M2 and 16 GB unified memory kept in active use for local development, Codex-assisted RustChain bounty work, GitHub automation, and RustChain miner dry-run testing. Reusing this low-power Apple Silicon laptop for agent workflows avoids replacing it with new dedicated compute and keeps an already-manufactured machine productive.",
+  "wallet_name": "keon0711",
+  "wallet_address": "RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e",
+  "contributor": "keon0711",
+  "added_date": "2026-05-31"
+}


### PR DESCRIPTION
## Summary
- add `community/machines/keon0711-macbook-air-m2.json` for bounty #2218
- documents a MacBook Air M2 kept in active use for Codex-assisted RustChain bounty work, GitHub automation, local development, and miner dry-run testing

## Validation
- `python3 -m json.tool community/machines/keon0711-macbook-air-m2.json`
- parsed all `community/machines/*.json` with Python `json.load`
- `git diff --check -- community/machines/keon0711-macbook-air-m2.json`

RTC wallet: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`
Bounty: Scottcjn/rustchain-bounties#2218