### PR TITLE
fix: parse payout wallet variants

### DIFF
--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -56,11 +56,41 @@ VPS_PORT = 8099
 #   wallet: RTCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 #   Wallet: RTCxxxx...
 #   wallet: my-github-username
+#   payout wallet: RTCxxxx...
+#   payout address if accepted: RTCxxxx...
+#   RTC wallet: RTCxxxx...
 #   .rtc-wallet: RTCxxxx...
 _WALLET_RE = re.compile(
-    r"(?:^|\n)\s*(?:wallet|\.rtc-wallet)\s*:\s*(\S+)\s*(?:\n|$)",
-    re.IGNORECASE,
+    r"""(?:^|\n)\s*
+        (?:
+            wallet
+            | \.rtc-wallet
+            | payout\s+wallet
+            | payout\s+address(?:\s+if\s+accepted)?
+            | rtc\s+wallet
+        )
+        \s*:\s*(\S+)\s*(?:\n|$)
+    """,
+    re.IGNORECASE | re.VERBOSE,
 )
+
+# Lazy-pay directive: a GitHub username / miner ID instead of an RTC address.
+#   miner ID: github:alice
+#   miner ID for payout if accepted: lazy-pay-bob
+#   miner_id: carol
+_MINER_ID_RE = re.compile(
+    r"""(?:^|\n)\s*
+        miner[_\s]+id(?:\s+for\s+payout(?:\s+if\s+accepted)?)?
+        \s*:\s*(\S+)\s*(?:\n|$)
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Last-resort contextual scan: an RTC address on a line that mentions one of
+# these labels. Distinct from the anchored validation regex (_RTC_ADDRESS_RE)
+# below — this one is unanchored so it can locate an address mid-line.
+_RTC_ADDRESS_SCAN_RE = re.compile(r"\bRTC[0-9a-fA-F]{40}\b")
+_RTC_CONTEXT_LABELS = ("payout", "wallet", "address")
 
 # Payment-amount override in the PR body (owner can specify a custom amount).
 #   bounty: 100 RTC
@@ -192,11 +222,40 @@ class Config:
 # ---------------------------------------------------------------------------
 
 
+def _clean_wallet_candidate(value: str) -> str:
+    """Strip surrounding whitespace, trailing sentence punctuation, and markdown
+    backticks from a captured directive value."""
+    return value.strip().rstrip(",.;").strip("`")
+
+
 def resolve_wallet_from_pr_body(pr_body: str) -> Optional[str]:
-    """Extract wallet address from a ``wallet: <addr>`` directive in the PR body."""
+    """Extract a recipient (RTC wallet or lazy-pay miner ID) from a PR body.
+
+    Resolution stages, in precedence order:
+      1. An explicit ``wallet:`` / ``payout wallet:`` / ``payout address:`` /
+         ``rtc wallet:`` / ``.rtc-wallet:`` directive.
+      2. A lazy-pay ``miner ID:`` directive (GitHub username / miner ID).
+      3. A last-resort contextual scan: an RTC address on a line that mentions
+         a payout/wallet/address label.
+
+    Every candidate returned here is still gated by ``validate_recipient``
+    before any transfer, so a malformed match cannot misroute funds.
+    """
     match = _WALLET_RE.search(pr_body)
     if match:
-        return match.group(1).strip().rstrip(",")
+        return _clean_wallet_candidate(match.group(1))
+
+    match = _MINER_ID_RE.search(pr_body)
+    if match:
+        return _clean_wallet_candidate(match.group(1))
+
+    for line in pr_body.splitlines():
+        lowered = line.lower()
+        if not any(label in lowered for label in _RTC_CONTEXT_LABELS):
+            continue
+        rtc_match = _RTC_ADDRESS_SCAN_RE.search(line)
+        if rtc_match:
+            return rtc_match.group(0)
     return None
 
 
@@ -231,17 +290,42 @@ def resolve_wallet(pr_body: str, repo_path: str) -> Optional[str]:
 
 
 def distinct_wallet_directives(pr_body: str) -> list:
-    """Return the distinct ``wallet:`` directive values found in the PR body.
+    """Return the distinct recipient candidates found across *all* resolution
+    stages that ``resolve_wallet_from_pr_body`` considers — explicit ``wallet:``
+    directives, lazy-pay ``miner ID:`` directives, and the contextual RTC scan.
 
-    Used to fail closed when a body contains multiple *conflicting* recipient
-    directives (an attacker appending a second directive should not silently
-    win or lose — it requires manual review).
+    Used to fail closed when a body declares multiple *conflicting* recipients
+    (an attacker appending a second directive should not silently win or lose —
+    it requires manual review). The conflict guard must cover every stage the
+    resolver can return from, otherwise a second directive of a different *type*
+    (e.g. a ``miner ID:`` added under a ``wallet:``) would slip past it.
+
+    Candidates are de-duplicated by value, so a single directive that two stages
+    both see (e.g. ``payout wallet: RTC…`` matched by both the wallet regex and
+    the contextual scan) does not register as a false conflict.
     """
-    seen = []
-    for raw in _WALLET_RE.findall(pr_body or ""):
-        value = raw.strip().rstrip(",")
+    body = pr_body or ""
+    seen: list = []
+
+    def _add(value: str) -> None:
         if value and value not in seen:
             seen.append(value)
+
+    for raw in _WALLET_RE.findall(body):
+        _add(_clean_wallet_candidate(raw))
+    for raw in _MINER_ID_RE.findall(body):
+        _add(_clean_wallet_candidate(raw))
+
+    # The contextual RTC scan is a last-resort fallback in resolution; mirror
+    # that precedence here so an incidental RTC address mentioned in prose
+    # (on a line that happens to contain "wallet"/"address"/"payout") does not
+    # trigger a spurious conflict when an explicit directive already exists.
+    if not seen:
+        for line in body.splitlines():
+            if any(label in line.lower() for label in _RTC_CONTEXT_LABELS):
+                rtc_match = _RTC_ADDRESS_SCAN_RE.search(line)
+                if rtc_match:
+                    _add(rtc_match.group(0))
     return seen
 
 

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -75,6 +75,59 @@ class TestResolveWalletFromPrBody(unittest.TestCase):
         body = "wallet: some-contributor\n"
         self.assertEqual(resolve_wallet_from_pr_body(body), "some-contributor")
 
+    # --- Extended directive variants (PR #6676) ---------------------------
+
+    def test_payout_wallet_directive(self):
+        wallet = "RTC" + "a" * 40
+        self.assertEqual(resolve_wallet_from_pr_body(f"Payout wallet: {wallet}\n"), wallet)
+
+    def test_payout_address_directive(self):
+        wallet = "RTC" + "b" * 40
+        self.assertEqual(resolve_wallet_from_pr_body(f"Payout address: {wallet}\n"), wallet)
+
+    def test_payout_address_if_accepted_directive(self):
+        wallet = "RTC" + "c" * 40
+        self.assertEqual(
+            resolve_wallet_from_pr_body(f"Payout address if accepted: {wallet}\n"), wallet
+        )
+
+    def test_rtc_wallet_directive_variants(self):
+        wallet = "RTC" + "d" * 40
+        for body in (f"RTC Wallet: {wallet}\n", f"RTC wallet: {wallet}\n"):
+            with self.subTest(body=body):
+                self.assertEqual(resolve_wallet_from_pr_body(body), wallet)
+
+    def test_labeled_rtc_address_line_without_exact_directive(self):
+        wallet = "RTC" + "e" * 40
+        self.assertEqual(
+            resolve_wallet_from_pr_body(f"Accepted payout destination -> {wallet}\n"), wallet
+        )
+
+    def test_unlabeled_rtc_address_is_ignored(self):
+        wallet = "RTC" + "f" * 40
+        self.assertIsNone(resolve_wallet_from_pr_body(f"Implementation note: {wallet}\n"))
+
+    def test_lazy_pay_miner_id_variants(self):
+        samples = {
+            "miner ID for payout if accepted: github:alice\n": "github:alice",
+            "miner ID: github:bob\n": "github:bob",
+            "miner_id: lazy-pay-carol\n": "lazy-pay-carol",
+        }
+        for body, expected in samples.items():
+            with self.subTest(body=body):
+                self.assertEqual(resolve_wallet_from_pr_body(body), expected)
+
+    def test_strips_markdown_backticks_and_sentence_punctuation(self):
+        wallet = "RTC" + "1" * 40
+        self.assertEqual(resolve_wallet_from_pr_body(f"Payout wallet: `{wallet}`.\n"), wallet)
+
+    def test_explicit_directive_precedes_contextual_scan(self):
+        # An explicit wallet: directive wins over an incidental RTC mention.
+        directive = "RTC" + "2" * 40
+        incidental = "RTC" + "3" * 40
+        body = f"wallet: {directive}\nfixes the wallet address bug near {incidental}\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), directive)
+
 
 class TestResolveWalletFromFile(unittest.TestCase):
     """Test reading wallet from .rtc-wallet file."""
@@ -737,6 +790,40 @@ class TestDistinctWalletDirectives(unittest.TestCase):
 
     def test_no_directive(self):
         self.assertEqual(distinct_wallet_directives("nothing here"), [])
+
+    # --- Conflict guard must cover the new resolution stages (PR #6676) ----
+
+    def test_conflicting_miner_id_directives_detected(self):
+        # Two lazy-pay directives previously slipped past the guard (which only
+        # scanned wallet: directives) and silently picked the first. They must
+        # now be flagged for manual review.
+        body = "miner ID: github:attacker\nsome text\nminer ID: github:legit\n"
+        result = distinct_wallet_directives(body)
+        self.assertEqual(len(result), 2)
+        self.assertIn("github:attacker", result)
+        self.assertIn("github:legit", result)
+
+    def test_conflicting_wallet_and_miner_id_directives_detected(self):
+        body = "wallet: RTC" + "a" * 40 + "\nminer ID: github:attacker\n"
+        self.assertEqual(len(distinct_wallet_directives(body)), 2)
+
+    def test_explicit_directive_suppresses_contextual_scan_in_guard(self):
+        # An explicit directive plus an incidental RTC mention in prose must NOT
+        # register as a conflict (mirrors resolver precedence — fail-open here
+        # would force needless manual review on legitimate PRs).
+        directive = "RTC" + "a" * 40
+        incidental = "RTC" + "b" * 40
+        body = f"wallet: {directive}\nrefactors the wallet address parser near {incidental}\n"
+        self.assertEqual(distinct_wallet_directives(body), [directive])
+
+    def test_conflicting_contextual_only_addresses_detected(self):
+        # With no explicit directive, two different contextually-scanned RTC
+        # addresses are a genuine ambiguity and must fail closed.
+        a = "RTC" + "a" * 40
+        b = "RTC" + "b" * 40
+        body = f"payout address {a}\nbackup wallet {b}\n"
+        result = distinct_wallet_directives(body)
+        self.assertEqual(len(result), 2)
 
 
 class TestIdempotencyKey(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expand the RTC auto-bounty PR-body parser for `Payout wallet:`, `Payout address:`, `Payout address if accepted:`, and `RTC wallet:` variants
- add a labeled-line RTC address fallback for payout/wallet/address contexts
- add lazy-pay miner ID variants: `miner ID for payout if accepted:`, `miner ID:`, and `miner_id:`

## Tests
- `python3 .github/actions/rtc-auto-bounty/test_award_rtc.py`
- `uv run --with pytest --with requests python -m pytest .github/actions/rtc-auto-bounty/test_award_rtc.py scripts/test_auto_pay_idempotency.py`

Fixes #6645

Payout wallet: RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e