### PR TITLE
Fix Sophia governor malformed transfer amount handling

### DIFF
--- a/node/sophia_governor.py
+++ b/node/sophia_governor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hmac
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -210,6 +211,34 @@ def _risk_rank(value: str) -> int:
 
 def _strongest_risk(left: str, right: str) -> str:
     return left if _risk_rank(left) >= _risk_rank(right) else right
+
+
+def _safe_nonnegative_float(value: Any) -> tuple[float | None, bool]:
+    """Parse JSON scalar numeric fields without accepting booleans/containers."""
+    if value is None or value == "":
+        return None, False
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        return None, True
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None, True
+    if not math.isfinite(parsed) or parsed < 0:
+        return None, True
+    return parsed, False
+
+
+def _pending_transfer_amount_rtc(payload: dict[str, Any]) -> tuple[float, bool]:
+    """Return best-effort pending transfer RTC amount and whether it was malformed."""
+    amount_rtc, invalid = _safe_nonnegative_float(payload.get("amount_rtc"))
+    if amount_rtc:
+        return amount_rtc, invalid
+
+    amount_i64, i64_invalid = _safe_nonnegative_float(payload.get("amount_i64"))
+    if amount_i64 is not None:
+        return amount_i64 / 1_000_000.0, invalid or i64_invalid
+
+    return 0.0, invalid or i64_invalid
 
 
 def _load_continuity_packet() -> dict[str, Any]:
@@ -469,10 +498,14 @@ def _heuristic_review(event_type: str, payload: dict[str, Any]) -> dict[str, Any
             recommended_actions.append("keep proposal on local watchlist")
 
     elif event_type == "pending_transfer":
-        amount_rtc = float(payload.get("amount_rtc") or 0.0)
-        if not amount_rtc and payload.get("amount_i64") is not None:
-            amount_rtc = float(payload["amount_i64"]) / 1_000_000.0
+        amount_rtc, amount_invalid = _pending_transfer_amount_rtc(payload)
         reason_text = str(payload.get("reason", "")).lower()
+        if amount_invalid:
+            risk_level = "medium"
+            route = ROUTE_LOCAL_THEN_PHONE_HOME
+            stance = "watch"
+            signals.append("invalid_transfer_amount")
+            recommended_actions.append("review malformed transfer amount")
         if amount_rtc >= _transfer_critical_rtc():
             risk_level = "critical"
             route = ROUTE_IMMEDIATE_PHONE_HOME

--- a/node/tests/test_sophia_governor.py
+++ b/node/tests/test_sophia_governor.py
@@ -239,7 +239,10 @@ def test_governor_endpoints_require_admin_for_manual_review(client):
 
 
 def test_governor_recent_rejects_malformed_limit(client):
-    response = client.get("/sophia/governor/recent?limit=not-an-int")
+    response = client.get(
+        "/sophia/governor/recent?limit=not-an-int",
+        headers={"X-Admin-Key": "test-admin"},
+    )
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "limit must be an integer"
@@ -247,7 +250,10 @@ def test_governor_recent_rejects_malformed_limit(client):
 
 @pytest.mark.parametrize("limit", ["0", "-1"])
 def test_governor_recent_rejects_non_positive_limit(client, limit):
-    response = client.get(f"/sophia/governor/recent?limit={limit}")
+    response = client.get(
+        f"/sophia/governor/recent?limit={limit}",
+        headers={"X-Admin-Key": "test-admin"},
+    )
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "limit must be positive"
@@ -267,7 +273,10 @@ def test_governor_recent_caps_oversized_limit(client, monkeypatch):
         )
         assert review.status_code == 200
 
-    response = client.get("/sophia/governor/recent?limit=500")
+    response = client.get(
+        "/sophia/governor/recent?limit=500",
+        headers={"X-Admin-Key": "test-admin"},
+    )
 
     assert response.status_code == 200
     assert len(response.get_json()["events"]) == 1
@@ -311,6 +320,36 @@ def test_governor_review_rejects_structured_source(client):
 
     assert response.status_code == 400
     assert response.get_json()["error"] == "source must be a string"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"amount_rtc": ["not", "numeric"]},
+        {"amount_rtc": {"nested": "amount"}},
+        {"amount_rtc": True},
+        {"amount_i64": ["not", "numeric"]},
+        {"amount_i64": {"nested": "amount"}},
+        {"amount_i64": True},
+    ],
+)
+def test_governor_review_handles_malformed_pending_transfer_amount(client, payload):
+    response = client.post(
+        "/sophia/governor/review",
+        headers={"X-Admin-Key": "test-admin"},
+        json={
+            "event_type": "pending_transfer",
+            "source": "pytest.manual",
+            "payload": payload,
+        },
+    )
+
+    assert response.status_code == 200
+    review = response.get_json()["review"]
+    assert review["risk_level"] == "medium"
+    assert review["route"] == "local_then_phone_home"
+    assert "invalid_transfer_amount" in review["signals"]
+    assert "review malformed transfer amount" in review["recommended_actions"]
 
 
 def test_governor_admin_auth_uses_constant_time_compare(client, monkeypatch):
@@ -370,7 +409,10 @@ def test_governor_endpoints_report_status_and_recent(client):
     assert status_body["service"] == "sophia-rustchain-governor"
     assert status_body["totals"]["events"] >= 1
 
-    recent = client.get("/sophia/governor/recent?limit=5")
+    recent = client.get(
+        "/sophia/governor/recent?limit=5",
+        headers={"X-Admin-Key": "test-admin"},
+    )
     assert recent.status_code == 200
     recent_body = recent.get_json()
     assert recent_body["ok"] is True


### PR DESCRIPTION
## Summary
- add safe scalar parsing for `pending_transfer` amount fields in the Sophia governor
- reject booleans, arrays, objects, negative values, and non-finite values as malformed transfer amounts
- preserve review flow by emitting `invalid_transfer_amount` instead of raising HTTP 500
- align existing recent-endpoint tests with the current admin gate

Fixes #6678.
Claiming under bug bounty #305.
Payout miner_id: `github:darlina-bounty-codex`

## Tests
- `uv run --no-project --with pytest --with flask python -m pytest -q node/tests/test_sophia_governor.py --tb=short`
- `python3 -m py_compile node/sophia_governor.py node/tests/test_sophia_governor.py`
- `git diff --check -- node/sophia_governor.py node/tests/test_sophia_governor.py`

## Manual verification
Malformed pending transfer amount payloads now return HTTP 200 with a medium-risk `local_then_phone_home` review and the `invalid_transfer_amount` signal instead of crashing.
