### PR TITLE
Fix zh-CN token economics API reference link

### DIFF
--- a/docs/zh-CN/TOKEN_ECONOMICS.md
+++ b/docs/zh-CN/TOKEN_ECONOMICS.md
@@ -261,4 +261,4 @@ wRTC 也可在 Base L2 上使用：
 
 ---
 
-**下一步**: 查看 [api-reference.md](./api-reference.md) 了解所有公共端点。
+**下一步**: 查看 [API_REFERENCE.md](./API_REFERENCE.md) 了解所有公共端点。


### PR DESCRIPTION
## Summary
- fix the final `docs/zh-CN/TOKEN_ECONOMICS.md` API reference link to point at the existing `API_REFERENCE.md`
- resolves the case-sensitive missing-link bug reported in #6682

Fixes #6682.

## Verification
- `test -f docs/zh-CN/API_REFERENCE.md`
- `! test -f docs/zh-CN/api-reference.md`
- `rg -n "api-reference\\.md|API_REFERENCE\\.md" docs/zh-CN/TOKEN_ECONOMICS.md`
- `git diff --check`

RTC wallet for any merged-PR reward: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`
