### PR TITLE
RIP-202 B1: deterministic producer-enrollment module (dormant, tested)

### DIFF
--- a/node/rip0202_enrollment.py
+++ b/node/rip0202_enrollment.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+RIP-202 — deterministic producer-enrollment derivation (Phase B1).
+
+PURE, side-effect-free core (except the explicit sealing helper, which takes a
+caller-supplied connection). Nothing in the live node calls this yet — it is the
+deterministic foundation that block-apply (B2) and epoch sealing (B3) will use.
+
+Design constraints (see rips/docs/RIP-0202):
+  * Producer selection is deterministic consensus. This module must compute the
+    SAME enrollment on every node from the SAME committed block attestations.
+  * Weights are carried as INTEGER fixed-point units, never raw floats, so the
+    snapshot hash is identical across architectures (no float-repr divergence).
+  * The hardware-weight policy is NOT duplicated here: ``derive_verified_device``
+    and the ``HARDWARE_WEIGHTS`` table are INJECTED, so the one source of truth
+    in the main node stays authoritative.
+
+Scope (operator decision 2026-05-31, option (a)): eligibility is ATTESTATION-LEVEL
+— a miner is eligible iff its fingerprint passed AND its derived hardware weight
+is positive. The RIP-309 temporal fingerprint-rotation ``active_ratio`` is OUT OF
+SCOPE for RIP-202 and deferred to a follow-up RIP; this module derives the base
+hardware weight only.
+
+Contracts & intentional decisions (settled across tri-brain review rounds):
+  * FAIL-CLOSED policy divergence (intentional): an empty / unrecognised derived
+    family yields weight 0 (excluded) here, NOT the live reward path's 1.0
+    fallback. This is a SEPARATE consensus path (producer eligibility), not the
+    reward-weight computation, and an unrecognised identity means derivation
+    failed — failing closed is correct for a gate. Legit miners always derive to
+    a known family, so this never excludes real hardware.
+  * B0 INPUT CONTRACT: committed attestations are deserialised from the block's
+    JSON (the ``attestations_hash`` payload), so ``device``/``fingerprint`` are
+    always JSON-primitive structures — ``json.dumps(sort_keys=True)`` is therefore
+    deterministic for all real inputs. The repr fallback in ``_attestation_tiebreak``
+    is a defensive non-abort path for impossible-in-practice malformed data.
+  * ``finalized_at`` is AUDIT METADATA, not consensus-bound: it is NOT part of
+    ``snapshot_hash``, so a divergent value across nodes does not fork consensus
+    (the eligible set, captured in ``snapshot_hash``, is what binds). B3 should
+    still pass a chain-derived value for clean audit.
+  * INTEGRATION (B2/B3) REQUIREMENTS, not satisfiable in this dormant module:
+    (1) call ``ensure_epoch_enroll_state_schema`` ONCE at node/DB init (NOT in a
+    consensus tx — DDL implicit-commit); (2) wire the REAL ``derive_verified_device``
+    + ``HARDWARE_WEIGHTS`` and add integration tests over real committed shapes;
+    (3) the snapshot-hash field set + WEIGHT_SCALE + threshold become an immutable
+    consensus contract once any epoch is sealed — change them only behind the
+    on-chain activation height (PREREQ-A).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import sqlite3
+from typing import Callable, Dict, List, Mapping, Optional
+
+# Fixed-point scale for weights. 1e6 keeps the legitimate weight ladder exact
+# (e.g. 0.0005 -> 500 units, 2.5 -> 2_500_000) while the ~1e-9 failed-fingerprint
+# value rounds to 0 units, so it is excluded without a special case.
+WEIGHT_SCALE = 1_000_000
+
+# A miner is eligible iff its derived weight is at least this many units.
+# 1 unit (= 1e-6) is below every legitimate hardware weight (min 0.0005 = 500u)
+# and above the rounded failed-fingerprint value (0u), so it cleanly excludes
+# VMs/emulators while admitting all real hardware classes.
+DEFAULT_ELIGIBILITY_THRESHOLD_UNITS = 1
+
+
+def to_weight_units(weight: float) -> int:
+    """Canonicalise a float hardware weight to deterministic integer units.
+
+    Non-numeric / NaN / negative weights canonicalise to 0 units (excluded) so
+    a malformed injected weight fails closed rather than crashing or admitting a
+    miner with a bogus weight.
+    """
+    try:
+        w = float(weight)
+    except (TypeError, ValueError):
+        return 0
+    if not math.isfinite(w) or w < 0:  # NaN / +-inf / negative -> excluded
+        return 0
+    return int(round(w * WEIGHT_SCALE))
+
+
+def _strict_int(value):
+    """Return value as int iff it is a genuine int (not bool/float/str), else None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _safe_int(value, default: int = 0) -> int:
+    """Coerce to int, falling back to ``default`` on any malformed value."""
+    try:
+        if value is None:
+            return default
+        return int(value)
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: int(float("inf")) — a malformed committed timestamp must
+        # not abort the whole-block sort; fall back to the default.
+        return default
+
+
+def _coerce_dict(value) -> dict:
+    """Return ``value`` if it is a dict, else an empty dict (fail-closed)."""
+    return value if isinstance(value, dict) else {}
+
+
+def _attestation_tiebreak(attestation: Mapping) -> str:
+    """Deterministic content digest of an attestation's consensus fields.
+
+    Used as the FINAL sort tiebreaker so two attestations for the same miner
+    with the same timestamp resolve identically on every node (total order).
+    Truly-identical attestations hash equally and are interchangeable.
+    """
+    payload = {
+        "device": _coerce_dict(attestation.get("device")),
+        "fingerprint": _coerce_dict(attestation.get("fingerprint")),
+        "fingerprint_passed": attestation.get("fingerprint_passed") is True,
+    }
+    try:
+        canonical = json.dumps(payload, separators=(",", ":"), sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        # Non-JSON-safe content (e.g. non-string dict keys) must not abort the
+        # whole block's enrollment from inside the sort key. Fall back to a
+        # deterministic repr-based digest of the sorted items.
+        canonical = repr(sorted((str(k), str(v)) for k, v in payload.items()))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _validate_threshold(threshold_units: int) -> int:
+    """Eligibility threshold must be >= 1 unit, else INV-2 can be defeated."""
+    if isinstance(threshold_units, bool) or not isinstance(threshold_units, int) or threshold_units < 1:
+        raise ValueError("threshold_units must be an int >= 1")
+    return threshold_units
+
+
+def _lookup_hardware_weight(weight_table: Mapping, family: str, arch: str) -> float:
+    """Mirror the live lookup: HARDWARE_WEIGHTS[family][arch] with default fallback.
+
+    Matches ``HARDWARE_WEIGHTS.get(family, {}).get(arch, ...default...)`` used in
+    the main node. Unknown family/arch falls back to the family default, then 1.0.
+    """
+    # Fail CLOSED on an unrecognised / empty derived identity: an empty family
+    # (derivation produced junk) or a family absent from the table must NOT be
+    # admitted via a positive default — that is the fail-open hole. Only a KNOWN
+    # family falls back to its own "default" arch weight.
+    if not family:
+        return 0.0
+    fam = weight_table.get(family)
+    if not isinstance(fam, Mapping):
+        return 0.0  # unknown family or malformed table -> excluded
+    if arch in fam:
+        return fam[arch]
+    return fam.get("default", 0.0)  # known family, unknown arch -> family default
+
+
+def attestation_weight_units(
+    attestation: Mapping,
+    derive_fn: Callable[[dict, dict, bool], dict],
+    weight_table: Mapping,
+) -> int:
+    """Deterministic base hardware weight (in units) for one committed attestation.
+
+    ``attestation`` is a block-committed record carrying ``device`` (dict),
+    ``fingerprint`` (dict) and ``fingerprint_passed`` (bool) — the B0 format.
+    A failed fingerprint yields 0 units (excluded), mirroring the live
+    FAILED_FINGERPRINT path. Otherwise the verified (family, arch) from
+    ``derive_fn`` drives the ``weight_table`` lookup.
+    """
+    if attestation.get("fingerprint_passed") is not True:
+        return 0  # failed/ambiguous fingerprint (VM/emulator) -> excluded
+    device = attestation.get("device")
+    fingerprint = attestation.get("fingerprint")
+    # Malformed or missing device/fingerprint -> EXCLUDE (fail closed). Do NOT
+    # coerce to {} and let the table default admit the miner — that fails OPEN.
+    if not isinstance(device, dict) or not isinstance(fingerprint, dict):
+        return 0
+    verified = _coerce_dict(derive_fn(device, fingerprint, True))
+    family = verified.get("device_family", "")
+    arch = verified.get("device_arch", "")
+    weight = _lookup_hardware_weight(weight_table, family, arch)
+    units = to_weight_units(weight)
+    return units if units > 0 else 0
+
+
+def derive_block_enrollment(
+    attestations: List[Mapping],
+    derive_fn: Callable[[dict, dict, bool], dict],
+    weight_table: Mapping,
+) -> Dict[str, int]:
+    """Deterministically map committed block attestations -> {miner: weight_units}.
+
+    PURE and fully order-independent. Results are keyed by miner; duplicate
+    attestations for one miner are resolved by a TOTAL ordering — (miner id,
+    committed timestamp ascending, content digest) — and the last in that order
+    wins, so every node resolves duplicates (including same-timestamp ones)
+    identically. Non-Mapping items and miner-less records are skipped.
+    """
+    # miner ID must be a non-empty STRING — accepting truthy non-strings and
+    # str()-coercing would collide distinct identities (e.g. 1 vs "1").
+    valid = [
+        a for a in attestations
+        if isinstance(a, Mapping)
+        and isinstance(a.get("miner"), str)
+        and a.get("miner")
+    ]
+    # Total order: miner, then timestamp asc, then a deterministic content
+    # digest so same-(miner,timestamp) attestations cannot resolve by input
+    # order (which would diverge snapshot_hash across nodes -> fork).
+    ordered = sorted(
+        valid,
+        key=lambda a: (
+            str(a.get("miner")),
+            _safe_int(a.get("timestamp"), 0),
+            _attestation_tiebreak(a),
+        ),
+    )
+    enrollment: Dict[str, int] = {}
+    for att in ordered:
+        miner = att["miner"]  # guaranteed non-empty str by the filter above
+        # Per-attestation containment: a single attestation that makes the
+        # injected derive_fn raise must NOT abort the whole block's enrollment.
+        # On any error, exclude that miner (weight 0) and continue — fail closed.
+        try:
+            enrollment[miner] = attestation_weight_units(att, derive_fn, weight_table)
+        except Exception:
+            enrollment[miner] = 0
+    return enrollment
+
+
+def eligible_miners(
+    enrollment: Mapping[str, int],
+    threshold_units: int = DEFAULT_ELIGIBILITY_THRESHOLD_UNITS,
+) -> List[str]:
+    """Sorted list of producer-eligible miners (weight >= threshold).
+
+    Weights are coerced to int units (the module contract) so a stray float
+    cannot be counted eligible at one value but hashed at another.
+    """
+    _validate_threshold(threshold_units)
+    return sorted(m for m, w in enrollment.items() if _safe_int(w, 0) >= threshold_units)
+
+
+def enrollment_snapshot_hash(
+    enrollment: Mapping[str, int],
+    threshold_units: int = DEFAULT_ELIGIBILITY_THRESHOLD_UNITS,
+) -> str:
+    """Deterministic SHA-256 over the eligible (miner, weight_units) set.
+
+    Integer units + sorted canonical JSON => identical on every node/arch.
+    Excluded miners (weight < threshold) are omitted so the hash reflects the
+    eligible set the consensus rule actually uses.
+    """
+    _validate_threshold(threshold_units)
+    eligible = [
+        [m, _safe_int(enrollment[m], 0)]
+        for m in sorted(enrollment)
+        if _safe_int(enrollment[m], 0) >= threshold_units
+    ]
+    # Embed the threshold so a sealed hash is unambiguous if policy ever changes.
+    canonical = {"threshold_units": threshold_units, "eligible": eligible}
+    blob = json.dumps(canonical, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+# --- Epoch enrollment sealing (B3 core; INV-2/INV-3) ------------------------
+
+EPOCH_ENROLL_STATE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS epoch_enroll_state (
+    epoch          INTEGER PRIMARY KEY,
+    finalized      INTEGER NOT NULL DEFAULT 0,
+    snapshot_hash  TEXT,
+    finalized_at   INTEGER
+)
+"""
+
+
+def ensure_epoch_enroll_state_schema(conn: sqlite3.Connection) -> None:
+    """Create the epoch_enroll_state table if absent.
+
+    Call this ONCE at node/DB init (migration), NOT inside a consensus tx —
+    SQLite DDL can implicit-commit and would break a caller's transaction
+    atomicity. ``seal_epoch_enrollment`` assumes the table already exists.
+    """
+    conn.execute(EPOCH_ENROLL_STATE_SCHEMA)
+
+
+def is_epoch_finalized(conn: sqlite3.Connection, epoch: int) -> bool:
+    """True iff epoch ``epoch``'s enrollment snapshot is sealed (finalized == 1).
+
+    Absent table/row/column -> False (not finalized). Never raises into a
+    consensus hot path: a transient/missing-state read is treated as not sealed.
+    """
+    try:
+        row = conn.execute(
+            "SELECT finalized FROM epoch_enroll_state WHERE epoch = ?",
+            (epoch,),
+        ).fetchone()
+    except sqlite3.OperationalError:
+        return False
+    if row is None:
+        return False
+    try:
+        return row[0] == 1
+    except (KeyError, IndexError, TypeError):
+        return False
+
+
+def seal_epoch_enrollment(
+    conn: sqlite3.Connection,
+    epoch: int,
+    enrollment: Mapping[str, int],
+    finalized_at: int,
+    threshold_units: int = DEFAULT_ELIGIBILITY_THRESHOLD_UNITS,
+) -> bool:
+    """Seal epoch ``epoch``'s enrollment snapshot. Returns True iff sealed.
+
+    INV-2: NEVER seal an empty / all-excluded snapshot — a finalized snapshot
+    must contain at least one eligible producer, so the fail-closed gate can
+    never strand the chain without a producer. Returns False (does not seal)
+    when no miner clears the threshold.
+
+    ``finalized_at`` MUST be a deterministic, chain-derived value (e.g. the
+    sealing block height/slot) — NOT node-local wall-clock — or finalization
+    would diverge across nodes (INV-1). The caller supplies it.
+
+    A sealed epoch is IMMUTABLE: re-sealing an already-finalized (finalized==1)
+    epoch is refused (returns False), so a later call cannot swap the snapshot.
+    A pre-existing UNsealed row (finalized==0) IS upgraded to sealed (it would
+    otherwise strand the epoch forever).
+
+    The table must already exist (call ``ensure_epoch_enroll_state_schema`` at
+    init). This writes within the caller's transaction; the CALLER must commit.
+    ``True`` means "written in this tx", not yet durable until commit.
+    """
+    _validate_threshold(threshold_units)
+    # epoch / finalized_at must be genuine ints (not bool/float/str): a float
+    # epoch=1.9 must NOT silently seal epoch 1.
+    epoch_i = _strict_int(epoch)
+    finalized_at_i = _strict_int(finalized_at)
+    if epoch_i is None or finalized_at_i is None or epoch_i < 0 or finalized_at_i < 0:
+        return False  # malformed chain-derived inputs -> fail closed, do not seal
+
+    eligible = eligible_miners(enrollment, threshold_units)
+    if not eligible:
+        return False  # INV-2: refuse to finalize an empty eligible set
+    snapshot_hash = enrollment_snapshot_hash(enrollment, threshold_units)
+
+    # Atomic, TOCTOU-free seal (no separate finalized SELECT to race against):
+    #   * pre-existing finalized==0 row -> the conditional UPDATE upgrades it
+    #   * no row                        -> the INSERT OR IGNORE creates it
+    #   * already finalized==1          -> UPDATE no-ops (WHERE finalized=0) AND
+    #     INSERT OR IGNORE no-ops (PK conflict) -> returns False (IMMUTABLE)
+    try:
+        upd = conn.execute(
+            "UPDATE epoch_enroll_state SET finalized=1, snapshot_hash=?, finalized_at=? "
+            "WHERE epoch=? AND finalized=0",
+            (snapshot_hash, finalized_at_i, epoch_i),
+        )
+        if upd.rowcount == 1:
+            return True
+        ins = conn.execute(
+            "INSERT OR IGNORE INTO epoch_enroll_state "
+            "(epoch, finalized, snapshot_hash, finalized_at) VALUES (?, 1, ?, ?)",
+            (epoch_i, snapshot_hash, finalized_at_i),
+        )
+        return ins.rowcount == 1
+    except sqlite3.OperationalError:
+        # Table missing/locked: not sealed. Caller must run
+        # ensure_epoch_enroll_state_schema() at init. Fail closed, don't crash.
+        return False

--- a/node/tests/test_rip0202_enrollment.py
+++ b/node/tests/test_rip0202_enrollment.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Unit tests for RIP-202 Phase B1 (rip0202_enrollment). Pure — no node deps."""
+
+import sqlite3
+import importlib.util
+import os
+
+import pytest
+
+# Load the module under test. It lives at node/rip0202_enrollment.py while this
+# test lives at node/tests/ — so search the test dir AND its parent (and handle
+# a flat layout). Pick the first candidate that exists.
+_here = os.path.dirname(os.path.abspath(__file__))
+_candidates = [
+    os.path.join(_here, "rip0202_enrollment.py"),          # flat layout
+    os.path.join(_here, os.pardir, "rip0202_enrollment.py"),  # node/tests -> node
+]
+_mod_path = next((p for p in _candidates if os.path.exists(p)), _candidates[-1])
+_spec = importlib.util.spec_from_file_location("rip0202_enrollment", _mod_path)
+enr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(enr)
+
+
+# --- stub the injected consensus deps (so the test has zero node deps) -------
+
+STUB_WEIGHTS = {
+    "PowerPC": {"G4": 2.5, "G5": 2.0, "default": 1.5},
+    "ARM": {"aarch64": 0.0005, "default": 0.0005},
+    "x86": {"modern": 0.8, "retro": 1.4, "default": 1.0},
+}
+
+
+def stub_derive(device, fingerprint, fingerprint_passed):
+    """Deterministic stand-in for derive_verified_device: echoes device family/arch."""
+    return {
+        "device_family": device.get("family", "x86"),
+        "device_arch": device.get("arch", "modern"),
+    }
+
+
+def _db():
+    """In-memory sqlite with the epoch_enroll_state schema ensured."""
+    conn = sqlite3.connect(":memory:")
+    enr.ensure_epoch_enroll_state_schema(conn)
+    return conn
+
+
+def att(miner, family="PowerPC", arch="G4", passed=True, ts=1000, fp=None):
+    return {
+        "miner": miner,
+        "device": {"family": family, "arch": arch},
+        "fingerprint": fp or {"simd": "x"},
+        "fingerprint_passed": passed,
+        "timestamp": ts,
+    }
+
+
+# --- weight derivation -------------------------------------------------------
+
+def test_eligible_weight_units():
+    e = enr.derive_block_enrollment([att("alice", "PowerPC", "G4")], stub_derive, STUB_WEIGHTS)
+    assert e["alice"] == 2_500_000  # 2.5 * 1e6
+
+
+def test_failed_fingerprint_excluded():
+    e = enr.derive_block_enrollment([att("vm", passed=False)], stub_derive, STUB_WEIGHTS)
+    assert e["vm"] == 0
+    assert "vm" not in enr.eligible_miners(e)
+
+
+def test_near_zero_weight_rounds_to_excluded():
+    # A weight below 1e-6 (a VM-ish ~1e-9) must round to 0 units -> excluded.
+    tbl = {"x86": {"modern": 1e-9, "default": 1e-9}}
+    e = enr.derive_block_enrollment([att("ghost", "x86", "modern", passed=True)], stub_derive, tbl)
+    assert e["ghost"] == 0
+    assert enr.eligible_miners(e) == []
+
+
+def test_penalty_arch_still_eligible():
+    # 0.0005 (ARM NAS penalty) is a real, fingerprint-passed weight -> eligible (500u).
+    e = enr.derive_block_enrollment([att("nas", "ARM", "aarch64")], stub_derive, STUB_WEIGHTS)
+    assert e["nas"] == 500
+    assert "nas" in enr.eligible_miners(e)
+
+
+def test_default_fallback_weight():
+    e = enr.derive_block_enrollment([att("u", "PowerPC", "unknown_arch")], stub_derive, STUB_WEIGHTS)
+    assert e["u"] == 1_500_000  # PowerPC default 1.5
+
+
+# --- determinism (the consensus-critical property) ---------------------------
+
+def test_order_independent():
+    a = [att("a", "PowerPC", "G4"), att("b", "PowerPC", "G5"), att("c", "ARM", "aarch64")]
+    e1 = enr.derive_block_enrollment(a, stub_derive, STUB_WEIGHTS)
+    e2 = enr.derive_block_enrollment(list(reversed(a)), stub_derive, STUB_WEIGHTS)
+    assert e1 == e2
+    assert enr.enrollment_snapshot_hash(e1) == enr.enrollment_snapshot_hash(e2)
+
+
+def test_duplicate_miner_resolved_deterministically():
+    # Same miner twice (different ts) -> latest timestamp wins, deterministically.
+    a = [att("dup", "PowerPC", "G4", ts=100), att("dup", "PowerPC", "G5", ts=200)]
+    e = enr.derive_block_enrollment(a, stub_derive, STUB_WEIGHTS)
+    assert e["dup"] == 2_000_000  # G5 (ts=200) wins
+    # reversed input -> identical result
+    assert enr.derive_block_enrollment(list(reversed(a)), stub_derive, STUB_WEIGHTS) == e
+
+
+def test_snapshot_hash_excludes_zero_weight():
+    eligible_only = {"a": 2_500_000}
+    with_excluded = {"a": 2_500_000, "vm": 0}
+    assert enr.enrollment_snapshot_hash(eligible_only) == enr.enrollment_snapshot_hash(with_excluded)
+
+
+def test_snapshot_hash_sensitive_to_set():
+    h1 = enr.enrollment_snapshot_hash({"a": 2_500_000})
+    h2 = enr.enrollment_snapshot_hash({"a": 2_500_000, "b": 2_000_000})
+    assert h1 != h2
+
+
+# --- sealing (INV-2 / INV-3) -------------------------------------------------
+
+def test_seal_writes_state():
+    conn = _db()
+    e = {"a": 2_500_000}
+    assert enr.seal_epoch_enrollment(conn, 42, e, finalized_at=999) is True
+    assert enr.is_epoch_finalized(conn, 42) is True
+    row = conn.execute("SELECT finalized, snapshot_hash, finalized_at FROM epoch_enroll_state WHERE epoch=42").fetchone()
+    assert row[0] == 1 and row[1] == enr.enrollment_snapshot_hash(e) and row[2] == 999
+
+
+def test_inv2_refuses_empty_snapshot():
+    conn = _db()
+    assert enr.seal_epoch_enrollment(conn, 7, {}, finalized_at=1) is False
+    assert enr.is_epoch_finalized(conn, 7) is False
+
+
+def test_inv2_refuses_all_excluded_snapshot():
+    conn = _db()
+    assert enr.seal_epoch_enrollment(conn, 8, {"vm1": 0, "vm2": 0}, finalized_at=1) is False
+    assert enr.is_epoch_finalized(conn, 8) is False
+
+
+def test_is_finalized_missing_table_is_false():
+    conn = sqlite3.connect(":memory:")  # no epoch_enroll_state table created
+    assert enr.is_epoch_finalized(conn, 1) is False
+
+
+def test_is_finalized_rejects_non_one():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(enr.EPOCH_ENROLL_STATE_SCHEMA)
+    conn.execute("INSERT INTO epoch_enroll_state (epoch, finalized) VALUES (5, 0)")
+    conn.execute("INSERT INTO epoch_enroll_state (epoch, finalized) VALUES (6, -1)")
+    assert enr.is_epoch_finalized(conn, 5) is False
+    assert enr.is_epoch_finalized(conn, 6) is False
+
+
+# --- loop-2 hardening: determinism on ts-tie, validation, immutability -------
+
+def test_same_timestamp_tie_is_deterministic():
+    # Two DIFFERENT attestations for one miner with the SAME timestamp must
+    # resolve identically regardless of input order (content-digest tiebreaker).
+    a1 = att("dup", "PowerPC", "G4", ts=500)
+    a2 = att("dup", "PowerPC", "G5", ts=500)  # same ts, different arch
+    e_fwd = enr.derive_block_enrollment([a1, a2], stub_derive, STUB_WEIGHTS)
+    e_rev = enr.derive_block_enrollment([a2, a1], stub_derive, STUB_WEIGHTS)
+    assert e_fwd == e_rev
+    assert enr.enrollment_snapshot_hash(e_fwd) == enr.enrollment_snapshot_hash(e_rev)
+
+
+def test_non_mapping_and_minerless_skipped():
+    items = [att("a", "PowerPC", "G4"), None, 42, {"device": {}}, {"miner": ""}]
+    e = enr.derive_block_enrollment(items, stub_derive, STUB_WEIGHTS)
+    assert list(e) == ["a"]
+
+
+def test_fingerprint_passed_must_be_true():
+    for bad in (1, "true", "1", "yes"):
+        e = enr.derive_block_enrollment(
+            [att("m", "PowerPC", "G4", passed=bad)], stub_derive, STUB_WEIGHTS)
+        assert e["m"] == 0  # only literal True counts
+
+
+def test_malformed_timestamp_does_not_crash():
+    a = att("m", "PowerPC", "G4")
+    a["timestamp"] = None
+    e = enr.derive_block_enrollment([a], stub_derive, STUB_WEIGHTS)
+    assert e["m"] == 2_500_000
+
+
+def test_non_dict_device_fingerprint_failclosed():
+    # Malformed device/fingerprint must EXCLUDE (fail closed), not get a default weight.
+    a = {"miner": "m", "device": "notadict", "fingerprint": 5, "fingerprint_passed": True, "timestamp": 1}
+    e = enr.derive_block_enrollment([a], stub_derive, STUB_WEIGHTS)
+    assert e["m"] == 0
+    assert enr.eligible_miners(e) == []
+
+
+def test_missing_device_or_fingerprint_excluded():
+    a = {"miner": "m", "fingerprint_passed": True, "timestamp": 1}  # no device/fingerprint
+    assert enr.derive_block_enrollment([a], stub_derive, STUB_WEIGHTS)["m"] == 0
+
+
+def test_inf_weight_excluded_no_crash():
+    tbl = {"x86": {"modern": float("inf"), "default": float("inf")}}
+    e = enr.derive_block_enrollment([att("a", "x86", "modern")], stub_derive, tbl)
+    assert e["a"] == 0  # +inf must not OverflowError, must exclude
+
+
+def test_nonstring_miner_excluded():
+    # miner=1 (int) and miner="1" (str) must NOT collide; non-str miner is skipped.
+    items = [att("1", "PowerPC", "G4"), {**att("x", "PowerPC", "G5"), "miner": 1}]
+    e = enr.derive_block_enrollment(items, stub_derive, STUB_WEIGHTS)
+    assert list(e) == ["1"]  # only the genuine string id survives
+
+
+def test_raising_derive_fn_contained():
+    def boom(device, fingerprint, passed):
+        raise RuntimeError("derive blew up")
+    a = [att("a", "PowerPC", "G4"), att("b", "PowerPC", "G5")]
+    e = enr.derive_block_enrollment(a, boom, STUB_WEIGHTS)
+    assert e == {"a": 0, "b": 0}  # contained per-attestation, excluded, no crash
+
+
+def test_empty_derived_identity_excluded():
+    # derive_fn returning {} (no family) must EXCLUDE, not get the 1.0 default.
+    e = enr.derive_block_enrollment([att("a", "PowerPC", "G4")], lambda d, f, p: {}, STUB_WEIGHTS)
+    assert e["a"] == 0
+
+
+def test_unknown_family_excluded():
+    e = enr.derive_block_enrollment(
+        [att("a", "PowerPC", "G4")],
+        lambda d, f, p: {"device_family": "Martian", "device_arch": "x"},
+        STUB_WEIGHTS,
+    )
+    assert e["a"] == 0  # family not in table -> fail closed
+
+
+def test_non_dict_derive_return_excluded():
+    e = enr.derive_block_enrollment([att("a", "PowerPC", "G4")], lambda d, f, p: None, STUB_WEIGHTS)
+    assert e["a"] == 0
+
+
+def test_threshold_rejects_bool():
+    with pytest.raises(ValueError):
+        enr.eligible_miners({"a": 5}, threshold_units=True)
+
+
+def test_threshold_embedded_in_hash():
+    e = {"a": 2_500_000, "b": 500}
+    # different thresholds -> different eligible set -> different hash
+    h1 = enr.enrollment_snapshot_hash(e, threshold_units=1)
+    h2 = enr.enrollment_snapshot_hash(e, threshold_units=1000)
+    assert h1 != h2
+
+
+def test_nan_and_negative_weight_excluded():
+    tbl = {"x86": {"modern": float("nan"), "neg": -1.0, "default": float("nan")}}
+    e_nan = enr.derive_block_enrollment([att("a", "x86", "modern")], stub_derive, tbl)
+    e_neg = enr.derive_block_enrollment([att("b", "x86", "neg")], stub_derive, tbl)
+    assert e_nan["a"] == 0 and e_neg["b"] == 0
+
+
+def test_threshold_must_be_positive():
+    e = {"vm": 0}
+    for bad in (0, -1, 1.0, None):
+        with pytest.raises(ValueError):
+            enr.eligible_miners(e, threshold_units=bad)
+        with pytest.raises(ValueError):
+            enr.seal_epoch_enrollment(_db(), 1, e, 1, threshold_units=bad)
+
+
+def test_seal_is_immutable():
+    conn = _db()
+    assert enr.seal_epoch_enrollment(conn, 3, {"a": 2_500_000}, finalized_at=10) is True
+    # second seal of the same epoch (different snapshot) must be refused
+    assert enr.seal_epoch_enrollment(conn, 3, {"b": 2_000_000}, finalized_at=20) is False
+    row = conn.execute("SELECT snapshot_hash, finalized_at FROM epoch_enroll_state WHERE epoch=3").fetchone()
+    assert row[0] == enr.enrollment_snapshot_hash({"a": 2_500_000}) and row[1] == 10
+
+
+def test_seal_rejects_malformed_epoch_or_finalized_at():
+    conn = _db()
+    assert enr.seal_epoch_enrollment(conn, None, {"a": 2_500_000}, finalized_at=1) is False
+    assert enr.seal_epoch_enrollment(conn, 1, {"a": 2_500_000}, finalized_at=None) is False
+
+
+def test_seal_upgrades_preexisting_finalized_zero():
+    # A pre-existing UNsealed (finalized=0) row must be upgradable, not stranded.
+    conn = _db()
+    conn.execute("INSERT INTO epoch_enroll_state (epoch, finalized) VALUES (9, 0)")
+    assert enr.seal_epoch_enrollment(conn, 9, {"a": 2_500_000}, finalized_at=5) is True
+    assert enr.is_epoch_finalized(conn, 9) is True
+
+
+def test_seal_missing_table_fails_closed():
+    conn = sqlite3.connect(":memory:")  # schema NOT ensured
+    assert enr.seal_epoch_enrollment(conn, 1, {"a": 2_500_000}, finalized_at=1) is False
+
+
+def test_seal_rejects_float_epoch():
+    conn = _db()
+    assert enr.seal_epoch_enrollment(conn, 1.9, {"a": 2_500_000}, finalized_at=1) is False
+    assert enr.seal_epoch_enrollment(conn, True, {"a": 2_500_000}, finalized_at=1) is False
+    assert enr.is_epoch_finalized(conn, 1) is False
+
+
+def test_empty_inputs():
+    assert enr.derive_block_enrollment([], stub_derive, STUB_WEIGHTS) == {}
+    assert enr.eligible_miners({}) == []
+    assert enr.enrollment_snapshot_hash({}) == enr.enrollment_snapshot_hash({"vm": 0})
+
+
+
+def test_inf_timestamp_does_not_crash():
+    a = att("m", "PowerPC", "G4")
+    a["timestamp"] = float("inf")  # int(inf) raises OverflowError -> must be caught
+    e = enr.derive_block_enrollment([a], stub_derive, STUB_WEIGHTS)
+    assert e["m"] == 2_500_000
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

First implementation step of **RIP-202** (`rips/docs/RIP-0202-fail-closed-producer-enrollment.md`): the deterministic enrollment-derivation core (Phase **B1**). Adds `node/rip0202_enrollment.py` + `node/tests/test_rip0202_enrollment.py`.

**This is INERT** — nothing in the live node calls it. It is the deterministic foundation that block-apply (B2) and epoch sealing (B3) will use. Merging changes no consensus behavior.

## What it does
- `derive_block_enrollment(attestations, derive_fn, weight_table)` — pure, order-independent map of committed block attestations → `{miner: weight_units}`. Reuses `derive_verified_device` + `HARDWARE_WEIGHTS` **by injection** (no consensus-logic duplication).
- Integer **fixed-point units** throughout → platform-deterministic `enrollment_snapshot_hash` (no float-repr divergence across the PowerPC/x86/POWER8 fleet).
- `seal_epoch_enrollment` — atomic, TOCTOU-free, **INV-2** (never seal an empty/all-excluded set), immutable once sealed; `epoch_enroll_state` table + `ensure_epoch_enroll_state_schema`.
- Scope (operator decision): **attestation-level eligibility** — eligible iff fingerprint passed AND derived weight > 0. RIP-309 temporal `active_ratio` deferred to a follow-up RIP.

## Quality
- **37 unit tests, all passing** (pure — no node deps): determinism, ts-tie total-order tiebreak, fail-closed on failed-fingerprint / malformed device / unrecognised family / non-finite weight / non-string miner, per-attestation exception containment, INV-2 refusal, seal immutability + finalized=0 upgrade, threshold validation.
- **Tri-brain reviewed (Codex 5.5 + Grok), 4 recurrent-depth rounds** — every BLOCKING in the module's own logic fixed (fail-open class closed, atomic immutability, inf/NaN handling, deterministic tiebreak).

## Intentional decisions / contracts (documented in the module header)
- **Fail-closed divergence**: unrecognised derived family → weight 0 (excluded), NOT the live reward path's 1.0 fallback. This is a separate consensus path (producer eligibility); failing closed on a failed derivation is correct for a gate.
- **B0 input contract**: committed attestations are JSON-deserialised, so `json.dumps(sort_keys=True)` is deterministic for all real inputs.
- `finalized_at` is audit metadata (not in `snapshot_hash`) → divergence is cosmetic, not a fork.

## Integration requirements for B2/B3 (NOT in this PR)
1. Call `ensure_epoch_enroll_state_schema` once at node/DB init (not in a consensus tx).
2. Wire the real `derive_verified_device` + `HARDWARE_WEIGHTS`; add integration tests over real committed attestation shapes.
3. The snapshot-hash field set + `WEIGHT_SCALE` + threshold become an immutable consensus contract once an epoch is sealed — change only behind the on-chain activation height (PREREQ-A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)