### PR TITLE
Expand RTC payout parser variants

### DIFF
--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -56,10 +56,27 @@ VPS_PORT = 8099
 #   Wallet: RTCxxxx...
 #   wallet: my-github-username
 #   .rtc-wallet: RTCxxxx...
-_WALLET_RE = re.compile(
-    r"(?:^|\n)\s*(?:wallet|\.rtc-wallet)\s*:\s*(\S+)\s*(?:\n|$)",
+#   Payout wallet: RTCxxxx...
+#   Payout address: RTCxxxx...
+#   Payout address if accepted: RTCxxxx...
+#   RTC wallet: RTCxxxx...
+#   miner ID for payout if accepted: some-miner-id
+#   miner ID: some-miner-id
+#   miner_id: some-miner-id
+_DIRECTIVE_RE = re.compile(
+    r"^\s*(?:"
+    r"wallet|"
+    r"\.rtc-wallet|"
+    r"payout wallet|"
+    r"payout address(?: if accepted)?|"
+    r"rtc wallet|"
+    r"miner id for payout if accepted|"
+    r"miner id|"
+    r"miner_id"
+    r")\s*:\s*(\S.*?)\s*$",
     re.IGNORECASE,
 )
+_RTC_ADDRESS_RE = re.compile(r"RTC[0-9a-f]{40}", re.IGNORECASE)
 
 # Payment-amount override in the PR body (owner can specify a custom amount).
 #   bounty: 100 RTC
@@ -171,10 +188,18 @@ class Config:
 
 
 def resolve_wallet_from_pr_body(pr_body: str) -> Optional[str]:
-    """Extract wallet address from a ``wallet: <addr>`` directive in the PR body."""
-    match = _WALLET_RE.search(pr_body)
-    if match:
-        return match.group(1).strip().rstrip(",")
+    """Extract wallet or lazy-pay recipient hints from the PR body."""
+    for raw_line in pr_body.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _DIRECTIVE_RE.match(line)
+        if match:
+            return match.group(1).strip().rstrip(",")
+        if re.search(r"(payout|wallet|address)", line, re.IGNORECASE):
+            address_match = _RTC_ADDRESS_RE.search(line)
+            if address_match:
+                return address_match.group(0)
     return None
 
 

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -77,6 +77,7 @@ _DIRECTIVE_RE = re.compile(
     re.IGNORECASE,
 )
 _RTC_ADDRESS_RE = re.compile(r"RTC[0-9a-f]{40}", re.IGNORECASE)
+_MINER_ID_RE = re.compile(r"[A-Za-z0-9._:-]+")
 
 # Payment-amount override in the PR body (owner can specify a custom amount).
 #   bounty: 100 RTC
@@ -201,6 +202,10 @@ def resolve_wallet_from_pr_body(pr_body: str) -> Optional[str]:
                 address_match = _RTC_ADDRESS_RE.search(value)
                 if address_match:
                     return address_match.group(0)
+                return value
+            miner_match = _MINER_ID_RE.search(value)
+            if miner_match:
+                return miner_match.group(0)
             return value
         if re.search(r"(payout|wallet|address)", line, re.IGNORECASE):
             address_match = _RTC_ADDRESS_RE.search(line)

--- a/.github/actions/rtc-auto-bounty/award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/award_rtc.py
@@ -64,7 +64,7 @@ VPS_PORT = 8099
 #   miner ID: some-miner-id
 #   miner_id: some-miner-id
 _DIRECTIVE_RE = re.compile(
-    r"^\s*(?:"
+    r"^\s*(?P<label>"
     r"wallet|"
     r"\.rtc-wallet|"
     r"payout wallet|"
@@ -73,7 +73,7 @@ _DIRECTIVE_RE = re.compile(
     r"miner id for payout if accepted|"
     r"miner id|"
     r"miner_id"
-    r")\s*:\s*(\S.*?)\s*$",
+    r")\s*:\s*(?P<value>\S.*?)\s*$",
     re.IGNORECASE,
 )
 _RTC_ADDRESS_RE = re.compile(r"RTC[0-9a-f]{40}", re.IGNORECASE)
@@ -195,7 +195,13 @@ def resolve_wallet_from_pr_body(pr_body: str) -> Optional[str]:
             continue
         match = _DIRECTIVE_RE.match(line)
         if match:
-            return match.group(1).strip().rstrip(",")
+            label = match.group("label").strip().lower()
+            value = match.group("value").strip().rstrip(",")
+            if "miner" not in label:
+                address_match = _RTC_ADDRESS_RE.search(value)
+                if address_match:
+                    return address_match.group(0)
+            return value
         if re.search(r"(payout|wallet|address)", line, re.IGNORECASE):
             address_match = _RTC_ADDRESS_RE.search(line)
             if address_match:

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -61,6 +61,16 @@ class TestResolveWalletFromPrBody(unittest.TestCase):
             "RTC4730a64f821a590972e8b37781fae5d568b5865c",
         )
 
+    def test_annotated_payout_address_directive_returns_rtc_token_only(self):
+        body = (
+            "Payout address if accepted: "
+            "RTC4730a64f821a590972e8b37781fae5d568b5865c (preferred wallet)\n"
+        )
+        self.assertEqual(
+            resolve_wallet_from_pr_body(body),
+            "RTC4730a64f821a590972e8b37781fae5d568b5865c",
+        )
+
     def test_rtc_wallet_directive(self):
         body = "RTC Wallet: RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
         self.assertEqual(
@@ -71,6 +81,13 @@ class TestResolveWalletFromPrBody(unittest.TestCase):
     def test_miner_id_for_payout_directive(self):
         body = "miner ID for payout if accepted: my-miner-id\n"
         self.assertEqual(resolve_wallet_from_pr_body(body), "my-miner-id")
+
+    def test_miner_id_directive_keeps_annotated_value(self):
+        body = "miner ID for payout if accepted: my-miner-id (fallback worker)\n"
+        self.assertEqual(
+            resolve_wallet_from_pr_body(body),
+            "my-miner-id (fallback worker)",
+        )
 
     def test_miner_id_underscore_directive(self):
         body = "miner_id: fallback-miner\n"

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -54,6 +54,35 @@ class TestResolveWalletFromPrBody(unittest.TestCase):
         body = ".rtc-wallet: RTCdotfile123\n"
         self.assertEqual(resolve_wallet_from_pr_body(body), "RTCdotfile123")
 
+    def test_payout_address_if_accepted_directive(self):
+        body = "Payout address if accepted: RTC4730a64f821a590972e8b37781fae5d568b5865c\n"
+        self.assertEqual(
+            resolve_wallet_from_pr_body(body),
+            "RTC4730a64f821a590972e8b37781fae5d568b5865c",
+        )
+
+    def test_rtc_wallet_directive(self):
+        body = "RTC Wallet: RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n"
+        self.assertEqual(
+            resolve_wallet_from_pr_body(body),
+            "RTCaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+
+    def test_miner_id_for_payout_directive(self):
+        body = "miner ID for payout if accepted: my-miner-id\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "my-miner-id")
+
+    def test_miner_id_underscore_directive(self):
+        body = "miner_id: fallback-miner\n"
+        self.assertEqual(resolve_wallet_from_pr_body(body), "fallback-miner")
+
+    def test_rtc_address_with_contextual_label(self):
+        body = "Please use this payout address RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb for settlement.\n"
+        self.assertEqual(
+            resolve_wallet_from_pr_body(body),
+            "RTCbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+
     def test_wallet_with_trailingling_comma(self):
         body = "wallet: RTCwithcomma,\n"
         self.assertEqual(resolve_wallet_from_pr_body(body), "RTCwithcomma")

--- a/.github/actions/rtc-auto-bounty/test_award_rtc.py
+++ b/.github/actions/rtc-auto-bounty/test_award_rtc.py
@@ -82,11 +82,11 @@ class TestResolveWalletFromPrBody(unittest.TestCase):
         body = "miner ID for payout if accepted: my-miner-id\n"
         self.assertEqual(resolve_wallet_from_pr_body(body), "my-miner-id")
 
-    def test_miner_id_directive_keeps_annotated_value(self):
+    def test_miner_id_directive_returns_token_without_annotation(self):
         body = "miner ID for payout if accepted: my-miner-id (fallback worker)\n"
         self.assertEqual(
             resolve_wallet_from_pr_body(body),
-            "my-miner-id (fallback worker)",
+            "my-miner-id",
         )
 
     def test_miner_id_underscore_directive(self):


### PR DESCRIPTION
Fixes #6645

Summary:
- expand the PR body parser to accept payout wallet/address variants
- accept `miner ID` lazy-pay variants alongside wallet directives
- fall back to contextual RTC address extraction when payout labels are present
- add unit coverage for the new parser cases

Verification:
- python3 .github/actions/rtc-auto-bounty/test_award_rtc.py
- python3 tests/test_award_rtc_workflow.py