### PR TITLE
[UTXO-BUG] epoch dual-write aborts on sub-dust reward outputs

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -44,9 +44,14 @@ except Exception as e:
 # UTXO Layer (Phase 1 — dual-write alongside account model)
 UTXO_DUAL_WRITE = os.environ.get("UTXO_DUAL_WRITE", "0") == "1"
 try:
-    from utxo_db import UtxoDB, MAX_OUTPUTS as UTXO_MAX_OUTPUTS
+    from utxo_db import (
+        DUST_THRESHOLD as UTXO_DUST_THRESHOLD,
+        MAX_OUTPUTS as UTXO_MAX_OUTPUTS,
+        UtxoDB,
+    )
     HAVE_UTXO = True
 except ImportError:
+    UTXO_DUST_THRESHOLD = 1_000
     UTXO_MAX_OUTPUTS = 100
     HAVE_UTXO = False
     if UTXO_DUAL_WRITE:
@@ -3625,6 +3630,7 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
         try:
             c.execute("BEGIN TRANSACTION")
             utxo_reward_outputs = []
+            skipped_utxo_dust_nrtc = 0
 
             # Distribute rewards with precision
             for pk, weight in miners:
@@ -3643,10 +3649,17 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                 )
 
                 if UTXO_DUAL_WRITE:
-                    utxo_reward_outputs.append({
-                        "address": pk,
-                        "value_nrtc": amount_nrtc,
-                    })
+                    if amount_nrtc >= UTXO_DUST_THRESHOLD:
+                        utxo_reward_outputs.append({
+                            "address": pk,
+                            "value_nrtc": amount_nrtc,
+                        })
+                    else:
+                        # The UTXO layer intentionally rejects sub-dust boxes.
+                        # Keep the account-model reward settlement alive and
+                        # skip the unspendable UTXO output until a carry-forward
+                        # accumulator exists for tiny shares.
+                        skipped_utxo_dust_nrtc += max(0, amount_nrtc)
                 # Update metrics with decimal value for accuracy
                 balance_gauge.labels(miner_pk=pk).set(float(amount_decimal))
 
@@ -3679,6 +3692,11 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                             "UTXO reward settlement failed for "
                             f"batch {batch_index + 1}/{len(reward_batches)}"
                         )
+                if skipped_utxo_dust_nrtc:
+                    print(
+                        "[UTXO] Skipped sub-dust epoch reward outputs totaling "
+                        f"{skipped_utxo_dust_nrtc} nRTC"
+                    )
 
             # Mark epoch as settled - use UPDATE with WHERE settled=0 to prevent race
             result = c.execute(

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -299,6 +299,13 @@ class TestIntegratedBalanceScale(unittest.TestCase):
             )
 
         self.assertEqual(len(calls), 1)
+        emitted_values = [
+            out["value_nrtc"]
+            for tx, _, _ in calls
+            for out in tx["outputs"]
+        ]
+        self.assertEqual(emitted_values, [143999280])
+        self.assertTrue(all(value >= DUST_THRESHOLD for value in emitted_values))
 
 
 if __name__ == "__main__":

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -255,6 +255,51 @@ class TestIntegratedBalanceScale(unittest.TestCase):
             [72_000_000, 72_000_000],
         )
 
+    def test_finalize_epoch_does_not_abort_on_sub_dust_utxo_reward(self):
+        """A tiny miner share must not roll back the whole epoch settlement.
+
+        UTXO boxes reject outputs below DUST_THRESHOLD, but finalize_epoch()
+        currently forwards every positive reward share directly into the
+        mining_reward outputs batch. A miner with a very small fixed-point
+        weight can therefore make UTXO dual-write fail and abort settlement for
+        the whole epoch.
+        """
+        self._add_epoch_miner("miner-dust", 0.000005)
+        calls = []
+
+        from utxo_db import DUST_THRESHOLD
+
+        class DustRejectingUtxoDB:
+            def __init__(self, db_path):
+                self.db_path = db_path
+
+            def apply_transaction(self, tx, height, conn=None):
+                calls.append((tx, height, conn is not None))
+                return all(
+                    out["value_nrtc"] >= DUST_THRESHOLD
+                    for out in tx["outputs"]
+                )
+
+        self.mod.UTXO_DUAL_WRITE = True
+        self.mod.UtxoDB = DustRejectingUtxoDB
+
+        try:
+            self.mod.finalize_epoch(7, 0.01, b"")
+        except RuntimeError as exc:
+            emitted_values = [
+                out["value_nrtc"]
+                for tx, _, _ in calls
+                for out in tx["outputs"]
+            ]
+            self.fail(
+                "finalize_epoch should skip, aggregate, or account-only handle "
+                f"sub-dust UTXO rewards instead of aborting settlement; "
+                f"emitted reward outputs={emitted_values}, "
+                f"dust_threshold={DUST_THRESHOLD}: {exc}"
+            )
+
+        self.assertEqual(len(calls), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/node/tests/test_integrated_balance_scale.py
+++ b/node/tests/test_integrated_balance_scale.py
@@ -280,23 +280,29 @@ class TestIntegratedBalanceScale(unittest.TestCase):
                     for out in tx["outputs"]
                 )
 
+        original_utxo_dual_write = self.mod.UTXO_DUAL_WRITE
+        original_utxo_db = self.mod.UtxoDB
         self.mod.UTXO_DUAL_WRITE = True
         self.mod.UtxoDB = DustRejectingUtxoDB
 
         try:
-            self.mod.finalize_epoch(7, 0.01, b"")
-        except RuntimeError as exc:
-            emitted_values = [
-                out["value_nrtc"]
-                for tx, _, _ in calls
-                for out in tx["outputs"]
-            ]
-            self.fail(
-                "finalize_epoch should skip, aggregate, or account-only handle "
-                f"sub-dust UTXO rewards instead of aborting settlement; "
-                f"emitted reward outputs={emitted_values}, "
-                f"dust_threshold={DUST_THRESHOLD}: {exc}"
-            )
+            try:
+                self.mod.finalize_epoch(7, 0.01, b"")
+            except RuntimeError as exc:
+                emitted_values = [
+                    out["value_nrtc"]
+                    for tx, _, _ in calls
+                    for out in tx["outputs"]
+                ]
+                self.fail(
+                    "finalize_epoch should skip, aggregate, or account-only handle "
+                    f"sub-dust UTXO rewards instead of aborting settlement; "
+                    f"emitted reward outputs={emitted_values}, "
+                    f"dust_threshold={DUST_THRESHOLD}: {exc}"
+                )
+        finally:
+            self.mod.UTXO_DUAL_WRITE = original_utxo_dual_write
+            self.mod.UtxoDB = original_utxo_db
 
         self.assertEqual(len(calls), 1)
         emitted_values = [


### PR DESCRIPTION
Bounty context: Scottcjn/rustchain-bounties#2819 (UTXO red team).

Bug report: https://github.com/Scottcjn/Rustchain/issues/6696

This PR adds a regression test and minimal fix for an epoch-settlement availability bug in the UTXO dual-write path.

Issue summary:
- `finalize_epoch()` converted every positive miner reward share directly into a `mining_reward` UTXO output.
- `UtxoDB.apply_transaction()` rejects outputs below `DUST_THRESHOLD`.
- A very small but nonzero miner weight could produce a sub-dust reward output, causing the UTXO reward batch to fail.
- Because `finalize_epoch()` treats UTXO apply failure as fatal, the entire epoch settlement rolled back instead of settling the valid rewards.

Reproducer before the fix:
```bash
PYTHONPATH=node python -m pytest -q node/tests/test_integrated_balance_scale.py::TestIntegratedBalanceScale::test_finalize_epoch_does_not_abort_on_sub_dust_utxo_reward --tb=short --noconftest -o addopts=
```

Observed failure before the fix:
```text
emitted reward outputs=[719, 143999280], dust_threshold=1000
RuntimeError: UTXO reward settlement failed for batch 1/1
```

Fix included:
- import the UTXO dust threshold into the integrated server
- skip unspendable sub-dust UTXO reward outputs during dual-write reward batching
- log the skipped nRTC total so the behavior is visible until a carry-forward accumulator exists

Verification after the fix:
```text
PYTHONPATH=node /tmp/rustchain-utxo-test-venv/bin/python -m pytest -q node/tests/test_integrated_balance_scale.py --tb=short --noconftest -o addopts=  # 5 passed
PYTHONPATH=node python3 -m pytest -q node/test_utxo_db.py node/test_utxo_genesis_migration_units.py --tb=short --noconftest -o addopts=  # 103 passed, 28 subtests passed
python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_balance_scale.py  # passed
git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_integrated_balance_scale.py  # passed
```

RTC payout wallet: JONASXZB