### PR TITLE
[UTXO-BUG] fix governance.py balance check — OperationalError on schema-B nodes blocks all proposals

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -157,6 +157,52 @@ def init_governance_tables(db_path: str):
 # Helper functions
 # ---------------------------------------------------------------------------
 
+def _balance_rtc_for_miner(conn: sqlite3.Connection, miner_id: str) -> float:
+    """Return miner balance in RTC, tolerant to both known balances schemas.
+
+    Schema A (legacy):  balances(miner_pk TEXT PRIMARY KEY, balance_rtc REAL)
+    Schema B (current): balances(miner_id TEXT PRIMARY KEY, amount_i64 INTEGER)
+    """
+    try:
+        row = conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?", (miner_id,)
+        ).fetchone()
+        if row is not None:
+            return int(row[0] or 0) / 1_000_000.0
+    except Exception:
+        pass
+    try:
+        row = conn.execute(
+            "SELECT balance_rtc FROM balances WHERE miner_pk = ?", (miner_id,)
+        ).fetchone()
+        if row is not None:
+            return float(row[0] or 0)
+    except Exception:
+        pass
+    return 0.0
+
+
+def _deduct_proposal_fee(conn: sqlite3.Connection, miner_id: str, fee_rtc: float) -> None:
+    """Deduct proposal fee from miner balance, tolerant to both schemas."""
+    fee_i64 = int(fee_rtc * 1_000_000)
+    try:
+        updated = conn.execute(
+            "UPDATE balances SET amount_i64 = amount_i64 - ? WHERE miner_id = ?",
+            (fee_i64, miner_id),
+        ).rowcount
+        if updated > 0:
+            return
+    except Exception:
+        pass
+    try:
+        conn.execute(
+            "UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?",
+            (fee_rtc, miner_id),
+        )
+    except Exception:
+        pass
+
+
 def _get_miner_antiquity_weight(miner_id: str, db_path: str) -> float:
     """Return the antiquity multiplier for a miner (default 1.0 if not found)."""
     try:
@@ -387,19 +433,12 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='balances'"
                 ).fetchone()
                 if table_check:
-                    bal_row = conn.execute(
-                        "SELECT balance_rtc FROM balances WHERE miner_pk = ?",
-                        (miner_id,)
-                    ).fetchone()
-                    if not bal_row or float(bal_row[0]) < PROPOSAL_FEE_RTC:
+                    balance = _balance_rtc_for_miner(conn, miner_id)
+                    if balance < PROPOSAL_FEE_RTC:
                         return jsonify({
                             "error": f"Insufficient balance: proposal fee is {PROPOSAL_FEE_RTC} RTC"
                         }), 402
-                    # Deduct fee (inside table-check guard — balances table confirmed)
-                    conn.execute(
-                        "UPDATE balances SET balance_rtc = balance_rtc - ? WHERE miner_pk = ?",
-                        (PROPOSAL_FEE_RTC, miner_id)
-                    )
+                    _deduct_proposal_fee(conn, miner_id, PROPOSAL_FEE_RTC)
 
                 # Anti-spam: max active proposals per miner
                 active_count = conn.execute(

--- a/node/test_governance_balance_schema_poc.py
+++ b/node/test_governance_balance_schema_poc.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: MIT
+"""
+PoC: governance.py create_proposal balance check fails on schema-B nodes.
+
+Schema A (legacy):  balances(miner_pk TEXT PRIMARY KEY, balance_rtc REAL)
+Schema B (current): balances(miner_id TEXT PRIMARY KEY, amount_i64 INTEGER)
+
+Before the fix, _create_proposal_ queried `balance_rtc FROM balances WHERE
+miner_pk = ?` unconditionally. On a schema-B node this raises
+sqlite3.OperationalError (no such column: balance_rtc), which is caught by
+the outer `except Exception` and returns HTTP 500, blocking all governance
+proposals regardless of the miner's actual balance.
+
+After the fix, _balance_rtc_for_miner and _deduct_proposal_fee probe both
+schemas, so proposal creation succeeds on either.
+"""
+
+import sqlite3
+import unittest
+
+from governance import _balance_rtc_for_miner, _deduct_proposal_fee
+
+
+def _schema_a_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
+        ("deadbeef01", 50.0),
+    )
+    conn.commit()
+    return conn
+
+
+def _schema_b_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+        ("deadbeef01", 50_000_000),  # 50 RTC
+    )
+    conn.commit()
+    return conn
+
+
+class TestBalanceRtcForMiner(unittest.TestCase):
+
+    def test_schema_a_reads_balance(self):
+        with _schema_a_db() as conn:
+            bal = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertAlmostEqual(bal, 50.0)
+
+    def test_schema_b_reads_balance(self):
+        with _schema_b_db() as conn:
+            bal = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertAlmostEqual(bal, 50.0)
+
+    def test_schema_a_unknown_miner_returns_zero(self):
+        with _schema_a_db() as conn:
+            bal = _balance_rtc_for_miner(conn, "unknown")
+        self.assertEqual(bal, 0.0)
+
+    def test_schema_b_unknown_miner_returns_zero(self):
+        with _schema_b_db() as conn:
+            bal = _balance_rtc_for_miner(conn, "unknown")
+        self.assertEqual(bal, 0.0)
+
+
+class TestDeductProposalFee(unittest.TestCase):
+
+    def test_schema_a_deducts_fee(self):
+        conn = _schema_a_db()
+        _deduct_proposal_fee(conn, "deadbeef01", 10.0)
+        row = conn.execute(
+            "SELECT balance_rtc FROM balances WHERE miner_pk = ?", ("deadbeef01",)
+        ).fetchone()
+        self.assertAlmostEqual(row[0], 40.0)
+        conn.close()
+
+    def test_schema_b_deducts_fee(self):
+        conn = _schema_b_db()
+        _deduct_proposal_fee(conn, "deadbeef01", 10.0)
+        row = conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?", ("deadbeef01",)
+        ).fetchone()
+        self.assertEqual(row[0], 40_000_000)
+        conn.close()
+
+    def test_schema_a_insufficient_balance_not_deducted_when_caller_checks(self):
+        conn = _schema_a_db()
+        bal = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertGreater(bal, 10.0)
+        _deduct_proposal_fee(conn, "deadbeef01", 10.0)
+        remaining = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertAlmostEqual(remaining, 40.0)
+        conn.close()
+
+    def test_schema_b_insufficient_balance_not_deducted_when_caller_checks(self):
+        conn = _schema_b_db()
+        bal = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertGreater(bal, 10.0)
+        _deduct_proposal_fee(conn, "deadbeef01", 10.0)
+        remaining = _balance_rtc_for_miner(conn, "deadbeef01")
+        self.assertAlmostEqual(remaining, 40.0)
+        conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Bug

`governance.py` `create_proposal` hardcodes `balance_rtc` and `miner_pk` in the proposal fee check:

```python
bal_row = conn.execute(
    "SELECT balance_rtc FROM balances WHERE miner_pk = ?", (miner_id,)
).fetchone()
```

The production codebase documents two known `balances` schemas:

- **Schema A (legacy):** `balances(miner_pk TEXT PRIMARY KEY, balance_rtc REAL)` — matches governance.py
- **Schema B (current):** `balances(miner_id TEXT PRIMARY KEY, amount_i64 INTEGER)` — used by `_balance_i64_for_wallet` in the main node

On a schema-B node, `SELECT balance_rtc FROM balances WHERE miner_pk = ?` raises `sqlite3.OperationalError: table balances has no column named balance_rtc`. This is caught by the outer `except Exception` block, which returns HTTP 500. Result: **all governance proposals fail on schema-B nodes** regardless of miner balance.

The fee deduction has the same issue (`UPDATE balances SET balance_rtc = ... WHERE miner_pk = ?` also fails on schema-B).

## Fix

Added two schema-tolerant helpers to `governance.py`:

- `_balance_rtc_for_miner(conn, miner_id)` — tries `amount_i64/miner_id` (schema B) first, falls back to `balance_rtc/miner_pk` (schema A), returns 0.0 if neither exists.
- `_deduct_proposal_fee(conn, miner_id, fee_rtc)` — same pattern for the UPDATE path.

`create_proposal` now calls these helpers instead of issuing hardcoded queries.

## Test

`node/test_governance_balance_schema_poc.py` — 8 tests using in-memory SQLite databases with each schema variant:

```
python -B -m unittest test_governance_balance_schema_poc.py -v
```

All 8 tests pass on both schema A and schema B.