### PR TITLE
docs(zh-CN): fix license badge link to use absolute URL (Fixes #6697)

### DIFF
--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: 古董证明区块链
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/Scottcjn/Rustchain/blob/main/LICENSE)
 [![GitHub Stars](https://img.shields.io/github.com/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github.com/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github.com/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)


### PR DESCRIPTION
## Summary
Fixes broken license badge link in Chinese README that points to non-existent `docs/zh-CN/LICENSE` instead of the root LICENSE file.

## Changes
- Update license badge link from relative `LICENSE` to absolute `https://github.com/Scottcjn/Rustchain/blob/main/LICENSE`
- Badge now correctly resolves when viewing from the `docs/zh-CN/` directory

## Testing
1. Navigate to `docs/zh-CN/README.md` on GitHub
2. Click the Apache 2.0 license badge
3. Verify it opens the root LICENSE file instead of showing a 404

## Related Issues
Fixes #6697