### PR TITLE
Add JONASXZB MacBook Air M2 to Green Tracker

### DIFF
--- a/community/machines/jonasxzb-macbook-air-m2.json
+++ b/community/machines/jonasxzb-macbook-air-m2.json
@@ -1,0 +1,21 @@
+{
+  "machine_name": "JONASXZB MacBook Air M2",
+  "model": "MacBook Air (2022)",
+  "model_identifier": "Mac14,2",
+  "year_manufactured": 2022,
+  "architecture": "Apple Silicon M2 (arm64)",
+  "cpu_cores": "8 (4P + 4E)",
+  "memory_gb": 16,
+  "power_draw_watts": 15,
+  "usage": [
+    "Codex-assisted RustChain bounty work",
+    "GitHub issue triage and PR preparation",
+    "local React and Vite development",
+    "RustChain miner dry-run testing"
+  ],
+  "description": "MacBook Air with Apple M2 and 16 GB unified memory kept in active use for Codex-assisted RustChain bounty work, GitHub issue triage, pull request preparation, and local frontend development. Reusing this efficient Apple Silicon laptop keeps an already-manufactured machine productive for open source work instead of replacing it with new dedicated compute.",
+  "wallet_name": "JONASXZB",
+  "wallet_address": "RTCc4e01222a53820fdde5e3f4adc6b6d46f965e467",
+  "contributor": "JONASXZB",
+  "added_date": "2026-06-01"
+}


### PR DESCRIPTION
## Summary
- Add a Green Tracker machine entry for a MacBook Air M2 kept in active use for RustChain bounty work and local development
- Include model, year, architecture, approximate power draw, usage, and RTC wallet details for bounty #2218

## Validation
- `python3 -m json.tool community/machines/jonasxzb-macbook-air-m2.json`
- Parsed all `community/machines/*.json` with Python `json.load`
- `git diff --check -- community/machines/jonasxzb-macbook-air-m2.json`

Bounty reference: Scottcjn/rustchain-bounties#2218