### PR TITLE
Enforce monotonic nonce ordering on /utxo/transfer

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -322,6 +322,35 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(self.utxo_db.get_balance(sender), 90 * UNIT)
         self.assertEqual(self.utxo_db.get_balance(recipient), 10 * UNIT)
 
+    def test_transfer_accepts_legacy_string_nonce_signature_form(self):
+        sender = 'RTC_test_aabbccdd'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        def verify_only_string_nonce(pubkey_hex, message, sig_hex):
+            payload = json.loads(message.decode())
+            return payload.get('nonce') == '123'
+
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        register_utxo_blueprint(
+            app, self.utxo_db, self.db_path,
+            verify_sig_fn=verify_only_string_nonce,
+            addr_from_pk_fn=mock_addr_from_pk,
+            current_slot_fn=mock_current_slot,
+            dual_write=False,
+        )
+        client = app.test_client()
+
+        r = client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': 'bob',
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': '123',
+        })
+        self.assertEqual(r.status_code, 200, r.get_json())
+
     def test_transfer_with_fee(self):
         self._seed_coinbase('RTC_test_aabbccdd', 100 * UNIT)
 

--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -272,6 +272,56 @@ class TestUtxoEndpoints(unittest.TestCase):
         data = r.get_json()
         self.assertIn('does not match', data['error'])
 
+    def test_transfer_rejects_invalid_nonce_values(self):
+        sender = 'RTC_test_aabbccdd'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        for bad_nonce in (-1, 'abc', '12.5'):
+            with self.subTest(nonce=bad_nonce):
+                r = self.client.post('/utxo/transfer', json={
+                    'from_address': sender,
+                    'to_address': 'bob',
+                    'amount_rtc': 10.0,
+                    'public_key': 'aabbccdd' * 8,
+                    'signature': 'sig' * 22,
+                    'nonce': bad_nonce,
+                })
+                self.assertEqual(r.status_code, 400)
+                data = r.get_json()
+                self.assertEqual(data['code'], 'INVALID_NONCE')
+                self.assertIn('greater than or equal to 0', data['error'])
+
+    def test_transfer_rejects_stale_nonce_after_newer_nonce(self):
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        first = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': 200,
+        })
+        self.assertEqual(first.status_code, 200, first.get_json())
+
+        stale = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 5.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': 100,
+        })
+        self.assertEqual(stale.status_code, 400)
+        data = stale.get_json()
+        self.assertEqual(data['code'], 'OUT_OF_ORDER_NONCE')
+        self.assertEqual(data['nonce'], '100')
+        self.assertEqual(data['latest_nonce'], 200)
+        self.assertEqual(self.utxo_db.get_balance(sender), 90 * UNIT)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 10 * UNIT)
+
     def test_transfer_with_fee(self):
         self._seed_coinbase('RTC_test_aabbccdd', 100 * UNIT)
 

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -226,6 +226,23 @@ def _parse_transfer_nonce(nonce_raw):
     return str(nonce_int), nonce_int
 
 
+def _nonce_signature_forms(nonce_raw, nonce_int):
+    """
+    Return candidate nonce representations for signature verification.
+
+    Older clients could sign the raw string form that the endpoint previously
+    accepted, while newer clients may already sign the normalized integer.
+    """
+    forms = [nonce_int]
+    if isinstance(nonce_raw, str):
+        nonce_text = nonce_raw.strip()
+        if nonce_text and nonce_text != str(nonce_int):
+            forms.append(nonce_text)
+        elif nonce_text == str(nonce_int):
+            forms.append(nonce_text)
+    return forms
+
+
 def _transfer_string_field(data: dict, field: str):
     value = data.get(field)
     if value is None:
@@ -546,28 +563,38 @@ def utxo_transfer():
     # keep the signed-payload bytes byte-identical to what the wallet computed.
     amount_for_sig = float(amount_rtc)
     fee_for_sig = float(fee_rtc)
-    tx_data_v2 = {
-        'from': from_address,
-        'to': to_address,
-        'amount': amount_for_sig,
-        'fee': fee_for_sig,
-        'memo': memo,
-        'nonce': nonce_int,
-    }
-    message_v2 = json.dumps(tx_data_v2, sort_keys=True, separators=(',', ':')).encode()
+    signature_verified = False
+    used_legacy_signature = False
+    for nonce_for_sig in _nonce_signature_forms(data.get('nonce'), nonce_int):
+        tx_data_v2 = {
+            'from': from_address,
+            'to': to_address,
+            'amount': amount_for_sig,
+            'fee': fee_for_sig,
+            'memo': memo,
+            'nonce': nonce_for_sig,
+        }
+        message_v2 = json.dumps(tx_data_v2, sort_keys=True, separators=(',', ':')).encode()
+        if _verify_sig_fn(public_key, message_v2, signature):
+            signature_verified = True
+            break
 
-    tx_data_legacy = {
-        'from': from_address,
-        'to': to_address,
-        'amount': amount_for_sig,
-        'memo': memo,
-        'nonce': nonce_int,
-    }
-    message_legacy = json.dumps(tx_data_legacy, sort_keys=True, separators=(',', ':')).encode()
+        tx_data_legacy = {
+            'from': from_address,
+            'to': to_address,
+            'amount': amount_for_sig,
+            'memo': memo,
+            'nonce': nonce_for_sig,
+        }
+        message_legacy = json.dumps(tx_data_legacy, sort_keys=True, separators=(',', ':')).encode()
+        if _verify_sig_fn(public_key, message_legacy, signature):
+            signature_verified = True
+            used_legacy_signature = True
+            break
 
-    if _verify_sig_fn(public_key, message_v2, signature):
-        pass  # New client — fee is signed, MITM-resistant
-    elif _verify_sig_fn(public_key, message_legacy, signature):
+    if not signature_verified:
+        return jsonify({'error': 'Invalid Ed25519 signature'}), 401
+    if used_legacy_signature:
         if fee_nrtc != 0:
             return jsonify({
                 'error': 'Legacy signature format cannot authorize nonzero fee',
@@ -583,8 +610,6 @@ def utxo_transfer():
             "Upgrade client to include fee in signed message.",
             from_address[:20],
         )
-    else:
-        return jsonify({'error': 'Invalid Ed25519 signature'}), 401
 
     # --- UTXO transaction ---------------------------------------------------
 

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -206,6 +206,26 @@ def _missing_transfer_nonce(nonce) -> bool:
     )
 
 
+def _parse_transfer_nonce(nonce_raw):
+    if _missing_transfer_nonce(nonce_raw):
+        raise ValueError('nonce is required')
+
+    if isinstance(nonce_raw, int):
+        nonce_int = nonce_raw
+    elif isinstance(nonce_raw, str):
+        nonce_text = nonce_raw.strip()
+        if not nonce_text.isdigit():
+            raise ValueError('nonce must be an integer greater than or equal to 0')
+        nonce_int = int(nonce_text)
+    else:
+        raise ValueError('nonce must be an integer greater than or equal to 0')
+
+    if nonce_int < 0:
+        raise ValueError('nonce must be an integer greater than or equal to 0')
+
+    return str(nonce_int), nonce_int
+
+
 def _transfer_string_field(data: dict, field: str):
     value = data.get(field)
     if value is None:
@@ -507,6 +527,14 @@ def utxo_transfer():
             'got': from_address,
         }), 400
 
+    try:
+        nonce, nonce_int = _parse_transfer_nonce(nonce)
+    except ValueError as e:
+        return jsonify({
+            'error': str(e),
+            'code': 'INVALID_NONCE',
+        }), 400
+
     # Reconstruct signed message.
     # FIX(#2202): Include fee in signed data to prevent MITM fee manipulation.
     # Backward-compatible: try new format (with fee) first, fall back to legacy
@@ -524,7 +552,7 @@ def utxo_transfer():
         'amount': amount_for_sig,
         'fee': fee_for_sig,
         'memo': memo,
-        'nonce': nonce,
+        'nonce': nonce_int,
     }
     message_v2 = json.dumps(tx_data_v2, sort_keys=True, separators=(',', ':')).encode()
 
@@ -533,7 +561,7 @@ def utxo_transfer():
         'to': to_address,
         'amount': amount_for_sig,
         'memo': memo,
-        'nonce': nonce,
+        'nonce': nonce_int,
     }
     message_legacy = json.dumps(tx_data_legacy, sort_keys=True, separators=(',', ':')).encode()
 
@@ -611,6 +639,21 @@ def utxo_transfer():
                 'error': 'Nonce already used (replay attack detected)',
                 'code': 'REPLAY_DETECTED',
                 'nonce': str(nonce),
+            }), 400
+        previous_nonce = conn.execute(
+            """
+            SELECT MAX(CAST(nonce AS INTEGER)) FROM transfer_nonces
+            WHERE from_address = ? AND nonce != ?
+            """,
+            (from_address, nonce),
+        ).fetchone()[0]
+        if previous_nonce is not None and int(previous_nonce) >= nonce_int:
+            conn.rollback()
+            return jsonify({
+                'error': 'Signed transfer nonce must increase for this wallet',
+                'code': 'OUT_OF_ORDER_NONCE',
+                'nonce': nonce,
+                'latest_nonce': int(previous_nonce),
             }), 400
 
         ok = _utxo_db.apply_transaction(tx, block_height, conn=conn)


### PR DESCRIPTION
Fixes #6710

## Summary
- normalize `/utxo/transfer` nonces as positive integers and reject malformed or non-positive values with `INVALID_NONCE`
- enforce monotonic nonce ordering after atomic replay reservation so stale signed nonces return `OUT_OF_ORDER_NONCE`
- add regression coverage for invalid nonce values and the stale-after-newer ordering case

## Testing
- `python3 -m unittest test_utxo_endpoints -v`
- `python3 -m unittest test_utxo_db test_utxo_genesis_migration_units -v`
- `python3 -m py_compile node/utxo_endpoints.py node/test_utxo_endpoints.py`
- `git diff --check -- node/utxo_endpoints.py node/test_utxo_endpoints.py`