### PR TITLE
docs: fix Chinese mining guide relative links

### DIFF
--- a/docs/zh-CN/MINING_GUIDE.md
+++ b/docs/zh-CN/MINING_GUIDE.md
@@ -68,7 +68,7 @@
 
 支持的 CPU 系列包括 Linux `x86_64`、`ppc64le`、`aarch64`、`mips`、`sparc`、`m68k`、`riscv64`、`ia64` 和 `s390x`，以及 macOS Intel、Apple Silicon、PowerPC、IBM POWER8、Windows、老版 Mac OS X 和树莓派系统。现代 ARM NAS 或单板系统可以运行矿工，但会获得文档中所述的惩罚乘数。
 
-有关安装前提条件，请参见 [INSTALL.md](../INSTALL.md)。有关完整的古董乘数和架构验证模型，请参见 [CPU_ANTIQUITY_SYSTEM.md](../CPU_ANTIQUITY_SYSTEM.md)。
+有关安装前提条件，请参见 [INSTALL.md](../../INSTALL.md)。有关完整的古董乘数和架构验证模型，请参见 [CPU_ANTIQUITY_SYSTEM.md](../../CPU_ANTIQUITY_SYSTEM.md)。
 
 ---
 
@@ -169,7 +169,7 @@ python3 wallet/rustchain_wallet.py generate
 
 - 加入 [Discord](https://discord.gg/rustchain) 获取实时支持
 - 在 [GitHub](https://github.com/Scottcjn/rustchain/issues) 上提交 Issue 报告错误
-- 查看 [FAQ_TROUBLESHOOTING.md](FAQ_TROUBLESHOOTING.md) 获取常见解决方案
+- 查看 [FAQ_TROUBLESHOOTING.md](../FAQ_TROUBLESHOOTING.md) 获取常见解决方案
 
 ---
 


### PR DESCRIPTION
## What Changed

- Fixed three broken relative links in `docs/zh-CN/MINING_GUIDE.md`.
- Updated the two top-level document links to resolve from `docs/zh-CN/`.
- Updated the troubleshooting FAQ link to resolve to the shared docs FAQ.

## Why It Matters

The Chinese mining guide currently sends readers to missing Markdown targets for install prerequisites, CPU antiquity details, and troubleshooting. This keeps the translated guide navigable without changing the surrounding content.

## Validation

- `python3` focused Markdown relative-link scan for `docs/zh-CN/MINING_GUIDE.md` -> checked 6 relative links, `missing_count=0`.
- `git diff --check upstream/main...HEAD -- docs/zh-CN/MINING_GUIDE.md` -> passed.
- GitHub `CI / test` is still red with the same repo-wide baseline failure seen on unrelated docs-only PRs; that baseline is being handled separately in #6711, without broadening this docs PR.

## Scope / Risk

- Touched files/subsystems: `docs/zh-CN/MINING_GUIDE.md`
- Documentation-only change; no runtime behavior, API, protocol, or dependency changes.
- Related bounty issue: #305

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
