### PR TITLE
[UTXO] Refuse genesis rollback after later ledger history

### DIFF
--- a/node/test_rollback_atomicity.py
+++ b/node/test_rollback_atomicity.py
@@ -339,6 +339,103 @@ class TestRollbackAtomicity(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_10_rollback_refuses_after_non_genesis_state_exists(self):
+        """Rollback must not delete genesis once later UTXO history exists."""
+        migrate(self.db_path, dry_run=False)
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            genesis = conn.execute(
+                """SELECT box_id, value_nrtc, owner_address
+                   FROM utxo_boxes
+                   WHERE transaction_id IN (
+                       SELECT tx_id FROM utxo_transactions
+                       WHERE tx_type = 'genesis'
+                   )
+                   ORDER BY owner_address ASC
+                   LIMIT 1"""
+            ).fetchone()
+            self.assertIsNotNone(genesis)
+
+            transfer_tx_id = "3" * 64
+            transfer_box_id = "4" * 64
+            recipient = "recipient_wallet"
+            now = 2
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """UPDATE utxo_boxes
+                   SET spent_at = ?, spent_by_tx = ?
+                   WHERE box_id = ?""",
+                (now, transfer_tx_id, genesis["box_id"]),
+            )
+            conn.execute(
+                """INSERT INTO utxo_transactions
+                   (tx_id, tx_type, inputs_json, outputs_json,
+                    data_inputs_json, fee_nrtc, timestamp,
+                    block_height, status)
+                   VALUES (?,?,?,?,?,?,?,?,?)""",
+                (
+                    transfer_tx_id,
+                    "transfer",
+                    '[{"box_id":"%s"}]' % genesis["box_id"],
+                    '[{"box_id":"%s","value_nrtc":%d,"owner":"%s"}]' % (
+                        transfer_box_id,
+                        genesis["value_nrtc"],
+                        recipient,
+                    ),
+                    "[]",
+                    0,
+                    now,
+                    GENESIS_HEIGHT + 1,
+                    "confirmed",
+                ),
+            )
+            conn.execute(
+                """INSERT INTO utxo_boxes
+                   (box_id, value_nrtc, proposition, owner_address,
+                    creation_height, transaction_id, output_index,
+                    tokens_json, registers_json, created_at)
+                   VALUES (?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    transfer_box_id,
+                    genesis["value_nrtc"],
+                    address_to_proposition(recipient),
+                    recipient,
+                    GENESIS_HEIGHT + 1,
+                    transfer_tx_id,
+                    0,
+                    "[]",
+                    "{}",
+                    now,
+                ),
+            )
+            conn.execute("COMMIT")
+        finally:
+            conn.close()
+
+        with self.assertRaisesRegex(RuntimeError, "non-genesis UTXO state"):
+            rollback_genesis(self.db_path)
+
+        conn = UtxoDB(self.db_path)._conn()
+        try:
+            genesis_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_transactions WHERE tx_type = 'genesis'",
+            ).fetchone()[0]
+            transfer_count = conn.execute(
+                "SELECT COUNT(*) FROM utxo_transactions WHERE tx_type = 'transfer'",
+            ).fetchone()[0]
+            spent_input_count = conn.execute(
+                """SELECT COUNT(*) FROM utxo_boxes
+                   WHERE box_id = ? AND spent_by_tx = ?""",
+                (genesis["box_id"], transfer_tx_id),
+            ).fetchone()[0]
+
+            self.assertEqual(genesis_count, 3)
+            self.assertEqual(transfer_count, 1)
+            self.assertEqual(spent_input_count, 1)
+        finally:
+            conn.close()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/node/utxo_genesis_migration.py
+++ b/node/utxo_genesis_migration.py
@@ -322,6 +322,16 @@ def rollback_genesis(db_path: str) -> int:
     try:
         conn.execute("BEGIN IMMEDIATE")
 
+        has_genesis = check_existing_genesis(utxo_db, conn=conn)
+        if has_genesis and check_existing_non_genesis_utxo_state(
+            utxo_db,
+            conn=conn,
+        ):
+            conn.execute("ROLLBACK")
+            raise RuntimeError(
+                "refusing to rollback genesis while non-genesis UTXO state exists"
+            )
+
         # Delete only boxes produced by genesis transactions. A non-genesis
         # box can legitimately have creation_height=0.
         deleted = conn.execute(


### PR DESCRIPTION
## Summary
- Refuse `rollback_genesis()` when genesis transactions exist and any non-genesis UTXO state has already been recorded.
- Keep rollback idempotent for empty/non-genesis-only databases and preserve the existing height-0 non-genesis behavior.
- Add a regression test that proves rollback no longer deletes genesis inputs after a later transfer has spent them.

## Security impact
Without this guard, an operator or maintenance path can call genesis rollback after the UTXO ledger has progressed. The current deletion removes genesis boxes and genesis transactions while leaving later transfer/mining history behind, which corrupts ledger provenance and can leave confirmed transaction inputs pointing at deleted boxes.

## Bounty
Bounty: Scottcjn/rustchain-bounties#2819
Payout address: RTCd86d0556cb717e14285b4a5e3229913d1ad3966e

## Validation
- `python3 node/test_rollback_atomicity.py`

/claim Scottcjn/rustchain-bounties#2819
