### PR TITLE
fix(security): require admin auth on /governance/vote

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6415,6 +6415,7 @@ def governance_proposal_detail(proposal_id: int):
 
 
 @app.route('/governance/vote', methods=['POST'])
+@admin_required
 def governance_vote():
     data = request.get_json(silent=True)
     if data is None:


### PR DESCRIPTION
## Security Fix: Require admin auth on /governance/vote

**Severity: HIGH**

### Problem
The `POST /governance/vote` endpoint had no authentication. Any unauthenticated actor could cast votes on any governance proposal, enabling vote manipulation and governance attacks (e.g., sybil-style manipulation of proposal outcomes).

### Fix
Added `@admin_required` decorator to `governance_vote()`, enforcing `X-Admin-Key` / `X-API-Key` header authentication via `RC_ADMIN_KEY`.

### Impact
- **Before**: Anyone could cast governance votes without authentication
- **After**: Requires valid admin key (set via `RC_ADMIN_KEY` environment variable)

### Testing
- Existing admin-key authenticated endpoints continue to work
- Unauthenticated calls now return 401 with `{"ok":false,"reason":"admin_required"}`