### PR TITLE
Improve RustChain Telegram bot Raydium price support

### DIFF
--- a/tests/test_telegram_bot_miners_envelope.py
+++ b/tests/test_telegram_bot_miners_envelope.py
@@ -125,3 +125,119 @@ def test_inline_query_uses_paginated_miner_total(monkeypatch):
     assert kwargs == {"cache_time": 30}
     assert results[0].kwargs["title"] == "Active Miners: 9"
     assert results[0].kwargs["input_message_content"].text == "RustChain has 9 active miners."
+
+
+def test_parse_raydium_mint_price_payload(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    price = module.parse_raydium_mint_price(
+        {
+            "success": True,
+            "data": {
+                module.WRTC_MINT: "0.10214647024163659",
+            },
+        }
+    )
+
+    assert price == 0.10214647024163659
+
+
+def test_parse_raydium_pool_info_for_wrapped_rtc_pair(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    pool = module.parse_raydium_pool_info(
+        {
+            "success": True,
+            "data": {
+                "data": [
+                    {
+                        "id": "8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb",
+                        "mintA": {"address": module.WRTC_MINT},
+                        "mintB": {"address": module.WSOL_MINT},
+                        "price": 0.00126628405540796,
+                        "tvl": 778.37,
+                        "day": {"volume": 12.5},
+                    }
+                ],
+            },
+        }
+    )
+
+    assert pool["pool_id"] == "8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb"
+    assert pool["price_sol"] == 0.00126628405540796
+    assert pool["liquidity"] == 778.37
+    assert pool["volume_24h"] == 12.5
+    assert pool["url"].startswith("https://raydium.io/swap/")
+
+
+def test_parse_raydium_pool_info_inverts_when_wrtc_is_quote_mint(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    pool = module.parse_raydium_pool_info(
+        {
+            "success": True,
+            "data": {
+                "data": [
+                    {
+                        "mintA": {"address": module.WSOL_MINT},
+                        "mintB": {"address": module.WRTC_MINT},
+                        "price": 800.0,
+                        "tvl": "1000.5",
+                        "day": {"volume": "20.25"},
+                    }
+                ],
+            },
+        }
+    )
+
+    assert pool["price_sol"] == 0.00125
+    assert pool["liquidity"] == 1000.5
+    assert pool["volume_24h"] == 20.25
+
+
+def test_fetch_price_data_uses_raydium_endpoints(monkeypatch):
+    module = load_bot_module(monkeypatch)
+    calls = []
+
+    async def fake_get_json(url, params=None, *, verify_ssl=True):
+        calls.append((url, params, verify_ssl))
+        if url == module.RAYDIUM_MINT_PRICE_URL:
+            return {"success": True, "data": {module.WRTC_MINT: "0.102"}}
+        if url == module.RAYDIUM_POOL_INFO_URL:
+            return {
+                "success": True,
+                "data": {
+                    "data": [
+                        {
+                            "id": "pool-1",
+                            "mintA": {"address": module.WRTC_MINT},
+                            "mintB": {"address": module.WSOL_MINT},
+                            "price": "0.0012",
+                            "tvl": "900",
+                            "day": {"volume": "7.5"},
+                        }
+                    ],
+                },
+            }
+        raise AssertionError(url)
+
+    monkeypatch.setattr(module, "_get_json", fake_get_json)
+
+    price = asyncio.run(module.fetch_price_data())
+
+    assert price == {
+        "price_usd": 0.102,
+        "price_sol": 0.0012,
+        "liquidity": 900.0,
+        "volume_24h": 7.5,
+        "pool_id": "pool-1",
+        "url": module.RAYDIUM_SWAP_URL,
+    }
+    assert calls[0] == (
+        module.RAYDIUM_MINT_PRICE_URL,
+        {"mints": module.WRTC_MINT},
+        True,
+    )
+    assert calls[1][0] == module.RAYDIUM_POOL_INFO_URL
+    assert calls[1][1]["mint1"] == module.WRTC_MINT
+    assert calls[1][1]["mint2"] == module.WSOL_MINT

--- a/tests/test_telegram_bot_miners_envelope.py
+++ b/tests/test_telegram_bot_miners_envelope.py
@@ -151,6 +151,14 @@ def test_parse_raydium_pool_info_for_wrapped_rtc_pair(monkeypatch):
             "data": {
                 "data": [
                     {
+                        "id": "unrelated-pool",
+                        "mintA": {"address": module.WSOL_MINT},
+                        "mintB": {"address": "other-token"},
+                        "price": 99,
+                        "tvl": 999999,
+                        "day": {"volume": 999999},
+                    },
+                    {
                         "id": "8CF2Q8nSCxRacDShbtF86XTSrYjueBMKmfdR3MLdnYzb",
                         "mintA": {"address": module.WRTC_MINT},
                         "mintB": {"address": module.WSOL_MINT},
@@ -168,6 +176,36 @@ def test_parse_raydium_pool_info_for_wrapped_rtc_pair(monkeypatch):
     assert pool["liquidity"] == 778.37
     assert pool["volume_24h"] == 12.5
     assert pool["url"].startswith("https://raydium.io/swap/")
+
+
+def test_parse_raydium_pool_info_ignores_unmatched_pool_rows(monkeypatch):
+    module = load_bot_module(monkeypatch)
+
+    pool = module.parse_raydium_pool_info(
+        {
+            "success": True,
+            "data": {
+                "data": [
+                    {
+                        "id": "unrelated-pool",
+                        "mintA": {"address": module.WSOL_MINT},
+                        "mintB": {"address": "other-token"},
+                        "price": 99,
+                        "tvl": 999999,
+                        "day": {"volume": 999999},
+                    }
+                ],
+            },
+        }
+    )
+
+    assert pool == {
+        "price_sol": None,
+        "liquidity": 0.0,
+        "volume_24h": 0.0,
+        "pool_id": "",
+        "url": module.RAYDIUM_SWAP_URL,
+    }
 
 
 def test_parse_raydium_pool_info_inverts_when_wrtc_is_quote_mint(monkeypatch):

--- a/tools/telegram_bot/.env.example
+++ b/tools/telegram_bot/.env.example
@@ -3,3 +3,13 @@ TELEGRAM_BOT_TOKEN=your_bot_token_here
 
 # RustChain API URL (optional)
 RUSTCHAIN_API=https://rustchain.org
+RUSTCHAIN_VERIFY_SSL=true
+
+# Raydium API URLs (optional)
+RAYDIUM_MINT_PRICE_URL=https://api-v3.raydium.io/mint/price
+RAYDIUM_POOL_INFO_URL=https://api-v3.raydium.io/pools/info/mint
+
+# Alert tuning (optional)
+PRICE_ALERT_INTERVAL=120
+MINER_ALERT_INTERVAL=60
+PRICE_CHANGE_THRESHOLD=5.0

--- a/tools/telegram_bot/README.md
+++ b/tools/telegram_bot/README.md
@@ -6,7 +6,7 @@ Telegram bot for RustChain community — Bounty #249 (50 RTC + bonuses).
 
 | Command | Description |
 |---------|-------------|
-| `/price` | wRTC price from Raydium via DexScreener |
+| `/price` | wRTC price from Raydium price and pool APIs |
 | `/miners` | Active miner list and count |
 | `/epoch` | Current epoch, slot, pot, enrolled miners |
 | `/balance <wallet>` | Check RTC balance for a wallet |
@@ -47,6 +47,9 @@ python telegram_bot.py
 |----------|---------|-------------|
 | `TELEGRAM_BOT_TOKEN` | _(required)_ | Bot token from BotFather |
 | `RUSTCHAIN_API` | `https://rustchain.org` | RustChain node URL |
+| `RUSTCHAIN_VERIFY_SSL` | `true` | Set to `false` only for self-signed test nodes |
+| `RAYDIUM_MINT_PRICE_URL` | `https://api-v3.raydium.io/mint/price` | Raydium token price endpoint |
+| `RAYDIUM_POOL_INFO_URL` | `https://api-v3.raydium.io/pools/info/mint` | Raydium pool metadata endpoint |
 | `PRICE_ALERT_INTERVAL` | `120` | Seconds between price checks |
 | `MINER_ALERT_INTERVAL` | `60` | Seconds between miner checks |
 | `PRICE_CHANGE_THRESHOLD` | `5.0` | % change to trigger price alert |
@@ -60,6 +63,7 @@ docker run --env-file .env rustchain-tg-bot
 
 ## Key Improvements
 
-- **Async HTTP** — uses `aiohttp` instead of blocking `requests` in async handlers
+- **Raydium-native price** — `/price` reads Raydium v3 price and pool endpoints directly
+- **Non-blocking handlers** — uses `asyncio.to_thread` so live HTTP calls do not block Telegram polling
 - **Correct API fields** — uses `amount_rtc`, `ok`, `slot`, `enrolled_miners` per API docs
 - **All bonus features** — mining alerts, price alerts, inline queries

--- a/tools/telegram_bot/requirements.txt
+++ b/tools/telegram_bot/requirements.txt
@@ -1,3 +1,3 @@
 python-telegram-bot>=20.0
-aiohttp>=3.9
+requests>=2.31
 python-dotenv

--- a/tools/telegram_bot/telegram_bot.py
+++ b/tools/telegram_bot/telegram_bot.py
@@ -26,6 +26,7 @@ import logging
 from typing import Any
 
 import requests
+import urllib3
 from dotenv import load_dotenv
 from telegram import Update, InlineQueryResultArticle, InputTextMessageContent
 from telegram.ext import (
@@ -52,6 +53,9 @@ RUSTCHAIN_VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "true").lower() not in 
     "false",
     "no",
 }
+if not RUSTCHAIN_VERIFY_SSL:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 WRTC_MINT = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
 WSOL_MINT = "So11111111111111111111111111111111111111112"
 RAYDIUM_MINT_PRICE_URL = os.getenv(
@@ -132,7 +136,20 @@ def parse_raydium_pool_info(payload: dict, mint: str = WRTC_MINT) -> dict:
     if not isinstance(rows, list) or not rows:
         return empty
 
-    pool = rows[0]
+    expected_mints = {mint, WSOL_MINT}
+    pool = next(
+        (
+            row
+            for row in rows
+            if isinstance(row, dict)
+            and {
+                (row.get("mintA") or {}).get("address"),
+                (row.get("mintB") or {}).get("address"),
+            }
+            == expected_mints
+        ),
+        None,
+    )
     if not isinstance(pool, dict):
         return empty
 
@@ -159,10 +176,8 @@ def parse_raydium_pool_info(payload: dict, mint: str = WRTC_MINT) -> dict:
 async def fetch_price_data() -> dict | None:
     """Fetch wRTC price from Raydium price and pool APIs."""
     try:
-        price_payload = await _get_json(
-            RAYDIUM_MINT_PRICE_URL, {"mints": WRTC_MINT}
-        )
-        pool_payload = await _get_json(
+        price_request = _get_json(RAYDIUM_MINT_PRICE_URL, {"mints": WRTC_MINT})
+        pool_request = _get_json(
             RAYDIUM_POOL_INFO_URL,
             {
                 "mint1": WRTC_MINT,
@@ -174,6 +189,7 @@ async def fetch_price_data() -> dict | None:
                 "page": "1",
             },
         )
+        price_payload, pool_payload = await asyncio.gather(price_request, pool_request)
         price_usd = parse_raydium_mint_price(price_payload)
         pool = parse_raydium_pool_info(pool_payload)
         if price_usd is None:

--- a/tools/telegram_bot/telegram_bot.py
+++ b/tools/telegram_bot/telegram_bot.py
@@ -3,7 +3,7 @@ RustChain Telegram Community Bot
 Bounty #249 — 50 RTC + Bonuses
 
 Core commands:
-  /price   — wRTC price from Raydium (DexScreener)
+  /price   — wRTC price from Raydium
   /miners  — Active miner list & count
   /epoch   — Current epoch info
   /balance — Check RTC balance
@@ -15,7 +15,7 @@ Bonus features:
   - Inline queries  (type @bot price/miners/epoch)
 
 Improvements over prior version:
-  - Async HTTP (aiohttp) instead of blocking requests in async handlers
+  - HTTP calls run off the event loop with asyncio.to_thread
   - Correct API field names per REFERENCE.md (amount_rtc, ok, slot, etc.)
   - All three bonus features implemented
 """
@@ -23,8 +23,9 @@ Improvements over prior version:
 import os
 import asyncio
 import logging
+from typing import Any
 
-import aiohttp
+import requests
 from dotenv import load_dotenv
 from telegram import Update, InlineQueryResultArticle, InputTextMessageContent
 from telegram.ext import (
@@ -46,48 +47,144 @@ logger = logging.getLogger("rustchain_bot")
 # ---------------------------------------------------------------------------
 BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API", "https://rustchain.org")
+RUSTCHAIN_VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "true").lower() not in {
+    "0",
+    "false",
+    "no",
+}
 WRTC_MINT = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
-DEXSCREENER_URL = f"https://api.dexscreener.com/latest/dex/tokens/{WRTC_MINT}"
+WSOL_MINT = "So11111111111111111111111111111111111111112"
+RAYDIUM_MINT_PRICE_URL = os.getenv(
+    "RAYDIUM_MINT_PRICE_URL", "https://api-v3.raydium.io/mint/price"
+)
+RAYDIUM_POOL_INFO_URL = os.getenv(
+    "RAYDIUM_POOL_INFO_URL", "https://api-v3.raydium.io/pools/info/mint"
+)
+RAYDIUM_SWAP_URL = (
+    "https://raydium.io/swap/?inputMint=sol&outputMint="
+    f"{WRTC_MINT}"
+)
 
 # Alert config
 PRICE_ALERT_INTERVAL = int(os.getenv("PRICE_ALERT_INTERVAL", "120"))   # seconds
 MINER_ALERT_INTERVAL = int(os.getenv("MINER_ALERT_INTERVAL", "60"))    # seconds
 PRICE_CHANGE_THRESHOLD = float(os.getenv("PRICE_CHANGE_THRESHOLD", "5.0"))  # percent
+HTTP_HEADERS = {
+    "Accept": "application/json",
+    "User-Agent": "RustChain-Telegram-Bot/1.0 (+https://github.com/Scottcjn/Rustchain)",
+}
 
 
 # ---------------------------------------------------------------------------
 # Async HTTP helpers (non-blocking, self-signed cert safe)
 # ---------------------------------------------------------------------------
 async def _get_json(url: str, params: dict | None = None, *, verify_ssl: bool = True):
-    connector = aiohttp.TCPConnector(ssl=verify_ssl)
-    async with aiohttp.ClientSession(connector=connector) as session:
-        async with session.get(
-            url, params=params, timeout=aiohttp.ClientTimeout(total=10)
-        ) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+    def fetch():
+        resp = requests.get(
+            url,
+            params=params,
+            headers=HTTP_HEADERS,
+            timeout=10,
+            verify=verify_ssl,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    return await asyncio.to_thread(fetch)
 
 
 async def fetch_rustchain(path: str, params: dict | None = None):
-    """Fetch from RustChain node (self-signed cert → ssl=False)."""
-    return await _get_json(f"{RUSTCHAIN_API}{path}", params, verify_ssl=False)
+    """Fetch from RustChain node; set RUSTCHAIN_VERIFY_SSL=false for self-signed nodes."""
+    return await _get_json(f"{RUSTCHAIN_API}{path}", params, verify_ssl=RUSTCHAIN_VERIFY_SSL)
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_raydium_mint_price(payload: dict, mint: str = WRTC_MINT) -> float | None:
+    """Return Raydium's USD price for the requested mint."""
+    if not isinstance(payload, dict) or payload.get("success") is False:
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    return _to_float(data.get(mint))
+
+
+def parse_raydium_pool_info(payload: dict, mint: str = WRTC_MINT) -> dict:
+    """Extract the most liquid Raydium pool details for display."""
+    empty = {
+        "price_sol": None,
+        "liquidity": 0.0,
+        "volume_24h": 0.0,
+        "pool_id": "",
+        "url": RAYDIUM_SWAP_URL,
+    }
+    if not isinstance(payload, dict) or payload.get("success") is False:
+        return empty
+
+    data = payload.get("data")
+    rows = data.get("data") if isinstance(data, dict) else None
+    if not isinstance(rows, list) or not rows:
+        return empty
+
+    pool = rows[0]
+    if not isinstance(pool, dict):
+        return empty
+
+    mint_a = (pool.get("mintA") or {}).get("address")
+    mint_b = (pool.get("mintB") or {}).get("address")
+    raw_price = _to_float(pool.get("price"))
+    price_sol = None
+    if raw_price and raw_price > 0:
+        if mint_a == mint:
+            price_sol = raw_price
+        elif mint_b == mint:
+            price_sol = 1 / raw_price
+
+    day = pool.get("day") if isinstance(pool.get("day"), dict) else {}
+    return {
+        "price_sol": price_sol,
+        "liquidity": _to_float(pool.get("tvl")) or 0.0,
+        "volume_24h": _to_float(day.get("volume")) or 0.0,
+        "pool_id": str(pool.get("id") or ""),
+        "url": RAYDIUM_SWAP_URL,
+    }
 
 
 async def fetch_price_data() -> dict | None:
-    """Fetch wRTC price from DexScreener, preferring the Raydium pair."""
+    """Fetch wRTC price from Raydium price and pool APIs."""
     try:
-        data = await _get_json(DEXSCREENER_URL)
-        pairs = data.get("pairs", [])
-        if not pairs:
+        price_payload = await _get_json(
+            RAYDIUM_MINT_PRICE_URL, {"mints": WRTC_MINT}
+        )
+        pool_payload = await _get_json(
+            RAYDIUM_POOL_INFO_URL,
+            {
+                "mint1": WRTC_MINT,
+                "mint2": WSOL_MINT,
+                "poolType": "all",
+                "poolSortField": "liquidity",
+                "sortType": "desc",
+                "pageSize": "1",
+                "page": "1",
+            },
+        )
+        price_usd = parse_raydium_mint_price(price_payload)
+        pool = parse_raydium_pool_info(pool_payload)
+        if price_usd is None:
             return None
-        pair = next((p for p in pairs if p.get("dexId") == "raydium"), pairs[0])
         return {
-            "price_usd": float(pair.get("priceUsd", 0)),
-            "price_sol": pair.get("priceNative", "N/A"),
-            "h24_change": pair.get("priceChange", {}).get("h24", 0),
-            "liquidity": pair.get("liquidity", {}).get("usd", 0),
-            "volume_24h": pair.get("volume", {}).get("h24", 0),
-            "url": pair.get("url", "https://dexscreener.com"),
+            "price_usd": price_usd,
+            "price_sol": pool["price_sol"],
+            "liquidity": pool["liquidity"],
+            "volume_24h": pool["volume_24h"],
+            "pool_id": pool["pool_id"],
+            "url": pool["url"],
         }
     except Exception as e:
         logger.error("fetch_price_data: %s", e)
@@ -143,11 +240,11 @@ async def cmd_price(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     text = (
         f"*wRTC Price*\n\n"
         f"USD: `${data['price_usd']:.6f}`\n"
-        f"SOL: `{data['price_sol']}`\n"
-        f"24h: `{data['h24_change']}%`\n"
-        f"Liquidity: `${data['liquidity']:,.0f}`\n"
-        f"Volume 24h: `${data['volume_24h']:,.0f}`\n\n"
-        f"[DexScreener]({data['url']})"
+        f"SOL: `{data['price_sol'] or 'N/A'}`\n"
+        f"Raydium TVL: `${data['liquidity']:,.0f}`\n"
+        f"Raydium 24h Volume: `{data['volume_24h']:,.4f}`\n"
+        f"Pool: `{data['pool_id'] or 'N/A'}`\n\n"
+        f"[Raydium]({data['url']})"
     )
     await update.message.reply_text(
         text, parse_mode="Markdown", disable_web_page_preview=True
@@ -354,9 +451,9 @@ async def inline_query(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
                 InlineQueryResultArticle(
                     id="price",
                     title=f"wRTC ${data['price_usd']:.6f}",
-                    description=f"24h change: {data['h24_change']}%",
+                    description=f"Raydium TVL: ${data['liquidity']:,.0f}",
                     input_message_content=InputTextMessageContent(
-                        f"wRTC: ${data['price_usd']:.6f} | 24h: {data['h24_change']}%"
+                        f"wRTC: ${data['price_usd']:.6f} | Raydium TVL: ${data['liquidity']:,.0f}"
                     ),
                 )
             )


### PR DESCRIPTION
Implements the Telegram community bot bounty scope from Scottcjn/rustchain-bounties#249 for the existing `tools/telegram_bot` implementation.

What changed:
- `/price` now reads Raydium v3 directly through `mint/price` and `pools/info/mint`, instead of labeling a DexScreener response as Raydium.
- Keeps the required RustChain commands wired to live endpoints: `/miners`, `/epoch`, `/balance <wallet>`, and `/health`.
- Adds config for RustChain SSL verification and Raydium endpoint overrides.
- Preserves bonus features already present in this bot: mining alerts, price alerts, and inline queries.
- Adds parser and endpoint-selection tests for the Raydium price/pool path.

Verification:
- `.venv/bin/python -m py_compile tools/telegram_bot/telegram_bot.py`
- `.venv/bin/python -m pytest tests/test_telegram_bot_miners_envelope.py` -> 7 passed
- Live smoke: Raydium price/pool endpoints returned wRTC price and pool id; RustChain `/health`, `/epoch`, and `/api/miners` returned current data.

Bounty: Scottcjn/rustchain-bounties#249
Wallet/name for payout: JONASXZB
