### PR TITLE
docs: fix localized miner setup commands

### DIFF
--- a/README_DE.md
+++ b/README_DE.md
@@ -46,20 +46,14 @@ Der RustChain Token (RTC) ist jetzt als **wRTC** auf Solana über die BoTTube Br
 ## ⚡ Schnellstart
 
 ```bash
-# 1. Repo klonen
-git clone https://github.com/Scottcjn/Rustchain.git && cd Rustchain
+# 1. Miner mit dem aktuellen Installer einrichten
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
 
-# 2. Python-Umgebung aufsetzen (Linux/macOS)
-python3 -m venv venv && source venv/bin/activate
+# 2. Optional zuerst einen Testlauf ausführen
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 
-# 3. Abhängigkeiten installieren
-pip install -r requirements.txt
-
-# 4. Wallet erstellen
-python3 -c "from rustchain.wallet import Wallet; w = Wallet.create('meine_wallet.json'); print(w.address)"
-
-# 5. Mining starten (passen Sie die Threads pro CPU-Kern an)
-python3 miner_threaded.py --threads 4 --wallet meine_wallet.json
+# 3. Mit einem eigenen Walletnamen starten
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet mein-wallet
 ```
 
 **Hardware-Anforderungen:**

--- a/README_ZH-TW.md
+++ b/README_ZH-TW.md
@@ -134,8 +134,10 @@ tail -f ~/.rustchain/miner.log             # 查看日誌
 ```bash
 git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
-pip install -r requirements.txt
-python3 rustchain_universal_miner.py --wallet 你的錢包名稱
+bash install-miner.sh --wallet 你的錢包名稱
+
+# 如需先驗證環境，可執行：
+bash install-miner.sh --dry-run --wallet 你的錢包名稱
 ```
 
 ## 💰 古董倍率
@@ -284,10 +286,13 @@ open https://rustchain.org/explorer
 
 ```
 Rustchain/
-├── rustchain_universal_miner.py    # 主礦工程式（所有平台）
-├── rustchain_v2_integrated.py      # 完整節點實作
-├── fingerprint_checks.py           # 硬體驗證
-├── install.sh                      # 一行安裝程式
+├── install-miner.sh                # 一行礦工安裝程式
+├── miners/linux/
+│   ├── rustchain_linux_miner.py    # Linux 礦工入口
+│   └── fingerprint_checks.py       # 礦工硬體驗證
+├── node/
+│   ├── rustchain_v2_integrated_v2.2.1_rip200.py  # 完整節點實作
+│   └── fingerprint_checks.py       # 節點硬體驗證
 ├── docs/
 │   ├── RustChain_Whitepaper_*.pdf  # 技術白皮書
 │   └── chain_architecture.md       # 架構文件

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -178,8 +178,10 @@ tail -f ~/.rustchain/miner.log             # 查看日志
 ```bash
 git clone https://github.com/Scottcjn/Rustchain.git
 cd Rustchain
-pip install -r requirements.txt
-python3 rustchain_universal_miner.py --wallet YOUR_WALLET_NAME
+bash install-miner.sh --wallet YOUR_WALLET_NAME
+
+# 如需先验证环境，可运行：
+bash install-miner.sh --dry-run --wallet YOUR_WALLET_NAME
 ```
 
 ## 💰 古董倍数
@@ -328,10 +330,13 @@ open https://rustchain.org/explorer
 
 ```
 Rustchain/
-├── rustchain_universal_miner.py    # 主矿工（所有平台）
-├── rustchain_v2_integrated.py      # 全节点实现
-├── fingerprint_checks.py           # 硬件验证
-├── install.sh                      # 一键安装器
+├── install-miner.sh                # 一键矿工安装器
+├── miners/linux/
+│   ├── rustchain_linux_miner.py    # Linux 矿工入口
+│   └── fingerprint_checks.py       # 矿工硬件验证
+├── node/
+│   ├── rustchain_v2_integrated_v2.2.1_rip200.py  # 全节点实现
+│   └── fingerprint_checks.py       # 节点硬件验证
 ├── docs/
 │   ├── RustChain_Whitepaper_*.pdf  # 技术白皮书
 │   └── chain_architecture.md       # 架构文档

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: 古董证明区块链
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](../../LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github.com/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github.com/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github.com/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -52,6 +52,17 @@
 
 ---
 
+## x402 高级 API
+
+以下高级 API 已部署在 BoTTube 域名上（当前免费用于验证流程）：
+
+- `GET https://bottube.ai/api/premium/videos` - 批量视频导出（BoTTube）
+- `GET https://bottube.ai/api/premium/analytics/<agent>` - 深度 Agent 分析（BoTTube）
+- `GET /api/premium/reputation` - 完整声誉导出（Beacon Atlas）
+- `GET /wallet/swap-info` - USDC/wRTC 兑换指引（RustChain）
+
+---
+
 ## 🔥 Crypto 迷失了方向。我们回到原点。
 
 2026年，加密货币开发者提交量下降75%。以太坊流失了34%的活跃开发者。Solana流失了40%。建设者们离开了，投奔AI。
@@ -213,25 +224,24 @@ RustChain支持**15+种CPU架构**——比任何其他区块链都多：
 ### 安装
 
 ```bash
-# 克隆仓库
-git clone https://github.com/Scottcjn/Rustchain.git
-cd Rustchain
+# 一键安装并启动矿工
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash
 
-# 安装依赖
-pip install -r requirements.txt
+# 或者先进行干运行测试
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --dry-run
 
-# 启动矿工
-python3 miner.py
+# 使用指定钱包名称
+curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash -s -- --wallet 我的钱包
 ```
 
 ### 验证你的矿工
 
 ```bash
-# 检查矿工状态
-python3 miner.py --status
+# 检查用户服务状态（Linux/systemd）
+systemctl --user status rustchain-miner
 
-# 查看硬件指纹
-python3 miner.py --fingerprint
+# 查看矿工日志
+journalctl --user -u rustchain-miner -f
 ```
 
 你的矿工启动后，会自动进行6项硬件检查并注册到网络。无需额外配置。

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -3,7 +3,7 @@
 # 🧱 RustChain: 古董证明区块链
 
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](../../LICENSE)
 [![GitHub Stars](https://img.shields.io/github.com/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
 [![Contributors](https://img.shields.io/github.com/contributors/Scottcjn/Rustchain?color=brightgreen)](https://github.com/Scottcjn/Rustchain/graphs/contributors)
 [![Last Commit](https://img.shields.io/github.com/last-commit/Scottcjn/Rustchain?color=blue)](https://github.com/Scottcjn/Rustchain/commits/main)


### PR DESCRIPTION
## Summary
- Replace the stale German quickstart wallet/miner_threaded flow with the current install-miner.sh onboarding path.
- Replace zh-CN miner.py status/fingerprint commands with current installer, service status, and log commands.
- Update simplified/traditional Chinese manual install and repository tree examples away from removed root-level miner files.
- Keep the zh-CN x402 premium API host references aligned with the existing docs test.

## Validation
- git diff --check
- rg -n "miner_threaded|rustchain_universal_miner|python3 miner.py|miner.py --status|miner.py --fingerprint|from rustchain.wallet|pip install -r requirements.txt" README_DE.md docs/zh-CN/README.md README_ZH.md README_ZH-TW.md
- uv run --with pytest --no-project python -m pytest tests/test_premium_endpoint_host_docs.py -q

Fixes #6700
Fixes #6699
Fixes #6698

Payout wallet: RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e