### PR TITLE
attractor: consensus-invariant harness

### DIFF
--- a/docs/CONSENSUS_INVARIANT_ATTRACTOR.md
+++ b/docs/CONSENSUS_INVARIANT_ATTRACTOR.md
@@ -1,0 +1,93 @@
+# Consensus Invariant Attractor Harness
+
+This document defines the reusable submission grammar and acceptance rubric for
+small adversarial tests that pin RustChain consensus invariants. The goal is to
+make future bounty submissions cheap to review: one invariant per test, one
+explicit oracle, and a deterministic fixture that runs without live network
+state.
+
+## PR Title
+
+`attractor: consensus-invariant harness`
+
+## Submission Grammar
+
+Each submitted test MUST declare exactly one invariant case with these fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `invariant_id` | yes | Stable lowercase identifier, for example `consensus.reward.emission_conserved`. |
+| `statement` | yes | One-sentence invariant that must hold across all valid executions. |
+| `fixture` | yes | Minimal deterministic chain, database, or module state needed to exercise the invariant. |
+| `adversarial_move` | yes | The mutation, ordering change, replay, duplicate, delay, or alias attempt being tested. |
+| `oracle` | yes | Objective pass/fail predicate checked by the test. |
+| `determinism_controls` | yes | How time, randomness, live services, and filesystem state are bounded or mocked. |
+| `command` | yes | Exact command reviewers can run from repository root. |
+| `bcos_tier` | yes for code PRs | `BCOS-L1` for ordinary regression harnesses, `BCOS-L2` for consensus/reward/auth/crypto-sensitive behavior. |
+
+Recommended test name:
+
+`test_<domain>__<invariant_id_slug>__<adversarial_move_slug>`
+
+Example:
+
+`test_consensus__machine_identity_stable__fingerprint_key_reorder`
+
+## Reusable Template
+
+Copy this block into future attractor submissions and fill in every field:
+
+```markdown
+### Invariant Case
+
+- invariant_id:
+- statement:
+- fixture:
+- adversarial_move:
+- oracle:
+- determinism_controls:
+- command:
+- bcos_tier:
+
+### Review Notes
+
+- Expected failure if the invariant is broken:
+- Files touched:
+- Runtime bound:
+```
+
+## Acceptance Rubric
+
+Accept a submitted invariant test when all checks below are true:
+
+| Check | Accept | Reject |
+| --- | --- | --- |
+| Single invariant | The test pins one stated invariant. | The test mixes unrelated properties or has no clear invariant. |
+| Meaningful adversary | The adversarial move could expose a consensus, reward, enrollment, settlement, identity, or idempotency regression. | The test only asserts a tautology or mirrors implementation constants without pressure. |
+| Objective oracle | Pass/fail is decided by deterministic assertions. | Reviewers must interpret logs, screenshots, timing, or subjective prose. |
+| Deterministic fixture | No live network, wall-clock dependency, random seed drift, or persistent local state is required. | The test can pass or fail depending on external services, current time, or host state. |
+| Bounded runtime | The focused command should complete in under 10 seconds on a normal development machine. | The test is a long soak, load test, or unbounded fuzz run. |
+| Reviewable scope | The fixture is small enough to understand inline or in one helper. | The submission brings a broad framework or rewrites production code only to test it. |
+| Failure signal | A plausible one-line mutation to the guarded behavior would fail the test. | The test would still pass if the invariant were broken. |
+
+## Reference Example Tests
+
+The first three reference cases live in `tests/test_consensus_invariant_attractor.py`:
+
+| Test | Invariant pinned |
+| --- | --- |
+| `test_consensus__machine_identity_stable__fingerprint_key_reorder` | Reordered fingerprint JSON cannot change a physical machine identity hash. |
+| `test_consensus__machine_identity_separates__architecture_alias` | The same fingerprint on a different architecture is a different machine identity. |
+| `test_consensus__representative_selection_idempotent__input_order_shuffle` | Duplicate-miner representative selection is deterministic and preserves the highest enrolled epoch weight. |
+
+Run them with:
+
+```bash
+python -m pytest tests/test_consensus_invariant_attractor.py -q
+```
+
+Fallback without pytest:
+
+```bash
+python -m unittest tests.test_consensus_invariant_attractor
+```

--- a/tests/consensus_invariant_harness.py
+++ b/tests/consensus_invariant_harness.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Small metadata wrapper for consensus invariant attractor tests."""
+
+from dataclasses import dataclass
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class ConsensusInvariantCase:
+    """A single deterministic consensus invariant and its executable oracle."""
+
+    invariant_id: str
+    statement: str
+    fixture: str
+    adversarial_move: str
+    oracle: Callable[[], None]
+
+    def validate(self) -> None:
+        missing = [
+            field
+            for field in ("invariant_id", "statement", "fixture", "adversarial_move")
+            if not getattr(self, field).strip()
+        ]
+        if missing:
+            raise AssertionError(f"invariant case is missing required fields: {missing}")
+
+
+def assert_consensus_invariant(case: ConsensusInvariantCase) -> None:
+    """Validate the invariant metadata, then execute its deterministic oracle."""
+
+    case.validate()
+    case.oracle()

--- a/tests/test_consensus_invariant_attractor.py
+++ b/tests/test_consensus_invariant_attractor.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Reference adversarial tests for the consensus invariant attractor bounty."""
+
+import sqlite3
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
+
+from anti_double_mining import compute_machine_identity_hash, select_representative_miner
+from tests.consensus_invariant_harness import (
+    ConsensusInvariantCase,
+    assert_consensus_invariant,
+)
+
+
+class TestConsensusInvariantAttractor(unittest.TestCase):
+    def test_consensus__machine_identity_stable__fingerprint_key_reorder(self):
+        def oracle():
+            left = {
+                "checks": {
+                    "clock_drift": {"data": {"mean_ns": 101.2345, "cv": 0.00123456}},
+                    "cpu_serial": {"data": {"serial": "BOARD-SERIAL-42"}},
+                }
+            }
+            right = {
+                "checks": {
+                    "cpu_serial": {"data": {"serial": "BOARD-SERIAL-42"}},
+                    "clock_drift": {"data": {"cv": 0.00123456, "mean_ns": 101.2345}},
+                }
+            }
+
+            self.assertEqual(
+                compute_machine_identity_hash("ppc_g4", left),
+                compute_machine_identity_hash("ppc_g4", right),
+            )
+
+        assert_consensus_invariant(
+            ConsensusInvariantCase(
+                invariant_id="consensus.machine_identity.canonical_fingerprint",
+                statement="Machine identity is invariant to JSON object ordering.",
+                fixture="Two semantically identical hardware fingerprints with reordered keys.",
+                adversarial_move="Reorder nested fingerprint check keys and data keys.",
+                oracle=oracle,
+            )
+        )
+
+    def test_consensus__machine_identity_separates__architecture_alias(self):
+        def oracle():
+            fingerprint = {
+                "checks": {
+                    "cpu_serial": {"data": {"serial": "BOARD-SERIAL-99"}},
+                    "cache_timing": {"data": {"hierarchy_ratio": 2.5}},
+                }
+            }
+
+            self.assertNotEqual(
+                compute_machine_identity_hash("ppc_g4", fingerprint),
+                compute_machine_identity_hash("ppc_g5", fingerprint),
+            )
+
+        assert_consensus_invariant(
+            ConsensusInvariantCase(
+                invariant_id="consensus.machine_identity.architecture_separation",
+                statement="A physical fingerprint under a different device architecture is a different machine identity.",
+                fixture="One stable fingerprint evaluated under two architecture labels.",
+                adversarial_move="Replay the same fingerprint while changing only device_arch.",
+                oracle=oracle,
+            )
+        )
+
+    def test_consensus__representative_selection_idempotent__input_order_shuffle(self):
+        def oracle():
+            conn = sqlite3.connect(":memory:")
+            try:
+                conn.executescript(
+                    """
+                    CREATE TABLE miner_attest_recent (
+                        miner TEXT PRIMARY KEY,
+                        device_arch TEXT,
+                        ts_ok INTEGER,
+                        entropy_score REAL
+                    );
+                    CREATE TABLE epoch_enroll (
+                        epoch INTEGER,
+                        miner_pk TEXT,
+                        weight REAL,
+                        PRIMARY KEY (epoch, miner_pk)
+                    );
+                    """
+                )
+                rows = [
+                    ("alias-high-entropy", 1.0, 1728000200, 0.99),
+                    ("canonical-high-weight", 5.0, 1728000000, 0.10),
+                    ("alias-newer", 1.0, 1728000300, 0.50),
+                ]
+                for miner, weight, ts_ok, entropy in rows:
+                    conn.execute(
+                        "INSERT INTO miner_attest_recent (miner, device_arch, ts_ok, entropy_score) VALUES (?, ?, ?, ?)",
+                        (miner, "ppc_g4", ts_ok, entropy),
+                    )
+                    conn.execute(
+                        "INSERT INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                        (9, miner, weight),
+                    )
+                conn.commit()
+
+                forward = [row[0] for row in rows]
+                reversed_order = list(reversed(forward))
+
+                self.assertEqual(
+                    select_representative_miner(conn, forward, epoch=9),
+                    "canonical-high-weight",
+                )
+                self.assertEqual(
+                    select_representative_miner(conn, reversed_order, epoch=9),
+                    "canonical-high-weight",
+                )
+            finally:
+                conn.close()
+
+        assert_consensus_invariant(
+            ConsensusInvariantCase(
+                invariant_id="consensus.duplicate_miner.representative_idempotent",
+                statement="Duplicate-miner representative selection is deterministic and preserves the highest enrolled epoch weight.",
+                fixture="Three aliases for one machine in an in-memory epoch enrollment snapshot.",
+                adversarial_move="Shuffle candidate miner order and give aliases fresher timestamps or higher entropy.",
+                oracle=oracle,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#12789

## Reusable Template

### Invariant Case

- invariant_id: stable lowercase identifier for one consensus invariant
- statement: one sentence describing the invariant that must always hold
- fixture: minimal deterministic chain, database, or module state required by the test
- adversarial_move: the mutation, replay, ordering shuffle, duplicate, delay, or alias attempt being tested
- oracle: objective assertion that decides pass/fail
- determinism_controls: no live network; bound time, randomness, filesystem state, and host dependencies
- command: exact command from repository root
- bcos_tier: BCOS-L1 for ordinary regression harnesses; BCOS-L2 for consensus/reward/auth/crypto-sensitive cases

## Objective Rubric

Accept a future attractor test when it:

- pins exactly one stated invariant
- uses a meaningful adversarial move against consensus, reward, enrollment, settlement, identity, or idempotency behavior
- has a deterministic fixture with no live network or wall-clock dependency
- has an objective oracle that would fail under a plausible invariant break
- runs as a focused test in under 10 seconds on a normal development machine
- keeps scope small enough for review without a broad framework rewrite

Reject it when it:

- mixes unrelated properties in one test
- asserts a tautology or implementation constant without pressure
- depends on logs, screenshots, timing, live services, or subjective interpretation
- is flaky, unbounded, or too vague to evaluate consistently

## Example Invariant Tests

This PR adds `tests/test_consensus_invariant_attractor.py` with three green reference cases:

- `test_consensus__machine_identity_stable__fingerprint_key_reorder`: reordered fingerprint JSON cannot change a physical machine identity hash.
- `test_consensus__machine_identity_separates__architecture_alias`: the same fingerprint on a different architecture is a different machine identity.
- `test_consensus__representative_selection_idempotent__input_order_shuffle`: duplicate-miner representative selection is deterministic and preserves the highest enrolled epoch weight.

The reusable helper lives in `tests/consensus_invariant_harness.py`, and the full submission grammar/rubric lives in `docs/CONSENSUS_INVARIANT_ATTRACTOR.md`.

## Validation

- PASS: `python -m unittest tests.test_consensus_invariant_attractor -v`
- PASS: `git diff --cached --check` before commit
- NOTE: `python -m pytest tests/test_consensus_invariant_attractor.py -q` could not run in my local interpreter because pytest is not installed (`No module named pytest`). The test module is unittest-compatible and should collect under pytest where pytest is available.

## BCOS / Payout

- BCOS tier: BCOS-L2, because the examples pin consensus/reward-adjacent miner identity and settlement selection behavior.
- Requested RTC payout wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8