### PR TITLE
Add JavaScript SDK for RustChain API

### DIFF
--- a/sdk/javascript/rustchain-sdk/README.md
+++ b/sdk/javascript/rustchain-sdk/README.md
@@ -1,0 +1,63 @@
+# RustChain JavaScript SDK
+
+Lightweight JavaScript SDK for the RustChain node API. It works in Node.js 18+ and modern browsers that provide `fetch`.
+
+## Install
+
+This package is currently shipped from the RustChain repository:
+
+```bash
+cd sdk/javascript/rustchain-sdk
+npm test
+```
+
+## Usage
+
+```js
+import { RustChainClient } from "./src/index.js";
+
+const client = new RustChainClient({
+  baseUrl: "https://rustchain.org"
+});
+
+const health = await client.health();
+const epoch = await client.epoch();
+const miners = await client.miners({ limit: 10 });
+
+console.log({ health, epoch, miners });
+```
+
+## API
+
+### `new RustChainClient(options)`
+
+Options:
+
+- `baseUrl`: RustChain node URL. Defaults to `https://rustchain.org`.
+- `timeoutMs`: request timeout in milliseconds. Defaults to `30000`.
+- `fetch`: optional custom fetch implementation for tests or older runtimes.
+
+### Public methods
+
+- `health()` -> `GET /health`
+- `epoch()` -> `GET /epoch`
+- `miners({ limit, offset, hardwareType })` -> `GET /api/miners`
+- `balance(minerId)` -> `GET /wallet/balance?miner_id=...`
+- `transfer({ from, to, amount, signature, fee })` -> `POST /transfer`
+- `attestChallenge(payload)` -> `POST /attest/challenge`
+- `submitAttestation(payload)` -> `POST /attest/submit`
+- `transferHistory(wallet, { limit })` -> `GET /wallet/history`
+
+## Example
+
+```bash
+RUSTCHAIN_NODE_URL=https://50.28.86.131 node examples/health.js
+```
+
+## Validation
+
+```bash
+npm test
+```
+
+The test suite uses Node's built-in `node:test` runner and mocked `fetch`, so it does not require network access or dependency installation.

--- a/sdk/javascript/rustchain-sdk/examples/health.js
+++ b/sdk/javascript/rustchain-sdk/examples/health.js
@@ -1,0 +1,15 @@
+import { RustChainClient } from "../src/index.js";
+
+const client = new RustChainClient({
+  baseUrl: process.env.RUSTCHAIN_NODE_URL || "https://rustchain.org"
+});
+
+const health = await client.health();
+const epoch = await client.epoch();
+const miners = await client.miners({ limit: 10 });
+
+console.log(JSON.stringify({
+  health,
+  epoch,
+  minerCount: miners.length
+}, null, 2));

--- a/sdk/javascript/rustchain-sdk/package.json
+++ b/sdk/javascript/rustchain-sdk/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "rustchain-sdk",
+  "version": "0.1.0",
+  "description": "Lightweight JavaScript SDK for the RustChain node API",
+  "type": "module",
+  "main": "src/index.js",
+  "files": [
+    "src",
+    "examples",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "rustchain",
+    "rtc",
+    "blockchain",
+    "sdk",
+    "proof-of-antiquity"
+  ],
+  "author": "RustChain Contributors",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Scottcjn/Rustchain.git",
+    "directory": "sdk/javascript/rustchain-sdk"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/sdk/javascript/rustchain-sdk/src/index.js
+++ b/sdk/javascript/rustchain-sdk/src/index.js
@@ -1,0 +1,217 @@
+const DEFAULT_BASE_URL = "https://rustchain.org";
+const DEFAULT_TIMEOUT_MS = 30000;
+
+export class RustChainError extends Error {
+  constructor(message, options = {}) {
+    super(message);
+    this.name = "RustChainError";
+    this.cause = options.cause;
+  }
+}
+
+export class RustChainApiError extends RustChainError {
+  constructor(message, options = {}) {
+    super(message, options);
+    this.name = "RustChainApiError";
+    this.status = options.status;
+    this.endpoint = options.endpoint;
+    this.body = options.body;
+  }
+}
+
+export class RustChainValidationError extends RustChainError {
+  constructor(message) {
+    super(message);
+    this.name = "RustChainValidationError";
+  }
+}
+
+export class RustChainClient {
+  constructor(options = {}) {
+    const baseUrl = typeof options === "string" ? options : options.baseUrl;
+
+    this.baseUrl = normalizeBaseUrl(baseUrl || DEFAULT_BASE_URL);
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+
+    if (typeof this.fetchImpl !== "function") {
+      throw new RustChainValidationError("A fetch implementation is required. Use Node 18+ or pass { fetch }.");
+    }
+  }
+
+  async health() {
+    return this.request("GET", "/health");
+  }
+
+  async epoch() {
+    return this.request("GET", "/epoch");
+  }
+
+  async miners(options = {}) {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(validatePositiveInteger(options.limit, "limit")));
+    if (options.offset !== undefined) params.set("offset", String(validateNonNegativeInteger(options.offset, "offset")));
+    if (options.hardwareType) params.set("hardware_type", String(options.hardwareType));
+
+    const result = await this.request("GET", withQuery("/api/miners", params));
+    if (Array.isArray(result)) return result;
+    if (Array.isArray(result?.miners)) return result.miners;
+    if (Array.isArray(result?.data)) return result.data;
+    if (Array.isArray(result?.items)) return result.items;
+    return [];
+  }
+
+  async balance(minerId) {
+    assertNonEmptyString(minerId, "minerId");
+    const params = new URLSearchParams({ miner_id: minerId });
+    return this.request("GET", withQuery("/wallet/balance", params));
+  }
+
+  async transfer({ from, to, amount, signature, fee = 0.01 }) {
+    assertNonEmptyString(from, "from");
+    assertNonEmptyString(to, "to");
+    validatePositiveNumber(amount, "amount");
+    validateNonNegativeNumber(fee, "fee");
+
+    return this.request("POST", "/transfer", {
+      from,
+      to,
+      amount,
+      fee,
+      ...(signature ? { signature } : {})
+    });
+  }
+
+  async attestChallenge(payload = {}) {
+    return this.request("POST", "/attest/challenge", payload);
+  }
+
+  async submitAttestation(payload) {
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new RustChainValidationError("payload must be an object");
+    }
+    return this.request("POST", "/attest/submit", payload);
+  }
+
+  async transferHistory(wallet, options = {}) {
+    assertNonEmptyString(wallet, "wallet");
+    const params = new URLSearchParams({ wallet });
+    if (options.limit !== undefined) params.set("limit", String(validatePositiveInteger(options.limit, "limit")));
+    return this.request("GET", withQuery("/wallet/history", params));
+  }
+
+  async request(method, endpoint, body) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    const headers = {
+      Accept: "application/json",
+      "User-Agent": "rustchain-js-sdk/0.1.0"
+    };
+
+    let fetchBody;
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      fetchBody = JSON.stringify(body);
+    }
+
+    try {
+      const response = await this.fetchImpl(`${this.baseUrl}${endpoint}`, {
+        method,
+        headers,
+        body: fetchBody,
+        redirect: "manual",
+        signal: controller.signal
+      });
+
+      const responseText = await response.text();
+      const parsed = parseResponseBody(responseText);
+
+      if (response.status >= 300 && response.status < 400) {
+        throw new RustChainApiError(`API redirected with HTTP ${response.status}`, {
+          status: response.status,
+          endpoint,
+          body: parsed
+        });
+      }
+
+      if (!response.ok) {
+        throw new RustChainApiError(`API request failed with HTTP ${response.status}`, {
+          status: response.status,
+          endpoint,
+          body: parsed
+        });
+      }
+
+      return parsed;
+    } catch (error) {
+      if (error instanceof RustChainApiError) throw error;
+      if (error?.name === "AbortError") {
+        throw new RustChainError(`Request timed out after ${this.timeoutMs} ms`, { cause: error });
+      }
+      throw new RustChainError(`Request failed: ${error?.message || String(error)}`, { cause: error });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export function createClient(options) {
+  return new RustChainClient(options);
+}
+
+function normalizeBaseUrl(baseUrl) {
+  assertNonEmptyString(baseUrl, "baseUrl");
+  return baseUrl.replace(/\/+$/, "");
+}
+
+function withQuery(path, params) {
+  const query = params.toString();
+  return query ? `${path}?${query}` : path;
+}
+
+function parseResponseBody(text) {
+  if (!text) return {};
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { rawResponse: text };
+  }
+}
+
+function assertNonEmptyString(value, name) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new RustChainValidationError(`${name} must be a non-empty string`);
+  }
+}
+
+function validatePositiveInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new RustChainValidationError(`${name} must be a positive integer`);
+  }
+  return number;
+}
+
+function validateNonNegativeInteger(value, name) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 0) {
+    throw new RustChainValidationError(`${name} must be a non-negative integer`);
+  }
+  return number;
+}
+
+function validatePositiveNumber(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new RustChainValidationError(`${name} must be a positive number`);
+  }
+  return number;
+}
+
+function validateNonNegativeNumber(value, name) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0) {
+    throw new RustChainValidationError(`${name} must be a non-negative number`);
+  }
+  return number;
+}

--- a/sdk/javascript/rustchain-sdk/test/rustchain.test.js
+++ b/sdk/javascript/rustchain-sdk/test/rustchain.test.js
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  RustChainApiError,
+  RustChainClient,
+  RustChainValidationError,
+  createClient
+} from "../src/index.js";
+
+function mockFetch(handler) {
+  return async (url, init) => {
+    const result = await handler(url, init);
+    return {
+      ok: result.status >= 200 && result.status < 300,
+      status: result.status,
+      text: async () => result.body ?? "{}"
+    };
+  };
+}
+
+test("creates a client with defaults", () => {
+  const client = createClient({ fetch: mockFetch(() => ({ status: 200 })) });
+  assert.equal(client.baseUrl, "https://rustchain.org");
+});
+
+test("normalizes base URL", () => {
+  const client = new RustChainClient({
+    baseUrl: "https://example.test///",
+    fetch: mockFetch(() => ({ status: 200 }))
+  });
+  assert.equal(client.baseUrl, "https://example.test");
+});
+
+test("fetches health endpoint", async () => {
+  const client = new RustChainClient({
+    baseUrl: "https://node.test",
+    fetch: mockFetch((url, init) => {
+      assert.equal(url, "https://node.test/health");
+      assert.equal(init.method, "GET");
+      return { status: 200, body: JSON.stringify({ ok: true, version: "2.2.1-rip200" }) };
+    })
+  });
+
+  assert.deepEqual(await client.health(), { ok: true, version: "2.2.1-rip200" });
+});
+
+test("normalizes miners array responses", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch((url) => {
+      assert.equal(url, "https://rustchain.org/api/miners?limit=5&offset=2&hardware_type=PowerPC");
+      return { status: 200, body: JSON.stringify({ miners: [{ miner: "alice" }] }) };
+    })
+  });
+
+  assert.deepEqual(await client.miners({ limit: 5, offset: 2, hardwareType: "PowerPC" }), [{ miner: "alice" }]);
+});
+
+test("validates balance miner id", async () => {
+  const client = new RustChainClient({ fetch: mockFetch(() => ({ status: 200 })) });
+  await assert.rejects(() => client.balance(""), RustChainValidationError);
+});
+
+test("posts transfer payload", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch((url, init) => {
+      assert.equal(url, "https://rustchain.org/transfer");
+      assert.equal(init.method, "POST");
+      assert.deepEqual(JSON.parse(init.body), {
+        from: "alice",
+        to: "bob",
+        amount: 1.25,
+        fee: 0.01
+      });
+      return { status: 200, body: JSON.stringify({ success: true }) };
+    })
+  });
+
+  assert.deepEqual(await client.transfer({ from: "alice", to: "bob", amount: 1.25 }), { success: true });
+});
+
+test("throws API errors with status and endpoint", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch(() => ({ status: 500, body: JSON.stringify({ error: "boom" }) }))
+  });
+
+  await assert.rejects(
+    () => client.epoch(),
+    (error) => error instanceof RustChainApiError && error.status === 500 && error.endpoint === "/epoch"
+  );
+});


### PR DESCRIPTION
Refs Scottcjn/rustchain-bounties#402

Adds a lightweight JavaScript SDK for the RustChain node API under `sdk/javascript/rustchain-sdk`.

What changed:
- Adds `RustChainClient` with health, epoch, miners, balance, transfer, attestation, and transfer history helpers
- Supports Node 18+ and browser runtimes via `fetch`
- Includes validation errors and API errors with status/endpoint context
- Adds dependency-free tests using Node's built-in `node:test`
- Adds README and a small health example

Validation:
- `node --test`
- `git diff --check`

Test result:
- 7 tests passed