### PR TITLE
docs: add pt-BR miner localization pass

### DIFF
--- a/docs/pt-BR/RUSTCHAIN_EXPLAINED.md
+++ b/docs/pt-BR/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain explicada (pt-BR)
+
+RustChain e uma rede Proof-of-Antiquity que recompensa maquinas reais, especialmente hardware antigo, por provar que continuam operando. A ideia central e simples: hardware preservado tem valor, e a rede deve conseguir diferenciar uma maquina real de uma VM, container ou declaracao fabricada.
+
+## Como a verificacao funciona
+
+O minerador coleta sinais locais e envia uma `attestation` ao no RustChain. Essa `attestation` inclui um `fingerprint` de hardware. O no usa esses dados para estimar a `antiquity` da maquina e calcular o multiplicador de recompensa.
+
+O processo deve ser honesto:
+
+- nao invente arquitetura;
+- nao force uma familia de CPU que a maquina nao possui;
+- nao altere o payload para parecer mais antigo;
+- nao traduza flags de comando ou nomes de endpoints.
+
+## Verificar antes de minerar
+
+Use os comandos abaixo antes de deixar qualquer minerador rodando:
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Esses comandos ajudam a revisar a maquina detectada, o payload de `attestation` e a conectividade com o no. Eles devem permanecer exatamente assim em documentacao localizada.
+
+## O que o usuario consente
+
+Ao confirmar a primeira execucao, o usuario declara que entende que:
+
+1. o minerador pode enviar dados de `fingerprint` e `attestation`;
+2. o hardware deve ser reportado honestamente;
+3. recompensas em `RTC` dependem da aceitacao da rede e nao sao garantidas;
+4. spoofing, emulacao nao declarada ou payload fabricado podem reduzir recompensas ou causar rejeicao.
+
+A tela de consentimento em portugues deve exigir uma entrada afirmativa explicita, como `SIM`. Apenas pressionar Enter nao deve iniciar a mineracao.
+
+## Glossario preservado
+
+| Termo | Significado operacional |
+|---|---|
+| `RTC` | Token usado pela RustChain para recompensas e bounties. |
+| `attestation` | Declaracao verificavel da maquina enviada ao no. |
+| `antiquity` | Sinal de idade, raridade e preservacao do hardware. |
+| `fingerprint` | Conjunto de sinais de hardware usados para verificacao. |
+
+## Guia do minerador Linux
+
+O guia localizado do minerador Linux fica em:
+
+- [miners/linux/README.pt-BR.md](../../miners/linux/README.pt-BR.md)

--- a/i18n/pt-BR.json
+++ b/i18n/pt-BR.json
@@ -1,0 +1,111 @@
+{
+  "locale": "pt-BR",
+  "language": "Portuguese (Brazil)",
+  "version": "1.0.0",
+  "description": "Localizacao pt-BR para mensagens do minerador/carteira RustChain e consentimento de primeira execucao.",
+  "errors": {
+    "wallet": {
+      "invalid_amount": "Valor invalido",
+      "please_load_wallet_first": "Carregue a carteira primeiro",
+      "please_enter_recipient_wallet_id": "Informe o ID da carteira destinataria",
+      "amount_must_be_positive": "O valor deve ser positivo",
+      "transaction_failed": "Transacao falhou",
+      "please_enter_wallet_id": "Informe o ID da carteira",
+      "network_error_check_connection": "Erro de rede - verifique a conexao",
+      "request_timeout_node_busy": "Tempo esgotado - o no pode estar ocupado",
+      "dns_resolution_failed": "Falha na resolucao DNS: {host}: {error}",
+      "cannot_connect_to_host": "Nao foi possivel conectar a {host}:{port} (codigo de erro: {result})",
+      "network_check_failed": "Verificacao de rede falhou: {error}",
+      "network_unreachable": "Rede inacessivel: {error}",
+      "request_timeout_after_retries": "Solicitacao expirou apos {timeout} segundos ({max_retries} tentativas)",
+      "api_error_http": "Erro de API: HTTP {status}",
+      "request_failed": "Solicitacao falhou: {error}",
+      "request_failed_after_retries": "Solicitacao falhou apos {max_retries} tentativas: {last_error}",
+      "new_wallet_created": "Nova carteira criada",
+      "save_wallet_id_warning": "Guarde este ID - ele sera necessario para acessar seus fundos",
+      "confirm_transfer": "Confirmar transferencia",
+      "send_confirmation": "Enviar {amount:.6f} RTC para:\n{to_wallet}\n\nContinuar?"
+    },
+    "miner": {
+      "attestation_failed": "attestation falhou",
+      "epoch_enrollment_failed": "Inscricao na epoca falhou",
+      "challenge_failed_http": "Desafio falhou: HTTP {status_code}",
+      "challenge_error": "Erro no desafio: {error}",
+      "attestation_rejected": "attestation rejeitada: {response}",
+      "attestation_submission_failed": "Envio de attestation falhou: {error}",
+      "enrollment_failed": "Inscricao falhou: {error}",
+      "enrollment_rejected": "Inscricao rejeitada: {response}",
+      "enrollment_http_error": "Erro HTTP na inscricao {status}: {text}",
+      "submit_error": "Erro de envio: {error}",
+      "fingerprint_failed_reduced_rewards": "fingerprint de hardware: falhou (recompensa reduzida)",
+      "fingerprint_passed": "fingerprint de hardware: aprovado",
+      "fingerprint_n_a": "fingerprint de hardware: indisponivel (modulo ausente)",
+      "attestation_accepted": "attestation aceita",
+      "enrolled_success": "Inscricao concluida. Epoca: {epoch} Peso: {weight}x",
+      "miner_loop_error": "Erro no loop do minerador: {error}",
+      "fingerprint_checks_incomplete": "Verificacoes de fingerprint incompletas ou com falha",
+      "fingerprint_checks_complete": "Verificacoes de fingerprint concluidas",
+      "fingerprint_checks_failed": "Verificacoes de fingerprint falharam: {failed_checks}"
+    },
+    "network": {
+      "troubleshooting_title": "Solucao de problemas:",
+      "check_internet_connection": "1. Verifique sua conexao com a internet",
+      "verify_dns_working": "2. Verifique se o DNS funciona (tente: ping {node_url})",
+      "check_firewall_proxy": "3. Verifique firewall/proxy",
+      "node_may_be_offline": "4. O no pode estar temporariamente offline",
+      "node_syncing_maintenance": "1. O no pode estar sincronizando ou em manutencao",
+      "try_again_later": "2. Tente novamente mais tarde",
+      "check_node_dashboard": "3. Verifique o painel de status da RustChain",
+      "network_issue_detected": "Problema de rede detectado:",
+      "node_response_issue": "Problema de resposta do no:",
+      "network_error_title": "Erro de rede",
+      "warning_title": "Aviso",
+      "error_title": "Erro",
+      "success_title": "Sucesso"
+    },
+    "common": {
+      "error": "Erro",
+      "failed": "Falhou",
+      "success": "Sucesso",
+      "warning": "Aviso",
+      "info": "Informacao",
+      "confirm": "Confirmar",
+      "cancel": "Cancelar",
+      "ok": "OK",
+      "yes": "Sim",
+      "no": "Nao",
+      "loading": "Carregando...",
+      "retry": "Tentar novamente",
+      "close": "Fechar"
+    }
+  },
+  "messages": {
+    "wallet": {
+      "balance_display": "Saldo: {balance:.8f} RTC",
+      "wallet_id_label": "ID da carteira:",
+      "load_button": "Carregar",
+      "new_wallet_button": "Nova carteira",
+      "send_rtc_button": "Enviar RTC",
+      "to_label": "Destinatario:",
+      "amount_label": "Valor:",
+      "rtc_unit": "RTC",
+      "transaction_history": "Transacoes recentes"
+    },
+    "miner": {
+      "cpu_info": "CPU: {processor}",
+      "arch_info": "Arquitetura: {arch}",
+      "status_attesting": "Executando attestation...",
+      "status_enrolling": "Inscrevendo...",
+      "status_mining": "Minerando...",
+      "status_waiting": "Aguardando qualificacao...",
+      "status_error": "Erro: {message}"
+    },
+    "miner_consent": {
+      "title": "Consentimento de primeira execucao do RustChain Miner",
+      "body": "Antes de minerar, revise os comandos --dry-run, --show-payload e --test-only. O minerador enviara dados de fingerprint e attestation ao no RustChain. O hardware deve ser declarado honestamente; nao fabrique arquitetura, antiquity ou sinais de hardware. Recompensas em RTC nao sao garantidas.",
+      "prompt": "Digite SIM para confirmar que voce entende e deseja continuar:",
+      "affirmative": "SIM",
+      "rejected": "Consentimento nao confirmado. A mineracao nao sera iniciada."
+    }
+  }
+}

--- a/miners/linux/README.pt-BR.md
+++ b/miners/linux/README.pt-BR.md
@@ -1,0 +1,69 @@
+# RustChain Miner para Linux (pt-BR)
+
+Este guia localiza o fluxo do minerador Linux para falantes de portugues do Brasil. Ele preserva os termos de arte `RTC`, `attestation`, `antiquity` e `fingerprint`, porque esses termos aparecem no protocolo, nos logs e nas APIs.
+
+## Verificar antes de confiar
+
+Antes de minerar, rode os comandos de verificacao. Eles mostram o que sera enviado ao no e permitem revisar o payload sem iniciar uma sessao de mineracao.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Nao traduza nem altere as flags acima. `--dry-run`, `--show-payload` e `--test-only` sao comandos literais.
+
+## O que o minerador faz
+
+O minerador Linux detecta a maquina local, coleta sinais honestos de hardware e envia uma `attestation` ao no RustChain. Esses sinais formam um `fingerprint` de hardware usado para avaliar a `antiquity` da maquina e aplicar o multiplicador correto.
+
+O minerador nao deve fabricar arquitetura, idade do hardware, numero de nucleos, serial, hostname ou qualquer outro sinal. Se um sinal nao estiver disponivel, o comportamento correto e declarar a ausencia ou degradar a verificacao.
+
+## Instalar dependencias
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+Em distribuicoes Debian/Ubuntu, se `python3` ou `pip` nao estiverem instalados:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Executar o minerador
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Use uma carteira ou identificador que voce consiga reconhecer depois. O payout de bounties pode usar `github:seu-usuario`, mas a mineracao normal usa o valor passado em `--wallet`.
+
+## Primeiro consentimento
+
+Na primeira execucao interativa, o usuario deve confirmar explicitamente que entende:
+
+- o minerador envia `fingerprint` e dados de `attestation` ao no RustChain;
+- os comandos de verificacao devem ser usados antes da mineracao;
+- recompensas em `RTC` nao sao garantidas;
+- a maquina deve se apresentar honestamente, sem spoofing de hardware.
+
+Resposta afirmativa em portugues: `SIM`.
+
+## Referencia cruzada
+
+Para uma explicacao curta do protocolo e dos termos preservados, leia:
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/pt-BR/RUSTCHAIN_EXPLAINED.md)
+
+## Glossario
+
+| Termo | Como manter | Observacao |
+|---|---|---|
+| `RTC` | `RTC` | Token nativo da RustChain. |
+| `attestation` | `attestation` | Prova enviada ao no sobre a maquina. |
+| `antiquity` | `antiquity` | Idade/raridade relativa usada no multiplicador. |
+| `fingerprint` | `fingerprint` | Conjunto de sinais de hardware. |


### PR DESCRIPTION
## Summary
Adds a Portuguese (Brazil) localization pass for the miner documentation and first-run consent strings for rustchain-bounties#12790.

## Submission grammar
- target_lang: pt-BR
- files:
  - miners/linux/README.pt-BR.md
  - docs/pt-BR/RUSTCHAIN_EXPLAINED.md
  - i18n/pt-BR.json
- glossary / terms-of-art kept literal:
  - RTC
  - attestation
  - antiquity
  - fingerprint

## Acceptance notes
- Consent strings require explicit affirmative input: SIM.
- Verification commands are preserved literally: --dry-run, --show-payload, --test-only.
- RUSTCHAIN_EXPLAINED.md cross-reference is included from the Linux miner README and links back to the Linux README.
- No README badge/self-promo content is added.

## Validation
- python -m json.tool i18n/pt-BR.json
- PYTHONIOENCODING=utf-8 python i18n/validate_i18n.py
- git diff --cached --check

Requested bounty: 10 RTC to canonical account github:darlina-bounty-codex.