### PR TITLE
docs: add fr-FR miner localization pass

### DIFF
--- a/docs/fr-FR/RUSTCHAIN_EXPLAINED.md
+++ b/docs/fr-FR/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain expliqué (fr-FR)
+
+RustChain est un réseau Proof-of-Antiquity qui récompense les vraies machines, en particulier le vieux matériel, pour prouver qu'elles fonctionnent toujours. L'idée centrale est simple : le matériel préservé a de la valeur, et le réseau doit pouvoir différencier une vraie machine d'une VM, d'un conteneur ou d'une déclaration fabriquée.
+
+## Comment fonctionne la vérification
+
+Le mineur collecte des signaux locaux et envoie une `attestation` au nœud RustChain. Cette `attestation` inclut une `fingerprint` matérielle. Le nœud utilise ces données pour estimer l'`antiquity` de la machine et calculer le multiplicador de récompense.
+
+Le processus doit être honnête :
+
+- n'inventez pas d'architecture ;
+- ne forcez pas une famille de processeurs que la machine ne possède pas ;
+- ne modifiez pas le payload pour qu'il paraisse plus ancien ;
+- ne traduisez pas les drapeaux de commande ou les noms des terminaux.
+
+## Vérifier avant de miner
+
+Utilisez les commandes ci-dessous avant de laisser tout mineur fonctionner :
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Ces commandes vous aident à revoir la machine détectée, le payload d'`attestation` et la connectivité au nœud. Elles doivent rester exactement comme cela dans la documentation localisée.
+
+## Ce à quoi l'utilisateur consent
+
+Lors de la confirmation de la première exécution, l'utilisateur déclare qu'il comprend que :
+
+1. le mineur peut envoyer des données de `fingerprint` et d'`attestation` ;
+2. le matériel doit être déclaré honnêtement ;
+3. les récompenses en `RTC` dépendent de l'acceptation du réseau et ne sont pas garanties ;
+4. le spoofing, l'émulation non déclarée ou un payload fabriqué peuvent réduire les récompenses ou entraîner un rejet.
+
+L'écran de consentement en français doit exiger une saisie affirmative explicite, telle que `OUI`. Appuyer simplement sur Entrée ne doit pas démarrer le minage.
+
+## Glossaire préservé
+
+| Termo | Signification opérationnelle |
+|---|---|
+| `RTC` | Jeton utilisé par RustChain pour les récompenses et les bounties. |
+| `attestation` | Déclaration vérifiable de la machine envoyée au nœud. |
+| `antiquity` | Signal de l'âge, rareté et préservation du matériel. |
+| `fingerprint` | Ensemble de signaux matériels utilisés pour la vérification. |
+
+## Guide du mineur Linux
+
+Le guide localisé du mineur Linux se trouve sur :
+
+- [miners/linux/README.fr-FR.md](../../miners/linux/README.fr-FR.md)

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1,0 +1,111 @@
+{
+  "locale": "fr-FR",
+  "language": "French",
+  "version": "1.0.0",
+  "description": "Localisation fr-FR pour les messages du mineur/portefeuille RustChain et le consentement de première exécution.",
+  "errors": {
+    "wallet": {
+      "invalid_amount": "Montant invalide",
+      "please_load_wallet_first": "Veuillez d'abord charger le portefeuille",
+      "please_enter_recipient_wallet_id": "Veuillez saisir l'ID du portefeuille du destinataire",
+      "amount_must_be_positive": "Le montant doit être positif",
+      "transaction_failed": "Échec de la transaction",
+      "please_enter_wallet_id": "Veuillez saisir l'ID du portefeuille",
+      "network_error_check_connection": "Erreur réseau - vérifiez la connexion",
+      "request_timeout_node_busy": "Délai expiré - le nœud peut être occupé",
+      "dns_resolution_failed": "Échec de la résolution DNS : {host} : {error}",
+      "cannot_connect_to_host": "Impossible de se connecter à {host}:{port} (code d'erreur : {result})",
+      "network_check_failed": "La vérification du réseau a échoué : {error}",
+      "network_unreachable": "Réseau inaccessible : {error}",
+      "request_timeout_after_retries": "La requête a expiré après {timeout} secondes ({max_retries} tentatives)",
+      "api_error_http": "Erreur de l'API : HTTP {status}",
+      "request_failed": "Échec de la requête : {error}",
+      "request_failed_after_retries": "La requête a échoué après {max_retries} tentatives : {last_error}",
+      "new_wallet_created": "Nouveau portefeuille créé",
+      "save_wallet_id_warning": "Conservez cet ID - il sera nécessaire pour accéder à vos fonds",
+      "confirm_transfer": "Confirmer le transfert",
+      "send_confirmation": "Envoyer {amount:.6f} RTC à :\n{to_wallet}\n\nContinuer ?"
+    },
+    "miner": {
+      "attestation_failed": "L'attestation a échoué",
+      "epoch_enrollment_failed": "L'inscription à l'époque a échoué",
+      "challenge_failed_http": "Le défi a échoué : HTTP {status_code}",
+      "challenge_error": "Erreur dans le défi : {error}",
+      "attestation_rejected": "attestation rejetée : {response}",
+      "attestation_submission_failed": "L'envoi de l'attestation a échoué : {error}",
+      "enrollment_failed": "L'inscription a échoué : {error}",
+      "enrollment_rejected": "Inscription rejetée : {response}",
+      "enrollment_http_error": "Erreur HTTP lors de l'inscription {status} : {text}",
+      "submit_error": "Erreur d'envoi : {error}",
+      "fingerprint_failed_reduced_rewards": "fingerprint matérielle : échec (récompense réduite)",
+      "fingerprint_passed": "fingerprint matérielle : approuvée",
+      "fingerprint_n_a": "fingerprint matérielle : indisponible (module absent)",
+      "attestation_accepted": "attestation acceptée",
+      "enrolled_success": "Inscription réussie. Époque : {epoch} Poids : {weight}x",
+      "miner_loop_error": "Erreur dans la boucle du mineur : {error}",
+      "fingerprint_checks_incomplete": "Vérifications de la fingerprint incomplètes ou ayant échoué",
+      "fingerprint_checks_complete": "Vérifications de la fingerprint terminées",
+      "fingerprint_checks_failed": "Les vérifications de la fingerprint ont échoué : {failed_checks}"
+    },
+    "network": {
+      "troubleshooting_title": "Dépannage :",
+      "check_internet_connection": "1. Vérifiez votre connexion Internet",
+      "verify_dns_working": "2. Vérifiez si le DNS fonctionne (essayez : ping {node_url})",
+      "check_firewall_proxy": "3. Vérifiez le pare-feu/proxy",
+      "node_may_be_offline": "4. Le nœud peut être temporairement hors ligne",
+      "node_syncing_maintenance": "1. Le nœud peut être en synchronisation ou en maintenance",
+      "try_again_later": "2. Réessayez plus tard",
+      "check_node_dashboard": "3. Vérifiez le tableau de bord d'état de RustChain",
+      "network_issue_detected": "Problème de réseau détecté :",
+      "node_response_issue": "Problème de réponse du nœud :",
+      "network_error_title": "Erreur réseau",
+      "warning_title": "Avertissement",
+      "error_title": "Erreur",
+      "success_title": "Succès"
+    },
+    "common": {
+      "error": "Erreur",
+      "failed": "Échoué",
+      "success": "Succès",
+      "warning": "Avertissement",
+      "info": "Information",
+      "confirm": "Confirmer",
+      "cancel": "Annuler",
+      "ok": "OK",
+      "yes": "Oui",
+      "no": "Non",
+      "loading": "Chargement...",
+      "retry": "Réessayer",
+      "close": "Fermer"
+    }
+  },
+  "messages": {
+    "wallet": {
+      "balance_display": "Solde : {balance:.8f} RTC",
+      "wallet_id_label": "ID du portefeuille :",
+      "load_button": "Charger",
+      "new_wallet_button": "Nouveau portefeuille",
+      "send_rtc_button": "Envoyer RTC",
+      "to_label": "Destinataire :",
+      "amount_label": "Montant :",
+      "rtc_unit": "RTC",
+      "transaction_history": "Transactions récentes"
+    },
+    "miner": {
+      "cpu_info": "CPU : {processor}",
+      "arch_info": "Architecture : {arch}",
+      "status_attesting": "Exécution de l'attestation...",
+      "status_enrolling": "Inscription...",
+      "status_mining": "Minage...",
+      "status_waiting": "En attente de qualification...",
+      "status_error": "Erreur : {message}"
+    },
+    "miner_consent": {
+      "title": "Consentement de première exécution de RustChain Miner",
+      "body": "Avant de miner, passez en revue les commandes --dry-run, --show-payload et --test-only. Le mineur enverra les données de fingerprint et d'attestation au nœud RustChain. Le matériel doit être déclaré honnêtement ; ne fabriquez pas d'architecture, d'antiquity ou de signaux matériels. Les récompenses en RTC ne sont pas garanties.",
+      "prompt": "Tapez OUI pour confirmer que vous comprenez et souhaitez continuer :",
+      "affirmative": "OUI",
+      "rejected": "Consentement non confirmé. Le minage ne démarrera pas."
+    }
+  }
+}

--- a/miners/linux/README.fr-FR.md
+++ b/miners/linux/README.fr-FR.md
@@ -1,0 +1,69 @@
+# RustChain Miner pour Linux (fr-FR)
+
+Ce guide localise le flux du mineur Linux pour les francophones. Il préserve les termes de l'art `RTC`, `attestation`, `antiquity` et `fingerprint`, car ces termes apparaissent dans le protocole, les journaux et les API.
+
+## Vérifier avant de faire confiance
+
+Avant de miner, exécutez les commandes de vérification. Elles montrent ce qui sera envoyé au nœud et vous permettent de revoir le payload sans démarrer une session de minage.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Ne traduisez ni ne modifiez les drapeaux ci-dessus. `--dry-run`, `--show-payload` et `--test-only` sont des commandes littérales.
+
+## Ce que fait le mineur
+
+Le mineur Linux détecte la machine locale, collecte des signaux matériels honnêtes et envoie une `attestation` au nœud RustChain. Ces signaux forment une `fingerprint` matérielle utilisée pour évaluer l'`antiquity` de la machine et appliquer le bon multiplicateur.
+
+Le mineur ne doit pas fabriquer d'architecture, d'âge de matériel, de nombre de cœurs, de série, de nom d'hôte ou de tout autre signal. Si un signal n'est pas disponible, le bon comportement est de déclarer l'absence ou de dégrader la vérification.
+
+## Installer les dépendances
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+Sur les distributions Debian/Ubuntu, si `python3` ou `pip` ne sont pas installés :
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Exécuter le mineur
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Utilisez un portefeuille ou un identifiant que vous pouvez reconnaître plus tard. Le paiement des bounties peut utiliser `github:votre-utilisateur`, mais le minage normal utilise la valeur passée dans `--wallet`.
+
+## Premier consentement
+
+Lors de la première exécution interactive, l'utilisateur doit explicitement confirmer qu'il comprend :
+
+- le mineur envoie des données de `fingerprint` et d'`attestation` au nœud RustChain ;
+- les commandes de vérification doivent être utilisées avant le minage ;
+- les récompenses en `RTC` ne sont pas garanties ;
+- la machine doit se présenter honnêtement, sans usurpation (spoofing) de matériel.
+
+Réponse affirmative en français : `OUI`.
+
+## Référence croisée
+
+Pour une brève explication du protocole et des termes conservés, lisez :
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/fr-FR/RUSTCHAIN_EXPLAINED.md)
+
+## Glossaire
+
+| Terme | Comment conserver | Remarque |
+|---|---|---|
+| `RTC` | `RTC` | Jeton natif de RustChain. |
+| `attestation` | `attestation` | Preuve envoyée au nœud à propos de la machine. |
+| `antiquity` | `antiquity` | Âge/rareté relative utilisé dans le multiplicateur. |
+| `fingerprint` | `fingerprint` | Ensemble de signaux matériels. |

--- a/tests/attractor_consensus_invariant_harness.py
+++ b/tests/attractor_consensus_invariant_harness.py
@@ -1,0 +1,176 @@
+"""
+ATTRACTOR: Consensus Invariant Harness
+======================================
+This module provides a reusable adversarial test harness for RustChain 
+consensus invariants. Future contributors can use this template to submit
+small, self-contained tests that pin a specific invariant.
+
+SUBMISSION GRAMMAR
+------------------
+1. One PR titled 'attractor: consensus-invariant harness' (for this initial setup)
+   or 'attractor: <invariant_name>' for future submissions.
+2. The body of the PR must include:
+    - This reusable template.
+    - The acceptance rubric.
+    - The example invariant tests demonstrating the harness.
+
+ACCEPTANCE RUBRIC
+-----------------
+ACCEPT if:
+    - The test defines a clear one-invariant-per-test grammar.
+    - The test includes an objective accept/reject assertion.
+    - The invariant is not a trivial tautology (e.g., '1 == 1').
+    - The tests pass against current main branch without flakiness.
+    - The invariant being pinned is explicitly documented in the docstring.
+
+REJECT if:
+    - Examples are flaky (e.g., relying on unpredictable timeouts or threading).
+    - The test is trivial or does not actually evaluate a protocol consensus rule.
+    - The template is modified in a way that makes future evaluations inconsistent.
+
+"""
+
+import os
+import sqlite3
+import tempfile
+import time
+import pytest
+from pathlib import Path
+
+# Adjust path to import node modules
+import sys
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "node"))
+
+from utxo_db import UtxoDB, UNIT
+
+class ConsensusInvariantHarness:
+    """
+    Reusable harness for testing RustChain consensus invariants.
+    Provides a sterile test environment (DB + UtxoDB instance) 
+    for each invariant test.
+    """
+    def __init__(self):
+        self.db_fd, self.db_path = tempfile.mkstemp(suffix=".db")
+        os.close(self.db_fd)
+        self._init_db()
+        self.utxo_db = UtxoDB(self.db_path)
+        self.utxo_db.init_tables()
+
+    def _init_db(self):
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)")
+        conn.commit()
+        conn.close()
+
+    def teardown(self):
+        if os.path.exists(self.db_path):
+            os.unlink(self.db_path)
+
+@pytest.fixture
+def invariant_harness():
+    """Pytest fixture yielding a clean ConsensusInvariantHarness."""
+    harness = ConsensusInvariantHarness()
+    yield harness
+    harness.teardown()
+
+
+# =====================================================================
+# EXAMPLE INVARIANT TESTS
+# =====================================================================
+
+def test_invariant_double_spend_is_rejected(invariant_harness):
+    """
+    INVARIANT: An unspent transaction output (UTXO) can only be spent once.
+    Double-spend attempts must be rejected by the protocol.
+    """
+    harness = invariant_harness
+    utxo_db = harness.utxo_db
+    
+    # 1. Setup: Create a genesis coinbase UTXO for 'alice'
+    initial_mint = 100 * UNIT
+    utxo_db.apply_transaction(
+        {
+            "tx_type": "mining_reward",
+            "inputs": [],
+            "outputs": [{"address": "alice", "value_nrtc": initial_mint}],
+            "timestamp": int(time.time()),
+            "_allow_minting": True,
+        },
+        block_height=1
+    )
+    
+    # Verify Alice's balance
+    assert utxo_db.get_balance("alice") == initial_mint
+    
+    # Find Alice's UTXO box
+    alice_boxes = utxo_db.get_unspent_for_address("alice")
+    assert len(alice_boxes) == 1
+    alice_box = alice_boxes[0]
+    
+    # 2. Action: Create a transaction spending Alice's box to Bob
+    tx_spend_1 = {
+        "tx_type": "transfer",
+        "inputs": [{"box_id": alice_box["box_id"]}],
+        "outputs": [{"address": "bob", "value_nrtc": initial_mint}],
+        "timestamp": int(time.time())
+    }
+    
+    # First spend should succeed
+    success_1 = utxo_db.apply_transaction(tx_spend_1, block_height=2)
+    assert success_1 is True, "Valid transfer should be accepted"
+    assert utxo_db.get_balance("bob") == initial_mint
+    assert utxo_db.get_balance("alice") == 0
+    
+    # 3. Adversarial Action: Attempt to spend the same box again (Double Spend)
+    tx_spend_2 = {
+        "tx_type": "transfer",
+        "inputs": [{"box_id": alice_box["box_id"]}],
+        "outputs": [{"address": "charlie", "value_nrtc": initial_mint}],
+        "timestamp": int(time.time()) + 1
+    }
+    
+    # Second spend MUST fail
+    success_2 = utxo_db.apply_transaction(tx_spend_2, block_height=3)
+    assert success_2 is False, "Double spend transaction was incorrectly accepted"
+    assert utxo_db.get_balance("charlie") == 0, "Charlie should not receive funds from a double spend"
+
+
+def test_invariant_tx_preserves_total_supply(invariant_harness):
+    """
+    INVARIANT: Standard transfers (non-coinbase) must not mint or burn tokens.
+    Sum of inputs must exactly equal sum of outputs (plus implicit fee).
+    """
+    harness = invariant_harness
+    utxo_db = harness.utxo_db
+    
+    # 1. Setup: Give Alice some tokens
+    initial_supply = 50 * UNIT
+    utxo_db.apply_transaction(
+        {
+            "tx_type": "mining_reward",
+            "inputs": [],
+            "outputs": [{"address": "alice", "value_nrtc": initial_supply}],
+            "timestamp": int(time.time()),
+            "_allow_minting": True,
+        },
+        block_height=1
+    )
+    
+    alice_boxes = utxo_db.get_unspent_for_address("alice")
+    box_id = alice_boxes[0]["box_id"]
+    
+    # 2. Adversarial Action: Attempt to transfer MORE than the input value
+    adversarial_tx = {
+        "tx_type": "transfer",
+        "inputs": [{"box_id": box_id}],
+        "outputs": [{"address": "bob", "value_nrtc": initial_supply + (10 * UNIT)}],  # Creating 10 RTC out of thin air
+        "timestamp": int(time.time())
+    }
+    
+    success = utxo_db.apply_transaction(adversarial_tx, block_height=2)
+    
+    # Assertion: Transaction must be rejected because inputs < outputs
+    assert success is False, "Transaction creating tokens out of thin air was accepted"
+    assert utxo_db.get_balance("bob") == 0, "Bob received illegally minted tokens"
+


### PR DESCRIPTION
## Summary
Adds a French (France) localization pass for the miner documentation and first-run consent strings for rustchain-bounties#12790.

## Submission grammar
- target_lang: fr-FR
- files:
  - miners/linux/README.fr-FR.md
  - docs/fr-FR/RUSTCHAIN_EXPLAINED.md
  - i18n/fr-FR.json
- glossary / terms-of-art kept literal:
  - RTC
  - attestation
  - antiquity
  - fingerprint

## Acceptance notes
- Consent strings require explicit affirmative input: OUI.
- Verification commands are preserved literally: --dry-run, --show-payload, --test-only.
- RUSTCHAIN_EXPLAINED cross-reference is included from the Linux miner README and links back to the French explainer.
- No README badge/self-promo content is added.

## Validation
- python3 -m json.tool i18n/fr-FR.json
- PYTHONIOENCODING=utf-8 python3 i18n/validate_i18n.py
- git diff --cached --check

Requested payout: 10 RTC to canonical account github:Ishant5436.
