### PR TITLE
feat(rip-202): B0 canonical block-format contract (pure, dormant)

### DIFF
--- a/node/rip0202_block_format.py
+++ b/node/rip0202_block_format.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+RIP-202 — B0 block-format canonical contract (PURE, dormant).
+
+B0 widens each committed block attestation from the current
+``{miner, arch, family, timestamp}`` (insufficient to re-derive the anti-VM
+weight) to carry the full ``device`` + ``fingerprint`` + ``fingerprint_passed``
+that ``derive_verified_device`` consumes (RIP-202 operator decision D3 =
+commit full raw evidence for fully trustless re-derivation), and commits the
+``slot`` so a block's epoch is a deterministic function of *chain* data rather
+than wall-clock (``current_slot()`` reads ``time.time()`` and is unsafe on
+replay — found in B2 grounding).
+
+This module is the PURE, side-effect-free canonical contract: the record shape,
+the deterministic attestations hash over the widened records, and the
+slot→epoch map. It is NOT wired into ``produce_block`` / ``_apply_blocks`` — that
+wiring is the gated hard fork (ships dormant; byte-identical pre-activation).
+
+Consensus-determinism guarantees (the reasons this is its own pinned module):
+  * TOTAL ORDER for hashing — (miner, timestamp, content-digest) — so two
+    attestations from the same miner cannot reorder by input order and diverge
+    the hash across nodes (the live ``compute_attestations_hash`` sorts by miner
+    ONLY; B0 tightens this).
+  * CANONICAL JSON — sort_keys, tight separators, and ``allow_nan=False``.
+    CPython's float ``repr`` is platform-independent (short-repr/David Gay
+    dtoa), so a committed IEEE-754 double hashes identically on big-endian
+    PowerPC and x86. Non-finite floats (NaN/Inf) are NOT valid consensus data
+    and are rejected at build time (fail closed) rather than serialised to the
+    invalid, non-round-tripping ``NaN`` token.
+  * FROZEN ON FIRST USE — the field set, encoding, and ``BLOCK_VERSION`` become
+    an immutable consensus contract once any block is produced under B0; change
+    them only behind the on-chain activation height (PREREQ-A).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any, Dict, List, Mapping
+
+# Block-format version stamped in the header once B0 is active. produce_block
+# sets header.version = B0_BLOCK_VERSION at/after the activation epoch; older
+# blocks keep version=1 and validate under the legacy hash, so replay of
+# pre-activation history is byte-identical (no retroactive fork).
+B0_BLOCK_VERSION = 2
+
+# Must match the node's epoch length (BLOCKS_PER_EPOCH). Kept here as the
+# canonical divisor for the slot→epoch map; the wiring step asserts equality
+# with the node constant at import.
+BLOCKS_PER_EPOCH = 144
+
+# The exact committed fields, in the canonical record. Pinned: adding/removing
+# a field is a consensus change gated by activation.
+B0_ATTESTATION_FIELDS = ("miner", "device", "fingerprint", "fingerprint_passed", "timestamp")
+
+
+class B0FormatError(ValueError):
+    """Raised when an attestation cannot be canonicalised into a B0 record."""
+
+
+def _assert_finite(obj: Any, path: str = "") -> None:
+    """Recursively reject non-finite floats (NaN/+-Inf) anywhere in the payload.
+
+    Non-finite values have no valid canonical JSON token (json emits the
+    non-standard ``NaN``/``Infinity``), would not round-trip, and are never
+    legitimate fingerprint/device data — reject at build time, fail closed.
+    """
+    if isinstance(obj, float):
+        if not math.isfinite(obj):
+            raise B0FormatError(f"non-finite float at {path or '<root>'}")
+    elif isinstance(obj, Mapping):
+        for k, v in obj.items():
+            _assert_finite(v, f"{path}.{k}")
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            _assert_finite(v, f"{path}[{i}]")
+
+
+def build_b0_attestation(
+    miner: str,
+    device: Mapping,
+    fingerprint: Mapping,
+    fingerprint_passed: bool,
+    timestamp: int,
+) -> Dict[str, Any]:
+    """Construct one canonical B0 committed-attestation record (validated).
+
+    Fail closed: a non-str/empty miner, non-dict device/fingerprint, non-bool
+    pass flag, non-int timestamp, or any non-finite float raises B0FormatError
+    so a malformed attestation never enters a block (and thus the hash).
+    """
+    if not isinstance(miner, str) or not miner:
+        raise B0FormatError("miner must be a non-empty str")
+    if not isinstance(device, Mapping):
+        raise B0FormatError("device must be a dict")
+    if not isinstance(fingerprint, Mapping):
+        raise B0FormatError("fingerprint must be a dict")
+    if not isinstance(fingerprint_passed, bool):
+        raise B0FormatError("fingerprint_passed must be a bool")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int):
+        raise B0FormatError("timestamp must be an int")
+    device = dict(device)
+    fingerprint = dict(fingerprint)
+    _assert_finite(device, "device")
+    _assert_finite(fingerprint, "fingerprint")
+    return {
+        "miner": miner,
+        "device": device,
+        "fingerprint": fingerprint,
+        "fingerprint_passed": fingerprint_passed,
+        "timestamp": timestamp,
+    }
+
+
+def _canonical_bytes(obj: Any) -> bytes:
+    """Canonical JSON bytes: sorted keys, tight separators, no non-finite floats."""
+    return json.dumps(
+        obj, separators=(",", ":"), sort_keys=True, allow_nan=False
+    ).encode("utf-8")
+
+
+def _attestation_digest(att: Mapping) -> str:
+    """Deterministic content digest of a B0 record (hash-order tiebreaker)."""
+    projected = {k: att.get(k) for k in B0_ATTESTATION_FIELDS}
+    return hashlib.sha256(_canonical_bytes(projected)).hexdigest()
+
+
+def canonical_b0_attestations_hash(attestations: List[Mapping]) -> str:
+    """Deterministic blake2b-256 over the B0 attestation set.
+
+    TOTAL ORDER (miner, timestamp, content-digest) so the hash is independent of
+    input order and stable for same-(miner,timestamp) records. Empty set hashes
+    to the all-zero sentinel, matching the legacy ``compute_attestations_hash``.
+    """
+    if not attestations:
+        return "0" * 64
+    ordered = sorted(
+        attestations,
+        key=lambda a: (
+            str(a.get("miner", "")),
+            a.get("timestamp", 0) if isinstance(a.get("timestamp"), int)
+            and not isinstance(a.get("timestamp"), bool) else 0,
+            _attestation_digest(a),
+        ),
+    )
+    # Hash the canonical projection of each record (only the pinned fields), so
+    # incidental extra keys can never perturb the consensus hash.
+    projected = [{k: a.get(k) for k in B0_ATTESTATION_FIELDS} for a in ordered]
+    return hashlib.blake2b(_canonical_bytes(projected), digest_size=32).hexdigest()
+
+
+def slot_to_epoch(slot: int, blocks_per_epoch: int = BLOCKS_PER_EPOCH) -> int:
+    """Deterministic epoch for a committed slot. Pure; no wall-clock."""
+    if isinstance(slot, bool) or not isinstance(slot, int) or slot < 0:
+        raise B0FormatError("slot must be a non-negative int")
+    if blocks_per_epoch < 1:
+        raise B0FormatError("blocks_per_epoch must be >= 1")
+    return slot // blocks_per_epoch
+
+
+def block_epoch(header: Mapping, blocks_per_epoch: int = BLOCKS_PER_EPOCH) -> int:
+    """Epoch of a block from its committed ``slot`` header field (B0 adds it).
+
+    Fail closed: a header lacking a valid committed slot raises, rather than
+    silently falling back to wall-clock (which would diverge on replay).
+    """
+    slot = header.get("slot")
+    if isinstance(slot, bool) or not isinstance(slot, int):
+        raise B0FormatError("header missing committed integer 'slot' (B0)")
+    return slot_to_epoch(slot, blocks_per_epoch)

--- a/node/tests/test_rip0202_block_format.py
+++ b/node/tests/test_rip0202_block_format.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-202 B0 canonical block-format contract — unit tests."""
+import json
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _d in (os.path.dirname(_HERE), _HERE):  # ../ (repo node/) first, then . (flat staging)
+    if os.path.exists(os.path.join(_d, "rip0202_block_format.py")):
+        sys.path.insert(0, _d)
+        break
+import rip0202_block_format as b0  # noqa: E402
+
+
+# ---- record construction / fail-closed validation -------------------------
+DEV = {"machine": "x86_64", "cpu_brand": "Intel i7"}
+FP = {"simd_identity": {"data": {}}, "clock_drift": {"data": {"cv": 0.0931}}}
+
+
+def test_build_valid_record():
+    r = b0.build_b0_attestation("miner-a", DEV, FP, True, 1000)
+    assert set(r) == set(b0.B0_ATTESTATION_FIELDS)
+    assert r["miner"] == "miner-a" and r["fingerprint_passed"] is True
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"miner": ""}, {"miner": 1}, {"device": "x"}, {"fingerprint": None},
+    {"fingerprint_passed": 1}, {"fingerprint_passed": "true"},
+    {"timestamp": "10"}, {"timestamp": True},
+])
+def test_build_rejects_malformed(kwargs):
+    base = dict(miner="m", device=DEV, fingerprint=FP, fingerprint_passed=True, timestamp=1)
+    base.update(kwargs)
+    with pytest.raises(b0.B0FormatError):
+        b0.build_b0_attestation(**base)
+
+
+def test_build_rejects_non_finite_float():
+    for bad in ({"x": float("nan")}, {"nested": {"y": float("inf")}}, {"arr": [1.0, float("-inf")]}):
+        with pytest.raises(b0.B0FormatError):
+            b0.build_b0_attestation("m", DEV, bad, True, 1)
+
+
+# ---- canonical hash determinism -------------------------------------------
+def _att(miner, ts=1000, passed=True, fp=None):
+    return b0.build_b0_attestation(miner, DEV, fp or FP, passed, ts)
+
+
+def test_empty_hash_sentinel():
+    assert b0.canonical_b0_attestations_hash([]) == "0" * 64
+
+
+def test_hash_deterministic_and_order_independent():
+    a, b, c = _att("c", 3), _att("a", 1), _att("b", 2)
+    h1 = b0.canonical_b0_attestations_hash([a, b, c])
+    h2 = b0.canonical_b0_attestations_hash([c, b, a])  # shuffled
+    h3 = b0.canonical_b0_attestations_hash([b, c, a])
+    assert h1 == h2 == h3 and len(h1) == 64
+
+
+def test_same_miner_same_ts_tiebreak_is_total_order():
+    """Two records, same miner+ts, different content -> deterministic order."""
+    x = b0.build_b0_attestation("dup", DEV, {"k": 1}, True, 5)
+    y = b0.build_b0_attestation("dup", DEV, {"k": 2}, True, 5)
+    assert b0.canonical_b0_attestations_hash([x, y]) == b0.canonical_b0_attestations_hash([y, x])
+
+
+def test_hash_ignores_incidental_extra_keys():
+    a = _att("m", 1)
+    a_extra = dict(a)
+    a_extra["_debug"] = "ignore me"  # not a pinned field
+    assert b0.canonical_b0_attestations_hash([a]) == b0.canonical_b0_attestations_hash([a_extra])
+
+
+def test_float_round_trip_stable_hash():
+    """The cross-arch claim: a committed float hashes identically after a
+    JSON deserialise/serialise round-trip (CPython short-repr is stable)."""
+    fp = {"clock_drift": {"data": {"cv": 0.09313725490196078, "lat": [1.5, 2.25, 0.125]}}}
+    a = b0.build_b0_attestation("m", DEV, fp, True, 1)
+    a_round = json.loads(json.dumps(a))  # simulate commit -> deserialize on apply
+    assert b0.canonical_b0_attestations_hash([a]) == b0.canonical_b0_attestations_hash([a_round])
+
+
+def test_passed_flag_changes_hash():
+    assert b0.canonical_b0_attestations_hash([_att("m", 1, passed=True)]) != \
+           b0.canonical_b0_attestations_hash([_att("m", 1, passed=False)])
+
+
+# ---- slot -> epoch --------------------------------------------------------
+def test_slot_to_epoch():
+    assert b0.slot_to_epoch(0) == 0
+    assert b0.slot_to_epoch(143) == 0
+    assert b0.slot_to_epoch(144) == 1
+    assert b0.slot_to_epoch(289) == 2
+
+
+@pytest.mark.parametrize("bad", [-1, True, "5", 1.0, None])
+def test_slot_to_epoch_rejects_bad(bad):
+    with pytest.raises(b0.B0FormatError):
+        b0.slot_to_epoch(bad)
+
+
+def test_block_epoch_reads_committed_slot():
+    assert b0.block_epoch({"height": 200, "slot": 288}) == 2
+
+
+def test_block_epoch_fails_closed_without_slot():
+    """No wall-clock fallback: a header without a committed slot must raise."""
+    for hdr in ({"height": 200}, {"slot": "288"}, {"slot": True}):
+        with pytest.raises(b0.B0FormatError):
+            b0.block_epoch(hdr)
+
+
+def test_block_version_constant():
+    assert b0.B0_BLOCK_VERSION == 2


### PR DESCRIPTION
## BCOS Checklist

- [x] Tier label: **BCOS-L1** (pure module + tests; NOT wired into any consensus path)
- [x] SPDX header present on both new files (`# SPDX-License-Identifier: MIT`)
- [x] Test evidence below

## What Changed

Adds the **RIP-202 B0** canonical block-format contract — the deterministic foundation that B2 (materialize enrollment on block apply) builds on. Two new files, **no production code wired**:

- `node/rip0202_block_format.py` — pure module
- `node/tests/test_rip0202_block_format.py` — 25 unit tests

### Why
B1 (`node/rip0202_enrollment.py`, #6692) re-derives producer enrollment from committed attestations, but the current committed record is only `{miner, arch, family, timestamp}` (see `get_attestations_for_block`, `rustchain_block_producer.py:447`) — **insufficient** to re-run `derive_verified_device`. B0 defines the widened record (`device` + `fingerprint` + `fingerprint_passed`, per operator decision D3) plus a deterministic hash and a `slot`→`epoch` map (`current_slot()` reads wall-clock and is unsafe on replay).

### What's in the module
- `build_b0_attestation(...)` — fail-closed canonical record builder (rejects bad types **and non-finite floats** — NaN/Inf have no valid canonical-JSON token).
- `canonical_b0_attestations_hash(...)` — **total order** `(miner, timestamp, content-digest)` (tightens the live `compute_attestations_hash`, which sorts by miner only), `allow_nan=False`, projects to pinned fields so incidental keys can't perturb the hash. CPython's platform-independent float `repr` keeps the hash identical on big-endian PowerPC and x86.
- `slot_to_epoch` / `block_epoch` — pure, **no wall-clock**; `block_epoch` fails closed without a committed `slot`.
- `B0_BLOCK_VERSION = 2` — the version the (future, gated) wire step stamps; pre-activation blocks keep v1 and replay byte-identically.

### Scope / safety
This PR is **pure logic only**. It does **not** modify `produce_block`, `_apply_blocks`, the attestation handler, or the schema. Wiring the widened format in is a separate **version-gated hard fork** that ships dormant and flips only via the RIP-202 on-chain activation height. So this is safe to merge now as the pinned canonical contract (mirrors how B1 landed dormant in #6692).

## Testing / Evidence

```
$ python3 -m pytest node/tests/test_rip0202_block_format.py -q
.........................                                                [100%]
25 passed in 0.04s
```

Covers: record construction + fail-closed validation (8 malformed cases), non-finite-float rejection, empty-set sentinel, hash determinism + order-independence, same-(miner,timestamp) total-order tiebreak, pinned-field projection, **float round-trip hash stability** (the cross-arch guarantee), pass-flag sensitivity, `slot_to_epoch` + bad-input rejection, `block_epoch` fail-closed-without-slot, version constant.

Tests are path-robust (resolve the module from `../` in repo layout or alongside in staging; no extra deps beyond `pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)