### PR TITLE
feat(rip-202): B0-persist — attestation_evidence capture (additive, dormant)

### DIFF
--- a/node/rip0202_evidence.py
+++ b/node/rip0202_evidence.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+RIP-202 — B0-persist: raw attestation-evidence capture (additive, dormant).
+
+Today ``/attest/submit`` derives ``device_family`` / ``device_arch`` /
+``fingerprint_passed`` and DISCARDS the raw ``device`` + ``fingerprint`` dicts;
+``miner_attest_recent`` never stores them. The producer therefore can't commit
+the evidence B1 needs to re-derive enrollment (B0). This module captures that
+evidence in an ADDITIVE side table so the producer can later read it.
+
+Design:
+  * PURE-except-DB: a caller supplies the connection; no global state, no
+    wall-clock (``ts`` is passed in by the caller, i.e. the attestation ts).
+  * FAIL CLOSED at capture: records are validated/canonicalised through
+    ``rip0202_block_format.build_b0_attestation`` (rejects bad types + non-finite
+    floats) BEFORE storage, so malformed evidence never persists and a later
+    committed block can't carry it.
+  * NON-DISRUPTIVE: a new ``attestation_evidence`` table; nothing existing reads
+    or writes it. Wiring the one ``record_attestation_evidence`` call into
+    ``_submit_attestation_impl`` and the join into ``get_attestations_for_block``
+    are separate, low-risk follow-ups; this module ships unwired.
+  * Canonical JSON storage (sort_keys, allow_nan=False) so device/fingerprint
+    round-trip byte-stably for the B0 hash.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict, List, Mapping, Optional
+
+from rip0202_block_format import build_b0_attestation, B0FormatError
+
+ATTESTATION_EVIDENCE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS attestation_evidence (
+    miner              TEXT PRIMARY KEY,
+    device_json        TEXT NOT NULL,
+    fingerprint_json   TEXT NOT NULL,
+    fingerprint_passed INTEGER NOT NULL,
+    ts                 INTEGER NOT NULL
+)
+"""
+
+
+def ensure_attestation_evidence_schema(conn: sqlite3.Connection) -> None:
+    """Create the evidence table if absent. Call once at DB init (DDL implicit-
+    commits — do NOT call inside a consensus transaction)."""
+    conn.execute(ATTESTATION_EVIDENCE_SCHEMA)
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True, allow_nan=False)
+
+
+def record_attestation_evidence(
+    conn: sqlite3.Connection,
+    miner: str,
+    device: Mapping,
+    fingerprint: Mapping,
+    fingerprint_passed: bool,
+    ts: int,
+) -> None:
+    """Validate (fail-closed) and upsert one miner's raw attestation evidence.
+
+    Latest-evidence-per-miner (PRIMARY KEY miner, INSERT OR REPLACE), mirroring
+    ``miner_attest_recent``'s per-miner keying. Raises B0FormatError on malformed
+    input so the caller can reject the attestation rather than store junk.
+    """
+    rec = build_b0_attestation(miner, device, fingerprint, fingerprint_passed, ts)
+    conn.execute(
+        "INSERT OR REPLACE INTO attestation_evidence "
+        "(miner, device_json, fingerprint_json, fingerprint_passed, ts) VALUES (?,?,?,?,?)",
+        (
+            rec["miner"],
+            _canonical(rec["device"]),
+            _canonical(rec["fingerprint"]),
+            1 if rec["fingerprint_passed"] else 0,
+            rec["timestamp"],
+        ),
+    )
+
+
+def load_committed_attestations(
+    conn: sqlite3.Connection,
+    min_ts: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Rebuild B0 attestation records from stored evidence (for the producer).
+
+    Returns the widened ``build_b0_attestation`` records, sorted by miner for a
+    stable base order. Rows that fail to parse/validate are skipped (fail
+    closed) so one corrupt row can't break block production. ``min_ts`` mirrors
+    the producer's ATTESTATION_TTL window when provided.
+    """
+    sql = "SELECT miner, device_json, fingerprint_json, fingerprint_passed, ts FROM attestation_evidence"
+    params: tuple = ()
+    if min_ts is not None:
+        sql += " WHERE ts >= ?"
+        params = (min_ts,)
+    sql += " ORDER BY miner"
+    out: List[Dict[str, Any]] = []
+    for miner, dev_j, fp_j, passed, ts in conn.execute(sql, params).fetchall():
+        try:
+            device = json.loads(dev_j)
+            fingerprint = json.loads(fp_j)
+            out.append(
+                build_b0_attestation(miner, device, fingerprint, bool(passed), int(ts))
+            )
+        except (json.JSONDecodeError, B0FormatError, TypeError, ValueError):
+            continue  # fail closed: skip a corrupt/invalid row
+    return out

--- a/node/tests/test_rip0202_evidence.py
+++ b/node/tests/test_rip0202_evidence.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-202 B0-persist attestation-evidence capture — unit tests."""
+import os
+import sqlite3
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _d in (os.path.dirname(_HERE), _HERE):  # ../ (repo node/) first, then . (flat)
+    if os.path.exists(os.path.join(_d, "rip0202_evidence.py")):
+        sys.path.insert(0, _d)
+        break
+import rip0202_evidence as ev  # noqa: E402
+import rip0202_block_format as b0  # noqa: E402
+
+DEV = {"machine": "x86_64", "cpu_brand": "Intel i7"}
+FP = {"clock_drift": {"data": {"cv": 0.0931}}, "simd_identity": {"data": {}}}
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    ev.ensure_attestation_evidence_schema(c)
+    yield c
+    c.close()
+
+
+def test_schema_idempotent(conn):
+    ev.ensure_attestation_evidence_schema(conn)  # second call is a no-op
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(attestation_evidence)")]
+    assert cols == ["miner", "device_json", "fingerprint_json", "fingerprint_passed", "ts"]
+
+
+def test_record_and_load_round_trip(conn):
+    ev.record_attestation_evidence(conn, "miner-a", DEV, FP, True, 1000)
+    recs = ev.load_committed_attestations(conn)
+    assert recs == [b0.build_b0_attestation("miner-a", DEV, FP, True, 1000)]
+
+
+def test_record_fail_closed_on_malformed(conn):
+    with pytest.raises(b0.B0FormatError):
+        ev.record_attestation_evidence(conn, "", DEV, FP, True, 1)          # empty miner
+    with pytest.raises(b0.B0FormatError):
+        ev.record_attestation_evidence(conn, "m", {"x": float("nan")}, FP, True, 1)  # non-finite
+    assert conn.execute("SELECT COUNT(*) FROM attestation_evidence").fetchone()[0] == 0
+
+
+def test_upsert_latest_wins(conn):
+    ev.record_attestation_evidence(conn, "dup", DEV, {"k": 1}, True, 100)
+    ev.record_attestation_evidence(conn, "dup", DEV, {"k": 2}, False, 200)
+    rows = conn.execute("SELECT COUNT(*) FROM attestation_evidence").fetchone()[0]
+    assert rows == 1
+    rec = ev.load_committed_attestations(conn)[0]
+    assert rec["fingerprint"] == {"k": 2} and rec["fingerprint_passed"] is False and rec["timestamp"] == 200
+
+
+def test_load_skips_corrupt_rows(conn):
+    ev.record_attestation_evidence(conn, "good", DEV, FP, True, 10)
+    # inject a corrupt row directly (simulates legacy/garbage data)
+    conn.execute(
+        "INSERT INTO attestation_evidence VALUES (?,?,?,?,?)",
+        ("bad", "{not json", "{}", 1, 20),
+    )
+    recs = ev.load_committed_attestations(conn)
+    assert [r["miner"] for r in recs] == ["good"]  # corrupt skipped, no crash
+
+
+def test_load_min_ts_filter(conn):
+    ev.record_attestation_evidence(conn, "old", DEV, FP, True, 100)
+    ev.record_attestation_evidence(conn, "new", DEV, FP, True, 500)
+    recs = ev.load_committed_attestations(conn, min_ts=300)
+    assert [r["miner"] for r in recs] == ["new"]
+
+
+def test_loaded_records_hash_equals_original(conn):
+    """Evidence round-trip preserves the B0 attestations hash (storage is
+    byte-stable through canonical JSON) — ties B0-persist to the B0 contract."""
+    originals = [
+        b0.build_b0_attestation("a", DEV, FP, True, 1),
+        b0.build_b0_attestation("b", DEV, {"lat": [1.5, 0.125]}, True, 2),
+    ]
+    for r in originals:
+        ev.record_attestation_evidence(conn, r["miner"], r["device"], r["fingerprint"],
+                                       r["fingerprint_passed"], r["timestamp"])
+    loaded = ev.load_committed_attestations(conn)
+    assert b0.canonical_b0_attestations_hash(loaded) == b0.canonical_b0_attestations_hash(originals)


### PR DESCRIPTION
## BCOS Checklist

- [x] Tier label: **BCOS-L1** (additive side table + pure-except-DB helpers; unwired)
- [x] SPDX header on both new files
- [x] Test evidence below

> **Stacked PR:** based on `rip0202-b0-block-format` (#6761), which it imports (`build_b0_attestation`). Merge #6761 first, then this re-targets `main` cleanly.

## What Changed

**RIP-202 B0-persist** — capture the raw attestation evidence the producer needs to commit (B0). Two new files, **no production code wired**:

- `node/rip0202_evidence.py`
- `node/tests/test_rip0202_evidence.py` — 7 tests

### Why
`/attest/submit` (`_submit_attestation_impl`) derives `device_family`/`device_arch`/`fingerprint_passed` and **discards** the raw `device` + `fingerprint`; `miner_attest_recent` never stores them. So the producer can't commit the evidence B1 re-derives enrollment from. This adds an **additive `attestation_evidence` side table** + capture/load helpers.

### What's in the module
- `ensure_attestation_evidence_schema` — additive table (nothing existing reads/writes it).
- `record_attestation_evidence(...)` — **fail-closed at capture**: validates through `build_b0_attestation` (rejects bad types + non-finite floats) before storing canonical JSON; latest-per-miner upsert (mirrors `miner_attest_recent` keying).
- `load_committed_attestations(...)` — rebuilds B0 records for the producer; skips corrupt rows (fail closed); optional `min_ts` window (mirrors `ATTESTATION_TTL`).

### Scope / safety
Purely additive. The one-line `record_attestation_evidence` call into `_submit_attestation_impl` and the join into `get_attestations_for_block` are **separate low-risk follow-ups** — this module ships **unwired**, so it changes no behaviour.

## Testing / Evidence

```
$ python3 -m pytest node/tests/test_rip0202_evidence.py -q
.......                                                                  [100%]
7 passed
```

Covers: schema idempotency, record↔load round-trip, fail-closed on malformed/non-finite (nothing persisted), latest-wins upsert, corrupt-row skip on load, `min_ts` filter, and **loaded-records B0 hash == originals** (ties B0-persist to the #6761 canonical contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)