### PR TITLE
security(api): redact internal exception details from error responses (#3202)

### DIFF
--- a/node/claims_settlement.py
+++ b/node/claims_settlement.py
@@ -915,7 +915,7 @@ def get_settlement_stats(
         print(f"[SETTLEMENT] Error getting stats: {e}")
         return {
             "period_days": days,
-            "error": str(e)
+            "error": "internal_error"
         }
 
 

--- a/node/fingerprint_checks.py
+++ b/node/fingerprint_checks.py
@@ -885,7 +885,8 @@ def validate_all_checks(include_rom_check: bool = True) -> Tuple[bool, Dict]:
             passed, data = func()
         except Exception as e:
             passed = False
-            data = {"error": str(e)}
+            print(f"[FINGERPRINT] check error: {e!r}")
+            data = {"error": "internal_error"}
         results[key] = {"passed": passed, "data": data}
         if not passed:
             all_passed = False

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6173,7 +6173,8 @@ def gov_rotate_approve():
             sig = bytes.fromhex(sig_hex.replace("0x",""))
             nacl.signing.VerifyKey(pk).verify(msg, sig)
         except Exception as e:
-            return jsonify({"ok": False, "reason": "bad_signature", "error": str(e)}), 400
+            print(f"[ERROR] signature verify failed: {e!r}")
+            return jsonify({"ok": False, "reason": "bad_signature", "error": "verification_failed"}), 400
 
         db.execute("""INSERT OR IGNORE INTO gov_rotation_approvals
                       (epoch_effective, signer_id, sig_hex, approved_ts)
@@ -9035,7 +9036,8 @@ def confirm_pending():
                     c.execute(f"RELEASE SAVEPOINT {savepoint}")
                 except Exception:
                     pass
-                errors.append({"id": pid, "error": str(e)})
+                print(f"[ERROR] confirm_pending {pid}: {e!r}")
+                errors.append({"id": pid, "error": "internal_error"})
         
         conn.commit()
         
@@ -9302,7 +9304,8 @@ try:
             blocks = block_sync.get_blocks_for_sync(start_height, limit)
             return jsonify({"ok": True, "blocks": blocks})
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 400
+            print(f"[ERROR] p2p request failed: {e!r}")
+            return jsonify({"ok": False, "error": "internal_error"}), 400
 
     @app.route('/p2p/add_peer', methods=['POST'])
     @require_peer_auth
@@ -9323,7 +9326,8 @@ try:
                 return jsonify({"ok": bool(success), "message": message})
             return jsonify({"ok": bool(result)})
         except Exception as e:
-            return jsonify({"ok": False, "error": str(e)}), 400
+            print(f"[ERROR] p2p request failed: {e!r}")
+            return jsonify({"ok": False, "error": "internal_error"}), 400
 
     # Start background sync unless an integration test explicitly disables it.
     if os.environ.get("RUSTCHAIN_DISABLE_P2P_AUTO_START") != "1":
@@ -9357,7 +9361,8 @@ def download_installer():
             mimetype="application/x-bat"
         )
     except Exception as e:
-        return jsonify({"error": str(e)}), 404
+        print(f"[ERROR] request failed: {e!r}")
+        return jsonify({"error": "not_found"}), 404
 
 @app.route("/download/miner")
 def download_miner():
@@ -9370,7 +9375,8 @@ def download_miner():
             mimetype="text/x-python"
         )
     except Exception as e:
-        return jsonify({"error": str(e)}), 404
+        print(f"[ERROR] request failed: {e!r}")
+        return jsonify({"error": "not_found"}), 404
 
 
 @app.route("/download/uninstaller")
@@ -10175,7 +10181,8 @@ def download_test_bat():
                 h.update(chunk)
         expected_sha256 = h.hexdigest().upper()
     except Exception as e:
-        return jsonify({"error": str(e)}), 404
+        print(f"[ERROR] request failed: {e!r}")
+        return jsonify({"error": "not_found"}), 404
 
     # Keep legacy HTTP download URL, but verify hash before running.
     bat = f"""@echo off


### PR DESCRIPTION
Closes #3202. Endpoints returned `str(e)` to clients, leaking SQL/schema, file paths, and exception internals. Redacts **only** the 9 broad-except sites (`except Exception`/`sqlite3.Error`) to generic codes (`internal_error`/`verification_failed`/`not_found`) + a server-side `print` of the real exception; the 13 `except ValueError` sites returning **controlled validation messages** are intentionally left as-is. HTTP status codes unchanged. Logs use `repr()` (no log-injection from malformed-signature exceptions — tri-brain Codex). 82 claims-settlement tests green. **Not** PR #5905 (Guzzzzzzzz, which removed security rules) — this is a clean scoped redaction.