### PR TITLE
feat(rip-202): B0-persist attestation_evidence capture (additive, dormant)

### DIFF
--- a/node/rip0202_block_format.py
+++ b/node/rip0202_block_format.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+RIP-202 — B0 block-format canonical contract (PURE, dormant).
+
+B0 widens each committed block attestation from the current
+``{miner, arch, family, timestamp}`` (insufficient to re-derive the anti-VM
+weight) to carry the full ``device`` + ``fingerprint`` + ``fingerprint_passed``
+that ``derive_verified_device`` consumes (RIP-202 operator decision D3 =
+commit full raw evidence for fully trustless re-derivation), and commits the
+``slot`` so a block's epoch is a deterministic function of *chain* data rather
+than wall-clock (``current_slot()`` reads ``time.time()`` and is unsafe on
+replay — found in B2 grounding).
+
+This module is the PURE, side-effect-free canonical contract: the record shape,
+the deterministic attestations hash over the widened records, and the
+slot→epoch map. It is NOT wired into ``produce_block`` / ``_apply_blocks`` — that
+wiring is the gated hard fork (ships dormant; byte-identical pre-activation).
+
+Consensus-determinism guarantees (the reasons this is its own pinned module):
+  * TOTAL ORDER for hashing — (miner, timestamp, content-digest) — so two
+    attestations from the same miner cannot reorder by input order and diverge
+    the hash across nodes (the live ``compute_attestations_hash`` sorts by miner
+    ONLY; B0 tightens this).
+  * CANONICAL JSON — sort_keys, tight separators, and ``allow_nan=False``.
+    CPython's float ``repr`` is platform-independent (short-repr/David Gay
+    dtoa), so a committed IEEE-754 double hashes identically on big-endian
+    PowerPC and x86. Non-finite floats (NaN/Inf) are NOT valid consensus data
+    and are rejected at build time (fail closed) rather than serialised to the
+    invalid, non-round-tripping ``NaN`` token.
+  * FROZEN ON FIRST USE — the field set, encoding, and ``BLOCK_VERSION`` become
+    an immutable consensus contract once any block is produced under B0; change
+    them only behind the on-chain activation height (PREREQ-A).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any, Dict, List, Mapping
+
+# Block-format version stamped in the header once B0 is active. produce_block
+# sets header.version = B0_BLOCK_VERSION at/after the activation epoch; older
+# blocks keep version=1 and validate under the legacy hash, so replay of
+# pre-activation history is byte-identical (no retroactive fork).
+B0_BLOCK_VERSION = 2
+
+# Must match the node's epoch length (BLOCKS_PER_EPOCH). Kept here as the
+# canonical divisor for the slot→epoch map; the wiring step asserts equality
+# with the node constant at import.
+BLOCKS_PER_EPOCH = 144
+
+# The exact committed fields, in the canonical record. Pinned: adding/removing
+# a field is a consensus change gated by activation.
+B0_ATTESTATION_FIELDS = ("miner", "device", "fingerprint", "fingerprint_passed", "timestamp")
+
+
+class B0FormatError(ValueError):
+    """Raised when an attestation cannot be canonicalised into a B0 record."""
+
+
+def _assert_finite(obj: Any, path: str = "") -> None:
+    """Recursively reject non-finite floats (NaN/+-Inf) anywhere in the payload.
+
+    Non-finite values have no valid canonical JSON token (json emits the
+    non-standard ``NaN``/``Infinity``), would not round-trip, and are never
+    legitimate fingerprint/device data — reject at build time, fail closed.
+    """
+    if isinstance(obj, float):
+        if not math.isfinite(obj):
+            raise B0FormatError(f"non-finite float at {path or '<root>'}")
+    elif isinstance(obj, Mapping):
+        for k, v in obj.items():
+            _assert_finite(v, f"{path}.{k}")
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            _assert_finite(v, f"{path}[{i}]")
+
+
+def build_b0_attestation(
+    miner: str,
+    device: Mapping,
+    fingerprint: Mapping,
+    fingerprint_passed: bool,
+    timestamp: int,
+) -> Dict[str, Any]:
+    """Construct one canonical B0 committed-attestation record (validated).
+
+    Fail closed: a non-str/empty miner, non-dict device/fingerprint, non-bool
+    pass flag, non-int timestamp, or any non-finite float raises B0FormatError
+    so a malformed attestation never enters a block (and thus the hash).
+    """
+    if not isinstance(miner, str) or not miner:
+        raise B0FormatError("miner must be a non-empty str")
+    if not isinstance(device, Mapping):
+        raise B0FormatError("device must be a dict")
+    if not isinstance(fingerprint, Mapping):
+        raise B0FormatError("fingerprint must be a dict")
+    if not isinstance(fingerprint_passed, bool):
+        raise B0FormatError("fingerprint_passed must be a bool")
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int):
+        raise B0FormatError("timestamp must be an int")
+    device = dict(device)
+    fingerprint = dict(fingerprint)
+    _assert_finite(device, "device")
+    _assert_finite(fingerprint, "fingerprint")
+    return {
+        "miner": miner,
+        "device": device,
+        "fingerprint": fingerprint,
+        "fingerprint_passed": fingerprint_passed,
+        "timestamp": timestamp,
+    }
+
+
+def _canonical_bytes(obj: Any) -> bytes:
+    """Canonical JSON bytes: sorted keys, tight separators, no non-finite floats."""
+    return json.dumps(
+        obj, separators=(",", ":"), sort_keys=True, allow_nan=False
+    ).encode("utf-8")
+
+
+def _attestation_digest(att: Mapping) -> str:
+    """Deterministic content digest of a B0 record (hash-order tiebreaker)."""
+    projected = {k: att.get(k) for k in B0_ATTESTATION_FIELDS}
+    return hashlib.sha256(_canonical_bytes(projected)).hexdigest()
+
+
+def canonical_b0_attestations_hash(attestations: List[Mapping]) -> str:
+    """Deterministic blake2b-256 over the B0 attestation set.
+
+    TOTAL ORDER (miner, timestamp, content-digest) so the hash is independent of
+    input order and stable for same-(miner,timestamp) records. Empty set hashes
+    to the all-zero sentinel, matching the legacy ``compute_attestations_hash``.
+    """
+    if not attestations:
+        return "0" * 64
+    ordered = sorted(
+        attestations,
+        key=lambda a: (
+            str(a.get("miner", "")),
+            a.get("timestamp", 0) if isinstance(a.get("timestamp"), int)
+            and not isinstance(a.get("timestamp"), bool) else 0,
+            _attestation_digest(a),
+        ),
+    )
+    # Hash the canonical projection of each record (only the pinned fields), so
+    # incidental extra keys can never perturb the consensus hash.
+    projected = [{k: a.get(k) for k in B0_ATTESTATION_FIELDS} for a in ordered]
+    return hashlib.blake2b(_canonical_bytes(projected), digest_size=32).hexdigest()
+
+
+def slot_to_epoch(slot: int, blocks_per_epoch: int = BLOCKS_PER_EPOCH) -> int:
+    """Deterministic epoch for a committed slot. Pure; no wall-clock."""
+    if isinstance(slot, bool) or not isinstance(slot, int) or slot < 0:
+        raise B0FormatError("slot must be a non-negative int")
+    if blocks_per_epoch < 1:
+        raise B0FormatError("blocks_per_epoch must be >= 1")
+    return slot // blocks_per_epoch
+
+
+def block_epoch(header: Mapping, blocks_per_epoch: int = BLOCKS_PER_EPOCH) -> int:
+    """Epoch of a block from its committed ``slot`` header field (B0 adds it).
+
+    Fail closed: a header lacking a valid committed slot raises, rather than
+    silently falling back to wall-clock (which would diverge on replay).
+    """
+    slot = header.get("slot")
+    if isinstance(slot, bool) or not isinstance(slot, int):
+        raise B0FormatError("header missing committed integer 'slot' (B0)")
+    return slot_to_epoch(slot, blocks_per_epoch)

--- a/node/rip0202_evidence.py
+++ b/node/rip0202_evidence.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""
+RIP-202 — B0-persist: raw attestation-evidence capture (additive, dormant).
+
+Today ``/attest/submit`` derives ``device_family`` / ``device_arch`` /
+``fingerprint_passed`` and DISCARDS the raw ``device`` + ``fingerprint`` dicts;
+``miner_attest_recent`` never stores them. The producer therefore can't commit
+the evidence B1 needs to re-derive enrollment (B0). This module captures that
+evidence in an ADDITIVE side table so the producer can later read it.
+
+Design:
+  * PURE-except-DB: a caller supplies the connection; no global state, no
+    wall-clock (``ts`` is passed in by the caller, i.e. the attestation ts).
+  * FAIL CLOSED at capture: records are validated/canonicalised through
+    ``rip0202_block_format.build_b0_attestation`` (rejects bad types + non-finite
+    floats) BEFORE storage, so malformed evidence never persists and a later
+    committed block can't carry it.
+  * NON-DISRUPTIVE: a new ``attestation_evidence`` table; nothing existing reads
+    or writes it. Wiring the one ``record_attestation_evidence`` call into
+    ``_submit_attestation_impl`` and the join into ``get_attestations_for_block``
+    are separate, low-risk follow-ups; this module ships unwired.
+  * Canonical JSON storage (sort_keys, allow_nan=False) so device/fingerprint
+    round-trip byte-stably for the B0 hash.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+from typing import Any, Dict, List, Mapping, Optional
+
+from rip0202_block_format import build_b0_attestation, B0FormatError
+
+ATTESTATION_EVIDENCE_SCHEMA = """
+CREATE TABLE IF NOT EXISTS attestation_evidence (
+    miner              TEXT PRIMARY KEY,
+    device_json        TEXT NOT NULL,
+    fingerprint_json   TEXT NOT NULL,
+    fingerprint_passed INTEGER NOT NULL,
+    ts                 INTEGER NOT NULL
+)
+"""
+
+
+def ensure_attestation_evidence_schema(conn: sqlite3.Connection) -> None:
+    """Create the evidence table if absent. Call once at DB init (DDL implicit-
+    commits — do NOT call inside a consensus transaction)."""
+    conn.execute(ATTESTATION_EVIDENCE_SCHEMA)
+
+
+def _canonical(obj: Any) -> str:
+    return json.dumps(obj, separators=(",", ":"), sort_keys=True, allow_nan=False)
+
+
+def record_attestation_evidence(
+    conn: sqlite3.Connection,
+    miner: str,
+    device: Mapping,
+    fingerprint: Mapping,
+    fingerprint_passed: bool,
+    ts: int,
+) -> None:
+    """Validate (fail-closed) and upsert one miner's raw attestation evidence.
+
+    Latest-evidence-per-miner (PRIMARY KEY miner, INSERT OR REPLACE), mirroring
+    ``miner_attest_recent``'s per-miner keying. Raises B0FormatError on malformed
+    input so the caller can reject the attestation rather than store junk.
+    """
+    rec = build_b0_attestation(miner, device, fingerprint, fingerprint_passed, ts)
+    conn.execute(
+        "INSERT OR REPLACE INTO attestation_evidence "
+        "(miner, device_json, fingerprint_json, fingerprint_passed, ts) VALUES (?,?,?,?,?)",
+        (
+            rec["miner"],
+            _canonical(rec["device"]),
+            _canonical(rec["fingerprint"]),
+            1 if rec["fingerprint_passed"] else 0,
+            rec["timestamp"],
+        ),
+    )
+
+
+def load_committed_attestations(
+    conn: sqlite3.Connection,
+    min_ts: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """Rebuild B0 attestation records from stored evidence (for the producer).
+
+    Returns the widened ``build_b0_attestation`` records, sorted by miner for a
+    stable base order. Rows that fail to parse/validate are skipped (fail
+    closed) so one corrupt row can't break block production. ``min_ts`` mirrors
+    the producer's ATTESTATION_TTL window when provided.
+    """
+    sql = "SELECT miner, device_json, fingerprint_json, fingerprint_passed, ts FROM attestation_evidence"
+    params: tuple = ()
+    if min_ts is not None:
+        sql += " WHERE ts >= ?"
+        params = (min_ts,)
+    sql += " ORDER BY miner"
+    out: List[Dict[str, Any]] = []
+    for miner, dev_j, fp_j, passed, ts in conn.execute(sql, params).fetchall():
+        try:
+            device = json.loads(dev_j)
+            fingerprint = json.loads(fp_j)
+            out.append(
+                build_b0_attestation(miner, device, fingerprint, bool(passed), int(ts))
+            )
+        except (json.JSONDecodeError, B0FormatError, TypeError, ValueError):
+            continue  # fail closed: skip a corrupt/invalid row
+    return out

--- a/node/rip0202_evidence.py
+++ b/node/rip0202_evidence.py
@@ -67,9 +67,17 @@ def record_attestation_evidence(
     input so the caller can reject the attestation rather than store junk.
     """
     rec = build_b0_attestation(miner, device, fingerprint, fingerprint_passed, ts)
+    # TS-MONOTONIC upsert: only overwrite when the incoming attestation is at
+    # least as new as the stored one. A delayed/replayed OLDER attestation must
+    # not clobber newer evidence (which would silently drop a miner from the
+    # producer's TTL-filtered view). Deterministic + order-independent.
     conn.execute(
-        "INSERT OR REPLACE INTO attestation_evidence "
-        "(miner, device_json, fingerprint_json, fingerprint_passed, ts) VALUES (?,?,?,?,?)",
+        "INSERT INTO attestation_evidence "
+        "(miner, device_json, fingerprint_json, fingerprint_passed, ts) VALUES (?,?,?,?,?) "
+        "ON CONFLICT(miner) DO UPDATE SET "
+        "device_json=excluded.device_json, fingerprint_json=excluded.fingerprint_json, "
+        "fingerprint_passed=excluded.fingerprint_passed, ts=excluded.ts "
+        "WHERE excluded.ts >= attestation_evidence.ts",
         (
             rec["miner"],
             _canonical(rec["device"]),
@@ -100,10 +108,17 @@ def load_committed_attestations(
     out: List[Dict[str, Any]] = []
     for miner, dev_j, fp_j, passed, ts in conn.execute(sql, params).fetchall():
         try:
+            # Strict stored-type validation (fail closed): a corrupt row with
+            # passed=2 or ts=1.9 must be skipped, NOT loosely coerced via
+            # bool()/int() (which would admit garbage into the committed set).
+            if passed not in (0, 1):
+                continue
+            if isinstance(ts, bool) or not isinstance(ts, int):
+                continue
             device = json.loads(dev_j)
             fingerprint = json.loads(fp_j)
             out.append(
-                build_b0_attestation(miner, device, fingerprint, bool(passed), int(ts))
+                build_b0_attestation(miner, device, fingerprint, passed == 1, ts)
             )
         except (json.JSONDecodeError, B0FormatError, TypeError, ValueError):
             continue  # fail closed: skip a corrupt/invalid row

--- a/node/tests/test_rip0202_block_format.py
+++ b/node/tests/test_rip0202_block_format.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-202 B0 canonical block-format contract — unit tests."""
+import json
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _d in (os.path.dirname(_HERE), _HERE):  # ../ (repo node/) first, then . (flat staging)
+    if os.path.exists(os.path.join(_d, "rip0202_block_format.py")):
+        sys.path.insert(0, _d)
+        break
+import rip0202_block_format as b0  # noqa: E402
+
+
+# ---- record construction / fail-closed validation -------------------------
+DEV = {"machine": "x86_64", "cpu_brand": "Intel i7"}
+FP = {"simd_identity": {"data": {}}, "clock_drift": {"data": {"cv": 0.0931}}}
+
+
+def test_build_valid_record():
+    r = b0.build_b0_attestation("miner-a", DEV, FP, True, 1000)
+    assert set(r) == set(b0.B0_ATTESTATION_FIELDS)
+    assert r["miner"] == "miner-a" and r["fingerprint_passed"] is True
+
+
+@pytest.mark.parametrize("kwargs", [
+    {"miner": ""}, {"miner": 1}, {"device": "x"}, {"fingerprint": None},
+    {"fingerprint_passed": 1}, {"fingerprint_passed": "true"},
+    {"timestamp": "10"}, {"timestamp": True},
+])
+def test_build_rejects_malformed(kwargs):
+    base = dict(miner="m", device=DEV, fingerprint=FP, fingerprint_passed=True, timestamp=1)
+    base.update(kwargs)
+    with pytest.raises(b0.B0FormatError):
+        b0.build_b0_attestation(**base)
+
+
+def test_build_rejects_non_finite_float():
+    for bad in ({"x": float("nan")}, {"nested": {"y": float("inf")}}, {"arr": [1.0, float("-inf")]}):
+        with pytest.raises(b0.B0FormatError):
+            b0.build_b0_attestation("m", DEV, bad, True, 1)
+
+
+# ---- canonical hash determinism -------------------------------------------
+def _att(miner, ts=1000, passed=True, fp=None):
+    return b0.build_b0_attestation(miner, DEV, fp or FP, passed, ts)
+
+
+def test_empty_hash_sentinel():
+    assert b0.canonical_b0_attestations_hash([]) == "0" * 64
+
+
+def test_hash_deterministic_and_order_independent():
+    a, b, c = _att("c", 3), _att("a", 1), _att("b", 2)
+    h1 = b0.canonical_b0_attestations_hash([a, b, c])
+    h2 = b0.canonical_b0_attestations_hash([c, b, a])  # shuffled
+    h3 = b0.canonical_b0_attestations_hash([b, c, a])
+    assert h1 == h2 == h3 and len(h1) == 64
+
+
+def test_same_miner_same_ts_tiebreak_is_total_order():
+    """Two records, same miner+ts, different content -> deterministic order."""
+    x = b0.build_b0_attestation("dup", DEV, {"k": 1}, True, 5)
+    y = b0.build_b0_attestation("dup", DEV, {"k": 2}, True, 5)
+    assert b0.canonical_b0_attestations_hash([x, y]) == b0.canonical_b0_attestations_hash([y, x])
+
+
+def test_hash_ignores_incidental_extra_keys():
+    a = _att("m", 1)
+    a_extra = dict(a)
+    a_extra["_debug"] = "ignore me"  # not a pinned field
+    assert b0.canonical_b0_attestations_hash([a]) == b0.canonical_b0_attestations_hash([a_extra])
+
+
+def test_float_round_trip_stable_hash():
+    """The cross-arch claim: a committed float hashes identically after a
+    JSON deserialise/serialise round-trip (CPython short-repr is stable)."""
+    fp = {"clock_drift": {"data": {"cv": 0.09313725490196078, "lat": [1.5, 2.25, 0.125]}}}
+    a = b0.build_b0_attestation("m", DEV, fp, True, 1)
+    a_round = json.loads(json.dumps(a))  # simulate commit -> deserialize on apply
+    assert b0.canonical_b0_attestations_hash([a]) == b0.canonical_b0_attestations_hash([a_round])
+
+
+def test_passed_flag_changes_hash():
+    assert b0.canonical_b0_attestations_hash([_att("m", 1, passed=True)]) != \
+           b0.canonical_b0_attestations_hash([_att("m", 1, passed=False)])
+
+
+# ---- slot -> epoch --------------------------------------------------------
+def test_slot_to_epoch():
+    assert b0.slot_to_epoch(0) == 0
+    assert b0.slot_to_epoch(143) == 0
+    assert b0.slot_to_epoch(144) == 1
+    assert b0.slot_to_epoch(289) == 2
+
+
+@pytest.mark.parametrize("bad", [-1, True, "5", 1.0, None])
+def test_slot_to_epoch_rejects_bad(bad):
+    with pytest.raises(b0.B0FormatError):
+        b0.slot_to_epoch(bad)
+
+
+def test_block_epoch_reads_committed_slot():
+    assert b0.block_epoch({"height": 200, "slot": 288}) == 2
+
+
+def test_block_epoch_fails_closed_without_slot():
+    """No wall-clock fallback: a header without a committed slot must raise."""
+    for hdr in ({"height": 200}, {"slot": "288"}, {"slot": True}):
+        with pytest.raises(b0.B0FormatError):
+            b0.block_epoch(hdr)
+
+
+def test_block_version_constant():
+    assert b0.B0_BLOCK_VERSION == 2

--- a/node/tests/test_rip0202_evidence.py
+++ b/node/tests/test_rip0202_evidence.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""RIP-202 B0-persist attestation-evidence capture — unit tests."""
+import os
+import sqlite3
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+for _d in (os.path.dirname(_HERE), _HERE):  # ../ (repo node/) first, then . (flat)
+    if os.path.exists(os.path.join(_d, "rip0202_evidence.py")):
+        sys.path.insert(0, _d)
+        break
+import rip0202_evidence as ev  # noqa: E402
+import rip0202_block_format as b0  # noqa: E402
+
+DEV = {"machine": "x86_64", "cpu_brand": "Intel i7"}
+FP = {"clock_drift": {"data": {"cv": 0.0931}}, "simd_identity": {"data": {}}}
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    ev.ensure_attestation_evidence_schema(c)
+    yield c
+    c.close()
+
+
+def test_schema_idempotent(conn):
+    ev.ensure_attestation_evidence_schema(conn)  # second call is a no-op
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(attestation_evidence)")]
+    assert cols == ["miner", "device_json", "fingerprint_json", "fingerprint_passed", "ts"]
+
+
+def test_record_and_load_round_trip(conn):
+    ev.record_attestation_evidence(conn, "miner-a", DEV, FP, True, 1000)
+    recs = ev.load_committed_attestations(conn)
+    assert recs == [b0.build_b0_attestation("miner-a", DEV, FP, True, 1000)]
+
+
+def test_record_fail_closed_on_malformed(conn):
+    with pytest.raises(b0.B0FormatError):
+        ev.record_attestation_evidence(conn, "", DEV, FP, True, 1)          # empty miner
+    with pytest.raises(b0.B0FormatError):
+        ev.record_attestation_evidence(conn, "m", {"x": float("nan")}, FP, True, 1)  # non-finite
+    assert conn.execute("SELECT COUNT(*) FROM attestation_evidence").fetchone()[0] == 0
+
+
+def test_upsert_latest_wins(conn):
+    ev.record_attestation_evidence(conn, "dup", DEV, {"k": 1}, True, 100)
+    ev.record_attestation_evidence(conn, "dup", DEV, {"k": 2}, False, 200)
+    rows = conn.execute("SELECT COUNT(*) FROM attestation_evidence").fetchone()[0]
+    assert rows == 1
+    rec = ev.load_committed_attestations(conn)[0]
+    assert rec["fingerprint"] == {"k": 2} and rec["fingerprint_passed"] is False and rec["timestamp"] == 200
+
+
+def test_load_skips_corrupt_rows(conn):
+    ev.record_attestation_evidence(conn, "good", DEV, FP, True, 10)
+    # inject a corrupt row directly (simulates legacy/garbage data)
+    conn.execute(
+        "INSERT INTO attestation_evidence VALUES (?,?,?,?,?)",
+        ("bad", "{not json", "{}", 1, 20),
+    )
+    recs = ev.load_committed_attestations(conn)
+    assert [r["miner"] for r in recs] == ["good"]  # corrupt skipped, no crash
+
+
+def test_load_min_ts_filter(conn):
+    ev.record_attestation_evidence(conn, "old", DEV, FP, True, 100)
+    ev.record_attestation_evidence(conn, "new", DEV, FP, True, 500)
+    recs = ev.load_committed_attestations(conn, min_ts=300)
+    assert [r["miner"] for r in recs] == ["new"]
+
+
+def test_loaded_records_hash_equals_original(conn):
+    """Evidence round-trip preserves the B0 attestations hash (storage is
+    byte-stable through canonical JSON) — ties B0-persist to the B0 contract."""
+    originals = [
+        b0.build_b0_attestation("a", DEV, FP, True, 1),
+        b0.build_b0_attestation("b", DEV, {"lat": [1.5, 0.125]}, True, 2),
+    ]
+    for r in originals:
+        ev.record_attestation_evidence(conn, r["miner"], r["device"], r["fingerprint"],
+                                       r["fingerprint_passed"], r["timestamp"])
+    loaded = ev.load_committed_attestations(conn)
+    assert b0.canonical_b0_attestations_hash(loaded) == b0.canonical_b0_attestations_hash(originals)

--- a/node/tests/test_rip0202_evidence.py
+++ b/node/tests/test_rip0202_evidence.py
@@ -86,3 +86,24 @@ def test_loaded_records_hash_equals_original(conn):
                                        r["fingerprint_passed"], r["timestamp"])
     loaded = ev.load_committed_attestations(conn)
     assert b0.canonical_b0_attestations_hash(loaded) == b0.canonical_b0_attestations_hash(originals)
+
+
+# ---- tri-brain fixes: ts-monotonic upsert + strict load validation ----
+def test_older_attestation_does_not_clobber_newer(conn):
+    ev.record_attestation_evidence(conn, "m", DEV, {"v": "new"}, True, 200)
+    ev.record_attestation_evidence(conn, "m", DEV, {"v": "old"}, True, 100)  # older ts
+    rec = ev.load_committed_attestations(conn)[0]
+    assert rec["fingerprint"] == {"v": "new"} and rec["timestamp"] == 200
+
+
+def test_equal_ts_overwrites(conn):
+    ev.record_attestation_evidence(conn, "m", DEV, {"v": 1}, True, 100)
+    ev.record_attestation_evidence(conn, "m", DEV, {"v": 2}, True, 100)  # same ts -> replace
+    assert ev.load_committed_attestations(conn)[0]["fingerprint"] == {"v": 2}
+
+
+def test_load_skips_out_of_range_passed_and_float_ts(conn):
+    ev.record_attestation_evidence(conn, "good", DEV, FP, True, 10)
+    conn.execute("INSERT INTO attestation_evidence VALUES (?,?,?,?,?)", ("bad_passed", "{}", "{}", 2, 20))
+    conn.execute("INSERT INTO attestation_evidence VALUES (?,?,?,?,?)", ("bad_ts", "{}", "{}", 1, 1.9))
+    assert [r["miner"] for r in ev.load_committed_attestations(conn)] == ["good"]


### PR DESCRIPTION
## BCOS Checklist
- [x] **BCOS-L1** (additive side table + pure-except-DB helpers; unwired)
- [x] SPDX headers present
- [x] Test evidence below

> Replaces the auto-closed #6763 (its base branch merged via #6761 and was deleted). `rip0202_block_format` — the import dependency — is now on `main`, so this targets `main` directly. Includes the tri-brain review fixes.

## What Changed
**RIP-202 B0-persist** — capture the raw attestation evidence the producer needs to commit (B0), in an **additive** side table. Two new files, **no production code wired**:
- `node/rip0202_evidence.py`, `node/tests/test_rip0202_evidence.py`

`/attest/submit` derives family/arch/passed and **discards** the raw `device`+`fingerprint`; `miner_attest_recent` never stores them. This adds `attestation_evidence` + capture/load helpers (fail-closed via `build_b0_attestation`). The one-line capture call into `_submit_attestation_impl` and the producer join are separate low-risk follow-ups — this ships unwired.

### Tri-brain fixes included (Codex+Grok)
- **TS-monotonic upsert:** a delayed/replayed *older* attestation no longer clobbers newer evidence (which would silently drop a miner from the producer's TTL view). `ON CONFLICT … WHERE excluded.ts >= ts`.
- **Strict load validation:** corrupt rows with `passed=2` or `ts=1.9` are skipped, not loosely coerced via `bool()`/`int()`.

## Testing / Evidence
```
$ python3 -m pytest node/tests/test_rip0202_evidence.py -q
..........                                                               [100%]
10 passed
```
(7 original + 3 fix-coverage: older-doesn't-clobber-newer, equal-ts-overwrites, skip out-of-range passed/float ts.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)