### PR TITLE
[UTXO-BUG] Domain-separate UTXO transfer signatures

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -565,8 +565,14 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertIn('signed payload', r.get_json()['error'])
         self.assertEqual(self.utxo_db.get_balance(recipient), 0)
 
-    def test_legacy_signature_rejects_nonzero_fee(self):
-        """Legacy signatures omit fee_rtc, so they cannot authorize fees."""
+    def test_legacy_account_signature_rejected_without_utxo_domain(self):
+        """A legacy account-shaped signature (no UTXO domain) cannot move UTXO funds.
+
+        UTXO transfers are now domain-separated: the signed message must carry
+        ``domain == UTXO_SIGNATURE_DOMAIN``. A legacy account-model signature
+        omits that field, so it is rejected with UTXO_SIGNATURE_DOMAIN_REQUIRED
+        before any fee handling, and balances stay untouched.
+        """
         sender = 'RTC_test_aabbccdd'
         recipient = 'bob'
         self._seed_coinbase(sender, 100 * UNIT)
@@ -601,7 +607,7 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(r.status_code, 401)
         self.assertEqual(
             r.get_json()['code'],
-            'LEGACY_SIGNATURE_FEE_UNBOUND',
+            'UTXO_SIGNATURE_DOMAIN_REQUIRED',
         )
         self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
         self.assertEqual(self.utxo_db.get_balance(recipient), 0)

--- a/node/tests/test_dual_write_unit_mismatch.py
+++ b/node/tests/test_dual_write_unit_mismatch.py
@@ -307,7 +307,19 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         self.assertNotEqual(recipient_i64, 1_000_000)
 
     def test_dual_write_large_amount_no_overflow(self):
-        """Transferring 10,000 RTC should write 10,000,000,000 uRTC."""
+        """A large transfer must write the correct large i64 to the shadow row.
+
+        Amount note / invariant: a single ``/utxo/transfer`` can be funded by at
+        most ``MAX_INPUTS`` (100) UTXOs, and coinbase outputs are capped at
+        ``MAX_COINBASE_OUTPUT_NRTC`` (150 RTC). A coinbase-only sender therefore
+        cannot move more than 100 * 150 = 15,000 RTC in one transfer, so the
+        original 1_000_000 RTC amount is structurally unreachable through this
+        endpoint path (it needs ~6,667 inputs and is rejected before settling).
+        The full 1_000_000 RTC i64-overflow magnitude is covered directly at the
+        conversion boundary by ``test_account_i64_no_overflow_at_one_million_rtc``
+        below; this case exercises a large end-to-end transfer near the feasible
+        ceiling.
+        """
         sender = 'RTC_test_aabbccdd'
         recipient = 'RTC_test_eeffgghh'
         self._seed_coinbase(sender, 20_000 * UNIT)
@@ -333,6 +345,22 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         recipient_i64 = self._get_account_balance_i64(recipient)
         expected_i64 = int(10_000.0 * ACCOUNT_UNIT)  # 10_000_000_000
         self.assertEqual(recipient_i64, expected_i64)
+
+    def test_account_i64_no_overflow_at_one_million_rtc(self):
+        """Restore 1_000_000 RTC i64-overflow coverage at the conversion boundary.
+
+        This is the exact helper the dual-write path uses to mirror UTXO amounts
+        into the 6-decimal account shadow row. It is not bounded by MAX_INPUTS, so
+        it can assert the full 1_000_000 RTC magnitude (1_000_000_000_000 uRTC)
+        converts exactly, stays positive, and remains far below the int64 ceiling.
+        """
+        from decimal import Decimal
+        from utxo_endpoints import _decimal_to_account_i64
+
+        result = _decimal_to_account_i64(Decimal('1000000'), 'amount_rtc')
+        self.assertEqual(result, 1_000_000_000_000)
+        self.assertGreater(result, 0)
+        self.assertLess(result, 2 ** 63 - 1)
 
     # -- Integrity endpoint tests --------------------------------------------
 

--- a/node/tests/test_dual_write_unit_mismatch.py
+++ b/node/tests/test_dual_write_unit_mismatch.py
@@ -24,7 +24,11 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from flask import Flask
 
 from utxo_db import MAX_COINBASE_OUTPUT_NRTC, UtxoDB, UNIT
-from utxo_endpoints import register_utxo_blueprint, ACCOUNT_UNIT
+from utxo_endpoints import (
+    ACCOUNT_UNIT,
+    UTXO_SIGNATURE_DOMAIN,
+    register_utxo_blueprint,
+)
 
 
 # Mock crypto functions for testing
@@ -38,6 +42,94 @@ def mock_addr_from_pk(pubkey_hex):
 
 def mock_current_slot():
     return 100
+
+
+class TestUtxoSignatureDomain(unittest.TestCase):
+    """UTXO transfers must not accept account-transfer signatures."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        self.utxo_db = UtxoDB(self.db_path)
+        self.utxo_db.init_tables()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def _seed_coinbase(self, address, value_nrtc, height=1):
+        ok = self.utxo_db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': address, 'value_nrtc': value_nrtc}],
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=height)
+        self.assertTrue(ok, "Coinbase fixture should seed UTXO balance")
+
+    def _client_with_verifier(self, verifier):
+        app = Flask(__name__)
+        app.config['TESTING'] = True
+        register_utxo_blueprint(
+            app, self.utxo_db, self.db_path,
+            verify_sig_fn=verifier,
+            addr_from_pk_fn=mock_addr_from_pk,
+            current_slot_fn=mock_current_slot,
+            dual_write=False,
+        )
+        return app.test_client()
+
+    def _payload(self, nonce=123):
+        return {
+            'from_address': 'RTC_test_aabbccdd',
+            'to_address': 'RTC_test_eeffgghh',
+            'amount_rtc': 10.0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': nonce,
+        }
+
+    def test_account_transfer_signature_rejected_on_utxo_endpoint(self):
+        """An account-model signed payload must not settle immediately as UTXO."""
+        sender = 'RTC_test_aabbccdd'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        def account_style_verifier(pubkey_hex, message, sig_hex):
+            signed = json.loads(message.decode())
+            return (
+                signed.get('from') == sender
+                and signed.get('to') == 'RTC_test_eeffgghh'
+                and signed.get('amount') == 10.0
+                and signed.get('memo') == ''
+                and signed.get('nonce') == 123
+                and 'domain' not in signed
+            )
+
+        client = self._client_with_verifier(account_style_verifier)
+        response = client.post('/utxo/transfer', json=self._payload())
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.get_json()['code'],
+            'UTXO_SIGNATURE_DOMAIN_REQUIRED',
+        )
+        self.assertEqual(self.utxo_db.get_balance(sender), 100 * UNIT)
+
+    def test_utxo_domain_signature_still_authorizes_transfer(self):
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'RTC_test_eeffgghh'
+        self._seed_coinbase(sender, 100 * UNIT)
+
+        def utxo_domain_verifier(pubkey_hex, message, sig_hex):
+            signed = json.loads(message.decode())
+            return signed.get('domain') == UTXO_SIGNATURE_DOMAIN
+
+        client = self._client_with_verifier(utxo_domain_verifier)
+        response = client.post('/utxo/transfer', json=self._payload())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()['ok'])
+        self.assertEqual(self.utxo_db.get_balance(recipient), 10 * UNIT)
 
 
 class TestDualWriteUnitCorrectness(unittest.TestCase):
@@ -215,16 +307,16 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         self.assertNotEqual(recipient_i64, 1_000_000)
 
     def test_dual_write_large_amount_no_overflow(self):
-        """Transferring 1_000_000 RTC should write 1_000_000_000_000 uRTC."""
+        """Transferring 10,000 RTC should write 10,000,000,000 uRTC."""
         sender = 'RTC_test_aabbccdd'
         recipient = 'RTC_test_eeffgghh'
-        self._seed_coinbase(sender, 2_000_000 * UNIT)
+        self._seed_coinbase(sender, 20_000 * UNIT)
 
         # Seed shadow balance so dual-write can proceed
         conn = sqlite3.connect(self.db_path)
         conn.execute(
             "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
-            (sender, int(2_000_000.0 * ACCOUNT_UNIT)),
+            (sender, int(20_000.0 * ACCOUNT_UNIT)),
         )
         conn.commit()
         conn.close()
@@ -232,14 +324,14 @@ class TestDualWriteUnitCorrectness(unittest.TestCase):
         self.client.post('/utxo/transfer', json={
             'from_address': sender,
             'to_address': recipient,
-            'amount_rtc': 1_000_000.0,
+            'amount_rtc': 10_000.0,
             'public_key': 'aabbccdd' * 8,
             'signature': 'sig' * 22,
             'nonce': int(time.time() * 1000),
         })
 
         recipient_i64 = self._get_account_balance_i64(recipient)
-        expected_i64 = int(1_000_000.0 * ACCOUNT_UNIT)  # 1_000_000_000_000
+        expected_i64 = int(10_000.0 * ACCOUNT_UNIT)  # 10_000_000_000
         self.assertEqual(recipient_i64, expected_i64)
 
     # -- Integrity endpoint tests --------------------------------------------

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -17,7 +17,6 @@ Endpoints:
 """
 
 import json
-import logging
 import sqlite3
 import time
 from decimal import Decimal, InvalidOperation
@@ -142,7 +141,7 @@ def _ensure_signed_float_preserves_nrtc(amount: Decimal, nrtc: int,
 # This MUST match the multiplier used in rustchain_v2_integrated_v2.2.1_rip200.py
 # (e.g. line 2370: amount_i64 = int(amount_decimal * Decimal(1000000))).
 ACCOUNT_UNIT = 1_000_000  # 1 RTC = 1,000,000 uRTC (6 decimals)
-LEGACY_SIGNATURE_CUTOFF_TS = 1782864000  # 2026-07-01T00:00:00Z
+UTXO_SIGNATURE_DOMAIN = "rustchain-utxo-transfer-v1"
 
 
 def _decimal_to_account_i64(amount: Decimal, field_name: str) -> int:
@@ -554,8 +553,11 @@ def utxo_transfer():
 
     # Reconstruct signed message.
     # FIX(#2202): Include fee in signed data to prevent MITM fee manipulation.
-    # Backward-compatible: try new format (with fee) first, fall back to legacy
-    # (without fee) with a deprecation warning. Remove fallback after 2026-07-01.
+    # UTXO transfers must be domain-separated from account-model
+    # /wallet/transfer/signed payloads. The account endpoint places accepted
+    # transfers into a delayed pending window, while this endpoint settles UTXO
+    # state immediately. Accepting the account-shaped message here lets a valid
+    # wallet signature be substituted onto the immediate-settlement path.
     #
     # FIX(#2867 M2 follow-up): the M2 fix parses amount as Decimal internally
     # for precision-safe int conversion, but Decimal isn't JSON-serializable.
@@ -564,9 +566,10 @@ def utxo_transfer():
     amount_for_sig = float(amount_rtc)
     fee_for_sig = float(fee_rtc)
     signature_verified = False
-    used_legacy_signature = False
+    legacy_wallet_signature_seen = False
     for nonce_for_sig in _nonce_signature_forms(data.get('nonce'), nonce_int):
         tx_data_v2 = {
+            'domain': UTXO_SIGNATURE_DOMAIN,
             'from': from_address,
             'to': to_address,
             'amount': amount_for_sig,
@@ -588,28 +591,16 @@ def utxo_transfer():
         }
         message_legacy = json.dumps(tx_data_legacy, sort_keys=True, separators=(',', ':')).encode()
         if _verify_sig_fn(public_key, message_legacy, signature):
-            signature_verified = True
-            used_legacy_signature = True
-            break
+            legacy_wallet_signature_seen = True
 
     if not signature_verified:
+        if legacy_wallet_signature_seen:
+            return jsonify({
+                'error': 'UTXO transfer signature must include UTXO domain',
+                'code': 'UTXO_SIGNATURE_DOMAIN_REQUIRED',
+                'domain': UTXO_SIGNATURE_DOMAIN,
+            }), 401
         return jsonify({'error': 'Invalid Ed25519 signature'}), 401
-    if used_legacy_signature:
-        if fee_nrtc != 0:
-            return jsonify({
-                'error': 'Legacy signature format cannot authorize nonzero fee',
-                'code': 'LEGACY_SIGNATURE_FEE_UNBOUND',
-            }), 401
-        if int(time.time()) >= LEGACY_SIGNATURE_CUTOFF_TS:
-            return jsonify({
-                'error': 'Legacy signature format expired. Upgrade client to sign fee_rtc.',
-                'code': 'LEGACY_SIGNATURE_EXPIRED',
-            }), 401
-        logging.warning(
-            "[UTXO/SIG] DEPRECATED: signature without fee accepted for %s... "
-            "Upgrade client to include fee in signed message.",
-            from_address[:20],
-        )
 
     # --- UTXO transaction ---------------------------------------------------
 

--- a/tests/test_utxo_legacy_signature_deadline.py
+++ b/tests/test_utxo_legacy_signature_deadline.py
@@ -3,7 +3,6 @@ import sqlite3
 import sys
 import time
 from pathlib import Path
-from unittest.mock import patch
 
 from flask import Flask
 
@@ -11,17 +10,18 @@ from flask import Flask
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(PROJECT_ROOT / "node"))
 
-import utxo_endpoints
 from utxo_db import UtxoDB, UNIT
-from utxo_endpoints import register_utxo_blueprint
+from utxo_endpoints import UTXO_SIGNATURE_DOMAIN, register_utxo_blueprint
 
 
-def legacy_only_verify(pubkey_hex, message, sig_hex):
+def account_style_verify(pubkey_hex, message, sig_hex):
     return sig_hex == "legacy" and b'"fee":' not in message
 
 
-def v2_only_verify(pubkey_hex, message, sig_hex):
-    return sig_hex == "v2" and b'"fee":' in message
+def utxo_domain_verify(pubkey_hex, message, sig_hex):
+    if sig_hex != "v2" or b'"fee":' not in message:
+        return False
+    return f'"domain":"{UTXO_SIGNATURE_DOMAIN}"'.encode() in message
 
 
 def mock_addr_from_pk(pubkey_hex):
@@ -84,45 +84,32 @@ def transfer_payload(signature, fee_rtc=1.0):
     }
 
 
-def test_legacy_signature_is_accepted_before_cutoff(tmp_path):
-    client, utxo_db, _db_path = build_client(tmp_path, legacy_only_verify)
+def test_account_style_signature_is_rejected_on_utxo_endpoint(tmp_path):
+    client, utxo_db, _db_path = build_client(tmp_path, account_style_verify)
     seed_coinbase(utxo_db, "RTC_test_aabbccdd", 100 * UNIT)
-    with patch.object(utxo_endpoints.time, "time", return_value=1782863999):
-        response = client.post("/utxo/transfer", json=transfer_payload("legacy", fee_rtc=0.0))
-
-    assert response.status_code == 200
-    assert response.get_json()["ok"] is True
-
-
-def test_legacy_signature_cannot_authorize_nonzero_fee_before_cutoff(tmp_path):
-    client, utxo_db, _db_path = build_client(tmp_path, legacy_only_verify)
-    seed_coinbase(utxo_db, "RTC_test_aabbccdd", 100 * UNIT)
-    with patch.object(utxo_endpoints.time, "time", return_value=1782863999):
-        response = client.post("/utxo/transfer", json=transfer_payload("legacy", fee_rtc=1.0))
+    response = client.post("/utxo/transfer", json=transfer_payload("legacy", fee_rtc=0.0))
 
     assert response.status_code == 401
-    assert response.get_json()["code"] == "LEGACY_SIGNATURE_FEE_UNBOUND"
+    assert response.get_json()["code"] == "UTXO_SIGNATURE_DOMAIN_REQUIRED"
     assert utxo_db.get_balance("RTC_test_aabbccdd") == 100 * UNIT
     assert utxo_db.get_balance("bob") == 0
 
 
-def test_legacy_signature_is_rejected_after_cutoff(tmp_path):
-    client, utxo_db, _db_path = build_client(tmp_path, legacy_only_verify)
+def test_account_style_signature_with_fee_is_rejected_for_domain(tmp_path):
+    client, utxo_db, _db_path = build_client(tmp_path, account_style_verify)
     seed_coinbase(utxo_db, "RTC_test_aabbccdd", 100 * UNIT)
-    with patch.object(utxo_endpoints.time, "time", return_value=1782864000):
-        response = client.post("/utxo/transfer", json=transfer_payload("legacy", fee_rtc=0.0))
+    response = client.post("/utxo/transfer", json=transfer_payload("legacy", fee_rtc=1.0))
 
     assert response.status_code == 401
-    assert response.get_json()["code"] == "LEGACY_SIGNATURE_EXPIRED"
+    assert response.get_json()["code"] == "UTXO_SIGNATURE_DOMAIN_REQUIRED"
     assert utxo_db.get_balance("RTC_test_aabbccdd") == 100 * UNIT
     assert utxo_db.get_balance("bob") == 0
 
 
-def test_v2_signature_still_accepts_fee_after_cutoff(tmp_path):
-    client, utxo_db, _db_path = build_client(tmp_path, v2_only_verify)
+def test_utxo_domain_signature_still_accepts_fee(tmp_path):
+    client, utxo_db, _db_path = build_client(tmp_path, utxo_domain_verify)
     seed_coinbase(utxo_db, "RTC_test_aabbccdd", 100 * UNIT)
-    with patch.object(utxo_endpoints.time, "time", return_value=1782864000):
-        response = client.post("/utxo/transfer", json=transfer_payload("v2"))
+    response = client.post("/utxo/transfer", json=transfer_payload("v2"))
 
     assert response.status_code == 200
     assert response.get_json()["ok"] is True


### PR DESCRIPTION
## Summary

This PR fixes a UTXO red-team finding: `/utxo/transfer` accepted the same account-shaped signed payload used by `/wallet/transfer/signed`, but `/wallet/transfer/signed` routes accepted transfers through the pending/confirmation window while `/utxo/transfer` settles UTXO state immediately.

That means a valid account-transfer signature could be substituted onto the immediate UTXO settlement endpoint when the wallet also had UTXO funds. The nonce table prevents later reuse, but it does not prevent first-use endpoint substitution.

## Fix

- Adds `UTXO_SIGNATURE_DOMAIN = rustchain-utxo-transfer-v1`.
- Requires the signed UTXO message to include that domain.
- Detects old account-shaped signatures and rejects them with `UTXO_SIGNATURE_DOMAIN_REQUIRED` instead of treating them as valid UTXO authorization.
- Updates legacy-signature tests so account-shaped signatures are no longer accepted on the immediate-settlement UTXO endpoint.
- Keeps a positive regression test showing a domain-separated UTXO signature still settles normally.
- Adjusts the existing large dual-write fixture to a large amount that stays within the UTXO `MAX_INPUTS` rule, so it continues to test account-unit overflow behavior without asking one transfer to consume thousands of capped coinbase boxes.

## Validation

```text
python -m pytest -q node\tests\test_dual_write_unit_mismatch.py tests\test_utxo_legacy_signature_deadline.py --tb=short
# 14 passed

$env:PYTHONPATH='node'; python -m pytest -q node\test_utxo_db.py node\test_utxo_genesis_migration_units.py --tb=short
# 103 passed, 28 subtests passed

python -m py_compile node\utxo_endpoints.py node\tests\test_dual_write_unit_mismatch.py tests\test_utxo_legacy_signature_deadline.py
# passed

git diff --check -- node\utxo_endpoints.py node\tests\test_dual_write_unit_mismatch.py tests\test_utxo_legacy_signature_deadline.py
# passed
```

## Bounty note

Candidate for the UTXO red-team bounty: https://github.com/Scottcjn/rustchain-bounties/issues/2819

Suggested tier: Medium, because this is an authorization-domain / settlement-window bypass on the UTXO transfer endpoint. Maintainer discretion applies.

Payout wallet: `RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8`