### PR TITLE
fix(verifier): use public wallet balance endpoint

### DIFF
--- a/tests/test_star_checker.py
+++ b/tests/test_star_checker.py
@@ -153,24 +153,34 @@ def test_count_user_stars_uses_supplied_repos_without_fetching_owner_repos(monke
     assert star_checker.count_user_stars("targetuser", "owner", "secret", repos=["alpha", "beta"]) == 1
 
 
-def test_check_wallet_exists_uses_local_cert_when_present(monkeypatch, tmp_path):
+def test_check_wallet_exists_uses_public_wallet_balance_endpoint(monkeypatch, tmp_path):
     cert = tmp_path / ".rustchain" / "node_cert.pem"
     cert.parent.mkdir()
     cert.write_text("certificate", encoding="utf-8")
     seen = {}
 
-    def fake_get(url, verify, timeout):
+    def fake_get(url, params, verify, timeout):
         seen["url"] = url
+        seen["params"] = params
         seen["verify"] = verify
         seen["timeout"] = timeout
-        return FakeResponse(status_code=200)
+        return FakeResponse(status_code=200, payload={"amount_rtc": 0.0, "miner_id": "rtc-wallet"})
 
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setattr(star_checker.requests, "get", fake_get)
 
     assert star_checker.check_wallet_exists("rtc-wallet") is True
-    assert seen == {
-        "url": f"{star_checker.RUSTCHAIN_NODE_URL}/api/balance/rtc-wallet",
-        "verify": str(cert),
-        "timeout": 10,
-    }
+    assert seen["url"] == f"{star_checker.RUSTCHAIN_NODE_URL}/wallet/balance"
+    assert seen["params"] == {"miner_id": "rtc-wallet"}
+    assert Path(seen["verify"]) == cert
+    assert seen["timeout"] == 10
+
+
+def test_check_wallet_exists_rejects_non_object_balance_payload(monkeypatch):
+    def fake_get(url, params, verify, timeout):
+        return FakeResponse(status_code=200, payload=["not", "a", "wallet"])
+
+    monkeypatch.setattr(star_checker.requests, "get", fake_get)
+
+    assert star_checker.check_wallet_exists("rtc-wallet") is False

--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -132,13 +132,22 @@ def count_user_stars(
 def check_wallet_exists(wallet_address: str) -> bool:
     """Verify that a wallet address exists on the RustChain node."""
     try:
-        url = f"{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}"
+        url = f"{RUSTCHAIN_NODE_URL}/wallet/balance"
         import os
         _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
         _verify = _cert if os.path.exists(_cert) else True
-        resp = requests.get(url, verify=_verify, timeout=10)
+        resp = requests.get(
+            url,
+            params={"miner_id": wallet_address},
+            verify=_verify,
+            timeout=10,
+        )
         if resp.status_code == 200:
-            return True
+            try:
+                body = resp.json()
+            except ValueError:
+                return False
+            return isinstance(body, dict)
     except Exception as exc:
         logger.error("Error checking wallet %s: %s", wallet_address, exc)
     return False


### PR DESCRIPTION
## Summary
- update the bounty verifier star-checker wallet probe from stale `/api/balance/<wallet>` to the maintained public `/wallet/balance?miner_id=<wallet>` endpoint
- pass the wallet as a `miner_id` query parameter so requests handles encoding safely
- require the balance response to be a JSON object instead of accepting any HTTP 200 from the old path
- add regression coverage for the endpoint/params/cert path and malformed balance payloads

## Validation
- `python -m pytest -q tests\test_star_checker.py --tb=short` -> 11 passed
- `python -m py_compile tools\bounty_verifier\star_checker.py tests\test_star_checker.py`
- `git diff --check -- tools\bounty_verifier\star_checker.py tests\test_star_checker.py`

## Bounty / payout
General bug bounty: Scottcjn/Rustchain#305

Wallet: `RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8`