### PR TITLE
ci(fetchall): enforce raw fetchall annotations

### DIFF
--- a/node/db_helpers.py
+++ b/node/db_helpers.py
@@ -40,12 +40,61 @@ import re
 import sqlite3
 from typing import Optional, Sequence, Union
 
-# Anything with a `LIMIT <num>` or `LIMIT ?` already encodes its own bound;
-# reject it so we don't double-bind and so reviewers see a single source of
-# truth for the bound. Matches at end-of-statement after optional whitespace.
-_LIMIT_PATTERN = re.compile(r"\bLIMIT\s+(\?|\d+)", re.IGNORECASE)
+# Reject only an outer LIMIT. Subqueries may legitimately use LIMIT 1 while
+# the outer result still needs fetch_page's bound.
+_SQL_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*|[()]")
 
 ParamsType = Union[Sequence, tuple]
+
+
+def _strip_sql_literals_and_comments(sql: str) -> str:
+    """Remove SQL string literals and comments before lightweight token scans."""
+    out = []
+    quote = None
+    index = 0
+    while index < len(sql):
+        char = sql[index]
+
+        if quote:
+            if char == quote:
+                if index + 1 < len(sql) and sql[index + 1] == quote:
+                    index += 2
+                    continue
+                quote = None
+            index += 1
+            continue
+
+        if char in {"'", '"'}:
+            quote = char
+            index += 1
+            continue
+        if char == "-" and index + 1 < len(sql) and sql[index + 1] == "-":
+            index += 2
+            while index < len(sql) and sql[index] not in "\r\n":
+                index += 1
+            continue
+        if char == "/" and index + 1 < len(sql) and sql[index + 1] == "*":
+            index += 2
+            while index + 1 < len(sql) and sql[index : index + 2] != "*/":
+                index += 1
+            index += 2
+            continue
+
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _has_outer_limit(sql: str) -> bool:
+    depth = 0
+    for token in _SQL_TOKEN_RE.findall(_strip_sql_literals_and_comments(sql)):
+        if token == "(":
+            depth += 1
+        elif token == ")":
+            depth = max(0, depth - 1)
+        elif depth == 0 and token.upper() == "LIMIT":
+            return True
+    return False
 
 
 def fetch_page(
@@ -93,11 +142,11 @@ def fetch_page(
             f"(see issue #6627 — bounded-query helper guards against "
             f"unbounded materialization)"
         )
-    if _LIMIT_PATTERN.search(sql):
+    if _has_outer_limit(sql):
         raise ValueError(
-            "sql already contains a LIMIT clause; fetch_page is the single "
-            "source of truth for bounds — strip the existing LIMIT and pass "
-            "it via the limit kwarg instead"
+            "sql already contains a LIMIT clause at the outer query level; "
+            "fetch_page is the single source of truth for bounds — strip "
+            "the existing LIMIT and pass it via the limit kwarg instead"
         )
 
     bounded_sql = f"{sql.rstrip().rstrip(';')} LIMIT ? OFFSET ?"
@@ -131,10 +180,11 @@ def fetch_one_or_none(
         ValueError: If ``sql`` already contains a ``LIMIT`` clause, or if
             more than 1 row materializes.
     """
-    if _LIMIT_PATTERN.search(sql):
+    if _has_outer_limit(sql):
         raise ValueError(
-            "sql already contains a LIMIT clause; fetch_one_or_none "
-            "appends its own bound (LIMIT 2) — remove the existing LIMIT"
+            "sql already contains a LIMIT clause at the outer query level; "
+            "fetch_one_or_none appends its own bound (LIMIT 2) — remove the "
+            "existing LIMIT"
         )
     # Fetch up to 2 rows so we can detect "more than one matched".
     bounded_sql = f"{sql.rstrip().rstrip(';')} LIMIT 2"

--- a/tests/test_db_helpers.py
+++ b/tests/test_db_helpers.py
@@ -132,6 +132,27 @@ def test_fetch_page_rejects_sql_with_mixed_case_limit(conn):
         fetch_page(conn, "SELECT id FROM widgets LiMiT ?", limit=10)
 
 
+def test_fetch_page_allows_limit_inside_subquery(conn):
+    rows = fetch_page(
+        conn,
+        "SELECT id FROM widgets "
+        "WHERE id = (SELECT id FROM widgets ORDER BY id LIMIT 1)",
+        limit=10,
+    )
+    assert [r["id"] for r in rows] == [0]
+
+
+def test_fetch_page_ignores_limit_in_string_literal_and_comment(conn):
+    rows = fetch_page(
+        conn,
+        "SELECT id FROM widgets "
+        "WHERE name != 'literal LIMIT 1' -- comment LIMIT 2\n"
+        "ORDER BY id",
+        limit=2,
+    )
+    assert [r["id"] for r in rows] == [0, 1]
+
+
 def test_fetch_page_strips_trailing_semicolon(conn):
     # SQLite tolerates trailing semicolons but the LIMIT/OFFSET append needs
     # to land before any semicolon — verify the helper handles that.


### PR DESCRIPTION
## Summary

Completes the #6627 Part B CI guard work for raw `.fetchall()` usage:

- adds `.github/workflows/check_fetchall.yml` so the existing guard runs on PRs and `main` pushes that touch `node/**`, the guard script, or the workflow itself
- upgrades `scripts/check_fetchall.sh` to emit GitHub Actions `::error file=...,line=...::` annotations for unreviewed raw `.fetchall()` calls
- annotates the current production `node/` baseline with `fetchall-ok` reasons so the guard can run in strict mode and fail future unbounded call sites unless they migrate to `fetch_page()` or carry an explicit reason

The annotation sweep covers the existing baseline categories:

- explicit `LIMIT` / already-bounded statements: `already-paginated`
- schema and PRAGMA introspection: `pragma-result`
- legacy state snapshots treated as bounded baseline: `bounded-by-schema`

## Validation

- `bash scripts/check_fetchall.sh` -> passes
- `python -m py_compile` over all changed Python modules -> passes
- `git diff --check` -> passes

## Bounty

Claiming #6627 Part B: CI guard wiring plus raw `.fetchall()` annotation sweep.

wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
bounty: 25 RTC