### PR TITLE
fix: keep governance vote auth on signed wallet proof

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6579,7 +6579,6 @@ def governance_proposal_detail(proposal_id: int):
 
 
 @app.route('/governance/vote', methods=['POST'])
-@admin_required
 def governance_vote():
     data = request.get_json(silent=True)
     if data is None:


### PR DESCRIPTION
## Summary
- remove the admin-key gate from `POST /governance/vote`
- keep governance voting authorized by the existing Ed25519 wallet signature, active-miner, balance, active proposal, and duplicate-vote checks
- restore the holder-voting contract required by the governance bounty and already exercised by `node/tests/test_integrated_governance_vote_race.py`

## Why
PR #6719 added `@admin_required` because the vote route was described as unauthenticated. The route already authenticates user intent by deriving the wallet from `public_key` and verifying a signature over `proposal_id`, `wallet`, `vote`, and `nonce`. Requiring `RC_ADMIN_KEY` on top means normal RTC holders/miners cannot cast signed votes unless they know the node operator secret.

## Validation
Not run locally in this Windows workspace because only the single-line source patch was applied through the GitHub API. Existing regression coverage should exercise this path:
- `node/tests/test_integrated_governance_vote_race.py` posts a signed governance vote without an admin header and expects the route to reach governance vote logic.

Fixes Scottcjn/rustchain-bounties#12818
Related: Scottcjn/rustchain-bounties#71, Scottcjn/rustchain-bounties#50

Payout target if accepted: `luisalias007-cmyk` / wallet registration Scottcjn/rustchain-bounties#12816