### PR TITLE
localization: add es-ES Linux miner consent pass

### DIFF
--- a/docs/es-ES/RUSTCHAIN_EXPLAINED.md
+++ b/docs/es-ES/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain explicada (es-ES)
+
+RustChain es una red Proof-of-Antiquity que recompensa máquinas reales, especialmente hardware antiguo, por demostrar que siguen funcionando. La idea central es simple: el hardware preservado tiene valor, y la red debe poder diferenciar una máquina real de una VM, contenedor o declaración fabricada.
+
+## Cómo funciona la verificación
+
+El miner recoge señales locales y envía una `attestation` al nodo RustChain. Esa `attestation` incluye un `fingerprint` de hardware. El nodo usa esos datos para estimar la `antiquity` de la máquina y calcular el multiplicador de recompensa.
+
+El proceso debe ser honesto:
+
+- no inventes arquitectura;
+- no fuerces una familia de CPU que la máquina no tiene;
+- no alteres el payload para parecer más antiguo;
+- no traduzcas flags de comando ni nombres de endpoints.
+
+## Verificar antes de minar
+
+Usa los comandos siguientes antes de dejar cualquier miner ejecutándose:
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Estos comandos ayudan a revisar la máquina detectada, el payload de `attestation` y la conectividad con el nodo. Deben permanecer exactamente así en la documentación localizada.
+
+## Qué consiente el usuario
+
+Al confirmar la primera ejecución, el usuario declara que entiende que:
+
+1. el miner puede enviar datos de `fingerprint` y `attestation`;
+2. el hardware debe declararse de forma honesta;
+3. las recompensas en `RTC` dependen de la aceptación de la red y no están garantizadas;
+4. el spoofing, la emulación no declarada o un payload fabricado pueden reducir recompensas o causar rechazo.
+
+La pantalla de consentimiento en español debe exigir una entrada afirmativa explícita, como `SI`. Pulsar Enter sin más no debe iniciar la minería.
+
+## Glosario preservado
+
+| Término | Significado operativo |
+|---|---|
+| `RTC` | Token usado por RustChain para recompensas y bounties. |
+| `attestation` | Declaración verificable de la máquina enviada al nodo. |
+| `antiquity` | Señal de edad, rareza y preservación del hardware. |
+| `fingerprint` | Conjunto de señales de hardware usadas para verificación. |
+
+## Guía del miner de Linux
+
+La guía localizada del miner de Linux está en:
+
+- [miners/linux/README.es-ES.md](../../miners/linux/README.es-ES.md)

--- a/i18n/es-ES.json
+++ b/i18n/es-ES.json
@@ -2,8 +2,7 @@
   "locale": "es-ES",
   "language": "Spanish",
   "version": "1.0.0",
-  "description": "Traducción al español de mensajes de error de la interfaz de usuario de RustChain Miner/Billetera",
-
+  "description": "Traducción al español de mensajes de error de la interfaz de usuario de RustChain Miner/Billetera y consentimiento de primera ejecución",
   "errors": {
     "wallet": {
       "invalid_amount": "Cantidad inválida",
@@ -95,7 +94,6 @@
       "close": "Cerrar"
     }
   },
-
   "messages": {
     "wallet": {
       "balance_display": "Saldo: {balance:.8f} RTC",
@@ -122,6 +120,13 @@
       "status_mining": "Minando...",
       "status_waiting": "Esperando calificación...",
       "status_error": "Error: {message}"
+    },
+    "miner_consent": {
+      "title": "Consentimiento de primera ejecución de RustChain Miner",
+      "body": "Antes de minar, revisa los comandos --dry-run, --show-payload y --test-only. El miner enviará datos de fingerprint y attestation al nodo RustChain. El hardware debe declararse de forma honesta; no fabriques arquitectura, antiquity ni señales de hardware. Las recompensas en RTC no están garantizadas.",
+      "prompt": "Escribe SI para confirmar que entiendes y quieres continuar:",
+      "affirmative": "SI",
+      "rejected": "Consentimiento no confirmado. La minería no se iniciará."
     }
   }
 }

--- a/miners/linux/README.es-ES.md
+++ b/miners/linux/README.es-ES.md
@@ -1,0 +1,69 @@
+# RustChain Miner para Linux (es-ES)
+
+Esta guía localiza el flujo del miner de Linux para hablantes de español. Conserva los términos de arte `RTC`, `attestation`, `antiquity` y `fingerprint`, porque aparecen igual en el protocolo, los logs y las APIs.
+
+## Verificar antes de confiar
+
+Antes de minar, ejecuta los comandos de verificación. Muestran qué se enviará al nodo y permiten revisar el payload sin iniciar una sesión de minería.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+No traduzcas ni cambies las flags anteriores. `--dry-run`, `--show-payload` y `--test-only` son comandos literales.
+
+## Qué hace el miner
+
+El miner de Linux detecta la máquina local, recoge señales honestas de hardware y envía una `attestation` al nodo RustChain. Esas señales forman un `fingerprint` de hardware que se usa para estimar la `antiquity` de la máquina y aplicar el multiplicador correcto.
+
+El miner no debe inventar arquitectura, edad del hardware, número de núcleos, número de serie, hostname ni ninguna otra señal. Si una señal no está disponible, el comportamiento correcto es declarar su ausencia o degradar la verificación.
+
+## Instalar dependencias
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+En distribuciones Debian/Ubuntu, si `python3` o `pip` no están instalados:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Ejecutar el miner
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Usa una cartera o identificador que puedas reconocer después. El payout de bounties puede usar `github:tu-usuario`, pero la minería normal usa el valor pasado en `--wallet`.
+
+## Consentimiento de primera ejecución
+
+En la primera ejecución interactiva, el usuario debe confirmar explícitamente que entiende:
+
+- el miner envía datos de `fingerprint` y `attestation` al nodo RustChain;
+- los comandos de verificación deben usarse antes de minar;
+- las recompensas en `RTC` no están garantizadas;
+- la máquina debe presentarse de forma honesta, sin spoofing de hardware.
+
+Respuesta afirmativa en español: `SI`.
+
+## Referencia cruzada
+
+Para una explicación corta del protocolo y de los términos preservados, lee:
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/es-ES/RUSTCHAIN_EXPLAINED.md)
+
+## Glosario
+
+| Término | Cómo mantenerlo | Nota |
+|---|---|---|
+| `RTC` | `RTC` | Token nativo de RustChain. |
+| `attestation` | `attestation` | Prueba enviada al nodo sobre la máquina. |
+| `antiquity` | `antiquity` | Edad/rareza relativa usada en el multiplicador. |
+| `fingerprint` | `fingerprint` | Conjunto de señales de hardware. |


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#12790

Submission grammar:
- target_lang: es-ES
- files:
  - `miners/linux/README.es-ES.md`
  - `docs/es-ES/RUSTCHAIN_EXPLAINED.md`
  - `i18n/es-ES.json`
- glossary / terms-of-art kept literal: `RTC`, `attestation`, `antiquity`, `fingerprint`

Acceptance notes:
- Consent text still requires explicit affirmative input: `SI`.
- Verification commands are preserved literally: `--dry-run`, `--show-payload`, `--test-only`.
- The localized Linux miner README cross-links to the es-ES RustChain explainer, and the explainer links back to the localized miner README.
- No README badge/self-promo content added.

Validation:
- `python3 -m json.tool i18n/es-ES.json`
- `python3 i18n/validate_i18n.py`
- `git diff --check -- miners/linux/README.es-ES.md docs/es-ES/RUSTCHAIN_EXPLAINED.md i18n/es-ES.json`

Requested payout: 10 RTC to the existing canonical GitHub payout identity `github:JONASXZB` / `JONASXZB`.