### PR TITLE
Fix PoA validator direct-run imports

### DIFF
--- a/rustchain-poa/api/poa_api.py
+++ b/rustchain-poa/api/poa_api.py
@@ -1,9 +1,17 @@
 # SPDX-License-Identifier: MIT
 
-from flask import Flask, request, jsonify
-from validator.validate_genesis import validate_genesis
-import tempfile
 import os
+import sys
+import tempfile
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+
+POA_ROOT = Path(__file__).resolve().parents[1]
+if str(POA_ROOT) not in sys.path:
+    sys.path.insert(0, str(POA_ROOT))
+
+from validator.validate_genesis import validate_genesis
 
 app = Flask(__name__)
 

--- a/rustchain-poa/cli/run_validator.py
+++ b/rustchain-poa/cli/run_validator.py
@@ -1,6 +1,12 @@
-import sys
-from validator.validate_genesis import validate_genesis
 import json
+import sys
+from pathlib import Path
+
+POA_ROOT = Path(__file__).resolve().parents[1]
+if str(POA_ROOT) not in sys.path:
+    sys.path.insert(0, str(POA_ROOT))
+
+from validator.validate_genesis import validate_genesis
 
 if len(sys.argv) != 2:
     print("Usage: python run_validator.py path/to/genesis.json")

--- a/tests/test_poa_validator_entrypoints.py
+++ b/tests/test_poa_validator_entrypoints.py
@@ -1,0 +1,22 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_poa_cli_runs_without_external_pythonpath(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    genesis = tmp_path / "genesis.json"
+    genesis.write_text("{}", encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, "rustchain-poa/cli/run_validator.py", str(genesis)],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = result.stdout[result.stdout.find("{") :]
+    assert json.loads(output)["validated"] in {True, False}


### PR DESCRIPTION
Fixes a PoA validator entrypoint import bug where running the CLI/API files directly cannot resolve `validator.validate_genesis` unless callers manually set `PYTHONPATH=rustchain-poa`.

Before:
```bash
python3 rustchain-poa/cli/run_validator.py /tmp/genesis.json
# ModuleNotFoundError: No module named 'validator'
```

What changed:
- adds the `rustchain-poa` package root to `sys.path` at the CLI/API entrypoints before importing `validator.validate_genesis`
- keeps normal package imports unchanged after the path is present
- adds a focused regression test under the existing `tests/` suite that runs the CLI without external `PYTHONPATH`

Validation:
```bash
python3 rustchain-poa/cli/run_validator.py /tmp/poa-genesis.json
# returns JSON containing "validated"
```

Local note: `python3 -m pytest tests/test_poa_validator_entrypoints.py -q` requires the repo's CI dependencies (for example Flask via `tests/conftest.py`); direct CLI validation above passed locally.

Bug bounty context: this is a small direct-runner reliability bug for the RustChain PoA validator tooling.