### PR TITLE
Fix monitor miners envelope normalization

### DIFF
--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -77,12 +77,6 @@ def get_epoch():
     except Exception as e:
         return {"error": str(e)}
 
-def normalize_miners_payload(data):
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict) and isinstance(data.get("miners"), list):
-        return data["miners"]
-    return None
 
 def print_health(data):
     if "error" in data:
@@ -112,7 +106,7 @@ def print_miners(data):
         print(f"❌ Failed to fetch miners: {data['error']}")
         return
     miners = normalize_miners_payload(data)
-    if miners is None:
+    if not isinstance(miners, list):
         print(f"⚠ Unexpected response: {data}")
         return
     print(f"📊 Active miners: {len(miners)}")


### PR DESCRIPTION
Fixes a RustChain monitor bug where the correct `/api/miners` envelope normalizer was immediately overwritten by a second narrower `normalize_miners_payload` definition.

Before:
- `get_miners()` could fetch the current API shape `{ "items": [...], "pagination": ... }`
- the later duplicate normalizer only accepted `{ "miners": [...] }`
- the monitor returned the raw envelope instead of miner rows, and `tests/test_rustchain_monitor.py::test_request_helpers_call_expected_endpoints` failed

What changed:
- remove the duplicate narrower normalizer
- keep the earlier normalizer that accepts legacy lists plus `miners`, `data`, and `items` envelopes
- make `print_miners` check for a normalized list explicitly before printing rows

Validation:
```bash
python3 - <<'CHECK'
import importlib.util
from pathlib import Path
spec = importlib.util.spec_from_file_location('rustchain_monitor', Path('tools/rustchain-monitor/rustchain_monitor.py'))
mod = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
assert mod.normalize_miners_payload({'items':[{'miner':'alice'}], 'pagination': {'total': 1}}) == [{'miner':'alice'}]
assert mod.normalize_miners_payload({'data':[{'miner':'bob'}]}) == [{'miner':'bob'}]
assert mod.normalize_miners_payload({'pagination': {'total': 0}}) == {'pagination': {'total': 0}}
print('direct monitor normalization checks passed')
CHECK
```

Local note: `python3 -m pytest tests/test_rustchain_monitor.py -q` is blocked in this local environment before reaching the test file because `tests/conftest.py` imports the integrated Flask node and Flask is not installed locally. Hosted CI installs Flask in `.github/workflows/ci.yml`.