### PR TITLE
Fix bridge initiate miner source validation

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -272,6 +272,15 @@ def validate_chain_address_format(chain: str, address: str) -> Tuple[bool, str]:
     return True, ""
 
 
+def validate_bridge_route_address(
+    chain: str, address: str, *, rustchain_source_is_miner: bool = False
+) -> Tuple[bool, str]:
+    """Validate a bridge route address without conflating miner IDs and wallets."""
+    if chain == "rustchain" and rustchain_source_is_miner:
+        return validate_miner_id_format(address)
+    return validate_chain_address_format(chain, address)
+
+
 # =============================================================================
 # Bridge Transfer Functions
 # =============================================================================
@@ -801,27 +810,35 @@ def register_bridge_routes(app):
         if not validation.ok:
             return jsonify({"error": validation.error}), 400
         details = validation.details or {}
+
+        # Deposits lock balances keyed by RustChain miner_id. Require operator
+        # authorization before any address-format response can mask auth state
+        # or leak validation behavior for another miner's balance.
+        admin_key = request.headers.get("X-Admin-Key", "")
+        expected_admin_key = os.environ.get("RC_ADMIN_KEY", "")
+        admin_initiated = bool(expected_admin_key) and hmac.compare_digest(admin_key, expected_admin_key)
+        if details["direction"] == "deposit":
+            if not expected_admin_key:
+                return jsonify({"error": "RC_ADMIN_KEY not configured"}), 503
+            if not admin_initiated:
+                return jsonify({"error": "unauthorized"}), 401
         
         # Validate address formats
         for chain, addr in [
             (details["source_chain"], details["source_address"]),
             (details["dest_chain"], details["dest_address"])
         ]:
-            valid, msg = validate_chain_address_format(chain, addr)
+            valid, msg = validate_bridge_route_address(
+                chain,
+                addr,
+                rustchain_source_is_miner=(
+                    details["direction"] == "deposit"
+                    and chain == details["source_chain"]
+                    and chain == "rustchain"
+                ),
+            )
             if not valid:
                 return jsonify({"error": f"Invalid {chain} address: {msg}"}), 400
-        
-        # Check admin initiation (bypasses balance check)
-        admin_key = request.headers.get("X-Admin-Key", "")
-        expected_admin_key = os.environ.get("RC_ADMIN_KEY", "")
-        admin_initiated = bool(expected_admin_key) and hmac.compare_digest(admin_key, expected_admin_key)
-        if details["direction"] == "deposit":
-            # Deposits create balance locks by source_address; require operator
-            # authorization until a wallet-owner signature flow exists.
-            if not expected_admin_key:
-                return jsonify({"error": "RC_ADMIN_KEY not configured"}), 503
-            if not admin_initiated:
-                return jsonify({"error": "unauthorized"}), 401
         
         # Create bridge transfer
         req = BridgeTransferRequest(

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -315,7 +315,7 @@ class TestAddressValidation:
     def test_valid_rustchain_address(self, setup_test_db):
         """Test valid RustChain address."""
         bridge_api = setup_test_db["bridge_api"]
-        valid, msg = bridge_api.validate_chain_address_format("rustchain", "RTC_test123abc")
+        valid, msg = bridge_api.validate_chain_address_format("rustchain", "RTC" + "a" * 40)
         assert valid is True
     
     def test_invalid_rustchain_address_prefix(self, setup_test_db):


### PR DESCRIPTION
## Summary

Refs #305.

Fixes a bridge-initiate regression where deposit requests treated the RustChain `source_address` as a strict `RTC` + 40-hex wallet address before checking operator authorization. Deposit locks are keyed by `balances.miner_id`, so valid miner IDs such as `RTC_test_miner` were rejected with `400` and unauthenticated requests were masked as validation errors instead of returning `401`/`503`.

Changes:
- Check the deposit operator/admin key before address-format validation so auth state is not masked by source-address validation.
- Add route-specific address validation that uses `validate_miner_id_format()` only for the RustChain deposit source miner ID.
- Keep `validate_chain_address_format("rustchain", ...)` strict for canonical `RTC` + 40-hex wallet/address checks and all non-deposit route address validation.
- Align the direct RustChain address test fixture with the strict faucet-format validator.

## Validation

Focused passing checks:
- `.venv/bin/python -m pytest node/test_bridge_address_validation_6193_6195.py tests/test_bridge_lock_ledger.py::TestAddressValidation tests/test_bridge_lock_ledger.py::TestBridgeInitiateAuth -q` -> `42 passed`

Broader bridge-file check:
- `.venv/bin/python -m pytest tests/test_bridge_lock_ledger.py -q` -> `58 passed, 4 failed`
- The remaining 4 failures are existing `lock_ledger` read-route admin-auth expectations. I did not change those routes because `node/lock_ledger.py` explicitly documents that they expose miner lock balances / pending unlocks and require an admin key.

No private keys, wallet secrets, production mutation, proxy/profile changes, or payout operations were used.
