### PR TITLE
test(ci): fix 21 stale tests + httpx dep (main pytest was red)

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -16,3 +16,5 @@ matplotlib>=3.10.9
 seaborn>=0.13.2
 # Needed by node/rustchain_dashboard.py during dashboard security tests.
 psutil>=5.9.0
+# Needed by sdk/python/rustchain_sdk/client.py import during signed-transfer/SDK tests.
+httpx>=0.27.0

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -60,7 +60,38 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         # Initialize database tables
         init_beacon_tables(cls.test_db_path)
         
-        cls.client = cls.app.test_client()
+        # Beacon read endpoints (/api/contracts, /api/reputation, ...) became
+        # admin-gated (#6322-era). Configure RC_ADMIN_KEY and inject X-Admin-Key
+        # on every request so these admin-context workflow tests reach the routes.
+        cls._orig_admin_key = os.environ.get("RC_ADMIN_KEY")
+        os.environ["RC_ADMIN_KEY"] = "beacon-admin-key"
+
+        class _AdminClient:
+            def __init__(self, c):
+                self._c = c
+
+            def _with_admin(self, kwargs):
+                headers = dict(kwargs.pop("headers", {}) or {})
+                headers.setdefault("X-Admin-Key", "beacon-admin-key")
+                kwargs["headers"] = headers
+                return kwargs
+
+            def get(self, *a, **k):
+                return self._c.get(*a, **self._with_admin(k))
+
+            def post(self, *a, **k):
+                return self._c.post(*a, **self._with_admin(k))
+
+            def put(self, *a, **k):
+                return self._c.put(*a, **self._with_admin(k))
+
+            def delete(self, *a, **k):
+                return self._c.delete(*a, **self._with_admin(k))
+
+            def __getattr__(self, name):
+                return getattr(self._c, name)
+
+        cls.client = _AdminClient(cls.app.test_client())
         cls.agent_keys = {
             agent_id: Ed25519PrivateKey.generate()
             for agent_id in [
@@ -76,6 +107,10 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         """Clean up after all tests."""
         cls.client = None
         cls.app = None
+        if cls._orig_admin_key is None:
+            os.environ.pop("RC_ADMIN_KEY", None)
+        else:
+            os.environ["RC_ADMIN_KEY"] = cls._orig_admin_key
         gc.collect()
         os.close(cls.test_db_fd)
         os.unlink(cls.test_db_path)

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -166,11 +166,11 @@ def funded_miner(setup_test_db):
     conn = sqlite3.connect(setup_test_db['db_path'])
     conn.execute(
         "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
-        ("RTC_test_miner", 100 * 1000000)  # 100 RTC
+        ("RTC0123456789abcdef0123456789abcdef01234567", 100 * 1000000)  # 100 RTC
     )
     conn.commit()
     conn.close()
-    return "RTC_test_miner"
+    return "RTC0123456789abcdef0123456789abcdef01234567"
 
 
 def assert_generic_database_error(result):
@@ -315,7 +315,7 @@ class TestAddressValidation:
     def test_valid_rustchain_address(self, setup_test_db):
         """Test valid RustChain address."""
         bridge_api = setup_test_db["bridge_api"]
-        valid, msg = bridge_api.validate_chain_address_format("rustchain", "RTC_test123abc")
+        valid, msg = bridge_api.validate_chain_address_format("rustchain", "RTC0123456789abcdef0123456789abcdef01234567")
         assert valid is True
     
     def test_invalid_rustchain_address_prefix(self, setup_test_db):
@@ -648,7 +648,7 @@ class TestLockLedger:
 
         success, result = lock_ledger.create_lock(
             conn,
-            miner_id="RTC_test_miner",
+            miner_id="RTC0123456789abcdef0123456789abcdef01234567",
             amount_i64=10 * 1000000,
             lock_type="bridge_deposit",
             unlock_at=int(time.time()) + 3600
@@ -802,26 +802,29 @@ class TestLockLedgerRoutes:
                 (lock_id, miner_id, 5 * 1000000, "bridge_deposit", now - 3600, now + 3600, "locked", now - 3600),
             )
 
-    def test_miner_locks_rejects_malformed_limit(self, setup_test_db, funded_miner):
+    def test_miner_locks_rejects_malformed_limit(self, setup_test_db, funded_miner, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
+        monkeypatch.setenv("RC_ADMIN_KEY", "lock-admin-key")
         client = self._client(lock_ledger, setup_test_db["db_path"])
 
-        response = client.get(f"/api/lock/miner/{funded_miner}?limit=abc")
+        response = client.get(f"/api/lock/miner/{funded_miner}?limit=abc", headers={"X-Admin-Key": "lock-admin-key"})
 
         assert response.status_code == 400
         assert response.get_json() == {"error": "limit must be an integer"}
 
-    def test_pending_unlock_rejects_malformed_before(self, setup_test_db):
+    def test_pending_unlock_rejects_malformed_before(self, setup_test_db, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
+        monkeypatch.setenv("RC_ADMIN_KEY", "lock-admin-key")
         client = self._client(lock_ledger, setup_test_db["db_path"])
 
-        response = client.get("/api/lock/pending-unlock?before=not-a-timestamp")
+        response = client.get("/api/lock/pending-unlock?before=not-a-timestamp", headers={"X-Admin-Key": "lock-admin-key"})
 
         assert response.status_code == 400
         assert response.get_json() == {"error": "before must be an integer"}
 
-    def test_pending_unlock_route_calls_database_helper(self, setup_test_db, funded_miner):
+    def test_pending_unlock_route_calls_database_helper(self, setup_test_db, funded_miner, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
+        monkeypatch.setenv("RC_ADMIN_KEY", "lock-admin-key")
         db_path = setup_test_db["db_path"]
         now = int(time.time())
         with sqlite3.connect(db_path) as conn:
@@ -842,7 +845,7 @@ class TestLockLedgerRoutes:
 
         client = self._client(lock_ledger, db_path)
 
-        response = client.get("/api/lock/pending-unlock?limit=10")
+        response = client.get("/api/lock/pending-unlock?limit=10", headers={"X-Admin-Key": "lock-admin-key"})
 
         assert response.status_code == 200
         body = response.get_json()
@@ -850,8 +853,9 @@ class TestLockLedgerRoutes:
         assert body["count"] == 1
         assert body["locks"][0]["miner_id"] == funded_miner
 
-    def test_pending_unlock_before_zero_applies_cutoff(self, setup_test_db, funded_miner):
+    def test_pending_unlock_before_zero_applies_cutoff(self, setup_test_db, funded_miner, monkeypatch):
         lock_ledger = setup_test_db["lock_ledger"]
+        monkeypatch.setenv("RC_ADMIN_KEY", "lock-admin-key")
         db_path = setup_test_db["db_path"]
         now = int(time.time())
         with sqlite3.connect(db_path) as conn:
@@ -872,7 +876,7 @@ class TestLockLedgerRoutes:
 
         client = self._client(lock_ledger, db_path)
 
-        response = client.get("/api/lock/pending-unlock?before=0&limit=10")
+        response = client.get("/api/lock/pending-unlock?before=0&limit=10", headers={"X-Admin-Key": "lock-admin-key"})
 
         assert response.status_code == 200
         body = response.get_json()

--- a/tests/test_governance_api.py
+++ b/tests/test_governance_api.py
@@ -44,16 +44,21 @@ def test_governance_propose_requires_gt_10_rtc_balance():
         integrated_node.app.config["DB_PATH"] = db_path
         integrated_node.init_db()
 
+        pub_hex = "22" * 32
+        wallet = integrated_node.address_from_pubkey(pub_hex)
         with sqlite3.connect(db_path) as c:
-            c.execute("INSERT INTO balances(miner_pk, balance_rtc) VALUES(?, ?)", ("RTC-low", 10.0))
+            c.execute("INSERT INTO balances(miner_pk, balance_rtc) VALUES(?, ?)", (wallet, 10.0))
             c.commit()
 
         integrated_node.app.config["TESTING"] = True
         with integrated_node.app.test_client() as client:
-            resp = client.post(
-                "/governance/propose",
-                json={"wallet": "RTC-low", "title": "No", "description": "insufficient"},
-            )
+            # propose now requires proposer authentication (signed); sig verify mocked
+            with patch("integrated_node.verify_rtc_signature", return_value=True):
+                resp = client.post(
+                    "/governance/propose",
+                    json={"wallet": wallet, "title": "No", "description": "insufficient",
+                          "nonce": "p-1", "signature": "ab" * 64, "public_key": pub_hex},
+                )
             assert resp.status_code == 403
             assert resp.get_json()["error"] == "insufficient_balance_to_propose"
 
@@ -67,20 +72,25 @@ def test_governance_propose_rejects_non_object_json():
     assert resp.get_json()["error"] == "JSON object required"
 
 
-def test_governance_vote_rejects_non_object_json():
+def test_governance_vote_rejects_non_object_json(monkeypatch):
+    # /governance/vote is @admin_required since #6719; authenticate to reach validation
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "gov-admin-key", raising=False)
     integrated_node.app.config["TESTING"] = True
     with integrated_node.app.test_client() as client:
-        resp = client.post("/governance/vote", json=["not", "an", "object"])
+        resp = client.post("/governance/vote", json=["not", "an", "object"],
+                           headers={"X-Admin-Key": "gov-admin-key"})
 
     assert resp.status_code == 400
     assert resp.get_json()["error"] == "JSON object required"
 
 
-def test_governance_vote_rejects_invalid_proposal_id():
+def test_governance_vote_rejects_invalid_proposal_id(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "gov-admin-key", raising=False)  # vote @admin_required (#6719)
     integrated_node.app.config["TESTING"] = True
     with integrated_node.app.test_client() as client:
         resp = client.post(
             "/governance/vote",
+            headers={"X-Admin-Key": "gov-admin-key"},
             json={
                 "proposal_id": "not-an-int",
                 "wallet": "RTC-test",
@@ -97,7 +107,8 @@ def test_governance_vote_rejects_invalid_proposal_id():
     )
 
 
-def test_governance_vote_flow_and_lifecycle_finalization():
+def test_governance_vote_flow_and_lifecycle_finalization(monkeypatch):
+    monkeypatch.setattr(integrated_node, "ADMIN_KEY", "gov-admin-key", raising=False)  # vote @admin_required (#6719)
     with _temporary_directory() as td:
         db_path = str(Path(td) / "gov.db")
         integrated_node.DB_PATH = db_path
@@ -135,11 +146,13 @@ def test_governance_vote_flow_and_lifecycle_finalization():
 
         integrated_node.app.config["TESTING"] = True
         with integrated_node.app.test_client() as client:
-            # Create proposal
-            r1 = client.post(
-                "/governance/propose",
-                json={"wallet": wallet, "title": "Raise testnet fee", "description": "for anti-spam"},
-            )
+            # Create proposal (propose now requires proposer auth; sig verify mocked)
+            with patch("integrated_node.verify_rtc_signature", return_value=True):
+                r1 = client.post(
+                    "/governance/propose",
+                    json={"wallet": wallet, "title": "Raise testnet fee", "description": "for anti-spam",
+                          "nonce": "p-1", "signature": "ab" * 64, "public_key": pub_hex},
+                )
             assert r1.status_code == 201
             proposal_id = r1.get_json()["proposal"]["id"]
 
@@ -148,6 +161,7 @@ def test_governance_vote_flow_and_lifecycle_finalization():
             with patch("integrated_node.verify_rtc_signature", return_value=True):
                 r2 = client.post(
                     "/governance/vote",
+                    headers={"X-Admin-Key": "gov-admin-key"},
                     json={
                         **payload,
                         "public_key": pub_hex,

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -327,7 +327,8 @@ def test_gpu_protocol_attest_requires_admin_key_before_write(tmp_path, monkeypat
 
     assert response.status_code == 401
     assert response.get_json() == {"error": "Unauthorized - admin key required"}
-    nodes = client.get("/gpu/nodes").get_json()
+    # /gpu/nodes became admin-gated in #6557; authenticate the read
+    nodes = client.get("/gpu/nodes", headers={"X-Admin-Key": "test-admin-key"}).get_json()
     assert nodes["count"] == 0
 
 
@@ -348,8 +349,8 @@ def test_gpu_protocol_attest_fails_closed_without_admin_key(tmp_path, monkeypatc
 
     assert response.status_code == 503
     assert response.get_json() == {"error": "RC_ADMIN_KEY not configured"}
-    nodes = client.get("/gpu/nodes").get_json()
-    assert nodes["count"] == 0
+    # with RC_ADMIN_KEY unset, the admin-gated /gpu/nodes also fails closed (#6557)
+    assert client.get("/gpu/nodes").status_code == 503
 
 
 def test_gpu_protocol_attest_accepts_api_key_header(tmp_path, monkeypatch):
@@ -369,7 +370,8 @@ def test_gpu_protocol_attest_accepts_api_key_header(tmp_path, monkeypatch):
 
     assert response.status_code == 200
     assert response.get_json()["status"] == "attested"
-    nodes = client.get("/gpu/nodes").get_json()
+    # /gpu/nodes' _admin_key_required (#6557) checks X-Admin-Key only (attest also takes X-API-Key)
+    nodes = client.get("/gpu/nodes", headers={"X-Admin-Key": "test-admin-key"}).get_json()
     assert nodes["count"] == 1
 
 

--- a/tests/test_otc_bridge_htlc_preimage.py
+++ b/tests/test_otc_bridge_htlc_preimage.py
@@ -182,7 +182,11 @@ def test_buy_order_defers_htlc_secret_to_matching_seller(tmp_path):
         assert "htlc_secret" not in public_order
 
         with patch.object(module.requests, "post") as mock_post:
-            mock_post.return_value = MagicMock(ok=True, text='{"ok": true}')
+            # .json() must return a serializable dict — the broadcast/escrow path
+            # does r.json().get(...) and embeds the result in the response.
+            mock_resp = MagicMock(ok=True, status_code=200, text='{"ok": true}')
+            mock_resp.json.return_value = {"ok": True, "status": "broadcast", "job_id": "job-test"}
+            mock_post.return_value = mock_resp
             confirm_response = client.post(
                 f"/api/orders/{order['order_id']}/confirm",
                 json={

--- a/tests/test_server_proxy_path.py
+++ b/tests/test_server_proxy_path.py
@@ -92,7 +92,7 @@ def test_proxy_keeps_safe_requests_under_api(monkeypatch):
         text = "ok"
         headers = {"Content-Type": "text/plain"}
 
-    def fake_get(url, timeout):
+    def fake_get(url, timeout, headers=None):  # proxy now forwards headers= (node/server_proxy.py)
         captured["url"] = url
         captured["timeout"] = timeout
         return FakeResponse()

--- a/tests/test_signed_transfer_replay.py
+++ b/tests/test_signed_transfer_replay.py
@@ -573,7 +573,7 @@ def test_pending_confirm_keeps_transfer_pending_on_unsupported_balance_schema(mo
     assert body["confirmed_count"] == 0
     assert body["confirmed_ids"] == []
     assert body["errors"] == [
-        {"id": 1, "error": "unsupported balances schema for wallet transfer"}
+        {"id": 1, "error": "internal_error"}  # confirm_pending now redacts internal exceptions (#3202/#5546)
     ]
 
     with closing(sqlite3.connect(db_path)) as conn:

--- a/tests/test_tx_handler_error_redaction.py
+++ b/tests/test_tx_handler_error_redaction.py
@@ -4,9 +4,18 @@
 Regression tests for transaction API internal error redaction.
 """
 
+import os
+
 from flask import Flask
 
 from node.rustchain_tx_handler import create_tx_api_routes
+
+# These GET endpoints became admin-gated in #6295 ("require admin auth on tx
+# handler GET endpoints — prevents unauthorized transaction surveillance"). The
+# redaction these tests verify happens AFTER the auth check, so the request must
+# authenticate to reach (and trigger) the internal-error path.
+_ADMIN_KEY = "test-admin-key"
+_ADMIN_HDR = {"X-Admin-Key": _ADMIN_KEY}
 
 
 LEAKY_ERROR = "no such table: pending_transactions at /srv/rustchain/prod.db"
@@ -41,6 +50,7 @@ class ExplodingPool:
 
 
 def _client_for_exploding_pool():
+    os.environ["RC_ADMIN_KEY"] = _ADMIN_KEY  # so require_admin() is configured (not 503)
     app = Flask(__name__)
     app.config["TESTING"] = True
     create_tx_api_routes(app, ExplodingPool())
@@ -56,22 +66,22 @@ def _assert_redacted(response):
 
 def test_tx_status_redacts_internal_exception_details():
     with _client_for_exploding_pool() as client:
-        _assert_redacted(client.get("/tx/status/hash_1"))
+        _assert_redacted(client.get("/tx/status/hash_1", headers=_ADMIN_HDR))
 
 
 def test_tx_pending_redacts_internal_exception_details():
     with _client_for_exploding_pool() as client:
-        _assert_redacted(client.get("/tx/pending"))
+        _assert_redacted(client.get("/tx/pending", headers=_ADMIN_HDR))
 
 
 def test_wallet_balance_redacts_internal_exception_details():
     with _client_for_exploding_pool() as client:
-        _assert_redacted(client.get("/wallet/alice/balance"))
+        _assert_redacted(client.get("/wallet/alice/balance", headers=_ADMIN_HDR))
 
 
 def test_wallet_nonce_redacts_internal_exception_details():
     with _client_for_exploding_pool() as client:
-        _assert_redacted(client.get("/wallet/alice/nonce"))
+        _assert_redacted(client.get("/wallet/alice/nonce", headers=_ADMIN_HDR))
 
 
 def test_wallet_history_redacts_internal_exception_details(monkeypatch):
@@ -83,4 +93,4 @@ def test_wallet_history_redacts_internal_exception_details(monkeypatch):
     monkeypatch.setattr(tx_handler.sqlite3, "connect", raise_connect_error)
 
     with _client_for_exploding_pool() as client:
-        _assert_redacted(client.get("/wallet/alice/history"))
+        _assert_redacted(client.get("/wallet/alice/history", headers=_ADMIN_HDR))

--- a/tests/test_tx_handler_error_redaction.py
+++ b/tests/test_tx_handler_error_redaction.py
@@ -4,8 +4,7 @@
 Regression tests for transaction API internal error redaction.
 """
 
-import os
-
+import pytest
 from flask import Flask
 
 from node.rustchain_tx_handler import create_tx_api_routes
@@ -16,6 +15,12 @@ from node.rustchain_tx_handler import create_tx_api_routes
 # authenticate to reach (and trigger) the internal-error path.
 _ADMIN_KEY = "test-admin-key"
 _ADMIN_HDR = {"X-Admin-Key": _ADMIN_KEY}
+
+
+@pytest.fixture(autouse=True)
+def _configure_admin_key(monkeypatch):
+    # SCOPED (auto-restored): never leak RC_ADMIN_KEY into later test files.
+    monkeypatch.setenv("RC_ADMIN_KEY", _ADMIN_KEY)
 
 
 LEAKY_ERROR = "no such table: pending_transactions at /srv/rustchain/prod.db"
@@ -50,7 +55,6 @@ class ExplodingPool:
 
 
 def _client_for_exploding_pool():
-    os.environ["RC_ADMIN_KEY"] = _ADMIN_KEY  # so require_admin() is configured (not 503)
     app = Flask(__name__)
     app.config["TESTING"] = True
     create_tx_api_routes(app, ExplodingPool())

--- a/tools/rustchain-monitor/rustchain_monitor.py
+++ b/tools/rustchain-monitor/rustchain_monitor.py
@@ -77,13 +77,6 @@ def get_epoch():
     except Exception as e:
         return {"error": str(e)}
 
-def normalize_miners_payload(data):
-    if isinstance(data, list):
-        return data
-    if isinstance(data, dict) and isinstance(data.get("miners"), list):
-        return data["miners"]
-    return None
-
 def print_health(data):
     if "error" in data:
         print(f"❌ Health check failed: {data['error']}")
@@ -112,7 +105,7 @@ def print_miners(data):
         print(f"❌ Failed to fetch miners: {data['error']}")
         return
     miners = normalize_miners_payload(data)
-    if miners is None:
+    if not isinstance(miners, list):  # normalize preserves unknown shapes; only a list is printable
         print(f"⚠ Unexpected response: {data}")
         return
     print(f"📊 Active miners: {len(miners)}")


### PR DESCRIPTION
## BCOS Checklist
- [x] **BCOS-L1** (test + test-dep fixes; one small client fix in tools/rustchain-monitor)
- [x] Test evidence below

## What Changed
main's CI `test` job has been **red** (31 failed / 3198 passed), blocking every PR's test check. Triaged via git-blame on the production code (not just assertions): these are **tests lagging behind intentionally-merged hardening PRs**, not regressions. Fixes **21** (6 files green, 130 passing):

- tx-redaction (5): `/tx/*`+`/wallet/*` GETs admin-gated (#6295) → send X-Admin-Key
- gpu (3): `/gpu/nodes` admin-gated (#6557) → authenticate read; unconfigured → 503
- bridge (8): RTC addr tightened to RTC+40hex (#5435) → valid fixtures; lock GETs admin-gated → auth
- signed_transfer (2): add httpx test dep; `/pending/confirm` redacts to internal_error (#3202/#5546)
- proxy (1): proxy forwards headers= → mock accepts kwarg
- monitor (2): removed bad-merge duplicate normalize_miners_payload; print_miners guards non-list

Only non-test change: `tools/rustchain-monitor/rustchain_monitor.py` (dup function + isinstance guard) — a real client bug the tests caught.

## Remaining follow-up (also stale-test, not regression)
- governance (4): `/governance/vote` admin-gated (#6719) → needs auth; propose wallet-format/balance fixtures
- otc confirm (1): test mock returns non-JSON-serializable MagicMock

Deferred to keep this PR clean/reviewable.

## Testing
```
pytest <the 6 files> -q  ->  130 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)