### PR TITLE
fix: use maintained wallet-balance endpoint in star_checker

### DIFF
--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -130,15 +130,27 @@ def count_user_stars(
 
 
 def check_wallet_exists(wallet_address: str) -> bool:
-    """Verify that a wallet address exists on the RustChain node."""
+    """Verify that a wallet address exists on the RustChain node.
+
+    Uses the maintained public wallet-balance endpoint
+    ``/wallet/balance?miner_id=<wallet>`` instead of the stale
+    ``/api/balance/<wallet>`` route.
+    """
     try:
-        url = f"{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}"
+        url = f"{RUSTCHAIN_NODE_URL}/wallet/balance"
         import os
         _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
         _verify = _cert if os.path.exists(_cert) else True
-        resp = requests.get(url, verify=_verify, timeout=10)
+        resp = requests.get(
+            url,
+            params={"miner_id": wallet_address},
+            verify=_verify,
+            timeout=10,
+        )
         if resp.status_code == 200:
-            return True
+            body = resp.json()
+            if isinstance(body, dict) and "amount_i64" in body:
+                return True
     except Exception as exc:
         logger.error("Error checking wallet %s: %s", wallet_address, exc)
     return False


### PR DESCRIPTION
Fixes #6779

## Summary

`check_wallet_exists()` in `tools/bounty_verifier/star_checker.py` was calling the stale `/api/balance/<wallet>` route, which can report a wallet as missing even when the node's public wallet-balance endpoint is healthy.

## Changes

- Switched URL from `/api/balance/<wallet>` to `/wallet/balance?miner_id=<wallet>` (same maintained endpoint used by `verifier.py`)
- Added `params=` dict for proper query-string encoding
- Response validation now checks for a JSON dict containing `amount_i64` rather than treating any HTTP 200 as success

## Testing

- Verified that `verifier.py` already uses `/wallet/balance?miner_id=` successfully
- The new code mirrors the same endpoint + response-shape pattern
- `check_wallet_exists()` now returns `True` only when the node confirms the wallet has a balance record