### PR TITLE
[UTXO-BUG] Fix dual-write accounting for absorbed dust fees

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -729,6 +729,24 @@ class TestUtxoDualWrite(unittest.TestCase):
         conn.commit()
         conn.close()
 
+    def _seed_sender_nrtc(self, address, value_nrtc):
+        self.utxo_db.apply_transaction({
+            'tx_type': 'mining_reward',
+            'inputs': [],
+            'outputs': [{'address': address, 'value_nrtc': value_nrtc}],
+            'timestamp': int(time.time()),
+            '_allow_minting': True,
+        }, block_height=1)
+
+        import sqlite3
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            (address, value_nrtc // (UNIT // utxo_endpoints.ACCOUNT_UNIT)),
+        )
+        conn.commit()
+        conn.close()
+
     def _account_balance(self, address):
         import sqlite3
         conn = sqlite3.connect(self.db_path)
@@ -774,6 +792,40 @@ class TestUtxoDualWrite(unittest.TestCase):
             self._account_balance(recipient),
             90 * utxo_endpoints.ACCOUNT_UNIT,
         )
+
+    def test_dual_write_debits_absorbed_dust_fee_from_shadow_balance(self):
+        """dual_write must mirror dust absorbed into the effective UTXO fee."""
+        sender = 'RTC_test_aabbccdd'
+        recipient = 'bob'
+        absorbed_fee_nrtc = 500
+        self._seed_sender_nrtc(sender, 10 * UNIT + absorbed_fee_nrtc)
+
+        r = self.client.post('/utxo/transfer', json={
+            'from_address': sender,
+            'to_address': recipient,
+            'amount_rtc': 10.0,
+            'fee_rtc': 0,
+            'public_key': 'aabbccdd' * 8,
+            'signature': 'sig' * 22,
+            'nonce': int(time.time() * 1000),
+        })
+        data = r.get_json()
+
+        self.assertEqual(r.status_code, 200, data)
+        self.assertEqual(data['requested_fee_nrtc'], 0)
+        self.assertEqual(data['absorbed_fee_nrtc'], absorbed_fee_nrtc)
+        self.assertEqual(data['fee_nrtc'], absorbed_fee_nrtc)
+        self.assertEqual(self.utxo_db.get_balance(sender), 0)
+        self.assertEqual(self.utxo_db.get_balance(recipient), 10 * UNIT)
+        self.assertEqual(self._account_balance(sender), 0)
+        self.assertEqual(
+            self._account_balance(recipient),
+            10 * utxo_endpoints.ACCOUNT_UNIT,
+        )
+
+        integrity = self.client.get('/utxo/integrity').get_json()
+        self.assertTrue(integrity['ok'], integrity)
+        self.assertTrue(integrity['models_agree'], integrity)
 
     def test_dual_write_rejects_sub_micro_amounts(self):
         """dual_write cannot safely mirror nanoRTC values below 1 microRTC."""

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -157,6 +157,17 @@ def _decimal_to_account_i64(amount: Decimal, field_name: str) -> int:
     return int(integral)
 
 
+def _nrtc_to_account_i64(amount_nrtc: int, field_name: str) -> int:
+    """Convert nanoRTC to legacy account units without dropping precision."""
+    scale = UNIT // ACCOUNT_UNIT
+    if amount_nrtc % scale != 0:
+        raise ValueError(
+            f"{field_name} cannot be mirrored by dual-write account model "
+            "(max 6 decimal places)"
+        )
+    return amount_nrtc // scale
+
+
 utxo_bp = Blueprint('utxo', __name__, url_prefix='/utxo')
 
 # These get set by register_utxo_blueprint() from the main server
@@ -506,13 +517,10 @@ def utxo_transfer():
         _ensure_signed_float_preserves_nrtc(amount_rtc, amount_nrtc, 'amount_rtc')
         _ensure_signed_float_preserves_nrtc(fee_rtc, fee_nrtc, 'fee_rtc')
         amount_i64_for_dual_write = None
-        fee_i64_for_dual_write = None
+        effective_fee_i64_for_dual_write = None
         if _dual_write:
             amount_i64_for_dual_write = _decimal_to_account_i64(
                 amount_rtc, 'amount_rtc'
-            )
-            fee_i64_for_dual_write = _decimal_to_account_i64(
-                fee_rtc, 'fee_rtc'
             )
     except ValueError as e:
         return jsonify({'error': f'Invalid amount: {e}'}), 400
@@ -642,6 +650,14 @@ def utxo_transfer():
         return jsonify({'error': 'UTXO coin selection underfunded transaction'}), 500
     effective_fee_nrtc = fee_nrtc + absorbed_fee_nrtc
 
+    if _dual_write:
+        try:
+            effective_fee_i64_for_dual_write = _nrtc_to_account_i64(
+                effective_fee_nrtc, 'effective_fee_nrtc'
+            )
+        except ValueError as e:
+            return jsonify({'error': f'Invalid amount: {e}'}), 400
+
     # Build and apply UTXO transaction
     block_height = _current_slot_fn()
     tx = {
@@ -703,7 +719,7 @@ def utxo_transfer():
             conn = sqlite3.connect(_db_path)
             c = conn.cursor()
             amount_i64 = amount_i64_for_dual_write
-            fee_i64 = fee_i64_for_dual_write
+            fee_i64 = effective_fee_i64_for_dual_write
             debit_i64 = amount_i64 + fee_i64
 
             # Re-check sender shadow-balance before debit (security: prevent


### PR DESCRIPTION
## Summary

Fixes the UTXO dual-write shadow-account divergence reported in Scottcjn/rustchain-bounties#12839 for bounty Scottcjn/rustchain-bounties#2819.

When coin selection absorbs dust change into the effective fee, the UTXO ledger stores and applies `effective_fee_nrtc = requested fee + absorbed dust`, but the dual-write account mirror was debiting only the originally requested fee. This left tiny but spendable balances behind in `balances.amount_i64` even when the shadow account started exactly matched to the UTXO value.

This patch converts the effective fee back into the 6-decimal account unit after coin selection, rejects non-mirrorable effective fees before applying the UTXO transaction, and uses that effective fee for the shadow-account debit and ledger reason.

## Tests

- `python -m unittest test_utxo_endpoints.TestUtxoDualWrite.test_dual_write_debits_absorbed_dust_fee_from_shadow_balance -v`
- `python -m unittest test_utxo_endpoints.TestUtxoDualWrite -v`
- `python -m unittest test_utxo_endpoints -v`
