### PR TITLE
localization: add pl-PL miner consent pass

### DIFF
--- a/docs/pl-PL/RUSTCHAIN_EXPLAINED.md
+++ b/docs/pl-PL/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain wyjaśniony (pl-PL)
+
+RustChain to sieć Proof-of-Antiquity, która nagradza realne maszyny, szczególnie starszy sprzęt, za udowodnienie, że nadal działają. Główna idea jest prosta: zachowany sprzęt ma wartość, a sieć musi umieć odróżnić prawdziwą maszynę od VM, kontenera lub sfabrykowanej deklaracji.
+
+## Jak działa weryfikacja
+
+Miner zbiera lokalne sygnały i wysyła `attestation` do węzła RustChain. Ta `attestation` zawiera sprzętowy `fingerprint`. Węzeł używa tych danych do oszacowania `antiquity` maszyny i obliczenia mnożnika nagrody.
+
+Proces musi być uczciwy:
+
+- nie wymyślaj architektury;
+- nie wymuszaj rodziny CPU, której maszyna nie posiada;
+- nie zmieniaj payload, aby sprzęt wyglądał na starszy;
+- nie tłumacz flag komend ani nazw endpointów.
+
+## Sprawdź przed kopaniem
+
+Przed zostawieniem minera w pracy użyj poniższych komend:
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Te komendy pomagają sprawdzić wykrytą maszynę, payload `attestation` i łączność z węzłem. W dokumentacji lokalizowanej muszą pozostać dokładnie w tej formie.
+
+## Na co zgadza się użytkownik
+
+Potwierdzając pierwsze uruchomienie, użytkownik deklaruje, że rozumie:
+
+1. miner może wysyłać dane `fingerprint` i `attestation`;
+2. sprzęt musi być raportowany uczciwie;
+3. nagrody w `RTC` zależą od akceptacji sieci i nie są gwarantowane;
+4. spoofing, nieujawniona emulacja albo sfabrykowany payload mogą obniżyć nagrody albo spowodować odrzucenie.
+
+Polski ekran zgody musi wymagać wyraźnego wpisu twierdzącego, np. `TAK`. Samo naciśnięcie Enter nie może rozpocząć kopania.
+
+## Zachowany słownik
+
+| Termin | Znaczenie operacyjne |
+|---|---|
+| `RTC` | Token używany przez RustChain do nagród i bounty. |
+| `attestation` | Weryfikowalna deklaracja maszyny wysyłana do węzła. |
+| `antiquity` | Sygnał wieku, rzadkości i zachowania sprzętu. |
+| `fingerprint` | Zestaw sygnałów sprzętowych używanych do weryfikacji. |
+
+## Przewodnik Linux miner
+
+Zlokalizowany przewodnik Linux miner znajduje się tutaj:
+
+- [miners/linux/README.pl-PL.md](../../miners/linux/README.pl-PL.md)

--- a/i18n/pl-PL.json
+++ b/i18n/pl-PL.json
@@ -1,0 +1,111 @@
+{
+  "locale": "pl-PL",
+  "language": "Polish",
+  "version": "1.0.0",
+  "description": "Polska lokalizacja pl-PL komunikatów RustChain miner/portfel oraz zgody przy pierwszym uruchomieniu.",
+  "errors": {
+    "wallet": {
+      "invalid_amount": "Nieprawidłowa kwota",
+      "please_load_wallet_first": "Najpierw wczytaj portfel",
+      "please_enter_recipient_wallet_id": "Podaj ID portfela odbiorcy",
+      "amount_must_be_positive": "Kwota musi być dodatnia",
+      "transaction_failed": "Transakcja nie powiodła się",
+      "please_enter_wallet_id": "Podaj ID portfela",
+      "network_error_check_connection": "Błąd sieci - sprawdź połączenie",
+      "request_timeout_node_busy": "Przekroczono czas oczekiwania - węzeł może być zajęty",
+      "dns_resolution_failed": "Rozwiązywanie DNS nie powiodło się: {host}: {error}",
+      "cannot_connect_to_host": "Nie można połączyć z {host}:{port} (kod błędu: {result})",
+      "network_check_failed": "Sprawdzenie sieci nie powiodło się: {error}",
+      "network_unreachable": "Sieć jest nieosiągalna: {error}",
+      "request_timeout_after_retries": "Żądanie wygasło po {timeout} sekundach ({max_retries} prób)",
+      "api_error_http": "Błąd API: HTTP {status}",
+      "request_failed": "Żądanie nie powiodło się: {error}",
+      "request_failed_after_retries": "Żądanie nie powiodło się po {max_retries} próbach: {last_error}",
+      "new_wallet_created": "Utworzono nowy portfel",
+      "save_wallet_id_warning": "Zachowaj ten ID - będzie potrzebny do dostępu do środków",
+      "confirm_transfer": "Potwierdź przelew",
+      "send_confirmation": "Wysłać {amount:.6f} RTC do:\n{to_wallet}\n\nKontynuować?"
+    },
+    "miner": {
+      "attestation_failed": "attestation nie powiodła się",
+      "epoch_enrollment_failed": "Rejestracja epoki nie powiodła się",
+      "challenge_failed_http": "Wyzwanie nie powiodło się: HTTP {status_code}",
+      "challenge_error": "Błąd wyzwania: {error}",
+      "attestation_rejected": "attestation odrzucona: {response}",
+      "attestation_submission_failed": "Wysłanie attestation nie powiodło się: {error}",
+      "enrollment_failed": "Rejestracja nie powiodła się: {error}",
+      "enrollment_rejected": "Rejestracja odrzucona: {response}",
+      "enrollment_http_error": "Blad HTTP rejestracji {status}: {text}",
+      "submit_error": "Błąd wysyłania: {error}",
+      "fingerprint_failed_reduced_rewards": "fingerprint sprzetu: niepowodzenie (zmniejszona nagroda)",
+      "fingerprint_passed": "fingerprint sprzetu: zaliczony",
+      "fingerprint_n_a": "fingerprint sprzetu: niedostepny (brak modulu)",
+      "attestation_accepted": "attestation zaakceptowana",
+      "enrolled_success": "Rejestracja zakończona. Epoka: {epoch} Waga: {weight}x",
+      "miner_loop_error": "Błąd pętli minera: {error}",
+      "fingerprint_checks_incomplete": "Kontrole fingerprint są niepełne albo zakończone błędem",
+      "fingerprint_checks_complete": "Kontrole fingerprint zakończone",
+      "fingerprint_checks_failed": "Kontrole fingerprint nie powiodły się: {failed_checks}"
+    },
+    "network": {
+      "troubleshooting_title": "Rozwiązywanie problemów:",
+      "check_internet_connection": "1. Sprawdź połączenie z internetem",
+      "verify_dns_working": "2. Sprawdź, czy DNS działa (spróbuj: ping {node_url})",
+      "check_firewall_proxy": "3. Sprawdź firewall/proxy",
+      "node_may_be_offline": "4. Węzeł może być tymczasowo offline",
+      "node_syncing_maintenance": "1. Węzeł może się synchronizować albo być w konserwacji",
+      "try_again_later": "2. Spróbuj ponownie później",
+      "check_node_dashboard": "3. Sprawdź panel statusu RustChain",
+      "network_issue_detected": "Wykryto problem z siecią:",
+      "node_response_issue": "Problem z odpowiedzią węzła:",
+      "network_error_title": "Błąd sieci",
+      "warning_title": "Ostrzeżenie",
+      "error_title": "Błąd",
+      "success_title": "Sukces"
+    },
+    "common": {
+      "error": "Błąd",
+      "failed": "Niepowodzenie",
+      "success": "Sukces",
+      "warning": "Ostrzeżenie",
+      "info": "Informacja",
+      "confirm": "Potwierdź",
+      "cancel": "Anuluj",
+      "ok": "OK",
+      "yes": "Tak",
+      "no": "Nie",
+      "loading": "Ładowanie...",
+      "retry": "Spróbuj ponownie",
+      "close": "Zamknij"
+    }
+  },
+  "messages": {
+    "wallet": {
+      "balance_display": "Saldo: {balance:.8f} RTC",
+      "wallet_id_label": "ID portfela:",
+      "load_button": "Wczytaj",
+      "new_wallet_button": "Nowy portfel",
+      "send_rtc_button": "Wyślij RTC",
+      "to_label": "Odbiorca:",
+      "amount_label": "Kwota:",
+      "rtc_unit": "RTC",
+      "transaction_history": "Ostatnie transakcje"
+    },
+    "miner": {
+      "cpu_info": "CPU: {processor}",
+      "arch_info": "Architektura: {arch}",
+      "status_attesting": "Wykonywanie attestation...",
+      "status_enrolling": "Rejestrowanie...",
+      "status_mining": "Kopanie...",
+      "status_waiting": "Oczekiwanie na kwalifikację...",
+      "status_error": "Błąd: {message}"
+    },
+    "miner_consent": {
+      "title": "Zgoda przy pierwszym uruchomieniu RustChain Miner",
+      "body": "Przed kopaniem przejrzyj komendy --dry-run, --show-payload i --test-only. Miner wyśle dane fingerprint i attestation do węzła RustChain. Sprzęt musi być zadeklarowany uczciwie; nie fabrykuj architektury, antiquity ani sygnałów sprzętowych. Nagrody w RTC nie są gwarantowane.",
+      "prompt": "Wpisz TAK, aby potwierdzić, że rozumiesz i chcesz kontynuować:",
+      "affirmative": "TAK",
+      "rejected": "Zgoda nie została potwierdzona. Kopanie nie zostanie uruchomione."
+    }
+  }
+}

--- a/miners/linux/README.pl-PL.md
+++ b/miners/linux/README.pl-PL.md
@@ -1,0 +1,69 @@
+# RustChain Miner dla Linuxa (pl-PL)
+
+Ten przewodnik lokalizuje przepływ Linux miner dla osób czytających po polsku. Terminy `RTC`, `attestation`, `antiquity` i `fingerprint` pozostają bez tłumaczenia, ponieważ występują w protokole, logach i API.
+
+## Sprawdź zanim zaufasz
+
+Przed rozpoczęciem kopania uruchom komendy weryfikacyjne. Pokazują one, co zostanie wysłane do węzła, i pozwalają obejrzeć payload bez startu sesji mining.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Nie tłumacz ani nie zmieniaj powyższych flag. `--dry-run`, `--show-payload` i `--test-only` są literalnymi komendami.
+
+## Co robi miner
+
+Linux miner wykrywa lokalną maszynę, zbiera uczciwe sygnały sprzętowe i wysyła `attestation` do węzła RustChain. Te sygnały tworzą sprzętowy `fingerprint`, który pomaga ocenić `antiquity` maszyny i zastosować odpowiedni mnożnik.
+
+Miner nie może fabrykować architektury, wieku sprzętu, liczby rdzeni, numeru seryjnego, nazwy hosta ani żadnego innego sygnału. Jeśli sygnał nie jest dostępny, prawidłowe zachowanie to zgłosić brak danych albo obniżyć poziom weryfikacji.
+
+## Instalacja zależności
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+W dystrybucjach Debian/Ubuntu, jeśli `python3` lub `pip` nie są zainstalowane:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Uruchomienie minera
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Użyj portfela lub identyfikatora, który później rozpoznasz. Wypłaty bounty mogą używać `github:twoj-login`, ale zwykłe kopanie używa wartości przekazanej przez `--wallet`.
+
+## Zgoda przy pierwszym uruchomieniu
+
+Przy pierwszym interaktywnym uruchomieniu użytkownik musi wyraźnie potwierdzić, że rozumie:
+
+- miner wysyła `fingerprint` i dane `attestation` do węzła RustChain;
+- komendy weryfikacyjne powinny być użyte przed kopaniem;
+- nagrody w `RTC` nie są gwarantowane;
+- maszyna musi przedstawić się uczciwie, bez spoofingu sprzętu.
+
+Polska odpowiedź twierdząca: `TAK`.
+
+## Odnośnik
+
+Krótkie wyjaśnienie protokołu i zachowanych terminów znajduje się tutaj:
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/pl-PL/RUSTCHAIN_EXPLAINED.md)
+
+## Słownik
+
+| Termin | Jak zachowac | Uwaga |
+|---|---|---|
+| `RTC` | `RTC` | Natywny token RustChain. |
+| `attestation` | `attestation` | Dowód wysyłany do węzła o maszynie. |
+| `antiquity` | `antiquity` | Wiek/rzadkość używana w mnożniku. |
+| `fingerprint` | `fingerprint` | Zestaw sygnałów sprzętowych. |


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#12790

Submission grammar:
- target_lang: pl-PL
- files:
  - `miners/linux/README.pl-PL.md`
  - `docs/pl-PL/RUSTCHAIN_EXPLAINED.md`
  - `i18n/pl-PL.json`
- glossary / terms-of-art kept literal: `RTC`, `attestation`, `antiquity`, `fingerprint`

Acceptance notes:
- Consent text still requires explicit affirmative input: `TAK`.
- Verification commands are preserved literally: `--dry-run`, `--show-payload`, and `--test-only`.
- The localized Linux miner README cross-links to the pl-PL RustChain explainer, and the explainer links back to the localized miner README.
- No README badge/self-promo content added.

Validation:
- `python -m json.tool i18n\pl-PL.json`
- `PYTHONIOENCODING=utf-8 python i18n\validate_i18n.py`
- `git diff --cached --check`
- `git diff --check -- miners\linux\README.pl-PL.md docs\pl-PL\RUSTCHAIN_EXPLAINED.md i18n\pl-PL.json`

Requested payout: 10 RTC if accepted, maintainer discretion.

wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8