### PR TITLE
docs: add README language index

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A Power Mac G5 earns **2.0x**. A 486 with rusty serial ports earns the most resp
 
 [Explorer](https://rustchain.org/explorer/) · [Machines Preserved](https://rustchain.org/preserved.html) · [Install Miner](#quickstart) · [Beginner Guide](docs/QUICKSTART.md) · [Manifesto](https://rustchain.org/manifesto.html) · [Whitepaper](docs/WHITEPAPER.md)
 
-中文入口: [中文文档](docs/zh-CN/README.md) · [中文 API 快速参考](docs/zh-CN/API.md)
+Languages: [English](README.md) · [简体中文](docs/zh-CN/README.md) · [繁體中文](README_ZH-TW.md) · [Español](README_ES.md) · [Deutsch](README_DE.md) · [日本語](README_JA.md) · [Русский](README_RU.md) · [Tiếng Việt](README.vi.md) · [Português (BR)](README.pt-BR.md) · [हिन्दी](README_HI.md) · [Italiano](docs/it-IT/README.md) · [한국어](docs/ko-KR/README.md) · [中文 API 快速参考](docs/zh-CN/API.md)
 
 </div>
 


### PR DESCRIPTION
## What changed

- Replaced the root README's single Chinese entry line with a compact language index for existing README translations.
- Kept the Chinese API quick reference link in the same top README navigation area.

## Why it matters

This makes the existing translated README files easier to discover from the first screen of the project README without adding new translation content or broad documentation changes.

Related issue: #6793

## Validation

- `for f in README.md docs/zh-CN/README.md README_ZH-TW.md README_ES.md README_DE.md README_JA.md README_RU.md README.vi.md README.pt-BR.md README_HI.md docs/it-IT/README.md docs/ko-KR/README.md docs/zh-CN/API.md; do test -f "$f" || { echo "missing $f"; exit 1; }; done; echo "all README language links resolve"` -> passed
- `git diff --check origin/main...HEAD -- README.md` -> passed
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo . --changed-files-from-git origin/main...HEAD` -> passed, no findings
- `.venv-bounty-validation/bin/python -m pytest -q tests/test_wrtc_docs.py::TestWRTCDocumentation::test_readme_links_to_wrtc_docs tests/test_wrtc_docs.py::TestWRTCDocumentation::test_readme_has_canonical_mint tests/test_wrtc_docs.py::TestWRTCDocumentation::test_readme_has_bridge_link tests/test_wrtc_docs.py::TestWRTCDocumentation::test_readme_has_raydium_link --tb=short --noconftest -o addopts=''` -> 4 passed

## CI note

GitHub Actions `CI / test` is currently failing in unrelated repo-wide baseline suites including beacon atlas, bridge lock ledger, governance API, GPU render protocol, monitor/proxy, and tx handler redaction tests. No README/link/language-index test failed in the log; this PR remains docs-only and should not be broadened to repair the repo-wide baseline.

## Touched files/subsystems

- `README.md` only

## Scope/risk boundary

This PR only changes the root README navigation line. It does not add, rewrite, or validate translation content.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
