### PR TITLE
fix(gpu): atomic escrow transitions — close release/refund TOCTOU race

### DIFF
--- a/node/gpu_render_protocol.py
+++ b/node/gpu_render_protocol.py
@@ -336,11 +336,17 @@ class GPURenderProtocol:
                 return auth_error
 
             now = int(time.time())
-            conn.execute(
-                "UPDATE render_escrow SET status='released', released_at=? WHERE job_id=?",
+            # Atomic transition guarded on status='locked' so a concurrent
+            # release/refund cannot both win (TOCTOU between the read above and
+            # this write). rowcount==0 means we lost the race.
+            cur = conn.execute(
+                "UPDATE render_escrow SET status='released', released_at=? "
+                "WHERE job_id=? AND status='locked'",
                 (now, job_id),
             )
             conn.commit()
+            if cur.rowcount != 1:
+                return {"error": "escrow no longer locked (concurrent release/refund)"}
             return {
                 "status": "released",
                 "job_id": job_id,
@@ -372,11 +378,14 @@ class GPURenderProtocol:
                 return auth_error
 
             now = int(time.time())
-            conn.execute(
-                "UPDATE render_escrow SET status='refunded', released_at=? WHERE job_id=?",
+            cur = conn.execute(
+                "UPDATE render_escrow SET status='refunded', released_at=? "
+                "WHERE job_id=? AND status='locked'",
                 (now, job_id),
             )
             conn.commit()
+            if cur.rowcount != 1:
+                return {"error": "escrow no longer locked (concurrent release/refund)"}
             return {
                 "status": "refunded",
                 "job_id": job_id,

--- a/tests/test_gpu_render_protocol.py
+++ b/tests/test_gpu_render_protocol.py
@@ -86,6 +86,25 @@ class TestGPURenderProtocol(unittest.TestCase):
         refund = self.proto.refund_escrow(job_id, "wallet-b", result["escrow_secret"])
         self.assertEqual(refund["status"], "refunded")
 
+    def test_escrow_transition_is_atomic_under_race(self):
+        # A concurrent winner transitions the row between our read and write;
+        # the WHERE status='locked' guard must make the loser fail (no double-spend).
+        result = self.proto.create_escrow("render", "wallet-a", "wallet-b", 10.0)
+        job_id = result["job_id"]
+        secret = result["escrow_secret"]
+        orig_auth = self.proto._authorize_escrow_action
+
+        def racing_auth(row, **kwargs):
+            c = self.proto._get_conn()
+            c.execute("UPDATE render_escrow SET status='released' WHERE job_id=?", (job_id,))
+            c.commit()
+            c.close()
+            return orig_auth(row, **kwargs)
+
+        self.proto._authorize_escrow_action = racing_auth
+        res = self.proto.refund_escrow(job_id, "wallet-b", secret)
+        self.assertIn("no longer locked", res.get("error", ""))
+
     def test_release_requires_payer_and_secret(self):
         result = self.proto.create_escrow("render", "wallet-a", "wallet-b", 10.0)
         job_id = result["job_id"]


### PR DESCRIPTION
## BCOS Checklist
- [x] **BCOS-L1**
- [x] Test evidence below

## What Changed
From a tri-brain (Codex) audit of `node/gpu_render_protocol.py`. The genuine, verified bug:

**TOCTOU race in release/refund** — both read `status=='locked'` then `UPDATE ... WHERE job_id=?` *without* re-checking status. Two concurrent ops could both pass the check and both write (a `released` escrow flipped to `refunded`). Fixed: `UPDATE ... WHERE job_id=? AND status='locked'` + `rowcount==1` guard; the loser returns `"escrow no longer locked (concurrent release/refund)"`. Adds a deterministic race regression test.

## Audit context (transparency)
- **False positive corrected:** the audit flagged "forgeable authorization," but `_authorize_escrow_action` verifies the `escrow_secret` hash (`hmac.compare_digest`) + participant + `required_wallet`. Auth is **not** forgeable. (Adversarial verification of the audit, not just relaying it.)
- **Separate, NOT in this PR (needs design):** the module is **dormant** (`register_routes` is only called by tests, never the node app) and the escrow **moves no actual RTC** (status ledger only). Real fund custody via the node's signed `/wallet/transfer`, integer micro-unit money, and real device attestation are **pre-activation requirements** — tracked in memory (`gpu-render-escrow-review-2026-06-02`). This PR fixes the one concrete concurrency bug now.

## Testing
```
pytest tests/test_gpu_render_protocol.py -q  ->  34 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)