### PR TITLE
fix(otc): idempotent payout + fail-closed admin transport (double-spend + key-leak)

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -30,6 +30,7 @@ import secrets
 import sqlite3
 import time
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from functools import wraps
 
@@ -195,6 +196,38 @@ def is_valid_wallet_id(wallet_id):
     return bool(_MINER_ID_RE.fullmatch(wallet_id))
 
 
+def _admin_transport_block_reason():
+    """Return a reason string if it is UNSAFE to send the admin key to the
+    configured node, else None.
+
+    Fail-closed: the RC_ADMIN_KEY must never leave over plaintext (http://) or
+    to a non-local host with TLS verification disabled (MITM credential theft).
+    Loopback hosts and an explicit OTC_ALLOW_INSECURE_ADMIN opt-out are allowed
+    for local development.
+    """
+    if os.environ.get("OTC_ALLOW_INSECURE_ADMIN", "").strip().lower() in ("1", "true", "yes"):
+        return None  # explicit operator opt-out (dev only)
+
+    parsed = urlparse(RUSTCHAIN_NODE)
+    host = (parsed.hostname or "").lower()
+    if host in ("localhost", "127.0.0.1", "::1"):
+        return None  # loopback dev is acceptable
+
+    if parsed.scheme != "https":
+        return (
+            f"insecure scheme '{parsed.scheme or 'none'}' for admin endpoint "
+            f"{RUSTCHAIN_NODE!r}: set RUSTCHAIN_NODE to https:// "
+            f"(or OTC_ALLOW_INSECURE_ADMIN=1 for local dev)"
+        )
+    if TLS_VERIFY is False:
+        return (
+            "TLS verification disabled (RUSTCHAIN_TLS_VERIFY=false) for a "
+            "non-local admin endpoint — MITM credential exposure; pin "
+            "RUSTCHAIN_CA_BUNDLE instead of disabling verification"
+        )
+    return None
+
+
 def send_bridge_alert(level, message, fields):
     """Best-effort alert hook for payout failures and manual recovery events."""
     webhook = os.environ.get("RC_SOPHIACHECK_WEBHOOK", "").strip()
@@ -230,6 +263,19 @@ def rtc_transfer_from_worker(recipient_wallet, amount_rtc, order_id):
     accepted into pending pool), or ``{"ok": False, "error": str, "details": {...}}``
     on terminal failure after retries.
     """
+    # Fail-closed BEFORE sending the admin key: never leak RC_ADMIN_KEY over an
+    # insecure transport. Refusing strands funds in otc_bridge_worker (alerted +
+    # recoverable) — strictly safer than exfiltrating the admin credential.
+    block_reason = _admin_transport_block_reason()
+    if block_reason:
+        log.error(f"OTC payout blocked for {order_id}: {block_reason}")
+        send_bridge_alert(
+            "critical",
+            "OTC payout blocked: insecure admin transport",
+            {"order_id": order_id, "node": RUSTCHAIN_NODE, "reason": block_reason},
+        )
+        return {"ok": False, "error": f"insecure_admin_transport: {block_reason}", "details": {}}
+
     last_error = "unknown payout error"
     last_payload = {}
     retry_delays = (0, 1, 2, 4)
@@ -247,6 +293,12 @@ def rtc_transfer_from_worker(recipient_wallet, amount_rtc, order_id):
                     "to_miner": recipient_wallet,
                     "amount_rtc": amount_rtc,
                     "reason": f"otc_payout:{order_id}",
+                    # Idempotency: stable, unique-per-payout key so retries (and
+                    # any double-confirm) dedup server-side in wallet_transfer_v2
+                    # instead of paying twice. Derived from the immutable
+                    # order_id (one worker payout per order), and kept equal to
+                    # `reason` so the server's reason-consistency check passes.
+                    "idempotency_key": f"otc_payout:{order_id}",
                 },
                 verify=TLS_VERIFY, timeout=15
             )

--- a/tests/test_otc_bridge_payout_idempotency.py
+++ b/tests/test_otc_bridge_payout_idempotency.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests: the OTC bridge worker payout MUST be idempotent.
+
+`rtc_transfer_from_worker` retries `/wallet/transfer` on timeout/5xx. Without a
+stable idempotency key, a retry after the server already debited (e.g. response
+lost to a timeout) pays the recipient twice -- a real double-spend on a live
+RTC money path. The node's `wallet_transfer_v2` dedups on `idempotency_key`, so
+the fix is for every retry of the SAME logical payout to carry the SAME key.
+
+These tests pin both halves of that contract:
+  1. the payout sends a stable, order-derived `idempotency_key`, and
+  2. across retries the key never changes (so the server can dedup it).
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import requests
+
+
+def load_otc_bridge(tmp_path):
+    module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
+    db_path = tmp_path / "otc_bridge.db"
+    previous_db_path = os.environ.get("OTC_DB_PATH")
+    os.environ["OTC_DB_PATH"] = str(db_path)
+
+    module_name = f"otc_bridge_payout_test_{abs(hash(db_path))}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        module.init_db()
+        return module
+    finally:
+        if previous_db_path is None:
+            os.environ.pop("OTC_DB_PATH", None)
+        else:
+            os.environ["OTC_DB_PATH"] = previous_db_path
+
+
+def _ok_response(payload=None):
+    resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
+    resp.json.return_value = payload or {"ok": True, "phase": "pending"}
+    return resp
+
+
+def test_payout_sends_stable_order_derived_idempotency_key(tmp_path):
+    module = load_otc_bridge(tmp_path)
+    order_id = "otc_deadbeefcafef00d"
+
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        mock_requests.post.return_value = _ok_response()
+        result = module.rtc_transfer_from_worker("RTC" + "a" * 40, 1.5, order_id)
+
+    assert result["ok"] is True
+    sent = mock_requests.post.call_args.kwargs["json"]
+    expected_key = f"otc_payout:{order_id}"
+    assert sent["idempotency_key"] == expected_key
+    # Kept equal to `reason` so the node's reason-consistency check never 409s.
+    assert sent["reason"] == expected_key
+
+
+def test_retries_reuse_identical_idempotency_key(tmp_path):
+    """The core double-spend defense: a timeout then a success must send the
+    SAME idempotency_key both times, so the node dedups instead of re-paying."""
+    module = load_otc_bridge(tmp_path)
+    order_id = "otc_0123456789abcdef"
+
+    # Attempt 1 raises (response lost -- server may have already debited),
+    # attempt 2 succeeds. Both must carry the same key.
+    side_effects = [requests.exceptions.Timeout("boom"), _ok_response()]
+
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        mock_requests.exceptions = requests.exceptions
+        mock_requests.post.side_effect = side_effects
+        result = module.rtc_transfer_from_worker("RTC" + "b" * 40, 2.0, order_id)
+
+    assert result["ok"] is True
+    assert mock_requests.post.call_count == 2
+    keys = {c.kwargs["json"]["idempotency_key"] for c in mock_requests.post.call_args_list}
+    assert keys == {f"otc_payout:{order_id}"}, (
+        "every retry must reuse one stable key so the server can dedup it"
+    )
+
+
+# --- admin-transport hardening: never leak RC_ADMIN_KEY over an insecure link ---
+
+
+def test_payout_refuses_plaintext_http_scheme(tmp_path, monkeypatch):
+    module = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(module, "RUSTCHAIN_NODE", "http://50.28.86.131")
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        result = module.rtc_transfer_from_worker("RTC" + "a" * 40, 1.0, "otc_abc")
+    assert result["ok"] is False
+    assert "insecure_admin_transport" in result["error"]
+    mock_requests.post.assert_not_called()  # key must never be sent
+
+
+def test_payout_refuses_tls_verify_disabled_to_nonlocal(tmp_path, monkeypatch):
+    module = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(module, "RUSTCHAIN_NODE", "https://50.28.86.131")
+    monkeypatch.setattr(module, "TLS_VERIFY", False)
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        result = module.rtc_transfer_from_worker("RTC" + "a" * 40, 1.0, "otc_abc")
+    assert result["ok"] is False
+    mock_requests.post.assert_not_called()
+
+
+def test_payout_allows_loopback_http_for_dev(tmp_path, monkeypatch):
+    module = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(module, "RUSTCHAIN_NODE", "http://localhost:8099")
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        mock_requests.post.return_value = _ok_response()
+        result = module.rtc_transfer_from_worker("RTC" + "a" * 40, 1.0, "otc_abc")
+    assert result["ok"] is True
+    mock_requests.post.assert_called_once()
+
+
+def test_payout_allows_explicit_insecure_optout(tmp_path, monkeypatch):
+    module = load_otc_bridge(tmp_path)
+    monkeypatch.setattr(module, "RUSTCHAIN_NODE", "http://50.28.86.131")
+    monkeypatch.setenv("OTC_ALLOW_INSECURE_ADMIN", "1")
+    with patch.object(module, "requests") as mock_requests, \
+            patch.object(module.time, "sleep"):
+        mock_requests.post.return_value = _ok_response()
+        result = module.rtc_transfer_from_worker("RTC" + "a" * 40, 1.0, "otc_abc")
+    assert result["ok"] is True
+    mock_requests.post.assert_called_once()


### PR DESCRIPTION
Two hardening fixes to the OTC bridge worker payout (`rtc_transfer_from_worker`). Unlike the dormant gpu-render escrow, this module is **live and moves real RTC**, so both are active exposures.

## 1. Idempotent payout — prevents double-spend on retry

The payout retries `POST /wallet/transfer` up to 4× on timeout/5xx. Without an idempotency key, a retry after the server **already debited** (response lost to a timeout, or a double-`confirm_order`) pays the recipient **twice**.

The node's `wallet_transfer_v2` **already** dedups on `idempotency_key` (derives a deterministic `tx_hash`, returns the prior pending result on a match, 409 on a conflicting replay). The client just never sent one, so each retry produced a fresh random `tx_hash` and re-executed.

Fix: send a stable key `otc_payout:{order_id}`.
- **Unique per payout** — `order_id` is a PK (`generate_order_id`); `confirm_order` pays exactly one recipient per order.
- **Stable across retries** — derived from the immutable `order_id`, not `time.time()`.
- **Matches the server regex** `[A-Za-z0-9._:-]{1,128}`.
- **Equal to `reason`** so the node's reason-consistency check never 409s a legitimate retry.

## 2. Fail-closed admin transport — prevents RC_ADMIN_KEY leak

The admin key was sent to the env-controlled `RUSTCHAIN_NODE` with no scheme/TLS enforcement: `http://` or `RUSTCHAIN_TLS_VERIFY=false` would exfiltrate the credential in plaintext / to an unverified (MITM-able) host.

New `_admin_transport_block_reason()` refuses to send the key when the endpoint is a non-`https` scheme, or has TLS verification disabled to a non-local host. Loopback (`localhost`/`127.0.0.1`/`::1`) and an explicit `OTC_ALLOW_INSECURE_ADMIN=1` opt-out remain for dev. Refusing strands funds in `otc_bridge_worker` (alerted via `send_bridge_alert` + recoverable) — strictly safer than leaking the admin key.

## Tests — `tests/test_otc_bridge_payout_idempotency.py`
1. stable, order-derived `idempotency_key` is sent (== `reason`);
2. **a timeout-then-success resends the identical key** (the dedup contract that stops the double-spend);
3. transport guard **blocks** `http://` and TLS-off-to-nonlocal (key never sent), and **allows** loopback-http + explicit opt-out.

All 36 otc-bridge tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)