### PR TITLE
fix(otc): harden precision-column migration — allowlist tables + idempotent ALTER

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -153,17 +153,41 @@ def money_view(row):
     return data
 
 
+# SQLite cannot parameterize identifiers (PRAGMA/ALTER/UPDATE take a literal
+# table name), so every table name interpolated into the DDL below MUST be
+# validated against this allowlist first — never against caller-supplied text.
+_KNOWN_TABLES = frozenset({"orders", "trades", "rate_limits"})
+# Integer precision columns we add (also literal, never caller-supplied).
+_PRECISION_COLUMNS = ("amount_micro_rtc", "price_per_rtc_nano_quote", "total_quote_nano")
+
+
+def _require_known_table(table_name):
+    """Guard before building DDL: refuse any table name not on the allowlist."""
+    if table_name not in _KNOWN_TABLES:
+        raise ValueError(f"refusing to build SQL for unknown table {table_name!r}")
+    return table_name
+
+
 def migrate_precision_columns(cursor, table_name):
+    # Validate before interpolation so only known-safe identifiers reach the SQL.
+    _require_known_table(table_name)
+
     columns = {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
-    if "amount_micro_rtc" not in columns:
-        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN amount_micro_rtc INTEGER")
-    if "price_per_rtc_nano_quote" not in columns:
-        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN price_per_rtc_nano_quote INTEGER")
-    if "total_quote_nano" not in columns:
-        cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN total_quote_nano INTEGER")
+    for col in _PRECISION_COLUMNS:
+        if col in columns:
+            continue
+        try:
+            cursor.execute(f"ALTER TABLE {table_name} ADD COLUMN {col} INTEGER")
+        except sqlite3.OperationalError as exc:
+            # Idempotent under concurrent migrations: another worker may have
+            # added the column between the PRAGMA read above and this ALTER.
+            if "duplicate column name" not in str(exc).lower():
+                raise
 
     refreshed = {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
     if {"amount_rtc", "price_per_rtc", "total_quote"}.issubset(refreshed):
+        # COALESCE keeps the backfill idempotent: re-runs converge to the same
+        # values, so concurrent migrations are safe without a write lock.
         cursor.execute(f"""
             UPDATE {table_name}
             SET amount_micro_rtc = COALESCE(amount_micro_rtc, CAST(ROUND(amount_rtc * ?) AS INTEGER)),
@@ -173,6 +197,7 @@ def migrate_precision_columns(cursor, table_name):
 
 
 def table_columns(cursor, table_name):
+    _require_known_table(table_name)
     return {row[1] for row in cursor.execute(f"PRAGMA table_info({table_name})")}
 
 

--- a/tests/test_otc_bridge_migration.py
+++ b/tests/test_otc_bridge_migration.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: MIT
+"""
+Tests for OTC bridge precision-column migration hardening.
+
+Two defects closed:
+  1. SQL injection — table_name was interpolated straight into PRAGMA/ALTER/
+     UPDATE DDL (SQLite can't parameterize identifiers). Now allowlist-gated.
+  2. Migration atomicity — concurrent workers racing the PRAGMA->ALTER window
+     hit `duplicate column name`. ALTER is now idempotent; COALESCE backfill is
+     already idempotent.
+"""
+import importlib.util
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def load_otc_bridge(tmp_path):
+    module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
+    db_path = tmp_path / "otc_bridge.db"
+    previous_db_path = os.environ.get("OTC_DB_PATH")
+    os.environ["OTC_DB_PATH"] = str(db_path)
+
+    module_name = f"otc_bridge_migration_test_{abs(hash(db_path))}"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous_db_path is None:
+            os.environ.pop("OTC_DB_PATH", None)
+        else:
+            os.environ["OTC_DB_PATH"] = previous_db_path
+
+
+def _legacy_orders_table(conn):
+    """A pre-migration orders table carrying the old float money columns."""
+    conn.execute("""
+        CREATE TABLE orders (
+            order_id TEXT PRIMARY KEY,
+            amount_rtc REAL,
+            price_per_rtc REAL,
+            total_quote REAL
+        )
+    """)
+    conn.execute(
+        "INSERT INTO orders (order_id, amount_rtc, price_per_rtc, total_quote) "
+        "VALUES ('otc_x', 2.5, 0.1, 0.25)"
+    )
+
+
+def test_migration_backfills_integer_columns(tmp_path):
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    _legacy_orders_table(conn)
+
+    module.migrate_precision_columns(conn.cursor(), "orders")
+
+    row = conn.execute(
+        "SELECT amount_micro_rtc, price_per_rtc_nano_quote, total_quote_nano "
+        "FROM orders WHERE order_id='otc_x'"
+    ).fetchone()
+    assert row == (
+        round(2.5 * module.RTC_UNIT),
+        round(0.1 * module.QUOTE_PRICE_SCALE),
+        round(0.25 * module.QUOTE_PRICE_SCALE),
+    )
+
+
+def test_migration_is_idempotent_when_run_twice(tmp_path):
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    _legacy_orders_table(conn)
+
+    module.migrate_precision_columns(conn.cursor(), "orders")
+    # Second run must not raise (the common no-op path).
+    module.migrate_precision_columns(conn.cursor(), "orders")
+
+    cols = module.table_columns(conn.cursor(), "orders")
+    assert {"amount_micro_rtc", "price_per_rtc_nano_quote", "total_quote_nano"}.issubset(cols)
+
+
+def test_migration_tolerates_concurrent_duplicate_column(tmp_path):
+    """Simulates the race: a column already added by another worker between the
+    PRAGMA read and the ALTER. Must be swallowed, not raised."""
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    _legacy_orders_table(conn)
+    # Pre-add one of the precision columns out of band.
+    conn.execute("ALTER TABLE orders ADD COLUMN price_per_rtc_nano_quote INTEGER")
+
+    # Should complete and add the remaining columns without raising.
+    module.migrate_precision_columns(conn.cursor(), "orders")
+    cols = module.table_columns(conn.cursor(), "orders")
+    assert {"amount_micro_rtc", "total_quote_nano"}.issubset(cols)
+
+
+def test_migration_rejects_unknown_table(tmp_path):
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    with pytest.raises(ValueError):
+        module.migrate_precision_columns(conn.cursor(), "orders; DROP TABLE orders")
+
+
+def test_table_columns_rejects_unknown_table(tmp_path):
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")
+    with pytest.raises(ValueError):
+        module.table_columns(conn.cursor(), "sqlite_master")
+
+
+def test_real_duplicate_column_error_still_raises(tmp_path):
+    """Only `duplicate column name` is swallowed; other OperationalErrors (e.g.
+    a missing table) must still surface."""
+    module = load_otc_bridge(tmp_path)
+    conn = sqlite3.connect(":memory:")  # no 'orders' table at all
+    with pytest.raises(sqlite3.OperationalError):
+        module.migrate_precision_columns(conn.cursor(), "orders")


### PR DESCRIPTION
Two lower-severity defects from the otc-bridge review, in `migrate_precision_columns` / `table_columns`.

## 1. SQL injection (latent)
`table_name` was interpolated directly into `PRAGMA table_info(...)`, `ALTER TABLE ...`, and `UPDATE ...` DDL. **All current callers pass literals** (`"orders"`/`"trades"`), so there is no live vector — but SQLite **cannot parameterize identifiers**, so any future dynamic caller would be injectable.

Fix: a module `_KNOWN_TABLES` allowlist + `_require_known_table()` guard runs **before** any interpolation. Both functions now raise `ValueError` on an unknown name (e.g. `"orders; DROP TABLE orders"`).

## 2. Migration atomicity
Concurrent workers (e.g. gunicorn forks at startup) race the PRAGMA→ALTER window: the second to ALTER hits `duplicate column name` and crashes init. The `ALTER` loop now swallows **only** that specific `OperationalError` (everything else — including a genuinely missing table — still raises). The `COALESCE` backfill `UPDATE` was already idempotent, so re-runs converge and no write lock is needed.

## Tests — `tests/test_otc_bridge_migration.py`
- backfill computes correct integer micro/nano values;
- running the migration twice is a no-op (no raise);
- a column pre-added out-of-band (the race) is tolerated, remaining columns still added;
- unknown / injection-shaped table names rejected on **both** functions;
- a non-duplicate `OperationalError` (missing table) still surfaces.

42 otc-bridge tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)