### PR TITLE
fix(otc): WSGI schema init + list_trades fail-open + remove dead release_escrow

### DIFF
--- a/otc-bridge/otc_bridge.py
+++ b/otc-bridge/otc_bridge.py
@@ -642,22 +642,6 @@ def rtc_create_escrow_job(poster_wallet, amount_rtc, title, description):
         return {"ok": False, "error": GENERIC_INTERNAL_ERROR}
 
 
-def rtc_release_escrow(job_id, poster_wallet):
-    """Release escrow -- accept delivery to pay the taker."""
-    try:
-        # First, claim the job as the taker (OTC bridge acts as intermediary)
-        # Then deliver and accept to release funds
-        r = requests.post(
-            f"{RUSTCHAIN_NODE}/agent/jobs/{job_id}/accept",
-            json={"poster_wallet": poster_wallet},
-            verify=TLS_VERIFY, timeout=15
-        )
-        return r.ok
-    except Exception as e:
-        log.error(f"Escrow release failed: {e}")
-        return False
-
-
 def rtc_cancel_escrow(job_id, poster_wallet):
     """Cancel escrow job -- refund to poster."""
     try:
@@ -1366,10 +1350,14 @@ def list_trades():
     limit, error = positive_int_arg("limit", 50, max_value=200)
     if error:
         return jsonify({"error": error}), 400
+    # Fail closed, not open: an unsupported (e.g. typo'd) pair must NOT fall
+    # through to the unfiltered full-history feed. Mirrors /api/orderbook.
+    if pair and pair not in SUPPORTED_PAIRS:
+        return jsonify({"error": "unsupported pair"}), 400
 
     conn = get_db()
     try:
-        if pair and pair in SUPPORTED_PAIRS:
+        if pair:
             trades = conn.execute(
                 "SELECT * FROM trades WHERE pair = ? ORDER BY completed_at DESC LIMIT ?",
                 (pair, limit)
@@ -1550,7 +1538,15 @@ def static_files(path):
 # Main
 # ---------------------------------------------------------------------------
 
+# Initialize the schema at import time so the app works under WSGI servers.
+# The Dockerfile runs `gunicorn otc_bridge:app`, where __name__ != "__main__"
+# and the block below never executes — without this, a fresh container has no
+# tables and 500s on first request. init_db() is idempotent (CREATE TABLE IF
+# NOT EXISTS + idempotent precision-column migration), so it is safe on every
+# import and across concurrent gunicorn workers.
+init_db()
+
+
 if __name__ == "__main__":
-    init_db()
     port = int(os.environ.get("OTC_PORT", 5580))
     app.run(host="0.0.0.0", port=port, debug=False)

--- a/tests/test_otc_bridge_clean_fixes.py
+++ b/tests/test_otc_bridge_clean_fixes.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+"""
+Tests for three self-contained OTC bridge fixes:
+  1. list_trades fail-open — an unsupported pair must 400, not return the full
+     unfiltered feed.
+  2. init_db runs at import — so WSGI/gunicorn deploys (otc_bridge:app) create
+     the schema, not only `python otc_bridge.py`.
+  3. rtc_release_escrow dead code removed.
+"""
+import importlib.util
+import os
+import sqlite3
+import sys
+import types
+from pathlib import Path
+
+
+def _load(tmp_path, call_init_db):
+    if "flask_cors" not in sys.modules:
+        flask_cors = types.ModuleType("flask_cors")
+        flask_cors.CORS = lambda app, *args, **kwargs: app
+        sys.modules["flask_cors"] = flask_cors
+
+    db_path = tmp_path / "otc_bridge.db"
+    os.environ["OTC_DB_PATH"] = str(db_path)
+    module_path = Path(__file__).resolve().parents[1] / "otc-bridge" / "otc_bridge.py"
+    name = f"otc_bridge_cleanfix_{abs(hash(db_path))}"
+    spec = importlib.util.spec_from_file_location(name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    module.app.testing = True
+    if call_init_db:
+        module.init_db()
+    return module
+
+
+def test_list_trades_rejects_unsupported_pair(tmp_path):
+    module = _load(tmp_path, call_init_db=True)
+    client = module.app.test_client()
+    resp = client.get("/api/trades?pair=BOGUS")
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "unsupported pair"
+
+
+def test_list_trades_supported_pair_ok(tmp_path):
+    module = _load(tmp_path, call_init_db=True)
+    client = module.app.test_client()
+    resp = client.get("/api/trades?pair=RTC/USDC")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_list_trades_no_pair_returns_feed(tmp_path):
+    module = _load(tmp_path, call_init_db=True)
+    client = module.app.test_client()
+    resp = client.get("/api/trades")
+    assert resp.status_code == 200
+    assert resp.get_json()["ok"] is True
+
+
+def test_init_db_runs_at_import_for_wsgi(tmp_path):
+    """Importing the module (as gunicorn does) must create the schema without
+    anyone calling init_db() explicitly."""
+    module = _load(tmp_path, call_init_db=False)
+    conn = sqlite3.connect(module.DB_PATH)
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    finally:
+        conn.close()
+    assert {"orders", "trades", "rate_limits"}.issubset(tables)
+
+
+def test_dead_release_escrow_removed(tmp_path):
+    module = _load(tmp_path, call_init_db=True)
+    assert not hasattr(module, "rtc_release_escrow")


### PR DESCRIPTION
Three self-contained fixes from the otc-bridge tri-brain review. **No money-path logic is changed** — the settlement-atomicity race cluster (match/cancel/confirm/expire) is a separate, larger follow-up.

## 1. `init_db` at import — WSGI deploys had no schema (live bug)
The Dockerfile runs `gunicorn -w 2 ... otc_bridge:app`, where `__name__ != "__main__"`, so `init_db()` **never ran** → a fresh container has no tables → 500 on the first request to any endpoint. `init_db()` is now called at import. It's idempotent (`CREATE TABLE IF NOT EXISTS` + idempotent precision-column migration), so it's safe on every import.

> ⚠️ **Merge order:** `gunicorn -w 2` imports in two workers concurrently → two migrations race. That race is made safe by **#6800** (idempotent `ALTER`). **Merge #6800 first (or together).**

## 2. `list_trades` fail-open → 400
`GET /api/trades?pair=<unsupported>` fell through to the `else` branch and returned the **entire unfiltered feed**. A non-empty pair not in `SUPPORTED_PAIRS` now returns `400` (mirroring `/api/orderbook`); an empty `pair` still returns the full feed.

## 3. Remove `rtc_release_escrow` — dead code
Never called (`confirm_order` inlines claim→deliver→accept), and its body didn't even match its own docstring (it did a single `/accept`). Both review brains flagged the mismatch; removing the trap is cleaner than fixing unused code.

## Tests — `tests/test_otc_bridge_clean_fixes.py`
- unsupported pair → 400; valid + empty pair → 200;
- schema present after a **bare import** (the WSGI path), no explicit `init_db()` call;
- `rtc_release_escrow` attribute gone.

35 otc-bridge tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)