### PR TITLE
fix: update stale balance endpoint in star_checker.py (fixes #6779)

### DIFF
--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -132,7 +132,7 @@ def count_user_stars(
 def check_wallet_exists(wallet_address: str) -> bool:
     """Verify that a wallet address exists on the RustChain node."""
     try:
-        url = f"{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}"
+        url = f"{RUSTCHAIN_NODE_URL}/wallet/balance?miner_id={wallet_address}"
         import os
         _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
         _verify = _cert if os.path.exists(_cert) else True


### PR DESCRIPTION
## Summary
Fix the bounty verifier wallet check to use the maintained /wallet/balance endpoint instead of the stale /api/balance path.

## Changes
- Updated tools/bounty_verifier/star_checker.py: check_wallet_exists() now uses the correct /wallet/balance?miner_id={wallet_address} endpoint, consistent with verifier.py

## Testing
- Code change only — function signature and behavior unchanged
- Aligns with maintained endpoint pattern in verifier.py

## Related Issues
Fixes #6779