### PR TITLE
fix(bounty_verifier): use /wallet/balance endpoint instead of stale /api/balance (#6779)

### DIFF
--- a/tools/bounty_verifier/star_checker.py
+++ b/tools/bounty_verifier/star_checker.py
@@ -132,13 +132,22 @@ def count_user_stars(
 def check_wallet_exists(wallet_address: str) -> bool:
     """Verify that a wallet address exists on the RustChain node."""
     try:
-        url = f"{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}"
+        url = f"{RUSTCHAIN_NODE_URL}/wallet/balance"
         import os
         _cert = os.path.expanduser("~/.rustchain/node_cert.pem")
         _verify = _cert if os.path.exists(_cert) else True
-        resp = requests.get(url, verify=_verify, timeout=10)
+        resp = requests.get(
+            url,
+            params={"miner_id": wallet_address},
+            verify=_verify,
+            timeout=10,
+        )
         if resp.status_code == 200:
-            return True
+            try:
+                body = resp.json()
+            except ValueError:
+                return False
+            return isinstance(body, dict)
     except Exception as exc:
         logger.error("Error checking wallet %s: %s", wallet_address, exc)
     return False


### PR DESCRIPTION
## Summary

The `check_wallet_exists()` function in `tools/bounty_verifier/star_checker.py` was calling the deprecated `/api/balance/<wallet>` endpoint.

## Fix

- Replaced stale URL `{RUSTCHAIN_NODE_URL}/api/balance/{wallet_address}` with the correct maintained endpoint `{RUSTCHAIN_NODE_URL}/wallet/balance`
- Wallet address is now passed as a query parameter: `params={"miner_id": wallet_address}`
- Added JSON response validation (`body = resp.json()` + `isinstance(body, dict)`) for robustness

## Files changed

- `tools/bounty_verifier/star_checker.py`: Updated `check_wallet_exists()`

Fixes #6779