### PR TITLE
docs: add French (fr-FR) localization pass

### DIFF
--- a/docs/fr-FR/RUSTCHAIN_EXPLAINED.md
+++ b/docs/fr-FR/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain expliquée (fr-FR)
+
+RustChain est un réseau Proof-of-Antiquity qui récompense les machines réelles, en particulier le matériel ancien, pour prouver qu'elles continuent de fonctionner. L'idée centrale est simple : le matériel préservé a de la valeur, et le réseau doit pouvoir différencier une machine réelle d'une machine virtuelle (VM), d'un conteneur ou d'une déclaration falsifiée.
+
+## Comment fonctionne la vérification
+
+Le mineur collecte des signaux locaux et envoie une `attestation` au nœud RustChain. Cette `attestation` contient une empreinte matérielle (`fingerprint`). Le nœud utilise ces données pour évaluer l'ancienneté (`antiquity`) de la machine et calculer le multiplicateur de récompense.
+
+Le processus doit être honnête :
+
+- ne simulez pas l'architecture ;
+- ne forcez pas une famille de processeur que la machine ne possède pas ;
+- ne modifiez pas la charge utile (payload) pour paraître plus ancien ;
+- ne traduisez pas les options de commande ou les noms de points d'accès (endpoints).
+
+## Vérifier avant de miner
+
+Utilisez les commandes ci-dessous avant de laisser tourner un mineur :
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Ces commandes vous permettent de passer en revue la machine détectée, la charge utile d' `attestation` et la connectivité avec le nœud. Elles doivent rester exactement telles quelles dans la documentation localisée.
+
+## Ce à quoi consent l'utilisateur
+
+En confirmant le premier lancement, l'utilisateur déclare comprendre que :
+
+1. le mineur peut envoyer des données de `fingerprint` et d'`attestation` ;
+2. le matériel doit être déclaré honnêtement ;
+3. les récompenses en `RTC` dépendent de l'acceptation par le réseau et ne sont pas garanties ;
+4. l'usurpation (spoofing), l'émulation non déclarée ou les charges utiles falsifiées peuvent réduire les récompenses ou entraîner un rejet.
+
+L'écran de consentement en français doit exiger une confirmation affirmative explicite, telle que `OUI`. Appuyer simplement sur Entrée ne doit pas démarrer le minage.
+
+## Glossaire préservé
+
+| Terme | Signification opérationnelle |
+|---|---|
+| `RTC` | Jeton utilisé par RustChain pour les récompenses et bounties. |
+| `attestation` | Déclaration vérifiable de la machine envoyée au nœud. |
+| `antiquity` | Signal d'âge, de rareté et de préservation du matériel. |
+| `fingerprint` | Ensemble de signaux matériels utilisés pour la vérification. |
+
+## Guide du mineur Linux
+
+Le guide localisé du mineur Linux se trouve à l'adresse suivante :
+
+- [miners/linux/README.fr-FR.md](../../miners/linux/README.fr-FR.md)

--- a/i18n/fr-FR.json
+++ b/i18n/fr-FR.json
@@ -1,0 +1,111 @@
+{
+  "locale": "fr-FR",
+  "language": "French",
+  "version": "1.0.0",
+  "description": "Localisation fr-FR pour les messages du mineur/portefeuille RustChain et le consentement de premier lancement.",
+  "errors": {
+    "wallet": {
+      "invalid_amount": "Montant invalide",
+      "please_load_wallet_first": "Veuillez d'abord charger le portefeuille",
+      "please_enter_recipient_wallet_id": "Veuillez saisir l'identifiant du portefeuille destinataire",
+      "amount_must_be_positive": "Le montant doit être positif",
+      "transaction_failed": "Échec de la transaction",
+      "please_enter_wallet_id": "Veuillez saisir l'identifiant du portefeuille",
+      "network_error_check_connection": "Erreur réseau - vérifiez votre connexion",
+      "request_timeout_node_busy": "Délai d'attente dépassé - le nœud est peut-être occupé",
+      "dns_resolution_failed": "Échec de la résolution DNS : {host} : {error}",
+      "cannot_connect_to_host": "Impossible de se connecter à {host}:{port} (code d'erreur : {result})",
+      "network_check_failed": "La vérification du réseau a échoué : {error}",
+      "network_unreachable": "Réseau inaccessible : {error}",
+      "request_timeout_after_retries": "La demande a expiré après {timeout} secondes ({max_retries} tentatives)",
+      "api_error_http": "Erreur API : HTTP {status}",
+      "request_failed": "La demande a échoué : {error}",
+      "request_failed_after_retries": "La demande a échoué après {max_retries} tentatives : {last_error}",
+      "new_wallet_created": "Nouveau portefeuille créé",
+      "save_wallet_id_warning": "Conservez cet identifiant - il sera nécessaire pour accéder à vos fonds",
+      "confirm_transfer": "Confirmer le transfert",
+      "send_confirmation": "Envoyer {amount:.6f} RTC à :\n{to_wallet}\n\nContinuer ?"
+    },
+    "miner": {
+      "attestation_failed": "L'attestation a échoué",
+      "epoch_enrollment_failed": "L'inscription à l'époque a échoué",
+      "challenge_failed_http": "Échec du défi : HTTP {status_code}",
+      "challenge_error": "Erreur de défi : {error}",
+      "attestation_rejected": "Attestation rejetée : {response}",
+      "attestation_submission_failed": "Échec de l'envoi de l'attestation : {error}",
+      "enrollment_failed": "L'inscription a échoué : {error}",
+      "enrollment_rejected": "Inscription rejetée : {response}",
+      "enrollment_http_error": "Erreur HTTP lors de l'inscription {status} : {text}",
+      "submit_error": "Erreur d'envoi : {error}",
+      "fingerprint_failed_reduced_rewards": "Empreinte matérielle : échec (récompenses réduites)",
+      "fingerprint_passed": "Empreinte matérielle : réussie",
+      "fingerprint_n_a": "Empreinte matérielle : non disponible (module manquant)",
+      "attestation_accepted": "Attestation acceptée",
+      "enrolled_success": "Inscription réussie. Époque : {epoch} Multiplicateur : {weight}x",
+      "miner_loop_error": "Erreur dans la boucle du mineur : {error}",
+      "fingerprint_checks_incomplete": "Vérifications d'empreinte incomplètes ou en échec",
+      "fingerprint_checks_complete": "Vérifications d'empreinte terminées",
+      "fingerprint_checks_failed": "Échec des vérifications d'empreinte : {failed_checks}"
+    },
+    "network": {
+      "troubleshooting_title": "Dépannage :",
+      "check_internet_connection": "1. Vérifiez votre connexion Internet",
+      "verify_dns_working": "2. Vérifiez si le DNS fonctionne (essayez : ping {node_url})",
+      "check_firewall_proxy": "3. Vérifiez le pare-feu/proxy",
+      "node_may_be_offline": "4. Le nœud est peut-être temporairement hors ligne",
+      "node_syncing_maintenance": "1. Le nœud est peut-être en cours de synchronisation ou en maintenance",
+      "try_again_later": "2. Réessayez plus tard",
+      "check_node_dashboard": "3. Vérifiez le tableau de bord d'état de RustChain",
+      "network_issue_detected": "Problème réseau détecté :",
+      "node_response_issue": "Problème de réponse du nœud :",
+      "network_error_title": "Erreur réseau",
+      "warning_title": "Avertissement",
+      "error_title": "Erreur",
+      "success_title": "Succès"
+    },
+    "common": {
+      "error": "Erreur",
+      "failed": "Échoué",
+      "success": "Succès",
+      "warning": "Avertissement",
+      "info": "Information",
+      "confirm": "Confirmer",
+      "cancel": "Annuler",
+      "ok": "OK",
+      "yes": "Oui",
+      "no": "Non",
+      "loading": "Chargement...",
+      "retry": "Réessayer",
+      "close": "Fermer"
+    }
+  },
+  "messages": {
+    "wallet": {
+      "balance_display": "Solde : {balance:.8f} RTC",
+      "wallet_id_label": "ID du portefeuille :",
+      "load_button": "Charger",
+      "new_wallet_button": "Nouveau portefeuille",
+      "send_rtc_button": "Envoyer RTC",
+      "to_label": "Destinataire :",
+      "amount_label": "Montant :",
+      "rtc_unit": "RTC",
+      "transaction_history": "Transactions récentes"
+    },
+    "miner": {
+      "cpu_info": "Processeur : {processor}",
+      "arch_info": "Architecture : {arch}",
+      "status_attesting": "Attestation en cours...",
+      "status_enrolling": "Inscription...",
+      "status_mining": "Minage...",
+      "status_waiting": "En attente de qualification...",
+      "status_error": "Erreur : {message}"
+    },
+    "miner_consent": {
+      "title": "Consentement de premier lancement du mineur RustChain",
+      "body": "Avant de miner, veuillez examiner les commandes --dry-run, --show-payload et --test-only. Le mineur transmettra les données d'empreinte et d'attestation au nœud RustChain. Le matériel doit être déclaré honnêtement ; ne simulez pas l'architecture, l'ancienneté (antiquity) ou les signaux matériels. Les récompenses RTC ne sont pas garanties.",
+      "prompt": "Saisissez OUI pour confirmer que vous comprenez et souhaitez continuer :",
+      "affirmative": "OUI",
+      "rejected": "Consentement non confirmé. Le minage ne démarrera pas."
+    }
+  }
+}

--- a/miners/linux/README.fr-FR.md
+++ b/miners/linux/README.fr-FR.md
@@ -1,0 +1,69 @@
+# RustChain Miner pour Linux (fr-FR)
+
+Ce guide localise le flux du mineur Linux pour les utilisateurs francophones. Il conserve les termes techniques `RTC`, `attestation`, `antiquity` et `fingerprint`, car ils apparaissent dans le protocole, les journaux de console (logs) et les API.
+
+## Vérifier avant de s'engager
+
+Avant de lancer le minage, exécutez les commandes de vérification. Elles affichent ce qui sera envoyé au nœud et vous permettent d'examiner la charge utile (payload) sans démarrer de session de minage.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Ne traduisez pas et ne modifiez pas les options (flags) ci-dessus. `--dry-run`, `--show-payload` et `--test-only` sont des commandes littérales.
+
+## Ce que fait le mineur
+
+Le mineur Linux détecte la machine locale, collecte des signaux matériels honnêtes et envoie une `attestation` au nœud RustChain. Ces signaux forment une empreinte matérielle (`fingerprint`) utilisée pour évaluer l'ancienneté (`antiquity`) de la machine et appliquer le bon multiplicateur.
+
+Le mineur ne doit pas simuler ou falsifier l'architecture, l'âge du matériel, le nombre de cœurs, le numéro de série, le nom d'hôte (hostname) ou tout autre signal. Si un signal n'est pas disponible, le comportement correct est de déclarer son absence ou de dégrader la vérification.
+
+## Installer les dépendances
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+Sur les distributions Debian/Ubuntu, si `python3` ou `pip` ne sont pas installés :
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Exécuter le mineur
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Utilisez une adresse de portefeuille ou un identifiant que vous pourrez reconnaître plus tard. Le paiement des bounties peut utiliser `github:votre-utilisateur`, mais le minage normal utilise la valeur passée à `--wallet`.
+
+## Premier consentement
+
+Lors du premier lancement interactif, l'utilisateur doit confirmer explicitement qu'il comprend :
+
+- le mineur transmet des données de `fingerprint` et d'`attestation` au nœud RustChain ;
+- les commandes de vérification doivent être utilisées avant de miner ;
+- les récompenses en `RTC` ne sont pas garanties ;
+- la machine doit se présenter honnêtement, sans usurpation (spoofing) de matériel.
+
+Réponse affirmative en français : `OUI`.
+
+## Référence croisée
+
+Pour une explication courte du protocole et des termes préservés, veuillez lire :
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/fr-FR/RUSTCHAIN_EXPLAINED.md)
+
+## Glossaire
+
+| Terme | Comment le maintenir | Remarque |
+|---|---|---|
+| `RTC` | `RTC` | Jeton natif de RustChain. |
+| `attestation` | `attestation` | Preuve envoyée au nœud concernant la machine. |
+| `antiquity` | `antiquity` | Âge/rareté relative utilisé dans le multiplicateur. |
+| `fingerprint` | `fingerprint` | Ensemble de signaux matériels. |


### PR DESCRIPTION
This PR adds the French (fr-FR) translation pass for the miner CLI and wallet messages, along with the Linux miner README and explainers.

- Added `i18n/fr-FR.json` with the required error and GUI keys (explicit affirmative response is `"OUI"`).
- Added `miners/linux/README.fr-FR.md` detailing setup and execution.
- Added `docs/fr-FR/RUSTCHAIN_EXPLAINED.md` outlining the Proof-of-Antiquity protocol details.
- Validated JSON structure and keys using the `validate_i18n.py` script.

Resolves Scottcjn/rustchain-bounties#12790

Payout Wallet: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`
