### PR TITLE
docs: add Vietnamese miner localization

### DIFF
--- a/docs/vi-VN/RUSTCHAIN_EXPLAINED.md
+++ b/docs/vi-VN/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# Giải thích RustChain (vi-VN)
+
+RustChain là một mạng Proof-of-Antiquity thưởng cho các máy thật, đặc biệt là phần cứng cũ, khi chúng chứng minh rằng vẫn đang hoạt động. Ý tưởng cốt lõi rất đơn giản: phần cứng được giữ lại có giá trị, và mạng cần phân biệt được máy thật với VM, container hoặc khai báo bị tạo dựng.
+
+## Cách quá trình kiểm tra hoạt động
+
+Miner thu thập các tín hiệu cục bộ và gửi một `attestation` tới node RustChain. `attestation` này bao gồm một `fingerprint` phần cứng. Node dùng các dữ liệu đó để ước tính `antiquity` của máy và tính multiplier phần thưởng.
+
+Quá trình này phải trung thực:
+
+- không tự tạo kiến trúc CPU;
+- không ép máy thành một dòng CPU mà nó không có;
+- không sửa payload để máy trông có vẻ cũ hơn;
+- không dịch flag dòng lệnh hoặc tên endpoint.
+
+## Kiểm tra trước khi mining
+
+Hãy dùng các lệnh dưới đây trước khi để bất kỳ miner nào chạy liên tục:
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Các lệnh này giúp xem lại máy được phát hiện, payload `attestation` và kết nối tới node. Chúng phải được giữ chính xác như trên trong tài liệu đã bản địa hóa.
+
+## Người dùng đồng ý với điều gì
+
+Khi xác nhận lần chạy đầu tiên, người dùng tuyên bố rằng họ hiểu:
+
+1. miner có thể gửi dữ liệu `fingerprint` và `attestation`;
+2. phần cứng phải được báo cáo trung thực;
+3. phần thưởng bằng `RTC` phụ thuộc vào việc mạng chấp nhận và không được đảm bảo;
+4. spoofing, giả lập không khai báo hoặc payload bị tạo dựng có thể làm giảm phần thưởng hoặc bị từ chối.
+
+Màn hình đồng ý tiếng Việt phải yêu cầu một input khẳng định rõ ràng, ví dụ `CO` (dạng không dấu của "Có" để dễ nhập trong terminal). Chỉ bấm Enter không được bắt đầu mining.
+
+## Bảng thuật ngữ được giữ nguyên
+
+| Thuật ngữ | Ý nghĩa vận hành |
+|---|---|
+| `RTC` | Token RustChain dùng cho phần thưởng và bounty. |
+| `attestation` | Khai báo có thể kiểm chứng của máy gửi tới node. |
+| `antiquity` | Thuật ngữ riêng của RustChain về tuổi đời, độ hiếm và mức độ bảo tồn của phần cứng. |
+| `fingerprint` | Tập hợp tín hiệu phần cứng dùng để kiểm tra. |
+
+## Hướng dẫn miner Linux
+
+Hướng dẫn miner Linux đã bản địa hóa nằm tại:
+
+- [miners/linux/README.vi-VN.md](../../miners/linux/README.vi-VN.md)

--- a/i18n/vi-VN.json
+++ b/i18n/vi-VN.json
@@ -1,0 +1,111 @@
+{
+  "locale": "vi-VN",
+  "language": "Vietnamese (Vietnam)",
+  "version": "1.0.0",
+  "description": "Bản địa hóa vi-VN cho thông báo lỗi miner/wallet RustChain và đồng ý lần chạy đầu tiên.",
+  "errors": {
+    "wallet": {
+      "invalid_amount": "Giá trị không hợp lệ",
+      "please_load_wallet_first": "Hãy tải wallet trước",
+      "please_enter_recipient_wallet_id": "Hãy nhập ID wallet người nhận",
+      "amount_must_be_positive": "Số tiền phải lớn hơn 0",
+      "transaction_failed": "Giao dịch thất bại",
+      "please_enter_wallet_id": "Hãy nhập ID wallet",
+      "network_error_check_connection": "Lỗi mạng - hãy kiểm tra kết nối",
+      "request_timeout_node_busy": "Hết thời gian chờ - node có thể đang bận",
+      "dns_resolution_failed": "Không phân giải được DNS: {host}: {error}",
+      "cannot_connect_to_host": "Không thể kết nối tới {host}:{port} (mã lỗi: {result})",
+      "network_check_failed": "Kiểm tra mạng thất bại: {error}",
+      "network_unreachable": "Không truy cập được mạng: {error}",
+      "request_timeout_after_retries": "Yêu cầu hết thời gian sau {timeout} giây ({max_retries} lần thử)",
+      "api_error_http": "Lỗi API: HTTP {status}",
+      "request_failed": "Yêu cầu thất bại: {error}",
+      "request_failed_after_retries": "Yêu cầu thất bại sau {max_retries} lần thử: {last_error}",
+      "new_wallet_created": "Đã tạo wallet mới",
+      "save_wallet_id_warning": "Hãy lưu ID này - bạn sẽ cần nó để truy cập tiền",
+      "confirm_transfer": "Xác nhận chuyển",
+      "send_confirmation": "Gửi {amount:.6f} RTC tới:\n{to_wallet}\n\nTiếp tục?"
+    },
+    "miner": {
+      "attestation_failed": "attestation thất bại",
+      "epoch_enrollment_failed": "Đăng ký epoch thất bại",
+      "challenge_failed_http": "Challenge thất bại: HTTP {status_code}",
+      "challenge_error": "Lỗi challenge: {error}",
+      "attestation_rejected": "attestation bị từ chối: {response}",
+      "attestation_submission_failed": "Gửi attestation thất bại: {error}",
+      "enrollment_failed": "Đăng ký thất bại: {error}",
+      "enrollment_rejected": "Đăng ký bị từ chối: {response}",
+      "enrollment_http_error": "Lỗi HTTP khi đăng ký {status}: {text}",
+      "submit_error": "Lỗi gửi dữ liệu: {error}",
+      "fingerprint_failed_reduced_rewards": "fingerprint phần cứng: thất bại (phần thưởng giảm)",
+      "fingerprint_passed": "fingerprint phần cứng: đạt",
+      "fingerprint_n_a": "fingerprint phần cứng: không có sẵn (thiếu module)",
+      "attestation_accepted": "attestation đã được chấp nhận",
+      "enrolled_success": "Đăng ký thành công. Epoch: {epoch} Weight: {weight}x",
+      "miner_loop_error": "Lỗi vòng lặp miner: {error}",
+      "fingerprint_checks_incomplete": "Kiểm tra fingerprint chưa đủ hoặc thất bại",
+      "fingerprint_checks_complete": "Kiểm tra fingerprint hoàn tất",
+      "fingerprint_checks_failed": "Kiểm tra fingerprint thất bại: {failed_checks}"
+    },
+    "network": {
+      "troubleshooting_title": "Hướng xử lý:",
+      "check_internet_connection": "1. Kiểm tra kết nối internet",
+      "verify_dns_working": "2. Kiểm tra DNS có hoạt động không (thử: ping {node_url})",
+      "check_firewall_proxy": "3. Kiểm tra firewall/proxy",
+      "node_may_be_offline": "4. Node có thể đang tạm thời offline",
+      "node_syncing_maintenance": "1. Node có thể đang sync hoặc bảo trì",
+      "try_again_later": "2. Thử lại sau",
+      "check_node_dashboard": "3. Kiểm tra dashboard trạng thái RustChain",
+      "network_issue_detected": "Phát hiện vấn đề mạng:",
+      "node_response_issue": "Vấn đề phản hồi của node:",
+      "network_error_title": "Lỗi mạng",
+      "warning_title": "Cảnh báo",
+      "error_title": "Lỗi",
+      "success_title": "Thành công"
+    },
+    "common": {
+      "error": "Lỗi",
+      "failed": "Thất bại",
+      "success": "Thành công",
+      "warning": "Cảnh báo",
+      "info": "Thông tin",
+      "confirm": "Xác nhận",
+      "cancel": "Hủy",
+      "ok": "OK",
+      "yes": "Có",
+      "no": "Không",
+      "loading": "Đang tải...",
+      "retry": "Thử lại",
+      "close": "Đóng"
+    }
+  },
+  "messages": {
+    "wallet": {
+      "balance_display": "Số dư: {balance:.8f} RTC",
+      "wallet_id_label": "ID wallet:",
+      "load_button": "Tải",
+      "new_wallet_button": "Wallet mới",
+      "send_rtc_button": "Gửi RTC",
+      "to_label": "Người nhận:",
+      "amount_label": "Số tiền:",
+      "rtc_unit": "RTC",
+      "transaction_history": "Giao dịch gần đây"
+    },
+    "miner": {
+      "cpu_info": "CPU: {processor}",
+      "arch_info": "Kiến trúc: {arch}",
+      "status_attesting": "Đang chạy attestation...",
+      "status_enrolling": "Đang đăng ký...",
+      "status_mining": "Đang mining...",
+      "status_waiting": "Đang chờ đủ điều kiện...",
+      "status_error": "Lỗi: {message}"
+    },
+    "miner_consent": {
+      "title": "Đồng ý lần chạy đầu tiên của RustChain Miner",
+      "body": "Trước khi mining, hãy xem lại các lệnh --dry-run, --show-payload và --test-only. Miner sẽ gửi dữ liệu fingerprint và attestation tới node RustChain. Phần cứng phải được khai báo trung thực; không tạo giả kiến trúc, antiquity hoặc tín hiệu phần cứng. Phần thưởng bằng RTC không được đảm bảo.",
+      "prompt": "Nhập CO (dạng không dấu của Có) để xác nhận rằng bạn hiểu và muốn tiếp tục:",
+      "affirmative": "CO",
+      "rejected": "Chưa xác nhận đồng ý. Mining sẽ không được bắt đầu."
+    }
+  }
+}

--- a/miners/linux/README.vi-VN.md
+++ b/miners/linux/README.vi-VN.md
@@ -1,0 +1,69 @@
+# RustChain Miner cho Linux (vi-VN)
+
+Hướng dẫn này bản địa hóa luồng cài đặt miner Linux cho người dùng tiếng Việt. Các thuật ngữ `RTC`, `attestation`, `antiquity` và `fingerprint` được giữ nguyên vì chúng xuất hiện trong protocol, log và API của RustChain.
+
+## Kiểm tra trước khi tin cậy
+
+Trước khi mining, hãy chạy các lệnh kiểm tra. Chúng cho bạn thấy dữ liệu nào sẽ được gửi tới node và cho phép xem payload trước khi bắt đầu một phiên mining.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Không dịch hoặc thay đổi các flag ở trên. `--dry-run`, `--show-payload` và `--test-only` là các lệnh literal.
+
+## Miner làm gì
+
+Miner Linux phát hiện máy cục bộ, thu thập các tín hiệu phần cứng trung thực và gửi một `attestation` tới node RustChain. Các tín hiệu này tạo thành một `fingerprint` phần cứng dùng để đánh giá `antiquity` của máy và áp dụng multiplier phù hợp.
+
+Miner không nên tự tạo kiến trúc CPU, tuổi đời phần cứng, số core, serial, hostname hoặc bất kỳ tín hiệu nào khác. Nếu một tín hiệu không có sẵn, hành vi đúng là khai báo rằng tín hiệu đó vắng mặt hoặc hạ mức kiểm tra.
+
+## Cài đặt phụ thuộc
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+Trên Debian/Ubuntu, nếu `python3` hoặc `pip` chưa được cài đặt:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Chạy miner
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Hãy dùng một wallet hoặc định danh mà bạn có thể nhận ra sau này. Payout bounty có thể dùng `github:ten-nguoi-dung`, nhưng mining thông thường dùng giá trị truyền vào `--wallet`.
+
+## Đồng ý lần chạy đầu tiên
+
+Trong lần chạy tương tác đầu tiên, người dùng phải xác nhận rõ ràng rằng họ hiểu:
+
+- miner sẽ gửi dữ liệu `fingerprint` và `attestation` tới node RustChain;
+- các lệnh kiểm tra nên được chạy trước khi mining;
+- phần thưởng bằng `RTC` không được đảm bảo;
+- máy phải tự khai báo trung thực, không spoof phần cứng.
+
+Token xác nhận đồng ý là `CO` (viết không dấu để dễ nhập trong terminal). Đây là dạng không dấu của "Có".
+
+## Tham chiếu chéo
+
+Để đọc giải thích ngắn về protocol và các thuật ngữ được giữ nguyên, xem:
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/vi-VN/RUSTCHAIN_EXPLAINED.md)
+
+## Bảng thuật ngữ
+
+| Thuật ngữ | Cách giữ nguyên | Ghi chú |
+|---|---|---|
+| `RTC` | `RTC` | Token gốc của RustChain. |
+| `attestation` | `attestation` | Bằng chứng gửi tới node về máy. |
+| `antiquity` | `antiquity` | Thuật ngữ riêng của RustChain về tuổi đời/độ hiếm tương đối dùng trong multiplier. |
+| `fingerprint` | `fingerprint` | Tập hợp tín hiệu phần cứng. |


### PR DESCRIPTION
## Summary

Adds a Vietnamese (`vi-VN`) localization pass for the RustChain Linux miner onboarding flow.

## Files

- `miners/linux/README.vi-VN.md`
- `docs/vi-VN/RUSTCHAIN_EXPLAINED.md`
- `i18n/vi-VN.json`

## Bounty grammar

- target_lang: `vi-VN`
- files:
  - README_LINUX: `miners/linux/README.vi-VN.md`
  - RUSTCHAIN_EXPLAINED: `docs/vi-VN/RUSTCHAIN_EXPLAINED.md`
  - consent strings: `i18n/vi-VN.json`
- glossary terms kept literal: `RTC`, `attestation`, `antiquity`, `fingerprint`

## Acceptance notes

- Consent requires explicit affirmative input: `CO`.
- Verification commands are preserved literally: `--dry-run`, `--show-payload`, and `--test-only`.
- Cross-reference between the localized Linux miner README and `RUSTCHAIN_EXPLAINED.md` is preserved.
- No README badge/self-promo content added.

## Validation

- `python3 -m json.tool i18n/vi-VN.json`
- `python3 i18n/validate_i18n.py`
- `git diff --check -- miners/linux/README.vi-VN.md docs/vi-VN/RUSTCHAIN_EXPLAINED.md i18n/vi-VN.json`

## Payout

RTC wallet: `RTC78f1fa6b385aafa9ae46f74c09ca1e2ced61c725`
