### PR TITLE
fix: validate Hall of Rust JSON bodies

### DIFF
--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -15,6 +15,14 @@ import random
 hall_bp = Blueprint('hall_of_rust', __name__)
 logger = logging.getLogger(__name__)
 
+
+def _json_object_required():
+    """Return parsed JSON only when the request body is a JSON object."""
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return None, (jsonify({'error': 'JSON object required'}), 400)
+    return data, None
+
 # Rust Score calculation weights
 RUST_WEIGHTS = {
     'age_years': 10,           # Points per year of hardware age

--- a/explorer/hall_of_rust.py
+++ b/explorer/hall_of_rust.py
@@ -17,8 +17,10 @@ logger = logging.getLogger(__name__)
 
 
 def _json_object_required():
-    """Return parsed JSON only when the request body is a JSON object."""
+    """Return parsed JSON object data or a 400 response for non-object JSON."""
     data = request.get_json(silent=True)
+    if data is None:
+        return {}, None
     if not isinstance(data, dict):
         return None, (jsonify({'error': 'JSON object required'}), 400)
     return data, None
@@ -160,11 +162,10 @@ def estimate_manufacture_year(model, arch):
 @hall_bp.route('/hall/induct', methods=['POST'])
 def induct_machine():
     """Automatically induct a machine into the Hall of Rust on first attestation."""
-    data = request.get_json(silent=True)
-    if data is None:
-        data = {}
-    if not isinstance(data, dict):
-        return jsonify({"error": "JSON object required"}), 400
+    data, error_response = _json_object_required()
+    if error_response:
+        return error_response
+    assert data is not None
     
     # Generate fingerprint hash from hardware identifiers
     # SECURITY FIX: Fingerprint based on HARDWARE ONLY (not wallet ID)
@@ -317,11 +318,10 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
-    data = request.get_json(silent=True)
-    if data is None:
-        data = {}
-    if not isinstance(data, dict):
-        return jsonify({"error": "JSON object required"}), 400
+    data, error_response = _json_object_required()
+    if error_response:
+        return error_response
+    assert data is not None
     
     try:
         from flask import current_app

--- a/tests/test_explorer_hall_of_rust_current_year.py
+++ b/tests/test_explorer_hall_of_rust_current_year.py
@@ -86,6 +86,56 @@ def test_explorer_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeyp
     assert response.get_json()["age_years"] == 23
 
 
+def test_explorer_hall_induct_rejects_non_object_json(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/induct", json=["not", "an", "object"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_explorer_hall_induct_rejects_empty_array_json(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/induct", json=[])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_explorer_hall_eulogy_rejects_non_object_json(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/eulogy/fp-1", json=["nickname"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_explorer_hall_eulogy_rejects_empty_array_json(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/eulogy/fp-1", json=[])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
+def test_explorer_hall_eulogy_rejects_json_string(tmp_path):
+    hall = load_explorer_hall()
+    client = client_for(hall, tmp_path / "hall.db")
+
+    response = client.post("/hall/eulogy/fp-1", json="nickname")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "JSON object required"}
+
+
 def test_explorer_hall_stats_hides_sqlite_error_details(tmp_path):
     hall = load_explorer_hall()
     db_path = tmp_path / "missing_schema.db"


### PR DESCRIPTION
## Summary\n\nFollow-up clean replacement for #6135, scoped to the Hall of Rust JSON-body validation fix only.\n\nFixes #6134 by requiring JSON object bodies for Hall of Rust write endpoints before handler logic assumes dictionary methods/keys.\n\nChanges:\n- keep JSON object validation for Hall of Rust write endpoints\n- add focused regressions for non-object and falsy JSON payloads\n\n## Validation\n\n- `python3 -m pytest tests/test_explorer_hall_of_rust_current_year.py -q` → 10 passed\n- `python3 -m py_compile explorer/hall_of_rust.py tests/test_explorer_hall_of_rust_current_year.py`\n- `git diff --cached --check`\n\nSupersedes #6135 with a focused diff.


RTC wallet: RTC6d1f27d28961279f1034d9561c2403697eb55602
