### PR TITLE
fix: keep GPU fingerprint import safe on CPU CI

### DIFF
--- a/miners/gpu_fingerprint.py
+++ b/miners/gpu_fingerprint.py
@@ -24,6 +24,8 @@ Usage:
 Author: Elyan Labs (RIP-0308: Proof of Physical AI)
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import hashlib
@@ -40,12 +42,17 @@ try:
     import torch
     import torch.cuda
 except ImportError:
-    print("ERROR: PyTorch with CUDA support required. Install: pip install torch")
-    sys.exit(1)
+    torch = None
+    HAS_TORCH = False
+else:
+    HAS_TORCH = True
 
-if not torch.cuda.is_available():
-    print("ERROR: No CUDA-capable GPU detected.")
-    sys.exit(1)
+
+def check_requirements():
+    if not HAS_TORCH or torch is None:
+        raise RuntimeError("PyTorch with CUDA support required. Install: pip install torch")
+    if not torch.cuda.is_available():
+        raise RuntimeError("No CUDA-capable GPU detected.")
 
 
 # ---------------------------------------------------------------------------
@@ -789,6 +796,7 @@ def cross_validate_gpu(device: torch.device) -> ChannelResult:
 
 def run_gpu_fingerprint(device_index: int = 0, samples: int = 200, epoch_salt: str = "") -> GPUFingerprint:
     """Run all GPU fingerprint channels and return results."""
+    check_requirements()
     device = torch.device(f"cuda:{device_index}")
 
     # GPU info
@@ -898,16 +906,20 @@ if __name__ == "__main__":
                         help="Epoch salt for privacy (prevents cross-epoch correlation)")
     args = parser.parse_args()
 
-    if args.json:
-        # Suppress banner output for clean JSON
-        import io, contextlib
-        with contextlib.redirect_stdout(io.StringIO()):
+    try:
+        if args.json:
+            # Suppress banner output for clean JSON
+            import io, contextlib
+            with contextlib.redirect_stdout(io.StringIO()):
+                fp = run_gpu_fingerprint(device_index=args.device, samples=args.samples, epoch_salt=args.epoch_salt)
+            print(json.dumps(fp.to_dict(), indent=2))
+        else:
             fp = run_gpu_fingerprint(device_index=args.device, samples=args.samples, epoch_salt=args.epoch_salt)
-        print(json.dumps(fp.to_dict(), indent=2))
-    else:
-        fp = run_gpu_fingerprint(device_index=args.device, samples=args.samples, epoch_salt=args.epoch_salt)
-        # Print channel summary
-        print("Channel Details:")
-        for ch in fp.channels:
-            status = "PASS" if ch["passed"] else "FAIL"
-            print(f"  [{status}] {ch['name']}: {ch['notes']}")
+            # Print channel summary
+            print("Channel Details:")
+            for ch in fp.channels:
+                status = "PASS" if ch["passed"] else "FAIL"
+                print(f"  [{status}] {ch['name']}: {ch['notes']}")
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/miners/gpu_fingerprint.py
+++ b/miners/gpu_fingerprint.py
@@ -40,18 +40,21 @@ from typing import Optional
 
 try:
     import torch
-    import torch.cuda
 except ImportError:
     torch = None
     HAS_TORCH = False
 else:
     HAS_TORCH = True
+    try:
+        import torch.cuda
+    except ImportError:
+        pass
 
 
 def check_requirements():
     if not HAS_TORCH or torch is None:
         raise RuntimeError("PyTorch with CUDA support required. Install: pip install torch")
-    if not torch.cuda.is_available():
+    if not hasattr(torch, "cuda") or not torch.cuda.is_available():
         raise RuntimeError("No CUDA-capable GPU detected.")
 
 

--- a/tests/test_gpu_fingerprint_import.py
+++ b/tests/test_gpu_fingerprint_import.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Regression coverage for importing the GPU fingerprint helper on CPU CI."""
 
+import builtins
 import importlib.util
 import sys
 from pathlib import Path
@@ -9,8 +10,16 @@ import pytest
 
 
 def test_gpu_fingerprint_import_without_torch_does_not_exit(monkeypatch):
-    monkeypatch.setitem(sys.modules, "torch", None)
-    monkeypatch.setitem(sys.modules, "torch.cuda", None)
+    original_import = builtins.__import__
+
+    def import_without_torch(name, *args, **kwargs):
+        if name == "torch" or name.startswith("torch."):
+            raise ImportError(f"No module named '{name}'")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.delitem(sys.modules, "torch", raising=False)
+    monkeypatch.delitem(sys.modules, "torch.cuda", raising=False)
+    monkeypatch.setattr(builtins, "__import__", import_without_torch)
 
     module_path = Path(__file__).resolve().parents[1] / "miners" / "gpu_fingerprint.py"
     spec = importlib.util.spec_from_file_location("gpu_fingerprint_without_torch", module_path)

--- a/tests/test_gpu_fingerprint_import.py
+++ b/tests/test_gpu_fingerprint_import.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+"""Regression coverage for importing the GPU fingerprint helper on CPU CI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_gpu_fingerprint_import_without_torch_does_not_exit(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", None)
+    monkeypatch.setitem(sys.modules, "torch.cuda", None)
+
+    module_path = Path(__file__).resolve().parents[1] / "miners" / "gpu_fingerprint.py"
+    spec = importlib.util.spec_from_file_location("gpu_fingerprint_without_torch", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    monkeypatch.setitem(sys.modules, spec.name, module)
+
+    spec.loader.exec_module(module)
+
+    assert module.HAS_TORCH is False
+    with pytest.raises(RuntimeError, match="PyTorch with CUDA support required"):
+        module.check_requirements()


### PR DESCRIPTION
## Summary

- Defers PyTorch/CUDA requirement checks until the GPU fingerprint flow actually runs.
- Keeps module import safe on CPU-only CI / no-torch environments.
- Adds an import-only regression test for the no-torch path.

## Follow-up scope

This is the small GPU import-safety slice called out as acceptable in #6711.

It intentionally does not touch node/admin/auth endpoints, production security guards, or the repo-wide stale-test/admin-key baseline handled separately in #6788.

## Validation

- `python3 -m py_compile miners/gpu_fingerprint.py tests/test_gpu_fingerprint_import.py`
- `uv run --no-project --with pytest --with flask --with requests --with flask-cors --with httpx --with cryptography python -m pytest -q tests/test_gpu_fingerprint_import.py --tb=short -o addopts='' --basetemp=.pytest-tmp` -> `1 passed`
- `git diff --check`
- `python3 miners/gpu_fingerprint.py --json` without torch -> exits `1` with `ERROR: PyTorch with CUDA support required. Install: pip install torch`

Refs #305.
Follow-up to #6711.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
