### PR TITLE
fix: resolve Sophia Beacon Atlas profile

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -291,6 +291,106 @@ def _authenticate_contract_agent(db, allowed_agents, body_bytes):
     return agent_id, None
 
 
+PUBLIC_ATLAS_AGENT_PROFILES = {
+    'sophia-elya': {
+        'agent_id': 'bcn_sophia_elya',
+        'slug': 'sophia-elya',
+        'name': 'Sophia Elya',
+        'status': 'active',
+        'city': 'compiler_heights',
+        'role': 'Inference Orchestrator | #1 Creator',
+        'beacon_id': 'bcn_c850ea702e8f',
+        'grade': 'S',
+        'atlas_url': 'https://rustchain.org/beacon/agent/sophia-elya',
+        'profile_source': 'legacy_atlas_override',
+    },
+}
+
+
+def _agent_lookup_variants(value):
+    if not isinstance(value, str):
+        return set()
+    raw = ' '.join(value.strip().casefold().split())
+    if not raw:
+        return set()
+    variants = {
+        raw,
+        raw.replace('_', '-'),
+        raw.replace('-', '_'),
+        raw.replace(' ', '-'),
+        raw.replace(' ', '_'),
+    }
+    return {variant for variant in variants if variant}
+
+
+def _build_public_agent_aliases():
+    aliases = {}
+    for slug, profile in PUBLIC_ATLAS_AGENT_PROFILES.items():
+        alias_values = [
+            slug,
+            profile.get('agent_id'),
+            profile.get('beacon_id'),
+            profile.get('name'),
+        ]
+        for alias_value in alias_values:
+            for key in _agent_lookup_variants(alias_value):
+                aliases[key] = slug
+    return aliases
+
+
+PUBLIC_ATLAS_AGENT_ALIASES = _build_public_agent_aliases()
+
+
+def _legacy_public_agent_profile(agent_id):
+    for key in _agent_lookup_variants(agent_id):
+        slug = PUBLIC_ATLAS_AGENT_ALIASES.get(key)
+        if slug:
+            profile = dict(PUBLIC_ATLAS_AGENT_PROFILES[slug])
+            profile['requested_id'] = agent_id
+            return profile
+    return None
+
+
+def _public_agent_profile_from_row(row, requested_id):
+    profile = {
+        'agent_id': row['agent_id'],
+        'name': row['name'],
+        'status': row['status'],
+        'created_at': row['created_at'],
+        'updated_at': row['updated_at'],
+        'profile_source': 'relay_agents',
+    }
+    if requested_id != row['agent_id']:
+        profile['requested_id'] = requested_id
+    return profile
+
+
+def _find_public_agent_row(db, agent_id):
+    row = db.execute(
+        """SELECT agent_id, name, status, created_at, updated_at
+           FROM relay_agents
+           WHERE agent_id = ? OR LOWER(name) = LOWER(?)""",
+        (agent_id, agent_id)
+    ).fetchone()
+    if row:
+        return row
+
+    lookup_keys = _agent_lookup_variants(agent_id)
+    if not lookup_keys:
+        return None
+    rows = db.execute(
+        "SELECT agent_id, name, status, created_at, updated_at FROM relay_agents"
+    ).fetchall()
+    for candidate in rows:
+        candidate_keys = (
+            _agent_lookup_variants(candidate['agent_id'])
+            | _agent_lookup_variants(candidate['name'])
+        )
+        if lookup_keys & candidate_keys:
+            return candidate
+    return None
+
+
 # ============================================================
 # AGENTS ENDPOINTS
 # ============================================================
@@ -356,6 +456,37 @@ def get_agent(agent_id):
             'created_at': row['created_at'],
             'updated_at': row['updated_at'],
         })
+    except Exception as e:
+        return jsonify({'error': 'internal_error'}), 500
+
+
+@beacon_api.route('/beacon/agent/<agent_id>', methods=['GET', 'OPTIONS'])
+def get_public_beacon_agent(agent_id):
+    """Get a redacted public Beacon Atlas agent profile."""
+    if request.method == 'OPTIONS':
+        resp = jsonify({'ok': True})
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        resp.headers['Access-Control-Allow-Headers'] = 'Content-Type'
+        resp.headers['Access-Control-Allow-Methods'] = 'GET, OPTIONS'
+        return resp
+
+    try:
+        legacy_profile = _legacy_public_agent_profile(agent_id)
+        if legacy_profile:
+            resp = jsonify(legacy_profile)
+            resp.headers['Access-Control-Allow-Origin'] = '*'
+            return resp
+
+        db = get_db()
+        row = _find_public_agent_row(db, agent_id)
+        if row:
+            resp = jsonify(_public_agent_profile_from_row(row, agent_id))
+            resp.headers['Access-Control-Allow-Origin'] = '*'
+            return resp
+
+        resp = jsonify({'agent_id': agent_id, 'error': 'Agent not found'})
+        resp.headers['Access-Control-Allow-Origin'] = '*'
+        return resp, 404
     except Exception as e:
         return jsonify({'error': 'internal_error'}), 500
 

--- a/tests/test_beacon_join_routing.py
+++ b/tests/test_beacon_join_routing.py
@@ -632,6 +632,122 @@ class TestBeaconJoinRouting(unittest.TestCase):
         self.assertIn('GET', headers.get('Access-Control-Allow-Methods', ''))
 
     # ============================================================
+    # GET /beacon/agent Tests
+    # ============================================================
+
+    def test_public_agent_returns_registered_agent_without_admin_fields(self):
+        """GET /beacon/agent/<id> returns a redacted registered agent profile."""
+        payload = {
+            'agent_id': 'bcn_public_profile',
+            'pubkey_hex': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+            'name': 'Public Profile Agent',
+            'coinbase_address': '0x1234567890123456789012345678901234567890',
+        }
+
+        self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        response = self.client.get('/beacon/agent/bcn_public_profile')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'bcn_public_profile')
+        self.assertEqual(data['name'], 'Public Profile Agent')
+        self.assertEqual(data['status'], 'active')
+        self.assertEqual(data['profile_source'], 'relay_agents')
+        self.assertNotIn('pubkey_hex', data)
+        self.assertNotIn('coinbase_address', data)
+
+    def test_public_agent_resolves_registered_agent_by_slugged_name(self):
+        """GET /beacon/agent/<id> resolves registered agents by name slug."""
+        payload = {
+            'agent_id': 'bcn_slug_lookup',
+            'pubkey_hex': '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+            'name': 'Slug Lookup Agent',
+        }
+
+        self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+
+        response = self.client.get('/beacon/agent/slug-lookup-agent')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'bcn_slug_lookup')
+        self.assertEqual(data['requested_id'], 'slug-lookup-agent')
+
+    def test_public_agent_resolves_sophia_legacy_slug(self):
+        """GET /beacon/agent/sophia-elya resolves the Sophia Atlas profile."""
+        response = self.client.get('/beacon/agent/sophia-elya')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'bcn_sophia_elya')
+        self.assertEqual(data['slug'], 'sophia-elya')
+        self.assertEqual(data['name'], 'Sophia Elya')
+        self.assertEqual(data['beacon_id'], 'bcn_c850ea702e8f')
+        self.assertEqual(data['atlas_url'], 'https://rustchain.org/beacon/agent/sophia-elya')
+        self.assertEqual(data['profile_source'], 'legacy_atlas_override')
+
+    def test_public_agent_legacy_slug_is_not_shadowed_by_registered_name(self):
+        """Registered agent aliases cannot shadow the reserved Sophia Atlas slug."""
+        payload = {
+            'agent_id': 'bcn_shadow_attempt',
+            'pubkey_hex': '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabce',
+            'name': 'Sophia Elya',
+        }
+
+        join_response = self.client.post(
+            '/beacon/join',
+            data=json.dumps(payload),
+            content_type='application/json'
+        )
+        self.assertEqual(join_response.status_code, 200)
+
+        response = self.client.get('/beacon/agent/sophia-elya')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'bcn_sophia_elya')
+        self.assertEqual(data['slug'], 'sophia-elya')
+        self.assertEqual(data['profile_source'], 'legacy_atlas_override')
+
+    def test_public_agent_resolves_sophia_beacon_id(self):
+        """GET /beacon/agent/<beacon_id> resolves Sophia's machine-readable ID."""
+        response = self.client.get('/beacon/agent/bcn_c850ea702e8f')
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'bcn_sophia_elya')
+        self.assertEqual(data['beacon_id'], 'bcn_c850ea702e8f')
+        self.assertEqual(data['requested_id'], 'bcn_c850ea702e8f')
+
+    def test_public_agent_missing_returns_404_with_requested_id(self):
+        """GET /beacon/agent/<id> keeps the public 404 shape for unknown agents."""
+        response = self.client.get('/beacon/agent/missing-agent')
+
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        self.assertEqual(data['agent_id'], 'missing-agent')
+        self.assertEqual(data['error'], 'Agent not found')
+
+    def test_public_agent_options_returns_cors_headers(self):
+        """OPTIONS /beacon/agent/<id> returns CORS headers."""
+        response = self.client.options('/beacon/agent/sophia-elya')
+
+        self.assertEqual(response.status_code, 200)
+        headers = response.headers
+        self.assertEqual(headers.get('Access-Control-Allow-Origin'), '*')
+        self.assertIn('Content-Type', headers.get('Access-Control-Allow-Headers', ''))
+        self.assertIn('GET', headers.get('Access-Control-Allow-Methods', ''))
+
+    # ============================================================
     # Integration Tests
     # ============================================================
 


### PR DESCRIPTION
## Summary

- Adds a public redacted `GET /beacon/agent/<agent_id>` Beacon Atlas profile endpoint.
- Resolves Sophia Elya through the live metadata slug `sophia-elya`, the legacy Atlas id `bcn_sophia_elya`, and Beacon id `bcn_c850ea702e8f`.
- Keeps `/api/agent/<agent_id>` admin-only and avoids returning admin-only fields such as pubkey or coinbase address from the public profile route.
- Resolves reserved legacy Atlas aliases before relay agent alias lookup so a public `/beacon/join` registration cannot shadow the Sophia profile.

## Root cause

`elyanlabs.ai/agent.json` points Sophia's Atlas URL at `https://rustchain.org/beacon/agent/sophia-elya`, and nginx already proxies `/beacon/agent/` to the Beacon API. The backend only exposed admin-only `/api/agent/<id>` and did not have a public `/beacon/agent/<id>` route, so the machine-readable discovery link returned `Agent not found`.

## Validation

- `python -m pytest -q tests/test_beacon_join_routing.py` -> `32 passed`
- `python -m unittest tests.test_beacon_join_routing` -> `Ran 32 tests ... OK`
- `python -m py_compile node/beacon_api.py tests/test_beacon_join_routing.py`
- `git diff --check upstream/main...HEAD`
- `scan_hidden_unicode.py --changed-files-from-git upstream/main...HEAD` -> no findings
- `python -m pytest tests/ -q --ignore=tests/test_epoch_settlement_formal.py --ignore=tests/test_rip201_bucket_spoof.py` -> blocked during unrelated wallet test collection because local Python lacks `_tkinter`; focused Beacon route tests above passed.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
