### PR TITLE
feat: add explorer block filters

### DIFF
--- a/explorer/index.html
+++ b/explorer/index.html
@@ -423,10 +423,8 @@
             
             // Sync blocks table
             if (viewName === 'blocks') {
-                const blocksTbody = document.getElementById('blocks-tbody-full');
-                const blocksTbodyOverview = document.getElementById('blocks-tbody');
-                if (blocksTbody && blocksTbodyOverview) {
-                    blocksTbody.innerHTML = blocksTbodyOverview.innerHTML;
+                if (window.RustChainExplorer && window.RustChainExplorer.renderBlocksTable) {
+                    window.RustChainExplorer.renderBlocksTable();
                 }
             }
             

--- a/explorer/index.html
+++ b/explorer/index.html
@@ -132,12 +132,15 @@
                                     <th scope="col">Height</th>
                                     <th scope="col">Hash</th>
                                     <th scope="col">Timestamp</th>
+                                    <th scope="col">Proposer</th>
+                                    <th scope="col">Txs</th>
+                                    <th scope="col">Gas</th>
                                     <th scope="col">Miners</th>
                                     <th scope="col">Reward</th>
                                 </tr>
                             </thead>
                             <tbody id="blocks-tbody">
-                                <tr><td colspan="5" class="loading"><div class="spinner" aria-hidden="true"></div>Loading blocks...</td></tr>
+                                <tr><td colspan="8" class="loading"><div class="spinner" aria-hidden="true"></div>Loading blocks...</td></tr>
                             </tbody>
                         </table>
                     </div>
@@ -179,6 +182,40 @@
                             <span aria-hidden="true">🔄</span> Refresh
                         </button>
                     </div>
+                    <form class="block-filter-grid" role="search" aria-label="Filter blocks" onsubmit="return false;">
+                        <label>
+                            <span>Proposer</span>
+                            <input type="search" id="block-filter-proposer" data-block-filter placeholder="Miner, proposer, or producer">
+                        </label>
+                        <label>
+                            <span>From Time</span>
+                            <input type="datetime-local" id="block-filter-from-time" data-block-filter>
+                        </label>
+                        <label>
+                            <span>To Time</span>
+                            <input type="datetime-local" id="block-filter-to-time" data-block-filter>
+                        </label>
+                        <label>
+                            <span>Min Txs</span>
+                            <input type="number" id="block-filter-min-tx" data-block-filter min="0" step="1">
+                        </label>
+                        <label>
+                            <span>Max Txs</span>
+                            <input type="number" id="block-filter-max-tx" data-block-filter min="0" step="1">
+                        </label>
+                        <label>
+                            <span>Min Gas</span>
+                            <input type="number" id="block-filter-min-gas" data-block-filter min="0" step="1">
+                        </label>
+                        <label>
+                            <span>Max Gas</span>
+                            <input type="number" id="block-filter-max-gas" data-block-filter min="0" step="1">
+                        </label>
+                        <div class="block-filter-actions">
+                            <button type="button" id="clear-block-filters" class="btn btn-secondary btn-sm">Clear</button>
+                            <span id="block-filter-summary" class="text-muted" aria-live="polite">0 of 0 blocks</span>
+                        </div>
+                    </form>
                     <div class="table-container" role="region" aria-label="All blocks" tabindex="0">
                         <table>
                             <caption class="sr-only">Complete list of blocks on the RustChain network</caption>
@@ -187,12 +224,15 @@
                                     <th scope="col">Height</th>
                                     <th scope="col">Hash</th>
                                     <th scope="col">Timestamp</th>
+                                    <th scope="col">Proposer</th>
+                                    <th scope="col">Txs</th>
+                                    <th scope="col">Gas</th>
                                     <th scope="col">Miners</th>
                                     <th scope="col">Reward</th>
                                 </tr>
                             </thead>
                             <tbody id="blocks-tbody-full">
-                                <tr><td colspan="5" class="loading"><div class="spinner" aria-hidden="true"></div>Loading blocks...</td></tr>
+                                <tr><td colspan="8" class="loading"><div class="spinner" aria-hidden="true"></div>Loading blocks...</td></tr>
                             </tbody>
                         </table>
                     </div>

--- a/explorer/static/css/explorer.css
+++ b/explorer/static/css/explorer.css
@@ -463,6 +463,47 @@ tbody tr:hover {
     color: var(--text-muted);
 }
 
+.block-filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    align-items: end;
+}
+
+.block-filter-grid label {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.block-filter-grid input {
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.block-filter-grid input:focus {
+    outline: none;
+    border-color: var(--accent-primary);
+    box-shadow: var(--shadow-glow);
+}
+
+.block-filter-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    min-height: 38px;
+    flex-wrap: wrap;
+}
+
 /* Loading States */
 .loading {
     display: flex;

--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -308,7 +308,7 @@ async function fetchBlocks() {
         state.loading.blocks = true;
         state.error.blocks = null;
         const blocks = normalizeBlocksResponse(await fetchAPI('/blocks'));
-        state.blocks = blocks.slice(0, CONFIG.MAX_RECENT_BLOCKS);
+        state.blocks = blocks;
     } catch (error) {
         state.error.blocks = error.message;
         // Fallback mock data
@@ -527,16 +527,17 @@ function renderMinersTable() {
 }
 
 function renderBlocksTable() {
-    const container = document.getElementById('blocks-tbody');
-    if (!container) return;
+    const recentContainer = document.getElementById('blocks-tbody');
+    const fullContainer = document.getElementById('blocks-tbody-full');
     
     if (state.loading.blocks) {
-        container.innerHTML = '<tr><td colspan="8" class="loading"><div class="spinner"></div>Loading blocks...</td></tr>';
+        setBlockTableHtml(recentContainer, '<tr><td colspan="8" class="loading"><div class="spinner"></div>Loading blocks...</td></tr>');
+        setBlockTableHtml(fullContainer, '<tr><td colspan="8" class="loading"><div class="spinner"></div>Loading blocks...</td></tr>');
         return;
     }
     
     if (state.error.blocks && state.blocks.length === 0) {
-        container.innerHTML = `
+        const errorHtml = `
             <tr><td colspan="8">
                 <div class="error-message">
                     <span class="error-icon">⚠️</span>
@@ -544,23 +545,39 @@ function renderBlocksTable() {
                 </div>
             </td></tr>
         `;
+        setBlockTableHtml(recentContainer, errorHtml);
+        setBlockTableHtml(fullContainer, errorHtml);
+        renderBlockFilterSummary(0);
         return;
     }
     
     if (!state.blocks || state.blocks.length === 0) {
-        container.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="empty-icon">📦</div>No blocks found</td></tr>';
+        const emptyHtml = '<tr><td colspan="8" class="empty-state"><div class="empty-icon">📦</div>No blocks found</td></tr>';
+        setBlockTableHtml(recentContainer, emptyHtml);
+        setBlockTableHtml(fullContainer, emptyHtml);
+        renderBlockFilterSummary(0);
         return;
     }
 
-    const blocks = filterBlocks();
+    const recentBlocks = state.blocks.slice(0, CONFIG.MAX_RECENT_BLOCKS);
+    setBlockTableHtml(recentContainer, renderBlockRows(recentBlocks));
+
+    const blocks = filterBlocks(state.blocks);
     renderBlockFilterSummary(blocks.length);
     if (blocks.length === 0) {
-        container.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="empty-icon">🔎</div>No blocks match the current filters</td></tr>';
-        syncFullBlocksTable();
+        setBlockTableHtml(fullContainer, '<tr><td colspan="8" class="empty-state"><div class="empty-icon">🔎</div>No blocks match the current filters</td></tr>');
         return;
     }
 
-    container.innerHTML = blocks.map(block => `
+    setBlockTableHtml(fullContainer, renderBlockRows(blocks));
+}
+
+function setBlockTableHtml(container, html) {
+    if (container) container.innerHTML = html;
+}
+
+function renderBlockRows(blocks) {
+    return blocks.map(block => `
         <tr>
             <td><strong class="text-accent">#${formatNumber(block.height, 0)}</strong></td>
             <td class="mono" title="${escapeHtml(block.hash)}">${escapeHtml(shortenHash(block.hash || '0x'))}</td>
@@ -572,7 +589,6 @@ function renderBlocksTable() {
             <td class="text-success">${formatNumber(block.reward || 0, 2)} RTC</td>
         </tr>
     `).join('');
-    syncFullBlocksTable();
 }
 
 function renderBlockFilterSummary(matchingCount) {
@@ -583,11 +599,7 @@ function renderBlockFilterSummary(matchingCount) {
 }
 
 function syncFullBlocksTable() {
-    const blocksTbody = document.getElementById('blocks-tbody-full');
-    const blocksTbodyOverview = document.getElementById('blocks-tbody');
-    if (blocksTbody && blocksTbodyOverview) {
-        blocksTbody.innerHTML = blocksTbodyOverview.innerHTML;
-    }
+    renderBlocksTable();
 }
 
 function renderTransactionsTable() {
@@ -915,6 +927,7 @@ window.RustChainExplorer = {
     ]),
     search: handleSearch,
     filterBlocks,
+    renderBlocksTable,
     setBlockFilters: filters => {
         state.blockFilters = { ...state.blockFilters, ...filters };
         renderBlocksTable();

--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -42,6 +42,15 @@ const state = {
     },
     activeTab: 'overview',
     searchQuery: '',
+    blockFilters: {
+        proposer: '',
+        fromTime: '',
+        toTime: '',
+        minTransactions: '',
+        maxTransactions: '',
+        minGas: '',
+        maxGas: ''
+    },
     lastUpdate: null
 };
 
@@ -108,6 +117,73 @@ function normalizeMinersResponse(payload) {
         (Array.isArray(payload?.miners) ? payload.miners :
         (Array.isArray(payload?.data) ? payload.data : []));
     return rows.filter(row => row && typeof row === 'object');
+}
+
+function normalizeBlocksResponse(payload) {
+    const rows = Array.isArray(payload) ? payload :
+        (Array.isArray(payload?.blocks) ? payload.blocks :
+        (Array.isArray(payload?.data) ? payload.data : []));
+    return rows.filter(row => row && typeof row === 'object');
+}
+
+function blockProposer(block) {
+    return block.proposer || block.miner || block.producer || block.validator || '';
+}
+
+function blockTransactionCount(block) {
+    return block.tx_count ?? block.transactions_count ?? block.transaction_count ??
+        (Array.isArray(block.transactions) ? block.transactions.length : undefined);
+}
+
+function blockGasUsed(block) {
+    return block.gas_used ?? block.gasUsed ?? block.total_gas_used ?? block.gas;
+}
+
+function parseFilterNumber(value) {
+    if (value === null || value === undefined || String(value).trim() === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function blockTimestampMillis(block) {
+    const value = block.timestamp ?? block.time ?? block.created_at ?? block.createdAt;
+    if (value === null || value === undefined || value === '') return null;
+    if (typeof value === 'number') {
+        return value < 100000000000 ? value * 1000 : value;
+    }
+    const parsed = Date.parse(String(value));
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+function filterBlocks(blocks = state.blocks) {
+    const filters = state.blockFilters;
+    const proposerQuery = filters.proposer.trim().toLowerCase();
+    const fromTime = filters.fromTime ? Date.parse(filters.fromTime) : null;
+    const toTime = filters.toTime ? Date.parse(filters.toTime) : null;
+    const minTransactions = parseFilterNumber(filters.minTransactions);
+    const maxTransactions = parseFilterNumber(filters.maxTransactions);
+    const minGas = parseFilterNumber(filters.minGas);
+    const maxGas = parseFilterNumber(filters.maxGas);
+
+    return blocks.filter(block => {
+        if (proposerQuery && !String(blockProposer(block)).toLowerCase().includes(proposerQuery)) {
+            return false;
+        }
+
+        const timestamp = blockTimestampMillis(block);
+        if (fromTime && (timestamp === null || timestamp < fromTime)) return false;
+        if (toTime && (timestamp === null || timestamp > toTime)) return false;
+
+        const txCount = parseFilterNumber(blockTransactionCount(block));
+        if (minTransactions !== null && (txCount === null || txCount < minTransactions)) return false;
+        if (maxTransactions !== null && (txCount === null || txCount > maxTransactions)) return false;
+
+        const gasUsed = parseFilterNumber(blockGasUsed(block));
+        if (minGas !== null && (gasUsed === null || gasUsed < minGas)) return false;
+        if (maxGas !== null && (gasUsed === null || gasUsed > maxGas)) return false;
+
+        return true;
+    });
 }
 
 function getArchitectureTier(arch) {
@@ -231,7 +307,7 @@ async function fetchBlocks() {
     try {
         state.loading.blocks = true;
         state.error.blocks = null;
-        const blocks = await fetchAPI('/blocks') || [];
+        const blocks = normalizeBlocksResponse(await fetchAPI('/blocks'));
         state.blocks = blocks.slice(0, CONFIG.MAX_RECENT_BLOCKS);
     } catch (error) {
         state.error.blocks = error.message;
@@ -455,13 +531,13 @@ function renderBlocksTable() {
     if (!container) return;
     
     if (state.loading.blocks) {
-        container.innerHTML = '<tr><td colspan="5" class="loading"><div class="spinner"></div>Loading blocks...</td></tr>';
+        container.innerHTML = '<tr><td colspan="8" class="loading"><div class="spinner"></div>Loading blocks...</td></tr>';
         return;
     }
     
     if (state.error.blocks && state.blocks.length === 0) {
         container.innerHTML = `
-            <tr><td colspan="5">
+            <tr><td colspan="8">
                 <div class="error-message">
                     <span class="error-icon">⚠️</span>
                     <span>${escapeHtml(state.error.blocks)}</span>
@@ -472,19 +548,46 @@ function renderBlocksTable() {
     }
     
     if (!state.blocks || state.blocks.length === 0) {
-        container.innerHTML = '<tr><td colspan="5" class="empty-state"><div class="empty-icon">📦</div>No blocks found</td></tr>';
+        container.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="empty-icon">📦</div>No blocks found</td></tr>';
         return;
     }
-    
-    container.innerHTML = state.blocks.map(block => `
+
+    const blocks = filterBlocks();
+    renderBlockFilterSummary(blocks.length);
+    if (blocks.length === 0) {
+        container.innerHTML = '<tr><td colspan="8" class="empty-state"><div class="empty-icon">🔎</div>No blocks match the current filters</td></tr>';
+        syncFullBlocksTable();
+        return;
+    }
+
+    container.innerHTML = blocks.map(block => `
         <tr>
             <td><strong class="text-accent">#${formatNumber(block.height, 0)}</strong></td>
             <td class="mono" title="${escapeHtml(block.hash)}">${escapeHtml(shortenHash(block.hash || '0x'))}</td>
             <td class="mono">${formatTimestamp(block.timestamp)}</td>
+            <td class="mono" title="${escapeHtml(blockProposer(block))}">${escapeHtml(shortenAddress(blockProposer(block) || 'N/A'))}</td>
+            <td>${formatNumber(blockTransactionCount(block) || 0, 0)}</td>
+            <td>${formatNumber(blockGasUsed(block) || 0, 0)}</td>
             <td><span class="badge badge-info">${formatNumber(block.miners_count || 0, 0)} miners</span></td>
             <td class="text-success">${formatNumber(block.reward || 0, 2)} RTC</td>
         </tr>
     `).join('');
+    syncFullBlocksTable();
+}
+
+function renderBlockFilterSummary(matchingCount) {
+    const summary = document.getElementById('block-filter-summary');
+    if (!summary) return;
+    const total = state.blocks.length;
+    summary.textContent = `${matchingCount} of ${total} blocks`;
+}
+
+function syncFullBlocksTable() {
+    const blocksTbody = document.getElementById('blocks-tbody-full');
+    const blocksTbodyOverview = document.getElementById('blocks-tbody');
+    if (blocksTbody && blocksTbodyOverview) {
+        blocksTbody.innerHTML = blocksTbodyOverview.innerHTML;
+    }
 }
 
 function renderTransactionsTable() {
@@ -699,6 +802,36 @@ function handleSearch(query) {
     renderSearchResults();
 }
 
+function handleBlockFilterChange() {
+    const getValue = id => document.getElementById(id)?.value || '';
+    state.blockFilters = {
+        proposer: getValue('block-filter-proposer'),
+        fromTime: getValue('block-filter-from-time'),
+        toTime: getValue('block-filter-to-time'),
+        minTransactions: getValue('block-filter-min-tx'),
+        maxTransactions: getValue('block-filter-max-tx'),
+        minGas: getValue('block-filter-min-gas'),
+        maxGas: getValue('block-filter-max-gas')
+    };
+    renderBlocksTable();
+}
+
+function resetBlockFilters() {
+    [
+        'block-filter-proposer',
+        'block-filter-from-time',
+        'block-filter-to-time',
+        'block-filter-min-tx',
+        'block-filter-max-tx',
+        'block-filter-min-gas',
+        'block-filter-max-gas'
+    ].forEach(id => {
+        const input = document.getElementById(id);
+        if (input) input.value = '';
+    });
+    handleBlockFilterChange();
+}
+
 // Initial Load
 async function initialize() {
     console.log('[Explorer] Initializing...');
@@ -743,6 +876,15 @@ document.addEventListener('DOMContentLoaded', () => {
             handleSearch(e.target.value);
         });
     }
+
+    document.querySelectorAll('[data-block-filter]').forEach(input => {
+        input.addEventListener('input', handleBlockFilterChange);
+    });
+
+    const clearBlockFiltersBtn = document.getElementById('clear-block-filters');
+    if (clearBlockFiltersBtn) {
+        clearBlockFiltersBtn.addEventListener('click', resetBlockFilters);
+    }
     
     // Manual refresh button
     const refreshBtn = document.getElementById('refresh-btn');
@@ -772,5 +914,10 @@ window.RustChainExplorer = {
         fetchTransactions()
     ]),
     search: handleSearch,
+    filterBlocks,
+    setBlockFilters: filters => {
+        state.blockFilters = { ...state.blockFilters, ...filters };
+        renderBlocksTable();
+    },
     switchTab
 };

--- a/tests/test_explorer_block_filters.py
+++ b/tests/test_explorer_block_filters.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+import json
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXPLORER_HTML = REPO_ROOT / "explorer" / "index.html"
+EXPLORER_JS = REPO_ROOT / "explorer" / "static" / "js" / "explorer.js"
+
+
+def test_block_filter_controls_are_available_in_blocks_view():
+    html = EXPLORER_HTML.read_text(encoding="utf-8")
+
+    for element_id in (
+        "block-filter-proposer",
+        "block-filter-from-time",
+        "block-filter-to-time",
+        "block-filter-min-tx",
+        "block-filter-max-tx",
+        "block-filter-min-gas",
+        "block-filter-max-gas",
+        "clear-block-filters",
+        "block-filter-summary",
+    ):
+        assert f'id="{element_id}"' in html
+
+    for heading in (
+        "<th scope=\"col\">Proposer</th>",
+        "<th scope=\"col\">Txs</th>",
+        "<th scope=\"col\">Gas</th>",
+    ):
+        assert heading in html
+
+
+def test_block_filter_logic_handles_requested_filter_fields():
+    js = EXPLORER_JS.read_text(encoding="utf-8")
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(js)};
+const context = {{
+  window: {{ EXPLORER_API_BASE: 'https://example.test' }},
+  document: {{
+    addEventListener() {{}},
+    getElementById() {{ return null; }},
+    querySelectorAll() {{ return []; }},
+  }},
+  console: {{ log() {{}}, error() {{}} }},
+  setInterval() {{ return 1; }},
+  clearInterval() {{}},
+  setTimeout() {{ return 1; }},
+  clearTimeout() {{}},
+  fetch() {{ throw new Error('network disabled in test'); }},
+  AbortController: function() {{ this.signal = {{}}; this.abort = function() {{}}; }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+const result = vm.runInContext(`
+  const api = window.RustChainExplorer;
+  api.state.blocks = [
+    {{
+      height: 3,
+      proposer: 'alice',
+      timestamp: '2026-06-03T10:00:00',
+      tx_count: 8,
+      gas_used: 12000
+    }},
+    {{
+      height: 2,
+      miner: 'bob',
+      timestamp: '2026-06-03T09:00:00',
+      transactions: [{{}}, {{}}],
+      total_gas_used: 4000
+    }},
+    {{
+      height: 1,
+      producer: 'alice-backup',
+      timestamp: '2026-06-03T08:00:00',
+      transactions_count: 3,
+      gasUsed: 9000
+    }}
+  ];
+  api.state.blockFilters = {{
+    proposer: 'alice',
+    fromTime: '2026-06-03T08:30',
+    toTime: '2026-06-03T10:30',
+    minTransactions: '4',
+    maxTransactions: '10',
+    minGas: '10000',
+    maxGas: '13000'
+  }};
+  JSON.stringify({{
+    filteredHeights: api.filterBlocks().map(block => block.height),
+    envelopeHeights: normalizeBlocksResponse({{ blocks: [{{ height: 9 }}, null, 'bad'] }}).map(block => block.height)
+  }});
+`, context);
+console.log(result);
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["filteredHeights"] == [3]
+    assert data["envelopeHeights"] == [9]

--- a/tests/test_explorer_block_filters.py
+++ b/tests/test_explorer_block_filters.py
@@ -107,3 +107,91 @@ console.log(result);
 
     assert data["filteredHeights"] == [3]
     assert data["envelopeHeights"] == [9]
+
+
+def test_all_blocks_filter_uses_untruncated_fetched_blocks():
+    js = EXPLORER_JS.read_text(encoding="utf-8")
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(js)};
+
+(async () => {{
+  const elements = {{}};
+  const elementFor = id => {{
+    if (!elements[id]) {{
+      elements[id] = {{
+        value: '',
+        innerHTML: '',
+        textContent: '',
+        addEventListener() {{}},
+        classList: {{ toggle() {{}}, add() {{}}, remove() {{}} }},
+        setAttribute() {{}},
+        removeAttribute() {{}}
+      }};
+    }}
+    return elements[id];
+  }};
+  const context = {{
+    window: {{ EXPLORER_API_BASE: 'https://example.test' }},
+    document: {{
+      addEventListener() {{}},
+      getElementById: elementFor,
+      querySelectorAll() {{ return []; }},
+      querySelector() {{ return null; }},
+    }},
+    console: {{ log() {{}}, error() {{}} }},
+    setInterval() {{ return 1; }},
+    clearInterval() {{}},
+    setTimeout() {{ return 1; }},
+    clearTimeout() {{}},
+    fetch(url) {{
+      const blocks = [
+        {{ height: 103, hash: '0x103', timestamp: '2026-06-03T10:00:00', proposer: 'recent-a', tx_count: 1, gas_used: 100 }},
+        {{ height: 102, hash: '0x102', timestamp: '2026-06-03T09:00:00', proposer: 'recent-b', tx_count: 2, gas_used: 200 }},
+        {{ height: 101, hash: '0x101', timestamp: '2026-06-03T08:00:00', proposer: 'archive-miner', tx_count: 9, gas_used: 900 }}
+      ];
+      const payload = url.endsWith('/blocks') ? blocks :
+        (url.endsWith('/api/miners') ? [] :
+        (url.endsWith('/api/transactions') ? [] :
+        (url.endsWith('/epoch') ? {{ epoch: 1, slot: 1, blocks_per_epoch: 144 }} :
+        {{ status: 'ok', version: 'test' }})));
+      return Promise.resolve({{ ok: true, json: () => Promise.resolve(payload) }});
+    }},
+    AbortController: function() {{ this.signal = {{}}; this.abort = function() {{}}; }},
+  }};
+  vm.createContext(context);
+  vm.runInContext(script, context);
+  const result = await vm.runInContext(`
+    (async () => {{
+      const api = window.RustChainExplorer;
+      api.CONFIG.MAX_RECENT_BLOCKS = 2;
+      await api.refresh();
+      api.setBlockFilters({{ proposer: 'archive-miner' }});
+      return JSON.stringify({{
+        storedBlockCount: api.state.blocks.length,
+        summary: document.getElementById('block-filter-summary').textContent,
+        recentHtml: document.getElementById('blocks-tbody').innerHTML,
+        fullHtml: document.getElementById('blocks-tbody-full').innerHTML,
+        filteredHeights: api.filterBlocks().map(block => block.height)
+      }});
+    }})()
+  `, context);
+  console.log(result);
+}})().catch(error => {{
+  console.error(error);
+  process.exit(1);
+}});
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    data = json.loads(result.stdout)
+
+    assert data["storedBlockCount"] == 3
+    assert data["summary"] == "1 of 3 blocks"
+    assert data["filteredHeights"] == [101]
+    assert "#101" not in data["recentHtml"]
+    assert "#101" in data["fullHtml"]


### PR DESCRIPTION
## What changed
- Added block explorer filter controls for proposer/miner, time range, transaction count range, and gas used range.
- Rendered proposer, transaction count, and gas columns in the blocks tables.
- Normalized block API responses that arrive either as a bare array or a `{ blocks: [...] }` envelope.
- Added VM-backed regression coverage for the new filter behavior.

## Why it matters
This addresses #2373 by making the existing block explorer table searchable across the requested block fields when those fields are present in block payloads, while preserving current behavior for sparse block responses.

## Validation
- `node --check explorer/static/js/explorer.js`
- `.venv-bounty-validation/bin/python -m pytest tests/test_explorer_block_filters.py -q`
- `git diff --check`
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo $PWD --changed-files-from-git origin/main...HEAD`
- Playwright smoke check against `http://127.0.0.1:8899/`: filtered sample block data to `1 of 3 blocks` with only block `#103` visible.

## Touched files/subsystems
- `explorer/index.html`
- `explorer/static/css/explorer.css`
- `explorer/static/js/explorer.js`
- `tests/test_explorer_block_filters.py`

## Scope/risk boundary
This is a client-side explorer filtering slice. It does not change block production, consensus, API authorization, or persisted chain data.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
