### PR TITLE
feat: add event faucet claim codes

### DIFF
--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -80,7 +80,7 @@ distribution:
 
 # Event claim codes
 event_codes:
-  enabled: true
+  enabled: false
   admin_token: null  # Prefer FAUCET_EVENT_ADMIN_TOKEN in production
   default_amount: 0.5
   max_amount: 1.0
@@ -119,7 +119,7 @@ event_codes:
 #### Event Codes
 | Option | Default | Description |
 |--------|---------|-------------|
-| `enabled` | `true` | Enable event claim-code endpoints |
+| `enabled` | `false` | Enable event claim-code endpoints |
 | `admin_token` | `null` | Admin token for creating codes; `FAUCET_EVENT_ADMIN_TOKEN` takes precedence |
 | `default_amount` | `0.5` | RTC amount for created codes when request omits `amount` |
 | `max_amount` | `1.0` | Maximum RTC amount allowed for a single event code |
@@ -202,7 +202,7 @@ curl -X POST http://localhost:8090/faucet/event-codes \
 
 ### POST /faucet/event-claim
 
-Redeem one event code for a wallet. Each code can be claimed once and cannot be claimed after `expires_at`.
+Redeem one event code for a wallet. Each code can be claimed once after a successful transfer and cannot be claimed after `expires_at`. Event claims are recorded in a separate ledger from normal faucet drips, so they do not affect `/faucet/drip` rate limits or `/faucet/status` drip statistics.
 
 **Request:**
 ```json

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -83,6 +83,7 @@ event_codes:
   enabled: true
   admin_token: null  # Prefer FAUCET_EVENT_ADMIN_TOKEN in production
   default_amount: 0.5
+  max_amount: 1.0
   max_batch_size: 500
   code_prefix: "EVENT"
 ```
@@ -121,6 +122,7 @@ event_codes:
 | `enabled` | `true` | Enable event claim-code endpoints |
 | `admin_token` | `null` | Admin token for creating codes; `FAUCET_EVENT_ADMIN_TOKEN` takes precedence |
 | `default_amount` | `0.5` | RTC amount for created codes when request omits `amount` |
+| `max_amount` | `1.0` | Maximum RTC amount allowed for a single event code |
 | `max_batch_size` | `500` | Maximum codes created in a single request |
 | `code_prefix` | `EVENT` | Default prefix for generated event codes |
 

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -86,6 +86,7 @@ event_codes:
   max_amount: 1.0
   max_batch_size: 500
   code_prefix: "EVENT"
+  pending_claim_ttl_seconds: 300
 ```
 
 ### Configuration Options
@@ -125,6 +126,7 @@ event_codes:
 | `max_amount` | `1.0` | Maximum RTC amount allowed for a single event code |
 | `max_batch_size` | `500` | Maximum codes created in a single request |
 | `code_prefix` | `EVENT` | Default prefix for generated event codes |
+| `pending_claim_ttl_seconds` | `300` | Seconds before a pre-transfer event claim reservation may be retried |
 
 ## API Endpoints
 
@@ -202,7 +204,7 @@ curl -X POST http://localhost:8090/faucet/event-codes \
 
 ### POST /faucet/event-claim
 
-Redeem one event code for a wallet. Each code can be claimed once after a successful transfer and cannot be claimed after `expires_at`. Event claims are recorded in a separate ledger from normal faucet drips, so they do not affect `/faucet/drip` rate limits or `/faucet/status` drip statistics.
+Redeem one event code for a wallet. Each code can be claimed once after a successful transfer and cannot be claimed after `expires_at`. Event claims are recorded in a separate ledger from normal faucet drips, so they do not affect `/faucet/drip` rate limits or `/faucet/status` drip statistics. Stale pre-transfer reservations can be retried after `pending_claim_ttl_seconds`; claims that have reached transfer start remain locked for reconciliation.
 
 **Request:**
 ```json

--- a/faucet_service/README.md
+++ b/faucet_service/README.md
@@ -11,6 +11,7 @@ A production-ready Flask-based faucet service for dispensing free test RTC token
 - **Web UI**: Modern, responsive HTML interface
 - **Monitoring**: Health checks and Prometheus metrics support
 - **Mock Mode**: Test without actual token transfers
+- **Event Claim Codes**: Admin-gated one-time codes with per-code amounts and expiration dates
 
 ## Quick Start
 
@@ -76,6 +77,14 @@ validation:
 distribution:
   amount: 0.5
   mock_mode: true  # Set to false for actual transfers
+
+# Event claim codes
+event_codes:
+  enabled: true
+  admin_token: null  # Prefer FAUCET_EVENT_ADMIN_TOKEN in production
+  default_amount: 0.5
+  max_batch_size: 500
+  code_prefix: "EVENT"
 ```
 
 ### Configuration Options
@@ -105,6 +114,15 @@ distribution:
 | `max_length` | `66` | Maximum wallet length |
 | `blocklist` | `[]` | Blocked wallet addresses |
 | `allowlist` | `[]` | Allowed wallet addresses (empty = all) |
+
+#### Event Codes
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable event claim-code endpoints |
+| `admin_token` | `null` | Admin token for creating codes; `FAUCET_EVENT_ADMIN_TOKEN` takes precedence |
+| `default_amount` | `0.5` | RTC amount for created codes when request omits `amount` |
+| `max_batch_size` | `500` | Maximum codes created in a single request |
+| `code_prefix` | `EVENT` | Default prefix for generated event codes |
 
 ## API Endpoints
 
@@ -148,6 +166,66 @@ Request test tokens.
 {
   "ok": false,
   "error": "Invalid wallet address"
+}
+```
+
+### POST /faucet/event-codes
+
+Create one-time claim codes for a community event. This endpoint requires `X-Faucet-Admin-Token` and returns generated codes that organizers can distribute to participants.
+
+**Request:**
+```bash
+curl -X POST http://localhost:8090/faucet/event-codes \
+  -H "Content-Type: application/json" \
+  -H "X-Faucet-Admin-Token: $FAUCET_EVENT_ADMIN_TOKEN" \
+  -d '{
+    "count": 25,
+    "amount": 0.5,
+    "expires_at": "2026-07-01T00:00:00Z",
+    "prefix": "MEETUP"
+  }'
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "amount": 0.5,
+  "expires_at": "2026-07-01T00:00:00",
+  "codes": [
+    "MEETUP-dpSrU6YGRSZVIWll"
+  ]
+}
+```
+
+### POST /faucet/event-claim
+
+Redeem one event code for a wallet. Each code can be claimed once and cannot be claimed after `expires_at`.
+
+**Request:**
+```json
+{
+  "code": "MEETUP-dpSrU6YGRSZVIWll",
+  "wallet": "RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce"
+}
+```
+
+**Response (Success):**
+```json
+{
+  "ok": true,
+  "amount": 0.5,
+  "wallet": "RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce",
+  "code": "MEETUP-dpSrU6YGRSZVIWll",
+  "tx_hash": null
+}
+```
+
+**Response (Already Claimed):**
+```json
+{
+  "ok": false,
+  "error": "Event code already claimed"
 }
 ```
 

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -102,7 +102,8 @@ DEFAULT_CONFIG = {
         'default_amount': 0.5,
         'max_amount': 1.0,
         'max_batch_size': 500,
-        'code_prefix': 'EVENT'
+        'code_prefix': 'EVENT',
+        'pending_claim_ttl_seconds': 300
     },
     'logging': {
         'level': 'INFO',
@@ -875,18 +876,28 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             return jsonify({'ok': False, 'error': 'expires_at must be a future ISO timestamp'}), 400
 
         prefix = str(data.get('prefix') or event_config.get('code_prefix', 'EVENT')).strip() or 'EVENT'
-        codes = [_generate_event_code(prefix) for _ in range(count)]
         db_path = config.get('database', {}).get('path', 'faucet.db')
         created_at = datetime.now().isoformat()
+        codes = []
+        max_attempts = max(count * 5, count + 5)
 
         conn = sqlite3.connect(db_path)
         try:
             c = conn.cursor()
-            for code in codes:
-                c.execute('''
-                    INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
-                    VALUES (?, ?, ?, ?)
-                ''', (code, float(amount), expires_at.isoformat(), created_at))
+            attempts = 0
+            while len(codes) < count and attempts < max_attempts:
+                attempts += 1
+                code = _generate_event_code(prefix)
+                try:
+                    c.execute('''
+                        INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                        VALUES (?, ?, ?, ?)
+                    ''', (code, float(amount), expires_at.isoformat(), created_at))
+                except sqlite3.IntegrityError:
+                    continue
+                codes.append(code)
+            if len(codes) != count:
+                raise RuntimeError('Unable to generate unique event codes')
             conn.commit()
         finally:
             conn.close()
@@ -947,8 +958,11 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
 
             amount, expires_at_raw, claimed_at = row
             if claimed_at:
-                c.execute('ROLLBACK')
-                return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
+                if _release_stale_event_claim_reservation(c, code, now, config.get('event_codes', {})):
+                    claimed_at = None
+                else:
+                    c.execute('ROLLBACK')
+                    return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
 
             expires_at = datetime.fromisoformat(expires_at_raw)
             if expires_at <= now:
@@ -968,7 +982,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
                 INSERT INTO event_claims
                     (code, wallet, ip_address, amount, status, tx_hash, created_at, updated_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (code, wallet, ip, float(amount), 'pending', None, now.isoformat(), now.isoformat()))
+            ''', (code, wallet, ip, float(amount), 'reserved', None, now.isoformat(), now.isoformat()))
             claim_id = c.lastrowid
             c.execute('COMMIT')
         except Exception as exc:
@@ -982,6 +996,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             conn.close()
 
         try:
+            _mark_event_claim_transfer_started(db_path, claim_id)
             tx_hash = _perform_faucet_transfer(
                 config,
                 logger,
@@ -1162,6 +1177,66 @@ def _event_claim_idempotency_key(code: str) -> str:
     """Build a stable node idempotency key for a one-time event claim code."""
     digest = hashlib.sha256(code.encode()).hexdigest()[:32]
     return f"event_claim:{digest}"
+
+
+def _release_stale_event_claim_reservation(
+    c: sqlite3.Cursor,
+    code: str,
+    now: datetime,
+    event_config: Dict[str, Any],
+) -> bool:
+    """Release stale pre-transfer event claim reservations for retry."""
+    ttl_seconds = int(event_config.get('pending_claim_ttl_seconds', 300))
+    if ttl_seconds < 0:
+        return False
+
+    c.execute('''
+        SELECT id, status, updated_at FROM event_claims
+        WHERE code = ?
+        ORDER BY id DESC
+        LIMIT 1
+    ''', (code,))
+    row = c.fetchone()
+    if not row:
+        return False
+
+    claim_id, status, updated_at_raw = row
+    if status != 'reserved':
+        return False
+
+    try:
+        updated_at = datetime.fromisoformat(updated_at_raw)
+    except (TypeError, ValueError):
+        return False
+
+    if (now - updated_at).total_seconds() < ttl_seconds:
+        return False
+
+    c.execute('''
+        UPDATE event_claim_codes
+        SET claimed_wallet = NULL, claimed_ip = NULL, claimed_at = NULL, tx_hash = NULL
+        WHERE code = ?
+    ''', (code,))
+    c.execute('''
+        UPDATE event_claims
+        SET status = ?, updated_at = ?
+        WHERE id = ?
+    ''', ('released_stale_reservation', now.isoformat(), claim_id))
+    return True
+
+
+def _mark_event_claim_transfer_started(db_path: str, claim_id: Optional[int]) -> None:
+    """Mark an event claim past the locally retryable reservation point."""
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        conn.execute('''
+            UPDATE event_claims
+            SET status = ?, updated_at = ?
+            WHERE id = ?
+        ''', ('transfer_started', datetime.now().isoformat(), claim_id))
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def _perform_faucet_transfer(

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -899,13 +899,11 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
                 c.execute('ROLLBACK')
                 return jsonify({'ok': False, 'error': 'Event code expired'}), 410
 
-            tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
-
             c.execute('''
                 UPDATE event_claim_codes
-                SET claimed_wallet = ?, claimed_ip = ?, claimed_at = ?, tx_hash = ?
+                SET claimed_wallet = ?, claimed_ip = ?, claimed_at = ?
                 WHERE code = ? AND claimed_at IS NULL
-            ''', (wallet, ip, now.isoformat(), tx_hash, code))
+            ''', (wallet, ip, now.isoformat(), code))
             if c.rowcount != 1:
                 c.execute('ROLLBACK')
                 return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
@@ -913,7 +911,8 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             c.execute('''
                 INSERT INTO drip_requests (wallet, ip_address, amount, timestamp, status, tx_hash)
                 VALUES (?, ?, ?, ?, ?, ?)
-            ''', (wallet, ip, float(amount), now.isoformat(), 'completed', tx_hash))
+            ''', (wallet, ip, float(amount), now.isoformat(), 'pending', None))
+            drip_request_id = c.lastrowid
             c.execute('COMMIT')
         except Exception as exc:
             try:
@@ -924,6 +923,34 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
         finally:
             conn.close()
+
+        try:
+            tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
+            with sqlite3.connect(db_path, timeout=30) as conn:
+                c = conn.cursor()
+                c.execute('PRAGMA busy_timeout = 30000')
+                c.execute('''
+                    UPDATE event_claim_codes
+                    SET tx_hash = ?
+                    WHERE code = ?
+                ''', (tx_hash, code))
+                c.execute('''
+                    UPDATE drip_requests
+                    SET status = ?, tx_hash = ?
+                    WHERE id = ?
+                ''', ('completed', tx_hash, drip_request_id))
+        except Exception as exc:
+            try:
+                with sqlite3.connect(db_path, timeout=30) as conn:
+                    conn.execute('''
+                        UPDATE drip_requests
+                        SET status = ?
+                        WHERE id = ?
+                    ''', ('transfer_failed', drip_request_id))
+            except Exception:
+                logger.exception(f"Failed to mark event claim transfer failure for code={code}")
+            logger.error(f"Event claim transfer failed for code={code}: {exc}")
+            return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
 
         return jsonify({
             'ok': True,

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -25,6 +25,7 @@ import os
 import re
 import sys
 import json
+import secrets
 import requests
 import sqlite3
 import logging
@@ -92,6 +93,13 @@ DEFAULT_CONFIG = {
         'mock_mode': True,
         'node_rpc': None,
         'wallet_key': None
+    },
+    'event_codes': {
+        'enabled': True,
+        'admin_token': None,
+        'default_amount': 0.5,
+        'max_batch_size': 500,
+        'code_prefix': 'EVENT'
     },
     'logging': {
         'level': 'INFO',
@@ -572,6 +580,19 @@ def init_database(db_path: str) -> None:
             unique_ips INTEGER DEFAULT 0
         )
     ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS event_claim_codes (
+            code TEXT PRIMARY KEY,
+            amount REAL NOT NULL,
+            expires_at DATETIME NOT NULL,
+            created_at DATETIME NOT NULL,
+            claimed_wallet TEXT,
+            claimed_ip TEXT,
+            claimed_at DATETIME,
+            tx_hash TEXT
+        )
+    ''')
     
     c.execute('''
         CREATE INDEX IF NOT EXISTS idx_drip_wallet ON drip_requests(wallet)
@@ -581,6 +602,14 @@ def init_database(db_path: str) -> None:
     ''')
     c.execute('''
         CREATE INDEX IF NOT EXISTS idx_drip_timestamp ON drip_requests(timestamp)
+    ''')
+    c.execute('''
+        CREATE INDEX IF NOT EXISTS idx_event_claim_codes_expires_at
+        ON event_claim_codes(expires_at)
+    ''')
+    c.execute('''
+        CREATE INDEX IF NOT EXISTS idx_event_claim_codes_claimed_wallet
+        ON event_claim_codes(claimed_wallet)
     ''')
     
     conn.commit()
@@ -757,6 +786,152 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             'tx_hash': tx_hash,
             'next_available': next_avail.isoformat()
         })
+
+    @app.route(f'{base_path}/event-codes', methods=['POST'])
+    def create_event_codes():
+        """
+        Create one-time faucet claim codes for community events.
+
+        Request body:
+            {"count": 25, "amount": 0.5, "expires_at": "2026-07-01T00:00:00"}
+        """
+        auth_error = _require_event_admin(config)
+        if auth_error:
+            return auth_error
+
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'ok': False, 'error': 'JSON object required'}), 400
+
+        count = data.get('count', 1)
+        if not isinstance(count, int) or count < 1:
+            return jsonify({'ok': False, 'error': 'count must be a positive integer'}), 400
+
+        event_config = config.get('event_codes', {})
+        max_batch_size = int(event_config.get('max_batch_size', 500))
+        if count > max_batch_size:
+            return jsonify({'ok': False, 'error': f'count exceeds max batch size {max_batch_size}'}), 400
+
+        amount = data.get('amount', event_config.get('default_amount', 0.5))
+        if not isinstance(amount, (int, float)) or amount <= 0:
+            return jsonify({'ok': False, 'error': 'amount must be a positive number'}), 400
+
+        expires_at_raw = data.get('expires_at')
+        expires_at = _parse_future_datetime(expires_at_raw)
+        if expires_at is None:
+            return jsonify({'ok': False, 'error': 'expires_at must be a future ISO timestamp'}), 400
+
+        prefix = str(data.get('prefix') or event_config.get('code_prefix', 'EVENT')).strip() or 'EVENT'
+        codes = [_generate_event_code(prefix) for _ in range(count)]
+        db_path = config.get('database', {}).get('path', 'faucet.db')
+        created_at = datetime.now().isoformat()
+
+        conn = sqlite3.connect(db_path)
+        try:
+            c = conn.cursor()
+            for code in codes:
+                c.execute('''
+                    INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                    VALUES (?, ?, ?, ?)
+                ''', (code, float(amount), expires_at.isoformat(), created_at))
+            conn.commit()
+        finally:
+            conn.close()
+
+        return jsonify({
+            'ok': True,
+            'codes': codes,
+            'amount': float(amount),
+            'expires_at': expires_at.isoformat()
+        }), 201
+
+    @app.route(f'{base_path}/event-claim', methods=['POST'])
+    def claim_event_code():
+        """
+        Claim a one-time event faucet code.
+
+        Request body:
+            {"code": "EVENT-...", "wallet": "RTC..."}
+        """
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'ok': False, 'error': 'JSON object required'}), 400
+
+        code = str(data.get('code') or '').strip()
+        wallet_value = data.get('wallet')
+        if not code:
+            return jsonify({'ok': False, 'error': 'code required'}), 400
+        if not isinstance(wallet_value, str) or not wallet_value.strip():
+            return jsonify({'ok': False, 'error': 'Wallet address required'}), 400
+
+        wallet = wallet_value.strip()
+        valid, error = validator.validate_wallet(wallet)
+        if not valid:
+            return jsonify({'ok': False, 'error': error}), 400
+
+        trust_proxy_headers = config.get('security', {}).get('trust_proxy_headers', False)
+        ip = get_client_ip(request, trust_proxy_headers=trust_proxy_headers)
+        db_path = config.get('database', {}).get('path', 'faucet.db')
+        now = datetime.now()
+        conn = sqlite3.connect(db_path, timeout=30)
+
+        try:
+            conn.isolation_level = None
+            c = conn.cursor()
+            c.execute('PRAGMA busy_timeout = 30000')
+            c.execute('BEGIN IMMEDIATE')
+            c.execute('''
+                SELECT amount, expires_at, claimed_at FROM event_claim_codes
+                WHERE code = ?
+            ''', (code,))
+            row = c.fetchone()
+            if not row:
+                c.execute('ROLLBACK')
+                return jsonify({'ok': False, 'error': 'Invalid event code'}), 404
+
+            amount, expires_at_raw, claimed_at = row
+            if claimed_at:
+                c.execute('ROLLBACK')
+                return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
+
+            expires_at = datetime.fromisoformat(expires_at_raw)
+            if expires_at <= now:
+                c.execute('ROLLBACK')
+                return jsonify({'ok': False, 'error': 'Event code expired'}), 410
+
+            tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
+
+            c.execute('''
+                UPDATE event_claim_codes
+                SET claimed_wallet = ?, claimed_ip = ?, claimed_at = ?, tx_hash = ?
+                WHERE code = ? AND claimed_at IS NULL
+            ''', (wallet, ip, now.isoformat(), tx_hash, code))
+            if c.rowcount != 1:
+                c.execute('ROLLBACK')
+                return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
+
+            c.execute('''
+                INSERT INTO drip_requests (wallet, ip_address, amount, timestamp, status, tx_hash)
+                VALUES (?, ?, ?, ?, ?, ?)
+            ''', (wallet, ip, float(amount), now.isoformat(), 'completed', tx_hash))
+            c.execute('COMMIT')
+        except Exception as exc:
+            try:
+                conn.execute('ROLLBACK')
+            except sqlite3.OperationalError:
+                pass
+            logger.error(f"Event claim failed for code={code}: {exc}")
+            return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
+        finally:
+            conn.close()
+
+        return jsonify({
+            'ok': True,
+            'amount': float(amount),
+            'wallet': wallet,
+            'code': code,
+            'tx_hash': tx_hash
+        })
     
     @app.route(f'{base_path}/status')
     def status():
@@ -864,6 +1039,78 @@ def get_client_ip(request, trust_proxy_headers: bool = False) -> str:
     if trust_proxy_headers and request.headers.get('X-Real-IP'):
         return request.headers.get('X-Real-IP')
     return request.remote_addr or '127.0.0.1'
+
+
+def _require_event_admin(config: Dict) -> Optional[Tuple[Any, int]]:
+    """Require an event faucet admin token before minting claim codes."""
+    event_config = config.get('event_codes', {})
+    if not event_config.get('enabled', True):
+        return jsonify({'ok': False, 'error': 'Event codes disabled'}), 404
+
+    expected = os.environ.get('FAUCET_EVENT_ADMIN_TOKEN') or event_config.get('admin_token')
+    if not expected:
+        return jsonify({'ok': False, 'error': 'Event code admin token not configured'}), 503
+
+    supplied = request.headers.get('X-Faucet-Admin-Token', '')
+    if not secrets.compare_digest(str(supplied), str(expected)):
+        return jsonify({'ok': False, 'error': 'Unauthorized'}), 401
+
+    return None
+
+
+def _parse_future_datetime(value: Any) -> Optional[datetime]:
+    """Parse an ISO timestamp and ensure it is in the future."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if parsed.tzinfo is not None:
+        parsed = parsed.astimezone().replace(tzinfo=None)
+    if parsed <= datetime.now():
+        return None
+    return parsed
+
+
+def _generate_event_code(prefix: str) -> str:
+    """Generate a short URL-safe event code with an organizer-readable prefix."""
+    safe_prefix = re.sub(r'[^A-Za-z0-9_-]+', '-', prefix).strip('-') or 'EVENT'
+    return f"{safe_prefix}-{secrets.token_urlsafe(12)}"
+
+
+def _perform_faucet_transfer(config: Dict, logger: logging.Logger, wallet: str, amount: float) -> Optional[str]:
+    """Perform a faucet transfer or return None in mock mode."""
+    if config.get('distribution', {}).get('mock_mode', True):
+        logger.info(f"Mock event faucet claim: {amount} RTC to {wallet}")
+        return None
+
+    dist = config.get('distribution', {})
+    node_url = dist.get('node_url', 'http://127.0.0.1:8198')
+    faucet_wallet = dist.get('faucet_wallet', 'testnet_faucet')
+    admin_key = os.environ.get('RC_ADMIN_KEY') or dist.get('admin_key', '')
+
+    if not admin_key:
+        raise RuntimeError('RC_ADMIN_KEY not set, cannot perform real drip')
+
+    response = requests.post(
+        f"{node_url}/wallet/transfer",
+        json={
+            "from_miner": faucet_wallet,
+            "to_miner": wallet,
+            "amount_rtc": amount,
+        },
+        headers={"X-Admin-Key": admin_key},
+        timeout=10
+    )
+
+    if response.status_code != 200:
+        raise RuntimeError(f"Transfer failed on node: {response.status_code}")
+
+    result = response.json()
+    if not result.get('ok'):
+        raise RuntimeError('Transfer failed on node')
+    return result.get('tx_hash')
 
 
 def get_template_vars(config: Dict) -> Dict:

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -26,6 +26,7 @@ import re
 import sys
 import json
 import math
+import hashlib
 import secrets
 import requests
 import sqlite3
@@ -981,7 +982,14 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             conn.close()
 
         try:
-            tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
+            tx_hash = _perform_faucet_transfer(
+                config,
+                logger,
+                wallet,
+                float(amount),
+                idempotency_key=_event_claim_idempotency_key(code),
+                reason=f"event_claim:{code}",
+            )
         except Exception as exc:
             try:
                 _release_event_claim(db_path, code, claim_id, 'transfer_failed')
@@ -1150,7 +1158,20 @@ def _generate_event_code(prefix: str) -> str:
     return f"{safe_prefix}-{secrets.token_urlsafe(12)}"
 
 
-def _perform_faucet_transfer(config: Dict, logger: logging.Logger, wallet: str, amount: float) -> Optional[str]:
+def _event_claim_idempotency_key(code: str) -> str:
+    """Build a stable node idempotency key for a one-time event claim code."""
+    digest = hashlib.sha256(code.encode()).hexdigest()[:32]
+    return f"event_claim:{digest}"
+
+
+def _perform_faucet_transfer(
+    config: Dict,
+    logger: logging.Logger,
+    wallet: str,
+    amount: float,
+    idempotency_key: Optional[str] = None,
+    reason: Optional[str] = None,
+) -> Optional[str]:
     """Perform a faucet transfer or return None in mock mode."""
     if config.get('distribution', {}).get('mock_mode', True):
         logger.info(f"Mock event faucet claim: {amount} RTC to {wallet}")
@@ -1164,13 +1185,19 @@ def _perform_faucet_transfer(config: Dict, logger: logging.Logger, wallet: str, 
     if not admin_key:
         raise RuntimeError('RC_ADMIN_KEY not set, cannot perform real drip')
 
+    payload = {
+        "from_miner": faucet_wallet,
+        "to_miner": wallet,
+        "amount_rtc": amount,
+    }
+    if idempotency_key:
+        payload["idempotency_key"] = idempotency_key
+    if reason:
+        payload["reason"] = reason
+
     response = requests.post(
         f"{node_url}/wallet/transfer",
-        json={
-            "from_miner": faucet_wallet,
-            "to_miner": wallet,
-            "amount_rtc": amount,
-        },
+        json=payload,
         headers={"X-Admin-Key": admin_key},
         timeout=10
     )

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -96,7 +96,7 @@ DEFAULT_CONFIG = {
         'wallet_key': None
     },
     'event_codes': {
-        'enabled': True,
+        'enabled': False,
         'admin_token': None,
         'default_amount': 0.5,
         'max_amount': 1.0,
@@ -597,6 +597,19 @@ def init_database(db_path: str) -> None:
             tx_hash TEXT
         )
     ''')
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS event_claims (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            code TEXT NOT NULL,
+            wallet TEXT NOT NULL,
+            ip_address TEXT NOT NULL,
+            amount REAL NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending',
+            tx_hash TEXT,
+            created_at DATETIME NOT NULL,
+            updated_at DATETIME NOT NULL
+        )
+    ''')
     
     c.execute('''
         CREATE INDEX IF NOT EXISTS idx_drip_wallet ON drip_requests(wallet)
@@ -615,6 +628,18 @@ def init_database(db_path: str) -> None:
         CREATE INDEX IF NOT EXISTS idx_event_claim_codes_claimed_wallet
         ON event_claim_codes(claimed_wallet)
     ''')
+    c.execute('''
+        CREATE INDEX IF NOT EXISTS idx_event_claims_code
+        ON event_claims(code)
+    ''')
+    c.execute('''
+        CREATE INDEX IF NOT EXISTS idx_event_claims_wallet
+        ON event_claims(wallet)
+    ''')
+    c.execute('''
+        CREATE INDEX IF NOT EXISTS idx_event_claims_status
+        ON event_claims(status)
+    ''')
     
     conn.commit()
     conn.close()
@@ -625,7 +650,11 @@ def _ensure_column(c: sqlite3.Cursor, table: str, column: str, definition: str) 
     c.execute(f'PRAGMA table_info({table})')
     columns = {row[1] for row in c.fetchall()}
     if column not in columns:
-        c.execute(f'ALTER TABLE {table} ADD COLUMN {column} {definition}')
+        try:
+            c.execute(f'ALTER TABLE {table} ADD COLUMN {column} {definition}')
+        except sqlite3.OperationalError as exc:
+            if 'duplicate column name' not in str(exc).lower():
+                raise
 
 
 # =============================================================================
@@ -880,7 +909,7 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         if not isinstance(data, dict):
             return jsonify({'ok': False, 'error': 'JSON object required'}), 400
 
-        if not config.get('event_codes', {}).get('enabled', True):
+        if not config.get('event_codes', {}).get('enabled', False):
             return jsonify({'ok': False, 'error': 'Event codes disabled'}), 404
 
         code = str(data.get('code') or '').strip()
@@ -935,10 +964,11 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
                 return jsonify({'ok': False, 'error': 'Event code already claimed'}), 409
 
             c.execute('''
-                INSERT INTO drip_requests (wallet, ip_address, amount, timestamp, status, tx_hash)
-                VALUES (?, ?, ?, ?, ?, ?)
-            ''', (wallet, ip, float(amount), now.isoformat(), 'pending', None))
-            drip_request_id = c.lastrowid
+                INSERT INTO event_claims
+                    (code, wallet, ip_address, amount, status, tx_hash, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (code, wallet, ip, float(amount), 'pending', None, now.isoformat(), now.isoformat()))
+            claim_id = c.lastrowid
             c.execute('COMMIT')
         except Exception as exc:
             try:
@@ -954,14 +984,14 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
         except Exception as exc:
             try:
-                _finalize_event_claim(db_path, code, drip_request_id, None, 'transfer_failed')
+                _release_event_claim(db_path, code, claim_id, 'transfer_failed')
             except Exception as finalize_exc:
                 logger.error(f"Event claim failure finalization failed for code={code}: {finalize_exc}")
             logger.error(f"Event claim transfer failed for code={code}: {exc}")
             return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
 
         try:
-            _finalize_event_claim(db_path, code, drip_request_id, tx_hash, 'completed')
+            _finalize_event_claim(db_path, code, claim_id, tx_hash, 'completed')
         except Exception as exc:
             logger.error(f"Event claim finalization failed for code={code}: {exc}")
             return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
@@ -1085,7 +1115,7 @@ def get_client_ip(request, trust_proxy_headers: bool = False) -> str:
 def _require_event_admin(config: Dict) -> Optional[Tuple[Any, int]]:
     """Require an event faucet admin token before minting claim codes."""
     event_config = config.get('event_codes', {})
-    if not event_config.get('enabled', True):
+    if not event_config.get('enabled', False):
         return jsonify({'ok': False, 'error': 'Event codes disabled'}), 404
 
     expected = os.environ.get('FAUCET_EVENT_ADMIN_TOKEN') or event_config.get('admin_token')
@@ -1157,7 +1187,7 @@ def _perform_faucet_transfer(config: Dict, logger: logging.Logger, wallet: str, 
 def _finalize_event_claim(
     db_path: str,
     code: str,
-    request_id: Optional[int],
+    claim_id: Optional[int],
     tx_hash: Optional[str],
     status: str,
 ) -> None:
@@ -1171,10 +1201,36 @@ def _finalize_event_claim(
             WHERE code = ?
         ''', (tx_hash, code))
         c.execute('''
-            UPDATE drip_requests
-            SET status = ?, tx_hash = ?
+            UPDATE event_claims
+            SET status = ?, tx_hash = ?, updated_at = ?
             WHERE id = ?
-        ''', (status, tx_hash, request_id))
+        ''', (status, tx_hash, datetime.now().isoformat(), claim_id))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _release_event_claim(
+    db_path: str,
+    code: str,
+    claim_id: Optional[int],
+    status: str,
+) -> None:
+    """Release a code when no transfer was completed, allowing a later retry."""
+    now = datetime.now().isoformat()
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        c = conn.cursor()
+        c.execute('''
+            UPDATE event_claim_codes
+            SET claimed_wallet = NULL, claimed_ip = NULL, claimed_at = NULL, tx_hash = NULL
+            WHERE code = ?
+        ''', (code,))
+        c.execute('''
+            UPDATE event_claims
+            SET status = ?, updated_at = ?
+            WHERE id = ?
+        ''', (status, now, claim_id))
         conn.commit()
     finally:
         conn.close()

--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -25,6 +25,7 @@ import os
 import re
 import sys
 import json
+import math
 import secrets
 import requests
 import sqlite3
@@ -98,6 +99,7 @@ DEFAULT_CONFIG = {
         'enabled': True,
         'admin_token': None,
         'default_amount': 0.5,
+        'max_amount': 1.0,
         'max_batch_size': 500,
         'code_prefix': 'EVENT'
     },
@@ -569,6 +571,8 @@ def init_database(db_path: str) -> None:
             tx_hash TEXT
         )
     ''')
+    _ensure_column(c, 'drip_requests', 'status', "TEXT DEFAULT 'completed'")
+    _ensure_column(c, 'drip_requests', 'tx_hash', 'TEXT')
     
     c.execute('''
         CREATE TABLE IF NOT EXISTS faucet_stats (
@@ -614,6 +618,14 @@ def init_database(db_path: str) -> None:
     
     conn.commit()
     conn.close()
+
+
+def _ensure_column(c: sqlite3.Cursor, table: str, column: str, definition: str) -> None:
+    """Add a SQLite column when upgrading an existing faucet database."""
+    c.execute(f'PRAGMA table_info({table})')
+    columns = {row[1] for row in c.fetchall()}
+    if column not in columns:
+        c.execute(f'ALTER TABLE {table} ADD COLUMN {column} {definition}')
 
 
 # =============================================================================
@@ -813,8 +825,19 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
             return jsonify({'ok': False, 'error': f'count exceeds max batch size {max_batch_size}'}), 400
 
         amount = data.get('amount', event_config.get('default_amount', 0.5))
-        if not isinstance(amount, (int, float)) or amount <= 0:
+        max_amount = float(event_config.get(
+            'max_amount',
+            config.get('rate_limit', {}).get('max_amount', 0.5),
+        ))
+        if (
+            not isinstance(amount, (int, float))
+            or isinstance(amount, bool)
+            or not math.isfinite(float(amount))
+            or amount <= 0
+        ):
             return jsonify({'ok': False, 'error': 'amount must be a positive number'}), 400
+        if float(amount) > max_amount:
+            return jsonify({'ok': False, 'error': f'amount exceeds max event amount {max_amount}'}), 400
 
         expires_at_raw = data.get('expires_at')
         expires_at = _parse_future_datetime(expires_at_raw)
@@ -856,6 +879,9 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'ok': False, 'error': 'JSON object required'}), 400
+
+        if not config.get('event_codes', {}).get('enabled', True):
+            return jsonify({'ok': False, 'error': 'Event codes disabled'}), 404
 
         code = str(data.get('code') or '').strip()
         wallet_value = data.get('wallet')
@@ -926,30 +952,18 @@ def register_routes(app: Flask, config: Dict, logger: logging.Logger,
 
         try:
             tx_hash = _perform_faucet_transfer(config, logger, wallet, float(amount))
-            with sqlite3.connect(db_path, timeout=30) as conn:
-                c = conn.cursor()
-                c.execute('PRAGMA busy_timeout = 30000')
-                c.execute('''
-                    UPDATE event_claim_codes
-                    SET tx_hash = ?
-                    WHERE code = ?
-                ''', (tx_hash, code))
-                c.execute('''
-                    UPDATE drip_requests
-                    SET status = ?, tx_hash = ?
-                    WHERE id = ?
-                ''', ('completed', tx_hash, drip_request_id))
         except Exception as exc:
             try:
-                with sqlite3.connect(db_path, timeout=30) as conn:
-                    conn.execute('''
-                        UPDATE drip_requests
-                        SET status = ?
-                        WHERE id = ?
-                    ''', ('transfer_failed', drip_request_id))
-            except Exception:
-                logger.exception(f"Failed to mark event claim transfer failure for code={code}")
+                _finalize_event_claim(db_path, code, drip_request_id, None, 'transfer_failed')
+            except Exception as finalize_exc:
+                logger.error(f"Event claim failure finalization failed for code={code}: {finalize_exc}")
             logger.error(f"Event claim transfer failed for code={code}: {exc}")
+            return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
+
+        try:
+            _finalize_event_claim(db_path, code, drip_request_id, tx_hash, 'completed')
+        except Exception as exc:
+            logger.error(f"Event claim finalization failed for code={code}: {exc}")
             return jsonify({'ok': False, 'error': 'Internal transfer error'}), 500
 
         return jsonify({
@@ -1138,6 +1152,32 @@ def _perform_faucet_transfer(config: Dict, logger: logging.Logger, wallet: str, 
     if not result.get('ok'):
         raise RuntimeError('Transfer failed on node')
     return result.get('tx_hash')
+
+
+def _finalize_event_claim(
+    db_path: str,
+    code: str,
+    request_id: Optional[int],
+    tx_hash: Optional[str],
+    status: str,
+) -> None:
+    """Finalize the durable event claim record after the transfer attempt."""
+    conn = sqlite3.connect(db_path, timeout=30)
+    try:
+        c = conn.cursor()
+        c.execute('''
+            UPDATE event_claim_codes
+            SET tx_hash = ?
+            WHERE code = ?
+        ''', (tx_hash, code))
+        c.execute('''
+            UPDATE drip_requests
+            SET status = ?, tx_hash = ?
+            WHERE id = ?
+        ''', (status, tx_hash, request_id))
+        conn.commit()
+    finally:
+        conn.close()
 
 
 def get_template_vars(config: Dict) -> Dict:

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -384,6 +384,7 @@ class TestDatabase(unittest.TestCase):
         
         self.assertIn('drip_requests', tables)
         self.assertIn('faucet_stats', tables)
+        self.assertIn('event_claim_codes', tables)
         
         # Check indexes exist
         c.execute("SELECT name FROM sqlite_master WHERE type='index'")
@@ -393,6 +394,31 @@ class TestDatabase(unittest.TestCase):
         self.assertTrue(any('idx_drip_ip' in idx for idx in indexes))
         
         conn.close()
+
+    def test_event_claim_codes_schema(self):
+        """Test event code table supports one-time faucet claims."""
+        init_database(self.temp_db.name)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            c = conn.cursor()
+            c.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'EVENT-test-code',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                datetime.now().isoformat(),
+            ))
+            conn.commit()
+
+            c.execute('SELECT amount, claimed_at FROM event_claim_codes WHERE code = ?', ('EVENT-test-code',))
+            amount, claimed_at = c.fetchone()
+            self.assertEqual(amount, 0.5)
+            self.assertIsNone(claimed_at)
+        finally:
+            conn.close()
     
     def test_insert_drip_request(self):
         """Test inserting drip request."""
@@ -431,6 +457,7 @@ class TestFlaskApp(unittest.TestCase):
         self.config['server']['debug'] = False
         self.config['monitoring']['health_enabled'] = True
         self.config['monitoring']['metrics_enabled'] = False
+        self.config['event_codes']['admin_token'] = 'test-admin-token'
         # Clear allowlist for testing
         self.config['validation']['allowlist'] = []
         
@@ -579,6 +606,106 @@ class TestFlaskApp(unittest.TestCase):
         data = json.loads(response.data)
         self.assertEqual(data['status'], 'healthy')
         self.assertIn('timestamp', data)
+
+    def test_event_code_creation_requires_admin_token(self):
+        """Event organizers cannot mint claim codes without admin auth."""
+        expires_at = (datetime.now() + timedelta(days=1)).isoformat()
+
+        response = self.client.post('/faucet/event-codes',
+                                    json={'count': 1, 'expires_at': expires_at},
+                                    content_type='application/json')
+
+        self.assertEqual(response.status_code, 401)
+        data = json.loads(response.data)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Unauthorized')
+
+    def test_event_code_create_and_claim_once(self):
+        """Created event codes can be claimed once by a valid wallet."""
+        expires_at = (datetime.now() + timedelta(days=1)).isoformat()
+        create_response = self.client.post(
+            '/faucet/event-codes',
+            json={'count': 1, 'amount': 0.75, 'expires_at': expires_at, 'prefix': 'MEETUP'},
+            headers={'X-Faucet-Admin-Token': 'test-admin-token'},
+            content_type='application/json',
+        )
+
+        self.assertEqual(create_response.status_code, 201)
+        created = json.loads(create_response.data)
+        self.assertTrue(created['ok'])
+        self.assertEqual(created['amount'], 0.75)
+        self.assertEqual(len(created['codes']), 1)
+        self.assertTrue(created['codes'][0].startswith('MEETUP-'))
+
+        claim_response = self.client.post(
+            '/faucet/event-claim',
+            json={
+                'code': created['codes'][0],
+                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(claim_response.status_code, 200)
+        claimed = json.loads(claim_response.data)
+        self.assertTrue(claimed['ok'])
+        self.assertEqual(claimed['amount'], 0.75)
+        self.assertEqual(claimed['tx_hash'], None)
+
+        duplicate_response = self.client.post(
+            '/faucet/event-claim',
+            json={
+                'code': created['codes'][0],
+                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(duplicate_response.status_code, 409)
+        duplicate = json.loads(duplicate_response.data)
+        self.assertFalse(duplicate['ok'])
+        self.assertEqual(duplicate['error'], 'Event code already claimed')
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            c = conn.cursor()
+            c.execute('SELECT COUNT(*) FROM drip_requests WHERE wallet = ?', (
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            ))
+            self.assertEqual(c.fetchone()[0], 1)
+        finally:
+            conn.close()
+
+    def test_event_code_claim_rejects_expired_code(self):
+        """Expired event codes are not claimable."""
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'EVENT-expired',
+                0.5,
+                (datetime.now() - timedelta(seconds=1)).isoformat(),
+                (datetime.now() - timedelta(days=1)).isoformat(),
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        response = self.client.post(
+            '/faucet/event-claim',
+            json={
+                'code': 'EVENT-expired',
+                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 410)
+        data = json.loads(response.data)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Event code expired')
 
     def test_metrics_endpoint_uses_configured_database(self):
         """Test metrics endpoint reads from the configured database path."""

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -691,6 +691,36 @@ class TestFlaskApp(unittest.TestCase):
                 data = json.loads(response.data)
                 self.assertFalse(data['ok'])
 
+    def test_event_code_creation_retries_generated_code_collisions(self):
+        """Rare token collisions should not turn an admin batch into a 500."""
+        expires_at = (datetime.now() + timedelta(days=1)).isoformat()
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'MEETUP-collision',
+                0.5,
+                expires_at,
+                datetime.now().isoformat(),
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        with patch('faucet_service.secrets.token_urlsafe', side_effect=['collision', 'new-one', 'new-two']):
+            response = self.client.post(
+                '/faucet/event-codes',
+                json={'count': 2, 'amount': 0.5, 'expires_at': expires_at, 'prefix': 'MEETUP'},
+                headers={'X-Faucet-Admin-Token': 'test-admin-token'},
+                content_type='application/json',
+            )
+
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data)
+        self.assertEqual(data['codes'], ['MEETUP-new-one', 'MEETUP-new-two'])
+
     def test_event_code_claim_respects_disabled_kill_switch(self):
         """Disabling event codes blocks redemption as well as creation."""
         self.config['event_codes']['enabled'] = False
@@ -939,7 +969,125 @@ class TestFlaskApp(unittest.TestCase):
 
         self.assertIsNotNone(claimed_at)
         self.assertIsNone(tx_hash)
-        self.assertEqual(status, 'pending')
+        self.assertEqual(status, 'transfer_started')
+
+    def test_event_code_claim_releases_stale_pre_transfer_reservation(self):
+        """A crash before transfer start leaves a stale reservation that can retry."""
+        old_time = (datetime.now() - timedelta(minutes=10)).isoformat()
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes
+                    (code, amount, expires_at, created_at, claimed_wallet, claimed_ip, claimed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                'EVENT-stale-reserved',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                old_time,
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                '127.0.0.1',
+                old_time,
+            ))
+            conn.execute('''
+                INSERT INTO event_claims
+                    (code, wallet, ip_address, amount, status, tx_hash, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                'EVENT-stale-reserved',
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                '127.0.0.1',
+                0.5,
+                'reserved',
+                None,
+                old_time,
+                old_time,
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        with patch('faucet_service._perform_faucet_transfer', return_value='tx-after-stale-release') as transfer:
+            response = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-stale-reserved',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(transfer.call_count, 1)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            statuses = [
+                row[0]
+                for row in conn.execute('''
+                    SELECT status FROM event_claims
+                    WHERE code = ? ORDER BY id
+                ''', ('EVENT-stale-reserved',)).fetchall()
+            ]
+            claimed_at, tx_hash = conn.execute('''
+                SELECT claimed_at, tx_hash FROM event_claim_codes
+                WHERE code = ?
+            ''', ('EVENT-stale-reserved',)).fetchone()
+        finally:
+            conn.close()
+
+        self.assertEqual(statuses, ['released_stale_reservation', 'completed'])
+        self.assertIsNotNone(claimed_at)
+        self.assertEqual(tx_hash, 'tx-after-stale-release')
+
+    def test_event_code_claim_keeps_fresh_reservation_locked(self):
+        """Fresh reservations are not released into duplicate transfer attempts."""
+        now = datetime.now().isoformat()
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes
+                    (code, amount, expires_at, created_at, claimed_wallet, claimed_ip, claimed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                'EVENT-fresh-reserved',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                now,
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                '127.0.0.1',
+                now,
+            ))
+            conn.execute('''
+                INSERT INTO event_claims
+                    (code, wallet, ip_address, amount, status, tx_hash, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ''', (
+                'EVENT-fresh-reserved',
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                '127.0.0.1',
+                0.5,
+                'reserved',
+                None,
+                now,
+                now,
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        with patch('faucet_service._perform_faucet_transfer') as transfer:
+            response = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-fresh-reserved',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
+
+        self.assertEqual(response.status_code, 409)
+        transfer.assert_not_called()
 
     def test_event_claim_transfer_uses_node_idempotency_key(self):
         """Real event payouts use stable node-side idempotency keys."""

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -676,6 +676,113 @@ class TestFlaskApp(unittest.TestCase):
         finally:
             conn.close()
 
+    def test_event_code_claim_locks_code_before_transfer_finalization(self):
+        """A post-transfer DB error must not make an event code reusable."""
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'EVENT-durable',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                datetime.now().isoformat(),
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        real_connect = sqlite3.connect
+        state = {'transfer_started': False, 'fail_tx_hash_update': True, 'transfer_calls': 0}
+
+        class CursorWrapper:
+            def __init__(self, cursor):
+                self.cursor = cursor
+
+            def execute(self, sql, params=()):
+                if (
+                    state['fail_tx_hash_update']
+                    and 'UPDATE event_claim_codes' in sql
+                    and 'SET tx_hash' in sql
+                ):
+                    state['fail_tx_hash_update'] = False
+                    raise sqlite3.OperationalError('simulated finalization failure')
+                return self.cursor.execute(sql, params)
+
+            def __getattr__(self, name):
+                return getattr(self.cursor, name)
+
+        class ConnectionWrapper:
+            def __init__(self, conn):
+                self.conn = conn
+
+            def cursor(self):
+                return CursorWrapper(self.conn.cursor())
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, _exc, _tb):
+                if exc_type:
+                    self.conn.rollback()
+                else:
+                    self.conn.commit()
+                self.conn.close()
+                return False
+
+            def __getattr__(self, name):
+                return getattr(self.conn, name)
+
+        def connect_with_finalization_failure(*args, **kwargs):
+            conn = real_connect(*args, **kwargs)
+            if state['transfer_started']:
+                return ConnectionWrapper(conn)
+            return conn
+
+        def fake_transfer(_config, _logger, _wallet, _amount):
+            state['transfer_started'] = True
+            state['transfer_calls'] += 1
+            return 'tx-success-before-db-error'
+
+        with patch('faucet_service.sqlite3.connect', side_effect=connect_with_finalization_failure), \
+             patch('faucet_service._perform_faucet_transfer', side_effect=fake_transfer):
+            first_response = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-durable',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
+            retry_response = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-durable',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
+
+        self.assertEqual(first_response.status_code, 500)
+        self.assertEqual(retry_response.status_code, 409)
+        self.assertEqual(state['transfer_calls'], 1)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            claimed_at, tx_hash = conn.execute('''
+                SELECT claimed_at, tx_hash FROM event_claim_codes WHERE code = ?
+            ''', ('EVENT-durable',)).fetchone()
+            status = conn.execute('''
+                SELECT status FROM drip_requests WHERE wallet = ?
+            ''', ('RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',)).fetchone()[0]
+        finally:
+            conn.close()
+
+        self.assertIsNotNone(claimed_at)
+        self.assertIsNone(tx_hash)
+        self.assertEqual(status, 'transfer_failed')
+
     def test_event_code_claim_rejects_expired_code(self):
         """Expired event codes are not claimable."""
         conn = sqlite3.connect(self.temp_db.name)

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -37,6 +37,7 @@ from faucet_service import (
     init_database,
     create_app,
     get_client_ip,
+    _ensure_column,
     DEFAULT_CONFIG
 )
 
@@ -385,6 +386,7 @@ class TestDatabase(unittest.TestCase):
         self.assertIn('drip_requests', tables)
         self.assertIn('faucet_stats', tables)
         self.assertIn('event_claim_codes', tables)
+        self.assertIn('event_claims', tables)
         
         # Check indexes exist
         c.execute("SELECT name FROM sqlite_master WHERE type='index'")
@@ -392,6 +394,7 @@ class TestDatabase(unittest.TestCase):
         
         self.assertTrue(any('idx_drip_wallet' in idx for idx in indexes))
         self.assertTrue(any('idx_drip_ip' in idx for idx in indexes))
+        self.assertTrue(any('idx_event_claims_wallet' in idx for idx in indexes))
         
         conn.close()
 
@@ -449,6 +452,24 @@ class TestDatabase(unittest.TestCase):
             self.assertIn('tx_hash', columns)
         finally:
             conn.close()
+
+    def test_ensure_column_tolerates_duplicate_column_race(self):
+        """Concurrent startup migrations can lose the PRAGMA/ALTER race safely."""
+        class RaceCursor:
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, sql):
+                self.calls.append(sql)
+                if sql.startswith('ALTER TABLE'):
+                    raise sqlite3.OperationalError('duplicate column name: status')
+
+            def fetchall(self):
+                return []
+
+        cursor = RaceCursor()
+        _ensure_column(cursor, 'drip_requests', 'status', "TEXT DEFAULT 'completed'")
+        self.assertEqual(len(cursor.calls), 2)
     
     def test_insert_drip_request(self):
         """Test inserting drip request."""
@@ -487,6 +508,7 @@ class TestFlaskApp(unittest.TestCase):
         self.config['server']['debug'] = False
         self.config['monitoring']['health_enabled'] = True
         self.config['monitoring']['metrics_enabled'] = False
+        self.config['event_codes']['enabled'] = True
         self.config['event_codes']['admin_token'] = 'test-admin-token'
         # Clear allowlist for testing
         self.config['validation']['allowlist'] = []
@@ -736,7 +758,7 @@ class TestFlaskApp(unittest.TestCase):
         conn = sqlite3.connect(self.temp_db.name)
         try:
             c = conn.cursor()
-            c.execute('SELECT COUNT(*), MAX(status) FROM drip_requests WHERE wallet = ?', (
+            c.execute('SELECT COUNT(*), MAX(status) FROM event_claims WHERE wallet = ?', (
                 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
             ))
             count, status = c.fetchone()
@@ -745,15 +767,15 @@ class TestFlaskApp(unittest.TestCase):
         finally:
             conn.close()
 
-    def test_event_code_claim_blocks_retry_after_transfer_finalization_failure(self):
-        """A post-transfer DB failure must not leave the event code reusable."""
+    def test_event_code_claim_allows_retry_after_transfer_failure(self):
+        """A failed transfer releases the code so a participant can retry."""
         conn = sqlite3.connect(self.temp_db.name)
         try:
             conn.execute('''
                 INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
                 VALUES (?, ?, ?, ?)
             ''', (
-                'EVENT-finalize-fails',
+                'EVENT-transfer-fails',
                 0.5,
                 (datetime.now() + timedelta(days=1)).isoformat(),
                 datetime.now().isoformat(),
@@ -762,33 +784,30 @@ class TestFlaskApp(unittest.TestCase):
         finally:
             conn.close()
 
-        with patch('faucet_service._perform_faucet_transfer', return_value='tx-once') as transfer:
-            with patch('faucet_service._finalize_event_claim', side_effect=RuntimeError('commit failed')):
-                response = self.client.post(
-                    '/faucet/event-claim',
-                    json={
-                        'code': 'EVENT-finalize-fails',
-                        'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
-                    },
-                    content_type='application/json',
-                )
+        with patch('faucet_service._perform_faucet_transfer', side_effect=[RuntimeError('node down'), 'tx-retry']) as transfer:
+            response = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-transfer-fails',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
+            retry = self.client.post(
+                '/faucet/event-claim',
+                json={
+                    'code': 'EVENT-transfer-fails',
+                    'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                },
+                content_type='application/json',
+            )
 
         self.assertEqual(response.status_code, 500)
-        transfer.assert_called_once()
-
-        retry = self.client.post(
-            '/faucet/event-claim',
-            json={
-                'code': 'EVENT-finalize-fails',
-                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
-            },
-            content_type='application/json',
-        )
-
-        self.assertEqual(retry.status_code, 409)
+        self.assertEqual(retry.status_code, 200)
+        self.assertEqual(transfer.call_count, 2)
         data = json.loads(retry.data)
-        self.assertFalse(data['ok'])
-        self.assertEqual(data['error'], 'Event code already claimed')
+        self.assertTrue(data['ok'])
+        self.assertEqual(data['tx_hash'], 'tx-retry')
 
         conn = sqlite3.connect(self.temp_db.name)
         try:
@@ -797,11 +816,19 @@ class TestFlaskApp(unittest.TestCase):
                 SELECT claimed_wallet, claimed_at, tx_hash
                 FROM event_claim_codes
                 WHERE code = ?
-            ''', ('EVENT-finalize-fails',))
+            ''', ('EVENT-transfer-fails',))
             claimed_wallet, claimed_at, tx_hash = c.fetchone()
             self.assertEqual(claimed_wallet, 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce')
             self.assertIsNotNone(claimed_at)
-            self.assertIsNone(tx_hash)
+            self.assertEqual(tx_hash, 'tx-retry')
+            statuses = [
+                row[0]
+                for row in c.execute('''
+                    SELECT status FROM event_claims
+                    WHERE code = ? ORDER BY id
+                ''', ('EVENT-transfer-fails',)).fetchall()
+            ]
+            self.assertEqual(statuses, ['transfer_failed', 'completed'])
         finally:
             conn.close()
 
@@ -903,7 +930,7 @@ class TestFlaskApp(unittest.TestCase):
                 SELECT claimed_at, tx_hash FROM event_claim_codes WHERE code = ?
             ''', ('EVENT-durable',)).fetchone()
             status = conn.execute('''
-                SELECT status FROM drip_requests WHERE wallet = ?
+                SELECT status FROM event_claims WHERE wallet = ?
             ''', ('RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',)).fetchone()[0]
         finally:
             conn.close()
@@ -911,6 +938,46 @@ class TestFlaskApp(unittest.TestCase):
         self.assertIsNotNone(claimed_at)
         self.assertIsNone(tx_hash)
         self.assertEqual(status, 'pending')
+
+    def test_event_claims_do_not_affect_drip_rate_limit_or_status(self):
+        """Event claims use their own ledger and do not skew normal faucet stats."""
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'EVENT-isolated',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                datetime.now().isoformat(),
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        wallet = 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce'
+        claim_response = self.client.post(
+            '/faucet/event-claim',
+            json={'code': 'EVENT-isolated', 'wallet': wallet},
+            content_type='application/json',
+        )
+        self.assertEqual(claim_response.status_code, 200)
+
+        status_response = self.client.get('/faucet/status')
+        self.assertEqual(status_response.status_code, 200)
+        stats = json.loads(status_response.data)['statistics']
+        self.assertEqual(stats['total_drips'], 0)
+        self.assertEqual(stats['total_amount'], 0)
+        self.assertEqual(stats['unique_wallets'], 0)
+        self.assertEqual(stats['unique_ips'], 0)
+
+        drip_response = self.client.post(
+            '/faucet/drip',
+            json={'wallet': wallet},
+            content_type='application/json',
+        )
+        self.assertEqual(drip_response.status_code, 200)
 
     def test_event_code_claim_rejects_expired_code(self):
         """Expired event codes are not claimable."""

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -38,6 +38,8 @@ from faucet_service import (
     create_app,
     get_client_ip,
     _ensure_column,
+    _event_claim_idempotency_key,
+    _perform_faucet_transfer,
     DEFAULT_CONFIG
 )
 
@@ -896,7 +898,7 @@ class TestFlaskApp(unittest.TestCase):
                 return ConnectionWrapper(conn)
             return conn
 
-        def fake_transfer(_config, _logger, _wallet, _amount):
+        def fake_transfer(_config, _logger, _wallet, _amount, **_kwargs):
             state['transfer_started'] = True
             state['transfer_calls'] += 1
             return 'tx-success-before-db-error'
@@ -938,6 +940,33 @@ class TestFlaskApp(unittest.TestCase):
         self.assertIsNotNone(claimed_at)
         self.assertIsNone(tx_hash)
         self.assertEqual(status, 'pending')
+
+    def test_event_claim_transfer_uses_node_idempotency_key(self):
+        """Real event payouts use stable node-side idempotency keys."""
+        self.config['distribution']['mock_mode'] = False
+        self.config['distribution']['admin_key'] = 'test-admin-key'
+        expected_key = _event_claim_idempotency_key('EVENT-idempotent')
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {'ok': True, 'tx_hash': 'tx-idempotent'}
+
+        with patch('faucet_service.requests.post', return_value=response) as post:
+            tx_hash = _perform_faucet_transfer(
+                self.config,
+                self.app.logger,
+                'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                0.5,
+                idempotency_key=expected_key,
+                reason='event_claim:EVENT-idempotent',
+            )
+
+        self.assertEqual(tx_hash, 'tx-idempotent')
+        post.assert_called_once()
+        payload = post.call_args.kwargs['json']
+        self.assertEqual(payload['idempotency_key'], expected_key)
+        self.assertEqual(payload['reason'], 'event_claim:EVENT-idempotent')
+        self.assertEqual(payload['amount_rtc'], 0.5)
 
     def test_event_claims_do_not_affect_drip_rate_limit_or_status(self):
         """Event claims use their own ledger and do not skew normal faucet stats."""

--- a/faucet_service/test_faucet_service.py
+++ b/faucet_service/test_faucet_service.py
@@ -419,6 +419,36 @@ class TestDatabase(unittest.TestCase):
             self.assertIsNone(claimed_at)
         finally:
             conn.close()
+
+    def test_init_database_migrates_existing_drip_request_columns(self):
+        """Existing faucet databases gain event-claim status/tx columns."""
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                CREATE TABLE drip_requests (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    wallet TEXT NOT NULL,
+                    ip_address TEXT NOT NULL,
+                    amount REAL NOT NULL,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+                )
+            ''')
+            conn.commit()
+        finally:
+            conn.close()
+
+        init_database(self.temp_db.name)
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            columns = {
+                row[1]
+                for row in conn.execute('PRAGMA table_info(drip_requests)').fetchall()
+            }
+            self.assertIn('status', columns)
+            self.assertIn('tx_hash', columns)
+        finally:
+            conn.close()
     
     def test_insert_drip_request(self):
         """Test inserting drip request."""
@@ -620,6 +650,43 @@ class TestFlaskApp(unittest.TestCase):
         self.assertFalse(data['ok'])
         self.assertEqual(data['error'], 'Unauthorized')
 
+    def test_event_code_creation_rejects_non_finite_or_excessive_amount(self):
+        """Event code amounts must be finite and bounded."""
+        expires_at = (datetime.now() + timedelta(days=1)).isoformat()
+
+        for amount in (float('nan'), float('inf'), 1.5):
+            with self.subTest(amount=amount):
+                response = self.client.post(
+                    '/faucet/event-codes',
+                    json={'count': 1, 'amount': amount, 'expires_at': expires_at},
+                    headers={'X-Faucet-Admin-Token': 'test-admin-token'},
+                    content_type='application/json',
+                )
+
+                self.assertEqual(response.status_code, 400)
+                data = json.loads(response.data)
+                self.assertFalse(data['ok'])
+
+    def test_event_code_claim_respects_disabled_kill_switch(self):
+        """Disabling event codes blocks redemption as well as creation."""
+        self.config['event_codes']['enabled'] = False
+        app = create_app(self.config)
+        client = app.test_client()
+
+        response = client.post(
+            '/faucet/event-claim',
+            json={
+                'code': 'EVENT-disabled',
+                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(response.status_code, 404)
+        data = json.loads(response.data)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Event codes disabled')
+
     def test_event_code_create_and_claim_once(self):
         """Created event codes can be claimed once by a valid wallet."""
         expires_at = (datetime.now() + timedelta(days=1)).isoformat()
@@ -669,10 +736,72 @@ class TestFlaskApp(unittest.TestCase):
         conn = sqlite3.connect(self.temp_db.name)
         try:
             c = conn.cursor()
-            c.execute('SELECT COUNT(*) FROM drip_requests WHERE wallet = ?', (
+            c.execute('SELECT COUNT(*), MAX(status) FROM drip_requests WHERE wallet = ?', (
                 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
             ))
-            self.assertEqual(c.fetchone()[0], 1)
+            count, status = c.fetchone()
+            self.assertEqual(count, 1)
+            self.assertEqual(status, 'completed')
+        finally:
+            conn.close()
+
+    def test_event_code_claim_blocks_retry_after_transfer_finalization_failure(self):
+        """A post-transfer DB failure must not leave the event code reusable."""
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            conn.execute('''
+                INSERT INTO event_claim_codes (code, amount, expires_at, created_at)
+                VALUES (?, ?, ?, ?)
+            ''', (
+                'EVENT-finalize-fails',
+                0.5,
+                (datetime.now() + timedelta(days=1)).isoformat(),
+                datetime.now().isoformat(),
+            ))
+            conn.commit()
+        finally:
+            conn.close()
+
+        with patch('faucet_service._perform_faucet_transfer', return_value='tx-once') as transfer:
+            with patch('faucet_service._finalize_event_claim', side_effect=RuntimeError('commit failed')):
+                response = self.client.post(
+                    '/faucet/event-claim',
+                    json={
+                        'code': 'EVENT-finalize-fails',
+                        'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+                    },
+                    content_type='application/json',
+                )
+
+        self.assertEqual(response.status_code, 500)
+        transfer.assert_called_once()
+
+        retry = self.client.post(
+            '/faucet/event-claim',
+            json={
+                'code': 'EVENT-finalize-fails',
+                'wallet': 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce',
+            },
+            content_type='application/json',
+        )
+
+        self.assertEqual(retry.status_code, 409)
+        data = json.loads(retry.data)
+        self.assertFalse(data['ok'])
+        self.assertEqual(data['error'], 'Event code already claimed')
+
+        conn = sqlite3.connect(self.temp_db.name)
+        try:
+            c = conn.cursor()
+            c.execute('''
+                SELECT claimed_wallet, claimed_at, tx_hash
+                FROM event_claim_codes
+                WHERE code = ?
+            ''', ('EVENT-finalize-fails',))
+            claimed_wallet, claimed_at, tx_hash = c.fetchone()
+            self.assertEqual(claimed_wallet, 'RTCe4fbe4c9085b8b2ed3f1228504de66799025f6ce')
+            self.assertIsNotNone(claimed_at)
+            self.assertIsNone(tx_hash)
         finally:
             conn.close()
 
@@ -781,7 +910,7 @@ class TestFlaskApp(unittest.TestCase):
 
         self.assertIsNotNone(claimed_at)
         self.assertIsNone(tx_hash)
-        self.assertEqual(status, 'transfer_failed')
+        self.assertEqual(status, 'pending')
 
     def test_event_code_claim_rejects_expired_code(self):
         """Expired event codes are not claimable."""


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` is applied.
- [x] No new code files added; existing faucet files were updated.
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Adds admin-gated `/faucet/event-codes` creation for organizer-generated one-time event claim codes.
- Adds opt-in `/faucet/event-claim` redemption with wallet validation, expiration checks, one-time completion enforcement, and transfer status tracking.
- Records event redemptions in a separate `event_claims` ledger so event payouts do not affect normal `/faucet/drip` rate limits or `/faucet/status` drip statistics.
- Sends event payouts with a deterministic node idempotency key, releases the code for retry when the transfer call fails before completion, and keeps post-transfer finalization failures non-retryable to avoid duplicate payout attempts.
- Marks event claims as `reserved` before transfer start, releases only stale pre-transfer reservations after `pending_claim_ttl_seconds`, and keeps transfer-started claims locked for reconciliation.
- Retries rare generated event-code collisions instead of failing an organizer batch on the first duplicate token.
- Adds idempotent migration handling for existing `drip_requests` columns under concurrent startup.
- Documents the event-code configuration and API flow.
- Adds tests for event-code schema, admin authorization, successful claim, duplicate claim rejection, expired code rejection, transfer-failure retry safety, stale reservation recovery, generated-code collision retry, event/drip isolation, and migration race handling.

## Why It Matters

Fixes #2340 by giving community event organizers a bounded faucet flow: create claim codes, distribute them to participants, allow one successful wallet claim per code, and expire unused codes without changing regular faucet drip behavior.

## Touched Files / Subsystems

- `faucet_service/faucet_service.py`: event-code config, SQLite schema, creation endpoint, claim endpoint, isolated event claim ledger, retry/finalization handling, and transfer helper.
- `faucet_service/test_faucet_service.py`: schema and API regression tests for event codes.
- `faucet_service/README.md`: configuration and endpoint documentation.

## Testing / Evidence

- `.venv-bounty-validation/bin/python -m pytest -q faucet_service/test_faucet_service.py` -> 59 passed.
- `.venv-bounty-validation/bin/python -m py_compile faucet_service/faucet_service.py faucet_service/test_faucet_service.py` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.
- `python3 /Users/ssr/.codex/bounty-radar/automation/scan_hidden_unicode.py --repo . --changed-files-from-git upstream/main...HEAD` -> passed, 3 paths scanned, no findings.

## Scope / Risk

This keeps the existing faucet drip behavior unchanged and adds event-code redemption as a separate, opt-in admin-gated flow. Real transfers still use the existing faucet transfer configuration; mock mode returns `tx_hash: null` for local testing.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
