### PR TITLE
docs: add German (de-DE) localization pass

### DIFF
--- a/docs/de-DE/RUSTCHAIN_EXPLAINED.md
+++ b/docs/de-DE/RUSTCHAIN_EXPLAINED.md
@@ -1,0 +1,52 @@
+# RustChain erklärt (de-DE)
+
+RustChain ist ein Proof-of-Antiquity-Netzwerk, das reale Maschinen, insbesondere ältere Hardware, dafür belohnt, dass sie nachweisen, dass sie weiterhin in Betrieb sind. Die Kernidee ist einfach: Erhaltene Hardware hat einen Wert, und das Netzwerk muss in der Lage sein, eine reale Maschine von einer virtuellen Maschine (VM), einem Container oder einer gefälschten Deklaration zu unterscheiden.
+
+## Wie die Verifizierung funktioniert
+
+Der Miner sammelt lokale Signale und sendet eine `attestation` an den RustChain-Knoten. Diese `attestation` enthält einen Hardware-Fingerabdruck (`fingerprint`). Der Knoten verwendet diese Daten, um das Alter/die Seltenheit (`antiquity`) der Maschine zu bewerten und den Belohnungsmultiplikator zu berechnen.
+
+Der Prozess muss ehrlich sein:
+
+- Simulieren Sie die Architektur nicht;
+- Erzwingen Sie keine Prozessor-Familie, die die Maschine nicht besitzt;
+- Ändern Sie die Nutzlast (Payload) nicht, um älter zu erscheinen;
+- Übersetzen Sie keine Befehlsoptionen oder API-Endpunktnamen.
+
+## Vor dem Mining überprüfen
+
+Verwenden Sie die folgenden Befehle, bevor Sie einen Miner laufen lassen:
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Diese Befehle ermöglichen es Ihnen, die erkannte Maschine, die `attestation`-Nutzlast und die Konnektivität mit dem Knoten zu überprüfen. Sie müssen in der lokalisierten Dokumentation exakt so beibehalten werden.
+
+## Worüber der Benutzer einwilligt
+
+Durch die Bestätigung des ersten Starts erklärt der Benutzer sein Einverständnis damit, dass:
+
+1. Der Miner `fingerprint`- und `attestation`-Daten senden darf;
+2. Die Hardware ehrlich deklariert werden muss;
+3. Belohnungen in `RTC` von der Annahme durch das Netzwerk abhängen und nicht garantiert sind;
+4. Spoofing (Fälschung), unerkannte Emulation oder manipulierte Nutzlasten Belohnungen reduzieren oder zur Ablehnung führen können.
+
+Der Zustimmungsbildschirm auf Deutsch muss eine explizite affirmative Bestätigung erfordern, wie z. B. `JA`. Das bloße Drücken der Eingabetaste darf das Mining nicht starten.
+
+## Beibehaltenes Glossar
+
+| Begriff | Operative Bedeutung |
+|---|---|
+| `RTC` | Token, das von RustChain für Belohnungen und Bounties verwendet wird. |
+| `attestation` | Überprüfbare Deklaration der Maschine, die an den Knoten gesendet wird. |
+| `antiquity` | Signal für Alter, Seltenheit und Erhaltung der Hardware. |
+| `fingerprint` | Satz von Hardware-Signalen, die zur Verifizierung verwendet werden. |
+
+## Leitfaden für Linux-Miner
+
+Der lokalisierte Leitfaden für den Linux-Miner befindet sich unter:
+
+- [miners/linux/README.de-DE.md](../../miners/linux/README.de-DE.md)

--- a/miners/linux/README.de-DE.md
+++ b/miners/linux/README.de-DE.md
@@ -1,0 +1,69 @@
+# RustChain Miner für Linux (de-DE)
+
+Dieses Handbuch lokalisiert den Ablauf des Linux-Miners für deutschsprachige Benutzer. Es behält die technischen Begriffe `RTC`, `attestation`, `antiquity` und `fingerprint` bei, da sie im Protokoll, in den Konsolenprotokollen (Logs) und in den APIs vorkommen.
+
+## Vor dem Start überprüfen
+
+Führen Sie vor dem Starten des Minings die Überprüfungsbefehle aus. Diese zeigen an, was an den Knoten gesendet wird, und ermöglichen es Ihnen, die Nutzlast (Payload) zu überprüfen, ohne eine Mining-Sitzung zu starten.
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --dry-run --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --show-payload --wallet YOUR_WALLET_ID
+python3 miners/linux/rustchain_linux_miner.py --test-only --wallet YOUR_WALLET_ID
+```
+
+Übersetzen oder ändern Sie die oben genannten Optionen (Flags) nicht. `--dry-run`, `--show-payload` und `--test-only` sind wörtliche Befehle.
+
+## Was der Miner tut
+
+Der Linux-Miner erkennt die lokale Maschine, sammelt ehrliche Hardware-Signale und sendet eine `attestation` an den RustChain-Knoten. Diese Signale bilden einen Hardware-Fingerabdruck (`fingerprint`), der verwendet wird, um das Alter/die Seltenheit (`antiquity`) der Maschine zu bewerten und den richtigen Multiplikator anzuwenden.
+
+Der Miner darf die Architektur, das Alter der Hardware, die Anzahl der Kerne, die Seriennummer, den Hostnamen oder andere Signale nicht simulieren oder fälschen. Wenn ein Signal nicht verfügbar ist, besteht das korrekte Verhalten darin, sein Fehlen zu deklarieren oder die Verifizierung herabzustufen.
+
+## Abhängigkeiten installieren
+
+```bash
+python3 --version
+python3 -m pip install requests
+```
+
+Auf Debian/Ubuntu-Distributionen, falls `python3` oder `pip` nicht installiert sind:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y python3 python3-pip
+```
+
+## Miner ausführen
+
+```bash
+python3 miners/linux/rustchain_linux_miner.py --wallet YOUR_WALLET_ID
+```
+
+Verwenden Sie eine Wallet-Adresse oder eine Kennung, die Sie später wiedererkennen können. Die Auszahlung von Bounties kann `github:ihr-benutzername` verwenden, das normale Mining verwendet jedoch den an `--wallet` übergebenen Wert.
+
+## Erstmalige Zustimmung
+
+Beim ersten interaktiven Start muss der Benutzer explizit bestätigen, dass er Folgendes versteht:
+
+- Der Miner überträgt `fingerprint`- und `attestation`-Daten an den RustChain-Knoten;
+- Die Überprüfungsbefehle müssen vor dem Mining verwendet werden;
+- Belohnungen in `RTC` sind nicht garantiert;
+- Die Maschine muss sich ehrlich darstellen, ohne Hardware-Spoofing (Fälschung).
+
+Affirmative (zustimmende) Antwort auf Deutsch: `JA`.
+
+## Querverweis
+
+Für eine kurze Erklärung des Protokolls und der beibehaltenen Begriffe lesen Sie bitte:
+
+- [RUSTCHAIN_EXPLAINED.md](../../docs/de-DE/RUSTCHAIN_EXPLAINED.md)
+
+## Glossar
+
+| Begriff | Umgang mit dem Begriff | Hinweis |
+|---|---|---|
+| `RTC` | `RTC` | Nativer Token von RustChain. |
+| `attestation` | `attestation` | An den Knoten gesendeter Nachweis über die Maschine. |
+| `antiquity` | `antiquity` | Relatives Alter/Seltenheit, das im Multiplikator verwendet wird. |
+| `fingerprint` | `fingerprint` | Satz von Hardware-Signalen. |


### PR DESCRIPTION
This PR adds the German (de-DE) translation pass for the miner CLI and wallet messages, along with the Linux miner README and explainers.

- Added `miners/linux/README.de-DE.md` detailing setup and execution.
- Added `docs/de-DE/RUSTCHAIN_EXPLAINED.md` outlining the Proof-of-Antiquity protocol details.
- Validated JSON structure and keys using the `validate_i18n.py` script.

Resolves Scottcjn/rustchain-bounties#12790

Payout Wallet: `RTC1410e82d545ce0b3ffd21ca83e2465a8f2c3a64e`
