### PR TITLE
[codex] cap coin_select fallback inputs

### DIFF
--- a/node/test_coin_select_extended.py
+++ b/node/test_coin_select_extended.py
@@ -63,6 +63,13 @@ class TestCoinSelectEdgeCases(unittest.TestCase):
         # Should pick the large one, not lots of small ones
         self.assertLessEqual(len(result), 2)
 
+    def test_equal_value_utxos_fail_when_over_twenty_inputs_are_required(self):
+        """Equal-value UTXOs that still need >20 inputs should fail cleanly."""
+        utxos = [{"value_nrtc": 1} for _ in range(25)]
+        result, change = coin_select(utxos, 21)
+        self.assertEqual(result, [])
+        self.assertEqual(change, 0)
+
     def test_mixed_values(self):
         """Mix of values: smallest-first accumulation."""
         utxos = [

--- a/node/test_utxo_db.py
+++ b/node/test_utxo_db.py
@@ -1972,6 +1972,13 @@ class TestCoinSelect(unittest.TestCase):
         # Should switch to largest-first and pick the 200 UNIT box
         self.assertLessEqual(len(selected), 20)
 
+    def test_equal_value_utxos_fail_if_input_limit_cannot_be_met(self):
+        """Equal-value inputs should not return an oversized fallback selection."""
+        utxos = [self._box(1 * UNIT) for _ in range(25)]
+        selected, change = coin_select(utxos, 21 * UNIT)
+        self.assertEqual(selected, [])
+        self.assertEqual(change, 0)
+
 
 class TestMultiInputTransfer(unittest.TestCase):
     """Test transfers that consume multiple UTXOs."""

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1449,6 +1449,8 @@ def coin_select(utxos: List[dict], target_nrtc: int
     Strategy:
     - Smallest-first accumulation (consolidates dust).
     - If input count > 20, restart with largest-first (fewer inputs).
+    - If the best available selection still needs >20 inputs, fail cleanly
+      instead of returning an oversized spend.
     - Dust change (< DUST_THRESHOLD) absorbed into fee.
 
     Returns (selected_utxos, change_nrtc).  Empty list if insufficient.
@@ -1472,15 +1474,17 @@ def coin_select(utxos: List[dict], target_nrtc: int
     # If too many small inputs, try largest-first
     if len(selected) > 20:
         sorted_desc = sorted(utxos, key=lambda u: u['value_nrtc'], reverse=True)
-        selected = []
-        total = 0
+        fallback: List[dict] = []
+        fallback_total = 0
         for u in sorted_desc:
-            selected.append(u)
-            total += u['value_nrtc']
-            if total >= target_nrtc:
+            fallback.append(u)
+            fallback_total += u['value_nrtc']
+            if fallback_total >= target_nrtc:
                 break
-        if total < target_nrtc:
+        if fallback_total < target_nrtc or len(fallback) > 20:
             return [], 0
+        selected = fallback
+        total = fallback_total
 
     change = total - target_nrtc
     if change < DUST_THRESHOLD:


### PR DESCRIPTION
Fixes bug report #6830.

## What changed
- `coin_select()` now fails cleanly if the fallback selection still needs more than 20 inputs.
- Added regression tests for equal-value UTXO edge cases.

## Why
The documented largest-first fallback could still return an oversized selection when all UTXOs had the same value. That made the fallback appear successful even though it violated the input limit.

## Impact
- Prevents oversized multi-input spends from slipping through the fallback path.
- Keeps selection behavior consistent with the documented input cap.
- Adds explicit test coverage for the equal-value edge case.

## Validation
- `python3 -m unittest node.test_coin_select_extended node.test_utxo_db`
- Result: 109 tests passed

## Bounty wallet
- RTC address: `RTCd90fc88820a76397d26d80bcd63c8b5711a383bd`
- Public key: `ddcb08b3006a6337354813ed2f8b56fa619c26d58ef83e791427edd5d043490e`

## Notes
- Local commit: `65029da fix: cap coin_select fallback inputs`
