### PR TITLE
fix: rate limit core RPC API

### DIFF
--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -84,30 +84,49 @@ class SlidingWindowRateLimiter:
     def __init__(self):
         self._lock = threading.Lock()
         self._requests: Dict[Tuple[str, str], list[float]] = {}
+        self._last_sweep = 0.0
+
+    def _sweep_expired_locked(self, cutoff: float):
+        expired_keys = []
+        for key, timestamps in self._requests.items():
+            active_timestamps = [timestamp for timestamp in timestamps if timestamp > cutoff]
+            if active_timestamps:
+                self._requests[key] = active_timestamps
+            else:
+                expired_keys.append(key)
+
+        for key in expired_keys:
+            del self._requests[key]
 
     def check(self, client_id: str, limit: int, window_seconds: int = 60) -> tuple[bool, int]:
         now = time.monotonic()
         cutoff = now - window_seconds
+        key = (client_id, str(limit))
 
         with self._lock:
+            if now - self._last_sweep >= window_seconds:
+                self._sweep_expired_locked(cutoff)
+                self._last_sweep = now
+
             timestamps = [
                 timestamp
-                for timestamp in self._requests.get((client_id, str(limit)), [])
+                for timestamp in self._requests.get(key, [])
                 if timestamp > cutoff
             ]
 
             if len(timestamps) >= limit:
                 retry_after = max(1, int(window_seconds - (now - timestamps[0])) + 1)
-                self._requests[(client_id, str(limit))] = timestamps
+                self._requests[key] = timestamps
                 return False, retry_after
 
             timestamps.append(now)
-            self._requests[(client_id, str(limit))] = timestamps
+            self._requests[key] = timestamps
             return True, 0
 
     def reset(self):
         with self._lock:
             self._requests.clear()
+            self._last_sweep = 0.0
 
 
 # =============================================================================

--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -423,7 +423,7 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
             self.send_header("Vary", "Origin")
             self.send_header(
                 "Access-Control-Allow-Headers",
-                f"Content-Type, {CSRF_HEADER}, {LEGACY_CSRF_HEADER}",
+                f"Content-Type, {CSRF_HEADER}, {LEGACY_CSRF_HEADER}, {API_KEY_HEADER}",
             )
             self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 

--- a/rips/rustchain-core/api/rpc.py
+++ b/rips/rustchain-core/api/rpc.py
@@ -17,7 +17,7 @@ import json
 import os
 import time
 from dataclasses import dataclass
-from typing import Dict, Any, Optional, Callable, Set
+from typing import Dict, Any, Optional, Callable, Tuple
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
 import threading
@@ -27,6 +27,11 @@ ALLOWED_ORIGINS_ENV = "RUSTCHAIN_API_ALLOWED_ORIGINS"
 CSRF_TOKEN_ENV = "RUSTCHAIN_API_CSRF_TOKEN"
 CSRF_HEADER = "X-RustChain-CSRF-Token"
 LEGACY_CSRF_HEADER = "X-CSRF-Token"
+RATE_LIMIT_PER_MINUTE_ENV = "RUSTCHAIN_API_RATE_LIMIT_PER_MINUTE"
+RATE_LIMIT_BURST_ENV = "RUSTCHAIN_API_RATE_LIMIT_BURST"
+API_KEY_ENV = "RUSTCHAIN_API_KEY"
+API_KEY_HEADER = "X-RustChain-API-Key"
+API_KEY_RATE_LIMIT_PER_MINUTE_ENV = "RUSTCHAIN_API_KEY_RATE_LIMIT_PER_MINUTE"
 
 RPC_PUBLIC_METHODS = frozenset({
     "getStats",
@@ -67,6 +72,42 @@ class ApiResponse:
             "error": self.error,
             "timestamp": self.timestamp,
         })
+
+
+# =============================================================================
+# Rate Limiting
+# =============================================================================
+
+class SlidingWindowRateLimiter:
+    """Thread-safe per-client sliding-window rate limiter."""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._requests: Dict[Tuple[str, str], list[float]] = {}
+
+    def check(self, client_id: str, limit: int, window_seconds: int = 60) -> tuple[bool, int]:
+        now = time.monotonic()
+        cutoff = now - window_seconds
+
+        with self._lock:
+            timestamps = [
+                timestamp
+                for timestamp in self._requests.get((client_id, str(limit)), [])
+                if timestamp > cutoff
+            ]
+
+            if len(timestamps) >= limit:
+                retry_after = max(1, int(window_seconds - (now - timestamps[0])) + 1)
+                self._requests[(client_id, str(limit))] = timestamps
+                return False, retry_after
+
+            timestamps.append(now)
+            self._requests[(client_id, str(limit))] = timestamps
+            return True, 0
+
+    def reset(self):
+        with self._lock:
+            self._requests.clear()
 
 
 # =============================================================================
@@ -278,6 +319,7 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
     """HTTP request handler for API"""
 
     api: RustChainApi = None  # Set by server
+    rate_limiter = SlidingWindowRateLimiter()
     MUTATING_RPC_METHODS = {"submitProof", "createProposal", "vote"}
     MUTATING_REST_PATHS = {
         "/api/mine",
@@ -293,6 +335,62 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
     @staticmethod
     def _configured_csrf_token() -> str:
         return os.getenv(CSRF_TOKEN_ENV, "").strip()
+
+    @staticmethod
+    def _configured_rate_limit() -> int:
+        raw = os.getenv(RATE_LIMIT_PER_MINUTE_ENV, "60").strip()
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            return 60
+
+    @staticmethod
+    def _configured_burst_limit() -> int:
+        raw = os.getenv(RATE_LIMIT_BURST_ENV, "20").strip()
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            return 20
+
+    @staticmethod
+    def _configured_api_key_rate_limit() -> int:
+        raw = os.getenv(API_KEY_RATE_LIMIT_PER_MINUTE_ENV, "600").strip()
+        try:
+            return max(1, int(raw))
+        except ValueError:
+            return 600
+
+    def _client_rate_limit_id(self) -> str:
+        host = self.client_address[0] if getattr(self, "client_address", None) else "unknown"
+        return f"ip:{host}"
+
+    def _request_rate_limit(self) -> int:
+        configured_key = os.getenv(API_KEY_ENV, "").strip()
+        provided_key = self.headers.get(API_KEY_HEADER, "").strip()
+        if configured_key and provided_key and hmac.compare_digest(provided_key, configured_key):
+            return self._configured_api_key_rate_limit()
+
+        return self._configured_rate_limit() + self._configured_burst_limit()
+
+    def _rate_limit_error(self) -> Optional[int]:
+        allowed, retry_after = self.rate_limiter.check(
+            self._client_rate_limit_id(),
+            self._request_rate_limit(),
+        )
+        if allowed:
+            return None
+        return retry_after
+
+    def _reject_rate_limited(self, retry_after: int):
+        self._send_response(
+            ApiResponse(
+                success=False,
+                error="rate_limited",
+                data={"retry_after_seconds": retry_after},
+            ),
+            status_code=429,
+            extra_headers={"Retry-After": str(retry_after)},
+        )
 
     def _is_allowed_origin(self, origin: Optional[str]) -> bool:
         """Check whether a request Origin is explicitly allowed."""
@@ -324,6 +422,11 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         """Handle GET requests"""
+        retry_after = self._rate_limit_error()
+        if retry_after:
+            self._reject_rate_limited(retry_after)
+            return
+
         parsed = urlparse(self.path)
         path = parsed.path
         params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
@@ -333,6 +436,11 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         """Handle POST requests"""
+        retry_after = self._rate_limit_error()
+        if retry_after:
+            self._reject_rate_limited(retry_after)
+            return
+
         content_length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(content_length).decode()
 
@@ -441,10 +549,17 @@ class ApiRequestHandler(BaseHTTPRequestHandler):
 
         return None
 
-    def _send_response(self, response: ApiResponse, status_code: Optional[int] = None):
+    def _send_response(
+        self,
+        response: ApiResponse,
+        status_code: Optional[int] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ):
         """Send HTTP response"""
         self.send_response(status_code or (200 if response.success else 400))
         self.send_header("Content-Type", "application/json")
+        for name, value in (extra_headers or {}).items():
+            self.send_header(name, value)
         self._send_cors_headers()
         self.end_headers()
         self.wfile.write(response.to_json().encode())

--- a/test_rpc_cors_csrf.py
+++ b/test_rpc_cors_csrf.py
@@ -64,6 +64,16 @@ class _ApiServerFixture:
         finally:
             connection.close()
 
+    def options(self, path, headers=None):
+        connection = HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
+        try:
+            connection.request("OPTIONS", path, headers=headers or {})
+            response = connection.getresponse()
+            response.read()
+            return response.status, response.headers
+        finally:
+            connection.close()
+
 
 def test_default_response_does_not_send_wildcard_cors():
     with patch.dict(os.environ, {}, clear=True):
@@ -94,6 +104,28 @@ def test_configured_origin_is_reflected_in_cors_response():
     assert body["success"] is True
     assert headers.get("Access-Control-Allow-Origin") == "https://wallet.example"
     assert headers.get("Vary") == "Origin"
+
+
+def test_api_key_header_is_allowed_for_browser_preflight():
+    with patch.dict(
+        os.environ,
+        {"RUSTCHAIN_API_ALLOWED_ORIGINS": "https://wallet.example"},
+        clear=True,
+    ):
+        with _ApiServerFixture() as server:
+            status, headers = server.options(
+                "/api/stats",
+                headers={
+                    "Origin": "https://wallet.example",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Headers": "x-rustchain-api-key",
+                },
+            )
+
+    allowed_headers = headers.get("Access-Control-Allow-Headers", "")
+    assert status == 204
+    assert headers.get("Access-Control-Allow-Origin") == "https://wallet.example"
+    assert "X-RustChain-API-Key" in allowed_headers
 
 
 def test_browser_state_changing_post_requires_csrf_token():

--- a/test_rpc_rate_limit.py
+++ b/test_rpc_rate_limit.py
@@ -123,3 +123,18 @@ def test_configured_api_key_uses_higher_rate_limit_bucket():
         assert ApiRequestHandler._rate_limit_error(handler) is None
         assert ApiRequestHandler._rate_limit_error(handler) is not None
         ApiRequestHandler.rate_limiter.reset()
+
+
+def test_rate_limiter_removes_expired_idle_client_buckets():
+    limiter = RPC.SlidingWindowRateLimiter()
+
+    with patch.object(RPC.time, "monotonic", return_value=100.0):
+        assert limiter.check("ip:192.0.2.10", limit=10, window_seconds=60) == (True, 0)
+        assert limiter.check("ip:198.51.100.20", limit=10, window_seconds=60) == (True, 0)
+
+    assert len(limiter._requests) == 2
+
+    with patch.object(RPC.time, "monotonic", return_value=161.0):
+        assert limiter.check("ip:203.0.113.30", limit=10, window_seconds=60) == (True, 0)
+
+    assert list(limiter._requests) == [("ip:203.0.113.30", "10")]

--- a/test_rpc_rate_limit.py
+++ b/test_rpc_rate_limit.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for core API rate limiting in rips/rustchain-core/api/rpc.py.
+
+The API module is loaded directly because the package path contains a hyphen.
+"""
+
+import importlib.util
+import json
+import os
+import threading
+from http.client import HTTPConnection
+from http.server import HTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_rpc_module():
+    rpc_path = Path(__file__).resolve().parent / "rips" / "rustchain-core" / "api" / "rpc.py"
+    spec = importlib.util.spec_from_file_location("rustchain_rpc_rate_limit_test_target", rpc_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+RPC = _load_rpc_module()
+ApiRequestHandler = RPC.ApiRequestHandler
+RustChainApi = RPC.RustChainApi
+MockNode = RPC.MockNode
+
+
+class _ApiServerFixture:
+    def __enter__(self):
+        ApiRequestHandler.rate_limiter.reset()
+        ApiRequestHandler.api = RustChainApi(MockNode())
+        self.server = HTTPServer(("127.0.0.1", 0), ApiRequestHandler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+        ApiRequestHandler.rate_limiter.reset()
+
+    def get(self, path, headers=None):
+        connection = HTTPConnection("127.0.0.1", self.server.server_port, timeout=5)
+        try:
+            connection.request("GET", path, headers=headers or {})
+            response = connection.getresponse()
+            return response.status, json.loads(response.read().decode()), response.headers
+        finally:
+            connection.close()
+
+
+def _make_handler(client_ip):
+    handler = object.__new__(ApiRequestHandler)
+    handler.headers = {}
+    handler.client_address = (client_ip, 12345)
+    return handler
+
+
+def test_core_api_returns_429_after_per_ip_limit_is_exhausted():
+    with patch.dict(
+        os.environ,
+        {
+            "RUSTCHAIN_API_RATE_LIMIT_PER_MINUTE": "2",
+            "RUSTCHAIN_API_RATE_LIMIT_BURST": "0",
+        },
+        clear=True,
+    ):
+        with _ApiServerFixture() as server:
+            first_status, first_body, _ = server.get("/api/stats")
+            second_status, second_body, _ = server.get("/api/stats")
+            limited_status, limited_body, limited_headers = server.get("/api/stats")
+
+    assert first_status == 200
+    assert first_body["success"] is True
+    assert second_status == 200
+    assert second_body["success"] is True
+    assert limited_status == 429
+    assert limited_body["success"] is False
+    assert limited_body["error"] == "rate_limited"
+    assert limited_body["data"]["retry_after_seconds"] >= 1
+    assert limited_headers["Retry-After"] == str(limited_body["data"]["retry_after_seconds"])
+
+
+def test_rate_limit_buckets_are_per_client_ip():
+    with patch.dict(
+        os.environ,
+        {
+            "RUSTCHAIN_API_RATE_LIMIT_PER_MINUTE": "1",
+            "RUSTCHAIN_API_RATE_LIMIT_BURST": "0",
+        },
+        clear=True,
+    ):
+        ApiRequestHandler.rate_limiter.reset()
+        first = _make_handler("192.0.2.10")
+        second = _make_handler("198.51.100.20")
+
+        assert ApiRequestHandler._rate_limit_error(first) is None
+        assert ApiRequestHandler._rate_limit_error(first) is not None
+        assert ApiRequestHandler._rate_limit_error(second) is None
+        ApiRequestHandler.rate_limiter.reset()
+
+
+def test_configured_api_key_uses_higher_rate_limit_bucket():
+    with patch.dict(
+        os.environ,
+        {
+            "RUSTCHAIN_API_KEY": "trusted-key",
+            "RUSTCHAIN_API_RATE_LIMIT_PER_MINUTE": "1",
+            "RUSTCHAIN_API_RATE_LIMIT_BURST": "0",
+            "RUSTCHAIN_API_KEY_RATE_LIMIT_PER_MINUTE": "2",
+        },
+        clear=True,
+    ):
+        ApiRequestHandler.rate_limiter.reset()
+        handler = _make_handler("203.0.113.30")
+        handler.headers = {"X-RustChain-API-Key": "trusted-key"}
+
+        assert ApiRequestHandler._rate_limit_error(handler) is None
+        assert ApiRequestHandler._rate_limit_error(handler) is None
+        assert ApiRequestHandler._rate_limit_error(handler) is not None
+        ApiRequestHandler.rate_limiter.reset()


### PR DESCRIPTION
## What changed

- Adds a thread-safe in-memory sliding-window limiter to the core API request handler.
- Applies the limiter before GET routing and before POST body parsing so repeated requests from one client IP receive `429 rate_limited` with `Retry-After` metadata.
- Adds environment configuration for the default per-minute limit, burst allowance, and an optional trusted API key with a higher limit.
- Adds focused HTTP and helper-level regression tests for rate limiting, per-IP isolation, API-key higher limits, and API-key CORS preflight support.

## Why it matters

Fixes #2337 by bounding request volume against the core RPC/API handler without adding a new dependency or changing existing read/write API contracts.

## Validation

- `.venv-bounty-validation/bin/python -m pytest test_rpc_rate_limit.py test_rpc_cors_csrf.py test_rpc_malformed_json.py tests/test_core_rpc_allowlist.py tests/test_rustchain_core_api_cors.py -q` -> 23 passed.
- `.venv-bounty-validation/bin/python -m py_compile rips/rustchain-core/api/rpc.py test_rpc_rate_limit.py test_rpc_cors_csrf.py test_rpc_malformed_json.py tests/test_core_rpc_allowlist.py tests/test_rustchain_core_api_cors.py` -> passed.
- `git diff --check upstream/main...HEAD` -> passed.
- Hidden Unicode scan -> passed, 2 touched paths scanned, no findings.
- `python3 tools/bcos_spdx_check.py --base-ref upstream/main` -> BCOS SPDX check: OK.

## Touched files / subsystems

- `rips/rustchain-core/api/rpc.py`: core HTTP API and JSON-RPC request handler rate limiting.
- `test_rpc_rate_limit.py`: regression coverage for the new limiter behavior.
- `test_rpc_cors_csrf.py`: regression coverage for CORS preflight support for the trusted API-key header.

## Scope / risk boundary

This is process-local in-memory throttling for the existing HTTP handler. It does not add persistence, external services, wallet/payment behavior, governance behavior, mining proof behavior, or live node traffic.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
