### PR TITLE
feat: add reorg resistance metrics

### DIFF
--- a/node/fork_choice_visualizer.py
+++ b/node/fork_choice_visualizer.py
@@ -284,9 +284,13 @@ def _reorg_resistance_metrics(
 
 def _descendant_hashes(root_hash: str, children: Dict[str, List[str]]) -> List[str]:
     descendants = []
+    visited = {root_hash}
     stack = list(children.get(root_hash, []))
     while stack:
         block_hash = stack.pop()
+        if block_hash in visited:
+            continue
+        visited.add(block_hash)
         descendants.append(block_hash)
         stack.extend(children.get(block_hash, []))
     return descendants

--- a/node/fork_choice_visualizer.py
+++ b/node/fork_choice_visualizer.py
@@ -25,6 +25,15 @@ class ForkChoiceBlock:
     miner: str = ""
 
 
+REORG_ALERT_THRESHOLDS = {
+    "frequency": 3,
+    "max_depth": 6,
+    "duration_seconds": 900,
+}
+
+REORG_DURATION_BUCKETS = (60, 300, 900)
+
+
 FORK_CHOICE_HTML = """
 <!doctype html>
 <html>
@@ -127,6 +136,12 @@ def build_fork_choice_graph(blocks: Iterable[Dict]) -> Dict:
 
     fork_points = [block_hash for block_hash, child_hashes in children.items() if len(child_hashes) > 1]
     canonical_height = canonical_head.height if canonical_head else 0
+    reorg_metrics = _reorg_resistance_metrics(
+        normalized,
+        children,
+        canonical_hashes,
+        fork_points,
+    )
 
     return {
         "nodes": nodes,
@@ -142,6 +157,7 @@ def build_fork_choice_graph(blocks: Iterable[Dict]) -> Dict:
             "heads": len(heads),
             "max_depth": max((block.height for block in normalized), default=0),
             "canonical_height": canonical_height,
+            **reorg_metrics,
         },
     }
 
@@ -188,6 +204,111 @@ def _fork_history(blocks: List[ForkChoiceBlock], fork_points: List[str]) -> List
         if block:
             history.append(asdict(block))
     return sorted(history, key=lambda item: (item["height"], item["block_hash"]))
+
+
+def _reorg_resistance_metrics(
+    blocks: List[ForkChoiceBlock],
+    children: Dict[str, List[str]],
+    canonical_hashes: set,
+    fork_points: List[str],
+) -> Dict:
+    by_hash = {block.block_hash: block for block in blocks}
+    durations = []
+    max_reorg_depth = 0
+    reorg_events = []
+
+    for fork_hash in sorted(fork_points):
+        fork_block = by_hash.get(fork_hash)
+        if not fork_block:
+            continue
+
+        fork_max_depth = 0
+        fork_max_duration = 0
+        abandoned_heads = []
+
+        for child_hash in children.get(fork_hash, []):
+            if child_hash in canonical_hashes:
+                continue
+
+            descendant_hashes = _descendant_hashes(child_hash, children)
+            branch_hashes = [child_hash, *descendant_hashes]
+            abandoned_hashes = [hash_ for hash_ in branch_hashes if hash_ not in canonical_hashes]
+            if not abandoned_hashes:
+                continue
+
+            abandoned_blocks = [by_hash[hash_] for hash_ in abandoned_hashes if hash_ in by_hash]
+            if not abandoned_blocks:
+                continue
+
+            branch_depth = max(block.height for block in abandoned_blocks) - fork_block.height
+            branch_duration = max(
+                max(block.timestamp - fork_block.timestamp, 0)
+                for block in abandoned_blocks
+            )
+            branch_heads = [
+                block.block_hash
+                for block in abandoned_blocks
+                if not any(child in abandoned_hashes for child in children.get(block.block_hash, []))
+            ]
+
+            fork_max_depth = max(fork_max_depth, branch_depth)
+            fork_max_duration = max(fork_max_duration, branch_duration)
+            abandoned_heads.extend(sorted(branch_heads))
+
+        if fork_max_depth:
+            durations.append(fork_max_duration)
+            max_reorg_depth = max(max_reorg_depth, fork_max_depth)
+            reorg_events.append({
+                "fork_point": fork_hash,
+                "height": fork_block.height,
+                "max_depth": fork_max_depth,
+                "duration_seconds": fork_max_duration,
+                "abandoned_heads": sorted(abandoned_heads),
+            })
+
+    max_duration = max(durations, default=0)
+
+    return {
+        "reorg_frequency_counter": len(reorg_events),
+        "max_reorg_depth": max_reorg_depth,
+        "reorg_duration_histogram": _duration_histogram(durations),
+        "reorg_alert_thresholds": dict(REORG_ALERT_THRESHOLDS),
+        "reorg_alerts": {
+            "frequency": len(reorg_events) >= REORG_ALERT_THRESHOLDS["frequency"],
+            "max_depth": max_reorg_depth >= REORG_ALERT_THRESHOLDS["max_depth"],
+            "duration_seconds": max_duration >= REORG_ALERT_THRESHOLDS["duration_seconds"],
+        },
+        "reorg_events": reorg_events,
+    }
+
+
+def _descendant_hashes(root_hash: str, children: Dict[str, List[str]]) -> List[str]:
+    descendants = []
+    stack = list(children.get(root_hash, []))
+    while stack:
+        block_hash = stack.pop()
+        descendants.append(block_hash)
+        stack.extend(children.get(block_hash, []))
+    return descendants
+
+
+def _duration_histogram(durations: List[int]) -> Dict[str, int]:
+    histogram = {
+        "le_60": 0,
+        "le_300": 0,
+        "le_900": 0,
+        "gt_900": 0,
+    }
+    for duration in durations:
+        if duration <= REORG_DURATION_BUCKETS[0]:
+            histogram["le_60"] += 1
+        elif duration <= REORG_DURATION_BUCKETS[1]:
+            histogram["le_300"] += 1
+        elif duration <= REORG_DURATION_BUCKETS[2]:
+            histogram["le_900"] += 1
+        else:
+            histogram["gt_900"] += 1
+    return histogram
 
 
 def _to_int(value, default: int = 0) -> int:

--- a/node/tests/test_fork_choice_visualizer.py
+++ b/node/tests/test_fork_choice_visualizer.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from fork_choice_visualizer import build_fork_choice_graph, normalize_blocks
+from fork_choice_visualizer import _descendant_hashes, build_fork_choice_graph, normalize_blocks
 
 
 def test_build_graph_marks_weighted_canonical_path():
@@ -135,3 +135,10 @@ def test_reorg_metrics_track_duration_buckets_and_alerts():
         "max_depth": False,
         "duration_seconds": True,
     }
+
+
+def test_descendant_hashes_ignores_malformed_cycles():
+    assert _descendant_hashes("b", {
+        "b": ["c"],
+        "c": ["b"],
+    }) == ["c"]

--- a/node/tests/test_fork_choice_visualizer.py
+++ b/node/tests/test_fork_choice_visualizer.py
@@ -25,6 +25,33 @@ def test_build_graph_marks_weighted_canonical_path():
         "heads": 2,
         "max_depth": 2,
         "canonical_height": 1,
+        "reorg_frequency_counter": 1,
+        "max_reorg_depth": 2,
+        "reorg_duration_histogram": {
+            "le_60": 1,
+            "le_300": 0,
+            "le_900": 0,
+            "gt_900": 0,
+        },
+        "reorg_alert_thresholds": {
+            "frequency": 3,
+            "max_depth": 6,
+            "duration_seconds": 900,
+        },
+        "reorg_alerts": {
+            "frequency": False,
+            "max_depth": False,
+            "duration_seconds": False,
+        },
+        "reorg_events": [
+            {
+                "fork_point": "genesis",
+                "height": 0,
+                "max_depth": 2,
+                "duration_seconds": 0,
+                "abandoned_heads": ["a2"],
+            }
+        ],
     }
 
     canonical = {node["id"] for node in graph["nodes"] if node["is_canonical"]}
@@ -76,3 +103,35 @@ def test_graph_suppresses_edges_to_missing_windowed_parents():
     assert graph["nodes"][0]["parent"] == "missing-parent"
     assert graph["edges"] == []
     assert graph["heads"] == ["child"]
+
+
+def test_reorg_metrics_track_duration_buckets_and_alerts():
+    graph = build_fork_choice_graph([
+        {"hash": "genesis", "height": 0, "weight": 1, "timestamp": 100},
+        {"hash": "a1", "parent_hash": "genesis", "height": 1, "weight": 10, "timestamp": 140},
+        {"hash": "a2", "parent_hash": "a1", "height": 2, "weight": 11, "timestamp": 470},
+        {"hash": "b1", "parent_hash": "genesis", "height": 1, "weight": 20, "timestamp": 200},
+        {"hash": "b2", "parent_hash": "b1", "height": 2, "weight": 30, "timestamp": 300},
+        {"hash": "b3", "parent_hash": "b2", "height": 3, "weight": 40, "timestamp": 400},
+        {"hash": "b4", "parent_hash": "b3", "height": 4, "weight": 50, "timestamp": 500},
+        {"hash": "b5", "parent_hash": "b4", "height": 5, "weight": 60, "timestamp": 600},
+        {"hash": "b6", "parent_hash": "b5", "height": 6, "weight": 70, "timestamp": 700},
+        {"hash": "b7", "parent_hash": "b6", "height": 7, "weight": 80, "timestamp": 800},
+        {"hash": "c1", "parent_hash": "b2", "height": 3, "weight": 1, "timestamp": 1500},
+        {"hash": "d1", "parent_hash": "b3", "height": 4, "weight": 1, "timestamp": 690},
+    ])
+
+    assert graph["canonical_head"] == "b7"
+    assert graph["metrics"]["reorg_frequency_counter"] == 3
+    assert graph["metrics"]["max_reorg_depth"] == 2
+    assert graph["metrics"]["reorg_duration_histogram"] == {
+        "le_60": 0,
+        "le_300": 1,
+        "le_900": 1,
+        "gt_900": 1,
+    }
+    assert graph["metrics"]["reorg_alerts"] == {
+        "frequency": True,
+        "max_depth": False,
+        "duration_seconds": True,
+    }


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1`
- [x] If adding new code files, include SPDX header near the top
- [x] Provide test evidence

## What Changed

- Added reorg-resistance metrics to the existing fork-choice graph helper.
- Metrics now report reorg frequency, max abandoned branch depth, duration buckets, alert thresholds, alert state, and per-fork event details.
- Added focused tests covering the new metrics, duration buckets, and alert threshold behavior.

## Why It Matters

Issue #2359 asks for a way to measure chain stability and reorg resistance. This keeps the first slice narrow by extending the existing fork-choice metrics surface instead of changing consensus or node runtime behavior.

## Validation

- `.venv-bounty-validation/bin/python -B -m pytest -q node/tests/test_fork_choice_visualizer.py` -> 6 passed
- `.venv-bounty-validation/bin/python -B -m py_compile node/fork_choice_visualizer.py node/tests/test_fork_choice_visualizer.py` -> passed
- `git diff --check` -> passed
- sample `build_fork_choice_graph(...)` run emitted `reorg_frequency_counter`, `max_reorg_depth`, `reorg_duration_histogram`, `reorg_alert_thresholds`, `reorg_alerts`, and `reorg_events`

## Touched Files / Subsystems

- `node/fork_choice_visualizer.py`: fork-choice graph metrics and reorg-resistance metric derivation.
- `node/tests/test_fork_choice_visualizer.py`: regression coverage for reorg metrics and alert thresholds.

## Scope / Risk Boundary

This does not change consensus, block production, fork choice selection, database schema, alerts delivery, or Prometheus exporter behavior. It only enriches the existing fork-choice graph metrics payload.

Closes #2359

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
