### PR TITLE
docs: clarify CPU vote reward weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ For command examples, backup guidance, and the signed-transfer payload format, s
 ### 1 CPU = 1 Vote
 
 Unlike Proof-of-Work where hash power = votes:
-- Each unique hardware device gets exactly 1 vote per epoch
-- Rewards split equally, then multiplied by antiquity
+- Each unique hardware device gets one consensus participation slot per epoch
+- Reward shares are then weighted by the device's antiquity multiplier
 - No advantage from faster CPUs or multiple threads
 
 ### Epoch Rewards


### PR DESCRIPTION
Fixes #6847.

## Summary
- Clarifies that "1 CPU = 1 Vote" means one consensus participation slot per unique hardware device.
- Clarifies that epoch reward shares are still weighted by the antiquity multiplier, matching the reward example below the section.

## Validation
- git diff --check

wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
