### PR TITLE
feat: add wallet history verifier integration

### DIFF
--- a/integrations/FakerHideInBush-wallet-history/INTEGRATION.md
+++ b/integrations/FakerHideInBush-wallet-history/INTEGRATION.md
@@ -1,0 +1,32 @@
+tier: T2
+target: rustchain
+language: python
+endpoints_used: ["/health", "/wallet/history"]
+wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
+starred: yes
+
+# RustChain Wallet History Verifier
+
+This integration reads live RustChain node state and verifies a wallet's transfer
+history response. It is a T2 verification integration because it does more than
+render endpoint output:
+
+- confirms the node health endpoint returns `ok: true`
+- confirms `/wallet/history` echoes the requested RTC wallet/miner id
+- verifies every returned transaction has a numeric amount, a known status, and
+  a 32-character hex transaction hash
+- totals pending transfer-in rows so an agent can compare public wallet history
+  against expected paid-pending bounty records
+
+No private key, seed phrase, wallet password, API secret, or transaction signing
+is required. The script performs read-only public HTTP requests.
+
+Run:
+
+```bash
+python integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py \
+  --miner-id RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
+```
+
+The default node is `https://50.28.86.131`, which is the live node endpoint used
+by current RustChain wallet payout checks.

--- a/integrations/FakerHideInBush-wallet-history/README.md
+++ b/integrations/FakerHideInBush-wallet-history/README.md
@@ -1,0 +1,43 @@
+# RustChain Wallet History Verifier
+
+Small T2 integration for bounty #13040. It verifies live wallet-history data
+from a RustChain node without using secrets or signing transactions.
+
+## Run
+
+```bash
+python integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py \
+  --miner-id RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
+```
+
+Optional flags:
+
+- `--node https://50.28.86.131` selects the live node base URL.
+- `--limit 10` limits history rows requested.
+- `--strict-tls` requires normal TLS certificate verification. The default live
+  IP endpoint is queried with certificate verification disabled because the IP
+  endpoint is used directly by the RustChain wallet checks.
+
+## Live Transcript
+
+Run on 2026-06-04 UTC against `https://50.28.86.131`:
+
+```text
+RustChain wallet history verifier
+node ok: version=2.2.1-rip200 db_rw=True
+wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
+transactions: 3 returned, total field=3
+pending transfer_in total: 12.5 RTC
+result: verified 3 transaction hash(es)
+```
+
+## What Is Verified
+
+- `/health` reports a live node with `ok: true`.
+- `/wallet/history` returns `ok: true` and echoes the requested wallet id.
+- Each transaction has a numeric `amount`, a known `status`, and a 32-character
+  hex `tx_hash`.
+- Pending `transfer_in` amounts are summed for payout tracking.
+
+This integration is read-only. It does not connect wallets, store secrets, sign
+transactions, bridge, swap, or cash out funds.

--- a/integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py
+++ b/integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Verify live RustChain wallet history without using wallet secrets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import ssl
+import sys
+from decimal import Decimal, InvalidOperation
+from typing import Any
+from urllib.parse import urlencode
+from urllib.request import urlopen
+
+
+DEFAULT_NODE = "https://50.28.86.131"
+DEFAULT_MINER_ID = "RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8"
+HEX_32 = re.compile(r"^[0-9a-fA-F]{32}$")
+KNOWN_STATUSES = {"pending", "confirmed", "failed", "rejected"}
+
+
+def fetch_json(url: str, *, strict_tls: bool) -> dict[str, Any]:
+    context = None if strict_tls else ssl._create_unverified_context()
+    with urlopen(url, timeout=15, context=context) as response:
+        payload = response.read().decode("utf-8")
+    data = json.loads(payload)
+    if not isinstance(data, dict):
+        raise ValueError(f"expected JSON object from {url}")
+    return data
+
+
+def amount_as_decimal(value: Any) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ValueError(f"invalid transaction amount: {value!r}") from exc
+
+
+def verify_history(history: dict[str, Any], miner_id: str) -> tuple[int, Decimal]:
+    if history.get("ok") is not True:
+        raise ValueError("wallet history did not return ok=true")
+    if history.get("miner_id") != miner_id:
+        raise ValueError("wallet history miner_id does not match request")
+
+    transactions = history.get("transactions")
+    if not isinstance(transactions, list) or not transactions:
+        raise ValueError("wallet history must contain at least one transaction")
+
+    pending_transfer_in = Decimal("0")
+    verified_hashes = 0
+    for index, tx in enumerate(transactions, start=1):
+        if not isinstance(tx, dict):
+            raise ValueError(f"transaction {index} is not an object")
+
+        tx_hash = tx.get("tx_hash")
+        if not isinstance(tx_hash, str) or not HEX_32.fullmatch(tx_hash):
+            raise ValueError(f"transaction {index} has invalid tx_hash")
+        verified_hashes += 1
+
+        status = tx.get("status")
+        if status not in KNOWN_STATUSES:
+            raise ValueError(f"transaction {index} has unknown status {status!r}")
+
+        amount = amount_as_decimal(tx.get("amount"))
+        if amount < 0:
+            raise ValueError(f"transaction {index} has negative amount")
+
+        if tx.get("type") == "transfer_in" and status == "pending":
+            pending_transfer_in += amount
+
+    return verified_hashes, pending_transfer_in
+
+
+def build_url(node: str, path: str, params: dict[str, Any] | None = None) -> str:
+    base = node.rstrip("/")
+    query = f"?{urlencode(params)}" if params else ""
+    return f"{base}{path}{query}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--node", default=DEFAULT_NODE, help="RustChain node URL")
+    parser.add_argument("--miner-id", default=DEFAULT_MINER_ID, help="RTC wallet/miner id")
+    parser.add_argument("--limit", type=int, default=10, help="history row limit")
+    parser.add_argument(
+        "--strict-tls",
+        action="store_true",
+        help="require normal TLS certificate verification",
+    )
+    args = parser.parse_args()
+
+    health = fetch_json(build_url(args.node, "/health"), strict_tls=args.strict_tls)
+    if health.get("ok") is not True:
+        raise ValueError("node health did not return ok=true")
+
+    history = fetch_json(
+        build_url(
+            args.node,
+            "/wallet/history",
+            {"miner_id": args.miner_id, "limit": args.limit},
+        ),
+        strict_tls=args.strict_tls,
+    )
+    verified_hashes, pending_total = verify_history(history, args.miner_id)
+
+    print("RustChain wallet history verifier")
+    print(f"node ok: version={health.get('version', 'unknown')} db_rw={health.get('db_rw')}")
+    print(f"wallet: {args.miner_id}")
+    print(f"transactions: {len(history['transactions'])} returned, total field={history.get('total')}")
+    print(f"pending transfer_in total: {pending_total} RTC")
+    print(f"result: verified {verified_hashes} transaction hash(es)")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # noqa: BLE001 - command-line verifier reports concise failures.
+        print(f"verification failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
Submission for Scottcjn/rustchain-bounties#13040.

Tier: T2 (Verify)
Target: rustchain
Language: Python
Endpoints used: /health, /wallet/history
Wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8
Starred: yes

What changed:
- Added a read-only wallet history verifier under integrations/FakerHideInBush-wallet-history/.
- Verifies live node health, wallet-history ok/miner_id echo, transaction hash shape, known statuses, numeric amounts, and pending transfer_in totals.
- Avoids private keys, wallet connection, signing, transfers, bridge/swap, and cash-out actions.

Validation:
- python integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py --miner-id RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8 --limit 3
  - result: verified 3 transaction hash(es); pending transfer_in total: 12.5 RTC
- python -m py_compile integrations/FakerHideInBush-wallet-history/wallet_history_verifier.py
- git diff --check
