### PR TITLE
chore(ci): miner checksum auto-regen script + pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Auto-regenerate miners/checksums.sha256 when a tracked miner artifact is staged.
+# Enable once with:  git config core.hooksPath .githooks
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MANIFEST="$REPO_ROOT/miners/checksums.sha256"
+[ -f "$MANIFEST" ] || exit 0
+mapfile -t TRACKED < <(awk '{print "miners/"$2}' "$MANIFEST")
+staged="$(git diff --cached --name-only)"
+for f in "${TRACKED[@]}"; do
+  if grep -qxF "$f" <<<"$staged"; then
+    "$REPO_ROOT/scripts/regenerate_miner_checksums.sh"
+    git add miners/checksums.sha256
+    echo "[pre-commit] miner artifact changed -> regenerated + staged checksums.sha256"
+    break
+  fi
+done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,3 +213,31 @@ When reviewing PRs or preparing your own:
 - [ ] Tests added/updated for changes
 - [ ] Documentation updated if needed
 - [ ] No unrelated changes in the PR
+
+
+---
+
+## Editing miner files (avoid the red `test` check)
+
+Four miner artifacts are pinned by SHA256 in `miners/checksums.sha256` and verified by
+`tests/test_install_miner_checksums.py`. If you edit any of them, regenerate the manifest
+in the same commit or the `test` CI check goes red (`AssertionError`, while the other
+3000+ tests pass):
+
+- `miners/linux/rustchain_linux_miner.py`
+- `miners/linux/fingerprint_checks.py`
+- `miners/macos/rustchain_mac_miner_v2.4.py`
+- `miners/macos/rustchain_mac_miner_v2.5.py`
+
+**One command:**
+```bash
+./scripts/regenerate_miner_checksums.sh
+```
+
+**Or enable the pre-commit hook once** (auto-regenerates + re-stages when you commit a miner file):
+```bash
+git config core.hooksPath .githooks
+```
+
+A red checksum `test` means the manifest is stale — it is **not** a code bug, and it does
+**not** indicate `tests/test_p2p_mtls_gate.py` or any global gate (that test passes).

--- a/scripts/regenerate_miner_checksums.sh
+++ b/scripts/regenerate_miner_checksums.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Regenerate miners/checksums.sha256 from the artifacts it already tracks.
+# Run this after editing any pinned miner file (or let the pre-commit hook do it).
+# The tracked artifact list is derived from the manifest itself, so it never
+# drifts from what tests/test_install_miner_checksums.py verifies.
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT/miners"
+[ -f checksums.sha256 ] || { echo "no miners/checksums.sha256 found" >&2; exit 1; }
+tmp="$(mktemp)"
+# Preserve order + the exact tracked set; recompute each digest.
+while read -r _ artifact; do
+  [ -n "${artifact:-}" ] || continue
+  sha256sum "$artifact"
+done < checksums.sha256 > "$tmp"
+mv "$tmp" checksums.sha256
+echo "Regenerated miners/checksums.sha256 ($(wc -l < checksums.sha256) artifacts)"


### PR DESCRIPTION
## Problem
Any PR that edits a pinned miner artifact (`miners/linux/*.py`, `miners/macos/*.py`) fails the `test` CI job — `tests/test_install_miner_checksums.py` recomputes their SHA256 and asserts they match `miners/checksums.sha256`. Contributors routinely forget to regenerate the manifest, so the `test` check goes red (`1 failed, 3276 passed`) on otherwise-correct PRs (e.g. #6826), and it keeps getting misdiagnosed as a global gate (#6344 claimed `test_p2p_mtls_gate.py` "blocks all PRs" — it passes 7/7).

## Fix (tooling only — no behavior change, no miner edits, manifest untouched)
- **`scripts/regenerate_miner_checksums.sh`** — one command to rebuild the manifest. Derives the tracked artifact list from `checksums.sha256` itself, so it can never drift from what the test verifies. On clean `main` it's a no-op.
- **`.githooks/pre-commit`** — opt-in hook (`git config core.hooksPath .githooks`) that auto-regenerates and re-stages the manifest whenever a tracked miner file is committed. Kills the trap for diligent local contributors.
- **`CONTRIBUTING.md`** — documents the one-liner and clears up the "p2p_mtls gate" myth.

## Validation
- On clean `main`, the script reproduces the existing manifest byte-for-byte (no spurious diff).
- Run against a branch that edited a miner file without updating the manifest, it correctly regenerates the changed digest (verified locally — it caught real drift on an in-flight branch).

Closes the recurring red-`test` class for all future miner-editing PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)