### PR TITLE
docs: fix Dutch README contributing link

### DIFF
--- a/docs/nl-NL/README.md
+++ b/docs/nl-NL/README.md
@@ -101,7 +101,7 @@ Nee. RustChain gebruikt **Proof-of-Antiquity (PoA)**, een uniek mechanisme dat z
 
 ## Bijdragen
 
-We verwelkomen bijdragen! Zie [CONTRIBUTING.md](CONTRIBUTING.md) voor richtlijnen.
+We verwelkomen bijdragen! Zie [CONTRIBUTING.md](../../CONTRIBUTING.md) voor richtlijnen.
 
 ## Licentie
 


### PR DESCRIPTION
Refs #305

## What changed

- Updated the Dutch README contribution link so it points from `docs/nl-NL/README.md` back to the root `CONTRIBUTING.md`.

## Why it matters

- The previous relative link resolved to `docs/nl-NL/CONTRIBUTING.md`, which is not present.
- Readers of the Dutch README can now reach the contributor guidelines without hitting a missing local Markdown target.

## Validation commands and results

- Focused Markdown relative-link resolver for `docs/nl-NL/README.md` -> `docs/nl-NL/README.md relative Markdown links resolve`
- `git diff --check origin/main...HEAD` -> passed
- Changed-file hidden Unicode scan -> passed, no findings

## Touched files/subsystems

- `docs/nl-NL/README.md`

## Scope/risk boundary

- Documentation-only relative-link fix.
- No runtime code, API behavior, auth, payment, wallet, generated assets, or workflow files changed.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
