### PR TITLE
test(clawrtc): skip integration tests when clawrtc.cli is absent (fix flaky CI red)

### DIFF
--- a/tests/test_clawrtc_integration.py
+++ b/tests/test_clawrtc_integration.py
@@ -32,14 +32,24 @@ def _isolate_wallet(tmp_path, monkeypatch):
         monkeypatch.setattr("clawrtc.cli.WALLET_FILE", str(wallet_dir / "wallet.json"))
         monkeypatch.setattr("clawrtc.cli.INSTALL_DIR", str(install_dir))
         monkeypatch.setattr("clawrtc.cli.DATA_DIR", str(install_dir / "data"))
-    except AttributeError:
-        pytest.skip("clawrtc.cli does not export wallet paths yet")
+    except (AttributeError, ImportError):
+        # AttributeError: clawrtc.cli exists but doesn't export the wallet paths.
+        # ImportError/ModuleNotFoundError: clawrtc.cli isn't importable in this
+        # environment (it is not committed in-repo). Either way these integration
+        # tests can't run here — skip cleanly instead of erroring. Catching
+        # ImportError makes the skip deterministic; a missing module raised
+        # ModuleNotFoundError (an ImportError), which slipped past the
+        # AttributeError-only guard and flakily reddened the `test` check.
+        pytest.skip("clawrtc.cli not importable / does not export wallet paths")
     return wallet_dir
 
 
 @pytest.fixture
 def cli():
-    from clawrtc import cli as _cli
+    try:
+        from clawrtc import cli as _cli
+    except ImportError:
+        pytest.skip("clawrtc.cli not importable in this environment")
     return _cli
 
 


### PR DESCRIPTION
## Problem
`tests/test_clawrtc_integration.py` imports `clawrtc.cli`, which is **not committed in-repo** (the `miners/clawrtc/` package has `__init__/config/pow_miners/test_config` but no `cli.py`). The autouse `_isolate_wallet` fixture guarded its `monkeypatch.setattr("clawrtc.cli...")` calls with `except AttributeError` only. A missing module raises `ModuleNotFoundError` (a subclass of `ImportError`), which slips past that guard → the fixture **errors** for all 27 tests instead of skipping.

Because `clawrtc.cli` is only sometimes importable (depends on test ordering / build side-effects in a given run), the blocking `test` check **flaps red nondeterministically** — main itself went green on one commit and red on the next with identical content. This reddens unrelated PRs and forces manual `--admin` merges.

## Fix
Catch `ImportError` (covers `ModuleNotFoundError`) in both the autouse fixture and the `cli` fixture, so the suite **skips cleanly** wherever `clawrtc.cli` isn't importable. No behavior change where it *is* importable.

## Verification
```
$ python3 -m pytest tests/test_clawrtc_integration.py -q
27 skipped in 0.13s   # was: 27 errors
```

This is a test-only change; it removes a recurring false-negative on the `test` gate. A proper follow-up is to either commit the real `clawrtc/cli.py` or remove the orphaned integration test (Bounty #426/#1913).

🤖 Generated with [Claude Code](https://claude.com/claude-code)