### PR TITLE
[API] Add X-Total-Count header to /api/miners (issue #6565)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7139,6 +7139,9 @@ def api_miners():
             "count": len(miners)
         }
     })
+    response.headers["X-Total-Count"] = str(total_count)
+    response.headers["X-Page-Limit"] = str(limit)
+    response.headers["X-Page-Offset"] = str(offset)
     add_rate_limit_headers(response, rate_info)
     return response
 


### PR DESCRIPTION
## Problem

The  endpoint lacks  header needed for frontend pagination libraries. While limit/offset pagination exists in the response body, frontend SDKs (like BoTTube) rely on standard pagination headers.

## Fix

Add three headers to  GET response:
- : Total number of miners
- : Current page size (limit query param)
- : Current page offset (offset query param)

Pagination logic unchanged — headers are additive.

Fixes #6565