### PR TITLE
fix: require admin authentication on POST /api/bridge/lock (H-03)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -1442,6 +1442,9 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
     @app.route("/api/bridge/lock", methods=["POST"])
     def create_bridge_lock():
         """Create bridge lock."""
+        auth_error = require_admin_key()
+        if auth_error:
+            return auth_error
         data, error = parse_json_object_body()
         if error:
             return error


### PR DESCRIPTION
## Security Fix: POST /api/bridge/lock Unauthenticated Access (H-03)

### Vulnerability
Unauthenticated attackers can create arbitrary bridge lock records by calling `POST /api/bridge/lock` without any authentication header. This poisons the `bridge_locks` database table with fake lock entries, potentially disrupting bridge accounting.

### Root Cause
The `create_bridge_lock()` route handler in `node/airdrop_v2.py` had no authentication — all other bridge endpoints (`/confirm`, `/release`) require `X-Admin-Key`, but this one was missing.

### Fix
Add `require_admin_key()` authentication check at the start of `create_bridge_lock()`.

### Severity
**High** — Bridge state poisoning without any credentials required.

### Testing
- Verify `POST /api/bridge/lock` without `X-Admin-Key` → `401 unauthorized`
- Verify `POST /api/bridge/lock` with correct `X-Admin-Key` → proceeds to DB write

### Bounty Claim
Filed as H-03 on Algora bounty board.
