### PR TITLE
fix: rate-limit public governance votes

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -10199,6 +10199,59 @@ def beacon_envelopes_list():
     envelopes = get_recent_envelopes(limit=limit, offset=offset, db_path=DB_PATH)
     return jsonify({"ok": True, "count": len(envelopes), "envelopes": envelopes})
 
+
+GOVERNANCE_VOTE_RATE_LIMIT_MAX = int(
+    os.environ.get("RC_GOVERNANCE_VOTE_RATE_LIMIT_MAX", "20")
+)
+GOVERNANCE_VOTE_RATE_LIMIT_WINDOW = int(
+    os.environ.get("RC_GOVERNANCE_VOTE_RATE_LIMIT_WINDOW_SECONDS", "60")
+)
+_GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS = {}
+_GOVERNANCE_VOTE_RATE_LIMIT_LOCK = Lock()
+
+
+def _check_governance_vote_rate_limit(client_ip: str, now_ts: Optional[int] = None):
+    """Bound signature-verification work for public governance vote attempts."""
+    if GOVERNANCE_VOTE_RATE_LIMIT_MAX <= 0:
+        return True, 0
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    window = max(1, GOVERNANCE_VOTE_RATE_LIMIT_WINDOW)
+    cutoff = now_ts - window
+    key = client_ip or "unknown"
+    with _GOVERNANCE_VOTE_RATE_LIMIT_LOCK:
+        attempts = [
+            ts
+            for ts in _GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS.get(key, [])
+            if ts > cutoff
+        ]
+        if len(attempts) >= GOVERNANCE_VOTE_RATE_LIMIT_MAX:
+            _GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS[key] = attempts
+            retry_after = max(1, window - (now_ts - attempts[0]))
+            return False, retry_after
+        attempts.append(now_ts)
+        _GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS[key] = attempts
+        return True, 0
+
+
+@app.before_request
+def _limit_governance_vote_requests():
+    if request.method != "POST" or request.path != "/governance/vote":
+        return None
+    allowed, retry_after = _check_governance_vote_rate_limit(get_client_ip())
+    if allowed:
+        return None
+    response = jsonify({
+        "ok": False,
+        "error": "rate_limited",
+        "code": "GOVERNANCE_VOTE_RATE_LIMIT",
+        "limit": GOVERNANCE_VOTE_RATE_LIMIT_MAX,
+        "window_seconds": GOVERNANCE_VOTE_RATE_LIMIT_WINDOW,
+    })
+    response.status_code = 429
+    response.headers["Retry-After"] = str(retry_after)
+    return response
+
+
 if __name__ == "__main__":
     enforce_mock_signature_runtime_guard()
 

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -141,23 +141,23 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:6024:        ).fetchall():
 node/rustchain_v2_integrated_v2.2.1_rip200.py:6746:                            WHERE active=1 ORDER BY signer_id""").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:6776:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:6972:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7159:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7257:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7276:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7667:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7700:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7731:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8010:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8466:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8611:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8658:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8683:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9083:        """, (now,)).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9186:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9191:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9198:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9359:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9718:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7162:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7260:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7279:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7670:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7703:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7734:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8013:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8469:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8614:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8661:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8686:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9086:        """, (now,)).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9189:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9194:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9201:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9362:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9721:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())

--- a/tests/test_governance_vote_rate_limit.py
+++ b/tests/test_governance_vote_rate_limit.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+integrated_node = sys.modules["integrated_node"]
+
+
+def _invalid_signature_payload():
+    public_key = "11" * 32
+    return {
+        "proposal_id": 1,
+        "wallet": integrated_node.address_from_pubkey(public_key),
+        "vote": "yes",
+        "nonce": "rate-limit-test",
+        "signature": "22" * 64,
+        "public_key": public_key,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_governance_vote_rate_limit(monkeypatch):
+    monkeypatch.setattr(integrated_node, "GOVERNANCE_VOTE_RATE_LIMIT_MAX", 2)
+    monkeypatch.setattr(integrated_node, "GOVERNANCE_VOTE_RATE_LIMIT_WINDOW", 60)
+    integrated_node._GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS.clear()
+    yield
+    integrated_node._GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS.clear()
+
+
+def test_governance_vote_rate_limit_returns_429_with_retry_after():
+    payload = _invalid_signature_payload()
+
+    with patch.object(integrated_node.time, "time", return_value=1000), \
+            patch.object(integrated_node, "verify_rtc_signature", return_value=False):
+        with integrated_node.app.test_client() as client:
+            responses = [
+                client.post(
+                    "/governance/vote",
+                    json=payload,
+                    environ_base={"REMOTE_ADDR": "198.51.100.20"},
+                )
+                for _ in range(3)
+            ]
+
+    assert [response.status_code for response in responses] == [401, 401, 429]
+    assert responses[2].get_json()["code"] == "GOVERNANCE_VOTE_RATE_LIMIT"
+    assert responses[2].headers["Retry-After"] == "60"
+
+
+def test_governance_vote_rate_limit_is_isolated_per_client_ip(monkeypatch):
+    monkeypatch.setattr(integrated_node, "GOVERNANCE_VOTE_RATE_LIMIT_MAX", 1)
+    payload = _invalid_signature_payload()
+
+    with patch.object(integrated_node.time, "time", return_value=1000), \
+            patch.object(integrated_node, "verify_rtc_signature", return_value=False):
+        with integrated_node.app.test_client() as client:
+            first = client.post(
+                "/governance/vote",
+                json=payload,
+                environ_base={"REMOTE_ADDR": "198.51.100.21"},
+            )
+            limited = client.post(
+                "/governance/vote",
+                json=payload,
+                environ_base={"REMOTE_ADDR": "198.51.100.21"},
+            )
+            other_client = client.post(
+                "/governance/vote",
+                json=payload,
+                environ_base={"REMOTE_ADDR": "198.51.100.22"},
+            )
+
+    assert first.status_code == 401
+    assert limited.status_code == 429
+    assert other_client.status_code == 401
+
+
+def test_invalid_governance_vote_signature_does_not_open_database():
+    payload = _invalid_signature_payload()
+
+    with patch.object(integrated_node, "verify_rtc_signature", return_value=False), \
+            patch.object(
+                integrated_node.sqlite3,
+                "connect",
+                side_effect=AssertionError("invalid signature must fail before SQLite"),
+            ):
+        with integrated_node.app.test_client() as client:
+            response = client.post(
+                "/governance/vote",
+                json=payload,
+                environ_base={"REMOTE_ADDR": "198.51.100.23"},
+            )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "invalid_signature"


### PR DESCRIPTION
/claim #6869

Fixes #6869

## Summary

- adds a dedicated per-client sliding-window limit for `POST /governance/vote`
- returns HTTP 429 with `Retry-After` after 20 attempts per 60 seconds by default
- keeps holder self-voting open; no admin gate is restored
- uses the existing trusted client-IP resolution, including the configured proxy allowlist
- preserves the existing fail-fast ordering: malformed wallet/public-key/signature requests are rejected before SQLite is opened
- syncs the fetchall baseline line numbers shifted by the three response-header lines merged in #6866

## Security behavior

The limiter runs in `before_request`, so repeated invalid-signature traffic is bounded before signature verification or database work. Limits are isolated per client IP and configurable with:

- `RC_GOVERNANCE_VOTE_RATE_LIMIT_MAX`
- `RC_GOVERNANCE_VOTE_RATE_LIMIT_WINDOW_SECONDS`

## Validation

```text
python -m pytest -q tests/test_governance_vote_rate_limit.py tests/test_governance_api.py node/tests/test_admin_rate_limit.py node/test_signature_pubkey_type_validation.py
22 passed

PATH=/usr/bin:/bin bash scripts/check_fetchall.sh
OK: no new unannotated .fetchall() calls in node/.

python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_governance_vote_rate_limit.py
git diff --check origin/main
```

Wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`