### PR TITLE
fix: restore Windows signed header production

### DIFF
--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -145,6 +145,7 @@ class RustChainMiner:
         self.mining = False
         self.shares_submitted = 0
         self.shares_accepted = 0
+        self._last_submitted_slot = None
         self.miner_id = f"windows_{hashlib.md5(wallet_address.encode()).hexdigest()[:8]}"
         self.node_url = RUSTCHAIN_API
         self.attestation_valid_until = 0
@@ -153,6 +154,7 @@ class RustChainMiner:
         self.hw_info = self._get_hw_info()
         self.last_entropy = {}
         self.last_attestation_error = ""
+        self.last_header_error = ""
         # Surfaced fingerprint status — non-empty string means the miner is
         # submitting NO fingerprint and will be enrolled at VM-tier weight
         # (1e-9), i.e. earning ~zero. Shown loudly every attest cycle.
@@ -307,9 +309,14 @@ class RustChainMiner:
                     continue
 
                 self._emit_ready_status(callback)
-                eligible = self.check_eligibility()
-                if eligible:
-                    header = self.generate_header()
+                eligibility = self.check_eligibility()
+                slot = eligibility.get("slot")
+                if (
+                    eligibility.get("eligible")
+                    and slot is not None
+                    and slot != self._last_submitted_slot
+                ):
+                    header = self.generate_header(slot)
                     success = self.submit_header(header)
                     self.shares_submitted += 1
                     if success:
@@ -661,53 +668,75 @@ class RustChainMiner:
         return False
 
     def check_eligibility(self):
-        """Check if eligible to mine"""
+        """Return lottery eligibility for the attested wallet identity."""
         try:
             response = requests.get(
-                f"{RUSTCHAIN_API}/lottery/eligibility?miner_id={self.miner_id}"
+                f"{self.node_url}/lottery/eligibility",
+                params={"miner_id": self.wallet_address},
+                timeout=10,
             )
             if response.ok:
-                return response.json().get("eligible", False)
-        except Exception:
-            pass
-        return False
+                result = response.json()
+                if isinstance(result, dict):
+                    return result
+            return {
+                "eligible": False,
+                "reason": f"HTTP {getattr(response, 'status_code', 'unknown')}",
+            }
+        except Exception as e:
+            return {"eligible": False, "reason": str(e)}
 
-    def generate_header(self):
-        """
-        Generate mining header.
+    def generate_header(self, slot):
+        """Build the signed-header envelope accepted by the production node."""
+        if not CRYPTO_AVAILABLE or not self.keypair or not self.public_key:
+            raise RuntimeError("Ed25519 keypair required for header submission")
 
-        Extended for Zephyr dual-mining: the most recently built pow_proof
-        (from the last attest() cycle) is included when present. This binds
-        the PoW evidence to the specific header submission so the node can
-        correlate the attestation proof with the reward claim.
-        """
+        slot = int(slot)
         timestamp = int(time.time())
-        nonce     = os.urandom(4).hex()
-        header    = {
-            "miner_id":  self.miner_id,
-            "wallet":    self.wallet_address,
+        chain_identity = self.wallet_address
+        message = (
+            f"slot:{slot}:miner:{chain_identity}:ts:{timestamp}".encode("utf-8")
+        )
+        header = {
+            "slot": slot,
+            "miner": chain_identity,
             "timestamp": timestamp,
-            "nonce":     nonce
         }
-        header_str    = json.dumps(header, sort_keys=True)
-        header["hash"] = hashlib.sha256(header_str.encode()).hexdigest()
 
-        # Attach the cached PoW proof from the last attestation cycle.
-        # Using the cached value (rather than re-detecting on every header)
-        # avoids repeated process scans and RPC calls in the 10-second loop.
         if self._pow_proof:
             header["pow_proof"] = self._pow_proof
 
-        return header
+        return {
+            "miner_id": chain_identity,
+            "header": header,
+            "message": message.hex(),
+            "signature": sign_payload(message, self.keypair["private_key"]),
+            "pubkey": self.public_key,
+        }
 
-    def submit_header(self, header):
-        """Submit mining header"""
+    def submit_header(self, payload):
+        """Submit one signed header and remember accepted slots."""
+        slot = payload.get("header", {}).get("slot")
         try:
             response = requests.post(
-                f"{RUSTCHAIN_API}/headers/ingest_signed", json=header, timeout=5
+                f"{self.node_url}/headers/ingest_signed",
+                json=payload,
+                timeout=15,
             )
-            return response.status_code == 200
-        except Exception:
+            result = response.json()
+            success = (
+                response.status_code == 200
+                and isinstance(result, dict)
+                and bool(result.get("ok"))
+            )
+            if success:
+                self._last_submitted_slot = slot
+                self.last_header_error = ""
+            else:
+                self.last_header_error = self._response_diagnostic(response)
+            return success
+        except Exception as e:
+            self.last_header_error = f"header request failed: {e}"
             return False
 
 

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -4455,10 +4455,15 @@ def _submit_attestation_impl():
             )
             header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner)
             if header_pubkey:
-                enroll_conn.execute(
-                    "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
-                    (miner_id, header_pubkey)
-                )
+                # Lottery participation and header authorization use the
+                # attested wallet (`miner`). Keep the client-local miner_id as
+                # a compatibility alias, but always register the canonical
+                # chain identity too.
+                for header_miner_id in dict.fromkeys((miner, miner_id)):
+                    enroll_conn.execute(
+                        "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
+                        (header_miner_id, header_pubkey)
+                    )
             enroll_conn.commit()
 
         # Issue #19 temporal consistency only sets a review flag (no hard-fail).
@@ -4776,10 +4781,11 @@ def enroll_epoch():
         # Register a real Ed25519 pubkey for block-header verification when available.
         header_pubkey = _valid_ed25519_pubkey_hex(pubkey_hex) or _valid_ed25519_pubkey_hex(miner_pk)
         if header_pubkey:
-            c.execute(
-                "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
-                (miner_id, header_pubkey)
-            )
+            for header_miner_id in dict.fromkeys((miner_pk, miner_id)):
+                c.execute(
+                    "INSERT OR REPLACE INTO miner_header_keys (miner_id, pubkey_hex) VALUES (?, ?)",
+                    (header_miner_id, header_pubkey)
+                )
 
     app.logger.info(
         f"[RIP-309] epoch={epoch} miner={miner_pk[:20]}... nonce={rotation_eval['measurement_nonce'][:16]} "

--- a/node/tests/test_enroll_signature_verification.py
+++ b/node/tests/test_enroll_signature_verification.py
@@ -204,7 +204,10 @@ class TestEnrollSignatureVerification(unittest.TestCase):
             "report": {"nonce": nonce, "commitment": commitment},
             "device": {"family": "PowerPC", "arch": "G4", "model": "test-box", "cores": 4},
             "signals": {"hostname": "test-host", "macs": []},
-            "fingerprint": {},
+            "fingerprint": {
+                "all_passed": True,
+                "checks": {"clock_drift": {"passed": True}},
+            },
             "signature": sig_hex,
             "public_key": pubkey_hex,
         }
@@ -242,13 +245,14 @@ class TestEnrollSignatureVerification(unittest.TestCase):
         self.assertEqual(body["miner_pk"], miner)
 
         with sqlite3.connect(db_path) as conn:
-            row = conn.execute(
-                "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id = ?",
-                (miner_id,),
-            ).fetchone()
+            rows = dict(conn.execute(
+                "SELECT miner_id, pubkey_hex FROM miner_header_keys "
+                "WHERE miner_id IN (?, ?)",
+                (miner, miner_id),
+            ).fetchall())
 
-        self.assertIsNotNone(row)
-        self.assertEqual(row[0], pubkey_hex)
+        self.assertEqual(rows[miner], pubkey_hex)
+        self.assertEqual(rows[miner_id], pubkey_hex)
 
     @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
     def test_auto_enroll_registers_attestation_pubkey(self):
@@ -260,13 +264,14 @@ class TestEnrollSignatureVerification(unittest.TestCase):
         _, pubkey_hex = self._attest_and_get_signing_key(mod, miner, miner_id)
 
         with sqlite3.connect(db_path) as conn:
-            row = conn.execute(
-                "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id = ?",
-                (miner_id,),
-            ).fetchone()
+            rows = dict(conn.execute(
+                "SELECT miner_id, pubkey_hex FROM miner_header_keys "
+                "WHERE miner_id IN (?, ?)",
+                (miner, miner_id),
+            ).fetchall())
 
-        self.assertIsNotNone(row)
-        self.assertEqual(row[0], pubkey_hex)
+        self.assertEqual(rows[miner], pubkey_hex)
+        self.assertEqual(rows[miner_id], pubkey_hex)
 
     @unittest.skipUnless(HAVE_NACL, "pynacl not installed")
     def test_enrollment_with_wrong_key_rejected(self):

--- a/tests/test_windows_miner_chain_identity.py
+++ b/tests/test_windows_miner_chain_identity.py
@@ -1,0 +1,126 @@
+# SPDX-License-Identifier: MIT
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MINER_PATH = ROOT / "miners" / "windows" / "rustchain_windows_miner.py"
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 400
+        self.text = str(payload)
+
+    def json(self):
+        return self._payload
+
+
+def load_miner_module():
+    spec = importlib.util.spec_from_file_location(
+        "windows_miner_chain_identity", MINER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_miner(module):
+    miner = module.RustChainMiner.__new__(module.RustChainMiner)
+    miner.wallet_address = "RTCwallet"
+    miner.miner_id = "windows_local"
+    miner.node_url = "https://node.example"
+    miner.keypair = {"private_key": "private"}
+    miner.public_key = "ab" * 32
+    miner._pow_proof = None
+    miner._last_submitted_slot = None
+    miner.last_header_error = ""
+    return miner
+
+
+def test_eligibility_uses_configured_node_and_attested_wallet(monkeypatch):
+    module = load_miner_module()
+    miner = make_miner(module)
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return FakeResponse({
+            "eligible": False,
+            "reason": "not_your_turn",
+            "slot": 42,
+        })
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    result = miner.check_eligibility()
+
+    assert result["slot"] == 42
+    assert captured == {
+        "url": "https://node.example/lottery/eligibility",
+        "params": {"miner_id": "RTCwallet"},
+        "timeout": 10,
+    }
+
+
+def test_header_uses_wallet_identity_and_real_signature_shape(monkeypatch):
+    module = load_miner_module()
+    miner = make_miner(module)
+    signed = {}
+
+    def fake_sign(message, private_key):
+        signed["message"] = message
+        signed["private_key"] = private_key
+        return "cd" * 64
+
+    monkeypatch.setattr(module, "CRYPTO_AVAILABLE", True)
+    monkeypatch.setattr(module, "sign_payload", fake_sign, raising=False)
+    monkeypatch.setattr(module.time, "time", lambda: 1234)
+
+    payload = miner.generate_header(42)
+
+    message = b"slot:42:miner:RTCwallet:ts:1234"
+    assert signed == {"message": message, "private_key": "private"}
+    assert payload == {
+        "miner_id": "RTCwallet",
+        "header": {
+            "slot": 42,
+            "miner": "RTCwallet",
+            "timestamp": 1234,
+        },
+        "message": message.hex(),
+        "signature": "cd" * 64,
+        "pubkey": "ab" * 32,
+    }
+
+
+def test_submit_uses_configured_node_and_deduplicates_accepted_slot(monkeypatch):
+    module = load_miner_module()
+    miner = make_miner(module)
+    captured = {}
+    payload = {
+        "miner_id": "RTCwallet",
+        "header": {"slot": 42, "miner": "RTCwallet", "timestamp": 1234},
+        "message": "00",
+        "signature": "cd" * 64,
+        "pubkey": "ab" * 32,
+    }
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return FakeResponse({"ok": True})
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    assert miner.submit_header(payload) is True
+    assert miner._last_submitted_slot == 42
+    assert captured == {
+        "url": "https://node.example/headers/ingest_signed",
+        "json": payload,
+        "timeout": 15,
+    }


### PR DESCRIPTION
## Summary

Fixes #6896.

The Windows source miner could attest and show `ready/enrolled`, but it polled lottery eligibility with an unattested client-local ID and posted an unsigned, flat payload to the production signed-header endpoint. This made every Windows producer turn impossible to use.

This PR restores the complete production flow:

- query `/lottery/eligibility` through the configured `self.node_url`
- use the attested wallet identity that the node stores in `miner_attest_recent` and `epoch_enroll`
- preserve the server-provided slot
- build the required `miner_id/header/message/signature/pubkey` envelope
- sign the exact submitted message with the miner's persistent Ed25519 key
- submit through the configured node and prevent duplicate submissions for an accepted slot
- register the signing key under the canonical wallet identity while retaining the client-local ID as a compatibility alias

## Live reproduction

Before the fix, the same active Windows miner produced these two responses on the public node:

- `miner_id=windows_dbe53391` -> `reason=not_attested`
- `miner_id=RTCf69dd944558d4e843a4a676495a97638055caea2` -> `reason=not_your_turn` with a scheduled producer slot

A production-compatible local run now passes all six hardware checks, submits a signed attestation, enrolls successfully, and polls the wallet identity. I will attach the accepted-header result from the scheduled live slot in a follow-up comment.

## Verification

- `python -m pytest tests/test_windows_miner_chain_identity.py tests/test_windows_headless_lifecycle_logging.py -q` -> `7 passed`
- Both focused server registration tests pass their assertions locally. On Windows, their existing integrated-node harness then reports the known locked temporary SQLite file during teardown.
- `python -m py_compile` passed for all four changed Python files.
- `python tools/bcos_spdx_check.py --base-ref origin/main` -> `BCOS SPDX check: OK`
- `git diff --check` -> clean

/claim #305

Payout wallet: `RTCf69dd944558d4e843a4a676495a97638055caea2`