### PR TITLE
node: harden bounded /pending/confirm observability (tri-brain follow-up to #6900)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8928,9 +8928,13 @@ def _pending_confirm_env_int(name, default):
     if raw in (None, ""):
         return default
     try:
-        return max(1, int(raw))
+        value = int(raw)
     except (TypeError, ValueError):
         return default
+    # A non-positive override (e.g. "0" or a negative) is a misconfiguration. Fall
+    # back to the default rather than silently clamping the batch size to 1, which
+    # would throttle the confirm scheduler to one transfer per call with no error.
+    return value if value >= 1 else default
 
 
 # Bounded /pending/confirm: a single call confirms at most this many transfers so
@@ -8963,7 +8967,12 @@ def _pending_overdue_stats(c, now):
             """,
             (now, now),
         ).fetchone()
-    except Exception:
+    except sqlite3.Error as e:
+        # Degrade gracefully so observability never 500s the endpoint, but LOG it:
+        # a locked DB or schema drift on pending_ledger must not masquerade as a
+        # healthy "0 overdue" — monitors that trust these fields would miss a real
+        # backlog. Narrowed from bare Exception so genuine bugs still surface.
+        print(f"[WARN] _pending_overdue_stats DB error (reporting 0 overdue): {e!r}", flush=True)
         return {"stale_pending_count": 0, "max_confirm_overdue_seconds": 0}
     return {
         "stale_pending_count": int(row[0] or 0),

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -152,11 +152,11 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:8469:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:8614:            ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:8661:            ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:8686:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9259:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9264:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9271:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9432:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9791:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9268:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9273:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9280:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9441:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9800:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())


### PR DESCRIPTION
## Tri-brain follow-up to #6900 — bounded `/pending/confirm` observability hardening

The tri-brain review of #6900 surfaced two non-blocking robustness items (the BLOCKING finding — scheduler-throttle — was already fixed in rustchain-bounties#13228). This lands the two SHOULD-FIX items.

### 1. `_pending_confirm_env_int` — non-positive override now falls back to default
Previously `max(1, int(raw))` meant `RC_PENDING_CONFIRM_MAX_LIMIT=0` (or negative) silently became **1**, throttling the confirm scheduler to one transfer per call with `ok: true` and no error. Now a non-positive override falls back to the configured default, so a misconfig fails loud-enough (default throughput) instead of silently starving the queue.

### 2. `_pending_overdue_stats` — narrow the swallow + log
Was `except Exception: return {0, 0}`. For an *observability* helper that's the worst case: a locked DB or `pending_ledger` schema drift would masquerade as a healthy **"0 overdue"** to any monitor trusting the new fields. Now:
- narrowed to `except sqlite3.Error` (genuine code bugs propagate instead of being absorbed),
- **logs a WARN** on the degrade so a real DB problem is visible rather than a silent false-healthy,
- still returns `0,0` so the endpoint never 500s on observability alone.

### Verification
- `py_compile` clean
- `scripts/check_fetchall.sh` **green** — baseline regenerated for the +8 line shift; **content-identical** (no `.fetchall()` site added or removed, only 5 main-node line numbers moved)
- `pending`/`confirm`/`overdue` test **failure-set is byte-identical to `main`** before vs after this change (the 19 reds are pre-existing bare-clone fixture gaps, green in CI; 78 pass both ways)

Pure robustness, no behavior change on the happy path. Credit to the tri-brain pass (Codex NIT #2 + Grok SHOULD-FIX) for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
