### PR TITLE
fix(migrate): column-preserving miner_header_keys composite migration (prod-deploy blocker)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1810,25 +1810,41 @@ def init_db():
         # (miner_id, pubkey_hex) key so one wallet identity can hold a header key per
         # device (multi-device-per-wallet) instead of last-writer-wins overwriting
         # — which previously broke the non-last device's signed-header verification.
-        # Idempotent: only rebuilds a table still carrying the old PRIMARY KEY(miner_id).
+        # COLUMN-PRESERVING: production tables may carry extra columns (e.g. an
+        # `added_at` timestamp) absent from the CREATE above; the rebuild reconstructs
+        # every existing column (type / NOT NULL / DEFAULT) rather than a fixed 2-col
+        # shape, so no column or data is dropped. Idempotent: only rebuilds a table
+        # still carrying the old single-column PRIMARY KEY(miner_id). Verified by a
+        # dry-run against a 247,619-row snapshot of the production DB.
         try:
             _mhk_cols = c.execute("PRAGMA table_info(miner_header_keys)").fetchall()  # fetchall-ok: pragma-result
             _mhk_pk = [col[1] for col in _mhk_cols if col[5]]  # col[5] = pk position (>0 means part of PK)
-            if _mhk_pk == ["miner_id"]:
+            _mhk_names = [col[1] for col in _mhk_cols]
+            if (_mhk_pk == ["miner_id"]
+                    and "miner_id" in _mhk_names and "pubkey_hex" in _mhk_names):
+                # Reconstruct each column's definition WITHOUT an inline PRIMARY KEY,
+                # then add a table-level composite PK. Defaults are always parenthesized
+                # — valid for literals AND expression defaults like (strftime('%s','now')),
+                # which PRAGMA returns without the surrounding parens.
+                _mhk_defs, _mhk_list = [], []
+                for _cid, _name, _ctype, _notnull, _dflt, _pk in _mhk_cols:
+                    _d = '"%s" %s' % (_name, _ctype or "TEXT")
+                    if _notnull:
+                        _d += " NOT NULL"
+                    if _dflt is not None:
+                        _d += " DEFAULT (%s)" % _dflt
+                    _mhk_defs.append(_d)
+                    _mhk_list.append('"%s"' % _name)
+                _mhk_cols_sql = ", ".join(_mhk_defs)
+                _mhk_col_list = ", ".join(_mhk_list)
                 c.execute("ALTER TABLE miner_header_keys RENAME TO miner_header_keys_legacy_single")
-                c.execute("""
-                    CREATE TABLE miner_header_keys(
-                        miner_id TEXT NOT NULL,
-                        pubkey_hex TEXT NOT NULL,
-                        PRIMARY KEY (miner_id, pubkey_hex)
-                    )
-                """)
+                c.execute("CREATE TABLE miner_header_keys (%s, PRIMARY KEY (miner_id, pubkey_hex))" % _mhk_cols_sql)
                 c.execute(
-                    "INSERT OR IGNORE INTO miner_header_keys (miner_id, pubkey_hex) "
-                    "SELECT miner_id, pubkey_hex FROM miner_header_keys_legacy_single"
+                    "INSERT OR IGNORE INTO miner_header_keys (%s) SELECT %s FROM miner_header_keys_legacy_single"
+                    % (_mhk_col_list, _mhk_col_list)
                 )
                 c.execute("DROP TABLE miner_header_keys_legacy_single")
-                logging.info("[migrate] miner_header_keys upgraded to composite (miner_id, pubkey_hex) PK")
+                logging.info("[migrate] miner_header_keys upgraded to composite (miner_id, pubkey_hex) PK; preserved columns: %s" % _mhk_names)
         except Exception as _mhk_err:
             # Fail loud rather than continue on a half-migrated key table: running
             # header verification against a renamed/duplicate/missing table would be

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -129,34 +129,34 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:1316:    columns = conn.execute("P
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1323:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1478:            """, (limit, offset)).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1525:        _epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:2701:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:2848:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3049:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3064:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3704:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:4875:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:5341:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6103:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6112:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6834:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6864:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7060:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7250:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7348:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7367:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7758:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7791:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7822:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8101:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8557:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8702:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8749:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8774:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9356:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9361:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9368:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9529:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9888:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:2717:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:2864:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3065:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3080:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3720:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:4891:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:5357:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6119:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6128:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6850:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6880:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7076:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7266:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7364:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7383:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7774:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7807:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7838:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8117:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8573:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8718:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8765:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8790:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9372:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9377:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9384:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9545:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9904:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())

--- a/tests/test_header_keys_composite_6897.py
+++ b/tests/test_header_keys_composite_6897.py
@@ -25,20 +25,61 @@ def _make_composite(c):
 
 
 def _migrate(c):
-    """Mirror of the init_db() legacy->composite migration."""
+    """Mirror of the init_db() COLUMN-PRESERVING legacy->composite migration:
+    reconstructs every existing column (type / NOT NULL / DEFAULT) so a production
+    table carrying extra columns (e.g. `added_at`) keeps them."""
     cols = c.execute("PRAGMA table_info(miner_header_keys)").fetchall()
     pk = [col[1] for col in cols if col[5]]
-    if pk == ["miner_id"]:
-        c.execute("ALTER TABLE miner_header_keys RENAME TO miner_header_keys_legacy_single")
-        _make_composite(c)
-        c.execute(
-            "INSERT OR IGNORE INTO miner_header_keys (miner_id, pubkey_hex) "
-            "SELECT miner_id, pubkey_hex FROM miner_header_keys_legacy_single"
-        )
-        c.execute("DROP TABLE miner_header_keys_legacy_single")
-        c.commit()
-        return "migrated"
-    return "noop"
+    names = [col[1] for col in cols]
+    if pk != ["miner_id"] or "miner_id" not in names or "pubkey_hex" not in names:
+        return "noop"
+    defs, col_list = [], []
+    for _cid, name, ctype, notnull, dflt, _pk in cols:
+        d = '"%s" %s' % (name, ctype or "TEXT")
+        if notnull:
+            d += " NOT NULL"
+        if dflt is not None:
+            d += " DEFAULT (%s)" % dflt
+        defs.append(d)
+        col_list.append('"%s"' % name)
+    c.execute("ALTER TABLE miner_header_keys RENAME TO miner_header_keys_legacy_single")
+    c.execute("CREATE TABLE miner_header_keys (%s, PRIMARY KEY (miner_id, pubkey_hex))" % ", ".join(defs))
+    c.execute(
+        "INSERT OR IGNORE INTO miner_header_keys (%s) SELECT %s FROM miner_header_keys_legacy_single"
+        % (", ".join(col_list), ", ".join(col_list))
+    )
+    c.execute("DROP TABLE miner_header_keys_legacy_single")
+    c.commit()
+    return "migrated"
+
+
+def test_migration_preserves_extra_columns_like_production_added_at():
+    """Production `miner_header_keys` carries a 3rd `added_at` column (with an
+    expression default) absent from the code's CREATE. The migration must keep it
+    and its data — not silently drop it. Mirrors the exact prod DDL."""
+    c = sqlite3.connect(":memory:")
+    c.executescript(
+        "CREATE TABLE miner_header_keys (\n"
+        "  miner_id TEXT PRIMARY KEY,\n"
+        "  pubkey_hex TEXT NOT NULL,\n"
+        "  added_at  INTEGER NOT NULL DEFAULT (strftime('%s','now'))\n"
+        ")"
+    )
+    c.execute("INSERT INTO miner_header_keys(miner_id,pubkey_hex,added_at) VALUES('walletA','aaaa',1759701180)")
+    c.execute("INSERT INTO miner_header_keys(miner_id,pubkey_hex,added_at) VALUES('walletB','bbbb',1780774414)")
+    c.commit()
+    before = c.execute("SELECT miner_id,pubkey_hex,added_at FROM miner_header_keys ORDER BY miner_id").fetchall()
+
+    assert _migrate(c) == "migrated"
+    assert _pk_cols(c) == ["miner_id", "pubkey_hex"]
+    # the added_at column survived with its values...
+    assert "added_at" in [col[1] for col in c.execute("PRAGMA table_info(miner_header_keys)").fetchall()]
+    assert c.execute("SELECT miner_id,pubkey_hex,added_at FROM miner_header_keys ORDER BY miner_id").fetchall() == before
+    # ...and its default still fires for a new device key
+    c.execute("INSERT INTO miner_header_keys(miner_id,pubkey_hex) VALUES('walletA','cccc') ON CONFLICT(miner_id,pubkey_hex) DO NOTHING")
+    c.commit()
+    assert c.execute("SELECT added_at>0 FROM miner_header_keys WHERE miner_id='walletA' AND pubkey_hex='cccc'").fetchone()[0] == 1
+    assert _migrate(c) == "noop"  # idempotent
 
 
 def _pk_cols(c):


### PR DESCRIPTION
## Make the `miner_header_keys` composite migration column-preserving (deploy-blocker for #6903)

Caught during pre-deploy recon of the production node (Step 2 of the prod-deploy prep).

### The bug
The migration merged in #6903 rebuilt `miner_header_keys` with a **hardcoded 2-column** shape:
```python
CREATE TABLE miner_header_keys(miner_id ..., pubkey_hex ..., PRIMARY KEY (miner_id, pubkey_hex))
INSERT ... SELECT miner_id, pubkey_hex FROM ...legacy
```
The **production** `miner_header_keys` carries a third column the code's `CREATE` doesn't have:
```sql
added_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))   -- 247,619 rows, all populated
```
So the merged migration would have **silently dropped `added_at`** (column + all data) the first time the node restarted on prod. (It's unused by code today, but dropping a column from a live consensus table is unacceptable silent data loss.)

### The fix
The rebuild now reconstructs **every existing column** from `PRAGMA table_info` — preserving type, `NOT NULL`, and `DEFAULT` (defaults are always parenthesized so expression defaults like `(strftime('%s','now'))`, which PRAGMA returns *without* the parens, survive) — and copies all columns. Composite PK + verify-any behavior unchanged. Still idempotent + fail-loud.

### Validation — dry-run against the real prod DB
A `.backup` snapshot of the live 268 MB DB (live DB never touched) → ran this migration on the copy:
```
BEFORE  count/with_added_at/min/max: (247619, 247619, 1759701180, 1780774414)
migrate : migrated
AFTER   count/with_added_at/min/max: (247619, 247619, 1759701180, 1780774414)
composite PK     : ['miner_id', 'pubkey_hex']
counts identical : True    sample identical : True    idempotent 2nd: noop
new schema       : ...("added_at" INTEGER NOT NULL DEFAULT (strftime('%s','now')), PRIMARY KEY (miner_id, pubkey_hex))
```
All rows + every `added_at` value preserved.

### Tests
`test_migration_preserves_extra_columns_like_production_added_at` mirrors the exact prod DDL and asserts `added_at` (column + values) survives the rebuild and its default still fires for newly-registered keys. 5/5 in the suite pass; `_migrate` test helper updated to the column-preserving logic. `py_compile` + fetchall guard green (baseline content-identical).

This unblocks a safe prod deployment of the multi-key header-identity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
