### PR TITLE
feat(epoch): add /epoch/history endpoint and CLI support (S8)

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -345,6 +345,42 @@ def get_epoch():
         "epoch_pot": PER_BLOCK_RTC * blocks
     })
 
+
+@app.get("/epoch/history")
+def get_epoch_history():
+    """Get recent epoch history (last 50 epochs)"""
+    now_slot = int(time.time() // BLOCK_TIME)
+    current_epoch = slot_to_epoch(now_slot)
+    min_epoch = max(0, current_epoch - 50)
+
+    with sqlite3.connect(DB_PATH) as c:
+        rows = c.execute("""
+            SELECT e.epoch, e.accepted_blocks, e.finalized,
+                   COALESCE(COUNT(en.miner_pk), 0) as enrolled_miners,
+                   COALESCE(SUM(en.weight), 0) as total_weight
+            FROM epoch_state e
+            LEFT JOIN epoch_enroll en ON en.epoch = e.epoch
+            WHERE e.epoch >= ?
+            GROUP BY e.epoch
+            ORDER BY e.epoch DESC
+        """, (min_epoch,)).fetchall()
+
+    return jsonify({
+        "epochs": [
+            {
+                "epoch": int(r[0]),
+                "accepted_blocks": int(r[1]),
+                "finalized": bool(r[2]),
+                "enrolled_miners": int(r[3]),
+                "total_weight": float(r[4]),
+                "epoch_pot": PER_BLOCK_RTC * int(r[1])
+            }
+            for r in rows
+        ],
+        "current_epoch": current_epoch,
+        "count": len(rows)
+    })
+
 @app.post("/epoch/enroll")
 def epoch_enroll():
     """Enroll miner in current epoch"""

--- a/tools/cli/rustchain_cli.py
+++ b/tools/cli/rustchain_cli.py
@@ -203,9 +203,32 @@ def cmd_balance(args):
 def cmd_epoch(args):
     """Show epoch information."""
     if args.history:
-        # Note: This would need a history endpoint
-        print("Epoch history not yet implemented.", file=sys.stderr)
-        print("Tip: Check /epoch endpoint for current epoch info.")
+        data = fetch_api("/epoch/history")
+        epochs = data.get("epochs", [])
+        if args.json:
+            print(json.dumps(data, indent=2))
+            return
+        
+        if not epochs:
+            print("No epoch history available.")
+            return
+        
+        headers = ["Epoch", "Blocks", "Miners", "Weight", "Finalized", "Pot (RTC)"]
+        rows = []
+        for ep in epochs:
+            rows.append([
+                str(ep["epoch"]),
+                str(ep["accepted_blocks"]),
+                str(ep["enrolled_miners"]),
+                f"{ep['total_weight']:.1f}",
+                "✅" if ep["finalized"] else "⋯",
+                f"{ep['epoch_pot']:,.0f}"
+            ])
+        
+        print(f"=== Epoch History (last {data['count']}) ===")
+        print(f"Current Epoch: {data['current_epoch']}")
+        print()
+        print(format_table(headers, rows))
         return
     
     data = fetch_api("/epoch")


### PR DESCRIPTION
## Description
Replaces the 'Epoch history not yet implemented' stub in CLI with real implementation.

## Changes
- Adds `/epoch/history` GET endpoint to `sophia_elya_service.py` — returns last 50 epochs with blocks, miners, weight, finalized status, and epoch pot
- Updates `cmd_epoch --history` to call the new endpoint and display results as a formatted table
- Supports `--json` flag for machine-readable output

## Labels
BCOS-L2

## Related
S8 on Battleship grid

---

**RTC Wallet for bounty:** `RTC17c0d21f04f6f65c1a85c0aeb5d4a305d57531096`