### PR TITLE
fix(sophia): guard _ensure_balance_micro_schema from wiping the consensus balances ledger

### DIFF
--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -65,6 +65,17 @@ def _ensure_balance_micro_schema(conn):
         return
 
     by_name = {row[1]: row for row in columns}
+
+    # SAFETY GUARD: never rebuild the CONSENSUS balances ledger. The RustChain node
+    # keys `balances` by `miner_id` with the canonical micro-RTC amount in `amount_i64`
+    # (plus miner_pk / coinbase_address). This Sophia helper only manages its own
+    # 2-column (miner_pk, balance_rtc) micro-schema. If `DB_PATH` ever resolves to the
+    # shared consensus DB (it is a relative "./rustchain_v2.db"), the rebuild below
+    # would DROP miner_id / amount_i64 / coinbase_address and WIPE every balance.
+    # If we see the consensus money columns, leave the table completely untouched.
+    if "amount_i64" in by_name or "coinbase_address" in by_name:
+        return
+
     balance_column = by_name.get("balance_rtc")
     if balance_column and "INT" in (balance_column[2] or "").upper():
         return

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -163,8 +163,8 @@ node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f
 node/sophia_attestation_inspector.py:413:                ).fetchall()
 node/sophia_attestation_inspector.py:576:            ).fetchall()
 node/sophia_attestation_inspector.py:679:            ).fetchall()
+node/sophia_elya_service.py:108:    columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
 node/sophia_elya_service.py:60:    columns = conn.execute("PRAGMA table_info(balances)").fetchall()
-node/sophia_elya_service.py:97:    columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
 node/sophia_governor_inbox.py:535:        ).fetchall()
 node/sophia_governor_inbox.py:894:        rows = conn.execute(query, params).fetchall()
 node/sophia_governor_inbox.py:968:        ).fetchall()

--- a/tests/test_sophia_balances_consensus_guard.py
+++ b/tests/test_sophia_balances_consensus_guard.py
@@ -23,7 +23,7 @@ def _load_fn():
     start = src.index("def _ensure_balance_micro_schema(conn):")
     end = src.index("\ndef _ensure_epoch_state_settlement_schema")
     ns = {"RTC_MICRO_UNITS": 1_000_000}
-    exec(src[start:end], ns)
+    exec(src[start:end], ns)  # nosec B102 - loads one pure helper from source for an isolated unit test
     return ns["_ensure_balance_micro_schema"]
 
 

--- a/tests/test_sophia_balances_consensus_guard.py
+++ b/tests/test_sophia_balances_consensus_guard.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+"""Guard test: sophia_elya_service._ensure_balance_micro_schema must NEVER rebuild
+the consensus balances ledger.
+
+`sophia_elya_service.py` uses a relative `DB_PATH = "./rustchain_v2.db"` and, when run
+as __main__, calls `_ensure_balance_micro_schema`, which (for a non-INTEGER balance_rtc)
+RENAMEs `balances`, recreates it as 2 columns (miner_pk, balance_rtc), and drops the
+original. The consensus `balances` is keyed by `miner_id` with the canonical micro-RTC
+amount in `amount_i64` (+ coinbase_address) — rebuilding it would WIPE every balance.
+The guard must detect consensus columns and leave the table untouched, while still
+migrating a genuine Sophia-shaped table.
+"""
+import os
+import re
+import sqlite3
+
+HERE = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = os.path.join(HERE, "node", "sophia_elya_service.py")
+
+
+def _load_fn():
+    src = open(SRC, encoding="utf-8").read()
+    start = src.index("def _ensure_balance_micro_schema(conn):")
+    end = src.index("\ndef _ensure_epoch_state_settlement_schema")
+    ns = {"RTC_MICRO_UNITS": 1_000_000}
+    exec(src[start:end], ns)
+    return ns["_ensure_balance_micro_schema"]
+
+
+CONSENSUS_DDL = (
+    "CREATE TABLE balances (miner_id TEXT PRIMARY KEY NOT NULL, "
+    "amount_i64 INTEGER NOT NULL DEFAULT 0 CHECK(amount_i64 >= 0), "
+    "miner_pk TEXT, balance_rtc REAL DEFAULT 0.0, coinbase_address TEXT DEFAULT NULL)"
+)
+
+
+def test_consensus_balances_left_untouched():
+    fn = _load_fn()
+    c = sqlite3.connect(":memory:")
+    c.executescript(CONSENSUS_DDL)
+    c.execute("INSERT INTO balances(miner_id,amount_i64,miner_pk,balance_rtc) VALUES('m1',5000000,'pk1',0.0)")
+    c.execute("INSERT INTO balances(miner_id,amount_i64,miner_pk) VALUES('m2',9000000,'pk2')")
+    c.commit()
+    before = c.execute("SELECT miner_id,amount_i64,coinbase_address FROM balances ORDER BY miner_id").fetchall()
+
+    fn(c)  # must be a no-op on the consensus ledger
+
+    cols = {r[1] for r in c.execute("PRAGMA table_info(balances)").fetchall()}
+    assert cols == {"miner_id", "amount_i64", "miner_pk", "balance_rtc", "coinbase_address"}
+    after = c.execute("SELECT miner_id,amount_i64,coinbase_address FROM balances ORDER BY miner_id").fetchall()
+    assert after == before  # amount_i64 NOT wiped, no rows lost
+
+
+def test_genuine_sophia_balances_still_migrate_to_integer_micro():
+    fn = _load_fn()
+    c = sqlite3.connect(":memory:")
+    c.execute("CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc REAL DEFAULT 0.0)")
+    c.execute("INSERT INTO balances VALUES('pk1', 2.5)")
+    c.commit()
+
+    fn(c)  # legit migration path preserved
+
+    btype = c.execute("SELECT type FROM pragma_table_info('balances') WHERE name='balance_rtc'").fetchone()[0]
+    assert btype == "INTEGER"
+    assert c.execute("SELECT balance_rtc FROM balances WHERE miner_pk='pk1'").fetchone()[0] == 2_500_000


### PR DESCRIPTION
## Guard `_ensure_balance_micro_schema` against wiping the consensus balances ledger

Found during the **Step-3 pre-deploy migration audit** (dry-running every main migration against a snapshot of the production DB).

### The landmine
`sophia_elya_service.py` sets `DB_PATH = "./rustchain_v2.db"` (relative) and, when run as `__main__`, calls `_ensure_balance_micro_schema()`. For a non-INTEGER `balance_rtc` that function does:
```python
ALTER TABLE balances RENAME TO balances_legacy_real
CREATE TABLE balances (miner_pk TEXT PRIMARY KEY, balance_rtc INTEGER DEFAULT 0)   # 2 columns
INSERT ... SELECT miner_pk, balance_rtc*MICRO FROM balances_legacy_real
DROP TABLE balances_legacy_real
```
But the **consensus** `balances` ledger is:
```sql
balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER ... CHECK(amount_i64>=0),
          miner_pk TEXT, balance_rtc REAL DEFAULT 0.0, coinbase_address TEXT)
```
`balance_rtc` is **REAL** (not INTEGER) → the rebuild **would fire**, and it would **drop `miner_id`/`amount_i64`/`coinbase_address` and wipe every balance** (it repopulates from the typically-zero `balance_rtc` REAL column, not the canonical `amount_i64`).

### Current exposure
**Not currently triggered** — recon confirmed no systemd service or cron runs `sophia_elya_service.py`, and prod's Oct-2025 copy doesn't even contain this migration (it's new in `main`). But running `python3 sophia_elya_service.py` from the node dir would detonate it.

### The fix
Add a safety guard: if `balances` carries the consensus money columns (`amount_i64` or `coinbase_address`), **leave the table completely untouched**. The genuine Sophia 2-column micro-schema migration path is unchanged.

### Tests
- consensus-shaped `balances` → byte-identical after (amount_i64 preserved, no rows lost)
- genuine Sophia `balances` → still migrates `REAL → INTEGER` micro (2.5 → 2,500,000)

`py_compile` + fetchall guard green (baseline content-identical).

### Step-3 audit summary (context)
Node-startup migrations were dry-run against a `.backup` of the live 268 MB DB: **70 tables → 70, 1,590,693 rows → 1,590,693**, only `epoch_enroll` (weight REAL→INT) and `miner_header_keys` (composite PK, #6905) changed — both intended, no data lost. This PR closes the one catastrophic landmine that audit surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
