### PR TITLE
fix: add from __future__ import annotations for Python 3.9 compat

### DIFF
--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -7,6 +7,8 @@ Includes Zephyr (RandomX) dual-mining integration.
 See: https://github.com/Scottcjn/rustchain-bounties/issues/461
 """
 
+from __future__ import annotations
+
 import os
 import sys
 import time


### PR DESCRIPTION
## Summary

The Windows miner module (`miners/windows/rustchain_windows_miner.py`) uses PEP 604 union syntax (`dict | None`) in return type annotations without `from __future__ import annotations`.

On Python 3.9 (which `pyproject.toml` declares as `requires-python = '>=3.9'`), these annotations are evaluated at import time and raise:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

This blocks any CI or installer path that imports the Windows miner module on Python 3.9.

## Fix

Added `from __future__ import annotations` at the top of `rustchain_windows_miner.py` (after the module docstring). This defers annotation evaluation to string form, making the PEP 604 syntax available on Python 3.9 without any runtime evaluation.

## Verification

```bash
python3.9 -c 'from miners.windows.rustchain_windows_miner import RustchainMiner'
```

Before fix: `TypeError`. After fix: imports cleanly.

## Related

Fixes #6910.