### PR TITLE
bcos: broaden recognition while retroactively honoring scores

### DIFF
--- a/tests/test_bcos_recognition_broadening.py
+++ b/tests/test_bcos_recognition_broadening.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: MIT
+"""Regression tests for BCOS recognition broadening (2026-06).
+
+These lock in two properties:
+
+1. The engine now *recognizes* more source languages, OSI license identifiers,
+   and test/CI conventions than the legacy hard-coded sets.
+2. Broadening never *lowers* a repository's score — the SPDX subscore is the
+   max of the legacy and extended views, retroactively honoring prior scores.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def bcos_engine_module():
+    module_path = Path(__file__).resolve().parents[1] / "tools" / "bcos_engine.py"
+    spec = importlib.util.spec_from_file_location("bcos_engine", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extended_extension_set_is_a_superset_of_legacy(bcos_engine_module):
+    legacy = bcos_engine_module.CODE_EXTS
+    extended = bcos_engine_module.CODE_EXTS_EXTENDED
+    assert legacy <= extended
+    # A few languages the legacy set never recognized.
+    for ext in (".scala", ".php", ".ex", ".vue", ".clj"):
+        assert ext in extended
+        assert ext not in legacy
+
+
+def test_osi_license_list_recognizes_more_identifiers(bcos_engine_module):
+    osi = bcos_engine_module.OSI_LICENSES
+    for lic in ("EPL-2.0", "CC0-1.0", "MPL-2.0", "GPL-3.0-or-later",
+                "Apache-2.0 WITH LLVM-exception"):
+        assert lic in osi
+
+
+def test_spdx_score_never_below_legacy_view(bcos_engine_module, tmp_path):
+    """A repo with un-headered files in a newly-recognized language must not
+    score lower than the legacy engine (which ignored that language)."""
+    # Legacy-recognized file WITH an SPDX header -> legacy view = 100% coverage.
+    (tmp_path / "main.py").write_text("# SPDX-License-Identifier: MIT\nprint(1)\n")
+    # Newly-recognized language file WITHOUT a header. Naively counting it would
+    # drag coverage below 100%, but the max-guard must protect the legacy score.
+    (tmp_path / "app.scala").write_text("object App { def main(a: Array[String]) = () }\n")
+
+    engine = bcos_engine_module.BCOSEngine(str(tmp_path), commit_sha="abc123")
+    engine._check_spdx()
+    lic = engine.checks["license_compliance"]
+
+    assert lic["spdx_coverage_pct_legacy"] == 100.0
+    # Extended view sees the unheadered .scala file -> lower raw coverage...
+    assert lic["spdx_coverage_pct_extended"] < 100.0
+    # ...but the scored SPDX points must equal the legacy (full) credit.
+    # license_compliance = spdx_pts (max view) + dep_score; isolate spdx_pts.
+    assert engine.score_breakdown["license_compliance"] >= 10
+
+
+def test_test_evidence_recognizes_makefile_and_inline_rust(bcos_engine_module, tmp_path):
+    # Makefile with a `test:` target — a real harness the fixed list missed.
+    (tmp_path / "Makefile").write_text("build:\n\tcc x.c\ntest:\n\t./run-tests\n")
+    # Idiomatic inline Rust test in a normal source file (not *_test.rs).
+    (tmp_path / "lib.rs").write_text(
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\n"
+        "#[cfg(test)]\nmod tests { #[test] fn t() { assert_eq!(2, 1 + 1); } }\n"
+    )
+
+    engine = bcos_engine_module.BCOSEngine(str(tmp_path), commit_sha="abc123")
+    engine._check_test_evidence()
+    ev = engine.checks["test_evidence"]
+
+    assert ev["passed"] is True
+    assert "Makefile[test]" in ev["test_configs"]
+    assert ev["test_file_count"] >= 1  # inline Rust test recognized
+    assert engine.score_breakdown["test_evidence"] >= 5
+
+
+def test_npm_init_placeholder_test_script_is_ignored(bcos_engine_module, tmp_path):
+    (tmp_path / "package.json").write_text(
+        '{"scripts": {"test": "echo \\"Error: no test specified\\" && exit 1"}}'
+    )
+    engine = bcos_engine_module.BCOSEngine(str(tmp_path), commit_sha="abc123")
+    engine._check_test_evidence()
+    assert "package.json[scripts.test]" not in engine.checks["test_evidence"]["test_configs"]

--- a/tools/bcos_engine.py
+++ b/tools/bcos_engine.py
@@ -57,10 +57,26 @@ SCORE_WEIGHTS = {
 TIER_THRESHOLDS = {"L0": 40, "L1": 60, "L2": 80}
 
 # SPDX detection (reused from bcos_spdx_check.py)
+# CODE_EXTS is the *legacy* recognition set. It is kept frozen so historical
+# scores remain reproducible — the SPDX subscore is computed against both this
+# set and the broadened set below, and the HIGHER of the two is used, so a
+# repository can never score lower than the legacy engine would have given it
+# (see _check_spdx). This is how recognition is broadened while retroactively
+# honoring the established scoring system.
 CODE_EXTS = {
     ".py", ".sh", ".js", ".ts", ".tsx", ".jsx", ".rs",
     ".c", ".cc", ".cpp", ".h", ".hpp", ".go", ".rb",
     ".java", ".kt", ".swift", ".lua", ".zig",
+}
+# Broadened (2026-06): additional real source-language extensions so projects
+# written in languages the legacy set never listed get recognized. Only ever
+# applied via max(legacy, broadened) so it cannot reduce an existing score.
+CODE_EXTS_EXTENDED = CODE_EXTS | {
+    ".mjs", ".cjs", ".pyi", ".bash", ".zsh", ".sql", ".scala", ".sc",
+    ".php", ".cs", ".fs", ".m", ".mm", ".dart", ".ex", ".exs", ".erl",
+    ".clj", ".cljs", ".cljc", ".hs", ".pl", ".pm", ".r", ".jl", ".vue",
+    ".svelte", ".sol", ".v", ".sv", ".nim", ".cr", ".groovy", ".ml",
+    ".mli", ".f90", ".f95", ".pas", ".d", ".vala",
 }
 SPDX_RE = re.compile(r"SPDX-License-Identifier:\s*[A-Za-z0-9.\-+]+")
 
@@ -71,6 +87,21 @@ OSI_LICENSES = {
     "Unlicense", "0BSD", "Artistic-2.0", "BSL-1.0", "PostgreSQL",
     "GPL-2.0-only", "GPL-3.0-only", "Apache-2.0 OR MIT",
     "MIT OR Apache-2.0", "Zlib", "WTFPL",
+    # Broadened recognition (2026-06): additional valid SPDX identifiers so
+    # legitimately-licensed dependencies stop being under-credited. Purely
+    # additive — matching is substring-based, so this can only raise or hold
+    # a repo's dependency-license score, never lower it.
+    "MIT-0", "BSD-3-Clause-Clear", "BSD-4-Clause", "BSD-Source-Code",
+    "Python-2.0", "PSF-2.0", "CC0-1.0", "CC-BY-4.0", "CC-BY-3.0",
+    "EPL-1.0", "EPL-2.0", "CDDL-1.0", "CDDL-1.1", "MPL-1.1",
+    "GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.1-only", "LGPL-2.1-or-later",
+    "LGPL-3.0-only", "LGPL-3.0-or-later", "AGPL-3.0-only", "AGPL-3.0-or-later",
+    "Apache-1.1", "Artistic-1.0", "NCSA", "Zlib-acknowledgement",
+    "BlueOak-1.0.0", "Unicode-DFS-2015", "Unicode-DFS-2016", "Unicode-3.0",
+    "OFL-1.1", "EUPL-1.2", "MS-PL", "MS-RL", "OpenSSL", "Vim",
+    # Common SPDX "WITH exception" forms seen in real dependency metadata.
+    "Apache-2.0 WITH LLVM-exception", "GPL-2.0 WITH Classpath-exception-2.0",
+    "GPL-3.0 WITH GCC-exception-3.1", "GPL-2.0-or-later WITH Bison-exception-2.2",
 }
 
 
@@ -177,47 +208,71 @@ class BCOSEngine:
     # ── Check 1: License Compliance (20 pts) ──────────────────────
 
     def _check_spdx(self):
-        """Check SPDX headers on code files + dependency license scan."""
-        code_files = []
-        spdx_present = 0
-        spdx_missing = []
+        """Check SPDX headers on code files + dependency license scan.
 
-        for ext in CODE_EXTS:
-            for f in self.repo_path.rglob(f"*{ext}"):
-                # Skip hidden dirs, node_modules, venvs
-                parts = f.relative_to(self.repo_path).parts
-                if any(p.startswith(".") or p in ("node_modules", "venv", ".venv", "__pycache__", "build", "dist") for p in parts):
-                    continue
-                code_files.append(f)
+        Recognition is computed against both the legacy extension set and the
+        broadened set, and the SPDX subscore is the MAX of the two. This lets
+        the engine recognize more source languages without ever scoring a repo
+        lower than the legacy engine would have — honoring prior scores.
+        """
 
-        for f in code_files:
-            try:
-                with open(f, "r", encoding="utf-8", errors="replace") as fh:
-                    head = fh.read(2048)
-                if SPDX_RE.search(head):
-                    spdx_present += 1
-                else:
-                    spdx_missing.append(str(f.relative_to(self.repo_path)))
-            except Exception:
-                pass
+        def _scan(exts: set) -> tuple:
+            present = 0
+            missing = []
+            files = []
+            for ext in exts:
+                for f in self.repo_path.rglob(f"*{ext}"):
+                    parts = f.relative_to(self.repo_path).parts
+                    if any(p.startswith(".") or p in ("node_modules", "venv", ".venv", "__pycache__", "build", "dist") for p in parts):
+                        continue
+                    files.append(f)
+            for f in files:
+                try:
+                    with open(f, "r", encoding="utf-8", errors="replace") as fh:
+                        head = fh.read(2048)
+                    if SPDX_RE.search(head):
+                        present += 1
+                    else:
+                        missing.append(str(f.relative_to(self.repo_path)))
+                except Exception:
+                    pass
+            total = len(files)
+            pct = (present / total * 100) if total > 0 else 100
+            return present, total, pct, missing
 
-        total = len(code_files)
-        pct = (spdx_present / total * 100) if total > 0 else 100
+        legacy_present, legacy_total, legacy_pct, legacy_missing = _scan(CODE_EXTS)
+        ext_present, ext_total, ext_pct, ext_missing = _scan(CODE_EXTS_EXTENDED)
+
+        # Honor prior scoring: never let the broadened recognition lower the
+        # SPDX subscore. Report the broadened coverage for transparency but
+        # score on whichever view is more favorable to the repo.
+        legacy_spdx_pts = min(10, int(legacy_pct / 10))
+        ext_spdx_pts = min(10, int(ext_pct / 10))
+        spdx_pts = max(legacy_spdx_pts, ext_spdx_pts)
+
+        # Surface the view that was actually scored.
+        if ext_spdx_pts >= legacy_spdx_pts:
+            present, total, pct, missing = ext_present, ext_total, ext_pct, ext_missing
+        else:
+            present, total, pct, missing = legacy_present, legacy_total, legacy_pct, legacy_missing
 
         # Check dependency licenses via pip-licenses
         dep_score = self._check_dep_licenses()
 
         # Score: 10 pts for SPDX coverage, 10 pts for dep licenses
-        spdx_pts = min(10, int(pct / 10))
         total_pts = spdx_pts + dep_score
 
         self.checks["license_compliance"] = {
             "passed": pct >= 80 and dep_score >= 5,
             "spdx_coverage_pct": round(pct, 1),
+            "spdx_coverage_pct_legacy": round(legacy_pct, 1),
+            "spdx_coverage_pct_extended": round(ext_pct, 1),
             "code_files_total": total,
-            "spdx_present": spdx_present,
-            "spdx_missing_sample": spdx_missing[:10],
+            "code_files_total_extended": ext_total,
+            "spdx_present": present,
+            "spdx_missing_sample": missing[:10],
             "dep_license_score": dep_score,
+            "scored_view": "extended" if ext_spdx_pts >= legacy_spdx_pts else "legacy",
         }
         self.score_breakdown["license_compliance"] = min(total_pts, 20)
 
@@ -491,22 +546,50 @@ class BCOSEngine:
         ci_configs = []
 
         # Check for test directories
-        for name in ["tests", "test", "spec", "__tests__", "testing"]:
+        # Broadened (2026-06): added e2e/integration/unit/features conventions.
+        # Detection is additive — a repo can only gain recognition here.
+        for name in ["tests", "test", "spec", "__tests__", "testing",
+                     "e2e", "integration", "unit", "features"]:
             d = self.repo_path / name
             if d.is_dir():
                 test_dirs.append(name)
                 has_tests = True
                 test_files += sum(1 for _ in d.rglob("*test*"))
 
-        # Check for test files in root or src
+        # Check for test files in root or src.
+        # Broadened to recognize Java/Kotlin/C#/Ruby/Elixir/TSX test naming.
         for pattern in ["test_*.py", "*_test.py", "*_test.go", "*_test.rs",
-                        "*.test.js", "*.test.ts", "*.spec.js", "*.spec.ts"]:
+                        "*.test.js", "*.test.ts", "*.test.tsx", "*.test.jsx",
+                        "*.spec.js", "*.spec.ts", "*.spec.tsx", "*.spec.rb",
+                        "*_spec.rb", "*_test.exs", "*Test.java", "*Tests.java",
+                        "*Test.kt", "*Tests.cs", "*Test.cs", "*_test.cc",
+                        "*_test.cpp"]:
             test_files += len(list(self.repo_path.rglob(pattern)))
+
+        # Recognize idiomatic inline Rust tests (#[test] / #[cfg(test)]) which
+        # live in regular .rs source files, not separate *_test.rs files.
+        # Bounded scan so large repos stay fast. Additive recognition only.
+        if test_files == 0:
+            scanned = 0
+            for f in self.repo_path.rglob("*.rs"):
+                if any(p in ("target", ".git") for p in f.relative_to(self.repo_path).parts):
+                    continue
+                scanned += 1
+                if scanned > 400:
+                    break
+                try:
+                    head = f.read_text(encoding="utf-8", errors="replace")[:8192]
+                except Exception:
+                    continue
+                if "#[cfg(test)]" in head or "#[test]" in head:
+                    test_files += 1
+                    break
 
         if test_files > 0:
             has_tests = True
 
         # Check for CI configs
+        # Broadened with Woodpecker/Drone/Bitbucket/Buildkite/Cirrus.
         ci_files = [
             ".github/workflows",
             ".gitlab-ci.yml",
@@ -514,6 +597,11 @@ class BCOSEngine:
             "Jenkinsfile",
             ".circleci/config.yml",
             "azure-pipelines.yml",
+            ".woodpecker.yml",
+            ".drone.yml",
+            "bitbucket-pipelines.yml",
+            ".buildkite",
+            ".cirrus.yml",
         ]
         for cf in ci_files:
             p = self.repo_path / cf
@@ -521,9 +609,13 @@ class BCOSEngine:
                 ci_configs.append(cf)
 
         # Check for test runner configs
+        # Broadened with conftest/nox/vitest/playwright/rspec/phpunit/go-test.
         test_configs = []
         for name in ["pytest.ini", "setup.cfg", "tox.ini", "jest.config.js",
-                      "jest.config.ts", ".mocharc.yml", "karma.conf.js"]:
+                      "jest.config.ts", ".mocharc.yml", "karma.conf.js",
+                      "conftest.py", "noxfile.py", "vitest.config.ts",
+                      "vitest.config.js", "playwright.config.ts", ".rspec",
+                      "phpunit.xml", "phpunit.xml.dist", "Cargo.toml"]:
             if (self.repo_path / name).exists():
                 test_configs.append(name)
 
@@ -534,6 +626,29 @@ class BCOSEngine:
                 content = pyproject.read_text()
                 if "pytest" in content or "tool.pytest" in content:
                     test_configs.append("pyproject.toml[pytest]")
+            except Exception:
+                pass
+
+        # Recognize a `test` target/script in Make or package.json — a common
+        # signal of a real test harness that the fixed config list missed.
+        makefile = self.repo_path / "Makefile"
+        if not makefile.exists():
+            makefile = self.repo_path / "makefile"
+        if makefile.exists():
+            try:
+                if re.search(r"(?m)^test\s*:", makefile.read_text(errors="replace")):
+                    test_configs.append("Makefile[test]")
+            except Exception:
+                pass
+
+        pkg_json = self.repo_path / "package.json"
+        if pkg_json.exists():
+            try:
+                pkg = json.loads(pkg_json.read_text(errors="replace"))
+                test_script = (pkg.get("scripts") or {}).get("test", "")
+                # Ignore the npm-init placeholder that does nothing.
+                if test_script and "no test specified" not in test_script:
+                    test_configs.append("package.json[scripts.test]")
             except Exception:
                 pass
 


### PR DESCRIPTION
## Fix BCOS to better recognize — while retroactively honoring existing scores

Prompted by @aleag3000's honest reliability review (which included a real bug in our own BCOS badge generator, #6921/#6922), this broadens what the BCOS trust engine **recognizes**, under a hard invariant: **no repository can score lower than the legacy engine would have given it.**

### What's broadened
- **OSI license recognition** — ~35 more valid SPDX identifiers (EPL-2.0, CC0-1.0, MPL variants, `*-or-later` forms, `WITH`-exception forms). Substring-matched in the dependency check → purely additive (raise-or-hold).
- **Source-language recognition** — `CODE_EXTS_EXTENDED` adds ~35 languages the legacy set never listed (Scala, PHP, Elixir, Vue, Svelte, Clojure, OCaml, …). SPDX coverage is computed for **both** the legacy and extended views and the subscore is `max(legacy, extended)` — so recognizing more files can **never** drag a score down, it only surfaces more in the report.
- **Test/CI evidence** — more test dirs; Java/Kotlin/C#/Ruby/Elixir/TSX test naming; **inline Rust tests** (`#[cfg(test)]`/`#[test]`); more CI systems (Woodpecker/Drone/Bitbucket/Buildkite/Cirrus); conftest/nox/vitest/playwright/rspec/phpunit configs; and a `test` target in `Makefile` / `package.json` (npm-init placeholder ignored). All additive.

### Honoring the scoring system
The legacy `CODE_EXTS` set is kept frozen and the SPDX subscore takes the higher of the legacy vs. extended view. Every other change only adds detection paths. Net effect: scores can only **hold or rise** — historical/anchored scores are preserved.

### Tests
`tests/test_bcos_recognition_broadening.py` locks in the superset relation, the broadened OSI list, the **never-below-legacy** SPDX guarantee (un-headered file in a newly-recognized language must not lower the score), inline-Rust + Makefile test recognition, and the npm-init placeholder exclusion.

```
23 passed  (5 new + 18 existing BCOS engine/spdx tests)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
