### PR TITLE
fix(ci): pass GITHUB_TOKEN to rtc-reward so merge rewards actually run

### DIFF
--- a/.github/workflows/rtc-reward.yml
+++ b/.github/workflows/rtc-reward.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Award RTC to contributor
         continue-on-error: true  # rewards are best-effort; never gate CI
         uses: Scottcjn/rustchain-bounties/actions/rtc-reward@main
+        env:
+          # The action reads GITHUB_TOKEN from env; without this it crashed on
+          # every merge ("Error: GITHUB_TOKEN not set") and paid no one, masked
+          # by continue-on-error. Pass the workflow token explicitly.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           node-url: https://50.28.86.131
           amount: 5


### PR DESCRIPTION
## Fix: PR-merge RTC rewards never actually ran

While paying @aleag3000 for six merged reliability PRs, I found the auto-reward had **silently paid no one**. Every `rtc-reward.yml` run on PR merge crashed with:

```
Error: GITHUB_TOKEN not set
```

The `rtc-reward` action reads `GITHUB_TOKEN` from its environment, but the workflow never set it. `continue-on-error: true` then masked the crash as a green "success", so the failure was invisible — contributors merged PRs and received nothing.

### Fix
Pass the token explicitly:
```yaml
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```
Reward stays best-effort (`continue-on-error` retained) so it still never gates CI.

### Heads-up (separate from this fix)
The action extracts the payout wallet from the **PR body** via `RTC[0-9a-fA-F]{36,44}`. Contributors who only put their wallet in a comment (or use a username placeholder) won't be auto-paid even after this fix — they need the RTC address in the PR description. Worth surfacing in CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
