### PR TITLE
fix(ci): rtc-reward node-url -> rustchain.org (valid TLS cert)

### DIFF
--- a/.github/workflows/rtc-reward.yml
+++ b/.github/workflows/rtc-reward.yml
@@ -31,7 +31,7 @@ jobs:
           # by continue-on-error. Pass the workflow token explicitly.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          node-url: https://50.28.86.131
+          node-url: https://rustchain.org
           amount: 5
           wallet-from: founder_community
           admin-key: ${{ secrets.RTC_ADMIN_KEY }}


### PR DESCRIPTION
Bare IP `https://50.28.86.131` fails TLS validation from GitHub runners (`HTTP 000`). `https://rustchain.org` is the same node with a valid cert and exposes `/wallet/transfer`. Final piece of the merge-reward fix (with #6930 token + rustchain-bounties#13275 contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)