### PR TITLE
feat(tools): cve-lite — stdlib-only CVE/OWASP-A06 dependency scanner

### DIFF
--- a/tests/test_cve_lite.py
+++ b/tests/test_cve_lite.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: MIT
+"""Tests for tools/cve_lite.py — parsers, severity mapping, and scan flow.
+
+Network is never touched: OSV calls are monkeypatched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def cve():
+    p = Path(__file__).resolve().parents[1] / "tools" / "cve_lite.py"
+    spec = importlib.util.spec_from_file_location("cve_lite", p)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_parse_requirements(cve):
+    out = cve.parse_requirements(
+        "requests==2.20.0\n# comment\nflask\n-r other.txt\ndjango==3.2.1  # pin\n"
+    )
+    assert ("PyPI", "requests", "2.20.0") in out
+    assert ("PyPI", "django", "3.2.1") in out
+    assert ("PyPI", "flask", None) in out
+    assert all(name != "other.txt" for _, name, _ in out)
+
+
+def test_parse_package_json_only_exact_versions(cve):
+    out = cve.parse_package_json('{"dependencies":{"lodash":"4.17.11","x":"^1.0.0"},'
+                                 '"devDependencies":{"jest":"29.0.0"}}')
+    assert ("npm", "lodash", "4.17.11") in out
+    assert ("npm", "jest", "29.0.0") in out
+    # caret range is not an exact pin -> version None, still surfaced
+    assert ("npm", "x", None) in out
+
+
+def test_parse_package_lock_v2_and_v1(cve):
+    v2 = '{"packages":{"":{"name":"root"},"node_modules/foo":{"version":"1.2.3"}}}'
+    assert ("npm", "foo", "1.2.3") in cve.parse_package_lock(v2)
+    v1 = '{"dependencies":{"bar":{"version":"0.9.0"}}}'
+    assert ("npm", "bar", "0.9.0") in cve.parse_package_lock(v1)
+
+
+def test_parse_cargo_and_go(cve):
+    cargo = ('[[package]]\nname = "serde"\nversion = "1.0.0"\n'
+             'source = "registry+https://github.com/rust-lang/crates.io-index"\n')
+    assert ("crates.io", "serde", "1.0.0") in cve.parse_cargo_lock(cargo)
+    go = "module x\n\nrequire github.com/foo/bar v1.4.2\n"
+    assert ("Go", "github.com/foo/bar", "v1.4.2") in cve.parse_go_mod(go)
+
+
+def test_cargo_skips_git_and_workspace_crates(cve):
+    text = (
+        '[[package]]\nname = "registrydep"\nversion = "1.0.0"\n'
+        'source = "registry+https://github.com/rust-lang/crates.io-index"\n\n'
+        '[[package]]\nname = "gitdep"\nversion = "0.1.0"\n'
+        'source = "git+https://github.com/x/gitdep#abc"\n\n'
+        '[[package]]\nname = "myworkspacecrate"\nversion = "0.0.1"\n'  # no source
+    )
+    out = cve.parse_cargo_lock(text)
+    assert ("crates.io", "registrydep", "1.0.0") in out
+    assert all(n != "gitdep" for _, n, _ in out)            # git source skipped
+    assert all(n != "myworkspacecrate" for _, n, _ in out)  # local crate skipped
+
+
+def test_requirements_extras_are_pinned(cve):
+    out = cve.parse_requirements("requests[security]==2.20.0\n")
+    assert ("PyPI", "requests", "2.20.0") in out  # extras must not break pin detection
+
+
+def test_pyproject_optional_dependencies_parsed(cve):
+    text = (
+        "[project]\n"
+        'dependencies = ["requests==2.20.0"]\n'
+        "\n[project.optional-dependencies]\n"
+        'test = ["pytest==7.0.0", "coverage>=6.0"]\n'
+    )
+    out = cve.parse_pyproject(text)
+    assert ("PyPI", "pytest", "7.0.0") in out      # optional-deps group pinned
+    assert ("PyPI", "coverage", None) in out       # range -> unpinned
+
+
+def test_cvss_rejects_vector_without_scope(cve):
+    # A vector missing S must be rejected (None), not silently assumed S:U,
+    # so it falls through to UNKNOWN and fails closed.
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/C:H/I:H/A:H") is None
+
+
+def test_cvss3_calculator_known_vectors(cve):
+    # Canonical FIRST.org examples.
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H") == 9.8
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H") == 7.5
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:N/A:N") == 1.8
+    # Scope-changed inflates the score.
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H") == 10.0
+    # Malformed / incomplete vector -> None, not a crash.
+    assert cve._cvss3_base_from_vector("CVSS:3.1/AV:N/oops") is None
+
+
+def test_severity_from_cvss_and_label(cve):
+    crit = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    assert cve.extract_severity({"severity": [{"type": "CVSS_V3", "score": crit}]}) == "CRITICAL"
+    assert cve.extract_severity({"severity": [{"score": "7.5"}]}) == "HIGH"
+    assert cve.extract_severity({"severity": [{"score": "5.0"}]}) == "MEDIUM"
+    # GHSA label normalization (MODERATE -> MEDIUM) when no CVSS vector present.
+    assert cve.extract_severity({"database_specific": {"severity": "MODERATE"}}) == "MEDIUM"
+    assert cve.extract_severity({"database_specific": {"severity": "LOW"}}) == "LOW"
+    assert cve.extract_severity({}) == "UNKNOWN"
+
+
+def test_severity_rank_orders_worst_first(cve):
+    assert cve._severity_rank("CRITICAL") < cve._severity_rank("HIGH") < cve._severity_rank("LOW")
+
+
+def test_discover_dedupes_and_separates_unpinned(cve, tmp_path):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\nflask\n")
+    sub = tmp_path / "svc"
+    sub.mkdir()
+    (sub / "requirements.txt").write_text("requests==2.20.0\n")  # dup across files
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "requirements.txt").write_text("evil==6.6.6\n")  # must be skipped
+    pinned, unpinned = cve.discover_dependencies(str(tmp_path))
+    assert ("PyPI", "requests", "2.20.0") in pinned
+    assert pinned.count(("PyPI", "requests", "2.20.0")) == 1  # deduped
+    assert ("PyPI", "flask") in unpinned
+    assert all(n != "evil" for _, n, _ in pinned)  # node_modules skipped
+
+
+def test_scan_offline_skips_network(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+
+    def boom(*a, **k):
+        raise AssertionError("network must not be touched in offline mode")
+
+    monkeypatch.setattr(cve, "query_osv_batch", boom)
+    report = cve.scan(str(tmp_path), offline=True)
+    assert report["offline"] is True
+    assert report["scanned"] == 1
+    assert report["vulnerabilities"] == []
+
+
+def test_scan_reports_vuln_and_threshold(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    dep = ("PyPI", "requests", "2.20.0")
+    monkeypatch.setattr(cve, "query_osv_batch", lambda deps, timeout: {dep: ["GHSA-x"]})
+    monkeypatch.setattr(cve, "fetch_vuln_detail",
+                        lambda vid, timeout: {"id": vid, "summary": "boom",
+                                              "severity": [{"score": "9.8"}]})
+    report = cve.scan(str(tmp_path), severity_threshold="HIGH")
+    assert len(report["vulnerabilities"]) == 1
+    v = report["vulnerabilities"][0]
+    assert v["severity"] == "CRITICAL"
+    assert v["at_or_above_threshold"] is True
+
+
+def test_scan_below_threshold_not_flagged(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    dep = ("PyPI", "requests", "2.20.0")
+    monkeypatch.setattr(cve, "query_osv_batch", lambda deps, timeout: {dep: ["GHSA-y"]})
+    monkeypatch.setattr(cve, "fetch_vuln_detail",
+                        lambda vid, timeout: {"id": vid, "severity": [{"score": "3.1"}]})
+    report = cve.scan(str(tmp_path), severity_threshold="HIGH")
+    assert report["vulnerabilities"][0]["severity"] == "LOW"
+    assert report["vulnerabilities"][0]["at_or_above_threshold"] is False
+
+
+def test_scan_handles_osv_unavailable(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+
+    def unavailable(deps, timeout):
+        raise cve.OSVUnavailable("connection refused")
+
+    monkeypatch.setattr(cve, "query_osv_batch", unavailable)
+    report = cve.scan(str(tmp_path))
+    assert report["osv_available"] is False
+    assert "unavailable" in report["note"].lower()
+
+
+def test_pyproject_only_double_equals_is_pinned(cve):
+    text = (
+        "[project]\n"
+        'dependencies = ["requests==2.20.0", "flask>=1.0", "click"]\n'
+        "\n[tool.poetry.dependencies]\n"
+        'python = "^3.9"\n'
+        'django = "^3.2.1"\n'
+        'urllib3 = "==1.25.0"\n'
+    )
+    out = cve.parse_pyproject(text)
+    assert ("PyPI", "requests", "2.20.0") in out          # == -> pinned
+    assert ("PyPI", "flask", None) in out                 # >= -> unpinned
+    assert ("PyPI", "click", None) in out                 # bare -> unpinned
+    assert ("PyPI", "django", None) in out                # poetry caret -> unpinned
+    assert ("PyPI", "urllib3", "1.25.0") in out           # poetry == -> pinned
+    assert all(n != "python" for _, n, _ in out)          # python requirement skipped
+
+
+def test_package_lock_v1_nested(cve):
+    lock = ('{"dependencies":{"a":{"version":"1.0.0",'
+            '"dependencies":{"b":{"version":"2.0.0"}}}}}')
+    out = cve.parse_package_lock(lock)
+    assert ("npm", "a", "1.0.0") in out
+    assert ("npm", "b", "2.0.0") in out  # transitive recursion
+
+
+def test_batch_truncation_fails_closed(cve, monkeypatch):
+    # OSV returns fewer results than queries -> must raise, not drop deps.
+    monkeypatch.setattr(cve, "_http_json", lambda url, payload, timeout: {"results": []})
+    with pytest.raises(cve.OSVUnavailable):
+        cve.query_osv_batch([("PyPI", "x", "1.0.0")], timeout=5)
+
+
+def test_confirmed_vuln_with_failed_detail_fails_closed(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    dep = ("PyPI", "requests", "2.20.0")
+    monkeypatch.setattr(cve, "query_osv_batch", lambda deps, timeout: {dep: ["GHSA-x"]})
+    # detail fetch failed -> severity UNKNOWN, but it is a CONFIRMED vuln.
+    monkeypatch.setattr(cve, "fetch_vuln_detail",
+                        lambda vid, timeout: {"id": vid, "_fetch_failed": True})
+    report = cve.scan(str(tmp_path), severity_threshold="LOW")
+    v = report["vulnerabilities"][0]
+    assert v["severity"] == "UNKNOWN"
+    assert v["detail_unavailable"] is True
+    assert v["at_or_above_threshold"] is True  # fail closed
+    assert report["detail_fetch_failures"] == 1
+
+
+def test_online_only_unpinned_is_not_silent_clean(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("flask\n")  # no exact pin
+
+    def boom(*a, **k):
+        raise AssertionError("should not query OSV with nothing pinned")
+
+    monkeypatch.setattr(cve, "query_osv_batch", boom)
+    report = cve.scan(str(tmp_path))  # online
+    assert report["scanned"] == 0
+    assert "unpinned" in report["note"].lower()
+
+
+def test_invalid_threshold_defaults_to_low(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    dep = ("PyPI", "requests", "2.20.0")
+    monkeypatch.setattr(cve, "query_osv_batch", lambda deps, timeout: {dep: ["GHSA-y"]})
+    monkeypatch.setattr(cve, "fetch_vuln_detail",
+                        lambda vid, timeout: {"id": vid, "severity": [{"score": "3.1"}]})
+    # bogus threshold defaults to LOW, so a LOW finding IS flagged (and a
+    # fall-through rank bug would also flag it — this pins the default path)
+    report = cve.scan(str(tmp_path), severity_threshold="BOGUS")
+    assert report["vulnerabilities"][0]["severity"] == "LOW"
+    assert report["vulnerabilities"][0]["at_or_above_threshold"] is True  # default LOW
+
+
+def test_main_fails_closed_when_osv_unavailable_online(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    monkeypatch.setattr(cve, "query_osv_batch",
+                        lambda deps, timeout: (_ for _ in ()).throw(cve.OSVUnavailable("down")))
+    assert cve.main(["scan", str(tmp_path), "--json"]) == 1   # online + unavailable -> fail closed
+    assert cve.main(["scan", str(tmp_path), "--offline", "--json"]) == 0  # offline opt-out -> 0
+
+
+def test_main_exit_codes(cve, tmp_path, monkeypatch):
+    (tmp_path / "requirements.txt").write_text("requests==2.20.0\n")
+    # clean offline scan -> 0
+    assert cve.main(["scan", str(tmp_path), "--offline", "--json"]) == 0
+    # bad path -> 2
+    assert cve.main(["scan", str(tmp_path / "nope")]) == 2
+    # vuln at threshold -> 1
+    dep = ("PyPI", "requests", "2.20.0")
+    monkeypatch.setattr(cve, "query_osv_batch", lambda deps, timeout: {dep: ["GHSA-z"]})
+    monkeypatch.setattr(cve, "fetch_vuln_detail",
+                        lambda vid, timeout: {"id": vid, "severity": [{"score": "9.0"}]})
+    assert cve.main(["scan", str(tmp_path), "--severity", "HIGH", "--json"]) == 1

--- a/tools/cve_lite.py
+++ b/tools/cve_lite.py
@@ -1,0 +1,552 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""cve-lite — a tiny, dependency-free CVE / OWASP-A06 vulnerability scanner.
+
+Why this exists
+---------------
+BCOS' vulnerability check shells out to ``pip-audit`` / ``osv-scanner``, which
+must be installed separately and pull large dependency trees. ``cve-lite`` does
+the same core job — find known-vulnerable dependencies (OWASP A06: *Vulnerable
+and Outdated Components*) — using **only the Python standard library**. It reads
+common manifests, asks the free OSV.dev API, and prints findings. That makes it
+portable enough to bundle with ``clawrtc`` or run on a vintage box where you
+can't ``pip install`` a scanner.
+
+Ecosystems: PyPI (requirements.txt, pyproject.toml), npm (package.json,
+package-lock.json), crates.io (Cargo.lock), Go (go.mod).
+
+Usage
+-----
+Run directly (no install step needed — that's the point):
+
+    python cve_lite.py scan [PATH] [--json] [--severity LOW|MEDIUM|HIGH|CRITICAL]
+                            [--offline] [--timeout SECONDS]
+
+(If packaged with a console-script entry it is also exposed as ``cve-lite``.)
+
+Exit codes: 0 = clean (or only sub-threshold findings), 1 = vulnerabilities at
+or above the severity threshold, 2 = usage / input error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from typing import Dict, List, Optional, Tuple
+
+OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
+OSV_VULN_URL = "https://api.osv.dev/v1/vulns/"
+
+# Ordered worst-first so severity comparisons are simple index math.
+SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW", "UNKNOWN"]
+
+
+def _severity_rank(sev: str) -> int:
+    """Lower rank = more severe. UNKNOWN sorts last."""
+    try:
+        return SEVERITY_ORDER.index(sev.upper())
+    except ValueError:
+        return len(SEVERITY_ORDER)
+
+
+# ── Manifest parsing ────────────────────────────────────────────────
+# Each parser yields (ecosystem, package_name, version) triples. Version may be
+# None when a manifest pins no exact version; OSV needs a version, so unpinned
+# entries are reported separately rather than silently dropped.
+
+# Accept an optional extras group, e.g. requests[security]==2.20.0
+_REQ_LINE = re.compile(r"^\s*([A-Za-z0-9._-]+)\s*(?:\[[A-Za-z0-9._,\s-]+\])?\s*==\s*([A-Za-z0-9._+!-]+)")
+
+
+def parse_requirements(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    out: List[Tuple[str, str, Optional[str]]] = []
+    for raw in text.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue  # skip options like -r, -e, --hash
+        m = _REQ_LINE.match(line)
+        if m:
+            out.append(("PyPI", m.group(1), m.group(2)))
+        else:
+            name = re.match(r"^([A-Za-z0-9._-]+)", line)
+            if name:
+                out.append(("PyPI", name.group(1), None))
+    return out
+
+
+def parse_pyproject(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    """Best-effort, regex-based (no toml dep) parse of dependency sections.
+
+    Only an exact ``==`` constraint counts as a pinned version. Ranges
+    (``>=``, ``~=``, ``^``, ``~``, ``*``) and poetry's bare ``"1.2.3"`` (which
+    means ``^1.2.3``) are treated as UNPINNED — their installed version is only
+    knowable from a lockfile, and querying OSV against a guessed version yields
+    false results. Parsing is scoped to ``*dependencies`` keys/sections so
+    unrelated config strings aren't misread as dependencies.
+    """
+    out: List[Tuple[str, str, Optional[str]]] = []
+
+    def add(name: str, rest: str) -> None:
+        m = re.match(r"^==\s*([0-9][A-Za-z0-9._+!-]*)$", rest.strip())
+        out.append(("PyPI", name, m.group(1) if m else None))
+
+    def add_array_items(arr: str) -> None:
+        for item in re.findall(r"""["']([^"']+)["']""", arr):
+            mm = re.match(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:\[[^\]]*\])?\s*(.*)$", item.strip())
+            if mm:
+                add(mm.group(1), mm.group(2))
+
+    # PEP 621: `dependencies = [...]` arrays (key ends in "dependencies").
+    for arr in re.findall(r"(?ims)^[ \t]*[\w.-]*dependencies\s*=\s*\[(.*?)\]", text):
+        add_array_items(arr)
+
+    # PEP 621 `[project.optional-dependencies]` table: each value is an array
+    # keyed by an arbitrary group name (test = [...], dev = [...]), which the
+    # `*dependencies = [...]` pattern above does not match.
+    for sect in re.findall(r"(?ims)^\[[\w.-]*optional-dependencies\][ \t]*\n(.*?)(?=^\[|\Z)", text):
+        for arr in re.findall(r"\[(.*?)\]", sect, re.DOTALL):
+            add_array_items(arr)
+
+    # Poetry tables: [tool.poetry.dependencies], [tool.poetry.group.*.dependencies].
+    # Poetry specs are ranges (bare "1.2.3" == "^1.2.3"), so all are unpinned
+    # unless written as an explicit ==; the exact source is poetry.lock.
+    for sect in re.findall(r"(?ims)^\[tool\.poetry[\w.]*dependencies\][ \t]*\n(.*?)(?=^\[|\Z)", text):
+        for line in sect.splitlines():
+            mm = re.match(r"""^\s*([A-Za-z0-9][A-Za-z0-9._-]*)\s*=\s*["']([^"']+)["']""", line)
+            if mm and mm.group(1).lower() != "python":
+                spec = mm.group(2).strip()
+                em = re.match(r"^==\s*([0-9][A-Za-z0-9._+!-]*)$", spec)
+                out.append(("PyPI", mm.group(1), em.group(1) if em else None))
+    return out
+
+
+def parse_package_json(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    out: List[Tuple[str, str, Optional[str]]] = []
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return out
+    for key in ("dependencies", "devDependencies", "optionalDependencies"):
+        for name, spec in (data.get(key) or {}).items():
+            ver = _exact_npm_version(spec)
+            out.append(("npm", name, ver))
+    return out
+
+
+def parse_package_lock(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    out: List[Tuple[str, str, Optional[str]]] = []
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return out
+    # lockfile v2/v3: {"packages": {"node_modules/foo": {"version": "1.2.3"}}}
+    for path, meta in (data.get("packages") or {}).items():
+        if not path or not isinstance(meta, dict):
+            continue
+        name = path.split("node_modules/")[-1]
+        ver = meta.get("version")
+        if name and ver:
+            out.append(("npm", name, ver))
+    # lockfile v1: {"dependencies": {"foo": {"version": "1.2.3",
+    #   "dependencies": {"bar": {...}}}}} — recurse so nested/transitive
+    # installed packages are reported, not just top-level.
+    def _walk_v1(deps: object) -> None:
+        if not isinstance(deps, dict):
+            return
+        for name, meta in deps.items():
+            if isinstance(meta, dict):
+                if meta.get("version"):
+                    out.append(("npm", name, meta["version"]))
+                _walk_v1(meta.get("dependencies"))
+
+    _walk_v1(data.get("dependencies"))
+    return out
+
+
+def _exact_npm_version(spec: object) -> Optional[str]:
+    """Return an exact semver pin, or None for ranges (^, ~, >=, *, x).
+
+    Range specs aren't a known installed version — only ``package-lock.json``
+    resolves those — so they're surfaced as unpinned rather than guessed at.
+    """
+    if not isinstance(spec, str):
+        return None
+    m = re.match(r"^=?v?([0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?)$", spec.strip())
+    return m.group(1) if m else None
+
+
+def parse_cargo_lock(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    """Parse Cargo.lock, emitting only packages sourced from the crates.io
+    registry. Git/path/workspace crates (different or no ``source``) have an
+    identity OSV can't match by name@version, so they're skipped to avoid
+    false positives."""
+    out: List[Tuple[str, str, Optional[str]]] = []
+    name = ver = source = None
+
+    def flush() -> None:
+        if name and ver and source and "crates.io-index" in source:
+            out.append(("crates.io", name, ver))
+
+    for line in text.splitlines():
+        line = line.strip()
+        if line == "[[package]]":
+            flush()
+            name = ver = source = None
+        elif line.startswith("name ="):
+            name = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("version ="):
+            ver = line.split("=", 1)[1].strip().strip('"')
+        elif line.startswith("source ="):
+            source = line.split("=", 1)[1].strip().strip('"')
+    flush()
+    return out
+
+
+def parse_go_mod(text: str) -> List[Tuple[str, str, Optional[str]]]:
+    out: List[Tuple[str, str, Optional[str]]] = []
+    for m in re.finditer(r"(?m)^\s*(?:require\s+)?([\w./-]+)\s+v([0-9][0-9A-Za-z.+-]*)", text):
+        path = m.group(1)
+        if path in ("require", "module", "go", "toolchain"):
+            continue
+        out.append(("Go", path, "v" + m.group(2)))
+    return out
+
+
+MANIFESTS = {
+    "requirements.txt": parse_requirements,
+    "requirements-dev.txt": parse_requirements,
+    "pyproject.toml": parse_pyproject,
+    "package.json": parse_package_json,
+    "package-lock.json": parse_package_lock,
+    "Cargo.lock": parse_cargo_lock,
+    "go.mod": parse_go_mod,
+}
+
+_SKIP_DIRS = {".git", "node_modules", "venv", ".venv", "__pycache__",
+              "build", "dist", "target", "vendor", ".tox"}
+
+
+def discover_dependencies(root: str) -> Tuple[List[Tuple[str, str, str]], List[Tuple[str, str]]]:
+    """Walk ``root`` and parse every recognized manifest.
+
+    Returns (pinned, unpinned): pinned is a deduped list of (ecosystem, name,
+    version); unpinned is (ecosystem, name) entries we couldn't version.
+    """
+    pinned: "dict[Tuple[str, str, str], None]" = {}
+    unpinned: "dict[Tuple[str, str], None]" = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")]
+        for fn in filenames:
+            parser = MANIFESTS.get(fn)
+            if not parser:
+                continue
+            try:
+                with open(os.path.join(dirpath, fn), "r", encoding="utf-8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            for eco, name, ver in parser(text):
+                if ver:
+                    pinned[(eco, name, ver)] = None
+                else:
+                    unpinned[(eco, name)] = None
+    return list(pinned), list(unpinned)
+
+
+# ── OSV client (stdlib only) ────────────────────────────────────────
+
+
+def _http_json(url: str, payload: Optional[dict], timeout: float) -> dict:
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        url, data=data, method="POST" if data else "GET",
+        headers={"Content-Type": "application/json", "User-Agent": "cve-lite/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 (fixed hosts)
+        return json.loads(resp.read().decode())
+
+
+def query_osv_batch(deps: List[Tuple[str, str, str]], timeout: float) -> Dict[Tuple[str, str, str], List[str]]:
+    """Return {dep: [vuln_id, ...]} for deps with known OSV vulnerabilities.
+
+    OSV's querybatch caps at 1000 queries/request; we chunk to stay safe and so
+    one network hiccup doesn't lose the whole scan.
+    """
+    found: Dict[Tuple[str, str, str], List[str]] = {}
+    CHUNK = 500
+    for i in range(0, len(deps), CHUNK):
+        chunk = deps[i:i + CHUNK]
+        queries = [{"package": {"name": n, "ecosystem": e}, "version": v} for (e, n, v) in chunk]
+        try:
+            resp = _http_json(OSV_BATCH_URL, {"queries": queries}, timeout)
+        except (urllib.error.URLError, TimeoutError, ValueError, OSError) as exc:
+            raise OSVUnavailable(str(exc)) from exc
+        results = resp.get("results", [])
+        # Fail closed: OSV must return exactly one result per query. A short or
+        # misaligned response would silently mark trailing deps as clean.
+        if len(results) != len(chunk):
+            raise OSVUnavailable(
+                f"OSV returned {len(results)} results for {len(chunk)} queries (misaligned)")
+        for dep, result in zip(chunk, results):
+            vulns = result.get("vulns") or []
+            if vulns:
+                found[dep] = [v.get("id") for v in vulns if v.get("id")]
+    return found
+
+
+def fetch_vuln_detail(vuln_id: str, timeout: float) -> dict:
+    try:
+        return _http_json(OSV_VULN_URL + vuln_id, None, timeout)
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        # Mark the failure so the caller can fail closed instead of treating a
+        # confirmed vulnerability as severity-UNKNOWN-and-therefore-passing.
+        return {"id": vuln_id, "_fetch_failed": True}
+
+
+class OSVUnavailable(Exception):
+    """Raised when the OSV API can't be reached (offline / network error)."""
+
+
+# GitHub Security Advisory labels use MODERATE; normalize to our scale.
+_GHSA_LABELS = {"CRITICAL": "CRITICAL", "HIGH": "HIGH", "MODERATE": "MEDIUM",
+                "MEDIUM": "MEDIUM", "LOW": "LOW"}
+
+
+def extract_severity(detail: dict) -> str:
+    """Map an OSV record to one of SEVERITY_ORDER.
+
+    Order of preference: an explicit CVSS base score (computed from the vector,
+    most precise), then a qualitative DB label (GHSA's MODERATE etc.).
+    """
+    best = None
+    for sev in detail.get("severity") or []:
+        score = _cvss_base(sev.get("score", ""))
+        if score is not None and (best is None or score > best):
+            best = score
+    if best is not None:
+        return _band(best)
+
+    db_sev = (detail.get("database_specific") or {}).get("severity")
+    if isinstance(db_sev, str):
+        mapped = _GHSA_LABELS.get(db_sev.upper())
+        if mapped:
+            return mapped
+    return "UNKNOWN"
+
+
+def _band(score: float) -> str:
+    """CVSS v3 qualitative band for a numeric base score."""
+    if score >= 9.0:
+        return "CRITICAL"
+    if score >= 7.0:
+        return "HIGH"
+    if score >= 4.0:
+        return "MEDIUM"
+    if score > 0.0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+def _cvss_base(score: str) -> Optional[float]:
+    """Return a CVSS base score from a bare number or a CVSS:3.x vector string."""
+    if not isinstance(score, str):
+        return None
+    s = score.strip()
+    if not s:
+        return None
+    if s.upper().startswith("CVSS:3") or "/AV:" in s.upper():
+        return _cvss3_base_from_vector(s)
+    try:  # bare numeric score (some DBs store "7.5")
+        val = float(s)
+        return val if 0.0 <= val <= 10.0 else None
+    except ValueError:
+        return None
+
+
+# CVSS v3.0/3.1 base-score metric weights (FIRST.org specification).
+_AV = {"N": 0.85, "A": 0.62, "L": 0.55, "P": 0.2}
+_AC = {"L": 0.77, "H": 0.44}
+_PR_U = {"N": 0.85, "L": 0.62, "H": 0.27}
+_PR_C = {"N": 0.85, "L": 0.68, "H": 0.5}
+_UI = {"N": 0.85, "R": 0.62}
+_CIA = {"N": 0.0, "L": 0.22, "H": 0.56}
+
+
+def _roundup(x: float) -> float:
+    """CVSS 3.1 roundup: smallest one-decimal number >= x (avoids fp drift)."""
+    import math
+    i = int(round(x * 100000))
+    if i % 10000 == 0:
+        return i / 100000.0
+    return (math.floor(i / 10000) + 1) / 10.0
+
+
+def _cvss3_base_from_vector(vector: str) -> Optional[float]:
+    """Compute the CVSS v3.x base score from its vector string."""
+    m = {}
+    for part in vector.split("/"):
+        if ":" in part:
+            k, _, v = part.partition(":")
+            m[k.upper()] = v.upper()
+    s_val = m.get("S")
+    if s_val not in ("U", "C"):
+        return None  # a valid CVSS v3 vector always specifies scope; reject
+    try:
+        scope_changed = s_val == "C"
+        pr_table = _PR_C if scope_changed else _PR_U
+        iss = 1 - (1 - _CIA[m["C"]]) * (1 - _CIA[m["I"]]) * (1 - _CIA[m["A"]])
+        if scope_changed:
+            impact = 7.52 * (iss - 0.029) - 3.25 * (iss - 0.02) ** 15
+        else:
+            impact = 6.42 * iss
+        expl = 8.22 * _AV[m["AV"]] * _AC[m["AC"]] * pr_table[m["PR"]] * _UI[m["UI"]]
+    except KeyError:
+        return None  # malformed / incomplete vector
+    if impact <= 0:
+        return 0.0
+    raw = (1.08 * (impact + expl)) if scope_changed else (impact + expl)
+    return _roundup(min(raw, 10.0))
+
+
+# ── Scan orchestration ──────────────────────────────────────────────
+
+
+def scan(root: str, severity_threshold: str = "LOW", offline: bool = False,
+         timeout: float = 20.0) -> dict:
+    # Guard library callers: an unrecognized threshold must not become a rank
+    # larger than every severity (which would flag everything). Default to LOW.
+    if not isinstance(severity_threshold, str) or severity_threshold.upper() not in SEVERITY_ORDER:
+        severity_threshold = "LOW"
+    severity_threshold = severity_threshold.upper()
+
+    pinned, unpinned = discover_dependencies(root)
+    report = {
+        "root": os.path.abspath(root),
+        "scanned": len(pinned),
+        "unpinned": [{"ecosystem": e, "package": n} for (e, n) in unpinned],
+        "offline": offline,
+        "vulnerabilities": [],
+        "osv_available": not offline,
+        "detail_fetch_failures": 0,
+    }
+    if offline or not pinned:
+        if offline:
+            report["note"] = "offline mode: dependency CVE lookup skipped"
+        elif unpinned:
+            report["note"] = (f"no pinned dependencies to check ({len(unpinned)} unpinned); "
+                              "provide a lockfile (package-lock.json, etc.) for exact versions")
+        else:
+            report["note"] = "no recognized dependency manifests found"
+        return report
+
+    try:
+        hits = query_osv_batch(pinned, timeout)
+    except OSVUnavailable as exc:
+        report["osv_available"] = False
+        report["note"] = f"OSV API unavailable: {exc}"
+        return report
+
+    thr = _severity_rank(severity_threshold)
+    for (eco, name, ver), vuln_ids in sorted(hits.items()):
+        for vid in vuln_ids:
+            detail = fetch_vuln_detail(vid, timeout)
+            detail_failed = bool(detail.get("_fetch_failed"))
+            if detail_failed:
+                report["detail_fetch_failures"] += 1
+            sev = extract_severity(detail)
+            # Fail closed: every entry here is a CONFIRMED OSV hit. If we can't
+            # classify its severity (UNKNOWN — no CVSS data, or the detail fetch
+            # failed) we must still trip the gate rather than silently pass it.
+            at_or_above = (_severity_rank(sev) <= thr) or (sev == "UNKNOWN")
+            report["vulnerabilities"].append({
+                "ecosystem": eco,
+                "package": name,
+                "version": ver,
+                "id": vid,
+                "severity": sev,
+                "summary": (detail.get("summary") or "").strip()[:200],
+                "aliases": detail.get("aliases", []),
+                "detail_unavailable": detail_failed,
+                "at_or_above_threshold": at_or_above,
+            })
+    report["vulnerabilities"].sort(key=lambda v: (_severity_rank(v["severity"]), v["package"]))
+    return report
+
+
+# ── CLI ─────────────────────────────────────────────────────────────
+
+
+def _print_human(report: dict, threshold: str) -> None:
+    vulns = report["vulnerabilities"]
+    print(f"cve-lite scan: {report['root']}")
+    print(f"  dependencies scanned: {report['scanned']}")
+    if report.get("unpinned"):
+        print(f"  unpinned (not checkable): {len(report['unpinned'])}")
+    if not report.get("osv_available", True):
+        print(f"  ⚠ {report.get('note', 'OSV lookup skipped')}")
+        return
+    if not vulns:
+        print("  ✓ no known vulnerabilities found")
+        return
+    counts: Dict[str, int] = {}
+    for v in vulns:
+        counts[v["severity"]] = counts.get(v["severity"], 0) + 1
+    summary = ", ".join(f"{counts[s]} {s}" for s in SEVERITY_ORDER if s in counts)
+    print(f"  ⚠ {len(vulns)} known vulnerabilities ({summary})")
+    print()
+    for v in vulns:
+        if v["at_or_above_threshold"]:
+            flag = "  (severity unknown — flagged fail-closed)" if v.get("detail_unavailable") or v["severity"] == "UNKNOWN" else ""
+        else:
+            flag = "  (below threshold)"
+        print(f"  [{v['severity']:<8}] {v['ecosystem']}:{v['package']}@{v['version']} — {v['id']}{flag}")
+        if v["summary"]:
+            print(f"             {v['summary']}")
+    print(f"\n  threshold: {threshold} (exit 1 if any finding at/above)")
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="cve-lite", description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command")
+    sp = sub.add_parser("scan", help="scan a directory for vulnerable dependencies")
+    sp.add_argument("path", nargs="?", default=".", help="project root (default: .)")
+    sp.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    sp.add_argument("--severity", default="LOW",
+                    choices=[s for s in SEVERITY_ORDER if s != "UNKNOWN"],
+                    help="fail (exit 1) on findings at or above this severity")
+    sp.add_argument("--offline", action="store_true",
+                    help="parse manifests but skip the OSV network lookup")
+    sp.add_argument("--timeout", type=float, default=20.0, help="per-request HTTP timeout (s)")
+    args = parser.parse_args(argv)
+
+    if args.command != "scan":
+        parser.print_help()
+        return 2
+    if not os.path.isdir(args.path):
+        print(f"cve-lite: not a directory: {args.path}", file=sys.stderr)
+        return 2
+
+    report = scan(args.path, args.severity, args.offline, args.timeout)
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        _print_human(report, args.severity)
+
+    if any(v["at_or_above_threshold"] for v in report["vulnerabilities"]):
+        return 1
+    # Fail closed: if we were online but OSV couldn't be reached, we cannot
+    # assert the project is clean. Offline mode is an explicit opt-out, so it
+    # stays exit 0.
+    if not args.offline and not report.get("osv_available", True):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## cve-lite — a stdlib-only CVE / OWASP-A06 dependency scanner

Our own lightweight vulnerability scanner for **OWASP A06: Vulnerable & Outdated Components**. BCOS' existing vuln check shells out to `pip-audit` / `osv-scanner` (separate installs, big dependency trees); **cve-lite uses only the Python standard library** plus the free OSV.dev API — portable enough to bundle with `clawrtc` or run on a vintage box where you can't `pip install` a scanner.

### What it does
```
python tools/cve_lite.py scan [PATH] [--json] [--severity LOW|MEDIUM|HIGH|CRITICAL] [--offline]
```
- **Ecosystems:** PyPI (`requirements.txt`, `pyproject.toml` incl. `[project.optional-dependencies]`), npm (`package.json` + `package-lock` v1/v2/v3 incl. transitive), crates.io (`Cargo.lock`, registry-sourced only), Go (`go.mod`).
- **Real CVSS v3.1 base-score calculator** — verified against FIRST.org reference vectors (9.8 / 7.5 / 1.8 / 10.0 / 8.1) — plus GHSA label normalization (`MODERATE`→`MEDIUM`).
- **Severity-gated exit codes** (0 clean / 1 finding at-or-above threshold / 2 usage).

### Fail-closed by design
- A confirmed vuln whose severity can't be classified (no CVSS / detail fetch failed) **trips the gate** rather than passing.
- OSV unreachable while online → **exit 1** (offline is the explicit opt-out → exit 0).
- Only-unpinned / no-lockfile projects get a clear note instead of a false "clean."
- Truncated OSV batch → error, never a silent under-report.
- Only exact `==` pins are queried; ranges (`^`, `~`, `>=`) are reported as unpinned (querying a guessed version gives false results).

### Review
Hardened across **two tri-brain loops** (Codex 5.5 + Grok; the GPT-OSS coherence lens timed out on POWER8, noted). Loop 1 caught two BLOCKING issues (range-as-exact-pin; fail-*open* on detail-fetch failure) — both fixed. Loop 2 caught real parsing-accuracy bugs (extras pins, optional-deps, Cargo git-source, malformed-CVSS scope) — all fixed. **24 tests, ruff-clean.**

### Known limitations (follow-ups, non-blocking)
- No `[project.scripts]` console-script entry yet (run via `python tools/cve_lite.py`).
- poetry.lock / pnpm-lock / yarn.lock not yet parsed (poetry ranges report unpinned).
- A `--strict` mode could fail-closed on only-unpinned trees for CVE gates.

Natural next step: wire as a `clawrtc scan` subcommand and/or as an alternative BCOS `vulnerability_scan` backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
