### PR TITLE
fix: close Vulkan GPU sysfs probe handles

### DIFF
--- a/miners/gpu_fingerprint_vulkan.py
+++ b/miners/gpu_fingerprint_vulkan.py
@@ -53,6 +53,11 @@ class ChannelResult:
     notes: str = ""
 
 
+def _read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read().strip()
+
+
 def _get_vulkan_devices():
     """Enumerate Vulkan physical devices."""
     app_info = vk.VkApplicationInfo(
@@ -257,9 +262,9 @@ def channel_system_gpu_probe() -> ChannelResult:
         drm_info = []
         for vendor_path in drm_cards:
             card = vendor_path.split("/")[4]
-            vendor = open(vendor_path).read().strip()
+            vendor = _read_text(vendor_path)
             device_path = vendor_path.replace("vendor", "device")
-            device = open(device_path).read().strip() if __import__("os").path.exists(device_path) else "unknown"
+            device = _read_text(device_path) if __import__("os").path.exists(device_path) else "unknown"
             drm_info.append({"card": card, "vendor": vendor, "device": device})
         data["drm_cards"] = drm_info
     except Exception:
@@ -271,7 +276,7 @@ def channel_system_gpu_probe() -> ChannelResult:
         amd_hwmon = glob.glob("/sys/class/drm/card*/device/hwmon/hwmon*/temp1_input")
         for path in amd_hwmon:
             card = path.split("/")[4]
-            temp = int(open(path).read().strip()) // 1000
+            temp = int(_read_text(path)) // 1000
             data[f"{card}_temp_c"] = temp
     except Exception:
         pass

--- a/tests/test_gpu_fingerprint_vulkan_probe.py
+++ b/tests/test_gpu_fingerprint_vulkan_probe.py
@@ -1,0 +1,76 @@
+import importlib.util
+import io
+import os
+import subprocess
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_PATH = os.path.join(ROOT, "miners", "gpu_fingerprint_vulkan.py")
+
+
+class TrackingFile(io.StringIO):
+    def __init__(self, value):
+        super().__init__(value)
+        self.was_closed = False
+
+    def close(self):
+        self.was_closed = True
+        super().close()
+
+
+def load_module():
+    fake_vk = types.SimpleNamespace()
+    with patch.dict(sys.modules, {"vulkan": fake_vk}):
+        spec = importlib.util.spec_from_file_location("gpu_fingerprint_vulkan", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+class VulkanSystemProbeTests(unittest.TestCase):
+    def test_system_probe_closes_sysfs_file_handles(self):
+        module = load_module()
+        opened = []
+
+        def fake_open(path, *args, **kwargs):
+            values = {
+                "/sys/class/drm/card0/device/vendor": "0x1002\n",
+                "/sys/class/drm/card0/device/device": "0x73bf\n",
+                "/sys/class/drm/card0/device/hwmon/hwmon0/temp1_input": "42000\n",
+            }
+            handle = TrackingFile(values[path])
+            opened.append(handle)
+            return handle
+
+        completed = subprocess.CompletedProcess(
+            args=["lspci", "-v", "-s", ""],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=completed), \
+             patch("glob.glob") as fake_glob, \
+             patch("os.path.exists", return_value=True), \
+             patch("builtins.open", side_effect=fake_open):
+            fake_glob.side_effect = [
+                ["/sys/class/drm/card0/device/vendor"],
+                ["/sys/class/drm/card0/device/hwmon/hwmon0/temp1_input"],
+            ]
+
+            result = module.channel_system_gpu_probe()
+
+        self.assertTrue(result.passed)
+        self.assertEqual(result.data["drm_cards"][0]["vendor"], "0x1002")
+        self.assertEqual(result.data["drm_cards"][0]["device"], "0x73bf")
+        self.assertEqual(result.data["card0_temp_c"], 42)
+        self.assertEqual(len(opened), 3)
+        self.assertTrue(all(handle.was_closed for handle in opened))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a tiny `_read_text()` helper for Vulkan GPU sysfs reads
- replace `open(...).read()` probe reads with context-managed reads
- add a focused regression test that loads the module without a real Vulkan install and verifies fake sysfs handles are closed

## Why
`channel_system_gpu_probe()` reads DRM vendor/device and AMD hwmon temperature files with bare `open(...).read()` calls. Repeated GPU fingerprint probes can leave sysfs file handles open if the interpreter does not collect them promptly. This patch keeps the probe behavior identical while making the resource lifetime explicit.

## Tests
- `python -m unittest tests.test_gpu_fingerprint_vulkan_probe -v`
- `python -m py_compile miners/gpu_fingerprint_vulkan.py tests/test_gpu_fingerprint_vulkan_probe.py`

RTC payout wallet/miner id: `github-qiann0512-gif`
