### PR TITLE
fix: close miner score API responses

### DIFF
--- a/tests/test_miner_score.py
+++ b/tests/test_miner_score.py
@@ -100,12 +100,21 @@ def test_score_handles_empty_or_failed_api_payload(monkeypatch, capsys):
 def test_api_uses_configured_node_timeout_and_ssl_context(monkeypatch):
     calls = []
     contexts = []
+    responses = []
 
     class DummyContext:
         check_hostname = True
         verify_mode = None
 
     class DummyResponse:
+        closed = False
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.closed = True
+
         def read(self):
             return b'{"miners": []}'
 
@@ -116,7 +125,9 @@ def test_api_uses_configured_node_timeout_and_ssl_context(monkeypatch):
 
     def fake_urlopen(*args, **kwargs):
         calls.append((args, kwargs))
-        return DummyResponse()
+        response = DummyResponse()
+        responses.append(response)
+        return response
 
     monkeypatch.setattr(miner_score, "NODE", "https://node.example")
     monkeypatch.setattr(miner_score.ssl, "create_default_context", fake_context)
@@ -126,6 +137,7 @@ def test_api_uses_configured_node_timeout_and_ssl_context(monkeypatch):
     assert calls == [(("https://node.example/api/miners",), {"timeout": 10, "context": contexts[0]})]
     assert contexts[0].check_hostname is False
     assert contexts[0].verify_mode == miner_score.ssl.CERT_NONE
+    assert responses[0].closed is True
 
 
 def test_api_returns_empty_dict_on_request_error(monkeypatch):

--- a/tools/miner_score.py
+++ b/tools/miner_score.py
@@ -14,7 +14,8 @@ def api(p):
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
     try:
-        return json.loads(urllib.request.urlopen(f"{NODE}{p}", timeout=10, context=ctx).read())
+        with urllib.request.urlopen(f"{NODE}{p}", timeout=10, context=ctx) as response:
+            return json.loads(response.read())
     except Exception:
         return {}
 


### PR DESCRIPTION
## Summary
- wrap `urllib.request.urlopen()` in `tools/miner_score.py` with a context manager
- extend the existing API test to assert the dummy response is closed

## Why
`api()` read the response body from `urlopen(...).read()` without closing the response object. The tool is short-lived in many cases, but explicit closure avoids leaking network resources when the miner score helper is called repeatedly from scripts or tests.

## Tests
- `python -m pytest tests/test_miner_score.py -q` -> `7 passed`
- `python -m py_compile tools/miner_score.py tests/test_miner_score.py`

RTC payout wallet/miner id: `github-qiann0512-gif`
