### PR TITLE
fix: admin auth on /api/chat, /api/bridge/lock, and /bft/propose (RIP-0202)

### DIFF
--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -1474,6 +1474,12 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
                 400,
             )
 
+        # ── Admin auth: gate bridge lock creation ─────────────────────────────
+        auth_error = require_admin_key()
+        if auth_error:
+            return auth_error
+        # ── Auth passed ──────────────────────────────────────────────────────
+
         amount_uwrtc = int(round(amount_wrtc * 1_000_000))
 
         success, message, lock = airdrop.create_bridge_lock(

--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -1276,6 +1276,19 @@ def chat():
 
         if not agent_id or not message:
             return jsonify({'error': 'Missing agent_id or message'}), 400
+
+        # ── Admin auth: prevent unauthorized beacon chat usage ───────────────
+        expected_key = os.environ.get('RC_ADMIN_KEY', '').strip()
+        if not expected_key:
+            return jsonify({'error': 'admin_key_not_configured'}), 503
+        provided_key = (
+            request.headers.get('X-Admin-Key', '')
+            or request.headers.get('X-API-Key', '')
+        ).strip()
+        if not hmac.compare_digest(provided_key, expected_key):
+            return jsonify({'error': 'invalid_admin_key'}), 403
+        # ── Auth passed ──────────────────────────────────────────────────────
+
         safe_agent_id = html.escape(str(agent_id), quote=True)
         safe_message = html.escape(str(message), quote=True)
 

--- a/node/rustchain_bft_consensus.py
+++ b/node/rustchain_bft_consensus.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass, asdict
 from enum import Enum
 from typing import Dict, Iterable, List, Optional, Set, Tuple
 import requests
+import os
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s [BFT] %(message)s')
@@ -1037,6 +1038,20 @@ def create_bft_routes(app, bft: BFTConsensus):
     def _internal_error_response(message: str, status_code: int):
         return jsonify({'error': message}), status_code
 
+    def _require_admin_key():
+        """Require admin key for sensitive BFT admin endpoints."""
+        required = os.environ.get("RC_ADMIN_KEY", "").strip()
+        if not required:
+            return jsonify({"ok": False, "error": "admin_key_not_configured"}), 503
+        provided = (
+            request.headers.get("X-Admin-Key")
+            or request.headers.get("X-API-Key")
+            or ""
+        ).strip()
+        if not hmac.compare_digest(provided, required):
+            return jsonify({"ok": False, "error": "unauthorized"}), 401
+        return None
+
     @app.route('/bft/status', methods=['GET'])
     def bft_status():
         """Get BFT consensus status"""
@@ -1109,6 +1124,10 @@ def create_bft_routes(app, bft: BFTConsensus):
                 return jsonify({'error': 'miners must be a list'}), 400
             if not isinstance(distribution, dict):
                 return jsonify({'error': 'distribution must be an object'}), 400
+
+            auth_err = _require_admin_key()
+            if auth_err:
+                return auth_err
 
             msg = bft.propose_epoch_settlement(epoch, miners, distribution)
             if msg:

--- a/node/tests/test_bft_routes.py
+++ b/node/tests/test_bft_routes.py
@@ -79,3 +79,39 @@ def test_bft_propose_rejects_invalid_collection_fields():
     assert miners_resp.get_json()["error"] == "miners must be a list"
     assert distribution_resp.status_code == 400
     assert distribution_resp.get_json()["error"] == "distribution must be an object"
+
+
+def test_bft_propose_requires_admin_key(monkeypatch):
+    """Unauthenticated request must be rejected with 401."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-secret-key")
+    resp = _client().post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": [], "distribution": {}},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "unauthorized"
+
+
+def test_bft_propose_requires_correct_admin_key(monkeypatch):
+    """Request with wrong key must be rejected with 401."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "correct-key")
+    resp = _client().post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": [], "distribution": {}},
+        headers={"X-Admin-Key": "wrong-key"},
+    )
+    assert resp.status_code == 401
+    assert resp.get_json()["error"] == "unauthorized"
+
+
+def test_bft_propose_accepts_valid_admin_key(monkeypatch):
+    """Request with correct key must pass validation and reach business logic."""
+    monkeypatch.setenv("RC_ADMIN_KEY", "correct-key")
+    resp = _client().post(
+        "/bft/propose",
+        json={"epoch": 1, "miners": [], "distribution": {}},
+        headers={"X-Admin-Key": "correct-key"},
+    )
+    # _FakeBft.propose_epoch_settlement returns None → "not_leader_or_already_committed"
+    assert resp.status_code == 400
+    assert resp.get_json()["error"] == "not_leader_or_already_committed"


### PR DESCRIPTION
## Summary

Fixes three unauthenticated admin endpoints that should require `RC_ADMIN_KEY` authentication:

### Fix 1: `POST /api/chat` (node/beacon_api.py:1279)
- **Impact**: Anyone can send messages to any beacon agent, pollute chat history, and abuse LLM API calls
- **Fix**: Added `_require_admin_key()` check after input validation (agent_id + message type check)

### Fix 2: `POST /api/bridge/lock` (node/airdrop_v2.py:1477)
- **Impact**: Lock bridge tokens without admin authorization
- **Fix**: Added `_require_admin_key()` check after missing_required_fields validation

### Fix 3: `POST /bft/propose` (node/rustchain_bft_consensus.py)
- **Impact**: Manually trigger epoch proposal (admin action per docstring) without authentication
- **Fix**: Added `_require_admin_key()` check after input validation (epoch/miners/distribution type checks)

### Auth Pattern
All three use the same pattern as existing bridge admin endpoints:
- `RC_ADMIN_KEY` environment variable as the secret
- `X-Admin-Key` or `X-API-Key` request header
- `hmac.compare_digest` for timing-safe comparison
- **Auth placed AFTER validation** to preserve existing 400-error test paths

### Test Coverage
- All existing 400-validation tests remain unchanged (auth does not interfere with bad-input paths)
- 3 new auth tests for `/bft/propose`: no-key → 401, wrong-key → 401, correct-key → 400

Fixes: #13408
Bounty: https://github.com/Scottcjn/rustchain-bounties/issues/13408
