### PR TITLE
fix: return full row from _find_balance_row instead of single column (closes #305)

### DIFF
--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -85,14 +85,14 @@ def _find_balance_row(conn, miner_id):
             "SELECT miner_id FROM balances WHERE miner_id = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_id"
+            return row, "miner_id"
 
     if "miner_pk" in columns:
         row = conn.execute(
             "SELECT miner_pk FROM balances WHERE miner_pk = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_pk"
+            return row, "miner_pk"
 
     return None, None
 


### PR DESCRIPTION
## What
In `_find_balance_row`, when a matching row is found, the function returns `row[0]` (a single column value) as the first element of the tuple, but the callers expect a full row object. This can lead to attribute errors or incorrect data being passed.

## Fix
Changed the return statements to return the full `row` object instead of `row[0]`, so callers receive the complete row data as intended.

Closes #305