### PR TITLE
Fix admin UI session links

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5453,13 +5453,14 @@ _ADMIN_SESSION_TTL = 3600
 def _get_or_create_admin_session(req):
     now = time.time()
     # Clean expired
-    expired = [k for k, v in _ADMIN_SESSIONS.items() if now - v > 3600]
+    expired = [k for k, v in _ADMIN_SESSIONS.items() if now - v > _ADMIN_SESSION_TTL]
     for k in expired:
         _ADMIN_SESSIONS.pop(k, None)
     # Check existing session
     sid = req.values.get("session_id", "")
     if sid and sid in _ADMIN_SESSIONS:
         _ADMIN_SESSIONS[sid] = now  # refresh TTL
+        req._admin_session_id = sid  # type: ignore[attr-defined]
         return True
     # Check header auth
     if is_admin(req):
@@ -5485,7 +5486,12 @@ def _wallet_review_ui_authorized(req):
         or req.form.get("admin_key")
         or ""
     ).strip()
-    return bool(need and got and hmac.compare_digest(need, got))
+    if need and got and hmac.compare_digest(need, got):
+        sid = secrets.token_hex(16)
+        _ADMIN_SESSIONS[sid] = time.time()
+        req._admin_session_id = sid  # type: ignore[attr-defined]
+        return True
+    return False
 
 
 def get_wallet_review_counts():
@@ -5712,6 +5718,7 @@ def admin_operator_ui():
         return jsonify({"ok": False, "error": "forbidden"}), 403
 
     admin_key = str(request.values.get("admin_key") or "").strip()
+    sid = getattr(request, '_admin_session_id', '')
     counts = get_wallet_review_counts()
     return render_template_string(
         """
@@ -5764,6 +5771,7 @@ def admin_operator_ui():
 </html>
         """,
         admin_key=admin_key,
+        sid=sid,
         counts=counts,
     )
 

--- a/tests/test_wallet_review_holds.py
+++ b/tests/test_wallet_review_holds.py
@@ -1,3 +1,4 @@
+import re
 import sqlite3
 import sys
 import uuid
@@ -330,3 +331,51 @@ def test_admin_operator_ui_links_to_wallet_review_surface(client):
     assert "Wallet Review Queue" in html
     assert "needs_review" in html
     assert ">1<" in html
+
+
+def test_admin_operator_ui_header_auth_links_to_live_session(client):
+    test_client, db_path = client
+    with sqlite3.connect(db_path) as conn:
+        integrated_node.ensure_wallet_review_tables(conn)
+        conn.execute(
+            """
+            INSERT INTO wallet_review_holds(wallet, status, reason, coach_note, reviewer_note, created_at, reviewed_at)
+            VALUES (?, 'needs_review', ?, ?, '', 1000, 0)
+            """,
+            ("review-miner", "manual review", "coach note"),
+        )
+        conn.commit()
+
+    response = test_client.get("/admin/ui", headers={"X-Admin-Key": "0" * 32})
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    match = re.search(r'/admin/wallet-review-holds/ui\?session_id=([0-9a-f]+)', html)
+    assert match is not None
+    sid = match.group(1)
+
+    response = test_client.get(f"/admin/wallet-review-holds/ui?session_id={sid}")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "RustChain Wallet Review Holds" in html
+    assert "review-miner" in html
+    assert f"session_id={sid}" in html
+
+
+def test_admin_operator_ui_reuses_existing_session_id(client):
+    test_client, _db_path = client
+
+    response = test_client.get("/admin/ui", headers={"X-Admin-Key": "0" * 32})
+    assert response.status_code == 200
+    match = re.search(
+        r'/admin/wallet-review-holds/ui\?session_id=([0-9a-f]+)',
+        response.get_data(as_text=True),
+    )
+    assert match is not None
+    sid = match.group(1)
+
+    response = test_client.get(f"/admin/ui?session_id={sid}")
+
+    assert response.status_code == 200
+    assert f"/admin/wallet-review-holds/ui?session_id={sid}" in response.get_data(as_text=True)


### PR DESCRIPTION
## Summary

Fix the wallet review admin UI session propagation introduced by the session-link remediation for query-string admin keys.

- Preserve valid existing `session_id` values on the request so rendered links/forms keep using the registered session.
- Pass the minted `sid` into the `/admin/ui` template context so header-authenticated admin landing pages render a usable Wallet Review Holds link.
- Mint a session when the legacy query/form admin-key path succeeds, so follow-up links can use session ids instead of carrying the admin key.
- Add regression tests for header-auth navigation and existing-session reuse.

Fixes #7048.
Contributes to bug bounty #305.

## Tests

```text
python -m pytest tests/test_wallet_review_holds.py -q
11 passed in 3.04s
```