### PR TITLE
fix(feed): reject non-positive feed limits (cherry-pick #6390)

### DIFF
--- a/node/bottube_feed_routes.py
+++ b/node/bottube_feed_routes.py
@@ -59,9 +59,12 @@ def _parse_feed_limit(default: int = 20, maximum: int = 100) -> int:
     if raw_limit in (None, ""):
         return default
     try:
-        return max(1, min(int(raw_limit), maximum))
+        limit = int(raw_limit)
     except (ValueError, TypeError):
         abort(400, description="Invalid limit parameter")
+    if limit < 1:
+        abort(400, description="limit must be at least 1")
+    return min(limit, maximum)
 
 
 def _get_db_connection():


### PR DESCRIPTION
Cherry-picks @galanime's #6390 onto current `main` (adapted to the drifted `abort(400)` structure): `limit < 1` → 400 instead of silent clamp, all feed routes. 26 tests pass. Credit + bounty to @galanime.

Closes #6390

🤖 Generated with [Claude Code](https://claude.com/claude-code)