### PR TITLE
fix(explorer): drop hardcoded IP + fix hall-of-fame endpoint (cherry-pick #6574)

### DIFF
--- a/explorer/enhanced-explorer.html
+++ b/explorer/enhanced-explorer.html
@@ -528,7 +528,7 @@
     </main>
 
     <script>
-        const API_BASE = 'https://50.28.86.131';
+        const API_BASE = window.location.origin;
         
         function switchView(viewName) {
             document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
@@ -586,9 +586,9 @@
                 const overviewTable = document.getElementById('miners-table');
                 overviewTable.innerHTML = minerList.slice(0, 10).map(miner => `
                     <tr>
-                        <td><strong>${esc(miner.miner_id || 'Unknown')}</strong></td>
+                        <td><strong>${esc(miner.miner || miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${esc(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
+                        <td><span class="multiplier">x${esc(miner.antiquity_multiplier || miner.multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
                         <td>${esc(formatNumber(miner.earnings || miner.total_earned, 2))} RTC</td>
@@ -598,9 +598,9 @@
                 const allMinersTable = document.getElementById('all-miners-table');
                 allMinersTable.innerHTML = minerList.map(miner => `
                     <tr>
-                        <td><strong>${esc(miner.miner_id || 'Unknown')}</strong></td>
+                        <td><strong>${esc(miner.miner || miner.miner_id || 'Unknown')}</strong></td>
                         <td><span class="arch-badge">${esc(miner.architecture || miner.device_arch || 'Unknown')}</span></td>
-                        <td><span class="multiplier">x${esc(miner.multiplier || miner.antiquity_multiplier || '1.0')}</span></td>
+                        <td><span class="multiplier">x${esc(miner.antiquity_multiplier || miner.multiplier || '1.0')}</span></td>
                         <td><span class="badge badge-success">Online</span></td>
                         <td>${esc(formatTime(miner.last_attestation || miner.last_seen))}</td>
                         <td><code>${esc(miner.wallet || miner.wallet_address || 'N/A')}</code></td>

--- a/web/hall-of-fame/index.html
+++ b/web/hall-of-fame/index.html
@@ -217,7 +217,7 @@
 </div>
 
 <script>
-const API_LEADERBOARD = '/api/hall_of_fame/leaderboard';
+const API_LEADERBOARD = '/hall/leaderboard';
 const API_STATS       = '/api/hall_of_fame/stats';
 
 function esc(s){ return String(s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }


### PR DESCRIPTION
Cherry-picks @crowniteto's #6574 onto current `main`. explorer → `window.location.origin` (no hardcoded IP); hall-of-fame → `/hall/leaderboard` (verified live 200; old path 404s); miner field fallbacks. Dropped the no-op CRLF hunk. Credit + bounty to @crowniteto.

Closes #6574

🤖 Generated with [Claude Code](https://claude.com/claude-code)