### PR TITLE
fix(consensus/T3.2): make vintage arch multiplier non-forgeable

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2572,8 +2572,30 @@ def derive_verified_device(device: dict, fingerprint: dict, fingerprint_passed: 
     if _claims_powerpc(device):
         # If CPU brand contains PowerPC/IBM/POWER identifiers, trust the claim
         ppc_brands = {"powerpc", "power8", "power9", "ibm power", "altivec", "970", "7450", "g3", "g4", "g5"}
-        brand_matches = _has_any_token(cpu_brand, ppc_brands)
-        
+        brand_has_ppc = _has_any_token(cpu_brand, ppc_brands)
+
+        # T3.2: a PowerPC brand token ALONE is forgeable — a spoofer stuffs "g4" into
+        # cpu_brand on an x86 box to grab the 2.5x antiquity tier (observed live:
+        # clockspoof/bypass miners recorded device_arch=g4). Veto this brand fast-path
+        # on POSITIVE x86 contradiction, mirroring the machine_field path above (2554):
+        #   - x86/ARM brand tokens present, OR
+        #   - the SIMD fingerprint reports SSE/AVX / x86 features.
+        # We reject ONLY on contradiction, never on the mere ABSENCE of PowerPC
+        # evidence, so genuine PowerPC silicon (AltiVec, no SSE/AVX, no x86/ARM brand
+        # tokens) is unaffected — the live G4/G5 fleet all carry no x86 evidence.
+        # Contradicting claims fall through to the strict-validation path below, which
+        # downgrades them to x86_64/default.
+        brand_foreign_contaminated = _has_any_token(cpu_brand, X86_CPU_BRANDS | ARM_CPU_BRANDS)
+        simd_shows_x86 = bool(
+            simd_data.get("has_sse")
+            or simd_data.get("has_avx")
+            or simd_data.get("x86_features")
+        )
+        brand_matches = brand_has_ppc and not brand_foreign_contaminated and not simd_shows_x86
+        if brand_has_ppc and not brand_matches:
+            print(f"[PPC_DETECT] brand_match VETOED (x86/arm contradiction): brand={cpu_brand[:40]} "
+                  f"foreign_brand={brand_foreign_contaminated} simd_x86={simd_shows_x86} -> strict validation")
+
         if brand_matches:
             # CPU brand confirms PowerPC — determine specific arch
             ppc_arch = arch.upper() if arch.lower() in ("g3", "g4", "g5", "power8", "power9") else "default"
@@ -9976,14 +9998,30 @@ def _reserve_governance_nonce(c: sqlite3.Cursor, wallet: str, nonce: str, used_a
 
 
 def _get_active_miner_antiquity_multiplier(c: sqlite3.Cursor, wallet: str):
-    row = c.execute(
-        """
-        SELECT ts_ok, device_family, device_arch
-        FROM miner_attest_recent
-        WHERE miner = ?
-        """,
-        (wallet,),
-    ).fetchone()
+    # fingerprint_passed gates the antiquity BONUS (see below). Read it tolerantly:
+    # the live nodes run a divergent lineage and an older one may predate the column —
+    # an unknown-column error must NOT crash every governance call. If the column is
+    # absent we fall back to the pre-cap behavior (the derive_verified_device arch
+    # downgrade still protects those nodes).
+    fp_col_present = True
+    try:
+        row = c.execute(
+            "SELECT ts_ok, device_family, device_arch, fingerprint_passed "
+            "FROM miner_attest_recent WHERE miner = ?",
+            (wallet,),
+        ).fetchone()
+    except sqlite3.OperationalError as e:
+        # Only the specific "column absent" case falls back. A transient lock / I/O
+        # error must NOT be misread as a missing column (which would silently disable
+        # the bonus cap); re-raise anything else.
+        if "fingerprint_passed" not in str(e) and "no such column" not in str(e).lower():
+            raise
+        fp_col_present = False
+        row = c.execute(
+            "SELECT ts_ok, device_family, device_arch "
+            "FROM miner_attest_recent WHERE miner = ?",
+            (wallet,),
+        ).fetchone()
     if not row or not row[0]:
         return False, 0.0, "miner_not_attested"
 
@@ -9993,11 +10031,26 @@ def _get_active_miner_antiquity_multiplier(c: sqlite3.Cursor, wallet: str):
 
     family = row[1] or "unknown"
     arch = row[2] or "unknown"
-    multiplier = HARDWARE_WEIGHTS.get(family, {}).get(
+    multiplier = float(HARDWARE_WEIGHTS.get(family, {}).get(
         arch,
         HARDWARE_WEIGHTS.get(family, {}).get("default", 1.0),
-    )
-    return True, float(multiplier), "ok"
+    ))
+
+    # T3.2 defense-in-depth: the antiquity BONUS (multiplier > 1.0) is the forgeable
+    # part — only grant it to miners whose hardware fingerprint passed. The stored value
+    # is an INTEGER 1 on live nodes, but coerce explicitly so a stray text "0"/"false"/
+    # NULL can never read truthy and grant a forged bonus. A miner that failed (or never
+    # ran) the 6-check fingerprint keeps base voting weight (capped at 1.0) so liveness
+    # is preserved, but cannot wield a forged vintage tier in governance. The live
+    # G4/G5/POWER8 fleet all attest fingerprint_passed=1, so this never touches honest
+    # vintage hardware; it only neutralizes spoofers the stored device_arch downgrade
+    # may not have caught.
+    if fp_col_present and multiplier > 1.0:
+        fp_raw = row[3] if len(row) > 3 else None
+        fingerprint_passed = str(fp_raw).strip().lower() in ("1", "true", "yes")
+        if not fingerprint_passed:
+            return True, 1.0, "antiquity_bonus_requires_fingerprint"
+    return True, multiplier, "ok"
 
 
 def _refresh_proposal_status(c: sqlite3.Cursor, proposal_row: sqlite3.Row):

--- a/node/tests/test_arch_multiplier_guard_t32.py
+++ b/node/tests/test_arch_multiplier_guard_t32.py
@@ -1,0 +1,180 @@
+"""T3.2 regression: vintage arch-multiplier must not be forgeable via CPU-brand string.
+
+Two layers are tested:
+
+1. `derive_verified_device` Path B (`_claims_powerpc`) — the `brand_matches`
+   fast-path used to return PowerPC/G4 on a CPU-brand token ALONE (a spoofer stuffs
+   "g4" into cpu_brand on an x86 box → 2.5x antiquity tier; observed live as
+   clockspoof/bypass miners recorded device_arch=g4). The fix vetoes the fast-path on
+   POSITIVE x86 contradiction (x86/ARM brand tokens OR SSE/AVX in the SIMD fingerprint),
+   never on the mere absence of PowerPC evidence — so honest PowerPC silicon (AltiVec,
+   no SSE/AVX) is unaffected. Contradicting claims fall through to x86_64/default.
+
+2. `_get_active_miner_antiquity_multiplier` — the antiquity BONUS (>1.0) is now
+   gated on fingerprint_passed; a miner that failed/never ran the fingerprint keeps
+   base weight (capped 1.0) but cannot wield a forged vintage tier in governance.
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+def _simd_fp(**data):
+    """Build a fingerprint with a simd_identity check carrying `data`."""
+    return {"checks": {"simd_identity": {"data": dict(data)}}}
+
+
+class ArchMultiplierGuardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        os.environ.setdefault("RUSTCHAIN_DB_PATH", os.path.join(cls._tmp.name, "t32.db"))
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        spec = importlib.util.spec_from_file_location("rcnode_t32_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    def _derive(self, device, fingerprint=None, fp_passed=True):
+        return self.mod.derive_verified_device(device, fingerprint or {}, fp_passed)
+
+    # --- Path B brand fast-path: honest PowerPC unaffected --------------------
+    def test_real_g4_brand_with_altivec_is_powerpc(self):
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC G4 7450", "machine": "Power Macintosh"}
+        out = self._derive(d, _simd_fp(altivec=True))
+        self.assertEqual(out, {"device_family": "PowerPC", "device_arch": "G4"})
+
+    def test_real_g4_brand_no_fingerprint_still_powerpc(self):
+        """Legacy miners with no SIMD fingerprint must keep their tier (no x86
+        contradiction == not a spoof). Absence of PPC evidence must NOT zero them."""
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC G4 7450", "machine": "Power Macintosh"}
+        out = self._derive(d, {}, fp_passed=False)
+        self.assertEqual(out, {"device_family": "PowerPC", "device_arch": "G4"})
+
+    def test_real_g5_brand_is_powerpc(self):
+        d = {"family": "PowerPC", "arch": "g5", "cpu": "PowerPC G5 970", "machine": "Power Macintosh"}
+        out = self._derive(d, _simd_fp(altivec=True))
+        self.assertEqual(out, {"device_family": "PowerPC", "device_arch": "G5"})
+
+    def test_power8_brand_is_powerpc(self):
+        d = {"family": "PowerPC", "arch": "power8", "cpu": "IBM POWER8 8286", "machine": ""}
+        out = self._derive(d, _simd_fp(vsx=True))
+        self.assertEqual(out, {"device_family": "PowerPC", "device_arch": "POWER8"})
+
+    # --- Path B brand fast-path: spoofers vetoed ------------------------------
+    def test_spoof_g4_brand_with_sse_is_downgraded(self):
+        """clockspoof pattern: 'g4' brand on a box whose SIMD fingerprint honestly
+        reports SSE → x86 contradiction → must NOT get PowerPC."""
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC G4", "machine": ""}
+        out = self._derive(d, _simd_fp(has_sse=True))
+        self.assertNotEqual(out["device_family"], "PowerPC")
+        self.assertIn(out["device_arch"], ("default", "modern"))
+
+    def test_spoof_g4_brand_with_avx_is_downgraded(self):
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC G4", "machine": ""}
+        out = self._derive(d, _simd_fp(has_avx=True))
+        self.assertNotEqual(out["device_family"], "PowerPC")
+
+    def test_spoof_g4_brand_with_x86_features_is_downgraded(self):
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "PowerPC G4", "machine": ""}
+        out = self._derive(d, _simd_fp(x86_features=["sse2", "avx2"]))
+        self.assertNotEqual(out["device_family"], "PowerPC")
+
+    def test_brand_contaminated_intel_plus_g4_is_downgraded(self):
+        """Brand stuffing: 'Intel Core i7 ... g4' has BOTH tokens → x86-contaminated
+        → vetoed → strict validation downgrades to x86_64/default."""
+        d = {"family": "PowerPC", "arch": "g4", "cpu": "Intel Core i7-9750H g4", "machine": ""}
+        out = self._derive(d, _simd_fp())
+        self.assertEqual(out, {"device_family": "x86_64", "device_arch": "default"})
+
+    # --- governance multiplier: antiquity bonus gated on fingerprint ----------
+    def _attest_db(self):
+        c = sqlite3.connect(":memory:")
+        c.execute(
+            "CREATE TABLE miner_attest_recent (miner TEXT PRIMARY KEY, ts_ok INTEGER, "
+            "device_family TEXT, device_arch TEXT, entropy_score REAL DEFAULT 0, "
+            "fingerprint_passed INTEGER DEFAULT 0)"
+        )
+        return c
+
+    def _seed_attest(self, c, miner, family, arch, fp):
+        now = int(__import__("time").time())
+        c.execute(
+            "INSERT INTO miner_attest_recent (miner, ts_ok, device_family, device_arch, fingerprint_passed) "
+            "VALUES (?,?,?,?,?)", (miner, now, family, arch, fp))
+
+    def test_g4_with_fingerprint_keeps_full_multiplier(self):
+        c = self._attest_db()
+        self._seed_attest(c, "g4-real", "PowerPC", "G4", 1)
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "g4-real")
+        self.assertTrue(active)
+        self.assertEqual(mult, 2.5)
+        self.assertEqual(reason, "ok")
+
+    def test_g4_without_fingerprint_capped_to_one(self):
+        c = self._attest_db()
+        self._seed_attest(c, "g4-spoof", "PowerPC", "G4", 0)
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "g4-spoof")
+        self.assertTrue(active)            # still active — liveness preserved
+        self.assertEqual(mult, 1.0)        # but no forged antiquity bonus
+        self.assertEqual(reason, "antiquity_bonus_requires_fingerprint")
+
+    def test_modern_miner_unaffected_by_cap(self):
+        """A modern miner's base weight (<=1.0) is never raised or 'capped' oddly."""
+        c = self._attest_db()
+        self._seed_attest(c, "modern-x", "modern", "default", 0)
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "modern-x")
+        self.assertTrue(active)
+        self.assertLessEqual(mult, 1.0)
+        self.assertEqual(reason, "ok")     # cap only triggers when multiplier > 1.0
+
+    def test_not_attested(self):
+        c = self._attest_db()
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "ghost")
+        self.assertFalse(active)
+        self.assertEqual(reason, "miner_not_attested")
+
+    def test_text_zero_fingerprint_does_not_grant_bonus(self):
+        """Codex audit: a TEXT '0'/'false' must not read truthy and grant a forged
+        bonus (bool('0') is True in Python — explicit coercion required)."""
+        for bad in ("0", "false", "False", "no", ""):
+            c = self._attest_db()
+            c.execute(
+                "INSERT INTO miner_attest_recent (miner, ts_ok, device_family, device_arch, fingerprint_passed) "
+                "VALUES (?,?,?,?,?)", ("g4-textfp", int(__import__("time").time()), "PowerPC", "G4", bad))
+            active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "g4-textfp")
+            self.assertEqual(mult, 1.0, f"text fingerprint_passed={bad!r} must NOT grant bonus")
+            self.assertEqual(reason, "antiquity_bonus_requires_fingerprint")
+
+    def test_text_one_fingerprint_grants_bonus(self):
+        c = self._attest_db()
+        c.execute(
+            "INSERT INTO miner_attest_recent (miner, ts_ok, device_family, device_arch, fingerprint_passed) "
+            "VALUES (?,?,?,?,?)", ("g4-textok", int(__import__("time").time()), "PowerPC", "G4", "1"))
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "g4-textok")
+        self.assertEqual(mult, 2.5)
+        self.assertEqual(reason, "ok")
+
+    def test_legacy_schema_without_fingerprint_column_does_not_crash(self):
+        """Grok blast-radius: a divergent/older node whose miner_attest_recent lacks the
+        fingerprint_passed column must NOT raise on every governance call — it falls
+        back to pre-cap behavior (derive-side arch downgrade still protects it)."""
+        c = sqlite3.connect(":memory:")
+        c.execute(
+            "CREATE TABLE miner_attest_recent (miner TEXT PRIMARY KEY, ts_ok INTEGER, "
+            "device_family TEXT, device_arch TEXT)")  # NO fingerprint_passed column
+        c.execute(
+            "INSERT INTO miner_attest_recent (miner, ts_ok, device_family, device_arch) VALUES (?,?,?,?)",
+            ("g4-legacy", int(__import__("time").time()), "PowerPC", "G4"))
+        active, mult, reason = self.mod._get_active_miner_antiquity_multiplier(c.cursor(), "g4-legacy")
+        self.assertTrue(active)
+        self.assertEqual(mult, 2.5)        # no cap applied (column absent) — no crash
+        self.assertEqual(reason, "ok")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## T3.2 — Arch multiplier forgery (reward + governance integrity)

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #4). Reward/governance-layer integrity — **not** a consensus break.

### The gap
`derive_verified_device` has two PowerPC paths. The `machine_field` path (Path A) was already hardened (hard-rejects x86 tokens, soft-rejects no-evidence). But Path B (`_claims_powerpc`) had a **`brand_matches` fast-path that returned `PowerPC/G4` on a CPU-brand string token alone** — no x86 contradiction check, no SIMD corroboration. A spoofer stuffing `"g4"` into `cpu_brand` on an x86 box grabbed the **2.5× antiquity tier**.

This is **live-observed**: on Node 1, `clockspoof-*` / `bypass-nofp-*` red-team wallets are recorded `device_arch=g4, fingerprint_passed=1`.

### The fix
1. **Root (`derive_verified_device` Path B):** veto the brand fast-path on **positive x86/ARM contradiction** — foreign brand tokens (`X86_CPU_BRANDS | ARM_CPU_BRANDS`), or `has_sse`/`has_avx`/`x86_features` in the SIMD fingerprint. Mirrors Path A. Contradicting claims fall through to strict validation → `x86_64/default`. Correcting the **stored** `device_arch` propagates to *both* the reward path and governance weight (both read the same column).
2. **Defense-in-depth (`_get_active_miner_antiquity_multiplier`):** cap the antiquity **bonus** (>1.0) on `fingerprint_passed`. Failed/un-fingerprinted miners keep base weight (capped 1.0) — liveness preserved — but can't wield a forged vintage tier in governance.

### Why it's fleet-safe (grounded against live Node 1 DB)
- **Reject only on contradiction, never on absence** of PowerPC evidence — genuine PowerPC silicon (AltiVec, no SSE/AVX, no foreign brand tokens) is untouched.
- Verified live: **every real vintage miner passes fingerprint** — `g4-powerbook-115`, `dual-g4-125`, `g5-selena-179`, `ppc_g5_130_*`, `power8-s824-sophia` all `fp=1`. **Every `fp=0` "g4" is a test/spoof wallet** (`test-spoof-g4-no-hw-evidence`, `fpfail-*`, etc.).
- The cap only affects **active** attesters — stale rows return `miner_not_active` before the cap, so historical NULL/`fp=0` rows never lose a tier they'd otherwise hold.
- **Schema-tolerant:** divergent/older nodes lacking the `fingerprint_passed` column fall back to pre-cap behavior (narrowed to the missing-column error only; transient lock/IO errors re-raise) — no governance call crashes. The derive-side arch downgrade still protects those nodes' new writes.
- **Explicit fingerprint coercion:** a stored text `"0"`/`"false"`/NULL can never read truthy (`bool("0")` is `True` in Python — coerced to `== 1` semantics).

### Known residual (documented, not blocking)
A spoofer sending PowerPC brand tokens, *no* foreign tokens, and *omitting* SIMD data entirely could still take the brand fast-path. This needs positive AltiVec/VSX corroboration to close — deferred until the fleet's `simd_identity` telemetry is captured (real G4 AltiVec evidence confirmed) so the stricter gate is provably fleet-safe. The `fingerprint_passed` cap + the requirement to forge a passing 6-check fingerprint constrain it meanwhile.

### Tests
- `node/tests/test_arch_multiplier_guard_t32.py` — **15 tests**: honest G4/G5/POWER8 classification preserved (incl. no-fingerprint legacy), spoof vetoes (SSE/AVX/x86_features/brand-contamination), bonus cap on/off, text-coercion (`"0"` ≠ bonus), legacy-schema (no column) no-crash.
- Regression: 46 existing device/enrollment/entropy tests pass.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), **3 loops, converged**. Loop 2 found + fixed 2 real bugs (schema-crash on column-absent, `bool("0")` truthy-inversion); loop 3 surfaced no new defects — applied one refinement (narrowed `OperationalError` catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)