### PR TITLE
fix(consensus/T2.1): bind attestation challenge nonces to requesting identity

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -607,7 +607,7 @@ def attest_ensure_tables(conn):
     try:
         conn.execute("ALTER TABLE nonces ADD COLUMN bound_miner TEXT")
     except sqlite3.OperationalError:
-        cols = [r[1] for r in conn.execute("PRAGMA table_info(nonces)").fetchall()]
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(nonces)").fetchall()]  # fetchall-ok: pragma-result
         if "bound_miner" not in cols:
             raise
     conn.execute(

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -596,6 +596,20 @@ def _normalize_attestation_report(report):
 def attest_ensure_tables(conn):
     """Create the attestation nonce tables expected by replay protection."""
     conn.execute("CREATE TABLE IF NOT EXISTS nonces (nonce TEXT PRIMARY KEY, expires_at INTEGER)")
+    # T2.1: a challenge may be BOUND to the identity that requested it. Additive column
+    # so existing DBs upgrade in place; NULL bound_miner == legacy unbound nonce
+    # (any miner may consume it), preserving backward compatibility for miners that
+    # don't send miner_id to /attest/challenge. The ALTER is attempted idempotently and
+    # is race/lock tolerant: on ANY OperationalError (duplicate-column from a concurrent
+    # writer that won the race, or a transient "database is locked"), re-check the actual
+    # schema — if the column is present we proceed, otherwise the error was real and we
+    # re-raise. The PRAGMA only runs on the (rare) exception path.
+    try:
+        conn.execute("ALTER TABLE nonces ADD COLUMN bound_miner TEXT")
+    except sqlite3.OperationalError:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(nonces)").fetchall()]
+        if "bound_miner" not in cols:
+            raise
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS used_nonces (
@@ -627,18 +641,33 @@ def attest_cleanup_expired(conn, now_ts: Optional[int] = None):
     conn.commit()
 
 
-def attest_validate_challenge(conn, nonce: str, now_ts: Optional[int] = None):
-    """Validate and consume a one-time challenge nonce from the active node store."""
+def attest_validate_challenge(conn, nonce: str, now_ts: Optional[int] = None,
+                              required_miner: Optional[str] = None):
+    """Validate and consume a one-time challenge nonce from the active node store.
+
+    T2.1: if the challenge was issued BOUND to an identity (``bound_miner`` set), a
+    submission claiming a different ``required_miner`` is rejected *without consuming*
+    the nonce — so an attacker submitting the wrong identity cannot burn a rightful
+    miner's live challenge (DoS), and a harvested/MITM'd nonce can't be replayed under
+    another identity. An unbound (NULL) nonce stays consumable by any miner (legacy).
+    """
     now_ts = int(time.time()) if now_ts is None else int(now_ts)
     attest_cleanup_expired(conn, now_ts=now_ts)
     row = conn.execute(
-        "SELECT expires_at FROM nonces WHERE nonce = ? AND expires_at >= ?",
+        "SELECT expires_at, bound_miner FROM nonces WHERE nonce = ? AND expires_at >= ?",
         (nonce, now_ts),
     ).fetchone()
     if not row:
         return False, "challenge_invalid", None
 
     expires_at = int(row[0])
+    bound_miner = (row[1] or "").strip()
+    if bound_miner and bound_miner != (required_miner or "").strip():
+        # A BOUND nonce is consumable ONLY by its bound identity — a mismatch OR a
+        # missing/empty required_miner is rejected (a caller cannot dodge the binding
+        # by omitting its identity). Do NOT delete: leave the nonce for its owner.
+        return False, "nonce_identity_mismatch", None
+
     deleted = conn.execute(
         "DELETE FROM nonces WHERE nonce = ? AND expires_at = ?",
         (nonce, expires_at),
@@ -670,7 +699,9 @@ def attest_validate_and_store_nonce(
     if replay_row:
         return False, "nonce_replay", None
 
-    ok, err, challenge_expires_at = attest_validate_challenge(conn, nonce, now_ts=now_ts)
+    ok, err, challenge_expires_at = attest_validate_challenge(
+        conn, nonce, now_ts=now_ts, required_miner=(miner or None)
+    )
     if not ok:
         return False, err, None
 
@@ -4013,13 +4044,30 @@ def get_challenge():
     nonce = secrets.token_hex(32)
     expires = int(time.time()) + 300  # 5 minutes
 
+    # T2.1: optionally BIND the challenge to the requesting identity. A miner that
+    # sends its miner_id gets a nonce only IT can consume at /attest/submit; legacy
+    # miners that send no identity get an unbound nonce (backward compatible).
+    body = request.get_json(silent=True)
+    requested_miner = None
+    if isinstance(body, dict):
+        # Extract identity in the SAME order the submit path resolves `miner`
+        # (_submit_attestation_impl: data.get('miner') or data.get('miner_id')) so a
+        # client where miner != miner_id binds to exactly the identity that will be
+        # enforced at consume time — otherwise binding would lock out the rightful owner.
+        requested_miner = _attest_valid_miner(body.get('miner')) or _attest_valid_miner(body.get('miner_id'))
+
     with closing(sqlite3.connect(DB_PATH)) as c:
-        c.execute("INSERT INTO nonces (nonce, expires_at) VALUES (?, ?)", (nonce, expires))
+        attest_ensure_tables(c)  # guarantees the bound_miner column exists
+        c.execute(
+            "INSERT INTO nonces (nonce, expires_at, bound_miner) VALUES (?, ?, ?)",
+            (nonce, expires, requested_miner),
+        )
         c.commit()
 
     return jsonify({
         "nonce": nonce,
         "expires_at": expires,
+        "bound_miner": requested_miner,
         "server_time": int(time.time())
     })
 
@@ -4238,17 +4286,25 @@ def _submit_attestation_impl():
                 "Attestation nonce has already been used",
                 "NONCE_REPLAY",
             ),
+            "nonce_identity_mismatch": (
+                "nonce_identity_mismatch",
+                "Attestation challenge was issued to a different identity; request a "
+                "challenge with this miner_id",
+                "NONCE_IDENTITY_MISMATCH",
+            ),
         }
         error_name, message, code = nonce_messages.get(
             nonce_err,
             ("invalid_nonce", "Attestation nonce is invalid", "INVALID_NONCE"),
         )
+        # 403 for an identity mismatch (authorization), 409 for stale/replayed nonce.
+        http_status = 403 if nonce_err == "nonce_identity_mismatch" else 409
         return jsonify({
             "ok": False,
             "error": error_name,
             "message": message,
             "code": code
-        }), 409
+        }), http_status
     signals = _normalize_attestation_signals(data.get('signals'))
     fingerprint = _attest_mapping(data.get('fingerprint'))  # NEW: Extract fingerprint
 

--- a/node/tests/test_attest_nonce_identity_binding_t21.py
+++ b/node/tests/test_attest_nonce_identity_binding_t21.py
@@ -1,0 +1,134 @@
+"""T2.1 regression: challenge nonces may be BOUND to the requesting identity.
+
+`/attest/challenge` used to issue a free-floating nonce bound to nobody — any
+claimed miner could consume any live nonce, so a harvested/MITM'd challenge could be
+replayed under a different identity (feeds the T1.1 impersonation surface). T2.1 lets
+the requester bind the nonce to its miner_id; a submission claiming a different
+identity is rejected WITHOUT consuming the nonce (so it can't DoS the rightful owner).
+Unbound nonces stay consumable by anyone (backward compatible for legacy miners).
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class NonceIdentityBindingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        os.environ.setdefault("RUSTCHAIN_DB_PATH", os.path.join(cls._tmp.name, "t21.db"))
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        os.environ.setdefault("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+        spec = importlib.util.spec_from_file_location("rcnode_t21_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    def _conn(self):
+        c = sqlite3.connect(":memory:")
+        self.mod.attest_ensure_tables(c)
+        c.commit()
+        return c
+
+    def _issue(self, c, nonce, bound_miner=None, ttl=300):
+        c.execute("INSERT INTO nonces (nonce, expires_at, bound_miner) VALUES (?, ?, ?)",
+                  (nonce, int(time.time()) + ttl, bound_miner))
+        c.commit()
+
+    # --- schema ------------------------------------------------------------
+    def test_ensure_tables_adds_bound_miner_column(self):
+        c = self._conn()
+        cols = [r[1] for r in c.execute("PRAGMA table_info(nonces)").fetchall()]
+        self.assertIn("bound_miner", cols)
+
+    def test_ensure_tables_migrates_legacy_nonces_table(self):
+        """An existing 2-column nonces table must gain bound_miner in place (ALTER),
+        not error and not drop rows."""
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE nonces (nonce TEXT PRIMARY KEY, expires_at INTEGER)")
+        c.execute("INSERT INTO nonces (nonce, expires_at) VALUES ('legacy', ?)", (int(time.time()) + 300,))
+        c.commit()
+        self.mod.attest_ensure_tables(c)  # must ALTER, not raise
+        cols = [r[1] for r in c.execute("PRAGMA table_info(nonces)").fetchall()]
+        self.assertIn("bound_miner", cols)
+        self.assertEqual(c.execute("SELECT bound_miner FROM nonces WHERE nonce='legacy'").fetchone()[0], None)
+
+    # --- unbound (legacy) --------------------------------------------------
+    def test_unbound_nonce_consumable_by_any_miner(self):
+        c = self._conn()
+        self._issue(c, "n-unbound", bound_miner=None)
+        ok, err, _ = self.mod.attest_validate_and_store_nonce(c, miner="whoever-x", nonce="n-unbound")
+        self.assertTrue(ok, err)
+
+    # --- bound: matching identity -----------------------------------------
+    def test_bound_nonce_consumed_by_matching_miner(self):
+        c = self._conn()
+        self._issue(c, "n-bound", bound_miner="g4-powerbook-115")
+        ok, err, _ = self.mod.attest_validate_and_store_nonce(c, miner="g4-powerbook-115", nonce="n-bound")
+        self.assertTrue(ok, err)
+        # consumed: moved to used_nonces, removed from nonces
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM nonces WHERE nonce='n-bound'").fetchone()[0], 0)
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce='n-bound'").fetchone()[0], 1)
+
+    # --- bound: mismatched identity ---------------------------------------
+    def test_bound_nonce_rejected_for_other_miner_and_preserved(self):
+        c = self._conn()
+        self._issue(c, "n-victim", bound_miner="g4-powerbook-115")
+        # attacker tries to consume the victim's bound challenge
+        ok, err, _ = self.mod.attest_validate_and_store_nonce(c, miner="attacker-wallet", nonce="n-victim")
+        self.assertFalse(ok)
+        self.assertEqual(err, "nonce_identity_mismatch")
+        # NOT consumed — still available for the rightful owner (no DoS)
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM nonces WHERE nonce='n-victim'").fetchone()[0], 1)
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce='n-victim'").fetchone()[0], 0)
+        # rightful owner can still use it afterward
+        ok2, err2, _ = self.mod.attest_validate_and_store_nonce(c, miner="g4-powerbook-115", nonce="n-victim")
+        self.assertTrue(ok2, err2)
+
+    def test_bound_nonce_rejected_when_no_identity_supplied(self):
+        """Codex audit: a bound nonce must NOT be consumable by a caller that omits its
+        identity (required_miner None/empty) — otherwise binding is trivially dodged."""
+        c = self._conn()
+        self._issue(c, "n-noident", bound_miner="owner")
+        for bad in (None, "", "   "):
+            ok, err, _ = self.mod.attest_validate_challenge(c, "n-noident", required_miner=bad)
+            self.assertFalse(ok)
+            self.assertEqual(err, "nonce_identity_mismatch")
+            self.assertEqual(c.execute("SELECT COUNT(*) FROM nonces WHERE nonce='n-noident'").fetchone()[0], 1)
+
+    def test_ensure_tables_idempotent_double_call(self):
+        """The race-safe ALTER must be idempotent: a second ensure_tables call must not
+        raise duplicate-column, and must not add the column twice."""
+        c = self._conn()                       # ensured once
+        self.mod.attest_ensure_tables(c)       # second call — must not raise
+        self.mod.attest_ensure_tables(c)       # third for good measure
+        cols = [r[1] for r in c.execute("PRAGMA table_info(nonces)").fetchall()]
+        self.assertEqual(cols.count("bound_miner"), 1)
+
+    def test_validate_challenge_mismatch_does_not_delete(self):
+        """Lower-level guard: attest_validate_challenge must not consume on mismatch."""
+        c = self._conn()
+        self._issue(c, "n-low", bound_miner="owner")
+        ok, err, _ = self.mod.attest_validate_challenge(c, "n-low", required_miner="intruder")
+        self.assertFalse(ok)
+        self.assertEqual(err, "nonce_identity_mismatch")
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM nonces WHERE nonce='n-low'").fetchone()[0], 1)
+
+    # --- replay (unchanged behavior) --------------------------------------
+    def test_replay_rejected_after_consume(self):
+        c = self._conn()
+        self._issue(c, "n-replay", bound_miner="g5-selena-179")
+        ok, _, _ = self.mod.attest_validate_and_store_nonce(c, miner="g5-selena-179", nonce="n-replay")
+        self.assertTrue(ok)
+        ok2, err2, _ = self.mod.attest_validate_and_store_nonce(c, miner="g5-selena-179", nonce="n-replay")
+        self.assertFalse(ok2)
+        self.assertEqual(err2, "nonce_replay")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/node/tests/test_attest_submit_challenge_binding.py
+++ b/node/tests/test_attest_submit_challenge_binding.py
@@ -260,6 +260,38 @@ class TestAttestSubmitChallengeBinding(unittest.TestCase):
                         0,
                     )
 
+    def test_bound_challenge_endpoint_matching_miner_succeeds(self):
+        """T2.1: a challenge requested WITH a miner_id binds to it; a submit from the
+        same miner succeeds and the response advertises the binding."""
+        mod, db_path = self._load_module("rustchain_attest_bound_ok", "bound_ok.db")
+        miner = "RTC_REPLAY_POC_MINER"
+        with mod.app.test_request_context("/attest/challenge", method="POST", json={"miner_id": miner}):
+            challenge = mod.get_challenge().get_json()
+        self.assertEqual(challenge.get("bound_miner"), miner)
+        with closing(sqlite3.connect(db_path)) as conn:
+            self.assertEqual(
+                conn.execute("SELECT bound_miner FROM nonces WHERE nonce=?", (challenge["nonce"],)).fetchone()[0],
+                miner)
+        status, body = self._submit(mod, self._attestation_payload(challenge["nonce"]))
+        self.assertEqual(status, 200)
+        self.assertTrue(body["ok"])
+
+    def test_bound_challenge_endpoint_other_miner_rejected_and_preserved(self):
+        """A submit claiming a DIFFERENT identity than the bound challenge is rejected
+        403 NONCE_IDENTITY_MISMATCH and the nonce is NOT consumed (no DoS)."""
+        mod, db_path = self._load_module("rustchain_attest_bound_mismatch", "bound_mismatch.db")
+        with mod.app.test_request_context("/attest/challenge", method="POST", json={"miner_id": "RTC_RIGHTFUL_OWNER"}):
+            challenge = mod.get_challenge().get_json()
+        payload = self._attestation_payload(challenge["nonce"])  # default miner = RTC_REPLAY_POC_MINER (≠ owner)
+        status, body = self._submit(mod, payload)
+        self.assertEqual(status, 403)
+        self.assertEqual(body["code"], "NONCE_IDENTITY_MISMATCH")
+        with closing(sqlite3.connect(db_path)) as conn:
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM nonces WHERE nonce=?", (challenge["nonce"],)).fetchone()[0], 1)
+            self.assertEqual(
+                conn.execute("SELECT COUNT(*) FROM used_nonces WHERE nonce=?", (challenge["nonce"],)).fetchone()[0], 0)
+
     def test_non_string_signature_does_not_consume_nonce(self):
         mod, db_path = self._load_module("rustchain_attest_signature_type", "signature_type.db")
 


### PR DESCRIPTION
## T2.1 — Challenge nonce not miner-bound + unsigned attestation

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #2). HIGH severity, external attack surface. **Completes the T1.1 story** (#6904 closed the header-key add-path; this closes the challenge-nonce gap that feeds the impersonation).

### The gap
`/attest/challenge` issued a **free-floating nonce bound to nobody** — any claimed `miner` could consume any live nonce. A challenge harvested or MITM'd from one miner could be replayed under a different identity, feeding the header-key impersonation surface.

### The fix (backward-compatible)
- **`nonces` gains an additive `bound_miner` column** — migrates existing DBs in place; the `ALTER` is idempotent and **race/lock-tolerant** (on any `OperationalError` it re-checks the actual schema and only re-raises if the column is genuinely absent). `init_db` ensures it at startup, so the hot path normally never migrates.
- **`/attest/challenge` accepts an optional `miner_id`** and binds the nonce to it. The identity extraction order **matches the submit path** (`miner` → `miner_id`) so a client where `miner != miner_id` binds to exactly the identity that gets enforced (no legit lockout). The response advertises `bound_miner`.
- **`attest_validate_challenge` rejects a BOUND nonce for any non-matching consumer** — a mismatched *or missing/empty* identity is rejected **without consuming the nonce**, so an attacker can't burn a rightful miner's live challenge (no DoS) and a harvested nonce can't be replayed under another identity → **403 `NONCE_IDENTITY_MISMATCH`**.
- **Unbound (NULL) nonces stay consumable by anyone** → backward-compatible for legacy miners that send no identity.

### Why no blanket signature requirement
Deliberately **not** requiring signatures on all attestations — that would brick vintage named wallets (G4/G5 PowerBooks). The unsigned → header-key-registration vector is already closed by #6904's `_header_key_authorized` (self-auth `address_from_pubkey(pubkey)==identity` + admin allowlist for named identities). Binding raises the bar on nonce reuse without breaking the honest vintage fleet.

### Status semantics
`NONCE_IDENTITY_MISMATCH` → **403** (authorization: request a challenge with the correct `miner_id`), distinct from the existing **409** for stale/replayed nonces. The added `bound_miner` response field is additive (unknown-field-tolerant clients unaffected).

### Tests (23, all green)
- `node/tests/test_attest_nonce_identity_binding_t21.py` — function-level: column migration (incl. legacy 2-col table in place), idempotent double-ensure, unbound consumable by any miner, bound consumed by match, **bound rejected for other miner + preserved for owner**, bound rejected when no identity supplied, lower-level `attest_validate_challenge` mismatch-no-delete, replay.
- `node/tests/test_attest_submit_challenge_binding.py` — endpoint-level: bound challenge + matching submit succeeds (response advertises binding); mismatched submit → 403 + nonce preserved. Existing cross-node/replay/timestamp/missing-evidence tests still pass.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), **3 loops, converged**. Loop 2 caught + fixed 2 real bugs (bound-nonce bypass when identity omitted; non-idempotent ALTER race); loop 3 added the lock-tolerant ALTER refinement.

### Documented follow-up (not blocking)
Other modules create a 2-col `nonces` table directly (`sophia_elya_service.py`, `tools/db-migrate` V0018 baseline, deprecated nodes). The live node self-heals (every nonce path runs `attest_ensure_tables`), but those creation sites could carry `bound_miner` for cleanliness in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)