### PR TITLE
fix(ci): sync frontend and miner baseline checks

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -118,10 +118,12 @@ function normalizeMinersResponse(payload) {
     if (Array.isArray(payload)) {
         rows = payload;
     } else if (payload && typeof payload === 'object') {
-        if (Array.isArray(payload.miners)) {
+        if (Array.isArray(payload?.miners)) {
             rows = payload.miners;
-        } else if (Array.isArray(payload.data)) {
+        } else if (Array.isArray(payload?.data)) {
             rows = payload.data;
+        } else if (Array.isArray(payload?.items)) {
+            rows = payload.items;
         } else if (typeof payload === 'object' && payload !== null) {
             // Handle case where payload is a single miner object
             rows = [payload];

--- a/setup_miner.py
+++ b/setup_miner.py
@@ -20,7 +20,7 @@ from pathlib import Path
 MINER_ARTIFACTS = {
     "Linux": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/linux/rustchain_linux_miner.py",
-        "sha256": "ca2931797a7a76fb7c9e61d69abdf75c57dab204ec77c2c5e9f23f323af63f9d",
+        "sha256": "77cc08915f9a64a2aed3ceb8c6517bd9935d4447d9dfce70a50af3038914a1dc",
     },
     "Darwin": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/macos/rustchain_mac_miner_v2.5.py",
@@ -28,7 +28,7 @@ MINER_ARTIFACTS = {
     },
     "Windows": {
         "url": "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/rustchain_windows_miner.py",
-        "sha256": "e2c91305b641b1639d4b33f0a65bcf25afcb06eeceeebbe852f03d47bc957d13",
+        "sha256": "a4c07a32f9e475efb60bb5bef548a91c8eecc15b978ba57eca4fb4c6603642fd",
     },
 }
 

--- a/web/hall-of-fame/index.html
+++ b/web/hall-of-fame/index.html
@@ -217,7 +217,7 @@
 </div>
 
 <script>
-const API_LEADERBOARD = '/hall/leaderboard';
+const API_LEADERBOARD = '/api/hall_of_fame/leaderboard';
 const API_STATS       = '/api/hall_of_fame/stats';
 
 function esc(s){ return String(s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }


### PR DESCRIPTION
## Summary

Fixes three narrow CI baseline drifts currently visible in the broad test job:

- Explorer miners normalization static checks expected the hardened optional-chaining helper shape; this also adds support for `/api/miners` payloads using an `items` envelope.
- Hall of Fame static frontend was still using `/hall/leaderboard` while docs/tests expect the compat `/api/hall_of_fame/leaderboard` route.
- `setup_miner.py` pinned stale Linux and Windows miner SHA256 values after miner artifact changes.

This intentionally does not touch the `fetchall_guard` baseline issue, which is broader and tracked separately.

## Validation

```text
PYTHONPATH=C:\Users\Administrator\AppData\Local\Temp\codex-rustchain-pydeps python -m pytest -q \
  tests/test_explorer_miners_normalization.py::test_explorer_normalizes_paginated_miners_response \
  tests/test_explorer_miners_normalization.py::test_explorer_keeps_legacy_array_response_compatible \
  tests/test_hall_of_fame_api_docs.py \
  tests/test_hall_of_fame_frontend_endpoints.py \
  tests/test_setup_miner_downloads.py
# 8 passed

python -m py_compile setup_miner.py
git diff --check -- explorer/static/js/explorer.js web/hall-of-fame/index.html setup_miner.py
```

Note: the full `tests/test_explorer_miners_normalization.py` file includes Node VM probes executed via `node -e`. On this Windows host those two probes exceed the Windows command-line length limit (`WinError 206`). The GitHub Linux runner does not have that platform limit; the failing CI string/assertion portion is covered above.

Payout handle if accepted under #305: `github:pqmfei`.
