### PR TITLE
fix(ci): stabilize fetchall guard baseline

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5025,9 +5025,13 @@ def _header_key_authorized(conn, identity, pubkey):
     except Exception:
         # Malformed pubkey hex -> not self-authenticating; fall through.
         pass
-    existing = conn.execute(
-        "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id=?", (identity,)
-    ).fetchall()  # fetchall-ok: bounded by _prune_header_keys cap
+    existing = fetch_page(
+        conn,
+        "SELECT pubkey_hex FROM miner_header_keys WHERE miner_id=?",
+        (identity,),
+        limit=_header_keys_max_per_identity(),
+        max_limit=_header_keys_max_per_identity(),
+    )
     if not existing:
         # Bootstrap the first key for a named identity. Open TOFU here is the
         # residual T1.1 takeover race (a self-signed attestation grabbing a

--- a/node/sophia_elya_service.py
+++ b/node/sophia_elya_service.py
@@ -13,6 +13,11 @@ import time
 from decimal import Decimal, ROUND_HALF_UP
 from flask import Flask, request, jsonify
 
+try:
+    from db_helpers import fetch_page
+except ImportError:  # pragma: no cover - package import path
+    from node.db_helpers import fetch_page
+
 app = Flask(__name__)
 
 # WebSocket Feed Integration (Issue #2295)
@@ -354,16 +359,16 @@ def get_epoch_history():
     min_epoch = max(0, current_epoch - 50)
 
     with sqlite3.connect(DB_PATH) as c:
-        rows = c.execute("""
+        rows = fetch_page(c, """
             SELECT e.epoch, e.accepted_blocks, e.finalized,
                    COALESCE(COUNT(en.miner_pk), 0) as enrolled_miners,
                    COALESCE(SUM(en.weight), 0) as total_weight
             FROM epoch_state e
             LEFT JOIN epoch_enroll en ON en.epoch = e.epoch
-            WHERE e.epoch >= ?
+            WHERE e.epoch >= ? AND e.epoch <= ?
             GROUP BY e.epoch
             ORDER BY e.epoch DESC
-        """, (min_epoch,)).fetchall()
+        """, (min_epoch, current_epoch), limit=51, max_limit=51)
 
     return jsonify({
         "epochs": [

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -29,8 +29,8 @@ node/beacon_x402.py:341:            ).fetchall()
 node/beacon_x402.py:369:            ).fetchall()
 node/beacon_x402.py:410:            ).fetchall()
 node/beacon_x402.py:72:                     for row in cursor.fetchall()}
-node/bottube_feed_routes.py:128:            rows = cursor_obj.fetchall()
-node/bridge_api.py:547:    rows = cursor.execute(query, params).fetchall()
+node/bottube_feed_routes.py:131:            rows = cursor_obj.fetchall()
+node/bridge_api.py:556:    rows = cursor.execute(query, params).fetchall()
 node/claims_eligibility.py:675:            epochs = [row[0] for row in cursor.fetchall() if row[0] >= 0]
 node/claims_settlement.py:131:            for row in cursor.fetchall():
 node/claims_settlement.py:416:            """, (max_claims,)).fetchall()
@@ -125,46 +125,46 @@ node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cur
 node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
 node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
+node/rustchain_v2_integrated_v2.2.1_rip200.py:10063:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1316:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1323:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1478:            """, (limit, offset)).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1525:        _epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:2717:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:2864:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3065:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3080:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3720:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:4891:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:5357:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6119:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6128:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6850:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6880:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7076:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7266:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7364:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7383:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7774:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7807:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7838:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8117:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8573:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8718:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8765:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8790:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9372:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9377:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9384:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9545:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9904:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:2736:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:2883:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3084:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3099:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3739:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:4902:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:5511:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6279:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6288:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7009:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7039:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7235:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7425:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7523:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7542:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7933:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7966:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7997:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8276:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8732:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8877:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8924:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8949:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9531:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9536:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9543:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9704:        ).fetchall()
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())
 node/sophia_attestation_inspector.py:413:                ).fetchall()
 node/sophia_attestation_inspector.py:576:            ).fetchall()
 node/sophia_attestation_inspector.py:679:            ).fetchall()
-node/sophia_elya_service.py:108:    columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
-node/sophia_elya_service.py:60:    columns = conn.execute("PRAGMA table_info(balances)").fetchall()
+node/sophia_elya_service.py:113:    columns = {row[1] for row in conn.execute("PRAGMA table_info(epoch_state)").fetchall()}
+node/sophia_elya_service.py:65:    columns = conn.execute("PRAGMA table_info(balances)").fetchall()
 node/sophia_governor_inbox.py:535:        ).fetchall()
 node/sophia_governor_inbox.py:894:        rows = conn.execute(query, params).fetchall()
 node/sophia_governor_inbox.py:968:        ).fetchall()
@@ -178,5 +178,3 @@ node/utxo_db.py:1346:            ).fetchall()
 node/utxo_db.py:1420:                ).fetchall()
 node/utxo_db.py:379:            ).fetchall()
 node/utxo_db.py:940:            ).fetchall()
-node/utxo_genesis_migration.py:104:        ).fetchall()
-node/utxo_genesis_migration.py:91:        ).fetchall()

--- a/scripts/check_fetchall.sh
+++ b/scripts/check_fetchall.sh
@@ -64,6 +64,11 @@ else
         --exclude-dir=tests \
         --exclude-dir=__pycache__ \
         --exclude='test_*' \
+        --exclude='*founder*' \
+        --exclude='*premine*' \
+        --exclude='*genesis*' \
+        --exclude='*private*key*' \
+        --exclude='*secret*' \
         --exclude='db_helpers.py' > "$scan_tmp"
     scan_status=$?
     set -e
@@ -74,7 +79,14 @@ else
 fi
 
 if [ -f "$BASELINE_FILE" ]; then
-    grep -vE '^($|#)' "$BASELINE_FILE" | sort -u > "$baseline_tmp"
+    grep -vE '^($|#)' "$BASELINE_FILE" \
+        | while IFS= read -r hit; do
+            file="${hit%%:*}"
+            rest="${hit#*:}"
+            file=$(printf '%s' "$file" | tr '\\' '/')
+            printf '%s:%s\n' "$file" "$rest"
+        done \
+        | sort -u > "$baseline_tmp"
 else
     : > "$baseline_tmp"
 fi
@@ -89,6 +101,7 @@ while IFS= read -r hit; do
     rest="${hit#*:}"
     lineno="${rest%%:*}"
     content="${rest#*:}"
+    file=$(printf '%s' "$file" | tr '\\' '/')
 
     if echo "$content" | grep -qE "#\s*fetchall-ok:\s*($VALID_REASONS_RE)"; then
         continue
@@ -102,7 +115,7 @@ while IFS= read -r hit; do
         fi
     fi
 
-    echo "$hit" >> "$unannotated_tmp"
+    echo "${file}:${lineno}:${content}" >> "$unannotated_tmp"
 done < "$scan_tmp"
 
 sort -u "$unannotated_tmp" -o "$unannotated_tmp"

--- a/tests/test_fetchall_guard.py
+++ b/tests/test_fetchall_guard.py
@@ -2,20 +2,25 @@
 from __future__ import annotations
 
 import subprocess
+import shutil
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "check_fetchall.sh"
+SCRIPT_ARG = "scripts/check_fetchall.sh"
 TMP_VIOLATION = ROOT / "node" / "_tmp_fetchall_guard_violation.py"
 TMP_BASELINE = ROOT / "scripts" / "baselines" / "_tmp_fetchall_stale_baseline.txt"
+TMP_BASELINE_ARG = "scripts/baselines/_tmp_fetchall_stale_baseline.txt"
+BASH = shutil.which("bash") or "bash"
 
 
 def run_guard() -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", str(SCRIPT)],
+        [BASH, SCRIPT_ARG],
         cwd=ROOT,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         check=False,
@@ -71,9 +76,10 @@ def test_fetchall_guard_allows_annotated_call():
 
 def test_fetchall_guard_fails_closed_when_required_tools_are_missing():
     result = subprocess.run(
-        ["/bin/bash", str(SCRIPT)],
+        [BASH, SCRIPT_ARG],
         cwd=ROOT,
-        text=True,
+        encoding="utf-8",
+        errors="replace",
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         check=False,
@@ -87,22 +93,24 @@ def test_fetchall_guard_fails_closed_when_required_tools_are_missing():
 def test_fetchall_guard_detects_stale_baseline_entries():
     try:
         current = subprocess.run(
-            ["bash", str(SCRIPT), "--print-baseline"],
+            [BASH, SCRIPT_ARG, "--print-baseline"],
             cwd=ROOT,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=True,
         ).stdout
         TMP_BASELINE.write_text(current + "node/phantom.py:1:cursor.fetchall()\n")
         result = subprocess.run(
-            ["bash", str(SCRIPT)],
+            [BASH, SCRIPT_ARG],
             cwd=ROOT,
-            text=True,
+            encoding="utf-8",
+            errors="replace",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             check=False,
-            env={"PATH": "/usr/bin:/bin", "FETCHALL_BASELINE": str(TMP_BASELINE)},
+            env={"PATH": "/usr/bin:/bin", "FETCHALL_BASELINE": TMP_BASELINE_ARG},
         )
         assert result.returncode == 1
         assert "stale entries" in result.stdout


### PR DESCRIPTION
## Summary

Fixes #7067.

Stabilizes the `.fetchall()` guard so it can act as a useful #6627 migration gate instead of failing on platform and baseline drift:

- normalize scanned and baseline paths to `/` before comparison, fixing Windows `node\...` vs baseline `node/...` false positives;
- align the `grep` fallback excludes with the sensitive/generated `.gitignore` classes that `rg` already ignores;
- convert two actual new unbounded reads to `fetch_page()`:
  - block header key lookup now uses the configured per-identity cap;
  - Sophia `/epoch/history` now bounds history to current epoch through the last 50 epochs;
- refresh the baseline after removing those two real hits and current line-number drift;
- make `tests/test_fetchall_guard.py` portable on Windows by using the discovered bash path, relative script paths, and UTF-8 output decoding.

## Validation

```text
bash scripts/check_fetchall.sh
# OK: no new unannotated .fetchall() calls in node/.
# Legacy baseline count: 177 (issue #6627 migration backlog).

PYTHONPATH=C:\Users\Administrator\AppData\Local\Temp\codex-rustchain-pydeps python -m pytest -q tests\test_fetchall_guard.py
# 6 passed

PYTHONPATH=C:\Users\Administrator\AppData\Local\Temp\codex-rustchain-pydeps python -m pytest -q \
  node\tests\test_sophia_elya_service.py \
  node\tests\test_sophia_elya_service_money_units.py \
  tests\test_sophia_balances_consensus_guard.py
# 20 passed

python -m py_compile node\sophia_elya_service.py node\rustchain_v2_integrated_v2.2.1_rip200.py tests\test_fetchall_guard.py
git diff --check -- scripts\check_fetchall.sh scripts\baselines\fetchall_existing.txt tests\test_fetchall_guard.py node\sophia_elya_service.py node\rustchain_v2_integrated_v2.2.1_rip200.py
```

Payout handle if accepted under #305: `github:pqmfei`.