### PR TITLE
fix(wallet): query current coinbase balance route

### DIFF
--- a/wallet/coinbase_wallet.py
+++ b/wallet/coinbase_wallet.py
@@ -10,7 +10,7 @@ import os
 import sys
 import socket
 import time
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 import requests
 
@@ -109,7 +109,7 @@ def _fetch_with_retry(url, method="GET", data=None, max_retries=3, timeout=10, v
 
 def _get_wallet_balance_from_node(address):
     """Get wallet balance from RustChain node."""
-    url = f"{NODE_URL}/wallet/balance/{address}"
+    url = f"{NODE_URL}/wallet/balance?{urlencode({'miner_id': address})}"
     payload, error = _fetch_with_retry(url)
     if error:
         return None, error

--- a/wallet/tests/test_wallet_network_errors.py
+++ b/wallet/tests/test_wallet_network_errors.py
@@ -160,6 +160,22 @@ class TestGetWalletBalance:
             assert error is None
             assert balance == 42.5
 
+    def test_balance_fetch_uses_current_query_endpoint(self):
+        """Balance lookup should use the current miner_id query endpoint."""
+        from coinbase_wallet import NODE_URL, _get_wallet_balance_from_node
+
+        with patch(
+            'coinbase_wallet._fetch_with_retry',
+            return_value=({"amount_rtc": 0.0}, None),
+        ) as fetch:
+            balance, error = _get_wallet_balance_from_node("github:pqmfei")
+
+        assert error is None
+        assert balance == 0.0
+        fetch.assert_called_once_with(
+            f"{NODE_URL}/wallet/balance?miner_id=github%3Apqmfei"
+        )
+
     def test_balance_with_alternative_field(self):
         """Test balance extraction from alternative field names."""
         from coinbase_wallet import _get_wallet_balance_from_node


### PR DESCRIPTION
## Summary

Fixes #7072.

`wallet/coinbase_wallet.py` still queried RustChain balances with `/wallet/balance/{address}`. The live node returns 404 for that path; the current public API is `/wallet/balance?miner_id=...`.

This PR:

- switches the Coinbase wallet balance helper to the query-based `miner_id` endpoint;
- URL-encodes the miner id with `urllib.parse.urlencode`;
- adds a regression test for a handle containing `:` so the query encoding is covered.

## Live route evidence

```text
curl -sk -w "\nHTTP:%{http_code}\n" "https://rustchain.org/wallet/balance/pqmfei"
# Flask 404 HTML
# HTTP:404

curl -sk -w "\nHTTP:%{http_code}\n" "https://rustchain.org/wallet/balance?miner_id=pqmfei"
# {"amount_i64":0,"amount_rtc":0.0,"miner_id":"pqmfei"}
# HTTP:200
```

## Validation

```text
# Run from wallet/ to avoid the root tests/conftest.py integration-node import.
python -m pytest -q tests\test_wallet_network_errors.py --tb=short
# 17 passed

python -m py_compile wallet\coinbase_wallet.py wallet\tests\test_wallet_network_errors.py tests\test_wallet_coinbase_show.py
# passed

git diff --check -- wallet\coinbase_wallet.py wallet\tests\test_wallet_network_errors.py
# clean
```

Payout handle if accepted under #305: `github:pqmfei`.
