### PR TITLE
Fix mobile wallet history normalization

### DIFF
--- a/react-native-wallet/src/api/__tests__/rustchain.test.ts
+++ b/react-native-wallet/src/api/__tests__/rustchain.test.ts
@@ -78,6 +78,104 @@ describe('RustChainClient', () => {
     });
   });
 
+  describe('getTransferHistory', () => {
+    const legacyTransaction = {
+      id: 7,
+      tx_id: 'tx_legacy',
+      tx_hash: 'tx_legacy',
+      from_addr: TEST_ADDRESS,
+      to_addr: RECIPIENT_ADDRESS,
+      amount: 1.25,
+      amount_i64: 1_250_000,
+      amount_rtc: 1.25,
+      timestamp: 1700000000,
+      created_at: 1700000000,
+      confirmed_at: 1700000000,
+      confirms_at: 1700000000,
+      status: 'confirmed' as const,
+      raw_status: 'confirmed',
+      status_reason: null,
+      confirmations: 1,
+      direction: 'sent' as const,
+      counterparty: RECIPIENT_ADDRESS,
+      reason: 'signed_transfer:test',
+      memo: 'test',
+    };
+
+    it('should preserve legacy array wallet history responses', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [legacyTransaction],
+      });
+
+      const history = await client.getTransferHistory(TEST_ADDRESS, 10);
+
+      expect(history).toEqual([legacyTransaction]);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/wallet/history?address=${encodeURIComponent(TEST_ADDRESS)}&limit=10`),
+        expect.any(Object)
+      );
+    });
+
+    it('should normalize the live envelope wallet history response', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          ok: true,
+          miner_id: TEST_ADDRESS,
+          total: 1,
+          transactions: [
+            {
+              amount: 5.0,
+              epoch: null,
+              from: 'founder_community',
+              status: 'pending',
+              timestamp: 1780930000,
+              tx_hash: '09db0d0ace4ab297a54f4e2e392e69e7',
+              type: 'transfer_in',
+            },
+          ],
+        }),
+      });
+
+      const history = await client.getTransferHistory(TEST_ADDRESS, 5);
+
+      expect(history).toHaveLength(1);
+      expect(history[0]).toMatchObject({
+        id: 0,
+        tx_id: '09db0d0ace4ab297a54f4e2e392e69e7',
+        tx_hash: '09db0d0ace4ab297a54f4e2e392e69e7',
+        from_addr: 'founder_community',
+        to_addr: TEST_ADDRESS,
+        amount: 5,
+        amount_i64: 5_000_000,
+        amount_rtc: 5,
+        timestamp: 1780930000,
+        created_at: 1780930000,
+        confirmed_at: null,
+        confirms_at: null,
+        status: 'pending',
+        raw_status: 'pending',
+        status_reason: null,
+        confirmations: 0,
+        direction: 'received',
+        counterparty: 'founder_community',
+        memo: null,
+      });
+    });
+
+    it('should reject unexpected wallet history payloads', async () => {
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true, transactions: {} }),
+      });
+
+      await expect(client.getTransferHistory(TEST_ADDRESS)).rejects.toThrow(
+        'Unexpected wallet history response'
+      );
+    });
+  });
+
   describe('network info', () => {
     it('should fetch and cache the chain id', async () => {
       const info = {

--- a/react-native-wallet/src/api/rustchain.ts
+++ b/react-native-wallet/src/api/rustchain.ts
@@ -234,6 +234,91 @@ export class RustChainClient {
     };
   }
 
+  private normalizeTransferHistoryResponse(raw: any, address: string): TransferHistoryItem[] {
+    const records = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.transactions)
+        ? raw.transactions
+        : null;
+
+    if (!records) {
+      throw new RustChainApiError('Unexpected wallet history response');
+    }
+
+    return records.map((record: any, index: number) =>
+      this.normalizeTransferHistoryItem(record, address, index)
+    );
+  }
+
+  private normalizeTransferHistoryItem(raw: any, address: string, index: number): TransferHistoryItem {
+    const type = typeof raw?.type === 'string' ? raw.type : '';
+    const rawStatus = typeof raw?.status === 'string'
+      ? raw.status
+      : type === 'reward' || type === 'ledger' || type === 'transfer_in' || type === 'transfer_out'
+        ? 'confirmed'
+        : 'pending';
+    const status: TransferHistoryItem['status'] =
+      rawStatus === 'confirmed' ? 'confirmed' : rawStatus === 'pending' ? 'pending' : 'failed';
+    const amount_rtc = typeof raw?.amount_rtc === 'number'
+      ? raw.amount_rtc
+      : typeof raw?.amount === 'number'
+        ? raw.amount
+        : Number.isSafeInteger(raw?.amount_i64)
+          ? raw.amount_i64 / MICRO_RTC_PER_RTC
+          : 0;
+    const amount_i64 = Number.isSafeInteger(raw?.amount_i64)
+      ? raw.amount_i64
+      : Math.round(amount_rtc * MICRO_RTC_PER_RTC);
+    const timestamp = Number.isSafeInteger(raw?.timestamp)
+      ? raw.timestamp
+      : Number.isSafeInteger(raw?.created_at)
+        ? raw.created_at
+        : 0;
+    const direction: TransferHistoryItem['direction'] =
+      raw?.direction === 'sent' || raw?.direction === 'received'
+        ? raw.direction
+        : type === 'transfer_out' || raw?.from_addr === address || raw?.from === address
+          ? 'sent'
+          : 'received';
+    const from_addr = String(raw?.from_addr ?? raw?.from ?? (direction === 'sent' ? address : ''));
+    const to_addr = String(raw?.to_addr ?? raw?.to ?? (direction === 'received' ? address : ''));
+    const counterparty = String(raw?.counterparty ?? (direction === 'sent' ? to_addr : from_addr));
+    const tx_hash = String(raw?.tx_hash ?? raw?.tx_id ?? `history_${timestamp}_${index}`);
+    const tx_id = String(raw?.tx_id ?? tx_hash);
+    const confirmed_at = Number.isSafeInteger(raw?.confirmed_at)
+      ? raw.confirmed_at
+      : status === 'confirmed'
+        ? timestamp
+        : null;
+
+    return {
+      id: Number.isSafeInteger(raw?.id) ? raw.id : index,
+      tx_id,
+      tx_hash,
+      from_addr,
+      to_addr,
+      amount: amount_rtc,
+      amount_i64,
+      amount_rtc,
+      timestamp,
+      created_at: Number.isSafeInteger(raw?.created_at) ? raw.created_at : timestamp,
+      confirmed_at,
+      confirms_at: Number.isSafeInteger(raw?.confirms_at) ? raw.confirms_at : confirmed_at,
+      status,
+      raw_status: rawStatus,
+      status_reason: typeof raw?.status_reason === 'string' ? raw.status_reason : null,
+      confirmations: Number.isSafeInteger(raw?.confirmations)
+        ? raw.confirmations
+        : status === 'confirmed'
+          ? 1
+          : 0,
+      direction,
+      counterparty,
+      reason: typeof raw?.reason === 'string' ? raw.reason : undefined,
+      memo: typeof raw?.memo === 'string' || raw?.memo === null ? raw.memo : null,
+    };
+  }
+
   /**
    * Create client with custom URL
    */
@@ -315,10 +400,11 @@ export class RustChainClient {
       throw new RustChainApiError('Invalid wallet address format');
     }
     const safeLimit = Math.max(1, Math.min(Math.trunc(limit || 50), 200));
-    return this.request<TransferHistoryItem[]>(
+    const result = await this.request<any>(
       'GET',
       `/wallet/history?address=${encodeURIComponent(address)}&limit=${safeLimit}`
     );
+    return this.normalizeTransferHistoryResponse(result, address);
   }
 
   /**

--- a/wallet/mobile-v2/src/services/api.ts
+++ b/wallet/mobile-v2/src/services/api.ts
@@ -162,6 +162,91 @@ export class RustChainClient {
     };
   }
 
+  private normalizeTransferHistoryResponse(raw: any, address: string): TransferHistoryItem[] {
+    const records = Array.isArray(raw)
+      ? raw
+      : Array.isArray(raw?.transactions)
+        ? raw.transactions
+        : null;
+
+    if (!records) {
+      throw new RustChainApiError('Unexpected wallet history response');
+    }
+
+    return records.map((record: any, index: number) =>
+      this.normalizeTransferHistoryItem(record, address, index)
+    );
+  }
+
+  private normalizeTransferHistoryItem(raw: any, address: string, index: number): TransferHistoryItem {
+    const type = typeof raw?.type === 'string' ? raw.type : '';
+    const rawStatus = typeof raw?.status === 'string'
+      ? raw.status
+      : type === 'reward' || type === 'ledger' || type === 'transfer_in' || type === 'transfer_out'
+        ? 'confirmed'
+        : 'pending';
+    const status: TransferHistoryItem['status'] =
+      rawStatus === 'confirmed' ? 'confirmed' : rawStatus === 'pending' ? 'pending' : 'failed';
+    const amount_rtc = typeof raw?.amount_rtc === 'number'
+      ? raw.amount_rtc
+      : typeof raw?.amount === 'number'
+        ? raw.amount
+        : Number.isSafeInteger(raw?.amount_i64)
+          ? raw.amount_i64 / MICRO_RTC_PER_RTC
+          : 0;
+    const amount_i64 = Number.isSafeInteger(raw?.amount_i64)
+      ? raw.amount_i64
+      : Math.round(amount_rtc * MICRO_RTC_PER_RTC);
+    const timestamp = Number.isSafeInteger(raw?.timestamp)
+      ? raw.timestamp
+      : Number.isSafeInteger(raw?.created_at)
+        ? raw.created_at
+        : 0;
+    const direction: TransferHistoryItem['direction'] =
+      raw?.direction === 'sent' || raw?.direction === 'received'
+        ? raw.direction
+        : type === 'transfer_out' || raw?.from_addr === address || raw?.from === address
+          ? 'sent'
+          : 'received';
+    const from_addr = String(raw?.from_addr ?? raw?.from ?? (direction === 'sent' ? address : ''));
+    const to_addr = String(raw?.to_addr ?? raw?.to ?? (direction === 'received' ? address : ''));
+    const counterparty = String(raw?.counterparty ?? (direction === 'sent' ? to_addr : from_addr));
+    const tx_hash = String(raw?.tx_hash ?? raw?.tx_id ?? `history_${timestamp}_${index}`);
+    const tx_id = String(raw?.tx_id ?? tx_hash);
+    const confirmed_at = Number.isSafeInteger(raw?.confirmed_at)
+      ? raw.confirmed_at
+      : status === 'confirmed'
+        ? timestamp
+        : null;
+
+    return {
+      id: Number.isSafeInteger(raw?.id) ? raw.id : index,
+      tx_id,
+      tx_hash,
+      from_addr,
+      to_addr,
+      amount: amount_rtc,
+      amount_i64,
+      amount_rtc,
+      timestamp,
+      created_at: Number.isSafeInteger(raw?.created_at) ? raw.created_at : timestamp,
+      confirmed_at,
+      confirms_at: Number.isSafeInteger(raw?.confirms_at) ? raw.confirms_at : confirmed_at,
+      status,
+      raw_status: rawStatus,
+      status_reason: typeof raw?.status_reason === 'string' ? raw.status_reason : null,
+      confirmations: Number.isSafeInteger(raw?.confirmations)
+        ? raw.confirmations
+        : status === 'confirmed'
+          ? 1
+          : 0,
+      direction,
+      counterparty,
+      reason: typeof raw?.reason === 'string' ? raw.reason : undefined,
+      memo: typeof raw?.memo === 'string' || raw?.memo === null ? raw.memo : null,
+    };
+  }
+
   // ── Public API ──────────────────────────────────────────────────────────
 
   async getBalance(address: string): Promise<BalanceResponse> {
@@ -180,10 +265,11 @@ export class RustChainClient {
       throw new RustChainApiError('Invalid wallet address format');
     }
     const safeLimit = Math.max(1, Math.min(Math.trunc(limit || 50), 200));
-    return this.request<TransferHistoryItem[]>(
+    const raw = await this.request<any>(
       'GET',
       `/wallet/history?address=${encodeURIComponent(address)}&limit=${safeLimit}`
     );
+    return this.normalizeTransferHistoryResponse(raw, address);
   }
 
   async getNetworkInfo(): Promise<NetworkInfo> {


### PR DESCRIPTION
﻿## Summary

Fixes #7074.

- normalize `/wallet/history` responses in both React Native wallet clients before returning them to screens
- support the legacy/documented bare array response and the current live envelope shape (`{ ok, miner_id, total, transactions }`)
- map live transaction records (`from`, `to`, `amount`, `type`) into the `TransferHistoryItem` fields that the UI renders (`from_addr`, `to_addr`, `amount_i64`, `amount_rtc`, `direction`, `counterparty`)
- add regression coverage for legacy arrays, live envelopes, and unexpected payloads

## Root cause

The mobile clients cast the raw JSON from `/wallet/history` directly to `TransferHistoryItem[]`. The live node currently returns an object envelope, so the history screens can store an object in `transactions` and then fail when they call `transactions.filter(...)`.

## Validation

- `cd react-native-wallet && npm test -- --runTestsByPath src/api/__tests__/rustchain.test.ts --runInBand`
- `cd react-native-wallet && npx tsc --noEmit`
- `cd wallet/mobile-v2 && npm install --ignore-scripts --no-audit --no-fund --package-lock=false --legacy-peer-deps`
- `cd wallet/mobile-v2 && npx tsc --noEmit`
- `git diff --check -- react-native-wallet/src/api/rustchain.ts react-native-wallet/src/api/__tests__/rustchain.test.ts wallet/mobile-v2/src/services/api.ts`

Bounty payout handle: github:pqmfei
