### PR TITLE
Fix rustchain.org /api/stats proxy

### DIFF
--- a/site/nginx-rustchain-org.conf
+++ b/site/nginx-rustchain-org.conf
@@ -40,6 +40,12 @@ server {
         add_header Access-Control-Allow-Origin "*" always;
     }
 
+    location /api/stats {
+        proxy_pass http://127.0.0.1:8099/api/stats;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
     # Explorer UI (served by rustchain-gui on port 5555)
     location = /explorer {
         return 301 /explorer/;
@@ -323,6 +329,12 @@ server {
 
     location /api/status {
         proxy_pass http://127.0.0.1:8099/api/status;
+        proxy_set_header Host $host;
+        add_header Access-Control-Allow-Origin "*" always;
+    }
+
+    location /api/stats {
+        proxy_pass http://127.0.0.1:8099/api/stats;
         proxy_set_header Host $host;
         add_header Access-Control-Allow-Origin "*" always;
     }

--- a/tests/test_rustchain_org_nginx_config.py
+++ b/tests/test_rustchain_org_nginx_config.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_rustchain_org_nginx_proxies_api_stats_in_all_server_blocks():
+    config = (ROOT / "site" / "nginx-rustchain-org.conf").read_text(encoding="utf-8")
+
+    stats_locations = config.count("location /api/stats {")
+    miners_locations = config.count("location /api/miners {")
+
+    assert stats_locations == 2
+    assert stats_locations == miners_locations
+    assert config.count("proxy_pass http://127.0.0.1:8099/api/stats;") == stats_locations
+    assert config.count('add_header Access-Control-Allow-Origin "*" always;') >= stats_locations


### PR DESCRIPTION
﻿## Summary

Fixes #7076.

Adds the missing `location /api/stats` proxy mapping to both rustchain.org Nginx server blocks:

- port 8070 testing server block
- production `rustchain.org www.rustchain.org` server block

The backend Flask node already implements `/api/stats` and returns network metadata including `chain_id`, but the public Nginx config only proxied neighboring routes such as `/health`, `/epoch`, `/api/status`, `/api/miners`, and `/wallet/`.

## Impact

`https://rustchain.org/api/stats` currently returns a plain Nginx 404 before reaching the node. That breaks the documented public stats endpoint and also blocks clients such as the React Native wallet from fetching `chain_id` before signing transfers.

Live evidence before this fix:

```bash
curl -sk -w "\nHTTP:%{http_code}\n" https://rustchain.org/api/stats
```

returns Nginx `404`, while `/health`, `/epoch`, and `/api/miners?limit=3` return JSON through the same domain.

## Tests

```bash
pytest -q tests/test_rustchain_org_nginx_config.py tests/test_api_stats_route_registration.py
```

Result: `2 passed`.

```bash
git diff --check -- site/nginx-rustchain-org.conf tests/test_rustchain_org_nginx_config.py
```

Result: passed.
