### PR TITLE
Fix JavaScript SDK signed transfer endpoint

### DIFF
--- a/sdk/javascript/rustchain-sdk/README.md
+++ b/sdk/javascript/rustchain-sdk/README.md
@@ -43,7 +43,7 @@ Options:
 - `epoch()` -> `GET /epoch`
 - `miners({ limit, offset, hardwareType })` -> `GET /api/miners`
 - `balance(minerId)` -> `GET /wallet/balance?miner_id=...`
-- `transfer({ from, to, amount, signature, fee })` -> `POST /transfer`
+- `transfer({ from, to, amount, nonce, publicKey, signature, fee, memo, chainId })` -> `POST /wallet/transfer/signed`
 - `attestChallenge(payload)` -> `POST /attest/challenge`
 - `submitAttestation(payload)` -> `POST /attest/submit`
 - `transferHistory(wallet, { limit })` -> `GET /wallet/history`

--- a/sdk/javascript/rustchain-sdk/src/index.js
+++ b/sdk/javascript/rustchain-sdk/src/index.js
@@ -67,19 +67,41 @@ export class RustChainClient {
     return this.request("GET", withQuery("/wallet/balance", params));
   }
 
-  async transfer({ from, to, amount, signature, fee = 0.01 }) {
+  async transfer(options = {}) {
+    if (!options || typeof options !== "object" || Array.isArray(options)) {
+      throw new RustChainValidationError("transfer options must be an object");
+    }
+
+    const from = options.from ?? options.from_address;
+    const to = options.to ?? options.to_address;
+    const amount = options.amount ?? options.amount_rtc;
+    const fee = options.fee ?? options.fee_rtc ?? 0;
+    const publicKey = options.publicKey ?? options.public_key;
+    const chainId = options.chainId ?? options.chain_id;
+    const nonce = validatePositiveInteger(options.nonce, "nonce");
+
     assertNonEmptyString(from, "from");
     assertNonEmptyString(to, "to");
+    assertNonEmptyString(options.signature, "signature");
+    if (isRtcAddress(from) || publicKey !== undefined) {
+      assertNonEmptyString(publicKey, "publicKey");
+    }
     validatePositiveNumber(amount, "amount");
     validateNonNegativeNumber(fee, "fee");
 
-    return this.request("POST", "/transfer", {
-      from,
-      to,
-      amount,
-      fee,
-      ...(signature ? { signature } : {})
-    });
+    const payload = {
+      from_address: from,
+      to_address: to,
+      amount_rtc: Number(amount),
+      fee_rtc: Number(fee),
+      nonce,
+      signature: options.signature,
+      ...(publicKey ? { public_key: publicKey } : {}),
+      ...(options.memo !== undefined ? { memo: String(options.memo) } : {}),
+      ...(chainId !== undefined ? { chain_id: String(chainId) } : {})
+    };
+
+    return this.request("POST", "/wallet/transfer/signed", payload);
   }
 
   async attestChallenge(payload = {}) {
@@ -182,6 +204,10 @@ function assertNonEmptyString(value, name) {
   if (typeof value !== "string" || value.trim() === "") {
     throw new RustChainValidationError(`${name} must be a non-empty string`);
   }
+}
+
+function isRtcAddress(value) {
+  return typeof value === "string" && /^RTC[0-9a-fA-F]{40}$/.test(value);
 }
 
 function validatePositiveInteger(value, name) {

--- a/sdk/javascript/rustchain-sdk/test/rustchain.test.js
+++ b/sdk/javascript/rustchain-sdk/test/rustchain.test.js
@@ -60,22 +60,58 @@ test("validates balance miner id", async () => {
   await assert.rejects(() => client.balance(""), RustChainValidationError);
 });
 
-test("posts transfer payload", async () => {
+test("posts signed transfer payload", async () => {
+  const fromAddress = `RTC${"a".repeat(40)}`;
+  const toAddress = `RTC${"b".repeat(40)}`;
+
   const client = new RustChainClient({
     fetch: mockFetch((url, init) => {
-      assert.equal(url, "https://rustchain.org/transfer");
+      assert.equal(url, "https://rustchain.org/wallet/transfer/signed");
       assert.equal(init.method, "POST");
       assert.deepEqual(JSON.parse(init.body), {
-        from: "alice",
-        to: "bob",
-        amount: 1.25,
-        fee: 0.01
+        from_address: fromAddress,
+        to_address: toAddress,
+        amount_rtc: 1.25,
+        fee_rtc: 0,
+        nonce: 12345,
+        signature: "22".repeat(64),
+        public_key: "11".repeat(32),
+        memo: "sdk transfer",
+        chain_id: "rustchain-mainnet-v2"
       });
       return { status: 200, body: JSON.stringify({ success: true }) };
     })
   });
 
-  assert.deepEqual(await client.transfer({ from: "alice", to: "bob", amount: 1.25 }), { success: true });
+  assert.deepEqual(
+    await client.transfer({
+      from: fromAddress,
+      to: toAddress,
+      amount: 1.25,
+      nonce: 12345,
+      signature: "22".repeat(64),
+      publicKey: "11".repeat(32),
+      memo: "sdk transfer",
+      chainId: "rustchain-mainnet-v2"
+    }),
+    { success: true }
+  );
+});
+
+test("rejects signed transfer calls missing signature material", async () => {
+  const client = new RustChainClient({ fetch: mockFetch(() => ({ status: 200 })) });
+
+  await assert.rejects(
+    () =>
+      client.transfer({
+        from: `RTC${"a".repeat(40)}`,
+        to: `RTC${"b".repeat(40)}`,
+        amount: 1.25,
+        nonce: 12345,
+        signature: "22".repeat(64)
+      }),
+    RustChainValidationError
+  );
 });
 
 test("throws API errors with status and endpoint", async () => {


### PR DESCRIPTION
﻿## Summary

Fixes #7078.

Updates the JavaScript SDK `transfer()` method to use the live signed-transfer API:

- posts to `POST /wallet/transfer/signed` instead of stale `POST /transfer`
- maps existing `from` / `to` / `amount` options to `from_address` / `to_address` / `amount_rtc`
- requires `nonce`, `signature`, and `publicKey` for RTC-address sends before network I/O
- sends `fee_rtc` and defaults it to `0`, matching current signed-transfer settlement behavior
- documents the updated SDK method shape

## Impact

The default SDK target `https://rustchain.org/transfer` currently returns Nginx 404. The real route is `/wallet/transfer/signed` and responds with structured validation errors. Without this fix, JavaScript SDK users cannot submit signed transfers against the default RustChain node URL.

Live evidence before this fix:

```bash
curl -sk -w "\nHTTP:%{http_code}\n" -X POST https://rustchain.org/transfer \
  -H "Content-Type: application/json" \
  --data '{}'
# => Nginx 404

curl -sk -w "\nHTTP:%{http_code}\n" -X POST https://rustchain.org/wallet/transfer/signed \
  -H "Content-Type: application/json" \
  --data '{}'
# => {"error":"missing_required_fields", ...}
# => HTTP:400
```

## Tests

```bash
cd sdk/javascript/rustchain-sdk
npm test
```

Result: 8 tests passed.

```bash
git diff --check -- sdk/javascript/rustchain-sdk/src/index.js sdk/javascript/rustchain-sdk/test/rustchain.test.js sdk/javascript/rustchain-sdk/README.md
```

Result: passed.
