### PR TITLE
Fix JavaScript SDK wallet history query

### DIFF
--- a/sdk/javascript/rustchain-sdk/README.md
+++ b/sdk/javascript/rustchain-sdk/README.md
@@ -46,7 +46,7 @@ Options:
 - `transfer({ from, to, amount, signature, fee })` -> `POST /transfer`
 - `attestChallenge(payload)` -> `POST /attest/challenge`
 - `submitAttestation(payload)` -> `POST /attest/submit`
-- `transferHistory(wallet, { limit })` -> `GET /wallet/history`
+- `transferHistory(wallet, { limit })` -> `GET /wallet/history?miner_id=...`
 
 ## Example
 

--- a/sdk/javascript/rustchain-sdk/src/index.js
+++ b/sdk/javascript/rustchain-sdk/src/index.js
@@ -95,9 +95,14 @@ export class RustChainClient {
 
   async transferHistory(wallet, options = {}) {
     assertNonEmptyString(wallet, "wallet");
-    const params = new URLSearchParams({ wallet });
+    const params = new URLSearchParams({ miner_id: wallet });
     if (options.limit !== undefined) params.set("limit", String(validatePositiveInteger(options.limit, "limit")));
-    return this.request("GET", withQuery("/wallet/history", params));
+    const result = await this.request("GET", withQuery("/wallet/history", params));
+    if (Array.isArray(result)) return result;
+    if (Array.isArray(result?.transactions)) return result.transactions;
+    if (Array.isArray(result?.history)) return result.history;
+    if (Array.isArray(result?.items)) return result.items;
+    return [];
   }
 
   async request(method, endpoint, body) {

--- a/sdk/javascript/rustchain-sdk/test/rustchain.test.js
+++ b/sdk/javascript/rustchain-sdk/test/rustchain.test.js
@@ -78,6 +78,39 @@ test("posts transfer payload", async () => {
   assert.deepEqual(await client.transfer({ from: "alice", to: "bob", amount: 1.25 }), { success: true });
 });
 
+test("fetches transfer history with the live miner_id query", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch((url, init) => {
+      assert.equal(url, "https://rustchain.org/wallet/history?miner_id=alice&limit=5");
+      assert.equal(init.method, "GET");
+      return {
+        status: 200,
+        body: JSON.stringify({
+          ok: true,
+          miner_id: "alice",
+          total: 1,
+          transactions: [{ tx_hash: "abc123", amount: 5, type: "transfer_in" }]
+        })
+      };
+    })
+  });
+
+  assert.deepEqual(await client.transferHistory("alice", { limit: 5 }), [
+    { tx_hash: "abc123", amount: 5, type: "transfer_in" }
+  ]);
+});
+
+test("normalizes legacy array transfer history responses", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch(() => ({
+      status: 200,
+      body: JSON.stringify([{ tx_hash: "legacy", amount: 1 }])
+    }))
+  });
+
+  assert.deepEqual(await client.transferHistory("alice"), [{ tx_hash: "legacy", amount: 1 }]);
+});
+
 test("throws API errors with status and endpoint", async () => {
   const client = new RustChainClient({
     fetch: mockFetch(() => ({ status: 500, body: JSON.stringify({ error: "boom" }) }))


### PR DESCRIPTION
﻿## Summary

Fixes #7080.

Updates the JavaScript SDK `transferHistory()` method to match the live wallet history API:

- uses `miner_id=<wallet>` instead of unsupported `wallet=<wallet>`
- normalizes live envelope responses by returning `transactions`
- keeps legacy bare-array history responses working
- documents the live query shape

## Impact

The current SDK-style request fails against the default RustChain node:

```bash
curl -sk -w "\nHTTP:%{http_code}\n" "https://rustchain.org/wallet/history?wallet=pqmfei&limit=5"
# => {"error":"miner_id or address required","ok":false}
# => HTTP:400
```

The same wallet works with the live parameter:

```bash
curl -sk -w "\nHTTP:%{http_code}\n" "https://rustchain.org/wallet/history?miner_id=pqmfei&limit=5"
# => {"miner_id":"pqmfei","ok":true,"total":1,"transactions":[...]}
# => HTTP:200
```

Without this fix, JavaScript SDK users cannot fetch wallet history from `https://rustchain.org` even when the wallet has transactions.

## Tests

```bash
cd sdk/javascript/rustchain-sdk
npm test
```

Result: 9 tests passed.

```bash
git diff --check -- sdk/javascript/rustchain-sdk/src/index.js sdk/javascript/rustchain-sdk/test/rustchain.test.js sdk/javascript/rustchain-sdk/README.md
```

Result: passed.
