### PR TITLE
fix(sdk): use live endpoints for transferHistory and transfer

### DIFF
--- a/sdk/javascript/rustchain-sdk/src/index.js
+++ b/sdk/javascript/rustchain-sdk/src/index.js
@@ -67,18 +67,21 @@ export class RustChainClient {
     return this.request("GET", withQuery("/wallet/balance", params));
   }
 
-  async transfer({ from, to, amount, signature, fee = 0.01 }) {
+  async transfer({ from, to, amount, signature, publicKey, nonce, memo, fee = 0 }) {
     assertNonEmptyString(from, "from");
     assertNonEmptyString(to, "to");
     validatePositiveNumber(amount, "amount");
     validateNonNegativeNumber(fee, "fee");
 
-    return this.request("POST", "/transfer", {
-      from,
-      to,
-      amount,
-      fee,
-      ...(signature ? { signature } : {})
+    return this.request("POST", "/wallet/transfer/signed", {
+      from_address: from,
+      to_address: to,
+      amount_rtc: amount,
+      fee_rtc: fee,
+      ...(signature ? { signature } : {}),
+      ...(publicKey ? { public_key: publicKey } : {}),
+      ...(nonce !== undefined ? { nonce } : {}),
+      ...(memo ? { memo } : {})
     });
   }
 
@@ -95,9 +98,13 @@ export class RustChainClient {
 
   async transferHistory(wallet, options = {}) {
     assertNonEmptyString(wallet, "wallet");
-    const params = new URLSearchParams({ wallet });
+    const params = new URLSearchParams({ miner_id: wallet });
     if (options.limit !== undefined) params.set("limit", String(validatePositiveInteger(options.limit, "limit")));
-    return this.request("GET", withQuery("/wallet/history", params));
+    const result = await this.request("GET", withQuery("/wallet/history", params));
+    // Normalize envelope: live API returns { transactions: [...] }, but legacy returns bare array
+    if (Array.isArray(result)) return result;
+    if (Array.isArray(result?.transactions)) return result.transactions;
+    return [];
   }
 
   async request(method, endpoint, body) {

--- a/sdk/javascript/rustchain-sdk/test/rustchain.test.js
+++ b/sdk/javascript/rustchain-sdk/test/rustchain.test.js
@@ -60,22 +60,69 @@ test("validates balance miner id", async () => {
   await assert.rejects(() => client.balance(""), RustChainValidationError);
 });
 
-test("posts transfer payload", async () => {
+test("posts signed transfer payload", async () => {
   const client = new RustChainClient({
     fetch: mockFetch((url, init) => {
-      assert.equal(url, "https://rustchain.org/transfer");
+      assert.equal(url, "https://rustchain.org/wallet/transfer/signed");
       assert.equal(init.method, "POST");
       assert.deepEqual(JSON.parse(init.body), {
-        from: "alice",
-        to: "bob",
-        amount: 1.25,
-        fee: 0.01
+        from_address: "alice",
+        to_address: "bob",
+        amount_rtc: 1.25,
+        fee_rtc: 0,
+        signature: "sig123",
+        public_key: "pk456",
+        nonce: 7
       });
       return { status: 200, body: JSON.stringify({ success: true }) };
     })
   });
 
-  assert.deepEqual(await client.transfer({ from: "alice", to: "bob", amount: 1.25 }), { success: true });
+  assert.deepEqual(
+    await client.transfer({ from: "alice", to: "bob", amount: 1.25, signature: "sig123", publicKey: "pk456", nonce: 7 }),
+    { success: true }
+  );
+});
+
+test("transfer defaults fee_rtc to 0", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch((url, init) => {
+      const body = JSON.parse(init.body);
+      assert.equal(body.fee_rtc, 0);
+      return { status: 200, body: JSON.stringify({ ok: true }) };
+    })
+  });
+
+  await client.transfer({ from: "alice", to: "bob", amount: 5 });
+});
+
+test("transferHistory uses miner_id param and normalizes envelope", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch((url) => {
+      assert.ok(url.includes("miner_id=alice"), "should use miner_id param");
+      assert.ok(!url.includes("wallet="), "should not use wallet param");
+      assert.ok(url.includes("limit=3"), "should pass limit");
+      return {
+        status: 200,
+        body: JSON.stringify({ miner_id: "alice", ok: true, total: 1, transactions: [{ id: "tx1" }] })
+      };
+    })
+  });
+
+  const result = await client.transferHistory("alice", { limit: 3 });
+  assert.deepEqual(result, [{ id: "tx1" }]);
+});
+
+test("transferHistory handles legacy bare-array responses", async () => {
+  const client = new RustChainClient({
+    fetch: mockFetch(() => ({
+      status: 200,
+      body: JSON.stringify([{ id: "tx1" }, { id: "tx2" }])
+    }))
+  });
+
+  const result = await client.transferHistory("alice");
+  assert.deepEqual(result, [{ id: "tx1" }, { id: "tx2" }]);
 });
 
 test("throws API errors with status and endpoint", async () => {


### PR DESCRIPTION
## Summary

Fixes #7080 and #7078

Two stale-endpoint bugs in the JavaScript SDK that break functionality against the live `rustchain.org` node.

### 1. `transferHistory()` sends wrong query param (#7080)

The SDK sent `wallet=<id>` but the live `/wallet/history` endpoint only accepts `miner_id` or `address`, returning HTTP 400.

**Fix**: Changed query param from `wallet` to `miner_id`. Also added envelope normalization — the live API returns `{ transactions: [...] }` instead of a bare array, so the SDK now extracts the `transactions` array while keeping backward compat with bare-array responses.

### 2. `transfer()` posts to stale endpoint (#7078)

The SDK posted to `POST /transfer` with legacy field names (`from`, `to`, `amount`, `fee`). The live node does not route that path (returns Nginx 404). The real endpoint is `POST /wallet/transfer/signed`.

**Fix**: Updated to post to `/wallet/transfer/signed` with the correct field names:
- `from` → `from_address`
- `to` → `to_address`
- `amount` → `amount_rtc`
- `fee` → `fee_rtc` (default changed from 0.01 to 0, matching live signed-transfer requirements)
- Added optional `public_key`, `nonce`, `memo` params

## Testing

All 10 tests pass:

```
✔ creates a client with defaults
✔ normalizes base URL
✔ fetches health endpoint
✔ normalizes miners array responses
✔ validates balance miner id
✔ posts signed transfer payload
✔ transfer defaults fee_rtc to 0
✔ transferHistory uses miner_id param and normalizes envelope
✔ transferHistory handles legacy bare-array responses
✔ throws API errors with status and endpoint
```