### PR TITLE
fix(consensus/T3.4): make miner_header_keys composite migration atomic

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -1510,6 +1510,68 @@ def _ensure_transfer_ledger_table(db):
     )
 
 
+def _migrate_miner_header_keys_composite(c):
+    """Idempotently upgrade a legacy single-column-PK ``miner_header_keys`` to the
+    composite ``(miner_id, pubkey_hex)`` PK so one wallet identity can hold a header
+    key per device (multi-device) instead of last-writer-wins overwriting (which broke
+    the non-last device's signed-header verification).
+
+    COLUMN-PRESERVING: production tables may carry extra columns (e.g. an ``added_at``
+    timestamp) absent from the canonical CREATE; the rebuild reconstructs every existing
+    column (type / NOT NULL / DEFAULT), so no column or row is dropped. Idempotent: only
+    rebuilds a table still carrying the old single-column ``PRIMARY KEY(miner_id)``.
+    Verified by a dry-run against a 247,619-row production snapshot.
+
+    T3.4 — ATOMIC: the RENAME→CREATE→INSERT→DROP rebuild is wrapped in a SAVEPOINT so it
+    is all-or-nothing regardless of the surrounding transaction state. Previously a crash
+    or error after the RENAME but before the DROP could leave the original table renamed
+    to ``*_legacy_single`` with a fresh EMPTY composite table in its place; on the next
+    start the migration check sees the composite PK already present and SKIPS, stranding
+    every key in ``*_legacy_single`` — a silent loss of the block-header trust anchor.
+    ``ROLLBACK TO`` restores the original table intact for a clean retry. (A SAVEPOINT,
+    not BEGIN IMMEDIATE: init_db has already run DML by this point, so a transaction may
+    be open; SAVEPOINT nests cleanly and still rolls back DDL in SQLite.)
+    """
+    _mhk_cols = c.execute("PRAGMA table_info(miner_header_keys)").fetchall()  # fetchall-ok: pragma-result
+    _mhk_pk = [col[1] for col in _mhk_cols if col[5]]  # col[5] = pk position (>0 means part of PK)
+    _mhk_names = [col[1] for col in _mhk_cols]
+    if not (_mhk_pk == ["miner_id"] and "miner_id" in _mhk_names and "pubkey_hex" in _mhk_names):
+        return  # already composite (or unexpected shape) — nothing to migrate
+
+    # Reconstruct each column's definition WITHOUT an inline PRIMARY KEY, then add a
+    # table-level composite PK. Defaults are always parenthesized — valid for literals
+    # AND expression defaults like (strftime('%s','now')), which PRAGMA returns without
+    # the surrounding parens.
+    _mhk_defs, _mhk_list = [], []
+    for _cid, _name, _ctype, _notnull, _dflt, _pk in _mhk_cols:
+        _d = '"%s" %s' % (_name, _ctype or "TEXT")
+        if _notnull:
+            _d += " NOT NULL"
+        if _dflt is not None:
+            _d += " DEFAULT (%s)" % _dflt
+        _mhk_defs.append(_d)
+        _mhk_list.append('"%s"' % _name)
+    _mhk_cols_sql = ", ".join(_mhk_defs)
+    _mhk_col_list = ", ".join(_mhk_list)
+
+    c.execute("SAVEPOINT mhk_composite_migrate")
+    try:
+        c.execute("ALTER TABLE miner_header_keys RENAME TO miner_header_keys_legacy_single")
+        c.execute("CREATE TABLE miner_header_keys (%s, PRIMARY KEY (miner_id, pubkey_hex))" % _mhk_cols_sql)
+        c.execute(
+            "INSERT OR IGNORE INTO miner_header_keys (%s) SELECT %s FROM miner_header_keys_legacy_single"
+            % (_mhk_col_list, _mhk_col_list)
+        )
+        c.execute("DROP TABLE miner_header_keys_legacy_single")
+    except Exception:
+        # Undo every step of the rebuild as a unit; the original table is restored.
+        c.execute("ROLLBACK TO mhk_composite_migrate")
+        c.execute("RELEASE mhk_composite_migrate")
+        raise
+    c.execute("RELEASE mhk_composite_migrate")
+    logging.info("[migrate] miner_header_keys upgraded to composite (miner_id, pubkey_hex) PK; preserved columns: %s" % _mhk_names)
+
+
 def init_db():
     """Initialize all database tables"""
     with closing(sqlite3.connect(DB_PATH)) as c:
@@ -1807,49 +1869,15 @@ def init_db():
             )
         """)
         # Migrate a legacy single-column-PK miner_header_keys to the composite
-        # (miner_id, pubkey_hex) key so one wallet identity can hold a header key per
-        # device (multi-device-per-wallet) instead of last-writer-wins overwriting
-        # — which previously broke the non-last device's signed-header verification.
-        # COLUMN-PRESERVING: production tables may carry extra columns (e.g. an
-        # `added_at` timestamp) absent from the CREATE above; the rebuild reconstructs
-        # every existing column (type / NOT NULL / DEFAULT) rather than a fixed 2-col
-        # shape, so no column or data is dropped. Idempotent: only rebuilds a table
-        # still carrying the old single-column PRIMARY KEY(miner_id). Verified by a
-        # dry-run against a 247,619-row snapshot of the production DB.
+        # (miner_id, pubkey_hex) key (extracted to _migrate_miner_header_keys_composite
+        # for atomicity + testability — see T3.4).
         try:
-            _mhk_cols = c.execute("PRAGMA table_info(miner_header_keys)").fetchall()  # fetchall-ok: pragma-result
-            _mhk_pk = [col[1] for col in _mhk_cols if col[5]]  # col[5] = pk position (>0 means part of PK)
-            _mhk_names = [col[1] for col in _mhk_cols]
-            if (_mhk_pk == ["miner_id"]
-                    and "miner_id" in _mhk_names and "pubkey_hex" in _mhk_names):
-                # Reconstruct each column's definition WITHOUT an inline PRIMARY KEY,
-                # then add a table-level composite PK. Defaults are always parenthesized
-                # — valid for literals AND expression defaults like (strftime('%s','now')),
-                # which PRAGMA returns without the surrounding parens.
-                _mhk_defs, _mhk_list = [], []
-                for _cid, _name, _ctype, _notnull, _dflt, _pk in _mhk_cols:
-                    _d = '"%s" %s' % (_name, _ctype or "TEXT")
-                    if _notnull:
-                        _d += " NOT NULL"
-                    if _dflt is not None:
-                        _d += " DEFAULT (%s)" % _dflt
-                    _mhk_defs.append(_d)
-                    _mhk_list.append('"%s"' % _name)
-                _mhk_cols_sql = ", ".join(_mhk_defs)
-                _mhk_col_list = ", ".join(_mhk_list)
-                c.execute("ALTER TABLE miner_header_keys RENAME TO miner_header_keys_legacy_single")
-                c.execute("CREATE TABLE miner_header_keys (%s, PRIMARY KEY (miner_id, pubkey_hex))" % _mhk_cols_sql)
-                c.execute(
-                    "INSERT OR IGNORE INTO miner_header_keys (%s) SELECT %s FROM miner_header_keys_legacy_single"
-                    % (_mhk_col_list, _mhk_col_list)
-                )
-                c.execute("DROP TABLE miner_header_keys_legacy_single")
-                logging.info("[migrate] miner_header_keys upgraded to composite (miner_id, pubkey_hex) PK; preserved columns: %s" % _mhk_names)
+            _migrate_miner_header_keys_composite(c)
         except Exception as _mhk_err:
             # Fail loud rather than continue on a half-migrated key table: running
             # header verification against a renamed/duplicate/missing table would be
-            # worse than not starting. SQLite DDL here is uncommitted until init_db's
-            # final commit, so propagating leaves the original table intact.
+            # worse than not starting. The migration is SAVEPOINT-wrapped, so the
+            # original table is already restored intact before this propagates.
             logging.error(f"[migrate] miner_header_keys composite migration FAILED: {_mhk_err!r}")
             raise
 

--- a/node/tests/test_header_key_migration_atomic_t34.py
+++ b/node/tests/test_header_key_migration_atomic_t34.py
@@ -1,0 +1,146 @@
+"""T3.4 regression: the miner_header_keys composite-PK migration must be ATOMIC.
+
+The rebuild renames the legacy single-PK table, creates a composite-PK table, copies
+rows, then drops the legacy table. If a crash/error lands after the RENAME but before
+the DROP, the original table is renamed away and a fresh EMPTY composite table sits in
+its place — on restart the migration check sees the composite PK and SKIPS, stranding
+every key in *_legacy_single (silent loss of the block-header trust anchor). The
+SAVEPOINT wrap makes the rebuild all-or-nothing: ROLLBACK TO restores the original
+table intact for a clean retry.
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class _FailOn:
+    """Connection proxy that raises on the first statement containing `needle`."""
+    def __init__(self, real, needle):
+        object.__setattr__(self, "_real", real)
+        object.__setattr__(self, "_needle", needle)
+        object.__setattr__(self, "_tripped", False)
+
+    def execute(self, sql, *args):
+        if not self._tripped and self._needle in sql:
+            object.__setattr__(self, "_tripped", True)
+            raise sqlite3.OperationalError(f"injected failure at: {self._needle}")
+        return self._real.execute(sql, *args)
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+class HeaderKeyMigrationAtomicTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        os.environ.setdefault("RUSTCHAIN_DB_PATH", os.path.join(cls._tmp.name, "t34.db"))
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        os.environ.setdefault("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+        spec = importlib.util.spec_from_file_location("rcnode_t34_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    def _legacy_db(self, extra_col=False, rows=()):
+        c = sqlite3.connect(":memory:")
+        if extra_col:
+            c.execute("CREATE TABLE miner_header_keys (miner_id TEXT PRIMARY KEY, "
+                      "pubkey_hex TEXT NOT NULL, added_at INTEGER DEFAULT 0)")
+            for mid, pk, ts in rows:
+                c.execute("INSERT INTO miner_header_keys VALUES (?,?,?)", (mid, pk, ts))
+        else:
+            c.execute("CREATE TABLE miner_header_keys (miner_id TEXT PRIMARY KEY, pubkey_hex TEXT NOT NULL)")
+            for mid, pk in rows:
+                c.execute("INSERT INTO miner_header_keys VALUES (?,?)", (mid, pk))
+        c.commit()
+        return c
+
+    def _pk_cols(self, c):
+        return [r[1] for r in c.execute("PRAGMA table_info(miner_header_keys)").fetchall() if r[5]]
+
+    def _tables(self, c):
+        return {r[0] for r in c.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+
+    # --- happy path --------------------------------------------------------
+    def test_migrates_legacy_single_pk_preserving_rows(self):
+        c = self._legacy_db(rows=[("g4-115", "aa" * 32), ("g5-179", "bb" * 32)])
+        self.assertEqual(self._pk_cols(c), ["miner_id"])  # legacy single PK
+        self.mod._migrate_miner_header_keys_composite(c)
+        self.assertEqual(set(self._pk_cols(c)), {"miner_id", "pubkey_hex"})  # composite now
+        rows = set(c.execute("SELECT miner_id, pubkey_hex FROM miner_header_keys").fetchall())
+        self.assertEqual(rows, {("g4-115", "aa" * 32), ("g5-179", "bb" * 32)})
+        self.assertNotIn("miner_header_keys_legacy_single", self._tables(c))
+
+    def test_multidevice_allowed_after_migration(self):
+        """The whole point: composite PK lets one miner_id hold multiple device keys."""
+        c = self._legacy_db(rows=[("power8", "11" * 32)])
+        self.mod._migrate_miner_header_keys_composite(c)
+        c.execute("INSERT INTO miner_header_keys (miner_id, pubkey_hex) VALUES ('power8', ?)", ("22" * 32,))
+        c.commit()
+        n = c.execute("SELECT COUNT(*) FROM miner_header_keys WHERE miner_id='power8'").fetchone()[0]
+        self.assertEqual(n, 2)
+
+    def test_preserves_extra_columns(self):
+        c = self._legacy_db(extra_col=True, rows=[("g4-115", "aa" * 32, 1717000000)])
+        self.mod._migrate_miner_header_keys_composite(c)
+        names = [r[1] for r in c.execute("PRAGMA table_info(miner_header_keys)").fetchall()]
+        self.assertIn("added_at", names)
+        self.assertEqual(
+            c.execute("SELECT added_at FROM miner_header_keys WHERE miner_id='g4-115'").fetchone()[0],
+            1717000000)
+
+    def test_idempotent_on_already_composite(self):
+        c = self._legacy_db(rows=[("g4-115", "aa" * 32)])
+        self.mod._migrate_miner_header_keys_composite(c)   # first: migrates
+        self.mod._migrate_miner_header_keys_composite(c)   # second: no-op, must not raise
+        self.assertEqual(set(self._pk_cols(c)), {"miner_id", "pubkey_hex"})
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM miner_header_keys").fetchone()[0], 1)
+
+    # --- atomicity ---------------------------------------------------------
+    def test_failure_mid_migration_rolls_back_intact(self):
+        """Inject a failure on the DROP (after RENAME+CREATE+INSERT). The SAVEPOINT must
+        restore the ORIGINAL single-PK table with all rows, leave no *_legacy_single
+        behind, and re-raise (so init_db fails loud)."""
+        real = self._legacy_db(rows=[("g4-115", "aa" * 32), ("g5-179", "bb" * 32)])
+        proxy = _FailOn(real, "DROP TABLE")
+        with self.assertRaises(sqlite3.OperationalError):
+            self.mod._migrate_miner_header_keys_composite(proxy)
+        # original table restored: single PK, both rows, no legacy/scratch tables
+        self.assertEqual(self._pk_cols(real), ["miner_id"])
+        rows = set(real.execute("SELECT miner_id, pubkey_hex FROM miner_header_keys").fetchall())
+        self.assertEqual(rows, {("g4-115", "aa" * 32), ("g5-179", "bb" * 32)})
+        self.assertNotIn("miner_header_keys_legacy_single", self._tables(real))
+
+    def test_failure_on_create_rolls_back_intact(self):
+        """Failure even earlier (on CREATE, right after RENAME) must also restore."""
+        real = self._legacy_db(rows=[("g4-115", "aa" * 32)])
+        proxy = _FailOn(real, "CREATE TABLE")
+        with self.assertRaises(sqlite3.OperationalError):
+            self.mod._migrate_miner_header_keys_composite(proxy)
+        self.assertEqual(self._pk_cols(real), ["miner_id"])
+        self.assertEqual(
+            real.execute("SELECT pubkey_hex FROM miner_header_keys WHERE miner_id='g4-115'").fetchone()[0],
+            "aa" * 32)
+        self.assertNotIn("miner_header_keys_legacy_single", self._tables(real))
+
+    def test_retry_after_failure_succeeds(self):
+        """After a rolled-back failure, a clean retry must complete the migration —
+        proving no half-migrated state stranded the data."""
+        real = self._legacy_db(rows=[("g4-115", "aa" * 32)])
+        with self.assertRaises(sqlite3.OperationalError):
+            self.mod._migrate_miner_header_keys_composite(_FailOn(real, "DROP TABLE"))
+        # retry on the real (un-proxied) connection
+        self.mod._migrate_miner_header_keys_composite(real)
+        self.assertEqual(set(self._pk_cols(real)), {"miner_id", "pubkey_hex"})
+        self.assertEqual(
+            real.execute("SELECT pubkey_hex FROM miner_header_keys WHERE miner_id='g4-115'").fetchone()[0],
+            "aa" * 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## T3.4 — Atomic schema migration (de-risks the Friday catchup deploy)

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #6). HIGH severity.

### The fragility
The legacy single-PK → composite `(miner_id, pubkey_hex)` rebuild of `miner_header_keys` runs **RENAME → CREATE → INSERT → DROP**. A crash or error **after the RENAME but before the DROP** leaves the original table renamed to `*_legacy_single` with a fresh **empty** composite table in its place. On the next start the migration check sees the composite PK already present and **skips** — stranding every key in `*_legacy_single`. That table is the **block-header trust anchor**, so the failure mode is a *silent* loss of header-verification keys.

The old inline code relied on "SQLite DDL here is uncommitted until init_db's final commit" — true today, but fragile and version/transaction-state dependent.

### The fix
- Extract the migration into **`_migrate_miner_header_keys_composite(c)`** (testable in isolation).
- Wrap **RENAME → CREATE → INSERT → DROP in a SQLite `SAVEPOINT`**; `ROLLBACK TO` on any error undoes all four steps as a unit, restoring the original table intact for a clean retry.
- **`SAVEPOINT`, not `BEGIN IMMEDIATE`** — `init_db` has already run DML (the `epoch_state` settlement backfill) by this point, so a transaction may be open; a bare `BEGIN IMMEDIATE` would throw "cannot start a transaction within a transaction". `SAVEPOINT` nests cleanly inside an open transaction *and* opens one if none exists, and SQLite rolls back DDL inside transactions.
- Column-reconstruction + `INSERT OR IGNORE` copy logic is **byte-for-byte the prior inline code**, just relocated — migration eligibility unchanged, column-preserving behavior unchanged, fail-loud preserved (the original table is already restored before the error propagates).

### Why the "schema_version gate in money paths" half is deferred
A hard `schema_version` gate on money paths would **brick money ops on Friday's divergent-lineage nodes** that haven't bumped their `schema_version` — contradicting the very deploy it's meant to protect. A version gate is only safe to enforce *after* all nodes are known-current, so it belongs in a separate, post-Friday change. The atomic migration is the fleet-safe T3.4 deliverable.

### Tests (7, all green)
`node/tests/test_header_key_migration_atomic_t34.py`:
- happy path (legacy single-PK → composite, rows preserved), multi-device allowed after migration, extra-column preservation, idempotency on already-composite;
- **atomicity**: injected failure on `DROP` and on `CREATE` → original single-PK table + all rows restored, no `*_legacy_single` left behind, error re-raised;
- **retry-after-failure** completes cleanly (proves no half-migrated state strands data).

20 existing header-key-authorization + attest-challenge tests still pass.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), converged first loop — **Codex: no findings**. Grok's notes addressed inline:
- *"RELEASE durable early"* — a transaction is already open (init_db DML), so the SAVEPOINT nests and `RELEASE` merges into it (no early disk commit); and every later init step is idempotent (`CREATE IF NOT EXISTS`/`INSERT OR IGNORE`), so a partial-init crash completes on restart.
- *"crash/OOM rollback unproven"* — covered by SQLite's transactional DDL: the SAVEPOINT keeps all four steps in the uncommitted transaction, so power-loss/SIGKILL mid-migration is rolled back by the journal/WAL on next open. Strictly better than the old inline code for the crash case. The unit test covers the deterministically-simulatable Python-exception path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)