### PR TITLE
security: fix predictable nonce in p2p.py

### DIFF
--- a/rips/rustchain-core/networking/p2p.py
+++ b/rips/rustchain-core/networking/p2p.py
@@ -15,6 +15,7 @@ Security Features:
 import hashlib
 import json
 import os
+import secrets
 import socket
 import ssl
 import struct
@@ -186,7 +187,7 @@ class Message:
         if not self.timestamp:
             self.timestamp = int(time.time())
         if not self.nonce:
-            self.nonce = int.from_bytes(hashlib.sha256(str(time.time()).encode()).digest()[:4], 'big')
+            self.nonce = secrets.randbelow(MAX_NONCE)
 
     def to_bytes(self) -> bytes:
         """Serialize message to bytes"""


### PR DESCRIPTION
The P2P message nonce was generated using , which is predictable and could allow for message spoofing or replay attacks in certain edge cases. 

Replaced with  for cryptographically secure random numbers.