### PR TITLE
fix(consensus/T3.1): audit-ledger finalize_epoch block-path reward credits

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2848,6 +2848,32 @@ def _write_welcome_bonus(
     raise RuntimeError("unsupported welcome bonus balance/ledger schema")
 
 
+def _ledger_reward_row(c, ledger_cols, epoch, miner_id, amount_i64, reason):
+    """Append a single-sided reward credit to the canonical audit ledger.
+
+    T3.1: finalize_epoch (the auto block-path settlement) credited balances with NO
+    ledger row, while rewards_implementation_rip200.settle_epoch_rip200 and the
+    transfer/bonus paths DO — so block-path rewards were invisible to audit/
+    reconstruction and broke any ledger↔balance reconciliation.
+
+    Mirrors settle_epoch_rip200's row EXACTLY — the canonical
+    (ts, epoch, miner_id, delta_i64, reason) shape and the same `epoch_{n}_reward`
+    reason — so the two reward-settlement paths are indistinguishable in the ledger.
+    Only that shape is supported (matching settle_epoch_rip200, which has no fallback);
+    a non-canonical ledger is handled by the caller's one-time `ledger_writable`
+    pre-check, which logs and skips rather than aborting settlement. The guard checks
+    EVERY column the INSERT references, so a drifted table is skipped cleanly rather
+    than selected then failed. Returns True iff a row was written.
+    """
+    if not {"ts", "epoch", "miner_id", "delta_i64", "reason"}.issubset(ledger_cols):
+        return False
+    c.execute(
+        "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+        (int(time.time()), epoch, miner_id, amount_i64, reason),
+    )
+    return True
+
+
 def _check_welcome_bonus(miner: str):
     """Award welcome bonus on first-ever attestation. Funded from founder_community."""
     try:
@@ -3844,8 +3870,24 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
             utxo_reward_outputs = []
             skipped_utxo_dust_nrtc = 0
 
+            # T3.1: audit-ledger the block-path reward credits (settle_epoch_rip200 and
+            # the transfer/bonus paths already ledger; finalize_epoch did not, leaving
+            # block rewards invisible to reconstruction). The reward ledger row is a
+            # best-effort AUDIT side effect — it must NEVER abort reward settlement
+            # (liveness). Determine writability ONCE (a single log on a drifted schema,
+            # not one per miner); the per-row insert below is wrapped so a constraint/IO
+            # failure on the ledger table logs and continues rather than rolling back the
+            # already-valid balance credits.
+            ledger_cols = _table_columns(conn, "ledger")
+            ledger_writable = {"ts", "epoch", "miner_id", "delta_i64", "reason"}.issubset(ledger_cols)
+            if not ledger_writable:
+                logging.error(
+                    "[T3.1] ledger schema %s unrecognized — epoch %s reward audit rows "
+                    "omitted (rewards still credited)", sorted(ledger_cols), epoch,
+                )
+
             # Distribute rewards with precision
-            for pk, weight in miners:
+            for _led_i, (pk, weight) in enumerate(miners):
                 # Use Decimal arithmetic to avoid float precision loss
                 amount_decimal = Decimal(0) if Decimal(total_weight) == 0 else total_reward * Decimal(weight) / Decimal(total_weight)
                 amount_i64 = int(amount_decimal * Decimal(ACCOUNT_UNIT))
@@ -3855,10 +3897,44 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
                 if amount_i64 >= 2**63 or amount_nrtc >= 2**63:
                     raise ValueError(f"Reward overflow for miner {pk}: {amount_i64}")
 
-                c.execute(
+                upd = c.execute(
                     "UPDATE balances SET amount_i64 = amount_i64 + ?, balance_rtc = (amount_i64 + ?) / 1000000.0 WHERE miner_id = ?",
                     (amount_i64, amount_i64, pk)
                 )
+
+                # Ledger an audit row ONLY for an actual credit: amount_i64 > 0 AND the
+                # balance row existed (UPDATE mutated exactly one row — miner_id is the
+                # balances PK so rowcount is 0 or 1). Without the rowcount gate, a miner
+                # with no balance row (UPDATE hits 0 rows) would get a +X ledger row with
+                # no matching balance change — the exact ledger≠balance mismatch this fix
+                # exists to prevent. Integer truncation of tiny shares also yields
+                # amount_i64 == 0 (no mutation → no row). Best-effort: a ledger failure
+                # must not roll back the (valid) reward credit.
+                if amount_i64 > 0 and upd.rowcount == 1 and ledger_writable:
+                    # Best-effort audit row, isolated in a SAVEPOINT: on success it
+                    # commits together with the credit (reconciliation intact); on
+                    # failure ROLLBACK TO removes ONLY the failed insert and clears any
+                    # statement/transaction error state, so the outer transaction (this
+                    # and other miners' credits + the settled claim) stays usable and
+                    # commits. A bare try/except is NOT enough — a tx-poisoning error
+                    # (SQLITE_FULL/IOERR) would otherwise corrupt the rest of the loop.
+                    # Per-miner UNIQUE savepoint name so a (theoretical) leaked marker can
+                    # never nest/collide with the next iteration's savepoint.
+                    _sp = f"led_row_{_led_i}"
+                    c.execute(f"SAVEPOINT {_sp}")
+                    try:
+                        _ledger_reward_row(c, ledger_cols, epoch, pk, amount_i64, f"epoch_{epoch}_reward")
+                        c.execute(f"RELEASE {_sp}")
+                    except Exception as _led_err:
+                        try:
+                            c.execute(f"ROLLBACK TO {_sp}")
+                            c.execute(f"RELEASE {_sp}")
+                        except Exception:
+                            pass
+                        logging.error(
+                            "[T3.1] reward ledger row failed for %s epoch %s: %r "
+                            "(reward still credited)", pk, epoch, _led_err,
+                        )
 
                 if UTXO_DUAL_WRITE:
                     if amount_nrtc >= UTXO_DUST_THRESHOLD:

--- a/node/tests/test_finalize_epoch_ledger_t31.py
+++ b/node/tests/test_finalize_epoch_ledger_t31.py
@@ -1,0 +1,207 @@
+"""T3.1 regression: finalize_epoch must audit-ledger every reward credit.
+
+finalize_epoch (the auto block-path settlement) credited `balances` with NO `ledger`
+row, while settle_epoch_rip200 and the transfer/bonus paths DO. Block-path rewards were
+therefore invisible to audit/reconstruction and broke any ledger<->balance
+reconciliation. This adds a schema-tolerant single-sided reward row inside the same
+BEGIN IMMEDIATE that credits the balance (commit/rollback together).
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class LedgerRewardHelperTest(unittest.TestCase):
+    """Unit-level: the schema-tolerant _ledger_reward_row helper."""
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        os.environ.setdefault("RUSTCHAIN_DB_PATH", os.path.join(cls._tmp.name, "t31h.db"))
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        os.environ.setdefault("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+        spec = importlib.util.spec_from_file_location("rcnode_t31h_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    def test_shape_a_canonical(self):
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE ledger (id INTEGER PRIMARY KEY AUTOINCREMENT, ts INTEGER, "
+                  "epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+        cols = self.mod._table_columns(c, "ledger")
+        self.mod._ledger_reward_row(c, cols, 42, "g4-115", 108_000_000, "epoch_42_reward")
+        row = c.execute("SELECT epoch, miner_id, delta_i64, reason FROM ledger").fetchone()
+        self.assertEqual(row, (42, "g4-115", 108_000_000, "epoch_42_reward"))
+
+    def test_legacy_shape_b_not_supported_skips(self):
+        """Only the canonical shape is supported (matching settle_epoch_rip200, which has
+        no fallback). A legacy double-entry ledger is skipped, not written with a
+        synthetic mint source."""
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE ledger (from_miner TEXT, to_miner TEXT, amount_i64 INTEGER, memo TEXT, ts INTEGER)")
+        cols = self.mod._table_columns(c, "ledger")
+        wrote = self.mod._ledger_reward_row(c, cols, 42, "g4-115", 108_000_000, "epoch_42_reward")
+        self.assertFalse(wrote)
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM ledger").fetchone()[0], 0)
+
+    def test_unknown_schema_skips_gracefully(self):
+        """An unrecognized ledger schema must NOT raise (raising would halt reward
+        settlement on a non-canonical node). It logs + skips and returns False;
+        the caller still credits the balance."""
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE ledger (something_else TEXT)")
+        cols = self.mod._table_columns(c, "ledger")
+        wrote = self.mod._ledger_reward_row(c, cols, 42, "g4-115", 1, "epoch_42_reward")
+        self.assertFalse(wrote)
+        self.assertEqual(c.execute("SELECT COUNT(*) FROM ledger").fetchone()[0], 0)
+
+    def test_partial_shape_a_missing_ts_skips(self):
+        """A drifted shape-A table missing `ts` must NOT be selected then fail on the
+        INSERT — the all-columns guard sends it to the skip path."""
+        c = sqlite3.connect(":memory:")
+        c.execute("CREATE TABLE ledger (epoch INTEGER, miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+        cols = self.mod._table_columns(c, "ledger")
+        wrote = self.mod._ledger_reward_row(c, cols, 42, "g4-115", 1, "epoch_42_reward")
+        self.assertFalse(wrote)
+
+
+class FinalizeEpochLedgerTest(unittest.TestCase):
+    """End-to-end: finalize_epoch credits balances AND ledgers them, reconcilably."""
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        cls._db = os.path.join(cls._tmp.name, "t31e.db")
+        os.environ["RUSTCHAIN_DB_PATH"] = cls._db
+        os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+        os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = "1"
+        spec = importlib.util.spec_from_file_location("rcnode_t31e_test", MODULE_PATH)
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.mod.init_db()
+        # init_db creates the LEGACY balances(miner_pk, balance_rtc) shape, but the live
+        # node (and finalize_epoch) run on the migrated (miner_id, amount_i64) shape.
+        # Recreate it to match production so this test exercises the real code path.
+        with sqlite3.connect(cls._db) as c:
+            c.execute("DROP TABLE IF EXISTS balances")
+            c.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, "
+                      "amount_i64 INTEGER NOT NULL DEFAULT 0 CHECK(amount_i64>=0), "
+                      "balance_rtc REAL DEFAULT 0)")
+            c.commit()
+
+    def _seed_epoch(self, epoch, miners):
+        with sqlite3.connect(self._db) as c:
+            for pk, w in miners:
+                c.execute("INSERT OR REPLACE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                          (epoch, pk, w))
+                c.execute("INSERT OR IGNORE INTO balances (miner_id, amount_i64) VALUES (?, 0)", (pk,))
+            c.commit()
+
+    def test_finalize_writes_reconcilable_ledger_rows(self):
+        epoch = 5005
+        miners = [("g4-powerbook-115", self.mod.epoch_weight_to_units(2.5)),
+                  ("g5-selena-179", self.mod.epoch_weight_to_units(2.0))]
+        self._seed_epoch(epoch, miners)
+
+        self.mod.finalize_epoch(epoch, per_block_rtc=1.5, prev_block_hash=b"")
+
+        with sqlite3.connect(self._db) as c:
+            # every credited miner has a ledger row for this epoch
+            led = dict(c.execute(
+                "SELECT miner_id, SUM(delta_i64) FROM ledger WHERE reason = ? GROUP BY miner_id",
+                (f"epoch_{epoch}_reward",)).fetchall())
+            bals = dict(c.execute(
+                "SELECT miner_id, amount_i64 FROM balances WHERE miner_id IN (?, ?)",
+                (miners[0][0], miners[1][0])).fetchall())
+            settled = c.execute("SELECT settled FROM epoch_state WHERE epoch = ?", (epoch,)).fetchone()[0]
+
+        self.assertEqual(settled, 1)
+        self.assertTrue(led, "finalize_epoch wrote no reward ledger rows (the T3.1 gap)")
+        # RECONCILIATION: each miner's ledgered reward == its balance credit
+        for pk, _w in miners:
+            self.assertGreater(bals[pk], 0)
+            self.assertEqual(led.get(pk), bals[pk],
+                             f"ledger delta != balance credit for {pk} (unreconciled)")
+        # and the ledger total equals the total credited
+        self.assertEqual(sum(led.values()), sum(bals.values()))
+
+    def test_replay_does_not_double_ledger(self):
+        epoch = 5006
+        miners = [("dual-g4-125", self.mod.epoch_weight_to_units(2.5))]
+        self._seed_epoch(epoch, miners)
+        self.mod.finalize_epoch(epoch, per_block_rtc=1.5, prev_block_hash=b"")
+        with sqlite3.connect(self._db) as c:
+            n1 = c.execute("SELECT COUNT(*) FROM ledger WHERE reason = ?", (f"epoch_{epoch}_reward",)).fetchone()[0]
+            bal1 = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = 'dual-g4-125'").fetchone()[0]
+        # second finalize must be a no-op (epoch already settled)
+        self.mod.finalize_epoch(epoch, per_block_rtc=1.5, prev_block_hash=b"")
+        with sqlite3.connect(self._db) as c:
+            n2 = c.execute("SELECT COUNT(*) FROM ledger WHERE reason = ?", (f"epoch_{epoch}_reward",)).fetchone()[0]
+            bal2 = c.execute("SELECT amount_i64 FROM balances WHERE miner_id = 'dual-g4-125'").fetchone()[0]
+        self.assertEqual(n1, n2, "replay created duplicate ledger rows")
+        self.assertEqual(bal1, bal2, "replay double-credited the balance")
+
+
+    def test_no_phantom_ledger_when_balance_row_absent(self):
+        """Codex #18: a miner enrolled WITHOUT a balance row — the UPDATE hits 0 rows
+        (no credit) — must NOT get a ledger row (no ledger≠balance phantom)."""
+        epoch = 5007
+        pk = "ghost-no-balance-row"
+        with sqlite3.connect(self._db) as c:
+            c.execute("INSERT OR REPLACE INTO epoch_enroll (epoch, miner_pk, weight) VALUES (?, ?, ?)",
+                      (epoch, pk, self.mod.epoch_weight_to_units(2.5)))
+            # deliberately NO balances row for pk
+            c.commit()
+        self.mod.finalize_epoch(epoch, per_block_rtc=1.5, prev_block_hash=b"")
+        with sqlite3.connect(self._db) as c:
+            led = c.execute("SELECT COUNT(*) FROM ledger WHERE reason = ?",
+                            (f"epoch_{epoch}_reward",)).fetchone()[0]
+            bal = c.execute("SELECT COUNT(*) FROM balances WHERE miner_id = ?", (pk,)).fetchone()[0]
+        self.assertEqual(bal, 0, "no balance row should have been created")
+        self.assertEqual(led, 0, "phantom ledger row written for an uncredited miner")
+
+
+    def test_ledger_failure_one_miner_does_not_block_others(self):
+        """SAVEPOINT isolation: if the ledger INSERT fails for ONE miner mid-loop, the
+        epoch must still settle, EVERY miner (including the failing one) must still be
+        credited, and the non-failing miners must still get their audit rows. A bare
+        try/except would risk poisoning the transaction for the rest of the loop."""
+        epoch = 5008
+        w = self.mod.epoch_weight_to_units(2.5)
+        miners = [("led-ok-1", w), ("led-boom", w), ("led-ok-2", w)]
+        self._seed_epoch(epoch, miners)
+
+        orig = self.mod._ledger_reward_row
+
+        def _selective(c, cols, ep, mid, amt, reason):
+            if mid == "led-boom":
+                raise sqlite3.OperationalError("injected ledger failure for one miner")
+            return orig(c, cols, ep, mid, amt, reason)
+
+        self.mod._ledger_reward_row = _selective
+        try:
+            self.mod.finalize_epoch(epoch, per_block_rtc=1.5, prev_block_hash=b"")
+        finally:
+            self.mod._ledger_reward_row = orig
+
+        with sqlite3.connect(self._db) as c:
+            settled = c.execute("SELECT settled FROM epoch_state WHERE epoch = ?", (epoch,)).fetchone()[0]
+            bals = {pk: c.execute("SELECT amount_i64 FROM balances WHERE miner_id = ?", (pk,)).fetchone()[0]
+                    for pk, _ in miners}
+            led = {r[0] for r in c.execute(
+                "SELECT miner_id FROM ledger WHERE reason = ?", (f"epoch_{epoch}_reward",)).fetchall()}
+
+        self.assertEqual(settled, 1, "epoch left unsettled by a single ledger failure")
+        for pk, _ in miners:
+            self.assertGreater(bals[pk], 0, f"{pk} was not credited (transaction poisoned)")
+        # non-failing miners got audit rows; the failing one was rolled back but still credited
+        self.assertIn("led-ok-1", led)
+        self.assertIn("led-ok-2", led)
+        self.assertNotIn("led-boom", led)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## T3.1 — Full-ledger every balance mutation (block-path rewards)

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #5). Auditability/integrity.

### The gap
`finalize_epoch` (the auto block-path settlement) credited `balances` with **no `ledger` row**, while `rewards_implementation_rip200.settle_epoch_rip200`, transfers, and the welcome bonus all ledger. Block-path rewards were therefore invisible to audit/reconstruction and broke any ledger↔balance reconciliation. (This is the verified pinpoint from the triage: `finalize_epoch` credits with no ledger insert; `settle_epoch_rip200` does.)

### The fix
- **`_ledger_reward_row()`** writes the **canonical** `(ts, epoch, miner_id, delta_i64, reason)` row with the **same `epoch_{n}_reward` reason** `settle_epoch_rip200` uses — so the two reward-settlement paths are indistinguishable to any reconstruction. Only that shape is supported (matching settle, which has no fallback); the column guard checks every column the INSERT references.
- The row is written **inside the same `BEGIN IMMEDIATE`** that credits the balance, gated by **`amount_i64 > 0 and upd.rowcount == 1`** — a row exists **iff** the balance was actually mutated (`miner_id` is the balances PK → 0 or 1 rows). No phantom row for a miner with no balance row (which would itself be the ledger≠balance mismatch this fix prevents).
- **Best-effort liveness via per-miner `SAVEPOINT`:** on success the row commits with the credit (reconciliation intact); on failure `ROLLBACK TO` removes only that row and clears any statement/transaction error state, so the rest of the loop and the `settled` claim still commit. **A reward audit row can never halt or poison settlement** — a bare try/except is insufficient because a tx-poisoning error (`SQLITE_FULL`/`IOERR`) would corrupt the remaining loop. Unique savepoint name per miner so a leaked marker can't nest/collide.
- **Drifted/unrecognized ledger schema:** logged once per epoch and skipped (rewards still credited) rather than aborting settlement.

### Why the reconciliation *alarm* half is deferred
A *meaningful* scheduled reconciliation must model **minted emission + genesis premine** — `sum(balances) ≠ sum(transfer-deltas)` by design (block rewards are new supply, premine is seeded) — which is its own design task. This PR delivers the verified prerequisite: closing the `finalize_epoch` gap so the ledger *can* reconstruct reward history. The alarm belongs in a follow-up once the supply invariant is specified.

### Tests (8, all green)
`node/tests/test_finalize_epoch_ledger_t31.py`:
- helper: canonical shape A written; legacy shape-B **skipped** (not written with a synthetic source); drifted shape-A-missing-`ts` skipped; unknown schema skipped (no raise);
- end-to-end: finalize writes reward rows that **reconcile** (ledger delta == balance credit, per miner and in total); replay does **not** double-ledger or double-credit; **no phantom** ledger row when a miner has no balance row;
- **multi-miner SAVEPOINT isolation**: a ledger INSERT failure for one miner still settles the epoch and credits *all* miners, and the non-failing miners still get their audit rows.

95 epoch/settlement/reward/UTXO/claims regression tests pass.

### Grounding note (pre-existing, not introduced here)
`finalize_epoch` already required the live `(miner_id, amount_i64)` balances schema (fresh `init_db` creates the legacy `(miner_pk, balance_rtc)` shape); this PR doesn't change that. The `rowcount==1` gate also means a miner with no balance row gets neither credit nor ledger row — the missing-row lost-reward is a separate pre-existing (T2.2-adjacent) issue.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), **6 loops to convergence** (money-path rigor): loop 2 fixed a fail-closed-raise liveness foot-gun; loop 3 added best-effort handling; loop 4 dropped the shape-B branch (consistency with settle); loop 5 caught that try/except was insufficient → SAVEPOINT; loop 6 hardened the savepoint name. Codex + GPT-OSS clean at convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)