### PR TITLE
fix(freebsd): repair miner port install (404) + regression guard

### DIFF
--- a/install-miner-freebsd.sh
+++ b/install-miner-freebsd.sh
@@ -19,7 +19,7 @@ if [ "${DRY_RUN}" = "--dry-run" ] || [ "${DRY_RUN}" = "--show-payload" ]; then
     echo "[DRY-RUN] Actions that would be taken:"
     echo "  1. Install Python 3.11+ and dependencies via pkg"
     echo "  2. Create rustchain user and group"
-    echo "  3. Download miner client to /opt/rustchain/"
+    echo "  3. Download + SHA-256 verify miner client (+ fingerprint/crypto helpers) to /opt/rustchain/"
     echo "  4. Create FreeBSD rc.d service unit"
     echo "  5. Start miner service"
     echo ""
@@ -67,9 +67,10 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-# Install dependencies
+# Install dependencies (pkg is PEP-668 safe and avoids building PyNaCl from
+# source; py311-pynacl enables Ed25519 attestation signing).
 echo "[1/5] Installing dependencies..."
-pkg install -y python3 py311-pip py311-setuptools curl
+pkg install -y python3 py311-pip py311-setuptools py311-requests py311-pynacl curl
 
 # Create rustchain user
 echo "[2/5] Creating rustchain user..."
@@ -82,11 +83,45 @@ mkdir -p /var/log/rustchain
 chown rustchain:rustchain /opt/rustchain
 chown rustchain:rustchain /var/log/rustchain
 
-# Download miner client
-echo "[3/5] Downloading miner client..."
+# Download + verify miner client
+echo "[3/5] Downloading + checksum-verifying miner client..."
 cd /opt/rustchain
-curl -fsSL "https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/rustchain_miner.py" -o rustchain_miner.py
-pip3 install requests
+REPO_BASE="https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners"
+# FreeBSD runs the Python ("linux") miner. Fetch it plus its fingerprint and
+# Ed25519 signing helpers so attestations are SIGNED (unsigned = spam-tier).
+curl -fsSL "${REPO_BASE}/linux/rustchain_linux_miner.py" -o rustchain_miner.py
+curl -fsSL "${REPO_BASE}/linux/fingerprint_checks.py"    -o fingerprint_checks.py
+curl -fsSL "${REPO_BASE}/linux/miner_crypto.py"          -o miner_crypto.py
+
+# Verify-before-trust: SHA-256 against the published manifest (FreeBSD sha256 -q).
+curl -fsSL "${REPO_BASE}/checksums.sha256" -o sums
+verify_sum() {
+    _file="$1"; _path="$2"
+    _want="$(awk -v p="${_path}" '$2 == p { print $1 }' sums)"
+    _got="$(sha256 -q "${_file}")"
+    if [ -z "${_want}" ] || [ "${_got}" != "${_want}" ]; then
+        echo "ERROR: checksum verification failed for ${_file} (${_path})"
+        echo "  expected: ${_want:-<missing from manifest>}"
+        echo "  actual:   ${_got}"
+        exit 1
+    fi
+    echo "  verified ${_file}"
+}
+verify_sum rustchain_miner.py    linux/rustchain_linux_miner.py
+verify_sum fingerprint_checks.py linux/fingerprint_checks.py
+verify_sum miner_crypto.py       linux/miner_crypto.py
+rm -f sums
+chown rustchain:rustchain rustchain_miner.py fingerprint_checks.py miner_crypto.py
+
+# Wrapper sets cwd (so miner_crypto/fingerprint imports + key/log files resolve
+# under /opt/rustchain) and passes the wallet. rc.subr can't carry quoted args.
+cat > /opt/rustchain/start-miner.sh <<EOF
+#!/bin/sh
+cd /opt/rustchain
+exec /usr/local/bin/python3 /opt/rustchain/rustchain_miner.py --wallet "${WALLET_NAME}"
+EOF
+chmod +x /opt/rustchain/start-miner.sh
+chown rustchain:rustchain /opt/rustchain/start-miner.sh
 
 # Create configuration
 cat > /opt/rustchain/config.env << EOF
@@ -121,7 +156,7 @@ load_rc_config $name
 
 pidfile="/var/run/rustchain_miner.pid"
 command="/usr/sbin/daemon"
-command_args="-f -p ${pidfile} -u rustchain /usr/local/bin/python3 /opt/rustchain/rustchain_miner.py"
+command_args="-f -p ${pidfile} -u rustchain /opt/rustchain/start-miner.sh"
 
 run_rc_command "$1"
 RCSCRIPT

--- a/tests/test_freebsd_installer_artifacts.py
+++ b/tests/test_freebsd_installer_artifacts.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+"""Guard: the FreeBSD installer must reference miner artifacts that actually
+exist in the repo and verify them. The original installer fetched a
+non-existent miners/rustchain_miner.py (HTTP 404), silently breaking the port.
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "install-miner-freebsd.sh"
+REPO_BASE_RE = re.compile(r'\$\{REPO_BASE\}/([A-Za-z0-9_./-]+)')
+
+
+def test_freebsd_installer_exists():
+    assert INSTALLER.is_file(), "install-miner-freebsd.sh missing"
+
+
+def test_freebsd_installer_downloads_existing_artifacts():
+    script = INSTALLER.read_text(encoding="utf-8")
+
+    # The dead path that used to 404 must not come back.
+    assert "miners/rustchain_miner.py" not in script
+
+    # Every ${REPO_BASE}/<path> the installer curls (except the checksum
+    # manifest, which lives at miners/checksums.sha256) must exist under miners/.
+    referenced = set(REPO_BASE_RE.findall(script))
+    assert referenced, "installer references no ${REPO_BASE} artifacts"
+    for rel in referenced:
+        if rel == "checksums.sha256":
+            assert (ROOT / "miners" / rel).is_file()
+            continue
+        assert (ROOT / "miners" / rel).is_file(), f"installer fetches missing miners/{rel}"
+
+
+def test_freebsd_installer_verifies_checksums():
+    script = INSTALLER.read_text(encoding="utf-8")
+    # Verify-before-trust: it must pull the manifest and check hashes.
+    assert "checksums.sha256" in script
+    assert "verify_sum" in script


### PR DESCRIPTION
JesusMP22's FreeBSD port has been functionally broken since it merged (#6770): the installer fetched `miners/rustchain_miner.py`, a path that never existed → HTTP 404. This mirrors the Linux installer so the port works, adds verify-before-trust checksums, and adds a regression test.

Verified on Linux (manifest checksums match, sh -n/bash -n clean, 3317 tests pass). **Not yet smoke-tested on real FreeBSD** — pkg/rc.d/daemon path needs a FreeBSD box.

Credit: original port by @JesusMP22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)