### PR TITLE
fix(consensus/T3.5+T3.6): fail-closed beacon rate limit + RIP-309 rotation

### DIFF
--- a/node/rip_200_round_robin_1cpu1vote.py
+++ b/node/rip_200_round_robin_1cpu1vote.py
@@ -45,6 +45,18 @@ def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
 
 
 def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = ACTIVE_FINGERPRINT_CHECK_COUNT) -> Tuple[str, ...]:
+    # T3.6: fail CLOSED — activate ALL checks — when the previous block hash is
+    # unavailable (empty, or the all-zeros fallback used by derive_measurement_nonce).
+    # A predictable rotation seed would otherwise let an attacker know exactly which
+    # 4-of-6 subset is active and pass only those. Mirrors the integrated node's
+    # select_active_fingerprint_checks and the reward path's
+    # get_reward_active_fingerprint_checks (which already fail closed on no prev hash).
+    # This selector is a legacy/duplicate — the live reward path uses
+    # get_reward_active_fingerprint_checks — hardened for consistency so an alternate
+    # import can't reintroduce the predictable subset.
+    normalized = (previous_epoch_block_hash or "").strip().lower()
+    if not normalized or normalized == ("0" * 64):
+        return tuple(ROTATING_FINGERPRINT_CHECKS)
     nonce = derive_measurement_nonce(previous_epoch_block_hash)
     ranked = sorted(
         ROTATING_FINGERPRINT_CHECKS,

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -2068,6 +2068,17 @@ def derive_measurement_nonce(previous_epoch_block_hash: str) -> str:
 
 
 def select_active_fingerprint_checks(previous_epoch_block_hash: str, active_count: int = RIP309_ACTIVE_FINGERPRINT_CHECKS) -> tuple:
+    # T3.6: when the previous block hash is UNAVAILABLE (genesis/early epochs, or a
+    # read error → the all-zeros fallback), the rotation seed is fully predictable, so
+    # an attacker would know exactly which 4-of-6 subset is active and could prepare to
+    # pass only those, leaving the other two checks effectively optional. Fail CLOSED —
+    # activate ALL checks — matching the sibling paths that already do so when no prev
+    # hash is available: the reward path
+    # (rip_309_measurement_rotation.get_reward_active_fingerprint_checks) and
+    # finalize_epoch's inline selection both activate all six on an empty hash.
+    normalized = (previous_epoch_block_hash or "").strip().lower()
+    if not normalized or normalized == RIP309_NONCE_FALLBACK:
+        return tuple(RIP309_ROTATING_FINGERPRINT_CHECKS)
     nonce = derive_measurement_nonce(previous_epoch_block_hash)
     ranked = sorted(
         RIP309_ROTATING_FINGERPRINT_CHECKS,
@@ -10523,8 +10534,70 @@ def wallet_transfer_signed():
 BEACON_RATE_WINDOW = 60
 BEACON_RATE_LIMIT  = 60
 
+# T3.5: per-process, per-IP, DB-INDEPENDENT beacon submission backstop. The per-agent
+# DB count below (a) is keyed by agent_id, which an attacker rotates freely to evade,
+# and (b) is wrapped in `except Exception: pass`, so a DB error silently FAILS OPEN —
+# unbounded submissions. This in-memory limiter always runs (no DB dependency), is keyed
+# by client IP, and fails closed. Mirrors _check_governance_vote_rate_limit. NOTE: like
+# that sibling it is per-PROCESS — under a hypothetical multi-worker deployment each
+# worker enforces the cap independently; the node runs single-process today, and the
+# DB per-agent limit remains the cross-process layer. This is a flood backstop, not a
+# distributed ceiling. The default cap is generous (120/min) so shared NAT/proxy egress
+# IPs aren't throttled below the per-agent DB limit; tune via env if needed.
+BEACON_IP_RATE_LIMIT_MAX = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_MAX", "120"))
+BEACON_IP_RATE_LIMIT_WINDOW = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_WINDOW_SECONDS", "60"))
+_BEACON_IP_RATE_LIMIT_MAX_KEYS = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_MAX_KEYS", "8192"))
+_BEACON_IP_RATE_LIMIT_BUCKETS = {}
+_BEACON_IP_RATE_LIMIT_LOCK = Lock()
+
+
+def _check_beacon_rate_limit(client_ip: str, now_ts: Optional[int] = None):
+    """Per-IP, in-memory, fail-closed beacon submission backstop (bounds work before any
+    DB hit or signature verification; cannot be bypassed by a DB error or agent_id
+    rotation)."""
+    if BEACON_IP_RATE_LIMIT_MAX <= 0:
+        return True, 0
+    now_ts = int(time.time()) if now_ts is None else int(now_ts)
+    window = max(1, BEACON_IP_RATE_LIMIT_WINDOW)
+    cutoff = now_ts - window
+    key = client_ip or "unknown"
+    with _BEACON_IP_RATE_LIMIT_LOCK:
+        # Eviction (no background sweeper): when the table grows past the cap, first
+        # drop IP keys whose attempts have all aged out of the window; if a wide *active*
+        # flood keeps it over cap, drop the least-recently-active keys so the table size
+        # — and the per-call scan cost — is HARD-bounded by _MAX_KEYS.
+        if len(_BEACON_IP_RATE_LIMIT_BUCKETS) > _BEACON_IP_RATE_LIMIT_MAX_KEYS:
+            for _stale in [k for k, v in _BEACON_IP_RATE_LIMIT_BUCKETS.items()
+                           if not any(ts > cutoff for ts in v)]:
+                del _BEACON_IP_RATE_LIMIT_BUCKETS[_stale]
+            _overflow = len(_BEACON_IP_RATE_LIMIT_BUCKETS) - _BEACON_IP_RATE_LIMIT_MAX_KEYS
+            if _overflow > 0:
+                for _old in sorted(
+                    _BEACON_IP_RATE_LIMIT_BUCKETS,
+                    key=lambda k: max(_BEACON_IP_RATE_LIMIT_BUCKETS[k] or [0]),
+                )[:_overflow]:
+                    del _BEACON_IP_RATE_LIMIT_BUCKETS[_old]
+        attempts = [ts for ts in _BEACON_IP_RATE_LIMIT_BUCKETS.get(key, []) if ts > cutoff]
+        if len(attempts) >= BEACON_IP_RATE_LIMIT_MAX:
+            _BEACON_IP_RATE_LIMIT_BUCKETS[key] = attempts
+            return False, max(1, window - (now_ts - attempts[0]))
+        attempts.append(now_ts)
+        _BEACON_IP_RATE_LIMIT_BUCKETS[key] = attempts
+        return True, 0
+
+
 @app.route("/beacon/submit", methods=["POST"])
 def beacon_submit():
+    # T3.5: fail-closed per-IP ceiling FIRST — before JSON parse, DB lookup, or sig work.
+    _beacon_allowed, _beacon_retry = _check_beacon_rate_limit(get_client_ip())
+    if not _beacon_allowed:
+        resp = jsonify({
+            "ok": False, "error": "rate_limited", "code": "BEACON_IP_RATE_LIMIT",
+            "limit": BEACON_IP_RATE_LIMIT_MAX, "window_seconds": BEACON_IP_RATE_LIMIT_WINDOW,
+        })
+        resp.status_code = 429
+        resp.headers["Retry-After"] = str(_beacon_retry)
+        return resp
     data = request.get_json(silent=True)
     if not isinstance(data, dict) or not data:
         return jsonify({"ok": False, "error": "invalid_json"}), 400

--- a/node/tests/test_beacon_rip309_failclosed_t35.py
+++ b/node/tests/test_beacon_rip309_failclosed_t35.py
@@ -1,0 +1,189 @@
+"""T3.5 + T3.6 fail-closed hardening.
+
+T3.5: /beacon/submit had only a DB-backed, per-agent_id rate limit wrapped in
+`except Exception: pass` — a DB error failed OPEN and agent_id rotation evaded it.
+A DB-independent, per-IP, fail-closed in-memory ceiling now runs first.
+
+T3.6: the node-file RIP-309 rotation selector returned a PREDICTABLE 4-of-6 subset
+when the previous block hash was unavailable (the all-zeros fallback), letting an
+attacker know exactly which checks to pass. It now fails CLOSED (all 6 active),
+matching the reward path and finalize_epoch.
+"""
+import importlib.util
+import os
+import sqlite3
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+_MOD = None
+
+
+def _load():
+    # Memoized: load the 10k-line node module ONCE for this file (both test classes
+    # share it). Re-exec'ing it per-class re-registers module-global Prometheus metrics
+    # against the shared REGISTRY, which fails when this file runs in a large multi-file
+    # suite — a single load mirrors the well-behaved single-class beacon tests.
+    global _MOD
+    if _MOD is not None:
+        return _MOD
+    os.environ.setdefault("RUSTCHAIN_DB_PATH", tempfile.mkstemp(suffix=".db")[1])
+    os.environ.setdefault("RC_ADMIN_KEY", "0123456789abcdef0123456789abcdef")
+    os.environ.setdefault("RUSTCHAIN_DISABLE_P2P_AUTO_START", "1")
+    spec = importlib.util.spec_from_file_location("rcnode_t35_test", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    _MOD = mod
+    return mod
+
+
+class BeaconRateLimitT35(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load()
+
+    def setUp(self):
+        self.mod._BEACON_IP_RATE_LIMIT_BUCKETS.clear()
+        self._orig_max = self.mod.BEACON_IP_RATE_LIMIT_MAX
+        self.mod.BEACON_IP_RATE_LIMIT_MAX = 3
+
+    def tearDown(self):
+        self.mod.BEACON_IP_RATE_LIMIT_MAX = self._orig_max
+        self.mod._BEACON_IP_RATE_LIMIT_BUCKETS.clear()
+
+    def test_allows_up_to_max_then_blocks(self):
+        t = 1_000_000
+        for i in range(3):
+            allowed, _ = self.mod._check_beacon_rate_limit("1.2.3.4", now_ts=t)
+            self.assertTrue(allowed, f"call {i} should be allowed")
+        allowed, retry = self.mod._check_beacon_rate_limit("1.2.3.4", now_ts=t)
+        self.assertFalse(allowed)
+        self.assertGreaterEqual(retry, 1)
+
+    def test_db_independent(self):
+        """The limiter must not touch the DB at all (no fail-open on DB error)."""
+        # No DB connection involved; pure in-memory. Exhaust the bucket.
+        t = 2_000_000
+        for _ in range(3):
+            self.mod._check_beacon_rate_limit("9.9.9.9", now_ts=t)
+        allowed, _ = self.mod._check_beacon_rate_limit("9.9.9.9", now_ts=t)
+        self.assertFalse(allowed, "ceiling must hold with zero DB involvement")
+
+    def test_per_ip_isolation(self):
+        t = 3_000_000
+        for _ in range(3):
+            self.mod._check_beacon_rate_limit("10.0.0.1", now_ts=t)
+        # a different IP is unaffected
+        allowed, _ = self.mod._check_beacon_rate_limit("10.0.0.2", now_ts=t)
+        self.assertTrue(allowed)
+
+    def test_window_expiry_allows_again(self):
+        t = 4_000_000
+        for _ in range(3):
+            self.mod._check_beacon_rate_limit("8.8.8.8", now_ts=t)
+        self.assertFalse(self.mod._check_beacon_rate_limit("8.8.8.8", now_ts=t)[0])
+        later = t + self.mod.BEACON_IP_RATE_LIMIT_WINDOW + 1
+        self.assertTrue(self.mod._check_beacon_rate_limit("8.8.8.8", now_ts=later)[0])
+
+    def test_stale_buckets_evicted_when_over_cap(self):
+        """Memory bound: once the table exceeds the key cap, fully-expired IPs are
+        dropped on the next check."""
+        orig_cap = self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS
+        self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS = 5
+        try:
+            t = 5_000_000
+            # seed 8 stale IPs (attempts far in the past)
+            for i in range(8):
+                self.mod._BEACON_IP_RATE_LIMIT_BUCKETS[f"stale-{i}"] = [t - 10_000]
+            # a fresh check past the cap triggers eviction of the stale keys
+            self.mod._check_beacon_rate_limit("fresh-ip", now_ts=t)
+            self.assertNotIn("stale-0", self.mod._BEACON_IP_RATE_LIMIT_BUCKETS)
+            self.assertIn("fresh-ip", self.mod._BEACON_IP_RATE_LIMIT_BUCKETS)
+        finally:
+            self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS = orig_cap
+
+    def test_active_flood_hard_bounded(self):
+        """Even an all-ACTIVE flood (no stale keys) must not grow the table past the
+        cap — least-recently-active keys are evicted to a hard bound."""
+        orig_cap = self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS
+        self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS = 10
+        try:
+            t = 6_000_000
+            # 20 distinct IPs all active within the window (increasing recency)
+            for i in range(20):
+                self.mod._BEACON_IP_RATE_LIMIT_BUCKETS[f"active-{i}"] = [t - (20 - i)]
+            self.mod._check_beacon_rate_limit("newcomer", now_ts=t)
+            self.assertLessEqual(len(self.mod._BEACON_IP_RATE_LIMIT_BUCKETS),
+                                 self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS + 1)
+            # the most-recently-active survivors + newcomer remain; oldest evicted
+            self.assertIn("newcomer", self.mod._BEACON_IP_RATE_LIMIT_BUCKETS)
+            self.assertNotIn("active-0", self.mod._BEACON_IP_RATE_LIMIT_BUCKETS)
+        finally:
+            self.mod._BEACON_IP_RATE_LIMIT_MAX_KEYS = orig_cap
+
+    def test_endpoint_returns_429_when_exhausted(self):
+        self.mod._BEACON_IP_RATE_LIMIT_BUCKETS.clear()
+        self.mod.BEACON_IP_RATE_LIMIT_MAX = 2
+        with self.mod.app.test_request_context("/beacon/submit", method="POST", json={"x": 1}):
+            # exhaust
+            self.mod._check_beacon_rate_limit(self.mod.get_client_ip())
+            self.mod._check_beacon_rate_limit(self.mod.get_client_ip())
+            resp = self.mod.beacon_submit()
+        status = resp.status_code if hasattr(resp, "status_code") else resp[1]
+        self.assertEqual(status, 429)
+
+
+class Rip309FailClosedT36(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load()
+
+    def test_fallback_hash_activates_all_six(self):
+        active = self.mod.select_active_fingerprint_checks(self.mod.RIP309_NONCE_FALLBACK)
+        self.assertEqual(set(active), set(self.mod.RIP309_ROTATING_FINGERPRINT_CHECKS))
+        self.assertEqual(len(active), 6)
+
+    def test_empty_and_none_activate_all_six(self):
+        for bad in ("", "   ", None):
+            active = self.mod.select_active_fingerprint_checks(bad)
+            self.assertEqual(set(active), set(self.mod.RIP309_ROTATING_FINGERPRINT_CHECKS),
+                             f"{bad!r} must fail closed to all 6")
+
+    def test_real_hash_still_selects_subset(self):
+        """A genuine block hash keeps the rotating 4-of-6 (unpredictability preserved)."""
+        h = "a" * 64
+        active = self.mod.select_active_fingerprint_checks(h)
+        self.assertEqual(len(active), self.mod.RIP309_ACTIVE_FINGERPRINT_CHECKS)
+        # deterministic for the same hash
+        self.assertEqual(active, self.mod.select_active_fingerprint_checks(h))
+
+    def test_distinct_real_hashes_can_differ(self):
+        sets = {self.mod.select_active_fingerprint_checks(hex(i)[2:].rjust(64, "0"))
+                for i in range(50)}
+        self.assertGreater(len(sets), 1, "valid hashes should rotate the active subset")
+
+    def test_epoch_zero_rotation_is_all_six(self):
+        """get_epoch_fingerprint_rotation(epoch=0) → prev hash unavailable → all 6 active,
+        none inactive (matches the reward path's empty-hash fallback)."""
+        with sqlite3.connect(":memory:") as conn:
+            rot = self.mod.get_epoch_fingerprint_rotation(conn, 0)
+        self.assertEqual(set(rot["active_checks"]), set(self.mod.RIP309_ROTATING_FINGERPRINT_CHECKS))
+        self.assertEqual(rot["inactive_checks"], [])
+
+    def test_roundrobin_duplicate_selector_also_fails_closed(self):
+        """The duplicate selector in rip_200_round_robin_1cpu1vote must fail closed too
+        (a leaked-import landmine if it didn't)."""
+        import rip_200_round_robin_1cpu1vote as rr
+        for bad in ("", "0" * 64, None):
+            self.assertEqual(set(rr.select_active_fingerprint_checks(bad)),
+                             set(rr.ROTATING_FINGERPRINT_CHECKS), f"{bad!r} must fail closed")
+        # a real hash still rotates a subset
+        self.assertEqual(len(rr.select_active_fingerprint_checks("b" * 64)),
+                         rr.ACTIVE_FINGERPRINT_CHECK_COUNT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## T3.5 + T3.6 — fail-closed hardening (batched)

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #7). Two independent fail-open → fail-closed fixes.

### T3.5 — beacon submission rate limit fails open
`/beacon/submit` had only a **DB-backed, per-`agent_id`** rate limit, and it was wrapped in `except Exception: pass` — so a DB error (locked/missing table/IO) silently **failed open** (unbounded submissions), and an attacker simply **rotated `agent_id`** to evade it. There was no DB-independent ceiling.

**Fix:** a DB-independent, **per-IP, fail-closed** in-memory backstop (mirrors `_check_governance_vote_rate_limit`) that runs **first** — before JSON parse, DB lookup, or signature verification — so it can't be bypassed by a DB error or agent rotation, and it bounds work early.
- **Per-process** (the node runs single-process; the DB per-agent limit remains the cross-process layer). Honestly a flood **backstop**, not a distributed ceiling — documented as such.
- **Memory hard-bounded:** stale IPs are evicted, and a wide *active* flood evicts least-recently-active keys down to a cap (`RC_BEACON_IP_RATE_LIMIT_MAX_KEYS`, default 8192) — no background sweeper, no unbounded growth.
- Generous default (`120/min`, env-tunable) so shared NAT/proxy egress IPs aren't throttled below the per-agent DB limit.

### T3.6 — RIP-309 rotation predictable on missing prev-hash
The fingerprint-check rotation selected a **deterministic 4-of-6 subset** seeded from the previous epoch block hash. When that hash was **unavailable** (genesis/early epochs, or a read error → the all-zeros fallback), the seed was fully predictable — an attacker knew exactly which 4 checks were active and could prepare to pass only those, leaving the other two effectively optional.

**Fix:** **fail closed — activate all 6 checks** — on the empty/all-zeros fallback, aligning with the paths that already do so: `rip_309_measurement_rotation.get_reward_active_fingerprint_checks` (the live reward path) and `finalize_epoch`'s inline selection.
- Fixed in **both** RIP-309 selectors: the integrated-node `select_active_fingerprint_checks` (reward-gating via `evaluate_rotating_fingerprint_checks` at enroll/attest) **and** the legacy/duplicate copy in `rip_200_round_robin_1cpu1vote.py` — hardened for consistency so an alternate import can't reintroduce the predictable subset. (The live reward path doesn't use the round-robin copy, but a leaked import would.)
- Real block hashes still rotate the 4-of-6 (unpredictability preserved for the normal case).

### Tests (13, all green)
`node/tests/test_beacon_rip309_failclosed_t35.py`:
- **T3.5:** allow-up-to-max-then-block, DB-independent, per-IP isolation, window expiry, endpoint 429, stale-bucket eviction, and **active-flood hard-bound**;
- **T3.6:** fallback (empty/none/all-zeros) → all 6, real hash still selects a 4-subset (deterministic), distinct hashes rotate, `get_epoch_fingerprint_rotation(epoch=0)` → all 6 / none inactive, and the **round-robin duplicate also fails closed**.

The existing epoch-0 `simd_bias` assertion (`test_rip309_integrated_simd_alias`) still holds (all-6 includes it). Beacon + rip309 regression suites pass in isolation and co-loaded.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), **3 loops, converged** (no BLOCKING at convergence). Loop 2 fixed the duplicate round-robin selector (Grok) + softened the per-process over-claim (Codex) + added bucket eviction; loop 3 made the eviction a hard bound.

### Note
Two beacon tests fail on collection with `ModuleNotFoundError: No module named 'node'` (`test_beacon_keys_cli_unit`, `test_beacon_resolver_status`) — a pre-existing `from node import ...` path artifact, present on pristine `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)