### PR TITLE
Fail closed on legacy CLI wallet send errors

### DIFF
--- a/tests/test_cli_wallet_send_fail_closed.py
+++ b/tests/test_cli_wallet_send_fail_closed.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI_MAIN = ROOT / "tools" / "cli-wallet" / "src" / "main.rs"
+CLI_README = ROOT / "tools" / "cli-wallet" / "README.md"
+
+
+def test_cli_wallet_send_does_not_mock_successful_transactions():
+    source = CLI_MAIN.read_text(encoding="utf-8")
+
+    assert 'println!("Note: Mock transaction' not in source
+    assert "hex::encode(&signed_transaction.signature[0..8])" not in source
+    assert "Transaction endpoint returned HTTP" in source
+    assert "Transaction submission failed" in source
+    assert "if !status.is_success()" in source
+
+
+def test_cli_wallet_readme_does_not_claim_mock_send_success():
+    readme = CLI_README.read_text(encoding="utf-8")
+
+    assert "Simulated successful transactions" not in readme
+    assert "Transaction submission fails closed" in readme

--- a/tools/cli-wallet/README.md
+++ b/tools/cli-wallet/README.md
@@ -113,10 +113,11 @@ RustChain addresses use the canonical 43-character format: `RTC` followed by
 
 When the RustChain node is not available, the wallet operates in development mode with:
 - Mock balance of 1000 RTC
-- Simulated successful transactions
+- Transaction submission fails closed instead of reporting a mock success
 - Local address validation
 
-This allows testing wallet functionality without a running blockchain node.
+This allows testing wallet generation, address validation, and balance display
+without a running blockchain node, while preventing false "sent" confirmations.
 
 ## API Endpoints
 

--- a/tools/cli-wallet/src/main.rs
+++ b/tools/cli-wallet/src/main.rs
@@ -196,32 +196,27 @@ async fn send_transaction(
     let signature = wallet.sign_transaction(&transaction)?;
     let mut signed_transaction = transaction;
     signed_transaction.signature = signature;
-    
+
     let client = reqwest::Client::new();
-    let url = format!("{}/api/transaction", node_url);
+    let url = format!("{}/api/transaction", node_url.trim_end_matches('/'));
     
-    match client.post(&url).json(&signed_transaction).send().await {
-        Ok(response) => {
-            if response.status().is_success() {
-                let tx_response: TransactionResponse = response.json().await?;
-                if tx_response.success {
-                    Ok(tx_response.transaction_id.unwrap_or_else(|| "unknown".to_string()))
-                } else {
-                    Err(anyhow!("Transaction failed: {}", tx_response.message))
-                }
-            } else {
-                // Mock successful transaction when API is not available
-                println!("Note: Mock transaction (node API not available)");
-                let tx_id = hex::encode(&signed_transaction.signature[0..8]);
-                Ok(tx_id)
-            }
-        }
-        Err(_) => {
-            // Mock successful transaction when node is not reachable
-            println!("Note: Mock transaction (node not reachable)");
-            let tx_id = hex::encode(&signed_transaction.signature[0..8]);
-            Ok(tx_id)
-        }
+    let response = client
+        .post(&url)
+        .json(&signed_transaction)
+        .send()
+        .await
+        .map_err(|err| anyhow!("Transaction submission failed: {}", err))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(anyhow!("Transaction endpoint returned HTTP {}", status));
+    }
+
+    let tx_response: TransactionResponse = response.json().await?;
+    if tx_response.success {
+        Ok(tx_response.transaction_id.unwrap_or_else(|| "unknown".to_string()))
+    } else {
+        Err(anyhow!("Transaction failed: {}", tx_response.message))
     }
 }
 


### PR DESCRIPTION
## Summary
- stop the legacy CLI wallet from returning a fake tx id when transaction submission gets a non-2xx response
- fail closed on transaction network errors instead of printing mock-send success
- update README development-mode wording so it no longer promises simulated successful sends
- add a focused pytest guard for the fail-closed behavior and README claim

Fixes #7106.

## Live repro before fix
```bash
curl -sk -D - -X POST "https://rustchain.org/api/transaction" \
  -H "Content-Type: application/json" \
  --data "{}" -o -
```

Observed:
```http
HTTP/1.1 404 Not Found
Content-Type: text/html
Server: nginx
```

Before this patch, the legacy CLI turns that class of response into `Ok(tx_id)`, so the command prints `Transaction sent successfully!` even though the node rejected or never received the transaction.

## Validation
Validated on a local merge-check branch with current `origin/main` plus this PR patch:

```bash
pytest -q tests/test_cli_wallet_send_fail_closed.py
$env:CARGO_BUILD_JOBS="1"; $env:RUSTFLAGS="-Cdebuginfo=0"; $env:RUST_MIN_STACK="8388608"; cargo test --manifest-path tools/cli-wallet/Cargo.toml
git diff --check origin/main..HEAD -- tools/cli-wallet/src/main.rs tools/cli-wallet/README.md tests/test_cli_wallet_send_fail_closed.py
```

Results:
- pytest guard: 2 passed
- cli-wallet cargo tests: 7 passed
- diff check: passed
