### PR TITLE
fix(consensus/T3.3): opt-in fail-closed anti-double-mining (RC_REQUIRE_ADM)

### DIFF
--- a/node/rewards_implementation_rip200.py
+++ b/node/rewards_implementation_rip200.py
@@ -116,7 +116,16 @@ def settle_epoch_rip200(db_path, epoch: int, enable_anti_double_mining: bool = T
         epoch: Epoch number to settle
         enable_anti_double_mining: Enable Issue #1449 anti-double-mining (default: True)
 
+    Environment:
+        RC_REQUIRE_ADM=1 (T3.3, default off): make ADM MANDATORY for this path. When set,
+        if ADM is unavailable (module absent or disabled for the call) or its execution
+        raises, the epoch is NOT settled via the standard non-grouping path — it fails
+        closed and is left unsettled for retry. Default (unset) preserves the historical
+        standard-rewards fallback. Scope is this function only; finalize_epoch is not
+        gated.
+
     Returns:
+        Success:
         {
             "ok": True,
             "epoch": epoch number,
@@ -125,6 +134,9 @@ def settle_epoch_rip200(db_path, epoch: int, enable_anti_double_mining: bool = T
             "already_settled": bool,
             "anti_double_mining_telemetry": {...}  # Only if enabled
         }
+        Errors (ok=False, "error" code): "epoch_not_reached", "no_eligible_miners",
+        and — only under RC_REQUIRE_ADM=1 — "adm_required_unavailable" (ADM not usable
+        for this call) / "adm_required_failed" (ADM raised; no standard fall-through).
     """
     # Reject future epochs — defense in depth (caller should also check).
     current_epoch = slot_to_epoch(current_slot())
@@ -155,6 +167,25 @@ def settle_epoch_rip200(db_path, epoch: int, enable_anti_double_mining: bool = T
         # Calculate current slot for age calculation
         current = current_slot()
 
+        # T3.3: opt-in fail-closed anti-double-mining. RC_REQUIRE_ADM makes ADM
+        # MANDATORY for this (admin/operator) settlement path — if ADM is unavailable or
+        # fails, do NOT silently settle with the standard non-grouping path (which drops
+        # the one-machine-one-reward guard). Default (flag off) preserves the
+        # standard-rewards fallback the fleet relies on.
+        # SCOPE: settle_epoch_rip200 ONLY. finalize_epoch (the auto block-ingest path)
+        # intentionally does not group by hardware and is deliberately NOT gated here —
+        # adding ADM grouping there would break the live fleet (each fingerprinted miner
+        # is paid per epoch; ADM is an admin-path defense-in-depth measure, not the
+        # external-Sybil control).
+        require_adm = os.environ.get("RC_REQUIRE_ADM", "0") == "1"
+        if require_adm and not (enable_anti_double_mining and ANTI_DOUBLE_MINING_AVAILABLE):
+            db.rollback()
+            return {
+                "ok": False, "error": "adm_required_unavailable", "epoch": epoch,
+                "hint": "RC_REQUIRE_ADM=1 but anti-double-mining is disabled for this "
+                        "call or its module is unavailable",
+            }
+
         # Issue #1449: Use anti-double-mining rewards if enabled and available
         if enable_anti_double_mining and ANTI_DOUBLE_MINING_AVAILABLE:
             try:
@@ -174,13 +205,19 @@ def settle_epoch_rip200(db_path, epoch: int, enable_anti_double_mining: bool = T
                 db.commit()
                 return result
             except Exception as e:
-                print(f"[WARN] Anti-double-mining failed, falling back to standard: {e}")
-                # Rollback partial ADM writes before falling through to standard rewards.
-                # Without this, ADM may have already written rewards on the shared `db`
-                # connection. The standard path then adds MORE rewards on top, resulting
-                # in double-credited miners on the single commit below.
+                print(f"[WARN] Anti-double-mining failed: {e}")
+                # Rollback partial ADM writes before any fallback/return. Without this,
+                # ADM may have already written rewards on the shared `db` connection; the
+                # standard path would then add MORE on top → double-credit on commit.
                 db.rollback()
-                # Re-acquire the write lock after rollback (rollback releases it).
+                if require_adm:
+                    # T3.3: fail CLOSED — never fall through to the non-grouping standard
+                    # path when ADM is mandatory. The epoch stays unsettled for retry.
+                    return {
+                        "ok": False, "error": "adm_required_failed",
+                        "epoch": epoch, "detail": str(e),
+                    }
+                # Default: re-acquire the write lock (rollback released it) + fall through.
                 db.execute("BEGIN IMMEDIATE")
 
         # Standard RIP-200 rewards (no anti-double-mining)

--- a/node/tests/test_adm_require_optin_t33.py
+++ b/node/tests/test_adm_require_optin_t33.py
@@ -1,0 +1,117 @@
+"""T3.3 regression: opt-in fail-closed anti-double-mining (RC_REQUIRE_ADM).
+
+settle_epoch_rip200 historically falls back to the standard (non-grouping) reward path
+whenever ADM is unavailable or raises — silently dropping the one-machine-one-reward
+guard. RC_REQUIRE_ADM (default OFF) makes ADM mandatory for this admin/operator path:
+on unavailable-or-failure it FAILS CLOSED (epoch left unsettled) instead of degrading.
+
+Scope check: this gate lives ONLY in settle_epoch_rip200. finalize_epoch (the auto
+block path) is intentionally NOT gated (it doesn't group by hardware; gating it would
+break the live fleet).
+"""
+import importlib
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if NODE_DIR not in sys.path:
+    sys.path.insert(0, NODE_DIR)
+
+import rewards_implementation_rip200 as rmod
+
+
+def _minimal_db():
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    c = sqlite3.connect(path)
+    c.execute("CREATE TABLE epoch_state (epoch INTEGER PRIMARY KEY, settled INTEGER DEFAULT 0, settled_ts INTEGER)")
+    c.execute("CREATE TABLE epoch_enroll (epoch INTEGER, miner_pk TEXT, weight INTEGER DEFAULT 100)")
+    c.execute("CREATE TABLE miner_attest_recent (miner TEXT PRIMARY KEY, device_arch TEXT, ts_ok INTEGER, "
+              "fingerprint_passed INTEGER DEFAULT 1, entropy_score REAL, fingerprint_checks_json TEXT)")
+    c.execute("CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)")
+    c.execute("CREATE TABLE ledger (id INTEGER PRIMARY KEY AUTOINCREMENT, ts INTEGER, epoch INTEGER, "
+              "miner_id TEXT, delta_i64 INTEGER, reason TEXT)")
+    c.execute("CREATE TABLE epoch_rewards (epoch INTEGER, miner_id TEXT, share_i64 INTEGER)")
+    c.commit()
+    c.close()
+    return path
+
+def _settled(path, epoch):
+    with sqlite3.connect(path) as c:
+        row = c.execute("SELECT settled FROM epoch_state WHERE epoch=?", (epoch,)).fetchone()
+    return bool(row and row[0] == 1)
+
+
+class AdmRequireOptInTest(unittest.TestCase):
+    def setUp(self):
+        self._prev = os.environ.get("RC_REQUIRE_ADM")
+        self._prev_avail = rmod.ANTI_DOUBLE_MINING_AVAILABLE
+        self._prev_fn = getattr(rmod, "settle_epoch_with_anti_double_mining", None)
+
+    def tearDown(self):
+        if self._prev is None:
+            os.environ.pop("RC_REQUIRE_ADM", None)
+        else:
+            os.environ["RC_REQUIRE_ADM"] = self._prev
+        rmod.ANTI_DOUBLE_MINING_AVAILABLE = self._prev_avail
+        if self._prev_fn is not None:
+            rmod.settle_epoch_with_anti_double_mining = self._prev_fn
+
+    # --- fail-closed (RC_REQUIRE_ADM=1) -----------------------------------
+    def test_required_but_unavailable_fails_closed(self):
+        """ADM disabled-for-call (or module absent) + RC_REQUIRE_ADM=1 → no settlement."""
+        db = _minimal_db()
+        os.environ["RC_REQUIRE_ADM"] = "1"
+        res = rmod.settle_epoch_rip200(db, epoch=1, enable_anti_double_mining=False)
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["error"], "adm_required_unavailable")
+        self.assertFalse(_settled(db, 1), "epoch must NOT be settled when ADM is required but unavailable")
+        os.unlink(db)
+
+    def test_required_but_adm_raises_fails_closed(self):
+        """ADM available but raises + RC_REQUIRE_ADM=1 → adm_required_failed, NOT a
+        silent fall-through to the non-grouping standard path."""
+        db = _minimal_db()
+        rmod.ANTI_DOUBLE_MINING_AVAILABLE = True
+
+        def _boom(*a, **k):
+            raise RuntimeError("ADM kaboom")
+
+        rmod.settle_epoch_with_anti_double_mining = _boom
+        os.environ["RC_REQUIRE_ADM"] = "1"
+        res = rmod.settle_epoch_rip200(db, epoch=1, enable_anti_double_mining=True)
+        self.assertFalse(res["ok"])
+        self.assertEqual(res["error"], "adm_required_failed")
+        self.assertFalse(_settled(db, 1), "epoch must NOT be settled (no standard fall-through under RC_REQUIRE_ADM)")
+        os.unlink(db)
+
+    # --- default OFF: backward compatible ---------------------------------
+    def test_default_off_unavailable_falls_through_to_standard(self):
+        """Default (flag unset): ADM unavailable → standard path runs (no adm_* error).
+        With no enrolled miners it returns no_eligible_miners — proving the gate is
+        opt-in and did NOT short-circuit."""
+        db = _minimal_db()
+        os.environ.pop("RC_REQUIRE_ADM", None)
+        res = rmod.settle_epoch_rip200(db, epoch=1, enable_anti_double_mining=False)
+        self.assertNotEqual(res.get("error"), "adm_required_unavailable")
+        self.assertEqual(res.get("error"), "no_eligible_miners")
+        os.unlink(db)
+
+    def test_default_off_adm_raises_falls_through_to_standard(self):
+        """Default: ADM raises → falls through to standard path (reaches no_eligible_miners),
+        not adm_required_failed."""
+        db = _minimal_db()
+        rmod.ANTI_DOUBLE_MINING_AVAILABLE = True
+        rmod.settle_epoch_with_anti_double_mining = lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom"))
+        os.environ.pop("RC_REQUIRE_ADM", None)
+        res = rmod.settle_epoch_rip200(db, epoch=1, enable_anti_double_mining=True)
+        self.assertNotEqual(res.get("error"), "adm_required_failed")
+        self.assertEqual(res.get("error"), "no_eligible_miners")
+        os.unlink(db)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## T3.3 — Anti-double-mining is optional (silent degradation)

Part of the consensus stabilization roadmap (`CONSENSUS_TRIAGE.md`, PR #8 — the last item). This was flagged **verify-first** in triage, and the verification matters:

### Verified scoping (why this is narrow)
The triage workflow found T3.3 was **mis-scoped** in the original report. Anti-double-mining (ADM) is an **admin-path defense-in-depth** measure, **not** the external-Sybil control:
- `settle_epoch_rip200` is the operator/admin settlement path; it *can* use ADM.
- `finalize_epoch` (the auto block-ingest path that actually settles epochs in normal operation) **does not group by hardware at all** — each fingerprinted miner is paid per epoch.

So the fix must **not** add hardware grouping to `finalize_epoch` (that would break the live fleet), and the ADM enforcement must be **opt-in** (the fleet relies on the standard-rewards fallback working).

### The gap
`settle_epoch_rip200` silently falls back to the **standard (non-grouping)** reward path whenever ADM is unavailable (module never imported) or raises mid-settlement — dropping the one-machine-one-reward guard with no signal beyond a `[WARN]` log.

### The fix
`RC_REQUIRE_ADM` (default **OFF**) makes ADM mandatory for `settle_epoch_rip200` only:
- ADM unavailable/disabled for the call → `{"ok": False, "error": "adm_required_unavailable"}` — epoch **not** settled.
- ADM raises → rollback + `{"ok": False, "error": "adm_required_failed"}` — **no** fall-through to the non-grouping standard path; epoch left unsettled for retry.

**Default (flag unset) is byte-for-byte the prior behavior** — the standard-rewards fallback is preserved, so the live fleet is unaffected until an operator deliberately opts in.

### Tests (4) + regression
`node/tests/test_adm_require_optin_t33.py`:
- `RC_REQUIRE_ADM=1` + ADM unavailable → fail-closed, epoch unsettled;
- `RC_REQUIRE_ADM=1` + ADM raises → `adm_required_failed`, epoch unsettled (no standard fall-through);
- default off + unavailable → standard path runs (`no_eligible_miners`, not an `adm_*` error);
- default off + ADM raises → standard fall-through (proves the gate is opt-in).

25 existing ADM tests + 101 epoch/settlement/claims/rip309 regression tests pass.

### Review
Tri-brain (Codex security + GPT-OSS coherence + Grok regression), **converged loop 1, no BLOCKING**. Codex's non-findings explicitly confirm: the early-guard rollback runs with an active transaction (entry `BEGIN IMMEDIATE`), `own_conn`/passed-connection handling matches the pre-existing `already_settled` rollback pattern, and there is no change to `finalize_epoch` or the standard path. Grok confirms the contract change is opt-in and matches intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)