### PR TITLE
fix: return full row from _find_balance_row instead of column value (closes #305)

### DIFF
--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -82,17 +82,17 @@ def _find_balance_row(conn, miner_id):
 
     if "miner_id" in columns:
         row = conn.execute(
-            "SELECT miner_id FROM balances WHERE miner_id = ?", (miner_id,)
+            "SELECT rowid, * FROM balances WHERE miner_id = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_id"
+            return row, "miner_id"
 
     if "miner_pk" in columns:
         row = conn.execute(
-            "SELECT miner_pk FROM balances WHERE miner_pk = ?", (miner_id,)
+            "SELECT rowid, * FROM balances WHERE miner_pk = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_pk"
+            return row, "miner_pk"
 
     return None, None
 


### PR DESCRIPTION
## What
The `_find_balance_row` function incorrectly returns the column value (e.g., `row[0]` of a single-column SELECT) instead of the full database row. Callers of this function expect to receive the actual row to update the `coinbase_address` column, but they get back a string like the miner_id or miner_pk, which is useless for further operations. This breaks the `/wallet/link-coinbase` endpoint.

## Fix
Changed the SELECT query to return the full row (including `rowid`) and return `row` itself instead of `row[0]`. This ensures the returned object can be used to update the balance record with the coinbase address.

Closes #305