### PR TITLE
fix: escape status RSS incident fields

### DIFF
--- a/status/status_server.py
+++ b/status/status_server.py
@@ -13,6 +13,7 @@ import threading
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
+from xml.sax.saxutils import escape as xml_escape
 
 import requests
 from flask import Flask, render_template, jsonify, Response
@@ -161,6 +162,11 @@ def poller_loop():
         time.sleep(POLL_INTERVAL)
 
 
+def xml_text(value):
+    """Escape dynamic text before embedding it in RSS XML text nodes."""
+    return xml_escape(str(value), {'"': "&quot;", "'": "&apos;"})
+
+
 # ── Routes ────────────────────────────────────────────────────────
 
 @app.route("/")
@@ -218,9 +224,9 @@ def rss_feed():
     items = []
     for inc in incidents[:20]:
         items.append(f"""    <item>
-      <title>{inc['node']} — {inc['event']}</title>
-      <description>{inc.get('detail', inc['event'])}</description>
-      <pubDate>{inc['time']}</pubDate>
+      <title>{xml_text(inc['node'])} — {xml_text(inc['event'])}</title>
+      <description>{xml_text(inc.get('detail', inc['event']))}</description>
+      <pubDate>{xml_text(inc['time'])}</pubDate>
     </item>""")
     xml = f"""<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">

--- a/status/test_status.py
+++ b/status/test_status.py
@@ -173,6 +173,22 @@ class TestAPI:
         assert b"<rss" in resp.data
         assert b"Node 1" in resp.data
 
+    def test_rss_feed_escapes_incident_fields(self, client):
+        incidents.append({
+            "node": 'Node <1>',
+            "event": 'down </title><item><title>POISON</title></item>',
+            "detail": 'detail & "quotes" </description><item><title>POISON</title></item>',
+            "time": "2026-03-24T12:00:00Z",
+        })
+
+        resp = client.get("/feed.xml")
+
+        assert resp.status_code == 200
+        assert b"</title><item><title>POISON</title></item>" not in resp.data
+        assert b"</description><item><title>POISON</title></item>" not in resp.data
+        assert b"Node &lt;1&gt;" in resp.data
+        assert b"detail &amp; &quot;quotes&quot;" in resp.data
+
     def test_index_page(self, client):
         resp = client.get("/")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Fixes the status dashboard RSS feed XML serialization by escaping dynamic incident fields before embedding them in `/feed.xml` text nodes.

This addresses Scottcjn/Rustchain#7226 and is related to bounty claim Scottcjn/rustchain-bounties#13589.

## Root cause

`rss_feed()` interpolated incident `node`, `event`, `detail`, and `time` values directly into XML. If any of those values contained XML metacharacters or closing tags, the generated RSS could become malformed or include injected feed markup.

## Changes

- Add `xml_text()` helper using `xml.sax.saxutils.escape`.
- Escape incident `node`, `event`, `detail`, and `time` before writing RSS item fields.
- Add a regression test with injected `</title><item><title>POISON</title></item>` markup and XML metacharacters.

## Verification

```bash
/tmp/rustchain-money/.venv/bin/python -m pytest status/test_status.py -q
```

Result:

```text
16 passed, 72 warnings
```
