### PR TITLE
fix(security): escape Step 7 attestation wallet commands in setup wizard (Issue #7208)

### DIFF
--- a/tests/test_setup_wizard_frontend_security.py
+++ b/tests/test_setup_wizard_frontend_security.py
@@ -74,3 +74,49 @@ def test_miner_check_accepts_paginated_miners_response():
 
     assert "var miners=Array.isArray(data)?data:(data&&Array.isArray(data.miners)?data.miners:[]);" in html
     assert "for(var i=0;i<miners.length;i++)" in html
+
+
+def test_step7_miner_command_escapes_wallet_name():
+    """Regression: setup wizard Step 7 miner start command must escape wName before innerHTML injection.
+
+    A crafted imported wallet name (e.g. ``<img src=x onerror=alert(1)><wallet>``) used to flow
+    unescaped into the Step 7 ``<div class="cb">`` command block via raw string concatenation.
+    The fix wraps the value with the existing ``esc()`` helper before template interpolation.
+    """
+    html = WIZARD_HTML.read_text(encoding="utf-8")
+
+    # Sanity: the esc() helper exists and handles <, >, &.
+    assert "function esc(s)" in html
+    assert ".replace(/&/g,\"&amp;\")" in html
+    assert ".replace(/</g,\"&lt;\")" in html
+    assert ".replace(/>/g,\"&gt;\")" in html
+
+    # The renderAttest function MUST escape minerCmd before injection.
+    assert "'+esc(minerCmd)+'" in html
+    assert "'+minerCmd+'<span" not in html
+
+    # The renderAttest function MUST escape minersCmd before injection.
+    assert "'+esc(minersCmd)+'" in html
+    assert "'+minersCmd+'<span" not in html
+
+    # The Step 7 balance reminder <code> block must use the new balanceCmd string
+    # and escape it before injection.
+    assert "var balanceCmd=" in html
+    assert "'+esc(balanceCmd)+'" in html
+    assert "miner_id='+wName+'" not in html
+
+
+def test_step7_escape_helper_preserves_copy_button_semantics():
+    """The fix must keep the copy button working.
+
+    ``copyCode(btn)`` walks ``btn.previousSibling`` to find a text node. With escaping,
+    the innerHTML still contains the command text node followed by the ``<span class="cpy">``
+    element, so copyCode() behavior is preserved.
+    """
+    html = WIZARD_HTML.read_text(encoding="utf-8")
+
+    # The two cb blocks for Step 7 still embed the copy button next to the escaped text.
+    assert "esc(minerCmd)+'<span class=\"cpy\"" in html
+    assert "esc(minersCmd)+'<span class=\"cpy\"" in html
+    # The previousSibling walk in copyCode is unchanged.
+    assert "btn.previousSibling" in html

--- a/web/wizard/setup-wizard.html
+++ b/web/wizard/setup-wizard.html
@@ -163,20 +163,21 @@ function renderAttest(el){
   var wName=S.walletName||"YOUR_WALLET_NAME";
   var minerCmd="~/.rustchain/venv/bin/python ~/.rustchain/rustchain_miner.py --wallet "+wName;
   var minersCmd="curl -sk https://rustchain.org/api/miners";
+  var balanceCmd="curl -sk \"https://rustchain.org/wallet/balance?miner_id="+wName+"\"";
   el.innerHTML=
     '<div class="card"><h2>&#127776; Step 7 &mdash; First Attestation</h2><p>Start your miner and verify it appears on the RustChain network.</p></div>'+
     '<div class="card"><h3>&#9654; Start the miner</h3><div class="cl">Run in terminal (or use the service created by the installer)</div>'+
-    '<div class="cb">'+minerCmd+'<span class="cpy" onclick="copyCode(this)">Copy</span></div>'+
+    '<div class="cb">'+esc(minerCmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div>'+
     '<div class="ib">On Linux: the installer auto-creates a systemd service. Run <code>systemctl --user status rustchain-miner</code> to check status, or <code>journalctl --user -u rustchain-miner -f</code> to view logs.</div>'+
     '<div class="ib">On macOS: the installer creates a launchd plist. Run <code>launchctl list | grep rustchain</code> to check status.</div>'+
     '</div>'+
     '<div class="card"><h3>&#128202; Verify your miner appears on the network</h3><div class="cl">After starting the miner, check if it appears in the active miners list</div>'+
-    '<div class="cb">'+minersCmd+'<span class="cpy" onclick="copyCode(this)">Copy</span></div>'+
+    '<div class="cb">'+esc(minersCmd)+'<span class="cpy" onclick="copyCode(this)">Copy</span></div>'+
     '<div class="ir" style="margin-top:12px"><input type="text" id="minerCheckInput" placeholder="Paste miner output or leave blank to skip" style="min-width:300px" /><button class="bp" onclick="checkMiner()">Check</button></div>'+
     '<div id="minerResult" style="margin-top:10px"></div></div>'+
     '<div class="card"><h3>&#128640; Congratulations!</h3><div class="hero"><div class="ic">&#127881;</div><h2>You are now a RustChain Miner!</h2><p>Your hardware is contributing to the Proof-of-Antiquity network.<br/>Earn RTC tokens as your vintage hardware proves its age and authenticity.<br/><br/>Keep your miner running to accumulate attestations and rewards.</p></div>'+
     '<div class="sm"><div class="rw"><span class="lb">Wallet</span><span class="vl">'+esc(wName)+'</span></div><div class="rw"><span class="lb">Network</span><span class="vl">RustChain (https://rustchain.org)</span></div><div class="rw"><span class="lb">Bounty</span><span class="vl">50 RTC</span></div></div>'+
-    '<div class="ib"><strong>Next steps:</strong> Bookmark this wizard, monitor your balance with <code>curl -sk https://rustchain.org/wallet/balance?miner_id='+wName+'</code>, and join the Discord for help.</div></div>'+
+    '<div class="ib"><strong>Next steps:</strong> Bookmark this wizard, monitor your balance with <code>'+esc(balanceCmd)+'</code>, and join the Discord for help.</div></div>'+
     '<div class="br"><button class="bs" onclick="go(5)">&larr; Back</button><button class="bp" onclick="go(6)">I\'m Mining! &#10003;</button></div>';
 }
 function checkMiner(){


### PR DESCRIPTION
## Summary

The standalone miner setup wizard at `web/wizard/setup-wizard.html` accepts an imported wallet name and later renders the Step 7 miner start command, the Step 7 balance reminder command, and the Step 7 active-miners URL into `innerHTML` templates.

Earlier wizard steps escaped wallet values via the existing `esc()` helper, but `renderAttest()` concatenated `wName` and the derived `minerCmd` / `minersCmd` strings into `innerHTML` directly. A crafted imported wallet name (e.g. `<img src=x onerror=alert(1)><wallet>`) flowed through the parser sink and executed as DOM XSS in the public miner onboarding workflow.

## Proposed fix (per the issue's specification)

- Keep building the same command strings for display/copy behavior.
- Escape the Step 7 miner start command before inserting it into the command block.
- Escape the Step 7 active-miners URL command before inserting it into its command block.
- Escape the Step 7 balance reminder command before inserting it into the inline `<code>` element.
- Add a focused frontend regression test for all three render sites.

## Diff

```
 web/wizard/setup-wizard.html                 |  7 +++--
 tests/test_setup_wizard_frontend_security.py | 46 ++++++++++++++++++++
 2 files changed, 50 insertions(+), 3 deletions(-)
```

## Files touched

- `web/wizard/setup-wizard.html` — `renderAttest()` now wraps `minerCmd`, `minersCmd`, and a new `balanceCmd` string in the existing `esc()` helper before template interpolation.
- `tests/test_setup_wizard_frontend_security.py` — adds 2 new regression tests:
  - `test_step7_miner_command_escapes_wallet_name` — forbids the old `'+minerCmd+'<span`, `'+minersCmd+'<span`, and `miner_id='+wName+'` patterns; requires the new `'+esc(...)+'` wrappers.
  - `test_step7_escape_helper_preserves_copy_button_semantics` — confirms the `<span class="cpy">` copy button still sits next to the escaped text node, so the existing `copyCode()` `btn.previousSibling` walk continues to work.

## Validation (local)

```bash
python3 -m pytest tests/test_setup_wizard_frontend_security.py -q
# 7 passed in 0.20s

# Extract inline script and run node --check
python3 -c "import re,subprocess; from pathlib import Path; h=Path('web/wizard/setup-wizard.html').read_text(); s=re.findall(r'<script[^>]*>(.*?)</script>', h, re.DOTALL); subprocess.run(['node','-e','new Function(require(\"fs\").readFileSync(0,\"utf8\"))'], input=s[0], text=True, check=True)"
# exit 0, no stderr

git diff --check
# clean
```

## Non-overlapping scope

- No prior PR targets Issue #7208 (confirmed via `gh pr list --search '7208 in:title' --state all`).
- pqmfei bot has filed broader "Harden X" PRs (#7201, #7203, #7205, #7211, #7213, #7215, #7217, #7219, etc.) but they target other surfaces; this PR is a focused single-issue fix.
- The change is strictly additive on top of the existing `esc()` helper, so copy-to-clipboard semantics, the existing `S.walletName` source of truth, and the import-wallet flow are unchanged.

Refs #7208