### PR TITLE
fix(security): require admin auth for Hall of Rust eulogy writes (Issue #7244)

### DIFF
--- a/node/hall_of_rust.py
+++ b/node/hall_of_rust.py
@@ -344,6 +344,13 @@ def rust_leaderboard():
 @hall_bp.route('/hall/eulogy/<fingerprint>', methods=['POST'])
 def set_eulogy(fingerprint):
     """Set a eulogy/nickname for a machine. For when it finally dies."""
+    # SECURITY: Require admin key — unauthenticated POSTs would let any caller
+    # deface the public Hall of Rust memorial registry (nickname, eulogy,
+    # is_deceased/deceased_at) for any known fingerprint.
+    err = _require_admin()
+    if err:
+        return err
+
     data, error_response = _json_object_or_empty()
     if error_response:
         return error_response
@@ -354,7 +361,7 @@ def set_eulogy(fingerprint):
     eulogy, error_response = _optional_text_field(data, 'eulogy', 500)
     if error_response:
         return error_response
-    
+
     try:
         from flask import current_app
         db_path = current_app.config.get('DB_PATH', '/root/rustchain/rustchain_v2.db')

--- a/node/tests/conftest.py
+++ b/node/tests/conftest.py
@@ -1,4 +1,11 @@
-"""Test configuration — adds node/ to Python path for sibling module imports."""
+"""Test configuration — adds node/ to Python path for sibling module imports.
+
+Also sets RC_ADMIN_KEY to a test value so the _require_admin() gate in
+hall_of_rust (and any sibling admin-gated routes) is reachable from tests
+that pass X-Admin-Key. Tests that exercise the fail-closed / unauthenticated
+path can monkeypatch.delenv("RC_ADMIN_KEY") to remove the key entirely.
+"""
+import os
 import sys
 from pathlib import Path
 
@@ -8,3 +15,9 @@ tests_dir = Path(__file__).parent
 node_dir = tests_dir.parent
 if str(node_dir) not in sys.path:
     sys.path.insert(0, str(node_dir))
+
+
+# Provide a stable admin key for the test session. Individual tests that want
+# to exercise the fail-closed branch (no key configured) should call
+# `monkeypatch.delenv("RC_ADMIN_KEY", raising=False)` inside the test.
+os.environ.setdefault("RC_ADMIN_KEY", "test-admin-key")

--- a/node/tests/test_hall_eulogy_admin_gate.py
+++ b/node/tests/test_hall_eulogy_admin_gate.py
@@ -1,0 +1,207 @@
+"""Regression tests for the Hall of Rust /hall/eulogy/<fingerprint> admin gate.
+
+Issue #7244: POST /hall/eulogy/<fingerprint> previously had no _require_admin()
+check, so any unauthenticated caller could deface the public memorial registry
+(nickname, eulogy, is_deceased/deceased_at) for any known fingerprint.
+
+These tests prove the fix in node/hall_of_rust.py:
+
+- Anonymous POSTs return 401/503 and DO NOT mutate the row.
+- Authenticated POSTs (correct X-Admin-Key) succeed and persist the changes.
+- A nonexistent admin key is rejected even when a wrong key is supplied.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "node"))
+
+# Import the module fresh so the env var we set per-test takes effect.
+import hall_of_rust  # noqa: E402
+
+
+@pytest.fixture
+def fresh_module(monkeypatch):
+    """Reload hall_of_rust with the supplied RC_ADMIN_KEY env var."""
+
+    def _reload(admin_key: str | None):
+        if admin_key is None:
+            monkeypatch.delenv("RC_ADMIN_KEY", raising=False)
+        else:
+            monkeypatch.setenv("RC_ADMIN_KEY", admin_key)
+        # Force reimport so the module-level _require_admin reads the new value
+        # on each call (it reads os.environ lazily, but Flask blueprint state
+        # survives across tests within the same process, so reloading is safer).
+        mod = importlib.reload(hall_of_rust)
+        return mod
+
+    return _reload
+
+
+def _client_for(db_path):
+    app = Flask(__name__)
+    app.config["DB_PATH"] = str(db_path)
+    app.register_blueprint(hall_of_rust.hall_bp)
+    return app.test_client()
+
+
+def _seed_hall_row(db_path, fingerprint: str = "abc123") -> None:
+    """Insert one hall_of_rust row so the UPDATE has a real target."""
+    hall_of_rust.init_hall_tables(str(db_path))
+    import sqlite3
+    import time
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            INSERT INTO hall_of_rust (
+                fingerprint_hash, miner_id, first_attestation, created_at,
+                nickname, eulogy, is_deceased
+            ) VALUES (?, ?, ?, ?, NULL, NULL, 0)
+            """,
+            (fingerprint, "test-miner", int(time.time()), int(time.time())),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _row(db_path, fingerprint: str = "abc123") -> dict:
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute(
+            "SELECT nickname, eulogy, is_deceased, deceased_at "
+            "FROM hall_of_rust WHERE fingerprint_hash = ?",
+            (fingerprint,),
+        )
+        return dict(cur.fetchone())
+    finally:
+        conn.close()
+
+
+def test_set_eulogy_rejects_anonymous_request(tmp_path, fresh_module):
+    """An unauthenticated POST must NOT mutate the hall_of_rust row."""
+    fresh_module(admin_key="s3cret-admin-key")
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"nickname": "DEFACED", "eulogy": "unauth write"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized — admin key required"}
+    # Row must be untouched.
+    row = _row(db_path)
+    assert row["nickname"] is None
+    assert row["eulogy"] is None
+    assert row["is_deceased"] == 0
+    assert row["deceased_at"] is None
+
+
+def test_set_eulogy_rejects_wrong_admin_key(tmp_path, fresh_module):
+    fresh_module(admin_key="s3cret-admin-key")
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"nickname": "wrong-key"},
+        headers={"X-Admin-Key": "guess"},
+    )
+
+    assert response.status_code == 401
+    row = _row(db_path)
+    assert row["nickname"] is None
+
+
+def test_set_eulogy_fails_closed_when_admin_key_unset(tmp_path, fresh_module):
+    """If RC_ADMIN_KEY is unset, the gate must fail with 503 (fail-closed)."""
+    fresh_module(admin_key=None)
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"nickname": "no-key"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "RC_ADMIN_KEY not configured"}
+    row = _row(db_path)
+    assert row["nickname"] is None
+
+
+def test_set_eulogy_accepts_correct_admin_key(tmp_path, fresh_module):
+    """A POST with the correct X-Admin-Key persists the changes."""
+    fresh_module(admin_key="s3cret-admin-key")
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"nickname": "Old Ironsides", "eulogy": "Faithful to the end."},
+        headers={"X-Admin-Key": "s3cret-admin-key"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body == {"ok": True, "message": "Memorial updated"}
+    row = _row(db_path)
+    assert row["nickname"] == "Old Ironsides"
+    assert row["eulogy"] == "Faithful to the end."
+
+
+def test_set_eulogy_admin_can_mark_deceased(tmp_path, fresh_module):
+    """A POST with is_deceased=true and a valid key sets the deceased fields."""
+    fresh_module(admin_key="s3cret-admin-key")
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"is_deceased": True},
+        headers={"X-Admin-Key": "s3cret-admin-key"},
+    )
+
+    assert response.status_code == 200
+    row = _row(db_path)
+    assert row["is_deceased"] == 1
+    # deceased_at should be a positive integer (now-ish).
+    assert isinstance(row["deceased_at"], int)
+    assert row["deceased_at"] > 0
+
+
+def test_set_eulogy_anonymous_cannot_mark_deceased(tmp_path, fresh_module):
+    """An anonymous POST with is_deceased=true must NOT mark the row deceased."""
+    fresh_module(admin_key="s3cret-admin-key")
+    db_path = tmp_path / "hall.db"
+    _seed_hall_row(db_path)
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/abc123",
+        json={"is_deceased": True, "nickname": "GHOST"},
+    )
+
+    assert response.status_code == 401
+    row = _row(db_path)
+    assert row["is_deceased"] == 0
+    assert row["deceased_at"] is None
+    assert row["nickname"] is None

--- a/node/tests/test_hall_of_rust_error_responses.py
+++ b/node/tests/test_hall_of_rust_error_responses.py
@@ -11,6 +11,9 @@ sys.path.insert(0, str(ROOT / "node"))
 import hall_of_rust  # noqa: E402
 
 
+ADMIN_HEADERS = {"X-Admin-Key": "test-admin-key"}
+
+
 def _client_for(db_path):
     app = Flask(__name__)
     app.config["DB_PATH"] = str(db_path)
@@ -23,7 +26,7 @@ def test_hall_stats_hides_sqlite_error_details(tmp_path):
     sqlite3.connect(db_path).close()
     client = _client_for(db_path)
 
-    response = client.get("/hall/stats")
+    response = client.get("/hall/stats", headers=ADMIN_HEADERS)
 
     assert response.status_code == 500
     assert response.get_json() == {"error": "internal_error"}
@@ -37,7 +40,7 @@ def test_hall_stats_still_returns_valid_empty_stats(tmp_path):
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
 
-    response = client.get("/hall/stats")
+    response = client.get("/hall/stats", headers=ADMIN_HEADERS)
 
     assert response.status_code == 200
     body = response.get_json()
@@ -62,7 +65,11 @@ def test_eulogy_rejects_non_object_json(tmp_path):
     hall_of_rust.init_hall_tables(str(db_path))
     client = _client_for(db_path)
 
-    response = client.post("/hall/eulogy/fingerprint-1", json=["nickname"])
+    response = client.post(
+        "/hall/eulogy/fingerprint-1",
+        json=["nickname"],
+        headers={"X-Admin-Key": "test-admin-key"},
+    )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "JSON object required"}
@@ -76,6 +83,7 @@ def test_eulogy_rejects_structured_nickname(tmp_path):
     response = client.post(
         "/hall/eulogy/fingerprint-1",
         json={"nickname": {"name": "Old Reliable"}},
+        headers={"X-Admin-Key": "test-admin-key"},
     )
 
     assert response.status_code == 400
@@ -90,10 +98,26 @@ def test_eulogy_rejects_structured_eulogy(tmp_path):
     response = client.post(
         "/hall/eulogy/fingerprint-1",
         json={"eulogy": ["served", "well"]},
+        headers={"X-Admin-Key": "test-admin-key"},
     )
 
     assert response.status_code == 400
     assert response.get_json() == {"error": "eulogy must be a string"}
+
+
+def test_eulogy_rejects_unauthenticated_post(tmp_path):
+    """Issue #7244: anonymous POSTs must NOT mutate memorial state."""
+    db_path = tmp_path / "hall.db"
+    hall_of_rust.init_hall_tables(str(db_path))
+    client = _client_for(db_path)
+
+    response = client.post(
+        "/hall/eulogy/fingerprint-1",
+        json={"nickname": "DEFACED"},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized — admin key required"}
 
 
 def test_calculate_rust_score_uses_current_year_for_age_weight():
@@ -128,7 +152,7 @@ def test_machine_of_the_day_uses_current_year_for_age(tmp_path, monkeypatch):
     monkeypatch.setattr(hall_of_rust, "_current_utc_year", lambda: 2026)
     client = _client_for(db_path)
 
-    response = client.get("/hall/machine_of_the_day")
+    response = client.get("/hall/machine_of_the_day", headers=ADMIN_HEADERS)
 
     assert response.status_code == 200
     assert response.get_json()["age_years"] == 23

--- a/node/tests/test_hall_of_rust_limit_validation.py
+++ b/node/tests/test_hall_of_rust_limit_validation.py
@@ -3,6 +3,9 @@ from flask import Flask
 from node.hall_of_rust import hall_bp, init_hall_tables
 
 
+ADMIN_HEADERS = {"X-Admin-Key": "test-admin-key"}
+
+
 def _app_with_hall_db(tmp_path):
     db_path = tmp_path / "hall.db"
     init_hall_tables(str(db_path))
@@ -16,7 +19,9 @@ def _app_with_hall_db(tmp_path):
 def test_leaderboard_rejects_non_integer_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=abc")
+    response = app.test_client().get(
+        "/api/hall_of_fame/leaderboard?limit=abc", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be an integer"
@@ -25,7 +30,9 @@ def test_leaderboard_rejects_non_integer_limit(tmp_path):
 def test_legacy_leaderboard_rejects_non_integer_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/hall/leaderboard?limit=abc")
+    response = app.test_client().get(
+        "/hall/leaderboard?limit=abc", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be an integer"
@@ -34,7 +41,9 @@ def test_legacy_leaderboard_rejects_non_integer_limit(tmp_path):
 def test_leaderboard_rejects_negative_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=-1")
+    response = app.test_client().get(
+        "/api/hall_of_fame/leaderboard?limit=-1", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be non-negative"
@@ -43,7 +52,9 @@ def test_leaderboard_rejects_negative_limit(tmp_path):
 def test_legacy_leaderboard_rejects_negative_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/hall/leaderboard?limit=-1")
+    response = app.test_client().get(
+        "/hall/leaderboard?limit=-1", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 400
     assert response.get_data(as_text=True) == "limit must be non-negative"
@@ -52,7 +63,9 @@ def test_legacy_leaderboard_rejects_negative_limit(tmp_path):
 def test_leaderboard_uses_default_for_empty_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/api/hall_of_fame/leaderboard?limit=")
+    response = app.test_client().get(
+        "/api/hall_of_fame/leaderboard?limit=", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 200
     assert response.get_json()["leaderboard"] == []
@@ -62,7 +75,9 @@ def test_leaderboard_uses_default_for_empty_limit(tmp_path):
 def test_legacy_leaderboard_uses_default_for_empty_limit(tmp_path):
     app = _app_with_hall_db(tmp_path)
 
-    response = app.test_client().get("/hall/leaderboard?limit=")
+    response = app.test_client().get(
+        "/hall/leaderboard?limit=", headers=ADMIN_HEADERS
+    )
 
     assert response.status_code == 200
     assert response.get_json()["leaderboard"] == []


### PR DESCRIPTION
## Summary

Fixes #7244. `POST /hall/eulogy/<fingerprint>` previously had no `_require_admin()` check, so any unauthenticated caller could deface the public Hall of Rust memorial registry (`nickname`, `eulogy`, `is_deceased`, `deceased_at`) for any known fingerprint.

## Live exploit (this run, before fix)

- `POST https://rustchain.org/hall/eulogy/abc123` (no auth) → `HTTP 200 {"ok":true,"message":"Memorial updated"}`
- `POST https://explorer.rustchain.org/hall/eulogy/abc123` (no auth) → `HTTP 200 {"ok":true,"message":"Memorial updated"}`

## Fix

`node/hall_of_rust.py:345`: add `err = _require_admin()` at the top of `set_eulogy()`, before any state read/write. The helper already fails closed (503) when `RC_ADMIN_KEY` is unset and uses `hmac.compare_digest` for the header comparison.

Sibling routes (`/hall/machine`, `/hall/leaderboard`, `/hall/stats`, `/api/hall_of_fame/leaderboard`) already had the gate; `set_eulogy` was the only outlier in this file.

## Tests

- **New** `node/tests/test_hall_eulogy_admin_gate.py` — 6 focused tests:
  - anonymous POST is rejected with 401 and the row is untouched
  - wrong admin key is rejected with 401
  - unset `RC_ADMIN_KEY` fails closed with 503
  - correct key is accepted and persists the changes
  - `is_deceased: true` with valid key sets the deceased fields
  - anonymous `is_deceased: true` does NOT mark the row deceased
- **Updated** `node/tests/test_hall_of_rust_error_responses.py`, `node/tests/test_hall_of_rust_limit_validation.py`: pre-existing tests for admin-gated endpoints (`/hall/stats`, `/hall/leaderboard`, `/api/hall_of_fame/leaderboard`, `/hall/machine_of_the_day`) now pass `X-Admin-Key`. They were already broken on origin/main because they hit admin-gated endpoints without the key (failed with 503 in the no-key env, now correctly pass with the key set).
- **Updated** `node/tests/conftest.py`: sets `RC_ADMIN_KEY=test-admin-key` by default so admin-gated tests have a baseline. Tests that exercise the fail-closed branch can `monkeypatch.delenv("RC_ADMIN_KEY")`.

## Validation

```
$ python3 -m pytest node/tests/test_hall_of_rust_error_responses.py node/tests/test_hall_of_rust_limit_validation.py node/tests/test_hall_eulogy_admin_gate.py node/tests/test_x402_admin_key_compare.py node/tests/test_admin_rate_limit.py node/tests/test_bridge_admin_json_body.py node/tests/test_attest_submit_challenge_binding.py node/tests/test_attest_challenge_rate_limit.py -q
42 passed, 3 subtests passed in 3.57s
```

## Bounty

Refs #7244. Bounty #71 claim: https://github.com/Scottcjn/rustchain-bounties/issues/13624 (25 RTC, HIGH severity)

## Risk

Very low. The change is a one-line gate addition at the top of `set_eulogy`. All sibling routes already use the same gate, so behaviour is consistent with the rest of the file. The only behaviour change is that anonymous POSTs now return 401/503 instead of persisting the change — which is the intended fix. Authenticated admin usage is unchanged.