### PR TITLE
fix(ci): restore the `test` gate — fix 14 always-red baseline failures

### DIFF
--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -17,9 +17,15 @@ def _make_client(tmp_path):
     return app.test_client(), db_path
 
 
-def _create_pending_lock(client):
+def _create_pending_lock(client, admin_key=None):
+    # Bridge lock creation is admin-gated (see require_admin_key in
+    # create_bridge_lock); callers that expect a successful 200 must supply
+    # the matching X-Admin-Key. Validation-error tests POST directly without a
+    # key because field validation runs before the auth check.
+    headers = {"X-Admin-Key": admin_key} if admin_key else {}
     response = client.post(
         "/api/bridge/lock",
+        headers=headers,
         json={
             "from_address": "solana-source",
             "to_address": "base-destination",
@@ -42,8 +48,8 @@ def _lock_status(db_path, lock_id):
 
 def test_bridge_confirm_requires_admin_key(tmp_path, monkeypatch):
     client, db_path = _make_client(tmp_path)
-    lock_id = _create_pending_lock(client)
     monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    lock_id = _create_pending_lock(client, "expected-admin")
 
     response = client.post(
         f"/api/bridge/lock/{lock_id}/confirm",
@@ -57,8 +63,8 @@ def test_bridge_confirm_requires_admin_key(tmp_path, monkeypatch):
 
 def test_bridge_release_requires_admin_key(tmp_path, monkeypatch):
     client, db_path = _make_client(tmp_path)
-    lock_id = _create_pending_lock(client)
     monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    lock_id = _create_pending_lock(client, "expected-admin")
 
     authorized = client.post(
         f"/api/bridge/lock/{lock_id}/confirm",
@@ -79,8 +85,8 @@ def test_bridge_release_requires_admin_key(tmp_path, monkeypatch):
 
 def test_bridge_confirm_and_release_accept_valid_admin_key(tmp_path, monkeypatch):
     client, db_path = _make_client(tmp_path)
-    lock_id = _create_pending_lock(client)
     monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    lock_id = _create_pending_lock(client, "expected-admin")
 
     confirmed = client.post(
         f"/api/bridge/lock/{lock_id}/confirm",

--- a/tests/test_rip201_bucket_spoof.py
+++ b/tests/test_rip201_bucket_spoof.py
@@ -267,7 +267,11 @@ def test_attestation_downgrades_spoofed_g4_claim_to_non_vintage_weight(attest_cl
         ).fetchone()
 
     assert recent == ("x86_64", "default", 0)
-    assert enrollment == (85, 0.000000001)
+    # RIP-PoA strict enforcement: a FAILED fingerprint (here a spoofed-G4 claim
+    # rejected via cpu_brand_mismatch) now earns weight 0.0 — no rewards at all,
+    # not the old 1e-9 "spam tier". (Weight was changed 0.00001 -> 0.0 for
+    # failed fingerprints; VM-detection's 1e-9 tier is a separate path.)
+    assert enrollment == (85, 0)
     assert fleet_mod.classify_miner_bucket(recent[1]) != "vintage_powerpc"
 
 

--- a/tools/bcos_badge_generator.py
+++ b/tools/bcos_badge_generator.py
@@ -1137,35 +1137,21 @@ def generate_badge():
             'error': 'JSON object body required',
         }), 400
 
-    raw_repo_name = data.get('repo_name', '')
-    if not isinstance(raw_repo_name, str):
-        return jsonify({'success': False, 'error': 'Repository name must be a string'})
-    repo_name = raw_repo_name.strip()
-
-    raw_tier = data.get('tier', 'L1')
-    if not isinstance(raw_tier, str):
-        return jsonify({'success': False, 'error': 'Tier must be a string'})
-    tier = raw_tier.upper()
-    raw_trust_score = data.get('trust_score', 75)
-    data = request.get_json(silent=True)
-    if not data or not isinstance(data, dict):
-        return jsonify({'success': False, 'error': 'JSON body must be an object'}), 400
-    
     repo_name = data.get('repo_name')
     if not isinstance(repo_name, str):
-        return jsonify({'success': False, 'error': 'repo_name must be a string'}), 400
+        return jsonify({'success': False, 'error': 'Repository name must be a string'})
     if not repo_name or '/' not in repo_name:
         return jsonify({'success': False, 'error': 'Invalid repository format. Use: owner/repo'})
     
     tier = data.get('tier')
     if not isinstance(tier, str):
-        return jsonify({'success': False, 'error': 'tier must be a string'}), 400
+        return jsonify({'success': False, 'error': 'Tier must be a string'})
     if tier not in ['L0', 'L1', 'L2']:
         return jsonify({'success': False, 'error': 'Invalid tier. Must be L0, L1, or L2'})
     
-    raw_trust_score = data.get('trust_score')
-    if not isinstance(raw_trust_score, (int, float)):
-        return jsonify({'success': False, 'error': 'trust_score must be a number'}), 400
+    raw_trust_score = data.get('trust_score', 75)
+    if not isinstance(raw_trust_score, (int, float)) or isinstance(raw_trust_score, bool):
+        return jsonify({'success': False, 'error': 'Trust score must be a number'})
     
     try:
         trust_score = int(raw_trust_score)
@@ -1178,7 +1164,7 @@ def generate_badge():
     cert_id = data.get('cert_id', '')
     include_qr = data.get('include_qr', False)
     if not isinstance(include_qr, bool):
-        return jsonify({'success': False, 'error': 'include_qr must be a boolean'}), 400
+        return jsonify({'success': False, 'error': 'include_qr must be a boolean'})
 
     # Generate cert_id if not provided
     if not cert_id:


### PR DESCRIPTION
## Restore the `test` CI gate (fix 14 always-red baseline failures)

The `test` job has been red on **every** PR — 14 failures unrelated to the PR under review. A gate that's always red trains reviewers to override it, which is exactly how a real regression (#7220's `tuple`-bind bug) nearly merged as "just the flake." Each failing file fails **in isolation on `main`** (verified in a clean `origin/main` worktree) — these are genuine failures on main, not test pollution.

### Root causes & fixes

**1. `tools/bcos_badge_generator.py` — real code bug (bad merge from #7097)**
`generate_badge()` had a duplicated validation block (two `request.get_json()` reads). It:
- dropped the `trust_score` default, so valid requests omitting it returned 400 (→ `KeyError 'cert_id'` in `test_verify_endpoint`/`test_serve_badge_svg`);
- returned HTTP 400 for field-level errors with wrong messages, contradicting the test spec (body errors → 400; field errors → `200 + {success:False, error}`).

Fix: remove the dead duplicate block, restore the `trust_score` default, reject `bool` scores, return field errors as `200 + {success:False}`, align error messages.

**2. `tests/test_airdrop_bridge_admin_auth.py` — stale test**
Bridge-lock *creation* was hardened to require an admin key; the `_create_pending_lock` helper predated it. Fix: set + send `X-Admin-Key` when creating the lock.

**3. `tests/test_rip201_bucket_spoof.py` — stale test**
Expected the old `1e-9` "spam tier" weight for a failed-fingerprint spoof; RIP-PoA strict enforcement now uses `0.0` (no rewards for failed fingerprint). Fix: expect `0`.

### Verification
```
Full suite: 3356 passed, 46 skipped, 0 failed   (was 14 failed)
```
Only 3 files changed (+21/-25). After this, `test` red == real, so the next regression gets caught automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
