### PR TITLE
Harden explorer proxy path handling

### DIFF
--- a/explorer/explorer_server.py
+++ b/explorer/explorer_server.py
@@ -10,7 +10,7 @@ import json
 import time
 import requests
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import parse_qsl, quote, unquote, urlparse
 from datetime import datetime
 
 # Configuration
@@ -18,6 +18,44 @@ EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
 API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
 STATIC_DIR = os.path.join(os.path.dirname(__file__), 'static')
+
+ALLOWED_PROXY_ENDPOINTS = {
+    ('health',),
+    ('epoch',),
+    ('api', 'miners'),
+    ('blocks',),
+    ('api', 'transactions'),
+    ('hall', 'leaderboard'),
+}
+
+
+def normalize_proxy_endpoint(endpoint):
+    """Return a safe upstream path for Explorer read-only proxy endpoints."""
+    if not endpoint:
+        return None
+
+    decoded = unquote(endpoint)
+    if decoded != endpoint:
+        return None
+    if decoded.startswith('/') or decoded.endswith('/'):
+        return None
+    if '//' in decoded or '\\' in decoded:
+        return None
+
+    segments = tuple(decoded.split('/'))
+    if any(segment in {'', '.', '..'} for segment in segments):
+        return None
+    if segments not in ALLOWED_PROXY_ENDPOINTS:
+        return None
+
+    return '/'.join(quote(segment, safe='') for segment in segments)
+
+
+def proxy_query_params(query):
+    """Parse query parameters for requests without concatenating raw URLs."""
+    if not query:
+        return None
+    return parse_qsl(query, keep_blank_values=True)
 
 class ExplorerHandler(SimpleHTTPRequestHandler):
     """Custom HTTP handler with API proxy and caching"""
@@ -65,7 +103,13 @@ class ExplorerHandler(SimpleHTTPRequestHandler):
     
     def handle_proxy(self, endpoint, parsed):
         """Proxy requests to RustChain API with caching"""
-        cache_key = f"{endpoint}:{parsed.query}"
+        safe_endpoint = normalize_proxy_endpoint(endpoint)
+        if safe_endpoint is None:
+            self.send_error_json(404, 'Proxy endpoint not allowed')
+            return
+
+        query_params = proxy_query_params(parsed.query)
+        cache_key = f"{safe_endpoint}:{parsed.query}"
         
         # Check cache
         cached = self._cache.get(cache_key)
@@ -75,11 +119,9 @@ class ExplorerHandler(SimpleHTTPRequestHandler):
         
         # Fetch from API
         try:
-            url = f"{API_BASE}/{endpoint}"
-            if parsed.query:
-                url += f"?{parsed.query}"
+            url = f"{API_BASE}/{safe_endpoint}"
             
-            response = requests.get(url, timeout=API_TIMEOUT)
+            response = requests.get(url, params=query_params, timeout=API_TIMEOUT)
             response.raise_for_status()
             data = response.json()
             
@@ -92,8 +134,8 @@ class ExplorerHandler(SimpleHTTPRequestHandler):
             self.send_json(data, headers={'X-Cache': 'MISS'})
         except requests.exceptions.Timeout:
             self.send_error_json(504, 'Gateway Timeout')
-        except requests.exceptions.RequestException as e:
-            self.send_error_json(502, f'Bad Gateway: {str(e)}')
+        except requests.exceptions.RequestException:
+            self.send_error_json(502, 'Bad Gateway')
         except json.JSONDecodeError:
             self.send_error_json(502, 'Invalid JSON from upstream')
     

--- a/tests/test_explorer_server_proxy.py
+++ b/tests/test_explorer_server_proxy.py
@@ -1,0 +1,171 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import requests
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "explorer" / "explorer_server.py"
+SPEC = importlib.util.spec_from_file_location("explorer_server_under_test", MODULE_PATH)
+explorer_server = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(explorer_server)
+
+
+class DummyHandler:
+    def __init__(self):
+        self._cache = {}
+        self._cache_ttl = explorer_server.ExplorerHandler._cache_ttl
+        self.json_response = None
+        self.error_response = None
+
+    def send_json(self, data, status=200, headers=None):
+        self.json_response = {
+            "data": data,
+            "status": status,
+            "headers": headers or {},
+        }
+
+    def send_error_json(self, status, message):
+        self.error_response = {
+            "status": status,
+            "message": message,
+        }
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("health", "health"),
+        ("epoch", "epoch"),
+        ("api/miners", "api/miners"),
+        ("api/transactions", "api/transactions"),
+        ("blocks", "blocks"),
+        ("hall/leaderboard", "hall/leaderboard"),
+    ],
+)
+def test_normalize_proxy_endpoint_allows_explorer_read_paths(raw, expected):
+    assert explorer_server.normalize_proxy_endpoint(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "",
+        "/health",
+        "health/",
+        "admin/status",
+        "api/admin",
+        "api//miners",
+        "api/../admin",
+        "api/%2e%2e/admin",
+        "api%2Fminers",
+        r"api\\miners",
+    ],
+)
+def test_normalize_proxy_endpoint_rejects_unlisted_and_confused_paths(raw):
+    assert explorer_server.normalize_proxy_endpoint(raw) is None
+
+
+def test_handle_proxy_rejects_blocked_path_before_upstream_request(monkeypatch):
+    def fail_get(*args, **kwargs):
+        raise AssertionError("blocked proxy path should not call upstream")
+
+    monkeypatch.setattr(explorer_server.requests, "get", fail_get)
+
+    handler = DummyHandler()
+    explorer_server.ExplorerHandler.handle_proxy(
+        handler,
+        "admin/status",
+        SimpleNamespace(query=""),
+    )
+
+    assert handler.error_response == {
+        "status": 404,
+        "message": "Proxy endpoint not allowed",
+    }
+    assert handler.json_response is None
+
+
+def test_handle_proxy_forwards_allowed_path_with_parsed_query(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse({"ok": True, "miners": []})
+
+    monkeypatch.setattr(explorer_server, "API_BASE", "https://node.example")
+    monkeypatch.setattr(explorer_server.requests, "get", fake_get)
+
+    handler = DummyHandler()
+    explorer_server.ExplorerHandler.handle_proxy(
+        handler,
+        "api/miners",
+        SimpleNamespace(query="limit=10&empty="),
+    )
+
+    assert calls == [
+        (
+            "https://node.example/api/miners",
+            {
+                "params": [("limit", "10"), ("empty", "")],
+                "timeout": explorer_server.API_TIMEOUT,
+            },
+        )
+    ]
+    assert handler.json_response == {
+        "data": {"ok": True, "miners": []},
+        "status": 200,
+        "headers": {"X-Cache": "MISS"},
+    }
+
+
+def test_handle_proxy_cache_uses_normalized_endpoint(monkeypatch):
+    calls = []
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return FakeResponse({"height": 1})
+
+    monkeypatch.setattr(explorer_server, "API_BASE", "https://node.example")
+    monkeypatch.setattr(explorer_server.requests, "get", fake_get)
+
+    handler = DummyHandler()
+    parsed = SimpleNamespace(query="")
+    explorer_server.ExplorerHandler.handle_proxy(handler, "blocks", parsed)
+    explorer_server.ExplorerHandler.handle_proxy(handler, "blocks", parsed)
+
+    assert len(calls) == 1
+    assert handler.json_response["headers"] == {"X-Cache": "HIT"}
+
+
+def test_handle_proxy_does_not_leak_upstream_exception_details(monkeypatch):
+    def fake_get(url, **kwargs):
+        raise requests.exceptions.RequestException(
+            "connect to http://internal-admin.local/secrets failed"
+        )
+
+    monkeypatch.setattr(explorer_server.requests, "get", fake_get)
+
+    handler = DummyHandler()
+    explorer_server.ExplorerHandler.handle_proxy(
+        handler,
+        "health",
+        SimpleNamespace(query=""),
+    )
+
+    assert handler.error_response == {
+        "status": 502,
+        "message": "Bad Gateway",
+    }


### PR DESCRIPTION
## BCOS Checklist (Required For Non-Doc PRs)

- [x] Add a tier label: `BCOS-L1` or `BCOS-L2` (requesting `BCOS-L1`)
- [x] If adding new code files, include SPDX header near the top (not applicable; test-only new file)
- [x] Provide test evidence (commands + output or screenshots)

## What Changed

- Restricts `explorer/explorer_server.py` `/api/proxy/<path>` to the Explorer UI read-only endpoint allowlist.
- Rejects empty, encoded, dot/dot-dot, slash-confused, backslash, and unlisted proxy paths before any upstream request is made.
- Builds upstream requests from the normalized endpoint and parsed query params instead of concatenating arbitrary path/query strings.
- Redacts upstream `RequestException` details from browser-facing 502 responses.
- Adds focused regression coverage for allowed paths, blocked paths, no-upstream-call behavior, query parsing, cache behavior, and upstream error redaction.

Fixes #7222.

## Testing / Evidence

- `python -m pytest -q tests\\test_explorer_server_proxy.py` -> 20 passed
- `python -m py_compile explorer\\explorer_server.py tests\\test_explorer_server_proxy.py` -> passed
- `git diff --check -- explorer\\explorer_server.py tests\\test_explorer_server_proxy.py` -> passed
- `python tools\\bcos_spdx_check.py --base-ref origin/main` -> BCOS SPDX check: OK

## Bounty

Wallet/miner ID: `itosa-kazu` (GitHub handle fallback)

wallet: itosa-kazu
