### PR TITLE
Harden Beacon chat live message rendering

### DIFF
--- a/site/beacon/chat.js
+++ b/site/beacon/chat.js
@@ -32,7 +32,7 @@ export function getChatHTML(agentId, agentName) {
   html += '<div id="chat-messages" class="chat-messages">';
 
   if (history.length === 0) {
-    html += `<div class="chat-hint">Type below to hail ${agentName}...</div>`;
+    html += `<div class="chat-hint">Type below to hail ${escapeHtml(agentName)}...</div>`;
   } else {
     for (const msg of history) {
       if (msg.role === 'user') {
@@ -99,10 +99,10 @@ async function sendMessage() {
   if (hint) hint.remove();
 
   // Render user message
-  msgBox.innerHTML += `<div class="chat-msg chat-user"><span class="chat-prefix">you&gt;</span> ${escapeHtml(text)}</div>`;
+  appendChatMessage(msgBox, 'chat-user', 'you>', text);
 
   // Show typing indicator
-  msgBox.innerHTML += '<div class="chat-typing" id="chat-typing"><span class="typing-dots"></span> processing...</div>';
+  appendTypingIndicator(msgBox);
   msgBox.scrollTop = msgBox.scrollHeight;
 
   try {
@@ -125,20 +125,52 @@ async function sendMessage() {
     if (data.response) {
       history.push({ role: 'assistant', content: data.response });
       const agentName = data.agent || 'agent';
-      msgBox.innerHTML += `<div class="chat-msg chat-agent"><span class="chat-prefix">${escapeHtml(agentName.toLowerCase())}&gt;</span> ${escapeHtml(data.response)}</div>`;
+      appendChatMessage(msgBox, 'chat-agent', `${agentName.toLowerCase()}>`, data.response);
     } else if (data.error) {
-      msgBox.innerHTML += `<div class="chat-msg chat-error">[ERROR] ${escapeHtml(data.error)}</div>`;
+      appendErrorMessage(msgBox, data.error);
     }
   } catch (err) {
     const typing = document.getElementById('chat-typing');
     if (typing) typing.remove();
-    msgBox.innerHTML += '<div class="chat-msg chat-error">[ERROR] Comms channel unreachable.</div>';
+    appendErrorMessage(msgBox, 'Comms channel unreachable.');
   }
 
   msgBox.scrollTop = msgBox.scrollHeight;
   input.disabled = false;
   input.focus();
   sending = false;
+}
+
+function appendChatMessage(msgBox, className, prefix, message) {
+  const msg = document.createElement('div');
+  msg.className = `chat-msg ${className}`;
+
+  if (prefix) {
+    const prefixSpan = document.createElement('span');
+    prefixSpan.className = 'chat-prefix';
+    prefixSpan.textContent = prefix;
+    msg.appendChild(prefixSpan);
+    msg.appendChild(document.createTextNode(' '));
+  }
+
+  msg.appendChild(document.createTextNode(String(message ?? '')));
+  msgBox.appendChild(msg);
+}
+
+function appendErrorMessage(msgBox, message) {
+  appendChatMessage(msgBox, 'chat-error', null, `[ERROR] ${String(message ?? '')}`);
+}
+
+function appendTypingIndicator(msgBox) {
+  const typing = document.createElement('div');
+  typing.className = 'chat-typing';
+  typing.id = 'chat-typing';
+
+  const dots = document.createElement('span');
+  dots.className = 'typing-dots';
+  typing.appendChild(dots);
+  typing.appendChild(document.createTextNode(' processing...'));
+  msgBox.appendChild(typing);
 }
 
 function escapeHtml(str) {

--- a/tests/test_beacon_chat_frontend_security.py
+++ b/tests/test_beacon_chat_frontend_security.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+JS_PATH = Path(__file__).resolve().parents[1] / "site" / "beacon" / "chat.js"
+
+
+def test_empty_history_hint_escapes_agent_name():
+    source = JS_PATH.read_text(encoding="utf-8")
+
+    assert "Type below to hail ${escapeHtml(agentName)}..." in source
+    assert "Type below to hail ${agentName}..." not in source
+
+
+def test_live_chat_messages_use_dom_text_nodes():
+    source = JS_PATH.read_text(encoding="utf-8")
+
+    assert "function appendChatMessage(msgBox, className, prefix, message)" in source
+    assert "document.createTextNode(String(message ?? ''))" in source
+    assert "function appendTypingIndicator(msgBox)" in source
+    assert "msgBox.innerHTML +=" not in source
+
+    unsafe_patterns = [
+        "${escapeHtml(text)}</div>",
+        "${escapeHtml(data.response)}</div>",
+        "${escapeHtml(data.error)}</div>",
+        "id=\"chat-typing\"><span class=\"typing-dots\"></span> processing...</div>",
+    ]
+    for pattern in unsafe_patterns:
+        assert pattern not in source


### PR DESCRIPTION
## Summary
- Escape the empty-history agent name in `getChatHTML()` before it is interpolated into the chat panel HTML.
- Replace live chat `innerHTML +=` rendering for user, agent, error, and typing indicator updates with DOM/text-node helpers.
- Add frontend regression coverage that forbids the old live-message parser sink.

## Testing
- `python -m pytest -q tests\test_beacon_chat_frontend_security.py tests\test_beacon_chat_xss.py`
- `node --check site\beacon\chat.js`
- `python -m py_compile tests\test_beacon_chat_frontend_security.py tests\test_beacon_chat_xss.py`
- `git diff --check -- site\beacon\chat.js tests\test_beacon_chat_frontend_security.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Fixes #7196

Wallet/miner ID: `itosa-kazu` (GitHub handle fallback)

wallet: itosa-kazu
