### PR TITLE
Harden Beacon panel path rendering

### DIFF
--- a/site/beacon/ui.js
+++ b/site/beacon/ui.js
@@ -119,6 +119,13 @@ function updateHUD() {
   }
 }
 
+function setPanelPath(path) {
+  const prompt = document.createElement('span');
+  prompt.className = 'prompt';
+  prompt.textContent = 'beacon@atlas:~';
+  panelPath.replaceChildren(prompt, document.createTextNode(String(path ?? '')));
+}
+
 // --- Click handling ---
 function onObjectClick(mesh) {
   const data = mesh.userData;
@@ -196,7 +203,7 @@ function selectAgent(agentId) {
   if (pos) lerpCameraTo(pos, 40);
 
   // Panel path
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/agent/${agent.id}`;
+  setPanelPath(`/agent/${agent.id}`);
 
   // Build panel content
   const v = agent.valuation;
@@ -385,7 +392,7 @@ function selectCity(cityId) {
   const center = getCityCenter(cityId);
   if (center) lerpCameraTo(center, 60);
 
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/city/${city.id}`;
+  setPanelPath(`/city/${city.id}`);
 
   let html = '';
   html += `<div class="t-cmd"><span class="dollar">$</span>cat /city/${city.id}</div>`;
@@ -486,7 +493,7 @@ function showContractForm(preselectedFrom) {
     `<option value="${a.id}"${a.id === preselectedFrom ? ' selected' : ''}>${a.name}</option>`
   ).join('');
 
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/contracts/new`;
+  setPanelPath('/contracts/new');
 
   let html = '';
   html += `<div class="t-cmd"><span class="dollar">$</span>initiate_contract --mode=terminal</div>`;
@@ -816,7 +823,7 @@ function renderBountyList(bounties) {
 }
 
 async function showBounties() {
-  panelPath.innerHTML = `<span class="prompt">beacon@atlas:~</span>/bounties`;
+  setPanelPath('/bounties');
 
   // Show loading state
   panelContent.innerHTML = `<div class="t-cmd"><span class="dollar">$</span>beacon contracts --type=bounty --sync=github</div><div style="color:var(--amber);margin:12px 0">Syncing bounty contracts from GitHub...</div>`;

--- a/tests/test_beacon_site_ui_frontend_security.py
+++ b/tests/test_beacon_site_ui_frontend_security.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+JS_PATH = Path(__file__).resolve().parents[1] / "site" / "beacon" / "ui.js"
+
+
+def test_panel_path_uses_dom_text_nodes():
+    source = JS_PATH.read_text(encoding="utf-8")
+
+    assert "function setPanelPath(path)" in source
+    assert "prompt.textContent = 'beacon@atlas:~';" in source
+    assert "panelPath.replaceChildren(prompt, document.createTextNode(String(path ?? '')));" in source
+    assert "setPanelPath(`/agent/${agent.id}`);" in source
+    assert "setPanelPath(`/city/${city.id}`);" in source
+    assert "setPanelPath('/contracts/new');" in source
+    assert "setPanelPath('/bounties');" in source
+
+
+def test_panel_path_avoids_inner_html_parser_sink():
+    source = JS_PATH.read_text(encoding="utf-8")
+
+    assert "panelPath.innerHTML" not in source
+    assert '<span class="prompt">beacon@atlas:~</span>/agent/${agent.id}' not in source
+    assert '<span class="prompt">beacon@atlas:~</span>/city/${city.id}' not in source


### PR DESCRIPTION
## Summary
- Add `setPanelPath()` to build the static prompt span with DOM APIs and append the route suffix as a text node.
- Move agent, city, contract-form, and bounties panel path rendering away from `panelPath.innerHTML`.
- Add focused frontend regression coverage that forbids the old panel path parser sink.

## Testing
- `python -m pytest -q tests\test_beacon_site_ui_frontend_security.py tests\test_beacon_site_miners_normalization.py`
- `node --check site\beacon\ui.js`
- `python -m py_compile tests\test_beacon_site_ui_frontend_security.py tests\test_beacon_site_miners_normalization.py`
- `git diff --check -- site\beacon\ui.js tests\test_beacon_site_ui_frontend_security.py`
- `python tools\bcos_spdx_check.py --base-ref origin/main`

Fixes #7202

Wallet/miner ID: `itosa-kazu` (GitHub handle fallback)

wallet: itosa-kazu
