### PR TITLE
Harden tools explorer error card rendering

### DIFF
--- a/tests/test_tools_explorer_security.py
+++ b/tests/test_tools_explorer_security.py
@@ -51,8 +51,14 @@ def test_filter_options_are_built_with_option_nodes():
     assert "`<option value=\"${c}\">${c}</option>`" not in html
 
 
-def test_error_card_escapes_exception_message():
+def test_error_card_renders_exception_message_with_text_content():
     html = source()
 
-    assert "${safeText(err.message || err)}" in html
+    assert "function renderErrorCard(message)" in html
+    assert 'label.textContent = "Error";' in html
+    assert 'value.textContent = String(message ?? "-");' in html
+    assert "topCards.replaceChildren(card);" in html
+    assert "renderErrorCard(err.message || err);" in html
+    assert 'document.getElementById("topCards").innerHTML = `<div class="card">' not in html
+    assert "${safeText(err.message || err)}" not in html
     assert "${String(err.message || err)}" not in html

--- a/tools/explorer/index.html
+++ b/tools/explorer/index.html
@@ -376,6 +376,23 @@
       }
     }
 
+    function renderErrorCard(message) {
+      const topCards = document.getElementById("topCards");
+      const card = document.createElement("div");
+      card.className = "card";
+
+      const label = document.createElement("div");
+      label.className = "label";
+      label.textContent = "Error";
+
+      const value = document.createElement("div");
+      value.className = "value";
+      value.textContent = String(message ?? "-");
+
+      card.replaceChildren(label, value);
+      topCards.replaceChildren(card);
+    }
+
     async function fetchJson(path) {
       const res = await fetch(path);
       if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
@@ -644,7 +661,7 @@
         document.getElementById("updatedAt").textContent = `Last update: ${new Date().toLocaleTimeString()}`;
         document.getElementById("agentUpdatedAt").textContent = `Agent update: ${new Date().toLocaleTimeString()}`;
       } catch (err) {
-        document.getElementById("topCards").innerHTML = `<div class="card"><div class="label">Error</div><div class="value">${safeText(err.message || err)}</div></div>`;
+        renderErrorCard(err.message || err);
         document.getElementById("minerRows").innerHTML = "";
       }
     }


### PR DESCRIPTION
## Summary
- Add renderErrorCard() to build the tools explorer refresh error card with DOM nodes.
- Render exception text through textContent and replace the top-card contents with replaceChildren().
- Update the existing tools explorer security test to forbid the old innerHTML error-card template.

## Testing
- python -m pytest -q tests\test_tools_explorer_security.py tests\test_tools_explorer_miners_payload.py
- python -m py_compile tests\test_tools_explorer_security.py tests\test_tools_explorer_miners_payload.py
- Node inline script syntax check: scripts ok
- git diff --check -- tools\explorer\index.html tests\test_tools_explorer_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7170

Wallet/miner ID: itosa-kazu (GitHub handle fallback)

wallet: itosa-kazu
