### PR TITLE
Harden Hall of Fame machine timeline rendering

### DIFF
--- a/tests/test_hall_of_fame_machine_frontend_security.py
+++ b/tests/test_hall_of_fame_machine_frontend_security.py
@@ -1,17 +1,36 @@
+# SPDX-License-Identifier: MIT
 from pathlib import Path
 
 
-def test_machine_profile_escapes_timeline_fields_before_inner_html():
-    page = Path(__file__).resolve().parents[1] / "web" / "hall-of-fame" / "machine.html"
-    html = page.read_text(encoding="utf-8")
+PAGE = Path(__file__).resolve().parents[1] / "web" / "hall-of-fame" / "machine.html"
 
-    assert "function esc(s)" in html
+
+def source():
+    return PAGE.read_text(encoding="utf-8")
+
+
+def test_machine_profile_renders_timeline_with_text_nodes():
+    html = source()
+
     assert "function safeInt(v)" in html
     assert "function safeScore(v)" in html
-    assert "${esc(x.date||'—')}" in html
-    assert "${safeInt(x.attestations??x.samples??0)}" in html
-    assert "${safeScore(x.rust_score??m.rust_score??'—')}" in html
+    assert "function renderTimeline(timeline,machine)" in html
+    assert "function appendTextCell(row,value,colSpan)" in html
+    assert "appendTextCell(row,x.date||'—');" in html
+    assert "appendTextCell(row,safeInt(x.attestations??x.samples??0));" in html
+    assert "appendTextCell(row,safeScore(x.rust_score??machine.rust_score??'—'));" in html
+    assert "body.replaceChildren(...rows);" in html
 
-    assert "${x.date||'—'}</td>" not in html
-    assert "${x.attestations??x.samples??0}</td>" not in html
-    assert "${x.rust_score??m.rust_score??'—'}</td>" not in html
+    assert "document.getElementById('timeline').innerHTML" not in html
+    assert "t.map(x=>`<tr><td>" not in html
+
+
+def test_machine_profile_status_messages_use_dom_text():
+    html = source()
+
+    assert "function setStatusMessage(message,className)" in html
+    assert "span.textContent=String(message||'');" in html
+    assert "status.replaceChildren(span);" in html
+    assert "setStatusMessage('Missing machine id. Use ?id=<fingerprint_hash>.','err');" in html
+    assert "setStatusMessage('Not found or unavailable.','err');" in html
+    assert "document.getElementById('status').innerHTML" not in html

--- a/web/hall-of-fame/machine.html
+++ b/web/hall-of-fame/machine.html
@@ -143,11 +143,42 @@ function safeScore(v){
   const n=Number(v);
   return Number.isFinite(n)?String(n):esc(v||'—');
 }
+function setStatusMessage(message,className){
+  const status=document.getElementById('status');
+  const span=document.createElement('span');
+  if(className){ span.className=className; }
+  span.textContent=String(message||'');
+  status.replaceChildren(span);
+}
+function appendTextCell(row,value,colSpan){
+  const cell=document.createElement('td');
+  if(colSpan){ cell.colSpan=colSpan; }
+  cell.textContent=String(value??'');
+  row.appendChild(cell);
+  return cell;
+}
+function renderTimeline(timeline,machine){
+  const body=document.getElementById('timeline');
+  if(!timeline.length){
+    const row=document.createElement('tr');
+    appendTextCell(row,'No recent attestation activity',3);
+    body.replaceChildren(row);
+    return;
+  }
+  const rows=timeline.map(x=>{
+    const row=document.createElement('tr');
+    appendTextCell(row,x.date||'—');
+    appendTextCell(row,safeInt(x.attestations??x.samples??0));
+    appendTextCell(row,safeScore(x.rust_score??machine.rust_score??'—'));
+    return row;
+  });
+  body.replaceChildren(...rows);
+}
 (async()=>{
   const id=q('id')||q('machine');
-  if(!id){ document.getElementById('status').innerHTML='<span class="err">Missing machine id. Use ?id=&lt;fingerprint_hash&gt;.</span>'; return; }
+  if(!id){ setStatusMessage('Missing machine id. Use ?id=<fingerprint_hash>.','err'); return; }
   const res=await fetch('/api/hall_of_fame/machine?id='+encodeURIComponent(id));
-  if(!res.ok){ document.getElementById('status').innerHTML='<span class="err">Not found or unavailable.</span>'; return; }
+  if(!res.ok){ setStatusMessage('Not found or unavailable.','err'); return; }
   const data=await res.json();
   const m=data.machine||data||{};
   document.getElementById('status').style.display='none';
@@ -172,7 +203,7 @@ function safeScore(v){
 
   const t=data.attestation_timeline_30d||[];
   document.getElementById('timelineCard').style.display='block';
-  document.getElementById('timeline').innerHTML=t.length?t.map(x=>`<tr><td>${esc(x.date||'—')}</td><td>${safeInt(x.attestations??x.samples??0)}</td><td>${safeScore(x.rust_score??m.rust_score??'—')}</td></tr>`).join(''):'<tr><td colspan="3">No recent attestation activity</td></tr>';
+  renderTimeline(t,m);
 
   const r=data.reward_participation||{};
   document.getElementById('rewardCard').style.display='block';


### PR DESCRIPTION
## Summary
- Render missing-machine and not-found status messages with DOM/text APIs.
- Replace the Hall of Fame machine timeline innerHTML table-template sink with textContent row/cell rendering.
- Keep attestation counts normalized with safeInt() and rust scores normalized with safeScore().
- Update focused frontend regression coverage to forbid the old timeline/status parser sinks.

## Testing
- python -m pytest -q tests\test_hall_of_fame_machine_frontend_security.py tests\test_hall_of_fame_frontend_endpoints.py
- python -m py_compile tests\test_hall_of_fame_machine_frontend_security.py tests\test_hall_of_fame_frontend_endpoints.py
- UTF-8 extracted inline script checked with node --check
- git diff --check -- web\hall-of-fame\machine.html tests\test_hall_of_fame_machine_frontend_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7206

wallet: itosa-kazu