### PR TITLE
Harden explorer miners render error fallback

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -474,6 +474,16 @@ function renderEpochStats() {
     `;
 }
 
+function renderMinersTableError(container, message) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 7;
+    cell.className = 'error-message';
+    cell.textContent = `UI Render Error: ${String(message ?? '')}`;
+    row.appendChild(cell);
+    container.replaceChildren(row);
+}
+
 function renderMinersTable() {
     const container = document.getElementById('miners-tbody');
     if (!container) return;
@@ -528,7 +538,7 @@ function renderMinersTable() {
         }).join('');
     } catch (e) {
         console.error('Render error:', e);
-        container.innerHTML = `<tr><td colspan="7" class="error-message">UI Render Error: ${escapeHtml(e.message)}</td></tr>`;
+        renderMinersTableError(container, e.message);
     }
 }
 

--- a/tests/test_explorer_block_filters.py
+++ b/tests/test_explorer_block_filters.py
@@ -195,3 +195,13 @@ const script = {json.dumps(js)};
     assert data["filteredHeights"] == [101]
     assert "#101" not in data["recentHtml"]
     assert "#101" in data["fullHtml"]
+
+
+def test_miners_table_render_error_uses_text_content():
+    js = EXPLORER_JS.read_text(encoding="utf-8")
+
+    assert "function renderMinersTableError(container, message)" in js
+    assert "cell.textContent = `UI Render Error: ${String(message ?? '')}`;" in js
+    assert "container.replaceChildren(row);" in js
+    assert "renderMinersTableError(container, e.message);" in js
+    assert "UI Render Error: ${escapeHtml(e.message)}" not in js


### PR DESCRIPTION
## Summary
- Build the explorer miners table render-error fallback row and cell with DOM APIs.
- Write render exception text through textContent instead of parsing it through innerHTML.
- Add a focused regression assertion that forbids the old UI Render Error parser sink.

## Testing
- python -m pytest -q tests\test_explorer_block_filters.py::test_block_filter_controls_are_available_in_blocks_view tests\test_explorer_block_filters.py::test_miners_table_render_error_uses_text_content
- node --check explorer\static\js\explorer.js
- python -m py_compile tests\test_explorer_block_filters.py
- git diff --check -- explorer\static\js\explorer.js tests\test_explorer_block_filters.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7163

wallet: itosa-kazu