### PR TITLE
Harden faucet service result rendering

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -1576,6 +1576,43 @@ HTML_TEMPLATE = """
         const submitBtn = document.getElementById('submitBtn');
         const walletInput = document.getElementById('wallet');
 
+        function resetResult() {
+            result.className = 'result';
+            result.replaceChildren();
+        }
+
+        function appendResultLine(node) {
+            result.appendChild(document.createElement('br'));
+            result.appendChild(node);
+        }
+
+        function appendResultText(text) {
+            appendResultLine(document.createTextNode(String(text ?? '')));
+        }
+
+        function appendNextAvailable(nextAvailable) {
+            if (!nextAvailable) return;
+            const small = document.createElement('small');
+            small.textContent = `Next available: ${new Date(nextAvailable).toLocaleString()}`;
+            appendResultLine(small);
+        }
+
+        function setResultMessage(type, title, lines = [], nextAvailable = null) {
+            result.className = `result show ${type}`;
+            result.replaceChildren();
+
+            const strong = document.createElement('strong');
+            strong.textContent = String(title ?? '');
+            result.appendChild(strong);
+
+            lines.forEach(appendResultText);
+            appendNextAvailable(nextAvailable);
+        }
+
+        function shortenWallet(wallet) {
+            return `${wallet.substring(0, 10)}...${wallet.substring(wallet.length - 8)}`;
+        }
+
         // Load stats
         async function loadStats() {
             try {
@@ -1594,8 +1631,7 @@ HTML_TEMPLATE = """
             e.preventDefault();
             submitBtn.disabled = true;
             submitBtn.textContent = 'Processing...';
-            result.className = 'result';
-            result.innerHTML = '';
+            resetResult();
 
             const wallet = walletInput.value.trim();
 
@@ -1607,26 +1643,21 @@ HTML_TEMPLATE = """
                 });
 
                 const data = await response.json();
-
-                result.className = 'result show ' + (data.ok ? 'success' : 'error');
                 
                 if (data.ok) {
-                    result.innerHTML = `
-                        <strong>✅ Success!</strong><br>
-                        Sent ${data.amount} RTC to ${wallet.substring(0, 10)}...${wallet.substring(wallet.length - 8)}<br>
-                        ${data.next_available ? `<small>Next available: ${new Date(data.next_available).toLocaleString()}</small>` : ''}
-                    `;
+                    setResultMessage(
+                        'success',
+                        '✅ Success!',
+                        [`Sent ${data.amount} RTC to ${shortenWallet(wallet)}`],
+                        data.next_available
+                    );
                     walletInput.value = '';
                     loadStats();
                 } else {
-                    result.innerHTML = `
-                        <strong>❌ ${data.error}</strong><br>
-                        ${data.next_available ? `<small>Next available: ${new Date(data.next_available).toLocaleString()}</small>` : ''}
-                    `;
+                    setResultMessage('error', `❌ ${data.error}`, [], data.next_available);
                 }
             } catch (err) {
-                result.className = 'result show error';
-                result.innerHTML = `<strong>❌ Error:</strong> ${err.message}`;
+                setResultMessage('error', '❌ Error:', [err.message]);
             }
 
             submitBtn.disabled = false;

--- a/tests/test_faucet_service_frontend_security.py
+++ b/tests/test_faucet_service_frontend_security.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FAUCET_SERVICE = REPO_ROOT / "faucet_service" / "faucet_service.py"
+
+
+def test_faucet_result_rendering_uses_dom_text_nodes():
+    source = FAUCET_SERVICE.read_text(encoding="utf-8")
+
+    assert "result.innerHTML" not in source
+    assert "function setResultMessage(type, title, lines = [], nextAvailable = null)" in source
+    assert "result.replaceChildren();" in source
+    assert "document.createTextNode(String(text ?? ''))" in source
+    assert "strong.textContent = String(title ?? '');" in source
+    assert (
+        "small.textContent = `Next available: ${new Date(nextAvailable).toLocaleString()}`;"
+        in source
+    )
+    assert "'success'," in source
+    assert "setResultMessage('error'," in source


### PR DESCRIPTION
﻿## Summary
- Build faucet request result messages with DOM helpers instead of assigning dynamic templates to result.innerHTML.
- Write success, API error, and exception details through textContent/text nodes while preserving the existing result classes and messages.
- Add a focused regression test that forbids reintroducing the result.innerHTML sink.

## Testing
- python -m pytest -q tests\test_faucet_service_frontend_security.py tests\test_faucet_service_wallet_validation.py
- python -m pytest -q faucet_service\test_faucet_service.py::TestFlaskApp::test_faucet_page faucet_service\test_faucet_service.py::TestFlaskApp::test_drip_success
- python -m py_compile faucet_service\faucet_service.py tests\test_faucet_service_frontend_security.py
- git diff --check -- faucet_service\faucet_service.py tests\test_faucet_service_frontend_security.py
- node -e "const fs=require('fs'); const s=fs.readFileSync('faucet_service/faucet_service.py','utf8'); const scripts=[...s.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7160

wallet: itosa-kazu
