### PR TITLE
Harden Hall of Fame load error rendering

### DIFF
--- a/tests/test_hall_of_fame_frontend_endpoints.py
+++ b/tests/test_hall_of_fame_frontend_endpoints.py
@@ -21,3 +21,16 @@ def test_hall_of_fame_machine_uses_compat_machine_endpoint_and_shape():
 
     assert "fetch('/api/hall_of_fame/machine?id='+encodeURIComponent(id))" in html
     assert "const m=data.machine||data||{};" in html
+
+
+def test_hall_of_fame_load_error_uses_text_content():
+    html = (ROOT / "web" / "hall-of-fame" / "index.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function setLeaderboardMessage(tbody, message, options = {})" in html
+    assert "cell.textContent = String(message ?? '');" in html
+    assert "cell.appendChild(document.createTextNode(` ${String(message ?? '')}`));" in html
+    assert "tbody.replaceChildren(row);" in html
+    assert "setLeaderboardMessage(tbody, `Failed to load: ${message}`, { error: true });" in html
+    assert "Failed to load: ${esc(e.message)}" not in html

--- a/web/hall-of-fame/index.html
+++ b/web/hall-of-fame/index.html
@@ -271,11 +271,33 @@ function filterTable(){
   rows.forEach(r=>{ r.style.display = r.dataset.search.includes(q) ? '' : 'none'; });
 }
 
+function setLeaderboardMessage(tbody, message, options = {}){
+  const row = document.createElement('tr');
+  row.className = 'loading-row';
+
+  const cell = document.createElement('td');
+  cell.colSpan = 9;
+  if(options.error) cell.className = 'err';
+
+  if(options.blinking){
+    const marker = document.createElement('span');
+    marker.className = 'blinking';
+    marker.textContent = '█';
+    cell.appendChild(marker);
+    cell.appendChild(document.createTextNode(` ${String(message ?? '')}`));
+  } else {
+    cell.textContent = String(message ?? '');
+  }
+
+  row.appendChild(cell);
+  tbody.replaceChildren(row);
+}
+
 async function loadLeaderboard(){
   const limit = document.getElementById('filterLimit').value;
   const deceased = document.getElementById('filterDeceased').value;
   const tbody = document.getElementById('leaderTbody');
-  tbody.innerHTML = '<tr class="loading-row"><td colspan="9"><span class="blinking">█</span> Loading…</td></tr>';
+  setLeaderboardMessage(tbody, 'Loading...', { blinking: true });
 
   try {
     let url = API_LEADERBOARD + '?limit=' + limit;
@@ -287,14 +309,15 @@ async function loadLeaderboard(){
     const data = await res.json();
     const machines = data.leaderboard || [];
     if(!machines.length){
-      tbody.innerHTML = '<tr class="loading-row"><td colspan="9" class="err">No machines found.</td></tr>';
+      setLeaderboardMessage(tbody, 'No machines found.', { error: true });
       return;
     }
     allRows = machines.map((m, idx) => buildRow(m, idx+1));
     tbody.innerHTML = allRows.join('');
     filterTable();
   } catch(e){
-    tbody.innerHTML = `<tr class="loading-row"><td colspan="9" class="err">Failed to load: ${esc(e.message)}</td></tr>`;
+    const message = e && e.message ? e.message : '';
+    setLeaderboardMessage(tbody, `Failed to load: ${message}`, { error: true });
   }
 }
 


### PR DESCRIPTION
﻿## Summary
- Build Hall of Fame loading, empty, and load-error rows with a shared DOM helper.
- Write dynamic load exception text through textContent/text nodes instead of parsing it through innerHTML.
- Add a focused regression assertion that forbids the old escaped error template sink.

## Testing
- python -m pytest -q tests\test_hall_of_fame_frontend_endpoints.py tests\test_hall_of_fame_machine_frontend_security.py
- python -m py_compile tests\test_hall_of_fame_frontend_endpoints.py
- node -e "const fs=require('fs'); const html=fs.readFileSync('web/hall-of-fame/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- git diff --check -- web\hall-of-fame\index.html tests\test_hall_of_fame_frontend_endpoints.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7174

wallet: itosa-kazu
