### PR TITLE
Harden explorer dashboard search error rendering

### DIFF
--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -289,6 +289,21 @@ DASHBOARD_HTML = """
                 });
         }
 
+        function showSearchError(message) {
+            const resultDiv = document.getElementById('search-result');
+            resultDiv.replaceChildren();
+
+            const title = document.createElement('h3');
+            title.textContent = '❌ Error';
+            resultDiv.appendChild(title);
+
+            const detail = document.createElement('p');
+            detail.textContent = String(message ?? '');
+            resultDiv.appendChild(detail);
+
+            resultDiv.style.display = 'block';
+        }
+
         function searchWallet() {
             const wallet = document.getElementById('wallet-search').value.trim();
             if (!wallet) return;
@@ -318,9 +333,7 @@ DASHBOARD_HTML = """
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
-                    err = escapeHtml(err.message || err);
-                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
-                    document.getElementById('search-result').style.display = 'block';
+                    showSearchError(err && err.message ? err.message : err);
                 });
         }
 

--- a/tests/test_explorer_rustchain_dashboard_security.py
+++ b/tests/test_explorer_rustchain_dashboard_security.py
@@ -80,8 +80,13 @@ def test_explorer_dashboard_sanitizes_wallet_search_and_errors():
     assert "fetch(`/api/wallet/${wallet}`)" not in source
     assert "const tierToken = safeToken(data.tier" in source
     assert "badge-${tierToken}" in source
-    assert "err = escapeHtml(err.message || err);" in source
-    assert "document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;" in source
+    assert "function showSearchError(message)" in source
+    assert "resultDiv.replaceChildren();" in source
+    assert "title.textContent =" in source
+    assert "detail.textContent = String(message ?? '');" in source
+    assert "showSearchError(err && err.message ? err.message : err);" in source
+    assert "err = escapeHtml(err.message || err);" not in source
+    assert "document.getElementById('search-result').innerHTML = `<h3>" not in source
     assert "${escapeHtml(wallet)}" in source
     assert '<span class="mono">${wallet}</span>' not in source
 


### PR DESCRIPTION
﻿## Summary
- Add a DOM-based search error renderer for the explorer dashboard wallet lookup catch path.
- Write runtime error details with textContent instead of rebuilding an innerHTML template.
- Update the focused dashboard security test to require the safe renderer and forbid the old error template.

## Testing
- python -m pytest -q tests\test_explorer_rustchain_dashboard_security.py
- python -m py_compile explorer\rustchain_dashboard.py tests\test_explorer_rustchain_dashboard_security.py
- node -e "const fs=require('fs'); const s=fs.readFileSync('explorer/rustchain_dashboard.py','utf8'); const scripts=[...s.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- git diff --check -- explorer\rustchain_dashboard.py tests\test_explorer_rustchain_dashboard_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7150

wallet: itosa-kazu
