### PR TITLE
Harden static BCOS badge preview fallback

### DIFF
--- a/tests/test_bcos_badge_generator_frontend_security.py
+++ b/tests/test_bcos_badge_generator_frontend_security.py
@@ -16,3 +16,25 @@ def test_bcos_badge_preview_validates_ids_and_uses_dom_nodes():
     assert "if (/^BCOS-/i.test(input)) return input;" not in html
     assert "document.getElementById('preview').innerHTML =" not in html
     assert '<a href="${verifyUrl}" target="_blank"><img src="${badgeUrl}"' not in html
+
+
+def test_static_bcos_badge_preview_fallback_uses_dom_text_nodes():
+    page = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "bcos-badge-generator"
+        / "index.html"
+    )
+    html = page.read_text(encoding="utf-8")
+
+    assert "function renderPreviewFallback(url)" in html
+    assert "urlText.textContent = url;" in html
+    assert "previewArea.replaceChildren(wrapper);" in html
+    assert "function renderPreviewPlaceholder()" in html
+    assert "placeholder.textContent = PREVIEW_PLACEHOLDER;" in html
+    assert "previewArea.replaceChildren(placeholder);" in html
+    assert "previewArea.replaceChildren(img);" in html
+
+    assert "previewArea.innerHTML" not in html
+    assert "Badge URL: <span" not in html
+    assert "${url}</span>" not in html

--- a/tools/bcos-badge-generator/index.html
+++ b/tools/bcos-badge-generator/index.html
@@ -623,6 +623,7 @@
     // ── State ──────────────────────────────────────────────
     let currentCertId = '';
     let currentStyle = 'flat';
+    const PREVIEW_PLACEHOLDER = 'Enter a Certificate ID and click "Generate Preview" to see your badge';
 
     // ── DOM Elements ──────────────────────────────────────────────
     const badgeForm = document.getElementById('badgeForm');
@@ -723,6 +724,40 @@
       }
     }
 
+    function renderPreviewPlaceholder() {
+      const placeholder = document.createElement('span');
+      placeholder.className = 'preview-placeholder';
+      placeholder.textContent = PREVIEW_PLACEHOLDER;
+      previewArea.replaceChildren(placeholder);
+    }
+
+    function renderPreviewFallback(url) {
+      const wrapper = document.createElement('div');
+      wrapper.style.textAlign = 'left';
+
+      const warning = document.createElement('p');
+      warning.style.color = 'var(--term-orange)';
+      warning.style.marginBottom = '10px';
+      warning.textContent = '⚠ Preview endpoint unavailable (expected in static mode)';
+
+      const urlLine = document.createElement('p');
+      urlLine.style.color = 'var(--term-dim)';
+      urlLine.appendChild(document.createTextNode('Badge URL: '));
+
+      const urlText = document.createElement('span');
+      urlText.style.color = 'var(--term-blue)';
+      urlText.textContent = url;
+      urlLine.appendChild(urlText);
+
+      const note = document.createElement('p');
+      note.style.color = 'var(--term-dim)';
+      note.style.marginTop = '10px';
+      note.textContent = 'In production, this will fetch the badge from the BCOS API.';
+
+      wrapper.append(warning, urlLine, note);
+      previewArea.replaceChildren(wrapper);
+    }
+
     async function updatePreview(certId) {
       const style = currentStyle;
       const url = `${BADGE_ENDPOINT}/${certId}.svg?style=${style}`;
@@ -732,26 +767,13 @@
         img.alt = `BCOS Badge for ${certId}`;
 
         img.onload = () => {
-          previewArea.innerHTML = '';
-          previewArea.appendChild(img);
+          previewArea.replaceChildren(img);
           resolve();
         };
 
         img.onerror = () => {
           // For demo purposes, show a placeholder if endpoint is unavailable
-          previewArea.innerHTML = `
-            <div style="text-align: left;">
-              <p style="color: var(--term-orange); margin-bottom: 10px;">
-                ⚠ Preview endpoint unavailable (expected in static mode)
-              </p>
-              <p style="color: var(--term-dim);">
-                Badge URL: <span style="color: var(--term-blue);">${url}</span>
-              </p>
-              <p style="color: var(--term-dim); margin-top: 10px;">
-                In production, this will fetch the badge from the BCOS API.
-              </p>
-            </div>
-          `;
+          renderPreviewFallback(url);
           resolve(); // Don't reject, just show placeholder
         };
 
@@ -808,7 +830,7 @@
       currentStyle = 'flat';
       styleBtns.forEach(b => b.classList.remove('active'));
       styleBtns[0].classList.add('active');
-      previewArea.innerHTML = '<span class="preview-placeholder">Enter a Certificate ID and click "Generate Preview" to see your badge</span>';
+      renderPreviewPlaceholder();
       outputSection.classList.add('hidden');
       statusMessage.classList.add('hidden');
       inputType.value = 'cert_id';


### PR DESCRIPTION
﻿## Summary
- Render the static BCOS badge preview fallback with DOM nodes instead of a previewArea.innerHTML template.
- Put the generated badge URL into textContent and reset the placeholder through a DOM helper.
- Add focused frontend security coverage for the tools/bcos-badge-generator page.

## Testing
- python -m pytest -q tests\test_bcos_badge_generator_frontend_security.py tests\test_validate_bcos_generator.py
- python -m py_compile tests\test_bcos_badge_generator_frontend_security.py tests\test_validate_bcos_generator.py tools\validate_bcos_generator.py
- node -e "const fs=require('fs'); const html=fs.readFileSync('tools/bcos-badge-generator/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- git diff --check -- tools\bcos-badge-generator\index.html tests\test_bcos_badge_generator_frontend_security.py
- $env:PYTHONIOENCODING='utf-8'; python tools\validate_bcos_generator.py tools\bcos-badge-generator\index.html
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7137

wallet: itosa-kazu
