### PR TITLE
Harden docs miner setup wizard result rendering

### DIFF
--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -94,6 +94,62 @@ function h(value){
     .replace(/'/g,'&#39;');
 }
 
+function statusPill(label, type){
+  const status = document.createElement('span');
+  status.className = `pill ${type}`;
+  status.textContent = label;
+  return status;
+}
+
+function preText(text){
+  const pre = document.createElement('pre');
+  pre.textContent = String(text ?? '');
+  return pre;
+}
+
+function mutedText(text, tag = 'span'){
+  const node = document.createElement(tag);
+  node.className = 'muted';
+  node.textContent = String(text ?? '');
+  return node;
+}
+
+function renderHealthResult(el, result, url){
+  if(result.ok){
+    el.replaceChildren(
+      statusPill('Reachable', 'ok'),
+      document.createTextNode(' '),
+      preText(result.text)
+    );
+    return;
+  }
+
+  el.replaceChildren(
+    statusPill('Failed', 'bad'),
+    document.createTextNode(' '),
+    preText(result.text),
+    mutedText(`If this is a CORS error, test with terminal: curl -sk ${url.replace(/\/$/,'')}/health`, 'p')
+  );
+}
+
+function renderMinerResult(el, hit, error = null){
+  if(error !== null){
+    el.replaceChildren(statusPill('Check failed', 'bad'), preText(String(error)));
+    return;
+  }
+
+  if(hit){
+    el.replaceChildren(statusPill('Found', 'ok'), preText(JSON.stringify(hit,null,2)));
+    return;
+  }
+
+  el.replaceChildren(
+    statusPill('Not found yet', 'warn'),
+    document.createTextNode(' '),
+    mutedText('Miner may still be attesting/enrolling.')
+  );
+}
+
 function detectPlatform(){
   const ua=navigator.userAgent.toLowerCase();
   state.platform = ua.includes('mac')?'macOS':ua.includes('win')?'Windows':ua.includes('linux')?'Linux':'Unknown';
@@ -217,9 +273,7 @@ function renderPanel(){
         const url = document.getElementById('testNodeUrl').value.trim();
         state.nodeUrl = url;
         const r = await testNode(url);
-        document.getElementById('testOut').innerHTML = r.ok
-          ? `<span class='pill ok'>Reachable</span> <pre>${h(r.text)}</pre>`
-          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sk ${h(url.replace(/\/$/,''))}/health</p>`;
+        renderHealthResult(document.getElementById('testOut'), r, url);
       }
     },0);
     return;
@@ -243,11 +297,9 @@ function renderPanel(){
           const data = await r.json();
           const arr = Array.isArray(data)?data:(data.miners||[]);
           const hit = arr.find(x=>JSON.stringify(x).toLowerCase().includes(q));
-          document.getElementById('minerOut').innerHTML = hit
-            ? `<span class='pill ok'>Found</span><pre>${h(JSON.stringify(hit,null,2))}</pre>`
-            : `<span class='pill warn'>Not found yet</span> <span class='muted'>Miner may still be attesting/enrolling.</span>`;
+          renderMinerResult(document.getElementById('minerOut'), hit);
         }catch(e){
-          document.getElementById('minerOut').innerHTML = `<span class='pill bad'>Check failed</span><pre>${h(String(e))}</pre>`;
+          renderMinerResult(document.getElementById('minerOut'), null, e);
         }
       }
     },0);

--- a/tests/test_miner_setup_docs_wizard_security.py
+++ b/tests/test_miner_setup_docs_wizard_security.py
@@ -9,16 +9,24 @@ WIZARD_HTML = (
 )
 
 
-def test_remote_node_responses_are_escaped_before_inner_html_rendering():
+def test_remote_node_responses_render_with_dom_text_nodes():
     html = WIZARD_HTML.read_text(encoding="utf-8")
 
     assert "<pre>${r.text}</pre>" not in html
     assert "<pre>${JSON.stringify(hit,null,2)}</pre>" not in html
     assert "<pre>${String(e)}</pre>" not in html
 
-    assert "<pre>${h(r.text)}</pre>" in html
-    assert "<pre>${h(JSON.stringify(hit,null,2))}</pre>" in html
-    assert "<pre>${h(String(e))}</pre>" in html
+    assert "function statusPill(label, type)" in html
+    assert "status.textContent = label;" in html
+    assert "function preText(text)" in html
+    assert "pre.textContent = String(text ?? '');" in html
+    assert "function renderHealthResult(el, result, url)" in html
+    assert "function renderMinerResult(el, hit, error = null)" in html
+    assert "renderHealthResult(document.getElementById('testOut'), r, url);" in html
+    assert "renderMinerResult(document.getElementById('minerOut'), hit);" in html
+    assert "renderMinerResult(document.getElementById('minerOut'), null, e);" in html
+    assert "document.getElementById('testOut').innerHTML" not in html
+    assert "document.getElementById('minerOut').innerHTML" not in html
 
 
 def test_generated_command_blocks_escape_display_and_copy_attribute():


### PR DESCRIPTION
﻿## Summary
- Render the docs miner setup wizard /health and /api/miners result panels with DOM helpers.
- Write remote node response, miner JSON, and exception text through textContent instead of innerHTML templates.
- Update the focused wizard security regression test to require replaceChildren/textContent and forbid the old output sinks.

## Testing
- python -m pytest -q tests\test_miner_setup_docs_wizard_security.py tests\test_setup_wizard_frontend_security.py
- python -m py_compile tests\test_miner_setup_docs_wizard_security.py tests\test_setup_wizard_frontend_security.py
- node -e "const fs=require('fs'); const html=fs.readFileSync('docs/miner-setup-wizard/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\s\S]*?)<\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- git diff --check -- docs\miner-setup-wizard\index.html tests\test_miner_setup_docs_wizard_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7191

wallet: itosa-kazu
