### PR TITLE
Harden Beacon bounty panel rendering

### DIFF
--- a/site/beacon/ui.js
+++ b/site/beacon/ui.js
@@ -26,6 +26,28 @@ let reputationCache = {};
 let reputationTs = 0;
 const REP_CACHE_TTL = 60 * 1000; // 1 min
 
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[ch]));
+}
+
+function safeGithubUrl(value) {
+  try {
+    const url = new URL(String(value ?? ''));
+    const host = url.hostname.toLowerCase();
+    if (url.protocol !== 'https:') return '';
+    if (host !== 'github.com' && !host.endsWith('.github.com')) return '';
+    return url.href;
+  } catch {
+    return '';
+  }
+}
+
 function mergeReputationRecord(existing, incoming) {
   if (!existing) return incoming;
   return {
@@ -762,17 +784,17 @@ function renderBountyList(bounties) {
 
   // Open bounties
   for (const b of open.slice(0, 20)) {
-    const safeUrl = (b.url || '').replace(/'/g, '%27');
+    const safeUrl = safeGithubUrl(b.url);
     html += `<div class="bounty-card">`;
     html += `<div style="display:flex;justify-content:space-between;align-items:center">`;
-    html += `<span style="color:var(--green);font-weight:600;font-size:13px">${b.title}</span>`;
-    html += `<span style="color:#ffd700;font-size:12px;font-weight:600;white-space:nowrap;margin-left:8px">${b.reward}</span>`;
+    html += `<span style="color:var(--green);font-weight:600;font-size:13px">${escapeHtml(b.title)}</span>`;
+    html += `<span style="color:#ffd700;font-size:12px;font-weight:600;white-space:nowrap;margin-left:8px">${escapeHtml(b.reward)}</span>`;
     html += `</div>`;
     html += `<div style="display:flex;gap:8px;font-size:11px;margin-top:4px;align-items:center">`;
-    html += `<span style="color:${DIFF_COLORS[b.difficulty] || DIFF_COLORS.ANY}">[${b.difficulty}]</span>`;
-    html += `<span style="color:var(--text-dim)">${b.repo} ${b.ghNum || b.id}</span>`;
+    html += `<span style="color:${DIFF_COLORS[b.difficulty] || DIFF_COLORS.ANY}">[${escapeHtml(b.difficulty)}]</span>`;
+    html += `<span style="color:var(--text-dim)">${escapeHtml(b.repo)} ${escapeHtml(b.ghNum || b.id)}</span>`;
     if (safeUrl) {
-      html += `<a href="${safeUrl}" target="_blank" class="bounty-link" style="font-size:10px;padding:1px 6px">[GitHub]</a>`;
+      html += `<a href="${escapeHtml(safeUrl)}" target="_blank" class="bounty-link" style="font-size:10px;padding:1px 6px">[GitHub]</a>`;
     }
     html += `</div>`;
     html += `</div>`;
@@ -786,12 +808,13 @@ function renderBountyList(bounties) {
     html += `<div class="t-section">-- CLAIMED (${claimed.length}) --</div>`;
     for (const b of claimed) {
       const agent = AGENTS.find(a => a.id === b.claimant);
+      const claimantName = agent ? agent.name : b.claimant;
       html += `<div class="bounty-card" style="border-left-color:var(--amber)">`;
       html += `<div style="display:flex;justify-content:space-between">`;
-      html += `<span style="color:var(--amber);font-size:13px">${b.title}</span>`;
-      html += `<span style="color:#ffd700;font-size:12px">${b.reward}</span>`;
+      html += `<span style="color:var(--amber);font-size:13px">${escapeHtml(b.title)}</span>`;
+      html += `<span style="color:#ffd700;font-size:12px">${escapeHtml(b.reward)}</span>`;
       html += `</div>`;
-      html += `<div style="font-size:11px;color:var(--amber);margin-top:3px">Claimed by: ${agent ? agent.name : b.claimant}</div>`;
+      html += `<div style="font-size:11px;color:var(--amber);margin-top:3px">Claimed by: ${escapeHtml(claimantName || 'unknown')}</div>`;
       html += `</div>`;
     }
   }
@@ -801,13 +824,14 @@ function renderBountyList(bounties) {
     html += `<div class="t-section">-- COMPLETED (${completed.length}) --</div>`;
     for (const b of completed) {
       const agent = AGENTS.find(a => a.id === b.completed_by);
+      const completerName = agent ? agent.name : b.completed_by;
       const repGain = 10 + (b.reward_rtc || 0) * 0.1;
       html += `<div class="bounty-card" style="border-left-color:#8888ff;opacity:0.7">`;
       html += `<div style="display:flex;justify-content:space-between">`;
-      html += `<span style="color:#8888ff;font-size:13px">${b.title}</span>`;
-      html += `<span style="color:#ffd700;font-size:12px">${b.reward}</span>`;
+      html += `<span style="color:#8888ff;font-size:13px">${escapeHtml(b.title)}</span>`;
+      html += `<span style="color:#ffd700;font-size:12px">${escapeHtml(b.reward)}</span>`;
       html += `</div>`;
-      html += `<div style="font-size:11px;color:#8888ff;margin-top:3px">Completed by: ${agent ? agent.name : b.completed_by} (+${repGain.toFixed(0)} rep)</div>`;
+      html += `<div style="font-size:11px;color:#8888ff;margin-top:3px">Completed by: ${escapeHtml(completerName || 'unknown')} (+${repGain.toFixed(0)} rep)</div>`;
       html += `</div>`;
     }
   }
@@ -829,20 +853,23 @@ async function showBounties() {
 
   // Reputation Leaderboard
   const repEntries = Object.values(reputationCache)
-    .filter(r => r.score > 0)
-    .sort((a, b) => b.score - a.score)
+    .filter(r => Number(r.score) > 0)
+    .sort((a, b) => Number(b.score || 0) - Number(a.score || 0))
     .slice(0, 10);
   if (repEntries.length > 0) {
     html += `<div class="t-section">-- REPUTATION LEADERBOARD --</div>`;
     for (let i = 0; i < repEntries.length; i++) {
       const r = repEntries[i];
       const agent = AGENTS.find(a => a.id === r.agent_id);
-      const name = agent ? agent.name : r.agent_id;
+      const leaderboardAgentId = String(r.agent_id ?? '');
+      const name = agent ? agent.name : leaderboardAgentId;
+      const rawScore = Number(r.score || 0);
+      const score = Number.isFinite(rawScore) ? rawScore : 0;
       const medal = i === 0 ? '1st' : i === 1 ? '2nd' : i === 2 ? '3rd' : `${i+1}th`;
       const color = i === 0 ? '#ffd700' : i === 1 ? '#c0c0c0' : i === 2 ? '#cd7f32' : 'var(--text-dim)';
-      html += `<div style="display:flex;justify-content:space-between;font-size:12px;margin:2px 0;cursor:pointer" data-leaderboard-agent="${r.agent_id}">`;
-      html += `<span><span style="color:${color};width:28px;display:inline-block">${medal}</span> ${name}</span>`;
-      html += `<span style="color:${color}">${r.score} rep</span>`;
+      html += `<div style="display:flex;justify-content:space-between;font-size:12px;margin:2px 0;cursor:pointer" data-leaderboard-agent="${escapeHtml(leaderboardAgentId)}">`;
+      html += `<span><span style="color:${color};width:28px;display:inline-block">${medal}</span> ${escapeHtml(name)}</span>`;
+      html += `<span style="color:${color}">${score} rep</span>`;
       html += `</div>`;
     }
   }

--- a/tests/test_beacon_bounty_frontend_security.py
+++ b/tests/test_beacon_bounty_frontend_security.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+UI_JS = REPO_ROOT / "site" / "beacon" / "ui.js"
+
+
+def read_ui_source() -> str:
+    return UI_JS.read_text(encoding="utf-8")
+
+
+def test_bounty_panel_escapes_dynamic_fields() -> None:
+    source = read_ui_source()
+
+    assert "function escapeHtml(value)" in source
+    assert "${escapeHtml(b.title)}" in source
+    assert "${escapeHtml(b.reward)}" in source
+    assert "[${escapeHtml(b.difficulty)}]" in source
+    assert "${escapeHtml(b.repo)} ${escapeHtml(b.ghNum || b.id)}" in source
+    assert "Claimed by: ${escapeHtml(claimantName || 'unknown')}" in source
+    assert "Completed by: ${escapeHtml(completerName || 'unknown')}" in source
+    assert "data-leaderboard-agent=\"${escapeHtml(leaderboardAgentId)}\"" in source
+    assert "${escapeHtml(name)}" in source
+
+
+def test_bounty_links_are_limited_to_https_github_hosts() -> None:
+    source = read_ui_source()
+
+    assert "function safeGithubUrl(value)" in source
+    assert "url.protocol !== 'https:'" in source
+    assert "host !== 'github.com' && !host.endsWith('.github.com')" in source
+    assert "const safeUrl = safeGithubUrl(b.url);" in source
+    assert 'href="${escapeHtml(safeUrl)}"' in source
+
+
+def test_bounty_panel_does_not_use_old_raw_interpolations() -> None:
+    source = read_ui_source()
+
+    forbidden_fragments = [
+        "${b.title}",
+        "${b.reward}",
+        "[${b.difficulty}]",
+        "${b.repo} ${b.ghNum || b.id}",
+        "Claimed by: ${agent ? agent.name : b.claimant}",
+        "Completed by: ${agent ? agent.name : b.completed_by}",
+        "data-leaderboard-agent=\"${r.agent_id}\"",
+        "${name}</span>",
+        "${r.score} rep",
+        "const safeUrl = (b.url || '').replace(/'/g, '%27');",
+        'href="${safeUrl}"',
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in source


### PR DESCRIPTION
## Summary
- Escape dynamic Beacon bounty/reputation fields rendered through the bounty panel template.
- Add safeGithubUrl so bounty links only render for HTTPS GitHub hosts.
- Add focused regression coverage for the bounty panel sink.

## Testing
- python -m pytest -q tests\test_beacon_bounty_frontend_security.py
- node --check site\beacon\ui.js
- python -m py_compile tests\test_beacon_bounty_frontend_security.py
- git diff --check -- site\beacon\ui.js tests\test_beacon_bounty_frontend_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7210

wallet: itosa-kazu