### PR TITLE
Harden Explorer miner and health rendering

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -89,6 +89,11 @@ function formatNumber(num, decimals = 2) {
     });
 }
 
+function safeNumber(num, fallback = 0) {
+    const value = Number(num);
+    return Number.isFinite(value) ? value : fallback;
+}
+
 function formatTimestamp(ts) {
     if (!ts) return 'N/A';
     const timestamp = typeof ts === 'number' ? ts * 1000 : new Date(ts).getTime();
@@ -418,7 +423,7 @@ function renderStatusBar() {
             <span>${statusText}</span>
         </div>
         <div class="status-info mono">
-            ${state.health ? `v${state.health.version || '2.2.1'}` : ''}
+            ${state.health ? `v${escapeHtml(state.health.version || '2.2.1')}` : ''}
             ${state.health && state.health.uptime ? `| Uptime: ${formatUptime(state.health.uptime)}` : ''}
             ${state.lastUpdate ? `| Updated: ${formatRelativeTime(state.lastUpdate)}` : ''}
         </div>
@@ -446,7 +451,9 @@ function renderEpochStats() {
     }
     
     const epoch = state.epoch || { epoch: 0, pot: 0, slot: 0, blocks_per_epoch: 144 };
-    const progress = ((epoch.slot || 0) / (epoch.blocks_per_epoch || 144)) * 100;
+    const slot = safeNumber(epoch.slot, 0);
+    const blocksPerEpoch = Math.max(safeNumber(epoch.blocks_per_epoch, 144), 1);
+    const progress = Math.max(0, Math.min(100, (slot / blocksPerEpoch) * 100));
     
     container.innerHTML = `
         <div class="card">
@@ -466,7 +473,7 @@ function renderEpochStats() {
         </div>
         <div class="card">
             <div class="card-title">Progress</div>
-            <div class="card-value">${formatNumber(epoch.slot || 0, 0)}/${epoch.blocks_per_epoch || 144}</div>
+            <div class="card-value">${formatNumber(slot, 0)}/${formatNumber(blocksPerEpoch, 0)}</div>
             <div class="progress-bar">
                 <div class="progress-fill" style="width: ${progress}%"></div>
             </div>
@@ -516,7 +523,7 @@ function renderMinersTable() {
             const badgeClass = getArchitectureBadge(arch);
             return `
                 <tr>
-                    <td class="mono" title="${escapeHtml(minerId)}">${shortenAddress(minerId)}</td>
+                    <td class="mono" title="${escapeHtml(minerId)}">${escapeHtml(shortenAddress(minerId))}</td>
                     <td><span class="badge ${badgeClass}">${escapeHtml(arch)}</span></td>
                     <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                     <td class="text-accent">${formatNumber(multiplier, 2)}x</td>
@@ -780,7 +787,7 @@ function renderSearchResults() {
                         const badgeClass = getArchitectureBadge(miner.device_arch);
                         return `
                             <tr>
-                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${shortenAddress(miner.miner_id || 'unknown')}</td>
+                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}</td>
                                 <td><span class="badge ${badgeClass}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
                                 <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                                 <td class="text-accent">${formatNumber(miner.multiplier || 1.0, 2)}x</td>

--- a/tests/test_explorer_block_filters.py
+++ b/tests/test_explorer_block_filters.py
@@ -10,6 +10,18 @@ EXPLORER_HTML = REPO_ROOT / "explorer" / "index.html"
 EXPLORER_JS = REPO_ROOT / "explorer" / "static" / "js" / "explorer.js"
 
 
+def run_node_probe(tmp_path: Path, probe: str) -> subprocess.CompletedProcess[str]:
+    probe_path = tmp_path / "probe.js"
+    probe_path.write_text(probe, encoding="utf-8")
+    return subprocess.run(
+        ["node", str(probe_path)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+
 def test_block_filter_controls_are_available_in_blocks_view():
     html = EXPLORER_HTML.read_text(encoding="utf-8")
 
@@ -34,7 +46,7 @@ def test_block_filter_controls_are_available_in_blocks_view():
         assert heading in html
 
 
-def test_block_filter_logic_handles_requested_filter_fields():
+def test_block_filter_logic_handles_requested_filter_fields(tmp_path):
     js = EXPLORER_JS.read_text(encoding="utf-8")
     probe = f"""
 const vm = require('vm');
@@ -97,19 +109,14 @@ const result = vm.runInContext(`
 `, context);
 console.log(result);
 """
-    result = subprocess.run(
-        ["node", "-e", probe],
-        text=True,
-        capture_output=True,
-        check=True,
-    )
+    result = run_node_probe(tmp_path, probe)
     data = json.loads(result.stdout)
 
     assert data["filteredHeights"] == [3]
     assert data["envelopeHeights"] == [9]
 
 
-def test_all_blocks_filter_uses_untruncated_fetched_blocks():
+def test_all_blocks_filter_uses_untruncated_fetched_blocks(tmp_path):
     js = EXPLORER_JS.read_text(encoding="utf-8")
     probe = f"""
 const vm = require('vm');
@@ -182,12 +189,7 @@ const script = {json.dumps(js)};
   process.exit(1);
 }});
 """
-    result = subprocess.run(
-        ["node", "-e", probe],
-        text=True,
-        capture_output=True,
-        check=True,
-    )
+    result = run_node_probe(tmp_path, probe)
     data = json.loads(result.stdout)
 
     assert data["storedBlockCount"] == 3

--- a/tests/test_explorer_static_frontend_security.py
+++ b/tests/test_explorer_static_frontend_security.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+EXPLORER_JS = Path(__file__).resolve().parents[1] / "explorer" / "static" / "js" / "explorer.js"
+
+
+def source() -> str:
+    return EXPLORER_JS.read_text(encoding="utf-8")
+
+
+def test_explorer_health_and_epoch_rendering_are_sanitized() -> None:
+    js = source()
+
+    assert "function safeNumber(num, fallback = 0)" in js
+    assert "v${escapeHtml(state.health.version || '2.2.1')}" in js
+    assert "const slot = safeNumber(epoch.slot, 0);" in js
+    assert "const blocksPerEpoch = Math.max(safeNumber(epoch.blocks_per_epoch, 144), 1);" in js
+    assert "const progress = Math.max(0, Math.min(100, (slot / blocksPerEpoch) * 100));" in js
+    assert "${formatNumber(slot, 0)}/${formatNumber(blocksPerEpoch, 0)}" in js
+
+
+def test_explorer_miner_ids_escape_visible_table_text() -> None:
+    js = source()
+
+    assert '${escapeHtml(shortenAddress(minerId))}' in js
+    assert "${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}" in js
+    assert 'title="${escapeHtml(minerId)}"' in js
+    assert 'title="${escapeHtml(miner.miner_id)}"' in js
+
+
+def test_explorer_old_raw_interpolations_are_absent() -> None:
+    js = source()
+
+    forbidden_fragments = [
+        "v${state.health.version || '2.2.1'}",
+        "const progress = ((epoch.slot || 0) / (epoch.blocks_per_epoch || 144)) * 100;",
+        "${formatNumber(epoch.slot || 0, 0)}/${epoch.blocks_per_epoch || 144}",
+        'title="${escapeHtml(minerId)}">${shortenAddress(minerId)}</td>',
+        'title="${escapeHtml(miner.miner_id)}">${shortenAddress(miner.miner_id || \'unknown\')}</td>',
+    ]
+
+    for fragment in forbidden_fragments:
+        assert fragment not in js


### PR DESCRIPTION
﻿## Summary
- Escape Explorer health version and visible miner IDs before rendering them through innerHTML templates.
- Coerce epoch slot/progress fields to finite bounded numbers before rendering text and progress width.
- Add focused static coverage and move block-filter Node probes to temp JS files for Windows-safe validation.

## Testing
- python -m pytest -q tests\test_explorer_static_frontend_security.py tests\test_explorer_block_filters.py
- node --check explorer\static\js\explorer.js
- python -m py_compile tests\test_explorer_static_frontend_security.py tests\test_explorer_block_filters.py
- git diff --check -- explorer\static\js\explorer.js tests\test_explorer_static_frontend_security.py tests\test_explorer_block_filters.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7212

wallet: itosa-kazu
