### PR TITLE
Harden network status dynamic rendering

### DIFF
--- a/docs/network-status.html
+++ b/docs/network-status.html
@@ -119,6 +119,48 @@
       return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';
     }
 
+    function el(tag, className = '', text) {
+      const node = document.createElement(tag);
+      if (className) node.className = className;
+      if (text !== undefined) node.textContent = String(text ?? '-');
+      return node;
+    }
+
+    function renderNodeCard(card, base, ok, detailText) {
+      const statusRow = el('div', 'flex items-center gap-2 mb-1');
+      statusRow.append(
+        el('span', `inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}`),
+        el('span', `text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}`, ok ? 'UP' : 'DOWN')
+      );
+
+      card.replaceChildren(
+        el('div', 'font-mono text-xs break-all mb-2', base),
+        statusRow,
+        el('div', 'text-xs text-slate-400', detailText)
+      );
+    }
+
+    function renderNodeChecking(card, base) {
+      card.replaceChildren(
+        el('div', 'font-mono text-xs break-all mb-2', base),
+        el('div', 'text-sm', 'Checking...')
+      );
+    }
+
+    function renderArchitectureRow(arch, n, pct) {
+      const row = document.createElement('div');
+      const summary = el('div', 'flex justify-between mb-1');
+      summary.append(el('span', '', arch), el('span', '', `${n} (${pct}%)`));
+
+      const bar = el('div', 'h-2 w-full bg-slate-800 rounded');
+      const fill = el('div', 'h-2 bg-cyan-400 rounded');
+      fill.style.width = `${pct}%`;
+      bar.appendChild(fill);
+
+      row.replaceChildren(summary, bar);
+      return row;
+    }
+
     async function fetchJson(url) {
       const r = await fetch(url, { cache: 'no-store' });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -185,16 +227,26 @@
       const log = document.getElementById('incidentLog');
       const incidents = safeJson(INCIDENT_KEY, []);
       if (!incidents.length) {
-        log.innerHTML = '<div class="text-slate-400 text-sm">No incidents recorded yet.</div>';
+        log.replaceChildren(el('div', 'text-slate-400 text-sm', 'No incidents recorded yet.'));
         return;
       }
-      log.innerHTML = incidents.slice(0, 30).map(i => `
-        <div class="rounded border border-slate-800 bg-slate-950 p-2">
-          <div class="text-xs text-slate-400">${new Date(i.t).toLocaleString()}</div>
-          <div><span class="font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}">${safeText(i.type)}</span> · <span class="font-mono text-xs">${safeText(i.node)}</span></div>
-          <div class="text-sm text-slate-300">${safeText(i.message)}</div>
-        </div>
-      `).join('');
+
+      const rows = incidents.slice(0, 30).map(i => {
+        const row = el('div', 'rounded border border-slate-800 bg-slate-950 p-2');
+        const meta = document.createElement('div');
+        meta.append(
+          el('span', `font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}`, i.type),
+          document.createTextNode(' · '),
+          el('span', 'font-mono text-xs', i.node)
+        );
+        row.replaceChildren(
+          el('div', 'text-xs text-slate-400', new Date(i.t).toLocaleString()),
+          meta,
+          el('div', 'text-sm text-slate-300', i.message)
+        );
+        return row;
+      });
+      log.replaceChildren(...rows);
     }
 
     function escapeXml(s) {
@@ -254,31 +306,17 @@
       await Promise.all(NODE_ENDPOINTS.map(async (base) => {
         const card = document.createElement('div');
         card.className = 'rounded-lg border border-slate-800 bg-slate-950 p-3';
-        card.innerHTML = `<div class="font-mono text-xs break-all mb-2">${safeText(base)}</div><div class="text-sm">Checking...</div>`;
+        renderNodeChecking(card, base);
         grid.appendChild(card);
 
         try {
           const health = await fetchJson(`${base}/health`);
           const ok = !!health.ok;
           recordNodeStatus(base, ok);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}"></span>
-              <span class="text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}">${ok ? 'UP' : 'DOWN'}</span>
-            </div>
-            <div class="text-xs text-slate-400">version: ${safeText(health.version)}</div>
-          `;
+          renderNodeCard(card, base, ok, `version: ${health.version ?? '-'}`);
         } catch (e) {
           recordNodeStatus(base, false);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500"></span>
-              <span class="text-sm font-semibold text-red-300">DOWN</span>
-            </div>
-            <div class="text-xs text-slate-400">${safeText(e.message || e)}</div>
-          `;
+          renderNodeCard(card, base, false, e.message || e);
         }
       }));
     }
@@ -315,12 +353,7 @@
           .sort((a, b) => b[1] - a[1])
           .forEach(([arch, n]) => {
             const pct = Math.round((n / total) * 100);
-            const row = document.createElement('div');
-            row.innerHTML = `
-              <div class="flex justify-between mb-1"><span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span></div>
-              <div class="h-2 w-full bg-slate-800 rounded"><div class="h-2 bg-cyan-400 rounded" style="width:${pct}%"></div></div>
-            `;
-            archList.appendChild(row);
+            archList.appendChild(renderArchitectureRow(arch, n, pct));
           });
       } catch {
         document.getElementById('minerCount').textContent = 'N/A';

--- a/tests/test_docs_network_status_security.py
+++ b/tests/test_docs_network_status_security.py
@@ -1,60 +1,77 @@
 from pathlib import Path
 
 
-HTML = Path(__file__).resolve().parents[1] / "docs" / "network-status.html"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HTML_FILES = [
+    REPO_ROOT / "docs" / "network-status.html",
+    REPO_ROOT / "website" / "static" / "network-status.html",
+]
 
 
-def source():
-    return HTML.read_text(encoding="utf-8-sig")
+def sources():
+    return [path.read_text(encoding="utf-8-sig") for path in HTML_FILES]
+
+
+def test_network_status_public_copies_stay_synchronized():
+    assert sources()[0] == sources()[1]
 
 
 def test_network_status_defines_html_escaping_helpers():
-    html = source()
-
-    assert "function escapeHtml(s)" in html
-    assert "function safeText(value, fallback = '-')" in html
-
-
-def test_node_cards_escape_api_and_error_fields():
-    html = source()
-
-    assert "${safeText(base)}</div><div class=\"text-sm\">Checking...</div>" in html
-    assert "version: ${safeText(health.version)}" in html
-    assert "${safeText(e.message || e)}" in html
-    assert "version: ${health.version ?? '-'}" not in html
-    assert "${String(e.message || e)}" not in html
+    for html in sources():
+        assert "function escapeHtml(s)" in html
+        assert "function safeText(value, fallback = '-')" in html
+        assert "function el(tag, className = '', text)" in html
 
 
-def test_incident_rows_escape_local_storage_fields():
-    html = source()
+def test_node_cards_render_api_and_error_fields_as_text():
+    for html in sources():
+        assert "function renderNodeCard(card, base, ok, detailText)" in html
+        assert "function renderNodeChecking(card, base)" in html
+        assert "node.textContent = String(text ?? '-');" in html
+        assert "card.replaceChildren(" in html
+        assert "renderNodeChecking(card, base);" in html
+        assert "renderNodeCard(card, base, ok, `version: ${health.version ?? '-'}`);" in html
+        assert "renderNodeCard(card, base, false, e.message || e);" in html
 
-    assert "${safeText(i.type)}</span>" in html
-    assert "${safeText(i.node)}</span>" in html
-    assert "${safeText(i.message)}</div>" in html
-    assert "${i.type}</span>" not in html
-    assert "${i.node}</span>" not in html
-    assert "${i.message}</div>" not in html
+        assert "card.innerHTML = `" not in html
+        assert "version: ${safeText(health.version)}" not in html
+        assert "${safeText(e.message || e)}" not in html
 
 
-def test_architecture_breakdown_escapes_miner_fields():
-    html = source()
+def test_incident_rows_render_local_storage_fields_as_text():
+    for html in sources():
+        assert "log.replaceChildren(...rows);" in html
+        assert "el('span', `font-semibold ${i.type === 'OUTAGE'" in html
+        assert "el('span', 'font-mono text-xs', i.node)" in html
+        assert "el('div', 'text-sm text-slate-300', i.message)" in html
 
-    assert "<span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span>" in html
-    assert "<span>${arch}</span><span>${n} (${pct}%)</span>" not in html
+        assert "log.innerHTML = incidents.slice(0, 30).map" not in html
+        assert "${safeText(i.type)}</span>" not in html
+        assert "${safeText(i.node)}</span>" not in html
+        assert "${safeText(i.message)}</div>" not in html
+
+
+def test_architecture_breakdown_renders_miner_fields_as_text():
+    for html in sources():
+        assert "function renderArchitectureRow(arch, n, pct)" in html
+        assert "summary.append(el('span', '', arch), el('span', '', `${n} (${pct}%)`));" in html
+        assert "fill.style.width = `${pct}%`;" in html
+        assert "archList.appendChild(renderArchitectureRow(arch, n, pct));" in html
+
+        assert "<span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span>" not in html
+        assert "row.innerHTML = `\n              <div class=\"flex justify-between mb-1\"" not in html
 
 
 def test_network_status_normalizes_current_miners_api_envelopes():
-    html = source()
-
-    assert "function normalizeMinerRows(payload)" in html
-    assert "payload?.miners || payload?.data || payload?.items || []" in html
-    assert "const list = normalizeMinerRows(miners);" in html
-    assert "rows.filter(row => row && typeof row === 'object')" in html
+    for html in sources():
+        assert "function normalizeMinerRows(payload)" in html
+        assert "payload?.miners || payload?.data || payload?.items || []" in html
+        assert "const list = normalizeMinerRows(miners);" in html
+        assert "rows.filter(row => row && typeof row === 'object')" in html
 
 
 def test_network_status_architecture_breakdown_uses_current_miner_fields():
-    html = source()
-
-    assert "function minerArch(row)" in html
-    assert "return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';" in html
-    assert "const key = minerArch(m);" in html
+    for html in sources():
+        assert "function minerArch(row)" in html
+        assert "return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';" in html
+        assert "const key = minerArch(m);" in html

--- a/website/static/network-status.html
+++ b/website/static/network-status.html
@@ -119,6 +119,48 @@
       return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';
     }
 
+    function el(tag, className = '', text) {
+      const node = document.createElement(tag);
+      if (className) node.className = className;
+      if (text !== undefined) node.textContent = String(text ?? '-');
+      return node;
+    }
+
+    function renderNodeCard(card, base, ok, detailText) {
+      const statusRow = el('div', 'flex items-center gap-2 mb-1');
+      statusRow.append(
+        el('span', `inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}`),
+        el('span', `text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}`, ok ? 'UP' : 'DOWN')
+      );
+
+      card.replaceChildren(
+        el('div', 'font-mono text-xs break-all mb-2', base),
+        statusRow,
+        el('div', 'text-xs text-slate-400', detailText)
+      );
+    }
+
+    function renderNodeChecking(card, base) {
+      card.replaceChildren(
+        el('div', 'font-mono text-xs break-all mb-2', base),
+        el('div', 'text-sm', 'Checking...')
+      );
+    }
+
+    function renderArchitectureRow(arch, n, pct) {
+      const row = document.createElement('div');
+      const summary = el('div', 'flex justify-between mb-1');
+      summary.append(el('span', '', arch), el('span', '', `${n} (${pct}%)`));
+
+      const bar = el('div', 'h-2 w-full bg-slate-800 rounded');
+      const fill = el('div', 'h-2 bg-cyan-400 rounded');
+      fill.style.width = `${pct}%`;
+      bar.appendChild(fill);
+
+      row.replaceChildren(summary, bar);
+      return row;
+    }
+
     async function fetchJson(url) {
       const r = await fetch(url, { cache: 'no-store' });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -185,16 +227,26 @@
       const log = document.getElementById('incidentLog');
       const incidents = safeJson(INCIDENT_KEY, []);
       if (!incidents.length) {
-        log.innerHTML = '<div class="text-slate-400 text-sm">No incidents recorded yet.</div>';
+        log.replaceChildren(el('div', 'text-slate-400 text-sm', 'No incidents recorded yet.'));
         return;
       }
-      log.innerHTML = incidents.slice(0, 30).map(i => `
-        <div class="rounded border border-slate-800 bg-slate-950 p-2">
-          <div class="text-xs text-slate-400">${new Date(i.t).toLocaleString()}</div>
-          <div><span class="font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}">${safeText(i.type)}</span> · <span class="font-mono text-xs">${safeText(i.node)}</span></div>
-          <div class="text-sm text-slate-300">${safeText(i.message)}</div>
-        </div>
-      `).join('');
+
+      const rows = incidents.slice(0, 30).map(i => {
+        const row = el('div', 'rounded border border-slate-800 bg-slate-950 p-2');
+        const meta = document.createElement('div');
+        meta.append(
+          el('span', `font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}`, i.type),
+          document.createTextNode(' · '),
+          el('span', 'font-mono text-xs', i.node)
+        );
+        row.replaceChildren(
+          el('div', 'text-xs text-slate-400', new Date(i.t).toLocaleString()),
+          meta,
+          el('div', 'text-sm text-slate-300', i.message)
+        );
+        return row;
+      });
+      log.replaceChildren(...rows);
     }
 
     function escapeXml(s) {
@@ -254,31 +306,17 @@
       await Promise.all(NODE_ENDPOINTS.map(async (base) => {
         const card = document.createElement('div');
         card.className = 'rounded-lg border border-slate-800 bg-slate-950 p-3';
-        card.innerHTML = `<div class="font-mono text-xs break-all mb-2">${safeText(base)}</div><div class="text-sm">Checking...</div>`;
+        renderNodeChecking(card, base);
         grid.appendChild(card);
 
         try {
           const health = await fetchJson(`${base}/health`);
           const ok = !!health.ok;
           recordNodeStatus(base, ok);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}"></span>
-              <span class="text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}">${ok ? 'UP' : 'DOWN'}</span>
-            </div>
-            <div class="text-xs text-slate-400">version: ${safeText(health.version)}</div>
-          `;
+          renderNodeCard(card, base, ok, `version: ${health.version ?? '-'}`);
         } catch (e) {
           recordNodeStatus(base, false);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500"></span>
-              <span class="text-sm font-semibold text-red-300">DOWN</span>
-            </div>
-            <div class="text-xs text-slate-400">${safeText(e.message || e)}</div>
-          `;
+          renderNodeCard(card, base, false, e.message || e);
         }
       }));
     }
@@ -315,12 +353,7 @@
           .sort((a, b) => b[1] - a[1])
           .forEach(([arch, n]) => {
             const pct = Math.round((n / total) * 100);
-            const row = document.createElement('div');
-            row.innerHTML = `
-              <div class="flex justify-between mb-1"><span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span></div>
-              <div class="h-2 w-full bg-slate-800 rounded"><div class="h-2 bg-cyan-400 rounded" style="width:${pct}%"></div></div>
-            `;
-            archList.appendChild(row);
+            archList.appendChild(renderArchitectureRow(arch, n, pct));
           });
       } catch {
         document.getElementById('minerCount').textContent = 'N/A';


### PR DESCRIPTION
﻿## Summary
- Render network status node cards, incident rows, and architecture rows with DOM/text helpers instead of dynamic innerHTML templates.
- Keep docs and website/static network-status pages synchronized.
- Update regression tests to cover both public copies and forbid the old dynamic templates.

## Testing
- python -m pytest -q tests\test_docs_network_status_security.py
- python -m py_compile tests\test_docs_network_status_security.py
- node -e "const fs=require('fs'); for (const file of ['docs/network-status.html','website/static/network-status.html']) { const html=fs.readFileSync(file,'utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); } console.log('scripts ok');"
- git diff --check -- docs\network-status.html website\static\network-status.html tests\test_docs_network_status_security.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7198

wallet: itosa-kazu
