### PR TITLE
Harden governance proposal rendering

### DIFF
--- a/tests/test_governance_frontend_security.py
+++ b/tests/test_governance_frontend_security.py
@@ -1,22 +1,28 @@
 from pathlib import Path
 
 
-def test_governance_page_escapes_proposal_fields_before_inner_html():
+def test_governance_page_renders_proposal_fields_as_text_nodes():
     page = Path(__file__).resolve().parents[1] / "web" / "governance.html"
     html = page.read_text(encoding="utf-8")
 
-    assert "function escapeHtml(value)" in html
     assert "function safeNumber(value, fallback=0)" in html
-    assert "<b>#${safeNumber(p.id)} ${escapeHtml(p.title)}</b>" in html
-    assert "${escapeHtml(p.proposer_wallet)}" in html
-    assert "${escapeHtml(p.status)}" in html
-    assert "${escapeHtml(p.description)}" in html
-    assert "yes=${safeNumber(p.yes_weight).toFixed(4)}" in html
-    assert "no=${safeNumber(p.no_weight).toFixed(4)}" in html
+    assert "function text(value)" in html
+    assert "function renderProposalCard(p)" in html
+    assert "title.textContent = `#${safeNumber(p.id)} ${p.title ?? ''}`;" in html
+    assert "meta.textContent = `${p.proposer_wallet ?? ''} • ${p.status ?? ''}`;" in html
+    assert "text(p.description)" in html
+    assert "text(`yes=${safeNumber(p.yes_weight).toFixed(4)} `)" in html
+    assert "text(`no=${safeNumber(p.no_weight).toFixed(4)} `)" in html
+    assert "text(`abstain=${safeNumber(p.abstain_weight).toFixed(4)}`)" in html
+    assert "list.replaceChildren();" in html
+    assert "list.appendChild(renderProposalCard(p));" in html
 
+    assert "innerHTML" not in html
     assert "<b>#${p.id} ${p.title}</b>" not in html
+    assert "<b>#${safeNumber(p.id)} ${escapeHtml(p.title)}</b>" not in html
     assert "${p.proposer_wallet}" not in html
     assert "${p.status}" not in html
     assert "${p.description}<br>" not in html
+    assert "${escapeHtml(p.description)}" not in html
     assert "yes=${(p.yes_weight||0).toFixed(4)}" not in html
     assert "no=${(p.no_weight||0).toFixed(4)}" not in html

--- a/web/governance.html
+++ b/web/governance.html
@@ -59,14 +59,39 @@
 <script>
 const out = document.getElementById('out');
 function show(v){ out.textContent = JSON.stringify(v, null, 2); }
-function escapeHtml(value){
-  const div = document.createElement('div');
-  div.textContent = String(value ?? '');
-  return div.innerHTML;
-}
 function safeNumber(value, fallback=0){
   const number = Number(value);
   return Number.isFinite(number) ? number : fallback;
+}
+function text(value){
+  return document.createTextNode(String(value ?? ''));
+}
+function br(){
+  return document.createElement('br');
+}
+function renderProposalCard(p){
+  const div = document.createElement('div');
+  div.className = 'card';
+
+  const title = document.createElement('b');
+  title.textContent = `#${safeNumber(p.id)} ${p.title ?? ''}`;
+
+  const meta = document.createElement('span');
+  meta.className = 'muted';
+  meta.textContent = `${p.proposer_wallet ?? ''} • ${p.status ?? ''}`;
+
+  div.append(
+    title,
+    br(),
+    meta,
+    br(),
+    text(p.description),
+    br(),
+    text(`yes=${safeNumber(p.yes_weight).toFixed(4)} `),
+    text(`no=${safeNumber(p.no_weight).toFixed(4)} `),
+    text(`abstain=${safeNumber(p.abstain_weight).toFixed(4)}`)
+  );
+  return div;
 }
 
 async function api(path, method='GET', body=null){
@@ -110,21 +135,13 @@ async function submitVote(){
 async function loadProposals(){
   const data = await api('/api/governance/proposals');
   const list = document.getElementById('list');
-  list.innerHTML = '';
+  list.replaceChildren();
   for (const p of (data.proposals || [])) {
     p.proposer_wallet = p.proposed_by ?? p.proposer_wallet;
     p.yes_weight = p.votes_for ?? p.yes_weight;
     p.no_weight = p.votes_against ?? p.no_weight;
     p.abstain_weight = p.votes_abstain ?? p.abstain_weight;
-    const div = document.createElement('div');
-    div.className = 'card';
-    div.innerHTML = `<b>#${safeNumber(p.id)} ${escapeHtml(p.title)}</b><br>
-      <span class="muted">${escapeHtml(p.proposer_wallet)} • ${escapeHtml(p.status)}</span><br>
-      ${escapeHtml(p.description)}<br>
-      yes=${safeNumber(p.yes_weight).toFixed(4)}
-      no=${safeNumber(p.no_weight).toFixed(4)}
-      abstain=${safeNumber(p.abstain_weight).toFixed(4)}`;
-    list.appendChild(div);
+    list.appendChild(renderProposalCard(p));
   }
 }
 loadProposals();


### PR DESCRIPTION
﻿## Summary
- Render governance proposal cards with DOM/text helpers instead of dynamic innerHTML templates.
- Keep proposal title, proposer/status, description, and vote tallies out of HTML parser sinks.
- Update the focused frontend regression test to forbid the old proposal innerHTML template.

## Testing
- python -m pytest -q tests\test_governance_frontend_security.py tests\test_governance_ui_contract.py
- python -m py_compile tests\test_governance_frontend_security.py tests\test_governance_ui_contract.py
- node -e "const fs=require('fs'); const html=fs.readFileSync('web/governance.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok');"
- git diff --check -- web\governance.html tests\test_governance_frontend_security.py tests\test_governance_ui_contract.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7200

wallet: itosa-kazu
