### PR TITLE
Escape bridge dashboard transaction fields

### DIFF
--- a/tools/wrtc-bridge-dashboard/bridge_dashboard.js
+++ b/tools/wrtc-bridge-dashboard/bridge_dashboard.js
@@ -116,11 +116,30 @@ function demoData() {
 // ── UI Updates ──────────────────────────────────────────────────
 
 function fmt(n, decimals = 0) {
-  if (n === null || n === undefined) return "—";
-  return n.toLocaleString("en-US", { 
+  const value = Number(n);
+  if (!Number.isFinite(value)) return "—";
+  return value.toLocaleString("en-US", {
     minimumFractionDigits: decimals, 
     maximumFractionDigits: decimals 
   });
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function safeBridgeType(value) {
+  return value === "wrap" ? "wrap" : "unwrap";
+}
+
+function shortTx(value) {
+  const text = String(value ?? "");
+  return text ? `${text.slice(0, 8)}…` : "—";
 }
 
 function timeAgo(iso) {
@@ -162,14 +181,17 @@ function updateHealth(data) {
 
 function updateTxTable(id, txs) {
   const tbody = document.getElementById(id);
-  tbody.innerHTML = txs.map(tx => `
+  tbody.innerHTML = txs.map(tx => {
+    const bridgeType = safeBridgeType(tx.type);
+    return `
     <tr>
-      <td>${timeAgo(tx.time)}</td>
-      <td class="amount">${fmt(tx.amount)} ${tx.type === "wrap" ? "RTC" : "wRTC"}</td>
-      <td class="mono">${tx.wallet}</td>
-      <td class="mono">${tx.tx.slice(0, 8)}…</td>
+      <td>${escapeHtml(timeAgo(tx.time))}</td>
+      <td class="amount">${escapeHtml(fmt(tx.amount))} ${bridgeType === "wrap" ? "RTC" : "wRTC"}</td>
+      <td class="mono">${escapeHtml(tx.wallet)}</td>
+      <td class="mono">${escapeHtml(shortTx(tx.tx))}</td>
     </tr>
-  `).join("");
+  `;
+  }).join("");
 }
 
 function updateChart(history) {

--- a/tools/wrtc-bridge-dashboard/test_bridge_dashboard.py
+++ b/tools/wrtc-bridge-dashboard/test_bridge_dashboard.py
@@ -7,7 +7,10 @@ Run: python -m pytest tools/wrtc-bridge-dashboard/test_bridge_dashboard.py -v
 
 import os
 import re
+import subprocess
+import tempfile
 import unittest
+from pathlib import Path
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
@@ -111,6 +114,65 @@ class TestJSStructure(unittest.TestCase):
     def test_price_change_color(self):
         self.assertIn("#22c55e", self.js)  # green for positive
         self.assertIn("#ef4444", self.js)  # red for negative
+
+    def test_transaction_fields_are_escaped_before_inner_html(self):
+        self.assertIn("function escapeHtml(value)", self.js)
+        self.assertIn("function safeBridgeType(value)", self.js)
+        self.assertIn("function shortTx(value)", self.js)
+        self.assertIn("${escapeHtml(tx.wallet)}", self.js)
+        self.assertIn("${escapeHtml(shortTx(tx.tx))}", self.js)
+        self.assertIn("${escapeHtml(fmt(tx.amount))}", self.js)
+        self.assertNotIn("${tx.wallet}", self.js)
+        self.assertNotIn("${tx.tx.slice(0, 8)}", self.js)
+
+    def test_update_tx_table_escapes_malicious_transaction_rows(self):
+        js_path = Path(HERE) / "bridge_dashboard.js"
+        probe = f"""
+const fs = require("fs");
+const vm = require("vm");
+let script = fs.readFileSync({str(js_path)!r}, "utf8");
+script = script.replace(/\\nrefresh\\(\\);\\nsetInterval\\(refresh, REFRESH_MS\\);\\s*$/, "");
+const elements = {{
+  "wrap-table": {{ innerHTML: "" }}
+}};
+const context = {{
+  document: {{ getElementById: id => elements[id] || (elements[id] = {{ innerHTML: "", textContent: "", style: {{}}, setAttribute() {{}} }}) }},
+  Date,
+  Math,
+  console,
+  fetch() {{ throw new Error("network disabled in test"); }},
+  setInterval() {{}}
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+vm.runInContext(`
+  updateTxTable("wrap-table", [{{
+    time: new Date().toISOString(),
+    amount: "<img src=x>",
+    wallet: "<img src=x onerror=alert(1)>",
+    tx: "<script>alert(2)</script>",
+    type: "<b>bad</b>"
+  }}]);
+`, context);
+console.log(elements["wrap-table"].innerHTML);
+"""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            probe_path = Path(tmpdir) / "probe.js"
+            probe_path.write_text(probe, encoding="utf-8")
+            result = subprocess.run(
+                ["node", str(probe_path)],
+                text=True,
+                encoding="utf-8",
+                capture_output=True,
+                check=True,
+            )
+
+        html = result.stdout
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", html)
+        self.assertIn("&lt;script&gt;", html)
+        self.assertIn("wRTC", html)
+        self.assertNotIn("<img src=x onerror=alert(1)>", html)
+        self.assertNotIn("<script>alert(2)</script>", html)
 
 
 class TestStaticDeploy(unittest.TestCase):


### PR DESCRIPTION
﻿## Summary
- Escape wallet and transaction id fields before rendering bridge transactions through the table innerHTML template.
- Normalize transaction amount and bridge type before display so unexpected row values cannot affect the rendered unit/type branch.
- Add a Node VM regression test for malicious wallet/tx strings in updateTxTable.

## Testing
- python -m pytest -q tools\wrtc-bridge-dashboard\test_bridge_dashboard.py
- node --check tools\wrtc-bridge-dashboard\bridge_dashboard.js
- python -m py_compile tools\wrtc-bridge-dashboard\test_bridge_dashboard.py
- git diff --check -- tools\wrtc-bridge-dashboard\bridge_dashboard.js tools\wrtc-bridge-dashboard\test_bridge_dashboard.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7129

wallet: itosa-kazu
