### PR TITLE
Neutralize spreadsheet formulas in CSV exports

### DIFF
--- a/rustchain_export.py
+++ b/rustchain_export.py
@@ -296,6 +296,23 @@ DEFAULT_HEADERS = {
     "ledger": ["ts", "epoch", "miner_id", "delta_i64", "reason"],
 }
 
+CSV_FORMULA_PREFIXES = ("=", "+", "-", "@")
+CSV_IGNORABLE_PREFIX_CHARS = "".join(chr(codepoint) for codepoint in range(0x21))
+
+
+def neutralize_csv_cell(value: Any) -> Any:
+    """Prefix spreadsheet formula-like text cells for CSV consumers."""
+    if not isinstance(value, str):
+        return value
+    first_significant = value.lstrip(CSV_IGNORABLE_PREFIX_CHARS)
+    if first_significant.startswith(CSV_FORMULA_PREFIXES):
+        return f"'{value}"
+    return value
+
+
+def neutralize_csv_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {key: neutralize_csv_cell(value) for key, value in row.items()}
+
 
 def write_csv(path: Path, rows: list[dict[str, Any]], default_headers: list[str] | None = None) -> None:
     if rows:
@@ -306,7 +323,7 @@ def write_csv(path: Path, rows: list[dict[str, Any]], default_headers: list[str]
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         if fieldnames:
             writer.writeheader()
-        writer.writerows(rows)
+        writer.writerows(neutralize_csv_row(row) for row in rows)
 
 
 def write_json(path: Path, rows: list[dict[str, Any]]) -> None:

--- a/tests/test_rustchain_export.py
+++ b/tests/test_rustchain_export.py
@@ -150,6 +150,51 @@ class RustChainExportTests(unittest.TestCase):
             exporter.write_csv(path, [], ["col1", "col2"])
             self.assertEqual(path.read_text(encoding="utf-8").strip(), "col1,col2")
 
+    def test_write_csv_neutralizes_spreadsheet_formula_cells(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "miners.csv"
+            exporter.write_csv(
+                path,
+                [
+                    {
+                        "miner_id": "=cmd|' /C calc'!A0",
+                        "device_arch": "+SUM(1,1)",
+                        "hardware_type": "\t@IMPORTXML('https://example.test')",
+                        "reason": "  -10",
+                        "safe_note": "PowerPC G4",
+                        "entropy_score": 0.5,
+                    }
+                ],
+            )
+
+            with path.open(newline="", encoding="utf-8") as handle:
+                row = next(csv.DictReader(handle))
+
+            self.assertEqual(row["miner_id"], "'=cmd|' /C calc'!A0")
+            self.assertEqual(row["device_arch"], "'+SUM(1,1)")
+            self.assertEqual(row["hardware_type"], "'\t@IMPORTXML('https://example.test')")
+            self.assertEqual(row["reason"], "'  -10")
+            self.assertEqual(row["safe_note"], "PowerPC G4")
+            self.assertEqual(row["entropy_score"], "0.5")
+
+    def test_json_and_jsonl_exports_preserve_formula_like_values(self):
+        rows = [{"miner_id": "=alice", "device_arch": "\t@bad"}]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            json_path = tmp_path / "miners.json"
+            jsonl_path = tmp_path / "miners.jsonl"
+
+            exporter.write_json(json_path, rows)
+            exporter.write_jsonl(jsonl_path, rows)
+
+            self.assertEqual(json.loads(json_path.read_text(encoding="utf-8")), rows)
+            jsonl_rows = [
+                json.loads(line)
+                for line in jsonl_path.read_text(encoding="utf-8").splitlines()
+            ]
+            self.assertEqual(jsonl_rows, rows)
+
     def test_balance_amount_normalizes_micro_columns_by_source(self):
         self.assertEqual(exporter.balance_amount_rtc({"amount_i64": 1}), 0.000001)
         self.assertEqual(exporter.balance_amount_rtc({"amount_i64": 500_000}), 0.5)


### PR DESCRIPTION
﻿## Summary
- Neutralize spreadsheet formula-like string cells in RustChain CSV exports by prefixing risky values with a single quote.
- Treat leading whitespace/control-prefixed formula markers as risky while leaving non-string values unchanged.
- Add regression coverage proving CSV is neutralized and JSON/JSONL preserve raw values.

## Testing
- python -m pytest -q tests\test_rustchain_export.py
- python -m py_compile rustchain_export.py tests\test_rustchain_export.py
- git diff --check -- rustchain_export.py tests\test_rustchain_export.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7224

Clean alternative to #7225: this PR only touches rustchain_export.py and tests/test_rustchain_export.py.

wallet: itosa-kazu
