### PR TITLE
Require API key for BoTTube mood signals

### DIFF
--- a/bottube_mood_engine.py
+++ b/bottube_mood_engine.py
@@ -46,6 +46,7 @@ import os
 import json
 import random
 import logging
+import hmac
 from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional, Tuple
 from dataclasses import dataclass, field
@@ -916,6 +917,7 @@ class MoodEngine:
 
 
 mood_bp = Blueprint("bottube_mood", __name__, url_prefix="/api/v1/agents")
+MOOD_SIGNAL_API_KEY_ENV = "BOTTUBE_MOOD_SIGNAL_API_KEY"
 
 
 def get_mood_engine() -> MoodEngine:
@@ -923,6 +925,37 @@ def get_mood_engine() -> MoodEngine:
     from flask import current_app
     db_path = current_app.config.get("DB_PATH", "rustchain.db")
     return MoodEngine(db_path=db_path)
+
+
+def _configured_mood_signal_api_key() -> str:
+    from flask import current_app
+    configured = current_app.config.get(MOOD_SIGNAL_API_KEY_ENV, os.environ.get(MOOD_SIGNAL_API_KEY_ENV, ""))
+    if not isinstance(configured, str):
+        return ""
+    return configured.strip()
+
+
+def _provided_mood_signal_api_key() -> str:
+    authorization = request.headers.get("Authorization", "")
+    if authorization.lower().startswith("bearer "):
+        return authorization[7:].strip()
+    return (
+        request.headers.get("X-Mood-Signal-Key")
+        or request.headers.get("X-API-Key")
+        or ""
+    ).strip()
+
+
+def _require_mood_signal_api_key():
+    expected = _configured_mood_signal_api_key()
+    if not expected:
+        return jsonify({"error": f"{MOOD_SIGNAL_API_KEY_ENV} not configured"}), 503
+
+    provided = _provided_mood_signal_api_key()
+    if not provided or not hmac.compare_digest(provided, expected):
+        return jsonify({"error": "Unauthorized"}), 401
+
+    return None
 
 
 def _get_json_object(allow_empty: bool = False):
@@ -994,6 +1027,10 @@ def record_mood_signal(agent_name: str):
         value - Signal value data
         weight - Optional signal weight (default: 1.0)
     """
+    auth_error = _require_mood_signal_api_key()
+    if auth_error:
+        return auth_error
+
     try:
         engine = get_mood_engine()
         data, error = _get_json_object()

--- a/tests/test_bottube_mood.py
+++ b/tests/test_bottube_mood.py
@@ -565,8 +565,10 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
         app = Flask(__name__)
         app.config["TESTING"] = True
         app.config["DB_PATH"] = self.temp_db.name
+        app.config["BOTTUBE_MOOD_SIGNAL_API_KEY"] = "test-mood-signal-key"
         app.register_blueprint(mood_bp)
         self.client = app.test_client()
+        self.mood_signal_headers = {"X-Mood-Signal-Key": "test-mood-signal-key"}
 
     def tearDown(self):
         try:
@@ -583,7 +585,10 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
 
         for endpoint in endpoints:
             with self.subTest(endpoint=endpoint):
-                response = self.client.post(endpoint, json=["not", "an", "object"])
+                kwargs = {"json": ["not", "an", "object"]}
+                if endpoint.endswith("/mood/signal"):
+                    kwargs["headers"] = self.mood_signal_headers
+                response = self.client.post(endpoint, **kwargs)
 
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
@@ -600,10 +605,15 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
 
         for endpoint in endpoints:
             with self.subTest(endpoint=endpoint):
+                kwargs = {
+                    "data": "{",
+                    "content_type": "application/json",
+                }
+                if endpoint.endswith("/mood/signal"):
+                    kwargs["headers"] = self.mood_signal_headers
                 response = self.client.post(
                     endpoint,
-                    data="{",
-                    content_type="application/json",
+                    **kwargs,
                 )
 
                 self.assertEqual(response.status_code, 400)
@@ -620,7 +630,10 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
 
         for endpoint in endpoints:
             with self.subTest(endpoint=endpoint):
-                response = self.client.post(endpoint)
+                kwargs = {}
+                if endpoint.endswith("/mood/signal"):
+                    kwargs["headers"] = self.mood_signal_headers
+                response = self.client.post(endpoint, **kwargs)
 
                 self.assertEqual(response.status_code, 400)
                 self.assertEqual(
@@ -657,7 +670,10 @@ class TestMoodBlueprintJsonValidation(unittest.TestCase):
             (
                 "post",
                 "/api/v1/agents/test-agent/mood/signal",
-                {"json": {"signal_type": "video_views", "value": {"views": 1}}},
+                {
+                    "headers": self.mood_signal_headers,
+                    "json": {"signal_type": "video_views", "value": {"views": 1}},
+                },
             ),
             (
                 "post",

--- a/tests/test_bottube_mood_routes.py
+++ b/tests/test_bottube_mood_routes.py
@@ -6,6 +6,9 @@ from flask import Flask
 
 import bottube_mood_engine as mood
 
+MOOD_SIGNAL_KEY = "test-mood-signal-key"
+MOOD_SIGNAL_HEADERS = {"X-Mood-Signal-Key": MOOD_SIGNAL_KEY}
+
 
 @pytest.fixture
 def client():
@@ -13,6 +16,7 @@ def client():
     db_file = tempfile.NamedTemporaryFile(delete=True)
     db_file.close()
     app.config["DB_PATH"] = db_file.name
+    app.config[mood.MOOD_SIGNAL_API_KEY_ENV] = MOOD_SIGNAL_KEY
     app.register_blueprint(mood.mood_bp)
     return app.test_client()
 
@@ -28,6 +32,7 @@ def client():
 def test_mood_signal_rejects_non_numeric_weight(client, weight, error):
     response = client.post(
         "/api/v1/agents/bot/mood/signal",
+        headers=MOOD_SIGNAL_HEADERS,
         json={
             "signal_type": "video_views",
             "value": {"views": 1},
@@ -42,11 +47,60 @@ def test_mood_signal_rejects_non_numeric_weight(client, weight, error):
 def test_mood_signal_accepts_numeric_weight(client):
     response = client.post(
         "/api/v1/agents/bot/mood/signal",
+        headers=MOOD_SIGNAL_HEADERS,
         json={
             "signal_type": "video_views",
             "value": {"views": 1},
             "weight": 0.5,
         },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["agent_id"] == "bot"
+
+
+def test_mood_signal_fails_closed_when_api_key_unconfigured(monkeypatch):
+    monkeypatch.delenv(mood.MOOD_SIGNAL_API_KEY_ENV, raising=False)
+    app = Flask(__name__)
+    db_file = tempfile.NamedTemporaryFile(delete=True)
+    db_file.close()
+    app.config["DB_PATH"] = db_file.name
+    app.register_blueprint(mood.mood_bp)
+
+    response = app.test_client().post(
+        "/api/v1/agents/bot/mood/signal",
+        json={"signal_type": "video_views", "value": {"views": 1}},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": f"{mood.MOOD_SIGNAL_API_KEY_ENV} not configured"}
+
+
+@pytest.mark.parametrize(
+    "headers",
+    (
+        {},
+        {"X-Mood-Signal-Key": "wrong-key"},
+        {"X-API-Key": "wrong-key"},
+        {"Authorization": "Bearer wrong-key"},
+    ),
+)
+def test_mood_signal_rejects_missing_or_wrong_api_key(client, headers):
+    response = client.post(
+        "/api/v1/agents/bot/mood/signal",
+        headers=headers,
+        json={"signal_type": "video_views", "value": {"views": 1}},
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "Unauthorized"}
+
+
+def test_mood_signal_accepts_bearer_api_key(client):
+    response = client.post(
+        "/api/v1/agents/bot/mood/signal",
+        headers={"Authorization": f"Bearer {MOOD_SIGNAL_KEY}"},
+        json={"signal_type": "video_views", "value": {"views": 1}},
     )
 
     assert response.status_code == 200


### PR DESCRIPTION
﻿## Summary
- Require a configured BoTTube mood signal API key before accepting /mood/signal writes.
- Fail closed when BOTTUBE_MOOD_SIGNAL_API_KEY is unset, and reject missing/wrong X-Mood-Signal-Key, X-API-Key, or Bearer tokens with constant-time comparison.
- Update focused mood route tests so authorized writes still validate JSON/weights and unauthorized writes cannot mutate mood state.

## Testing
- python -m pytest -q tests\test_bottube_mood_routes.py tests\test_bottube_mood.py
- python -m py_compile bottube_mood_engine.py tests\test_bottube_mood_routes.py tests\test_bottube_mood.py
- git diff --check -- bottube_mood_engine.py tests\test_bottube_mood_routes.py tests\test_bottube_mood.py
- python tools\bcos_spdx_check.py --base-ref origin/main

Fixes #7241

Clean alternative to #7242: this PR only touches bottube_mood_engine.py and the focused mood tests.

wallet: itosa-kazu
