### PR TITLE
fix(wallet): reject normalized miner ids in balance lookup

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -8743,8 +8743,18 @@ def api_rewards_epoch(epoch: int):
 @app.route('/wallet/balance', methods=['GET'])
 def api_wallet_balance():
     """Get balance for a specific miner"""
-    miner_id = request.args.get("miner_id", "").strip()
-    address = request.args.get("address", "").strip()
+    raw_miner_id = request.args.get("miner_id")
+    raw_address = request.args.get("address")
+    miner_id = _validated_wallet_query_id(raw_miner_id)
+    address = _validated_wallet_query_id(raw_address)
+    miner_id_supplied = raw_miner_id is not None and raw_miner_id != ""
+    address_supplied = raw_address is not None and raw_address != ""
+
+    if miner_id_supplied and not miner_id:
+        return jsonify({"ok": False, "error": "invalid miner_id"}), 400
+
+    if address_supplied and not address:
+        return jsonify({"ok": False, "error": "invalid miner_id"}), 400
 
     if miner_id and address and miner_id != address:
         return jsonify({
@@ -8782,6 +8792,17 @@ def api_wallet_balance():
 _API_WALLET_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,80}$")
 
 
+def _validated_wallet_query_id(raw_value):
+    """Return a wallet query identifier only if it is already canonical."""
+    if not isinstance(raw_value, str):
+        return ""
+    if raw_value != raw_value.strip():
+        return ""
+    if not _API_WALLET_ID_RE.match(raw_value):
+        return ""
+    return raw_value
+
+
 # NOTE: any future *static* route under /api/wallet/ (e.g. /api/wallet/list)
 # must be declared BEFORE this variable rule or Werkzeug will capture it here.
 @app.route('/api/wallet/<miner_id>', methods=['GET'])
@@ -8796,8 +8817,8 @@ def api_wallet_lookup(miner_id):
     exposes no data that was not already reachable. Malformed ids return 400
     (not a zero balance) so the prefix still distinguishes bad input.
     """
-    miner_id = (miner_id or "").strip()
-    if not _API_WALLET_ID_RE.match(miner_id):
+    miner_id = _validated_wallet_query_id(miner_id)
+    if not miner_id:
         return jsonify({"ok": False, "error": "invalid miner_id"}), 400
     try:
         with sqlite3.connect(DB_PATH) as db:

--- a/tests/test_wallet_balance_query_validation_7117.py
+++ b/tests/test_wallet_balance_query_validation_7117.py
@@ -1,0 +1,55 @@
+import sqlite3
+import sys
+
+import pytest
+
+integrated_node = sys.modules["integrated_node"]
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    db_path = tmp_path / "wallets.db"
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "CREATE TABLE balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER NOT NULL)"
+        )
+        db.execute(
+            "INSERT INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("still_worthy", 809610),
+        )
+        db.commit()
+
+    monkeypatch.setattr(integrated_node, "DB_PATH", str(db_path), raising=False)
+    monkeypatch.setitem(
+        integrated_node.api_wallet_balance.__globals__,
+        "DB_PATH",
+        str(db_path),
+    )
+    integrated_node.app.config["TESTING"] = True
+    with integrated_node.app.test_client() as test_client:
+        yield test_client
+
+
+def test_wallet_balance_rejects_whitespace_wrapped_miner_id(client):
+    response = client.get("/wallet/balance?miner_id=%20still_worthy")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid miner_id"}
+
+
+def test_wallet_balance_rejects_wildcard_miner_id(client):
+    response = client.get("/wallet/balance?miner_id=*")
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False, "error": "invalid miner_id"}
+
+
+def test_wallet_balance_keeps_canonical_identifier_unchanged(client):
+    response = client.get("/wallet/balance?miner_id=still_worthy")
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "miner_id": "still_worthy",
+        "amount_i64": 809610,
+        "amount_rtc": 0.80961,
+    }


### PR DESCRIPTION
## Summary
- reject non-canonical miner_id and ddress query values on /wallet/balance
- align query validation with the conservative wallet identifier grammar already used by /api/wallet/<miner_id>
- add regression coverage for whitespace, wildcard, and canonical identifier cases

## Testing
- python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_wallet_balance_query_validation_7117.py
- full python -m pytest tests/test_wallet_balance_query_validation_7117.py -q is blocked locally because this checkout does not currently have lask installed

Fixes #7117

/opire try