### PR TITLE
fix: correct column selection in _find_balance_row (closes #305)

### DIFF
--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -89,10 +89,10 @@ def _find_balance_row(conn, miner_id):
 
     if "miner_pk" in columns:
         row = conn.execute(
-            "SELECT miner_pk FROM balances WHERE miner_pk = ?", (miner_id,)
+            "SELECT balance FROM balances WHERE miner_pk = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_pk"
+            return row[0], "balance"
 
     return None, None
 


### PR DESCRIPTION
## What
In `_find_balance_row`, the query selects `miner_pk` instead of `balance` when a matching row is found by `miner_pk`. This returns the miner's public key rather than their actual balance, causing incorrect balance reports.

## Fix
Changed the SELECT clause from `SELECT miner_pk` to `SELECT balance` and updated the returned column label to "balance".

Closes #305