### PR TITLE
ops: rescue ledger dashboard + payment reconciler (unpushed April work)

### DIFF
--- a/scripts/ledger_dashboard.py
+++ b/scripts/ledger_dashboard.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""
+RustChain Ledger Dashboard
+============================
+Queries the RustChain VPS and displays a live dashboard of ledger health,
+balances, recent transfers, and supply breakdown.
+
+Usage:
+    # Via SSH to VPS (default):
+    python3 ledger_dashboard.py
+
+    # With explicit credentials:
+    python3 ledger_dashboard.py --ssh-host 50.28.86.131 --ssh-user root --ssh-pass PASS
+
+    # With local DB copy:
+    python3 ledger_dashboard.py --db-path /path/to/rustchain_v2.db
+
+    # JSON output:
+    python3 ledger_dashboard.py --json
+
+Environment variables:
+    RC_SSH_HOST     VPS hostname (default: 50.28.86.131)
+    RC_SSH_USER     VPS SSH user (default: root)
+    RC_SSH_PASS     VPS SSH password
+    RC_DB_PATH      Local path to rustchain_v2.db
+"""
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MICRO_RTC = 1_000_000
+
+FOUNDER_WALLETS = {
+    "founder_community",
+    "founder_dev_fund",
+    "founder_founders",
+    "founder_team_bounty",
+}
+
+SYSTEM_WALLETS = {
+    "airdrop_pool",
+    "bottube_platform",
+    "team_bounty",
+    "premine_completion",
+}
+
+
+# ---------------------------------------------------------------------------
+# SSH query helper
+# ---------------------------------------------------------------------------
+
+def ssh_query(sql: str, ssh_host: str, ssh_user: str, ssh_pass: str,
+              db_path: str = "/root/rustchain/rustchain_v2.db") -> str:
+    """Run a SQLite query on the remote VPS via SSH and return raw output."""
+    # Escape single quotes in SQL for the shell
+    escaped_sql = sql.replace("'", "'\\''")
+    cmd = [
+        "sshpass", "-p", ssh_pass,
+        "ssh", "-o", "StrictHostKeyChecking=no",
+        "-o", "ConnectTimeout=10",
+        f"{ssh_user}@{ssh_host}",
+        f"sqlite3 -separator '|' {db_path} '{escaped_sql}'",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(f"SSH query failed: {result.stderr[:200]}")
+    return result.stdout.strip()
+
+
+def local_query(conn: sqlite3.Connection, sql: str) -> list[tuple]:
+    """Run a query against a local SQLite connection."""
+    cur = conn.cursor()
+    cur.execute(sql)
+    return cur.fetchall()
+
+
+class LedgerDashboard:
+    """Queries the RustChain ledger and generates a dashboard."""
+
+    def __init__(self, mode: str = "ssh", **kwargs):
+        self.mode = mode
+        self.ssh_host = kwargs.get("ssh_host", "50.28.86.131")
+        self.ssh_user = kwargs.get("ssh_user", "root")
+        self.ssh_pass = kwargs.get("ssh_pass", "")
+        self.conn = kwargs.get("conn", None)
+        self.data: dict[str, Any] = {}
+
+    def query(self, sql: str) -> list[list[str]]:
+        """Run a query and return rows as lists of strings."""
+        if self.mode == "local" and self.conn:
+            rows = local_query(self.conn, sql)
+            return [list(map(str, r)) for r in rows]
+        else:
+            raw = ssh_query(sql, self.ssh_host, self.ssh_user, self.ssh_pass)
+            if not raw:
+                return []
+            return [line.split("|") for line in raw.split("\n") if line]
+
+    def collect_all(self) -> dict:
+        """Collect all dashboard data."""
+        self.data["generated_at"] = datetime.now(timezone.utc).isoformat()
+        self.data["top_balances"] = self._top_balances()
+        self.data["recent_transfers"] = self._recent_transfers()
+        self.data["pending_transfers"] = self._pending_transfers()
+        self.data["supply_breakdown"] = self._supply_breakdown()
+        self.data["health"] = self._health_checks()
+        self.data["mining_stats"] = self._mining_stats()
+        self.data["ledger_stats"] = self._ledger_stats()
+        return self.data
+
+    def _top_balances(self) -> list[dict]:
+        rows = self.query(
+            "SELECT miner_id, amount_i64 FROM balances "
+            "WHERE amount_i64 > 0 ORDER BY amount_i64 DESC LIMIT 30"
+        )
+        return [
+            {"wallet": r[0], "balance_rtc": round(int(r[1]) / MICRO_RTC, 6)}
+            for r in rows
+        ]
+
+    def _recent_transfers(self) -> list[dict]:
+        cutoff = int(time.time()) - 86400  # last 24h
+        rows = self.query(
+            f"SELECT id, ts, miner_id, delta_i64, reason FROM ledger "
+            f"WHERE ts > {cutoff} ORDER BY ts DESC LIMIT 50"
+        )
+        transfers = []
+        for r in rows:
+            try:
+                transfers.append({
+                    "id": int(r[0]),
+                    "timestamp": datetime.fromtimestamp(int(r[1]), tz=timezone.utc).isoformat(),
+                    "wallet": r[2],
+                    "amount_rtc": round(int(r[3]) / MICRO_RTC, 6),
+                    "reason": r[4] if len(r) > 4 else "",
+                })
+            except (ValueError, IndexError):
+                continue
+        return transfers
+
+    def _pending_transfers(self) -> list[dict]:
+        rows = self.query(
+            "SELECT id, from_miner, to_miner, amount_i64, reason, status, "
+            "datetime(created_at, 'unixepoch'), datetime(confirms_at, 'unixepoch') "
+            "FROM pending_ledger WHERE status = 'pending' "
+            "ORDER BY created_at DESC LIMIT 30"
+        )
+        return [
+            {
+                "id": int(r[0]),
+                "from": r[1],
+                "to": r[2],
+                "amount_rtc": round(int(r[3]) / MICRO_RTC, 6),
+                "reason": r[4] if len(r) > 4 else "",
+                "status": r[5] if len(r) > 5 else "",
+                "created_at": r[6] if len(r) > 6 else "",
+                "confirms_at": r[7] if len(r) > 7 else "",
+            }
+            for r in rows
+        ]
+
+    def _supply_breakdown(self) -> dict:
+        # Total supply from all balances
+        rows = self.query("SELECT SUM(amount_i64) FROM balances")
+        total_supply = int(rows[0][0]) / MICRO_RTC if rows and rows[0][0] else 0
+
+        # Founder wallets
+        founder_total = 0.0
+        founder_detail = {}
+        for fw in FOUNDER_WALLETS:
+            rows = self.query(
+                f"SELECT amount_i64 FROM balances WHERE miner_id = '{fw}'"
+            )
+            bal = int(rows[0][0]) / MICRO_RTC if rows and rows[0] and rows[0][0] else 0
+            founder_detail[fw] = round(bal, 6)
+            founder_total += bal
+
+        # System wallets
+        system_total = 0.0
+        system_detail = {}
+        for sw in SYSTEM_WALLETS:
+            rows = self.query(
+                f"SELECT amount_i64 FROM balances WHERE miner_id = '{sw}'"
+            )
+            bal = int(rows[0][0]) / MICRO_RTC if rows and rows[0] and rows[0][0] else 0
+            system_detail[sw] = round(bal, 6)
+            system_total += bal
+
+        # Mining rewards (epoch_rewards total)
+        rows = self.query("SELECT SUM(share_i64) FROM epoch_rewards")
+        mining_total = int(rows[0][0]) / MICRO_RTC if rows and rows[0][0] else 0
+
+        distributed = total_supply - founder_total - system_total
+
+        return {
+            "total_supply_rtc": round(total_supply, 2),
+            "founder_wallets_rtc": round(founder_total, 2),
+            "founder_detail": founder_detail,
+            "system_wallets_rtc": round(system_total, 2),
+            "system_detail": system_detail,
+            "distributed_rtc": round(distributed, 2),
+            "mining_rewards_cumulative_rtc": round(mining_total, 2),
+        }
+
+    def _health_checks(self) -> dict:
+        """Verify ledger integrity: SUM(ledger.delta_i64) should equal SUM(balances.amount_i64)."""
+        # Sum of all ledger deltas
+        rows = self.query("SELECT SUM(delta_i64) FROM ledger")
+        ledger_sum = int(rows[0][0]) if rows and rows[0][0] else 0
+
+        # Sum of all balances
+        rows = self.query("SELECT SUM(amount_i64) FROM balances")
+        balance_sum = int(rows[0][0]) if rows and rows[0][0] else 0
+
+        diff = ledger_sum - balance_sum
+        ledger_ok = abs(diff) < MICRO_RTC  # within 1 RTC tolerance
+
+        # Check for negative balances (should be impossible with CHECK constraint)
+        rows = self.query(
+            "SELECT COUNT(*) FROM balances WHERE amount_i64 < 0"
+        )
+        negative_count = int(rows[0][0]) if rows else 0
+
+        # Ledger row count
+        rows = self.query("SELECT COUNT(*) FROM ledger")
+        ledger_rows = int(rows[0][0]) if rows else 0
+
+        # Unique wallets
+        rows = self.query("SELECT COUNT(DISTINCT miner_id) FROM balances WHERE amount_i64 > 0")
+        active_wallets = int(rows[0][0]) if rows else 0
+
+        # Pending count
+        rows = self.query("SELECT COUNT(*) FROM pending_ledger WHERE status = 'pending'")
+        pending_count = int(rows[0][0]) if rows else 0
+
+        return {
+            "ledger_sum_micro": ledger_sum,
+            "balance_sum_micro": balance_sum,
+            "difference_micro": diff,
+            "difference_rtc": round(diff / MICRO_RTC, 6),
+            "ledger_balance_match": ledger_ok,
+            "negative_balances": negative_count,
+            "ledger_rows": ledger_rows,
+            "active_wallets": active_wallets,
+            "pending_transfers": pending_count,
+        }
+
+    def _mining_stats(self) -> dict:
+        # Active miners (attested in last 24h)
+        cutoff = int(time.time()) - 86400
+        rows = self.query(
+            f"SELECT COUNT(*) FROM miner_attest_recent WHERE ts_ok > {cutoff}"
+        )
+        active_miners_24h = int(rows[0][0]) if rows else 0
+
+        # Total unique miners ever
+        rows = self.query("SELECT COUNT(*) FROM miner_attest_recent")
+        total_miners = int(rows[0][0]) if rows else 0
+
+        # Recent epoch rewards
+        rows = self.query(
+            "SELECT epoch, SUM(share_i64) FROM epoch_rewards "
+            "GROUP BY epoch ORDER BY epoch DESC LIMIT 5"
+        )
+        recent_epochs = [
+            {"epoch": int(r[0]), "total_rtc": round(int(r[1]) / MICRO_RTC, 6)}
+            for r in rows
+        ]
+
+        return {
+            "active_miners_24h": active_miners_24h,
+            "total_miners_ever": total_miners,
+            "recent_epochs": recent_epochs,
+        }
+
+    def _ledger_stats(self) -> dict:
+        # Reason breakdown (top 10 by volume)
+        rows = self.query(
+            "SELECT "
+            "  CASE "
+            "    WHEN reason LIKE 'transfer_in:founder_community%' THEN 'community_payments' "
+            "    WHEN reason LIKE 'transfer_in:founder_team_bounty%' THEN 'team_bounty_payments' "
+            "    WHEN reason LIKE 'transfer_in:founder_dev_fund%' THEN 'dev_fund_payments' "
+            "    WHEN reason LIKE 'transfer_out:%' THEN 'transfer_out' "
+            "    WHEN reason LIKE 'premine_%' THEN 'premine' "
+            "    WHEN reason LIKE 'epoch_reward%' THEN 'mining_rewards' "
+            "    WHEN reason LIKE 'wallet_consolidation%' THEN 'consolidation' "
+            "    WHEN reason LIKE 'ghost_wallet%' THEN 'ghost_recovery' "
+            "    WHEN reason LIKE 'clawback%' THEN 'clawback' "
+            "    ELSE 'other' "
+            "  END AS category, "
+            "  COUNT(*), "
+            "  SUM(delta_i64) "
+            "FROM ledger GROUP BY category ORDER BY ABS(SUM(delta_i64)) DESC"
+        )
+        return {
+            "categories": [
+                {
+                    "category": r[0],
+                    "count": int(r[1]),
+                    "total_rtc": round(int(r[2]) / MICRO_RTC, 2),
+                }
+                for r in rows
+            ]
+        }
+
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+
+def print_dashboard(data: dict) -> None:
+    """Print a formatted dashboard to the terminal."""
+    print("\n" + "=" * 72)
+    print("  RUSTCHAIN LEDGER DASHBOARD")
+    print(f"  Generated: {data['generated_at']}")
+    print("=" * 72)
+
+    # Health
+    h = data["health"]
+    status = "HEALTHY" if h["ledger_balance_match"] and h["negative_balances"] == 0 else "UNHEALTHY"
+    status_icon = "[OK]" if status == "HEALTHY" else "[!!]"
+    print(f"\n  {status_icon} Ledger Health: {status}")
+    print(f"    Ledger SUM:    {h['ledger_sum_micro'] / MICRO_RTC:>14.2f} RTC")
+    print(f"    Balance SUM:   {h['balance_sum_micro'] / MICRO_RTC:>14.2f} RTC")
+    if h["difference_rtc"] != 0:
+        print(f"    Difference:    {h['difference_rtc']:>14.6f} RTC")
+    print(f"    Ledger rows:   {h['ledger_rows']:>14,}")
+    print(f"    Active wallets:{h['active_wallets']:>14,}")
+    print(f"    Pending TXs:   {h['pending_transfers']:>14,}")
+    if h["negative_balances"] > 0:
+        print(f"    [!!] NEGATIVE BALANCES: {h['negative_balances']}")
+
+    # Supply
+    s = data["supply_breakdown"]
+    print(f"\n  Supply Breakdown:")
+    print(f"    Total supply:           {s['total_supply_rtc']:>12.2f} RTC")
+    print(f"    Founder wallets:        {s['founder_wallets_rtc']:>12.2f} RTC")
+    for name, bal in sorted(s["founder_detail"].items(), key=lambda x: -x[1]):
+        print(f"      {name:<28s} {bal:>12.2f} RTC")
+    print(f"    System wallets:         {s['system_wallets_rtc']:>12.2f} RTC")
+    for name, bal in sorted(s["system_detail"].items(), key=lambda x: -x[1]):
+        print(f"      {name:<28s} {bal:>12.2f} RTC")
+    print(f"    Distributed:            {s['distributed_rtc']:>12.2f} RTC")
+    print(f"    Mining cumulative:      {s['mining_rewards_cumulative_rtc']:>12.2f} RTC")
+
+    # Top Balances (non-founder)
+    bals = data["top_balances"]
+    non_founder = [b for b in bals
+                   if b["wallet"] not in FOUNDER_WALLETS
+                   and b["wallet"] not in SYSTEM_WALLETS]
+    print(f"\n  Top Balances (non-founder):")
+    print(f"    {'Wallet':<40s} {'Balance':>12s}")
+    print(f"    {'-' * 40} {'-' * 12}")
+    for b in non_founder[:15]:
+        print(f"    {b['wallet']:<40s} {b['balance_rtc']:>12.2f} RTC")
+
+    # Mining
+    m = data["mining_stats"]
+    print(f"\n  Mining:")
+    print(f"    Active miners (24h):    {m['active_miners_24h']}")
+    print(f"    Total miners ever:      {m['total_miners_ever']}")
+    if m["recent_epochs"]:
+        print(f"    Recent epoch rewards:")
+        for ep in m["recent_epochs"]:
+            print(f"      Epoch {ep['epoch']}: {ep['total_rtc']:.6f} RTC")
+
+    # Recent Transfers
+    transfers = data["recent_transfers"]
+    if transfers:
+        print(f"\n  Recent Transfers (last 24h): {len(transfers)}")
+        print(f"    {'Time':<22s} {'Wallet':<30s} {'Amount':>12s}  Reason")
+        print(f"    {'-' * 22} {'-' * 30} {'-' * 12}  {'-' * 30}")
+        for t in transfers[:15]:
+            ts = t["timestamp"][:19].replace("T", " ")
+            reason_short = t["reason"][:40] if t["reason"] else ""
+            print(f"    {ts:<22s} {t['wallet']:<30s} {t['amount_rtc']:>+12.2f}  {reason_short}")
+    else:
+        print(f"\n  No transfers in last 24h.")
+
+    # Pending
+    pending = data["pending_transfers"]
+    if pending:
+        print(f"\n  Pending Transfers: {len(pending)}")
+        for p in pending[:10]:
+            print(f"    {p['from']} -> {p['to']}: {p['amount_rtc']:.2f} RTC"
+                  f"  ({p['reason'][:30]})")
+    else:
+        print(f"\n  No pending transfers.")
+
+    # Ledger Categories
+    cats = data["ledger_stats"]["categories"]
+    if cats:
+        print(f"\n  Ledger Categories:")
+        print(f"    {'Category':<30s} {'Count':>8s} {'Total RTC':>14s}")
+        print(f"    {'-' * 30} {'-' * 8} {'-' * 14}")
+        for c in cats:
+            print(f"    {c['category']:<30s} {c['count']:>8,} {c['total_rtc']:>14.2f}")
+
+    print(f"\n{'=' * 72}")
+    print("  END OF DASHBOARD")
+    print(f"{'=' * 72}\n")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(description="RustChain Ledger Dashboard")
+    p.add_argument("--db-path", default=os.environ.get("RC_DB_PATH", ""),
+                    help="Path to local rustchain_v2.db")
+    p.add_argument("--ssh-host", default=os.environ.get("RC_SSH_HOST", "50.28.86.131"),
+                    help="VPS SSH host")
+    p.add_argument("--ssh-user", default=os.environ.get("RC_SSH_USER", "root"),
+                    help="VPS SSH user")
+    p.add_argument("--ssh-pass", default=os.environ.get("RC_SSH_PASS", ""),
+                    help="VPS SSH password")
+    p.add_argument("--json", action="store_true",
+                    help="Output JSON to stdout")
+    p.add_argument("--json-file", default="",
+                    help="Write JSON to file")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if args.db_path and os.path.exists(args.db_path):
+        conn = sqlite3.connect(args.db_path)
+        dash = LedgerDashboard(mode="local", conn=conn)
+    else:
+        ssh_pass = args.ssh_pass
+        if not ssh_pass:
+            # Try reading from environment
+            ssh_pass = os.environ.get("RC_SSH_PASS", "")
+        if not ssh_pass:
+            print("ERROR: No SSH password. Use --ssh-pass or set RC_SSH_PASS")
+            sys.exit(1)
+
+        dash = LedgerDashboard(
+            mode="ssh",
+            ssh_host=args.ssh_host,
+            ssh_user=args.ssh_user,
+            ssh_pass=ssh_pass,
+        )
+
+    print("Collecting data...")
+    data = dash.collect_all()
+
+    if args.json:
+        print(json.dumps(data, indent=2))
+    else:
+        print_dashboard(data)
+
+    if args.json_file:
+        with open(args.json_file, "w") as f:
+            json.dump(data, f, indent=2)
+        print(f"JSON written to {args.json_file}")
+
+    # Exit code based on health
+    if not data["health"]["ledger_balance_match"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/payment_reconciler.py
+++ b/scripts/payment_reconciler.py
@@ -1,0 +1,632 @@
+#!/usr/bin/env python3
+"""
+RustChain Payment Reconciler
+==============================
+Cross-references GitHub PR payment promises against the actual RTC ledger.
+
+Scans merged PRs in Scottcjn/Rustchain and Scottcjn/rustchain-bounties for
+payment comments by the repo owner (Scottcjn), extracts promised RTC amounts,
+then compares against the on-chain ledger to flag discrepancies.
+
+Usage:
+    # With local DB copy:
+    python3 payment_reconciler.py --github-token TOKEN --db-path /path/to/rustchain_v2.db
+
+    # Via SSH to VPS (production):
+    python3 payment_reconciler.py --github-token TOKEN --ssh-host 50.28.86.131
+
+    # Output JSON report:
+    python3 payment_reconciler.py --github-token TOKEN --ssh-host 50.28.86.131 --json
+
+    # Scan specific repos only:
+    python3 payment_reconciler.py --github-token TOKEN --ssh-host 50.28.86.131 \
+        --repos Scottcjn/Rustchain Scottcjn/BoTTube
+
+Environment variables (alternative to CLI flags):
+    GITHUB_TOKEN        GitHub personal access token
+    RC_SSH_HOST         VPS hostname (default: 50.28.86.131)
+    RC_SSH_USER         VPS SSH user (default: root)
+    RC_SSH_PASS         VPS SSH password
+    RC_DB_PATH          Local path to rustchain_v2.db
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_REPOS = [
+    "Scottcjn/Rustchain",
+    "Scottcjn/rustchain-bounties",
+    "Scottcjn/BoTTube",
+]
+
+REPO_OWNER = "Scottcjn"
+
+# Scale factor: ledger stores micro-RTC (1 RTC = 1_000_000 units)
+MICRO_RTC = 1_000_000
+
+# GitHub API base
+GH_API = "https://api.github.com"
+
+# Founder wallets that pay out bounties
+PAYOUT_WALLETS = {"founder_community", "founder_team_bounty", "founder_dev_fund", "team_bounty"}
+
+# Payment comment patterns (case-insensitive).
+# Matches things like:
+#   "Payment: 150 RTC"
+#   "Merged. 50 RTC"
+#   "75 RTC —"
+#   "**250 RTC** paid"
+#   "Approved for 100 RTC"
+#   "Paying 300 RTC"
+#   "200 RTC to createkr"
+PAYMENT_PATTERNS = [
+    # "Payment: 150 RTC" or "Payment: **150 RTC**"
+    re.compile(r"payment[:\s]+\*{0,2}(\d+(?:\.\d+)?)\s*RTC\b", re.IGNORECASE),
+    # "Merged. 50 RTC" or "Merged — 50 RTC"
+    re.compile(r"merged[\.\s—\-]+\*{0,2}(\d+(?:\.\d+)?)\s*RTC\b", re.IGNORECASE),
+    # "X RTC —" (amount followed by dash, common in payment notes)
+    re.compile(r"\b(\d+(?:\.\d+)?)\s*RTC\s*[—\-]", re.IGNORECASE),
+    # "X RTC paid" or "X RTC approved" or "**X RTC** paid"
+    re.compile(r"\*{0,2}(\d+(?:\.\d+)?)\s*RTC\*{0,2}\s*(?:paid|approved|sent|transferred|awarded)", re.IGNORECASE),
+    # "Approved for X RTC" or "Paying X RTC"
+    re.compile(r"(?:approved\s+for|paying|pay|awarding|award)\s+\*{0,2}(\d+(?:\.\d+)?)\s*RTC\b", re.IGNORECASE),
+    # "**X RTC** to username" or "X RTC to username"
+    re.compile(r"\b\*{0,2}(\d+(?:\.\d+)?)\s*RTC\*{0,2}\s+to\s+\w+", re.IGNORECASE),
+    # Bounty table rows: "| 150 RTC |" or "| **150 RTC** |"
+    re.compile(r"\|\s*\*{0,2}(\d+(?:\.\d+)?)\s*RTC\*{0,2}\s*\|", re.IGNORECASE),
+]
+
+# Known GitHub username -> wallet ID mappings.
+# The reconciler also tries lowercase github username as a fallback.
+USERNAME_TO_WALLET = {
+    "createkr": "createkr",
+    "B1tor": "B1tor",
+    "LaphoqueRC": "LaphoqueRC",
+    "simplereally": "simplereally",
+    "ArokyaMatthew": "aroky-x86-miner",
+    "BuilderFred": "BuilderFred",
+    "allornothingai": "allornothingai",
+    "ApextheBoss": "ApextheBoss",
+    "danielalanbates": "danielalanbates",
+    "mtarcure": "mtarcure",
+    "wirework": "wirework",
+    "nox-ventures": "nox-ventures",
+    "zhanglinqian": "zhanglinqian",
+    "liu971227-sys": "liu971227-sys",
+    "davidtang-codex": "davidtang-codex",
+    # Add mappings here as contributors register wallets
+}
+
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+def gh_request(endpoint: str, token: str, params: dict | None = None) -> dict | list:
+    """Make a GitHub API request using curl (no requests dependency)."""
+    url = f"{GH_API}{endpoint}"
+    if params:
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        url = f"{url}?{query}"
+
+    cmd = [
+        "curl", "-s", "-f",
+        "-H", f"Authorization: token {token}",
+        "-H", "Accept: application/vnd.github+json",
+        "-H", "X-GitHub-Api-Version: 2022-11-28",
+        url,
+    ]
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise RuntimeError(f"GitHub API error for {endpoint}: {result.stderr[:200]}")
+
+    return json.loads(result.stdout)
+
+
+def gh_paginate(endpoint: str, token: str, params: dict | None = None,
+                max_pages: int = 50) -> list:
+    """Paginate through GitHub API results."""
+    params = dict(params or {})
+    params.setdefault("per_page", "100")
+    all_items = []
+
+    for page in range(1, max_pages + 1):
+        params["page"] = str(page)
+        items = gh_request(endpoint, token, params)
+        if not items or not isinstance(items, list):
+            break
+        all_items.extend(items)
+        if len(items) < int(params["per_page"]):
+            break
+        # Respect rate limits
+        time.sleep(0.5)
+
+    return all_items
+
+
+def get_pr_comments(repo: str, pr_number: int, token: str) -> list:
+    """Get all comments on a PR (issue comments + review comments)."""
+    comments = gh_paginate(f"/repos/{repo}/issues/{pr_number}/comments", token)
+    return comments
+
+
+# ---------------------------------------------------------------------------
+# Payment extraction
+# ---------------------------------------------------------------------------
+
+def extract_payment_amount(text: str) -> float | None:
+    """Extract the RTC payment amount from a comment body.
+
+    Returns the largest amount found (comments sometimes mention amounts
+    in context like 'originally 50 RTC, now paying 75 RTC').
+    """
+    if not text:
+        return None
+
+    amounts = []
+    for pattern in PAYMENT_PATTERNS:
+        for match in pattern.finditer(text):
+            try:
+                amt = float(match.group(1))
+                if 0.001 <= amt <= 100000:  # sanity bounds
+                    amounts.append(amt)
+            except (ValueError, IndexError):
+                continue
+
+    return max(amounts) if amounts else None
+
+
+def extract_recipient_from_comment(text: str, pr_author: str) -> str | None:
+    """Try to extract who the payment is for from the comment text.
+
+    Falls back to the PR author if no explicit recipient mentioned.
+    """
+    # "X RTC to @username" or "X RTC to username"
+    m = re.search(r"\bRTC\b.*?\bto\s+@?(\w[\w-]*)", text, re.IGNORECASE)
+    if m:
+        return m.group(1)
+
+    # "paying @username" or "paid @username"
+    m = re.search(r"(?:paying|paid|awarded?\s+to)\s+@?(\w[\w-]*)", text, re.IGNORECASE)
+    if m:
+        candidate = m.group(1)
+        if candidate.lower() not in ("the", "for", "this", "a", "an"):
+            return candidate
+
+    return pr_author
+
+
+def scan_repo_payments(repo: str, token: str) -> list[dict]:
+    """Scan a repo for merged PRs with payment comments from the owner.
+
+    Returns list of payment records:
+        {repo, pr_number, pr_title, pr_author, amount_rtc, recipient_github,
+         wallet_id, comment_url, comment_date, comment_body_snippet}
+    """
+    print(f"  Scanning {repo} for merged PRs with payments...")
+
+    # Get merged PRs
+    prs = gh_paginate(
+        f"/repos/{repo}/pulls",
+        token,
+        params={"state": "closed", "sort": "updated", "direction": "desc"},
+    )
+
+    merged_prs = [pr for pr in prs if pr.get("merged_at")]
+    print(f"    Found {len(merged_prs)} merged PRs (of {len(prs)} closed)")
+
+    payments = []
+    for i, pr in enumerate(merged_prs):
+        pr_number = pr["number"]
+        pr_author = pr["user"]["login"]
+        pr_title = pr.get("title", "")
+
+        # Rate limit: check comments every 2 PRs
+        if i > 0 and i % 10 == 0:
+            time.sleep(1.0)
+
+        comments = get_pr_comments(repo, pr_number, token)
+
+        for comment in comments:
+            commenter = comment.get("user", {}).get("login", "")
+            # Only count payments from the repo owner
+            if commenter.lower() != REPO_OWNER.lower():
+                continue
+
+            body = comment.get("body", "")
+            amount = extract_payment_amount(body)
+            if amount is None:
+                continue
+
+            recipient_gh = extract_recipient_from_comment(body, pr_author)
+            wallet_id = resolve_wallet(recipient_gh)
+
+            payments.append({
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_title": pr_title,
+                "pr_author": pr_author,
+                "amount_rtc": amount,
+                "recipient_github": recipient_gh,
+                "wallet_id": wallet_id,
+                "comment_url": comment.get("html_url", ""),
+                "comment_date": comment.get("created_at", ""),
+                "comment_body_snippet": body[:200],
+            })
+
+    print(f"    Extracted {len(payments)} payment promises")
+    return payments
+
+
+def resolve_wallet(github_username: str) -> str | None:
+    """Resolve a GitHub username to a RustChain wallet ID."""
+    if not github_username:
+        return None
+
+    # Direct mapping
+    if github_username in USERNAME_TO_WALLET:
+        return USERNAME_TO_WALLET[github_username]
+
+    # Try lowercase
+    lower = github_username.lower()
+    for k, v in USERNAME_TO_WALLET.items():
+        if k.lower() == lower:
+            return v
+
+    # Fallback: use github username as wallet ID (common pattern)
+    return github_username
+
+
+# ---------------------------------------------------------------------------
+# Ledger queries (via SSH or local DB)
+# ---------------------------------------------------------------------------
+
+def get_db_connection(args) -> sqlite3.Connection:
+    """Get a SQLite connection, either local or via SSH-fetched copy."""
+    if args.db_path and os.path.exists(args.db_path):
+        print(f"  Using local DB: {args.db_path}")
+        return sqlite3.connect(args.db_path)
+
+    # Fetch via SSH
+    ssh_host = args.ssh_host or os.environ.get("RC_SSH_HOST", "50.28.86.131")
+    ssh_user = args.ssh_user or os.environ.get("RC_SSH_USER", "root")
+    ssh_pass = args.ssh_pass or os.environ.get("RC_SSH_PASS", "")
+
+    if not ssh_pass:
+        print("ERROR: No SSH password provided (--ssh-pass or RC_SSH_PASS)")
+        sys.exit(1)
+
+    remote_db = "/root/rustchain/rustchain_v2.db"
+    local_tmp = os.path.join(tempfile.gettempdir(), "rustchain_v2_reconciler.db")
+
+    print(f"  Fetching DB from {ssh_user}@{ssh_host}:{remote_db} ...")
+
+    cmd = [
+        "sshpass", "-p", ssh_pass,
+        "scp", "-o", "StrictHostKeyChecking=no",
+        f"{ssh_user}@{ssh_host}:{remote_db}",
+        local_tmp,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+    if result.returncode != 0:
+        print(f"ERROR: SCP failed: {result.stderr[:200]}")
+        sys.exit(1)
+
+    print(f"  DB fetched to {local_tmp} ({os.path.getsize(local_tmp) / 1024 / 1024:.1f} MB)")
+    return sqlite3.connect(local_tmp)
+
+
+def query_ledger_payments(conn: sqlite3.Connection) -> dict[str, float]:
+    """Query actual RTC payments from founder wallets to contributors.
+
+    Returns {wallet_id: total_rtc_received}.
+    """
+    cur = conn.cursor()
+
+    # Sum all transfer_in entries from founder payout wallets
+    # The reason format is: transfer_in:<from_wallet>:<tx_hash>
+    payout_patterns = [f"transfer_in:{w}%" for w in PAYOUT_WALLETS]
+
+    totals: dict[str, float] = defaultdict(float)
+
+    for pattern in payout_patterns:
+        cur.execute(
+            "SELECT miner_id, SUM(delta_i64) FROM ledger "
+            "WHERE reason LIKE ? GROUP BY miner_id",
+            (pattern,),
+        )
+        for row in cur.fetchall():
+            miner_id, sum_micro = row
+            # Skip internal transfers between founder wallets
+            if miner_id in PAYOUT_WALLETS or miner_id.startswith("founder_"):
+                continue
+            totals[miner_id] += sum_micro / MICRO_RTC
+
+    return dict(totals)
+
+
+def query_pending_transfers(conn: sqlite3.Connection) -> dict[str, float]:
+    """Query pending (in-transit) transfers."""
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT to_miner, SUM(amount_i64) FROM pending_ledger "
+        "WHERE status = 'pending' GROUP BY to_miner"
+    )
+    return {row[0]: row[1] / MICRO_RTC for row in cur.fetchall()}
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation logic
+# ---------------------------------------------------------------------------
+
+def reconcile(
+    github_payments: list[dict],
+    ledger_payments: dict[str, float],
+    pending_payments: dict[str, float],
+) -> dict:
+    """Cross-reference GitHub promises against ledger reality.
+
+    Returns a structured report.
+    """
+    # Aggregate GitHub promises by recipient wallet
+    promised: dict[str, dict] = defaultdict(lambda: {
+        "total_rtc": 0.0,
+        "prs": [],
+        "github_username": None,
+    })
+
+    for p in github_payments:
+        wallet = p["wallet_id"] or p["recipient_github"] or p["pr_author"]
+        promised[wallet]["total_rtc"] += p["amount_rtc"]
+        promised[wallet]["github_username"] = p["recipient_github"]
+        promised[wallet]["prs"].append({
+            "repo": p["repo"],
+            "pr": p["pr_number"],
+            "title": p["pr_title"],
+            "amount": p["amount_rtc"],
+            "date": p["comment_date"],
+            "url": p["comment_url"],
+        })
+
+    # Build reconciliation entries
+    all_wallets = set(promised.keys()) | set(ledger_payments.keys())
+    entries = []
+
+    for wallet in sorted(all_wallets):
+        promise_total = promised.get(wallet, {}).get("total_rtc", 0.0)
+        paid_total = ledger_payments.get(wallet, 0.0)
+        pending_total = pending_payments.get(wallet, 0.0)
+        effective_paid = paid_total + pending_total
+
+        diff = effective_paid - promise_total
+
+        if promise_total == 0 and paid_total > 0:
+            status = "NO_PR_REFERENCE"
+        elif abs(diff) < 0.01:
+            status = "OK"
+        elif diff < -0.01:
+            status = "UNPAID"
+        elif diff > 0.01:
+            status = "OVERPAID"
+        else:
+            status = "OK"
+
+        entry = {
+            "wallet": wallet,
+            "github_username": promised.get(wallet, {}).get("github_username"),
+            "promised_rtc": round(promise_total, 6),
+            "paid_rtc": round(paid_total, 6),
+            "pending_rtc": round(pending_total, 6),
+            "effective_paid_rtc": round(effective_paid, 6),
+            "discrepancy_rtc": round(diff, 6),
+            "status": status,
+            "prs": promised.get(wallet, {}).get("prs", []),
+        }
+        entries.append(entry)
+
+    # Summary stats
+    total_promised = sum(e["promised_rtc"] for e in entries)
+    total_paid = sum(e["paid_rtc"] for e in entries)
+    total_pending = sum(e["pending_rtc"] for e in entries)
+    unpaid_entries = [e for e in entries if e["status"] == "UNPAID"]
+    overpaid_entries = [e for e in entries if e["status"] == "OVERPAID"]
+    no_ref_entries = [e for e in entries if e["status"] == "NO_PR_REFERENCE"]
+    ok_entries = [e for e in entries if e["status"] == "OK"]
+
+    total_unpaid = sum(abs(e["discrepancy_rtc"]) for e in unpaid_entries)
+    total_overpaid = sum(e["discrepancy_rtc"] for e in overpaid_entries)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "total_promised_rtc": round(total_promised, 2),
+            "total_paid_rtc": round(total_paid, 2),
+            "total_pending_rtc": round(total_pending, 2),
+            "total_unpaid_rtc": round(total_unpaid, 2),
+            "total_overpaid_rtc": round(total_overpaid, 2),
+            "count_ok": len(ok_entries),
+            "count_unpaid": len(unpaid_entries),
+            "count_overpaid": len(overpaid_entries),
+            "count_no_pr_reference": len(no_ref_entries),
+            "total_contributors": len(entries),
+        },
+        "entries": entries,
+    }
+
+    return report
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def print_report(report: dict) -> None:
+    """Print a human-readable reconciliation report."""
+    s = report["summary"]
+    print("\n" + "=" * 72)
+    print("  RUSTCHAIN PAYMENT RECONCILIATION REPORT")
+    print(f"  Generated: {report['generated_at']}")
+    print("=" * 72)
+
+    print(f"\n  Total promised (from GitHub PRs):  {s['total_promised_rtc']:>12.2f} RTC")
+    print(f"  Total paid (on-chain):             {s['total_paid_rtc']:>12.2f} RTC")
+    print(f"  Total pending (in transit):        {s['total_pending_rtc']:>12.2f} RTC")
+    print(f"  Total unpaid shortfall:            {s['total_unpaid_rtc']:>12.2f} RTC")
+    print(f"  Total overpaid surplus:            {s['total_overpaid_rtc']:>12.2f} RTC")
+
+    print(f"\n  Contributors: {s['total_contributors']}")
+    print(f"    OK:               {s['count_ok']}")
+    print(f"    UNPAID:           {s['count_unpaid']}")
+    print(f"    OVERPAID:         {s['count_overpaid']}")
+    print(f"    NO_PR_REFERENCE:  {s['count_no_pr_reference']}")
+
+    # Show problem entries
+    entries = report["entries"]
+
+    unpaid = [e for e in entries if e["status"] == "UNPAID"]
+    if unpaid:
+        print(f"\n{'=' * 72}")
+        print("  UNPAID (Promised > Paid)")
+        print(f"{'=' * 72}")
+        for e in sorted(unpaid, key=lambda x: x["discrepancy_rtc"]):
+            print(f"\n  {e['wallet']}"
+                  f" ({e['github_username'] or '?'})")
+            print(f"    Promised: {e['promised_rtc']:>10.2f} RTC")
+            print(f"    Paid:     {e['paid_rtc']:>10.2f} RTC"
+                  f"  (+ {e['pending_rtc']:.2f} pending)")
+            print(f"    OWED:     {abs(e['discrepancy_rtc']):>10.2f} RTC")
+            for pr in e["prs"]:
+                print(f"      PR #{pr['pr']}: {pr['amount']:.2f} RTC"
+                      f" - {pr['title'][:50]}")
+                if pr.get("url"):
+                    print(f"        {pr['url']}")
+
+    overpaid = [e for e in entries if e["status"] == "OVERPAID"]
+    if overpaid:
+        print(f"\n{'=' * 72}")
+        print("  OVERPAID (Paid > Promised) -- may indicate direct payments without PR")
+        print(f"{'=' * 72}")
+        for e in sorted(overpaid, key=lambda x: -x["discrepancy_rtc"])[:20]:
+            print(f"\n  {e['wallet']}"
+                  f" ({e['github_username'] or '?'})")
+            print(f"    Promised: {e['promised_rtc']:>10.2f} RTC")
+            print(f"    Paid:     {e['paid_rtc']:>10.2f} RTC")
+            print(f"    SURPLUS:  {e['discrepancy_rtc']:>10.2f} RTC")
+
+    no_ref = [e for e in entries if e["status"] == "NO_PR_REFERENCE"]
+    if no_ref:
+        # Only show top 20 by amount
+        no_ref_sorted = sorted(no_ref, key=lambda x: -x["paid_rtc"])[:20]
+        print(f"\n{'=' * 72}")
+        print(f"  NO PR REFERENCE (top 20 of {len(no_ref)} -- paid on-chain, no matching PR)")
+        print(f"{'=' * 72}")
+        for e in no_ref_sorted:
+            print(f"  {e['wallet']:<35s} {e['paid_rtc']:>10.2f} RTC")
+
+    print(f"\n{'=' * 72}")
+    print("  END OF REPORT")
+    print(f"{'=' * 72}\n")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    p = argparse.ArgumentParser(description="RustChain Payment Reconciler")
+    p.add_argument("--github-token", default=os.environ.get("GITHUB_TOKEN", ""),
+                    help="GitHub personal access token")
+    p.add_argument("--db-path", default=os.environ.get("RC_DB_PATH", ""),
+                    help="Path to local rustchain_v2.db")
+    p.add_argument("--ssh-host", default=os.environ.get("RC_SSH_HOST", "50.28.86.131"),
+                    help="VPS SSH host")
+    p.add_argument("--ssh-user", default=os.environ.get("RC_SSH_USER", "root"),
+                    help="VPS SSH user")
+    p.add_argument("--ssh-pass", default=os.environ.get("RC_SSH_PASS", ""),
+                    help="VPS SSH password")
+    p.add_argument("--repos", nargs="+", default=DEFAULT_REPOS,
+                    help="GitHub repos to scan (owner/repo)")
+    p.add_argument("--json", action="store_true",
+                    help="Output JSON report to stdout")
+    p.add_argument("--json-file", default="",
+                    help="Write JSON report to file")
+    p.add_argument("--wallet-map", default="",
+                    help="JSON file mapping github usernames to wallet IDs")
+    p.add_argument("--max-prs", type=int, default=500,
+                    help="Maximum PRs to scan per repo")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    if not args.github_token:
+        print("ERROR: --github-token required (or set GITHUB_TOKEN env var)")
+        sys.exit(1)
+
+    # Load custom wallet mappings if provided
+    if args.wallet_map and os.path.exists(args.wallet_map):
+        with open(args.wallet_map) as f:
+            USERNAME_TO_WALLET.update(json.load(f))
+        print(f"  Loaded {len(USERNAME_TO_WALLET)} wallet mappings")
+
+    # Phase 1: Scan GitHub PRs for payment promises
+    print("\n[Phase 1] Scanning GitHub for payment promises...")
+    all_payments = []
+    for repo in args.repos:
+        try:
+            payments = scan_repo_payments(repo, args.github_token)
+            all_payments.extend(payments)
+        except Exception as e:
+            print(f"  WARNING: Failed to scan {repo}: {e}")
+
+    print(f"\n  Total payment promises found: {len(all_payments)}")
+
+    # Phase 2: Query the RustChain ledger
+    print("\n[Phase 2] Querying RustChain ledger...")
+    conn = get_db_connection(args)
+    ledger_payments = query_ledger_payments(conn)
+    pending_payments = query_pending_transfers(conn)
+    conn.close()
+
+    print(f"  Ledger: {len(ledger_payments)} wallets with founder transfers")
+    print(f"  Pending: {len(pending_payments)} wallets with pending transfers")
+
+    # Phase 3: Reconcile
+    print("\n[Phase 3] Reconciling...")
+    report = reconcile(all_payments, ledger_payments, pending_payments)
+
+    # Output
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        print_report(report)
+
+    if args.json_file:
+        with open(args.json_file, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"  JSON report written to {args.json_file}")
+
+    # Exit code: non-zero if unpaid entries exist
+    if report["summary"]["count_unpaid"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Recovers two ops scripts found during a repo-fleet audit, sitting in a local-only commit (`687be5fd`, 2026-04-06) that never reached the remote. The RIP-0308 spec from that same commit already landed on main (with its Zenodo DOI); these scripts did not.

- **`scripts/ledger_dashboard.py`** (480 lines) — live ledger health dashboard: balances, recent transfers, supply breakdown. SSH-to-VPS, local-DB, and `--json` modes.
- **`scripts/payment_reconciler.py`** (632 lines) — cross-checks GitHub bounty payout comments against on-chain ledger entries; complements the payout-pipeline fixes from June and the Phase 2 economic-metrics work.

## Safety

- Credentials via env vars / CLI flags only — no secrets embedded (verified by scan).
- No miner files touched — no checksum regeneration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)