### PR TITLE
docs(bridge): clarify operator-only bridge initiate flow

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -636,15 +636,22 @@ The Bridge API manages cross-chain transfers between RustChain and external chai
 
 ### POST /api/bridge/initiate
 
-Initiate a cross-chain bridge transfer (deposit or withdraw).
+Initiate a cross-chain bridge transfer (deposit or withdraw). RustChain-origin
+deposits are operator-assisted/admin-authenticated because they lock native RTC
+balances before external mint/release handling. This route is not a public
+self-service native RTC to wRTC/Solana payout endpoint, and public
+`https://rustchain.org` routing may intentionally leave bridge management APIs
+unavailable while an operator node returns `401 unauthorized` without a valid
+admin key.
 
 **Method:** `POST`
 **Path:** `/api/bridge/initiate`
-**Auth:** None (user-initiated)
+**Auth:** `X-Admin-Key` for RustChain-origin deposits
 
 **cURL:**
 ```bash
 curl -fsS -X POST https://rustchain.org/api/bridge/initiate \
+  -H "X-Admin-Key: $RC_ADMIN_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "direction": "deposit",
@@ -686,7 +693,17 @@ curl -fsS -X POST https://rustchain.org/api/bridge/initiate \
 }
 ```
 
-**Error Responses (400):**
+**Error Responses (401/503/400):**
+```json
+{
+  "error": "unauthorized"
+}
+```
+```json
+{
+  "error": "RC_ADMIN_KEY not configured"
+}
+```
 ```json
 {
   "error": "Insufficient available balance",
@@ -1250,6 +1267,7 @@ curl -fsS https://rustchain.org/beacon/api/premium/contracts/export | jq .
 ### Python — Quick Start
 
 ```python
+import os
 import requests
 
 BASE_URL = "https://rustchain.org"
@@ -1334,10 +1352,11 @@ print(resp.json())
 ### Python — Bridge Deposit
 
 ```python
-def initiate_bridge_deposit(miner_id, dest_address, amount_rtc):
-    """Initiate a bridge deposit from RustChain to Solana."""
+def initiate_bridge_deposit(miner_id, dest_address, amount_rtc, admin_key):
+    """Operator-assisted bridge deposit from RustChain to Solana."""
     resp = requests.post(
         f"{BASE_URL}/api/bridge/initiate",
+        headers={"X-Admin-Key": admin_key},
         json={
             "direction": "deposit",
             "source_chain": "rustchain",
@@ -1359,7 +1378,8 @@ def initiate_bridge_deposit(miner_id, dest_address, amount_rtc):
 result = initiate_bridge_deposit(
     miner_id="RTC_miner123",
     dest_address="4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
-    amount_rtc=100.0
+    amount_rtc=100.0,
+    admin_key=os.environ["RC_ADMIN_KEY"],
 )
 ```
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -862,8 +862,11 @@ paths:
       summary: Initiate bridge transfer
       description: |
         Create a new bridge transfer (deposit or withdraw) between
-        RustChain and external chains (Solana, Ergo, Base).
-        Requires admin authentication.
+        RustChain and external chains (Solana, Ergo, Base). RustChain-origin
+        deposits are operator-assisted/admin-authenticated and are not a public
+        self-service native RTC to wRTC/Solana payout endpoint. Public web
+        routing may leave this bridge management route unavailable; exposed
+        operator nodes return 401 without a valid X-Admin-Key.
       operationId: initiateBridge
       security:
         - AdminKeyAuth: []
@@ -914,6 +917,22 @@ paths:
                   summary: Invalid address
                   value:
                     error: "Invalid solana address: length must be 32-44 characters"
+        '401':
+          description: Missing or invalid admin key for RustChain-origin deposits
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: unauthorized
+        '503':
+          description: Bridge admin key is not configured on this node
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              example:
+                error: RC_ADMIN_KEY not configured
 
   /api/bridge/status/{tx_hash}:
     get:
@@ -1637,7 +1656,7 @@ components:
         memo:
           type: string
           nullable: true
-          description: Extracted memo from signed_transfer: prefix
+          description: "Extracted memo from signed_transfer: prefix"
 
     SignedTransferRequest:
       type: object

--- a/docs/bridge-api.md
+++ b/docs/bridge-api.md
@@ -19,6 +19,14 @@ Most bridge management endpoints require an admin key:
 X-Admin-Key: <your-admin-key>
 ```
 
+`POST /api/bridge/initiate` is not a public self-service native RTC to
+wRTC/Solana bridge endpoint. RustChain-origin deposits lock RustChain balances
+and are operator-assisted/admin-authenticated: the node must have `RC_ADMIN_KEY`
+configured and the caller must provide a matching `X-Admin-Key` header. Public
+web routing may intentionally leave the bridge management API unavailable; an
+operator node that exposes the route returns `401 unauthorized` when the admin
+key is missing or wrong.
+
 ### API Callbacks
 Bridge service callbacks use API key authentication:
 ```
@@ -29,9 +37,17 @@ X-API-Key: <bridge-api-key>
 
 ### 1. Initiate Bridge Transfer
 
-Create a new bridge transfer (deposit or withdraw).
+Create a new bridge transfer (deposit or withdraw). RustChain-origin deposits
+are operator-assisted and require admin authentication; do not treat this as a
+user-callable public payout, minting, or wallet-credit endpoint.
 
 **Endpoint:** `POST /api/bridge/initiate`
+
+**Headers (operator/admin only):**
+```
+X-Admin-Key: <admin-key>
+Content-Type: application/json
+```
 
 **Request:**
 ```json
@@ -76,6 +92,16 @@ Create a new bridge transfer (deposit or withdraw).
 
 **Error Responses:**
 ```json
+// 401 Unauthorized - missing or invalid admin key for RustChain deposits
+{
+    "error": "unauthorized"
+}
+
+// 503 Service Unavailable - operator bridge is not configured on this node
+{
+    "error": "RC_ADMIN_KEY not configured"
+}
+
 // 400 Bad Request - Insufficient balance
 {
     "error": "Insufficient available balance",

--- a/tests/test_bridge_initiate_docs.py
+++ b/tests/test_bridge_initiate_docs.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_doc(*parts):
+    return (ROOT.joinpath(*parts)).read_text(encoding="utf-8")
+
+
+def test_bridge_initiate_markdown_docs_are_operator_assisted():
+    bridge_api = read_doc("docs", "bridge-api.md")
+    api_reference = read_doc("docs", "API_REFERENCE.md")
+    combined = "\n".join([bridge_api, api_reference])
+    normalized = " ".join(combined.split())
+
+    assert "POST /api/bridge/initiate" in normalized
+    assert "operator-assisted" in normalized
+    assert "not a public self-service native RTC to wRTC/Solana" in normalized
+    assert "X-Admin-Key" in normalized
+    assert "RC_ADMIN_KEY" in normalized
+    assert "401 unauthorized" in normalized
+    assert "public payout, minting, or wallet-credit endpoint" in normalized
+    assert "**Auth:** None (user-initiated)" not in api_reference
+
+
+def test_bridge_initiate_openapi_exposes_admin_auth_errors():
+    openapi = read_doc("docs", "api", "openapi.yaml")
+
+    assert "/api/bridge/initiate:" in openapi
+    assert "operator-assisted/admin-authenticated" in openapi
+    assert "self-service native RTC to wRTC/Solana" in openapi
+    assert "AdminKeyAuth" in openapi
+    assert "'401':" in openapi
+    assert "error: unauthorized" in openapi
+    assert "'503':" in openapi
+    assert "error: RC_ADMIN_KEY not configured" in openapi


### PR DESCRIPTION
## Problem

`POST /api/bridge/initiate` had conflicting human-readable docs for the native RTC -> wRTC/Solana path. `docs/API_REFERENCE.md` described the endpoint as `Auth: None (user-initiated)`, while the current bridge route requires a configured `RC_ADMIN_KEY` plus matching `X-Admin-Key` for RustChain-origin deposits before it will create a lock-ledger bridge transfer.

That makes the production behavior hard to interpret: the public web route may be unavailable, while an operator-exposed node returns `401 unauthorized` without admin auth. This PR documents that boundary instead of changing it.

This is intentionally separate from the existing `/bridge` 500, `/wrtc/*` HTML route 404, and bridge-dashboard mock/demo-data reports.

## Impact

Confirmed native RTC holders and operators can otherwise read the docs as a public self-service native RTC -> wRTC/Solana bridge flow, then hit a 404/401 path with no clear explanation. That is confusing around a money-path/exit-path surface even when the underlying admin-only behavior is intentional.

## Fix

- Clarify in `docs/bridge-api.md` that RustChain-origin bridge deposits are operator-assisted/admin-authenticated and are not a public payout, minting, or wallet-credit endpoint.
- Update `docs/API_REFERENCE.md` from `Auth: None (user-initiated)` to `X-Admin-Key` for RustChain-origin deposits, including cURL/Python examples.
- Add explicit OpenAPI `401` and `503` responses for unauthorized or unconfigured bridge-admin cases.
- Fix an existing OpenAPI YAML quoting issue found while validating the docs.
- Add a docs regression test so the stale self-service wording does not come back.

## Tests

- `python3 -m pytest -q tests/test_bridge_initiate_docs.py tests/test_openapi_validator.py tests/test_wrtc_docs.py` -> 45 passed
- `python3 docs/api/validate_openapi.py docs/api/openapi.yaml` -> passed, no errors or warnings
- `git diff --check` -> passed

## Safety / BCOS

BCOS-L1 docs-only. This PR does not change runtime wallet, transfer, reward, bridge, lock-ledger, auth, minting, payout, admin-key, production-wallet, or manual-crediting behavior. It does not make the bridge user-callable.

Related: Scottcjn/rustchain-bounties#13052

This PR does not resolve or close that payout check. It only uses the current RTC exit-path ambiguity as a real-world example showing that pending/confirmed native RTC users need clearer bridge availability and operator-boundary documentation.

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
