### PR TITLE
Fix Russian README RTC reference rate

### DIFF
--- a/README_RU.md
+++ b/README_RU.md
@@ -105,7 +105,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 3. Сделайте форк, исправьте, создайте PR — получите RTC
 4. Смотрите [CONTRIBUTING.md](CONTRIBUTING.md) для полной документации
 
-**1 RTC = $0.10 USD** | `python3 -m pip install clawrtc` чтобы начать майнинг
+**1 RTC ≈ $0.15 USD** | `curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-miner.sh | bash` чтобы начать майнинг
 
 ---
 


### PR DESCRIPTION
Fixes the outdated Russian README reference noted in Scottcjn/rustchain-bounties#13766.

Changes:
- Updates the RTC reference rate from $0.10 to approximately $0.15.
- Replaces the outdated `python3 -m pip install clawrtc` mining setup command with the current `install-miner.sh` command used elsewhere in the file.