### PR TITLE
fix(discord): unwrap paginated miners payload

### DIFF
--- a/discord_rich_presence.py
+++ b/discord_rich_presence.py
@@ -81,10 +81,35 @@ def get_miners_list() -> List[Dict[str, Any]]:
             timeout=10
         )
         response.raise_for_status()
-        return response.json()  # type: ignore[no-any-return]
+        return normalize_miners_payload(response.json())
     except Exception as e:
         print(f"Error getting miners list: {e}")
         return []
+
+
+def normalize_miners_payload(payload: Any) -> List[Dict[str, Any]]:
+    """Return miner rows from legacy arrays or current paginated envelopes."""
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = []
+        for key in ("miners", "data", "items"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                rows = value
+                break
+    else:
+        rows = []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def miner_identifier(row: Dict[str, Any]) -> str:
+    """Resolve common miner id aliases returned by RustChain clients."""
+    for key in ("miner", "miner_id", "id", "name", "wallet"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return ""
 
 
 def get_epoch_info() -> Optional[Dict[str, Any]]:
@@ -262,7 +287,7 @@ def main() -> None:
             miners_list = get_miners_list()
             miner_data: Optional[Dict[str, Any]] = None
             for m in miners_list:
-                if m.get('miner') == miner_id:
+                if miner_identifier(m) == miner_id:
                     miner_data = m
                     break
 

--- a/tests/test_discord_rich_presence_miners.py
+++ b/tests/test_discord_rich_presence_miners.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "discord_rich_presence.py"
+
+
+def load_module():
+    fake_pypresence = types.ModuleType("pypresence")
+    fake_pypresence.Presence = object
+    sys.modules.setdefault("pypresence", fake_pypresence)
+    spec = importlib.util.spec_from_file_location("discord_rich_presence", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self.payload
+
+
+def test_normalize_miners_payload_accepts_current_envelope_and_legacy_list():
+    mod = load_module()
+    rows = [{"miner": "alice"}, {"miner_id": "bob"}, "bad-row"]
+
+    assert mod.normalize_miners_payload({"miners": rows, "pagination": {"total": 2}}) == rows[:2]
+    assert mod.normalize_miners_payload(rows) == rows[:2]
+    assert mod.normalize_miners_payload({"pagination": {"total": 0}}) == []
+
+
+def test_get_miners_list_unwraps_paginated_api_payload(monkeypatch):
+    mod = load_module()
+
+    def fake_get(url, verify, timeout):
+        assert url == "https://rustchain.org/api/miners"
+        assert timeout == 10
+        return FakeResponse(
+            {
+                "miners": [
+                    {"miner_id": "wallet-1", "hardware_type": "PowerPC G4"},
+                    {"name": "wallet-2", "hardware_type": "x86-64"},
+                ],
+                "pagination": {"total": 2, "limit": 100, "offset": 0},
+            }
+        )
+
+    monkeypatch.setattr(mod.requests, "get", fake_get)
+
+    assert mod.get_miners_list() == [
+        {"miner_id": "wallet-1", "hardware_type": "PowerPC G4"},
+        {"name": "wallet-2", "hardware_type": "x86-64"},
+    ]
+    assert mod.miner_identifier(mod.get_miners_list()[0]) == "wallet-1"
+


### PR DESCRIPTION
## Problem

`discord_rich_presence.py` treated `GET /api/miners` as a top-level list. The current RustChain API may return a paginated envelope with `miners` and `pagination`, so the script could iterate the wrong shape and fail to find an active miner.

## Impact

Discord Rich Presence users can see "miner not found" even when their miner is present in the live `/api/miners` response. The lookup was also limited to the `miner` field and missed common aliases such as `miner_id`, `id`, `name`, and `wallet`.

## Fix

- Add a small `normalize_miners_payload()` helper for legacy arrays and current `miners` / `data` / `items` envelopes.
- Filter malformed rows before matching.
- Resolve common miner-id aliases through `miner_identifier()`.

## Tests

- `python3 -m py_compile discord_rich_presence.py tests/test_discord_rich_presence_miners.py`
- `python3 -m pytest -q tests/test_discord_rich_presence_miners.py` -> 2 passed
- `git diff --check`

## Scope / Risk Boundary

- Client compatibility only.
- No wallet, transfer, reward, payout, admin-key, node, or production behavior changes.
- BCOS-L1.

Fixes #7319

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
