### PR TITLE
fix(prometheus): tolerate malformed numeric env

### DIFF
--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -55,6 +55,19 @@ def test_numeric_coercion_helpers_use_defaults_for_bad_values():
     assert module._to_int("bad", default=2) == 2
 
 
+def test_invalid_numeric_env_uses_defaults_without_import_crash(monkeypatch):
+    monkeypatch.setenv("EXPORTER_PORT", "not-a-port")
+    monkeypatch.setenv("SCRAPE_INTERVAL", "")
+    monkeypatch.setenv("REQUEST_TIMEOUT", "NaN")
+
+    module = load_module()
+
+    assert module.EXPORTER_PORT == 9100
+    assert module.SCRAPE_INTERVAL == 60
+    assert module.REQUEST_TIMEOUT == 15
+    assert module._env_int("MISSING_RUSTCHAIN_TEST_ENV", 42) == 42
+
+
 def test_fetch_json_returns_payload_and_handles_errors():
     module = load_module()
     response = Mock()

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -12,11 +12,23 @@ from urllib.parse import urlsplit, urlunsplit
 import requests
 from prometheus_client import Gauge, start_http_server
 
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable without crashing at import time."""
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 NODE_URL = os.getenv("NODE_URL", "https://rustchain.org").rstrip("/")
 P2P_NODE_URL = os.getenv("P2P_NODE_URL", "").rstrip("/")
-EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9100"))
-SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
-REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
+EXPORTER_PORT = _env_int("EXPORTER_PORT", 9100)
+SCRAPE_INTERVAL = _env_int("SCRAPE_INTERVAL", 60)
+REQUEST_TIMEOUT = _env_int("REQUEST_TIMEOUT", 15)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),


### PR DESCRIPTION
## Problem

`tools/prometheus/rustchain_exporter.py` parsed `EXPORTER_PORT`, `SCRAPE_INTERVAL`, and `REQUEST_TIMEOUT` with module-level `int(os.getenv(...))` calls.

A malformed numeric environment value could crash the exporter at import time before it starts, even though the module already has safe defaults for those settings.

## Impact

Ops mistakes such as `EXPORTER_PORT=not-a-port` or `REQUEST_TIMEOUT=NaN` can take the monitoring exporter down instead of falling back to defaults.

## Fix

Add `_env_int()` and use it for the exporter numeric environment settings. Missing, empty, or malformed values now use the existing defaults; valid integer values still work normally.

## Tests

- `python3 -m py_compile tools/prometheus/rustchain_exporter.py tests/test_prometheus_rustchain_exporter.py`
- `python3 -m pytest -q tests/test_prometheus_rustchain_exporter.py` -> 14 passed
- `git diff --check`

## Scope / Risk Boundary

- Monitoring-tool config hardening only.
- No node, wallet, transfer, reward, payout, admin-key, or production behavior changes.
- BCOS-L1.

Fixes #7321

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
