### PR TITLE
fix(alerts): tolerate malformed numeric env

### DIFF
--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -10,22 +10,44 @@ from pathlib import Path
 import pytest
 
 
-@pytest.fixture()
-def miner_alerts_module(monkeypatch):
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "tools"
+    / "miner_alerts"
+    / "miner_alerts.py"
+)
+
+
+def load_miner_alerts_module(monkeypatch):
     fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
-    module_path = (
-        Path(__file__).resolve().parents[1]
-        / "tools"
-        / "miner_alerts"
-        / "miner_alerts.py"
-    )
-    spec = importlib.util.spec_from_file_location("miner_alerts", module_path)
+    spec = importlib.util.spec_from_file_location("miner_alerts", MODULE_PATH)
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+@pytest.fixture()
+def miner_alerts_module(monkeypatch):
+    return load_miner_alerts_module(monkeypatch)
+
+
+def test_invalid_numeric_env_uses_defaults_without_import_crash(monkeypatch):
+    monkeypatch.setenv("POLL_INTERVAL", "soon")
+    monkeypatch.setenv("OFFLINE_THRESHOLD", "")
+    monkeypatch.setenv("LARGE_TRANSFER_THRESHOLD", "large")
+    monkeypatch.setenv("SMTP_PORT", "smtp")
+
+    module = load_miner_alerts_module(monkeypatch)
+
+    assert module.POLL_INTERVAL == 120
+    assert module.OFFLINE_THRESHOLD == 600
+    assert module.LARGE_TRANSFER_THRESHOLD == 10.0
+    assert module.SMTP_PORT == 587
+    assert module._env_int("MISSING_MINER_ALERTS_TEST_ENV", 9) == 9
+    assert module._env_float("MISSING_MINER_ALERTS_TEST_ENV", 1.5) == 1.5
 
 
 def test_alert_db_subscription_lifecycle_and_filters(

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -37,19 +37,42 @@ load_dotenv()
 
 # ─── Configuration ────────────────────────────────────────────────────────────
 
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable without import-time crashes."""
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read a float environment variable without import-time crashes."""
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API", "https://rustchain.org")
 VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true"
 
 # Polling intervals (seconds)
-POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "120"))  # 2 minutes default
-OFFLINE_THRESHOLD = int(os.getenv("OFFLINE_THRESHOLD", "600"))  # 10 min no attestation
+POLL_INTERVAL = _env_int("POLL_INTERVAL", 120)  # 2 minutes default
+OFFLINE_THRESHOLD = _env_int("OFFLINE_THRESHOLD", 600)  # 10 min no attestation
 
 # Large transfer threshold (RTC)
-LARGE_TRANSFER_THRESHOLD = float(os.getenv("LARGE_TRANSFER_THRESHOLD", "10.0"))
+LARGE_TRANSFER_THRESHOLD = _env_float("LARGE_TRANSFER_THRESHOLD", 10.0)
 
 # SMTP configuration
 SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_PORT = _env_int("SMTP_PORT", 587)
 SMTP_USER = os.getenv("SMTP_USER", "")
 SMTP_PASS = os.getenv("SMTP_PASS", "")
 SMTP_FROM = os.getenv("SMTP_FROM", "")


### PR DESCRIPTION
## Problem

`tools/miner_alerts/miner_alerts.py` parsed numeric environment settings with module-level `int(...)` / `float(...)` calls.

Malformed values for `POLL_INTERVAL`, `OFFLINE_THRESHOLD`, `LARGE_TRANSFER_THRESHOLD`, or `SMTP_PORT` could crash the miner alert daemon during import.

## Impact

A simple config typo can prevent the alerting tool from loading, even though safe defaults already exist for each value.

## Fix

- Add `_env_int()` and `_env_float()` helpers.
- Use them for miner-alert numeric config values.
- Preserve existing defaults and valid configuration behavior.

## Tests

- `python3 -m py_compile tools/miner_alerts/miner_alerts.py tests/test_miner_alerts.py`
- `python3 -m pytest -q tests/test_miner_alerts.py tests/test_miner_alerts_db.py` -> 12 passed
- `git diff --check`

## Scope / Risk Boundary

- Miner-alert tooling config hardening only.
- No node, wallet, transfer, reward, payout, admin-key, or production behavior changes.
- BCOS-L1.

Fixes #7323

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
