### PR TITLE
fix(webhooks): tolerate malformed numeric env

### DIFF
--- a/tests/test_webhook_server_helpers.py
+++ b/tests/test_webhook_server_helpers.py
@@ -28,6 +28,18 @@ def fake_addrinfo(ip):
     return [(None, None, None, None, (ip, 443))]
 
 
+def test_invalid_numeric_env_uses_defaults_without_import_crash(monkeypatch):
+    monkeypatch.setenv("WEBHOOK_POLL_INTERVAL", "fast")
+    monkeypatch.setenv("LARGE_TX_THRESHOLD", "huge")
+
+    module = load_module()
+
+    assert module.DEFAULT_POLL_INTERVAL == 10
+    assert module.DEFAULT_LARGE_TX_THRESHOLD == 100.0
+    assert module._env_int("MISSING_WEBHOOK_TEST_ENV", 7) == 7
+    assert module._env_float("MISSING_WEBHOOK_TEST_ENV", 2.5) == 2.5
+
+
 def make_admin_handler(module, payload):
     body = json.dumps(payload).encode()
     handler = object.__new__(module.WebhookAdminHandler)

--- a/tools/webhooks/webhook_server.py
+++ b/tools/webhooks/webhook_server.py
@@ -48,9 +48,33 @@ log = logging.getLogger("webhook-dispatcher")
 # ---------------------------------------------------------------------------
 # Constants & defaults
 # ---------------------------------------------------------------------------
+
+
+def _env_int(name: str, default: int) -> int:
+    """Read an integer environment variable without import-time crashes."""
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read a float environment variable without import-time crashes."""
+    raw = os.getenv(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 DEFAULT_NODE_URL = os.getenv("RUSTCHAIN_NODE", "http://localhost:5000")
-DEFAULT_POLL_INTERVAL = int(os.getenv("WEBHOOK_POLL_INTERVAL", "10"))
-DEFAULT_LARGE_TX_THRESHOLD = float(os.getenv("LARGE_TX_THRESHOLD", "100.0"))
+DEFAULT_POLL_INTERVAL = _env_int("WEBHOOK_POLL_INTERVAL", 10)
+DEFAULT_LARGE_TX_THRESHOLD = _env_float("LARGE_TX_THRESHOLD", 100.0)
 DEFAULT_DB_PATH = os.getenv("WEBHOOK_DB", "webhooks.db")
 MAX_ADMIN_BODY_BYTES = 1024 * 1024
 MAX_RETRIES = 5


### PR DESCRIPTION
## Problem

`tools/webhooks/webhook_server.py` parsed `WEBHOOK_POLL_INTERVAL` and `LARGE_TX_THRESHOLD` with module-level numeric casts.

Malformed values could crash the webhook dispatcher during import, before CLI args, defaults, or admin routes can be used.

## Impact

A simple config typo such as `WEBHOOK_POLL_INTERVAL=fast` or `LARGE_TX_THRESHOLD=huge` can prevent webhook monitoring from loading.

## Fix

- Add `_env_int()` and `_env_float()` helpers.
- Use them for webhook numeric environment defaults.
- Preserve existing defaults and valid configuration behavior.

## Tests

- `python3 -m py_compile tools/webhooks/webhook_server.py tests/test_webhook_server_helpers.py`
- `python3 -m pytest -q tests/test_webhook_server_helpers.py tools/webhooks/test_webhook_server.py tests/test_webhook_admin_auth.py` -> 27 passed
- `git diff --check`

## Scope / Risk Boundary

- Webhook-tool config hardening only.
- No node, wallet, transfer, reward, payout, admin-key, or production behavior changes.
- BCOS-L1.

Fixes #7325

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
