### PR TITLE
fix(settlement): fail closed on malformed epoch settler env

### DIFF
--- a/node/auto_epoch_settler.py
+++ b/node/auto_epoch_settler.py
@@ -15,13 +15,29 @@ import requests
 # Configure logging (daemon-friendly — writes to stderr + syslog in systemd)
 logger = logging.getLogger("rustchain.epoch_settler")
 
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
+
 # Configuration — environment variables with defaults
 NODE_URL = os.environ.get("RUSTCHAIN_NODE_URL", "http://localhost:8088")
 DB_PATH = os.environ.get("RUSTCHAIN_DB_PATH", "/root/rustchain/rustchain_v2.db")
 # Module-level env config — wrap integer casts so bad env values
 # (empty string, non-numeric text) don't crash the daemon at import.
-CHECK_INTERVAL = int(os.environ.get("RUSTCHAIN_SETTLE_INTERVAL", "300") or 300)
-SLOTS_PER_EPOCH = int(os.environ.get("RUSTCHAIN_SLOTS_PER_EPOCH", "144") or 144)
+CHECK_INTERVAL = _env_positive_int("RUSTCHAIN_SETTLE_INTERVAL", 300)
+SLOTS_PER_EPOCH = _env_positive_int("RUSTCHAIN_SLOTS_PER_EPOCH", 144)
 
 
 def get_current_slot():

--- a/node/auto_epoch_settler.py
+++ b/node/auto_epoch_settler.py
@@ -18,24 +18,24 @@ logger = logging.getLogger("rustchain.epoch_settler")
 
 def _env_positive_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
-    if raw is None or raw == "":
+    if raw is None:
         return default
+    if str(raw).strip() == "":
+        raise ValueError(f"{name} must be a positive integer")
     try:
         value = int(raw)
     except (TypeError, ValueError):
-        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-        return default
+        raise ValueError(f"{name} must be a positive integer") from None
     if value <= 0:
-        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-        return default
+        raise ValueError(f"{name} must be a positive integer")
     return value
 
 
 # Configuration — environment variables with defaults
 NODE_URL = os.environ.get("RUSTCHAIN_NODE_URL", "http://localhost:8088")
 DB_PATH = os.environ.get("RUSTCHAIN_DB_PATH", "/root/rustchain/rustchain_v2.db")
-# Module-level env config — wrap integer casts so bad env values
-# (empty string, non-numeric text) don't crash the daemon at import.
+# Missing env values use documented defaults; explicit malformed settlement
+# config fails closed instead of silently changing epoch timing.
 CHECK_INTERVAL = _env_positive_int("RUSTCHAIN_SETTLE_INTERVAL", 300)
 SLOTS_PER_EPOCH = _env_positive_int("RUSTCHAIN_SLOTS_PER_EPOCH", 144)
 

--- a/node/tests/test_auto_epoch_settler_config.py
+++ b/node/tests/test_auto_epoch_settler_config.py
@@ -2,6 +2,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "auto_epoch_settler.py"
 
@@ -24,26 +26,25 @@ def _load_settler(monkeypatch, **env):
         sys.modules.pop(module_name, None)
 
 
-def test_auto_epoch_settler_bad_numeric_env_falls_back(monkeypatch):
-    module = _load_settler(
-        monkeypatch,
-        RUSTCHAIN_SETTLE_INTERVAL="not-an-int",
-        RUSTCHAIN_SLOTS_PER_EPOCH="also-bad",
-    )
+def test_auto_epoch_settler_missing_numeric_env_uses_defaults(monkeypatch):
+    module = _load_settler(monkeypatch)
 
     assert module.CHECK_INTERVAL == 300
     assert module.SLOTS_PER_EPOCH == 144
 
 
-def test_auto_epoch_settler_non_positive_env_falls_back(monkeypatch):
-    module = _load_settler(
-        monkeypatch,
-        RUSTCHAIN_SETTLE_INTERVAL="0",
-        RUSTCHAIN_SLOTS_PER_EPOCH="-9",
-    )
-
-    assert module.CHECK_INTERVAL == 300
-    assert module.SLOTS_PER_EPOCH == 144
+@pytest.mark.parametrize(
+    ("name", "value"),
+    [
+        ("RUSTCHAIN_SETTLE_INTERVAL", "not-an-int"),
+        ("RUSTCHAIN_SETTLE_INTERVAL", ""),
+        ("RUSTCHAIN_SLOTS_PER_EPOCH", "0"),
+        ("RUSTCHAIN_SLOTS_PER_EPOCH", "-9"),
+    ],
+)
+def test_auto_epoch_settler_explicit_bad_numeric_env_fails_closed(monkeypatch, name, value):
+    with pytest.raises(ValueError, match=name):
+        _load_settler(monkeypatch, **{name: value})
 
 
 def test_auto_epoch_settler_valid_numeric_env_is_preserved(monkeypatch):

--- a/node/tests/test_auto_epoch_settler_config.py
+++ b/node/tests/test_auto_epoch_settler_config.py
@@ -1,0 +1,57 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "auto_epoch_settler.py"
+
+
+def _load_settler(monkeypatch, **env):
+    for name in ("RUSTCHAIN_SETTLE_INTERVAL", "RUSTCHAIN_SLOTS_PER_EPOCH"):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    module_name = f"auto_epoch_settler_config_test_{abs(hash(tuple(sorted(env.items()))))}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def test_auto_epoch_settler_bad_numeric_env_falls_back(monkeypatch):
+    module = _load_settler(
+        monkeypatch,
+        RUSTCHAIN_SETTLE_INTERVAL="not-an-int",
+        RUSTCHAIN_SLOTS_PER_EPOCH="also-bad",
+    )
+
+    assert module.CHECK_INTERVAL == 300
+    assert module.SLOTS_PER_EPOCH == 144
+
+
+def test_auto_epoch_settler_non_positive_env_falls_back(monkeypatch):
+    module = _load_settler(
+        monkeypatch,
+        RUSTCHAIN_SETTLE_INTERVAL="0",
+        RUSTCHAIN_SLOTS_PER_EPOCH="-9",
+    )
+
+    assert module.CHECK_INTERVAL == 300
+    assert module.SLOTS_PER_EPOCH == 144
+
+
+def test_auto_epoch_settler_valid_numeric_env_is_preserved(monkeypatch):
+    module = _load_settler(
+        monkeypatch,
+        RUSTCHAIN_SETTLE_INTERVAL="45",
+        RUSTCHAIN_SLOTS_PER_EPOCH="72",
+    )
+
+    assert module.CHECK_INTERVAL == 45
+    assert module.SLOTS_PER_EPOCH == 72


### PR DESCRIPTION
## Summary
- keep the epoch settler's documented defaults when the related environment variables are unset
- fail closed when an explicit epoch-settler numeric override is empty, malformed, zero, or negative
- preserve valid numeric overrides and keep the change scoped to configuration parsing/tests

## Risk / BCOS
BCOS-L2: settlement timing/config behavior touches reward/settlement operations.

This PR does not change settlement amounts, reward rules, wallet balances, admin keys, production wallets, or manual crediting paths. It only makes explicit malformed settlement configuration fail at startup instead of silently falling back to defaults.

## Validation
- `uv run --no-project --with pytest --with requests python -B -m pytest -q node/tests/test_auto_epoch_settler_config.py` -> 6 passed
- `python3 -m py_compile node/auto_epoch_settler.py node/tests/test_auto_epoch_settler_config.py` -> passed
- `git diff --check` -> passed

Related: #7327

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
