### PR TITLE
Handle invalid JSON responses in Python SDK

### DIFF
--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -71,6 +71,24 @@ class RustChainClient:
             )
         return self._client
 
+    @staticmethod
+    def _parse_json_response(response: httpx.Response, method: str, path: str) -> Any:
+        """Parse a successful response or raise an APIError with useful context."""
+        if not response.content or not response.content.strip():
+            raise APIError(
+                f"Invalid JSON response from {method} {path}: empty response body",
+                status_code=response.status_code,
+            )
+        try:
+            return response.json()
+        except ValueError as e:
+            content_type = response.headers.get("content-type", "unknown")
+            raise APIError(
+                f"Invalid JSON response from {method} {path} "
+                f"(content-type: {content_type}): {e}",
+                status_code=response.status_code,
+            ) from e
+
     async def _post(
         self,
         path: str,
@@ -100,7 +118,7 @@ class RustChainClient:
                 json=json_data,
             )
             response.raise_for_status()
-            return response.json()
+            return self._parse_json_response(response, "POST", path)
         except httpx.ConnectError as e:
             raise RCConnectionError(f"Failed to connect to {self._base_url}: {e}")
         except httpx.HTTPStatusError as e:
@@ -113,6 +131,8 @@ class RustChainClient:
                 f"API error {e.response.status_code}: {message}",
                 status_code=e.response.status_code,
             )
+        except APIError:
+            raise
         except Exception as e:
             raise RustChainError(f"Unexpected error: {e}")
 
@@ -145,7 +165,7 @@ class RustChainClient:
                     status_code=response.status_code,
                 )
             response.raise_for_status()
-            return response.json()
+            return self._parse_json_response(response, "GET", path)
         except httpx.ConnectError as e:
             raise RCConnectionError(f"Failed to connect to {self._base_url}: {e}")
         except httpx.HTTPStatusError as e:
@@ -158,6 +178,8 @@ class RustChainClient:
                 f"API error {e.response.status_code}: {message}",
                 status_code=e.response.status_code,
             )
+        except APIError:
+            raise
         except Exception as e:
             raise RustChainError(f"Unexpected error: {e}")
 

--- a/sdk/python/rustchain_sdk/tests/test_client.py
+++ b/sdk/python/rustchain_sdk/tests/test_client.py
@@ -93,6 +93,40 @@ class TestRustChainClientHealth:
             with pytest.raises(APIError, match="Expected JSON object response"):
                 await client.health()
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_health_rejects_empty_success_response(self):
+        """A successful response with an empty body raises a clear APIError."""
+        respx.get(f"{DEFAULT_NODE_URL}/health").mock(
+            return_value=httpx.Response(200, content=b"")
+        )
+        async with RustChainClient() as client:
+            with pytest.raises(
+                APIError,
+                match=r"Invalid JSON response from GET /health: empty response body",
+            ) as exc_info:
+                await client.health()
+        assert exc_info.value.status_code == 200
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_health_rejects_non_json_success_response(self):
+        """A successful non-JSON response raises a clear APIError."""
+        respx.get(f"{DEFAULT_NODE_URL}/health").mock(
+            return_value=httpx.Response(
+                200,
+                text="node is healthy",
+                headers={"content-type": "text/plain"},
+            )
+        )
+        async with RustChainClient() as client:
+            with pytest.raises(
+                APIError,
+                match=r"Invalid JSON response from GET /health",
+            ) as exc_info:
+                await client.health()
+        assert exc_info.value.status_code == 200
+
 
 class TestRustChainClientEpoch:
     """Test epoch endpoint."""
@@ -282,6 +316,26 @@ class TestRustChainClientTransfer:
                     "RTCfrom", "RTCto", 100, 0, "bad", 0, public_key="pubhex"
                 )
             assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_transfer_signed_rejects_empty_success_response(self):
+        """POST helpers reject an empty 200 response with endpoint context."""
+        respx.post(f"{DEFAULT_NODE_URL}/wallet/transfer/signed").mock(
+            return_value=httpx.Response(200, content=b"")
+        )
+        async with RustChainClient() as client:
+            with pytest.raises(
+                APIError,
+                match=(
+                    r"Invalid JSON response from POST /wallet/transfer/signed: "
+                    r"empty response body"
+                ),
+            ) as exc_info:
+                await client.transfer_signed(
+                    "RTCfrom", "RTCto", 100, 0, "sig", 0, public_key="pubhex"
+                )
+        assert exc_info.value.status_code == 200
 
 
 class TestRustChainClientExplorer:


### PR DESCRIPTION
Fixes the Python SDK response-parsing issue described in Scottcjn/rustchain-bounties#13795.

Changes:
- Detect empty successful response bodies before JSON parsing.
- Convert malformed/non-JSON successful responses into a clear `APIError` with method, path, content type, and HTTP status.
- Preserve `APIError` instead of wrapping it as a generic `RustChainError`.
- Add GET and POST regression tests for empty and non-JSON 200 responses.

Verification: `python -m pytest rustchain_sdk/tests/test_client.py -q` -> 28 passed.