### PR TITLE
fix(airdrop): redact public bridge lock status

### DIFF
--- a/docs/RIP305_AIRDROP_V2.md
+++ b/docs/RIP305_AIRDROP_V2.md
@@ -50,7 +50,7 @@ node/
    - `/api/bridge/lock` - Create bridge lock
    - `/api/bridge/lock/<id>/confirm` - Confirm lock
    - `/api/bridge/lock/<id>/release` - Release lock
-   - `/api/bridge/lock/<id>` - Get lock status
+   - `/api/bridge/lock/<id>` - Get lock status; unauthenticated responses are public-safe and omit bridge addresses / transaction ids, while valid admin-key requests return the full operator view
 
 ## Eligibility Tiers
 
@@ -174,6 +174,14 @@ curl -X POST https://rustchain.org/api/bridge/lock \
     "amount_wrtc": 100
   }'
 ```
+
+#### Get Bridge Lock Status
+
+`GET /api/bridge/lock/<id>` returns public-safe status fields by default:
+`lock_id`, `from_chain`, `to_chain`, `amount_uwrtc`, `amount_wrtc`,
+`timestamp`, `timestamp_iso`, and `status`. Include a valid admin key to see
+operator-only fields such as `from_address`, `to_address`, `source_tx`, and
+`dest_tx`.
 
 #### Get Statistics
 

--- a/node/airdrop_v2.py
+++ b/node/airdrop_v2.py
@@ -168,6 +168,20 @@ class BridgeLock:
         ).isoformat()
         return result
 
+    def to_public_dict(self) -> Dict[str, Any]:
+        return {
+            "lock_id": self.lock_id,
+            "from_chain": self.from_chain,
+            "to_chain": self.to_chain,
+            "amount_uwrtc": self.amount_uwrtc,
+            "amount_wrtc": self.amount_uwrtc / 1_000_000,
+            "timestamp": self.timestamp,
+            "timestamp_iso": datetime.fromtimestamp(
+                self.timestamp, tz=timezone.utc
+            ).isoformat(),
+            "status": self.status,
+        }
+
 
 # ============================================================================
 # Database Schema
@@ -1281,6 +1295,17 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
             return jsonify({"ok": False, "error": "unauthorized"}), 401
         return None
 
+    def has_admin_key():
+        required = os.environ.get("RC_ADMIN_KEY", "").strip()
+        if not required:
+            return False
+        provided = (
+            request.headers.get("X-Admin-Key")
+            or request.headers.get("X-API-Key")
+            or ""
+        ).strip()
+        return bool(provided) and hmac.compare_digest(provided, required)
+
     def parse_json_object_body(require_body: bool = True):
         data = request.get_json(silent=True)
         if data is None:
@@ -1544,7 +1569,9 @@ def init_airdrop_routes(app, airdrop: AirdropV2, db_path: str) -> None:
         """Get bridge lock status."""
         lock = airdrop.get_lock(lock_id)
         if lock:
-            return jsonify({"ok": True, "lock": lock.to_dict()})
+            if has_admin_key():
+                return jsonify({"ok": True, "lock": lock.to_dict()})
+            return jsonify({"ok": True, "lock": lock.to_public_dict()})
         return jsonify({"ok": False, "error": "lock_not_found"}), 404
 
 

--- a/node/test_airdrop_v2.py
+++ b/node/test_airdrop_v2.py
@@ -585,6 +585,7 @@ class TestAirdropBridgeRoutes(unittest.TestCase):
     def _create_lock(self):
         response = self.client.post(
             "/api/bridge/lock",
+            headers=ADMIN_HEADERS,
             json={
                 "from_address": "RTC1234567890123456789012345678901234567890",
                 "to_address": "0x1234567890123456789012345678901234567890",

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -1,10 +1,10 @@
 # Existing unannotated .fetchall() migration baseline for issue #6627.
 # Expected to shrink as legacy callers migrate to node.db_helpers.fetch_page()
 # or receive a narrow fetchall-ok annotation. Do not add new entries manually.
-node/airdrop_v2.py:1142:        rows = cursor.fetchall()
-node/airdrop_v2.py:1193:        rows = cursor.fetchall()
-node/airdrop_v2.py:1226:            for row in cursor.fetchall()
-node/airdrop_v2.py:1238:            for row in cursor.fetchall()
+node/airdrop_v2.py:1156:        rows = cursor.fetchall()
+node/airdrop_v2.py:1207:        rows = cursor.fetchall()
+node/airdrop_v2.py:1240:            for row in cursor.fetchall()
+node/airdrop_v2.py:1252:            for row in cursor.fetchall()
 node/anti_double_mining.py:160:    enrolled = cursor.fetchall()
 node/anti_double_mining.py:210:        rows = cursor.fetchall()
 node/anti_double_mining.py:333:    rows = cursor.fetchall()

--- a/scripts/check_fetchall.sh
+++ b/scripts/check_fetchall.sh
@@ -45,7 +45,7 @@ FETCHALL_PATTERN='\.fetchall[[:space:]]*\('
 
 if command -v rg >/dev/null 2>&1; then
     set +e
-    rg -n "$FETCHALL_PATTERN" node \
+    rg --no-ignore -n "$FETCHALL_PATTERN" node \
         --glob '!node/tests/**' \
         --glob '!node/test_*' \
         --glob '!node/__pycache__/**' \

--- a/tests/test_airdrop_bridge_admin_auth.py
+++ b/tests/test_airdrop_bridge_admin_auth.py
@@ -108,6 +108,59 @@ def test_bridge_confirm_and_release_accept_valid_admin_key(tmp_path, monkeypatch
     )
 
 
+def test_bridge_lock_status_public_redacts_addresses_and_tx_ids(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    lock_id = _create_pending_lock(client, "expected-admin")
+
+    confirmed = client.post(
+        f"/api/bridge/lock/{lock_id}/confirm",
+        headers={"X-Admin-Key": "expected-admin"},
+        json={"source_tx": "real-source-tx"},
+    )
+    assert confirmed.status_code == 200
+
+    response = client.get(f"/api/bridge/lock/{lock_id}")
+
+    assert response.status_code == 200
+    lock = response.get_json()["lock"]
+    assert lock["lock_id"] == lock_id
+    assert lock["status"] == "locked"
+    assert lock["from_chain"] == "solana"
+    assert lock["to_chain"] == "base"
+    assert lock["amount_uwrtc"] == 1_000_000
+    assert "timestamp_iso" in lock
+    assert "from_address" not in lock
+    assert "to_address" not in lock
+    assert "source_tx" not in lock
+    assert "dest_tx" not in lock
+
+
+def test_bridge_lock_status_admin_includes_full_lock_fields(tmp_path, monkeypatch):
+    client, _db_path = _make_client(tmp_path)
+    monkeypatch.setenv("RC_ADMIN_KEY", "expected-admin")
+    lock_id = _create_pending_lock(client, "expected-admin")
+
+    confirmed = client.post(
+        f"/api/bridge/lock/{lock_id}/confirm",
+        headers={"X-Admin-Key": "expected-admin"},
+        json={"source_tx": "real-source-tx"},
+    )
+    assert confirmed.status_code == 200
+
+    response = client.get(
+        f"/api/bridge/lock/{lock_id}",
+        headers={"X-Admin-Key": "expected-admin"},
+    )
+
+    assert response.status_code == 200
+    lock = response.get_json()["lock"]
+    assert lock["from_address"] == "solana-source"
+    assert lock["to_address"] == "base-destination"
+    assert lock["source_tx"] == "real-source-tx"
+    assert lock["dest_tx"] is None
+
+
 @pytest.mark.parametrize(
     ("path", "headers"),
     [


### PR DESCRIPTION
## Summary

- Keep `GET /api/bridge/lock/<lock_id>` usable as a public status endpoint, but return only public-safe status fields without bridge endpoint addresses or operator transaction ids.
- Return the full lock payload only when the request carries a valid admin key.
- Document the public vs admin response boundary and sync the existing bridge route fixture with the admin-gated create route.
- Keep the fetchall guard green after this file moved legacy baseline line numbers, and make the `rg` scan path match the fallback `grep` path for tracked ignored node sources.

## Impact

The route previously returned `from_address`, `to_address`, `source_tx`, and `dest_tx` to unauthenticated callers. The adjacent airdrop claim status endpoint and bridge mutation endpoints are admin-gated because they expose wallet / operator data. This PR preserves public status visibility while keeping bridge wallet and tx-id details in the operator-only view.

The fetchall guard update is test-only hygiene: it does not change bridge behavior. It keeps the existing migration baseline aligned after `node/airdrop_v2.py` line movement and prevents `rg` from skipping tracked node source files just because `.gitignore` contains broad sensitive-name patterns.

## BCOS

BCOS-L2. This touches bridge / wallet-adjacent status visibility and auth-boundary behavior, but does not change bridge amounts, payout or minting rules, admin secrets, production wallets, manual crediting, or create any user-callable payout endpoint.

## Validation

- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q tests/test_airdrop_bridge_admin_auth.py node/test_airdrop_v2.py tests/test_fetchall_guard.py` -> 71 passed
- `bash scripts/check_fetchall.sh` -> passed; legacy baseline count 179
- `python -m py_compile node/airdrop_v2.py` -> passed
- `git diff --check` -> passed

Related: #7340

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
