### PR TITLE
fix(bridge): guard void against terminal races

### DIFF
--- a/node/bridge_api.py
+++ b/node/bridge_api.py
@@ -599,21 +599,26 @@ def void_bridge_transfer(
 ) -> Tuple[bool, Dict[str, Any]]:
     """Void a bridge transfer and release associated lock."""
     cursor = db_conn.cursor()
-    
-    # Find the transfer
-    transfer = get_bridge_transfer_by_hash(db_conn, tx_hash)
-    if not transfer:
-        return False, {"error": "Bridge transfer not found"}
-    
-    if transfer["status"] not in ("pending", "locked", "confirming"):
-        return False, {
-            "error": f"Cannot void transfer with status '{transfer['status']}'",
-            "hint": "Only pending/locked/confirming transfers can be voided"
-        }
-    
     now = int(time.time())
     
     try:
+        cursor.execute("BEGIN IMMEDIATE")
+
+        # Find the transfer while holding the write lock. The guarded UPDATE
+        # below is still authoritative so a stale pre-transaction snapshot
+        # cannot overwrite a completed/failed/voided transfer.
+        transfer = get_bridge_transfer_by_hash(db_conn, tx_hash)
+        if not transfer:
+            db_conn.rollback()
+            return False, {"error": "Bridge transfer not found"}
+
+        if transfer["status"] not in ("pending", "locked", "confirming"):
+            db_conn.rollback()
+            return False, {
+                "error": f"Cannot void transfer with status '{transfer['status']}'",
+                "hint": "Only pending/locked/confirming transfers can be voided"
+            }
+
         # Update bridge transfer
         cursor.execute("""
             UPDATE bridge_transfers
@@ -622,7 +627,21 @@ def void_bridge_transfer(
                 voided_reason = ?,
                 updated_at = ?
             WHERE tx_hash = ?
+              AND status IN ('pending', 'locked', 'confirming')
         """, (voided_by, reason, now, tx_hash))
+
+        if cursor.rowcount != 1:
+            current = cursor.execute(
+                "SELECT status FROM bridge_transfers WHERE tx_hash = ?",
+                (tx_hash,),
+            ).fetchone()
+            db_conn.rollback()
+            if not current:
+                return False, {"error": "Bridge transfer not found"}
+            return False, {
+                "error": f"Cannot void transfer with status '{current[0]}'",
+                "hint": "Only pending/locked/confirming transfers can be voided",
+            }
         
         # Release associated lock
         cursor.execute("""

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -1163,6 +1163,66 @@ class TestIntegration:
         
         conn.close()
 
+    def test_stale_void_cannot_overwrite_completed_withdraw(
+        self, setup_test_db, monkeypatch
+    ):
+        """A stale admin void must not overwrite a completed withdraw."""
+        bridge_api = setup_test_db["bridge_api"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+
+        req = bridge_api.BridgeTransferRequest(
+            direction="withdraw",
+            source_chain="solana",
+            dest_chain="rustchain",
+            source_address="4TRwNqXqXqXqXqXqXqXqXqXqXqXqXqXqXq",
+            dest_address="RTCwithdrawdest",
+            amount_rtc=10.0,
+        )
+        success, result = bridge_api.create_bridge_transfer(conn, req)
+        assert success is True
+        tx_hash = result["tx_hash"]
+
+        stale_transfer = bridge_api.get_bridge_transfer_by_hash(conn, tx_hash)
+        success, result = bridge_api.update_external_confirmation(
+            conn,
+            tx_hash,
+            external_tx_hash="solana_tx_complete",
+            confirmations=12,
+            required_confirmations=12,
+        )
+        assert success is True
+        assert result["status"] == "completed"
+
+        original_get_bridge_transfer_by_hash = bridge_api.get_bridge_transfer_by_hash
+
+        def stale_once(_conn, current_tx_hash):
+            if current_tx_hash == tx_hash:
+                return stale_transfer
+            return original_get_bridge_transfer_by_hash(_conn, current_tx_hash)
+
+        monkeypatch.setattr(bridge_api, "get_bridge_transfer_by_hash", stale_once)
+
+        success, result = bridge_api.void_bridge_transfer(
+            conn,
+            tx_hash,
+            reason="late_admin_void",
+            voided_by="admin",
+        )
+
+        assert success is False
+        assert result["error"] == "Cannot void transfer with status 'completed'"
+
+        transfer = original_get_bridge_transfer_by_hash(conn, tx_hash)
+        assert transfer["status"] == "completed"
+        assert transfer["voided_by"] is None
+        balance_i64 = conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+            ("RTCwithdrawdest",),
+        ).fetchone()[0]
+        assert balance_i64 == 10 * bridge_api.BRIDGE_UNIT
+
+        conn.close()
+
 
 class TestBridgeCallbackAuth:
     """Test bridge service callback authentication."""


### PR DESCRIPTION
## Summary

- Wrap bridge voiding in the same kind of write transaction used by the external confirmation path.
- Guard the `bridge_transfers` update so void only succeeds while the current row is still `pending`, `locked`, or `confirming`.
- Add regression coverage for a stale admin void snapshot after a withdraw has already completed and credited the RustChain destination.

## Problem

`update_external_confirmation()` already protects terminal bridge transitions with `BEGIN IMMEDIATE` and a current-row status guard. `void_bridge_transfer()` read the transfer first, then updated by `tx_hash` without re-checking the current status. A stale admin/operator void decision could therefore overwrite a transfer that had already become `completed`.

For external-to-RustChain withdraws, that can leave the destination balance credited while the bridge transfer record says `voided`, which is bad accounting state for bridge reconciliation.

## Fix

The void path now:

- starts a write transaction before the status decision;
- keeps the existing pending/locked/confirming semantics;
- updates with `WHERE tx_hash = ? AND status IN (...)`;
- returns the current terminal status if another path completed/failed/voided the row first.

No bridge amounts, confirmation thresholds, payout/minting rules, admin keys, production wallets, or user-callable payout paths are changed.

## BCOS

BCOS-L2. This touches bridge / wallet-adjacent settlement state and protects bridge accounting from stale terminal-state overwrites.

## Validation

- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_bridge_lock_ledger.py node/test_bridge_withdraw_completion_credits_destination_poc.py node/test_bridge_initiate_type_validation.py` -> 71 passed, 10 subtests passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed; legacy baseline count 179
- `python -m py_compile node/bridge_api.py` -> passed
- `git diff --check` -> passed

Related: #7342

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945