### PR TITLE
fix(governance): avoid charging rejected proposals

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -428,6 +428,20 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
 
         try:
             with sqlite3.connect(db_path) as conn:
+                # Keep the active-proposal limit, fee debit, and proposal insert
+                # in one write transaction. Failed preflight checks must not
+                # commit a proposal-fee debit without creating a proposal.
+                conn.execute("BEGIN IMMEDIATE")
+
+                # Anti-spam: max active proposals per miner. Check this before
+                # debiting the proposal fee so a rejected request is not charged.
+                active_count = conn.execute(
+                    "SELECT COUNT(*) FROM governance_proposals WHERE proposed_by = ? AND status = ?",
+                    (miner_id, STATUS_ACTIVE)
+                ).fetchone()[0]
+                if active_count >= MAX_PROPOSALS_PER_MINER:
+                    return jsonify({"error": f"Max {MAX_PROPOSALS_PER_MINER} active proposals per miner"}), 429
+
                 # Fee check: ensure miner has sufficient balance
                 table_check = conn.execute(
                     "SELECT name FROM sqlite_master WHERE type='table' AND name='balances'"
@@ -439,14 +453,6 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
                             "error": f"Insufficient balance: proposal fee is {PROPOSAL_FEE_RTC} RTC"
                         }), 402
                     _deduct_proposal_fee(conn, miner_id, PROPOSAL_FEE_RTC)
-
-                # Anti-spam: max active proposals per miner
-                active_count = conn.execute(
-                    "SELECT COUNT(*) FROM governance_proposals WHERE proposed_by = ? AND status = ?",
-                    (miner_id, STATUS_ACTIVE)
-                ).fetchone()[0]
-                if active_count >= MAX_PROPOSALS_PER_MINER:
-                    return jsonify({"error": f"Max {MAX_PROPOSALS_PER_MINER} active proposals per miner"}), 429
 
                 # Build proposal data for Sophia evaluation
                 proposal_data = {
@@ -508,12 +514,12 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
                         "SELECT * FROM governance_proposals WHERE status = ? "
                         "ORDER BY created_at DESC LIMIT ? OFFSET ?",
                         (status_filter, limit, offset)
-                    ).fetchall()
+                    ).fetchall()  # fetchall-ok: already-paginated
                 else:
                     rows = conn.execute(
                         "SELECT * FROM governance_proposals ORDER BY created_at DESC LIMIT ? OFFSET ?",
                         (limit, offset)
-                    ).fetchall()
+                    ).fetchall()  # fetchall-ok: already-paginated
                 proposals = [dict(r) for r in rows]
 
         except Exception as e:

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -47,9 +47,7 @@ node/coalition.py:966:                    ).fetchall()
 node/ergo_miner_anchor.py:38:        miners = [dict(row) for row in cur.fetchall()]
 node/ergo_raw_tx.py:77:        miners = [dict(row) for row in cur.fetchall()]
 node/governance.py:280:            ).fetchall()
-node/governance.py:511:                    ).fetchall()
-node/governance.py:516:                    ).fetchall()
-node/governance.py:546:                ).fetchall()
+node/governance.py:552:                ).fetchall()
 node/gpu_render_endpoints.py:64:            cols = {row[1] for row in db.execute("PRAGMA table_info(render_escrow)").fetchall()}
 node/gpu_render_protocol.py:152:        cols = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
 node/gpu_render_protocol.py:272:            rows = conn.execute(query, params).fetchall()

--- a/tests/test_governance_proposal_validation.py
+++ b/tests/test_governance_proposal_validation.py
@@ -76,3 +76,67 @@ def test_create_proposal_stores_string_parameter_value(tmp_path, monkeypatch):
             (response.get_json()["proposal_id"],),
         ).fetchone()
     assert row[0] == "0.40"
+
+
+def _fund_miner(db_path, balance_rtc=50):
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+            ("miner-1", int(balance_rtc * 1_000_000)),
+        )
+        conn.commit()
+
+
+def _miner_balance_i64(db_path):
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute(
+            "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+            ("miner-1",),
+        ).fetchone()[0]
+
+
+def test_successful_create_proposal_charges_proposal_fee(tmp_path, monkeypatch):
+    client, db_path = _client(tmp_path, monkeypatch)
+    _fund_miner(db_path)
+
+    response = client.post("/api/governance/propose", json=_proposal_payload())
+
+    assert response.status_code == 201
+    assert _miner_balance_i64(db_path) == 40_000_000
+
+
+def test_max_active_proposal_rejection_does_not_charge_fee(tmp_path, monkeypatch):
+    client, db_path = _client(tmp_path, monkeypatch)
+    _fund_miner(db_path)
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        for idx in range(governance.MAX_PROPOSALS_PER_MINER):
+            conn.execute(
+                """
+                INSERT INTO governance_proposals (
+                    title, description, proposal_type, proposed_by,
+                    created_at, expires_at, status
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    f"Existing proposal {idx}",
+                    "already active",
+                    "feature_activation",
+                    "miner-1",
+                    now - idx,
+                    now + governance.VOTING_WINDOW_SECONDS,
+                    governance.STATUS_ACTIVE,
+                ),
+            )
+        conn.commit()
+
+    response = client.post("/api/governance/propose", json=_proposal_payload())
+
+    assert response.status_code == 429
+    assert response.get_json()["error"] == (
+        f"Max {governance.MAX_PROPOSALS_PER_MINER} active proposals per miner"
+    )
+    assert _miner_balance_i64(db_path) == 50_000_000


### PR DESCRIPTION
## Problem

`POST /api/governance/propose` deducted the 10 RTC proposal fee before enforcing `MAX_PROPOSALS_PER_MINER`. When a miner was already at the active proposal limit, the endpoint returned 429 without creating a proposal, but the sqlite context could still commit the earlier fee debit.

## Impact

Rejected governance submissions could burn miner balance even though no proposal was accepted. This is a governance/accounting integrity fix.

BCOS-L2: touches governance proposal fee / wallet balance accounting behavior.


## Fix

- Enforce the active-proposal limit before the proposal fee debit.
- Keep the active-limit check, fee debit, and proposal insert inside one `BEGIN IMMEDIATE` write transaction.
- Add regression coverage that accepted proposals still charge the fee while max-active rejections preserve balance.
- Mark the already-paginated governance proposal list fetchalls so the fetchall guard no longer tracks them as legacy debt; keep the unrelated unbounded votes fetchall as baseline-only.

No payout amounts, reward rules, admin secrets, production wallets, manual crediting, or user-callable payout endpoints are changed.

## Validation

- `uv run --no-project --with pytest --with flask --with pynacl python -B -m pytest -q tests/test_governance_proposal_validation.py node/test_governance_balance_schema_poc.py node/test_governance_security.py` -> 15 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 177
- `python -m py_compile node/governance.py` -> passed
- `git diff --check` -> passed

Related: #7344

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
