### PR TITLE
fix(governance): paginate api proposal votes

### DIFF
--- a/node/governance.py
+++ b/node/governance.py
@@ -98,6 +98,8 @@ MAX_PROPOSALS_PER_MINER = 10            # Anti-spam: max active proposals
 MAX_TITLE_LEN = 200
 MAX_DESCRIPTION_LEN = 10000
 PROPOSAL_FEE_RTC = 10  # Anti-spam: fee charged to propose a governance change
+VOTES_DEFAULT_LIMIT = 200
+VOTES_MAX_LIMIT = 500
 
 PROPOSAL_TYPES = ("parameter_change", "feature_activation", "emergency")
 VOTE_CHOICES = ("for", "against", "abstain")
@@ -508,12 +510,12 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
                         "SELECT * FROM governance_proposals WHERE status = ? "
                         "ORDER BY created_at DESC LIMIT ? OFFSET ?",
                         (status_filter, limit, offset)
-                    ).fetchall()
+                    ).fetchall()  # fetchall-ok: already-paginated
                 else:
                     rows = conn.execute(
                         "SELECT * FROM governance_proposals ORDER BY created_at DESC LIMIT ? OFFSET ?",
                         (limit, offset)
-                    ).fetchall()
+                    ).fetchall()  # fetchall-ok: already-paginated
                 proposals = [dict(r) for r in rows]
 
         except Exception as e:
@@ -530,6 +532,15 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
         if err:
             return err
         _settle_expired_proposals(db_path)
+        votes_limit, error_response = _parse_non_negative_int_arg(
+            "votes_limit", VOTES_DEFAULT_LIMIT, max_value=VOTES_MAX_LIMIT
+        )
+        if error_response:
+            return error_response
+        votes_offset, error_response = _parse_non_negative_int_arg("votes_offset", 0)
+        if error_response:
+            return error_response
+
         try:
             with sqlite3.connect(db_path) as conn:
                 conn.row_factory = sqlite3.Row
@@ -539,11 +550,15 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
                 if not proposal:
                     return jsonify({"error": "proposal not found"}), 404
 
+                votes_total = conn.execute(
+                    "SELECT COUNT(*) FROM governance_votes WHERE proposal_id = ?",
+                    (proposal_id,)
+                ).fetchone()[0]
                 votes = conn.execute(
                     "SELECT miner_id, vote, weight, voted_at FROM governance_votes "
-                    "WHERE proposal_id = ? ORDER BY voted_at DESC",
-                    (proposal_id,)
-                ).fetchall()
+                    "WHERE proposal_id = ? ORDER BY voted_at DESC LIMIT ? OFFSET ?",
+                    (proposal_id, votes_limit, votes_offset)
+                ).fetchall()  # fetchall-ok: already-paginated
 
         except Exception as e:
             log.error("Get proposal error: %s", e)
@@ -552,6 +567,9 @@ def create_governance_blueprint(db_path: str) -> Blueprint:
         now = int(time.time())
         p = dict(proposal)
         p["votes"] = [dict(v) for v in votes]
+        p["votes_total"] = votes_total
+        p["votes_limit"] = votes_limit
+        p["votes_offset"] = votes_offset
         p["time_remaining_seconds"] = max(0, p["expires_at"] - now)
         return jsonify(p), 200
 

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -46,10 +46,7 @@ node/coalition.py:960:                    ).fetchall()
 node/coalition.py:966:                    ).fetchall()
 node/ergo_miner_anchor.py:38:        miners = [dict(row) for row in cur.fetchall()]
 node/ergo_raw_tx.py:77:        miners = [dict(row) for row in cur.fetchall()]
-node/governance.py:280:            ).fetchall()
-node/governance.py:511:                    ).fetchall()
-node/governance.py:516:                    ).fetchall()
-node/governance.py:546:                ).fetchall()
+node/governance.py:282:            ).fetchall()
 node/gpu_render_endpoints.py:64:            cols = {row[1] for row in db.execute("PRAGMA table_info(render_escrow)").fetchall()}
 node/gpu_render_protocol.py:152:        cols = {row[1] for row in conn.execute("PRAGMA table_info(render_escrow)").fetchall()}
 node/gpu_render_protocol.py:272:            rows = conn.execute(query, params).fetchall()

--- a/tests/test_governance_proposal_validation.py
+++ b/tests/test_governance_proposal_validation.py
@@ -76,3 +76,80 @@ def test_create_proposal_stores_string_parameter_value(tmp_path, monkeypatch):
             (response.get_json()["proposal_id"],),
         ).fetchone()
     assert row[0] == "0.40"
+
+
+def _seed_proposal_with_votes(db_path, vote_count=7):
+    now = int(time.time())
+    with sqlite3.connect(db_path) as conn:
+        cursor = conn.execute(
+            """
+            INSERT INTO governance_proposals (
+                title, description, proposal_type, proposed_by,
+                created_at, expires_at, status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "Vote detail pagination",
+                "Exercise the admin proposal detail votes slice.",
+                "feature_activation",
+                "miner-1",
+                now,
+                now + governance.VOTING_WINDOW_SECONDS,
+                governance.STATUS_ACTIVE,
+            ),
+        )
+        proposal_id = cursor.lastrowid
+        for idx in range(vote_count):
+            conn.execute(
+                """
+                INSERT INTO governance_votes (
+                    proposal_id, miner_id, vote, weight, voted_at
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    proposal_id,
+                    f"voter-{idx}",
+                    "for" if idx % 2 == 0 else "against",
+                    1.0,
+                    now + idx,
+                ),
+            )
+        conn.commit()
+    return proposal_id
+
+
+def test_get_proposal_detail_paginates_votes(tmp_path, monkeypatch):
+    client, db_path = _client(tmp_path, monkeypatch)
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    proposal_id = _seed_proposal_with_votes(db_path, vote_count=7)
+
+    response = client.get(
+        f"/api/governance/proposal/{proposal_id}?votes_limit=3&votes_offset=2",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert len(data["votes"]) == 3
+    assert data["votes_total"] == 7
+    assert data["votes_limit"] == 3
+    assert data["votes_offset"] == 2
+    assert [vote["miner_id"] for vote in data["votes"]] == [
+        "voter-4",
+        "voter-3",
+        "voter-2",
+    ]
+
+
+def test_get_proposal_detail_rejects_invalid_votes_offset(tmp_path, monkeypatch):
+    client, db_path = _client(tmp_path, monkeypatch)
+    monkeypatch.setenv("RC_ADMIN_KEY", "test-admin")
+    proposal_id = _seed_proposal_with_votes(db_path, vote_count=1)
+
+    response = client.get(
+        f"/api/governance/proposal/{proposal_id}?votes_offset=abc",
+        headers={"X-Admin-Key": "test-admin"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["error"] == "votes_offset must be an integer"


### PR DESCRIPTION
## Problem

#6571 fixed unbounded vote loading for the legacy `/governance/proposal/<id>` route in the integrated node, but the newer admin-gated blueprint route `GET /api/governance/proposal/<id>` in `node/governance.py` still loaded every `governance_votes` row for a proposal in one response.

## Impact

This is not the same public unauthenticated path from #6571. The remaining `/api` route is admin-gated, but it still leaves admin/ops proposal-detail reads with unbounded response size and memory use on large proposals, and keeps this route as fetchall guard debt.

BCOS-L2: touches governance vote detail API behavior. No vote weights, vote outcomes, payout amounts, reward rules, admin secrets, or wallet crediting behavior are changed.


## Fix

- Add `votes_limit` and `votes_offset` to `/api/governance/proposal/<id>`.
- Cap vote slices at `VOTES_MAX_LIMIT = 500`, defaulting to 200.
- Return `votes_total`, `votes_limit`, and `votes_offset` so admin clients can page the full vote set explicitly.
- Reject malformed `votes_limit` / `votes_offset` with the existing integer parser.
- Mark the already-paginated governance fetchalls so the guard no longer tracks bounded reads as legacy debt; keep the unrelated settle-expired unbounded scan as baseline-only.

## Validation

- Pre-fix regression proof: the new vote pagination tests failed because the route returned all 7 votes and ignored malformed `votes_offset`.
- `uv run --no-project --with pytest --with flask --with pynacl python -B -m pytest -q tests/test_governance_proposal_validation.py` -> 4 passed
- `uv run --no-project --with pytest --with flask --with pynacl python -B -m pytest -q node/test_governance_balance_schema_poc.py node/test_governance_security.py tests/test_governance_proposal_validation.py` -> 15 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 176
- `python -m py_compile node/governance.py` -> passed
- `git diff --check` -> passed

Related: #7346
Related: #6627

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
