### PR TITLE
fix(utxo): enforce epoch-wide coinbase cap to prevent supply inflation (Bounty #13788)

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -44,7 +44,7 @@ except Exception as e:
 # UTXO Layer (Phase 1 — dual-write alongside account model)
 UTXO_DUAL_WRITE = os.environ.get("UTXO_DUAL_WRITE", "0") == "1"
 try:
-    from utxo_db import UtxoDB
+    from utxo_db import UtxoDB, MAX_COINBASE_OUTPUT_NRTC
     HAVE_UTXO = True
 except ImportError:
     HAVE_UTXO = False
@@ -3401,6 +3401,22 @@ def finalize_epoch(epoch, per_block_rtc, prev_block_hash: bytes = b""):
 
         # PRECISION: Use Decimal for exact financial calculations
         total_reward = Decimal(str(per_block_rtc)) * Decimal(EPOCH_SLOTS)
+
+        # EPOCH-WIDE COINBASE CAP (Bounty #13788)
+        # MAX_COINBASE_OUTPUT_NRTC documents a 150 RTC per-block cap, but
+        # enforcement was per-transaction in utxo_db.py.  With UTXO dual
+        # write enabled, finalize_epoch creates one mining_reward tx per
+        # miner inside a loop, so the per-tx cap never catches the total.
+        # Enforce the cap at epoch level before any UTXO rewards are written.
+        if UTXO_DUAL_WRITE and HAVE_UTXO:
+            total_reward_nrtc = int(total_reward * Decimal(100_000_000))
+            if total_reward_nrtc > MAX_COINBASE_OUTPUT_NRTC:
+                print(
+                    f"[SECURITY] Epoch {epoch} total reward {total_reward_nrtc / 100_000_000:.1f} RTC "
+                    f"exceeds MAX_COINBASE_OUTPUT_NRTC "
+                    f"({MAX_COINBASE_OUTPUT_NRTC / 100_000_000:.1f} RTC) — capping"
+                )
+                total_reward = Decimal(str(MAX_COINBASE_OUTPUT_NRTC / 100_000_000))
 
         # Filter out miners with 0 weight (VM/emulator detected)
         valid_miners = [(pk, w) for pk, w in miners if w > 0]

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -37,7 +37,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 UNIT = 100_000_000          # 1 RTC = 100,000,000 nanoRTC (8 decimals)
 DUST_THRESHOLD = 1_000      # nanoRTC below which change is absorbed into fee
-MAX_COINBASE_OUTPUT_NRTC = 150 * UNIT  # Max minting output per block (150 RTC)
+MAX_COINBASE_OUTPUT_NRTC = 150 * UNIT  # Max minting output per block (150 RTC) — enforced per-tx here; epoch-wide cap in rip200.py
 MAX_POOL_SIZE = 10_000
 
 # Anti-UTXO-bloat: maximum outputs per transaction


### PR DESCRIPTION
## Summary

`MAX_COINBASE_OUTPUT_NRTC` documents a 150 RTC per-block cap, but enforcement was **per-transaction** only in `utxo_db.py`. With UTXO dual-write enabled, `finalize_epoch` creates one `mining_reward` tx per miner in a loop, so the per-tx check never catches the aggregate total.

With 538 miners, this allows minting up to **538× the documented cap** per epoch — a silent conservation law violation.

## Changes

**node/rustchain_v2_integrated_v2.2.1_rip200.py:**
- Import `MAX_COINBASE_OUTPUT_NRTC` from `utxo_db`
- Add epoch-level cap check before reward distribution: if total reward exceeds the cap, log a warning and clamp `total_reward`

**node/utxo_db.py:**
- Update comment on `MAX_COINBASE_OUTPUT_NRTC` to clarify that epoch-wide enforcement lives in rip200.py

## Bounty

References: Scottcjn/rustchain-bounties#13788
Claimed by: crystal-tensor | Wallet: `RTC6d1f27d28961279f1034d9561c2403697eb55602`

## Test Plan

- [x] Verified import chain: `MAX_COINBASE_OUTPUT_NRTC` correctly imported
- [x] Logic: `total_reward_nrtc = total_reward × 100_000_000` correctly converts Decimal RTC to nanoRTC
- [x] Clamp: when exceeded, `total_reward` is replaced with capped Decimal value
- [x] Non-dual-write path: cap check skipped when `UTXO_DUAL_WRITE=0` (no impact on account-model rewards)
- [ ] Manual test: deploy with 538 miners, verify total epoch mint ≤ 150 RTC