### PR TITLE
fix(tx): serialize pending nonce admission

### DIFF
--- a/node/rustchain_tx_handler.py
+++ b/node/rustchain_tx_handler.py
@@ -422,6 +422,9 @@ class TransactionPool:
         # both pass the balance check before either is recorded.
         with self._get_connection() as conn:
             cursor = conn.cursor()
+            # Serialize nonce, pending-count, and balance reads across
+            # independent pool instances/processes before any pending insert.
+            cursor.execute("BEGIN IMMEDIATE")
 
             # SECURITY FIX #2019: Enforce per-wallet pending TX limit
             cursor.execute(

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -122,9 +122,9 @@ node/rustchain_tx_handler.py:133:            columns = [col[1] for col in cursor
 node/rustchain_tx_handler.py:187:        tables = {row[0] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:210:        columns = [col[1] for col in cursor.fetchall()]
 node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cursor.fetchall()}
-node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
-node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
-node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
+node/rustchain_tx_handler.py:454:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
+node/rustchain_tx_handler.py:548:                for row in cursor.fetchall()
+node/rustchain_tx_handler.py:913:                transactions = [dict(row) for row in cursor.fetchall()]
 node/rustchain_v2_integrated_v2.2.1_rip200.py:10059:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1316:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1323:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()

--- a/tests/test_tx_handler_pending_order.py
+++ b/tests/test_tx_handler_pending_order.py
@@ -6,6 +6,7 @@ import importlib
 import os
 import sqlite3
 import sys
+import threading
 import types
 
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "node"))
@@ -143,6 +144,121 @@ def test_submit_transaction_preserves_fifo_when_clock_collides(tmp_path, monkeyp
     pending = pool.get_pending_transactions()
 
     assert [tx.tx_hash for tx in pending] == ["z" * 64, "a" * 64]
+
+
+def test_submit_transaction_serializes_nonce_validation_across_pool_instances(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "tx.db"
+    first_pool = TransactionPool(str(db_path))
+    second_pool = TransactionPool(str(db_path))
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "INSERT INTO balances (wallet, balance_urtc, wallet_nonce) VALUES (?, ?, ?)",
+            ("aa", 10, 0),
+        )
+
+    original_connect = sqlite3.connect
+    pending_sum_barrier = threading.Barrier(2)
+
+    class InstrumentedCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+            self._last_sql = ""
+
+        def execute(self, sql, params=()):
+            self._last_sql = " ".join(str(sql).split())
+            self._cursor.execute(sql, params)
+            return self
+
+        def fetchone(self):
+            row = self._cursor.fetchone()
+            if "SELECT COALESCE(SUM(amount_urtc), 0) as pending" in self._last_sql:
+                try:
+                    pending_sum_barrier.wait(timeout=1.0)
+                except threading.BrokenBarrierError:
+                    pass
+            return row
+
+        def fetchall(self):
+            return self._cursor.fetchall()
+
+        def __getattr__(self, name):
+            return getattr(self._cursor, name)
+
+    class InstrumentedConnection:
+        def __init__(self, conn):
+            object.__setattr__(self, "_conn", conn)
+
+        def cursor(self):
+            return InstrumentedCursor(self._conn.cursor())
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+        def __setattr__(self, name, value):
+            setattr(self._conn, name, value)
+
+    def instrumented_connect(*args, **kwargs):
+        return InstrumentedConnection(original_connect(*args, **kwargs))
+
+    monkeypatch.setattr(rustchain_tx_handler.sqlite3, "connect", instrumented_connect)
+    monkeypatch.setattr(rustchain_tx_handler, "address_from_public_key", lambda data: data.hex())
+    monkeypatch.setattr(
+        TransactionPool,
+        "register_public_key",
+        lambda self, address, public_key: True,
+    )
+
+    first_tx = FakeSignedTransaction(
+        from_addr="aa",
+        to_addr="bb",
+        amount_urtc=1,
+        nonce=1,
+        timestamp=100,
+        memo="",
+        signature="sig",
+        public_key="aa",
+        tx_hash="1" * 64,
+    )
+    second_tx = FakeSignedTransaction(
+        from_addr="aa",
+        to_addr="cc",
+        amount_urtc=1,
+        nonce=1,
+        timestamp=101,
+        memo="",
+        signature="sig",
+        public_key="aa",
+        tx_hash="2" * 64,
+    )
+
+    results = []
+
+    def submit(pool, tx):
+        results.append(pool.submit_transaction(tx))
+
+    threads = [
+        threading.Thread(target=submit, args=(first_pool, first_tx)),
+        threading.Thread(target=submit, args=(second_pool, second_tx)),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(success for success, _ in results) == [False, True]
+
+    with original_connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT tx_hash, from_addr, nonce FROM pending_transactions WHERE from_addr = ?",
+            ("aa",),
+        ).fetchall()
+
+    assert len(rows) == 1
+    assert rows[0][2] == 1
 
 
 def test_legacy_pending_table_gets_created_at_migration(tmp_path):


### PR DESCRIPTION
## Problem

`TransactionPool.submit_transaction()` documents atomic validate-and-insert behavior, but it did not acquire a SQLite write lock before reading pending nonces, pending amount, balance, duplicate state, and then inserting the pending transaction. The Python lock is per `TransactionPool` instance, so two pool instances sharing the same DB can both validate the same wallet nonce before either insert is visible.

## Impact

A multi-worker or multi-pool node can admit duplicate pending transactions for the same `(from_addr, nonce)` boundary, weakening replay/nonce protection at pending-admission time.

BCOS-L2: touches wallet transaction admission / nonce replay boundary. No nonce rules, balance arithmetic, payout amounts, reward rules, admin secrets, manual wallet crediting, or payout endpoints are changed.


## Fix

- Start the validate-and-insert DB section with `BEGIN IMMEDIATE` so independent pool instances/processes serialize before nonce/pending/balance reads.
- Add a deterministic two-pool race regression test that previously admitted two pending txs with the same wallet nonce.
- Refresh only shifted fetchall baseline line numbers caused by the added transaction line.

## Validation

- Pre-fix regression proof: `test_submit_transaction_serializes_nonce_validation_across_pool_instances` failed because both concurrent submissions returned success.
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_tx_handler_pending_order.py::test_submit_transaction_serializes_nonce_validation_across_pool_instances` -> passed
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_tx_handler_pending_order.py tests/test_tx_handler_limits.py node/tests/test_confirm_balance_recheck.py tests/test_tx_submit_route.py` -> 28 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/rustchain_tx_handler.py` -> passed
- `git diff --check` -> passed

Related: #7349

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
