### PR TITLE
fix(withdraw): use remaining balance for gauge

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6147,7 +6147,6 @@ def request_withdrawal():
             amount_i64 = int(round(amount * ACCOUNT_UNIT))
             fee_i64 = int(round(WITHDRAWAL_FEE * ACCOUNT_UNIT))
             total_needed_i64 = amount_i64 + fee_i64
-            total_needed = total_needed_i64 / ACCOUNT_UNIT
             balance_i64 = _balance_i64_for_wallet(c, miner_pk)
 
             if balance_i64 < total_needed_i64:

--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -6238,12 +6238,13 @@ def request_withdrawal():
                 total_withdrawn = total_withdrawn + ?
             """, (miner_pk, today, amount, amount))
 
+            remaining_balance = _balance_i64_for_wallet(c, miner_pk) / ACCOUNT_UNIT
             c.commit()
         except Exception:
             c.rollback()
             raise
 
-        balance_gauge.labels(miner_pk=miner_pk).set(balance - total_needed)
+        balance_gauge.labels(miner_pk=miner_pk).set(remaining_balance)
         withdrawal_queue_size.inc()
 
     return jsonify({

--- a/node/tests/test_withdrawal_atomic_debit.py
+++ b/node/tests/test_withdrawal_atomic_debit.py
@@ -118,6 +118,24 @@ class TestWithdrawalAtomicDebit(unittest.TestCase):
             "nonce": nonce,
         }
 
+    def test_successful_withdrawal_request_does_not_crash_updating_balance_gauge(self):
+        self.mod.verify_sr25519_signature = lambda *_args, **_kwargs: True
+
+        with self.mod.app.test_client() as client:
+            resp = client.post("/withdraw/request", json=self._payload("nonce-1"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.get_json()["status"], "pending")
+
+        with sqlite3.connect(self.db_path) as conn:
+            balance = conn.execute(
+                "SELECT balance_rtc FROM balances WHERE miner_pk = 'miner-test'"
+            ).fetchone()[0]
+            withdrawal_count = conn.execute("SELECT COUNT(*) FROM withdrawals").fetchone()[0]
+
+        self.assertAlmostEqual(balance, 0.0, places=6)
+        self.assertEqual(withdrawal_count, 1)
+
     def test_concurrent_withdrawals_cannot_overdraw_balance(self):
         def slow_valid_signature(*_args, **_kwargs):
             time.sleep(0.05)

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -125,7 +125,7 @@ node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cur
 node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
 node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:10060:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:10059:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1316:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1323:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1478:            """, (limit, offset)).fetchall()
@@ -137,26 +137,26 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:3099:    ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:3739:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:4902:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:5507:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6276:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6285:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7006:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7036:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7232:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7422:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7520:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7539:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7930:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7963:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7994:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8273:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8729:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8874:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8921:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8946:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9528:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9533:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9540:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9701:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6275:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6284:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7005:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7035:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7231:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7421:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7519:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7538:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7929:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7962:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7993:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8272:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8728:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8873:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8920:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8945:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9527:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9532:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9539:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9700:        ).fetchall()
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -125,7 +125,7 @@ node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cur
 node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
 node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:10059:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:10060:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1316:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1323:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1478:            """, (limit, offset)).fetchall()
@@ -137,26 +137,26 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:3099:    ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:3739:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:4902:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:5507:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6275:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6284:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7005:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7035:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7231:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7421:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7519:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7538:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7929:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7962:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7993:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8272:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8728:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8873:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8920:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8945:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9527:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9532:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9539:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9700:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6276:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6285:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7006:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7036:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7232:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7422:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7520:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7539:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7930:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7963:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7994:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8273:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8729:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8874:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8921:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8946:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9528:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9533:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9540:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9701:        ).fetchall()
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())


### PR DESCRIPTION
## Summary

Fixes #7354.

- compute the post-debit wallet balance with the existing schema-tolerant `_balance_i64_for_wallet()` helper before committing `/withdraw/request`
- update `balance_gauge` with that captured `remaining_balance` instead of the removed `balance` local
- remove the now-stale `total_needed` local that only fed the old gauge expression
- add a focused regression that a successful withdrawal request returns 200 instead of crashing after the money-path state changes

## Problem

The current `/withdraw/request` success path commits the atomic withdrawal transaction, then calls:

```python
balance_gauge.labels(miner_pk=miner_pk).set(balance - total_needed)
```

`balance` is no longer defined after the atomic/schema-tolerant debit refactor, so a valid request can debit the wallet and insert a pending withdrawal row, then return HTTP 500 while updating metrics.

## Impact

This makes a successful withdrawal look failed to the caller after wallet state has already changed. Because this is withdrawal/wallet request handling, this PR is **BCOS-L2**.

## Fix

Use the existing wallet balance helper to capture the remaining balance inside the transaction, then update the gauge from that stable value after commit. No withdrawal amount, fee, debit rule, production wallet, admin key, or payout execution behavior is changed.

## Tests

- Failing-before-fix regression: `uv run --no-project --with pytest --with flask python -B -m pytest -q node/tests/test_withdrawal_atomic_debit.py::TestWithdrawalAtomicDebit::test_successful_withdrawal_request_does_not_crash_updating_balance_gauge` failed with HTTP 500 / `NameError: name balance is not defined`.
- `uv run --no-project --with pytest --with flask python -B -m pytest -q node/tests/test_withdrawal_atomic_debit.py node/tests/test_withdraw_amount_validation.py node/tests/test_withdrawal_validation.py node/tests/test_withdrawal_balance_schema_6932.py` -> 24 passed, 2 subtests passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_withdrawal_atomic_debit.py` -> passed
- `git diff --check` -> passed

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
