### PR TITLE
fix(beacon): persist bounty claims

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -1121,14 +1121,14 @@ def claim_bounty(bounty_id):
             return field_error, status
 
         db = get_db()
-        db.execute(
+        now = int(time.time())
+        cursor = db.execute(
             "UPDATE beacon_bounties SET state = 'claimed', claimant_agent = ?, updated_at = ? WHERE id = ?",
-            (agent_id, int(time.time()), bounty_id)
+            (agent_id, now, bounty_id)
         )
-
-        db = get_db()
-        if db.total_changes == 0:
+        if cursor.rowcount == 0:
             return jsonify({'error': 'Bounty not found'}), 404
+        db.commit()
 
         return jsonify({'ok': True, 'bounty_id': bounty_id, 'claimant': agent_id})
 

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -348,6 +348,42 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn('JSON object body required', response.get_data(as_text=True))
 
+    def test_bounty_claim_persists_state_and_claimant(self):
+        """Claiming a bounty must persist the claimed state after the request closes."""
+        created_at = int(time.time())
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (
+                'gh_claim_commit_test',
+                'Claim commit test (25 RTC)',
+                25.0,
+                'EASY',
+                'open',
+                created_at,
+            ))
+            conn.commit()
+
+        claim_response = self.client.post(
+            '/api/bounties/gh_claim_commit_test/claim',
+            data=json.dumps({'agent_id': 'bcn_claimer'}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(claim_response.status_code, 200)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            row = conn.execute(
+                "SELECT state, claimant_agent FROM beacon_bounties WHERE id = ?",
+                ('gh_claim_commit_test',),
+            ).fetchone()
+
+        self.assertEqual(row['state'], 'claimed')
+        self.assertEqual(row['claimant_agent'], 'bcn_claimer')
+
     def test_bounty_complete_rejects_non_string_agent_id(self):
         """Admin bounty completion route rejects non-string agent IDs."""
         response = self.client.post(


### PR DESCRIPTION
## Summary
- persist successful `/api/bounties/<id>/claim` updates with an explicit commit
- use the update cursor rowcount for the missing-bounty 404 path instead of connection-wide total_changes
- add a regression test that reopens the database after a 200 claim response and verifies `state=claimed` plus `claimant_agent`

## Impact
Before this change, the admin claim route could return success while SQLite rolled the uncommitted update back when the request connection closed. That left the bounty open and claimant_agent unset, creating duplicate-claim/accounting confusion in the Beacon bounty lifecycle.

## BCOS
BCOS-L2: this touches Beacon bounty / reward workflow state.

## Safety
- Does not change payout amounts or reward amounts
- Does not change wallet balances, production wallets, manual crediting, or admin keys
- Does not create user-callable payout endpoints

## Validation
- Failing-before-fix PoC: `test_bounty_claim_persists_state_and_claimant` returned 200 but the fresh DB read still showed `state=open`
- `uv run --no-project --with pytest --with flask --with cryptography python -B -m pytest -q tests/test_beacon_atlas_behavior.py` -> 27 passed
- `uv run --no-project --with pytest --with flask --with cryptography python -B -m pytest -q tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_lifecycle_workflow tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_claim_persists_state_and_claimant tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_claim_rejects_non_object_json tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_completion_updates_reputation` -> 4 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/beacon_api.py tests/test_beacon_atlas_behavior.py` -> passed
- `git diff --check` -> passed


Closes #7358

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
