### PR TITLE
fix(beacon): require claimed bounty completion

### DIFF
--- a/node/beacon_api.py
+++ b/node/beacon_api.py
@@ -1166,24 +1166,32 @@ def complete_bounty(bounty_id):
             return jsonify({'error': 'Bounty not found'}), 404
         if bounty['state'] == 'completed':
             return jsonify({'error': 'Bounty already completed'}), 409
+        if bounty['state'] != 'claimed':
+            return jsonify({'error': 'Bounty must be claimed before completion'}), 409
+        claimant_agent = bounty['claimant_agent']
+        if claimant_agent and claimant_agent != agent_id:
+            return jsonify({'error': 'Bounty completion must match claimant_agent'}), 409
 
-        db.execute(
-            "UPDATE beacon_bounties SET state = 'completed', completed_by = ?, updated_at = ? WHERE id = ?",
-            (agent_id, int(time.time()), bounty_id)
+        now = int(time.time())
+        cursor = db.execute(
+            "UPDATE beacon_bounties SET state = 'completed', completed_by = ?, updated_at = ? "
+            "WHERE id = ? AND state = 'claimed' AND (claimant_agent IS NULL OR claimant_agent = ?)",
+            (agent_id, now, bounty_id, agent_id)
         )
-        db.commit()
+        if cursor.rowcount == 0:
+            return jsonify({'error': 'Bounty state changed; retry completion'}), 409
 
         # Update agent reputation
         rep = db.execute("SELECT * FROM beacon_reputation WHERE agent_id = ?", (agent_id,)).fetchone()
         if rep:
             db.execute(
                 "UPDATE beacon_reputation SET bounties_completed = bounties_completed + 1, score = score + 10, last_updated = ? WHERE agent_id = ?",
-                (int(time.time()), agent_id)
+                (now, agent_id)
             )
         else:
             db.execute(
                 "INSERT INTO beacon_reputation (agent_id, bounties_completed, score, last_updated) VALUES (?, 1, 10, ?)",
-                (agent_id, int(time.time()))
+                (agent_id, now)
             )
         db.commit()
 

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -16,7 +16,7 @@ node/bcos_routes.py:544:            rows = conn.execute(query, params).fetchall(
 node/beacon_anchor.py:236:        ).fetchall()
 node/beacon_anchor.py:305:        ).fetchall()
 node/beacon_anchor.py:79:        for row in conn.execute("PRAGMA table_info(beacon_envelopes)").fetchall()
-node/beacon_api.py:1212:        rows = db.execute("SELECT * FROM beacon_reputation ORDER BY score DESC").fetchall()
+node/beacon_api.py:1220:        rows = db.execute("SELECT * FROM beacon_reputation ORDER BY score DESC").fetchall()
 node/beacon_api.py:383:    ).fetchall()
 node/beacon_api.py:412:        ).fetchall()
 node/beacon_api.py:678:            ).fetchall()

--- a/tests/test_beacon_atlas_behavior.py
+++ b/tests/test_beacon_atlas_behavior.py
@@ -617,6 +617,87 @@ class TestBeaconAtlasAPIBehavior(unittest.TestCase):
         self.assertEqual(rep['bounties_completed'], 1)
         self.assertEqual(rep['score'], 10)  # 10 points per bounty
 
+    def test_bounty_completion_requires_claimed_state(self):
+        """Open bounties cannot skip directly to completed reputation credit."""
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+            """, (
+                'gh_open_complete_test',
+                'Open completion test (50 RTC)',
+                50.0,
+                'MEDIUM',
+                'open',
+                int(time.time()),
+            ))
+            conn.commit()
+
+        complete_response = self.client.post(
+            '/api/bounties/gh_open_complete_test/complete',
+            data=json.dumps({'agent_id': 'bcn_completer'}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(complete_response.status_code, 409)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            bounty = conn.execute(
+                "SELECT state, completed_by FROM beacon_bounties WHERE id = ?",
+                ('gh_open_complete_test',),
+            ).fetchone()
+            reputation = conn.execute(
+                "SELECT * FROM beacon_reputation WHERE agent_id = ?",
+                ('bcn_completer',),
+            ).fetchone()
+
+        self.assertEqual(bounty['state'], 'open')
+        self.assertIsNone(bounty['completed_by'])
+        self.assertIsNone(reputation)
+
+    def test_bounty_completion_must_match_recorded_claimant(self):
+        """Completion cannot credit an agent different from the recorded claimant."""
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.execute("""
+                INSERT INTO beacon_bounties
+                (id, title, reward_rtc, difficulty, state, claimant_agent, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+            """, (
+                'gh_claimant_complete_test',
+                'Claimant completion test (75 RTC)',
+                75.0,
+                'HARD',
+                'claimed',
+                'bcn_alice_test',
+                int(time.time()),
+            ))
+            conn.commit()
+
+        complete_response = self.client.post(
+            '/api/bounties/gh_claimant_complete_test/complete',
+            data=json.dumps({'agent_id': 'bcn_bob_test'}),
+            content_type='application/json',
+            headers={'X-Admin-Key': os.environ['RC_ADMIN_KEY']},
+        )
+        self.assertEqual(complete_response.status_code, 409)
+
+        with sqlite3.connect(self.test_db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            bounty = conn.execute(
+                "SELECT state, completed_by FROM beacon_bounties WHERE id = ?",
+                ('gh_claimant_complete_test',),
+            ).fetchone()
+            bob_reputation = conn.execute(
+                "SELECT * FROM beacon_reputation WHERE agent_id = ?",
+                ('bcn_bob_test',),
+            ).fetchone()
+
+        self.assertEqual(bounty['state'], 'claimed')
+        self.assertIsNone(bounty['completed_by'])
+        self.assertIsNone(bob_reputation)
+
     def test_bounty_sync_requires_admin_before_network_fetch(self):
         """Unauthenticated sync cannot trigger GitHub fetches or DB writes."""
         with patch.dict(os.environ, {'RC_ADMIN_KEY': 'test-admin'}, clear=False):


### PR DESCRIPTION
## Summary
- require Beacon bounty completion to start from `state=claimed`
- if `claimant_agent` is recorded, only that agent can receive completion credit
- keep legacy `claimed` rows with a null claimant completable by the admin-provided `agent_id`
- guard the completion UPDATE with state/claimant predicates before reputation credit is written

## Impact
Before this change, `/api/bounties/<id>/complete` could complete an open bounty without a claim, or complete a bounty claimed by Alice while crediting Bob. Since the endpoint also increments `beacon_reputation`, stale or malformed admin automation could misattribute bounty completion credit.

## BCOS
BCOS-L2: this touches Beacon bounty / reward workflow state and reputation credit attribution.

## Safety
- Does not change payout amounts or reward amounts
- Does not change wallet balances, production wallets, manual crediting, or admin keys
- Does not create user-callable payout endpoints
- Keeps legacy `claimed` rows with null `claimant_agent` completable

## Validation
- Failing-before-fix PoC: open bounty completion returned 200 and credited reputation
- Failing-before-fix PoC: claimed bounty with `claimant_agent=bcn_alice_test` accepted completion for `bcn_bob_test`
- `uv run --no-project --with pytest --with flask --with cryptography python -B -m pytest -q tests/test_beacon_atlas_behavior.py` -> 28 passed
- `uv run --no-project --with pytest --with flask --with cryptography python -B -m pytest -q tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_completion_updates_reputation tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_completion_requires_claimed_state tests/test_beacon_atlas_behavior.py::TestBeaconAtlasAPIBehavior::test_bounty_completion_must_match_recorded_claimant` -> 3 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/beacon_api.py tests/test_beacon_atlas_behavior.py` -> passed
- `git diff --check` -> passed


Closes #7360

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
