### PR TITLE
fix(bridge): report last state change time

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -108,9 +108,10 @@ def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
     completed_in = by_status.get("completed", {}).get("total_rtc", 0.0)
     voided_in = by_status.get("voided", {}).get("total_rtc", 0.0)
 
-    # last_event_at: most recent created_at across all transfers
+    # last_event_at: most recent transfer creation or state-change timestamp.
     last_event = cursor.execute(
-        "SELECT COALESCE(MAX(created_at), 0) FROM bridge_transfers"
+        "SELECT COALESCE(MAX(COALESCE(updated_at, completed_at, created_at, 0)), 0) "
+        "FROM bridge_transfers"
     ).fetchone()  # fetchall-ok: pragma-result (single MAX)
     last_event_at = int(last_event[0]) if last_event else 0
 

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -133,15 +133,15 @@ def test_state_aggregates_by_status_and_direction(client, db_path):
     assert s["by_direction"]["withdraw"] == {"count": 1, "total_rtc": 100.0}
 
 
-def test_state_last_event_at_reflects_max_created_at(client, db_path):
+def test_state_last_event_at_reflects_max_state_change_at(client, db_path):
     base = int(time.time())
     _seed(db_path, [
-        {"created_at": base - 100, "status": "pending"},
-        {"created_at": base, "status": "completed"},
-        {"created_at": base - 50, "status": "locked"},
+        {"created_at": base, "updated_at": base, "status": "pending"},
+        {"created_at": base - 100, "updated_at": base + 60, "status": "completed"},
+        {"created_at": base - 50, "updated_at": base - 25, "status": "locked"},
     ])
     s = client.get("/bridge/state").get_json()["state"]
-    assert s["last_event_at"] == base
+    assert s["last_event_at"] == base + 60
 
 
 # ---------- /bridge/events ---------------------------------------------------


### PR DESCRIPTION
## Summary
- make `/bridge/state` `last_event_at` use the latest available state-change timestamp
- fall back across `updated_at`, `completed_at`, and `created_at` for legacy bridge rows
- update the federation route regression test to cover an older transfer with a newer update time

## Impact
Before this change, bridge federation observers could see stale freshness metadata because `last_event_at` only used `MAX(created_at)`. Confirmed/voided/updated transfers did not move the aggregate timestamp even though bridge state changed.

## BCOS
BCOS-L2: bridge observability / federation state metadata. This is read-only and does not alter transfer execution.

## Safety
- Does not change bridge payout amounts, minting rules, or confirmation rules
- Does not change transfer statuses, wallet balances, production wallets, manual crediting, or admin keys
- Does not create user-callable payout endpoints

## Validation
- Failing-before-fix PoC: `test_state_last_event_at_reflects_max_state_change_at` reported the newer creation time instead of the later update time
- `uv run --no-project --with pytest --with flask python -B -m pytest -q node/tests/test_bridge_federation_routes.py` -> 19 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/bridge_federation_routes.py node/tests/test_bridge_federation_routes.py` -> passed
- `git diff --check` -> passed


Closes #7362

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
