### PR TITLE
fix(lock): floor helper query limits

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -475,7 +475,7 @@ def get_locks_by_miner(
         params.append(status_filter)
 
     query += " ORDER BY id DESC LIMIT ?"
-    params.append(min(limit, 500))
+    params.append(_bounded_query_limit(limit))
 
     rows = cursor.execute(query, params).fetchall()
 
@@ -533,7 +533,7 @@ def get_pending_unlocks(
         params.append(before_timestamp)
 
     query += " ORDER BY unlock_at ASC LIMIT ?"
-    params.append(min(limit, 500))
+    params.append(_bounded_query_limit(limit))
 
     rows = cursor.execute(query, params).fetchall()
 
@@ -615,6 +615,14 @@ def get_miner_locked_balance(
         "breakdown": breakdown,
         "next_unlock": next_unlock
     }
+
+
+def _bounded_query_limit(limit: Any, default: int = 100, maximum: int = 500) -> int:
+    try:
+        value = int(limit)
+    except (TypeError, ValueError):
+        value = default
+    return max(1, min(value, maximum))
 
 
 def auto_release_expired_locks(

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -764,6 +764,56 @@ class TestLockLedger:
         assert len(locks) == 3
         
         conn.close()
+
+    def test_get_locks_by_miner_negative_limit_stays_bounded(self, setup_test_db, funded_miner):
+        """Helper callers cannot turn a negative SQLite LIMIT into an unbounded scan."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+        now = int(time.time())
+
+        for i in range(3):
+            lock_ledger.create_lock(
+                conn,
+                miner_id=funded_miner,
+                amount_i64=10 * 1000000,
+                lock_type="bridge_deposit",
+                unlock_at=now + 3600 + i,
+            )
+
+        locks = lock_ledger.get_locks_by_miner(conn, funded_miner, limit=-1)
+
+        assert len(locks) == 1
+
+        conn.close()
+
+    def test_get_pending_unlocks_negative_limit_stays_bounded(self, setup_test_db, funded_miner):
+        """Expired-lock helper callers cannot bypass the worker batch limit with -1."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+        now = int(time.time())
+
+        for i in range(3):
+            conn.execute(
+                """INSERT INTO lock_ledger
+                   (miner_id, amount_i64, lock_type, locked_at, unlock_at, status, created_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    funded_miner,
+                    5 * 1000000,
+                    "bridge_deposit",
+                    now - 3600,
+                    now - 60 - i,
+                    "locked",
+                    now - 3600,
+                ),
+            )
+        conn.commit()
+
+        locks = lock_ledger.get_pending_unlocks(conn, limit=-1)
+
+        assert len(locks) == 1
+
+        conn.close()
     
     def test_get_miner_locked_balance(self, setup_test_db, funded_miner):
         """Test getting miner's total locked balance."""


### PR DESCRIPTION
## Summary
- add a shared lock-ledger helper limit clamp with a 1-row floor and 500-row cap
- use it in `get_locks_by_miner` and `get_pending_unlocks` so negative direct helper limits cannot become unbounded SQLite scans
- add regression coverage for negative helper limits on miner lock lists and pending unlock scans

## Impact
The HTTP routes already clamp limits, but direct helper/worker callers could pass `limit=-1`. SQLite treats `LIMIT -1` as no limit, so helper usage could bypass the intended batch/query cap.

## BCOS
BCOS-L2: bridge lock-ledger helper query bounds. This does not alter lock state transitions or balances.

## Safety
- Does not change lock amounts, release/forfeit rules, or transfer statuses
- Does not change wallet balances, production wallets, manual crediting, or admin keys
- Does not create user-callable payout endpoints

## Validation
- Failing-before-fix PoC: `get_locks_by_miner(..., limit=-1)` returned all seeded rows
- Failing-before-fix PoC: `get_pending_unlocks(..., limit=-1)` returned all seeded rows
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_bridge_lock_ledger.py` -> 64 passed
- `uv run --no-project --with pytest --with flask python -B -m pytest -q tests/test_bridge_lock_ledger.py::TestLockLedger::test_get_locks_by_miner tests/test_bridge_lock_ledger.py::TestLockLedger::test_get_locks_by_miner_negative_limit_stays_bounded tests/test_bridge_lock_ledger.py::TestLockLedger::test_get_pending_unlocks_negative_limit_stays_bounded tests/test_bridge_lock_ledger.py::TestLockLedgerRoutes::test_pending_unlock_route_calls_database_helper` -> 4 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/lock_ledger.py tests/test_bridge_lock_ledger.py` -> passed
- `git diff --check` -> passed


Closes #7364

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
