### PR TITLE
fix(claims): return false for missing status rows

### DIFF
--- a/node/claims_submission.py
+++ b/node/claims_submission.py
@@ -358,7 +358,6 @@ def update_claim_status(
         True if update successful
     """
     current_ts = int(time.time())
-    
     try:
         with sqlite3.connect(db_path) as conn:
             cursor = conn.cursor()
@@ -374,7 +373,8 @@ def update_claim_status(
                 current_ts if status in ['approved', 'rejected'] else None,
                 claim_id
             ))
-            
+            if cursor.rowcount == 0:
+                return False
             # Add details if provided
             if details:
                 if status == 'settled':
@@ -411,7 +411,7 @@ def update_claim_status(
             ))
             
             conn.commit()
-            return cursor.rowcount > 0
+            return True
     except sqlite3.Error as e:
         print(f"[CLAIMS] Error updating status: {e}")
         return False

--- a/node/tests/test_claims_submission_status.py
+++ b/node/tests/test_claims_submission_status.py
@@ -1,0 +1,50 @@
+import sqlite3
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from claims_submission import update_claim_status
+
+
+def _init_claim_status_db(db_path):
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE claims (
+                claim_id TEXT PRIMARY KEY,
+                status TEXT,
+                updated_at INTEGER,
+                verified_at INTEGER,
+                transaction_hash TEXT,
+                settlement_batch TEXT,
+                settled_at INTEGER,
+                rejection_reason TEXT
+            );
+            CREATE TABLE claims_audit (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                claim_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                actor TEXT,
+                details TEXT,
+                timestamp INTEGER NOT NULL
+            );
+            """
+        )
+
+
+def test_update_claim_status_missing_claim_returns_false_without_audit(tmp_path):
+    db_path = str(tmp_path / "claims.db")
+    _init_claim_status_db(db_path)
+
+    ok = update_claim_status(
+        db_path,
+        "missing-claim",
+        "settled",
+        {"transaction_hash": "0xabc", "settlement_batch": "batch-1"},
+    )
+
+    assert ok is False
+    with sqlite3.connect(db_path) as conn:
+        audit_count = conn.execute("SELECT COUNT(*) FROM claims_audit").fetchone()[0]
+    assert audit_count == 0


### PR DESCRIPTION
## Summary
- make `claims_submission.update_claim_status()` return `False` when the primary claims row update touches zero rows
- skip details/audit writes for missing claim IDs
- add direct regression coverage for the production helper instead of relying on the patched settlement test helper

## Impact
Before this change, a missing `claim_id` could still produce a `claim_settled`/`claim_failed` audit row and return `True` because the final audit INSERT succeeded. Settlement helpers that consume this boolean could over-count successful updates and produce misleading reconciliation/audit output.

## BCOS
BCOS-L2: claims settlement status/audit integrity.

## Safety
- Does not change reward amounts, eligibility rules, or settlement batching rules
- Does not change wallet balances, production wallets, manual crediting, or admin keys
- Does not create user-callable payout endpoints

## Validation
- Failing-before-fix PoC: direct `update_claim_status(..., missing claim, settled, ...)` returned `True` and wrote an orphan audit row
- `uv run --no-project --with pytest --with flask python -B -m pytest -q node/tests/test_claims_submission_status.py node/tests/test_claims_settlement.py::TestUpdateClaimsSettled::test_updates_single_claim node/tests/test_claims_settlement.py::TestUpdateClaimsSettled::test_skips_nonexistent_claims tests/test_claims_integration.py` -> 17 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python -m py_compile node/claims_submission.py node/tests/test_claims_submission_status.py` -> passed
- `git diff --check` -> passed


Closes #7366

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
