### PR TITLE
fix(windows miner): bound failed header retries and show diagnostics

### DIFF
--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -147,6 +147,7 @@ class RustChainMiner:
         self.mining = False
         self.shares_submitted = 0
         self.shares_accepted = 0
+        self._last_attempted_slot = None
         self._last_submitted_slot = None
         self.miner_id = f"windows_{hashlib.md5(wallet_address.encode()).hexdigest()[:8]}"
         self.node_url = RUSTCHAIN_API
@@ -316,8 +317,9 @@ class RustChainMiner:
                 if (
                     eligibility.get("eligible")
                     and slot is not None
-                    and slot != self._last_submitted_slot
+                    and slot != self._last_attempted_slot
                 ):
+                    self._last_attempted_slot = slot
                     header = self.generate_header(slot)
                     success = self.submit_header(header)
                     self.shares_submitted += 1
@@ -328,7 +330,9 @@ class RustChainMiner:
                             "type":      "share",
                             "submitted": self.shares_submitted,
                             "accepted":  self.shares_accepted,
-                            "success":   success
+                            "success":   success,
+                            "slot":      slot,
+                            "error":     self.last_header_error,
                         })
                 time.sleep(10)
             except Exception as e:
@@ -834,10 +838,13 @@ def _format_headless_event(evt):
     t = evt.get("type")
     if t == "share":
         ok = "OK" if evt.get("success") else "FAIL"
-        return (
+        message = (
             f"[share] submitted={evt.get('submitted')} "
-            f"accepted={evt.get('accepted')} {ok}"
+            f"accepted={evt.get('accepted')} slot={evt.get('slot')} {ok}"
         )
+        if not evt.get("success") and evt.get("error"):
+            message += f" error={evt.get('error')}"
+        return message
     if t == "attest":
         return (
             f"[attest] {evt.get('message')} "

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -319,8 +319,9 @@ class RustChainMiner:
                     and slot is not None
                     and slot != self._last_attempted_slot
                 ):
-                    self._last_attempted_slot = slot
                     header = self.generate_header(slot)
+                    self.last_header_error = ""
+                    self._last_attempted_slot = slot
                     success = self.submit_header(header)
                     self.shares_submitted += 1
                     if success:
@@ -332,7 +333,7 @@ class RustChainMiner:
                             "accepted":  self.shares_accepted,
                             "success":   success,
                             "slot":      slot,
-                            "error":     self.last_header_error,
+                            "error":     self.last_header_error if not success else "",
                         })
                 time.sleep(10)
             except Exception as e:

--- a/tests/test_windows_headless_lifecycle_logging.py
+++ b/tests/test_windows_headless_lifecycle_logging.py
@@ -106,3 +106,19 @@ def test_response_diagnostic_includes_safe_json_fields():
         "HTTP 409 code=DUPLICATE_HARDWARE error=hardware_already_bound "
         "message=This hardware is already registered"
     )
+
+
+def test_headless_share_failure_includes_slot_and_diagnostic():
+    module = _load_windows_miner()
+
+    assert module._format_headless_event({
+        "type": "share",
+        "submitted": 1,
+        "accepted": 0,
+        "success": False,
+        "slot": 42,
+        "error": "HTTP 403 error=no pubkey registered for miner",
+    }) == (
+        "[share] submitted=1 accepted=0 slot=42 FAIL "
+        "error=HTTP 403 error=no pubkey registered for miner"
+    )

--- a/tests/test_windows_miner_chain_identity.py
+++ b/tests/test_windows_miner_chain_identity.py
@@ -171,3 +171,58 @@ def test_failed_header_attempt_is_not_retried_for_same_slot(monkeypatch):
         "slot": 42,
         "error": "HTTP 403 error=no pubkey registered for miner",
     }]
+
+
+def test_header_generation_failure_does_not_consume_slot(monkeypatch):
+    module = load_miner_module()
+    miner = make_miner(module)
+    miner.mining = True
+    generation_attempts = []
+    submission_attempts = []
+    events = []
+    sleeps = []
+
+    monkeypatch.setattr(miner, "_ensure_ready", lambda _callback: True)
+    monkeypatch.setattr(miner, "_emit_ready_status", lambda _callback: None)
+    monkeypatch.setattr(
+        miner,
+        "check_eligibility",
+        lambda: {"eligible": True, "slot": 42},
+    )
+
+    def generate(slot):
+        generation_attempts.append(slot)
+        if len(generation_attempts) == 1:
+            raise RuntimeError("temporary key load failure")
+        return {"header": {"slot": slot}}
+
+    def accept(_payload):
+        submission_attempts.append(42)
+        miner.last_header_error = "stale error"
+        return True
+
+    def stop_after_two_loops(_seconds):
+        sleeps.append(_seconds)
+        if len(sleeps) == 2:
+            miner.mining = False
+
+    monkeypatch.setattr(miner, "generate_header", generate)
+    monkeypatch.setattr(miner, "submit_header", accept)
+    monkeypatch.setattr(module.time, "sleep", stop_after_two_loops)
+
+    miner._mine_loop(events.append)
+
+    assert generation_attempts == [42, 42]
+    assert submission_attempts == [42]
+    assert sleeps == [30, 10]
+    assert events == [
+        {"type": "error", "message": "temporary key load failure"},
+        {
+            "type": "share",
+            "submitted": 1,
+            "accepted": 1,
+            "success": True,
+            "slot": 42,
+            "error": "",
+        },
+    ]

--- a/tests/test_windows_miner_chain_identity.py
+++ b/tests/test_windows_miner_chain_identity.py
@@ -36,8 +36,11 @@ def make_miner(module):
     miner.keypair = {"private_key": "private"}
     miner.public_key = "ab" * 32
     miner._pow_proof = None
+    miner._last_attempted_slot = None
     miner._last_submitted_slot = None
     miner.last_header_error = ""
+    miner.shares_submitted = 0
+    miner.shares_accepted = 0
     return miner
 
 
@@ -124,3 +127,47 @@ def test_submit_uses_configured_node_and_deduplicates_accepted_slot(monkeypatch)
         "json": payload,
         "timeout": 15,
     }
+
+
+def test_failed_header_attempt_is_not_retried_for_same_slot(monkeypatch):
+    module = load_miner_module()
+    miner = make_miner(module)
+    miner.mining = True
+    events = []
+    attempts = []
+    sleeps = []
+
+    monkeypatch.setattr(miner, "_ensure_ready", lambda _callback: True)
+    monkeypatch.setattr(miner, "_emit_ready_status", lambda _callback: None)
+    monkeypatch.setattr(
+        miner,
+        "check_eligibility",
+        lambda: {"eligible": True, "slot": 42},
+    )
+    monkeypatch.setattr(miner, "generate_header", lambda slot: {"header": {"slot": slot}})
+
+    def reject(_payload):
+        attempts.append(42)
+        miner.last_header_error = "HTTP 403 error=no pubkey registered for miner"
+        return False
+
+    def stop_after_two_loops(_seconds):
+        sleeps.append(_seconds)
+        if len(sleeps) == 2:
+            miner.mining = False
+
+    monkeypatch.setattr(miner, "submit_header", reject)
+    monkeypatch.setattr(module.time, "sleep", stop_after_two_loops)
+
+    miner._mine_loop(events.append)
+
+    assert attempts == [42]
+    assert sleeps == [10, 10]
+    assert events == [{
+        "type": "share",
+        "submitted": 1,
+        "accepted": 0,
+        "success": False,
+        "slot": 42,
+        "error": "HTTP 403 error=no pubkey registered for miner",
+    }]


### PR DESCRIPTION
## Summary

- track the last attempted slot so rejected headers are not resubmitted on every 10-second poll
- include the slot and safe server diagnostic in headless share events
- add regression coverage for same-slot rejection deduplication and failure formatting

## Reproduction

During eligible slot 27455, a live Windows miner received HTTP 403 from signed-header ingestion and retried the same rejected header 108 times. The existing headless output only displayed `FAIL`, hiding the actionable `no pubkey registered for miner` diagnostic.

## Validation

- `python -m pytest -q tests/test_windows_miner_chain_identity.py tests/test_windows_headless_lifecycle_logging.py` -> 9 passed
- `python -m py_compile miners/windows/rustchain_windows_miner.py`
- `git diff --check`

Closes #7368