### PR TITLE
fix(node): persist the pubkey that verified a signed header

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5227,9 +5227,11 @@ def ingest_signed_header():
 
     # Mock acceptance (TESTNET ONLY)
     accepted = False
+    verified_pubkey_hex = None
     if TESTNET_ALLOW_MOCK_SIG and len(sig_hex) == 128:
         METRICS_SNAPSHOT["rustchain_ingest_mock_accepted_total"] = METRICS_SNAPSHOT.get("rustchain_ingest_mock_accepted_total",0)+1
         accepted = True
+        verified_pubkey_hex = candidate_pubkeys[0]
     else:
         if not HAVE_NACL:
             return jsonify({"ok":False,"error":"ed25519 unavailable on server (install pynacl)"}), 500
@@ -5243,6 +5245,7 @@ def ingest_signed_header():
             try:
                 VerifyKey(hex_to_bytes(_cand)).verify(msg, sig)
                 accepted = True
+                verified_pubkey_hex = _cand
                 break
             except Exception:
                 continue
@@ -5301,7 +5304,7 @@ def ingest_signed_header():
     # Update tip + metrics
     with sqlite3.connect(DB_PATH) as db:
         db.execute("INSERT OR REPLACE INTO headers(slot, miner_id, message_hex, signature_hex, pubkey_hex, ts) VALUES(?,?,?,?,?,strftime('%s','now'))",
-                   (slot, miner_id, msg_hex, sig_hex, pubkey_hex))
+                   (slot, miner_id, msg_hex, sig_hex, verified_pubkey_hex))
         db.commit()
 
 

--- a/node/tests/test_ingest_round_robin_authorization.py
+++ b/node/tests/test_ingest_round_robin_authorization.py
@@ -155,11 +155,11 @@ class TestIngestRoundRobinAuthorization(unittest.TestCase):
             "miner_id": miner_id,
             "header": header,
             "signature": signature,
-        }
+        }, pubkey_hex
 
     def test_non_producer_cannot_submit_signed_header_for_slot(self):
         self._prepare_consensus_state(slot=101)
-        payload = self._signed_header_payload("attacker", slot=101)
+        payload, _ = self._signed_header_payload("attacker", slot=101)
 
         with self.mod.app.test_client() as client:
             response = client.post("/headers/ingest_signed", json=payload)
@@ -172,13 +172,25 @@ class TestIngestRoundRobinAuthorization(unittest.TestCase):
 
     def test_designated_producer_can_submit_signed_header_for_slot(self):
         self._prepare_consensus_state(slot=100)
-        payload = self._signed_header_payload("attacker", slot=100)
+        payload, expected_pubkey = self._signed_header_payload("attacker", slot=100)
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute(
+                "INSERT INTO miner_header_keys(miner_id, pubkey_hex) VALUES (?, ?)",
+                ("attacker", "00" * 32),
+            )
+            conn.commit()
 
         with self.mod.app.test_client() as client:
             response = client.post("/headers/ingest_signed", json=payload)
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.get_json()["ok"])
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            stored_pubkey = conn.execute(
+                "SELECT pubkey_hex FROM headers WHERE slot = ?",
+                (100,),
+            ).fetchone()[0]
+        self.assertEqual(stored_pubkey, expected_pubkey)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- retain the candidate public key that actually verifies a signed header
- persist that verified key instead of referencing the removed `pubkey_hex` local
- cover multi-key wallets with a decoy key and assert the matching key is stored

## Reproduction

With PyNaCl installed, the existing designated-producer integration path reached the final header insert and failed with:

```text
NameError: name 'pubkey_hex' is not defined
```

## Validation

- designated-producer integration path returned HTTP 200 and persisted the matching key with two registered candidates
- `python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_ingest_round_robin_authorization.py`
- `git diff --check`

Note: the full pytest invocation completes the functional assertions but the existing node fixture leaves a SQLite handle open during Windows temporary-directory cleanup. The same test path was therefore also run directly without cleanup; it passed and logged HTTP 200.

Closes #7370