### PR TITLE
fix: _find_balance_row returns full row instead of scalar (closes #305)

### DIFF
--- a/node/rustchain_x402.py
+++ b/node/rustchain_x402.py
@@ -82,17 +82,17 @@ def _find_balance_row(conn, miner_id):
 
     if "miner_id" in columns:
         row = conn.execute(
-            "SELECT miner_id FROM balances WHERE miner_id = ?", (miner_id,)
+            "SELECT * FROM balances WHERE miner_id = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_id"
+            return row, "miner_id"
 
     if "miner_pk" in columns:
         row = conn.execute(
-            "SELECT miner_pk FROM balances WHERE miner_pk = ?", (miner_id,)
+            "SELECT * FROM balances WHERE miner_pk = ?", (miner_id,)
         ).fetchone()
         if row:
-            return row[0], "miner_pk"
+            return row, "miner_pk"
 
     return None, None
 


### PR DESCRIPTION
## What
`_find_balance_row` was returning `row[0]` (the miner_id or miner_pk value itself) instead of the full row object. This made the function useless for accessing other balance fields like balance amount, coinbase_address, etc. Any caller expecting a row would receive a string instead, leading to AttributeErrors or incorrect data.

## Fix
Changed the SELECT queries from selecting only the identifier column to `SELECT *` and returning the full `row` object instead of `row[0]`. This preserves the intended API where callers can access row fields by index or by name.

Closes #305