### PR TITLE
fix(rate-limit): tolerate malformed env defaults

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -202,6 +202,16 @@ app = Flask(__name__)
 app.config['MAX_CONTENT_LENGTH'] = 1 * 1024 * 1024  # 1 MB — reject oversized request bodies before they reach route handlers
 
 
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw in (None, ""):
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 @app.before_request
 def _enforce_content_length():
     """Raise 413 before any route handler runs, so broad except-Exception wrappers cannot swallow it."""
@@ -229,8 +239,8 @@ HOF_DIR = os.path.join(REPO_ROOT, "web", "hall-of-fame")
 DASHBOARD_DIR = os.path.join(REPO_ROOT, "tools", "miner_dashboard")
 EXPLORER_DIR = os.path.join(REPO_ROOT, "tools", "explorer")
 
-ADMIN_RATE_LIMIT_MAX = int(os.environ.get("RC_ADMIN_RATE_LIMIT_MAX", "12"))
-ADMIN_RATE_LIMIT_WINDOW = int(os.environ.get("RC_ADMIN_RATE_LIMIT_WINDOW_SECONDS", "60"))
+ADMIN_RATE_LIMIT_MAX = _env_int("RC_ADMIN_RATE_LIMIT_MAX", 12)
+ADMIN_RATE_LIMIT_WINDOW = _env_int("RC_ADMIN_RATE_LIMIT_WINDOW_SECONDS", 60)
 _ADMIN_RATE_LIMIT_BUCKETS = {}
 _ADMIN_RATE_LIMIT_LOCK = Lock()
 _ADMIN_RATE_LIMIT_PREFIXES = (
@@ -3540,8 +3550,8 @@ def validate_fingerprint_data(fingerprint: dict, claimed_device: dict = None) ->
 # -- IP Rate Limiting for Attestations (SQLite-backed, gunicorn-safe) --
 ATTEST_IP_LIMIT = 15      # Max unique miners per IP per hour
 ATTEST_IP_WINDOW = 3600  # 1 hour window
-ATTEST_CHALLENGE_IP_LIMIT = int(os.environ.get("ATTEST_CHALLENGE_IP_LIMIT", "10"))
-ATTEST_CHALLENGE_IP_WINDOW = int(os.environ.get("ATTEST_CHALLENGE_IP_WINDOW", "60"))
+ATTEST_CHALLENGE_IP_LIMIT = _env_int("ATTEST_CHALLENGE_IP_LIMIT", 10)
+ATTEST_CHALLENGE_IP_WINDOW = _env_int("ATTEST_CHALLENGE_IP_WINDOW", 60)
 API_MINERS_RATE_LIMIT = 100
 API_MINERS_RATE_WINDOW = 60
 
@@ -10757,9 +10767,9 @@ BEACON_RATE_LIMIT  = 60
 # DB per-agent limit remains the cross-process layer. This is a flood backstop, not a
 # distributed ceiling. The default cap is generous (120/min) so shared NAT/proxy egress
 # IPs aren't throttled below the per-agent DB limit; tune via env if needed.
-BEACON_IP_RATE_LIMIT_MAX = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_MAX", "120"))
-BEACON_IP_RATE_LIMIT_WINDOW = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_WINDOW_SECONDS", "60"))
-_BEACON_IP_RATE_LIMIT_MAX_KEYS = int(os.environ.get("RC_BEACON_IP_RATE_LIMIT_MAX_KEYS", "8192"))
+BEACON_IP_RATE_LIMIT_MAX = _env_int("RC_BEACON_IP_RATE_LIMIT_MAX", 120)
+BEACON_IP_RATE_LIMIT_WINDOW = _env_int("RC_BEACON_IP_RATE_LIMIT_WINDOW_SECONDS", 60)
+_BEACON_IP_RATE_LIMIT_MAX_KEYS = _env_int("RC_BEACON_IP_RATE_LIMIT_MAX_KEYS", 8192)
 _BEACON_IP_RATE_LIMIT_BUCKETS = {}
 _BEACON_IP_RATE_LIMIT_LOCK = Lock()
 
@@ -10870,12 +10880,8 @@ def beacon_envelopes_list():
     return jsonify({"ok": True, "count": len(envelopes), "envelopes": envelopes})
 
 
-GOVERNANCE_VOTE_RATE_LIMIT_MAX = int(
-    os.environ.get("RC_GOVERNANCE_VOTE_RATE_LIMIT_MAX", "20")
-)
-GOVERNANCE_VOTE_RATE_LIMIT_WINDOW = int(
-    os.environ.get("RC_GOVERNANCE_VOTE_RATE_LIMIT_WINDOW_SECONDS", "60")
-)
+GOVERNANCE_VOTE_RATE_LIMIT_MAX = _env_int("RC_GOVERNANCE_VOTE_RATE_LIMIT_MAX", 20)
+GOVERNANCE_VOTE_RATE_LIMIT_WINDOW = _env_int("RC_GOVERNANCE_VOTE_RATE_LIMIT_WINDOW_SECONDS", 60)
 _GOVERNANCE_VOTE_RATE_LIMIT_BUCKETS = {}
 _GOVERNANCE_VOTE_RATE_LIMIT_LOCK = Lock()
 

--- a/node/tests/test_beacon_governance_rate_env_defaults.py
+++ b/node/tests/test_beacon_governance_rate_env_defaults.py
@@ -1,0 +1,60 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+
+
+class BeaconGovernanceRateEnvDefaults(unittest.TestCase):
+    def test_malformed_rate_limit_env_uses_defaults(self):
+        old_env = dict(os.environ)
+        module_name = "rcnode_rate_env_defaults_test"
+        tmp = tempfile.NamedTemporaryFile(suffix=".db", delete=False)
+        tmp.close()
+        try:
+            os.environ.update({
+                "RUSTCHAIN_DB_PATH": tmp.name,
+                "RC_ADMIN_KEY": "0123456789abcdef0123456789abcdef",
+                "RUSTCHAIN_DISABLE_P2P_AUTO_START": "1",
+                "RC_ADMIN_RATE_LIMIT_MAX": "oops",
+                "RC_ADMIN_RATE_LIMIT_WINDOW_SECONDS": "nope",
+                "ATTEST_CHALLENGE_IP_LIMIT": "ten",
+                "ATTEST_CHALLENGE_IP_WINDOW": "",
+                "RC_BEACON_IP_RATE_LIMIT_MAX": "not-an-int",
+                "RC_BEACON_IP_RATE_LIMIT_WINDOW_SECONDS": "",
+                "RC_BEACON_IP_RATE_LIMIT_MAX_KEYS": "many",
+                "RC_GOVERNANCE_VOTE_RATE_LIMIT_MAX": "NaN",
+                "RC_GOVERNANCE_VOTE_RATE_LIMIT_WINDOW_SECONDS": "later",
+            })
+
+            sys.modules.pop(module_name, None)
+            spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[module_name] = mod
+            spec.loader.exec_module(mod)
+
+            self.assertEqual(mod.ADMIN_RATE_LIMIT_MAX, 12)
+            self.assertEqual(mod.ADMIN_RATE_LIMIT_WINDOW, 60)
+            self.assertEqual(mod.ATTEST_CHALLENGE_IP_LIMIT, 10)
+            self.assertEqual(mod.ATTEST_CHALLENGE_IP_WINDOW, 60)
+            self.assertEqual(mod.BEACON_IP_RATE_LIMIT_MAX, 120)
+            self.assertEqual(mod.BEACON_IP_RATE_LIMIT_WINDOW, 60)
+            self.assertEqual(mod._BEACON_IP_RATE_LIMIT_MAX_KEYS, 8192)
+            self.assertEqual(mod.GOVERNANCE_VOTE_RATE_LIMIT_MAX, 20)
+            self.assertEqual(mod.GOVERNANCE_VOTE_RATE_LIMIT_WINDOW, 60)
+        finally:
+            sys.modules.pop(module_name, None)
+            os.environ.clear()
+            os.environ.update(old_env)
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -122,38 +122,38 @@ node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cur
 node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
 node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:10283:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:1347:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:1354:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:1509:            """, (limit, offset)).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:1618:        _epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:2828:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3001:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3202:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3217:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:3857:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:5095:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:5700:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6468:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6477:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7198:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7228:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7424:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7614:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7712:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7731:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8122:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8155:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8186:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8465:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8921:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9066:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9113:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9138:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9720:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9725:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9732:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9893:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:10293:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:1357:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:1364:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:1519:            """, (limit, offset)).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:1628:        _epoch_state_cols = {row[1] for row in c.execute("PRAGMA table_info(epoch_state)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:2838:    return {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3011:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3212:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3227:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:3867:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:5105:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:5710:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6478:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6487:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7208:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7238:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7434:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7624:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7722:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7741:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8132:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8165:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8196:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8475:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8931:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9076:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9123:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9148:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9730:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9735:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9742:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9903:        ).fetchall()
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())


### PR DESCRIPTION
## Summary

Related: Scottcjn/rustchain-bounties#13897. The bounty issue was closed under the 2026-06-11 live-surface policy; this PR is kept only as a focused defensive reliability patch for maintainer review, not as a live bounty claim.

- Add a small `_env_int()` parser for integrated-node rate-limit settings so malformed or empty env values fall back to safe defaults instead of crashing module import.
- Apply it only to rate-limit knobs for admin endpoints, attestation challenge, beacon submit, and governance vote limits.
- Add a direct import regression proving malformed rate-limit env values load with defaults.
- Regenerate the fetchall baseline because adding the helper near the top of the integrated node shifts existing legacy `.fetchall()` line numbers; no new `.fetchall()` call is introduced.

## Problem

The integrated node parsed several rate-limit env vars with module-level `int(os.environ.get(...))`. A typo like `RC_BEACON_IP_RATE_LIMIT_MAX=not-an-int` raises `ValueError` during import, so the node cannot start before any admin/auth/beacon/governance route is usable.

## Impact

This is a security-boundary reliability fix for rate-limit protections. A malformed operational setting should not turn the node into a startup failure. The patch preserves existing default values and does not change payout amounts, wallet balances, confirmation rules, admin secrets, production wallets, or manual crediting paths.

## BCOS

BCOS-L2: this touches admin/auth-adjacent rate-limit configuration and public beacon/governance request ceilings.

## Validation

```bash
uv run --no-project --with pytest --with flask --with cryptography --with pynacl --with requests --with httpx python -B -m pytest -q node/tests/test_beacon_governance_rate_env_defaults.py
# 1 passed

uv run --no-project --with pytest --with flask --with cryptography --with pynacl --with requests --with httpx python -B -m pytest -q node/tests/test_beacon_governance_rate_env_defaults.py node/tests/test_admin_rate_limit.py node/tests/test_attest_challenge_rate_limit.py node/tests/test_beacon_rip309_failclosed_t35.py node/tests/test_integrated_governance_vote_race.py
# 22 passed

python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_beacon_governance_rate_env_defaults.py
# passed

PATH=/usr/bin:/bin bash scripts/check_fetchall.sh
# OK: no new unannotated .fetchall() calls in node/.
# Legacy baseline count: 179 (issue #6627 migration backlog).

changed-file hidden Unicode scan
# passed, paths_scanned=3

git diff --check
# passed
```

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
