### PR TITLE
fix(explorer): restrict Socket.IO CORS origins

### DIFF
--- a/explorer/explorer_websocket_server.py
+++ b/explorer/explorer_websocket_server.py
@@ -16,7 +16,7 @@ Standalone usage:
 
 Integration:
     from explorer_websocket_server import socketio, app, start_explorer_poller
-    socketio.init_app(app, cors_allowed_origins="*", async_mode="threading")
+    socketio.init_app(app, cors_allowed_origins=SOCKETIO_CORS_ORIGINS, async_mode="threading")
     start_explorer_poller()
 
 Author: RustChain Team
@@ -39,6 +39,11 @@ except ModuleNotFoundError:
     from node.tls_config import get_ssl_context
 
 try:
+    from explorer.socketio_cors import parse_socketio_cors_origins
+except ModuleNotFoundError:
+    from socketio_cors import parse_socketio_cors_origins
+
+try:
     from flask_socketio import SocketIO, emit, join_room, leave_room
     HAVE_SOCKETIO = True
 except ImportError:
@@ -52,6 +57,7 @@ API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
 POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds between polls
 HEARTBEAT_S = 30  # ping/pong interval for connection health
 MAX_QUEUE = 100  # max buffered events per client (backpressure)
+SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)
 
 # SSL context for HTTPS node connections
 CTX = get_ssl_context()
@@ -315,7 +321,7 @@ ws_bp = Blueprint("explorer_ws", __name__)
 
 if HAVE_SOCKETIO:
     socketio = SocketIO(
-        cors_allowed_origins="*",
+        cors_allowed_origins=SOCKETIO_CORS_ORIGINS,
         async_mode="threading",
         ping_timeout=HEARTBEAT_S,
         ping_interval=HEARTBEAT_S,

--- a/explorer/realtime_server.py
+++ b/explorer/realtime_server.py
@@ -14,16 +14,22 @@ from datetime import datetime
 from flask import Flask, render_template, jsonify, request
 from flask_socketio import SocketIO, emit, join_room, leave_room
 
+try:
+    from explorer.socketio_cors import parse_socketio_cors_origins
+except ModuleNotFoundError:
+    from socketio_cors import parse_socketio_cors_origins
+
 # Configuration
 EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
 API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
 POLL_INTERVAL = float(os.environ.get('POLL_INTERVAL', '5'))  # seconds
+SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=EXPLORER_PORT)
 
 # Flask app with SocketIO
 app = Flask(__name__)
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'rustchain-explorer-secret')
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode='threading')
+socketio = SocketIO(app, cors_allowed_origins=SOCKETIO_CORS_ORIGINS, async_mode='threading')
 
 # State tracking
 class ExplorerState:

--- a/explorer/socketio_cors.py
+++ b/explorer/socketio_cors.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: MIT
+"""Socket.IO CORS origin helpers for explorer runtimes."""
+
+from __future__ import annotations
+
+import os
+
+
+TRUSTED_SOCKETIO_ORIGINS = (
+    "https://rustchain.org",
+    "https://www.rustchain.org",
+)
+
+
+def default_socketio_origins(*, local_port: int | str | None = None) -> list[str]:
+    origins = list(TRUSTED_SOCKETIO_ORIGINS)
+    if local_port is not None:
+        origins.extend(
+            [
+                f"http://localhost:{local_port}",
+                f"http://127.0.0.1:{local_port}",
+            ]
+        )
+    return origins
+
+
+def parse_socketio_cors_origins(
+    raw_value: str | None = None,
+    *,
+    local_port: int | str | None = None,
+) -> list[str]:
+    """Return an explicit Socket.IO origin allowlist.
+
+    Flask-SocketIO accepts "*" as a permissive origin policy; explorer feeds
+    carry live chain and miner state, so production should be allowlisted.
+    """
+    if raw_value is None:
+        raw_value = os.environ.get("EXPLORER_SOCKETIO_CORS_ORIGINS")
+
+    if raw_value is None or not raw_value.strip():
+        return default_socketio_origins(local_port=local_port)
+
+    origins: list[str] = []
+    for item in raw_value.split(","):
+        origin = item.strip()
+        if not origin:
+            continue
+        if origin == "*":
+            raise ValueError("EXPLORER_SOCKETIO_CORS_ORIGINS must not include '*'")
+        if origin not in origins:
+            origins.append(origin)
+
+    if not origins:
+        return default_socketio_origins(local_port=local_port)
+    return origins

--- a/explorer/ws_explorer_server.py
+++ b/explorer/ws_explorer_server.py
@@ -17,15 +17,21 @@ import requests
 from flask import Flask, render_template, jsonify
 from flask_socketio import SocketIO, emit
 
+try:
+    from explorer.socketio_cors import parse_socketio_cors_origins
+except ModuleNotFoundError:
+    from socketio_cors import parse_socketio_cors_origins
+
 # ── Configuration ─────────────────────────────────────────────────
 API_BASE = os.environ.get("RUSTCHAIN_API_BASE", "https://rustchain.org").rstrip("/")
 API_TIMEOUT = float(os.environ.get("API_TIMEOUT", "8"))
 POLL_INTERVAL = float(os.environ.get("WS_POLL_INTERVAL", "10"))
 PORT = int(os.environ.get("WS_EXPLORER_PORT", "8060"))
+SOCKETIO_CORS_ORIGINS = parse_socketio_cors_origins(local_port=PORT)
 
 app = Flask(__name__, template_folder="templates", static_folder="static")
 app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY", "rustchain-ws-explorer")
-socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
+socketio = SocketIO(app, cors_allowed_origins=SOCKETIO_CORS_ORIGINS, async_mode="threading")
 
 # ── State ─────────────────────────────────────────────────────────
 state = {

--- a/tests/test_explorer_socketio_cors.py
+++ b/tests/test_explorer_socketio_cors.py
@@ -1,0 +1,131 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(name, None)
+    return module
+
+
+def load_socketio_cors():
+    return load_module(
+        "test_socketio_cors_helper",
+        REPO_ROOT / "explorer" / "socketio_cors.py",
+    )
+
+
+@pytest.fixture
+def socketio_stub(monkeypatch):
+    socketio_module = types.ModuleType("flask_socketio")
+    instances = []
+
+    class SocketIO:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            instances.append(self)
+
+        def init_app(self, *args, **kwargs):
+            self.init_args = args
+            self.init_kwargs = kwargs
+
+        def on(self, *args, **kwargs):
+            def decorator(fn):
+                return fn
+
+            return decorator
+
+        def emit(self, *args, **kwargs):
+            pass
+
+        def run(self, *args, **kwargs):
+            pass
+
+    socketio_module.SocketIO = SocketIO
+    socketio_module.emit = lambda *args, **kwargs: None
+    socketio_module.join_room = lambda *args, **kwargs: None
+    socketio_module.leave_room = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "flask_socketio", socketio_module)
+    return instances
+
+
+def test_default_explorer_socketio_origins_are_allowlisted(monkeypatch):
+    monkeypatch.delenv("EXPLORER_SOCKETIO_CORS_ORIGINS", raising=False)
+    socketio_cors = load_socketio_cors()
+
+    origins = socketio_cors.parse_socketio_cors_origins(local_port=8080)
+
+    assert "*" not in origins
+    assert "https://rustchain.org" in origins
+    assert "https://www.rustchain.org" in origins
+    assert "http://localhost:8080" in origins
+    assert "http://127.0.0.1:8080" in origins
+
+
+def test_explorer_socketio_origins_parse_explicit_allowlist(monkeypatch):
+    monkeypatch.setenv(
+        "EXPLORER_SOCKETIO_CORS_ORIGINS",
+        "https://dash.rustchain.org, https://ops.rustchain.org, https://dash.rustchain.org",
+    )
+    socketio_cors = load_socketio_cors()
+
+    assert socketio_cors.parse_socketio_cors_origins(local_port=8080) == [
+        "https://dash.rustchain.org",
+        "https://ops.rustchain.org",
+    ]
+
+
+def test_explorer_socketio_origins_reject_wildcard(monkeypatch):
+    monkeypatch.setenv("EXPLORER_SOCKETIO_CORS_ORIGINS", "https://rustchain.org,*")
+    socketio_cors = load_socketio_cors()
+
+    with pytest.raises(ValueError, match="must not include"):
+        socketio_cors.parse_socketio_cors_origins(local_port=8080)
+
+
+def test_realtime_server_passes_allowlist_to_socketio(monkeypatch, socketio_stub):
+    monkeypatch.setenv("EXPLORER_SOCKETIO_CORS_ORIGINS", "https://dash.rustchain.org")
+
+    module = load_module(
+        "test_realtime_server_cors",
+        REPO_ROOT / "explorer" / "realtime_server.py",
+    )
+
+    assert module.SOCKETIO_CORS_ORIGINS == ["https://dash.rustchain.org"]
+    assert socketio_stub[0].kwargs["cors_allowed_origins"] == ["https://dash.rustchain.org"]
+
+
+def test_websocket_server_passes_allowlist_to_socketio(monkeypatch, socketio_stub):
+    monkeypatch.setenv("EXPLORER_SOCKETIO_CORS_ORIGINS", "https://dash.rustchain.org")
+
+    module = load_module(
+        "test_explorer_websocket_server_cors",
+        REPO_ROOT / "explorer" / "explorer_websocket_server.py",
+    )
+
+    assert module.SOCKETIO_CORS_ORIGINS == ["https://dash.rustchain.org"]
+    assert socketio_stub[0].kwargs["cors_allowed_origins"] == ["https://dash.rustchain.org"]
+
+
+def test_explorer_runtime_sources_no_longer_use_socketio_wildcard():
+    for rel_path in (
+        "explorer/ws_explorer_server.py",
+        "explorer/realtime_server.py",
+        "explorer/explorer_websocket_server.py",
+    ):
+        source = (REPO_ROOT / rel_path).read_text(encoding="utf-8")
+        assert 'cors_allowed_origins="*"' not in source
+        assert "cors_allowed_origins='*'" not in source


### PR DESCRIPTION
## Summary

Related: Scottcjn/rustchain-bounties#13898. The bounty issue was closed under the 2026-06-11 live-surface policy; this PR is kept only as a focused defensive hardening patch for maintainer review, not as a live bounty claim.

- Add a shared explorer Socket.IO CORS allowlist helper.
- Replace wildcard `*` in `ws_explorer_server.py`, `realtime_server.py`, and `explorer_websocket_server.py`.
- Support `EXPLORER_SOCKETIO_CORS_ORIGINS` and reject wildcard origins.

## Impact

Explorer websocket feeds expose live chain, miner, epoch, block, transaction, and health state. Browser access should be limited to trusted explorer origins unless an operator configures another allowlist.

BCOS-L2: public websocket security boundary. No wallet balances, rewards, payout amounts, event payloads, admin secrets, or production wallets are changed.

## Validation

- Focused pytest: `tests/test_explorer_socketio_cors.py`, `tests/test_realtime_explorer_limit_validation.py`, `tests/test_explorer_websocket_miners.py` -> 16 passed
- `py_compile` touched Python files -> passed
- changed-file hidden Unicode scan -> passed, paths_scanned=5
- `git diff --check` -> passed

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
