### PR TITLE
fix(tip-bot): validate decimal precision before float rounding

### DIFF
--- a/integrations/rustchain-bounties/test_tip_bot.py
+++ b/integrations/rustchain-bounties/test_tip_bot.py
@@ -106,6 +106,11 @@ class TestParseTipCommand:
         assert result.error is None
         assert result.command.amount == 12.5
 
+    def test_valid_max_decimal_places_amount(self):
+        result = parse_tip_command("/tip @bob 0.12345678 RTC", "RTC")
+        assert result.error is None
+        assert result.command.amount == 0.12345678
+
     def test_valid_inline_in_comment(self):
         body = "Great work! /tip @contributor 100 RTC for fixing that bug."
         result = parse_tip_command(body, "RTC")
@@ -183,6 +188,20 @@ class TestParseTipCommand:
         result = parse_tip_command(f"/tip @{long_name} 10 RTC", "RTC")
         assert result.command is None
         assert result.error is not None
+
+    @pytest.mark.parametrize(
+        "amount",
+        (
+            "0.10000000000000001",
+            "1.000000000",
+            "1.0000000000000001",
+        ),
+    )
+    def test_amount_with_more_than_max_decimal_places_rejected_before_float_rounding(self, amount):
+        result = parse_tip_command(f"/tip @alice {amount} RTC", "RTC")
+
+        assert result.command is None
+        assert result.error == f"Amount `{amount}` has too many decimal places. Max 8."
 
 
 # ---------------------------------------------------------------------------

--- a/integrations/rustchain-bounties/tip_bot.py
+++ b/integrations/rustchain-bounties/tip_bot.py
@@ -26,6 +26,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from typing import Optional
 
 import requests
@@ -59,6 +60,8 @@ _TIP_PATTERN = re.compile(
     r"(?:\s|$)",                 # followed by whitespace or end
     re.IGNORECASE | re.MULTILINE,
 )
+
+MAX_RTC_DECIMAL_PLACES = 8
 
 
 @dataclass
@@ -110,32 +113,33 @@ def parse_tip_command(comment_body: str, expected_token: str) -> ParseResult:
             error=f"Unknown token `{token}`. Only `{expected_token}` tips are supported.",
         )
 
-    # Validate amount
+    # Validate amount using Decimal before converting for existing storage /
+    # comment behavior. Float rounding can hide over-precision inputs.
     try:
-        amount = float(amount_str)
-    except ValueError:
+        amount_decimal = Decimal(amount_str)
+    except (InvalidOperation, ValueError):
         return ParseResult(
             command=None,
             error=f"Invalid amount `{amount_str}`. Must be a positive number.",
         )
 
-    if amount <= 0:
+    if amount_decimal <= 0:
         return ParseResult(
             command=None,
-            error=f"Amount must be greater than 0. Got `{amount}`.",
+            error=f"Amount must be greater than 0. Got `{amount_decimal}`.",
         )
 
-    # Reject obviously invalid amounts (too many decimal places for RTC)
-    if amount != round(amount, 8):
+    decimal_places = max(0, -amount_decimal.as_tuple().exponent)
+    if decimal_places > MAX_RTC_DECIMAL_PLACES:
         return ParseResult(
             command=None,
-            error=f"Amount `{amount}` has too many decimal places. Max 8.",
+            error=f"Amount `{amount_str}` has too many decimal places. Max {MAX_RTC_DECIMAL_PLACES}.",
         )
 
     return ParseResult(
         command=TipCommand(
             recipient=recipient,
-            amount=amount,
+            amount=float(amount_decimal),
             token=token.upper(),
             raw=match.group(0).strip(),
         ),


### PR DESCRIPTION
## Summary

Fixes Scottcjn/rustchain-bounties#13900.

- Validate `/tip` RTC amount precision with `Decimal` before converting to float.
- Reject over-precision values that previously collapsed to `0.1` or `1.0` before the max-8-decimal check.
- Keep existing downstream storage/comment behavior unchanged.

## Impact

The RustChain tip bot records pending manual RTC payouts. Precision checks should use the original decimal string so pending payout records do not silently normalize invalid over-precision input.

BCOS-L2: reward/tip accounting-adjacent validation. No payout amount rules, wallet balances, admin secrets, or production wallets are changed.

## Validation

- `integrations/rustchain-bounties/test_tip_bot.py` -> 72 passed
- `py_compile` touched Python files -> passed
- changed-file hidden Unicode scan -> passed, paths_scanned=2
- `git diff --check` -> passed

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
