### PR TITLE
fix(status): escape dashboard status fields

### DIFF
--- a/status/templates/status.html
+++ b/status/templates/status.html
@@ -74,6 +74,14 @@ function formatUptime(sec) {
   const h = Math.floor(sec/3600), m = Math.floor((sec%3600)/60);
   return h > 0 ? `${h}h ${m}m` : `${m}m`;
 }
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
 async function refresh() {
   try {
     const [statusRes, incRes, uptimeRes] = await Promise.all([
@@ -102,18 +110,18 @@ async function refresh() {
       card.className = 'node-card';
       card.innerHTML = `
         <div class="node-header">
-          <span class="node-name">${node.name}</span>
+          <span class="node-name">${escapeHtml(node.name)}</span>
           <span class="status-badge ${node.up?'up':'down'}">${node.up?'Operational':'Down'}</span>
         </div>
         <div class="node-stats">
-          <div><span class="stat-label">Location</span><br><span class="stat-value">${node.location||'—'}</span></div>
-          <div><span class="stat-label">Response</span><br><span class="stat-value">${node.response_ms||0}ms</span></div>
-          <div><span class="stat-label">Miners</span><br><span class="stat-value">${node.active_miners||'—'}</span></div>
-          <div><span class="stat-label">Epoch</span><br><span class="stat-value">${node.current_epoch||'—'}</span></div>
-          <div><span class="stat-label">Version</span><br><span class="stat-value">${node.version||'—'}</span></div>
-          <div><span class="stat-label">Uptime</span><br><span class="stat-value">${formatUptime(node.uptime)}</span></div>
+          <div><span class="stat-label">Location</span><br><span class="stat-value">${escapeHtml(node.location || '—')}</span></div>
+          <div><span class="stat-label">Response</span><br><span class="stat-value">${escapeHtml(node.response_ms || 0)}ms</span></div>
+          <div><span class="stat-label">Miners</span><br><span class="stat-value">${escapeHtml(node.active_miners || '—')}</span></div>
+          <div><span class="stat-label">Epoch</span><br><span class="stat-value">${escapeHtml(node.current_epoch || '—')}</span></div>
+          <div><span class="stat-label">Version</span><br><span class="stat-value">${escapeHtml(node.version || '—')}</span></div>
+          <div><span class="stat-label">Uptime</span><br><span class="stat-value">${escapeHtml(formatUptime(node.uptime))}</span></div>
         </div>
-        <div class="uptime-pct">${u.uptime_pct!==undefined?u.uptime_pct+'% uptime (24h)':'—'}</div>
+        <div class="uptime-pct">${u.uptime_pct!==undefined?escapeHtml(u.uptime_pct+'% uptime (24h)'):'—'}</div>
         <div class="uptime-bar" id="bar-${nodeId}"></div>
       `;
       container.appendChild(card);
@@ -141,9 +149,9 @@ async function refresh() {
     } else {
       incEl.innerHTML=incidents.slice(0,20).map(i=>`
         <div class="incident">
-          <span><span class="event-${i.event}">${i.event==='down'?'🔴':'🟢'} ${i.node} — ${i.event}</span>
-          ${i.detail?' · '+i.detail:''}</span>
-          <span class="time">${formatTime(i.time)}</span>
+          <span><span class="event-${i.event === 'down' ? 'down' : i.event === 'recovered' ? 'recovered' : 'unknown'}">${i.event==='down'?'🔴':'🟢'} ${escapeHtml(i.node)} — ${escapeHtml(i.event)}</span>
+          ${i.detail?' · '+escapeHtml(i.detail):''}</span>
+          <span class="time">${escapeHtml(formatTime(i.time))}</span>
         </div>
       `).join('');
     }

--- a/status/test_status.py
+++ b/status/test_status.py
@@ -193,6 +193,22 @@ class TestAPI:
         resp = client.get("/")
         assert resp.status_code == 200
 
+    def test_index_page_escapes_dynamic_status_fields(self, client):
+        resp = client.get("/")
+        html = resp.data.decode("utf-8")
+
+        assert "function escapeHtml(value)" in html
+        assert "${escapeHtml(node.name)}" in html
+        assert "${escapeHtml(node.location || '—')}" in html
+        assert "${escapeHtml(node.response_ms || 0)}ms" in html
+        assert "${escapeHtml(node.version || '—')}" in html
+        assert "${escapeHtml(i.node)}" in html
+        assert "${escapeHtml(i.event)}" in html
+        assert "escapeHtml(i.detail)" in html
+        assert "${node.name}" not in html
+        assert "${node.version||'—'}" not in html
+        assert "${i.detail?' · '+i.detail:''}" not in html
+
 
 class TestHistoryTrimming:
     """Test that history is properly trimmed to 24 hours."""


### PR DESCRIPTION
## Summary
- Escape dynamic node and incident text in the live status dashboard before inserting it with `innerHTML`.
- Allowlist incident event class names before rendering rows.
- Keep polling, RSS, API response shapes, and status semantics unchanged.

## Problem / Impact
`status/templates/status.html` rendered fields from `/api/status` and `/api/incidents` raw. A compromised monitored node health response, or poisoned incident state, could inject markup into the public status page.

## Tests
- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q status/test_status.py` -> 17 passed
- `python3 -m py_compile status/status_server.py status/test_status.py` -> passed
- changed-file hidden Unicode scan -> passed
- `git diff --check origin/main...HEAD` -> passed

Review tier: BCOS-L2 (security / public dashboard XSS hardening)

Related: Scottcjn/rustchain-bounties#13901. The linked bounty issue was closed under the 2026-06-11 live-surface policy; this PR is kept only as a focused defensive dashboard hardening patch for maintainer review, not as a live bounty claim.
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
