### PR TITLE
fix(poa): fail closed on malformed numeric env

### DIFF
--- a/rustchain-poa/api/poa_api.py
+++ b/rustchain-poa/api/poa_api.py
@@ -18,14 +18,16 @@ app = Flask(__name__)
 
 def _env_positive_int(name, default):
     raw = os.environ.get(name)
-    if raw is None or str(raw).strip() == "":
+    if raw is None:
         return default
+    if str(raw).strip() == "":
+        raise ValueError(f"{name} must be a positive integer")
     try:
         value = int(raw)
-    except (TypeError, ValueError):
-        return default
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
     if value <= 0:
-        return default
+        raise ValueError(f"{name} must be a positive integer")
     return value
 
 

--- a/rustchain-poa/api/poa_api.py
+++ b/rustchain-poa/api/poa_api.py
@@ -15,7 +15,21 @@ from validator.validate_genesis import validate_genesis
 
 app = Flask(__name__)
 
-MAX_UPLOAD_BYTES = int(os.environ.get("POA_VALIDATE_MAX_UPLOAD_BYTES", str(10 * 1024 * 1024)))
+
+def _env_positive_int(name, default):
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if value <= 0:
+        return default
+    return value
+
+
+MAX_UPLOAD_BYTES = _env_positive_int("POA_VALIDATE_MAX_UPLOAD_BYTES", 10 * 1024 * 1024)
 JSON_MIME_TYPES = {"", "application/json", "text/json"}
 
 

--- a/rustchain-poa/net/flame_beacon.py
+++ b/rustchain-poa/net/flame_beacon.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import math
 import os
 import time
 from datetime import datetime, timezone
@@ -21,6 +22,36 @@ logging.basicConfig(
 )
 logger = logging.getLogger("flame_beacon")
 
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Non-positive %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
+
+def _env_positive_float(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return default
+    if not math.isfinite(value) or value <= 0:
+        logger.warning("Non-positive %s=%r; using default %s", name, raw, default)
+        return default
+    return value
+
 # ---------------------------------------------------------------------------
 # Configuration (override via environment variables)
 # ---------------------------------------------------------------------------
@@ -33,15 +64,15 @@ DISCORD_CHANNEL_ID: str = os.environ.get("DISCORD_CHANNEL_ID", "")
 JSON_HISTORY_FILE: str = os.environ.get("FLAME_HISTORY_FILE", "flame_history.json")
 
 # Retry / back-off knobs
-MAX_RETRIES: int = int(os.environ.get("FLAME_MAX_RETRIES", "5"))
-RETRY_BASE_DELAY: float = float(os.environ.get("FLAME_RETRY_BASE_DELAY", "1.0"))  # seconds
-RETRY_MAX_DELAY: float = float(os.environ.get("FLAME_RETRY_MAX_DELAY", "60.0"))  # seconds
+MAX_RETRIES: int = _env_positive_int("FLAME_MAX_RETRIES", 5)
+RETRY_BASE_DELAY: float = _env_positive_float("FLAME_RETRY_BASE_DELAY", 1.0)  # seconds
+RETRY_MAX_DELAY: float = _env_positive_float("FLAME_RETRY_MAX_DELAY", 60.0)  # seconds
 
 # Listener poll interval (seconds)
-LISTENER_POLL_INTERVAL: float = float(os.environ.get("FLAME_LISTENER_POLL", "15.0"))
+LISTENER_POLL_INTERVAL: float = _env_positive_float("FLAME_LISTENER_POLL", 15.0)
 
 # Watcher sleep between file scans (seconds)
-WATCHER_INTERVAL: float = float(os.environ.get("FLAME_WATCHER_INTERVAL", "6.0"))
+WATCHER_INTERVAL: float = _env_positive_float("FLAME_WATCHER_INTERVAL", 6.0)
 
 
 # ---------------------------------------------------------------------------

--- a/rustchain-poa/net/flame_beacon.py
+++ b/rustchain-poa/net/flame_beacon.py
@@ -25,31 +25,31 @@ logger = logging.getLogger("flame_beacon")
 
 def _env_positive_int(name: str, default: int) -> int:
     raw = os.environ.get(name)
-    if raw is None or str(raw).strip() == "":
+    if raw is None:
         return default
+    if str(raw).strip() == "":
+        raise ValueError(f"{name} must be a positive integer")
     try:
         value = int(raw)
-    except (TypeError, ValueError):
-        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-        return default
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive integer") from exc
     if value <= 0:
-        logger.warning("Non-positive %s=%r; using default %s", name, raw, default)
-        return default
+        raise ValueError(f"{name} must be a positive integer")
     return value
 
 
 def _env_positive_float(name: str, default: float) -> float:
     raw = os.environ.get(name)
-    if raw is None or str(raw).strip() == "":
+    if raw is None:
         return default
+    if str(raw).strip() == "":
+        raise ValueError(f"{name} must be a positive finite number")
     try:
         value = float(raw)
-    except (TypeError, ValueError):
-        logger.warning("Invalid %s=%r; using default %s", name, raw, default)
-        return default
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a positive finite number") from exc
     if not math.isfinite(value) or value <= 0:
-        logger.warning("Non-positive %s=%r; using default %s", name, raw, default)
-        return default
+        raise ValueError(f"{name} must be a positive finite number")
     return value
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discord_transport.py
+++ b/tests/test_discord_transport.py
@@ -38,6 +38,16 @@ sys.modules["flame_beacon"] = flame_beacon
 _spec.loader.exec_module(flame_beacon)
 
 
+def _load_flame_beacon_with_env(env):
+    module_name = "flame_beacon_env_defaults_under_test"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, _FLAME_BEACON_PATH)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(os.environ, env, clear=False):
+        spec.loader.exec_module(module)
+    return module
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -70,6 +80,43 @@ def _mock_response(status_code: int, body=None, headers=None):
         resp.text = str(body)
         resp.json.side_effect = ValueError("not json")
     return resp
+
+
+# ---------------------------------------------------------------------------
+# Configuration defaults
+# ---------------------------------------------------------------------------
+
+class TestConfigDefaults(unittest.TestCase):
+
+    def test_malformed_numeric_env_falls_back_without_import_crash(self):
+        module = _load_flame_beacon_with_env({
+            "FLAME_MAX_RETRIES": "oops",
+            "FLAME_RETRY_BASE_DELAY": "nan",
+            "FLAME_RETRY_MAX_DELAY": "-1",
+            "FLAME_LISTENER_POLL": "",
+            "FLAME_WATCHER_INTERVAL": "0",
+        })
+
+        self.assertEqual(module.MAX_RETRIES, 5)
+        self.assertEqual(module.RETRY_BASE_DELAY, 1.0)
+        self.assertEqual(module.RETRY_MAX_DELAY, 60.0)
+        self.assertEqual(module.LISTENER_POLL_INTERVAL, 15.0)
+        self.assertEqual(module.WATCHER_INTERVAL, 6.0)
+
+    def test_valid_numeric_env_overrides_are_preserved(self):
+        module = _load_flame_beacon_with_env({
+            "FLAME_MAX_RETRIES": "7",
+            "FLAME_RETRY_BASE_DELAY": "0.25",
+            "FLAME_RETRY_MAX_DELAY": "9.5",
+            "FLAME_LISTENER_POLL": "2.5",
+            "FLAME_WATCHER_INTERVAL": "3.25",
+        })
+
+        self.assertEqual(module.MAX_RETRIES, 7)
+        self.assertEqual(module.RETRY_BASE_DELAY, 0.25)
+        self.assertEqual(module.RETRY_MAX_DELAY, 9.5)
+        self.assertEqual(module.LISTENER_POLL_INTERVAL, 2.5)
+        self.assertEqual(module.WATCHER_INTERVAL, 3.25)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_discord_transport.py
+++ b/tests/test_discord_transport.py
@@ -43,7 +43,11 @@ def _load_flame_beacon_with_env(env):
     sys.modules.pop(module_name, None)
     spec = importlib.util.spec_from_file_location(module_name, _FLAME_BEACON_PATH)
     module = importlib.util.module_from_spec(spec)
-    with patch.dict(os.environ, env, clear=False):
+    delete_keys = [key for key, value in env.items() if value is None]
+    patch_values = {key: value for key, value in env.items() if value is not None}
+    with patch.dict(os.environ, patch_values, clear=False):
+        for key in delete_keys:
+            os.environ.pop(key, None)
         spec.loader.exec_module(module)
     return module
 
@@ -88,13 +92,13 @@ def _mock_response(status_code: int, body=None, headers=None):
 
 class TestConfigDefaults(unittest.TestCase):
 
-    def test_malformed_numeric_env_falls_back_without_import_crash(self):
+    def test_missing_numeric_env_uses_defaults(self):
         module = _load_flame_beacon_with_env({
-            "FLAME_MAX_RETRIES": "oops",
-            "FLAME_RETRY_BASE_DELAY": "nan",
-            "FLAME_RETRY_MAX_DELAY": "-1",
-            "FLAME_LISTENER_POLL": "",
-            "FLAME_WATCHER_INTERVAL": "0",
+            "FLAME_MAX_RETRIES": None,
+            "FLAME_RETRY_BASE_DELAY": None,
+            "FLAME_RETRY_MAX_DELAY": None,
+            "FLAME_LISTENER_POLL": None,
+            "FLAME_WATCHER_INTERVAL": None,
         })
 
         self.assertEqual(module.MAX_RETRIES, 5)
@@ -102,6 +106,22 @@ class TestConfigDefaults(unittest.TestCase):
         self.assertEqual(module.RETRY_MAX_DELAY, 60.0)
         self.assertEqual(module.LISTENER_POLL_INTERVAL, 15.0)
         self.assertEqual(module.WATCHER_INTERVAL, 6.0)
+
+    def test_malformed_numeric_env_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "FLAME_MAX_RETRIES"):
+            _load_flame_beacon_with_env({"FLAME_MAX_RETRIES": "oops"})
+
+        with self.assertRaisesRegex(ValueError, "FLAME_RETRY_BASE_DELAY"):
+            _load_flame_beacon_with_env({"FLAME_RETRY_BASE_DELAY": "nan"})
+
+        with self.assertRaisesRegex(ValueError, "FLAME_RETRY_MAX_DELAY"):
+            _load_flame_beacon_with_env({"FLAME_RETRY_MAX_DELAY": "-1"})
+
+        with self.assertRaisesRegex(ValueError, "FLAME_LISTENER_POLL"):
+            _load_flame_beacon_with_env({"FLAME_LISTENER_POLL": ""})
+
+        with self.assertRaisesRegex(ValueError, "FLAME_WATCHER_INTERVAL"):
+            _load_flame_beacon_with_env({"FLAME_WATCHER_INTERVAL": "0"})
 
     def test_valid_numeric_env_overrides_are_preserved(self):
         module = _load_flame_beacon_with_env({

--- a/tests/test_poa_api_upload_hardening.py
+++ b/tests/test_poa_api_upload_hardening.py
@@ -4,6 +4,8 @@ import io
 import sys
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 POA_API_PATH = REPO_ROOT / "rustchain-poa" / "api" / "poa_api.py"
@@ -41,6 +43,23 @@ def test_validate_rejects_non_json_upload(monkeypatch):
     assert response.status_code == 400
     assert response.get_json() == {"error": "Only JSON files accepted"}
     assert called is False
+
+
+@pytest.mark.parametrize("env_value", ["oops", "", "0", "-1"])
+def test_malformed_upload_limit_env_falls_back(monkeypatch, env_value):
+    monkeypatch.setenv("POA_VALIDATE_MAX_UPLOAD_BYTES", env_value)
+
+    module = load_poa_api(monkeypatch)
+
+    assert module.MAX_UPLOAD_BYTES == 10 * 1024 * 1024
+
+
+def test_valid_upload_limit_env_is_preserved(monkeypatch):
+    monkeypatch.setenv("POA_VALIDATE_MAX_UPLOAD_BYTES", "2048")
+
+    module = load_poa_api(monkeypatch)
+
+    assert module.MAX_UPLOAD_BYTES == 2048
 
 
 def test_validate_rejects_oversized_upload_before_validation(monkeypatch):

--- a/tests/test_poa_api_upload_hardening.py
+++ b/tests/test_poa_api_upload_hardening.py
@@ -45,13 +45,20 @@ def test_validate_rejects_non_json_upload(monkeypatch):
     assert called is False
 
 
-@pytest.mark.parametrize("env_value", ["oops", "", "0", "-1"])
-def test_malformed_upload_limit_env_falls_back(monkeypatch, env_value):
-    monkeypatch.setenv("POA_VALIDATE_MAX_UPLOAD_BYTES", env_value)
+def test_missing_upload_limit_env_uses_default(monkeypatch):
+    monkeypatch.delenv("POA_VALIDATE_MAX_UPLOAD_BYTES", raising=False)
 
     module = load_poa_api(monkeypatch)
 
     assert module.MAX_UPLOAD_BYTES == 10 * 1024 * 1024
+
+
+@pytest.mark.parametrize("env_value", ["oops", "", "0", "-1"])
+def test_malformed_upload_limit_env_fails_closed(monkeypatch, env_value):
+    monkeypatch.setenv("POA_VALIDATE_MAX_UPLOAD_BYTES", env_value)
+
+    with pytest.raises(ValueError, match="POA_VALIDATE_MAX_UPLOAD_BYTES"):
+        load_poa_api(monkeypatch)
 
 
 def test_valid_upload_limit_env_is_preserved(monkeypatch):


### PR DESCRIPTION
## Summary
- keep PoA upload/beacon numeric defaults when the related environment variables are unset
- fail closed when explicit PoA/beacon numeric overrides are empty, malformed, zero, negative, NaN, or infinite
- preserve valid numeric overrides and keep the change scoped to configuration parsing/tests

## Risk / BCOS
BCOS-L2: PoA/beacon configuration controls upload limits, retry timing, listener polling, and watcher intervals.

This PR does not change payout amounts, wallet balances, reward rules, consensus rewards, admin keys, production wallets, or manual crediting paths. It only distinguishes missing configuration from explicitly malformed configuration.

## Validation
- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q tests/test_discord_transport.py tests/test_poa_api_upload_hardening.py` -> 44 passed
- `python3 -m py_compile rustchain-poa/net/flame_beacon.py rustchain-poa/api/poa_api.py tests/test_discord_transport.py tests/test_poa_api_upload_hardening.py` -> passed
- `git diff --check` -> passed

Related: #13904

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
