### PR TITLE
fix(faucet): report keeper claims as receipts

### DIFF
--- a/keeper_explorer.py
+++ b/keeper_explorer.py
@@ -17,7 +17,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import sqlite3
 import sys
 import time
@@ -137,18 +136,24 @@ def faucet_drip():
     if not WALLET_ADDRESS_RE.fullmatch(address):
         return jsonify({"success": False, "error": "Invalid wallet address"}), 400
         
-    # In a real scenario, this would call the node's transfer API
-    # For the bounty/demo, we log the success
     amount = 0.5 # 0.5 test RTC
     allowed, timestamp = record_faucet_claim(address, ip, amount)
     if not allowed:
         return jsonify({"success": False, "error": "Rate limit exceeded (1 drip per 24h)"}), 429
-    tx_hash = hashlib.sha256(f"{address}:{ip}:{timestamp}:{secrets.token_hex(16)}".encode()).hexdigest()
+    receipt_id = hashlib.sha256(f"keeper-faucet:{address}:{ip}:{timestamp}".encode()).hexdigest()
     
     return jsonify({
-        "success": True, 
-        "message": f"Drip successful! {amount} RTC sent to {address}",
-        "tx_hash": tx_hash
+        "success": True,
+        "status": "claim_recorded",
+        "settlement_status": "recorded_only",
+        "amount": amount,
+        "address": address,
+        "message": (
+            f"Faucet claim recorded for {address}; no on-chain transfer "
+            "was submitted by this explorer"
+        ),
+        "receipt_id": receipt_id,
+        "tx_hash": None,
     })
 
 # --- Fossil-punk UI Template ---
@@ -367,7 +372,7 @@ RETRO_HTML = r"""
 
             <div class="faucet-box">
                 <h3 class="glow">> KEEPER_FAUCET (TESTNET)</h3>
-                <p>Enter your RustChain wallet address to receive 0.5 test RTC.</p>
+                <p>Enter your RustChain wallet address to request a 0.5 test RTC faucet claim.</p>
                 <input type="text" id="wallet-addr" placeholder="0x... or MinerID">
                 <button onclick="requestDrip()">DISPENSE</button>
                 <p id="faucet-msg"></p>

--- a/tests/test_keeper_explorer_faucet.py
+++ b/tests/test_keeper_explorer_faucet.py
@@ -66,8 +66,16 @@ def test_faucet_drip_records_valid_address(tmp_path, monkeypatch):
     assert response.status_code == 200
     body = response.get_json()
     assert body["success"] is True
-    assert body["message"] == "Drip successful! 0.5 RTC sent to rtc-test-wallet"
-    assert len(body["tx_hash"]) == 64
+    assert body["status"] == "claim_recorded"
+    assert body["settlement_status"] == "recorded_only"
+    assert body["amount"] == 0.5
+    assert body["address"] == "rtc-test-wallet"
+    assert body["message"] == (
+        "Faucet claim recorded for rtc-test-wallet; no on-chain transfer "
+        "was submitted by this explorer"
+    )
+    assert len(body["receipt_id"]) == 64
+    assert body["tx_hash"] is None
 
     with sqlite3.connect(tmp_path / "faucet_service" / "faucet.db") as conn:
         row = conn.execute(


### PR DESCRIPTION
Summary:
- Change the Keeper faucet success response from a generated transfer hash to a recorded claim receipt.
- Return `settlement_status: recorded_only`, `receipt_id`, `tx_hash: null`, amount, and address.
- Update the UI copy and focused route test to avoid implying an on-chain transfer happened.

Problem / impact:
The integrated Keeper faucet only records a local claim, but the old API/UI said RTC was sent and returned a generated `tx_hash`. That made the settlement state look confirmed when no node transfer was submitted.

Review tier: BCOS-L2 (faucet/reward settlement messaging).

Validation:
- `uv run --no-project --with pytest --with flask --with requests python -B -m pytest -q tests/test_keeper_explorer_faucet.py` => 4 passed
- `python3 -m py_compile keeper_explorer.py tests/test_keeper_explorer_faucet.py`
- `git diff --check`

Related: Scottcjn/rustchain-bounties#13916. The linked bounty issue was closed under the 2026-06-11 live-surface policy; this PR is kept only as a focused settlement-messaging clarity patch for maintainer review, not as a live bounty claim.
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
