### PR TITLE
fix(payout): return 404 for missing status records

### DIFF
--- a/payout_ledger.py
+++ b/payout_ledger.py
@@ -194,12 +194,17 @@ def ledger_update_status(record_id, new_status, tx_hash="", notes=""):
         raise ValueError(f"Invalid status: {new_status}. Must be one of {valid}")
     now = int(time.time())
     with sqlite3.connect(DB_PATH) as conn:
-        conn.execute(
+        cursor = conn.execute(
             "UPDATE payout_ledger SET status=?, tx_hash=?, notes=?, updated_at=? WHERE id=?",
             (new_status, tx_hash or "", notes or "", now, record_id),
         )
+        updated = cursor.rowcount > 0
         conn.commit()
+    if not updated:
+        logger.info("Ledger %s status update skipped: record not found", record_id)
+        return False
     logger.info("Ledger %s → %s", record_id, new_status)
+    return True
 
 
 def ledger_summary():
@@ -316,13 +321,15 @@ def register_ledger_routes(app):
         if not new_status:
             return jsonify({"error": "missing status"}), 400
         try:
-            ledger_update_status(
+            updated = ledger_update_status(
                 record_id, new_status,
                 tx_hash=data.get("tx_hash", ""),
                 notes=data.get("notes", ""),
             )
         except ValueError as e:
             return jsonify({"error": str(e)}), 400
+        if not updated:
+            return jsonify({"error": "not found"}), 404
         return jsonify({"id": record_id, "status": new_status})
 
     @app.route("/api/ledger/summary", methods=["GET"])

--- a/tests/test_payout_ledger_admin_auth.py
+++ b/tests/test_payout_ledger_admin_auth.py
@@ -153,6 +153,24 @@ def test_ledger_status_update_rejects_non_object_json_before_mutation(tmp_path, 
     assert record["tx_hash"] == ""
 
 
+def test_ledger_status_update_reports_missing_record(tmp_path, monkeypatch):
+    client, db_path = _make_client(tmp_path, monkeypatch)
+    payout_ledger.init_payout_ledger_tables()
+
+    response = client.patch(
+        "/api/ledger/missing-record/status",
+        headers={"X-Admin-Key": ADMIN_KEY},
+        json={"status": "confirmed", "tx_hash": "tx-missing"},
+    )
+
+    assert response.status_code == 404
+    assert response.get_json() == {"error": "not found"}
+    assert payout_ledger.ledger_get("missing-record") is None
+    with sqlite3.connect(db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM payout_ledger").fetchone()[0]
+    assert count == 0
+
+
 def test_admin_key_allows_create_read_summary_and_status_update(tmp_path, monkeypatch):
     client, _db_path = _make_client(tmp_path, monkeypatch)
     headers = {"X-Admin-Key": ADMIN_KEY}


### PR DESCRIPTION
Summary:
- Detect when an admin payout status update matches no existing record.
- Return 404/not found instead of reporting a successful status transition for a missing id.
- Add focused regression coverage while preserving valid status updates.

Problem / impact:
The admin payout status route could report a queued/pending/confirmed transition for a missing record id because the update result was not checked. That can mislead payout reconciliation even though no payout record changed.

Review tier: BCOS-L2 (payout/reward status state).

Validation:
- Focused pytest coverage for payout admin auth and persistence migration => 14 passed
- py_compile for the changed module and test => passed
- git diff --check => passed

Related: Scottcjn/rustchain-bounties#13925. The linked bounty issue was closed under the 2026-06-11 live-surface policy; this PR is kept only as a focused payout/admin correctness patch for maintainer review, not as a live bounty claim.
wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945
