### PR TITLE
docs: clarify Windows miner install paths

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -49,9 +49,13 @@ python3 --version
 
 Then run the RustChain installer command above.
 
-On Windows, use the Windows miner installer instead of the Bash one-liner. See
-`miners/windows/installer/README.md` and run `miners/windows/rustchain_miner_setup.bat`
-from the Windows miner bundle.
+On Windows, choose one of these installer paths instead of the Bash one-liner:
+
+- **Quick bootstrap (recommended for most users):** run
+  `miners/windows/rustchain_miner_setup.bat` from the Windows miner bundle. This
+  self-bootstrapping script downloads Python if needed and installs the miner directly.
+- **Build a custom installer (for developers):** follow
+  `miners/windows/installer/README.md` to build a `.exe` installer with Inno Setup 6.
 
 **What this does:**
 


### PR DESCRIPTION
## Summary
- Clarifies that Windows users have two separate installer paths in `docs/QUICKSTART.md`
- Marks the `.bat` bootstrap path as the recommended simple install path
- Keeps the Inno Setup `.exe` build instructions framed as the developer/custom installer path

## Verification
- `python3` content assertions for required Windows installer guidance
- `git diff --check`
- Added-line security scan: `security_findings_count 0`
- Independent review: passed, no security or logic concerns

Closes #7381