### PR TITLE
[UTXO-BUG] Bound public address box reads

### DIFF
--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -142,21 +142,39 @@ class TestUtxoEndpoints(unittest.TestCase):
 
         first = self.client.get('/utxo/boxes/bob?limit=2').get_json()
         self.assertEqual(first['count'], 2)
-        self.assertEqual(first['total_count'], 3)
-        self.assertEqual(first['next_offset'], 2)
+        self.assertTrue(first['has_more'])
         self.assertEqual([box['value_nrtc'] for box in first['boxes']],
                          [10 * UNIT, 20 * UNIT])
 
-        second = self.client.get('/utxo/boxes/bob?limit=2&offset=2').get_json()
+        cursor = first['next_cursor']
+        second = self.client.get(
+            '/utxo/boxes/bob?limit=2&after_value_nrtc={}&after_box_id={}'.format(
+                cursor['after_value_nrtc'], cursor['after_box_id']))
+        second = second.get_json()
         self.assertEqual(second['count'], 1)
-        self.assertEqual(second['total_count'], 3)
-        self.assertIsNone(second['next_offset'])
+        self.assertFalse(second['has_more'])
+        self.assertIsNone(second['next_cursor'])
         self.assertEqual(second['boxes'][0]['value_nrtc'], 30 * UNIT)
+
+    def test_boxes_cursor_handles_equal_values(self):
+        self._seed_coinbase('bob', 10 * UNIT, height=1)
+        self._seed_coinbase('bob', 10 * UNIT, height=2)
+        self._seed_coinbase('bob', 10 * UNIT, height=3)
+
+        first = self.client.get('/utxo/boxes/bob?limit=2').get_json()
+        cursor = first['next_cursor']
+        second = self.client.get(
+            '/utxo/boxes/bob?limit=2&after_value_nrtc={}&after_box_id={}'.format(
+                cursor['after_value_nrtc'], cursor['after_box_id'])).get_json()
+        ids = [box['box_id'] for box in first['boxes'] + second['boxes']]
+        self.assertEqual(len(ids), 3)
+        self.assertEqual(len(set(ids)), 3)
 
     def test_boxes_endpoint_rejects_invalid_pagination(self):
         self.assertEqual(self.client.get('/utxo/boxes/bob?limit=0').status_code, 400)
         self.assertEqual(self.client.get('/utxo/boxes/bob?limit=501').status_code, 400)
-        self.assertEqual(self.client.get('/utxo/boxes/bob?offset=-1').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/bob?after_value_nrtc=1').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/bob?after_box_id=x').status_code, 400)
         self.assertEqual(self.client.get('/utxo/boxes/bob?limit=nope').status_code, 400)
 
     def test_box_not_found(self):

--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -130,7 +130,6 @@ class TestUtxoEndpoints(unittest.TestCase):
         r = self.client.get('/utxo/boxes/bob')
         data = r.get_json()
         self.assertEqual(data['count'], 2)
-        self.assertEqual(data['total_count'], 2)
         self.assertEqual(len(data['boxes']), 2)
         values = sorted(b['value_nrtc'] for b in data['boxes'])
         self.assertEqual(values, [30 * UNIT, 50 * UNIT])

--- a/node/test_utxo_endpoints.py
+++ b/node/test_utxo_endpoints.py
@@ -111,15 +111,53 @@ class TestUtxoEndpoints(unittest.TestCase):
         self.assertEqual(data['balance_rtc'], 100.0)
         self.assertEqual(data['utxo_count'], 1)
 
+    def test_balance_count_does_not_materialize_boxes(self):
+        self._seed_coinbase('alice', 100 * UNIT)
+        original = self.utxo_db.get_unspent_for_address
+        self.utxo_db.get_unspent_for_address = lambda *_args, **_kwargs: self.fail(
+            'balance endpoint must not materialize address boxes'
+        )
+        try:
+            r = self.client.get('/utxo/balance/alice')
+        finally:
+            self.utxo_db.get_unspent_for_address = original
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.get_json()['utxo_count'], 1)
+
     def test_boxes_endpoint(self):
         self._seed_coinbase('bob', 50 * UNIT, height=1)
         self._seed_coinbase('bob', 30 * UNIT, height=2)
         r = self.client.get('/utxo/boxes/bob')
         data = r.get_json()
         self.assertEqual(data['count'], 2)
+        self.assertEqual(data['total_count'], 2)
         self.assertEqual(len(data['boxes']), 2)
         values = sorted(b['value_nrtc'] for b in data['boxes'])
         self.assertEqual(values, [30 * UNIT, 50 * UNIT])
+
+    def test_boxes_endpoint_is_paginated(self):
+        self._seed_coinbase('bob', 10 * UNIT, height=1)
+        self._seed_coinbase('bob', 20 * UNIT, height=2)
+        self._seed_coinbase('bob', 30 * UNIT, height=3)
+
+        first = self.client.get('/utxo/boxes/bob?limit=2').get_json()
+        self.assertEqual(first['count'], 2)
+        self.assertEqual(first['total_count'], 3)
+        self.assertEqual(first['next_offset'], 2)
+        self.assertEqual([box['value_nrtc'] for box in first['boxes']],
+                         [10 * UNIT, 20 * UNIT])
+
+        second = self.client.get('/utxo/boxes/bob?limit=2&offset=2').get_json()
+        self.assertEqual(second['count'], 1)
+        self.assertEqual(second['total_count'], 3)
+        self.assertIsNone(second['next_offset'])
+        self.assertEqual(second['boxes'][0]['value_nrtc'], 30 * UNIT)
+
+    def test_boxes_endpoint_rejects_invalid_pagination(self):
+        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=0').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=501').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/bob?offset=-1').status_code, 400)
+        self.assertEqual(self.client.get('/utxo/boxes/bob?limit=nope').status_code, 400)
 
     def test_box_not_found(self):
         r = self.client.get('/utxo/box/deadbeef' * 8)

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -367,17 +367,44 @@ class UtxoDB:
         finally:
             conn.close()
 
-    def get_unspent_for_address(self, address: str) -> List[dict]:
-        """Get all unspent boxes for an address, ordered by value ASC."""
+    def get_unspent_for_address(self, address: str, limit: Optional[int] = None,
+                                offset: int = 0) -> List[dict]:
+        """Get unspent boxes for an address, optionally as a bounded page."""
+        if limit is not None and (
+            not isinstance(limit, int) or isinstance(limit, bool) or limit < 1
+        ):
+            raise ValueError("limit must be a positive integer")
+        if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+            raise ValueError("offset must be a non-negative integer")
+
+        query = """SELECT * FROM utxo_boxes
+                   WHERE owner_address = ? AND spent_at IS NULL
+                   ORDER BY value_nrtc ASC, box_id ASC"""
+        params = [address]
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        elif offset:
+            query += " LIMIT -1 OFFSET ?"
+            params.append(offset)
+
         conn = self._conn()
         try:
-            rows = conn.execute(
-                """SELECT * FROM utxo_boxes
-                   WHERE owner_address = ? AND spent_at IS NULL
-                   ORDER BY value_nrtc ASC""",
-                (address,),
-            ).fetchall()
+            rows = conn.execute(query, params).fetchall()
             return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+    def count_unspent_for_address(self, address: str) -> int:
+        """Count unspent boxes for an address without materializing them."""
+        conn = self._conn()
+        try:
+            row = conn.execute(
+                """SELECT COUNT(*) AS n FROM utxo_boxes
+                   WHERE owner_address = ? AND spent_at IS NULL""",
+                (address,),
+            ).fetchone()
+            return row['n']
         finally:
             conn.close()
 

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -162,6 +162,9 @@ CREATE TABLE IF NOT EXISTS utxo_boxes (
 CREATE INDEX IF NOT EXISTS idx_utxo_owner
     ON utxo_boxes(owner_address) WHERE spent_at IS NULL;
 
+CREATE INDEX IF NOT EXISTS idx_utxo_owner_value_box
+    ON utxo_boxes(owner_address, value_nrtc, box_id) WHERE spent_at IS NULL;
+
 CREATE INDEX IF NOT EXISTS idx_utxo_unspent
     ON utxo_boxes(spent_at) WHERE spent_at IS NULL;
 
@@ -368,25 +371,33 @@ class UtxoDB:
             conn.close()
 
     def get_unspent_for_address(self, address: str, limit: Optional[int] = None,
-                                offset: int = 0) -> List[dict]:
-        """Get unspent boxes for an address, optionally as a bounded page."""
+                                after_value_nrtc: Optional[int] = None,
+                                after_box_id: Optional[str] = None) -> List[dict]:
+        """Get unspent boxes for an address using bounded keyset pagination."""
         if limit is not None and (
             not isinstance(limit, int) or isinstance(limit, bool) or limit < 1
         ):
             raise ValueError("limit must be a positive integer")
-        if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
-            raise ValueError("offset must be a non-negative integer")
+        if (after_value_nrtc is None) != (after_box_id is None):
+            raise ValueError("both cursor fields must be provided together")
+        if after_value_nrtc is not None and (
+            not isinstance(after_value_nrtc, int) or isinstance(after_value_nrtc, bool)
+            or after_value_nrtc < 0 or not isinstance(after_box_id, str)
+            or not after_box_id
+        ):
+            raise ValueError("invalid cursor")
 
         query = """SELECT * FROM utxo_boxes
-                   WHERE owner_address = ? AND spent_at IS NULL
-                   ORDER BY value_nrtc ASC, box_id ASC"""
+                   WHERE owner_address = ? AND spent_at IS NULL"""
         params = [address]
+        if after_value_nrtc is not None:
+            query += """ AND (value_nrtc > ? OR
+                         (value_nrtc = ? AND box_id > ?))"""
+            params.extend([after_value_nrtc, after_value_nrtc, after_box_id])
+        query += " ORDER BY value_nrtc ASC, box_id ASC"
         if limit is not None:
-            query += " LIMIT ? OFFSET ?"
-            params.extend([limit, offset])
-        elif offset:
-            query += " LIMIT -1 OFFSET ?"
-            params.append(offset)
+            query += " LIMIT ?"
+            params.append(limit)
 
         conn = self._conn()
         try:

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -35,6 +35,10 @@ from utxo_db import (
 # which is far above any realistic balance and well within int64.
 _MAX_RTC_AMOUNT = Decimal(2) ** 53
 
+# Bound public address queries so fragmented wallets cannot force unbounded responses.
+_BOXES_DEFAULT_LIMIT = 100
+_BOXES_MAX_LIMIT = 500
+
 
 def _parse_rtc_amount(raw) -> Decimal:
     """
@@ -296,24 +300,39 @@ def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
 
 @utxo_bp.route('/balance/<address>')
 def utxo_balance(address):
-    """Get UTXO-derived balance for an address."""
+    """Get UTXO-derived balance and count for an address."""
     balance_nrtc = _utxo_db.get_balance(address)
-    boxes = _utxo_db.get_unspent_for_address(address)
+    utxo_count = _utxo_db.count_unspent_for_address(address)
     return jsonify({
         'address': address,
         'balance_nrtc': balance_nrtc,
         'balance_rtc': balance_nrtc / UNIT,
-        'utxo_count': len(boxes),
+        'utxo_count': utxo_count,
     })
 
 
 @utxo_bp.route('/boxes/<address>')
 def utxo_boxes(address):
-    """Get all unspent boxes for an address."""
-    boxes = _utxo_db.get_unspent_for_address(address)
+    """Get a bounded page of unspent boxes for an address."""
+    limit = request.args.get('limit', _BOXES_DEFAULT_LIMIT, type=int)
+    offset = request.args.get('offset', 0, type=int)
+    if limit is None or limit < 1 or limit > _BOXES_MAX_LIMIT:
+        return jsonify({
+            'error': f'limit must be between 1 and {_BOXES_MAX_LIMIT}',
+        }), 400
+    if offset is None or offset < 0:
+        return jsonify({'error': 'offset must be a non-negative integer'}), 400
+
+    boxes = _utxo_db.get_unspent_for_address(address, limit=limit, offset=offset)
+    total_count = _utxo_db.count_unspent_for_address(address)
+    next_offset = offset + len(boxes) if offset + len(boxes) < total_count else None
     return jsonify({
         'address': address,
         'count': len(boxes),
+        'total_count': total_count,
+        'limit': limit,
+        'offset': offset,
+        'next_offset': next_offset,
         'boxes': [
             {
                 'box_id': b['box_id'],

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -314,8 +314,11 @@ def utxo_balance(address):
 @utxo_bp.route('/boxes/<address>')
 def utxo_boxes(address):
     """Get a bounded page of unspent boxes for an address."""
-    limit = request.args.get('limit', _BOXES_DEFAULT_LIMIT, type=int)
-    offset = request.args.get('offset', 0, type=int)
+    try:
+        limit = int(request.args.get('limit', _BOXES_DEFAULT_LIMIT))
+        offset = int(request.args.get('offset', 0))
+    except (TypeError, ValueError):
+        return jsonify({'error': 'limit and offset must be integers'}), 400
     if limit is None or limit < 1 or limit > _BOXES_MAX_LIMIT:
         return jsonify({
             'error': f'limit must be between 1 and {_BOXES_MAX_LIMIT}',

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -313,29 +313,44 @@ def utxo_balance(address):
 
 @utxo_bp.route('/boxes/<address>')
 def utxo_boxes(address):
-    """Get a bounded page of unspent boxes for an address."""
+    """Get a bounded keyset-paginated page of unspent boxes."""
     try:
         limit = int(request.args.get('limit', _BOXES_DEFAULT_LIMIT))
-        offset = int(request.args.get('offset', 0))
+        after_value = request.args.get('after_value_nrtc')
+        after_value = int(after_value) if after_value is not None else None
     except (TypeError, ValueError):
-        return jsonify({'error': 'limit and offset must be integers'}), 400
-    if limit is None or limit < 1 or limit > _BOXES_MAX_LIMIT:
+        return jsonify({'error': 'limit and after_value_nrtc must be integers'}), 400
+    after_box_id = request.args.get('after_box_id')
+    if limit < 1 or limit > _BOXES_MAX_LIMIT:
         return jsonify({
             'error': f'limit must be between 1 and {_BOXES_MAX_LIMIT}',
         }), 400
-    if offset is None or offset < 0:
-        return jsonify({'error': 'offset must be a non-negative integer'}), 400
+    if (after_value is None) != (after_box_id is None) or (
+        after_value is not None and (after_value < 0 or not after_box_id)
+    ):
+        return jsonify({
+            'error': 'after_value_nrtc and after_box_id must form a valid cursor',
+        }), 400
 
-    boxes = _utxo_db.get_unspent_for_address(address, limit=limit, offset=offset)
-    total_count = _utxo_db.count_unspent_for_address(address)
-    next_offset = offset + len(boxes) if offset + len(boxes) < total_count else None
+    rows = _utxo_db.get_unspent_for_address(
+        address, limit=limit + 1, after_value_nrtc=after_value,
+        after_box_id=after_box_id,
+    )
+    has_more = len(rows) > limit
+    boxes = rows[:limit]
+    next_cursor = None
+    if has_more:
+        last = boxes[-1]
+        next_cursor = {
+            'after_value_nrtc': last['value_nrtc'],
+            'after_box_id': last['box_id'],
+        }
     return jsonify({
         'address': address,
         'count': len(boxes),
-        'total_count': total_count,
         'limit': limit,
-        'offset': offset,
-        'next_offset': next_offset,
+        'has_more': has_more,
+        'next_cursor': next_cursor,
         'boxes': [
             {
                 'box_id': b['box_id'],


### PR DESCRIPTION
## Summary

- replace the balance endpoint's full address-box materialization with a dedicated `COUNT(*)` query
- paginate `/utxo/boxes/<address>` with a default limit of 100 and maximum of 500
- add deterministic ordering, pagination metadata, input validation, and regression coverage

## Security impact

Public address reads currently call an unbounded `fetchall()`. A cheaply fragmented address can therefore make unauthenticated balance and boxes requests consume memory, CPU, database work, and response bandwidth proportional to its full UTXO count. This patch bounds the response path and prevents the balance path from loading boxes at all.

Detailed report: Scottcjn/rustchain-bounties#13975
Bounty: Scottcjn/rustchain-bounties#2819

## Tests

Added endpoint regressions covering:

- balance counts without calling `get_unspent_for_address`
- page boundaries and metadata
- invalid and oversized pagination values

I could not run the Python suite locally because this workspace has no usable Python runtime; CI should exercise the added tests.