### PR TITLE
fix(beacon): encode external agent panel fields

### DIFF
--- a/site/beacon/chat.js
+++ b/site/beacon/chat.js
@@ -32,7 +32,7 @@ export function getChatHTML(agentId, agentName) {
   html += '<div id="chat-messages" class="chat-messages">';
 
   if (history.length === 0) {
-    html += `<div class="chat-hint">Type below to hail ${agentName}...</div>`;
+    html += `<div class="chat-hint">Type below to hail ${escapeHtml(agentName)}...</div>`;
   } else {
     for (const msg of history) {
       if (msg.role === 'user') {

--- a/site/beacon/ui.js
+++ b/site/beacon/ui.js
@@ -29,6 +29,12 @@ function escapeHtml(value) {
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
 }
+
+function safeNumber(value, fallback = 0, min = 0, max = Number.MAX_SAFE_INTEGER) {
+  const number = Number(value);
+  if (!Number.isFinite(number)) return fallback;
+  return Math.min(max, Math.max(min, number));
+}
 // -- Reputation cache (loaded from backend) --
 let reputationCache = {};
 let reputationTs = 0;
@@ -213,6 +219,12 @@ function selectAgent(agentId) {
   const gradeColor = isRelay
     ? getProviderColor(agent.provider)
     : GRADE_COLORS[agent.grade];
+  const beatCount = safeNumber(agent.beat_count);
+  const score = safeNumber(agent.score);
+  const maxScore = safeNumber(agent.maxScore, 1, 1);
+  const videos = safeNumber(agent.videos);
+  const totalViews = safeNumber(agent.totalViews);
+  const antiquityMultiplier = safeNumber(agent.antiquity_multiplier, 1);
 
   let html = '';
   html += `<div class="t-cmd"><span class="dollar">$</span>cat /agent/${escapeHtml(agent.id)}</div>`;
@@ -232,8 +244,8 @@ function selectAgent(agentId) {
       html += `<div><span class="t-label">CAPS</span> <span class="t-value">${agent.capabilities.map(c => `[${escapeHtml(c)}]`).join(' ')}</span></div>`;
     }
 
-    if (agent.beat_count) {
-      html += `<div><span class="t-label">HEARTBEATS</span> <span class="t-value">${agent.beat_count}</span></div>`;
+    if (beatCount > 0) {
+      html += `<div><span class="t-label">HEARTBEATS</span> <span class="t-value">${beatCount}</span></div>`;
     }
 
     // Relay agents get a simpler valuation section (pending scoring)
@@ -247,7 +259,7 @@ function selectAgent(agentId) {
     html += `<div><span class="t-label">BEACON</span> <span class="t-value" style="color: var(--text-dim)">${escapeHtml(agent.beacon || agent.relay_agent_id || agent.id)}</span></div>`;
     html += `<div><span class="t-label">ROLE</span> <span class="t-value">${escapeHtml(agent.role)}</span></div>`;
     html += `<div><span class="t-label">GRADE</span> <span class="grade-badge grade-${escapeHtml(agent.grade)}">${escapeHtml(agent.grade)}</span>`;
-    html += `${renderBar(agent.score, agent.maxScore, gradeColor)} ${agent.score}/${agent.maxScore}</div>`;
+    html += `${renderBar(score, maxScore, gradeColor)} ${score}/${maxScore}</div>`;
     html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${escapeHtml(city ? city.name : '?')}, ${escapeHtml(region ? region.name : '?')}</span></div>`;
 
     // Valuation breakdown
@@ -325,16 +337,16 @@ function selectAgent(agentId) {
     html += `<div class="t-section">-- LINKS --</div>`;
     html += `<div style="display:flex;flex-wrap:wrap;gap:6px;margin:4px 0">`;
     html += `<a href="https://bottube.ai/agent/${encodeURIComponent(agent.bottube)}" target="_blank" class="bounty-link">[BoTTube Profile]</a>`;
-    if (agent.videos > 0) {
-      html += `<span style="color:var(--text-dim);font-size:11px;line-height:28px">${agent.videos} videos | ${(agent.totalViews||0).toLocaleString()} views</span>`;
+    if (videos > 0) {
+      html += `<span style="color:var(--text-dim);font-size:11px;line-height:28px">${videos} videos | ${totalViews.toLocaleString()} views</span>`;
     }
     html += `</div>`;
   }
   if (agent.miner) {
     html += agent.bottube ? '' : `<div class="t-section">-- LINKS --</div>`;
     html += `<div style="margin:4px 0"><span style="color:#88ff88">[Miner: ${escapeHtml(agent.device_arch || 'unknown')}]</span>`;
-    if (agent.antiquity_multiplier && agent.antiquity_multiplier > 1) {
-      html += ` <span style="color:#ffd700">${agent.antiquity_multiplier}x antiquity</span>`;
+    if (antiquityMultiplier > 1) {
+      html += ` <span style="color:#ffd700">${antiquityMultiplier}x antiquity</span>`;
     }
     html += `</div>`;
   }
@@ -450,7 +462,9 @@ function closePanel() {
 
 // --- Helpers ---
 function renderBar(value, max, color) {
-  const pct = Math.round((value / max) * 100);
+  const safeMax = safeNumber(max, 1, 1);
+  const safeValue = safeNumber(value, 0, 0, safeMax);
+  const pct = Math.min(100, Math.max(0, Math.round((safeValue / safeMax) * 100)));
   return `<span style="display:inline-block;width:80px;height:8px;background:rgba(0,20,0,0.5);border:1px solid var(--border);vertical-align:middle;margin:0 6px"><span style="display:block;height:100%;width:${pct}%;background:${color}"></span></span>`;
 }
 

--- a/site/beacon/ui.js
+++ b/site/beacon/ui.js
@@ -21,6 +21,14 @@ let selectedAgent = null;
 let selectedCity = null;
 let hoveredId = null;
 
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
 // -- Reputation cache (loaded from backend) --
 let reputationCache = {};
 let reputationTs = 0;
@@ -207,21 +215,21 @@ function selectAgent(agentId) {
     : GRADE_COLORS[agent.grade];
 
   let html = '';
-  html += `<div class="t-cmd"><span class="dollar">$</span>cat /agent/${agent.id}</div>`;
-  html += `<div><span class="t-label">NAME</span> <span class="t-value">${agent.name}</span></div>`;
+  html += `<div class="t-cmd"><span class="dollar">$</span>cat /agent/${escapeHtml(agent.id)}</div>`;
+  html += `<div><span class="t-label">NAME</span> <span class="t-value">${escapeHtml(agent.name)}</span></div>`;
 
   if (isRelay) {
     // Relay agent: show provider, model, status, capabilities
     const provColor = getProviderColor(agent.provider);
     html += `<div><span class="t-label">TYPE</span> <span class="grade-badge" style="background:${provColor};color:#000;padding:0 6px;font-size:11px">RELAY</span></div>`;
-    html += `<div><span class="t-label">PROVIDER</span> <span class="t-value" style="color:${provColor}">${(agent.provider || 'unknown').toUpperCase()}</span></div>`;
-    html += `<div><span class="t-label">MODEL</span> <span class="t-value">${agent.model_id || '?'}</span></div>`;
-    html += `<div><span class="t-label">STATUS</span> <span class="t-value" style="color:${agent.status === 'active' ? 'var(--green)' : agent.status === 'silent' ? 'var(--amber)' : 'var(--red)'}">${(agent.status || 'unknown').toUpperCase()}</span></div>`;
-    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${agent.role}</span></div>`;
-    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${city ? city.name : '?'}, ${region ? region.name : '?'}</span></div>`;
+    html += `<div><span class="t-label">PROVIDER</span> <span class="t-value" style="color:${provColor}">${escapeHtml((agent.provider || 'unknown').toUpperCase())}</span></div>`;
+    html += `<div><span class="t-label">MODEL</span> <span class="t-value">${escapeHtml(agent.model_id || '?')}</span></div>`;
+    html += `<div><span class="t-label">STATUS</span> <span class="t-value" style="color:${agent.status === 'active' ? 'var(--green)' : agent.status === 'silent' ? 'var(--amber)' : 'var(--red)'}">${escapeHtml((agent.status || 'unknown').toUpperCase())}</span></div>`;
+    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${escapeHtml(agent.role)}</span></div>`;
+    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${escapeHtml(city ? city.name : '?')}, ${escapeHtml(region ? region.name : '?')}</span></div>`;
 
     if (agent.capabilities && agent.capabilities.length > 0) {
-      html += `<div><span class="t-label">CAPS</span> <span class="t-value">${agent.capabilities.map(c => `[${c}]`).join(' ')}</span></div>`;
+      html += `<div><span class="t-label">CAPS</span> <span class="t-value">${agent.capabilities.map(c => `[${escapeHtml(c)}]`).join(' ')}</span></div>`;
     }
 
     if (agent.beat_count) {
@@ -236,11 +244,11 @@ function selectAgent(agentId) {
     html += `</div>`;
   } else {
     // Native agent: original display
-    html += `<div><span class="t-label">BEACON</span> <span class="t-value" style="color: var(--text-dim)">${agent.beacon || agent.relay_agent_id || agent.id}</span></div>`;
-    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${agent.role}</span></div>`;
-    html += `<div><span class="t-label">GRADE</span> <span class="grade-badge grade-${agent.grade}">${agent.grade}</span>`;
+    html += `<div><span class="t-label">BEACON</span> <span class="t-value" style="color: var(--text-dim)">${escapeHtml(agent.beacon || agent.relay_agent_id || agent.id)}</span></div>`;
+    html += `<div><span class="t-label">ROLE</span> <span class="t-value">${escapeHtml(agent.role)}</span></div>`;
+    html += `<div><span class="t-label">GRADE</span> <span class="grade-badge grade-${escapeHtml(agent.grade)}">${escapeHtml(agent.grade)}</span>`;
     html += `${renderBar(agent.score, agent.maxScore, gradeColor)} ${agent.score}/${agent.maxScore}</div>`;
-    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${city ? city.name : '?'}, ${region ? region.name : '?'}</span></div>`;
+    html += `<div><span class="t-label">ADDRESS</span> <span class="t-value">${escapeHtml(city ? city.name : '?')}, ${escapeHtml(region ? region.name : '?')}</span></div>`;
 
     // Valuation breakdown
     html += `<div class="t-section">-- VALUATION BREAKDOWN --</div>`;
@@ -282,10 +290,10 @@ function selectAgent(agentId) {
         ? AGENTS.find(a => a.id === c.to)
         : AGENTS.find(a => a.id === c.from);
       const dir = c.from === agentId ? '->' : '<-';
-      html += `<div class="contract-row ${c.type}">`;
-      html += `<span class="contract-type" style="background:${CONTRACT_STYLES_CSS[c.type]}">[${c.type.toUpperCase().replace('_', ' ')}]</span>`;
-      html += `<span>${dir} ${other ? other.name : '?'}  ${c.amount} ${c.currency}</span>`;
-      html += `<span class="contract-state state-${c.state}">${c.state}</span>`;
+      html += `<div class="contract-row ${escapeHtml(c.type)}">`;
+      html += `<span class="contract-type" style="background:${CONTRACT_STYLES_CSS[c.type]}">[${escapeHtml(c.type.toUpperCase().replace('_', ' '))}]</span>`;
+      html += `<span>${dir} ${escapeHtml(other ? other.name : '?')}  ${escapeHtml(c.amount)} ${escapeHtml(c.currency)}</span>`;
+      html += `<span class="contract-state state-${escapeHtml(c.state)}">${escapeHtml(c.state)}</span>`;
       html += `</div>`;
     }
   }
@@ -304,7 +312,7 @@ function selectAgent(agentId) {
     html += `<div style="display:flex;flex-wrap:wrap;gap:4px;margin:4px 0">`;
     for (const src of agent.sources) {
       const b = SOURCE_BADGE[src] || { label: src, color: '#aaa' };
-      html += `<span style="background:${b.color}22;color:${b.color};border:1px solid ${b.color}44;padding:1px 6px;font-size:10px;border-radius:3px">${b.label}</span>`;
+      html += `<span style="background:${b.color}22;color:${b.color};border:1px solid ${b.color}44;padding:1px 6px;font-size:10px;border-radius:3px">${escapeHtml(b.label)}</span>`;
     }
     if (agent.human) {
       html += `<span style="background:#ffd70022;color:#ffd700;border:1px solid #ffd70044;padding:1px 6px;font-size:10px;border-radius:3px">Human</span>`;
@@ -316,7 +324,7 @@ function selectAgent(agentId) {
   if (agent.bottube) {
     html += `<div class="t-section">-- LINKS --</div>`;
     html += `<div style="display:flex;flex-wrap:wrap;gap:6px;margin:4px 0">`;
-    html += `<a href="https://bottube.ai/agent/${agent.bottube}" target="_blank" class="bounty-link">[BoTTube Profile]</a>`;
+    html += `<a href="https://bottube.ai/agent/${encodeURIComponent(agent.bottube)}" target="_blank" class="bounty-link">[BoTTube Profile]</a>`;
     if (agent.videos > 0) {
       html += `<span style="color:var(--text-dim);font-size:11px;line-height:28px">${agent.videos} videos | ${(agent.totalViews||0).toLocaleString()} views</span>`;
     }
@@ -324,7 +332,7 @@ function selectAgent(agentId) {
   }
   if (agent.miner) {
     html += agent.bottube ? '' : `<div class="t-section">-- LINKS --</div>`;
-    html += `<div style="margin:4px 0"><span style="color:#88ff88">[Miner: ${agent.device_arch || 'unknown'}]</span>`;
+    html += `<div style="margin:4px 0"><span style="color:#88ff88">[Miner: ${escapeHtml(agent.device_arch || 'unknown')}]</span>`;
     if (agent.antiquity_multiplier && agent.antiquity_multiplier > 1) {
       html += ` <span style="color:#ffd700">${agent.antiquity_multiplier}x antiquity</span>`;
     }
@@ -332,7 +340,7 @@ function selectAgent(agentId) {
   }
 
   // New contract button
-  html += `<div class="contract-new-btn" data-from="${agentId}" id="new-contract-btn">[+ NEW CONTRACT]</div>`;
+  html += `<div class="contract-new-btn" data-from="${escapeHtml(agentId)}" id="new-contract-btn">[+ NEW CONTRACT]</div>`;
 
   // Calibrations
   const agentCals = CALIBRATIONS.filter(c => c.a === agentId || c.b === agentId);
@@ -342,7 +350,7 @@ function selectAgent(agentId) {
       const otherId = cal.a === agentId ? cal.b : cal.a;
       const other = AGENTS.find(a => a.id === otherId);
       html += `<div class="cal-row">`;
-      html += `<span class="cal-name">${other ? other.name : '?'}</span>`;
+      html += `<span class="cal-name">${escapeHtml(other ? other.name : '?')}</span>`;
       html += `<span class="cal-bar"><span class="cal-fill" style="width:${cal.score * 100}%"></span></span>`;
       html += `<span class="cal-score">${cal.score.toFixed(2)}</span>`;
       html += `</div>`;
@@ -589,7 +597,7 @@ async function submitContract() {
       return;
     }
 
-    // Success — add to data, create 3D line, update HUD
+    // Success - add to data, create 3D line, update HUD
     const normalized = addContract(data);
     addContractLine(normalized);
     updateHUD();

--- a/tests/test_beacon_site_agent_panel_xss.py
+++ b/tests/test_beacon_site_agent_panel_xss.py
@@ -19,6 +19,10 @@ def test_beacon_agent_panel_encodes_external_values_before_inner_html():
         "${escapeHtml(b.label)}",
         "${encodeURIComponent(agent.bottube)}",
         "data-from=\"${escapeHtml(agentId)}\"",
+        "const beatCount = safeNumber(agent.beat_count)",
+        "${renderBar(score, maxScore, gradeColor)} ${score}/${maxScore}",
+        "${videos} videos | ${totalViews.toLocaleString()} views",
+        "${antiquityMultiplier}x antiquity",
     ]
     for pattern in safe_patterns:
         assert pattern in js
@@ -30,6 +34,10 @@ def test_beacon_agent_panel_encodes_external_values_before_inner_html():
         "state-${c.state}\">${c.state}</span>",
         "https://bottube.ai/agent/${agent.bottube}",
         "data-from=\"${agentId}\"",
+        "${agent.beat_count}</span></div>",
+        "renderBar(agent.score, agent.maxScore, gradeColor)",
+        "${agent.videos} videos",
+        "${agent.antiquity_multiplier}x antiquity",
     ]
     for pattern in unsafe_patterns:
         assert pattern not in js
@@ -39,3 +47,11 @@ def test_beacon_chat_hint_encodes_stored_agent_name():
     js = CHAT_JS.read_text(encoding="utf-8")
     assert "Type below to hail ${escapeHtml(agentName)}..." in js
     assert "Type below to hail ${agentName}..." not in js
+
+def test_beacon_bar_clamps_numeric_inputs():
+    js = UI_JS.read_text(encoding="utf-8")
+    assert "function safeNumber(value, fallback = 0, min = 0, max = Number.MAX_SAFE_INTEGER)" in js
+    assert "if (!Number.isFinite(number)) return fallback" in js
+    assert "const safeMax = safeNumber(max, 1, 1)" in js
+    assert "const safeValue = safeNumber(value, 0, 0, safeMax)" in js
+    assert "Math.min(100, Math.max(0, Math.round((safeValue / safeMax) * 100)))" in js

--- a/tests/test_beacon_site_agent_panel_xss.py
+++ b/tests/test_beacon_site_agent_panel_xss.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+UI_JS = ROOT / "site" / "beacon" / "ui.js"
+CHAT_JS = ROOT / "site" / "beacon" / "chat.js"
+
+
+def test_beacon_agent_panel_encodes_external_values_before_inner_html():
+    js = UI_JS.read_text(encoding="utf-8")
+    assert "function escapeHtml(value)" in js
+    safe_patterns = [
+        "${escapeHtml(agent.name)}",
+        "${escapeHtml(agent.role)}",
+        "agent.capabilities.map(c => `[${escapeHtml(c)}]`)",
+        "${escapeHtml(other ? other.name : '?')}",
+        "${escapeHtml(c.amount)} ${escapeHtml(c.currency)}",
+        "state-${escapeHtml(c.state)}",
+        "${escapeHtml(b.label)}",
+        "${encodeURIComponent(agent.bottube)}",
+        "data-from=\"${escapeHtml(agentId)}\"",
+    ]
+    for pattern in safe_patterns:
+        assert pattern in js
+    unsafe_patterns = [
+        "${agent.name}</span></div>",
+        "${agent.role}</span></div>",
+        "agent.capabilities.map(c => `[${c}]`)",
+        "${other ? other.name : '?'}  ${c.amount} ${c.currency}",
+        "state-${c.state}\">${c.state}</span>",
+        "https://bottube.ai/agent/${agent.bottube}",
+        "data-from=\"${agentId}\"",
+    ]
+    for pattern in unsafe_patterns:
+        assert pattern not in js
+
+
+def test_beacon_chat_hint_encodes_stored_agent_name():
+    js = CHAT_JS.read_text(encoding="utf-8")
+    assert "Type below to hail ${escapeHtml(agentName)}..." in js
+    assert "Type below to hail ${agentName}..." not in js


### PR DESCRIPTION
## Summary

Fixes #7397.

- encodes external/stored agent, contract, source, and calibration display values before the Beacon Atlas detail panel assigns its assembled markup to `panelContent.innerHTML`;
- URL-encodes the external BoTTube profile path segment and encodes the contract button data attribute;
- encodes the stored agent name used by the empty chat hint;
- adds focused regression assertions that forbid the identified raw interpolation paths.

## Security rationale

Beacon Atlas merges live records from Beacon relay, BoTTube, SwarmHub, miners, contracts, and calibrations. Several fields crossed those trust boundaries and entered the selected-agent panel as raw HTML. This patch keeps the existing terminal-panel structure while applying output encoding at each dynamic HTML context.

This intentionally does not alter the separate panel-path and live-chat parser sinks tracked in #7202 and #7196.

## Validation

- parsed modified `site/beacon/ui.js` as an ES module: pass
- parsed modified `site/beacon/chat.js` as an ES module: pass
- verified identified unsafe interpolation patterns are absent on the branch
- added `tests/test_beacon_site_agent_panel_xss.py`

No payload was registered or executed against production.

RTC reward address: `RTC64fcd1317490a202596953699b1e6a742522365d`