### PR TITLE
fix(utxo): bound the per-address public read path (Refs #13975)

### DIFF
--- a/node/tests/test_utxo_bounded_reads.py
+++ b/node/tests/test_utxo_bounded_reads.py
@@ -1,0 +1,318 @@
+"""
+Tests for FIX(#13975): bound the per-address public read path.
+
+Covers the new helpers on `UtxoDB` and the public routes:
+  * `/utxo/balance/<address>` must use a scalar `COUNT(*)` so its cost
+    is independent of the box count.
+  * `/utxo/boxes/<address>` must require a `?limit=` and `?offset=`,
+    clamp `limit` to `MAX_BOXES_PER_PAGE`, and surface `has_more` +
+    `next_offset` so callers can page a fragmented address.
+  * `UtxoDB.get_unspent_for_address` (the internal full-read helper
+    used by coin selection) must still work for normal wallets, but
+    must refuse to silently materialize more than `MAX_BOXES_INTERNAL`
+    rows in one call.
+
+Run: python3 -m pytest test_utxo_bounded_reads.py -v
+"""
+
+import json
+import os
+import sqlite3
+import tempfile
+import time
+import unittest
+from decimal import Decimal
+
+from flask import Flask
+
+import utxo_endpoints
+from utxo_db import (
+    DUST_THRESHOLD,
+    UNIT,
+    UtxoDB,
+    address_to_proposition,
+    compute_box_id,
+)
+from utxo_endpoints import register_utxo_blueprint
+
+
+def _mock_verify_sig(pubkey_hex, message, sig_hex):
+    return True
+
+
+def _mock_addr_from_pk(pubkey_hex):
+    return f"RTC_test_{pubkey_hex[:8]}"
+
+
+def _mock_current_slot():
+    return 100
+
+
+def _seed_coinbase(db, address, value_nrtc, height=1):
+    return db.apply_transaction({
+        'tx_type': 'mining_reward',
+        'inputs': [],
+        'outputs': [{'address': address, 'value_nrtc': value_nrtc}],
+        'timestamp': int(time.time()),
+        '_allow_minting': True,
+    }, block_height=height)
+
+
+def _seed_existing_box(db, address, value_nrtc, height=1, tx_id=None, output_index=0):
+    if tx_id is None:
+        # Use a unique hex tx_id per box so the (transaction_id, output_index)
+        # unique index does not collide when we seed many boxes in one test,
+        # and so `compute_box_id` (which calls bytes.fromhex on it) succeeds.
+        unique = f"{int(time.time() * 1_000_000):x}{height:x}{output_index:x}"
+        tx_id = unique.ljust(64, '0')[:64]
+    prop = address_to_proposition(address)
+    box_id = compute_box_id(value_nrtc, prop, height, tx_id, output_index)
+    db.add_box({
+        'box_id': box_id,
+        'value_nrtc': value_nrtc,
+        'proposition': prop,
+        'owner_address': address,
+        'creation_height': height,
+        'transaction_id': tx_id,
+        'output_index': output_index,
+    })
+    return box_id
+
+
+class TestUtxoDBCountForAddress(unittest.TestCase):
+    """`get_unspent_count_for_address` is a cheap scalar COUNT(*)."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        self.db = UtxoDB(self.db_path)
+        self.db.init_tables()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_count_empty(self):
+        self.assertEqual(self.db.get_unspent_count_for_address('nobody'), 0)
+
+    def test_count_matches_coinbase(self):
+        _seed_coinbase(self.db, 'alice', 100 * UNIT)
+        _seed_coinbase(self.db, 'alice', 30 * UNIT, height=2)
+        self.assertEqual(self.db.get_unspent_count_for_address('alice'), 2)
+
+    def test_count_excludes_spent(self):
+        # A 0-value transfer spends one box, so the count drops by 1.
+        box_id = _seed_existing_box(self.db, 'alice', 50 * UNIT)
+        _seed_existing_box(self.db, 'alice', 50 * UNIT, height=2)
+        self.assertEqual(self.db.get_unspent_count_for_address('alice'), 2)
+        # Mark the first box spent directly
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "UPDATE utxo_boxes SET spent_at = ?, spent_by_tx = ? WHERE box_id = ?",
+            (int(time.time()), '00' * 32, box_id),
+        )
+        conn.commit()
+        conn.close()
+        self.assertEqual(self.db.get_unspent_count_for_address('alice'), 1)
+
+
+class TestUtxoDBPagedRead(unittest.TestCase):
+    """`get_unspent_for_address_paged` is bounded and stable."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        self.db = UtxoDB(self.db_path)
+        self.db.init_tables()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_paged_basic(self):
+        for i in range(5):
+            _seed_coinbase(self.db, 'bob', (i + 1) * UNIT, height=i + 1)
+        page, has_more = self.db.get_unspent_for_address_paged(
+            'bob', limit=3, offset=0
+        )
+        self.assertEqual(len(page), 3)
+        self.assertTrue(has_more)
+        # Ordered by value ASC, so the first 3 are 1, 2, 3 RTC
+        self.assertEqual([p['value_nrtc'] for p in page], [UNIT, 2 * UNIT, 3 * UNIT])
+
+    def test_paged_exact_last_page(self):
+        for i in range(5):
+            _seed_coinbase(self.db, 'bob', (i + 1) * UNIT, height=i + 1)
+        page, has_more = self.db.get_unspent_for_address_paged(
+            'bob', limit=10, offset=0
+        )
+        self.assertEqual(len(page), 5)
+        self.assertFalse(has_more)
+
+    def test_paged_offset_skips(self):
+        for i in range(5):
+            _seed_coinbase(self.db, 'bob', (i + 1) * UNIT, height=i + 1)
+        page, has_more = self.db.get_unspent_for_address_paged(
+            'bob', limit=2, offset=2
+        )
+        self.assertEqual([p['value_nrtc'] for p in page], [3 * UNIT, 4 * UNIT])
+        self.assertTrue(has_more)
+
+    def test_paged_clamps_oversize_limit(self):
+        # Caller asks for more than the hard cap; helper clamps to MAX_BOXES_PER_PAGE.
+        page, has_more = self.db.get_unspent_for_address_paged(
+            'bob', limit=10_000, offset=0
+        )
+        self.assertLessEqual(len(page), UtxoDB.MAX_BOXES_PER_PAGE)
+
+    def test_paged_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            self.db.get_unspent_for_address_paged('bob', limit=-1, offset=0)
+        with self.assertRaises(ValueError):
+            self.db.get_unspent_for_address_paged('bob', limit=1, offset=-1)
+
+    def test_paged_empty_address(self):
+        page, has_more = self.db.get_unspent_for_address_paged(
+            'nobody', limit=50, offset=0
+        )
+        self.assertEqual(page, [])
+        self.assertFalse(has_more)
+
+
+class TestUtxoDBInternalCap(unittest.TestCase):
+    """`get_unspent_for_address` (the internal full read) is bounded."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        self.db = UtxoDB(self.db_path)
+        self.db.init_tables()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_internal_read_normal_wallet(self):
+        for i in range(3):
+            _seed_coinbase(self.db, 'alice', (i + 1) * UNIT, height=i + 1)
+        # 3 boxes is well below MAX_BOXES_INTERNAL, so this must succeed.
+        boxes = self.db.get_unspent_for_address('alice')
+        self.assertEqual(len(boxes), 3)
+
+    def test_internal_read_refuses_fragmented(self):
+        # Bypass the public endpoint and seed `MAX_BOXES_INTERNAL + 1` rows
+        # directly via add_box so the coin-selection internal helper is
+        # exercised in the fragmented regime without us having to mine
+        # 50k blocks. We temporarily shrink the cap to a small number so
+        # the test stays fast.
+        original_cap = UtxoDB.MAX_BOXES_INTERNAL
+        UtxoDB.MAX_BOXES_INTERNAL = 5  # pyright: ignore[reportAttributeAccessIssue]
+        try:
+            for i in range(UtxoDB.MAX_BOXES_INTERNAL + 1):
+                _seed_existing_box(
+                    self.db, 'fragmented', DUST_THRESHOLD,
+                    height=1, output_index=i,
+                )
+            with self.assertRaises(ValueError) as ctx:
+                self.db.get_unspent_for_address('fragmented')
+            self.assertIn("more than", str(ctx.exception))
+        finally:
+            UtxoDB.MAX_BOXES_INTERNAL = original_cap
+
+
+class TestUtxoEndpointsBounded(unittest.TestCase):
+    """Public routes must use the bounded helpers and reject bad paging."""
+
+    def setUp(self):
+        self.tmp = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        self.tmp.close()
+        self.db_path = self.tmp.name
+        conn = sqlite3.connect(self.db_path)
+        conn.execute("CREATE TABLE IF NOT EXISTS balances (miner_id TEXT PRIMARY KEY, amount_i64 INTEGER DEFAULT 0)")
+        conn.commit()
+        conn.close()
+        self.utxo_db = UtxoDB(self.db_path)
+        self.utxo_db.init_tables()
+
+        self.app = Flask(__name__)
+        self.app.config['TESTING'] = True
+        register_utxo_blueprint(
+            self.app, self.utxo_db, self.db_path,
+            verify_sig_fn=_mock_verify_sig,
+            addr_from_pk_fn=_mock_addr_from_pk,
+            current_slot_fn=_mock_current_slot,
+            dual_write=False,
+        )
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        os.unlink(self.db_path)
+
+    def test_balance_does_not_materialize_rows(self):
+        # Seed 5 boxes and verify the balance route returns the count
+        # correctly while using the scalar COUNT(*) path.
+        for i in range(5):
+            _seed_coinbase(self.utxo_db, 'alice', (i + 1) * UNIT, height=i + 1)
+        r = self.client.get('/utxo/balance/alice')
+        self.assertEqual(r.status_code, 200)
+        data = r.get_json()
+        self.assertEqual(data['balance_nrtc'], sum((i + 1) * UNIT for i in range(5)))
+        self.assertEqual(data['utxo_count'], 5)
+
+    def test_boxes_default_page(self):
+        for i in range(5):
+            _seed_coinbase(self.utxo_db, 'alice', (i + 1) * UNIT, height=i + 1)
+        r = self.client.get('/utxo/boxes/alice')
+        self.assertEqual(r.status_code, 200)
+        data = r.get_json()
+        # Default page size is 50, so all 5 fit and has_more is False.
+        self.assertEqual(data['count'], 5)
+        self.assertEqual(data['limit'], 50)
+        self.assertEqual(data['offset'], 0)
+        self.assertFalse(data['has_more'])
+        self.assertIsNone(data['next_offset'])
+        self.assertFalse(data['truncated'])
+
+    def test_boxes_paging(self):
+        for i in range(5):
+            _seed_coinbase(self.utxo_db, 'alice', (i + 1) * UNIT, height=i + 1)
+        # Page 1: limit=2, offset=0 -> 2 boxes, has_more=True
+        r = self.client.get('/utxo/boxes/alice?limit=2&offset=0')
+        data = r.get_json()
+        self.assertEqual(data['count'], 2)
+        self.assertTrue(data['has_more'])
+        self.assertTrue(data['truncated'])
+        self.assertEqual(data['next_offset'], 2)
+
+        # Page 2: limit=2, offset=2 -> 2 boxes, has_more=True
+        r = self.client.get('/utxo/boxes/alice?limit=2&offset=2')
+        data = r.get_json()
+        self.assertEqual(data['count'], 2)
+        self.assertTrue(data['has_more'])
+        self.assertEqual(data['next_offset'], 4)
+
+        # Page 3: limit=2, offset=4 -> 1 box, has_more=False
+        r = self.client.get('/utxo/boxes/alice?limit=2&offset=4')
+        data = r.get_json()
+        self.assertEqual(data['count'], 1)
+        self.assertFalse(data['has_more'])
+        self.assertFalse(data['truncated'])
+        self.assertIsNone(data['next_offset'])
+
+    def test_boxes_clamps_oversize_limit(self):
+        r = self.client.get('/utxo/boxes/alice?limit=10000')
+        data = r.get_json()
+        # Server silently clamps to MAX_BOXES_PER_PAGE = 200.
+        self.assertEqual(data['limit'], 200)
+
+    def test_boxes_rejects_bad_paging(self):
+        r = self.client.get('/utxo/boxes/alice?limit=abc')
+        self.assertEqual(r.status_code, 400)
+        r = self.client.get('/utxo/boxes/alice?offset=-1')
+        self.assertEqual(r.status_code, 400)
+        r = self.client.get('/utxo/boxes/alice?limit=0')
+        self.assertEqual(r.status_code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -367,16 +367,120 @@ class UtxoDB:
         finally:
             conn.close()
 
-    def get_unspent_for_address(self, address: str) -> List[dict]:
-        """Get all unspent boxes for an address, ordered by value ASC."""
+    # FIX(#13975): bound the per-address public read path. Previously
+    # `get_unspent_for_address` did an unbounded `SELECT * ... fetchall()`
+    # over every unspent box owned by the supplied address. Combined with the
+    # minimum-output dust threshold (DUST_THRESHOLD = 1_000 nanoRTC) and the
+    # zero-fee public transfer endpoint, an attacker could fragment a target
+    # address into arbitrarily many tiny boxes and then repeatedly hit
+    # `/utxo/balance/<addr>` or `/utxo/boxes/<addr>` to cause linear growth
+    # in row materialization, CPU, and response size on every unauthenticated
+    # request.
+    #
+    # The public read path now exposes three bounded operations:
+    #   * `get_unspent_count_for_address(address)` — scalar `COUNT(*)`
+    #     for the cheap `/utxo/balance` summary, so the balance route no
+    #     longer materializes full rows just to compute `utxo_count`.
+    #   * `get_unspent_for_address_paged(address, *, limit, offset)` —
+    #     cursor/page-bounded listing for `/utxo/boxes` with a hard cap
+    #     (`MAX_BOXES_PER_PAGE`) and a `has_more` flag so callers can
+    #     walk a large result set without ever materializing the whole set
+    #     in a single response.
+    #   * `get_unspent_for_address(address)` is retained for internal
+    #     callers (coin selection in `apply_transaction`) that genuinely
+    #     need the full ordered set, with a defensive cap so a runaway
+    #     caller still cannot OOM the process silently.
+    #
+    # See issue #13975 for the original report and PoC; tests in
+    # `node/test_utxo_endpoints.py` and `node/tests/test_utxo_bounded_reads.py`.
+
+    MAX_BOXES_PER_PAGE = 200  # hard upper bound on a single /utxo/boxes page
+    MAX_BOXES_INTERNAL = 50_000  # defensive cap for full internal reads
+
+    def get_unspent_count_for_address(self, address: str) -> int:
+        """Return the count of unspent boxes owned by `address`.
+
+        Cheap scalar read for the public `/utxo/balance/<addr>` summary.
+        Does not materialize any box rows, so it is safe for fragmented
+        addresses with millions of unspent boxes.
+        """
+        conn = self._conn()
+        try:
+            row = conn.execute(
+                """SELECT COUNT(*) AS n
+                   FROM utxo_boxes
+                   WHERE owner_address = ? AND spent_at IS NULL""",
+                (address,),
+            ).fetchone()
+            return int(row['n'] or 0)
+        finally:
+            conn.close()
+
+    def get_unspent_for_address_paged(
+        self,
+        address: str,
+        *,
+        limit: int,
+        offset: int = 0,
+    ) -> Tuple[List[dict], bool]:
+        """Return one page of unspent boxes for `address`.
+
+        Returns `(boxes, has_more)` where:
+          * `boxes` is at most `limit` rows ordered by value ASC, then
+            box_id ASC for a stable page boundary;
+          * `has_more` is True iff more rows exist past the returned page.
+
+        The endpoint layer must clamp `limit` to `MAX_BOXES_PER_PAGE` and
+        reject negative `offset`/`limit` before calling this helper.
+        """
+        if limit < 0 or offset < 0:
+            raise ValueError("limit and offset must be non-negative")
+        capped_limit = min(int(limit), self.MAX_BOXES_PER_PAGE)
         conn = self._conn()
         try:
             rows = conn.execute(
                 """SELECT * FROM utxo_boxes
                    WHERE owner_address = ? AND spent_at IS NULL
-                   ORDER BY value_nrtc ASC""",
-                (address,),
+                   ORDER BY value_nrtc ASC, box_id ASC
+                   LIMIT ? OFFSET ?""",
+                (address, capped_limit + 1, int(offset)),
             ).fetchall()
+            page = [dict(r) for r in rows[:capped_limit]]
+            has_more = len(rows) > capped_limit
+            return page, has_more
+        finally:
+            conn.close()
+
+    def get_unspent_for_address(self, address: str) -> List[dict]:
+        """Get all unspent boxes for an address, ordered by value ASC.
+
+        Intended for internal callers (e.g. coin selection in
+        `apply_transaction`) that genuinely need the full ordered set.
+        Public HTTP callers must use `get_unspent_for_address_paged`
+        or `get_unspent_count_for_address` instead.
+
+        A defensive `MAX_BOXES_INTERNAL` cap is applied to prevent silent
+        OOM on a fragmented address; callers needing more must page.
+        """
+        conn = self._conn()
+        try:
+            rows = conn.execute(
+                """SELECT * FROM utxo_boxes
+                   WHERE owner_address = ? AND spent_at IS NULL
+                   ORDER BY value_nrtc ASC
+                   LIMIT ?""",
+                (address, self.MAX_BOXES_INTERNAL + 1),
+            ).fetchall()
+            if len(rows) > self.MAX_BOXES_INTERNAL:
+                # Refuse silently materializing the unbounded set; the
+                # coin-selection path should never hit this in practice
+                # for any real wallet, and surfacing the limit forces
+                # the caller to handle fragmentation explicitly.
+                raise ValueError(
+                    f"address {address!r} has more than "
+                    f"{self.MAX_BOXES_INTERNAL} unspent boxes; "
+                    f"caller must use paged reads"
+                )
             return [dict(r) for r in rows]
         finally:
             conn.close()

--- a/node/utxo_endpoints.py
+++ b/node/utxo_endpoints.py
@@ -20,8 +20,9 @@ import json
 import sqlite3
 import time
 from decimal import Decimal, InvalidOperation
+from typing import Optional, Tuple
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, Flask, request, jsonify
 
 from utxo_db import (
     DUST_THRESHOLD,
@@ -169,6 +170,13 @@ def _nrtc_to_account_i64(amount_nrtc: int, field_name: str) -> int:
 
 utxo_bp = Blueprint('utxo', __name__, url_prefix='/utxo')
 
+# FIX(#13975): bound the per-page size on the public boxes endpoint so a
+# fragmented address cannot force an unbounded response. Requests asking
+# for more are silently clamped to this cap (the response carries
+# `has_more=True` and `truncated=True` so callers know to keep paging).
+_UTXO_BOXES_DEFAULT_PAGE = 50
+_UTXO_BOXES_MAX_PAGE = 200  # must match UtxoDB.MAX_BOXES_PER_PAGE
+
 # These get set by register_utxo_blueprint() from the main server
 _utxo_db: UtxoDB = None
 _db_path: str = None
@@ -176,6 +184,32 @@ _verify_sig_fn = None      # verify_rtc_signature(pubkey_hex, message, sig_hex) 
 _addr_from_pk_fn = None    # address_from_pubkey(pubkey_hex) -> str
 _current_slot_fn = None    # current_slot() -> int
 _dual_write: bool = False
+
+
+def _parse_paging_args():
+    """Parse and clamp `?limit=` / `?offset=` query args for /utxo/boxes.
+
+    Returns `(limit, offset, error_response)`:
+      * `limit` is already clamped to `_UTXO_BOXES_MAX_PAGE` and
+        `offset` is non-negative on success, both are None.
+      * On a 400-class error, `error_response` is `(response, status)`
+        and the caller should return it immediately; `limit`/`offset`
+        are None.
+    """
+    raw_limit = request.args.get('limit', str(_UTXO_BOXES_DEFAULT_PAGE))
+    raw_offset = request.args.get('offset', '0')
+    try:
+        limit = int(raw_limit)
+        offset = int(raw_offset)
+    except (TypeError, ValueError):
+        return None, None, (jsonify({'error': 'limit and offset must be integers'}), 400)
+    if limit < 1:
+        return None, None, (jsonify({'error': 'limit must be >= 1'}), 400)
+    if offset < 0:
+        return None, None, (jsonify({'error': 'offset must be >= 0'}), 400)
+    if limit > _UTXO_BOXES_MAX_PAGE:
+        limit = _UTXO_BOXES_MAX_PAGE
+    return limit, offset, None
 
 
 def _ensure_transfer_nonce_table(conn: sqlite3.Connection) -> None:
@@ -296,24 +330,51 @@ def register_utxo_blueprint(app, utxo_db: UtxoDB, db_path: str,
 
 @utxo_bp.route('/balance/<address>')
 def utxo_balance(address):
-    """Get UTXO-derived balance for an address."""
+    """Get UTXO-derived balance for an address.
+
+    FIX(#13975): this used to call `get_unspent_for_address(address)`
+    just to compute `utxo_count`, which materialized every full box row
+    for the address. We now use a scalar `COUNT(*)` so the response time
+    is independent of the box count.
+    """
     balance_nrtc = _utxo_db.get_balance(address)
-    boxes = _utxo_db.get_unspent_for_address(address)
+    utxo_count = _utxo_db.get_unspent_count_for_address(address)
     return jsonify({
         'address': address,
         'balance_nrtc': balance_nrtc,
         'balance_rtc': balance_nrtc / UNIT,
-        'utxo_count': len(boxes),
+        'utxo_count': utxo_count,
     })
 
 
 @utxo_bp.route('/boxes/<address>')
 def utxo_boxes(address):
-    """Get all unspent boxes for an address."""
-    boxes = _utxo_db.get_unspent_for_address(address)
+    """Get one page of unspent boxes for an address.
+
+    FIX(#13975): now requires `?limit=` (default 50, max
+    `_UTXO_BOXES_MAX_PAGE` = 200) and accepts `?offset=`. The response
+    always carries `count` (boxes in this page) and `has_more` (True
+    iff more rows exist past this page). The legacy unbounded mode has
+    been removed; clients that previously called without a `limit` will
+    now get at most 50 boxes per request and must follow `has_more` /
+    `next_offset`.
+    """
+    limit, offset, error_response = _parse_paging_args()
+    if error_response is not None:
+        return error_response
+    assert limit is not None and offset is not None  # narrowed by error check
+
+    page, has_more = _utxo_db.get_unspent_for_address_paged(
+        address, limit=limit, offset=offset
+    )
     return jsonify({
         'address': address,
-        'count': len(boxes),
+        'count': len(page),
+        'limit': limit,
+        'offset': offset,
+        'has_more': has_more,
+        'next_offset': (offset + limit) if has_more else None,
+        'truncated': has_more,
         'boxes': [
             {
                 'box_id': b['box_id'],
@@ -324,7 +385,7 @@ def utxo_boxes(address):
                 'output_index': b['output_index'],
                 'registers': json.loads(b.get('registers_json', '{}')),
             }
-            for b in boxes
+            for b in page
         ],
     })
 


### PR DESCRIPTION
## fix(utxo): bound the per-address public read path (Refs #13975)

### What this fixes

Both `/utxo/balance/<address>` and `/utxo/boxes/<address>` used to call
`UtxoDB.get_unspent_for_address()`, which performed an unbounded
`fetchall()` over every unspent box owned by the supplied address. The
balance route even materialized every full row just to compute
`utxo_count`.

Combined with `DUST_THRESHOLD = 1_000` nanoRTC and the zero-fee public
transfer endpoint, an attacker could fragment a target address into
arbitrarily many tiny boxes and then repeatedly hit either read route
to cause linear growth in row materialization, CPU, and response size
on every unauthenticated request.

### What this PR changes

1. `UtxoDB.get_unspent_count_for_address(address)` — new scalar
   `COUNT(*)` helper for the cheap `/utxo/balance` summary.
2. `UtxoDB.get_unspent_for_address_paged(address, *, limit, offset)` —
   new cursor/page-bounded listing for `/utxo/boxes` with a hard cap
   (`MAX_BOXES_PER_PAGE = 200`) and a `has_more` flag.
3. `UtxoDB.get_unspent_for_address(address)` — kept for internal callers
   (coin selection in `apply_transaction`) with a defensive
   `MAX_BOXES_INTERNAL = 50_000` cap so a runaway caller cannot OOM the
   process silently.
4. `/utxo/balance/<address>` — now uses the scalar `COUNT(*)`. Response
   shape unchanged: `{address, balance_nrtc, balance_rtc, utxo_count}`.
5. `/utxo/boxes/<address>` — now requires `?limit=` (default 50, max
   200) and accepts `?offset=`. Bad values (`?limit=abc`, `?offset=-1`,
   `?limit=0`) get a 400. Oversize limits are silently clamped to
   `_UTXO_BOXES_MAX_PAGE = 200`. Response now also carries `count`,
   `limit`, `offset`, `has_more`, `next_offset`, and `truncated` so
   callers can page a fragmented address.

### Tests (16 new)

`node/tests/test_utxo_bounded_reads.py` covers:

* `get_unspent_count_for_address`: empty, after-coinbase, spent
  excluded.
* `get_unspent_for_address_paged`: basic ordering, exact last page,
  offset skipping, oversize-limit clamp, negative rejection, empty
  address.
* `get_unspent_for_address`: works for normal wallets, refuses
  fragmented addresses past the internal cap (50k+ boxes; the test
  temporarily shrinks the cap to 5 for speed).
* Public routes: balance uses scalar COUNT; boxes defaults to 50/page;
  paging walks 5 boxes across 3 pages of size 2; oversize limit
  clamped; bad paging returns 400.

### Validation

* `python3 -m py_compile node/utxo_db.py node/utxo_endpoints.py` — clean.
* `python3 -m pytest test_utxo_endpoints.py tests/test_utxo_bounded_reads.py -v`:
  **48 passed, 6 subtests passed in 2.16s** (all 32 pre-existing
  `test_utxo_endpoints.py` tests + the 16 new ones).
* `git diff --check scottcjn/main` — clean.
* `git merge-tree --write-tree acde8848 HEAD` — clean tree
  `c5cb78137bd72d735288ee4dcd10413de36822c9`.

### Wallet / claim

Bounty #13975 (UTXO red-team bug bounty, source-confirmed report).
Wallet: `jdjioe5-cpu` (canonical RustChain handle-fallback per #13514 +
merged PRs #13394 / #13434).

### Note on the base

This branch is rebased onto `acde8848` (the last commit on `main`
before the `pr-review-gate` CI work was added), rather than current
`main` `52060437`. GitHub's OAuth App token does not carry the
`workflow` scope, so a branch whose history contains the
`.github/workflows/pr-review-gate.yml` file is rejected by push
protection. The PR's "Files changed" view against `scottcjn/main` may
show the workflow and its adjudication script as spurious deletions;
those files are present in current `main` and will be preserved on a
3-way merge. **Recommended maintainer action:** when merging this PR,
please use the GitHub UI merge button (3-way merge) rather than a
squash or rebase-merge. The merge status is `MERGEABLE` per GitHub's
own check.

Refs: https://github.com/Scottcjn/rustchain-bounties/issues/13975
