### PR TITLE
feat(integrations): add native RustChain AutoGen tools

### DIFF
--- a/integrations/rustchain_autogen/README.md
+++ b/integrations/rustchain_autogen/README.md
@@ -34,8 +34,8 @@ pip install autogen-core
 Public node reads use `https://rustchain.org`. Open bounties are read from the
 public [`Scottcjn/rustchain-bounties`](https://github.com/Scottcjn/rustchain-bounties)
 issue board because the node does not expose a bounty-list endpoint.
-Node health uses `/health`, current epoch uses `/epoch`, and balances use
-`/wallet/balance?miner_id=...`.
+Node health uses `/health` with the public Explorer `/api/stats` as a fallback,
+current epoch uses `/epoch`, and balances use `/wallet/balance?miner_id=...`.
 
 All network failures return structured `{ok: false, error: ...}` dictionaries
 instead of raising into an agent loop.

--- a/integrations/rustchain_autogen/README.md
+++ b/integrations/rustchain_autogen/README.md
@@ -34,6 +34,8 @@ pip install autogen-core
 Public node reads use `https://rustchain.org`. Open bounties are read from the
 public [`Scottcjn/rustchain-bounties`](https://github.com/Scottcjn/rustchain-bounties)
 issue board because the node does not expose a bounty-list endpoint.
+Node health uses `/health`, current epoch uses `/epoch`, and balances use
+`/wallet/balance?miner_id=...`.
 
 All network failures return structured `{ok: false, error: ...}` dictionaries
 instead of raising into an agent loop.

--- a/integrations/rustchain_autogen/README.md
+++ b/integrations/rustchain_autogen/README.md
@@ -1,0 +1,39 @@
+# RustChain AutoGen Tools
+
+This focused integration exposes four public RustChain reads as Microsoft
+AutoGen `FunctionTool` objects:
+
+- `check_balance(wallet_id)`
+- `list_bounties(limit)`
+- `get_node_health()`
+- `get_current_epoch()`
+
+The HTTP client uses only the Python standard library. AutoGen is imported only
+when `as_autogen_tools()` is called, so the client remains usable and testable
+without installing the framework.
+
+## Usage
+
+```python
+from integrations.rustchain_autogen import RustChainAutoGenTools
+
+rustchain = RustChainAutoGenTools()
+tools = rustchain.as_autogen_tools()
+
+# Register `tools` with an AutoGen AssistantAgent or tool-enabled runtime.
+print(rustchain.check_balance("my-agent-wallet"))
+print(rustchain.list_bounties(5))
+```
+
+Install the adapter dependency with:
+
+```bash
+pip install autogen-core
+```
+
+Public node reads use `https://rustchain.org`. Open bounties are read from the
+public [`Scottcjn/rustchain-bounties`](https://github.com/Scottcjn/rustchain-bounties)
+issue board because the node does not expose a bounty-list endpoint.
+
+All network failures return structured `{ok: false, error: ...}` dictionaries
+instead of raising into an agent loop.

--- a/integrations/rustchain_autogen/__init__.py
+++ b/integrations/rustchain_autogen/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """AutoGen tools for the public RustChain API."""
 
 from .rustchain_autogen_tool import RustChainAutoGenTools

--- a/integrations/rustchain_autogen/__init__.py
+++ b/integrations/rustchain_autogen/__init__.py
@@ -1,0 +1,5 @@
+"""AutoGen tools for the public RustChain API."""
+
+from .rustchain_autogen_tool import RustChainAutoGenTools
+
+__all__ = ["RustChainAutoGenTools"]

--- a/integrations/rustchain_autogen/rustchain_autogen_tool.py
+++ b/integrations/rustchain_autogen/rustchain_autogen_tool.py
@@ -1,0 +1,113 @@
+"""Dependency-light RustChain tools for Microsoft AutoGen."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+class RustChainAutoGenTools:
+    """Expose RustChain public reads as methods and AutoGen FunctionTools."""
+
+    def __init__(
+        self,
+        base_url: str = "https://rustchain.org",
+        bounty_repo: str = "Scottcjn/rustchain-bounties",
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.bounty_repo = bounty_repo
+        self.timeout = timeout
+
+    def _get_json(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        request = Request(
+            url,
+            headers={"Accept": "application/json", "User-Agent": "rustchain-autogen"},
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            return {"ok": False, "error": f"HTTP {exc.code}", "url": url}
+        except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+            return {"ok": False, "error": str(exc), "url": url}
+
+    def check_balance(self, wallet_id: str) -> dict[str, Any]:
+        """Return the confirmed RTC balance for a wallet or miner ID."""
+        if not wallet_id.strip():
+            return {"ok": False, "error": "wallet_id must not be empty"}
+        result = self._get_json(
+            f"{self.base_url}/wallet/balance",
+            {"miner_id": wallet_id.strip()},
+        )
+        if isinstance(result, dict) and result.get("ok") is False:
+            return result
+        return {"ok": True, "wallet_id": wallet_id.strip(), "balance": result}
+
+    def list_bounties(self, limit: int = 10) -> dict[str, Any]:
+        """List recent open RustChain bounty-board issues."""
+        limit = max(1, min(int(limit), 50))
+        result = self._get_json(
+            f"https://api.github.com/repos/{self.bounty_repo}/issues",
+            {"state": "open", "per_page": limit, "labels": "bounty"},
+        )
+        if isinstance(result, dict):
+            return result
+        bounties = [
+            {
+                "number": item.get("number"),
+                "title": item.get("title"),
+                "url": item.get("html_url"),
+                "updated_at": item.get("updated_at"),
+            }
+            for item in result
+            if "pull_request" not in item
+        ]
+        return {"ok": True, "count": len(bounties), "bounties": bounties}
+
+    def get_node_health(self) -> dict[str, Any]:
+        """Return public node health, falling back to node statistics."""
+        health = self._get_json(f"{self.base_url}/health")
+        if not (isinstance(health, dict) and health.get("ok") is False):
+            return {"ok": True, "source": "/health", "health": health}
+        stats = self._get_json(f"{self.base_url}/api/stats")
+        if isinstance(stats, dict) and stats.get("ok") is False:
+            return {"ok": False, "error": "health and stats endpoints failed"}
+        return {"ok": True, "source": "/api/stats", "health": stats}
+
+    def get_current_epoch(self) -> dict[str, Any]:
+        """Return the current epoch from the public node statistics."""
+        stats = self._get_json(f"{self.base_url}/api/stats")
+        if isinstance(stats, dict) and stats.get("ok") is False:
+            return stats
+        if not isinstance(stats, dict):
+            return {"ok": False, "error": "stats response was not an object"}
+        epoch = stats.get("epoch", stats.get("current_epoch"))
+        if epoch is None:
+            return {"ok": False, "error": "stats response did not include an epoch"}
+        return {"ok": True, "epoch": epoch, "stats": stats}
+
+    def as_autogen_tools(self) -> list[Any]:
+        """Create AutoGen FunctionTool objects for the four public actions."""
+        try:
+            from autogen_core.tools import FunctionTool
+        except ImportError as exc:
+            raise RuntimeError(
+                "AutoGen is required for adapters: pip install autogen-core"
+            ) from exc
+
+        return [
+            FunctionTool(self.check_balance, description=self.check_balance.__doc__ or ""),
+            FunctionTool(self.list_bounties, description=self.list_bounties.__doc__ or ""),
+            FunctionTool(self.get_node_health, description=self.get_node_health.__doc__ or ""),
+            FunctionTool(self.get_current_epoch, description=self.get_current_epoch.__doc__ or ""),
+        ]

--- a/integrations/rustchain_autogen/rustchain_autogen_tool.py
+++ b/integrations/rustchain_autogen/rustchain_autogen_tool.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Dependency-light RustChain tools for Microsoft AutoGen."""
 
 from __future__ import annotations
@@ -55,7 +56,10 @@ class RustChainAutoGenTools:
 
     def list_bounties(self, limit: int = 10) -> dict[str, Any]:
         """List recent open RustChain bounty-board issues."""
-        limit = max(1, min(int(limit), 50))
+        try:
+            limit = max(1, min(int(limit), 50))
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "limit must be an integer from 1 to 50"}
         result = self._get_json(
             f"https://api.github.com/repos/{self.bounty_repo}/issues",
             {"state": "open", "per_page": limit, "labels": "bounty"},
@@ -79,10 +83,17 @@ class RustChainAutoGenTools:
         health = self._get_json(f"{self.base_url}/health")
         if not (isinstance(health, dict) and health.get("ok") is False):
             return {"ok": True, "source": "/health", "health": health}
-        stats = self._get_json(f"{self.base_url}/api/stats")
+        stats = self._get_json("https://explorer.rustchain.org/api/stats")
         if isinstance(stats, dict) and stats.get("ok") is False:
-            return {"ok": False, "error": "health and stats endpoints failed"}
-        return {"ok": True, "source": "/api/stats", "health": stats}
+            return {
+                "ok": False,
+                "error": "health and explorer stats endpoints failed",
+            }
+        return {
+            "ok": True,
+            "source": "https://explorer.rustchain.org/api/stats",
+            "health": stats,
+        }
 
     def get_current_epoch(self) -> dict[str, Any]:
         """Return the current epoch from the public node epoch endpoint."""

--- a/integrations/rustchain_autogen/rustchain_autogen_tool.py
+++ b/integrations/rustchain_autogen/rustchain_autogen_tool.py
@@ -85,16 +85,16 @@ class RustChainAutoGenTools:
         return {"ok": True, "source": "/api/stats", "health": stats}
 
     def get_current_epoch(self) -> dict[str, Any]:
-        """Return the current epoch from the public node statistics."""
-        stats = self._get_json(f"{self.base_url}/api/stats")
-        if isinstance(stats, dict) and stats.get("ok") is False:
-            return stats
-        if not isinstance(stats, dict):
-            return {"ok": False, "error": "stats response was not an object"}
-        epoch = stats.get("epoch", stats.get("current_epoch"))
+        """Return the current epoch from the public node epoch endpoint."""
+        epoch_data = self._get_json(f"{self.base_url}/epoch")
+        if isinstance(epoch_data, dict) and epoch_data.get("ok") is False:
+            return epoch_data
+        if not isinstance(epoch_data, dict):
+            return {"ok": False, "error": "epoch response was not an object"}
+        epoch = epoch_data.get("epoch", epoch_data.get("current_epoch"))
         if epoch is None:
-            return {"ok": False, "error": "stats response did not include an epoch"}
-        return {"ok": True, "epoch": epoch, "stats": stats}
+            return {"ok": False, "error": "epoch response did not include an epoch"}
+        return {"ok": True, "epoch": epoch, "epoch_data": epoch_data}
 
     def as_autogen_tools(self) -> list[Any]:
         """Create AutoGen FunctionTool objects for the four public actions."""

--- a/tests/test_rustchain_autogen_tool.py
+++ b/tests/test_rustchain_autogen_tool.py
@@ -1,0 +1,61 @@
+"""Focused tests for the dependency-light RustChain AutoGen integration."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from integrations.rustchain_autogen import RustChainAutoGenTools
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class RustChainAutoGenToolsTest(unittest.TestCase):
+    def setUp(self):
+        self.tools = RustChainAutoGenTools(timeout=1)
+
+    @patch("integrations.rustchain_autogen.rustchain_autogen_tool.urlopen")
+    def test_check_balance_wraps_public_response(self, mocked):
+        mocked.return_value = FakeResponse({"amount_rtc": 12.5})
+        result = self.tools.check_balance("wallet name")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["balance"]["amount_rtc"], 12.5)
+        self.assertIn("miner_id=wallet+name", mocked.call_args.args[0].full_url)
+
+    @patch("integrations.rustchain_autogen.rustchain_autogen_tool.urlopen")
+    def test_list_bounties_filters_pull_requests(self, mocked):
+        mocked.return_value = FakeResponse([
+            {"number": 1, "title": "Bounty", "html_url": "https://example/1"},
+            {"number": 2, "title": "PR", "pull_request": {}, "html_url": "https://example/2"},
+        ])
+        result = self.tools.list_bounties(999)
+        self.assertEqual(result["count"], 1)
+        self.assertIn("per_page=50", mocked.call_args.args[0].full_url)
+
+    @patch("integrations.rustchain_autogen.rustchain_autogen_tool.urlopen")
+    def test_epoch_is_extracted_from_stats(self, mocked):
+        mocked.return_value = FakeResponse({"epoch": 191, "chain_id": "rustchain-mainnet-v2"})
+        self.assertEqual(self.tools.get_current_epoch()["epoch"], 191)
+
+    def test_empty_wallet_is_rejected_without_http(self):
+        self.assertFalse(self.tools.check_balance(" ")["ok"])
+
+    def test_autogen_dependency_has_clear_error(self):
+        with patch.dict("sys.modules", {"autogen_core": None, "autogen_core.tools": None}):
+            with self.assertRaisesRegex(RuntimeError, "pip install autogen-core"):
+                self.tools.as_autogen_tools()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rustchain_autogen_tool.py
+++ b/tests/test_rustchain_autogen_tool.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: MIT
 """Focused tests for the dependency-light RustChain AutoGen integration."""
 
 import json
@@ -42,6 +43,24 @@ class RustChainAutoGenToolsTest(unittest.TestCase):
         result = self.tools.list_bounties(999)
         self.assertEqual(result["count"], 1)
         self.assertIn("per_page=50", mocked.call_args.args[0].full_url)
+
+    def test_list_bounties_rejects_invalid_limit_without_http(self):
+        result = self.tools.list_bounties("many")
+        self.assertFalse(result["ok"])
+        self.assertIn("limit must be an integer", result["error"])
+
+    @patch("integrations.rustchain_autogen.rustchain_autogen_tool.urlopen")
+    def test_health_falls_back_to_live_explorer_stats(self, mocked):
+        mocked.side_effect = [
+            FakeResponse({"ok": False, "error": "unhealthy"}),
+            FakeResponse({"epoch": 191, "chain_id": "rustchain-mainnet-v2"}),
+        ]
+        result = self.tools.get_node_health()
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            mocked.call_args.args[0].full_url,
+            "https://explorer.rustchain.org/api/stats",
+        )
 
     @patch("integrations.rustchain_autogen.rustchain_autogen_tool.urlopen")
     def test_epoch_is_extracted_from_stats(self, mocked):


### PR DESCRIPTION
## Summary
Adds a focused Microsoft AutoGen integration for the RustChain public HTTP API, claiming the AutoGen slot in Scottcjn/rustchain-bounties#13952.

## Delivered
- RustChainAutoGenTools with check_balance, list_bounties, get_node_health, and get_current_epoch
- lazy autogen_core.tools.FunctionTool adapters via as_autogen_tools()
- standard-library HTTP client with structured, non-throwing network errors
- short install/usage README
- focused mocked regression tests covering balance encoding, bounty filtering/limit clamping, epoch extraction, input validation, and the optional dependency error

## Safety and validation
- No credentials or authenticated node operations
- No third-party packages downloaded or executed
- Source reviewed for import-safe optional AutoGen handling; repository CI requested for authoritative parse/test validation

## Wallet
RTC64fcd1317490a202596953699b1e6a742522365d

Closes the AutoGen slot in Scottcjn/rustchain-bounties#13952.