### PR TITLE
fix(windows): verify bootstrap hashes

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,6 +23,10 @@ jobs:
         shell: pwsh
         run: |
           choco install innosetup --no-progress --yes
+
+      - name: Verify bootstrap checksums
+        run: |
+          python miners/windows/check_bootstrap_hashes.py
           
       - name: Install Dependencies
         run: |

--- a/miners/windows/check_bootstrap_hashes.py
+++ b/miners/windows/check_bootstrap_hashes.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate hashes embedded in rustchain_miner_setup.bat."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+BOOTSTRAP = ROOT / "rustchain_miner_setup.bat"
+
+EXPECTED_FILES = {
+    "MINER_SHA256": ROOT / "rustchain_windows_miner.py",
+    "CRYPTO_SHA256": ROOT / "miner_crypto.py",
+}
+
+
+def read_bootstrap_hashes() -> dict[str, str]:
+    content = BOOTSTRAP.read_text(encoding="utf-8")
+    hashes: dict[str, str] = {}
+    for name in EXPECTED_FILES:
+        match = re.search(rf'^set "{name}=([0-9a-fA-F]{{64}})"$', content, re.MULTILINE)
+        if not match:
+            raise ValueError(f"{BOOTSTRAP.name} is missing {name}")
+        hashes[name] = match.group(1).lower()
+    return hashes
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> int:
+    failures: list[str] = []
+    bootstrap_hashes = read_bootstrap_hashes()
+
+    for name, path in EXPECTED_FILES.items():
+        actual = sha256(path)
+        expected = bootstrap_hashes[name]
+        if actual != expected:
+            failures.append(f"{name}: expected {expected}, actual {actual} ({path.name})")
+
+    if failures:
+        print("Windows bootstrap hash check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    print("Windows bootstrap hashes are in sync.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/miners/windows/rustchain_miner_setup.bat
+++ b/miners/windows/rustchain_miner_setup.bat
@@ -9,7 +9,7 @@ set "MINER_SCRIPT=%SCRIPT_DIR%rustchain_windows_miner.py"
 set "MINER_SHA256=a4c07a32f9e475efb60bb5bef548a91c8eecc15b978ba57eca4fb4c6603642fd"
 set "CRYPTO_URL=https://raw.githubusercontent.com/Scottcjn/Rustchain/main/miners/windows/miner_crypto.py"
 set "CRYPTO_SCRIPT=%SCRIPT_DIR%miner_crypto.py"
-set "CRYPTO_SHA256=a987e2f0caaf75723c568de67ec848daec5e323cc5673cc17964da04eee07242"
+set "CRYPTO_SHA256=ffe2e4c78fdc3f53c129a2ef820cc84549a5720655140e69a3e0baf1f7f385fa"
 
 echo.
 echo === RustChain Windows Miner Bootstrap ===
@@ -67,8 +67,12 @@ if not exist "%CRYPTO_SCRIPT%" (
     echo WARNING: miner_crypto.py was not downloaded — miner will run in
     echo          legacy unsigned mode. Re-run setup with network access
     echo          to enable Ed25519 signing.
+    goto :crypto_ready
 )
+call :verify_crypto
+if errorlevel 1 exit /b 1
 
+:crypto_ready
 echo.
 echo Miner is ready. Run:
 echo    python "%MINER_SCRIPT%"
@@ -92,4 +96,20 @@ if /I not "!ACTUAL_MINER_SHA256!"=="%MINER_SHA256%" (
     exit /b 1
 )
 echo Miner script checksum verified.
+exit /b 0
+
+:verify_crypto
+if not exist "%CRYPTO_SCRIPT%" (
+    exit /b 0
+)
+set "ACTUAL_CRYPTO_SHA256="
+for /f "usebackq delims=" %%H in (`powershell -NoProfile -Command "(Get-FileHash -Algorithm SHA256 -Path '%CRYPTO_SCRIPT%').Hash.ToLowerInvariant()"`) do set "ACTUAL_CRYPTO_SHA256=%%H"
+if /I not "!ACTUAL_CRYPTO_SHA256!"=="%CRYPTO_SHA256%" (
+    echo ERROR: Crypto module SHA-256 mismatch.
+    echo Expected: %CRYPTO_SHA256%
+    echo Actual:   !ACTUAL_CRYPTO_SHA256!
+    del /f /q "%CRYPTO_SCRIPT%" >nul 2>&1
+    exit /b 1
+)
+echo Crypto module checksum verified.
 exit /b 0


### PR DESCRIPTION
Fixes #7388.

## Summary
- add a bootstrap hash checker used by the Windows miner workflow
- keep the miner script SHA-256 under CI so future miner edits cannot silently desync the bootstrap installer
- update and verify the `miner_crypto.py` SHA-256 in the `.bat` flow as well, instead of leaving the crypto hash constant unused

## Notes
- Current `rustchain_windows_miner.py` already matches the embedded `MINER_SHA256`; the reported mismatch appears to compare a Git blob SHA with file SHA-256. This PR preserves the current correct miner hash and adds regression coverage so the bootstrap stays correct.

## Validation
- `python miners/windows/check_bootstrap_hashes.py`
- `python -m py_compile miners/windows/check_bootstrap_hashes.py`
- `git diff --check`
