### PR TITLE
feat(integrations): add native RustChain Agno tools

### DIFF
--- a/integrations/rustchain_agno/README.md
+++ b/integrations/rustchain_agno/README.md
@@ -1,0 +1,42 @@
+# RustChain Agno / Phidata Tools
+
+This focused integration exposes four public RustChain reads to
+[Agno](https://github.com/agno-agi/agno) and legacy Phidata agents:
+
+- `check_balance(wallet_id)`
+- `list_bounties(limit)`
+- `get_node_health()`
+- `get_current_epoch()`
+
+The HTTP client uses only the Python standard library. Agno or Phidata is
+imported only when `as_agno_toolkit()` is called, so the client remains usable
+and testable without installing either framework.
+
+## Usage
+
+```python
+from integrations.rustchain_agno import RustChainAgnoTools
+
+rustchain = RustChainAgnoTools()
+toolkit = rustchain.as_agno_toolkit()
+
+# Pass `toolkit` to an Agno Agent, or call the methods directly.
+print(rustchain.check_balance("my-agent-wallet"))
+print(rustchain.list_bounties(5))
+```
+
+Install an adapter dependency with one of:
+
+```bash
+pip install agno
+pip install phidata
+```
+
+Public node reads use `https://rustchain.org`. Open bounties are read from the
+public [`Scottcjn/rustchain-bounties`](https://github.com/Scottcjn/rustchain-bounties)
+issue board because the node does not expose a bounty-list endpoint. Node health
+uses `/health` with the public Explorer `/api/stats` as a fallback, current epoch
+uses `/epoch`, and balances use `/wallet/balance?miner_id=...`.
+
+All network failures return structured `{ok: false, error: ...}` dictionaries
+instead of raising into an agent loop.

--- a/integrations/rustchain_agno/__init__.py
+++ b/integrations/rustchain_agno/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+"""RustChain public HTTP tools for Agno/Phidata agents."""
+
+from .rustchain_agno_tool import RustChainAgnoTools
+
+__all__ = ["RustChainAgnoTools"]

--- a/integrations/rustchain_agno/rustchain_agno_tool.py
+++ b/integrations/rustchain_agno/rustchain_agno_tool.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: MIT
+"""Dependency-light RustChain tools for Agno and legacy Phidata agents."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+class RustChainAgnoTools:
+    """Expose RustChain public reads as plain methods and an Agno Toolkit."""
+
+    def __init__(
+        self,
+        base_url: str = "https://rustchain.org",
+        bounty_repo: str = "Scottcjn/rustchain-bounties",
+        timeout: float = 10.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.bounty_repo = bounty_repo
+        self.timeout = timeout
+
+    def _get_json(
+        self,
+        url: str,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | list[Any]:
+        if params:
+            url = f"{url}?{urlencode(params)}"
+        request = Request(
+            url,
+            headers={"Accept": "application/json", "User-Agent": "rustchain-agno"},
+        )
+        try:
+            with urlopen(request, timeout=self.timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            return {"ok": False, "error": f"HTTP {exc.code}", "url": url}
+        except (URLError, TimeoutError, json.JSONDecodeError) as exc:
+            return {"ok": False, "error": str(exc), "url": url}
+
+    def check_balance(self, wallet_id: str) -> dict[str, Any]:
+        """Return the confirmed RTC balance for a wallet or miner ID."""
+        wallet_id = wallet_id.strip()
+        if not wallet_id:
+            return {"ok": False, "error": "wallet_id must not be empty"}
+        result = self._get_json(
+            f"{self.base_url}/wallet/balance",
+            {"miner_id": wallet_id},
+        )
+        if isinstance(result, dict) and result.get("ok") is False:
+            return result
+        return {"ok": True, "wallet_id": wallet_id, "balance": result}
+
+    def list_bounties(self, limit: int = 10) -> dict[str, Any]:
+        """List recent open RustChain bounty-board issues."""
+        try:
+            limit = max(1, min(int(limit), 50))
+        except (TypeError, ValueError):
+            return {"ok": False, "error": "limit must be an integer from 1 to 50"}
+
+        result = self._get_json(
+            f"https://api.github.com/repos/{self.bounty_repo}/issues",
+            {"state": "open", "per_page": limit, "labels": "bounty"},
+        )
+        if isinstance(result, dict):
+            return result
+
+        bounties = [
+            {
+                "number": item.get("number"),
+                "title": item.get("title"),
+                "url": item.get("html_url"),
+                "updated_at": item.get("updated_at"),
+            }
+            for item in result
+            if "pull_request" not in item
+        ]
+        return {"ok": True, "count": len(bounties), "bounties": bounties}
+
+    def get_node_health(self) -> dict[str, Any]:
+        """Return public node health, falling back to explorer statistics."""
+        health = self._get_json(f"{self.base_url}/health")
+        if not (isinstance(health, dict) and health.get("ok") is False):
+            return {"ok": True, "source": "/health", "health": health}
+
+        stats = self._get_json("https://explorer.rustchain.org/api/stats")
+        if isinstance(stats, dict) and stats.get("ok") is False:
+            return {
+                "ok": False,
+                "error": "health and explorer stats endpoints failed",
+            }
+        return {
+            "ok": True,
+            "source": "https://explorer.rustchain.org/api/stats",
+            "health": stats,
+        }
+
+    def get_current_epoch(self) -> dict[str, Any]:
+        """Return the current epoch from the public node epoch endpoint."""
+        epoch_data = self._get_json(f"{self.base_url}/epoch")
+        if isinstance(epoch_data, dict) and epoch_data.get("ok") is False:
+            return epoch_data
+        if not isinstance(epoch_data, dict):
+            return {"ok": False, "error": "epoch response was not an object"}
+        epoch = epoch_data.get("epoch", epoch_data.get("current_epoch"))
+        if epoch is None:
+            return {"ok": False, "error": "epoch response did not include an epoch"}
+        return {"ok": True, "epoch": epoch, "epoch_data": epoch_data}
+
+    @staticmethod
+    def _load_toolkit_class() -> type[Any]:
+        try:
+            from agno.tools import Toolkit
+
+            return Toolkit
+        except ImportError:
+            try:
+                from phi.tools import Toolkit
+
+                return Toolkit
+            except ImportError as exc:
+                raise RuntimeError(
+                    "Agno or Phidata is required for adapters: "
+                    "pip install agno or pip install phidata"
+                ) from exc
+
+    def as_agno_toolkit(self) -> Any:
+        """Create an Agno/Phidata Toolkit registering the four public actions."""
+        toolkit_cls = self._load_toolkit_class()
+        outer = self
+
+        class RustChainToolkit(toolkit_cls):  # type: ignore[misc, valid-type]
+            def __init__(self) -> None:
+                super().__init__(name="rustchain")
+                self.register(outer.check_balance)
+                self.register(outer.list_bounties)
+                self.register(outer.get_node_health)
+                self.register(outer.get_current_epoch)
+
+        return RustChainToolkit()

--- a/tests/test_rustchain_agno_tool.py
+++ b/tests/test_rustchain_agno_tool.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+"""Focused tests for the dependency-light RustChain Agno integration."""
+
+import json
+import unittest
+from unittest.mock import patch
+
+from integrations.rustchain_agno import RustChainAgnoTools
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class RustChainAgnoToolsTest(unittest.TestCase):
+    def setUp(self):
+        self.tools = RustChainAgnoTools(timeout=1)
+
+    @patch("integrations.rustchain_agno.rustchain_agno_tool.urlopen")
+    def test_check_balance_wraps_public_response(self, mocked):
+        mocked.return_value = FakeResponse({"amount_rtc": 25})
+        result = self.tools.check_balance("agent wallet")
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["balance"]["amount_rtc"], 25)
+        self.assertIn("miner_id=agent+wallet", mocked.call_args.args[0].full_url)
+
+    @patch("integrations.rustchain_agno.rustchain_agno_tool.urlopen")
+    def test_list_bounties_filters_pull_requests_and_clamps_limit(self, mocked):
+        mocked.return_value = FakeResponse([
+            {"number": 1, "title": "Bounty", "html_url": "https://example/1"},
+            {"number": 2, "title": "PR", "pull_request": {}, "html_url": "https://example/2"},
+        ])
+        result = self.tools.list_bounties(500)
+        self.assertEqual(result["count"], 1)
+        self.assertIn("per_page=50", mocked.call_args.args[0].full_url)
+
+    def test_list_bounties_rejects_invalid_limit_without_http(self):
+        result = self.tools.list_bounties("many")
+        self.assertFalse(result["ok"])
+        self.assertIn("limit must be an integer", result["error"])
+
+    @patch("integrations.rustchain_agno.rustchain_agno_tool.urlopen")
+    def test_health_falls_back_to_explorer_stats(self, mocked):
+        mocked.side_effect = [
+            FakeResponse({"ok": False, "error": "unhealthy"}),
+            FakeResponse({"epoch": 191, "chain_id": "rustchain-mainnet-v2"}),
+        ]
+        result = self.tools.get_node_health()
+        self.assertTrue(result["ok"])
+        self.assertEqual(
+            mocked.call_args.args[0].full_url,
+            "https://explorer.rustchain.org/api/stats",
+        )
+
+    @patch("integrations.rustchain_agno.rustchain_agno_tool.urlopen")
+    def test_epoch_is_extracted_from_response(self, mocked):
+        mocked.return_value = FakeResponse({"current_epoch": 192})
+        self.assertEqual(self.tools.get_current_epoch()["epoch"], 192)
+
+    def test_empty_wallet_is_rejected_without_http(self):
+        self.assertFalse(self.tools.check_balance(" ")["ok"])
+
+    def test_agno_dependency_has_clear_error(self):
+        with patch.dict("sys.modules", {"agno": None, "agno.tools": None, "phi": None, "phi.tools": None}):
+            with self.assertRaisesRegex(RuntimeError, "pip install agno"):
+                self.tools.as_agno_toolkit()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a focused Phidata/Agno integration for the RustChain public HTTP API, claiming the Phidata/Agno slot in Scottcjn/rustchain-bounties#13952.

## Delivered
- `RustChainAgnoTools` with `check_balance`, `list_bounties`, `get_node_health`, and `get_current_epoch`
- optional `as_agno_toolkit()` adapter that supports modern `agno.tools.Toolkit` and legacy `phi.tools.Toolkit`
- standard-library HTTP client with structured, non-throwing network errors
- short install/usage README
- focused mocked regression tests covering balance encoding, bounty filtering/limit clamping, epoch extraction, input validation, and optional dependency errors

## Safety and validation
- No credentials or authenticated node operations
- No third-party packages downloaded or executed
- `python -m unittest tests.test_rustchain_agno_tool`
- `python -m py_compile integrations\rustchain_agno\rustchain_agno_tool.py tests\test_rustchain_agno_tool.py`
- `git diff --check`

## Wallet
Jorel97

Closes the Phidata/Agno slot in Scottcjn/rustchain-bounties#13952.