### PR TITLE
fix(vintage_ai_video_pipeline): tolerate whitespace-only 200 OK responses (Issue #7351)

### DIFF
--- a/tests/test_vintage_ai_rustchain_client.py
+++ b/tests/test_vintage_ai_rustchain_client.py
@@ -43,3 +43,98 @@ def test_get_miners_returns_empty_list_for_unexpected_payload(monkeypatch):
     monkeypatch.setattr(client, "_get", lambda endpoint: {"pagination": {"total": 0}})
 
     assert client.get_miners() == []
+
+
+# --- Issue #7351: Unhandled JSONDecodeError on Empty 200 OK Responses ---
+
+
+def test_request_handles_empty_200_ok_body(monkeypatch):
+    """Issue #7351: 200 OK with empty body must NOT raise JSONDecodeError.
+
+    The original code only checked `if response_data else {}`, which missed
+    whitespace-only bodies (a common nginx/proxy response pattern).
+    """
+    module = load_client_module()
+    client = module.RustChainClient(base_url="https://node.example")
+
+    fake_response = _make_fake_response(b"")
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: fake_response
+    )
+
+    result = client._request("GET", "/api/health")
+    assert result == {}, f"expected {{}}, got {result!r}"
+
+
+def test_request_handles_whitespace_only_200_ok_body(monkeypatch):
+    """Issue #7351: 200 OK with whitespace-only body must NOT raise.
+
+    A whitespace-only body is JSON-invalid but semantically empty. The fix
+    strips before checking, so the response is treated as no-payload.
+    """
+    module = load_client_module()
+    client = module.RustChainClient(base_url="https://node.example")
+
+    fake_response = _make_fake_response(b"   \n\t  ")
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: fake_response
+    )
+
+    result = client._request("GET", "/api/health")
+    assert result == {}, f"expected {{}}, got {result!r}"
+
+
+def test_request_handles_valid_json(monkeypatch):
+    """Regression: normal JSON response still parses correctly."""
+    module = load_client_module()
+    client = module.RustChainClient(base_url="https://node.example")
+
+    fake_response = _make_fake_response(b'{"status": "ok", "epoch": 191}')
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: fake_response
+    )
+
+    result = client._request("GET", "/api/health")
+    assert result == {"status": "ok", "epoch": 191}
+
+
+def test_request_propagates_invalid_json(monkeypatch):
+    """Regression: non-empty non-JSON body still raises (per retry/raise policy).
+
+    The fix only narrows the 'empty / whitespace' case. Real JSON errors
+    must still surface so callers see upstream misconfiguration.
+    """
+    module = load_client_module()
+    client = module.RustChainClient(
+        base_url="https://node.example", retry_count=1, retry_delay=0
+    )
+
+    fake_response = _make_fake_response(b"<html>nginx error page</html>")
+    monkeypatch.setattr(
+        "urllib.request.urlopen", lambda *a, **kw: fake_response
+    )
+
+    raised = False
+    try:
+        client._request("GET", "/api/health")
+    except Exception as exc:
+        raised = True
+        assert "Invalid JSON" in str(exc) or "JSON" in str(exc), (
+            f"expected JSON-related error, got: {exc!r}"
+        )
+    assert raised, "non-JSON non-empty body should still raise after retries"
+
+
+def _make_fake_response(body: bytes):
+    """Build a context-manager fake that mimics urllib's response.read()."""
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return body
+
+    return FakeResp()

--- a/vintage_ai_video_pipeline/rustchain_client.py
+++ b/vintage_ai_video_pipeline/rustchain_client.py
@@ -94,8 +94,14 @@ class RustChainClient:
                     context=self._ctx,
                     timeout=self.timeout
                 ) as response:
-                    response_data = response.read().decode("utf-8")
-                    return json.loads(response_data) if response_data else {}
+                    raw = response.read()
+                    response_data = raw.decode("utf-8").strip() if raw else ""
+                    # Empty / whitespace-only 200 OK body: treat as "no payload"
+                    # rather than raising JSONDecodeError. This fixes Issue #7351
+                    # where any whitespace-only or empty 200 OK crashed the client.
+                    if not response_data:
+                        return {}
+                    return json.loads(response_data)
 
             except HTTPError as e:
                 error_body = e.read().decode("utf-8") if e.fp else ""


### PR DESCRIPTION
## Summary

The RustChainClient in `vintage_ai_video_pipeline/rustchain_client.py` crashed with `JSONDecodeError` when an upstream proxy returned a 200 OK with a whitespace-only (or otherwise non-content) body. The original check `if response_data else {}` only handled the exact-empty case; `response_data = '   \\t  '` would slip through to `json.loads()` and raise.

## Reproduction

```python
from vintage_ai_video_pipeline.rustchain_client import RustChainClient
import unittest.mock as mock

with mock.patch('urllib.request.urlopen') as mock_urlopen:
    fake = mock.MagicMock()
    fake.__enter__ = lambda s: fake
    fake.__exit__ = lambda s, *a: False
    fake.read.return_value = b'   \\t  '
    mock_urlopen.return_value = fake

    client = RustChainClient(retry_count=1, retry_delay=0)
    client._request('GET', '/api/health')   # raises: JSONDecodeError
```

## Fix

Strip the response body before the empty check so any whitespace-only / non-content 200 OK is treated as "no payload" and returns `{}`. Non-empty non-JSON bodies still surface via the existing retry/raise path.

## Validation

- `python3 -m pytest tests/test_vintage_ai_rustchain_client.py -v` -> 6/6 PASS (2 pre-existing + 4 new regression tests)
- `python3 -m py_compile vintage_ai_video_pipeline/rustchain_client.py` -> OK
- `git diff --check` -> clean

## Diff

- 2 files modified, +103/-2
- `vintage_ai_video_pipeline/rustchain_client.py`: +8/-2 (strip body before empty check)
- `tests/test_vintage_ai_rustchain_client.py`: +95 (4 new tests + 1 helper)

## Context

This replaces PR #7410 (closed 2026-06-13) and PR #7414 (closed same minute). The earlier PR head included an unrelated deletion of `.github/workflows/pr-review-gate.yml` (workaround for a separate OAuth-scope issue I cannot push from this cloud account without the `workflow` scope). Per @Asti1982's CHANGES_REQUESTED review on 2026-06-12T21:03:33Z, that deletion was a blocker. This branch (`fix/7351-on-fork-main`) isolates the client-parsing fix only.

Refs #7351

Wallet: `jdjioe5-cpu` (canonical GitHub-handle fallback per #13514)