### PR TITLE
fix(bridge): compute last event from max timestamp

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -108,9 +108,20 @@ def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
     completed_in = by_status.get("completed", {}).get("total_rtc", 0.0)
     voided_in = by_status.get("voided", {}).get("total_rtc", 0.0)
 
-    # last_event_at: most recent created_at across all transfers
+    # last_event_at: most recent transfer creation or state-change timestamp.
+    # Treat legacy null timestamps as 0 before choosing the latest column.
     last_event = cursor.execute(
-        "SELECT COALESCE(MAX(created_at), 0) FROM bridge_transfers"
+        """
+        SELECT COALESCE(
+            MAX(MAX(
+                COALESCE(updated_at, 0),
+                COALESCE(completed_at, 0),
+                COALESCE(created_at, 0)
+            )),
+            0
+        )
+        FROM bridge_transfers
+        """
     ).fetchone()  # fetchall-ok: pragma-result (single MAX)
     last_event_at = int(last_event[0]) if last_event else 0
 

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -71,6 +71,7 @@ def _seed(db_path, rows):
                 "lock_epoch": row.get("lock_epoch", 1),
                 "created_at": row.get("created_at", now - i),
                 "updated_at": row.get("updated_at", now - i),
+                "completed_at": row.get("completed_at"),
                 "tx_hash": row.get("tx_hash", f"hash_{i}"),
             }
             cur.execute(
@@ -81,13 +82,13 @@ def _seed(db_path, rows):
                     amount_i64, amount_rtc,
                     bridge_type, bridge_fee_i64,
                     external_tx_hash, external_confirmations, required_confirmations,
-                    status, lock_epoch, created_at, updated_at, tx_hash
+                    status, lock_epoch, created_at, updated_at, completed_at, tx_hash
                 ) VALUES (:direction, :source_chain, :dest_chain,
                           :source_address, :dest_address,
                           :amount_i64, :amount_rtc,
                           :bridge_type, :bridge_fee_i64,
                           :external_tx_hash, :external_confirmations, :required_confirmations,
-                          :status, :lock_epoch, :created_at, :updated_at, :tx_hash)
+                          :status, :lock_epoch, :created_at, :updated_at, :completed_at, :tx_hash)
                 """,
                 r,
             )
@@ -133,15 +134,25 @@ def test_state_aggregates_by_status_and_direction(client, db_path):
     assert s["by_direction"]["withdraw"] == {"count": 1, "total_rtc": 100.0}
 
 
-def test_state_last_event_at_reflects_max_created_at(client, db_path):
+def test_state_last_event_at_reflects_max_state_change_at(client, db_path):
     base = int(time.time())
     _seed(db_path, [
-        {"created_at": base - 100, "status": "pending"},
-        {"created_at": base, "status": "completed"},
-        {"created_at": base - 50, "status": "locked"},
+        {"created_at": base, "updated_at": base, "status": "pending"},
+        {
+            "created_at": base - 100,
+            "updated_at": base - 10,
+            "completed_at": base + 60,
+            "status": "completed",
+        },
+        {
+            "created_at": base - 50,
+            "updated_at": base + 25,
+            "completed_at": None,
+            "status": "locked",
+        },
     ])
     s = client.get("/bridge/state").get_json()["state"]
-    assert s["last_event_at"] == base
+    assert s["last_event_at"] == base + 60
 
 
 # ---------- /bridge/events ---------------------------------------------------


### PR DESCRIPTION
## Summary
- compute `/bridge/state` `last_event_at` from the latest bridge timestamp across `updated_at`, `completed_at`, and `created_at`
- treat null timestamp columns as `0` before taking the max
- add a regression where `completed_at` is newer than `updated_at`, matching the owner blocker from the closed #7363 attempt

## Why
Follow-up to closed PR #7363. The old implementation direction was right, but the query used first-non-null timestamp semantics instead of true latest-event semantics. This version uses `MAX` over the per-row timestamp columns and keeps the change read-only.

## Risk / BCOS
BCOS-L2: bridge observability metadata touches bridge state reconciliation.

This PR does not change bridge payout amounts, minting rules, transfer statuses, confirmation rules, wallet balances, admin keys, production wallets, or manual crediting paths. It only changes read-only aggregate freshness metadata returned by `/bridge/state`.

## Validation
- `uv run --no-project --with pytest --with flask python -B -m pytest -q node/tests/test_bridge_federation_routes.py` -> 19 passed
- `PATH=/usr/bin:/bin bash scripts/check_fetchall.sh` -> passed, legacy baseline count 179
- `python3 -m py_compile node/bridge_federation_routes.py node/tests/test_bridge_federation_routes.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `git merge-tree --write-tree origin/main HEAD` -> clean tree `b22a300232648bcd885e3bef5113407bb7c53f0d`

Related: #7363

wallet: RTC47bc28896a1a4bf240d1fd780f4559b242bcd945