### PR TITLE
fix: bound PoA TCP listener REST forwarding

### DIFF
--- a/rustchain-poa/tools/net/poa_tcp_listener.py
+++ b/rustchain-poa/tools/net/poa_tcp_listener.py
@@ -5,6 +5,7 @@ import requests
 
 LISTEN_PORT = 8585
 FORWARD_URL = "http://127.0.0.1:5000/validate"  # Your PoA REST API
+REQUEST_TIMEOUT = 10
 
 def handle_client(conn, addr):
     print(f"[+] Connection from {addr}")
@@ -18,7 +19,13 @@ def handle_client(conn, addr):
             print("[~] Parsed JSON:")
             print(json.dumps(payload, indent=2))
 
-            r = requests.post(FORWARD_URL, json=payload)
+            try:
+                r = requests.post(FORWARD_URL, json=payload, timeout=REQUEST_TIMEOUT)
+            except requests.RequestException as exc:
+                print(f"[!] REST API forward failed: {exc}")
+                conn.sendall(b"PoA forward failed.\n")
+                return
+
             print(f"[✓] Forwarded to REST API. Status: {r.status_code}")
             conn.sendall(f"PoA received. Status: {r.status_code}\n".encode())
         except json.JSONDecodeError:

--- a/tests/test_poa_tcp_listener_timeout.py
+++ b/tests/test_poa_tcp_listener_timeout.py
@@ -1,0 +1,78 @@
+import importlib.util
+from pathlib import Path
+
+import requests
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "rustchain-poa"
+    / "tools"
+    / "net"
+    / "poa_tcp_listener.py"
+)
+
+
+def load_listener():
+    spec = importlib.util.spec_from_file_location("poa_tcp_listener", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeConn:
+    def __init__(self, payload):
+        self.payload = payload
+        self.sent = []
+        self.closed = False
+
+    def recv(self, _size):
+        return self.payload
+
+    def sendall(self, data):
+        self.sent.append(data)
+
+    def close(self):
+        self.closed = True
+
+
+def test_handle_client_forwards_with_timeout(monkeypatch):
+    listener = load_listener()
+    conn = FakeConn(b'{"miner_id": "m1"}')
+    calls = []
+
+    class Response:
+        status_code = 202
+
+    def fake_post(url, json, timeout):
+        calls.append((url, json, timeout))
+        return Response()
+
+    monkeypatch.setattr(listener.requests, "post", fake_post)
+
+    listener.handle_client(conn, ("127.0.0.1", 12345))
+
+    assert calls == [
+        (
+            listener.FORWARD_URL,
+            {"miner_id": "m1"},
+            listener.REQUEST_TIMEOUT,
+        )
+    ]
+    assert conn.sent == [b"PoA received. Status: 202\n"]
+    assert conn.closed is True
+
+
+def test_handle_client_reports_forward_failure(monkeypatch):
+    listener = load_listener()
+    conn = FakeConn(b'{"miner_id": "m1"}')
+
+    def fake_post(*_args, **_kwargs):
+        raise requests.Timeout("slow API")
+
+    monkeypatch.setattr(listener.requests, "post", fake_post)
+
+    listener.handle_client(conn, ("127.0.0.1", 12345))
+
+    assert conn.sent == [b"PoA forward failed.\n"]
+    assert conn.closed is True


### PR DESCRIPTION
## Summary
- add a fixed timeout to the PoA TCP listener's REST API forwarding call
- report a clear client failure when the local validation API times out or refuses the request
- add focused tests for timeout wiring and forwarding failure handling

## Verification
- `python -m pytest tests/test_poa_tcp_listener_timeout.py` (2 passed)
- `python -m py_compile rustchain-poa/tools/net/poa_tcp_listener.py tests/test_poa_tcp_listener_timeout.py`