### PR TITLE
fix: close payout preflight input files

### DIFF
--- a/tools/payout_preflight_check.py
+++ b/tools/payout_preflight_check.py
@@ -16,7 +16,8 @@ def read_payload(path: str) -> Any:
     if path == "-":
         raw = sys.stdin.read()
     else:
-        raw = open(path, "r", encoding="utf-8").read()
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = fh.read()
     return json.loads(raw)
 
 


### PR DESCRIPTION
## Summary
- use a context manager when reading payout preflight JSON payloads from disk
- keep stdin behavior unchanged
- avoid leaving an input file descriptor open when the CLI is used repeatedly

## Verification
- `python -m pytest tests/test_payout_preflight_check.py` (5 passed)
- `python -m py_compile tools/payout_preflight_check.py tests/test_payout_preflight_check.py`