### PR TITLE
fix: close vintage image validation handles

### DIFF
--- a/tests/test_validate_vintage_submission.py
+++ b/tests/test_validate_vintage_submission.py
@@ -89,6 +89,40 @@ def test_screenshot_validation_preserves_small_file_warning(tmp_path):
     assert "Screenshot file is unusually small" in validator.warnings
 
 
+def test_image_validation_closes_pillow_handles(monkeypatch, tmp_path):
+    validator = SubmissionValidator()
+    photo_path = tmp_path / "photo.png"
+    photo_path.write_bytes(b"x" * 10000)
+    closed_handles = []
+
+    class FakeImage:
+        size = (640, 480)
+        format = "PNG"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            closed_handles.append(True)
+
+        def verify(self):
+            return None
+
+    class FakePillow:
+        @staticmethod
+        def open(_path):
+            return FakeImage()
+
+    monkeypatch.setattr(validate_vintage_submission, "HAVE_PILLOW", True)
+    monkeypatch.setattr(validate_vintage_submission, "Image", FakePillow)
+
+    result = validator.validate_photo(str(photo_path))
+
+    assert result["status"] == "PASS"
+    assert result["checks"]["format"] == "PNG"
+    assert closed_handles == [True, True]
+
+
 def test_validate_submission_extracts_arch_and_bounty_from_valid_log(tmp_path):
     validator = SubmissionValidator()
     log_path = tmp_path / "attestation.json"

--- a/tools/validate_vintage_submission.py
+++ b/tools/validate_vintage_submission.py
@@ -76,14 +76,15 @@ class SubmissionValidator:
             return result
 
         try:
-            img = Image.open(file_path)
-            img.verify()  # Checks image header integrity (fast, no pixel decode)
+            with Image.open(file_path) as img:
+                img.verify()  # Checks image header integrity (fast, no pixel decode)
             # Re-open to get dimensions (verify() invalidates the file handle)
-            img = Image.open(file_path)
-            width, height = img.size
+            with Image.open(file_path) as img:
+                width, height = img.size
+                image_format = img.format
             result["checks"]["width"] = width
             result["checks"]["height"] = height
-            result["checks"]["format"] = img.format
+            result["checks"]["format"] = image_format
 
             # Check resolution
             if width < min_resolution[0] or height < min_resolution[1]:
@@ -94,18 +95,18 @@ class SubmissionValidator:
 
             # Check extension matches format
             ext = os.path.splitext(file_path)[1].lower().lstrip(".")
-            if img.format and ext and ext not in img.format.lower() and ext not in ("jpg", "jpeg"):
+            if image_format and ext and ext not in image_format.lower() and ext not in ("jpg", "jpeg"):
                 # jpg/jpeg are interchangeable
-                if not (ext in ("jpg", "jpeg") and img.format.lower() in ("jpeg", "jpg")):
+                if not (ext in ("jpg", "jpeg") and image_format.lower() in ("jpeg", "jpg")):
                     result["status"] = "WARN"
-                    msg = f"{label} extension .{ext} doesn't match format {img.format}"
+                    msg = f"{label} extension .{ext} doesn't match format {image_format}"
                     result["message"] = (result["message"] + "; " + msg) if result["message"] else msg
                     self.warnings.append(f"{label} extension/format mismatch")
 
             # If we got here with no warnings, PASS
             if result["status"] not in ("WARN",):
                 result["status"] = "PASS"
-                result["message"] = f"{label} validated as real image ({width}x{height}, {img.format})"
+                result["message"] = f"{label} validated as real image ({width}x{height}, {image_format})"
 
         except Exception as e:
             # PIL couldn't identify the file — don't overwrite existing size/format warnings


### PR DESCRIPTION
## Summary
- wrap both Pillow image opens in context managers during vintage submission validation
- keep `verify()` and the second dimension/format read behavior unchanged
- add a focused regression test that confirms both opened image handles are closed

## Verification
- `python -m pytest tests/test_validate_vintage_submission.py` (9 passed)
- `python -m py_compile tools/validate_vintage_submission.py tests/test_validate_vintage_submission.py`