### PR TITLE
fix: bound Rent-a-Relic MCP client calls

### DIFF
--- a/bounties/issue-2312/examples/mcp_integration.py
+++ b/bounties/issue-2312/examples/mcp_integration.py
@@ -14,13 +14,17 @@ import requests
 class MCPClient:
     """Simple MCP client for Relic Market"""
     
-    def __init__(self, server_url: str = "http://localhost:5000"):
+    def __init__(self, server_url: str = "http://localhost:5000", timeout: int = 15):
         self.server_url = server_url.rstrip('/')
+        self.timeout = timeout
         self.session = requests.Session()
     
     def get_manifest(self):
         """Get MCP server manifest"""
-        response = self.session.get(f"{self.server_url}/mcp/manifest")
+        response = self.session.get(
+            f"{self.server_url}/mcp/manifest",
+            timeout=self.timeout,
+        )
         return response.json()
     
     def call_tool(self, tool_name: str, arguments: dict):
@@ -31,7 +35,8 @@ class MCPClient:
         }
         response = self.session.post(
             f"{self.server_url}/mcp/tool",
-            json=payload
+            json=payload,
+            timeout=self.timeout,
         )
         return response.json()
 

--- a/bounties/issue-2312/tests/test_mcp_integration_example.py
+++ b/bounties/issue-2312/tests/test_mcp_integration_example.py
@@ -1,0 +1,64 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "mcp_integration.py"
+)
+
+
+def load_example():
+    spec = importlib.util.spec_from_file_location("mcp_integration", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def json(self):
+        return self.payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.get_calls = []
+        self.post_calls = []
+
+    def get(self, *args, **kwargs):
+        self.get_calls.append((args, kwargs))
+        return FakeResponse({"name": "Relic MCP", "tools": {}})
+
+    def post(self, *args, **kwargs):
+        self.post_calls.append((args, kwargs))
+        return FakeResponse({"ok": True})
+
+
+def test_mcp_client_uses_timeout_for_manifest_and_tool_calls():
+    module = load_example()
+    client = module.MCPClient("http://example.test/", timeout=7)
+    fake_session = FakeSession()
+    client.session = fake_session
+
+    assert client.get_manifest()["name"] == "Relic MCP"
+    assert client.call_tool("list_machines", {"available_only": True}) == {"ok": True}
+
+    assert fake_session.get_calls == [
+        (("http://example.test/mcp/manifest",), {"timeout": 7})
+    ]
+    assert fake_session.post_calls == [
+        (
+            ("http://example.test/mcp/tool",),
+            {
+                "json": {
+                    "tool": "list_machines",
+                    "arguments": {"available_only": True},
+                },
+                "timeout": 7,
+            },
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a configurable timeout to the Rent-a-Relic MCP example client
- pass the timeout through both manifest and tool calls
- add a focused regression test for the request timeout wiring

## Verification
- `python -m pytest bounties/issue-2312/tests/test_mcp_integration_example.py` (1 passed)
- `python -m py_compile bounties/issue-2312/examples/mcp_integration.py bounties/issue-2312/tests/test_mcp_integration_example.py`

Note: the broader issue-2312 validation script reaches its unit-test phase locally but cannot import `nacl` in this runtime (`ModuleNotFoundError: No module named 'nacl'`), so I verified the touched example and new regression directly.