### PR TITLE
fix: bound auto-pay GitHub API calls

### DIFF
--- a/scripts/auto-pay.py
+++ b/scripts/auto-pay.py
@@ -31,6 +31,7 @@ import requests
 # ---------------------------------------------------------------------------
 
 GITHUB_API = "https://api.github.com"
+GITHUB_REQUEST_TIMEOUT_SECONDS = 15
 VPS_PORT = 8088
 FROM_WALLET = "founder_community"
 
@@ -77,7 +78,12 @@ def fetch_pr_comments(repo: str, pr_number: str) -> list:
     page = 1
     while True:
         url = f"{GITHUB_API}/repos/{repo}/issues/{pr_number}/comments"
-        resp = requests.get(url, headers=gh_headers(), params={"per_page": 100, "page": page})
+        resp = requests.get(
+            url,
+            headers=gh_headers(),
+            params={"per_page": 100, "page": page},
+            timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+        )
         resp.raise_for_status()
         batch = resp.json()
         if not batch:
@@ -90,7 +96,12 @@ def fetch_pr_comments(repo: str, pr_number: str) -> list:
 def post_comment(repo: str, pr_number: str, body: str) -> None:
     """Post a comment on a PR."""
     url = f"{GITHUB_API}/repos/{repo}/issues/{pr_number}/comments"
-    resp = requests.post(url, headers=gh_headers(), json={"body": body})
+    resp = requests.post(
+        url,
+        headers=gh_headers(),
+        json={"body": body},
+        timeout=GITHUB_REQUEST_TIMEOUT_SECONDS,
+    )
     resp.raise_for_status()
     print(f"Posted confirmation comment on PR #{pr_number}")
 

--- a/scripts/test_auto_pay_idempotency.py
+++ b/scripts/test_auto_pay_idempotency.py
@@ -48,7 +48,7 @@ def base_env():
 
 
 def paged_comments(comments):
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         page = (params or {}).get("page", 1)
         return FakeResponse(comments if page == 1 else [])
 
@@ -101,7 +101,7 @@ def test_confirmation_comment_failure_retries_with_same_idempotency_key():
     accepted_transfers = {}
     comment_attempts = []
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         page = (params or {}).get("page", 1)
         return FakeResponse(persisted_comments if page == 1 else [])
 
@@ -148,7 +148,7 @@ def test_started_marker_does_not_block_retry_after_transfer_connection_failure()
     transfer_calls = []
     comment_posts = []
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         page = (params or {}).get("page", 1)
         return FakeResponse(persisted_comments if page == 1 else [])
 
@@ -189,7 +189,7 @@ def test_manual_transfer_notice_does_not_block_later_auto_pay():
     transfer_calls = []
     comment_posts = []
 
-    def fake_get(url, headers=None, params=None):
+    def fake_get(url, headers=None, params=None, timeout=None):
         page = (params or {}).get("page", 1)
         return FakeResponse(persisted_comments if page == 1 else [])
 
@@ -259,3 +259,39 @@ def test_legacy_manual_transfer_notice_does_not_block_later_auto_pay():
 
     assert len(transfer_calls) == 1
     assert any("RTC-AutoPay-Confirmed" in body for body in comment_posts)
+
+
+def test_github_comment_api_calls_use_timeout():
+    auto_pay = load_auto_pay()
+    get_calls = []
+    post_calls = []
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        get_calls.append((url, params, timeout))
+        return FakeResponse([])
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        post_calls.append((url, json, timeout))
+        return FakeResponse({"id": 999})
+
+    with patch.dict(os.environ, base_env(), clear=True):
+        auto_pay.requests.get = fake_get
+        auto_pay.requests.post = fake_post
+
+        assert auto_pay.fetch_pr_comments("Scottcjn/Rustchain", "123") == []
+        auto_pay.post_comment("Scottcjn/Rustchain", "123", "paid")
+
+    assert get_calls == [
+        (
+            "https://api.github.com/repos/Scottcjn/Rustchain/issues/123/comments",
+            {"per_page": 100, "page": 1},
+            auto_pay.GITHUB_REQUEST_TIMEOUT_SECONDS,
+        )
+    ]
+    assert post_calls == [
+        (
+            "https://api.github.com/repos/Scottcjn/Rustchain/issues/123/comments",
+            {"body": "paid"},
+            auto_pay.GITHUB_REQUEST_TIMEOUT_SECONDS,
+        )
+    ]


### PR DESCRIPTION
## Summary
- add a shared timeout for auto-pay GitHub comment fetch/post requests
- keep the existing VPS transfer timeout unchanged
- cover the GitHub comment API timeout behavior in the auto-pay tests

## Tests
- python -m pytest scripts/test_auto_pay_idempotency.py -q
- python -m py_compile scripts/auto-pay.py scripts/test_auto_pay_idempotency.py