### PR TITLE
fix: route packaged Windows miner calls through configured node

### DIFF
--- a/miners/windows/installer/src/rustchain_windows_miner.py
+++ b/miners/windows/installer/src/rustchain_windows_miner.py
@@ -586,7 +586,12 @@ class RustChainMiner:
     def check_eligibility(self):
         """Check if eligible to mine"""
         try:
-            response = requests.get(f"{RUSTCHAIN_API}/lottery/eligibility?miner_id={self.miner_id}", verify=TLS_VERIFY)
+            response = requests.get(
+                f"{self.node_url}/lottery/eligibility",
+                params={"miner_id": self.miner_id},
+                timeout=10,
+                verify=TLS_VERIFY,
+            )
             if response.ok:
                 data = response.json()
                 return data.get("eligible", False)
@@ -611,7 +616,12 @@ class RustChainMiner:
     def submit_header(self, header):
         """Submit mining header"""
         try:
-            response = requests.post(f"{RUSTCHAIN_API}/headers/ingest_signed", json=header, timeout=5, verify=TLS_VERIFY)
+            response = requests.post(
+                f"{self.node_url}/headers/ingest_signed",
+                json=header,
+                timeout=5,
+                verify=TLS_VERIFY,
+            )
             return response.status_code == 200
         except:
             return False

--- a/tests/test_windows_installer_tkinter_fallback.py
+++ b/tests/test_windows_installer_tkinter_fallback.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 import builtins
+import importlib.util
 import runpy
 import sys
 from pathlib import Path
@@ -7,6 +8,34 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PACKAGED_MINER = ROOT / "miners" / "windows" / "installer" / "src" / "rustchain_windows_miner.py"
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.ok = 200 <= status_code < 400
+
+    def json(self):
+        return self._payload
+
+
+def load_packaged_miner():
+    spec = importlib.util.spec_from_file_location(
+        "packaged_windows_miner_under_test",
+        PACKAGED_MINER,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_miner(module):
+    miner = module.RustChainMiner.__new__(module.RustChainMiner)
+    miner.wallet_address = "RTCwallet"
+    miner.miner_id = "windows_local"
+    miner.node_url = "https://node.example"
+    return miner
 
 
 def test_packaged_miner_help_works_without_tkinter(monkeypatch, capsys):
@@ -28,3 +57,46 @@ def test_packaged_miner_help_works_without_tkinter(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "--headless" in captured.out
     assert "--wallet" in captured.out
+
+
+def test_packaged_miner_eligibility_uses_configured_node(monkeypatch):
+    module = load_packaged_miner()
+    miner = make_miner(module)
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return FakeResponse({"eligible": True})
+
+    monkeypatch.setattr(module.requests, "get", fake_get)
+
+    assert miner.check_eligibility() is True
+    assert captured == {
+        "url": "https://node.example/lottery/eligibility",
+        "params": {"miner_id": "windows_local"},
+        "timeout": 10,
+        "verify": module.TLS_VERIFY,
+    }
+
+
+def test_packaged_miner_submit_uses_configured_node(monkeypatch):
+    module = load_packaged_miner()
+    miner = make_miner(module)
+    captured = {}
+    header = {"miner_id": "windows_local", "hash": "abc123"}
+
+    def fake_post(url, **kwargs):
+        captured["url"] = url
+        captured.update(kwargs)
+        return FakeResponse({"ok": True})
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+
+    assert miner.submit_header(header) is True
+    assert captured == {
+        "url": "https://node.example/headers/ingest_signed",
+        "json": header,
+        "timeout": 5,
+        "verify": module.TLS_VERIFY,
+    }


### PR DESCRIPTION
## Summary
- make packaged Windows miner eligibility checks use the configured node URL
- add a timeout and params encoding for eligibility requests
- route packaged Windows miner header submissions through the configured node URL

## Tests
- python -m pytest tests/test_windows_installer_tkinter_fallback.py -q
- python -m py_compile miners/windows/installer/src/rustchain_windows_miner.py tests/test_windows_installer_tkinter_fallback.py