### PR TITLE
docs: fix related documentation links

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -395,15 +395,15 @@ Vintage mining is the core innovation of RustChain. By rewarding old hardware mo
 
 ## Related Documentation
 
-- [Protocol Specification](docs/PROTOCOL.md) — Detailed RIP-200 protocol spec
-- [Quick Start](docs/QUICKSTART.md) — Get mining in 5 minutes
-- [API Reference](docs/API_REFERENCE.md) — Complete REST API docs
-- [Miner Setup Guide](docs/INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
-- [Console Mining Setup](docs/CONSOLE_MINING_SETUP.md) — Mining via console
-- [Hardware Fingerprinting](docs/hardware-fingerprinting.md) — Deep dive into fingerprint checks
-- [Bridge API](docs/bridge-api.md) — Cross-chain bridge endpoints
-- [Wallet Setup](docs/WALLET_SETUP.md) — Configure your wallet
-- [Contributing](docs/CONTRIBUTING.md) — How to contribute to RustChain
+- [Protocol Specification](PROTOCOL.md) — Detailed RIP-200 protocol spec
+- [Quick Start](QUICKSTART.md) — Get mining in 5 minutes
+- [API Reference](API_REFERENCE.md) — Complete REST API docs
+- [Miner Setup Guide](INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
+- [Console Mining Setup](CONSOLE_MINING_SETUP.md) — Mining via console
+- [Hardware Fingerprinting](hardware-fingerprinting.md) — Deep dive into fingerprint checks
+- [Bridge API](bridge-api.md) — Cross-chain bridge endpoints
+- [Wallet Setup](WALLET_SETUP.md) — Configure your wallet
+- [Contributing](CONTRIBUTING.md) — How to contribute to RustChain
 
 ---
 

--- a/docs/NODE_OPERATOR_GUIDE.md
+++ b/docs/NODE_OPERATOR_GUIDE.md
@@ -665,16 +665,16 @@ Before expecting rewards, verify:
 
 ## Related Documentation
 
-- [Quick Start](docs/QUICKSTART.md) — Get mining in 5 minutes
-- [Installation Walkthrough](docs/INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
-- [Console Mining Setup](docs/CONSOLE_MINING_SETUP.md) — Mining via console
-- [Mastering the Miner](docs/MASTERING_THE_MINER.md) — Advanced mining techniques
-- [DevNet](docs/DEVNET.md) — Development network setup
-- [Architecture Overview](docs/ARCHITECTURE_OVERVIEW.md) — System architecture
-- [API Reference](docs/API_REFERENCE.md) — Complete REST API docs
-- [CLI Reference](docs/CLI.md) — Command-line interface
-- [Build Guide](docs/BUILD.md) — Build from source
-- [Payout Preflight](docs/PAYOUT_PREFLIGHT.md) — Before expecting rewards
+- [Quick Start](QUICKSTART.md) — Get mining in 5 minutes
+- [Installation Walkthrough](INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
+- [Console Mining Setup](CONSOLE_MINING_SETUP.md) — Mining via console
+- [Mastering the Miner](MASTERING_THE_MINER.md) — Advanced mining techniques
+- [DevNet](DEVNET.md) — Development network setup
+- [Architecture Overview](ARCHITECTURE_OVERVIEW.md) — System architecture
+- [API Reference](API_REFERENCE.md) — Complete REST API docs
+- [CLI Reference](CLI.md) — Command-line interface
+- [Build Guide](BUILD.md) — Build from source
+- [Payout Preflight](PAYOUT_PREFLIGHT.md) — Before expecting rewards
 
 ---
 

--- a/docs/zh-CN/ARCHITECTURE_OVERVIEW.md
+++ b/docs/zh-CN/ARCHITECTURE_OVERVIEW.md
@@ -395,15 +395,15 @@ graph LR
 
 ## 相关文档
 
-- [协议规范](docs/PROTOCOL.md) — 详细的 RIP-200 协议规范
-- [快速入门](docs/QUICKSTART.md) — 5 分钟上手挖矿
-- [API 参考](docs/API_REFERENCE.md) — 完整的 REST API 文档
-- [矿工安装指南](docs/INSTALLATION_WALKTHROUGH.md) — 详细安装指南
-- [控制台挖矿设置](docs/CONSOLE_MINING_SETUP.md) — 通过控制台挖矿
-- [硬件指纹识别](docs/hardware-fingerprinting.md) — 指纹检查深度解析
-- [桥接 API](docs/bridge-api.md) — 跨链桥接端点
-- [钱包设置](docs/WALLET_SETUP.md) — 配置钱包
-- [贡献指南](docs/CONTRIBUTING.md) — 如何向 RustChain 贡献
+- [协议规范](../PROTOCOL.md) — 详细的 RIP-200 协议规范
+- [快速入门](../QUICKSTART.md) — 5 分钟上手挖矿
+- [API 参考](../API_REFERENCE.md) — 完整的 REST API 文档
+- [矿工安装指南](../INSTALLATION_WALKTHROUGH.md) — 详细安装指南
+- [控制台挖矿设置](../CONSOLE_MINING_SETUP.md) — 通过控制台挖矿
+- [硬件指纹识别](../hardware-fingerprinting.md) — 指纹检查深度解析
+- [桥接 API](../bridge-api.md) — 跨链桥接端点
+- [钱包设置](../WALLET_SETUP.md) — 配置钱包
+- [贡献指南](../CONTRIBUTING.md) — 如何向 RustChain 贡献
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix related-documentation links inside docs pages so they resolve relative to the current file instead of `docs/docs/...`.
- Fix the zh-CN architecture overview links to point back to the shared docs directory.

## Verification
- `python .\verify_doc_links.py` -> checked markdown links in touched files
- `rg -n "\]\(docs/" docs\ARCHITECTURE_OVERVIEW.md docs\NODE_OPERATOR_GUIDE.md docs\zh-CN\ARCHITECTURE_OVERVIEW.md` -> no matches
- `git diff --check` -> clean

First PR candidate for the RustChain first-time contributor guide.
