### PR TITLE
fix(bridge): last_event_at reflects most recent state change

### DIFF
--- a/node/bridge_federation_routes.py
+++ b/node/bridge_federation_routes.py
@@ -108,9 +108,13 @@ def _aggregate_bridge_state(conn: sqlite3.Connection) -> Dict[str, Any]:
     completed_in = by_status.get("completed", {}).get("total_rtc", 0.0)
     voided_in = by_status.get("voided", {}).get("total_rtc", 0.0)
 
-    # last_event_at: most recent created_at across all transfers
+    # last_event_at: most recent state-change timestamp across all transfers.
+    # Per-row max of updated_at / completed_at / created_at so a later status
+    # change (confirm, complete, void) is not masked by an older value.
     last_event = cursor.execute(
-        "SELECT COALESCE(MAX(created_at), 0) FROM bridge_transfers"
+        "SELECT COALESCE(MAX("
+        "max(updated_at, COALESCE(completed_at, 0), created_at)"
+        "), 0) FROM bridge_transfers"
     ).fetchone()  # fetchall-ok: pragma-result (single MAX)
     last_event_at = int(last_event[0]) if last_event else 0
 

--- a/node/tests/test_bridge_federation_routes.py
+++ b/node/tests/test_bridge_federation_routes.py
@@ -72,6 +72,7 @@ def _seed(db_path, rows):
                 "created_at": row.get("created_at", now - i),
                 "updated_at": row.get("updated_at", now - i),
                 "tx_hash": row.get("tx_hash", f"hash_{i}"),
+                "completed_at": row.get("completed_at"),
             }
             cur.execute(
                 """
@@ -81,13 +82,13 @@ def _seed(db_path, rows):
                     amount_i64, amount_rtc,
                     bridge_type, bridge_fee_i64,
                     external_tx_hash, external_confirmations, required_confirmations,
-                    status, lock_epoch, created_at, updated_at, tx_hash
+                    status, lock_epoch, created_at, updated_at, completed_at, tx_hash
                 ) VALUES (:direction, :source_chain, :dest_chain,
                           :source_address, :dest_address,
                           :amount_i64, :amount_rtc,
                           :bridge_type, :bridge_fee_i64,
                           :external_tx_hash, :external_confirmations, :required_confirmations,
-                          :status, :lock_epoch, :created_at, :updated_at, :tx_hash)
+                          :status, :lock_epoch, :created_at, :updated_at, :completed_at, :tx_hash)
                 """,
                 r,
             )
@@ -142,6 +143,40 @@ def test_state_last_event_at_reflects_max_created_at(client, db_path):
     ])
     s = client.get("/bridge/state").get_json()["state"]
     assert s["last_event_at"] == base
+
+
+def test_state_last_event_at_uses_updated_when_newer_than_created(client, db_path):
+    """updated_at newer than created_at should win over created_at."""
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 200, "updated_at": base - 10, "status": "confirming"},
+    ])
+    s = client.get("/bridge/state").get_json()["state"]
+    assert s["last_event_at"] == base - 10
+
+
+def test_state_last_event_at_uses_completed_when_newer_than_updated(client, db_path):
+    """completed_at newer than updated_at should not be masked."""
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 300, "updated_at": base - 100,
+         "completed_at": base - 5, "status": "completed"},
+    ])
+    s = client.get("/bridge/state").get_json()["state"]
+    assert s["last_event_at"] == base - 5
+
+
+def test_state_last_event_at_picks_row_with_latest_state_change(client, db_path):
+    """Multiple rows: the row whose max timestamp is newest wins."""
+    base = int(time.time())
+    _seed(db_path, [
+        {"created_at": base - 500, "updated_at": base - 400, "status": "completed"},
+        {"created_at": base - 50, "updated_at": base - 20, "status": "locked"},
+        {"created_at": base - 300, "updated_at": base - 250,
+         "completed_at": base - 1, "status": "completed"},
+    ])
+    s = client.get("/bridge/state").get_json()["state"]
+    assert s["last_event_at"] == base - 1
 
 
 # ---------- /bridge/events ---------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #7362

`/bridge/state` reports `last_event_at` as `MAX(created_at)` only. When a transfer is later confirmed, completed, or voided, the timestamp stays frozen at the original creation time, so federation observers and reconciliation tooling see stale freshness metadata.

## What changed

- **`node/bridge_federation_routes.py`** — replaced `MAX(created_at)` with a per-row `max(updated_at, COALESCE(completed_at, 0), created_at)` inside the aggregate `MAX()`. SQLite's scalar `max()` picks the newest of the three per-row, then the outer `MAX()` takes the winner across all rows.

This avoids the `COALESCE(updated_at, completed_at, created_at, 0)` pitfall from #7363, which returned the first non-null column rather than the most recent — a populated-but-older `updated_at` would mask a newer `completed_at`.

## How to test

```bash
python3 -m pytest node/tests/test_bridge_federation_routes.py -v
```

Three regression tests added:
1. `updated_at` newer than `created_at` → `last_event_at` reflects `updated_at`
2. `completed_at` newer than `updated_at` → `last_event_at` reflects `completed_at` (the case #7363 got wrong)
3. Multiple rows with mixed timestamps → the row with the latest state change wins

All 22 tests pass.

## Safety

Read-only bridge observability metadata. No changes to transfer rows, payout amounts, minting rules, confirmation logic, wallet balances, or admin keys.