### PR TITLE
fix(utxo): cap coin_select at 20 inputs on equal-value fallback

### DIFF
--- a/node/test_coin_select_extended.py
+++ b/node/test_coin_select_extended.py
@@ -81,5 +81,30 @@ class TestCoinSelectEdgeCases(unittest.TestCase):
         result, change = coin_select(utxos, 350)
         self.assertEqual(len(result), 4)
 
+    def test_equal_value_utxos_capped_at_twenty(self):
+        """Regression for #6830: 25 equal-value UTXOs, target 21.
+        Both strategies return 21 inputs (>20); cap-aware fallback
+        returns empty since 20x1 < 21."""
+        utxos = [{"value_nrtc": 1} for _ in range(25)]
+        result, change = coin_select(utxos, 21)
+        self.assertEqual(len(result), 0)
+        self.assertEqual(change, 0)
+
+    def test_result_never_exceeds_twenty_inputs(self):
+        """coin_select must never return more than 20 inputs
+        regardless of UTXO distribution."""
+        import random
+        random.seed(42)
+        for _ in range(200):
+            n = random.randint(25, 50)
+            utxos = [{"value_nrtc": random.randint(1, 5)} for _ in range(n)]
+            target = random.randint(1, n * 3)
+            result, _ = coin_select(utxos, target)
+            self.assertLessEqual(
+                len(result), 20,
+                f"{len(result)} inputs for {n} UTXOs, target {target}",
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/node/utxo_db.py
+++ b/node/utxo_db.py
@@ -1496,6 +1496,15 @@ def coin_select(utxos: List[dict], target_nrtc: int
                 break
         if total < target_nrtc:
             return [], 0
+        # Equal-value edge case: largest-first produces the same
+        # selection as smallest-first, so the fallback alone does
+        # not reduce input count.  Cap at the 20 largest and verify
+        # they still cover the target.
+        if len(selected) > 20:
+            selected = sorted_desc[:20]
+            total = sum(u['value_nrtc'] for u in selected)
+            if total < target_nrtc:
+                return [], 0
 
     change = total - target_nrtc
     if change < DUST_THRESHOLD:


### PR DESCRIPTION
## Summary

Closes #6830

Re-submitting as discussed in #6907 — fresh branch off current main, scoped to the UTXO selection code only (no unrelated diffs this time).

## Problem

`coin_select()` falls back to largest-first when smallest-first exceeds 20 inputs, but when all UTXOs have the same value both strategies produce identical orderings. The fallback still returns >20 inputs, defeating the purpose.

With 25 equal-value UTXOs (value 1) and a target of 21:
- Smallest-first: 21 inputs → triggers fallback
- Largest-first: 21 inputs (same order) → still >20

## Fix

After the largest-first fallback, if the selection still exceeds 20 inputs, cap at the 20 largest UTXOs and verify they cover the target. If they don't, return empty (the transaction can't be built within the input limit).

```python
if len(selected) > 20:
    selected = sorted_desc[:20]
    total = sum(u["value_nrtc"] for u in selected)
    if total < target_nrtc:
        return [], 0
```

## How to test

```bash
python3 -m pytest node/test_coin_select_extended.py -v
```

Two new tests:
1. **`test_equal_value_utxos_capped_at_twenty`** — 25 equal-value UTXOs, target 21: returns empty (20 inputs of value 1 cannot cover 21)
2. **`test_result_never_exceeds_twenty_inputs`** — property test: 200 random UTXO sets (25-50 inputs, values 1-5), verifies the result never exceeds 20 inputs

All 11 tests pass.

## Scope

Only `node/utxo_db.py` (9 lines) and `node/test_coin_select_extended.py` (25 lines). No changes to workflows, CI, or unrelated files.