### PR TITLE
fix(lock-ledger): clamp negative limit to 1 in core helpers

### DIFF
--- a/node/lock_ledger.py
+++ b/node/lock_ledger.py
@@ -475,7 +475,7 @@ def get_locks_by_miner(
         params.append(status_filter)
 
     query += " ORDER BY id DESC LIMIT ?"
-    params.append(min(limit, 500))
+    params.append(max(1, min(limit, 500)))
 
     rows = cursor.execute(query, params).fetchall()
 
@@ -533,7 +533,7 @@ def get_pending_unlocks(
         params.append(before_timestamp)
 
     query += " ORDER BY unlock_at ASC LIMIT ?"
-    params.append(min(limit, 500))
+    params.append(max(1, min(limit, 500)))
 
     rows = cursor.execute(query, params).fetchall()
 

--- a/tests/test_bridge_lock_ledger.py
+++ b/tests/test_bridge_lock_ledger.py
@@ -782,6 +782,41 @@ class TestLockLedger:
         
         conn.close()
 
+    def test_negative_limit_clamped_to_min(self, setup_test_db, funded_miner):
+        """get_locks_by_miner and get_pending_unlocks must not treat negative
+        limit as unbounded (SQLite LIMIT -1 = no limit)."""
+        lock_ledger = setup_test_db["lock_ledger"]
+        conn = sqlite3.connect(setup_test_db["db_path"])
+        now = int(time.time())
+
+        # Seed 5 locks, all locked
+        for i in range(5):
+            lock_ledger.create_lock(
+                conn,
+                miner_id=funded_miner,
+                amount_i64=10 * 1000000,
+                lock_type="bridge_deposit",
+                unlock_at=now + 3600 + i,
+            )
+
+        # Negative limit must return at most 1 row, not all 5
+        locks = lock_ledger.get_locks_by_miner(conn, funded_miner, limit=-1)
+        assert len(locks) == 1
+
+        # Also check the pending-unlocks helper with negative limit
+        # Move unlock_at into the past so they become "pending"
+        conn.execute(
+            "UPDATE lock_ledger SET unlock_at = ? WHERE miner_id = ?",
+            (now - 10, funded_miner),
+        )
+        conn.commit()
+
+        pending = lock_ledger.get_pending_unlocks(conn, limit=-1)
+        assert len(pending) == 1
+
+        conn.close()
+
+
 
 class TestLockLedgerRoutes:
     """Test lock ledger route-level validation and helper dispatch."""


### PR DESCRIPTION
## Problem

The lock ledger core helpers `get_locks_by_miner()` and `get_pending_unlocks()` clamp the `limit` parameter with `min(limit, 500)`, which only enforces the upper bound. A negative value (e.g. `-1`) passes through unchanged, and SQLite treats `LIMIT -1` as **no limit at all** — so an internal caller passing a bad batch size triggers an unbounded scan.

The HTTP routes already enforce the full 1..500 range via `parse_bounded_int_arg`, but anything calling the helpers directly skips that guard.

Refs #7364

## Fix

Changed both helpers from `min(limit, 500)` to `max(1, min(limit, 500))` so the core functions enforce the same minimum the routes do. One-line change in each function.

## Test

Added `test_negative_limit_clamped_to_min` in `TestLockLedger` that:
- seeds 5 locked rows for a miner
- calls `get_locks_by_miner(..., limit=-1)` → asserts exactly 1 row returned (not all 5)
- flips `unlock_at` to the past and calls `get_pending_unlocks(..., limit=-1)` → asserts exactly 1 row

All 63 existing tests still pass.

---

BCOS-L2 (touches lock-ledger query paths)
Wallet: `RTCrebel117bountywallet0000000000000000001`