### PR TITLE
docs: fix related documentation links

### DIFF
--- a/docs/ARCHITECTURE_OVERVIEW.md
+++ b/docs/ARCHITECTURE_OVERVIEW.md
@@ -395,15 +395,15 @@ Vintage mining is the core innovation of RustChain. By rewarding old hardware mo
 
 ## Related Documentation
 
-- [Protocol Specification](docs/PROTOCOL.md) — Detailed RIP-200 protocol spec
-- [Quick Start](docs/QUICKSTART.md) — Get mining in 5 minutes
-- [API Reference](docs/API_REFERENCE.md) — Complete REST API docs
-- [Miner Setup Guide](docs/INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
-- [Console Mining Setup](docs/CONSOLE_MINING_SETUP.md) — Mining via console
-- [Hardware Fingerprinting](docs/hardware-fingerprinting.md) — Deep dive into fingerprint checks
-- [Bridge API](docs/bridge-api.md) — Cross-chain bridge endpoints
-- [Wallet Setup](docs/WALLET_SETUP.md) — Configure your wallet
-- [Contributing](docs/CONTRIBUTING.md) — How to contribute to RustChain
+- [Protocol Specification](PROTOCOL.md) — Detailed RIP-200 protocol spec
+- [Quick Start](QUICKSTART.md) — Get mining in 5 minutes
+- [API Reference](API_REFERENCE.md) — Complete REST API docs
+- [Miner Setup Guide](INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
+- [Console Mining Setup](CONSOLE_MINING_SETUP.md) — Mining via console
+- [Hardware Fingerprinting](hardware-fingerprinting.md) — Deep dive into fingerprint checks
+- [Bridge API](bridge-api.md) — Cross-chain bridge endpoints
+- [Wallet Setup](WALLET_SETUP.md) — Configure your wallet
+- [Contributing](../CONTRIBUTING.md) — How to contribute to RustChain
 
 ---
 

--- a/docs/NODE_OPERATOR_GUIDE.md
+++ b/docs/NODE_OPERATOR_GUIDE.md
@@ -665,16 +665,16 @@ Before expecting rewards, verify:
 
 ## Related Documentation
 
-- [Quick Start](docs/QUICKSTART.md) — Get mining in 5 minutes
-- [Installation Walkthrough](docs/INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
-- [Console Mining Setup](docs/CONSOLE_MINING_SETUP.md) — Mining via console
-- [Mastering the Miner](docs/MASTERING_THE_MINER.md) — Advanced mining techniques
-- [DevNet](docs/DEVNET.md) — Development network setup
-- [Architecture Overview](docs/ARCHITECTURE_OVERVIEW.md) — System architecture
-- [API Reference](docs/API_REFERENCE.md) — Complete REST API docs
-- [CLI Reference](docs/CLI.md) — Command-line interface
-- [Build Guide](docs/BUILD.md) — Build from source
-- [Payout Preflight](docs/PAYOUT_PREFLIGHT.md) — Before expecting rewards
+- [Quick Start](QUICKSTART.md) — Get mining in 5 minutes
+- [Installation Walkthrough](INSTALLATION_WALKTHROUGH.md) — Detailed installation guide
+- [Console Mining Setup](CONSOLE_MINING_SETUP.md) — Mining via console
+- [Mastering the Miner](MASTERING_THE_MINER.md) — Advanced mining techniques
+- [DevNet](DEVNET.md) — Development network setup
+- [Architecture Overview](ARCHITECTURE_OVERVIEW.md) — System architecture
+- [API Reference](API_REFERENCE.md) — Complete REST API docs
+- [CLI Reference](CLI.md) — Command-line interface
+- [Build Guide](BUILD.md) — Build from source
+- [Payout Preflight](PAYOUT_PREFLIGHT.md) — Before expecting rewards
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes broken relative links in the related-documentation sections of two docs files:

- `docs/ARCHITECTURE_OVERVIEW.md`
- `docs/NODE_OPERATOR_GUIDE.md`

Both files live inside `docs/`, but their related-doc links used `docs/...`, which resolves as `docs/docs/...` on GitHub and fails. This PR switches those links to same-directory relative paths and points the root contribution guide to `../CONTRIBUTING.md`.

## Validation

- `git diff --check`
- Focused Markdown relative-link check over the two touched files: `TOUCHED_FILE_MISSING_LINKS 0`

## Bounty / wallet

Potentially relevant to `rustchain-bounties#100` as a small documentation improvement PR.

GitHub username: foreverzyf
RTC wallet address: RTCc1a1c639df2f704fb9068e9e4f820cf9184f3675

I did not submit any private key, token, seed, mnemonic, or wallet secret.