### PR TITLE
docs: fix zh-CN quickstart relative links

### DIFF
--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -404,7 +404,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 - **GitHub Issues：** https://github.com/Scottcjn/Rustchain/issues
 - **Discord：** https://discord.gg/VqVVS2CW9Q
 - **Moltbook：** https://www.moltbook.com/m/rustchain
-- **FAQ：** [FAQ_TROUBLESHOOTING.md](FAQ_TROUBLESHOOTING.md)
+- **FAQ：** [FAQ_TROUBLESHOOTING.md](../FAQ_TROUBLESHOOTING.md)
 
 ---
 
@@ -426,11 +426,11 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 ## 后续步骤
 
-- **将 RTC 兑换为 Solana 代币：** [wRTC 指南](wrtc.md)
-- **运行完整节点：** [协议文档](PROTOCOL.md)
-- **深入了解 Proof-of-Antiquity：** [白皮书](WHITEPAPER.md)
+- **将 RTC 兑换为 Solana 代币：** [wRTC 指南](../wrtc.md)
+- **运行完整节点：** [协议文档](../PROTOCOL.md)
+- **深入了解 Proof-of-Antiquity：** [白皮书](../WHITEPAPER.md)
 - **贡献代码：** [贡献指南](../CONTRIBUTING.md)
-- **API 参考：** [API 教程](API_WALKTHROUGH.md)
+- **API 参考：** [API 教程](../API_WALKTHROUGH.md)
 
 ---
 


### PR DESCRIPTION
## Summary

Fix broken relative links in the Chinese quickstart guide.

`docs/zh-CN/QUICKSTART.md` lives one level below `docs/`, but several links pointed to same-directory files such as `FAQ_TROUBLESHOOTING.md`, `wrtc.md`, `PROTOCOL.md`, `WHITEPAPER.md`, and `API_WALKTHROUGH.md`. On GitHub those resolve under `docs/zh-CN/` and 404.

This PR points them at the existing files in the parent `docs/` directory.

## Validation

- `git diff --check`
- Focused Markdown relative-link check over `docs/zh-CN/QUICKSTART.md`: `TOUCHED_FILE_MISSING_LINKS 0`

## Bounty / wallet

Potentially relevant to `rustchain-bounties#100` as a small documentation improvement PR.

GitHub username: foreveropen66
RTC wallet address: RTCc1a1c639df2f704fb9068e9e4f820cf9184f3675

I did not submit any private key, token, seed, mnemonic, or wallet secret.