### PR TITLE
Fix Solana SPL placeholder configuration

### DIFF
--- a/integrations/solana-spl/config/default-config.json
+++ b/integrations/solana-spl/config/default-config.json
@@ -9,19 +9,13 @@
     "bridge_name": "BoTTube"
   },
   "multisig": {
-    "signers": [
-      "TODO_Signer1_Pubkey",
-      "TODO_Signer2_Pubkey",
-      "TODO_Signer3_Pubkey",
-      "TODO_Signer4_Pubkey",
-      "TODO_Signer5_Pubkey"
-    ],
+    "signers": [],
     "threshold": 3,
-    "description": "RustChain wRTC Multi-Sig Governance"
+    "description": "RustChain wRTC Multi-Sig Governance. Populate with signer pubkeys before deployment."
   },
   "escrow": {
     "escrow_authority": "BridgeProgramPDA",
-    "mint_address": "TO_BE_DEPLOYED",
+    "mint_address": null,
     "daily_mint_cap": 100000000000000,
     "per_tx_limit": 10000000000000,
     "total_supply_cap": null

--- a/integrations/solana-spl/config/testnet-config.json
+++ b/integrations/solana-spl/config/testnet-config.json
@@ -21,7 +21,7 @@
   },
   "escrow": {
     "escrow_authority": "BridgeProgramPDA",
-    "mint_address": "TO_BE_DEPLOYED",
+    "mint_address": null,
     "daily_mint_cap": 100000000000000,
     "per_tx_limit": 10000000000000,
     "total_supply_cap": null

--- a/integrations/solana-spl/sdk.py
+++ b/integrations/solana-spl/sdk.py
@@ -19,6 +19,7 @@ Usage:
 """
 
 import json
+import os
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass
 from pathlib import Path
@@ -40,13 +41,33 @@ except ImportError:
 # ============================================================================
 
 WRTC_MINT_MAINNET = "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
-WRTC_MINT_DEVNET = "TODO_DEPLOY_ON_DEVNET"
+WRTC_MINT_ENV_VARS = {
+    "devnet": "WRTC_MINT_DEVNET",
+    "testnet": "WRTC_MINT_TESTNET",
+    "localnet": "WRTC_MINT_LOCALNET",
+}
 
 RPC_ENDPOINTS = {
     "mainnet": "https://api.mainnet-beta.solana.com",
     "devnet": "https://api.devnet.solana.com",
     "testnet": "https://api.testnet.solana.com",
+    "localnet": "http://localhost:8899",
 }
+
+
+def resolve_mint_address(network: str) -> str:
+    """Resolve the configured wRTC mint address for a network."""
+    if network == "mainnet" or network not in WRTC_MINT_ENV_VARS:
+        return WRTC_MINT_MAINNET
+
+    env_var = WRTC_MINT_ENV_VARS.get(network)
+    mint_address = os.environ.get(env_var, "").strip() if env_var else ""
+    if not mint_address:
+        raise ValueError(
+            f"wRTC mint address for {network} is not configured. "
+            f"Deploy the SPL mint first or set {env_var}."
+        )
+    return mint_address
 
 # ============================================================================
 # Data Classes
@@ -114,7 +135,7 @@ class WRtcToken:
         """
         self.network = network
         self.rpc_url = RPC_ENDPOINTS.get(network, RPC_ENDPOINTS["mainnet"])
-        self.mint_address = WRTC_MINT_MAINNET if network == "mainnet" else WRTC_MINT_DEVNET
+        self.mint_address = resolve_mint_address(network)
         
         # Static token info
         self.info = TokenInfo(

--- a/integrations/solana-spl/spl_deployment.py
+++ b/integrations/solana-spl/spl_deployment.py
@@ -368,6 +368,7 @@ class BridgeIntegration:
         self.spl = spl_deployment
         self.lock_events: List[Dict] = []
         self.mint_events: List[Dict] = []
+        self.escrow_account: Optional[str] = None
     
     def verify_rtc_lock(self, rustchain_tx_hash: str, amount: int) -> bool:
         """
@@ -435,8 +436,13 @@ class BridgeIntegration:
     
     def generate_bridge_report(self) -> Dict[str, Any]:
         """Generate bridge status report."""
+        escrow_balance = 0
+        if self.spl.token_client and self.escrow_account:
+            escrow_balance = self.get_escrow_balance(self.escrow_account)
+
         return {
-            "escrow_balance": self.get_escrow_balance("TODO") if self.spl.token_client else 0,
+            "escrow_account": self.escrow_account,
+            "escrow_balance": escrow_balance,
             "pending_locks": len(self.lock_events),
             "completed_mints": len(self.mint_events),
             "status": "operational"

--- a/integrations/solana-spl/tests/test_sdk.py
+++ b/integrations/solana-spl/tests/test_sdk.py
@@ -20,6 +20,7 @@ from sdk import (
     BridgeQuote,
     get_token_info,
     get_bridge_quote,
+    resolve_mint_address,
 )
 
 
@@ -34,12 +35,21 @@ class TestWRtcToken:
         assert "mainnet" in token.rpc_url
         assert token.mint_address == "12TAdKXxcGf6oCv4rqDz2NkgxjyHq6HQKoxKZYGf5i4X"
     
-    def test_initialization_devnet(self):
+    def test_initialization_devnet(self, monkeypatch):
         """Test token initialization for devnet."""
+        monkeypatch.setenv("WRTC_MINT_DEVNET", "DevnetMintAddress1234567890123456789012345")
         token = WRtcToken(network="devnet")
         
         assert token.network == "devnet"
         assert "devnet" in token.rpc_url
+        assert token.mint_address == "DevnetMintAddress1234567890123456789012345"
+
+    def test_devnet_requires_configured_mint(self, monkeypatch):
+        """Test devnet does not silently use placeholder mint addresses."""
+        monkeypatch.delenv("WRTC_MINT_DEVNET", raising=False)
+
+        with pytest.raises(ValueError, match="WRTC_MINT_DEVNET"):
+            resolve_mint_address("devnet")
     
     def test_get_token_info(self):
         """Test getting token info."""

--- a/integrations/solana-spl/tests/test_spl_deployment.py
+++ b/integrations/solana-spl/tests/test_spl_deployment.py
@@ -355,7 +355,7 @@ class TestIntegrationScenarios:
         
         escrow_config = BridgeEscrowConfig(
             escrow_authority="BridgePDA",
-            mint_address="TODO",
+            mint_address="MintAddress123456789012345678901234567890",
             daily_mint_cap=100_000_000_000_000,
             per_tx_limit=10_000_000_000_000
         )


### PR DESCRIPTION
## Summary
- removes executable TODO placeholder mint/signers from the Solana SPL integration config and SDK
- requires explicit devnet/testnet/localnet mint configuration via environment variables instead of silently using TODO_DEPLOY_ON_DEVNET
- prevents bridge reports from querying a literal TODO escrow account
- adds regression tests for configured devnet mints and missing mint configuration

## Validation
- python3 -m py_compile integrations/solana-spl/deploy.py integrations/solana-spl/sdk.py integrations/solana-spl/spl_deployment.py integrations/solana-spl/verify.py
- /tmp/rustchain-solana-venv/bin/python -m pytest integrations/solana-spl/tests/test_sdk.py integrations/solana-spl/tests/test_spl_deployment.py -q: 52 passed
- rg TODO_Signer|TODO_DEPLOY_ON_DEVNET|\bTODO\b|TO_BE_DEPLOYED integrations/solana-spl: no matches

Related bounty: Scottcjn/rustchain-bounties#13782