### PR TITLE
fix: tolerate malformed Prometheus exporter env

### DIFF
--- a/tests/test_prometheus_rustchain_exporter.py
+++ b/tests/test_prometheus_rustchain_exporter.py
@@ -2,6 +2,7 @@
 """Unit tests for the simple RustChain Prometheus exporter."""
 
 import importlib.util
+import os
 import sys
 import types
 from pathlib import Path
@@ -53,6 +54,38 @@ def test_numeric_coercion_helpers_use_defaults_for_bad_values():
     assert module._to_int("9") == 9
     assert module._to_int(None, default=4) == 4
     assert module._to_int("bad", default=2) == 2
+
+
+def test_malformed_numeric_env_falls_back_to_defaults_on_import():
+    with patch.dict(
+        os.environ,
+        {
+            "EXPORTER_PORT": "not-a-port",
+            "SCRAPE_INTERVAL": "",
+            "REQUEST_TIMEOUT": "NaN",
+        },
+    ):
+        module = load_module()
+
+    assert module.EXPORTER_PORT == 9100
+    assert module.SCRAPE_INTERVAL == 60
+    assert module.REQUEST_TIMEOUT == 15
+
+
+def test_valid_numeric_env_still_overrides_defaults_on_import():
+    with patch.dict(
+        os.environ,
+        {
+            "EXPORTER_PORT": "9200",
+            "SCRAPE_INTERVAL": "30",
+            "REQUEST_TIMEOUT": "5",
+        },
+    ):
+        module = load_module()
+
+    assert module.EXPORTER_PORT == 9200
+    assert module.SCRAPE_INTERVAL == 30
+    assert module.REQUEST_TIMEOUT == 5
 
 
 def test_fetch_json_returns_payload_and_handles_errors():

--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -12,11 +12,22 @@ from urllib.parse import urlsplit, urlunsplit
 import requests
 from prometheus_client import Gauge, start_http_server
 
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
 NODE_URL = os.getenv("NODE_URL", "https://rustchain.org").rstrip("/")
 P2P_NODE_URL = os.getenv("P2P_NODE_URL", "").rstrip("/")
-EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9100"))
-SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
-REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
+EXPORTER_PORT = _env_int("EXPORTER_PORT", 9100)
+SCRAPE_INTERVAL = _env_int("SCRAPE_INTERVAL", 60)
+REQUEST_TIMEOUT = _env_int("REQUEST_TIMEOUT", 15)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),


### PR DESCRIPTION
## Summary
- Add safe integer parsing for the Prometheus exporter numeric environment variables.
- Fall back to the existing defaults when `EXPORTER_PORT`, `SCRAPE_INTERVAL`, or `REQUEST_TIMEOUT` are missing, empty, or malformed.
- Preserve valid numeric override behavior and add focused import-time regression coverage.

Fixes #7321.

## Testing
- `python -c "import runpy; ns=runpy.run_path('tests/test_prometheus_rustchain_exporter.py'); ns['test_malformed_numeric_env_falls_back_to_defaults_on_import'](); ns['test_valid_numeric_env_still_overrides_defaults_on_import'](); print('PROMETHEUS_ENV_TESTS=passed')"`
- `python -m py_compile tools\prometheus\rustchain_exporter.py tests\test_prometheus_rustchain_exporter.py`
- `git diff --check`
- Attempted: `python -m pytest tests/test_prometheus_rustchain_exporter.py -q` (pytest is not installed in this local Python environment)

## Bounty Claim
- Related bounty context: Scottcjn/rustchain-bounties#100 / issue #7321
- Wallet ID: RTCc1a1c639df2f704fb9068e9e4f820cf9184f3675

I did not submit any private key, token, seed, mnemonic, or wallet secret.