### PR TITLE
fix: tolerate malformed miner alerts env

### DIFF
--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -53,6 +53,28 @@ def test_numeric_env_defaults_survive_malformed_values(monkeypatch):
     assert module.SMTP_PORT == 587
 
 
+@pytest.mark.parametrize("threshold", ["NaN", "inf", "-inf", "1e309"])
+def test_large_transfer_threshold_rejects_non_finite_values(monkeypatch, threshold):
+    fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setenv("LARGE_TRANSFER_THRESHOLD", threshold)
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        f"miner_alerts_threshold_{threshold}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert module.LARGE_TRANSFER_THRESHOLD == 10.0
+
+
 def test_numeric_env_valid_values_still_override_defaults(monkeypatch):
     fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)

--- a/tests/test_miner_alerts.py
+++ b/tests/test_miner_alerts.py
@@ -28,6 +28,56 @@ def miner_alerts_module(monkeypatch):
     return module
 
 
+def test_numeric_env_defaults_survive_malformed_values(monkeypatch):
+    fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setenv("POLL_INTERVAL", "not-an-int")
+    monkeypatch.setenv("OFFLINE_THRESHOLD", "")
+    monkeypatch.setenv("LARGE_TRANSFER_THRESHOLD", "not-a-float")
+    monkeypatch.setenv("SMTP_PORT", "bad-port")
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location("miner_alerts_env_defaults", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert module.POLL_INTERVAL == 120
+    assert module.OFFLINE_THRESHOLD == 600
+    assert module.LARGE_TRANSFER_THRESHOLD == 10.0
+    assert module.SMTP_PORT == 587
+
+
+def test_numeric_env_valid_values_still_override_defaults(monkeypatch):
+    fake_dotenv = types.SimpleNamespace(load_dotenv=lambda: None)
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setenv("POLL_INTERVAL", "30")
+    monkeypatch.setenv("OFFLINE_THRESHOLD", "90")
+    monkeypatch.setenv("LARGE_TRANSFER_THRESHOLD", "2.5")
+    monkeypatch.setenv("SMTP_PORT", "2525")
+
+    module_path = (
+        Path(__file__).resolve().parents[1]
+        / "tools"
+        / "miner_alerts"
+        / "miner_alerts.py"
+    )
+    spec = importlib.util.spec_from_file_location("miner_alerts_env_valid", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    assert module.POLL_INTERVAL == 30
+    assert module.OFFLINE_THRESHOLD == 90
+    assert module.LARGE_TRANSFER_THRESHOLD == 2.5
+    assert module.SMTP_PORT == 2525
+
+
 def test_alert_db_subscription_lifecycle_and_filters(
     miner_alerts_module,
     tmp_path,

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -19,6 +19,7 @@ Architecture:
 
 import argparse
 import logging
+import math
 import os
 import smtplib
 import sqlite3
@@ -51,9 +52,10 @@ def _env_float(name: str, default: float) -> float:
     if value is None or value.strip() == "":
         return default
     try:
-        return float(value)
+        parsed = float(value)
     except ValueError:
         return default
+    return parsed if math.isfinite(parsed) else default
 
 
 # ─── Configuration ────────────────────────────────────────────────────────────

--- a/tools/miner_alerts/miner_alerts.py
+++ b/tools/miner_alerts/miner_alerts.py
@@ -35,21 +35,42 @@ from dotenv import load_dotenv
 # Load .env
 load_dotenv()
 
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
 # ─── Configuration ────────────────────────────────────────────────────────────
 
 RUSTCHAIN_API = os.getenv("RUSTCHAIN_API", "https://rustchain.org")
 VERIFY_SSL = os.getenv("RUSTCHAIN_VERIFY_SSL", "false").lower() == "true"
 
 # Polling intervals (seconds)
-POLL_INTERVAL = int(os.getenv("POLL_INTERVAL", "120"))  # 2 minutes default
-OFFLINE_THRESHOLD = int(os.getenv("OFFLINE_THRESHOLD", "600"))  # 10 min no attestation
+POLL_INTERVAL = _env_int("POLL_INTERVAL", 120)  # 2 minutes default
+OFFLINE_THRESHOLD = _env_int("OFFLINE_THRESHOLD", 600)  # 10 min no attestation
 
 # Large transfer threshold (RTC)
-LARGE_TRANSFER_THRESHOLD = float(os.getenv("LARGE_TRANSFER_THRESHOLD", "10.0"))
+LARGE_TRANSFER_THRESHOLD = _env_float("LARGE_TRANSFER_THRESHOLD", 10.0)
 
 # SMTP configuration
 SMTP_HOST = os.getenv("SMTP_HOST", "smtp.gmail.com")
-SMTP_PORT = int(os.getenv("SMTP_PORT", "587"))
+SMTP_PORT = _env_int("SMTP_PORT", 587)
 SMTP_USER = os.getenv("SMTP_USER", "")
 SMTP_PASS = os.getenv("SMTP_PASS", "")
 SMTP_FROM = os.getenv("SMTP_FROM", "")


### PR DESCRIPTION
## Summary
- Add safe numeric env parsing for miner alert configuration.
- Fall back to existing defaults when `POLL_INTERVAL`, `OFFLINE_THRESHOLD`, `LARGE_TRANSFER_THRESHOLD`, or `SMTP_PORT` are missing, empty, or malformed.
- Preserve valid numeric override behavior with focused import-time tests.

Fixes #7323.

## Testing
- `MINER_ALERTS_ENV_TESTS=passed` via direct import-time validation script
- `python -m py_compile tools\miner_alerts\miner_alerts.py tests\test_miner_alerts.py`
- `git diff --check`
- Attempted: `python -m pytest tests/test_miner_alerts.py -q` (pytest is not installed in this local Python environment)

## Bounty Claim
- Related bounty context: Scottcjn/rustchain-bounties#100 / issue #7323
- Wallet ID: RTCc1a1c639df2f704fb9068e9e4f820cf9184f3675

I did not submit any private key, token, seed, mnemonic, or wallet secret.