### PR TITLE
Harden docs miner setup wizard result rendering

### DIFF
--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -112,6 +112,25 @@ function commandBlock(cmd){
   return `<pre>${h(cmd)}</pre><div class="copy" data-copy="${h(cmd)}" onclick="copyText(this.dataset.copy)">Copy command</div>`;
 }
 
+function makeEl(tag, className, text){
+  const el = document.createElement(tag);
+  if (className) el.className = className;
+  if (text !== undefined) el.textContent = String(text);
+  return el;
+}
+
+function renderStatusResult(target, statusClass, label, bodyText, helpText){
+  const children = [makeEl('span', `pill ${statusClass}`, label)];
+  if (bodyText !== undefined && bodyText !== '') {
+    children.push(makeEl('pre', '', bodyText));
+  }
+  if (helpText) {
+    children.push(makeEl('p', 'muted', helpText));
+  }
+  target.classList.remove('muted');
+  target.replaceChildren(...children);
+}
+
 function walletAddressFromPub(hex){
   // Browser SHA-256 over public key bytes -> RTC + first 40 hex
   return crypto.subtle.digest('SHA-256', Uint8Array.from(hex.match(/.{2}/g).map(b=>parseInt(b,16))).buffer)
@@ -217,9 +236,18 @@ function renderPanel(){
         const url = document.getElementById('testNodeUrl').value.trim();
         state.nodeUrl = url;
         const r = await testNode(url);
-        document.getElementById('testOut').innerHTML = r.ok
-          ? `<span class='pill ok'>Reachable</span> <pre>${h(r.text)}</pre>`
-          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sk ${h(url.replace(/\/$/,''))}/health</p>`;
+        const out = document.getElementById('testOut');
+        if (r.ok) {
+          renderStatusResult(out, 'ok', 'Reachable', r.text);
+        } else {
+          renderStatusResult(
+            out,
+            'bad',
+            'Failed',
+            r.text,
+            `If this is a CORS error, test with terminal: curl -sk ${url.replace(/\/$/,'')}/health`
+          );
+        }
       }
     },0);
     return;
@@ -243,11 +271,14 @@ function renderPanel(){
           const data = await r.json();
           const arr = Array.isArray(data)?data:(data.miners||[]);
           const hit = arr.find(x=>JSON.stringify(x).toLowerCase().includes(q));
-          document.getElementById('minerOut').innerHTML = hit
-            ? `<span class='pill ok'>Found</span><pre>${h(JSON.stringify(hit,null,2))}</pre>`
-            : `<span class='pill warn'>Not found yet</span> <span class='muted'>Miner may still be attesting/enrolling.</span>`;
+          const out = document.getElementById('minerOut');
+          if (hit) {
+            renderStatusResult(out, 'ok', 'Found', JSON.stringify(hit, null, 2));
+          } else {
+            renderStatusResult(out, 'warn', 'Not found yet', '', 'Miner may still be attesting/enrolling.');
+          }
         }catch(e){
-          document.getElementById('minerOut').innerHTML = `<span class='pill bad'>Check failed</span><pre>${h(String(e))}</pre>`;
+          renderStatusResult(document.getElementById('minerOut'), 'bad', 'Check failed', String(e));
         }
       }
     },0);

--- a/scripts/baselines/fetchall_existing.txt
+++ b/scripts/baselines/fetchall_existing.txt
@@ -121,7 +121,7 @@ node/rustchain_tx_handler.py:368:            return {row["nonce"] for row in cur
 node/rustchain_tx_handler.py:451:            pending_nonces = {row["nonce"] for row in cursor.fetchall()}
 node/rustchain_tx_handler.py:545:                for row in cursor.fetchall()
 node/rustchain_tx_handler.py:910:                transactions = [dict(row) for row in cursor.fetchall()]
-node/rustchain_v2_integrated_v2.2.1_rip200.py:10283:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:10286:    return {row[1] for row in c.execute("PRAGMA table_info(balances)").fetchall()}
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1347:    columns = conn.execute("PRAGMA table_info(epoch_enroll)").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1354:    rows = conn.execute("SELECT epoch, miner_pk, weight FROM epoch_enroll").fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:1509:            """, (limit, offset)).fetchall()
@@ -132,27 +132,27 @@ node/rustchain_v2_integrated_v2.2.1_rip200.py:3202:    ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:3217:    ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:3857:        ).fetchall()
 node/rustchain_v2_integrated_v2.2.1_rip200.py:5095:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:5700:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6468:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:6477:        ).fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7198:                            WHERE active=1 ORDER BY signer_id""").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7228:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7424:            for row in c.fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7614:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7712:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:7731:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8122:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8155:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8186:    ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8465:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
-node/rustchain_v2_integrated_v2.2.1_rip200.py:8921:        ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9066:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9113:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9138:            ).fetchall()
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9720:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9725:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9732:        """).fetchall())
-node/rustchain_v2_integrated_v2.2.1_rip200.py:9893:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:5703:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6471:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:6480:        ).fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7201:                            WHERE active=1 ORDER BY signer_id""").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7231:        cols = {r[1] for r in cur.execute("PRAGMA table_info(balances)").fetchall()}
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7427:            for row in c.fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7617:        rows = conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7715:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:7734:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8125:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8158:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8189:    ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8468:            for r in c.execute("PRAGMA table_info(balances)").fetchall():
+node/rustchain_v2_integrated_v2.2.1_rip200.py:8924:        ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9069:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9116:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9141:            ).fetchall()
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9723:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9728:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9735:        """).fetchall())
+node/rustchain_v2_integrated_v2.2.1_rip200.py:9896:        ).fetchall()
 node/rustchain_x402.py:45:    existing = {row[1] for row in cursor.fetchall()}
 node/rustchain_x402.py:81:    columns = {row[1] for row in conn.execute("PRAGMA table_info(balances)").fetchall()}
 node/slashing_penalties.py:433:    return tuple(row[1] for row in conn.execute(f'PRAGMA table_info("{table_name}")').fetchall())

--- a/tests/test_miner_setup_docs_wizard_security.py
+++ b/tests/test_miner_setup_docs_wizard_security.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -9,16 +10,20 @@ WIZARD_HTML = (
 )
 
 
-def test_remote_node_responses_are_escaped_before_inner_html_rendering():
+def test_remote_node_results_use_text_dom_rendering():
     html = WIZARD_HTML.read_text(encoding="utf-8")
 
-    assert "<pre>${r.text}</pre>" not in html
-    assert "<pre>${JSON.stringify(hit,null,2)}</pre>" not in html
-    assert "<pre>${String(e)}</pre>" not in html
+    assert "document.getElementById('testOut').innerHTML = r.ok" not in html
+    assert "document.getElementById('minerOut').innerHTML = hit" not in html
+    assert "document.getElementById('minerOut').innerHTML = `<span class='pill bad'>" not in html
+    assert not re.search(r"(?:testOut|minerOut)['\"]\)\.innerHTML\s*=", html)
 
-    assert "<pre>${h(r.text)}</pre>" in html
-    assert "<pre>${h(JSON.stringify(hit,null,2))}</pre>" in html
-    assert "<pre>${h(String(e))}</pre>" in html
+    assert "function renderStatusResult(target, statusClass, label, bodyText, helpText)" in html
+    assert "target.replaceChildren(...children);" in html
+    assert "el.textContent = String(text);" in html
+    assert "renderStatusResult(out, 'ok', 'Reachable', r.text);" in html
+    assert "renderStatusResult(out, 'ok', 'Found', JSON.stringify(hit, null, 2));" in html
+    assert "renderStatusResult(document.getElementById('minerOut'), 'bad', 'Check failed', String(e));" in html
 
 
 def test_generated_command_blocks_escape_display_and_copy_attribute():


### PR DESCRIPTION
## Summary
- Replace the docs miner setup wizard `/health` and `/api/miners` result-panel `innerHTML` templates with DOM construction through `textContent` and `replaceChildren()`.
- Keep the status-pill and preformatted-output presentation while avoiding HTML parser sinks for remote node responses, miner records, and exception text.
- Update the focused docs wizard security regression test to forbid direct `testOut`/`minerOut` `innerHTML` assignment and require the text-DOM rendering helper.

Fixes #7191.

## Validation
- `uv run --no-project --with pytest --with flask python -m pytest -q tests/test_miner_setup_docs_wizard_security.py` -> 2 passed
- `python -m py_compile tests/test_miner_setup_docs_wizard_security.py` -> passed
- embedded script parse check with `node` / `new Function(...)` -> parsed 1 script
- `git diff --check -- docs/miner-setup-wizard/index.html tests/test_miner_setup_docs_wizard_security.py` -> passed
