### PR TITLE
fix(api): reject invalid /api/miners pagination limits

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -7535,8 +7535,12 @@ def api_miners():
         offset = int(raw_offset) if raw_offset not in (None, "") else 0
     except (ValueError, TypeError):
         return jsonify({"ok": False, "error": "offset must be an integer"}), 400
-    limit = min(max(limit, 1), 1000)
-    offset = max(offset, 0)
+    if limit < 1:
+        return jsonify({"ok": False, "error": "limit must be >= 1"}), 400
+    if limit > 1000:
+        return jsonify({"ok": False, "error": "limit must be <= 1000"}), 400
+    if offset < 0:
+        return jsonify({"ok": False, "error": "offset must be >= 0"}), 400
 
     with sqlite3.connect(DB_PATH) as conn:
         conn.row_factory = sqlite3.Row

--- a/node/tests/test_api_miners_rate_limit.py
+++ b/node/tests/test_api_miners_rate_limit.py
@@ -95,6 +95,24 @@ class TestApiMinersRateLimit(unittest.TestCase):
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "limit must be an integer"})
 
+    def test_api_miners_rejects_out_of_range_limits(self):
+        cases = [
+            ("-1", "limit must be >= 1"),
+            ("0", "limit must be >= 1"),
+            ("1001", "limit must be <= 1000"),
+            ("999999999999999", "limit must be <= 1000"),
+        ]
+
+        for index, (value, error) in enumerate(cases):
+            with self.subTest(limit=value):
+                resp = self.client.get(
+                    f"/api/miners?limit={value}",
+                    environ_base={"REMOTE_ADDR": f"203.0.113.{30 + index}"},
+                )
+
+                self.assertEqual(resp.status_code, 400)
+                self.assertEqual(resp.get_json(), {"ok": False, "error": error})
+
     def test_api_miners_rejects_malformed_offset(self):
         resp = self.client.get(
             "/api/miners?offset=abc",
@@ -103,6 +121,15 @@ class TestApiMinersRateLimit(unittest.TestCase):
 
         self.assertEqual(resp.status_code, 400)
         self.assertEqual(resp.get_json(), {"ok": False, "error": "offset must be an integer"})
+
+    def test_api_miners_rejects_negative_offset(self):
+        resp = self.client.get(
+            "/api/miners?offset=-1",
+            environ_base={"REMOTE_ADDR": "203.0.113.34"},
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.get_json(), {"ok": False, "error": "offset must be >= 0"})
 
     def test_api_miners_defaults_empty_pagination_values(self):
         resp = self.client.get(


### PR DESCRIPTION
## Summary
- reject /api/miners limit values below 1 instead of silently clamping to 1
- reject limit values above 1000 instead of silently clamping to the max page size
- reject negative offsets instead of silently coercing them to 0
- add focused tests for malformed and out-of-range pagination parameters

Fixes #7445

## Validation
- .venv-codex312/bin/python -m pytest node/tests/test_api_miners_rate_limit.py -q
- .venv-codex312/bin/python -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py
- git diff --check