### PR TITLE
fix(explorer): render miner fallback errors with textContent

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -474,6 +474,16 @@ function renderEpochStats() {
     `;
 }
 
+function renderMinersTableError(container, message) {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    cell.colSpan = 7;
+    cell.className = 'error-message';
+    cell.textContent = `UI Render Error: ${message || 'Unknown error'}`;
+    row.appendChild(cell);
+    container.replaceChildren(row);
+}
+
 function renderMinersTable() {
     const container = document.getElementById('miners-tbody');
     if (!container) return;
@@ -528,7 +538,7 @@ function renderMinersTable() {
         }).join('');
     } catch (e) {
         console.error('Render error:', e);
-        container.innerHTML = `<tr><td colspan="7" class="error-message">UI Render Error: ${escapeHtml(e.message)}</td></tr>`;
+        renderMinersTableError(container, e && e.message);
     }
 }
 

--- a/tests/test_explorer_block_filters.py
+++ b/tests/test_explorer_block_filters.py
@@ -34,6 +34,15 @@ def test_block_filter_controls_are_available_in_blocks_view():
         assert heading in html
 
 
+def test_miners_table_render_error_uses_text_content():
+    js = EXPLORER_JS.read_text(encoding="utf-8")
+
+    assert "UI Render Error: ${escapeHtml(e.message)}" not in js
+    assert "function renderMinersTableError(container, message)" in js
+    assert "cell.textContent = `UI Render Error: ${message || 'Unknown error'}`;" in js
+    assert "container.replaceChildren(row);" in js
+
+
 def test_block_filter_logic_handles_requested_filter_fields():
     js = EXPLORER_JS.read_text(encoding="utf-8")
     probe = f"""


### PR DESCRIPTION
## Summary
- replace the miners-table render exception fallback innerHTML template with DOM node construction
- write the exception message via textContent and swap the row with replaceChildren
- add regression coverage that forbids the previous parser-sink template

Fixes #7163

## Validation
- .venv-codex312/bin/python -m pytest -q tests/test_explorer_block_filters.py
- node --check explorer/static/js/explorer.js
- .venv-codex312/bin/python -m py_compile tests/test_explorer_block_filters.py
- git diff --check