### PR TITLE
fix(explorer): restrict proxy to allowed read endpoints

### DIFF
--- a/explorer/explorer_server.py
+++ b/explorer/explorer_server.py
@@ -10,7 +10,7 @@ import json
 import time
 import requests
 from http.server import HTTPServer, SimpleHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import quote, unquote, urlparse
 from datetime import datetime
 
 # Configuration
@@ -18,6 +18,39 @@ EXPLORER_PORT = int(os.environ.get('EXPLORER_PORT', 8080))
 API_BASE = os.environ.get('RUSTCHAIN_API_BASE', 'https://rustchain.org').rstrip('/')
 API_TIMEOUT = float(os.environ.get('API_TIMEOUT', '8'))
 STATIC_DIR = os.path.join(os.path.dirname(__file__), 'static')
+PROXY_ALLOWED_ENDPOINTS = {
+    'health',
+    'epoch',
+    'api/miners',
+    'blocks',
+    'api/transactions',
+    'hall/leaderboard',
+}
+
+
+def validate_proxy_endpoint(endpoint):
+    """Return a safe upstream path for explorer proxy requests, or None."""
+    decoded = unquote(endpoint or '')
+    segments = decoded.split('/')
+    if (
+        not decoded
+        or decoded != endpoint
+        or decoded.startswith('/')
+        or any(segment in ('', '.', '..') for segment in segments)
+        or decoded not in PROXY_ALLOWED_ENDPOINTS
+    ):
+        return None
+    return '/'.join(quote(segment, safe='') for segment in segments)
+
+
+def build_proxy_url(endpoint, query=''):
+    safe_endpoint = validate_proxy_endpoint(endpoint)
+    if safe_endpoint is None:
+        return None
+    url = f"{API_BASE}/{safe_endpoint}"
+    if query:
+        url += f"?{query}"
+    return url
 
 class ExplorerHandler(SimpleHTTPRequestHandler):
     """Custom HTTP handler with API proxy and caching"""
@@ -65,6 +98,11 @@ class ExplorerHandler(SimpleHTTPRequestHandler):
     
     def handle_proxy(self, endpoint, parsed):
         """Proxy requests to RustChain API with caching"""
+        url = build_proxy_url(endpoint, parsed.query)
+        if url is None:
+            self.send_error_json(400, 'Proxy endpoint is not allowed')
+            return
+
         cache_key = f"{endpoint}:{parsed.query}"
         
         # Check cache
@@ -75,10 +113,6 @@ class ExplorerHandler(SimpleHTTPRequestHandler):
         
         # Fetch from API
         try:
-            url = f"{API_BASE}/{endpoint}"
-            if parsed.query:
-                url += f"?{parsed.query}"
-            
             response = requests.get(url, timeout=API_TIMEOUT)
             response.raise_for_status()
             data = response.json()

--- a/tests/test_explorer_proxy_allowlist.py
+++ b/tests/test_explorer_proxy_allowlist.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "explorer" / "explorer_server.py"
+
+
+def load_explorer_server():
+    spec = importlib.util.spec_from_file_location("explorer_server_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_proxy_allowlist_accepts_explorer_read_endpoints():
+    server = load_explorer_server()
+
+    for endpoint in (
+        "health",
+        "epoch",
+        "api/miners",
+        "blocks",
+        "api/transactions",
+        "hall/leaderboard",
+    ):
+        assert server.validate_proxy_endpoint(endpoint) == endpoint
+
+
+def test_proxy_allowlist_rejects_unlisted_and_confused_paths():
+    server = load_explorer_server()
+
+    for endpoint in (
+        "",
+        ".",
+        "..",
+        "/health",
+        "admin/status",
+        "internal/metrics",
+        "api/admin/status",
+        "wallet/wind108369",
+        "../health",
+        "api/../admin",
+        "api//miners",
+        "api%2Fminers",
+        "%2e%2e/admin",
+    ):
+        assert server.validate_proxy_endpoint(endpoint) is None
+
+
+def test_proxy_url_preserves_query_for_allowed_endpoint(monkeypatch):
+    server = load_explorer_server()
+    monkeypatch.setattr(server, "API_BASE", "https://node.example")
+
+    assert (
+        server.build_proxy_url("hall/leaderboard", "limit=10&offset=0")
+        == "https://node.example/hall/leaderboard?limit=10&offset=0"
+    )
+
+
+def test_proxy_url_returns_none_for_blocked_endpoint(monkeypatch):
+    server = load_explorer_server()
+    monkeypatch.setattr(server, "API_BASE", "https://node.example")
+
+    assert server.build_proxy_url("admin/status", "") is None


### PR DESCRIPTION
## Summary
- add a fail-closed allowlist for `explorer_server.py` `/api/proxy/<path>` requests
- reject empty, traversal, slash-confused, percent-encoded, and unlisted proxy paths before any upstream request
- build upstream URLs from validated path segments while preserving query strings for allowed endpoints
- add focused regression coverage for allowed and blocked proxy paths

Fixes #7222

## Validation
- `.venv-codex312/bin/python -m pytest -q tests/test_explorer_proxy_allowlist.py`
- `.venv-codex312/bin/python -m py_compile explorer/explorer_server.py tests/test_explorer_proxy_allowlist.py`
- `git diff --check`