### PR TITLE
fix(tools): render explorer error cards with textContent

### DIFF
--- a/tests/test_tools_explorer_security.py
+++ b/tests/test_tools_explorer_security.py
@@ -51,8 +51,13 @@ def test_filter_options_are_built_with_option_nodes():
     assert "`<option value=\"${c}\">${c}</option>`" not in html
 
 
-def test_error_card_escapes_exception_message():
+def test_error_card_renders_exception_message_with_text_content():
     html = source()
 
-    assert "${safeText(err.message || err)}" in html
+    assert "function renderErrorCard(message)" in html
+    assert "value.textContent = String(message || \"Unknown error\");" in html
+    assert "document.getElementById(\"topCards\").replaceChildren(card);" in html
+    assert "renderErrorCard(err.message || err);" in html
+    assert "topCards\").innerHTML = `<div class=\"card\"><div class=\"label\">Error</div>" not in html
+    assert "${safeText(err.message || err)}" not in html
     assert "${String(err.message || err)}" not in html

--- a/tools/explorer/index.html
+++ b/tools/explorer/index.html
@@ -448,6 +448,19 @@
       `).join("");
     }
 
+    function renderErrorCard(message) {
+      const card = document.createElement("div");
+      card.className = "card";
+      const label = document.createElement("div");
+      label.className = "label";
+      label.textContent = "Error";
+      const value = document.createElement("div");
+      value.className = "value";
+      value.textContent = String(message || "Unknown error");
+      card.append(label, value);
+      document.getElementById("topCards").replaceChildren(card);
+    }
+
     function renderMinerTable() {
       const rows = applyFiltersAndSort();
       const tbody = document.getElementById("minerRows");
@@ -644,7 +657,7 @@
         document.getElementById("updatedAt").textContent = `Last update: ${new Date().toLocaleTimeString()}`;
         document.getElementById("agentUpdatedAt").textContent = `Agent update: ${new Date().toLocaleTimeString()}`;
       } catch (err) {
-        document.getElementById("topCards").innerHTML = `<div class="card"><div class="label">Error</div><div class="value">${safeText(err.message || err)}</div></div>`;
+        renderErrorCard(err.message || err);
         document.getElementById("minerRows").innerHTML = "";
       }
     }


### PR DESCRIPTION
## Summary
- replace the tools explorer refresh error-card `innerHTML` template with DOM node construction
- write exception text via `textContent` and replace the top-card contents with `replaceChildren`
- update the security regression test to forbid the previous parser-sink fallback

Fixes #7170

## Validation
- `.venv-codex312/bin/python -m pytest -q tests/test_tools_explorer_security.py tests/test_tools_explorer_miners_payload.py`
- `.venv-codex312/bin/python -m py_compile tests/test_tools_explorer_security.py`
- `node -e "const fs=require('fs'); const html=fs.readFileSync('tools/explorer/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok')"`
- `git diff --check`