### PR TITLE
fix(hall-of-fame): render load errors with textContent

### DIFF
--- a/tests/test_hall_of_fame_frontend_endpoints.py
+++ b/tests/test_hall_of_fame_frontend_endpoints.py
@@ -14,6 +14,18 @@ def test_hall_of_fame_index_uses_compat_leaderboard_endpoint():
     assert "const API_STATS       = '/api/hall_of_fame/stats';" in html
 
 
+def test_hall_of_fame_index_renders_load_messages_with_text_content():
+    html = (ROOT / "web" / "hall-of-fame" / "index.html").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function setLeaderboardMessage(message, opts = {})" in html
+    assert "cell.textContent = message;" in html
+    assert "tbody.replaceChildren(row);" in html
+    assert "Failed to load: ${esc(e.message)}" not in html
+    assert 'tbody.innerHTML = `<tr class="loading-row"><td colspan="9" class="err">' not in html
+
+
 def test_hall_of_fame_machine_uses_compat_machine_endpoint_and_shape():
     html = (ROOT / "web" / "hall-of-fame" / "machine.html").read_text(
         encoding="utf-8"

--- a/web/hall-of-fame/index.html
+++ b/web/hall-of-fame/index.html
@@ -233,6 +233,25 @@ function badgeClass(isDeceased){ return isDeceased ? 'badge badge-deceased' : 'b
 
 let allRows = [];
 
+function setLeaderboardMessage(message, opts = {}){
+  const tbody = document.getElementById('leaderTbody');
+  const row = document.createElement('tr');
+  row.className = 'loading-row';
+  const cell = document.createElement('td');
+  cell.colSpan = 9;
+  if(opts.error) cell.className = 'err';
+  if(opts.blink){
+    const cursor = document.createElement('span');
+    cursor.className = 'blinking';
+    cursor.textContent = '█';
+    cell.append(cursor, document.createTextNode(' ' + message));
+  } else {
+    cell.textContent = message;
+  }
+  row.appendChild(cell);
+  tbody.replaceChildren(row);
+}
+
 function buildRow(m, i){
   const fp = m.fingerprint_hash || '';
   const name = esc(m.nickname || (fp ? fp.slice(0,16)+'…' : 'Unknown'));
@@ -275,7 +294,7 @@ async function loadLeaderboard(){
   const limit = document.getElementById('filterLimit').value;
   const deceased = document.getElementById('filterDeceased').value;
   const tbody = document.getElementById('leaderTbody');
-  tbody.innerHTML = '<tr class="loading-row"><td colspan="9"><span class="blinking">█</span> Loading…</td></tr>';
+  setLeaderboardMessage('Loading...', {blink: true});
 
   try {
     let url = API_LEADERBOARD + '?limit=' + limit;
@@ -287,14 +306,14 @@ async function loadLeaderboard(){
     const data = await res.json();
     const machines = data.leaderboard || [];
     if(!machines.length){
-      tbody.innerHTML = '<tr class="loading-row"><td colspan="9" class="err">No machines found.</td></tr>';
+      setLeaderboardMessage('No machines found.', {error: true});
       return;
     }
     allRows = machines.map((m, idx) => buildRow(m, idx+1));
     tbody.innerHTML = allRows.join('');
     filterTable();
   } catch(e){
-    tbody.innerHTML = `<tr class="loading-row"><td colspan="9" class="err">Failed to load: ${esc(e.message)}</td></tr>`;
+    setLeaderboardMessage('Failed to load: ' + (e.message || e), {error: true});
   }
 }
 


### PR DESCRIPTION
Fixes #7174

## Summary
- add a DOM-based leaderboard message helper for loading, empty, and error rows
- render load failure text with textContent instead of an innerHTML template
- add a regression assertion for the safe rendering path

## Validation
- python3.12 -m venv .venv-codex312 && . .venv-codex312/bin/activate && python -m pip install -q pytest flask requests PyYAML Flask-Cors PyNaCl mnemonic pycryptodome aiohttp && pytest -q tests/test_hall_of_fame_frontend_endpoints.py tests/test_hall_of_fame_machine_frontend_security.py
- python3 -m py_compile tests/test_hall_of_fame_frontend_endpoints.py tests/test_hall_of_fame_machine_frontend_security.py
- node -e "const fs=require('fs'); const html=fs.readFileSync('web/hall-of-fame/index.html','utf8'); const scripts=[...html.matchAll(/<script>([\\s\\S]*?)<\\/script>/g)].map(m=>m[1]); for (const script of scripts) new Function(script); console.log('scripts ok')"
- git diff --check