### PR TITLE
fix(faucet): render result messages with text nodes

### DIFF
--- a/faucet_service/faucet_service.py
+++ b/faucet_service/faucet_service.py
@@ -1576,6 +1576,25 @@ HTML_TEMPLATE = """
         const submitBtn = document.getElementById('submitBtn');
         const walletInput = document.getElementById('wallet');
 
+        function showResult(ok, title, message, nextAvailable) {
+            result.className = 'result show ' + (ok ? 'success' : 'error');
+            const titleNode = document.createElement('strong');
+            titleNode.textContent = title;
+            result.replaceChildren(titleNode);
+
+            if (message) {
+                result.appendChild(document.createElement('br'));
+                result.appendChild(document.createTextNode(message));
+            }
+
+            if (nextAvailable) {
+                const small = document.createElement('small');
+                small.textContent = 'Next available: ' + new Date(nextAvailable).toLocaleString();
+                result.appendChild(document.createElement('br'));
+                result.appendChild(small);
+            }
+        }
+
         // Load stats
         async function loadStats() {
             try {
@@ -1595,7 +1614,7 @@ HTML_TEMPLATE = """
             submitBtn.disabled = true;
             submitBtn.textContent = 'Processing...';
             result.className = 'result';
-            result.innerHTML = '';
+            result.replaceChildren();
 
             const wallet = walletInput.value.trim();
 
@@ -1608,25 +1627,16 @@ HTML_TEMPLATE = """
 
                 const data = await response.json();
 
-                result.className = 'result show ' + (data.ok ? 'success' : 'error');
-                
                 if (data.ok) {
-                    result.innerHTML = `
-                        <strong>✅ Success!</strong><br>
-                        Sent ${data.amount} RTC to ${wallet.substring(0, 10)}...${wallet.substring(wallet.length - 8)}<br>
-                        ${data.next_available ? `<small>Next available: ${new Date(data.next_available).toLocaleString()}</small>` : ''}
-                    `;
+                    const walletPreview = wallet.substring(0, 10) + '...' + wallet.substring(wallet.length - 8);
+                    showResult(true, '✅ Success!', 'Sent ' + data.amount + ' RTC to ' + walletPreview, data.next_available);
                     walletInput.value = '';
                     loadStats();
                 } else {
-                    result.innerHTML = `
-                        <strong>❌ ${data.error}</strong><br>
-                        ${data.next_available ? `<small>Next available: ${new Date(data.next_available).toLocaleString()}</small>` : ''}
-                    `;
+                    showResult(false, '❌ ' + data.error, '', data.next_available);
                 }
             } catch (err) {
-                result.className = 'result show error';
-                result.innerHTML = `<strong>❌ Error:</strong> ${err.message}`;
+                showResult(false, '❌ Error:', err.message, null);
             }
 
             submitBtn.disabled = false;

--- a/tests/test_faucet_service_frontend_security.py
+++ b/tests/test_faucet_service_frontend_security.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_faucet_service_result_rendering_uses_text_nodes():
+    source = (ROOT / "faucet_service" / "faucet_service.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert "function showResult(ok, title, message, nextAvailable)" in source
+    assert "titleNode.textContent = title;" in source
+    assert "document.createTextNode(message)" in source
+    assert "small.textContent = 'Next available: ' +" in source
+    assert "result.replaceChildren" in source
+    assert "result.innerHTML" not in source
+    assert "Sent ${data.amount} RTC to" not in source
+    assert "<strong>❌ Error:</strong> ${err.message}" not in source


### PR DESCRIPTION
Fixes #7160

## Summary
- replace faucet result innerHTML templates with a DOM/text-node rendering helper
- keep success/error classes and visible messages intact
- add a regression test forbidding result.innerHTML in the faucet service template

## Validation
- pytest -q tests/test_faucet_service_frontend_security.py tests/test_faucet_service_wallet_validation.py faucet_service/test_faucet_service.py::TestFlaskApp::test_faucet_page faucet_service/test_faucet_service.py::TestFlaskApp::test_drip_success
- python3 -m py_compile faucet_service/faucet_service.py tests/test_faucet_service_frontend_security.py
- git diff --check