### PR TITLE
fix(explorer): render wallet search errors with textContent

### DIFF
--- a/explorer/rustchain_dashboard.py
+++ b/explorer/rustchain_dashboard.py
@@ -289,6 +289,16 @@ DASHBOARD_HTML = """
                 });
         }
 
+        function showSearchError(message) {
+            const resultDiv = document.getElementById('search-result');
+            const title = document.createElement('h3');
+            title.textContent = '❌ Error';
+            const detail = document.createElement('p');
+            detail.textContent = message;
+            resultDiv.replaceChildren(title, detail);
+            resultDiv.style.display = 'block';
+        }
+
         function searchWallet() {
             const wallet = document.getElementById('wallet-search').value.trim();
             if (!wallet) return;
@@ -318,9 +328,7 @@ DASHBOARD_HTML = """
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
-                    err = escapeHtml(err.message || err);
-                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
-                    document.getElementById('search-result').style.display = 'block';
+                    showSearchError(err.message || err);
                 });
         }
 

--- a/tests/test_explorer_rustchain_dashboard_security.py
+++ b/tests/test_explorer_rustchain_dashboard_security.py
@@ -80,8 +80,12 @@ def test_explorer_dashboard_sanitizes_wallet_search_and_errors():
     assert "fetch(`/api/wallet/${wallet}`)" not in source
     assert "const tierToken = safeToken(data.tier" in source
     assert "badge-${tierToken}" in source
-    assert "err = escapeHtml(err.message || err);" in source
-    assert "document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;" in source
+    assert "function showSearchError(message)" in source
+    assert "detail.textContent = message;" in source
+    assert "resultDiv.replaceChildren(title, detail);" in source
+    assert "showSearchError(err.message || err);" in source
+    assert "err = escapeHtml(err.message || err);" not in source
+    assert "document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;" not in source
     assert "${escapeHtml(wallet)}" in source
     assert '<span class="mono">${wallet}</span>' not in source
 


### PR DESCRIPTION
Fixes #7150

## Summary
- add a DOM-based wallet search error renderer
- render catch-path error messages with textContent instead of an innerHTML template
- update the dashboard security regression test to require the safe renderer

## Validation
- pytest -q tests/test_explorer_rustchain_dashboard_security.py
- python3 -m py_compile explorer/rustchain_dashboard.py tests/test_explorer_rustchain_dashboard_security.py
- git diff --check