### PR TITLE
fix(hall-of-fame): render machine timeline with textContent

### DIFF
--- a/tests/test_hall_of_fame_machine_frontend_security.py
+++ b/tests/test_hall_of_fame_machine_frontend_security.py
@@ -1,17 +1,24 @@
 from pathlib import Path
 
 
-def test_machine_profile_escapes_timeline_fields_before_inner_html():
+def test_machine_profile_renders_timeline_fields_with_text_content():
     page = Path(__file__).resolve().parents[1] / "web" / "hall-of-fame" / "machine.html"
     html = page.read_text(encoding="utf-8")
 
-    assert "function esc(s)" in html
     assert "function safeInt(v)" in html
     assert "function safeScore(v)" in html
-    assert "${esc(x.date||'—')}" in html
-    assert "${safeInt(x.attestations??x.samples??0)}" in html
-    assert "${safeScore(x.rust_score??m.rust_score??'—')}" in html
+    assert "function setStatusError(message)" in html
+    assert "function renderTimeline(timeline, fallbackScore)" in html
+    assert "status.replaceChildren(err);" in html
+    assert "tbody.replaceChildren();" in html
+    assert "cell.textContent=text;" in html
+    assert "appendTimelineCell(row, x.date||'—');" in html
+    assert "appendTimelineCell(row, safeInt(x.attestations??x.samples??0));" in html
+    assert "appendTimelineCell(row, safeScore(x.rust_score??fallbackScore??'—'));" in html
 
+    assert "document.getElementById('status').innerHTML" not in html
+    assert "document.getElementById('timeline').innerHTML" not in html
+    assert "t.map(x=>`<tr>" not in html
     assert "${x.date||'—'}</td>" not in html
     assert "${x.attestations??x.samples??0}</td>" not in html
     assert "${x.rust_score??m.rust_score??'—'}</td>" not in html

--- a/web/hall-of-fame/machine.html
+++ b/web/hall-of-fame/machine.html
@@ -141,13 +141,40 @@ function esc(s){ return String(s||'').replace(/[&<>"']/g, c=>({'&':'&amp;','<':'
 function safeInt(v){ const n=Number.parseInt(v,10); return Number.isFinite(n)?n:0; }
 function safeScore(v){
   const n=Number(v);
-  return Number.isFinite(n)?String(n):esc(v||'—');
+  return Number.isFinite(n)?String(n):String(v||'—');
+}
+function setStatusError(message){
+  const status=document.getElementById('status');
+  const err=document.createElement('span');
+  err.className='err';
+  err.textContent=message;
+  status.replaceChildren(err);
+}
+function appendTimelineCell(row, text, colSpan){
+  const cell=row.insertCell();
+  if(colSpan) cell.colSpan=colSpan;
+  cell.textContent=text;
+}
+function renderTimeline(timeline, fallbackScore){
+  const tbody=document.getElementById('timeline');
+  tbody.replaceChildren();
+  if(!timeline.length){
+    const row=tbody.insertRow();
+    appendTimelineCell(row, 'No recent attestation activity', 3);
+    return;
+  }
+  timeline.forEach(x=>{
+    const row=tbody.insertRow();
+    appendTimelineCell(row, x.date||'—');
+    appendTimelineCell(row, safeInt(x.attestations??x.samples??0));
+    appendTimelineCell(row, safeScore(x.rust_score??fallbackScore??'—'));
+  });
 }
 (async()=>{
   const id=q('id')||q('machine');
-  if(!id){ document.getElementById('status').innerHTML='<span class="err">Missing machine id. Use ?id=&lt;fingerprint_hash&gt;.</span>'; return; }
+  if(!id){ setStatusError('Missing machine id. Use ?id=<fingerprint_hash>.'); return; }
   const res=await fetch('/api/hall_of_fame/machine?id='+encodeURIComponent(id));
-  if(!res.ok){ document.getElementById('status').innerHTML='<span class="err">Not found or unavailable.</span>'; return; }
+  if(!res.ok){ setStatusError('Not found or unavailable.'); return; }
   const data=await res.json();
   const m=data.machine||data||{};
   document.getElementById('status').style.display='none';
@@ -172,7 +199,7 @@ function safeScore(v){
 
   const t=data.attestation_timeline_30d||[];
   document.getElementById('timelineCard').style.display='block';
-  document.getElementById('timeline').innerHTML=t.length?t.map(x=>`<tr><td>${esc(x.date||'—')}</td><td>${safeInt(x.attestations??x.samples??0)}</td><td>${safeScore(x.rust_score??m.rust_score??'—')}</td></tr>`).join(''):'<tr><td colspan="3">No recent attestation activity</td></tr>';
+  renderTimeline(t, m.rust_score);
 
   const r=data.reward_participation||{};
   document.getElementById('rewardCard').style.display='block';


### PR DESCRIPTION
Fixes #7206

## Summary
- add DOM/text helpers for machine profile status errors and timeline rows
- render timeline date/count/score cells with textContent instead of a tbody innerHTML template
- update the machine profile security regression test to forbid the old timeline sink

## Validation
- pytest -q tests/test_hall_of_fame_machine_frontend_security.py tests/test_hall_of_fame_frontend_endpoints.py
- python3 -m py_compile tests/test_hall_of_fame_machine_frontend_security.py tests/test_hall_of_fame_frontend_endpoints.py
- node inline script syntax check for web/hall-of-fame/machine.html
- git diff --check -- web/hall-of-fame/machine.html tests/test_hall_of_fame_machine_frontend_security.py