### PR TITLE
fix(docs): render miner wizard results with textContent

### DIFF
--- a/docs/miner-setup-wizard/index.html
+++ b/docs/miner-setup-wizard/index.html
@@ -144,6 +144,34 @@ async function genWallet(){
   }
 }
 
+function pill(text, kind){
+  const el = document.createElement('span');
+  el.className = `pill ${kind}`;
+  el.textContent = text;
+  return el;
+}
+
+function pre(text){
+  const el = document.createElement('pre');
+  el.textContent = text;
+  return el;
+}
+
+function mutedText(text, tag = 'span'){
+  const el = document.createElement(tag);
+  el.className = 'muted';
+  el.textContent = text;
+  return el;
+}
+
+function renderCheckOutput(id, badgeText, badgeKind, opts = {}){
+  const out = document.getElementById(id);
+  const nodes = [pill(badgeText, badgeKind)];
+  if (opts.preText !== undefined) nodes.push(pre(opts.preText));
+  if (opts.muted) nodes.push(mutedText(opts.muted, opts.mutedTag || 'span'));
+  out.replaceChildren(...nodes);
+}
+
 function openStep(id){ active=id; renderSteps(); renderPanel(); }
 
 function renderPanel(){
@@ -217,9 +245,11 @@ function renderPanel(){
         const url = document.getElementById('testNodeUrl').value.trim();
         state.nodeUrl = url;
         const r = await testNode(url);
-        document.getElementById('testOut').innerHTML = r.ok
-          ? `<span class='pill ok'>Reachable</span> <pre>${h(r.text)}</pre>`
-          : `<span class='pill bad'>Failed</span> <pre>${h(r.text)}</pre><p class='muted'>If this is a CORS error, test with terminal: curl -sk ${h(url.replace(/\/$/,''))}/health</p>`;
+        renderCheckOutput('testOut', r.ok ? 'Reachable' : 'Failed', r.ok ? 'ok' : 'bad', {
+          preText: r.text,
+          muted: r.ok ? '' : 'If this is a CORS error, test with terminal: curl -sk ' + url.replace(/\/$/,'') + '/health',
+          mutedTag: 'p',
+        });
       }
     },0);
     return;
@@ -243,11 +273,15 @@ function renderPanel(){
           const data = await r.json();
           const arr = Array.isArray(data)?data:(data.miners||[]);
           const hit = arr.find(x=>JSON.stringify(x).toLowerCase().includes(q));
-          document.getElementById('minerOut').innerHTML = hit
-            ? `<span class='pill ok'>Found</span><pre>${h(JSON.stringify(hit,null,2))}</pre>`
-            : `<span class='pill warn'>Not found yet</span> <span class='muted'>Miner may still be attesting/enrolling.</span>`;
+          if (hit) {
+            renderCheckOutput('minerOut', 'Found', 'ok', {preText: JSON.stringify(hit,null,2)});
+          } else {
+            renderCheckOutput('minerOut', 'Not found yet', 'warn', {
+              muted: 'Miner may still be attesting/enrolling.',
+            });
+          }
         }catch(e){
-          document.getElementById('minerOut').innerHTML = `<span class='pill bad'>Check failed</span><pre>${h(String(e))}</pre>`;
+          renderCheckOutput('minerOut', 'Check failed', 'bad', {preText: String(e)});
         }
       }
     },0);

--- a/tests/test_miner_setup_docs_wizard_security.py
+++ b/tests/test_miner_setup_docs_wizard_security.py
@@ -9,16 +9,24 @@ WIZARD_HTML = (
 )
 
 
-def test_remote_node_responses_are_escaped_before_inner_html_rendering():
+def test_remote_node_responses_are_rendered_with_text_content():
     html = WIZARD_HTML.read_text(encoding="utf-8")
 
+    assert "function renderCheckOutput(id, badgeText, badgeKind, opts = {})" in html
+    assert "el.textContent = text;" in html
+    assert "out.replaceChildren(...nodes);" in html
+    assert "renderCheckOutput('testOut'" in html
+    assert "renderCheckOutput('minerOut'" in html
+
+    assert "document.getElementById('testOut').innerHTML" not in html
+    assert "document.getElementById('minerOut').innerHTML" not in html
     assert "<pre>${r.text}</pre>" not in html
     assert "<pre>${JSON.stringify(hit,null,2)}</pre>" not in html
     assert "<pre>${String(e)}</pre>" not in html
 
-    assert "<pre>${h(r.text)}</pre>" in html
-    assert "<pre>${h(JSON.stringify(hit,null,2))}</pre>" in html
-    assert "<pre>${h(String(e))}</pre>" in html
+    assert "preText: r.text" in html
+    assert "preText: JSON.stringify(hit,null,2)" in html
+    assert "preText: String(e)" in html
 
 
 def test_generated_command_blocks_escape_display_and_copy_attribute():


### PR DESCRIPTION
Fixes #7191

## Summary
- add DOM/text helpers for the docs miner setup wizard result panels
- render /health, /api/miners, and exception output with textContent and replaceChildren
- update the docs wizard security regression test to forbid the old dynamic result templates

## Validation
- pytest -q tests/test_miner_setup_docs_wizard_security.py tests/test_setup_wizard_frontend_security.py
- python3 -m py_compile tests/test_miner_setup_docs_wizard_security.py tests/test_setup_wizard_frontend_security.py
- node inline script syntax check for docs/miner-setup-wizard/index.html
- git diff --check -- docs/miner-setup-wizard/index.html tests/test_miner_setup_docs_wizard_security.py