### PR TITLE
fix(explorer): escape miner and health rendering

### DIFF
--- a/explorer/static/js/explorer.js
+++ b/explorer/static/js/explorer.js
@@ -89,6 +89,11 @@ function formatNumber(num, decimals = 2) {
     });
 }
 
+function safeNumber(value, fallback = 0) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : fallback;
+}
+
 function formatTimestamp(ts) {
     if (!ts) return 'N/A';
     const timestamp = typeof ts === 'number' ? ts * 1000 : new Date(ts).getTime();
@@ -418,7 +423,7 @@ function renderStatusBar() {
             <span>${statusText}</span>
         </div>
         <div class="status-info mono">
-            ${state.health ? `v${state.health.version || '2.2.1'}` : ''}
+            ${state.health ? `v${escapeHtml(state.health.version || '2.2.1')}` : ''}
             ${state.health && state.health.uptime ? `| Uptime: ${formatUptime(state.health.uptime)}` : ''}
             ${state.lastUpdate ? `| Updated: ${formatRelativeTime(state.lastUpdate)}` : ''}
         </div>
@@ -446,7 +451,9 @@ function renderEpochStats() {
     }
     
     const epoch = state.epoch || { epoch: 0, pot: 0, slot: 0, blocks_per_epoch: 144 };
-    const progress = ((epoch.slot || 0) / (epoch.blocks_per_epoch || 144)) * 100;
+    const slot = safeNumber(epoch.slot, 0);
+    const blocksPerEpoch = Math.max(safeNumber(epoch.blocks_per_epoch, 144), 1);
+    const progress = Math.max(0, Math.min(100, (slot / blocksPerEpoch) * 100));
     
     container.innerHTML = `
         <div class="card">
@@ -466,7 +473,7 @@ function renderEpochStats() {
         </div>
         <div class="card">
             <div class="card-title">Progress</div>
-            <div class="card-value">${formatNumber(epoch.slot || 0, 0)}/${epoch.blocks_per_epoch || 144}</div>
+            <div class="card-value">${formatNumber(slot, 0)}/${formatNumber(blocksPerEpoch, 0)}</div>
             <div class="progress-bar">
                 <div class="progress-fill" style="width: ${progress}%"></div>
             </div>
@@ -526,7 +533,7 @@ function renderMinersTable() {
             const badgeClass = getArchitectureBadge(arch);
             return `
                 <tr>
-                    <td class="mono" title="${escapeHtml(minerId)}">${shortenAddress(minerId)}</td>
+                    <td class="mono" title="${escapeHtml(minerId)}">${escapeHtml(shortenAddress(minerId))}</td>
                     <td><span class="badge ${badgeClass}">${escapeHtml(arch)}</span></td>
                     <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                     <td class="text-accent">${formatNumber(multiplier, 2)}x</td>
@@ -790,7 +797,7 @@ function renderSearchResults() {
                         const badgeClass = getArchitectureBadge(miner.device_arch);
                         return `
                             <tr>
-                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${shortenAddress(miner.miner_id || 'unknown')}</td>
+                                <td class="mono" title="${escapeHtml(miner.miner_id)}">${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}</td>
                                 <td><span class="badge ${badgeClass}">${escapeHtml(miner.device_arch || 'Unknown')}</span></td>
                                 <td><span class="badge badge-${tier}">${tier.toUpperCase()}</span></td>
                                 <td class="text-accent">${formatNumber(miner.multiplier || 1.0, 2)}x</td>

--- a/tests/test_explorer_miners_normalization.py
+++ b/tests/test_explorer_miners_normalization.py
@@ -143,3 +143,87 @@ console.log(JSON.stringify({{
     assert "&lt;img" in data["blocksHtml"]
     assert "&lt;img" in data["txHtml"]
     assert "0 miners" in data["blocksHtml"]
+
+
+def test_explorer_escapes_health_epoch_and_miner_rendering():
+    assert "function safeNumber(value, fallback = 0)" in JS
+    assert "${state.health ? `v${escapeHtml(state.health.version || '2.2.1')}` : ''}" in JS
+    assert "const slot = safeNumber(epoch.slot, 0);" in JS
+    assert "const blocksPerEpoch = Math.max(safeNumber(epoch.blocks_per_epoch, 144), 1);" in JS
+    assert "Math.max(0, Math.min(100, (slot / blocksPerEpoch) * 100))" in JS
+    assert "${escapeHtml(shortenAddress(minerId))}" in JS
+    assert "${escapeHtml(shortenAddress(miner.miner_id || 'unknown'))}" in JS
+
+    assert "v${state.health.version || '2.2.1'}" not in JS
+    assert "const progress = ((epoch.slot || 0) / (epoch.blocks_per_epoch || 144)) * 100;" not in JS
+    assert '>${shortenAddress(minerId)}</td>' not in JS
+    assert '>${shortenAddress(miner.miner_id || \'unknown\')}</td>' not in JS
+
+
+def test_explorer_rendering_escapes_api_controlled_values():
+    probe = f"""
+const vm = require('vm');
+const script = {json.dumps(JS)};
+const elements = {{}};
+const element = () => ({{
+  innerHTML: '',
+  addEventListener() {{}},
+  dataset: {{}},
+}});
+const context = {{
+  window: {{ EXPLORER_API_BASE: 'https://example.test' }},
+  document: {{
+    addEventListener() {{}},
+    getElementById(id) {{
+      if (!elements[id]) elements[id] = element();
+      return elements[id];
+    }},
+    querySelectorAll() {{ return []; }},
+  }},
+  setInterval() {{}},
+  setTimeout() {{ return 1; }},
+  clearTimeout() {{}},
+  AbortController: class {{ constructor() {{ this.signal = {{}}; }} abort() {{}} }},
+  fetch: async () => ({{ ok: true, json: async () => ({{}}) }}),
+  console: {{ error() {{}}, warn() {{}}, log() {{}} }},
+}};
+vm.createContext(context);
+vm.runInContext(script, context);
+const payload = '<img src=x onerror=alert(1)>';
+context.payload = payload;
+vm.runInContext(`
+state.loading.health = false;
+state.loading.epoch = false;
+state.loading.miners = false;
+state.health = {{ status: 'ok', version: payload }};
+state.epoch = {{ epoch: 1, pot: 2, slot: payload, blocks_per_epoch: payload }};
+state.miners = [{{ miner_id: payload, device_arch: payload, multiplier: 1, balance: 0 }}];
+state.searchQuery = 'img';
+renderStatusBar();
+renderEpochStats();
+renderMinersTable();
+renderSearchResults();
+`, context);
+console.log(JSON.stringify({{
+  status: elements['status-bar-content'].innerHTML,
+  epoch: elements['epoch-stats'].innerHTML,
+  miners: elements['miners-tbody'].innerHTML,
+  search: elements['search-results'].innerHTML,
+}}));
+"""
+    result = subprocess.run(
+        ["node", "-e", probe],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    rendered = json.loads(result.stdout)
+
+    assert "<img" not in rendered["status"]
+    assert "<img" not in rendered["miners"]
+    assert "<img" not in rendered["search"]
+    assert "&lt;img" in rendered["status"]
+    assert "&lt;img" in rendered["miners"]
+    assert "&lt;img" in rendered["search"]
+    assert "NaN%" not in rendered["epoch"]
+    assert "Infinity%" not in rendered["epoch"]


### PR DESCRIPTION
Fixes #7212

## Summary
- escape static Explorer health version output before innerHTML rendering
- normalize epoch progress slot and blocks_per_epoch before formatting and width calculation
- escape shortened miner IDs in miners table and search results
- add focused regression coverage for API-controlled health, epoch, and miner values

## Validation
- pytest -q tests/test_explorer_miners_normalization.py tests/test_explorer_block_filters.py
- node --check explorer/static/js/explorer.js
- python3 -m py_compile tests/test_explorer_miners_normalization.py
- git diff --check -- explorer/static/js/explorer.js tests/test_explorer_miners_normalization.py