### PR TITLE
fix(docs): render network status fields with text nodes

### DIFF
--- a/docs/network-status.html
+++ b/docs/network-status.html
@@ -107,6 +107,72 @@
       return escapeHtml(value ?? fallback);
     }
 
+    function textEl(tag, className, text) {
+      const el = document.createElement(tag);
+      if (className) el.className = className;
+      el.textContent = text;
+      return el;
+    }
+
+    function renderNodeCard(card, base, status) {
+      const nodes = [textEl('div', 'font-mono text-xs break-all mb-2', base)];
+      if (status === 'checking') {
+        nodes.push(textEl('div', 'text-sm', 'Checking...'));
+        card.replaceChildren(...nodes);
+        return;
+      }
+
+      const ok = !!status.ok;
+      const statusRow = document.createElement('div');
+      statusRow.className = 'flex items-center gap-2 mb-1';
+      const dot = document.createElement('span');
+      dot.className = `inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}`;
+      statusRow.append(
+        dot,
+        textEl('span', `text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}`, ok ? 'UP' : 'DOWN')
+      );
+      nodes.push(statusRow);
+
+      if (Object.prototype.hasOwnProperty.call(status, 'version')) {
+        nodes.push(textEl('div', 'text-xs text-slate-400', `version: ${status.version ?? '-'}`));
+      } else if (status.message) {
+        nodes.push(textEl('div', 'text-xs text-slate-400', status.message));
+      }
+      card.replaceChildren(...nodes);
+    }
+
+    function renderIncidentRow(incident) {
+      const row = document.createElement('div');
+      row.className = 'rounded border border-slate-800 bg-slate-950 p-2';
+      const meta = document.createElement('div');
+      meta.append(
+        textEl('span', `font-semibold ${incident.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}`, incident.type ?? '-'),
+        document.createTextNode(' · '),
+        textEl('span', 'font-mono text-xs', incident.node ?? '-')
+      );
+      row.replaceChildren(
+        textEl('div', 'text-xs text-slate-400', new Date(incident.t).toLocaleString()),
+        meta,
+        textEl('div', 'text-sm text-slate-300', incident.message ?? '-')
+      );
+      return row;
+    }
+
+    function renderArchRow(arch, count, pct) {
+      const row = document.createElement('div');
+      const header = document.createElement('div');
+      header.className = 'flex justify-between mb-1';
+      header.append(textEl('span', '', arch), textEl('span', '', `${count} (${pct}%)`));
+      const bar = document.createElement('div');
+      bar.className = 'h-2 w-full bg-slate-800 rounded';
+      const fill = document.createElement('div');
+      fill.className = 'h-2 bg-cyan-400 rounded';
+      fill.style.width = `${pct}%`;
+      bar.appendChild(fill);
+      row.replaceChildren(header, bar);
+      return row;
+    }
+
     function normalizeMinerRows(payload) {
       const rows = Array.isArray(payload)
         ? payload
@@ -185,16 +251,10 @@
       const log = document.getElementById('incidentLog');
       const incidents = safeJson(INCIDENT_KEY, []);
       if (!incidents.length) {
-        log.innerHTML = '<div class="text-slate-400 text-sm">No incidents recorded yet.</div>';
+        log.replaceChildren(textEl('div', 'text-slate-400 text-sm', 'No incidents recorded yet.'));
         return;
       }
-      log.innerHTML = incidents.slice(0, 30).map(i => `
-        <div class="rounded border border-slate-800 bg-slate-950 p-2">
-          <div class="text-xs text-slate-400">${new Date(i.t).toLocaleString()}</div>
-          <div><span class="font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}">${safeText(i.type)}</span> · <span class="font-mono text-xs">${safeText(i.node)}</span></div>
-          <div class="text-sm text-slate-300">${safeText(i.message)}</div>
-        </div>
-      `).join('');
+      log.replaceChildren(...incidents.slice(0, 30).map(renderIncidentRow));
     }
 
     function escapeXml(s) {
@@ -254,31 +314,17 @@
       await Promise.all(NODE_ENDPOINTS.map(async (base) => {
         const card = document.createElement('div');
         card.className = 'rounded-lg border border-slate-800 bg-slate-950 p-3';
-        card.innerHTML = `<div class="font-mono text-xs break-all mb-2">${safeText(base)}</div><div class="text-sm">Checking...</div>`;
+        renderNodeCard(card, base, 'checking');
         grid.appendChild(card);
 
         try {
           const health = await fetchJson(`${base}/health`);
           const ok = !!health.ok;
           recordNodeStatus(base, ok);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}"></span>
-              <span class="text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}">${ok ? 'UP' : 'DOWN'}</span>
-            </div>
-            <div class="text-xs text-slate-400">version: ${safeText(health.version)}</div>
-          `;
+          renderNodeCard(card, base, { ok, version: health.version });
         } catch (e) {
           recordNodeStatus(base, false);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500"></span>
-              <span class="text-sm font-semibold text-red-300">DOWN</span>
-            </div>
-            <div class="text-xs text-slate-400">${safeText(e.message || e)}</div>
-          `;
+          renderNodeCard(card, base, { ok: false, message: e.message || e });
         }
       }));
     }
@@ -310,21 +356,16 @@
         const total = list.length || 1;
 
         const archList = document.getElementById('archList');
-        archList.innerHTML = '';
+        archList.replaceChildren();
         Object.entries(counts)
           .sort((a, b) => b[1] - a[1])
           .forEach(([arch, n]) => {
             const pct = Math.round((n / total) * 100);
-            const row = document.createElement('div');
-            row.innerHTML = `
-              <div class="flex justify-between mb-1"><span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span></div>
-              <div class="h-2 w-full bg-slate-800 rounded"><div class="h-2 bg-cyan-400 rounded" style="width:${pct}%"></div></div>
-            `;
-            archList.appendChild(row);
+            archList.appendChild(renderArchRow(arch, n, pct));
           });
       } catch {
         document.getElementById('minerCount').textContent = 'N/A';
-        document.getElementById('archList').innerHTML = '<div class="text-slate-400 text-sm">Unable to fetch miners.</div>';
+        document.getElementById('archList').replaceChildren(textEl('div', 'text-slate-400 text-sm', 'Unable to fetch miners.'));
       }
     }
 

--- a/tests/test_docs_network_status_security.py
+++ b/tests/test_docs_network_status_security.py
@@ -1,60 +1,81 @@
 from pathlib import Path
 
 
-HTML = Path(__file__).resolve().parents[1] / "docs" / "network-status.html"
+ROOT = Path(__file__).resolve().parents[1]
+HTMLS = [
+    ROOT / "docs" / "network-status.html",
+    ROOT / "website" / "static" / "network-status.html",
+]
 
 
-def source():
-    return HTML.read_text(encoding="utf-8-sig")
+def sources():
+    return [path.read_text(encoding="utf-8-sig") for path in HTMLS]
 
 
 def test_network_status_defines_html_escaping_helpers():
-    html = source()
+    for html in sources():
+        assert "function escapeHtml(s)" in html
+        assert "function safeText(value, fallback = '-')" in html
+        assert "function textEl(tag, className, text)" in html
 
-    assert "function escapeHtml(s)" in html
-    assert "function safeText(value, fallback = '-')" in html
+
+def test_network_status_copies_stay_synchronized():
+    assert sources()[0] == sources()[1]
 
 
 def test_node_cards_escape_api_and_error_fields():
-    html = source()
+    for html in sources():
+        assert "function renderNodeCard(card, base, status)" in html
+        assert "textEl('div', 'font-mono text-xs break-all mb-2', base)" in html
+        assert "textEl('div', 'text-xs text-slate-400', `version: ${status.version ?? '-'}`)" in html
+        assert "textEl('div', 'text-xs text-slate-400', status.message)" in html
+        assert "renderNodeCard(card, base, 'checking');" in html
+        assert "renderNodeCard(card, base, { ok, version: health.version });" in html
+        assert "renderNodeCard(card, base, { ok: false, message: e.message || e });" in html
 
-    assert "${safeText(base)}</div><div class=\"text-sm\">Checking...</div>" in html
-    assert "version: ${safeText(health.version)}" in html
-    assert "${safeText(e.message || e)}" in html
-    assert "version: ${health.version ?? '-'}" not in html
-    assert "${String(e.message || e)}" not in html
+        assert "${safeText(base)}</div><div class=\"text-sm\">Checking...</div>" not in html
+        assert "version: ${safeText(health.version)}" not in html
+        assert "${safeText(e.message || e)}" not in html
+        assert "version: ${health.version ?? '-'}" not in html
+        assert "${String(e.message || e)}" not in html
 
 
 def test_incident_rows_escape_local_storage_fields():
-    html = source()
+    for html in sources():
+        assert "function renderIncidentRow(incident)" in html
+        assert "incident.type ?? '-'" in html
+        assert "incident.node ?? '-'" in html
+        assert "incident.message ?? '-'" in html
+        assert "log.replaceChildren(...incidents.slice(0, 30).map(renderIncidentRow));" in html
 
-    assert "${safeText(i.type)}</span>" in html
-    assert "${safeText(i.node)}</span>" in html
-    assert "${safeText(i.message)}</div>" in html
-    assert "${i.type}</span>" not in html
-    assert "${i.node}</span>" not in html
-    assert "${i.message}</div>" not in html
+        assert "${safeText(i.type)}</span>" not in html
+        assert "${safeText(i.node)}</span>" not in html
+        assert "${safeText(i.message)}</div>" not in html
+        assert "${i.type}</span>" not in html
+        assert "${i.node}</span>" not in html
+        assert "${i.message}</div>" not in html
 
 
 def test_architecture_breakdown_escapes_miner_fields():
-    html = source()
+    for html in sources():
+        assert "function renderArchRow(arch, count, pct)" in html
+        assert "header.append(textEl('span', '', arch), textEl('span', '', `${count} (${pct}%)`));" in html
+        assert "archList.appendChild(renderArchRow(arch, n, pct));" in html
 
-    assert "<span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span>" in html
-    assert "<span>${arch}</span><span>${n} (${pct}%)</span>" not in html
+        assert "<span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span>" not in html
+        assert "<span>${arch}</span><span>${n} (${pct}%)</span>" not in html
 
 
 def test_network_status_normalizes_current_miners_api_envelopes():
-    html = source()
-
-    assert "function normalizeMinerRows(payload)" in html
-    assert "payload?.miners || payload?.data || payload?.items || []" in html
-    assert "const list = normalizeMinerRows(miners);" in html
-    assert "rows.filter(row => row && typeof row === 'object')" in html
+    for html in sources():
+        assert "function normalizeMinerRows(payload)" in html
+        assert "payload?.miners || payload?.data || payload?.items || []" in html
+        assert "const list = normalizeMinerRows(miners);" in html
+        assert "rows.filter(row => row && typeof row === 'object')" in html
 
 
 def test_network_status_architecture_breakdown_uses_current_miner_fields():
-    html = source()
-
-    assert "function minerArch(row)" in html
-    assert "return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';" in html
-    assert "const key = minerArch(m);" in html
+    for html in sources():
+        assert "function minerArch(row)" in html
+        assert "return row.device_arch || row.arch || row.device_family || row.family || row.machine || 'unknown';" in html
+        assert "const key = minerArch(m);" in html

--- a/website/static/network-status.html
+++ b/website/static/network-status.html
@@ -107,6 +107,72 @@
       return escapeHtml(value ?? fallback);
     }
 
+    function textEl(tag, className, text) {
+      const el = document.createElement(tag);
+      if (className) el.className = className;
+      el.textContent = text;
+      return el;
+    }
+
+    function renderNodeCard(card, base, status) {
+      const nodes = [textEl('div', 'font-mono text-xs break-all mb-2', base)];
+      if (status === 'checking') {
+        nodes.push(textEl('div', 'text-sm', 'Checking...'));
+        card.replaceChildren(...nodes);
+        return;
+      }
+
+      const ok = !!status.ok;
+      const statusRow = document.createElement('div');
+      statusRow.className = 'flex items-center gap-2 mb-1';
+      const dot = document.createElement('span');
+      dot.className = `inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}`;
+      statusRow.append(
+        dot,
+        textEl('span', `text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}`, ok ? 'UP' : 'DOWN')
+      );
+      nodes.push(statusRow);
+
+      if (Object.prototype.hasOwnProperty.call(status, 'version')) {
+        nodes.push(textEl('div', 'text-xs text-slate-400', `version: ${status.version ?? '-'}`));
+      } else if (status.message) {
+        nodes.push(textEl('div', 'text-xs text-slate-400', status.message));
+      }
+      card.replaceChildren(...nodes);
+    }
+
+    function renderIncidentRow(incident) {
+      const row = document.createElement('div');
+      row.className = 'rounded border border-slate-800 bg-slate-950 p-2';
+      const meta = document.createElement('div');
+      meta.append(
+        textEl('span', `font-semibold ${incident.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}`, incident.type ?? '-'),
+        document.createTextNode(' · '),
+        textEl('span', 'font-mono text-xs', incident.node ?? '-')
+      );
+      row.replaceChildren(
+        textEl('div', 'text-xs text-slate-400', new Date(incident.t).toLocaleString()),
+        meta,
+        textEl('div', 'text-sm text-slate-300', incident.message ?? '-')
+      );
+      return row;
+    }
+
+    function renderArchRow(arch, count, pct) {
+      const row = document.createElement('div');
+      const header = document.createElement('div');
+      header.className = 'flex justify-between mb-1';
+      header.append(textEl('span', '', arch), textEl('span', '', `${count} (${pct}%)`));
+      const bar = document.createElement('div');
+      bar.className = 'h-2 w-full bg-slate-800 rounded';
+      const fill = document.createElement('div');
+      fill.className = 'h-2 bg-cyan-400 rounded';
+      fill.style.width = `${pct}%`;
+      bar.appendChild(fill);
+      row.replaceChildren(header, bar);
+      return row;
+    }
+
     function normalizeMinerRows(payload) {
       const rows = Array.isArray(payload)
         ? payload
@@ -185,16 +251,10 @@
       const log = document.getElementById('incidentLog');
       const incidents = safeJson(INCIDENT_KEY, []);
       if (!incidents.length) {
-        log.innerHTML = '<div class="text-slate-400 text-sm">No incidents recorded yet.</div>';
+        log.replaceChildren(textEl('div', 'text-slate-400 text-sm', 'No incidents recorded yet.'));
         return;
       }
-      log.innerHTML = incidents.slice(0, 30).map(i => `
-        <div class="rounded border border-slate-800 bg-slate-950 p-2">
-          <div class="text-xs text-slate-400">${new Date(i.t).toLocaleString()}</div>
-          <div><span class="font-semibold ${i.type === 'OUTAGE' ? 'text-red-300' : 'text-emerald-300'}">${safeText(i.type)}</span> · <span class="font-mono text-xs">${safeText(i.node)}</span></div>
-          <div class="text-sm text-slate-300">${safeText(i.message)}</div>
-        </div>
-      `).join('');
+      log.replaceChildren(...incidents.slice(0, 30).map(renderIncidentRow));
     }
 
     function escapeXml(s) {
@@ -254,31 +314,17 @@
       await Promise.all(NODE_ENDPOINTS.map(async (base) => {
         const card = document.createElement('div');
         card.className = 'rounded-lg border border-slate-800 bg-slate-950 p-3';
-        card.innerHTML = `<div class="font-mono text-xs break-all mb-2">${safeText(base)}</div><div class="text-sm">Checking...</div>`;
+        renderNodeCard(card, base, 'checking');
         grid.appendChild(card);
 
         try {
           const health = await fetchJson(`${base}/health`);
           const ok = !!health.ok;
           recordNodeStatus(base, ok);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full ${ok ? 'bg-emerald-400' : 'bg-red-500'}"></span>
-              <span class="text-sm font-semibold ${ok ? 'text-emerald-300' : 'text-red-300'}">${ok ? 'UP' : 'DOWN'}</span>
-            </div>
-            <div class="text-xs text-slate-400">version: ${safeText(health.version)}</div>
-          `;
+          renderNodeCard(card, base, { ok, version: health.version });
         } catch (e) {
           recordNodeStatus(base, false);
-          card.innerHTML = `
-            <div class="font-mono text-xs break-all mb-2">${safeText(base)}</div>
-            <div class="flex items-center gap-2 mb-1">
-              <span class="inline-block w-2.5 h-2.5 rounded-full bg-red-500"></span>
-              <span class="text-sm font-semibold text-red-300">DOWN</span>
-            </div>
-            <div class="text-xs text-slate-400">${safeText(e.message || e)}</div>
-          `;
+          renderNodeCard(card, base, { ok: false, message: e.message || e });
         }
       }));
     }
@@ -310,21 +356,16 @@
         const total = list.length || 1;
 
         const archList = document.getElementById('archList');
-        archList.innerHTML = '';
+        archList.replaceChildren();
         Object.entries(counts)
           .sort((a, b) => b[1] - a[1])
           .forEach(([arch, n]) => {
             const pct = Math.round((n / total) * 100);
-            const row = document.createElement('div');
-            row.innerHTML = `
-              <div class="flex justify-between mb-1"><span>${safeText(arch)}</span><span>${safeText(n)} (${pct}%)</span></div>
-              <div class="h-2 w-full bg-slate-800 rounded"><div class="h-2 bg-cyan-400 rounded" style="width:${pct}%"></div></div>
-            `;
-            archList.appendChild(row);
+            archList.appendChild(renderArchRow(arch, n, pct));
           });
       } catch {
         document.getElementById('minerCount').textContent = 'N/A';
-        document.getElementById('archList').innerHTML = '<div class="text-slate-400 text-sm">Unable to fetch miners.</div>';
+        document.getElementById('archList').replaceChildren(textEl('div', 'text-slate-400 text-sm', 'Unable to fetch miners.'));
       }
     }
 


### PR DESCRIPTION
Fixes #7198

## Summary
- add DOM/text rendering helpers for network status node cards, incident rows, and architecture rows
- render health versions, error messages, local incident fields, and miner architecture labels without dynamic innerHTML templates
- keep docs/network-status.html and website/static/network-status.html synchronized
- update focused regression tests to cover both published copies

## Validation
- pytest -q tests/test_docs_network_status_security.py
- python3 -m py_compile tests/test_docs_network_status_security.py
- node inline script syntax check for docs/network-status.html and website/static/network-status.html
- git diff --check -- docs/network-status.html website/static/network-status.html tests/test_docs_network_status_security.py
- cmp -s docs/network-status.html website/static/network-status.html