### PR TITLE
Fix offline epoch catch-up with bounded vote certificates

### DIFF
--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -19,7 +19,7 @@ import secrets
 import sqlite3
 import threading
 import time
-from dataclasses import dataclass, asdict, field
+from dataclasses import dataclass, asdict
 from enum import Enum
 from typing import Dict, List, Optional, Set, Tuple, Any
 from collections import defaultdict, OrderedDict
@@ -611,6 +611,7 @@ class GossipLayer:
         self.balance_crdt = PNCounter()
         self.epoch_crdt = GSet()
         self._epoch_votes: Dict[Tuple[int, str], Dict[str, str]] = {}
+        self._epoch_vote_messages: Dict[Tuple[int, str], Dict[str, GossipMessage]] = {}
 
         # Phase F (#2256): per-peer Ed25519 identity, dual-mode signing.
         # Only loaded/generated when needed by the current signing mode;
@@ -812,8 +813,8 @@ class GossipLayer:
             "handshake": local_handshake_params(),
         })
 
-    def verify_message(self, msg: GossipMessage) -> bool:
-        """Verify message signature and freshness.
+    def _verify_message_signature(self, msg: GossipMessage, *, check_freshness: bool = True) -> bool:
+        """Verify message signature, optionally skipping freshness for commit certificates.
 
         SECURITY (#2256 + #2272): verifies sender_id, msg_id, and ttl as
         part of the signed content — any post-sign flip of those fields
@@ -824,7 +825,7 @@ class GossipLayer:
         to verify. HMAC remains a legacy fallback only for HMAC-only messages
         outside strict mode.
         """
-        if abs(time.time() - msg.timestamp) > MESSAGE_EXPIRY:
+        if check_freshness and abs(time.time() - msg.timestamp) > MESSAGE_EXPIRY:
             return False
 
         content = self._signed_content(msg.msg_type, msg.sender_id, msg.msg_id, msg.ttl, msg.payload)
@@ -854,6 +855,10 @@ class GossipLayer:
             P2P_SECRET.encode(), message.encode(), hashlib.sha256
         ).hexdigest()
         return hmac.compare_digest(hmac_sig, expected)
+
+    def verify_message(self, msg: GossipMessage) -> bool:
+        """Verify message signature and freshness."""
+        return self._verify_message_signature(msg, check_freshness=True)
 
     def _has_trusted_ed25519_identity(self, msg: GossipMessage) -> bool:
         """Return True only when msg has a valid trusted Ed25519 signature."""
@@ -1290,6 +1295,8 @@ class GossipLayer:
             return {"status": "error", "reason": "vote_persist_failed"}
 
         self._epoch_votes[key][voter] = vote
+        if vote == "accept":
+            self._epoch_vote_messages.setdefault(key, {})[voter] = msg
 
         # Count votes for THIS specific proposal_hash only.
         total_nodes = len(self.peers) + 1  # peers + self
@@ -1319,11 +1326,17 @@ class GossipLayer:
                 voter for voter, voter_vote in votes_for_proposal.items()
                 if voter_vote == "accept"
             ]
+            vote_certificate = [
+                self._epoch_vote_messages[key][voter].to_dict()
+                for voter in accept_voters
+                if voter in self._epoch_vote_messages.get(key, {})
+            ]
             commit_msg = self.create_message(MessageType.EPOCH_COMMIT, {
                 "epoch": epoch,
                 "proposal_hash": proposal_hash,
                 "accept_count": accept_count,
-                "voters": accept_voters
+                "voters": accept_voters,
+                "vote_certificate": vote_certificate
             })
             self.broadcast(commit_msg)
             return {"status": "committed", "epoch": epoch, "accept_count": accept_count}
@@ -1335,18 +1348,67 @@ class GossipLayer:
 
         return {"status": "ok", "epoch": epoch, "votes_so_far": len(votes_for_proposal)}
 
+    def _verify_epoch_vote_certificate(
+        self,
+        certificate: List[Dict],
+        epoch: int,
+        proposal_hash: str,
+        known_nodes: Set[str],
+    ) -> Tuple[Optional[Set[str]], Optional[str]]:
+        """Verify signed accept-vote messages attached to an epoch commit."""
+        accepted_voters: Set[str] = set()
+        verified_messages: Dict[str, GossipMessage] = {}
+
+        for entry in certificate:
+            try:
+                vote_msg = GossipMessage.from_dict(entry)
+            except (TypeError, ValueError):
+                return None, "invalid_vote_certificate"
+
+            if vote_msg.msg_type != MessageType.EPOCH_VOTE.value:
+                return None, "invalid_vote_certificate"
+            if vote_msg.sender_id not in known_nodes:
+                return None, "unknown_certificate_voter"
+            if not self._verify_message_signature(vote_msg, check_freshness=False):
+                return None, "invalid_vote_certificate_signature"
+
+            vote_payload = vote_msg.payload if isinstance(vote_msg.payload, dict) else {}
+            if vote_payload.get("epoch") != epoch:
+                return None, "certificate_epoch_mismatch"
+            if vote_payload.get("proposal_hash") != proposal_hash:
+                return None, "certificate_proposal_mismatch"
+            if vote_payload.get("vote") != "accept":
+                return None, "certificate_non_accept_vote"
+
+            payload_voter = vote_payload.get("voter")
+            if payload_voter is not None and payload_voter != vote_msg.sender_id:
+                return None, "certificate_voter_mismatch"
+
+            accepted_voters.add(vote_msg.sender_id)
+            verified_messages[vote_msg.sender_id] = vote_msg
+
+        key = (epoch, proposal_hash)
+        self._epoch_votes.setdefault(key, {}).update({
+            voter: "accept" for voter in accepted_voters
+        })
+        self._epoch_vote_messages.setdefault(key, {}).update(verified_messages)
+
+        return accepted_voters, None
+
     def _handle_epoch_commit(self, msg: GossipMessage) -> Dict:
-        """Handle finalized epoch commits only when backed by local votes.
+        """Handle finalized epoch commits when backed by votes or certificate.
 
         A commit sender's signature authenticates the committer, not every
-        listed voter. Finality is accepted only when the receiver has already
-        validated accept votes from a quorum of the claimed known voters.
+        listed voter. Finality is accepted only when the receiver has either
+        already validated accept votes from a quorum or the commit carries a
+        quorum certificate of signed accept-vote messages.
         """
         payload = msg.payload if isinstance(msg.payload, dict) else {}
         epoch = payload.get("epoch")
         proposal_hash = payload.get("proposal_hash")
         accept_count = payload.get("accept_count", 0)
         voters = payload.get("voters", [])
+        vote_certificate = payload.get("vote_certificate")
 
         if epoch is None or not proposal_hash:
             return {"status": "error", "reason": "missing_commit_fields"}
@@ -1368,6 +1430,34 @@ class GossipLayer:
         quorum = max(3, (total_nodes // 2) + 1)
         if accept_count < quorum or len(voter_set) < quorum:
             return {"status": "error", "reason": "insufficient_quorum"}
+
+        if vote_certificate is not None:
+            if not isinstance(vote_certificate, list):
+                return {"status": "error", "reason": "invalid_vote_certificate"}
+            accepted_voters, certificate_error = self._verify_epoch_vote_certificate(
+                vote_certificate,
+                epoch,
+                proposal_hash,
+                known_nodes,
+            )
+            if certificate_error:
+                return {"status": "error", "reason": certificate_error}
+            if accepted_voters is None or len(accepted_voters) < quorum:
+                return {"status": "error", "reason": "insufficient_certificate_quorum"}
+            if not voter_set.issubset(accepted_voters):
+                return {"status": "error", "reason": "certificate_voter_mismatch"}
+            if accept_count > len(accepted_voters):
+                return {"status": "error", "reason": "certificate_accept_count_mismatch"}
+
+            self.epoch_crdt.add(epoch, {
+                "proposal_hash": proposal_hash,
+                "finalized": True,
+                "accept_count": len(accepted_voters),
+                "voters": sorted(accepted_voters),
+                "committer": msg.sender_id,
+                "certificate": True,
+            })
+            return {"status": "committed", "epoch": epoch, "accept_count": len(accepted_voters)}
 
         votes_for_proposal = self._epoch_votes.get((epoch, proposal_hash), {})
         accepted_voters = {

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -1331,13 +1331,15 @@ class GossipLayer:
                 for voter in accept_voters
                 if voter in self._epoch_vote_messages.get(key, {})
             ]
-            commit_msg = self.create_message(MessageType.EPOCH_COMMIT, {
+            commit_payload = {
                 "epoch": epoch,
                 "proposal_hash": proposal_hash,
                 "accept_count": accept_count,
                 "voters": accept_voters,
-                "vote_certificate": vote_certificate
-            })
+            }
+            if len(vote_certificate) == len(accept_voters):
+                commit_payload["vote_certificate"] = vote_certificate
+            commit_msg = self.create_message(MessageType.EPOCH_COMMIT, commit_payload)
             self.broadcast(commit_msg)
             return {"status": "committed", "epoch": epoch, "accept_count": accept_count}
 
@@ -1354,7 +1356,7 @@ class GossipLayer:
         epoch: int,
         proposal_hash: str,
         known_nodes: Set[str],
-    ) -> Tuple[Optional[Set[str]], Optional[str]]:
+    ) -> Tuple[Optional[Set[str]], Dict[str, GossipMessage], Optional[str]]:
         """Verify signed accept-vote messages attached to an epoch commit."""
         accepted_voters: Set[str] = set()
         verified_messages: Dict[str, GossipMessage] = {}
@@ -1363,37 +1365,31 @@ class GossipLayer:
             try:
                 vote_msg = GossipMessage.from_dict(entry)
             except (TypeError, ValueError):
-                return None, "invalid_vote_certificate"
+                return None, {}, "invalid_vote_certificate"
 
             if vote_msg.msg_type != MessageType.EPOCH_VOTE.value:
-                return None, "invalid_vote_certificate"
+                return None, {}, "invalid_vote_certificate"
             if vote_msg.sender_id not in known_nodes:
-                return None, "unknown_certificate_voter"
+                return None, {}, "unknown_certificate_voter"
             if not self._verify_message_signature(vote_msg, check_freshness=False):
-                return None, "invalid_vote_certificate_signature"
+                return None, {}, "invalid_vote_certificate_signature"
 
             vote_payload = vote_msg.payload if isinstance(vote_msg.payload, dict) else {}
             if vote_payload.get("epoch") != epoch:
-                return None, "certificate_epoch_mismatch"
+                return None, {}, "certificate_epoch_mismatch"
             if vote_payload.get("proposal_hash") != proposal_hash:
-                return None, "certificate_proposal_mismatch"
+                return None, {}, "certificate_proposal_mismatch"
             if vote_payload.get("vote") != "accept":
-                return None, "certificate_non_accept_vote"
+                return None, {}, "certificate_non_accept_vote"
 
             payload_voter = vote_payload.get("voter")
             if payload_voter is not None and payload_voter != vote_msg.sender_id:
-                return None, "certificate_voter_mismatch"
+                return None, {}, "certificate_voter_mismatch"
 
             accepted_voters.add(vote_msg.sender_id)
             verified_messages[vote_msg.sender_id] = vote_msg
 
-        key = (epoch, proposal_hash)
-        self._epoch_votes.setdefault(key, {}).update({
-            voter: "accept" for voter in accepted_voters
-        })
-        self._epoch_vote_messages.setdefault(key, {}).update(verified_messages)
-
-        return accepted_voters, None
+        return accepted_voters, verified_messages, None
 
     def _handle_epoch_commit(self, msg: GossipMessage) -> Dict:
         """Handle finalized epoch commits when backed by votes or certificate.
@@ -1434,30 +1430,45 @@ class GossipLayer:
         if vote_certificate is not None:
             if not isinstance(vote_certificate, list):
                 return {"status": "error", "reason": "invalid_vote_certificate"}
-            accepted_voters, certificate_error = self._verify_epoch_vote_certificate(
-                vote_certificate,
-                epoch,
-                proposal_hash,
-                known_nodes,
+            (
+                certificate_voters,
+                verified_messages,
+                certificate_error,
+            ) = self._verify_epoch_vote_certificate(vote_certificate, epoch, proposal_hash, known_nodes)
+            certificate_is_complete = (
+                certificate_error is None
+                and certificate_voters is not None
+                and len(certificate_voters) >= quorum
+                and voter_set.issubset(certificate_voters)
+                and accept_count <= len(certificate_voters)
             )
-            if certificate_error:
-                return {"status": "error", "reason": certificate_error}
-            if accepted_voters is None or len(accepted_voters) < quorum:
-                return {"status": "error", "reason": "insufficient_certificate_quorum"}
-            if not voter_set.issubset(accepted_voters):
-                return {"status": "error", "reason": "certificate_voter_mismatch"}
-            if accept_count > len(accepted_voters):
-                return {"status": "error", "reason": "certificate_accept_count_mismatch"}
+            if certificate_is_complete:
+                key = (epoch, proposal_hash)
+                self._epoch_votes.setdefault(key, {}).update({
+                    voter: "accept" for voter in certificate_voters
+                })
+                self._epoch_vote_messages.setdefault(key, {}).update(verified_messages)
+                self.epoch_crdt.add(epoch, {
+                    "proposal_hash": proposal_hash,
+                    "finalized": True,
+                    "accept_count": len(certificate_voters),
+                    "voters": sorted(certificate_voters),
+                    "committer": msg.sender_id,
+                    "certificate": True,
+                })
+                return {
+                    "status": "committed",
+                    "epoch": epoch,
+                    "accept_count": len(certificate_voters),
+                }
 
-            self.epoch_crdt.add(epoch, {
-                "proposal_hash": proposal_hash,
-                "finalized": True,
-                "accept_count": len(accepted_voters),
-                "voters": sorted(accepted_voters),
-                "committer": msg.sender_id,
-                "certificate": True,
-            })
-            return {"status": "committed", "epoch": epoch, "accept_count": len(accepted_voters)}
+            if certificate_error is None:
+                if certificate_voters is None or len(certificate_voters) < quorum:
+                    certificate_error = "insufficient_certificate_quorum"
+                elif not voter_set.issubset(certificate_voters):
+                    certificate_error = "certificate_voter_mismatch"
+                elif accept_count > len(certificate_voters):
+                    certificate_error = "certificate_accept_count_mismatch"
 
         votes_for_proposal = self._epoch_votes.get((epoch, proposal_hash), {})
         accepted_voters = {
@@ -1466,12 +1477,16 @@ class GossipLayer:
         }
         unverified_voters = voter_set - accepted_voters
         if unverified_voters:
+            if vote_certificate is not None and certificate_error:
+                return {"status": "error", "reason": certificate_error}
             return {
                 "status": "error",
                 "reason": "unverified_voters",
                 "voters": sorted(unverified_voters),
             }
         if len(accepted_voters) < quorum:
+            if vote_certificate is not None and certificate_error:
+                return {"status": "error", "reason": certificate_error}
             return {"status": "error", "reason": "insufficient_local_quorum"}
 
         self.epoch_crdt.add(epoch, {

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -856,6 +856,43 @@ class GossipLayer:
         ).hexdigest()
         return hmac.compare_digest(hmac_sig, expected)
 
+    def _has_trusted_ed25519_identity(
+        self,
+        msg: GossipMessage,
+        *,
+        check_freshness: bool = True,
+    ) -> bool:
+        """Return True only when msg is signed by the sender's trusted Ed25519 key."""
+        if check_freshness and abs(time.time() - msg.timestamp) > MESSAGE_EXPIRY:
+            return False
+
+        from p2p_identity import PeerRegistry, unpack_signature, verify_ed25519
+
+        _hmac_sig, ed25519_sig, _key_version = unpack_signature(msg.signature)
+        if not ed25519_sig:
+            return False
+
+        registry = self._peer_registry
+        if registry is None:
+            registry = PeerRegistry()
+            registry.load()
+
+        pubkey = registry.get_pubkey(msg.sender_id)
+        if pubkey is None and msg.sender_id == self.node_id and self._keypair is not None:
+            pubkey = self._keypair.pubkey_hex
+        if pubkey is None:
+            return False
+
+        content = self._signed_content(
+            msg.msg_type,
+            msg.sender_id,
+            msg.msg_id,
+            msg.ttl,
+            msg.payload,
+        )
+        message = f"{content}:{msg.timestamp}"
+        return verify_ed25519(pubkey, ed25519_sig, message.encode())
+
     def verify_message(self, msg: GossipMessage) -> bool:
         """Verify message signature and freshness."""
         return self._verify_message_signature(msg, check_freshness=True)
@@ -1373,6 +1410,8 @@ class GossipLayer:
                 return None, {}, "unknown_certificate_voter"
             if not self._verify_message_signature(vote_msg, check_freshness=False):
                 return None, {}, "invalid_vote_certificate_signature"
+            if not self._has_trusted_ed25519_identity(vote_msg):
+                return None, {}, "certificate_requires_ed25519_identity"
 
             vote_payload = vote_msg.payload if isinstance(vote_msg.payload, dict) else {}
             if vote_payload.get("epoch") != epoch:

--- a/node/rustchain_p2p_gossip.py
+++ b/node/rustchain_p2p_gossip.py
@@ -897,32 +897,6 @@ class GossipLayer:
         """Verify message signature and freshness."""
         return self._verify_message_signature(msg, check_freshness=True)
 
-    def _has_trusted_ed25519_identity(self, msg: GossipMessage) -> bool:
-        """Return True only when msg has a valid trusted Ed25519 signature."""
-        from p2p_identity import unpack_signature, verify_ed25519
-
-        _hmac_sig, ed25519_sig, _key_version = unpack_signature(msg.signature)
-        if not ed25519_sig:
-            return False
-
-        pubkey = None
-        if self._peer_registry is not None:
-            pubkey = self._peer_registry.get_pubkey(msg.sender_id)
-        if pubkey is None and msg.sender_id == self.node_id and self._keypair is not None:
-            pubkey = self._keypair.pubkey_hex
-        if pubkey is None:
-            return False
-
-        content = self._signed_content(
-            msg.msg_type,
-            msg.sender_id,
-            msg.msg_id,
-            msg.ttl,
-            msg.payload,
-        )
-        message = f"{content}:{msg.timestamp}"
-        return verify_ed25519(pubkey, ed25519_sig, message.encode())
-
     def broadcast(self, msg: GossipMessage, exclude_peer: str = None):
         """Broadcast message to all peers"""
         for peer_id, peer_url in self.peers.items():
@@ -1395,6 +1369,9 @@ class GossipLayer:
         known_nodes: Set[str],
     ) -> Tuple[Optional[Set[str]], Dict[str, GossipMessage], Optional[str]]:
         """Verify signed accept-vote messages attached to an epoch commit."""
+        if len(certificate) > len(known_nodes):
+            return None, {}, "vote_certificate_too_large"
+
         accepted_voters: Set[str] = set()
         verified_messages: Dict[str, GossipMessage] = {}
 
@@ -1408,9 +1385,11 @@ class GossipLayer:
                 return None, {}, "invalid_vote_certificate"
             if vote_msg.sender_id not in known_nodes:
                 return None, {}, "unknown_certificate_voter"
+            if vote_msg.sender_id in accepted_voters:
+                return None, {}, "duplicate_certificate_voter"
             if not self._verify_message_signature(vote_msg, check_freshness=False):
                 return None, {}, "invalid_vote_certificate_signature"
-            if not self._has_trusted_ed25519_identity(vote_msg):
+            if not self._has_trusted_ed25519_identity(vote_msg, check_freshness=False):
                 return None, {}, "certificate_requires_ed25519_identity"
 
             vote_payload = vote_msg.payload if isinstance(vote_msg.payload, dict) else {}

--- a/node/tests/test_p2p_hardening_phase2.py
+++ b/node/tests/test_p2p_hardening_phase2.py
@@ -8,6 +8,7 @@ Covers:
 - Phase E: _handle_attestation future-ts + schema validation
 """
 import importlib.util
+import json
 import os
 import sqlite3
 import sys
@@ -47,6 +48,34 @@ def _mk_layer(node_id, peers_dict=None, db_path=None):
     return layer
 
 
+def _trusted_layer_factory(tmp_path, monkeypatch, node_ids):
+    import p2p_identity
+
+    registry_path = tmp_path / "peer-registry.json"
+    key_paths = {}
+    peers = []
+
+    monkeypatch.setattr(p2p_identity, "SIGNING_MODE", "dual")
+    for node_id in node_ids:
+        key_path = tmp_path / f"{node_id}-identity.pem"
+        key_paths[node_id] = key_path
+        peers.append({
+            "node_id": node_id,
+            "pubkey_hex": p2p_identity.LocalKeypair(key_path).pubkey_hex,
+        })
+
+    registry_path.write_text(json.dumps({"version": 1, "peers": peers}))
+
+    def make(node_id, peers_dict=None, db_path=None):
+        monkeypatch.setenv("RC_P2P_PRIVKEY_PATH", str(key_paths[node_id]))
+        layer = _mk_layer(node_id, peers_dict, db_path)
+        layer._peer_registry = p2p_identity.PeerRegistry(str(registry_path))
+        layer._peer_registry.load()
+        return layer
+
+    return make
+
+
 # Phase A regression
 def test_phase_a_sender_id_flip_fails_verification():
     """After Phase A, flipping sender_id post-sign invalidates the signature."""
@@ -63,11 +92,12 @@ def test_phase_a_sender_id_flip_fails_verification():
 
 
 # Phase A + old spoof regression
-def test_phase_a_old_payload_voter_spoof_still_blocked():
+def test_phase_a_old_payload_voter_spoof_still_blocked(tmp_path, monkeypatch):
     """The original PR #2257 dedup still holds under Phase A."""
-    target = _mk_layer("node1", {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"})
-    attacker = _mk_layer("node2", db_path=target.db_path)
-    attacker.broadcast = lambda *args, **kwargs: None
+    peers = {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"}
+    make_layer = _trusted_layer_factory(tmp_path, monkeypatch, {"node1", "node2", "node3", "node4"})
+    target = make_layer("node1", peers)
+    attacker = make_layer("node2", db_path=target.db_path)
 
     first = attacker.create_message(
         mod.MessageType.EPOCH_VOTE,
@@ -158,12 +188,12 @@ def test_phase_b_rr_delegate_gate_rejects_non_leader():
 
 
 # Phase C regression
-def test_phase_c_mixed_proposals_dont_aggregate_to_quorum():
+def test_phase_c_mixed_proposals_dont_aggregate_to_quorum(tmp_path, monkeypatch):
     """Phase C: two different proposal_hashes get separate quorum counts."""
-    target = _mk_layer("node1", {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"})
-    voters = [_mk_layer(nid, db_path=target.db_path) for nid in ("node2", "node3", "node4")]
-    for v in voters:
-        v.broadcast = lambda *args, **kwargs: None
+    peers = {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"}
+    make_layer = _trusted_layer_factory(tmp_path, monkeypatch, {"node1", "node2", "node3", "node4"})
+    target = make_layer("node1", peers)
+    voters = [make_layer(nid, db_path=target.db_path) for nid in ("node2", "node3", "node4")]
 
     # node2 votes accept on proposal_hash="A"
     # node3 votes accept on proposal_hash="B"
@@ -187,12 +217,12 @@ def test_phase_c_mixed_proposals_dont_aggregate_to_quorum():
     assert len(target._epoch_votes[(9, "B")]) == 1
 
 
-def test_epoch_votes_survive_restart_and_reject_retransmit():
+def test_epoch_votes_survive_restart_and_reject_retransmit(tmp_path, monkeypatch):
     """Persisted votes prevent restart from accepting a fresh duplicate vote."""
     peers = {"node2": "http://n2", "node3": "http://n3", "node4": "http://n4"}
-    target = _mk_layer("node1", peers)
-    voter = _mk_layer("node2", db_path=target.db_path)
-    voter.broadcast = lambda *args, **kwargs: None
+    make_layer = _trusted_layer_factory(tmp_path, monkeypatch, {"node1", "node2", "node3", "node4"})
+    target = make_layer("node1", peers)
+    voter = make_layer("node2", db_path=target.db_path)
 
     first = voter.create_message(
         mod.MessageType.EPOCH_VOTE,
@@ -200,7 +230,7 @@ def test_epoch_votes_survive_restart_and_reject_retransmit():
     )
     assert target.handle_message(first)["status"] == "ok"
 
-    restarted = _mk_layer("node1", peers, db_path=target.db_path)
+    restarted = make_layer("node1", peers, db_path=target.db_path)
     key = (12, "persisted-proposal")
     assert restarted._epoch_votes[key] == {"node2": "accept"}
 

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -202,6 +202,56 @@ def test_epoch_commit_accepts_quorum_backed_by_local_votes(tmp_path, monkeypatch
     assert victim.epoch_crdt.metadata[7]["voters"] == ["peer1", "peer2", "peer3"]
 
 
+def test_epoch_vote_omits_partial_certificate_after_vote_reload(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    node = _cluster_node(tmp_path, "victim")
+    peer3 = _cluster_node(tmp_path, "peer3")
+    key = (7, "proposal-a")
+    node._epoch_votes[key] = {
+        "peer1": "accept",
+        "peer2": "accept",
+    }
+    broadcasted = []
+    monkeypatch.setattr(node, "broadcast", lambda msg: broadcasted.append(msg))
+
+    result = node.handle_message(_accept_vote(peer3))
+
+    assert result["status"] == "committed"
+    assert len(broadcasted) == 1
+    assert "vote_certificate" not in broadcasted[0].payload
+    assert broadcasted[0].payload["voters"] == ["peer1", "peer2", "peer3"]
+
+
+def test_epoch_commit_partial_certificate_falls_back_to_local_votes(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = _cluster_node(tmp_path, "victim")
+    peer1 = _cluster_node(tmp_path, "peer1")
+    peer3 = _cluster_node(tmp_path, "peer3")
+    victim._epoch_votes[(7, "proposal-a")] = {
+        "peer1": "accept",
+        "peer2": "accept",
+        "peer3": "accept",
+    }
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": [_accept_vote(peer3).to_dict()],
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "committed"
+    assert victim.epoch_crdt.contains(7)
+    assert victim.epoch_crdt.metadata[7]["voters"] == ["peer1", "peer2", "peer3"]
+    assert "certificate" not in victim.epoch_crdt.metadata[7]
+
+
 def test_epoch_commit_accepts_quorum_backed_by_vote_certificate(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     victim = _cluster_node(tmp_path, "victim")

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -3,6 +3,7 @@
 import os
 import sys
 from pathlib import Path
+import json
 
 os.environ.setdefault("RC_P2P_SECRET", "a" * 64)
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -23,6 +24,44 @@ def _cluster_node(tmp_path, node_id):
         peers={peer_id: url for peer_id, url in all_nodes.items() if peer_id != node_id},
         db_path=str(tmp_path / f"{node_id}.db"),
     )
+
+
+def _ed25519_cluster_node_factory(tmp_path, monkeypatch):
+    import p2p_identity
+
+    all_nodes = {
+        "victim": "https://victim.example",
+        "peer1": "https://peer1.example",
+        "peer2": "https://peer2.example",
+        "peer3": "https://peer3.example",
+    }
+    registry_path = tmp_path / "peer-registry.json"
+    key_paths = {}
+    peers = []
+
+    monkeypatch.setattr(p2p_identity, "SIGNING_MODE", "dual")
+    for node_id in all_nodes:
+        key_path = tmp_path / f"{node_id}-identity.pem"
+        key_paths[node_id] = key_path
+        peers.append({
+            "node_id": node_id,
+            "pubkey_hex": p2p_identity.LocalKeypair(key_path).pubkey_hex,
+        })
+
+    registry_path.write_text(json.dumps({"version": 1, "peers": peers}))
+
+    def make(node_id):
+        monkeypatch.setenv("RC_P2P_PRIVKEY_PATH", str(key_paths[node_id]))
+        node = GossipLayer(
+            node_id=node_id,
+            peers={peer_id: url for peer_id, url in all_nodes.items() if peer_id != node_id},
+            db_path=str(tmp_path / f"{node_id}.db"),
+        )
+        node._peer_registry = p2p_identity.PeerRegistry(str(registry_path))
+        node._peer_registry.load()
+        return node
+
+    return make
 
 
 def _accept_vote(node, epoch=7, proposal_hash="proposal-a"):
@@ -204,8 +243,9 @@ def test_epoch_commit_accepts_quorum_backed_by_local_votes(tmp_path, monkeypatch
 
 def test_epoch_vote_omits_partial_certificate_after_vote_reload(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
-    node = _cluster_node(tmp_path, "victim")
-    peer3 = _cluster_node(tmp_path, "peer3")
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    node = make_node("victim")
+    peer3 = make_node("peer3")
     key = (7, "proposal-a")
     node._epoch_votes[key] = {
         "peer1": "accept",
@@ -224,9 +264,10 @@ def test_epoch_vote_omits_partial_certificate_after_vote_reload(tmp_path, monkey
 
 def test_epoch_commit_partial_certificate_falls_back_to_local_votes(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
-    victim = _cluster_node(tmp_path, "victim")
-    peer1 = _cluster_node(tmp_path, "peer1")
-    peer3 = _cluster_node(tmp_path, "peer3")
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer3 = make_node("peer3")
     victim._epoch_votes[(7, "proposal-a")] = {
         "peer1": "accept",
         "peer2": "accept",
@@ -252,12 +293,44 @@ def test_epoch_commit_partial_certificate_falls_back_to_local_votes(tmp_path, mo
     assert "certificate" not in victim.epoch_crdt.metadata[7]
 
 
-def test_epoch_commit_accepts_quorum_backed_by_vote_certificate(tmp_path, monkeypatch):
+def test_epoch_commit_rejects_hmac_only_vote_certificate(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     victim = _cluster_node(tmp_path, "victim")
     peer1 = _cluster_node(tmp_path, "peer1")
     peer2 = _cluster_node(tmp_path, "peer2")
     peer3 = _cluster_node(tmp_path, "peer3")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+        _accept_vote(peer3).to_dict(),
+    ]
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "error"
+    assert result["reason"] == "certificate_requires_ed25519_identity"
+    assert not victim.epoch_crdt.contains(7)
+
+
+def test_epoch_commit_accepts_quorum_backed_by_vote_certificate(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer2 = make_node("peer2")
+    peer3 = make_node("peer3")
 
     vote_certificate = [
         _accept_vote(peer1).to_dict(),
@@ -288,10 +361,11 @@ def test_epoch_commit_accepts_quorum_backed_by_vote_certificate(tmp_path, monkey
 def test_epoch_commit_certificate_allows_stale_votes_for_offline_catchup(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     now = p2p.time.time()
-    victim = _cluster_node(tmp_path, "victim")
-    peer1 = _cluster_node(tmp_path, "peer1")
-    peer2 = _cluster_node(tmp_path, "peer2")
-    peer3 = _cluster_node(tmp_path, "peer3")
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer2 = make_node("peer2")
+    peer3 = make_node("peer3")
 
     vote_certificate = [
         _accept_vote(peer1).to_dict(),
@@ -319,10 +393,11 @@ def test_epoch_commit_certificate_allows_stale_votes_for_offline_catchup(tmp_pat
 
 def test_epoch_commit_rejects_tampered_vote_certificate(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
-    victim = _cluster_node(tmp_path, "victim")
-    peer1 = _cluster_node(tmp_path, "peer1")
-    peer2 = _cluster_node(tmp_path, "peer2")
-    peer3 = _cluster_node(tmp_path, "peer3")
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer2 = make_node("peer2")
+    peer3 = make_node("peer3")
 
     vote_certificate = [
         _accept_vote(peer1).to_dict(),

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -5,9 +5,37 @@ import sys
 from pathlib import Path
 
 os.environ.setdefault("RC_P2P_SECRET", "a" * 64)
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "node"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+import rustchain_p2p_gossip as p2p
 from rustchain_p2p_gossip import GossipLayer, MessageType
+
+
+def _cluster_node(tmp_path, node_id):
+    all_nodes = {
+        "victim": "https://victim.example",
+        "peer1": "https://peer1.example",
+        "peer2": "https://peer2.example",
+        "peer3": "https://peer3.example",
+    }
+    return GossipLayer(
+        node_id=node_id,
+        peers={peer_id: url for peer_id, url in all_nodes.items() if peer_id != node_id},
+        db_path=str(tmp_path / f"{node_id}.db"),
+    )
+
+
+def _accept_vote(node, epoch=7, proposal_hash="proposal-a"):
+    return node.create_message(
+        MessageType.EPOCH_VOTE,
+        {
+            "epoch": epoch,
+            "proposal_hash": proposal_hash,
+            "vote": "accept",
+            "voter": node.node_id,
+        },
+        ttl=0,
+    )
 
 
 def test_signed_state_sync_cannot_inject_epoch_finality(tmp_path, monkeypatch):
@@ -172,6 +200,103 @@ def test_epoch_commit_accepts_quorum_backed_by_local_votes(tmp_path, monkeypatch
     assert victim.epoch_crdt.contains(7)
     assert victim.epoch_crdt.metadata[7]["proposal_hash"] == "proposal-a"
     assert victim.epoch_crdt.metadata[7]["voters"] == ["peer1", "peer2", "peer3"]
+
+
+def test_epoch_commit_accepts_quorum_backed_by_vote_certificate(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = _cluster_node(tmp_path, "victim")
+    peer1 = _cluster_node(tmp_path, "peer1")
+    peer2 = _cluster_node(tmp_path, "peer2")
+    peer3 = _cluster_node(tmp_path, "peer3")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+        _accept_vote(peer3).to_dict(),
+    ]
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "committed"
+    assert victim.epoch_crdt.contains(7)
+    assert victim.epoch_crdt.metadata[7]["proposal_hash"] == "proposal-a"
+    assert victim.epoch_crdt.metadata[7]["voters"] == ["peer1", "peer2", "peer3"]
+    assert victim.epoch_crdt.metadata[7]["certificate"] is True
+
+
+def test_epoch_commit_certificate_allows_stale_votes_for_offline_catchup(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    now = p2p.time.time()
+    victim = _cluster_node(tmp_path, "victim")
+    peer1 = _cluster_node(tmp_path, "peer1")
+    peer2 = _cluster_node(tmp_path, "peer2")
+    peer3 = _cluster_node(tmp_path, "peer3")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+        _accept_vote(peer3).to_dict(),
+    ]
+    monkeypatch.setattr(p2p.time, "time", lambda: now + p2p.MESSAGE_EXPIRY + 30)
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "committed"
+    assert victim.epoch_crdt.contains(7)
+
+
+def test_epoch_commit_rejects_tampered_vote_certificate(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    victim = _cluster_node(tmp_path, "victim")
+    peer1 = _cluster_node(tmp_path, "peer1")
+    peer2 = _cluster_node(tmp_path, "peer2")
+    peer3 = _cluster_node(tmp_path, "peer3")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+        _accept_vote(peer3).to_dict(),
+    ]
+    vote_certificate[1]["payload"]["proposal_hash"] = "proposal-b"
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "error"
+    assert result["reason"] == "invalid_vote_certificate_signature"
+    assert not victim.epoch_crdt.contains(7)
 
 
 def test_epoch_commit_rejects_without_quorum(tmp_path, monkeypatch):

--- a/node/tests/test_p2p_state_epoch_sync.py
+++ b/node/tests/test_p2p_state_epoch_sync.py
@@ -424,6 +424,71 @@ def test_epoch_commit_rejects_tampered_vote_certificate(tmp_path, monkeypatch):
     assert not victim.epoch_crdt.contains(7)
 
 
+def test_epoch_commit_rejects_duplicate_certificate_voter(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer2 = make_node("peer2")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+    ]
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "error"
+    assert result["reason"] == "duplicate_certificate_voter"
+    assert not victim.epoch_crdt.contains(7)
+
+
+def test_epoch_commit_rejects_oversized_vote_certificate(tmp_path, monkeypatch):
+    monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
+    make_node = _ed25519_cluster_node_factory(tmp_path, monkeypatch)
+    victim = make_node("victim")
+    peer1 = make_node("peer1")
+    peer2 = make_node("peer2")
+    peer3 = make_node("peer3")
+
+    vote_certificate = [
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+        _accept_vote(peer3).to_dict(),
+        _accept_vote(peer1).to_dict(),
+        _accept_vote(peer2).to_dict(),
+    ]
+    msg = peer1.create_message(
+        MessageType.EPOCH_COMMIT,
+        {
+            "epoch": 7,
+            "proposal_hash": "proposal-a",
+            "accept_count": 3,
+            "voters": ["peer1", "peer2", "peer3"],
+            "vote_certificate": vote_certificate,
+        },
+        ttl=0,
+    )
+
+    result = victim.handle_message(msg)
+
+    assert result["status"] == "error"
+    assert result["reason"] == "vote_certificate_too_large"
+    assert not victim.epoch_crdt.contains(7)
+
+
 def test_epoch_commit_rejects_without_quorum(tmp_path, monkeypatch):
     monkeypatch.setenv("RC_P2P_SECRET", "a" * 64)
     victim = GossipLayer(


### PR DESCRIPTION
## Summary
- Replaces the closed #5974 with the same epoch catch-up certificate fix replayed onto current `main`.
- Attach signed `EPOCH_VOTE` messages as a `vote_certificate` on `EPOCH_COMMIT` broadcasts so offline peers can verify quorum evidence instead of trusting the committer's voter list.
- Require every certificate vote to have a trusted Ed25519 identity while preserving freshness-neutral verification only for embedded historic vote messages.
- Address the #5974 close feedback: remove the duplicate `_has_trusted_ed25519_identity` definition, reject oversized certificates before expensive verification, and reject duplicate certificate voters early.

Fixes #5950.
Replaces #5974.

## Validation
- `uv run --no-project --with pytest --with flask --with requests --with pynacl --with cryptography python -m pytest node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_hardening_phase2.py -q` -> 25 passed
- `python3 -m py_compile node/rustchain_p2p_gossip.py node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_hardening_phase2.py`
- `git diff --check origin/main...HEAD -- node/rustchain_p2p_gossip.py node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_hardening_phase2.py`
- `uv run --no-project python tools/bcos_spdx_check.py --base-ref origin/main` -> OK
- `uv run --no-project --with ruff ruff check node/rustchain_p2p_gossip.py node/tests/test_p2p_state_epoch_sync.py node/tests/test_p2p_hardening_phase2.py --select E9,F821,F811,F841 --output-format=concise` -> OK

## Bounty payment
wallet: RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116
Payment method: RTC wallet `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`
