### PR TITLE
Fix package license metadata to match Apache 2.0 license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.2.1"
 description = "RustChain — Proof of Antiquity blockchain with hardware fingerprinting + RTC token"
 readme = "README.md"
 requires-python = ">=3.9"
-license = {text = "MIT"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "Scott Boudreaux / Elyan Labs", email = "scottbphone12@gmail.com"},
 ]


### PR DESCRIPTION
## Summary
- Update `pyproject.toml` license metadata from `MIT` to `Apache-2.0`
- Align Python package metadata with the repository README badge and license files

## Proof
- README license badge already shows Apache 2.0
- LICENSE, NOTICE, and NOTICE.md are present
- One-file metadata-only change

## Risk
Low. No runtime code changed.

No bounty claim or payout action is included in this PR.
