### PR TITLE
docs: add build status badge to README (#6791)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 # RustChain
 
+[![Build Status](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
+
 ### DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
 
 **The blockchain where old hardware outearns new hardware.**


### PR DESCRIPTION
Added a build status badge for the main CI workflow as requested in issue #6791.

Fixes #6791