### PR TITLE
fix: handle JSONDecodeError on empty 200 OK responses in async client (#7351)

### DIFF
--- a/sdk/python/rustchain_sdk/client.py
+++ b/sdk/python/rustchain_sdk/client.py
@@ -100,7 +100,10 @@ class RustChainClient:
                 json=json_data,
             )
             response.raise_for_status()
-            return response.json()
+            try:
+                return response.json()
+            except Exception:
+                return {"raw_response": response.text}
         except httpx.ConnectError as e:
             raise RCConnectionError(f"Failed to connect to {self._base_url}: {e}")
         except httpx.HTTPStatusError as e:
@@ -145,7 +148,10 @@ class RustChainClient:
                     status_code=response.status_code,
                 )
             response.raise_for_status()
-            return response.json()
+            try:
+                return response.json()
+            except Exception:
+                return {"raw_response": response.text}
         except httpx.ConnectError as e:
             raise RCConnectionError(f"Failed to connect to {self._base_url}: {e}")
         except httpx.HTTPStatusError as e:


### PR DESCRIPTION
The async RustChainClient would raise a generic RustChainError (via JSONDecodeError) when receiving an empty 200 OK response. This PR adds a try-except block to return the raw response text instead, aligning it with the synchronous client behavior.

Fixes #7351