### PR TITLE
fix(miner): detect macOS hardware serial in dry-run

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -102,6 +102,17 @@ def _parse_wmic_value(output, key):
     return ""
 
 
+def _parse_ioreg_serial(output):
+    for line in str(output or "").splitlines():
+        if "IOPlatformSerialNumber" not in line:
+            continue
+        _, _, value = line.partition("=")
+        serial = value.strip().strip('"')
+        if serial and serial.lower() != "none":
+            return serial
+    return ""
+
+
 def _linux_miner_platform_warning(system):
     if system in ("Linux", "Darwin"):
         return ""
@@ -213,6 +224,33 @@ def get_linux_serial():
 
     return None
 
+
+def get_macos_serial():
+    """Get hardware serial number for macOS systems."""
+    try:
+        result = subprocess.run(
+            ["ioreg", "-rd1", "-c", "IOPlatformExpertDevice"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            serial = _parse_ioreg_serial(result.stdout)
+            if serial:
+                return serial
+    except Exception:
+        pass
+
+    return None
+
+
+def get_hardware_serial(system=None):
+    system = system or platform.system()
+    if system == "Darwin":
+        return get_macos_serial()
+    return get_linux_serial()
+
+
 class LocalMiner:
     def __init__(self, wallet=None, wart_address=None, wart_pool=None,
                  bzminer_path=None, manage_bzminer=False, verbose=False, show_payload=False,
@@ -253,7 +291,7 @@ class LocalMiner:
                 manage_bzminer=manage_bzminer,
             )
 
-        self.serial = get_linux_serial()
+        self.serial = get_hardware_serial()
         print("="*70)
         print("RustChain Local Linux Miner")
         print("RIP-PoA Hardware Fingerprint + Serial Binding v2.0")
@@ -408,7 +446,7 @@ class LocalMiner:
             "hostname": socket.gethostname(),
             "family": "x86",
             "arch": "modern",  # Less than 10 years old
-            "serial": get_linux_serial(),  # Hardware serial for v2 binding
+            "serial": get_hardware_serial(system),  # Hardware serial for v2 binding
             "probe_warning": _linux_miner_platform_warning(system)
         }
 

--- a/tests/test_linux_miner_identity.py
+++ b/tests/test_linux_miner_identity.py
@@ -37,6 +37,30 @@ def test_linux_miner_source_does_not_hardcode_victus_identity():
     assert "RustChain Local Linux Miner" in source
 
 
+def test_parse_ioreg_serial_extracts_platform_serial():
+    miner = load_miner_module()
+
+    output = '''
+    +-o IOPlatformExpertDevice  <class IOPlatformExpertDevice, id 0x100000100, registered, matched, active, busy 0 (88 ms), retain 42>
+        "IOPlatformSerialNumber" = "C02TESTSERIAL"
+    '''
+
+    assert miner._parse_ioreg_serial(output) == "C02TESTSERIAL"
+
+
+def test_hardware_serial_uses_macos_probe(monkeypatch):
+    miner = load_miner_module()
+
+    monkeypatch.setattr(miner, "get_macos_serial", lambda: "mac-serial")
+    monkeypatch.setattr(
+        miner,
+        "get_linux_serial",
+        lambda: (_ for _ in ()).throw(AssertionError("Darwin should not use Linux serial probes")),
+    )
+
+    assert miner.get_hardware_serial("Darwin") == "mac-serial"
+
+
 def test_local_miner_can_use_ephemeral_keypair_without_persisting(monkeypatch):
     miner = load_miner_module()
     calls = {"ephemeral": 0, "persisted": 0}
@@ -53,7 +77,7 @@ def test_local_miner_can_use_ephemeral_keypair_without_persisting(monkeypatch):
     monkeypatch.setattr(miner, "FINGERPRINT_AVAILABLE", False)
     monkeypatch.setattr(miner, "generate_keypair", generate_ephemeral)
     monkeypatch.setattr(miner, "get_or_create_keypair", persist_key)
-    monkeypatch.setattr(miner, "get_linux_serial", lambda: "test-serial")
+    monkeypatch.setattr(miner, "get_hardware_serial", lambda: "test-serial")
 
     instance = miner.LocalMiner(wallet="RTC-test-wallet", persist_key=False)
 


### PR DESCRIPTION
## Summary
- add a macOS serial probe using `ioreg -rd1 -c IOPlatformExpertDevice`
- route miner startup and hardware info collection through a shared `get_hardware_serial()` helper
- add focused tests for `ioreg` parsing and Darwin serial dispatch

Fixes #7478.

## Validation
- `python3 -m py_compile miners/linux/rustchain_linux_miner.py tests/test_linux_miner_identity.py`
- `git diff --check`
- targeted direct execution of `tests/test_linux_miner_identity.py` assertions with `pytest.MonkeyPatch` because repository-level pytest collection imports the full node service stack and requires Flask
- `.venv/bin/python rustchain_linux_miner.py --wallet itisstevenliu-sys --dry-run --show-payload` on macOS/Darwin arm64: 6/6 fingerprint checks passed, health probe HTTP 200, node version 2.2.1-rip200, and `Serial present: yes`

## Notes
- The dry-run output was checked locally with the actual serial redacted from public reporting.
- No mining enrollment, payment, or chain state mutation was performed.

Wallet/miner identifier for any bounty processing: `itisstevenliu-sys`.