### PR TITLE
Use placeholder tip bot wallet in env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,8 +61,9 @@ RUN_AS_NON_ROOT=true
 RC_P2P_SECRET=
 
 # === GitHub Tip Bot Configuration ===
-# Payout wallet address for bounty distributions
-TIP_BOT_WALLET=RTC1d48d848a5aa5ecf2c5f01aa5fb64837daaf2f35
+# Payout wallet address for bounty distributions.
+# Replace this placeholder with the public RTC wallet address used by your deployment.
+TIP_BOT_WALLET=RTC_YOUR_TIP_BOT_WALLET
 
 # Comma-separated list of admin usernames (optional)
 TIP_BOT_ADMINS=


### PR DESCRIPTION
## Summary
- replace the real-format `TIP_BOT_WALLET` value in `.env.example` with an explicit placeholder
- add a short note telling deployers to provide their own public RTC wallet address

## Validation
- `rg -n "TIP_BOT_WALLET|RTC[0-9a-fA-F]{40}" .env.example`
- `git diff --check`

Closes #7483