### PR TITLE
miner: include fingerprint in enroll payload (fix zero-weight under rotating fingerprint check)

### DIFF
--- a/miners/linux/rustchain_linux_miner.py
+++ b/miners/linux/rustchain_linux_miner.py
@@ -735,7 +735,14 @@ class LocalMiner:
             "device": {
                 "family": self.hw_info["family"],
                 "arch": self.hw_info["arch"]
-            }
+            },
+            # Include the hardware fingerprint in the enrollment too. The node's
+            # per-epoch rotating-check (evaluate_rotating_fingerprint_checks)
+            # reads the fingerprint from the ENROLL body; without it active_ratio
+            # is 0 and the enrolled weight collapses to 0 even for real hardware
+            # that already passed attestation. (Node aliases simd_identity ->
+            # simd_bias itself, so no client-side rename is needed.)
+            "fingerprint": self.fingerprint_data
         }
 
         # Ed25519-sign the enrollment if we have a keypair AND a fresh epoch.

--- a/miners/windows/rustchain_windows_miner.py
+++ b/miners/windows/rustchain_windows_miner.py
@@ -531,6 +531,9 @@ class RustChainMiner:
                     "all_passed": fp_passed,
                     "checks":     fp_checks,
                 }
+                # Stash so enroll() can resubmit it for the per-epoch
+                # rotating-check (see enroll payload below).
+                self.fingerprint_data = attestation["fingerprint"]
                 self.last_fingerprint_warning = ""
             except Exception as e:
                 # Do NOT swallow: a runtime failure here means the miner
@@ -640,7 +643,12 @@ class RustChainMiner:
             "device": {
                 "family": self.hw_info["family"],
                 "arch":   self.hw_info["arch"]
-            }
+            },
+            # Resubmit the hardware fingerprint: the node's per-epoch rotating
+            # check reads it from the ENROLL body, and without it active_ratio
+            # is 0 -> enrolled weight collapses to 0 even for real hardware that
+            # already passed attestation.
+            "fingerprint": getattr(self, "fingerprint_data", {})
         }
 
         # Sign (miner_pubkey|miner_id|epoch) — server expects this exact


### PR DESCRIPTION
## Problem

Signed epoch enrollment succeeds but the **enrolled weight collapses to 0** for real hardware that already passed attestation.

The node's per-epoch rotating fingerprint check evaluates the fingerprint from the **enrollment** request body:

```python
rotation_eval = evaluate_rotating_fingerprint_checks(
    conn, epoch,
    data.get('fingerprint') if isinstance(data.get('fingerprint'), dict) else {},
)
...
weight_units = epoch_weight_to_units(hw_weight * rotation_eval['active_ratio'])
```

But the miner only sends `fingerprint` in the **attestation** payload — the enroll payload contains just `miner_pubkey` / `miner_id` / `device` (+ signature). So `data.get('fingerprint')` is empty at enroll, every active check resolves to *not present*, `active_ratio = 0`, and `weight = hw_weight * 0 = 0`.

Net effect: with the rotating-check active, **every signed miner enrolls at zero weight** despite passing attestation.

## Fix

Include the hardware fingerprint in the enroll payload (it's already computed/stored from the attestation pass — no extra work, no extra checks run):

- `miners/linux/rustchain_linux_miner.py` — add `"fingerprint": self.fingerprint_data` to the enroll payload.
- `miners/windows/rustchain_windows_miner.py` — stash the fingerprint on `self` at attest, resubmit it at enroll (parity).

The node already aliases `simd_identity ↔ simd_bias` internally, so no client-side check renaming is needed.

## Validation

Reproduced and fixed end-to-end on an Apple Silicon (M2) miner against the live node:
- Before: enroll succeeds, **`Weight: 0.0x`** (server record shows `fingerprint_passed=1`, so it wasn't an attestation failure).
- After: **`Weight: 1.0x`** (1.2x when all six rotating checks pass that cycle; the dock is a flaky `cache_timing` micro-bench under load, not this fix).

## Recommended complementary node-side fix (maintainer's call)

The most robust fix is **node-side**: have the enroll handler fall back to the **stored attestation fingerprint** (`miner_attest_recent.fingerprint_checks_json`) when the enroll body omits one. That un-zeros the *entire existing fleet* without requiring every miner to update first — the miner already proved the fingerprint at attestation seconds earlier, so requiring it twice is redundant and brittle. This client PR is the defense-in-depth half; pairing it with the node fallback closes the gap for un-updated miners too.
