### PR TITLE
[UTXO-BUG] pending confirm leaves migrated UTXOs spendable

### DIFF
--- a/node/tests/test_account_utxo_pending_confirm_ownership.py
+++ b/node/tests/test_account_utxo_pending_confirm_ownership.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: MIT
+
 import importlib.util
 import os
 import sqlite3

--- a/node/tests/test_account_utxo_pending_confirm_ownership.py
+++ b/node/tests/test_account_utxo_pending_confirm_ownership.py
@@ -1,0 +1,186 @@
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+NODE_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = NODE_DIR / "rustchain_v2_integrated_v2.2.1_rip200.py"
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+ACCOUNT_UNIT = 1_000_000
+
+
+def _load_node_module(db_path: str):
+    os.environ["RUSTCHAIN_DB_PATH"] = db_path
+    os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+    os.environ["UTXO_DUAL_WRITE"] = "0"
+    if str(NODE_DIR) not in sys.path:
+        sys.path.insert(0, str(NODE_DIR))
+
+    spec = importlib.util.spec_from_file_location(
+        "rustchain_pending_confirm_cross_model_test",
+        MODULE_PATH,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    mod.send_sophiacheck_alert = lambda *args, **kwargs: None
+    mod.init_db()
+    return mod
+
+
+def _seed_account_balance(db_path: str, wallet: str, rtc_amount: int) -> None:
+    with sqlite3.connect(db_path) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(balances)")}
+        if {"miner_id", "amount_i64"}.issubset(cols):
+            conn.execute(
+                "INSERT OR REPLACE INTO balances (miner_id, amount_i64) VALUES (?, ?)",
+                (wallet, rtc_amount * ACCOUNT_UNIT),
+            )
+            return
+        if {"miner_pk", "balance_rtc"}.issubset(cols):
+            conn.execute(
+                "INSERT OR REPLACE INTO balances (miner_pk, balance_rtc) VALUES (?, ?)",
+                (wallet, float(rtc_amount)),
+            )
+            return
+        raise AssertionError(f"unsupported balances schema: {sorted(cols)}")
+
+
+def _account_balance_rtc(db_path: str, wallet: str) -> float:
+    with sqlite3.connect(db_path) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(balances)")}
+        if {"miner_id", "amount_i64"}.issubset(cols):
+            row = conn.execute(
+                "SELECT amount_i64 FROM balances WHERE miner_id = ?",
+                (wallet,),
+            ).fetchone()
+            return (row[0] if row else 0) / ACCOUNT_UNIT
+        if {"miner_pk", "balance_rtc"}.issubset(cols):
+            row = conn.execute(
+                "SELECT balance_rtc FROM balances WHERE miner_pk = ?",
+                (wallet,),
+            ).fetchone()
+            return float(row[0] if row else 0)
+        raise AssertionError(f"unsupported balances schema: {sorted(cols)}")
+
+
+class TestPendingConfirmUtxoOwnership(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_env = {
+            "RUSTCHAIN_DB_PATH": os.environ.get("RUSTCHAIN_DB_PATH"),
+            "RC_ADMIN_KEY": os.environ.get("RC_ADMIN_KEY"),
+            "UTXO_DUAL_WRITE": os.environ.get("UTXO_DUAL_WRITE"),
+        }
+        self.db_path = os.path.join(self._tmp.name, "node.db")
+        self.mod = _load_node_module(self.db_path)
+
+    def tearDown(self):
+        for key, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        self._tmp.cleanup()
+
+    def test_pending_confirm_consumes_or_moves_matching_migrated_utxo(self):
+        """Account confirmation must not leave the sender's migrated UTXO spendable."""
+        from utxo_db import UNIT, UtxoDB
+
+        sender = "alice"
+        account_recipient = "bob"
+        utxo_recipient = "carol"
+        amount_rtc = 100
+        amount_i64 = amount_rtc * ACCOUNT_UNIT
+
+        _seed_account_balance(self.db_path, sender, amount_rtc)
+        _seed_account_balance(self.db_path, account_recipient, 0)
+
+        utxo = UtxoDB(self.db_path)
+        utxo.init_tables()
+        self.assertTrue(
+            utxo.apply_transaction(
+                {
+                    "tx_type": "mining_reward",
+                    "_allow_minting": True,
+                    "inputs": [],
+                    "outputs": [
+                        {"address": sender, "value_nrtc": amount_rtc * UNIT},
+                    ],
+                    "fee_nrtc": 0,
+                    "timestamp": 1,
+                },
+                block_height=1,
+            )
+        )
+        self.assertEqual(utxo.get_balance(sender), amount_rtc * UNIT)
+
+        now = int(time.time())
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO pending_ledger
+                (ts, epoch, from_miner, to_miner, amount_i64, reason,
+                 status, created_at, confirms_at, tx_hash)
+                VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                """,
+                (
+                    now - 10,
+                    1,
+                    sender,
+                    account_recipient,
+                    amount_i64,
+                    "signed_transfer:cross-model-regression",
+                    now - 10,
+                    now - 1,
+                    "acct-confirm-cross-model",
+                ),
+            )
+
+        response = self.mod.app.test_client().post(
+            "/pending/confirm",
+            json={"limit": 1},
+            headers={"X-Admin-Key": ADMIN_KEY},
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        self.assertEqual(response.get_json()["confirmed_count"], 1)
+        self.assertEqual(_account_balance_rtc(self.db_path, sender), 0)
+        self.assertEqual(_account_balance_rtc(self.db_path, account_recipient), amount_rtc)
+
+        stale_sender_boxes = utxo.get_unspent_for_address(sender)
+        stale_spend_ok = False
+        if stale_sender_boxes:
+            stale_spend_ok = utxo.apply_transaction(
+                {
+                    "tx_type": "transfer",
+                    "inputs": [
+                        {
+                            "box_id": stale_sender_boxes[0]["box_id"],
+                            "spending_proof": "already-authorized-account-transfer",
+                        }
+                    ],
+                    "outputs": [
+                        {"address": utxo_recipient, "value_nrtc": amount_rtc * UNIT},
+                    ],
+                    "fee_nrtc": 0,
+                    "timestamp": 2,
+                },
+                block_height=2,
+            )
+
+        self.assertFalse(
+            stale_sender_boxes or stale_spend_ok,
+            (
+                "confirmed account-model transfer left sender's migrated UTXO "
+                f"spendable; stale_box_count={len(stale_sender_boxes)}, "
+                f"stale_spend_ok={stale_spend_ok}"
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bounty: Scottcjn/rustchain-bounties#2819

## Summary

This PR adds a failing regression for a cross-model ownership split between the legacy account confirmation path and the UTXO set.

Starting from a migrated state where the same wallet has 100 RTC in `balances` and a matching 100 RTC unspent UTXO, `POST /pending/confirm` confirms a pending account-model transfer from Alice to Bob. The account model moves Alice -> Bob, but the confirmation path never consumes or moves Alice's matching migrated UTXO. Alice's stale UTXO remains unspent and can then be applied as a separate UTXO transfer to Carol.

Result: Bob has the 100 RTC account-model claim while Carol can receive the same original 100 RTC through the UTXO model. Aggregate UTXO/account totals can still match, so aggregate integrity checks do not catch the per-wallet ownership divergence.

## Regression

Added:

- `node/tests/test_account_utxo_pending_confirm_ownership.py`

The test uses the real integrated Flask `/pending/confirm` handler, not a hand-copied transfer helper. It seeds a local SQLite database with matching account and UTXO ownership, inserts a ready pending transfer, confirms it through the endpoint, then proves the sender's original migrated UTXO is still spendable.

## Current-main result

Command:

```text
PYTHONPATH=node uv run --no-project --with flask --with pynacl --with requests python3 -m unittest node.tests.test_account_utxo_pending_confirm_ownership -v
```

Observed on current `origin/main` (`7974ef2`):

```text
FAIL: test_pending_confirm_consumes_or_moves_matching_migrated_utxo
AssertionError: ... confirmed account-model transfer left sender's migrated UTXO spendable; stale_box_count=1, stale_spend_ok=True
```

Sanity checks:

```text
PYTHONPATH=node python3 -m py_compile node/tests/test_account_utxo_pending_confirm_ownership.py
# passed

git diff --check -- node/tests/test_account_utxo_pending_confirm_ownership.py
# passed
```

## Duplicate boundary

This is not a UTXO-first dual-write shadow failure, fee/dust precision drift, endpoint domain separation, nonce ordering, or mempool candidate issue. Those are already heavily covered in #2819. This regression targets the opposite account-first path: `/wallet/transfer/signed` / `pending_ledger` / `/pending/confirm` mutates account ownership while leaving the migrated UTXO ownership untouched and spendable.

## Suggested severity

High if account and UTXO settlement APIs are considered simultaneously live after genesis migration, because the same original migrated balance can be settled to one recipient in the account model and another recipient in the UTXO model. Medium if treated as a UTXO activation blocker rather than a live settlement path.

No production node was contacted; this is a local SQLite/Flask test only.

Wallet/miner ID for bounty payout: RTCe79b4bfa7af23dd6233f0dcd4463a52551af68f9
