### PR TITLE
docs: remove duplicate build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 # RustChain
 
-[![Build Status](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
-
 ### DePIN for Vintage Hardware — AI-Augmented Proof of Real Machines
 
 **The blockchain where old hardware outearns new hardware.**


### PR DESCRIPTION
## Summary
- Remove the duplicate top-level build status badge from the README.
- Keep the existing CI badge that links to the current workflow page.

## Verification
- `git diff --check`
- Confirmed the README now has one CI/build badge.

## RTC wallet
- `RTC28330b9f80d059ada95b31f5a67cfc9d9474c4d9`

Closes #7492
