### PR TITLE
fix(attest): reject Solana wallet IDs before hardware binding

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -316,6 +316,7 @@ def _attest_mapping(value):
 
 
 _ATTEST_MINER_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_SOLANA_WALLET_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
 _ED25519_PUBKEY_HEX_RE = re.compile(r"^[0-9a-fA-F]{64}$")
 
 
@@ -334,6 +335,12 @@ def _attest_valid_miner(value):
     if text and _ATTEST_MINER_RE.fullmatch(text):
         return text
     return None
+
+
+def _attest_looks_like_solana_wallet(value):
+    """Return True for raw Solana/base58 public keys accidentally used as miner IDs."""
+    text = _attest_text(value)
+    return bool(text and not text.startswith("RTC") and _SOLANA_WALLET_RE.fullmatch(text))
 
 
 def _valid_ed25519_pubkey_hex(value):
@@ -482,6 +489,11 @@ def _validate_attestation_payload_shape(data):
     for field_name in ("miner", "miner_id"):
         if field_name in data and data[field_name] is not None and not isinstance(data[field_name], str):
             return _attest_field_error("INVALID_MINER", f"Field '{field_name}' must be a non-empty string")
+        if field_name in data and _attest_looks_like_solana_wallet(data[field_name]):
+            return _attest_field_error(
+                "INVALID_MINER_WALLET_FORMAT",
+                "Solana-format wallet addresses cannot be used as RustChain miner IDs; create or use a native RTC wallet address",
+            )
         if field_name in data and _attest_text(data[field_name]) and not _attest_valid_miner(data[field_name]):
             return _attest_field_error(
                 "INVALID_MINER",
@@ -4241,6 +4253,14 @@ def get_challenge():
         }), 400
     requested_miner = None
     if isinstance(body, dict):
+        for field_name in ("miner", "miner_id"):
+            if _attest_looks_like_solana_wallet(body.get(field_name)):
+                return jsonify({
+                    "ok": False,
+                    "error": "invalid_miner_wallet_format",
+                    "code": "INVALID_MINER_WALLET_FORMAT",
+                    "message": "Solana-format wallet addresses cannot request RustChain attestation challenges; create or use a native RTC wallet address",
+                }), 400
         # Extract identity in the SAME order the submit path resolves `miner`
         # (_submit_attestation_impl: data.get('miner') or data.get('miner_id')) so a
         # client where miner != miner_id binds to exactly the identity that will be

--- a/tests/test_attestation_fuzz.py
+++ b/tests/test_attestation_fuzz.py
@@ -18,6 +18,7 @@ except ImportError:
     _HAS_REPLAY = False
 
 CORPUS_DIR = Path(__file__).parent / "attestation_corpus"
+SOLANA_FORMAT_WALLET = "8niYNmFMPQSoySjti2HdxfDeT9GVf7oTdBtpf8KC5xMH"
 
 
 def _init_attestation_db(db_path: Path) -> None:
@@ -216,6 +217,7 @@ def test_attest_submit_rejects_malformed_payload_shapes(client, file_name, expec
         ({"miner": "   ", "device": {"cores": 8}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "MISSING_MINER"),
         ({"miner": "fuzz\u200bminer", "device": {"cores": 8}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_MINER"),
         ({"miner": "'; DROP TABLE balances; --", "device": {"cores": 8}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_MINER"),
+        ({"miner": SOLANA_FORMAT_WALLET, "device": {"cores": 8}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_MINER_WALLET_FORMAT"),
         ({"miner": "f" * 129, "device": {"cores": 8}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_MINER"),
         ({"miner": "fuzz-miner", "device": {"cores": "999999999999999999999999"}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_DEVICE_CORES"),
         ({"miner": "fuzz-miner", "device": {"cores": []}, "signals": {"macs": ["AA:BB:CC:DD:EE:10"]}, "report": {}}, "INVALID_DEVICE_CORES"),
@@ -252,6 +254,23 @@ def test_attest_submit_rejects_invalid_miner_id_even_when_miner_is_valid(client)
 
     assert response.status_code == 400
     assert response.get_json()["code"] == "INVALID_MINER"
+
+
+def test_attest_submit_rejects_solana_wallet_before_hardware_binding(client):
+    payload = _base_payload()
+    payload["miner"] = SOLANA_FORMAT_WALLET
+
+    response = client.post("/attest/submit", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "INVALID_MINER_WALLET_FORMAT"
+
+
+def test_attest_challenge_rejects_solana_wallet_binding_identity(client):
+    response = client.post("/attest/challenge", json={"miner": SOLANA_FORMAT_WALLET})
+
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "INVALID_MINER_WALLET_FORMAT"
 
 
 def test_validate_fingerprint_data_rejects_non_dict_input():


### PR DESCRIPTION
## Summary

Prevents the hardware-binding lockout described in Scottcjn/Rustchain#969 by rejecting Solana-format base58 public keys when they are supplied as attestation miner identities.

Today those values pass the generic miner-id regex, so a user can accidentally bind hardware to a Solana wallet string and then hit DUPLICATE_HARDWARE when they switch to a native RTC wallet. This patch fails closed before nonce binding or hardware binding, with a clear INVALID_MINER_WALLET_FORMAT response telling the caller to use a native RTC wallet.

This does not mutate existing mistaken bindings; those still require operator cleanup. It prevents new accidental bindings from being created through /attest/challenge or /attest/submit.

## Changes

- Adds Solana/base58 public-key detection for 32-44 character non-RTC miner identifiers.
- Rejects those values in attestation payload validation before hardware binding.
- Rejects those values when requesting bound attestation challenges.
- Adds regression coverage for /attest/submit and /attest/challenge using the wallet from issue #969.

## Testing

- PYTHONPATH=. uv run --no-project --with flask --with pynacl --with requests --with pytest pytest -q tests/test_attestation_fuzz.py
- PYTHONPATH=node uv run --no-project --with flask --with pynacl --with requests python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_attestation_fuzz.py
- git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py tests/test_attestation_fuzz.py

Result: 50 passed; compile and diff checks clean.

Bounty routing: candidate fix for Rustchain#969 under rustchain-bounties#71. Wallet/miner ID: RTCe79b4bfa7af23dd6233f0dcd4463a52551af68f9