### PR TITLE
fix(wallet): add status-only transaction lookup

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -9158,6 +9158,180 @@ def api_wallet_lookup(miner_id):
     })
 
 
+_WALLET_TX_HASH_RE = re.compile(r"^[0-9a-fA-F]{32}$")
+
+
+def _wallet_tx_status_response(tx_hash: str, status: str, block_height=None,
+                               confirmations: int = 0):
+    body = {
+        "ok": True,
+        "tx_hash": tx_hash,
+        "status": status,
+        "confirmations": confirmations,
+        "block_height": block_height,
+    }
+    return jsonify(body)
+
+
+def _wallet_tx_has_table(db, table_name: str) -> bool:
+    try:
+        row = db.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+            (table_name,),
+        ).fetchone()
+    except sqlite3.Error:
+        return False
+    return row is not None
+
+
+def _wallet_tx_parse_ledger_transfer(row):
+    reason = str(row["reason"] or "")
+    direction, sep, rest = reason.partition(":")
+    if not sep or direction not in ("transfer_in", "transfer_out"):
+        return None
+    counterparty, sep, tx_hash = rest.rpartition(":")
+    if not sep or not counterparty or not _WALLET_TX_HASH_RE.fullmatch(tx_hash):
+        return None
+    delta = int(row["delta_i64"])
+    if direction == "transfer_out" and delta >= 0:
+        return None
+    if direction == "transfer_in" and delta <= 0:
+        return None
+    return {
+        "direction": direction,
+        "wallet": str(row["miner_id"]),
+        "counterparty": counterparty,
+        "amount_i64": abs(delta),
+        "epoch": row["epoch"],
+        "tx_hash": tx_hash.lower(),
+    }
+
+
+def _wallet_tx_verified_ledger_height(db, tx_hash: str):
+    if not _wallet_tx_has_table(db, "ledger"):
+        return None
+
+    rows = db.execute(
+        """
+        SELECT ts, epoch, miner_id, delta_i64, reason
+        FROM ledger
+        WHERE reason LIKE ?
+        ORDER BY ts DESC, rowid DESC
+        LIMIT 8
+        """,
+        (f"%:{tx_hash}",),
+    ).fetchall()
+    parsed = [
+        item for item in (_wallet_tx_parse_ledger_transfer(row) for row in rows)
+        if item and item["tx_hash"] == tx_hash
+    ]
+
+    outs = [item for item in parsed if item["direction"] == "transfer_out"]
+    ins = [item for item in parsed if item["direction"] == "transfer_in"]
+    matches = []
+    for out_row in outs:
+        for in_row in ins:
+            if (
+                out_row["wallet"] == in_row["counterparty"]
+                and out_row["counterparty"] == in_row["wallet"]
+                and out_row["amount_i64"] == in_row["amount_i64"]
+            ):
+                matches.append((out_row, in_row))
+
+    if len(matches) != 1:
+        return None
+
+    out_row, in_row = matches[0]
+    if out_row["epoch"] == in_row["epoch"] and out_row["epoch"] is not None:
+        try:
+            return int(out_row["epoch"])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _wallet_tx_pending_row_status(db, tx_hash: str):
+    if not _wallet_tx_has_table(db, "pending_ledger"):
+        return None, None
+
+    rows = db.execute(
+        """
+        SELECT id, epoch, status, confirmed_at, created_at, ts
+        FROM pending_ledger
+        WHERE tx_hash = ?
+        ORDER BY COALESCE(confirmed_at, created_at, ts, 0) DESC, id DESC
+        LIMIT 2
+        """,
+        (tx_hash,),
+    ).fetchall()
+    if not rows:
+        return None, None
+    if len(rows) > 1:
+        return "ambiguous", None
+
+    row = rows[0]
+    raw_status = str(row["status"] or "pending").lower()
+    if raw_status == "confirmed":
+        block_height = _wallet_tx_verified_ledger_height(db, tx_hash)
+        if block_height is not None:
+            return "confirmed", block_height
+        return "pending", None
+    if raw_status in {"voided", "failed", "rejected", "cancelled", "expired"}:
+        return "failed", None
+    return "pending", None
+
+
+@app.route('/wallet/tx/<tx_hash>', methods=['GET'])
+def api_wallet_tx_status(tx_hash: str):
+    """Return a status-only transaction lookup for wallet clients.
+
+    The route is intentionally public but does not expose participants, amounts,
+    pending IDs, internal reasons, or void details. A transaction is reported as
+    confirmed only after matching both immutable ledger entries for the hash.
+    """
+    tx_hash = str(tx_hash or "").strip().lower()
+    if not _WALLET_TX_HASH_RE.fullmatch(tx_hash):
+        return jsonify({
+            "ok": False,
+            "error": "tx_hash must be exactly 32 hexadecimal characters",
+        }), 400
+
+    try:
+        with sqlite3.connect(DB_PATH) as db:
+            db.row_factory = sqlite3.Row
+            status, block_height = _wallet_tx_pending_row_status(db, tx_hash)
+            if status == "ambiguous":
+                return jsonify({
+                    "ok": False,
+                    "error": "ambiguous_transaction",
+                }), 409
+            if status:
+                return _wallet_tx_status_response(
+                    tx_hash,
+                    status,
+                    block_height=block_height,
+                    confirmations=1 if status == "confirmed" else 0,
+                )
+
+            block_height = _wallet_tx_verified_ledger_height(db, tx_hash)
+            if block_height is not None:
+                return _wallet_tx_status_response(
+                    tx_hash,
+                    "confirmed",
+                    block_height=block_height,
+                    confirmations=1,
+                )
+    except sqlite3.Error:
+        return jsonify({"ok": False, "error": "transaction_lookup_unavailable"}), 503
+
+    return jsonify({
+        "ok": False,
+        "tx_hash": tx_hash,
+        "status": "not_found",
+        "error": "transaction_not_found",
+    }), 404
+
+
 @app.route('/wallet/history', methods=['GET'])
 def api_wallet_history():
     """Get unified transaction history for a wallet (fixes #775, #886).

--- a/node/tests/test_wallet_tx_status_endpoint.py
+++ b/node/tests/test_wallet_tx_status_endpoint.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: MIT
+import importlib.util
+import os
+import sqlite3
+import sys
+import tempfile
+import unittest
+
+
+NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
+ADMIN_KEY = "0123456789abcdef0123456789abcdef"
+TX_HASH = "0123456789abcdef0123456789abcdef"
+
+
+class TestWalletTxStatusEndpoint(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._tmp = tempfile.TemporaryDirectory()
+        cls._prev_env = {
+            key: os.environ.get(key)
+            for key in (
+                "RUSTCHAIN_DB_PATH",
+                "RC_ADMIN_KEY",
+                "RUSTCHAIN_DISABLE_P2P_AUTO_START",
+            )
+        }
+        os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "test.db")
+        os.environ["RC_ADMIN_KEY"] = ADMIN_KEY
+        os.environ["RUSTCHAIN_DISABLE_P2P_AUTO_START"] = "1"
+
+        if NODE_DIR not in sys.path:
+            sys.path.insert(0, NODE_DIR)
+
+        spec = importlib.util.spec_from_file_location(
+            "rustchain_integrated_wallet_tx_status_test",
+            MODULE_PATH,
+        )
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+        cls.client = cls.mod.app.test_client()
+
+    @classmethod
+    def tearDownClass(cls):
+        for key, value in cls._prev_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        cls._tmp.cleanup()
+
+    def setUp(self):
+        with sqlite3.connect(self.mod.DB_PATH) as db:
+            db.executescript(
+                """
+                DROP TABLE IF EXISTS pending_ledger;
+                DROP TABLE IF EXISTS ledger;
+
+                CREATE TABLE pending_ledger (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ts INTEGER,
+                    epoch INTEGER,
+                    from_miner TEXT,
+                    to_miner TEXT,
+                    amount_i64 INTEGER,
+                    reason TEXT,
+                    status TEXT,
+                    created_at INTEGER,
+                    confirms_at INTEGER,
+                    tx_hash TEXT,
+                    voided_by TEXT,
+                    voided_reason TEXT,
+                    confirmed_at INTEGER
+                );
+
+                CREATE TABLE ledger (
+                    ts INTEGER,
+                    epoch INTEGER,
+                    miner_id TEXT,
+                    delta_i64 INTEGER,
+                    reason TEXT
+                );
+                """
+            )
+
+    def _insert_pending(self, status="pending", tx_hash=TX_HASH, amount=5_000_000):
+        with sqlite3.connect(self.mod.DB_PATH) as db:
+            db.execute(
+                """
+                INSERT INTO pending_ledger
+                    (ts, epoch, from_miner, to_miner, amount_i64, reason,
+                     status, created_at, confirms_at, tx_hash, confirmed_at,
+                     voided_by, voided_reason)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    1700000000,
+                    42,
+                    "alice",
+                    "bob",
+                    amount,
+                    "signed_transfer:private memo",
+                    status,
+                    1700000000,
+                    1700003600,
+                    tx_hash,
+                    1700007200 if status == "confirmed" else None,
+                    "admin",
+                    "private void reason",
+                ),
+            )
+
+    def _insert_verified_ledger_pair(self, tx_hash=TX_HASH):
+        with sqlite3.connect(self.mod.DB_PATH) as db:
+            db.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+                (1700007300, 42, "alice", -5_000_000, f"transfer_out:bob:{tx_hash}"),
+            )
+            db.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+                (1700007300, 42, "bob", 5_000_000, f"transfer_in:alice:{tx_hash}"),
+            )
+
+    def test_pending_lookup_is_status_only(self):
+        self._insert_pending(status="pending")
+
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body, {
+            "ok": True,
+            "tx_hash": TX_HASH,
+            "status": "pending",
+            "confirmations": 0,
+            "block_height": None,
+        })
+        for private_key in (
+            "from_miner",
+            "to_miner",
+            "from",
+            "to",
+            "amount_i64",
+            "amount_rtc",
+            "pending_id",
+            "reason",
+            "voided_reason",
+        ):
+            self.assertNotIn(private_key, body)
+
+    def test_confirmed_pending_requires_verified_double_entry(self):
+        self._insert_pending(status="confirmed")
+
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["status"], "pending")
+
+        self._insert_verified_ledger_pair()
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["status"], "confirmed")
+        self.assertEqual(body["confirmations"], 1)
+        self.assertEqual(body["block_height"], 42)
+
+    def test_ledger_only_lookup_requires_balanced_double_entry(self):
+        with sqlite3.connect(self.mod.DB_PATH) as db:
+            db.execute(
+                "INSERT INTO ledger (ts, epoch, miner_id, delta_i64, reason) VALUES (?, ?, ?, ?, ?)",
+                (1700007300, 42, "bob", 5_000_000, f"transfer_in:alice:{TX_HASH}"),
+            )
+
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.get_json()["status"], "not_found")
+
+        with sqlite3.connect(self.mod.DB_PATH) as db:
+            db.execute("DELETE FROM ledger")
+
+        self._insert_verified_ledger_pair()
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["status"], "confirmed")
+
+    def test_duplicate_pending_hash_is_ambiguous(self):
+        self._insert_pending(status="pending")
+        self._insert_pending(status="voided")
+
+        response = self.client.get(f"/wallet/tx/{TX_HASH}")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.get_json(), {
+            "ok": False,
+            "error": "ambiguous_transaction",
+        })
+
+    def test_rejects_short_or_non_hex_hashes(self):
+        for bad_hash in ("abc", "g" * 32, TX_HASH + "00"):
+            response = self.client.get(f"/wallet/tx/{bad_hash}")
+            self.assertEqual(response.status_code, 400)
+            self.assertEqual(response.get_json()["ok"], False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #7088.

This replaces the closed `/wallet/tx/<hash>` attempt with a status-only lookup that addresses the blocking review on #7090:

- does not expose participants, amounts, pending IDs, internal reasons, memos, or void reasons
- requires an exact 32-character hexadecimal transaction hash
- treats duplicate `pending_ledger.tx_hash` rows as ambiguous instead of selecting an arbitrary row
- reports `confirmed` only when matching `transfer_out:<counterparty>:<tx_hash>` and `transfer_in:<counterparty>:<tx_hash>` ledger entries have opposite participants, equal absolute amounts, and the same epoch
- returns JSON for invalid, missing, pending, failed, and confirmed lookups so wallet clients do not receive Flask's HTML 404

Validation:

- `PYTHONPATH=node uv run --no-project --with pytest --with flask --with pynacl --with requests pytest -q node/tests/test_wallet_tx_status_endpoint.py` -> 5 passed
- `PYTHONPATH=node uv run --no-project --with flask --with pynacl --with requests python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_wallet_tx_status_endpoint.py` -> passed
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_wallet_tx_status_endpoint.py` -> passed

I also ran the nearby wallet/history and public API disclosure tests. They still contain the existing baseline drift around `/wallet/history` returning an object instead of a raw array and mocked `/api/miners` rate-limit state, so I kept this PR scoped to the new transaction-status endpoint.
