### PR TITLE
fix(headers): bind signed message to submitted header

### DIFF
--- a/node/rustchain_v2_integrated_v2.2.1_rip200.py
+++ b/node/rustchain_v2_integrated_v2.2.1_rip200.py
@@ -5493,6 +5493,15 @@ def ingest_signed_header():
     if header_miner and header_miner != miner_id:
         return jsonify({"ok":False,"error":"miner_mismatch"}), 400
 
+    canonical_msg = None
+    if header:
+        try:
+            canonical_msg = canonical_header_bytes(header)
+        except Exception:
+            return jsonify({"ok":False,"error":"bad header for canonicalization"}), 400
+        if msg_hex and msg_hex != bytes_to_hex(canonical_msg):
+            return jsonify({"ok":False,"error":"message_header_mismatch"}), 400
+
     # Resolve candidate public key(s). A wallet identity may have several enrolled
     # devices, each with its own header key (composite miner_header_keys PK), so we
     # collect every registered key and accept the header if its signature matches ANY.
@@ -5516,10 +5525,7 @@ def ingest_signed_header():
             return jsonify({"ok":False,"error":"bad message hex"}), 400
     else:
         # build canonical message from header
-        try:
-            msg = canonical_header_bytes(header)
-        except Exception:
-            return jsonify({"ok":False,"error":"bad header for canonicalization"}), 400
+        msg = canonical_msg if canonical_msg is not None else canonical_header_bytes(header)
         msg_hex = bytes_to_hex(msg)
 
     # Mock acceptance (TESTNET ONLY)

--- a/node/tests/test_ingest_round_robin_authorization.py
+++ b/node/tests/test_ingest_round_robin_authorization.py
@@ -192,6 +192,38 @@ class TestIngestRoundRobinAuthorization(unittest.TestCase):
             ).fetchone()[0]
         self.assertEqual(stored_pubkey, expected_pubkey)
 
+    def test_supplied_message_must_match_submitted_header(self):
+        self._prepare_consensus_state(slot=100)
+        signing_key = nacl.signing.SigningKey.generate()
+        pubkey_hex = signing_key.verify_key.encode().hex()
+        header = {"slot": 100, "miner": "attacker", "timestamp": int(time.time())}
+        signed_message = b"not-the-submitted-header"
+        payload = {
+            "miner_id": "attacker",
+            "header": header,
+            "message": signed_message.hex(),
+            "signature": signing_key.sign(signed_message).signature.hex(),
+        }
+
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO miner_header_keys(miner_id, pubkey_hex) VALUES (?, ?)",
+                ("attacker", pubkey_hex),
+            )
+            conn.commit()
+
+        with self.mod.app.test_client() as client:
+            response = client.post("/headers/ingest_signed", json=payload)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.get_json()["error"], "message_header_mismatch")
+        with sqlite3.connect(self.mod.DB_PATH) as conn:
+            stored = conn.execute(
+                "SELECT 1 FROM headers WHERE slot = ?",
+                (100,),
+            ).fetchone()
+        self.assertIsNone(stored)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes a signed-header authenticity gap in `/headers/ingest_signed`.

Before this change, a request could include both:

- `header`: the object later used for slot authorization and persistence
- `message`: the bytes actually verified by Ed25519

When `message` was present, the route verified the signature over `message` but did not require it to equal `canonical_header_bytes(header)`. That allowed an eligible producer to submit a valid signature over unrelated bytes while storing a different header object for the slot.

This PR binds those values together: if a header object is supplied, any supplied `message` must exactly match the canonical header preimage. Otherwise the route returns `400 message_header_mismatch` before signature acceptance, slot authorization, or persistence.

Validation:

- `PYTHONPATH=node uv run --no-project --with pytest --with flask --with pynacl --with requests pytest -q node/tests/test_ingest_round_robin_authorization.py` -> 3 passed
- `PYTHONPATH=node uv run --no-project --with pytest --with flask --with pynacl --with requests pytest -q node/tests/test_ingest_round_robin_authorization.py node/tests/test_ingest_slot_validation.py tests/test_header_routes_json_validation.py` -> 8 passed
- `PYTHONPATH=node uv run --no-project --with flask --with pynacl --with requests python3 -m py_compile node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_ingest_round_robin_authorization.py` -> passed
- `git diff --check -- node/rustchain_v2_integrated_v2.2.1_rip200.py node/tests/test_ingest_round_robin_authorization.py` -> passed

RTC claim wallet: `RTCe79b4bfa7af23dd6233f0dcd4463a52551af68f9`
