### PR TITLE
docs(zh-CN): fix broken doc links in QUICKSTART & PROTOCOL_OVERVIEW (#7505)

### DIFF
--- a/docs/zh-CN/PROTOCOL_OVERVIEW.md
+++ b/docs/zh-CN/PROTOCOL_OVERVIEW.md
@@ -247,14 +247,14 @@ curl -sk https://rustchain.org/api/miners
 
 ## 参考
 
-- **白皮书**: [WHITEPAPER.md](./WHITEPAPER.md)
+- **白皮书**: [RustChain_Whitepaper_zh-CN_v1.0.md](./RustChain_Whitepaper_zh-CN_v1.0.md)
 - **API 文档**: [API.md](./API.md)
-- **协议规范**: [PROTOCOL.md](./PROTOCOL.md)
-- **词汇表**: [GLOSSARY.md](./GLOSSARY.md)
+- **协议规范**: [PROTOCOL.md](../PROTOCOL.md)
+- **词汇表**: [GLOSSARY.md](../GLOSSARY.md)
 
 ---
 
 **下一步**:
-- 阅读 [attestation-flow.md](./attestation-flow.md) 进行矿工集成
-- 查看 [epoch-settlement.md](./epoch-settlement.md) 了解奖励机制
-- 查看 [hardware-fingerprinting.md](./hardware-fingerprinting.md) 了解技术细节
+- 阅读 [attestation-flow.md](../attestation-flow.md) 进行矿工集成
+- 查看 [epoch-settlement.md](../epoch-settlement.md) 了解奖励机制
+- 查看 [hardware-fingerprinting.md](../hardware-fingerprinting.md) 了解技术细节

--- a/docs/zh-CN/QUICKSTART.md
+++ b/docs/zh-CN/QUICKSTART.md
@@ -404,7 +404,7 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 - **GitHub Issues：** https://github.com/Scottcjn/Rustchain/issues
 - **Discord：** https://discord.gg/VqVVS2CW9Q
 - **Moltbook：** https://www.moltbook.com/m/rustchain
-- **FAQ：** [FAQ_TROUBLESHOOTING.md](FAQ_TROUBLESHOOTING.md)
+- **FAQ：** [FAQ_TROUBLESHOOTING.md](../FAQ_TROUBLESHOOTING.md)
 
 ---
 
@@ -426,11 +426,11 @@ curl -sSL https://raw.githubusercontent.com/Scottcjn/Rustchain/main/install-mine
 
 ## 后续步骤
 
-- **将 RTC 兑换为 Solana 代币：** [wRTC 指南](wrtc.md)
-- **运行完整节点：** [协议文档](PROTOCOL.md)
-- **深入了解 Proof-of-Antiquity：** [白皮书](WHITEPAPER.md)
+- **将 RTC 兑换为 Solana 代币：** [wRTC 指南](../wrtc.md)
+- **运行完整节点：** [协议文档](../PROTOCOL.md)
+- **深入了解 Proof-of-Antiquity：** [白皮书](RustChain_Whitepaper_zh-CN_v1.0.md)
 - **贡献代码：** [贡献指南](../CONTRIBUTING.md)
-- **API 参考：** [API 教程](API_WALKTHROUGH.md)
+- **API 参考：** [API 教程](API.md)
 
 ---
 


### PR DESCRIPTION
Fixes #7505.

The zh-CN `QUICKSTART.md` and `PROTOCOL_OVERVIEW.md` linked to localized `docs/zh-CN/*.md` files that don't exist on `origin/main`, so a Chinese reader following the next-steps / reference sections hit GitHub 404s.

### Changes
Each broken link is retargeted to a file that actually exists:

**`docs/zh-CN/QUICKSTART.md`**
- `WHITEPAPER.md` → `RustChain_Whitepaper_zh-CN_v1.0.md` (localized, same dir)
- `API_WALKTHROUGH.md` → `API.md` (localized zh-CN API doc, same dir)
- `FAQ_TROUBLESHOOTING.md`, `wrtc.md`, `PROTOCOL.md` → `../<file>.md` (no zh-CN version yet)

**`docs/zh-CN/PROTOCOL_OVERVIEW.md`**
- `WHITEPAPER.md` → `RustChain_Whitepaper_zh-CN_v1.0.md` (localized)
- `PROTOCOL.md`, `GLOSSARY.md`, `attestation-flow.md`, `epoch-settlement.md`, `hardware-fingerprinting.md` → `../<file>.md`

Where a localized zh-CN file exists I point to it (keeping the reader in-language); otherwise I fall back to the English doc in the parent `docs/` directory — the same pattern the file already uses for `../CONTRIBUTING.md`.

### Verification
Resolved every relative `.md` link in both files against the filesystem on `origin/main` (commit `7974ef2`): **13 links checked, 0 broken** after the change. No content/prose changes — link targets only.

/claim #7505
