### PR TITLE
[codex] bind wallet CLI transfers to chain ID

### DIFF
--- a/tests/test_wallet_cli_39.py
+++ b/tests/test_wallet_cli_39.py
@@ -51,8 +51,24 @@ def test_sign_transfer_shape():
     assert tx["from_address"].startswith("RTC")
     assert tx["to_address"].startswith("RTC")
     assert tx["amount_rtc"] == 1.23
+    assert tx["chain_id"] == cli.CHAIN_ID
     assert isinstance(tx["signature"], str) and len(tx["signature"]) > 20
     assert isinstance(tx["public_key"], str) and len(tx["public_key"]) == 64
+
+
+def test_sign_transfer_allows_legacy_no_chain_id():
+    priv = "01" * 32
+    tx = cli._sign_transfer(
+        priv,
+        "RTC" + "a" * 40,
+        "RTC" + "b" * 40,
+        1.23,
+        "m",
+        123,
+        chain_id="",
+    )
+
+    assert "chain_id" not in tx
 
 
 def test_balance_normalization():

--- a/tools/rustchain_wallet_cli.py
+++ b/tools/rustchain_wallet_cli.py
@@ -37,6 +37,7 @@ except Exception:  # pragma: no cover
     Mnemonic = None
 
 NODE_URL = os.environ.get("RUSTCHAIN_NODE_URL", "https://rustchain.org")
+CHAIN_ID = os.environ.get("RUSTCHAIN_CHAIN_ID", "rustchain-mainnet-v2")
 VERIFY_SSL = os.environ.get("RUSTCHAIN_VERIFY_SSL", "0") in {"1", "true", "True"}
 KEYSTORE_DIR = Path.home() / ".rustchain" / "wallets"
 KEYSTORE_DIR.mkdir(parents=True, exist_ok=True)
@@ -162,7 +163,15 @@ def _read_password(prompt: str, env_key: str) -> str:
         return env_val
     return getpass.getpass(prompt)
 
-def _sign_transfer(priv_hex: str, from_addr: str, to_addr: str, amount_rtc: float, memo: str, nonce: int) -> dict:
+def _sign_transfer(
+    priv_hex: str,
+    from_addr: str,
+    to_addr: str,
+    amount_rtc: float,
+    memo: str,
+    nonce: int,
+    chain_id: str = CHAIN_ID,
+) -> dict:
     tx_data = {
         "from": from_addr,
         "to": to_addr,
@@ -170,11 +179,13 @@ def _sign_transfer(priv_hex: str, from_addr: str, to_addr: str, amount_rtc: floa
         "memo": memo,
         "nonce": str(nonce),
     }
+    if chain_id:
+        tx_data["chain_id"] = chain_id
     message = json.dumps(tx_data, sort_keys=True, separators=(",", ":")).encode()
     priv = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(priv_hex))
     sig_hex = priv.sign(message).hex()
     pub_hex = priv.public_key().public_bytes_raw().hex()
-    return {
+    payload = {
         "from_address": from_addr,
         "to_address": to_addr,
         "amount_rtc": amount_rtc,
@@ -183,6 +194,9 @@ def _sign_transfer(priv_hex: str, from_addr: str, to_addr: str, amount_rtc: floa
         "public_key": pub_hex,
         "signature": sig_hex,
     }
+    if chain_id:
+        payload["chain_id"] = chain_id
+    return payload
 
 
 def cmd_create(args):
@@ -305,7 +319,15 @@ def cmd_send(args):
     priv_hex = _decrypt_private_key(ks["crypto"], password)
     from_addr = ks["address"]
     nonce = int(time.time())
-    payload = _sign_transfer(priv_hex, from_addr, args.to, float(args.amount), args.memo or "", nonce)
+    payload = _sign_transfer(
+        priv_hex,
+        from_addr,
+        args.to,
+        float(args.amount),
+        args.memo or "",
+        nonce,
+        args.chain_id,
+    )
 
     url = f"{NODE_URL}/wallet/transfer/signed"
     r = requests.post(url, json=payload, timeout=20, verify=VERIFY_SSL)
@@ -369,6 +391,7 @@ def build_parser():
     p_send.add_argument("amount", type=float, help="Amount in RTC")
     p_send.add_argument("--from", dest="from_wallet", required=True, help="Local keystore wallet name")
     p_send.add_argument("--memo", default="", help="Optional memo")
+    p_send.add_argument("--chain-id", default=CHAIN_ID, help=f"Chain identifier (default: {CHAIN_ID})")
     p_send.set_defaults(func=cmd_send)
 
     p_hist = sub.add_parser("history", help="Wallet transaction history")


### PR DESCRIPTION
## Summary

- bind wallet CLI signed transfers to the configured RustChain chain ID
- include `chain_id` in both the canonical signed message and submitted payload
- add `--chain-id` and `RUSTCHAIN_CHAIN_ID` overrides while retaining the legacy no-chain-ID path

## Why

The node API documents `chain_id` as part of the signed-transfer domain and validates it against the active network. The Python wallet CLI previously omitted it, so signatures used the legacy cross-network format by default. Binding the signature to `rustchain-mainnet-v2` prevents accidental replay across RustChain network identities and aligns the CLI with the current API contract.

This is a focused hardening follow-up for the wallet CLI associated with Scottcjn/rustchain-bounties#39; it does not claim to be the original full CLI implementation.

## Validation

- `python -m pytest tests/test_wallet_cli_39.py -q` (`9 passed`)
- `python -m compileall tools/rustchain_wallet_cli.py`
- `git diff --check`

## Maintainer note

Please apply the required `BCOS-L2` label. GitHub does not permit fork contributors to add labels to the upstream PR.