### PR TITLE
[codex] align wallet history tests and docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -153,9 +153,9 @@ curl -fsS "https://rustchain.org/wallet/balance?miner_id=eafc6f14eab6d5c5362fe65
 
 ### `GET /wallet/history`
 
-Read recent transfer history for a wallet. This is a public, wallet-scoped view
-over the pending transfer ledger and includes pending, confirmed, and voided
-transfers. Returns an empty array for wallets with no history.
+Read unified history for a wallet from the confirmed ledger, epoch rewards, and
+pending transfer ledger. Results from all three sources are sorted together by
+timestamp before pagination is applied.
 
 Canonical query parameter is `miner_id`. The endpoint also accepts `address`
 as a compatibility alias for older callers.
@@ -171,10 +171,47 @@ curl -fsS "https://rustchain.org/wallet/history?miner_id=eafc6f14eab6d5c5362fe65
 | `miner_id` | string | Yes* | Wallet identifier (canonical) |
 | `address` | string | Yes* | Backward-compatible alias for `miner_id` |
 | `limit` | integer | No | Max records (1-200, default: 50) |
+| `offset` | integer | No | Records to skip (0-9800, default: 0) |
 
-*Either `miner_id` or `address` is required.
+*Either `miner_id` or `address` is required. If both are provided, they must match.
 
-**Response:**
+**Current response (unified contract from #908/#997):**
+```json
+{
+  "ok": true,
+  "miner_id": "aliceRTC",
+  "transactions": [
+    {
+      "type": "transfer_in",
+      "amount": 1.25,
+      "epoch": null,
+      "timestamp": 1772848800,
+      "tx_hash": "6df5d4d25b6deef8f0b2e0fa726cecf1",
+      "status": "pending",
+      "from": "bobRTC"
+    },
+    {
+      "type": "reward",
+      "amount": 0.75,
+      "epoch": 424,
+      "timestamp": 0,
+      "tx_hash": null
+    }
+  ],
+  "total": 2
+}
+```
+
+Each transaction contains `type`, `amount`, `epoch`, `timestamp`, and
+`tx_hash`. Transfer entries also include `from` or `to`; pending transfers
+include `status`. Confirmed ledger entries may include `reason`. Unknown
+wallets return the same envelope with `transactions: []` and `total: 0`.
+
+<details>
+<summary>Legacy flat-array response (before #997; migration reference only)</summary>
+
+The fields below are not returned by the current unified endpoint.
+
 ```json
 [
   {
@@ -271,6 +308,8 @@ curl -fsS "https://rustchain.org/wallet/history?miner_id=eafc6f14eab6d5c5362fe65
 | `memo` | string | Signed-transfer memo when present |
 | `confirmed_at` | integer | Confirmation timestamp when confirmed |
 | `confirms_at` | integer | Scheduled confirmation time for pending transfers |
+
+</details>
 
 ### `POST /wallet/transfer/signed`
 
@@ -461,8 +500,8 @@ resp = requests.get(
     "https://rustchain.org/wallet/history",
     params={"miner_id": miner_id, "limit": 10},
 )
-for tx in resp.json().get("transfers", []):
-    print(f"{tx['txid'][:12]}... | {tx['direction']} | {tx['amount_rtc']} RTC")
+for tx in resp.json().get("transactions", []):
+    print(f"{tx['type']} | {tx['amount']} RTC | {tx.get('tx_hash')}")
 ```
 
 ### Submit Attestation (Authenticated)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -216,10 +216,9 @@ curl -sk "https://rustchain.org/wallet/balance?miner_id=scott"
 
 #### GET /wallet/history
 
-Read recent transfer history for a wallet. This endpoint is public but always
-scoped to a single wallet and only returns entries where that wallet is either
-the sender or recipient. Returns an empty array for wallets with no history
-(non-existent wallets do not produce an error).
+Read unified history for a wallet from the confirmed ledger, epoch rewards, and
+pending transfer ledger. The endpoint is public and wallet-scoped. Results from
+all sources are sorted together before pagination.
 
 ```bash
 curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10"
@@ -231,10 +230,47 @@ curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10"
 | `miner_id` | string | Yes* | Wallet identifier (canonical parameter) |
 | `address` | string | Yes* | Backward-compatible alias for `miner_id` |
 | `limit` | integer | No | Max records to return, clamped to `1..200` (default: 50) |
+| `offset` | integer | No | Records to skip, clamped to `0..9800` (default: 0) |
 
 *Either `miner_id` or `address` is required. If both are provided, they must match.
 
-**Response**:
+**Current Response**:
+```json
+{
+  "ok": true,
+  "miner_id": "scott",
+  "transactions": [
+    {
+      "type": "transfer_out",
+      "amount": 1.25,
+      "epoch": 424,
+      "timestamp": 1771187406,
+      "tx_hash": "6df5d4d25b6deef8f0b2e0fa726cecf1",
+      "reason": "transfer_out:friend:6df5d4d25b6deef8f0b2e0fa726cecf1",
+      "to": "friend"
+    },
+    {
+      "type": "reward",
+      "amount": 0.75,
+      "epoch": 423,
+      "timestamp": 0,
+      "tx_hash": null
+    }
+  ],
+  "total": 2
+}
+```
+
+Every transaction contains `type`, `amount`, `epoch`, `timestamp`, and
+`tx_hash`. Transfer entries also include `from` or `to`; pending transfers
+include `status`. Confirmed ledger entries may include `reason`. Unknown
+wallets return the same envelope with an empty transaction array.
+
+<details>
+<summary>Legacy flat-array response (before #997; migration reference only)</summary>
+
+The fields below are not returned by the current unified endpoint.
+
 ```json
 [
   {
@@ -320,6 +356,8 @@ curl -sk "https://rustchain.org/wallet/history?miner_id=scott&limit=10"
 - Empty array `[]` is returned for wallets with no history (not an error)
 - Non-existent wallets return empty array (no WALLET_NOT_FOUND error)
 
+</details>
+
 **Error Responses**:
 
 Missing identifier:
@@ -350,7 +388,8 @@ Invalid limit:
 - Default limit: 50 records
 - Minimum limit: 1 (values < 1 are clamped)
 - Maximum limit: 200 (values > 200 are clamped)
-- Invalid limit values (non-integer) return 400 error
+- Offset is clamped to `0..9800`
+- Invalid limit or offset values (non-integer) return 400 error
 
 ---
 

--- a/node/tests/test_public_api_disclosure.py
+++ b/node/tests/test_public_api_disclosure.py
@@ -14,7 +14,7 @@ ADMIN_KEY = "0123456789abcdef0123456789abcdef"
 class TestPublicApiDisclosure(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._tmp = tempfile.TemporaryDirectory()
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
         cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
         os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "import.db")
@@ -202,75 +202,46 @@ class TestPublicApiDisclosure(unittest.TestCase):
             },
         )
 
-    def test_wallet_history_public_formats_pending_confirmed_and_failed_rows(self):
+    def test_wallet_history_public_uses_unified_response_contract(self):
         with patch.object(self.mod.sqlite3, "connect") as mock_connect:
             mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    12,
-                    1700001000,
-                    "alice",
-                    "bob",
-                    2500000,
-                    "signed_transfer:coffee",
-                    "pending",
-                    1700001000,
-                    1700087400,
-                    None,
-                    "tx_pending",
-                    None,
-                ),
-                (
-                    11,
-                    1700000000,
-                    "carol",
-                    "alice",
-                    1250000,
-                    "signed_transfer:thanks",
-                    "confirmed",
-                    1700000000,
-                    1700086400,
-                    1700086500,
-                    "tx_confirmed",
-                    None,
-                ),
-                (
-                    10,
-                    1699999000,
-                    "alice",
-                    "mallory",
-                    500000,
-                    "manual_review",
-                    "voided",
-                    1699999000,
-                    1700085400,
-                    None,
-                    "tx_failed",
-                    "admin_void",
-                ),
-            ]
+
+            def execute(sql, _params):
+                result = MagicMock()
+                if "FROM ledger" in sql:
+                    result.fetchall.return_value = [
+                        (1700000000, 11, "alice", 1250000, "transfer_in:carol:tx_confirmed")
+                    ]
+                elif "FROM epoch_rewards" in sql:
+                    result.fetchall.return_value = []
+                elif "FROM pending_ledger" in sql:
+                    result.fetchall.return_value = [
+                        (
+                            1700001000,
+                            "alice",
+                            "bob",
+                            2500000,
+                            "coffee",
+                            "pending",
+                            "tx_pending",
+                            1700001000,
+                        )
+                    ]
+                return result
+
+            mock_conn.execute.side_effect = execute
 
             resp = self.client.get("/wallet/history?miner_id=alice&limit=3")
             self.assertEqual(resp.status_code, 200)
             body = resp.get_json()
 
-            self.assertEqual(len(body), 3)
-            self.assertEqual(body[0]["tx_id"], "tx_pending")
-            self.assertEqual(body[0]["direction"], "sent")
-            self.assertEqual(body[0]["counterparty"], "bob")
-            self.assertEqual(body[0]["memo"], "coffee")
-            self.assertEqual(body[0]["status"], "pending")
-            self.assertEqual(body[0]["amount_i64"], 2500000)
-
-            self.assertEqual(body[1]["direction"], "received")
-            self.assertEqual(body[1]["counterparty"], "carol")
-            self.assertEqual(body[1]["status"], "confirmed")
-            self.assertEqual(body[1]["confirmations"], 1)
-            self.assertEqual(body[1]["memo"], "thanks")
-
-            self.assertEqual(body[2]["status"], "failed")
-            self.assertEqual(body[2]["raw_status"], "voided")
-            self.assertEqual(body[2]["status_reason"], "admin_void")
+            self.assertEqual(body["ok"], True)
+            self.assertEqual(body["miner_id"], "alice")
+            self.assertEqual(body["total"], 2)
+            self.assertEqual(body["transactions"][0]["status"], "pending")
+            self.assertEqual(body["transactions"][0]["to"], "bob")
+            self.assertEqual(body["transactions"][1]["type"], "transfer_in")
+            self.assertEqual(body["transactions"][1]["from"], "carol")
 
     def test_wallet_history_public_accepts_address_alias(self):
         with patch.object(self.mod.sqlite3, "connect") as mock_connect:
@@ -279,7 +250,10 @@ class TestPublicApiDisclosure(unittest.TestCase):
 
             resp = self.client.get("/wallet/history?address=alice")
             self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.get_json(), [])
+            self.assertEqual(
+                resp.get_json(),
+                {"ok": True, "miner_id": "alice", "transactions": [], "total": 0},
+            )
 
     def test_wallet_history_requires_identifier(self):
         resp = self.client.get("/wallet/history")

--- a/node/tests/test_wallet_history.py
+++ b/node/tests/test_wallet_history.py
@@ -1,13 +1,4 @@
-"""
-Tests for GET /wallet/history endpoint (Issue #908)
-
-Tests cover:
-- Success cases with various transaction states
-- Empty history for valid/invalid wallets
-- Invalid wallet parameter handling
-- Pagination behavior (clamping, defaults, edge cases)
-- Response format validation
-"""
+"""Tests for the unified GET /wallet/history endpoint (Issue #908)."""
 
 import importlib.util
 import os
@@ -16,17 +7,22 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
+
 NODE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 MODULE_PATH = os.path.join(NODE_DIR, "rustchain_v2_integrated_v2.2.1_rip200.py")
 ADMIN_KEY = "0123456789abcdef0123456789abcdef"
 
 
-class TestWalletHistoryEndpoint(unittest.TestCase):
-    """Comprehensive tests for /wallet/history endpoint"""
+def _query_result(rows):
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    return result
 
+
+class TestWalletHistoryEndpoint(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls._tmp = tempfile.TemporaryDirectory()
+        cls._tmp = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         cls._prev_db_path = os.environ.get("RUSTCHAIN_DB_PATH")
         cls._prev_admin_key = os.environ.get("RC_ADMIN_KEY")
         os.environ["RUSTCHAIN_DB_PATH"] = os.path.join(cls._tmp.name, "test.db")
@@ -54,485 +50,167 @@ class TestWalletHistoryEndpoint(unittest.TestCase):
             os.environ["RC_ADMIN_KEY"] = cls._prev_admin_key
         cls._tmp.cleanup()
 
-    # ==================== Success Cases ====================
+    def _get_history(self, *, ledger=(), rewards=(), pending=(), query="miner_id=alice"):
+        def execute(sql, _params):
+            if "FROM ledger" in sql:
+                return _query_result(ledger)
+            if "FROM epoch_rewards" in sql:
+                return _query_result(rewards)
+            if "FROM pending_ledger" in sql:
+                return _query_result(pending)
+            raise AssertionError(f"Unexpected query: {sql}")
 
-    def test_wallet_history_success_sent_transaction(self):
-        """Test history returns sent transaction correctly formatted"""
         with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
+            connection = mock_connect.return_value.__enter__.return_value
+            connection.execute.side_effect = execute
+            return self.client.get(f"/wallet/history?{query}")
+
+    def test_unifies_ledger_rewards_and_pending_entries(self):
+        response = self._get_history(
+            ledger=[
+                (1700000200, 12, "alice", 2_500_000, "transfer_in:bob:tx-in"),
+                (1700000100, 12, "alice", -1_000_000, "transfer_out:carol:tx-out"),
+            ],
+            rewards=[(11, 750_000, 2)],
+            pending=[
+                (1700000300, "dave", "alice", 500_000, "tip", "pending", "tx-pending", 1700000300),
                 (
-                    1,
-                    1700000000,
+                    1700000400,
                     "alice",
-                    "bob",
-                    5000000,  # 5 RTC in micro-units
-                    "signed_transfer:payment",
+                    "erin",
+                    250_000,
+                    "tip",
                     "confirmed",
-                    1700000000,
-                    1700086400,
-                    1700086500,
-                    "tx_hash_abc123",
-                    None,
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertEqual(resp.status_code, 200)
-            body = resp.get_json()
-
-            self.assertEqual(len(body), 1)
-            tx = body[0]
-            self.assertEqual(tx["tx_id"], "tx_hash_abc123")
-            self.assertEqual(tx["tx_hash"], "tx_hash_abc123")
-            self.assertEqual(tx["from_addr"], "alice")
-            self.assertEqual(tx["to_addr"], "bob")
-            self.assertEqual(tx["amount"], 5.0)
-            self.assertEqual(tx["amount_i64"], 5000000)
-            self.assertEqual(tx["amount_rtc"], 5.0)
-            self.assertEqual(tx["direction"], "sent")
-            self.assertEqual(tx["counterparty"], "bob")
-            self.assertEqual(tx["status"], "confirmed")
-            self.assertEqual(tx["confirmations"], 1)
-            self.assertEqual(tx["memo"], "payment")
-            self.assertEqual(tx["confirmed_at"], 1700086500)
-            self.assertEqual(tx["confirms_at"], 1700086400)
-
-    def test_wallet_history_success_received_transaction(self):
-        """Test history returns received transaction with correct direction"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    2,
-                    1700001000,
-                    "carol",
-                    "alice",
-                    2500000,
-                    "signed_transfer:refund",
-                    "pending",
-                    1700001000,
-                    1700087400,
-                    None,
-                    None,
-                    None,
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertEqual(resp.status_code, 200)
-            body = resp.get_json()
-
-            self.assertEqual(len(body), 1)
-            tx = body[0]
-            self.assertEqual(tx["direction"], "received")
-            self.assertEqual(tx["counterparty"], "carol")
-            self.assertEqual(tx["status"], "pending")
-            self.assertEqual(tx["confirmations"], 0)
-            self.assertEqual(tx["memo"], "refund")
-            self.assertIsNone(tx["confirmed_at"])
-            self.assertEqual(tx["confirms_at"], 1700087400)
-
-    def test_wallet_history_success_failed_transaction(self):
-        """Test history returns failed/voided transaction correctly"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    3,
-                    1700002000,
-                    "alice",
-                    "mallory",
-                    1000000,
-                    "manual_review",
-                    "voided",
-                    1700002000,
-                    1700088400,
-                    None,
-                    "tx_voided",
-                    "suspicious_activity",
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertEqual(resp.status_code, 200)
-            body = resp.get_json()
-
-            tx = body[0]
-            self.assertEqual(tx["status"], "failed")
-            self.assertEqual(tx["raw_status"], "voided")
-            self.assertEqual(tx["status_reason"], "suspicious_activity")
-            self.assertEqual(tx["confirmations"], 0)
-
-    def test_wallet_history_success_pending_without_tx_hash(self):
-        """Test pending transaction uses pending_ID as tx_id"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    42,
-                    1700003000,
-                    "alice",
-                    "bob",
-                    500000,
-                    None,
-                    "pending",
-                    1700003000,
-                    1700089400,
-                    None,
-                    None,  # No tx_hash for pending
-                    None,
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertEqual(resp.status_code, 200)
-            body = resp.get_json()
-
-            tx = body[0]
-            self.assertEqual(tx["tx_id"], "pending_42")
-            self.assertEqual(tx["tx_hash"], "pending_42")
-
-    def test_wallet_history_success_without_memo(self):
-        """Test transaction without memo returns None"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    5,
-                    1700004000,
-                    "alice",
-                    "bob",
-                    100000,
-                    None,  # No reason/memo
-                    "confirmed",
-                    1700004000,
-                    1700090400,
-                    1700090500,
-                    "tx_nomemo",
-                    None,
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            body = resp.get_json()
-            self.assertIsNone(body[0]["memo"])
-
-    def test_wallet_history_success_multiple_transactions_ordering(self):
-        """Test transactions are ordered by created_at DESC, id DESC"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (3, 1700003000, "alice", "bob", 300000, None, "confirmed", 1700003000, 1700089400, 1700089500, "tx3", None),
-                (2, 1700002000, "carol", "alice", 200000, None, "confirmed", 1700002000, 1700088400, 1700088500, "tx2", None),
-                (1, 1700001000, "alice", "dave", 100000, None, "confirmed", 1700001000, 1700087400, 1700087500, "tx1", None),
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            body = resp.get_json()
-
-            self.assertEqual(len(body), 3)
-            # Should be ordered by created_at DESC
-            self.assertEqual(body[0]["tx_id"], "tx3")
-            self.assertEqual(body[1]["tx_id"], "tx2")
-            self.assertEqual(body[2]["tx_id"], "tx1")
-
-    # ==================== Empty History Cases ====================
-
-    def test_wallet_history_empty_no_transactions(self):
-        """Test empty array returned for wallet with no history"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=newbie")
-            self.assertEqual(resp.status_code, 200)
-            body = resp.get_json()
-            self.assertEqual(body, [])
-
-    def test_wallet_history_empty_nonexistent_wallet(self):
-        """Test empty array returned for non-existent wallet (not error)"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=does_not_exist")
-            self.assertEqual(resp.status_code, 200)
-            self.assertEqual(resp.get_json(), [])
-
-    # ==================== Invalid Wallet Parameter Cases ====================
-
-    def test_wallet_history_missing_identifier(self):
-        """Test error when neither miner_id nor address provided"""
-        resp = self.client.get("/wallet/history")
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.get_json(),
-            {"ok": False, "error": "miner_id or address required"},
+                    "tx-confirmed",
+                    1700000400,
+                ),
+            ],
         )
 
-    def test_wallet_history_empty_miner_id(self):
-        """Test error when miner_id is empty string"""
-        resp = self.client.get("/wallet/history?miner_id=")
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.get_json(),
-            {"ok": False, "error": "miner_id or address required"},
-        )
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["ok"], True)
+        self.assertEqual(body["miner_id"], "alice")
+        self.assertEqual(body["total"], 4)
 
-    def test_wallet_history_conflicting_identifiers(self):
-        """Test error when miner_id and address don't match"""
-        resp = self.client.get("/wallet/history?miner_id=alice&address=bob")
-        self.assertEqual(resp.status_code, 400)
+        pending, incoming, outgoing, reward = body["transactions"]
         self.assertEqual(
-            resp.get_json(),
+            pending,
             {
-                "ok": False,
-                "error": "miner_id and address must match when both are provided",
+                "type": "transfer_in",
+                "amount": 0.5,
+                "epoch": None,
+                "timestamp": 1700000300,
+                "tx_hash": "tx-pending",
+                "status": "pending",
+                "from": "dave",
             },
         )
+        self.assertEqual(incoming["type"], "transfer_in")
+        self.assertEqual(incoming["from"], "bob")
+        self.assertEqual(incoming["amount"], 2.5)
+        self.assertEqual(outgoing["type"], "transfer_out")
+        self.assertEqual(outgoing["to"], "carol")
+        self.assertEqual(outgoing["amount"], 1.0)
+        self.assertEqual(reward["type"], "reward")
+        self.assertEqual(reward["amount"], 0.75)
+        self.assertNotIn("status", incoming)
 
-    # ==================== Pagination Behavior Cases ====================
-
-    def test_wallet_history_pagination_default_limit(self):
-        """Test default limit of 50 is applied"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertEqual(resp.status_code, 200)
-
-            # Verify query used limit=50
-            call_args = mock_conn.execute.call_args
-            query = call_args[0][0]
-            params = call_args[0][1]
-            self.assertIn("LIMIT ?", query)
-            self.assertEqual(params[-1], 50)  # Last param is limit
-
-    def test_wallet_history_pagination_custom_limit(self):
-        """Test custom limit is respected"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=10")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 10)
-
-    def test_wallet_history_pagination_limit_clamped_to_minimum(self):
-        """Test limit=0 is clamped to 1"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=0")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 1)  # Clamped to minimum
-
-    def test_wallet_history_pagination_limit_negative_clamped(self):
-        """Test negative limit is clamped to 1"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=-100")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 1)  # Clamped to minimum
-
-    def test_wallet_history_pagination_limit_clamped_to_maximum(self):
-        """Test limit > 200 is clamped to 200"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=1000")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 200)  # Clamped to maximum
-
-    def test_wallet_history_pagination_limit_exactly_200(self):
-        """Test limit=200 is accepted"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=200")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 200)
-
-    def test_wallet_history_pagination_limit_exactly_1(self):
-        """Test limit=1 is accepted"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=1")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 1)
-
-    def test_wallet_history_pagination_invalid_limit_string(self):
-        """Test invalid limit string returns error"""
-        resp = self.client.get("/wallet/history?miner_id=alice&limit=abc")
-        self.assertEqual(resp.status_code, 400)
-        self.assertEqual(
-            resp.get_json(),
-            {"ok": False, "error": "limit must be an integer"},
+    def test_non_transfer_ledger_reason_uses_ledger_type(self):
+        response = self._get_history(
+            ledger=[(1700000000, 9, "alice", 125_000, "manual_adjustment")]
         )
 
-    def test_wallet_history_pagination_invalid_limit_float(self):
-        """Test float limit returns error"""
-        resp = self.client.get("/wallet/history?miner_id=alice&limit=10.5")
-        self.assertEqual(resp.status_code, 400)
+        transaction = response.get_json()["transactions"][0]
+        self.assertEqual(transaction["type"], "ledger")
+        self.assertEqual(transaction["reason"], "manual_adjustment")
+        self.assertNotIn("from", transaction)
+        self.assertNotIn("to", transaction)
+
+    def test_unknown_wallet_returns_empty_unified_response(self):
+        response = self._get_history(query="miner_id=unknown")
+
         self.assertEqual(
-            resp.get_json(),
-            {"ok": False, "error": "limit must be an integer"},
+            response.get_json(),
+            {"ok": True, "miner_id": "unknown", "transactions": [], "total": 0},
         )
 
-    def test_wallet_history_pagination_empty_limit_uses_default(self):
-        """Test empty limit parameter uses default"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
+    def test_pagination_applies_after_unified_sort(self):
+        response = self._get_history(
+            ledger=[
+                (300, 3, "alice", 300_000, "ledger-3"),
+                (100, 1, "alice", 100_000, "ledger-1"),
+            ],
+            rewards=[(2, 200_000, 1)],
+            pending=[(400, "alice", "bob", 400_000, None, "pending", "tx-4", 400)],
+            query="miner_id=alice&limit=2&offset=1",
+        )
 
-            resp = self.client.get("/wallet/history?miner_id=alice&limit=")
-            self.assertEqual(resp.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["total"], 4)
+        self.assertEqual(len(body["transactions"]), 2)
+        self.assertEqual([tx["timestamp"] for tx in body["transactions"]], [300, 100])
 
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[-1], 50)  # Default
-
-    # ==================== Address Alias Cases ====================
-
-    def test_wallet_history_address_alias_works(self):
-        """Test address parameter works as alias for miner_id"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?address=alice")
-            self.assertEqual(resp.status_code, 200)
-
-            call_args = mock_conn.execute.call_args
-            params = call_args[0][1]
-            self.assertEqual(params[0], "alice")
-            self.assertEqual(params[1], "alice")
-
-    def test_wallet_history_matching_identifiers_accepted(self):
-        """Test same miner_id and address is accepted"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = []
-
-            resp = self.client.get("/wallet/history?miner_id=alice&address=alice")
-            self.assertEqual(resp.status_code, 200)
-
-    # ==================== Response Schema Validation ====================
-
-    def test_wallet_history_response_contains_required_fields(self):
-        """Test response contains all required fields per OpenAPI spec"""
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (
-                    1,
-                    1700000000,
-                    "alice",
-                    "bob",
-                    1000000,
-                    "signed_transfer:test",
-                    "confirmed",
-                    1700000000,
-                    1700086400,
-                    1700086500,
-                    "tx123",
-                    None,
-                )
-            ]
-
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            body = resp.get_json()
-
-            required_fields = [
-                "tx_id", "from_addr", "to_addr", "amount",
-                "timestamp", "status", "direction", "counterparty"
-            ]
-            optional_fields = [
-                "amount_i64", "amount_rtc", "memo", "confirmed_at",
-                "confirms_at", "raw_status", "status_reason", "confirmations"
-            ]
-
-            tx = body[0]
-            for field in required_fields:
-                self.assertIn(field, tx, f"Required field '{field}' missing")
-
-            for field in optional_fields:
-                self.assertIn(field, tx, f"Optional field '{field}' missing")
-
-    def test_wallet_history_status_enum_values(self):
-        """Test status field only contains valid enum values"""
-        valid_statuses = {"pending", "confirmed", "failed"}
-
-        test_cases = [
-            ("pending", "pending"),
-            ("confirmed", "confirmed"),
-            ("voided", "failed"),
-            ("rejected", "failed"),
-            ("unknown_status", "failed"),
+    def test_limit_is_clamped_to_supported_range(self):
+        ledger = [
+            (timestamp, 1, "alice", 1, f"entry-{timestamp}")
+            for timestamp in range(250, 0, -1)
         ]
+        for raw_limit, expected in (("0", 1), ("-5", 1), ("1000", 200)):
+            with self.subTest(raw_limit=raw_limit):
+                response = self._get_history(
+                    ledger=ledger, query=f"miner_id=alice&limit={raw_limit}"
+                )
+                self.assertEqual(response.status_code, 200)
+                self.assertEqual(len(response.get_json()["transactions"]), expected)
 
-        for raw_status, expected_public_status in test_cases:
-            with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-                mock_conn = mock_connect.return_value.__enter__.return_value
-                mock_conn.execute.return_value.fetchall.return_value = [
-                    (1, 1700000000, "alice", "bob", 1000000, None, raw_status,
-                     1700000000, 1700086400, None, "tx", None)
-                ]
+    def test_offset_is_clamped_to_supported_range(self):
+        ledger = [
+            (timestamp, 1, "alice", 1, f"entry-{timestamp}")
+            for timestamp in range(10_000, 0, -1)
+        ]
+        response = self._get_history(
+            ledger=ledger, query="miner_id=alice&limit=10&offset=999999"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            [tx["timestamp"] for tx in response.get_json()["transactions"]],
+            list(range(200, 190, -1)),
+        )
 
-                resp = self.client.get("/wallet/history?miner_id=alice")
-                body = resp.get_json()
-                self.assertIn(body[0]["status"], valid_statuses)
-                self.assertEqual(body[0]["status"], expected_public_status)
+    def test_accepts_address_alias_and_matching_identifiers(self):
+        alias = self._get_history(query="address=alice")
+        matching = self._get_history(query="miner_id=alice&address=alice")
 
-    def test_wallet_history_direction_enum_values(self):
-        """Test direction field only contains valid enum values"""
-        valid_directions = {"sent", "received"}
+        self.assertEqual(alias.status_code, 200)
+        self.assertEqual(alias.get_json()["miner_id"], "alice")
+        self.assertEqual(matching.status_code, 200)
 
-        with patch.object(self.mod.sqlite3, "connect") as mock_connect:
-            mock_conn = mock_connect.return_value.__enter__.return_value
+    def test_requires_identifier(self):
+        response = self.client.get("/wallet/history")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(), {"ok": False, "error": "miner_id or address required"}
+        )
 
-            # Test sent
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (1, 1700000000, "alice", "bob", 1000000, None, "confirmed",
-                 1700000000, 1700086400, 1700086500, "tx", None)
-            ]
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertIn(resp.get_json()[0]["direction"], valid_directions)
+    def test_rejects_conflicting_identifiers(self):
+        response = self.client.get("/wallet/history?miner_id=alice&address=bob")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.get_json(),
+            {"ok": False, "error": "miner_id and address must match when both are provided"},
+        )
 
-            # Test received
-            mock_conn.execute.return_value.fetchall.return_value = [
-                (1, 1700000000, "bob", "alice", 1000000, None, "confirmed",
-                 1700000000, 1700086400, 1700086500, "tx", None)
-            ]
-            resp = self.client.get("/wallet/history?miner_id=alice")
-            self.assertIn(resp.get_json()[0]["direction"], valid_directions)
+    def test_rejects_invalid_limit_and_offset(self):
+        for query, error in (
+            ("miner_id=alice&limit=abc", "limit must be an integer"),
+            ("miner_id=alice&limit=", "limit must be an integer"),
+            ("miner_id=alice&offset=abc", "offset must be an integer"),
+        ):
+            with self.subTest(query=query):
+                response = self.client.get(f"/wallet/history?{query}")
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.get_json(), {"ok": False, "error": error})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- align the `/wallet/history` tests with the unified response merged in #997
- cover ledger, epoch reward, and pending-ledger entries plus unified pagination
- document the current response envelope and correct the Python example
- preserve the former flat-array schema only as an explicitly labeled migration reference

## Root cause

PR #997 replaced the pending-ledger-only flat array with the #908 unified envelope, but the endpoint tests and API references retained the superseded schema. The live endpoint and current implementation therefore disagreed with checked-in assertions and examples.

## Validation

- `python -m py_compile node/tests/test_wallet_history.py node/tests/test_public_api_disclosure.py`
- `python -m pytest node/tests/test_wallet_history.py -q` (`10 passed, 6 subtests passed`)
- `python -m pytest node/tests/test_public_api_disclosure.py -k wallet_history -q` (`5 passed, 10 deselected`)
- `git diff --check`

A full run of `test_public_api_disclosure.py` still has two unrelated pre-existing `/api/miners` failures because those tests do not mock the newer rate-limit query.

Closes #7513

wallet: RTCe0961d6b54f2fa96db57a373c84d8ad8986153f8