### PR TITLE
fix(#7321): guard env casts against malformed input

### DIFF
--- a/tools/prometheus/rustchain_exporter.py
+++ b/tools/prometheus/rustchain_exporter.py
@@ -14,9 +14,17 @@ from prometheus_client import Gauge, start_http_server
 
 NODE_URL = os.getenv("NODE_URL", "https://rustchain.org").rstrip("/")
 P2P_NODE_URL = os.getenv("P2P_NODE_URL", "").rstrip("/")
-EXPORTER_PORT = int(os.getenv("EXPORTER_PORT", "9100"))
-SCRAPE_INTERVAL = int(os.getenv("SCRAPE_INTERVAL", "60"))
-REQUEST_TIMEOUT = int(os.getenv("REQUEST_TIMEOUT", "15"))
+def _safe_int(val: str, default: int) -> int:
+    """Cast *val* to int, returning *default* on malformed input."""
+    try:
+        return int(val)
+    except (ValueError, TypeError):
+        return default
+
+
+EXPORTER_PORT = _safe_int(os.getenv("EXPORTER_PORT", "9100"), 9100)
+SCRAPE_INTERVAL = _safe_int(os.getenv("SCRAPE_INTERVAL", "60"), 60)
+REQUEST_TIMEOUT = _safe_int(os.getenv("REQUEST_TIMEOUT", "15"), 15)
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),


### PR DESCRIPTION
## Summary

Module-level `int(os.getenv(...))` / `float(os.getenv(...))` in `tools/prometheus/rustchain_exporter.py` crashes on import if the env var contains malformed (non-numeric) input.

## Fix

Wrapped casts with `_safe_int` / `_safe_float` helpers — return the default value instead of crashing.

## Testing

Before: malformed env var → `ValueError` on import.
After: gracefully falls back to default.

Closes #7321