### PR TITLE
fix(#7224): sanitize CSV formula injection in export

### DIFF
--- a/rustchain_export.py
+++ b/rustchain_export.py
@@ -297,16 +297,35 @@ DEFAULT_HEADERS = {
 }
 
 
+_FORMULA_LEADING = frozenset(("=", "+", "-", "@"))
+
+
+def _sanitize_csv_value(value: Any) -> str:
+    """Neutralize spreadsheet formula-leading text values."""
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if stripped and stripped[0] in _FORMULA_LEADING:
+        return "'" + value
+    # Also catch tab/control-prefixed variants
+    for ch in ("\t", "\r", "\n", "\x00", "\x1b"):
+        if ch in stripped:
+            return "'" + value
+    return value
+
+
 def write_csv(path: Path, rows: list[dict[str, Any]], default_headers: list[str] | None = None) -> None:
     if rows:
         fieldnames = sorted({key for row in rows for key in row.keys()})
     else:
         fieldnames = sorted(default_headers) if default_headers else []
+    # Sanitize formula-leading values
+    sanitized = [{k: _sanitize_csv_value(v) for k, v in row.items()} for row in rows]
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         if fieldnames:
             writer.writeheader()
-        writer.writerows(rows)
+        writer.writerows(sanitized)
 
 
 def write_json(path: Path, rows: list[dict[str, Any]]) -> None:


### PR DESCRIPTION
## Summary

`write_csv()` in `rustchain_export.py` passes raw values to `csv.DictWriter.writerows()` without neutralizing spreadsheet formula markers (`=`, `+`, `-`, `@`). Malicious or compromised API responses / DB rows can inject formulas into exported CSV.

## Fix

Added `_sanitize_csv_value()` that prepends `'` to text values starting with formula markers, and applied it in `write_csv()`. Non-string values unchanged.

## Testing

- `=CMD` → `'=CMD`
- `+SUM(A1:A10)` → `'+SUM(A1:A10)`  
- `@DDE` → `'@DDE`
- Normal values unchanged
- All 4 existing tests pass

## Bounty Claim

Security bug (HIGH) — formula injection in CSV export.  
**PayPal:** ahmadyusrizal89@gmail.com  
**EVM:** 0x683d2759cb626f536c842e8a3d943776198b8b8a

Closes #7224
