### PR TITLE
fix(#7525): normalize README badge URLs to Rustchain casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 [![CI](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml/badge.svg)](https://github.com/Scottcjn/Rustchain/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/Scottcjn/Rustchain?style=flat&color=gold)](https://github.com/Scottcjn/Rustchain/stargazers)
-[![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://rustchain.org/explorer/)
-[![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://rustchain.org)
+[![Nodes](https://img.shields.io/badge/Nodes-5%20Active-brightgreen)](https://Rustchain.org/explorer/)
+[![DePIN](https://img.shields.io/badge/DePIN-Vintage%20Hardware-8B4513)](https://Rustchain.org)
 [![Proof of Antiquity](https://img.shields.io/badge/Consensus-Proof%20of%20Antiquity-DAA520)](docs/WHITEPAPER.md)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.19442753-blue)](https://doi.org/10.5281/zenodo.19442753)
 


### PR DESCRIPTION
Fixes issue #7525

Changed badge URLs in README.md from `rustchain.org` (lowercase) to `Rustchain.org` (capital R) in the two badge link targets:

- `[![Nodes](...)](https://rustchain.org/explorer/)` → `https://Rustchain.org/explorer/`
- `[![DePIN](...)](https://rustchain.org)` → `https://Rustchain.org`

These are badge image links and should use the correct casing of the project name `Rustchain` for consistency and to ensure proper resolution.