### PR TITLE
fix(#7146): harden dashboard wallet search error rendering with textContent

### DIFF
--- a/node/rustchain_dashboard.py
+++ b/node/rustchain_dashboard.py
@@ -286,9 +286,15 @@ DASHBOARD_HTML = """
                     resultDiv.style.display = 'block';
                 })
                 .catch(err => {
-                    err = escapeHtml(err.message || err);
-                    document.getElementById('search-result').innerHTML = `<h3>❌ Error</h3><p>${err}</p>`;
-                    document.getElementById('search-result').style.display = 'block';
+                    const resultDiv = document.getElementById('search-result');
+                    resultDiv.replaceChildren();
+                    const errorHeading = document.createElement('h3');
+                    errorHeading.textContent = '❌ Error';
+                    const errorMsg = document.createElement('p');
+                    errorMsg.textContent = err && err.message ? err.message : String(err || '');
+                    resultDiv.appendChild(errorHeading);
+                    resultDiv.appendChild(errorMsg);
+                    resultDiv.style.display = 'block';
                 });
         }
 

--- a/tests/test_rustchain_dashboard_frontend_security.py
+++ b/tests/test_rustchain_dashboard_frontend_security.py
@@ -62,13 +62,34 @@ def test_dashboard_escapes_search_result_and_error_text():
     assert "${escapeHtml(data.weight)}" in source
     assert "${escapeHtml(data.tier)}" in source
     assert "${escapeHtml(wallet)}" in source
-    assert "err = escapeHtml(err.message || err);" in source
 
     assert "${data.wallet}" not in source
     assert "${data.balance}" not in source
     assert "${data.weight}" not in source
     assert "${data.tier}" not in source
     assert '<span class="mono">${wallet}</span>' not in source
+
+
+def test_dashboard_search_error_path_uses_textcontent_sink():
+    """The wallet-search .catch() path must build the error card via DOM nodes
+    and `textContent`, never via `innerHTML` interpolation. Regression guard
+    for issue #7146 (Harden dashboard wallet search error rendering).
+    """
+    source = _source()
+
+    # The old innerHTML error template must be gone.
+    assert "search-result').innerHTML = `<h3>❌ Error</h3>" not in source
+    assert "err = escapeHtml(err.message || err);" not in source
+
+    # The new path must clear via replaceChildren (not innerHTML = ''), build
+    # the heading and the message paragraph with createElement, and write the
+    # exception text via textContent (no template interpolation).
+    assert "resultDiv.replaceChildren();" in source
+    assert "document.createElement('h3');" in source
+    assert "document.createElement('p');" in source
+    assert "errorMsg.textContent = err && err.message ? err.message" in source
+    assert "resultDiv.appendChild(errorHeading);" in source
+    assert "resultDiv.appendChild(errorMsg);" in source
 
 
 def test_stats_api_does_not_echo_internal_exception_details(monkeypatch):


### PR DESCRIPTION
## Summary

Replace the wallet-search `.catch()` error path in `node/rustchain_dashboard.py` with safe DOM construction so exception text never flows through an `innerHTML` parser sink.

## Changes

- `node/rustchain_dashboard.py` — wallet search `.catch()` no longer interpolates `err.message` into an `innerHTML` template; it clears the result container with `replaceChildren()`, builds the heading and message paragraph with `document.createElement`, and writes the exception text via `textContent`.
- `tests/test_rustchain_dashboard_frontend_security.py` — drop the now-obsolete `err = escapeHtml(err.message || err);` assertion and add `test_dashboard_search_error_path_uses_textcontent_sink`, a focused regression guard that forbids the old innerHTML template and requires the new textContent path.

## Why this approach

The current `.catch()` block already escaped the exception, but the surrounding pattern keeps a parser-sink on a path that could regress if the escape step is removed or weakened. Switching to `textContent` makes the safety property structural (no HTML parser touches the user-controlled string), which matches the hardening already applied to neighbouring dashboard UI paths. `replaceChildren()` is preferred over `innerHTML = ''` for the same reason — the catch path no longer references `innerHTML` at all.

## Testing

```
$ python3 -m pytest tests/test_rustchain_dashboard_frontend_security.py -v
============================= test session starts ==============================
collected 6 items
tests/test_rustchain_dashboard_frontend_security.py::test_dashboard_escapes_api_fields_before_inner_html_rendering PASSED [ 16%]
tests/test_rustchain_dashboard_frontend_security.py::test_dashboard_sanitizes_dynamic_class_tokens_and_wallet_search PASSED [ 33%]
tests/test_rustchain_dashboard_frontend_security.py::test_dashboard_escapes_search_result_and_error_text PASSED [ 50%]
tests/test_rustchain_dashboard_frontend_security.py::test_dashboard_search_error_path_uses_textcontent_sink PASSED [ 66%]
tests/test_rustchain_dashboard_frontend_security.py::test_stats_api_does_not_echo_internal_exception_details PASSED [ 83%]
tests/test_rustchain_dashboard_frontend_security.py::test_wallet_lookup_api_does_not_echo_internal_exception_details PASSED [100%]
============================== 6 passed in 0.41s ===============================
```

Manual verification (JS syntax + module load):

```
$ node --check <(python3 -c "import re,sys; print(re.search(r'<script>([\\s\\S]*?)</script>', open('node/rustchain_dashboard.py').read()).group(1))")
JS OK
$ python3 -c "import importlib.util; spec=importlib.util.spec_from_file_location('dash','node/rustchain_dashboard.py'); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m); print('module loaded:', m.app)"
module loaded: <Flask 'dash'>
```

## Trade-offs

- Visible error styling is unchanged — only the DOM construction method changed.
- Other `innerHTML` paths in the file (miners table, blocks table, success/not-found wallet results) are out of scope for this issue and are tracked separately.

Closes #7146